### PR TITLE
docs(platform): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/platform/src/windows_service.rs
+++ b/crates/platform/src/windows_service.rs
@@ -175,8 +175,6 @@ mod windows_impl {
         let _ = report_status_raw(status_handle, SERVICE_START_PENDING, 0, 3000);
         let _ = report_status_raw(status_handle, SERVICE_RUNNING, 0, 0);
 
-        // Extract the callback from OnceLock<Mutex<Option>> with a flat chain
-        // of and_then to avoid deep nesting.
         let callback = SERVICE_CALLBACK
             .get()
             .and_then(|mutex| mutex.lock().ok())


### PR DESCRIPTION
## Summary

Per-crate comment cleanup for the platform crate following the CCL template (PR #4620 for metadata, plus #4626-#4639 for transfer/daemon/bandwidth/signature/checksums/cli/compress/fast_io/filters/core).

The platform crate was already in excellent shape after earlier passes: all 22 public items already had rustdoc (enforced via \`#![deny(missing_docs)]\`), and the comment population is dominated by SAFETY blocks for FFI calls and upstream rsync cites. This pass identified and removed a single residual restatement comment.

## Files touched

| File | +/- |
|------|-----|
| \`crates/platform/src/windows_service.rs\` | -2 |

**Net: +0 -2 lines.**

## Removed

- \`windows_service.rs\` lines 178-179: meta-restatement describing the \`and_then\` chain pattern (\"Extract the callback from OnceLock<Mutex<Option>> with a flat chain of and_then to avoid deep nesting.\") - the code itself is self-evident and the comment described style, not behaviour.

## Preserved

- **All 39 \`SAFETY:\` blocks** across daemonize, env, group, lib, name_resolution, privilege, signal, windows_service - documenting FFI invariants for libc, nix, and the windows crate.
- **All 16 \`upstream:\` cites** across daemonize, group, name_resolution, privilege, secrets, signal - pointing back to clientserver.c, authenticate.c, main.c, uidlist.c.
- **The use_chroot Windows no-op warning** at \`privilege.rs:56-66\` (per SEC-1.l): the \`#[cfg(not(unix))]\` stub keeps its docstring stating Windows does not support chroot and emits an \`eprintln!\` warning so daemon operators know the \`use chroot\` directive has no effect.
- **Cross-platform syscall fallback notes**: macOS \`setgroups\` fallback in privilege.rs, glibc \`tzset\` declaration in privilege.rs (libc crate version variance), Win32 two-call buffer-size idiom in name_resolution.rs.
- **Privilege escalation/drop semantics**: the security-critical setgroups -> setgid -> setuid ordering documentation in privilege.rs.
- **Win32 positional-argument hints** in CreateServiceW (load ordering group, dependencies, LocalSystem account, password slots) - opaque without them.

## Test plan

- [x] \`cargo fmt --all\` clean.
- [x] \`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings\` clean.
- [x] \`cargo check -p platform --all-features\` clean.
- [x] \`cargo nextest run -p platform\` - 48 tests run, 48 passed.
- [ ] CI green (fmt+clippy, nextest stable, Windows stable, macOS stable, Linux musl stable).