### PR TITLE
docs(apple-fs): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/apple-fs/src/apple_double.rs
+++ b/crates/apple-fs/src/apple_double.rs
@@ -59,21 +59,34 @@ pub const ENTRY_DESCRIPTOR_SIZE: usize = 12;
 /// Standard AppleDouble entry identifiers (RFC 1740 section 5.1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
-#[allow(missing_docs)]
 pub enum EntryId {
+    /// Data fork payload.
     DataFork = 1,
+    /// Resource fork payload (`com.apple.ResourceFork`).
     ResourceFork = 2,
+    /// Original filename in its native encoding.
     RealName = 3,
+    /// Standard Macintosh comment.
     Comment = 4,
+    /// Standard Macintosh black-and-white icon.
     IconBw = 5,
+    /// Standard Macintosh colour icon.
     IconColor = 6,
+    /// File creation, modification, and backup timestamps.
     FileDatesInfo = 8,
+    /// 32-byte Finder info block (`com.apple.FinderInfo`).
     FinderInfo = 9,
+    /// Macintosh-specific file attribute bits.
     MacFileInfo = 10,
+    /// ProDOS-specific file attribute bits.
     ProDosFileInfo = 11,
+    /// MS-DOS-specific file attribute bits.
     MsDosFileInfo = 12,
+    /// AFP-truncated short filename.
     ShortName = 13,
+    /// AFP-specific file information.
     AfpFileInfo = 14,
+    /// AFP directory identifier.
     DirectoryId = 15,
 }
 


### PR DESCRIPTION
## Summary

Per-crate comment cleanup for the `apple-fs` crate, following the CCL template.

- Audited every `.rs` file under `crates/apple-fs/` (`lib.rs`, `apple_double.rs`, `resource_fork.rs`, and the round-trip integration test).
- Added per-variant rustdoc to `apple_double::EntryId` and removed the `#[allow(missing_docs)]` waiver so the crate-wide `#![deny(missing_docs)]` lint covers every public symbol.
- No other restatement, decorative, debug, or commented-out lines remained: prior CCL passes (#4594, #3672, #4449) already scrubbed the trivial noise. The few remaining `//` lines all carry real information (RFC layout pointers, ENOATTR rationale on Darwin, xattr-probe fallback, NFD/NFC normalization fast path) and were kept as-is.

## Files touched

- `crates/apple-fs/src/apple_double.rs` (+14 / -1)

## SAFETY blocks preserved

0 (the crate keeps `#![deny(unsafe_code)]` and contains no `unsafe` blocks; macOS xattr syscalls are reached through the pre-vetted third-party `xattr` crate, which is the documented carrier of any unsafe FFI).

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo check -p apple-fs --all-features` clean (macOS host)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo check -p apple-fs --all-features`
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable)