### PR TITLE
docs(rsync_io): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/rsync_io/src/negotiation/buffer/storage.rs
+++ b/crates/rsync_io/src/negotiation/buffer/storage.rs
@@ -390,7 +390,6 @@ mod tests {
     fn new_clamps_prefix_len_to_buffer_len() {
         let data = vec![1, 2, 3];
         let buf = NegotiationBuffer::new(100, 0, data);
-        // prefix_len should be clamped to buffer length (3)
         assert_eq!(buf.sniffed_prefix_len(), 3);
     }
 
@@ -398,7 +397,6 @@ mod tests {
     fn new_clamps_pos_to_buffer_len() {
         let data = vec![1, 2, 3];
         let buf = NegotiationBuffer::new(0, 100, data);
-        // pos should be clamped to buffer length (3)
         assert_eq!(buf.buffered_consumed(), 3);
     }
 

--- a/crates/rsync_io/src/ssh/embedded/auth.rs
+++ b/crates/rsync_io/src/ssh/embedded/auth.rs
@@ -292,13 +292,12 @@ mod tests {
 
     #[test]
     fn effective_username_none_no_env() {
-        // Temporarily clear the env var to test the fallback error.
         let config = SshConfig {
             username: None,
             ..SshConfig::default()
         };
-        // We cannot safely unset USER in a multi-threaded test, so just verify
-        // the function returns something reasonable when the var is set.
+        // Cannot safely unset USER in a multi-threaded test - just smoke-check
+        // that the function returns without panicking when the var is set.
         let _ = effective_username(&config);
     }
 
@@ -354,7 +353,6 @@ mod tests {
 
     #[test]
     fn auth_methods_ordering() {
-        // Verify the tried-methods list is built correctly.
         let tried = ["agent", "publickey", "password"];
         assert_eq!(tried.join(", "), "agent, publickey, password");
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #4596 that scrubs three remaining restatement comments
the previous pass missed:

- `negotiation/buffer/storage.rs` (2 deletions): two test comments that
  simply repeated the assertion on the immediately following line
  (`// prefix_len should be clamped to buffer length (3)` directly above
  `assert_eq!(.., 3)`).
- `ssh/embedded/auth.rs::effective_username_none_no_env` (1 deletion,
  2-line WHY note tightened): the leading comment claimed the test
  "temporarily clears the env var" but the body immediately explains
  that doing so is unsafe in a multi-threaded test and the env var is
  therefore left alone. Dropped the contradiction and tightened the
  surviving WHY comment to two lines.
- `ssh/embedded/auth.rs::auth_methods_ordering` (1 deletion): the lone
  comment restated the test name.

## Scope

`rsync_io` enforces `#![deny(missing_docs)]`, so public-API rustdoc
coverage is complete by construction. PR #4596 already removed the
prior round of restatements; this pass picks up three stragglers found
by a targeted re-audit.

## Files touched

- `crates/rsync_io/src/negotiation/buffer/storage.rs` (-2)
- `crates/rsync_io/src/ssh/embedded/auth.rs` (+2 / -4)

Net: 2 insertions, 6 deletions across 2 files.

## Preserved

- All `// upstream:` cites (`io.c read_int`/`write_int`, `pipe.c:54-55`,
  `main.c:620-624`).
- SEC-3 leading-dash rejection rationale in `ssh/operand.rs` (added by
  PR #4613, `RemoteOperandParseError::LeadingDash` + `reject_leading_dash`).
- `SshChildHandle` drop/reap zombie prevention notes in `ssh/tests.rs`
  (`drop_child_handle_reaps_process`, `drop_child_handle_kills_running_process`).
- Socketpair vs anonymous-pipe fallback rationale in `ssh/aux_channel.rs`
  and `ssh/builder.rs`.
- Watchdog and drain-thread invariants in `ssh/connection.rs`,
  `ssh/async_stderr_drain.rs`, and `ssh/embedded/sync_bridge.rs`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (clean)
- [x] `cargo check -p rsync_io --all-features` (clean)
- [x] `cargo nextest run -p rsync_io --all-features -E 'test(ssh) or test(operand) or test(effective_username) or test(auth_methods) or test(clamp)'` (358 passed)