### PR TITLE
docs(checksums): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/checksums/src/comprehensive_tests.rs
+++ b/crates/checksums/src/comprehensive_tests.rs
@@ -1380,11 +1380,11 @@ mod pipelined_error_tests {
         let reader = FailingReader::new(data, 600);
         let config = PipelineConfig::default()
             .with_block_size(256)
-            .with_enabled(false); // Force sync mode
+            .with_enabled(false);
 
         let mut buffered = DoubleBufferedReader::new(reader, config);
 
-        // First two blocks should succeed (256 bytes each = 512 bytes)
+        // FailingReader allows the first two 256-byte blocks (512 bytes) through.
         let block1 = buffered.next_block();
         assert!(block1.is_ok());
         assert!(block1.unwrap().is_some());
@@ -1393,7 +1393,7 @@ mod pipelined_error_tests {
         assert!(block2.is_ok());
         assert!(block2.unwrap().is_some());
 
-        // Third block should fail (would need to read past 600 bytes)
+        // Reading the third block crosses the 600-byte failure threshold.
         let block3 = buffered.next_block();
         assert!(block3.is_err());
     }
@@ -1413,7 +1413,8 @@ mod pipelined_error_tests {
 
     #[test]
     fn double_buffered_reader_handles_early_read_error() {
-        // Error before first block is fully read
+        // The reader fails before the first block is fully populated; the pipeline
+        // must downgrade to sync mode or surface the error rather than hang.
         let data = vec![0xEF; 100];
         let reader = FailingReader::new(data, 50);
         let config = PipelineConfig::default()
@@ -1421,10 +1422,7 @@ mod pipelined_error_tests {
             .with_min_file_size(0)
             .with_enabled(true);
 
-        // Should fall back to sync mode on error
         let mut buffered = DoubleBufferedReader::with_size_hint(reader, config, Some(100));
-
-        // Should be in sync mode due to error
         assert!(!buffered.is_pipelined() || buffered.next_block().is_err());
     }
 }

--- a/crates/checksums/src/strong/md4_tests.rs
+++ b/crates/checksums/src/strong/md4_tests.rs
@@ -22,8 +22,8 @@ mod tests {
         }
         out
     }
-    // Test vectors from RFC 1320 "The MD4 Message-Digest Algorithm"
-    // https://www.rfc-editor.org/rfc/rfc1320
+
+    // RFC 1320 test vectors: https://www.rfc-editor.org/rfc/rfc1320
 
     #[test]
     fn md4_rfc1320_empty() {
@@ -111,7 +111,6 @@ mod tests {
     fn md4_empty_input_one_shot() {
         let digest = Md4::digest(b"");
         assert_eq!(digest.len(), 16, "MD4 digest should be 16 bytes");
-        // Verify against known value
         assert_eq!(to_hex(&digest), "31d6cfe0d16ae931b73c59d7e0c089c0");
     }
 
@@ -137,7 +136,6 @@ mod tests {
     fn md4_single_byte_zero() {
         let digest = Md4::digest(&[0x00]);
         assert_eq!(digest.len(), 16);
-        // Verify determinism
         assert_eq!(Md4::digest(&[0x00]), digest);
     }
 
@@ -145,13 +143,11 @@ mod tests {
     fn md4_single_byte_max() {
         let digest = Md4::digest(&[0xFF]);
         assert_eq!(digest.len(), 16);
-        // Should differ from 0x00
         assert_ne!(Md4::digest(&[0xFF]), Md4::digest(&[0x00]));
     }
 
     #[test]
     fn md4_single_byte_a() {
-        // Single 'a' character (0x61)
         let digest = Md4::digest(&[0x61]);
         assert_eq!(to_hex(&digest), "bde52cb31de33e46245e05fbdbd6fb24");
     }
@@ -164,13 +160,11 @@ mod tests {
             let digest = Md4::digest(&[byte]);
             digests.insert(digest);
         }
-        // All 256 single-byte inputs should produce unique digests
         assert_eq!(digests.len(), 256);
     }
 
     #[test]
     fn md4_small_sizes() {
-        // Test sizes from 1 to 128 bytes
         for size in 1..=128 {
             let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
             let digest = Md4::digest(&data);
@@ -180,13 +174,9 @@ mod tests {
 
     #[test]
     fn md4_block_boundary_sizes() {
-        // MD4 processes 64-byte blocks internally
-        // Test sizes around block boundaries
+        // MD4 processes 64-byte blocks internally; exercise around each boundary.
         for &size in &[
-            63, 64, 65, // First block boundary
-            127, 128, 129, // Second block boundary
-            191, 192, 193, // Third block boundary
-            255, 256, 257, // Fourth block boundary
+            63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 257,
         ] {
             let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
             let digest = Md4::digest(&data);
@@ -231,7 +221,6 @@ mod tests {
         let data = vec![0x34_u8; 1024 * 1024];
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify determinism
         assert_eq!(digest, Md4::digest(&data));
     }
 
@@ -240,7 +229,6 @@ mod tests {
         let data = vec![0x56_u8; 1024 * 1024];
         let oneshot = Md4::digest(&data);
 
-        // Compute incrementally with 64KB chunks
         let mut hasher = Md4::new();
         for chunk in data.chunks(64 * 1024) {
             hasher.update(chunk);
@@ -269,7 +257,6 @@ mod tests {
         let data: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
         let expected = Md4::digest(&data);
 
-        // Test with various chunk sizes
         for chunk_size in [1, 2, 3, 5, 7, 13, 17, 31, 64, 100, 256, 500] {
             let mut hasher = Md4::new();
             for chunk in data.chunks(chunk_size) {
@@ -344,25 +331,17 @@ mod tests {
         let mut hasher = Md4::new();
         hasher.update(b"first part");
 
-        // Clone the hasher mid-stream
         let cloned = hasher.clone();
 
-        // Continue with original
         hasher.update(b" second part");
         let original_result = hasher.finalize();
 
-        // Continue with clone differently
         let mut cloned2 = cloned.clone();
         cloned2.update(b" different");
         let cloned_result = cloned2.finalize();
 
-        // Results should differ
         assert_ne!(original_result, cloned_result);
-
-        // Verify original is correct
         assert_eq!(original_result, Md4::digest(b"first part second part"));
-
-        // Verify clone is correct
         assert_eq!(cloned_result, Md4::digest(b"first part different"));
     }
 
@@ -398,7 +377,6 @@ mod tests {
 
     #[test]
     fn md4_matches_reference_impl_binary_data() {
-        // Test with binary data (all byte values)
         let data: Vec<u8> = (0..=255).collect();
         let our_digest = Md4::digest(&data);
         let ref_digest: [u8; 16] = md4::Md4::digest(&data).into();
@@ -407,7 +385,6 @@ mod tests {
 
     #[test]
     fn md4_matches_reference_impl_large_data() {
-        // 64KB of patterned data
         let data: Vec<u8> = (0..65536).map(|i| (i % 256) as u8).collect();
         let our_digest = Md4::digest(&data);
         let ref_digest: [u8; 16] = md4::Md4::digest(&data).into();
@@ -418,14 +395,12 @@ mod tests {
     fn md4_matches_reference_impl_streaming() {
         let data = b"streaming comparison test with multiple updates";
 
-        // Our implementation
         let mut our_hasher = Md4::new();
         our_hasher.update(&data[..10]);
         our_hasher.update(&data[10..30]);
         our_hasher.update(&data[30..]);
         let our_digest = our_hasher.finalize();
 
-        // Reference implementation
         let mut ref_hasher = md4::Md4::new();
         ref_hasher.update(&data[..10]);
         ref_hasher.update(&data[10..30]);
@@ -464,7 +439,7 @@ mod tests {
 
     #[test]
     fn md4_strong_digest_trait_with_seed() {
-        // MD4 seed type is (), so with_seed should behave like new
+        // MD4's Seed type is `()`, so `with_seed` is equivalent to `new`.
         let hasher: Md4 = StrongDigest::with_seed(());
         let mut h = hasher;
         h.update(b"test");
@@ -503,7 +478,6 @@ mod tests {
         let hasher = Md4::new();
         let debug_str = format!("{:?}", hasher);
         assert!(debug_str.contains("Md4"));
-        // Should indicate backend type
         assert!(debug_str.contains("backend"));
     }
 
@@ -554,12 +528,11 @@ mod tests {
 
     #[test]
     fn md4_exactly_55_bytes() {
-        // 55 bytes is the maximum that fits in one block with padding
+        // 55 bytes is the maximum that fits in a single padded MD4 block.
         let data = vec![0xAA_u8; 55];
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
 
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -567,7 +540,7 @@ mod tests {
 
     #[test]
     fn md4_exactly_56_bytes() {
-        // 56 bytes requires two blocks due to padding
+        // 56 bytes pushes padding into a second MD4 block.
         let data = vec![0xBB_u8; 56];
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
@@ -575,7 +548,6 @@ mod tests {
 
     #[test]
     fn md4_exactly_64_bytes() {
-        // Exactly one full block
         let data = vec![0xCC_u8; 64];
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
@@ -583,7 +555,6 @@ mod tests {
 
     #[test]
     fn md4_repeated_same_input() {
-        // Verify determinism
         let data = b"determinism test";
         let digest1 = Md4::digest(data);
         let digest2 = Md4::digest(data);
@@ -605,7 +576,6 @@ mod tests {
 
         let digests: Vec<[u8; 16]> = inputs.iter().map(|i| Md4::digest(*i)).collect();
 
-        // All digests should be unique
         for i in 0..digests.len() {
             for j in (i + 1)..digests.len() {
                 assert_ne!(
@@ -622,8 +592,6 @@ mod tests {
         let data = b"before\x00after";
         let digest = Md4::digest(data);
         assert_eq!(digest.len(), 16);
-
-        // Should differ from version without null
         assert_ne!(digest, Md4::digest(b"beforeafter"));
     }
 

--- a/crates/checksums/src/strong/xxh64_tests.rs
+++ b/crates/checksums/src/strong/xxh64_tests.rs
@@ -11,10 +11,11 @@
 #[cfg(test)]
 mod tests {
     use crate::strong::{StrongDigest, Xxh64};
-    // These test vectors are derived from the official XXHash specification
-    // and verified against the reference C implementation.
 
-    /// Convert a u64 hash to little-endian bytes for comparison with Xxh64::digest output.
+    // Vectors below are derived from the official XXHash specification and
+    // verified against the reference C implementation.
+
+    /// Convert a u64 hash to little-endian bytes for comparison with `Xxh64::digest` output.
     fn expected_digest(hash: u64) -> [u8; 8] {
         hash.to_le_bytes()
     }
@@ -32,21 +33,16 @@ mod tests {
 
     #[test]
     fn known_test_vector_single_a_seed_0() {
-        // XXH64("a", 0) - verified against reference implementation
         let digest = Xxh64::digest(0, b"a");
-        // The actual hash value for "a" with seed 0
         let hash_value = u64::from_le_bytes(digest);
-        // Verify it's a valid 64-bit value (non-zero for non-empty input)
         assert_ne!(hash_value, 0, "Hash of 'a' should be non-zero");
         assert_eq!(digest.len(), 8, "Digest should be 8 bytes (64 bits)");
     }
 
     #[test]
     fn known_test_vector_hello_seed_0() {
-        // XXH64("Hello, World!", 0) - common test string
         let digest = Xxh64::digest(0, b"Hello, World!");
         let hash_value = u64::from_le_bytes(digest);
-        // Verify determinism - same input always produces same output
         let digest2 = Xxh64::digest(0, b"Hello, World!");
         assert_eq!(digest, digest2, "XXH64 should be deterministic");
         assert_ne!(hash_value, 0);
@@ -54,11 +50,9 @@ mod tests {
 
     #[test]
     fn known_test_vector_quick_brown_fox() {
-        // "The quick brown fox jumps over the lazy dog" is a well-known test string
         let input = b"The quick brown fox jumps over the lazy dog";
         let digest = Xxh64::digest(0, input);
 
-        // Verify against streaming implementation
         let mut hasher = Xxh64::new(0);
         hasher.update(input);
         let streaming_digest = hasher.finalize();
@@ -71,7 +65,6 @@ mod tests {
 
     #[test]
     fn known_test_vector_with_seed() {
-        // Test with various seeds
         let input = b"test";
         let digest_seed_0 = Xxh64::digest(0, input);
         let digest_seed_1 = Xxh64::digest(1, input);
@@ -93,35 +86,29 @@ mod tests {
 
     #[test]
     fn known_test_vector_123456789() {
-        // XXH64("123456789", 0) - numeric string test
         let digest = Xxh64::digest(0, b"123456789");
         let hash_value = u64::from_le_bytes(digest);
         assert_ne!(hash_value, 0);
 
-        // Verify reproducibility
         let digest2 = Xxh64::digest(0, b"123456789");
         assert_eq!(digest, digest2);
     }
 
     #[test]
     fn known_test_vector_all_zeros() {
-        // Test with buffer of all zeros
         let zeros = [0u8; 64];
         let digest = Xxh64::digest(0, &zeros);
         let hash_value = u64::from_le_bytes(digest);
-        // Even all zeros should produce a non-zero hash
         assert_ne!(hash_value, 0, "Hash of zeros should be non-zero");
     }
 
     #[test]
     fn known_test_vector_all_ones() {
-        // Test with buffer of all 0xFF bytes
         let ones = [0xFFu8; 64];
         let digest = Xxh64::digest(0, &ones);
         let hash_value = u64::from_le_bytes(digest);
         assert_ne!(hash_value, 0);
 
-        // Should differ from all zeros
         let zeros = [0u8; 64];
         let zeros_digest = Xxh64::digest(0, &zeros);
         assert_ne!(digest, zeros_digest, "Different inputs should produce different hashes");
@@ -140,7 +127,6 @@ mod tests {
         let digest = hasher.finalize();
         assert_eq!(digest.len(), 8);
 
-        // Should match one-shot
         let oneshot = Xxh64::digest(0, b"");
         assert_eq!(digest, oneshot);
     }
@@ -163,7 +149,6 @@ mod tests {
         let digest_1 = Xxh64::digest(1, b"");
         let digest_42 = Xxh64::digest(42, b"");
 
-        // Even for empty input, different seeds should produce different results
         assert_ne!(digest_0, digest_1);
         assert_ne!(digest_0, digest_42);
         assert_ne!(digest_1, digest_42);
@@ -171,12 +156,10 @@ mod tests {
 
     #[test]
     fn single_byte_all_values() {
-        // Test all 256 possible single-byte inputs
         for byte in 0u8..=255 {
             let digest = Xxh64::digest(0, &[byte]);
             assert_eq!(digest.len(), 8, "Single byte {:02x} should produce 8-byte digest", byte);
 
-            // Verify streaming matches
             let mut hasher = Xxh64::new(0);
             hasher.update(&[byte]);
             let streaming = hasher.finalize();
@@ -217,7 +200,6 @@ mod tests {
 
     #[test]
     fn various_sizes_small() {
-        // Test sizes around block boundaries and common small sizes
         let sizes = [1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 255, 256];
 
         for &size in &sizes {
@@ -225,7 +207,6 @@ mod tests {
             let digest = Xxh64::digest(0, &data);
             assert_eq!(digest.len(), 8, "Size {} should produce 8-byte digest", size);
 
-            // Verify streaming matches
             let mut hasher = Xxh64::new(0);
             hasher.update(&data);
             let streaming = hasher.finalize();
@@ -235,24 +216,13 @@ mod tests {
 
     #[test]
     fn various_sizes_medium() {
-        // Test medium sizes (1KB to 64KB)
-        let sizes = [
-            512,
-            1024,
-            2048,
-            4096,
-            8192,
-            16384,
-            32768,
-            65536,
-        ];
+        let sizes = [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
 
         for &size in &sizes {
             let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
             let digest = Xxh64::digest(0, &data);
             assert_eq!(digest.len(), 8, "Size {} should produce 8-byte digest", size);
 
-            // Verify streaming matches
             let mut hasher = Xxh64::new(0);
             hasher.update(&data);
             let streaming = hasher.finalize();
@@ -262,20 +232,13 @@ mod tests {
 
     #[test]
     fn various_sizes_large() {
-        // Test large sizes (128KB to 1MB)
-        let sizes = [
-            128 * 1024,    // 128KB
-            256 * 1024,    // 256KB
-            512 * 1024,    // 512KB
-            1024 * 1024,   // 1MB
-        ];
+        let sizes = [128 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024];
 
         for &size in &sizes {
             let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
             let digest = Xxh64::digest(0, &data);
             assert_eq!(digest.len(), 8, "Size {} should produce 8-byte digest", size);
 
-            // Verify streaming matches
             let mut hasher = Xxh64::new(0);
             hasher.update(&data);
             let streaming = hasher.finalize();
@@ -285,7 +248,7 @@ mod tests {
 
     #[test]
     fn various_sizes_prime_numbers() {
-        // Test with prime-number sizes to catch alignment edge cases
+        // Primes exercise alignment edges that powers-of-two miss.
         let primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
                       73, 79, 83, 89, 97, 101, 127, 131, 251, 509, 1021, 2039, 4093, 8191];
 
@@ -298,7 +261,6 @@ mod tests {
 
     #[test]
     fn various_sizes_powers_of_two_minus_one() {
-        // Test sizes that are one less than powers of two (often edge cases)
         let sizes = [1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767];
 
         for &size in &sizes {
@@ -306,7 +268,6 @@ mod tests {
             let digest = Xxh64::digest(0, &data);
             assert_eq!(digest.len(), 8);
 
-            // Verify with streaming
             let mut hasher = Xxh64::new(0);
             hasher.update(&data);
             assert_eq!(digest, hasher.finalize());
@@ -315,15 +276,12 @@ mod tests {
 
     #[test]
     fn size_1mb_comprehensive() {
-        // Comprehensive test for 1MB input
-        let size = 1024 * 1024; // 1MB
+        let size = 1024 * 1024;
         let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
 
-        // One-shot digest
         let oneshot = Xxh64::digest(0, &data);
         assert_eq!(oneshot.len(), 8);
 
-        // Streaming in various chunk sizes
         for chunk_size in [1024, 4096, 32768, 65536] {
             let mut hasher = Xxh64::new(0);
             for chunk in data.chunks(chunk_size) {
@@ -404,7 +362,6 @@ mod tests {
 
         assert_ne!(digest1, digest2, "Different continuations should produce different hashes");
 
-        // Verify cloned hasher produces correct result
         let expected = Xxh64::digest(42, b"partial data B");
         assert_eq!(digest2, expected);
     }
@@ -425,11 +382,9 @@ mod tests {
 
     #[test]
     fn streaming_incremental_large_data() {
-        // Test with large data to exercise internal state management
         let data: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
         let oneshot = Xxh64::digest(0, &data);
 
-        // Stream in irregular chunk sizes
         let mut hasher = Xxh64::new(0);
         let chunk_sizes = [17, 31, 64, 100, 256, 500, 1000, 2048, 5000];
         let mut offset = 0;
@@ -448,7 +403,6 @@ mod tests {
 
     #[test]
     fn streaming_trait_interface() {
-        // Test using the StrongDigest trait interface
         let seed = 12345u64;
         let data = b"trait interface test";
 
@@ -623,8 +577,7 @@ mod tests {
 
     #[test]
     fn boundary_at_internal_block_size() {
-        // XXH64 processes data in 32-byte chunks internally
-        // Test boundaries around 32 bytes
+        // XXH64 processes data in 32-byte chunks; exercise both sides of the boundary.
         for size in 30..=34 {
             let data = vec![0xAB; size];
             let digest = Xxh64::digest(0, &data);
@@ -638,14 +591,12 @@ mod tests {
 
     #[test]
     fn repeated_pattern_input() {
-        // Test with repeated patterns
         let pattern = b"ABCD";
         let repeated: Vec<u8> = pattern.iter().cycle().take(10000).cloned().collect();
 
         let digest = Xxh64::digest(0, &repeated);
         assert_eq!(digest.len(), 8);
 
-        // Different repeat counts should produce different hashes
         let repeated2: Vec<u8> = pattern.iter().cycle().take(10001).cloned().collect();
         let digest2 = Xxh64::digest(0, &repeated2);
         assert_ne!(digest, digest2);
@@ -658,7 +609,6 @@ mod tests {
             let digest = Xxh64::digest(0, &data);
             assert_eq!(digest.len(), 8);
 
-            // Different byte values should produce different hashes
             let other_byte = byte.wrapping_add(1);
             let other_data = vec![other_byte; 1000];
             let other_digest = Xxh64::digest(0, &other_data);
@@ -668,10 +618,9 @@ mod tests {
 
     #[test]
     fn avalanche_effect_single_bit() {
-        // Changing a single bit should produce a very different hash
         let data1 = vec![0u8; 100];
         let mut data2 = data1.clone();
-        data2[50] = 1; // Change single bit
+        data2[50] = 1;
 
         let digest1 = Xxh64::digest(0, &data1);
         let digest2 = Xxh64::digest(0, &data2);
@@ -679,7 +628,7 @@ mod tests {
         let hash1 = u64::from_le_bytes(digest1);
         let hash2 = u64::from_le_bytes(digest2);
 
-        // Count differing bits (should be roughly half due to avalanche effect)
+        // Good 64-bit avalanche flips ~32 bits; require at least 20.
         let diff = (hash1 ^ hash2).count_ones();
         assert!(
             diff >= 20,
@@ -690,8 +639,7 @@ mod tests {
 
     #[test]
     fn regression_known_hash_values() {
-        // Store some known hash values to catch regressions
-        // These values were computed with the current implementation
+        // Pin a few hashes to catch regressions across builds.
         let test_cases = [
             (0u64, b"".as_slice()),
             (0u64, b"a".as_slice()),
@@ -700,13 +648,11 @@ mod tests {
             (42u64, b"test".as_slice()),
         ];
 
-        // Compute current hashes
         let current_hashes: Vec<_> = test_cases
             .iter()
             .map(|(seed, data)| Xxh64::digest(*seed, data))
             .collect();
 
-        // Verify they remain consistent across multiple runs
         for (i, (seed, data)) in test_cases.iter().enumerate() {
             let digest = Xxh64::digest(*seed, data);
             assert_eq!(
@@ -719,7 +665,6 @@ mod tests {
 
     #[test]
     fn compatibility_with_xxhash_rust_reference() {
-        // Verify our implementation matches the xxhash-rust crate directly
         let test_inputs = [
             b"".as_slice(),
             b"a".as_slice(),

--- a/crates/checksums/src/strong/xxhash.rs
+++ b/crates/checksums/src/strong/xxhash.rs
@@ -516,7 +516,6 @@ mod tests {
             hasher.update(&input[split..]);
             let streaming_digest = hasher.finalize();
 
-            // Streaming should match xxhash-rust reference
             let expected = xxhash_rust::xxh3::xxh3_64_with_seed(input, seed).to_le_bytes();
             assert_eq!(
                 streaming_digest, expected,
@@ -537,8 +536,6 @@ mod tests {
         for (seed, input) in vectors {
             let one_shot = Xxh3::digest(seed, input);
 
-            // One-shot should match xxhash-rust reference (both implementations
-            // produce the same output, just potentially with different performance)
             let expected = xxhash_rust::xxh3::xxh3_64_with_seed(input, seed).to_le_bytes();
             assert_eq!(
                 one_shot, expected,
@@ -655,11 +652,10 @@ mod tests {
 
     #[test]
     fn large_input_oneshot_matches_streaming() {
-        // Test with a larger input to exercise SIMD paths
+        // 10 KB exceeds XXH3's single-block fast path, exercising the SIMD loop.
         let input: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
         let seed = 12345u64;
 
-        // XXH3-64
         let one_shot = Xxh3::digest(seed, &input);
         let mut streaming = Xxh3::new(seed);
         streaming.update(&input);
@@ -669,7 +665,6 @@ mod tests {
             "large input: one-shot should match streaming for XXH3-64"
         );
 
-        // XXH3-128
         let one_shot_128 = Xxh3_128::digest(seed, &input);
         let mut streaming_128 = Xxh3_128::new(seed);
         streaming_128.update(&input);

--- a/crates/checksums/tests/checksum_variants_upstream_compat.rs
+++ b/crates/checksums/tests/checksum_variants_upstream_compat.rs
@@ -276,13 +276,11 @@ fn protocol_version_boundary_produces_different_digests() {
     let d29 = v29.compute(data);
     let d30 = v30.compute(data);
 
-    // MD4 and MD5 produce different digests for the same input
     assert_ne!(
         d29, d30,
         "v29 (MD4) and v30 (MD5) should produce different digests"
     );
 
-    // Both produce 16-byte digests
     assert_eq!(d29.len(), 16);
     assert_eq!(d30.len(), 16);
 }
@@ -305,7 +303,6 @@ fn protocol_version_255_uses_md5() {
 
 #[test]
 fn algorithm_kind_from_name_canonical_names() {
-    // Test all canonical names that upstream rsync uses
     let expected = [
         ("md4", ChecksumAlgorithmKind::Md4),
         ("md5", ChecksumAlgorithmKind::Md5),
@@ -327,7 +324,6 @@ fn algorithm_kind_from_name_canonical_names() {
 
 #[test]
 fn algorithm_kind_from_name_aliases() {
-    // Test common aliases
     let aliases = [
         ("sha-1", ChecksumAlgorithmKind::Sha1),
         ("sha-256", ChecksumAlgorithmKind::Sha256),
@@ -385,7 +381,6 @@ fn algorithm_kind_from_name_rejects_invalid() {
 
 #[test]
 fn algorithm_kind_name_roundtrip_all() {
-    // Every algorithm's name() should roundtrip through from_name()
     for kind in ChecksumAlgorithmKind::all() {
         let name = kind.name();
         let parsed = ChecksumAlgorithmKind::from_name(name);
@@ -418,12 +413,10 @@ fn md5_seed_proper_order_is_prefix() {
     let seed_value: i32 = 0x42;
     let data = b"test data";
 
-    // Proper order: seed bytes hashed before data
     let mut proper = Md5::with_seed(Md5Seed::proper(seed_value));
     proper.update(data);
     let proper_digest = proper.finalize();
 
-    // Manual construction: new MD5, hash seed bytes, then data
     let mut manual = Md5::new();
     manual.update(&seed_value.to_le_bytes());
     manual.update(data);
@@ -445,7 +438,6 @@ fn md5_seed_legacy_order_is_suffix() {
     legacy.update(data);
     let legacy_digest = legacy.finalize();
 
-    // Manual construction: new MD5, hash data, then seed bytes
     let mut manual = Md5::new();
     manual.update(data);
     manual.update(&seed_value.to_le_bytes());

--- a/crates/checksums/tests/comprehensive_tests.rs
+++ b/crates/checksums/tests/comprehensive_tests.rs
@@ -59,12 +59,10 @@ mod rolling_edge_cases {
 
     #[test]
     fn maximum_window_size_edge() {
-        // Test with a very large window
         let data = vec![0xABu8; 65536];
         let mut checksum = RollingChecksum::new();
         checksum.update(&data);
         assert_eq!(checksum.len(), 65536);
-        // Rolling should still work on large windows
         let result = checksum.roll(0xAB, 0xCD);
         assert!(result.is_ok());
     }
@@ -101,12 +99,11 @@ mod rolling_edge_cases {
 
     #[test]
     fn roll_produces_correct_checksum() {
-        // Compute checksum for "BCDE" by rolling from "ABCD"
+        // Sliding the "ABCD" window by 'A' -> 'E' yields "BCDE".
         let mut rolling = RollingChecksum::new();
         rolling.update(b"ABCD");
         rolling.roll(b'A', b'E').unwrap();
 
-        // Compute directly
         let mut direct = RollingChecksum::new();
         direct.update(b"BCDE");
 
@@ -115,18 +112,15 @@ mod rolling_edge_cases {
 
     #[test]
     fn roll_many_produces_correct_checksum() {
-        // Roll multiple bytes at once
+        // roll_many preserves the window length: after replacing "ABC" with "XYZ",
+        // the 8-byte window contents are "DEFGHXYZ".
         let mut rolling = RollingChecksum::new();
         rolling.update(b"ABCDEFGH");
         rolling.roll_many(b"ABC", b"XYZ").unwrap();
 
-        // Compute what the checksum should be for "XYZDEFGH"
         let mut direct = RollingChecksum::new();
         direct.update(b"DEFGHXYZ");
 
-        // Note: roll_many maintains window size, so we need different comparison
-        // After rolling ABC->XYZ, window is "DEFGHXYZ" (8 bytes)
-        // But the rolling checksum tracks a sliding window
         assert_eq!(rolling.len(), 8);
     }
 
@@ -163,7 +157,8 @@ mod rolling_edge_cases {
 
     #[test]
     fn update_vectored_large_slice() {
-        // Test with slice larger than VECTORED_STACK_CAPACITY (128 bytes)
+        // 512 bytes exceeds VECTORED_STACK_CAPACITY (128 bytes), forcing the
+        // heap-allocated fallback path.
         let large_data = vec![0xAAu8; 512];
         let mut checksum = RollingChecksum::new();
         let slices = [IoSlice::new(&large_data)];
@@ -247,20 +242,18 @@ mod rolling_edge_cases {
 
     #[test]
     fn rolling_slice_error_properties() {
-        // Create error by providing wrong length slice
         let err = RollingDigest::from_le_slice(&[1, 2, 3, 4, 5], 0).unwrap_err();
         assert_eq!(err.len(), 5);
         assert!(!err.is_empty());
         assert_eq!(RollingSliceError::EXPECTED_LEN, 4);
 
-        // Test empty slice error
         let empty_err = RollingDigest::from_le_slice(&[], 0).unwrap_err();
         assert!(empty_err.is_empty());
     }
 
     #[test]
     fn rolling_digest_value_packing() {
-        // s1 in low 16 bits, s2 in high 16 bits
+        // Packed layout: s1 in low 16 bits, s2 in high 16 bits.
         let digest = RollingDigest::new(0x1234, 0x5678, 100);
         let value = digest.value();
         assert_eq!(value & 0xFFFF, 0x1234);
@@ -289,7 +282,7 @@ mod rolling_edge_cases {
 
     #[test]
     fn simd_acceleration_query() {
-        // Should not panic; result depends on platform
+        // Probe the query path; the value is platform-dependent.
         let _ = checksums::simd_acceleration_available();
     }
 }
@@ -364,15 +357,14 @@ mod strong_truncation {
 
     #[test]
     fn truncating_strong_digest_manually() {
-        // Test that we can safely truncate digests for protocol compatibility
+        // Rsync block matching often truncates SHA-256 to 16 bytes; verify the
+        // truncation is stable across repeated digests.
         let full_sha256 = Sha256::digest(b"block data");
         assert_eq!(full_sha256.len(), 32);
 
-        // Truncate to 16 bytes (128 bits) - common for rsync block matching
         let truncated = &full_sha256[..16];
         assert_eq!(truncated.len(), 16);
 
-        // Verify truncation is deterministic
         let another_sha256 = Sha256::digest(b"block data");
         assert_eq!(&another_sha256[..16], truncated);
     }
@@ -382,18 +374,16 @@ mod strong_truncation {
         let sha512 = Sha512::digest(b"data");
         assert_eq!(sha512.len(), 64);
 
-        // Truncate to first 32 bytes
         let truncated = &sha512[..32];
         assert_eq!(truncated.len(), 32);
     }
 
     #[test]
     fn digest_prefix_collision_detection() {
-        // Different inputs should have different prefixes (high probability)
+        // Distinct inputs should differ even in the first 4 bytes for a good hash.
         let digest1 = Sha256::digest(b"input one");
         let digest2 = Sha256::digest(b"input two");
 
-        // Even first 4 bytes should differ for different inputs
         assert_ne!(&digest1[..4], &digest2[..4]);
     }
 
@@ -412,8 +402,6 @@ mod strong_truncation {
         // SHA1("abc") = a9993e364706816aba3e25717850c26c9cd0d89d
         let digest = Sha1::digest(b"abc");
         assert_eq!(to_hex(&digest), "a9993e364706816aba3e25717850c26c9cd0d89d");
-
-        // Verify first 8 bytes
         assert_eq!(to_hex(&digest[..8]), "a9993e364706816a");
     }
 }
@@ -444,15 +432,14 @@ mod seed_handling {
 
     #[test]
     fn md5_proper_seed_hashes_before_data() {
+        // Proper ordering (CHECKSUM_SEED_FIX, protocol >= 30): seed bytes first, then data.
         let seed_value = 0x12345678i32;
         let data = b"test data";
 
-        // Using proper order seed
         let mut seeded = Md5::with_seed(Md5Seed::proper(seed_value));
         seeded.update(data);
         let seeded_result = seeded.finalize();
 
-        // Manual: hash seed bytes, then data
         let mut manual = Md5::new();
         manual.update(&seed_value.to_le_bytes());
         manual.update(data);
@@ -463,15 +450,14 @@ mod seed_handling {
 
     #[test]
     fn md5_legacy_seed_hashes_after_data() {
+        // Legacy ordering (pre-CHECKSUM_SEED_FIX): data first, then seed bytes.
         let seed_value = 0x12345678i32;
         let data = b"test data";
 
-        // Using legacy order seed
         let mut seeded = Md5::with_seed(Md5Seed::legacy(seed_value));
         seeded.update(data);
         let seeded_result = seeded.finalize();
 
-        // Manual: hash data, then seed bytes
         let mut manual = Md5::new();
         manual.update(data);
         manual.update(&seed_value.to_le_bytes());
@@ -538,19 +524,16 @@ mod seed_handling {
     fn md5_extreme_seed_values() {
         let data = b"test";
 
-        // i32::MAX
         let mut h1 = Md5::with_seed(Md5Seed::proper(i32::MAX));
         h1.update(data);
         let r1 = h1.finalize();
         assert_eq!(r1.len(), 16);
 
-        // i32::MIN
         let mut h2 = Md5::with_seed(Md5Seed::proper(i32::MIN));
         h2.update(data);
         let r2 = h2.finalize();
         assert_eq!(r2.len(), 16);
 
-        // Different extreme seeds should produce different results
         assert_ne!(r1, r2);
     }
 
@@ -562,7 +545,6 @@ mod seed_handling {
         let seed1_result = Xxh64::digest(1, data);
         let seed_max_result = Xxh64::digest(u64::MAX, data);
 
-        // Different seeds produce different results
         assert_ne!(seed0_result, seed1_result);
         assert_ne!(seed0_result, seed_max_result);
         assert_ne!(seed1_result, seed_max_result);
@@ -573,10 +555,8 @@ mod seed_handling {
         let seed = 12345u64;
         let data = b"streaming test";
 
-        // One-shot
         let oneshot = Xxh64::digest(seed, data);
 
-        // Streaming
         let mut streaming = Xxh64::new(seed);
         streaming.update(data);
         let streaming_result = streaming.finalize();
@@ -620,7 +600,7 @@ mod seed_handling {
 
     #[test]
     fn xxh3_simd_availability_query() {
-        // Should not panic; result depends on compile-time features
+        // Probe the query path; the value depends on compile-time features.
         let _ = checksums::xxh3_simd_available();
     }
 
@@ -677,8 +657,9 @@ mod pipelined_operations {
 
     #[test]
     fn double_buffered_reader_small_file_sync_mode() {
-        // File smaller than min_file_size should use sync mode
-        let data = vec![0xABu8; 64 * 1024]; // 64KB, less than default 256KB min
+        // 64KB is below the default 256KB pipeline threshold, so the reader
+        // must run synchronously.
+        let data = vec![0xABu8; 64 * 1024];
         let config = PipelineConfig::default();
         let mut reader = DoubleBufferedReader::with_size_hint(
             Cursor::new(data.clone()),
@@ -686,7 +667,6 @@ mod pipelined_operations {
             Some(64 * 1024),
         );
 
-        // Should be in synchronous mode
         assert!(!reader.is_pipelined());
 
         let mut total_bytes = 0;
@@ -698,7 +678,8 @@ mod pipelined_operations {
 
     #[test]
     fn double_buffered_reader_large_file_pipelined_mode() {
-        let data = vec![0xCDu8; 512 * 1024]; // 512KB, more than default 256KB min
+        // 512KB exceeds the default 256KB threshold and engages the pipeline.
+        let data = vec![0xCDu8; 512 * 1024];
         let config = PipelineConfig::default();
         let reader =
             DoubleBufferedReader::with_size_hint(Cursor::new(data), config, Some(512 * 1024));
@@ -727,21 +708,20 @@ mod pipelined_operations {
         while let Some(block) = reader.next_block().unwrap() {
             total_bytes += block.len();
             block_count += 1;
-            // Verify data integrity
             assert!(block.iter().all(|&b| b == 0x12));
         }
 
         assert_eq!(total_bytes, data.len());
-        assert_eq!(block_count, 4); // 256KB / 64KB = 4 blocks
+        assert_eq!(block_count, 4);
     }
 
     #[test]
     fn double_buffered_reader_partial_last_block() {
-        // 100KB with 64KB blocks = 1 full + 1 partial (36KB)
+        // 100KB / 64KB block size yields one full and one 36KB tail block.
         let data = vec![0x34u8; 100 * 1024];
         let config = PipelineConfig::default()
             .with_block_size(64 * 1024)
-            .with_min_file_size(0); // Force pipelining for small files
+            .with_min_file_size(0);
 
         let mut reader =
             DoubleBufferedReader::with_size_hint(Cursor::new(data), config, Some(100 * 1024));
@@ -778,7 +758,6 @@ mod pipelined_operations {
 
         assert_eq!(checksums.len(), 4);
 
-        // Verify each checksum matches direct computation
         for (i, cs) in checksums.iter().enumerate() {
             let start = i * 64 * 1024;
             let end = start + 64 * 1024;
@@ -809,11 +788,9 @@ mod pipelined_operations {
         let data = vec![0x78u8; 256 * 1024];
         let config = PipelineConfig::default().with_block_size(64 * 1024);
 
-        // Pipelined
         let pipelined =
             compute_checksums_pipelined::<Md5, _>(Cursor::new(data.clone()), config, None).unwrap();
 
-        // Sequential (with disabled pipelining)
         let sync_config = config.with_enabled(false);
         let sequential =
             compute_checksums_pipelined::<Md5, _>(Cursor::new(data), sync_config, None).unwrap();
@@ -851,9 +828,8 @@ mod pipelined_operations {
         let iter: PipelinedChecksumIterator<Md5, _> =
             PipelinedChecksumIterator::with_size_hint(Cursor::new(data), config, Some(128 * 1024));
 
-        // Should be pipelined since size >= min_file_size is not applicable here
-        // (min_file_size is 256KB, but we pass explicit size hint)
-        let _ = iter.is_pipelined(); // Just verify method exists
+        // Probe the accessor; the value depends on the size hint vs min_file_size.
+        let _ = iter.is_pipelined();
     }
 
     #[test]
@@ -880,7 +856,6 @@ mod pipelined_operations {
             .with_block_size(32 * 1024)
             .with_min_file_size(0);
 
-        // Test with various strong digest algorithms
         let _md5_checksums = compute_checksums_pipelined::<Md5, _>(
             Cursor::new(data.clone()),
             config,
@@ -902,7 +877,6 @@ mod pipelined_operations {
 
     #[test]
     fn pipelined_handles_exact_block_boundary() {
-        // Data size exactly divisible by block size
         let data = vec![0xF0u8; 128 * 1024];
         let config = PipelineConfig::default()
             .with_block_size(64 * 1024)
@@ -943,8 +917,6 @@ mod all_algorithms {
         out
     }
 
-    // --- MD4 Tests ---
-
     #[test]
     fn md4_rfc_vectors() {
         let vectors = [
@@ -980,8 +952,6 @@ mod all_algorithms {
         let sequential: Vec<_> = inputs.iter().map(|i| Md4::digest(i)).collect();
         assert_eq!(batch, sequential);
     }
-
-    // --- MD5 Tests ---
 
     #[test]
     fn md5_rfc_vectors() {
@@ -1037,8 +1007,6 @@ mod all_algorithms {
         assert_eq!(full, Md5::digest(b"hello world"));
     }
 
-    // --- SHA-1 Tests ---
-
     #[test]
     fn sha1_known_vectors() {
         let vectors = [
@@ -1064,8 +1032,6 @@ mod all_algorithms {
 
         assert_eq!(streaming, Sha1::digest(data));
     }
-
-    // --- SHA-256 Tests ---
 
     #[test]
     fn sha256_known_vectors() {
@@ -1096,8 +1062,6 @@ mod all_algorithms {
         assert_eq!(streaming, Sha256::digest(data));
     }
 
-    // --- SHA-512 Tests ---
-
     #[test]
     fn sha512_known_vectors() {
         // SHA-512("")
@@ -1116,15 +1080,12 @@ mod all_algorithms {
         assert_eq!(streaming, Sha512::digest(data));
     }
 
-    // --- XXH64 Tests ---
-
     #[test]
     fn xxh64_basic() {
         let data = b"test data";
         let digest = Xxh64::digest(0, data);
         assert_eq!(digest.len(), 8);
 
-        // Different seeds produce different results
         let digest_seed1 = Xxh64::digest(1, data);
         assert_ne!(digest, digest_seed1);
     }
@@ -1150,15 +1111,12 @@ mod all_algorithms {
         assert_eq!(digest.len(), 8);
     }
 
-    // --- XXH3 (64-bit) Tests ---
-
     #[test]
     fn xxh3_basic() {
         let data = b"test data";
         let digest = Xxh3::digest(0, data);
         assert_eq!(digest.len(), 8);
 
-        // Different seeds produce different results
         let digest_seed1 = Xxh3::digest(1, data);
         assert_ne!(digest, digest_seed1);
     }
@@ -1186,18 +1144,15 @@ mod all_algorithms {
 
     #[test]
     fn xxh3_large_input() {
-        // Test with larger input to potentially exercise SIMD paths
+        // 10 KB exercises the SIMD multi-block path.
         let data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
         let digest = Xxh3::digest(0, &data);
         assert_eq!(digest.len(), 8);
 
-        // Verify streaming matches
         let mut hasher = Xxh3::new(0);
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
     }
-
-    // --- XXH3-128 Tests ---
 
     #[test]
     fn xxh3_128_basic() {
@@ -1205,7 +1160,6 @@ mod all_algorithms {
         let digest = Xxh3_128::digest(0, data);
         assert_eq!(digest.len(), 16);
 
-        // Different seeds produce different results
         let digest_seed1 = Xxh3_128::digest(1, data);
         assert_ne!(digest, digest_seed1);
     }
@@ -1242,13 +1196,10 @@ mod all_algorithms {
         assert_eq!(hasher.finalize(), digest);
     }
 
-    // --- StrongDigest Trait Tests ---
-
     #[test]
     fn trait_digest_for_all_algorithms() {
         let data = b"trait test";
 
-        // Test that trait methods work for all algorithms
         let _md4: <Md4 as StrongDigest>::Digest = Md4::digest(data);
         let _md5: <Md5 as StrongDigest>::Digest = Md5::digest(data);
         let _sha1: <Sha1 as StrongDigest>::Digest = Sha1::digest(data);
@@ -1263,12 +1214,10 @@ mod all_algorithms {
     fn trait_digest_with_seed() {
         let data = b"seeded test";
 
-        // MD5 with seed
         let md5_seeded = Md5::digest_with_seed(Md5Seed::proper(42), data);
         let md5_default = Md5::digest(data);
         assert_ne!(md5_seeded, md5_default);
 
-        // XXH64 with seed
         let xxh64_seeded = Xxh64::digest_with_seed(42, data);
         let xxh64_default = Xxh64::digest_with_seed(0, data);
         assert_ne!(xxh64_seeded, xxh64_default);
@@ -1276,7 +1225,7 @@ mod all_algorithms {
 
     #[test]
     fn trait_new_and_with_seed_equivalence() {
-        // For algorithms without seeds, new() and with_seed(default) should be equivalent
+        // Algorithms whose `Seed` is `()` must treat `new` and `with_seed(())` identically.
         let data = b"equivalence test";
 
         let mut md4_new = Md4::new();
@@ -1335,7 +1284,7 @@ mod all_algorithms {
 
     #[test]
     fn openssl_acceleration_query() {
-        // Should not panic; result depends on feature flags
+        // Probe the query path; the value depends on the `openssl` feature flag.
         let _ = checksums::openssl_acceleration_available();
     }
 

--- a/crates/checksums/tests/md4_protocol_compat.rs
+++ b/crates/checksums/tests/md4_protocol_compat.rs
@@ -73,8 +73,8 @@ fn explicit_md4_selection() {
     assert_eq!(strategy.algorithm_kind(), ChecksumAlgorithmKind::Md4);
     assert_eq!(strategy.digest_len(), 16);
 }
-// These tests verify that our MD4 implementation matches the official
-// RFC 1320 specification, ensuring compatibility with upstream rsync.
+
+// RFC 1320 vectors pinned to guarantee upstream rsync compatibility.
 
 #[test]
 fn rfc1320_empty_string() {
@@ -86,7 +86,7 @@ fn rfc1320_empty_string() {
         "RFC 1320: MD4 of empty string"
     );
 
-    // Verify via strategy pattern
+    // The strategy pattern must produce the same bytes as direct `Md4::digest`.
     let strategy = ChecksumStrategySelector::for_algorithm(ChecksumAlgorithmKind::Md4, 0);
     let strategy_digest = strategy.compute(b"");
     assert_eq!(strategy_digest.as_bytes(), &digest);
@@ -290,11 +290,8 @@ fn protocol_version_boundary_at_30() {
     let d29 = v29.compute(test_data);
     let d30 = v30.compute(test_data);
 
-    // Both should produce 16-byte digests (MD4 and MD5)
     assert_eq!(d29.len(), 16);
     assert_eq!(d30.len(), 16);
-
-    // But the digests should be different (MD4 vs MD5)
     assert_ne!(d29, d30, "MD4 and MD5 should produce different digests");
 }
 
@@ -321,11 +318,12 @@ fn all_protocols_30_and_above_use_md5() {
         );
     }
 }
-// These tests simulate how rsync uses MD4 for block checksums in protocol < 30
+
+// Block-checksum scenarios below mirror how rsync uses MD4 in protocol < 30.
 
 #[test]
 fn simulate_block_checksum_small_file() {
-    // Simulate checksumming a small file in blocks (e.g., 700-byte blocks)
+    // Three 700-byte blocks from a 2100-byte file.
     let file_data: Vec<u8> = (0..2100).map(|i| (i % 256) as u8).collect();
     let block_size = 700;
 
@@ -338,10 +336,8 @@ fn simulate_block_checksum_small_file() {
         block_checksums.push(digest);
     }
 
-    // Should have 3 blocks
     assert_eq!(block_checksums.len(), 3);
 
-    // All checksums should be unique (different blocks)
     assert_ne!(block_checksums[0], block_checksums[1]);
     assert_ne!(block_checksums[1], block_checksums[2]);
     assert_ne!(block_checksums[0], block_checksums[2]);
@@ -349,7 +345,6 @@ fn simulate_block_checksum_small_file() {
 
 #[test]
 fn simulate_block_checksum_large_file() {
-    // Simulate checksumming a larger file
     let file_data: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
     let block_size = 4096;
 
@@ -364,10 +359,8 @@ fn simulate_block_checksum_large_file() {
         block_checksums.push(digest);
     }
 
-    // Verify we got the expected number of blocks
     assert_eq!(block_checksums.len(), block_count);
 
-    // Verify determinism: recompute and compare
     for (i, block) in file_data.chunks(block_size).enumerate() {
         let recomputed = strategy.compute(block);
         assert_eq!(
@@ -379,13 +372,12 @@ fn simulate_block_checksum_large_file() {
 
 #[test]
 fn simulate_incremental_block_generation() {
-    // Simulate generating block checksums incrementally (streaming)
+    // Reading a block in small chunks must produce the same digest as one-shot.
     let block_data = b"This is a block of data that would be checksummed by rsync";
 
     let oneshot = Md4::digest(block_data);
 
     let mut hasher = Md4::new();
-    // Simulate reading the block in smaller chunks
     for chunk in block_data.chunks(10) {
         hasher.update(chunk);
     }
@@ -404,28 +396,28 @@ fn md4_digest_length_constant() {
 
 #[test]
 fn md4_empty_input() {
+    // MD4("") = 31d6cfe0d16ae931b73c59d7e0c089c0
     let digest = Md4::digest(b"");
     assert_eq!(digest.len(), 16);
-    // Known empty string digest
     assert_eq!(to_hex(&digest), "31d6cfe0d16ae931b73c59d7e0c089c0");
 }
 
 #[test]
 fn md4_single_byte() {
-    let digest = Md4::digest(&[0x61]); // 'a'
+    // 0x61 = 'a' from RFC 1320.
+    let digest = Md4::digest(&[0x61]);
     assert_eq!(digest.len(), 16);
     assert_eq!(to_hex(&digest), "bde52cb31de33e46245e05fbdbd6fb24");
 }
 
 #[test]
 fn md4_block_boundary_sizes() {
-    // MD4 processes data in 64-byte blocks
+    // MD4 processes 64-byte blocks; sweep both sides of each boundary.
     for size in [63, 64, 65, 127, 128, 129] {
         let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16, "Size {size}: digest should be 16 bytes");
 
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -434,11 +426,10 @@ fn md4_block_boundary_sizes() {
 
 #[test]
 fn md4_large_input() {
-    let data = vec![0x42_u8; 1024 * 1024]; // 1 MB
+    let data = vec![0x42_u8; 1024 * 1024];
     let digest = Md4::digest(&data);
     assert_eq!(digest.len(), 16);
 
-    // Verify determinism
     assert_eq!(Md4::digest(&data), digest);
 }
 
@@ -451,11 +442,9 @@ fn md4_differs_from_md5() {
     let md4_digest = Md4::digest(data);
     let md5_digest = Md5::digest(data);
 
-    // Both are 16 bytes
     assert_eq!(md4_digest.len(), 16);
     assert_eq!(md5_digest.len(), 16);
 
-    // But the digests should be different
     assert_ne!(
         md4_digest.as_ref(),
         md5_digest.as_ref(),

--- a/crates/checksums/tests/md4_tests.rs
+++ b/crates/checksums/tests/md4_tests.rs
@@ -92,7 +92,6 @@ mod empty_input {
     #[test]
     fn empty_streaming_produces_same_digest() {
         let hasher = Md4::new();
-        // No update calls - immediately finalize
         let digest = hasher.finalize();
         assert_eq!(to_hex(&digest), "31d6cfe0d16ae931b73c59d7e0c089c0");
     }
@@ -123,56 +122,50 @@ mod various_sizes {
         (0..size).map(|i| (i % 256) as u8).collect()
     }
 
-    // 1 byte
     #[test]
     fn size_1_byte() {
         let data = generate_data(1);
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
     }
 
-    // 55 bytes - maximum that fits in one block with padding
-    // (64 - 8 length bytes - 1 padding byte = 55)
+    /// 55 bytes is the maximum payload that fits in one MD4 block once the
+    /// 8-byte length suffix and 1-byte padding marker are reserved.
     #[test]
     fn size_55_bytes() {
         let data = generate_data(55);
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
     }
 
-    // 56 bytes - exactly at padding boundary, requires extra block
+    /// 56 bytes lands exactly on the padding boundary and forces a second block.
     #[test]
     fn size_56_bytes() {
         let data = generate_data(56);
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
     }
 
-    // 64 bytes - exactly one full MD4 block
+    /// One full 64-byte MD4 block.
     #[test]
     fn size_64_bytes() {
         let data = generate_data(64);
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
     }
 
-    // Additional boundary cases
     #[test]
     fn size_63_bytes() {
         let data = generate_data(63);
@@ -194,9 +187,9 @@ mod various_sizes {
         assert_eq!(digest.len(), 16);
     }
 
+    /// Two full MD4 blocks.
     #[test]
     fn size_128_bytes() {
-        // Two full blocks
         let data = generate_data(128);
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
@@ -218,7 +211,7 @@ mod various_sizes {
 
     #[test]
     fn sizes_near_block_boundaries() {
-        // Test sizes around 64-byte block boundaries
+        // Sweep ±3 bytes around each 64-byte block boundary up to 16 blocks.
         for offset in [-3_i32, -2, -1, 0, 1, 2, 3] {
             for multiplier in [1, 2, 4, 8, 16] {
                 let base_size = 64 * multiplier;
@@ -238,7 +231,6 @@ mod various_sizes {
         }
     }
 
-    // Test critical padding boundaries
     #[test]
     fn padding_boundary_54_bytes() {
         let data = generate_data(54);
@@ -327,7 +319,6 @@ mod large_inputs {
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
 
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -335,7 +326,6 @@ mod large_inputs {
 
     #[test]
     fn size_1mb_chunked() {
-        // Hash 1MB in 4KB chunks
         let data = generate_data(1024 * 1024);
         let mut hasher = Md4::new();
         for chunk in data.chunks(4096) {
@@ -406,7 +396,6 @@ mod incremental_hashing {
         let data: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
         let expected = Md4::digest(&data);
 
-        // Test with various chunk sizes
         for chunk_size in [1, 2, 3, 5, 7, 13, 17, 31, 63, 64, 65, 100, 256, 500] {
             let mut hasher = Md4::new();
             for chunk in data.chunks(chunk_size) {
@@ -424,7 +413,6 @@ mod incremental_hashing {
     fn streaming_random_chunk_sizes() {
         let data: Vec<u8> = (0..1000).map(|i| (i * 17 % 256) as u8).collect();
 
-        // Use varied chunk sizes
         let chunk_sizes = [1, 3, 7, 13, 31, 63, 127, 255];
         let mut hasher = Md4::new();
         let mut offset = 0;
@@ -478,7 +466,6 @@ mod incremental_hashing {
         let mut hasher = Md4::new();
         hasher.update(b"hello");
 
-        // Clone and continue with different data
         let cloned = hasher.clone();
 
         hasher.update(b" world");
@@ -514,7 +501,6 @@ mod incremental_hashing {
         assert_eq!(r_a, Md4::digest(b"prefix_path_a"));
         assert_eq!(r_b, Md4::digest(b"prefix_path_b"));
 
-        // All three should be different
         assert_ne!(r_orig, r_a);
         assert_ne!(r_orig, r_b);
         assert_ne!(r_a, r_b);
@@ -557,7 +543,6 @@ mod incremental_hashing {
         let data = b"The quick brown fox";
         let expected = Md4::digest(data);
 
-        // Split into 5 parts
         let mut hasher = Md4::new();
         hasher.update(b"The ");
         hasher.update(b"qui");
@@ -575,7 +560,6 @@ mod single_byte {
     fn single_byte_zero() {
         let digest = Md4::digest(&[0x00]);
         assert_eq!(digest.len(), 16);
-        // Should be deterministic
         assert_eq!(Md4::digest(&[0x00]), digest);
     }
 
@@ -583,7 +567,6 @@ mod single_byte {
     fn single_byte_one() {
         let digest = Md4::digest(&[0x01]);
         assert_eq!(digest.len(), 16);
-        // Different from zero
         assert_ne!(digest, Md4::digest(&[0x00]));
     }
 
@@ -595,7 +578,7 @@ mod single_byte {
 
     #[test]
     fn single_byte_a() {
-        // Same as RFC vector
+        // Matches the RFC 1320 single-character vector.
         let digest = Md4::digest(b"a");
         assert_eq!(to_hex(&digest), "bde52cb31de33e46245e05fbdbd6fb24");
     }
@@ -669,7 +652,7 @@ mod strong_digest_trait {
 
     #[test]
     fn with_seed_matches_new() {
-        // MD4 seed is (), so with_seed should behave like new
+        // MD4's `Seed` type is `()`, so `with_seed(())` must equal `new()`.
         let mut seeded: Md4 = StrongDigest::with_seed(());
         seeded.update(b"test");
         let seeded_result = seeded.finalize();
@@ -719,9 +702,9 @@ mod edge_cases {
     #[test]
     fn similar_inputs_different_outputs() {
         let d1 = Md4::digest(b"test");
-        let d2 = Md4::digest(b"Test"); // Different case
-        let d3 = Md4::digest(b"test "); // Trailing space
-        let d4 = Md4::digest(b" test"); // Leading space
+        let d2 = Md4::digest(b"Test");
+        let d3 = Md4::digest(b"test ");
+        let d4 = Md4::digest(b" test");
 
         assert_ne!(d1, d2);
         assert_ne!(d1, d3);
@@ -775,18 +758,15 @@ mod edge_cases {
         let d1 = Md4::digest(data_with_null);
         let d2 = Md4::digest(data_without_null);
 
-        // Null byte should affect the hash
         assert_ne!(d1, d2);
     }
 
     #[test]
     fn all_byte_values() {
-        // Test with data containing all possible byte values
         let data: Vec<u8> = (0..=255).collect();
         let digest = Md4::digest(&data);
         assert_eq!(digest.len(), 16);
 
-        // Verify streaming matches
         let mut hasher = Md4::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -794,7 +774,6 @@ mod edge_cases {
 
     #[test]
     fn repeated_patterns() {
-        // Test with repeated patterns of various sizes
         let patterns: &[&[u8]] = &[&[0xAA; 1000], &[0x00; 1000], &[0xFF; 1000], &[0x55; 1000]];
 
         let mut digests = Vec::new();
@@ -804,7 +783,6 @@ mod edge_cases {
             digests.push(digest);
         }
 
-        // All patterns should produce unique digests
         for i in 0..digests.len() {
             for j in (i + 1)..digests.len() {
                 assert_ne!(digests[i], digests[j], "Patterns {i} and {j} should differ");

--- a/crates/checksums/tests/md5_tests.rs
+++ b/crates/checksums/tests/md5_tests.rs
@@ -132,11 +132,10 @@ mod rfc1321_test_vectors {
 
     #[test]
     fn rfc1321_119_bytes_two_block_padding_boundary() {
-        // 119 bytes: 55 + 64, padding fits in one block after two full blocks
+        // 119 = 55 + 64; padding fits inside one block after two full blocks.
         let input: Vec<u8> = (0..119).map(|i| b'0' + (i % 10) as u8).collect();
         assert_eq!(input.len(), 119);
         let digest = Md5::digest(&input);
-        // Verify streaming matches
         let mut hasher = Md5::new();
         hasher.update(&input);
         assert_eq!(hasher.finalize(), digest);
@@ -144,11 +143,10 @@ mod rfc1321_test_vectors {
 
     #[test]
     fn rfc1321_120_bytes_two_block_padding_boundary() {
-        // 120 bytes: 56 + 64, padding requires extra block
+        // 120 = 56 + 64; padding spills into a third block.
         let input: Vec<u8> = (0..120).map(|i| b'0' + (i % 10) as u8).collect();
         assert_eq!(input.len(), 120);
         let digest = Md5::digest(&input);
-        // Verify streaming matches
         let mut hasher = Md5::new();
         hasher.update(&input);
         assert_eq!(hasher.finalize(), digest);
@@ -168,7 +166,6 @@ mod empty_input {
     #[test]
     fn empty_streaming_produces_same_digest() {
         let hasher = Md5::new();
-        // No update calls
         let digest = hasher.finalize();
         assert_eq!(to_hex(&digest), "d41d8cd98f00b204e9800998ecf8427e");
     }
@@ -185,12 +182,11 @@ mod empty_input {
 
     #[test]
     fn empty_with_seed_proper_order() {
+        // With no payload, proper ordering reduces to MD5 of the 4-byte seed alone.
         let seed = Md5Seed::proper(0x12345678);
         let hasher = Md5::with_seed(seed);
-        // No data updates
         let seeded = hasher.finalize();
 
-        // Should equal hash of just the seed bytes
         let mut manual = Md5::new();
         manual.update(&0x12345678_i32.to_le_bytes());
         assert_eq!(seeded, manual.finalize());
@@ -198,12 +194,11 @@ mod empty_input {
 
     #[test]
     fn empty_with_seed_legacy_order() {
+        // With no payload, legacy ordering also reduces to MD5 of the seed alone.
         let seed = Md5Seed::legacy(0x12345678);
         let hasher = Md5::with_seed(seed);
-        // No data updates
         let seeded = hasher.finalize();
 
-        // Should equal hash of just the seed bytes (added after data)
         let mut manual = Md5::new();
         manual.update(&0x12345678_i32.to_le_bytes());
         assert_eq!(seeded, manual.finalize());
@@ -234,7 +229,7 @@ mod single_byte {
 
     #[test]
     fn single_byte_a() {
-        // Same as RFC vector
+        // Matches the RFC 1321 single-character vector.
         let digest = Md5::digest(b"a");
         assert_eq!(to_hex(&digest), "0cc175b9c0f1b6a831c399e269772661");
     }
@@ -276,7 +271,6 @@ mod various_sizes {
         let data = generate_data(1);
         let digest = Md5::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify streaming matches
         let mut hasher = Md5::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -287,7 +281,6 @@ mod various_sizes {
         let data = generate_data(16);
         let digest = Md5::digest(&data);
         assert_eq!(digest.len(), 16);
-        // Verify streaming matches
         let mut hasher = Md5::new();
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -295,15 +288,14 @@ mod various_sizes {
 
     #[test]
     fn size_63_bytes() {
-        // Just under one block
         let data = generate_data(63);
         let digest = Md5::digest(&data);
         assert_eq!(digest.len(), 16);
     }
 
+    /// One full 64-byte MD5 block.
     #[test]
     fn size_64_bytes() {
-        // Exactly one block
         let data = generate_data(64);
         let digest = Md5::digest(&data);
         assert_eq!(digest.len(), 16);
@@ -311,7 +303,6 @@ mod various_sizes {
 
     #[test]
     fn size_65_bytes() {
-        // Just over one block
         let data = generate_data(65);
         let digest = Md5::digest(&data);
         assert_eq!(digest.len(), 16);
@@ -324,9 +315,9 @@ mod various_sizes {
         assert_eq!(digest.len(), 16);
     }
 
+    /// Two full MD5 blocks.
     #[test]
     fn size_128_bytes() {
-        // Two blocks
         let data = generate_data(128);
         let digest = Md5::digest(&data);
         assert_eq!(digest.len(), 16);
@@ -388,7 +379,6 @@ mod various_sizes {
 
     #[test]
     fn size_1mb_chunked() {
-        // Hash 1MB in 4KB chunks
         let data = generate_data(1024 * 1024);
         let mut hasher = Md5::new();
         for chunk in data.chunks(4096) {
@@ -402,7 +392,7 @@ mod various_sizes {
 
     #[test]
     fn sizes_near_block_boundaries() {
-        // Test sizes around 64-byte block boundaries
+        // Sweep ±3 bytes around each 64-byte block boundary up to 16 blocks.
         for offset in [-3_i32, -2, -1, 0, 1, 2, 3] {
             for multiplier in [1, 2, 4, 8, 16] {
                 let base_size = 64 * multiplier;
@@ -457,7 +447,6 @@ mod streaming_api {
     fn streaming_random_chunk_sizes() {
         let data: Vec<u8> = (0..1000).map(|i| (i * 17 % 256) as u8).collect();
 
-        // Use varied chunk sizes
         let chunk_sizes = [1, 3, 7, 13, 31, 63, 127, 255];
         let mut hasher = Md5::new();
         let mut offset = 0;
@@ -501,7 +490,6 @@ mod streaming_api {
         let mut hasher = Md5::new();
         hasher.update(b"hello");
 
-        // Clone and continue with different data
         let cloned = hasher.clone();
 
         hasher.update(b" world");
@@ -541,7 +529,6 @@ mod streaming_api {
         hasher.update(b"test");
         let streaming = hasher.finalize();
 
-        // Compare with single-shot seeded
         let mut single = Md5::with_seed(seed);
         single.update(data);
         let single_result = single.finalize();
@@ -560,7 +547,6 @@ mod streaming_api {
         hasher.update(b"test");
         let streaming = hasher.finalize();
 
-        // Compare with single-shot seeded
         let mut single = Md5::with_seed(seed);
         single.update(data);
         let single_result = single.finalize();

--- a/crates/checksums/tests/xxh3_128_tests.rs
+++ b/crates/checksums/tests/xxh3_128_tests.rs
@@ -41,15 +41,12 @@ mod known_test_vectors {
         let digest = Xxh3_128::digest(0, b"");
         let hash = digest_to_u128(digest);
 
-        // Verify deterministic - same input always produces same output
         let digest2 = Xxh3_128::digest(0, b"");
         assert_eq!(digest, digest2, "XXH3-128 should be deterministic");
 
-        // Verify against reference implementation
         let expected = xxhash_rust::xxh3::xxh3_128_with_seed(b"", 0).to_le_bytes();
         assert_eq!(digest, expected, "Should match reference implementation");
 
-        // Hash should be non-zero (xxhash produces non-zero hash for empty with seed 0)
         assert_ne!(
             hash, 0,
             "Hash of empty string with seed 0 should be non-zero"
@@ -77,7 +74,6 @@ mod known_test_vectors {
         let expected = xxhash_rust::xxh3::xxh3_128_with_seed(input, 0).to_le_bytes();
         assert_eq!(digest, expected);
 
-        // Verify streaming matches one-shot
         let mut hasher = Xxh3_128::new(0);
         hasher.update(input);
         let streaming = hasher.finalize();
@@ -128,7 +124,6 @@ mod known_test_vectors {
         let digest = Xxh3_128::digest(0, &zeros);
         let hash = digest_to_u128(digest);
 
-        // Even all zeros should produce a non-zero hash
         assert_ne!(hash, 0, "Hash of zeros should be non-zero");
 
         let expected = xxhash_rust::xxh3::xxh3_128_with_seed(&zeros, 0).to_le_bytes();
@@ -140,7 +135,6 @@ mod known_test_vectors {
         let ones = [0xFFu8; 64];
         let digest = Xxh3_128::digest(0, &ones);
 
-        // Should differ from all zeros
         let zeros = [0u8; 64];
         let zeros_digest = Xxh3_128::digest(0, &zeros);
         assert_ne!(
@@ -192,7 +186,6 @@ mod empty_input {
     #[test]
     fn empty_streaming_produces_same_digest() {
         let hasher = Xxh3_128::new(0);
-        // No update calls
         let digest = hasher.finalize();
         let expected = xxhash_rust::xxh3::xxh3_128_with_seed(b"", 0).to_le_bytes();
         assert_eq!(digest, expected);
@@ -231,7 +224,6 @@ mod empty_input {
         let digest_42 = Xxh3_128::digest(42, b"");
         let digest_max = Xxh3_128::digest(u64::MAX, b"");
 
-        // Even for empty input, different seeds should produce different results
         assert_ne!(digest_0, digest_1, "Seed 0 vs 1");
         assert_ne!(digest_0, digest_42, "Seed 0 vs 42");
         assert_ne!(digest_0, digest_max, "Seed 0 vs max");
@@ -264,8 +256,6 @@ mod various_input_sizes {
     fn generate_data(size: usize) -> Vec<u8> {
         (0..size).map(|i| (i % 256) as u8).collect()
     }
-
-    // --- Single byte tests ---
 
     #[test]
     fn size_1_byte_zero() {
@@ -306,8 +296,6 @@ mod various_input_sizes {
         }
     }
 
-    // --- Small sizes ---
-
     #[test]
     fn size_2_bytes() {
         let data = generate_data(2);
@@ -340,7 +328,7 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- XXH3 internal block boundary (usually around 128 or 256 bytes) ---
+    // XXH3 transitions between fast paths around the 128- and 256-byte marks.
 
     #[test]
     fn size_31_bytes() {
@@ -406,8 +394,6 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- Medium sizes ---
-
     #[test]
     fn size_512_bytes() {
         let data = generate_data(512);
@@ -456,8 +442,6 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- Large sizes ---
-
     #[test]
     fn size_256kb() {
         let data = generate_data(256 * 1024);
@@ -482,8 +466,7 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- Prime number sizes (catch alignment edge cases) ---
-
+    /// Prime sizes exercise alignment edges that powers-of-two miss.
     #[test]
     fn prime_sizes() {
         let primes = [
@@ -498,8 +481,6 @@ mod various_input_sizes {
             assert_eq!(digest, expected, "Prime size {size} mismatch");
         }
     }
-
-    // --- Streaming matches one-shot for all sizes ---
 
     #[test]
     fn streaming_matches_oneshot_various_sizes() {
@@ -640,7 +621,6 @@ mod streaming_vs_oneshot {
             "Different continuations should produce different hashes"
         );
 
-        // Verify cloned hasher produces correct result
         let expected_b = Xxh3_128::digest(42, b"partial data B");
         assert_eq!(digest2, expected_b);
 
@@ -653,7 +633,6 @@ mod streaming_vs_oneshot {
         let data = b"abcdefghijklmnopqrstuvwxyz";
         let full_digest = Xxh3_128::digest(0, data);
 
-        // Clone after each byte and verify final result
         for i in 0..data.len() {
             let mut hasher = Xxh3_128::new(0);
             hasher.update(&data[..i]);
@@ -674,7 +653,6 @@ mod streaming_vs_oneshot {
         let data: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
         let oneshot = Xxh3_128::digest(0, &data);
 
-        // Stream in irregular chunk sizes
         let mut hasher = Xxh3_128::new(0);
         let chunk_sizes = [17, 31, 64, 100, 256, 500, 1000, 2048, 5000];
         let mut offset = 0;
@@ -696,7 +674,7 @@ mod streaming_vs_oneshot {
 
     #[test]
     fn streaming_1mb_in_various_chunk_sizes() {
-        let size = 1024 * 1024; // 1MB
+        let size = 1024 * 1024;
         let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let oneshot = Xxh3_128::digest(0, &data);
 
@@ -730,7 +708,7 @@ mod streaming_vs_oneshot {
 
     #[test]
     fn streaming_split_at_all_positions() {
-        let data = b"0123456789abcdef"; // 16 bytes
+        let data = b"0123456789abcdef";
         let expected = Xxh3_128::digest(0, data);
 
         for split_pos in 0..=data.len() {
@@ -750,7 +728,6 @@ mod streaming_vs_oneshot {
         let data = b"The quick brown fox";
         let expected = Xxh3_128::digest(0, data);
 
-        // Split into 5 parts
         let mut hasher = Xxh3_128::new(0);
         hasher.update(b"The ");
         hasher.update(b"qui");
@@ -762,7 +739,6 @@ mod streaming_vs_oneshot {
 
     #[test]
     fn size_1mb_chunked() {
-        // Hash 1MB in 4KB chunks
         let data: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
         let mut hasher = Xxh3_128::new(0);
         for chunk in data.chunks(4096) {
@@ -863,7 +839,6 @@ mod seed_variations {
             .map(|&seed| Xxh3_128::digest(seed, data))
             .collect();
 
-        // All digests should be unique
         for i in 0..digests.len() {
             for j in (i + 1)..digests.len() {
                 assert_ne!(
@@ -894,7 +869,6 @@ mod seed_variations {
         let seed = 12345u64;
         let data = b"trait interface test";
 
-        // Using StrongDigest trait
         let hasher: Xxh3_128 = StrongDigest::with_seed(seed);
         let mut h = hasher;
         h.update(data);
@@ -948,9 +922,9 @@ mod edge_cases {
     #[test]
     fn similar_inputs_different_outputs() {
         let d1 = Xxh3_128::digest(0, b"test");
-        let d2 = Xxh3_128::digest(0, b"Test"); // Different case
-        let d3 = Xxh3_128::digest(0, b"test "); // Trailing space
-        let d4 = Xxh3_128::digest(0, b" test"); // Leading space
+        let d2 = Xxh3_128::digest(0, b"Test");
+        let d3 = Xxh3_128::digest(0, b"test ");
+        let d4 = Xxh3_128::digest(0, b" test");
 
         assert_ne!(d1, d2);
         assert_ne!(d1, d3);
@@ -986,18 +960,15 @@ mod edge_cases {
         let d1 = Xxh3_128::digest(0, data_with_null);
         let d2 = Xxh3_128::digest(0, data_without_null);
 
-        // Null byte should affect the hash
         assert_ne!(d1, d2);
     }
 
     #[test]
     fn all_byte_values() {
-        // Test with data containing all possible byte values
         let data: Vec<u8> = (0..=255).collect();
         let digest = Xxh3_128::digest(0, &data);
         assert_eq!(digest.len(), 16);
 
-        // Verify streaming matches
         let mut hasher = Xxh3_128::new(0);
         hasher.update(&data);
         assert_eq!(hasher.finalize(), digest);
@@ -1005,7 +976,6 @@ mod edge_cases {
 
     #[test]
     fn repeated_patterns() {
-        // Test with repeated patterns of various sizes
         let patterns: &[&[u8]] = &[&[0xAA; 1000], &[0x00; 1000], &[0xFF; 1000], &[0x55; 1000]];
 
         let mut digests = Vec::new();
@@ -1015,7 +985,6 @@ mod edge_cases {
             digests.push(digest);
         }
 
-        // All patterns should produce unique digests
         for i in 0..digests.len() {
             for j in (i + 1)..digests.len() {
                 assert_ne!(digests[i], digests[j], "Patterns {i} and {j} should differ");

--- a/crates/checksums/tests/xxh64_tests.rs
+++ b/crates/checksums/tests/xxh64_tests.rs
@@ -31,10 +31,9 @@ fn to_hex(digest: &[u8; 8]) -> String {
     }
     out
 }
-// These test vectors are derived from the official xxHash specification
-// and verified against the reference C implementation.
-// Reference: https://github.com/Cyan4973/xxHash
-// Reference: https://pypi.org/project/xxhash/
+
+// Vectors below come from the official xxHash specification and the reference
+// C implementation: https://github.com/Cyan4973/xxHash, https://pypi.org/project/xxhash/.
 
 mod known_test_vectors {
     use super::*;
@@ -55,7 +54,6 @@ mod known_test_vectors {
     #[test]
     fn empty_string_seed_0_bytes() {
         let digest = Xxh64::digest(0, b"");
-        // The expected value 0xef46db3751d8e999 in little-endian bytes
         let expected = expected_le_bytes(0xef46db3751d8e999);
         assert_eq!(
             digest, expected,
@@ -69,11 +67,9 @@ mod known_test_vectors {
         let input = b"The quick brown fox jumps over the lazy dog";
         let digest = Xxh64::digest(0, input);
 
-        // Verify deterministic - same input always produces same output
         let digest2 = Xxh64::digest(0, input);
         assert_eq!(digest, digest2, "XXH64 should be deterministic");
 
-        // Verify streaming matches one-shot
         let mut hasher = Xxh64::new(0);
         hasher.update(input);
         let streaming = hasher.finalize();
@@ -86,10 +82,8 @@ mod known_test_vectors {
         let digest = Xxh64::digest(0, b"a");
         let hash = digest_to_u64(digest);
 
-        // Hash should be non-zero for non-empty input
         assert_ne!(hash, 0, "Hash of 'a' should be non-zero");
 
-        // Verify consistency with xxhash-rust reference
         let expected = xxhash_rust::xxh64::xxh64(b"a", 0).to_le_bytes();
         assert_eq!(digest, expected, "Should match xxhash-rust reference");
     }
@@ -151,7 +145,6 @@ mod known_test_vectors {
         let zeros = [0u8; 64];
         let digest = Xxh64::digest(0, &zeros);
         let hash = digest_to_u64(digest);
-        // Even all zeros should produce a non-zero hash
         assert_ne!(hash, 0, "Hash of zeros should be non-zero");
 
         let expected = xxhash_rust::xxh64::xxh64(&zeros, 0).to_le_bytes();
@@ -164,7 +157,6 @@ mod known_test_vectors {
         let ones = [0xFFu8; 64];
         let digest = Xxh64::digest(0, &ones);
 
-        // Should differ from all zeros
         let zeros = [0u8; 64];
         let zeros_digest = Xxh64::digest(0, &zeros);
         assert_ne!(
@@ -189,10 +181,9 @@ mod known_test_vectors {
     /// xxhash.xxh64_hexdigest('xxhash', seed=20141025) returns 'b559b98d844e0635'
     #[test]
     fn xxhash_string_with_documented_seed() {
+        // Expected 0xb559b98d844e0635 from the pypi xxhash documentation.
         let digest = Xxh64::digest(20141025, b"xxhash");
         let hash = digest_to_u64(digest);
-        // The documented result is 0xb559b98d844e0635 (from pypi xxhash docs)
-        // which equals 13067679811253438005 as integer
         assert_eq!(
             hash, 0xb559b98d844e0635,
             "XXH64('xxhash', seed=20141025) should be 0xb559b98d844e0635, got 0x{hash:016x}"
@@ -227,7 +218,6 @@ mod empty_input {
     #[test]
     fn empty_streaming_produces_same_digest() {
         let hasher = Xxh64::new(0);
-        // No update calls
         let digest = hasher.finalize();
         assert_eq!(digest_to_u64(digest), 0xef46db3751d8e999);
     }
@@ -264,7 +254,6 @@ mod empty_input {
         let digest_42 = Xxh64::digest(42, b"");
         let digest_max = Xxh64::digest(u64::MAX, b"");
 
-        // Even for empty input, different seeds should produce different results
         assert_ne!(digest_0, digest_1, "Seed 0 vs 1");
         assert_ne!(digest_0, digest_42, "Seed 0 vs 42");
         assert_ne!(digest_0, digest_max, "Seed 0 vs max");
@@ -290,8 +279,6 @@ mod various_input_sizes {
     fn generate_data(size: usize) -> Vec<u8> {
         (0..size).map(|i| (i % 256) as u8).collect()
     }
-
-    // --- Single byte tests ---
 
     #[test]
     fn size_1_byte_zero() {
@@ -331,8 +318,6 @@ mod various_input_sizes {
             assert_eq!(digest, expected, "Byte {byte:02x} mismatch");
         }
     }
-
-    // --- Small sizes around block boundaries ---
 
     #[test]
     fn size_2_bytes() {
@@ -390,7 +375,7 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- XXH64 internal block boundary (32 bytes) ---
+    // XXH64 processes data in 32-byte blocks; sweep both sides of the boundary.
 
     #[test]
     fn size_31_bytes() {
@@ -439,8 +424,6 @@ mod various_input_sizes {
         let expected = xxhash_rust::xxh64::xxh64(&data, 0).to_le_bytes();
         assert_eq!(digest, expected);
     }
-
-    // --- Medium sizes ---
 
     #[test]
     fn size_127_bytes() {
@@ -530,8 +513,6 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- Large sizes ---
-
     #[test]
     fn size_128kb() {
         let data = generate_data(128 * 1024);
@@ -564,8 +545,7 @@ mod various_input_sizes {
         assert_eq!(digest, expected);
     }
 
-    // --- Prime number sizes (catch alignment edge cases) ---
-
+    /// Prime sizes exercise alignment edges that powers-of-two miss.
     #[test]
     fn prime_sizes() {
         let primes = [
@@ -581,8 +561,6 @@ mod various_input_sizes {
         }
     }
 
-    // --- Powers of two minus one (boundary edge cases) ---
-
     #[test]
     fn power_of_two_minus_one_sizes() {
         let sizes = [
@@ -596,8 +574,6 @@ mod various_input_sizes {
             assert_eq!(digest, expected, "Size {size} (2^n - 1) mismatch");
         }
     }
-
-    // --- Streaming matches one-shot for all sizes ---
 
     #[test]
     fn streaming_matches_oneshot_various_sizes() {
@@ -721,7 +697,6 @@ mod seed_variations {
             .map(|&seed| Xxh64::digest(seed, data))
             .collect();
 
-        // All digests should be unique
         for i in 0..digests.len() {
             for j in (i + 1)..digests.len() {
                 assert_ne!(
@@ -752,7 +727,6 @@ mod seed_variations {
         let seed = 12345u64;
         let data = b"trait interface test";
 
-        // Using StrongDigest trait
         let hasher: Xxh64 = StrongDigest::with_seed(seed);
         let mut h = hasher;
         h.update(data);
@@ -885,7 +859,6 @@ mod streaming_incremental {
             "Different continuations should produce different hashes"
         );
 
-        // Verify cloned hasher produces correct result
         let expected_b = Xxh64::digest(42, b"partial data B");
         assert_eq!(digest2, expected_b);
 
@@ -898,7 +871,6 @@ mod streaming_incremental {
         let data = b"abcdefghijklmnopqrstuvwxyz";
         let full_digest = Xxh64::digest(0, data);
 
-        // Clone after each byte and verify final result
         for i in 0..data.len() {
             let mut hasher = Xxh64::new(0);
             hasher.update(&data[..i]);
@@ -919,7 +891,6 @@ mod streaming_incremental {
         let data: Vec<u8> = (0..100_000).map(|i| (i % 256) as u8).collect();
         let oneshot = Xxh64::digest(0, &data);
 
-        // Stream in irregular chunk sizes
         let mut hasher = Xxh64::new(0);
         let chunk_sizes = [17, 31, 64, 100, 256, 500, 1000, 2048, 5000];
         let mut offset = 0;
@@ -941,7 +912,7 @@ mod streaming_incremental {
 
     #[test]
     fn streaming_1mb_in_various_chunk_sizes() {
-        let size = 1024 * 1024; // 1MB
+        let size = 1024 * 1024;
         let data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         let oneshot = Xxh64::digest(0, &data);
 
@@ -1069,18 +1040,17 @@ mod verification {
 
     #[test]
     fn verify_little_endian_encoding() {
-        // The implementation returns little-endian bytes
+        // The implementation returns little-endian bytes; LE and BE readings
+        // must therefore disagree for any non-palindromic digest.
         let digest = Xxh64::digest(0, b"test");
         let from_le = u64::from_le_bytes(digest);
         let from_be = u64::from_be_bytes(digest);
 
-        // These should be different (unless palindromic, which is unlikely)
         assert_ne!(
             from_le, from_be,
             "Little-endian and big-endian interpretations should differ"
         );
 
-        // Verify against xxhash-rust reference
         let expected_hash = xxhash_rust::xxh64::xxh64(b"test", 0);
         assert_eq!(
             from_le, expected_hash,
@@ -1090,10 +1060,11 @@ mod verification {
 
     #[test]
     fn verify_avalanche_effect() {
-        // Changing a single bit should produce a very different hash
+        // Good 64-bit avalanche flips ~32 bits on a single-bit input change;
+        // require at least 20.
         let data1 = vec![0u8; 100];
         let mut data2 = data1.clone();
-        data2[50] = 1; // Change single bit
+        data2[50] = 1;
 
         let digest1 = Xxh64::digest(0, &data1);
         let digest2 = Xxh64::digest(0, &data2);
@@ -1101,7 +1072,6 @@ mod verification {
         let hash1 = u64::from_le_bytes(digest1);
         let hash2 = u64::from_le_bytes(digest2);
 
-        // Count differing bits (should be roughly half due to avalanche effect)
         let diff = (hash1 ^ hash2).count_ones();
         assert!(
             diff >= 20,
@@ -1111,7 +1081,7 @@ mod verification {
 
     #[test]
     fn verify_all_bits_can_be_set() {
-        // Hash many different inputs to verify all bit positions can be set
+        // OR-accumulate across many inputs; every bit must eventually flip on.
         let mut or_accumulator = 0u64;
 
         for i in 0..10000 {
@@ -1121,7 +1091,6 @@ mod verification {
             or_accumulator |= hash;
         }
 
-        // After many hashes, we should see all bits set at least once
         assert_eq!(
             or_accumulator.count_ones(),
             64,
@@ -1131,7 +1100,7 @@ mod verification {
 
     #[test]
     fn verify_bit_distribution() {
-        // Check that bits are reasonably distributed
+        // Each bit should be set roughly 50% of the time over 10k inputs.
         let mut bit_counts = [0u32; 64];
 
         for i in 0..10000 {
@@ -1146,7 +1115,6 @@ mod verification {
             }
         }
 
-        // Each bit should be set roughly 50% of the time (5000 +/- some tolerance)
         for (bit, &count) in bit_counts.iter().enumerate() {
             assert!(
                 count > 4000 && count < 6000,
@@ -1157,7 +1125,7 @@ mod verification {
 
     #[test]
     fn verify_hash_range() {
-        // Verify the hash can produce values across the full 64-bit range
+        // The hash should span a large fraction of the 64-bit space over 10k inputs.
         let mut min_hash = u64::MAX;
         let mut max_hash = 0u64;
 
@@ -1169,7 +1137,6 @@ mod verification {
             max_hash = max_hash.max(hash);
         }
 
-        // The range should span a significant portion of the 64-bit space
         let range = max_hash - min_hash;
         assert!(
             range > u64::MAX / 2,
@@ -1248,8 +1215,7 @@ mod compatibility {
 
     #[test]
     fn regression_known_hash_values() {
-        // Store some known hash values to catch regressions
-        // These are computed against xxhash-rust reference
+        // Hashes pinned against the xxhash-rust reference to catch regressions.
         let test_cases = [
             (0u64, b"".as_slice(), 0xef46db3751d8e999u64),
             (20141025u64, b"xxhash".as_slice(), 0xb559b98d844e0635u64),
@@ -1272,7 +1238,6 @@ mod compatibility {
 
     #[test]
     fn regression_consistency_across_runs() {
-        // Verify results remain consistent
         let test_cases = [
             (0u64, b"".as_slice()),
             (0u64, b"a".as_slice()),
@@ -1282,13 +1247,11 @@ mod compatibility {
             (u64::MAX, b"test".as_slice()),
         ];
 
-        // Compute hashes
         let hashes: Vec<_> = test_cases
             .iter()
             .map(|(seed, data)| Xxh64::digest(*seed, data))
             .collect();
 
-        // Verify they match on subsequent runs
         for (i, (seed, data)) in test_cases.iter().enumerate() {
             let digest = Xxh64::digest(*seed, data);
             assert_eq!(
@@ -1307,7 +1270,7 @@ mod edge_cases {
 
     #[test]
     fn boundary_at_internal_block_size_32() {
-        // XXH64 processes data in 32-byte chunks internally
+        // XXH64 consumes 32-byte chunks internally; sweep both sides of the boundary.
         for size in 30..=34 {
             let data = vec![0xAB; size];
             let digest = Xxh64::digest(0, &data);
@@ -1340,7 +1303,6 @@ mod edge_cases {
         let digest = Xxh64::digest(0, &repeated);
         assert_eq!(digest.len(), 8);
 
-        // Different repeat counts should produce different hashes
         let repeated2: Vec<u8> = pattern.iter().cycle().take(10001).cloned().collect();
         let digest2 = Xxh64::digest(0, &repeated2);
         assert_ne!(digest, digest2);
@@ -1353,7 +1315,6 @@ mod edge_cases {
             let digest = Xxh64::digest(0, &data);
             assert_eq!(digest.len(), 8);
 
-            // Different byte values should produce different hashes
             let other_byte = byte.wrapping_add(1);
             let other_data = vec![other_byte; 1000];
             let other_digest = Xxh64::digest(0, &other_data);
@@ -1386,7 +1347,6 @@ mod edge_cases {
         let expected = xxhash_rust::xxh64::xxh64(&reverse, 0).to_le_bytes();
         assert_eq!(digest, expected);
 
-        // Should differ from forward sequence
         let forward: Vec<u8> = (0..=255).collect();
         let forward_digest = Xxh64::digest(0, &forward);
         assert_ne!(digest, forward_digest);


### PR DESCRIPTION
## Summary

- Strip restatement, decorative dividers (`// --- Section ---`), and outdated comments across the checksums crate.
- Preserve every upstream rsync cite, SAFETY block on SIMD intrinsics, and meaningful WHY note (CHECKSUM_SEED_FIX ordering, MD4/MD5 padding boundaries, XXH64 32-byte block stride, avalanche thresholds, sign-extended schar interpretation).
- No API or behaviour changes.

## Scope

Touched files:
- `crates/checksums/src/comprehensive_tests.rs`
- `crates/checksums/src/strong/md4_tests.rs`
- `crates/checksums/src/strong/xxh64_tests.rs`
- `crates/checksums/src/strong/xxhash.rs`
- `crates/checksums/tests/checksum_variants_upstream_compat.rs`
- `crates/checksums/tests/comprehensive_tests.rs`
- `crates/checksums/tests/md4_protocol_compat.rs`
- `crates/checksums/tests/md4_tests.rs`
- `crates/checksums/tests/md5_tests.rs`
- `crates/checksums/tests/xxh3_128_tests.rs`
- `crates/checksums/tests/xxh64_tests.rs`

The audit also walked the remaining files under `crates/checksums/` (`lib.rs`, `cpu_features.rs`, `crc32c.rs`, `rolling/`, `parallel/`, `pipelined/`, `simd_batch/`, `simd_self_test.rs`, `simd_parity_tests.rs`, `strong/md4.rs`, `strong/md5.rs`, `strong/sha*.rs`, `strong/openssl_support.rs`, `strong/strategy/`, `tests/md4_tests.rs` test-vector blocks, `tests/rsync_rolling_compat.rs`, `tests/rolling_simd_parity.rs`, `tests/simd_override.rs`, `tests/strategy_integration.rs`, `tests/rolling_signed_byte_regression.rs`, `tests/xxh3_128_tests.rs` doc-vector blocks) and confirmed they were already clean or carried information-bearing comments (upstream cites, SIMD safety arguments, arithmetic derivations, RFC test-vector identifiers).

## Diff size

11 files changed, 106 insertions(+), 377 deletions(-).

## Preservation

- **51 SAFETY: comments** retained intact across SIMD intrinsics (rolling AVX2/SSE2/NEON, MD5/MD4 multi-lane backends).
- **23 upstream: citations** retained intact (`checksum.c:get_checksum1()`, `checksum.c:get_checksum2()`, `md4.c`, `simd-checksum-x86_64.cpp`, `lib/sumcheck.c`, `valid_checksums_items`, NEWS-3.4.2 MD4 buf1 fix, etc.).
- All `#[target_feature]` SIMD intrinsics, `#[allow(unsafe_code)]` gates, and runtime CPU-feature detection comments untouched.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo check -p checksums --all-features --tests`
- [x] `cargo nextest run -p checksums --all-features -E 'test(rolling) or test(md5) or test(xxh)' --no-fail-fast --test-threads=1` (383 tests passed)
- [ ] Full nextest matrix in CI