### PR TITLE
docs(core): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -132,7 +132,7 @@ fn includes_recursive_flag_when_enabled() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
-    // Sender (push): rsync --server -flags . /path - flags at index 2
+    // Push layout: rsync --server -flags . /path
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('r'), "expected 'r' in flags: {flags}");
 }
@@ -149,7 +149,6 @@ fn includes_multiple_preservation_flags() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
-    // Sender (push): rsync --server -flags . /path - flags at index 2
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('t'), "expected 't' in flags: {flags}");
     assert!(flags.contains('p'), "expected 'p' in flags: {flags}");
@@ -163,7 +162,6 @@ fn includes_compress_flag() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
-    // Sender (push): rsync --server -flags . /path - flags at index 2
     let flags = args[2].to_string_lossy();
     assert!(flags.contains('z'), "expected 'z' in flags: {flags}");
 }
@@ -2056,15 +2054,13 @@ fn all_flags_enabled_produces_valid_invocation() {
 
     let args = build_sender_args(&config);
 
-    // Verify structural integrity: program name, --server, flags, capability, dot, path
+    // Structural layout: program name, --server, flags, capability, dot, path
     assert_eq!(args[0], "/custom/rsync");
     assert_eq!(args[1], "--server");
 
-    // Verify --ignore-errors and --fsync are present
     assert!(args.contains(&"--ignore-errors".to_owned()));
     assert!(args.contains(&"--fsync".to_owned()));
 
-    // Verify flag string contains all expected single-char flags
     let flags = find_flag_string(&args);
     for (ch, name) in [
         ('l', "links"),
@@ -2099,15 +2095,12 @@ fn all_flags_enabled_produces_valid_invocation() {
         );
     }
 
-    // Verify 'x' count
     let x_count = flags.chars().filter(|c| *c == 'x').count();
     assert_eq!(x_count, 2, "expected 2 'x' flags for one_file_system=2");
 
-    // Verify 'v' count
     let v_count = flags.chars().filter(|c| *c == 'v').count();
     assert_eq!(v_count, 2, "expected 2 'v' flags for verbosity=2");
 
-    // Verify all long-form args
     let expected_long_args = [
         "--delete-before",
         "--delete-excluded",
@@ -2148,7 +2141,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         );
     }
 
-    // Verify args with values using prefix matching
     // upstream: options.c:2802 - explicit zlib is sent as --old-compress
     assert!(
         args.iter().any(|a| a == "--old-compress"),
@@ -2173,7 +2165,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         );
     }
 
-    // Verify capability string and structural elements
     assert!(args.contains(&build_capability_string(true)));
     assert!(args.contains(&".".to_owned()));
     assert!(args.contains(&"/path".to_owned()));

