### PR TITLE
docs(logging): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/logging/examples/tracing_demo.rs
+++ b/crates/logging/examples/tracing_demo.rs
@@ -6,17 +6,14 @@
 use logging::{VerbosityConfig, init_tracing};
 
 fn main() {
-    // Initialize with verbosity level 2 (-vv)
     let config = VerbosityConfig::from_verbose_level(2);
     init_tracing(config);
 
-    // Now use standard tracing macros
     tracing::info!(target: "rsync::copy", "Starting file transfer");
     tracing::debug!(target: "rsync::flist", "Building file list: {} entries", 42);
     tracing::debug!(target: "rsync::delta", "Computing delta for large_file.dat");
     tracing::trace!(target: "rsync::io", "Read 4096 bytes from fd 3");
 
-    // Or use convenience macros
     logging::trace_copy!("Transferred file.txt ({} bytes)", 1234);
     logging::trace_stats!("Total: {} files, {} bytes", 10, 12345);
     logging::trace_proto!("Negotiated protocol version {}", 31);

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn multiple_events_ordering() {
         init(VerbosityConfig::default());
-        drain_events(); // Clear any existing
+        drain_events();
 
         emit_info(InfoFlag::Copy, 1, "first".to_owned());
         emit_info(InfoFlag::Del, 2, "second".to_owned());
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn drain_events_clears_buffer() {
         init(VerbosityConfig::default());
-        drain_events(); // Clear existing
+        drain_events();
 
         emit_info(InfoFlag::Copy, 1, "test".to_owned());
         let first_drain = drain_events();

--- a/crates/logging/tests/debug_log_behavior.rs
+++ b/crates/logging/tests/debug_log_behavior.rs
@@ -14,7 +14,7 @@ fn debug_log_emits_when_level_sufficient() {
     let mut config = VerbosityConfig::default();
     config.debug.recv = 2;
     init(config);
-    drain_events(); // Clear any existing events
+    drain_events();
 
     debug_log!(Recv, 1, "test message");
 
@@ -81,7 +81,6 @@ fn debug_log_flags_are_independent() {
     debug_log!(Send, 1, "send message");
 
     let events = drain_events();
-    // Only recv should emit
     assert_eq!(events.len(), 1);
     match &events[0] {
         DiagnosticEvent::Debug { flag, message, .. } => {
@@ -302,7 +301,6 @@ fn debug_log_reinit_changes_behavior() {
     debug_log!(Recv, 1, "should emit");
     assert_eq!(drain_events().len(), 1);
 
-    // Reinitialize with different config
     let config2 = VerbosityConfig::default();
     init(config2);
 

--- a/crates/logging/tests/edge_cases.rs
+++ b/crates/logging/tests/edge_cases.rs
@@ -139,7 +139,6 @@ fn message_with_null_bytes() {
     init(config);
     drain_events();
 
-    // Null bytes in the middle of a message
     debug_log!(Io, 1, "before\0after");
 
     let events = drain_events();
@@ -249,7 +248,6 @@ fn message_with_rtl_text() {
     init(config);
     drain_events();
 
-    // Arabic text
     info_log!(Name, 1, "document.txt");
 
     let events = drain_events();
@@ -363,17 +361,15 @@ fn flag_with_high_level() {
 fn flag_with_level_zero() {
     init(VerbosityConfig::default());
 
-    // Level 0 should set the flag to 0
     let result = apply_info_flag("copy0");
     assert!(result.is_ok());
 }
 
-/// Verifies flag token with leading zeros.
+/// Verifies flag token with leading zeros parses as copy level 7.
 #[test]
 fn flag_with_leading_zeros() {
     init(VerbosityConfig::default());
 
-    // "copy007" should parse as copy level 7
     let result = apply_info_flag("copy007");
     assert!(result.is_ok());
 }
@@ -382,7 +378,7 @@ fn flag_with_leading_zeros() {
 #[test]
 fn drain_empty_returns_empty() {
     init(VerbosityConfig::default());
-    drain_events(); // Clear any existing
+    drain_events();
 
     let events = drain_events();
     assert!(events.is_empty());
@@ -423,7 +419,6 @@ fn many_events() {
     let events = drain_events();
     assert_eq!(events.len(), 1000);
 
-    // Verify first and last
     match &events[0] {
         DiagnosticEvent::Info { message, .. } => {
             assert_eq!(message, "message 0");
@@ -532,7 +527,6 @@ fn diagnostic_event_debug_trait() {
 fn verbosity_config_default() {
     let config = VerbosityConfig::default();
 
-    // All levels should be 0
     assert_eq!(config.info.copy, 0);
     assert_eq!(config.info.name, 0);
     assert_eq!(config.debug.recv, 0);

--- a/crates/logging/tests/info_log_formatting.rs
+++ b/crates/logging/tests/info_log_formatting.rs
@@ -75,7 +75,6 @@ fn info_log_flags_are_independent() {
     info_log!(Del, 1, "del message");
 
     let events = drain_events();
-    // Only copy should emit
     assert_eq!(events.len(), 1);
     match &events[0] {
         DiagnosticEvent::Info { flag, message, .. } => {
@@ -327,7 +326,6 @@ fn info_and_debug_mixed() {
     let events = drain_events();
     assert_eq!(events.len(), 3);
 
-    // Verify order and types
     assert!(matches!(&events[0], DiagnosticEvent::Info { .. }));
     assert!(matches!(&events[1], DiagnosticEvent::Debug { .. }));
     assert!(matches!(&events[2], DiagnosticEvent::Info { .. }));

--- a/crates/logging/tests/verbose_level_1_output.rs
+++ b/crates/logging/tests/verbose_level_1_output.rs
@@ -62,7 +62,6 @@ fn verbose_1_emits_file_names() {
     init(config);
     drain_events();
 
-    // Simulate file transfer with name output
     info_log!(Name, 1, "file1.txt");
     info_log!(Name, 1, "file2.txt");
     info_log!(Name, 1, "dir/file3.txt");
@@ -252,10 +251,8 @@ fn verbose_1_includes_statistics() {
     init(config);
     drain_events();
 
-    // Stats flag is enabled at level 1
     assert!(info_gte(InfoFlag::Stats, 1));
 
-    // Simulate statistics output
     info_log!(Stats, 1, "Number of files: 3");
     info_log!(Stats, 1, "Number of created files: 3");
     info_log!(Stats, 1, "Total file size: 1,024 bytes");
@@ -279,7 +276,6 @@ fn verbose_1_with_progress() {
     init(config);
     drain_events();
 
-    // Both file names and progress should be enabled
     info_log!(Name, 1, "large_file.bin");
     info_log!(Progress, 1, "50%");
     info_log!(Name, 1, "another_file.txt");
@@ -314,10 +310,8 @@ fn verbose_1_shows_deletions() {
     init(config);
     drain_events();
 
-    // Del flag is enabled at level 1
     assert!(info_gte(InfoFlag::Del, 1));
 
-    // Simulate file deletion messages
     info_log!(Del, 1, "deleting old_file.txt");
     info_log!(Del, 1, "deleting obsolete.bin");
 
@@ -345,7 +339,6 @@ fn verbose_1_shows_skipped_files() {
     init(config);
     drain_events();
 
-    // Nonreg flag is enabled at level 1 for skipping non-regular files
     assert!(info_gte(InfoFlag::Nonreg, 1));
 
     info_log!(Nonreg, 1, "skipping non-regular file \"device.pipe\"");
@@ -380,7 +373,6 @@ fn verbose_1_shows_only_transferred_files() {
     info_log!(Skip, 2, "file is uptodate");
 
     let events = drain_events();
-    // Only the 2 Name level 1 events should appear
     assert_eq!(events.len(), 2);
 }
 
@@ -466,7 +458,6 @@ fn verbose_1_handles_long_filenames() {
     init(config);
     drain_events();
 
-    // Create a very long filename
     let long_name = "a".repeat(500) + ".txt";
     info_log!(Name, 1, "{}", long_name);
 
@@ -475,7 +466,7 @@ fn verbose_1_handles_long_filenames() {
 
     match &events[0] {
         DiagnosticEvent::Info { message, .. } => {
-            assert_eq!(message.len(), 504); // 500 a's + .txt
+            assert_eq!(message.len(), 504);
         }
         _ => panic!("expected Info event"),
     }
@@ -488,7 +479,6 @@ fn verbose_1_handles_control_characters() {
     init(config);
     drain_events();
 
-    // Filenames with tabs, newlines should be handled
     info_log!(Name, 1, "file\twith\ttabs.txt");
     info_log!(Name, 1, "file\\nwith\\nescaped\\nnewlines.txt");
 
@@ -532,11 +522,9 @@ fn verbose_1_distinct_from_level_0() {
     let config0 = VerbosityConfig::from_verbose_level(0);
     let config1 = VerbosityConfig::from_verbose_level(1);
 
-    // Level 0 should not have Name output
     init(config0);
     assert!(!info_gte(InfoFlag::Name, 1));
 
-    // Level 1 should have Name output
     init(config1);
     assert!(info_gte(InfoFlag::Name, 1));
 }
@@ -547,12 +535,11 @@ fn verbose_1_distinct_from_level_2() {
     let config1 = VerbosityConfig::from_verbose_level(1);
     let config2 = VerbosityConfig::from_verbose_level(2);
 
-    // Level 1 should have Name at level 1, but not 2
     init(config1);
     assert!(info_gte(InfoFlag::Name, 1));
     assert!(!info_gte(InfoFlag::Name, 2));
 
-    // Level 2 should have Name at level 2 (itemize-changes)
+    // Level 2 enables Name at level 2 (itemize-changes).
     init(config2);
     assert!(info_gte(InfoFlag::Name, 2));
 }
@@ -564,12 +551,10 @@ fn verbose_1_no_debug_unlike_level_2() {
     let config1 = VerbosityConfig::from_verbose_level(1);
     let config2 = VerbosityConfig::from_verbose_level(2);
 
-    // Level 1 should have no debug
     init(config1);
     assert!(!debug_gte(DebugFlag::Flist, 1));
     assert!(!debug_gte(DebugFlag::Recv, 1));
 
-    // Level 2 should have debug enabled
     init(config2);
     assert!(debug_gte(DebugFlag::Flist, 1));
     assert!(debug_gte(DebugFlag::Recv, 1));

--- a/crates/logging/tests/verbose_level_2_output.rs
+++ b/crates/logging/tests/verbose_level_2_output.rs
@@ -93,7 +93,6 @@ fn verbose_level_2_outputs_misc_details() {
     let events = drain_events();
     assert_eq!(events.len(), 3);
 
-    // Verify the messages were captured
     let messages: Vec<_> = events
         .iter()
         .filter_map(|e| match e {


### PR DESCRIPTION
## Summary

- Walked every `.rs` file under `crates/logging/` and removed restatement comments that echo the code below them.
- Touched files: `examples/tracing_demo.rs`, `src/thread_local.rs`, `tests/debug_log_behavior.rs`, `tests/edge_cases.rs`, `tests/info_log_formatting.rs`, `tests/verbose_level_1_output.rs`, `tests/verbose_level_2_output.rs`.
- The bulk of the crate was already well-curated. The audit confirmed the rest of `crates/logging/` is clean: upstream rsync cites, verbosity-table references, info/debug flag rustdoc, and error-format contracts are all preserved verbatim.

## Scope

Touched:
- `crates/logging/examples/tracing_demo.rs` - dropped three restatement comments (`// Initialize with verbosity level 2 (-vv)`, `// Now use standard tracing macros`, `// Or use convenience macros`) that just echo the code below.
- `crates/logging/src/thread_local.rs` - dropped two trailing `// Clear any existing` / `// Clear existing` notes on `drain_events()` calls inside tests.
- `crates/logging/tests/debug_log_behavior.rs` - dropped `// Clear any existing events`, `// Only recv should emit`, `// Reinitialize with different config` restatement comments.
- `crates/logging/tests/edge_cases.rs` - dropped restatement comments and a misleading `// Arabic text` note above a message that is just `"document.txt"`; folded the leading-zeros explanation into the test's rustdoc.
- `crates/logging/tests/info_log_formatting.rs` - dropped `// Only copy should emit` and `// Verify order and types` restatements.
- `crates/logging/tests/verbose_level_1_output.rs` - dropped a cluster of `// Simulate ...`, `// Should/Should not ...`, and `// Create a very long filename` restatements; kept all comments that explain test intent or upstream behaviour.
- `crates/logging/tests/verbose_level_2_output.rs` - dropped `// Verify the messages were captured` restatement.

## Preservation

All `// upstream:` cites (`options.c:228-243` for `info_verbosity[]` / `debug_verbosity[]`, `options.c:513 set_output_verbosity()`, `options.c:parse_output_words()`, `log.c:rwrite()`, `rsync.h INFO_GTE` / `DEBUG_GTE`, `errcode.h`), the role-trailer contract (`[sender]`/`[receiver]`/`[generator]`/`[server]`/`[client]`/`[daemon]`), the error-format string `rsync error: ... (code N) at <basename>(<line>) [<role>=<version>]`, and every informational note that explains test intent or non-obvious semantics are preserved verbatim.

## Diff size

7 files changed, 7 insertions(+), 36 deletions(-).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo check -p logging --all-features` clean
- [x] `cargo nextest run -p logging --all-features` (320 passed, 1 skipped)
- [ ] Full CI matrix