### PR TITLE
docs(logging-sink): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/crates/logging-sink/src/line_mode.rs
+++ b/crates/logging-sink/src/line_mode.rs
@@ -35,10 +35,7 @@ impl LineMode {
 }
 
 impl From<bool> for LineMode {
-    /// Converts a boolean flag describing whether a trailing newline should be appended into a [`LineMode`].
-    ///
-    /// `true` maps to [`LineMode::WithNewline`]; `false` selects
-    /// [`LineMode::WithoutNewline`].
+    /// `true` maps to [`LineMode::WithNewline`]; `false` selects [`LineMode::WithoutNewline`].
     ///
     /// # Examples
     ///
@@ -58,8 +55,6 @@ impl From<bool> for LineMode {
 }
 
 impl From<LineMode> for bool {
-    /// Converts a [`LineMode`] back into a boolean flag describing whether a trailing newline is appended.
-    ///
     /// Delegates to [`LineMode::append_newline`].
     ///
     /// # Examples

--- a/crates/logging-sink/src/sink/message_sink/accessors.rs
+++ b/crates/logging-sink/src/sink/message_sink/accessors.rs
@@ -150,8 +150,6 @@ mod tests {
         let _scratch = sink.scratch();
     }
 
-    /// Exercises the mutable accessor; there is nothing to assert beyond
-    /// the fact that the call type-checks and does not panic.
     #[test]
     fn scratch_mut_returns_mutable_reference() {
         let mut sink = make_sink();

--- a/crates/logging-sink/src/sink/mod.rs
+++ b/crates/logging-sink/src/sink/mod.rs
@@ -1,7 +1,4 @@
-//! Streaming message sink and supporting types.
-//!
-//! This module re-exports [`MessageSink`], [`LineModeGuard`], and
-//! [`TryMapWriterError`] - the primary types for rendering
+//! Streaming message sink and supporting types for rendering
 //! [`core::message::Message`] values into arbitrary [`std::io::Write`] targets.
 
 mod guard;

--- a/crates/logging-sink/src/syslog.rs
+++ b/crates/logging-sink/src/syslog.rs
@@ -488,8 +488,6 @@ mod tests {
         assert_eq!(format!("{facility}"), "local3");
     }
 
-    /// Spot-check every variant maps to a [`syslog::Facility`] without
-    /// panicking; the wire mapping has no other observable side-effects.
     #[test]
     fn to_wire_covers_all_variants() {
         let facilities = [
@@ -605,18 +603,16 @@ mod tests {
         syslog_message(SyslogPriority::Info, "before\0after");
     }
 
-    /// Cold-path coverage: drop any previously opened logger so the
-    /// emit-without-open branch is exercised.
     #[test]
     fn syslog_message_without_open_is_noop() {
+        // Drop any previously opened logger so the emit-without-open branch
+        // is exercised.
         if let Ok(mut slot) = logger_slot().lock() {
             *slot = None;
         }
         syslog_message(SyslogPriority::Info, "no logger configured");
     }
 
-    /// Sanity check: each severity variant is constructible and the
-    /// `Copy`/`Clone` impls round-trip.
     #[test]
     fn priority_covers_all_severity_levels() {
         let priorities = [


### PR DESCRIPTION
## Summary

- Strip restatement-style doc preludes from `LineMode`'s `From<bool>` and `From<LineMode>` implementations; the supplementary line and example already convey the conversion semantics.
- Trim the `sink` module summary to a single sentence covering the same content without re-listing the re-exports.
- Remove three test-level doc comments whose function names already describe the assertion; preserve the lone meaningful rationale by demoting it to an inline comment next to the cold-path setup it explains.

## Scope

Touched files: `src/line_mode.rs`, `src/sink/mod.rs`, `src/sink/message_sink/accessors.rs`, `src/syslog.rs`.

The audit also walked `src/lib.rs`, `src/sink/guard.rs`, `src/sink/try_map_writer_error.rs`, `src/sink/message_sink/{mod,constructors,mapping,writing}.rs`, `src/sink/tests.rs`, and `src/line_mode/tests.rs` and confirmed they were already clean.

All upstream rsync cites (`upstream: log.c`, `upstream: loadparm.c`) and the syslog dispatch / RFC 3164 framing notes are preserved unchanged.

## Diff size

4 files changed, 4 insertions(+), 18 deletions(-).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo check -p logging-sink --all-features`
- [x] `cargo nextest run -p logging-sink` (136 tests, 0 failures)