--- a/crates/core/src/message/tests/part7.rs
+++ b/crates/core/src/message/tests/part7.rs
@@ -120,10 +120,9 @@ fn normalize_path_handles_root_with_parent_dir() {
 
 #[test]
 fn normalize_path_handles_trailing_slash_in_relative() {
-    // PathBuf normalizes away trailing slashes on most platforms
+    // PathBuf strips trailing separators on most platforms.
     let path = PathBuf::from("foo/bar/");
     let normalized = normalize_path(&path);
-    // After PathBuf parsing, trailing slash is typically removed
     assert_eq!(normalized, "foo/bar");
 }
 
@@ -137,15 +136,12 @@ fn normalize_path_handles_trailing_slash_in_absolute() {
 #[test]
 fn normalize_path_handles_empty_components() {
     let normalized = normalize_path(Path::new("foo//bar"));
-    // Path parsing collapses empty components
     assert_eq!(normalized, "foo/bar");
 }
 
 #[cfg(unix)]
 #[test]
 fn normalize_path_handles_symlink_like_paths() {
-    // This test doesn't actually create symlinks, just verifies
-    // that paths that might be symlinks are normalized correctly
     let normalized = normalize_path(Path::new("/usr/local/../bin/tool"));
     assert_eq!(normalized, "/usr/bin/tool");
 }
@@ -153,8 +149,8 @@ fn normalize_path_handles_symlink_like_paths() {
 #[cfg(unix)]
 #[test]
 fn normalize_path_preserves_path_without_following_symlinks() {
-    // normalize_path does NOT follow symlinks, it just normalizes the string
-    // If /link points to /target, normalize_path("/link/file") returns "/link/file"
+    // normalize_path is a string operation: it never resolves symlinks, so
+    // `/link/file` survives the call unchanged even when `/link -> /target`.
     let normalized = normalize_path(Path::new("/link/file"));
     assert_eq!(normalized, "/link/file");
 }

--- a/crates/core/src/message/tests/part8.rs
+++ b/crates/core/src/message/tests/part8.rs
@@ -479,7 +479,6 @@ fn error_message_is_parseable_by_regex() {
     let rendered = msg.to_string();
 
     // Pattern: rsync error: <text> (code <N>) at <basename>(<line>) [<role>=<version>]
-    // Verify components are present and in order
     assert!(rendered.starts_with("rsync error: "));
     assert!(rendered.contains("(code 23)"));
     assert!(rendered.contains(" at "));

--- a/crates/core/src/remote_shell.rs
+++ b/crates/core/src/remote_shell.rs
@@ -429,14 +429,14 @@ mod tests {
 
     #[test]
     fn test_command_with_escaped_quotes() {
-        // In single quotes, backslashes are literal (not escape chars)
+        // Inside single quotes, backslash is literal, so `Host\\` stays as `Host\\`
+        // and the trailing `'s'` group resolves to a literal `s`. The end-quote-
+        // escape-start-quote idiom (`'text'\''more'`) is the only way to embed an
+        // actual single quote in a single-quoted argument.
         let shell = RemoteShell::new("ssh -o 'Host\\'s'");
         assert_eq!(shell.program(), "ssh");
-        // This will actually be "Host\s" because backslash is literal in single quotes
         assert_eq!(shell.args(), &["-o", "Host\\s"]);
 
-        // To get an actual single quote, need to end the quote, add escaped quote, start new quote
-        // The pattern is: 'text'\''more' which becomes text'more
         let shell = RemoteShell::new("ssh -o 'Host'\\''s'");
         assert_eq!(shell.program(), "ssh");
         assert_eq!(shell.args(), &["-o", "Host's"]);

--- a/crates/core/src/signal/cleanup.rs
+++ b/crates/core/src/signal/cleanup.rs
@@ -288,7 +288,6 @@ mod tests {
         let path = PathBuf::from("/tmp/nonexistent_test.tmp");
         manager.register_temp_file(path);
 
-        // Should not panic
         manager.cleanup_temp_files();
         assert_eq!(manager.temp_file_count(), 0);
     }
@@ -319,7 +318,6 @@ mod tests {
         manager.cleanup();
 
         let final_order = order.lock().unwrap();
-        // Callbacks run in LIFO order (reverse of registration)
         assert_eq!(*final_order, vec![3, 2, 1]);
     }
 
@@ -363,8 +361,7 @@ mod tests {
 
         manager.cleanup_temp_files();
 
-        // File should still exist because it was unregistered
-        assert!(path.exists());
+        assert!(path.exists(), "unregistered file must survive cleanup");
     }
 
     #[test]
@@ -379,8 +376,7 @@ mod tests {
         manager.register_temp_file(path.clone());
         manager.register_temp_file(path);
 
-        // HashSet should deduplicate
-        assert_eq!(manager.temp_file_count(), 1);
+        assert_eq!(manager.temp_file_count(), 1, "HashSet deduplicates");
     }
 
     #[test]
@@ -392,7 +388,6 @@ mod tests {
         manager1.reset_for_testing();
         manager1.register_temp_file(PathBuf::from("/tmp/test_global.tmp"));
 
-        // Both references should see the same state
         assert_eq!(manager2.temp_file_count(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Per-crate comment cleanup for `core`, following the CCL playbook used for metadata (#4620), daemon (#4628), transfer (#4626), and the more recent cli/checksums/compress/signature/filters/bandwidth sweeps. The crate already carries rustdoc on every public item, so this pass only deletes echo-the-code comments and tightens two test-only WHY notes.

### Files touched

| File | Lines |
|------|-------|
| `crates/core/src/client/remote/invocation/tests.rs` | +2 -11 |
| `crates/core/src/message/tests/part7.rs` | +3 -7 |
| `crates/core/src/message/tests/part8.rs` | +0 -1 |
| `crates/core/src/remote_shell.rs` | +4 -4 |
| `crates/core/src/signal/cleanup.rs` | +2 -7 |
| **Total** | **+11 -30** |

### What was removed

- Duplicated "Sender (push): rsync --server -flags . /path - flags at index 2" headers in `invocation/tests.rs` (three copies in trivial flag-presence tests).
- "Verify components are present and in order", "Verify 'x' count", "Verify 'v' count", "Verify all long-form args", "Verify args with values using prefix matching", "Verify capability string and structural elements" inside the `all_flags_enabled_produces_valid_invocation` test - the assertions immediately below already say what is being verified.
- "PathBuf normalizes away trailing slashes", "After PathBuf parsing, trailing slash is typically removed", "Path parsing collapses empty components", "This test doesn't actually create symlinks, just verifies that paths that might be symlinks are normalized correctly" in `message/tests/part7.rs`.
- "Should not panic", "Callbacks run in LIFO order (reverse of registration)", "File should still exist because it was unregistered", "HashSet should deduplicate", "Both references should see the same state" in `signal/cleanup.rs` - lifted two into assertion messages so the contract still appears at the failure site.
- Scattered single-quote/backslash restatements in `remote_shell.rs::test_command_with_escaped_quotes` consolidated into one explanation of the quoting contract.

### What was explicitly preserved

- Every `// upstream:` cite touching `main.c`, `options.c`, `compat.c`, `socket.c`, `clientserver.c`, `pipe.c`, `match.c`, `checksum.c`, `flist.c`, `io.c`, `rsync.c`, `errcode.h`, `log.c`, `csprotocol.txt`, `util1.c`, `batch.c`, `token.c`.
- Capability-negotiation rationale, including the `-e.LsfxCIvu` SSH capability string (per the project coding standards "Performance" section) and the `'i'` INC_RECURSE bit gating: every SSH/daemon push/pull capability comment in `invocation/tests.rs` and `daemon_transfer/orchestration/tests.rs` is untouched, including the tracker #1862 cross-references.
- HTTP CONNECT proxy buffer cap note (`MAX_PROXY_LINE_BYTES = 1024` from `socket.c:53`) in `client/module_list/connect/proxy.rs` recently hardened in PR #4619 / SEC-2.
- Exit-code mapping rationale in `client/error.rs` (NotFound -> Vanished, all-other-IO -> Partial, FullFname quoting via `util1.c:1228`, `connection_unexpectedly_closed` upstream wording from `io.c:228-232`).
- Signal-handler unsafety boundary references in `signal/mod.rs` and `signal/unix.rs` (per BR-10b: unsafe sigaction lives in `fast_io::signal::install_signal_handler`).
- Iconv `--iconv=.` / `LOCAL,REMOTE` semantics and the `rsync.c:118-140` `ic_send`/`ic_recv` derivation that drives `resolve_local_copy_converter`.
- Batch header `do_compression = false` invariant explaining the divergence from upstream `batch.c:68`.
- All `#[allow(...)]` waivers retained verbatim with their REASON: trailers.

### Out of scope

- No semantic changes; no API or behaviour change.
- No new dependencies, tests, or `#[allow(...)]` waivers.
- Source files that contain genuinely valuable upstream / capability / mapping commentary (the bulk of `auth/mod.rs`, `iconv.rs`, `client/run/mod.rs`, `error.rs`, `message/macros.rs`, every config builder/client module, the version report, and the message rendering subsystem) were audited and left untouched because every comment carried real information.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo check -p core --all-features` clean
- [x] `cargo nextest run -p core --all-features -E 'test(/session/) or test(/config/) or test(cleanup) or test(/normalize_path/)'` - 680 tests pass, 0 fail