### PR TITLE
feat(fast_io): add DirSandbox + thread through receiver pipeline (SEC-1.e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ name = "fast_io"
 version = "0.6.2"
 dependencies = [
  "criterion",
+ "dashmap",
  "filetime",
  "io-uring",
  "libc",

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -32,6 +32,10 @@ libc = { workspace = true }
 # rustix is used for statx syscall on Linux (always compiled, runtime detection)
 rustix = { workspace = true, features = ["fs"] }
 
+# Concurrent hash map for the DirSandbox secondary-operand side cache
+# (SEC-1.e); read-mostly lookups by canonical operand path.
+dashmap = { workspace = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 # Optional: io_uring support (Linux 5.6+)
 io-uring = { version = "0.7", optional = true }

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -1,0 +1,391 @@
+//! Parent-dirfd carrier for the SEC-1 sandbox.
+//!
+//! [`DirSandbox`] is the runtime carrier the receiver pipeline threads
+//! through every per-entry operation so that the SEC-1.f-j site-by-site
+//! cutover from path-based syscalls to their `*at` siblings can resolve
+//! relative names against a sandboxed parent file descriptor instead of
+//! re-walking the path through the kernel. It implements the hybrid
+//! "in-tree dirfd stack + side-cache" shape picked in
+//! `docs/design/sec-1-b-dirfd-carrier.md` (section 1):
+//!
+//! 1. An **in-tree dirfd stack** ([`enter`](DirSandbox::enter) /
+//!    [`exit`](DirSandbox::exit)) mirrors the receiver's depth-first
+//!    descent. The top of the stack - or the root when the stack is empty -
+//!    is the parent dirfd for the entry currently being applied, exposed
+//!    via [`current_dirfd`](DirSandbox::current_dirfd) as a
+//!    `BorrowedFd<'_>` so rayon workers can capture it by copy with zero
+//!    synchronisation cost.
+//! 2. A **side cache** of `Arc<OwnedFd>` keyed by canonical path
+//!    ([`secondary`](DirSandbox::secondary)) covers the four
+//!    cross-directory operands (`--backup-dir`, `--temp-dir`,
+//!    `--link-dest`, `--copy-dest`, `--compare-dest`). The cache is a
+//!    [`DashMap`] so the read-mostly lookup path stays lock-free; entries
+//!    are inserted at receiver setup and never evicted.
+//!
+//! The module is `#[cfg(unix)]`. Windows uses NTFS handle-based ops per
+//! the SEC-1.l audit and intentionally bypasses this carrier.
+//!
+//! # Resolution policy
+//!
+//! Every `*at` open issued by [`DirSandbox`] refuses to follow a symlink
+//! at the leaf. On Linux 5.6+ kernels - detected via
+//! [`openat2_supported`](crate::linux_capabilities::openat2_supported) -
+//! the carrier upgrades to `openat2(2)` with
+//! `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` so the kernel also rejects
+//! any symlink along the path, any `..` traversal that would escape the
+//! anchoring dirfd, and any magic-link resolution. Pairing
+//! `RESOLVE_BENEATH` with a real anchoring dirfd is the supported
+//! configuration (unlike the `AT_FDCWD` bootstrap in
+//! [`secure_open_dir`](crate::secure_open_dir), which intentionally drops
+//! `RESOLVE_BENEATH` because the cwd anchor is the wrong scope for
+//! absolute paths).
+//!
+//! Older Linux and every other Unix target falls back to
+//! `openat(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`, which still rejects a
+//! symlink at the leaf but cannot reject mid-path `..` traversal.
+//!
+//! # Threading model
+//!
+//! The stack is owned by the receiver thread and mutated only through
+//! [`enter`](DirSandbox::enter) / [`exit`](DirSandbox::exit). Reads
+//! through [`current_dirfd`](DirSandbox::current_dirfd) hand out
+//! `BorrowedFd<'_>` values whose lifetime is bound to `&self`; rayon
+//! workers capturing the borrow do so by copy because `BorrowedFd<'_>`
+//! is `Copy + Send + Sync`. The side cache is a [`DashMap`] and supports
+//! concurrent registration plus concurrent reads.
+//!
+//! # `unsafe` budget
+//!
+//! The only `unsafe` block in this module is the `openat2(2)` syscall
+//! invocation, which mirrors the safety argument in
+//! [`secure_open_dir`](crate::secure_open_dir::secure_open_dir). The
+//! `openat(2)` fallback goes through `rustix`, which exposes a safe
+//! interface; no `unsafe` is needed there.
+
+use std::ffi::OsStr;
+use std::io;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use dashmap::DashMap;
+
+use crate::linux_capabilities::openat2_supported;
+use crate::secure_dir::secure_open_dir;
+
+#[cfg(test)]
+mod tests;
+
+/// Parent-dirfd carrier threaded through the receiver pipeline.
+///
+/// See the [module-level documentation](self) for the design rationale,
+/// resolution policy, and threading model.
+#[derive(Debug)]
+pub struct DirSandbox {
+    /// Root of the destination tree, opened once at receiver setup with
+    /// [`secure_open_dir`].
+    ///
+    /// Held in an [`Arc`] so worker tasks that outlive a single
+    /// [`enter`](Self::enter) / [`exit`](Self::exit) round can clone the
+    /// handle cheaply. The root is the resolution scope for
+    /// `RESOLVE_BENEATH` and the fallback when [`current_dirfd`] is
+    /// called on an empty stack.
+    ///
+    /// [`current_dirfd`]: Self::current_dirfd
+    root: Arc<OwnedFd>,
+    /// In-tree dirfd stack. The top frame's fd is the parent dirfd for
+    /// the entry currently being applied; an empty stack means the
+    /// receiver is operating directly on the root.
+    stack: Vec<DirFrame>,
+    /// Side cache of secondary operand roots keyed by the absolute path
+    /// the caller registered.
+    ///
+    /// Holds `Arc<OwnedFd>` so callers can keep a clone alive for the
+    /// duration of a syscall without contending on a mutex. The map is
+    /// sized by the number of CLI operands (typically <= 4) and is never
+    /// pruned during a session.
+    secondaries: DashMap<PathBuf, Arc<OwnedFd>>,
+}
+
+/// One frame of the in-tree descent stack.
+#[derive(Debug)]
+struct DirFrame {
+    /// Leaf name of the directory, retained for diagnostics and so
+    /// future SEC-1 work can reconstruct the relative path from the
+    /// stack without re-walking the kernel.
+    #[allow(dead_code)]
+    leaf: std::ffi::OsString,
+    /// Open `OwnedFd` for the directory.
+    fd: OwnedFd,
+}
+
+impl DirSandbox {
+    /// Open `root` and seed an empty descent stack.
+    ///
+    /// The root is opened through [`secure_open_dir`] so the bootstrap
+    /// open refuses a symlink at the leaf (and, on Linux 5.6+, refuses
+    /// any symlink anywhere in the path via
+    /// `openat2(RESOLVE_NO_SYMLINKS)`).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any failure from [`secure_open_dir`], including:
+    /// - `ENOENT` when `root` does not exist.
+    /// - `ENOTDIR` when `root` resolves to a non-directory.
+    /// - `ELOOP` when `root` is a symlink.
+    /// - `EACCES` per `open(2)` semantics.
+    pub fn open_root(root: &Path) -> io::Result<Self> {
+        let fd = secure_open_dir(root)?;
+        Ok(Self {
+            root: Arc::new(fd),
+            stack: Vec::new(),
+            secondaries: DashMap::new(),
+        })
+    }
+
+    /// Borrow the parent dirfd for the entry currently being applied.
+    ///
+    /// Returns the top of the descent stack when non-empty; otherwise
+    /// returns the root. The returned [`BorrowedFd`] is `Copy + Send +
+    /// Sync` and can be captured into rayon worker closures without
+    /// synchronisation. Hot-path accessor: returns in `O(1)` and issues
+    /// no syscalls.
+    #[must_use]
+    pub fn current_dirfd(&self) -> BorrowedFd<'_> {
+        match self.stack.last() {
+            Some(frame) => frame.fd.as_fd(),
+            None => self.root.as_fd(),
+        }
+    }
+
+    /// Borrow the root dirfd directly, ignoring any pushed frames.
+    ///
+    /// Used by callers that need to resolve a path against the sandbox
+    /// root rather than the current descent position (for example when
+    /// re-anchoring after a worker thread has popped its own frames).
+    #[must_use]
+    pub fn root_dirfd(&self) -> BorrowedFd<'_> {
+        self.root.as_fd()
+    }
+
+    /// Clone the root handle as an [`Arc`] for callers that need to
+    /// outlive `&self`.
+    ///
+    /// Cheap: increments an atomic refcount and returns. The cloned
+    /// handle is read-only from the receiver's perspective.
+    #[must_use]
+    pub fn root_arc(&self) -> Arc<OwnedFd> {
+        Arc::clone(&self.root)
+    }
+
+    /// Push a frame for `child_name` by opening the subdirectory off
+    /// the current parent dirfd.
+    ///
+    /// The open uses `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`
+    /// on Linux 5.6+ and `openat(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`
+    /// elsewhere. Both variants refuse a symlink at the leaf; the
+    /// `openat2` upgrade additionally refuses to descend across a
+    /// symlink anywhere in `child_name` and refuses `..` escapes.
+    ///
+    /// # Errors
+    ///
+    /// - `ELOOP` when `child_name` is or descends through a symlink
+    ///   (kernel error; varies by Unix flavour).
+    /// - `ENOENT` when `child_name` does not exist beneath the current
+    ///   parent dirfd.
+    /// - `ENOTDIR` when `child_name` resolves to a non-directory.
+    /// - `EXDEV` (Linux + `openat2` only) when `child_name` contains a
+    ///   `..` that would escape the parent dirfd under `RESOLVE_BENEATH`.
+    pub fn enter(&mut self, child_name: &OsStr) -> io::Result<()> {
+        let parent = self.current_dirfd();
+        let fd = openat_dir(parent, child_name)?;
+        self.stack.push(DirFrame {
+            leaf: child_name.to_os_string(),
+            fd,
+        });
+        Ok(())
+    }
+
+    /// Pop the top frame from the descent stack.
+    ///
+    /// Calling this with an empty stack is a no-op; callers are
+    /// responsible for balancing every [`enter`](Self::enter) with one
+    /// [`exit`](Self::exit). The popped `OwnedFd` is dropped, which
+    /// closes the descriptor.
+    pub fn exit(&mut self) {
+        self.stack.pop();
+    }
+
+    /// Returns the current descent depth (number of pushed frames).
+    ///
+    /// Diagnostic accessor used by tests and tracing. A depth of zero
+    /// means [`current_dirfd`](Self::current_dirfd) yields the root.
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Register or look up a secondary operand root.
+    ///
+    /// On first call for a given `path` the helper opens the directory
+    /// through [`secure_open_dir`] and stores the resulting `OwnedFd`
+    /// in the [`DashMap`] keyed by `path`. Subsequent calls return the
+    /// cached [`Arc`] without issuing a syscall. The clone is cheap and
+    /// hands the caller a shared owner whose [`BorrowedFd`] can be
+    /// passed to two-dirfd syscalls (`renameat`, `linkat`) alongside
+    /// the in-tree dirfd from [`current_dirfd`](Self::current_dirfd).
+    ///
+    /// The `path` is used verbatim as the cache key. Callers that need
+    /// to deduplicate across path aliases (`/var/log` vs
+    /// `/var/log/../log`) should canonicalise before calling; the
+    /// helper deliberately does not canonicalise on the caller's
+    /// behalf because canonicalisation issues its own syscall traffic
+    /// and is rarely the right default.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any failure from [`secure_open_dir`] on the first
+    /// call for `path`. A cached entry never fails.
+    pub fn secondary(&self, path: &Path) -> io::Result<Arc<OwnedFd>> {
+        if let Some(entry) = self.secondaries.get(path) {
+            return Ok(Arc::clone(entry.value()));
+        }
+        let fd = secure_open_dir(path)?;
+        let arc = Arc::new(fd);
+        // `entry().or_insert_with` would race with another writer that
+        // already opened the same operand. Use `entry().or_insert` on
+        // the prepared Arc and discard our open if we lost the race.
+        let stored = self
+            .secondaries
+            .entry(path.to_path_buf())
+            .or_insert_with(|| Arc::clone(&arc))
+            .clone();
+        Ok(stored)
+    }
+
+    /// Returns the number of secondary operand entries currently
+    /// cached.
+    ///
+    /// Diagnostic accessor used by tests and tracing to confirm
+    /// idempotency of [`secondary`](Self::secondary).
+    #[must_use]
+    pub fn secondary_count(&self) -> usize {
+        self.secondaries.len()
+    }
+}
+
+/// Open `child_name` as a directory off `parent_fd` using the strictest
+/// resolution policy the running kernel supports.
+///
+/// On Linux 5.6+ this uses `openat2(2)` with
+/// `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`; otherwise it falls back to
+/// `openat(2)` with `O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC` via `rustix`.
+fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
+    #[cfg(target_os = "linux")]
+    {
+        if openat2_supported()
+            && let Some(fd) = linux::openat2_beneath(parent_fd, child_name)?
+        {
+            return Ok(fd);
+        }
+    }
+    // Suppress the unused-import warning on non-Linux Unix targets.
+    let _ = openat2_supported;
+
+    openat_nofollow(parent_fd, child_name)
+}
+
+/// `openat(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` fallback.
+///
+/// Issued through `rustix::fs::openat`, which is a thin, safe wrapper
+/// over the raw syscall.
+fn openat_nofollow(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<OwnedFd> {
+    use rustix::fs::{Mode, OFlags};
+
+    let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+    let fd = rustix::fs::openat(parent_fd, child_name, flags, Mode::empty())
+        .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+    Ok(fd)
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    /// Issue an `openat2(2)` for `child_name` beneath `parent_fd` with
+    /// `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`.
+    ///
+    /// Returns `Ok(Some(fd))` on success, `Ok(None)` only if the kernel
+    /// reports `ENOSYS` (which the `openat2_supported` cache should
+    /// already have ruled out, but we defend against the race where the
+    /// probe ran in a seccomp profile that has since been relaxed),
+    /// and `Err` for every other failure - including the deliberate
+    /// strict-resolution refusals (`ELOOP`, `EXDEV`).
+    pub(super) fn openat2_beneath(
+        parent_fd: BorrowedFd<'_>,
+        child_name: &OsStr,
+    ) -> io::Result<Option<OwnedFd>> {
+        let c_name = CString::new(child_name.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "child name contains interior null byte",
+            )
+        })?;
+
+        // SAFETY: this single block performs three FFI touches:
+        //
+        // 1. `std::mem::zeroed::<open_how>()` - `libc::open_how` is
+        //    `#[non_exhaustive]`, so a struct expression is unavailable.
+        //    The type is `repr(C)` with integer-only fields, and an all-zero
+        //    bit pattern is the documented "no constraint" value for every
+        //    `openat2(2)` knob.
+        //
+        // 2. `libc::syscall(SYS_openat2, parent_fd, c_name, &how, size)` -
+        //    `parent_fd.as_raw_fd()` is a live, borrowed fd whose lifetime
+        //    is bound to `parent_fd: BorrowedFd<'_>` and outlives the
+        //    syscall. `c_name` is a valid NUL-terminated C string borrowed
+        //    for the duration of the call. `how` is a fully-initialised
+        //    `open_how` whose address and `size_of::<open_how>()` we hand
+        //    to the kernel as required by the syscall ABI. The kernel does
+        //    not retain any of the pointers past return. A non-negative
+        //    return value is a fresh, owned fd with `O_CLOEXEC` set.
+        //
+        // 3. `OwnedFd::from_raw_fd(raw)` - takes exclusive ownership of
+        //    the fd just returned. We do not duplicate, leak, or alias
+        //    the raw value anywhere else.
+        #[allow(unsafe_code)]
+        let raw = unsafe {
+            let mut how: libc::open_how = std::mem::zeroed();
+            how.flags =
+                (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC) as u64;
+            how.mode = 0;
+            how.resolve = libc::RESOLVE_BENEATH | libc::RESOLVE_NO_SYMLINKS;
+
+            libc::syscall(
+                libc::SYS_openat2,
+                parent_fd.as_raw_fd(),
+                c_name.as_ptr(),
+                &how as *const libc::open_how,
+                std::mem::size_of::<libc::open_how>(),
+            )
+        };
+
+        if raw >= 0 {
+            // SAFETY: `raw` is a non-negative fd just returned by
+            // `openat2(2)` with `O_CLOEXEC`. We have not duplicated or
+            // leaked it; this is the sole owner.
+            #[allow(unsafe_code)]
+            let fd = unsafe { OwnedFd::from_raw_fd(raw as libc::c_int) };
+            return Ok(Some(fd));
+        }
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ENOSYS) {
+            return Ok(None);
+        }
+        Err(err)
+    }
+}

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -1,0 +1,222 @@
+//! Unit tests for [`DirSandbox`](super::DirSandbox).
+//!
+//! Exercise the stack/cache invariants on tempdirs and confirm the
+//! symlink-rejection policy fires at both the root open
+//! ([`secure_open_dir`](crate::secure_open_dir::secure_open_dir)) and
+//! the descent open ([`super::DirSandbox::enter`]).
+
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::symlink;
+use std::sync::Arc;
+use std::thread;
+
+use tempfile::tempdir;
+
+use super::DirSandbox;
+
+/// `tempdir()` may return a path under a symlinked prefix (macOS
+/// `/tmp -> /private/tmp`, some CI runners stage `/tmp` through a
+/// symlink). `secure_open_dir` refuses such paths under
+/// `RESOLVE_NO_SYMLINKS`, so every test that opens a tempdir as the
+/// sandbox root first canonicalises.
+fn canonical_tempdir() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let canon = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+    (dir, canon)
+}
+
+#[test]
+fn open_root_yields_live_fd() {
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    assert!(sandbox.current_dirfd().as_raw_fd() >= 0);
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn open_root_rejects_symlink_root() {
+    let (_keep, root) = canonical_tempdir();
+    let target = root.join("real");
+    std::fs::create_dir(&target).expect("create real dir");
+    let link = root.join("link");
+    symlink(&target, &link).expect("create symlink");
+
+    let err = DirSandbox::open_root(&link).expect_err("symlink root must be rejected");
+    let code = err.raw_os_error();
+    // Linux + openat2 returns ELOOP; Linux + plain open(O_NOFOLLOW)
+    // also returns ELOOP; macOS/BSD evaluate O_DIRECTORY before
+    // O_NOFOLLOW and return ENOTDIR for symlink-to-directory.
+    assert!(
+        code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+        "expected ELOOP or ENOTDIR for symlink root, got: {err}"
+    );
+}
+
+#[test]
+fn enter_and_exit_balance_the_stack() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("a")).expect("mkdir a");
+    std::fs::create_dir(root.join("a/b")).expect("mkdir a/b");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let root_raw = sandbox.current_dirfd().as_raw_fd();
+    assert_eq!(sandbox.depth(), 0);
+
+    sandbox.enter(std::ffi::OsStr::new("a")).expect("enter a");
+    assert_eq!(sandbox.depth(), 1);
+    let a_raw = sandbox.current_dirfd().as_raw_fd();
+    assert_ne!(a_raw, root_raw, "entering must hand out a new fd");
+
+    sandbox.enter(std::ffi::OsStr::new("b")).expect("enter b");
+    assert_eq!(sandbox.depth(), 2);
+    let b_raw = sandbox.current_dirfd().as_raw_fd();
+    assert_ne!(b_raw, a_raw);
+
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 1);
+    assert_eq!(
+        sandbox.current_dirfd().as_raw_fd(),
+        a_raw,
+        "exit must restore the prior parent dirfd"
+    );
+
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+    assert_eq!(
+        sandbox.current_dirfd().as_raw_fd(),
+        root_raw,
+        "exit to empty must return the root"
+    );
+}
+
+#[test]
+fn exit_on_empty_stack_is_noop() {
+    let (_keep, root) = canonical_tempdir();
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    sandbox.exit();
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_rejects_symlink_child() {
+    let (_keep, root) = canonical_tempdir();
+    let real = root.join("real");
+    std::fs::create_dir(&real).expect("create real dir");
+    symlink(&real, root.join("link")).expect("symlink");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .enter(std::ffi::OsStr::new("link"))
+        .expect_err("symlink child must be rejected");
+    let code = err.raw_os_error();
+    assert!(
+        code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+        "expected ELOOP or ENOTDIR for symlink child, got: {err}"
+    );
+    // Stack must be untouched when the open fails.
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_rejects_missing_child() {
+    let (_keep, root) = canonical_tempdir();
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .enter(std::ffi::OsStr::new("does-not-exist"))
+        .expect_err("missing child must error");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_rejects_file_child() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::write(root.join("file"), b"x").expect("write file");
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .enter(std::ffi::OsStr::new("file"))
+        .expect_err("file child must error");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOTDIR));
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn secondary_is_idempotent() {
+    let (_keep_root, root) = canonical_tempdir();
+    let (_keep_other, other) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    assert_eq!(sandbox.secondary_count(), 0);
+
+    let fd1 = sandbox.secondary(&other).expect("register operand");
+    assert_eq!(sandbox.secondary_count(), 1);
+
+    let fd2 = sandbox.secondary(&other).expect("re-lookup operand");
+    assert_eq!(sandbox.secondary_count(), 1);
+    assert!(
+        Arc::ptr_eq(&fd1, &fd2),
+        "second call must return the same Arc"
+    );
+}
+
+#[test]
+fn secondary_rejects_symlink_operand() {
+    let (_keep_root, root) = canonical_tempdir();
+    let (_keep_other, other) = canonical_tempdir();
+    let target = other.join("real");
+    std::fs::create_dir(&target).expect("create real");
+    let link = other.join("link");
+    symlink(&target, &link).expect("symlink");
+
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .secondary(&link)
+        .expect_err("symlink operand must be rejected");
+    let code = err.raw_os_error();
+    assert!(
+        code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+        "expected ELOOP or ENOTDIR for symlink operand, got: {err}"
+    );
+    assert_eq!(sandbox.secondary_count(), 0);
+}
+
+#[test]
+fn secondary_concurrent_registrations_collapse_to_one() {
+    let (_keep_root, root) = canonical_tempdir();
+    let (_keep_other, other) = canonical_tempdir();
+    let sandbox = Arc::new(DirSandbox::open_root(&root).expect("open root"));
+
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let sandbox = Arc::clone(&sandbox);
+            let other = other.clone();
+            thread::spawn(move || sandbox.secondary(&other).expect("register"))
+        })
+        .collect();
+
+    let mut fds = Vec::new();
+    for handle in handles {
+        fds.push(handle.join().expect("thread"));
+    }
+
+    // Every thread must observe the same cached Arc, and the cache
+    // must contain exactly one entry regardless of registration races.
+    let first = &fds[0];
+    for other in &fds[1..] {
+        assert!(
+            Arc::ptr_eq(first, other),
+            "all threads must share one operand handle"
+        );
+    }
+    assert_eq!(sandbox.secondary_count(), 1);
+}
+
+#[test]
+fn root_arc_clones_share_owner() {
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    let arc1 = sandbox.root_arc();
+    let arc2 = sandbox.root_arc();
+    assert!(Arc::ptr_eq(&arc1, &arc2));
+    assert_eq!(arc1.as_raw_fd(), sandbox.root_dirfd().as_raw_fd());
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -81,6 +81,17 @@
 
 /// Cached sorting using the Schwartzian transform.
 pub mod cached_sort;
+/// Parent-dirfd carrier (`DirSandbox`) for the SEC-1 sandbox.
+///
+/// Threads an in-tree dirfd stack plus a `DashMap<PathBuf, Arc<OwnedFd>>`
+/// side cache through the receiver pipeline so SEC-1.f-j can convert
+/// path-based syscalls to `*at` siblings without re-walking the path
+/// through the kernel.
+///
+/// Unix-only: Windows callers use NTFS handle-based APIs which sidestep
+/// path TOCTOU naturally (see the SEC-1.l audit).
+#[cfg(unix)]
+pub mod dir_sandbox;
 /// Kernel version parsing and io_uring probe logging.
 pub mod kernel_version;
 /// Cached runtime probes for Linux-specific kernel capabilities used by the
@@ -212,6 +223,8 @@ pub use platform_copy::{
 };
 pub use traits::{FileReader, FileWriter};
 
+#[cfg(unix)]
+pub use dir_sandbox::DirSandbox;
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,
 };

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -83,6 +83,14 @@
 pub mod cached_sort;
 /// Kernel version parsing and io_uring probe logging.
 pub mod kernel_version;
+/// Cached runtime probes for Linux-specific kernel capabilities used by the
+/// SEC-1 dirfd sandbox.
+///
+/// Unix-only: on non-Linux Unix targets the helpers short-circuit to
+/// compile-time `false`. Windows callers use NTFS handle-based APIs (see
+/// the SEC-1.l audit) and do not depend on this module.
+#[cfg(unix)]
+pub mod linux_capabilities;
 /// Page-aligned buffer pool for IOCP no-buffering mode.
 pub mod page_aligned;
 /// Parallel file I/O operations using rayon.
@@ -207,6 +215,8 @@ pub use traits::{FileReader, FileWriter};
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,
 };
+#[cfg(unix)]
+pub use linux_capabilities::openat2_supported;
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]
 pub use secure_dir::secure_open_dir;

--- a/crates/fast_io/src/linux_capabilities.rs
+++ b/crates/fast_io/src/linux_capabilities.rs
@@ -1,0 +1,181 @@
+//! Cached runtime probes for Linux-specific kernel capabilities used by the
+//! SEC-1 dirfd sandbox.
+//!
+//! The SEC-1 family of patches replaces path-based `*` syscalls
+//! (`open`, `rename`, `link`, `unlink`, ...) with their dirfd-anchored `*at`
+//! siblings, preferring the `*2` variants (`openat2`, `renameat2`, ...) when
+//! the kernel supports them. Each call site needs to know whether the
+//! strict-resolution `openat2(2)` path is available so it can pick the right
+//! variant; rather than each site reinventing the probe, this module exposes
+//! [`openat2_supported`] as the single source of truth.
+//!
+//! The module is gated `#[cfg(unix)]` so callers can use the helper without
+//! `#[cfg(target_os = "linux")]` branching - on non-Linux Unix targets the
+//! probe is a compile-time constant `false`. Windows callers do not use
+//! this path at all (see the SEC-1.l audit on NTFS handle-based APIs).
+
+/// Returns `true` when the running kernel supports `openat2(2)` and `false`
+/// otherwise.
+///
+/// On Linux the first invocation issues a no-op
+/// `openat2(AT_FDCWD, ".", { resolve: 0 })` syscall and caches the outcome
+/// in a [`OnceLock`](std::sync::OnceLock):
+///
+/// - A non-negative return value (a fresh fd which we close immediately)
+///   means the kernel supports the syscall - cache `true`.
+/// - `ENOSYS` means the kernel pre-dates Linux 5.6 (or the syscall is
+///   blocked by seccomp) - cache `false`.
+/// - Any other errno still means the syscall reached the kernel, so the
+///   ABI is supported - cache `true`. Callers will see the real errno on
+///   their own subsequent invocations.
+///
+/// Subsequent invocations on Linux read the cached value and skip the
+/// syscall. The probe is thread-safe; the first caller wins the
+/// `OnceLock::set`, and every later caller observes the same result.
+///
+/// On non-Linux Unix targets this is a compile-time `false`.
+#[must_use]
+pub fn openat2_supported() -> bool {
+    imp::openat2_supported()
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::sync::OnceLock;
+
+    static OPENAT2_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+    pub(super) fn openat2_supported() -> bool {
+        if let Some(cached) = OPENAT2_AVAILABLE.get().copied() {
+            return cached;
+        }
+        let result = probe();
+        let _ = OPENAT2_AVAILABLE.set(result);
+        // Re-read in case another thread won the race; both writers wrote
+        // the same value, so the observed result is stable.
+        OPENAT2_AVAILABLE.get().copied().unwrap_or(result)
+    }
+
+    fn probe() -> bool {
+        // No-op probe path: "." resolves the current working directory,
+        // which is guaranteed to exist for any running process. The kernel
+        // returns a fresh fd we close immediately, or `ENOSYS` if the
+        // syscall is unavailable.
+        let path = c".";
+
+        // SAFETY: a single unsafe scope wraps every FFI touch the probe
+        // performs:
+        //
+        // 1. `std::mem::zeroed::<open_how>()` - `libc::open_how` is
+        //    `#[non_exhaustive]`, so a struct expression is unavailable. The
+        //    type is repr(C) with integer-only fields, and an all-zero bit
+        //    pattern is a valid value (the documented "no constraint" mode
+        //    for every `openat2(2)` knob).
+        //
+        // 2. `libc::syscall(SYS_openat2, AT_FDCWD, path, &how, size)` -
+        //    `path` is a valid NUL-terminated C string with static
+        //    lifetime; `how` is a fully-initialised `open_how` whose
+        //    address and `size_of::<open_how>()` we hand to the kernel as
+        //    required by the syscall ABI. The kernel does not retain the
+        //    pointer past return. A non-negative return value is a fresh,
+        //    owned fd with `O_CLOEXEC` set.
+        //
+        // 3. `libc::close(raw)` - `raw` is the fd we just received and
+        //    have not aliased or leaked. Closing it here keeps the probe
+        //    descriptor-neutral. We deliberately ignore the close return
+        //    value: the probe is a read-only directory open, so close
+        //    cannot return EIO or EINTR meaningfully.
+        #[allow(unsafe_code)]
+        unsafe {
+            let mut how: libc::open_how = std::mem::zeroed();
+            how.flags = (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
+            how.mode = 0;
+            how.resolve = 0;
+
+            let raw = libc::syscall(
+                libc::SYS_openat2,
+                libc::AT_FDCWD,
+                path.as_ptr(),
+                &how as *const libc::open_how,
+                std::mem::size_of::<libc::open_how>(),
+            );
+
+            if raw >= 0 {
+                libc::close(raw as libc::c_int);
+                return true;
+            }
+        }
+
+        let errno = std::io::Error::last_os_error().raw_os_error();
+        errno != Some(libc::ENOSYS)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    pub(super) fn openat2_supported() -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openat2_supported_returns_bool_without_panic() {
+        // Two back-to-back calls exercise both the "no cache yet" path and
+        // the "cache hit" path within a single test invocation. Either
+        // outcome (true on Linux 5.6+, false elsewhere) is valid; what we
+        // assert is the absence of panics and a consistent return value
+        // across the two calls.
+        let first = openat2_supported();
+        let second = openat2_supported();
+        assert_eq!(
+            first, second,
+            "openat2_supported() must return a stable value across calls"
+        );
+    }
+
+    #[test]
+    fn openat2_supported_is_cached() {
+        // Hammer the probe from many calls and confirm the cached result
+        // never wavers. The probe must not depend on transient kernel
+        // state, environment, or call ordering.
+        let baseline = openat2_supported();
+        for _ in 0..1024 {
+            assert_eq!(
+                openat2_supported(),
+                baseline,
+                "openat2_supported() result must be cached and stable"
+            );
+        }
+    }
+
+    #[test]
+    fn openat2_supported_is_thread_safe() {
+        // Spawn several threads that all race to read the probe. The
+        // OnceLock-backed cache must serialise the first writer and let
+        // every other thread observe the same outcome.
+        let baseline = openat2_supported();
+        let handles: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(openat2_supported))
+            .collect();
+        for handle in handles {
+            let observed = handle.join().expect("probe thread panicked");
+            assert_eq!(
+                observed, baseline,
+                "openat2_supported() must agree across threads"
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn openat2_supported_is_false_on_non_linux() {
+        // Non-Linux Unix targets (macOS, *BSD, illumos) do not implement
+        // `openat2(2)`. The helper must short-circuit to `false` without
+        // any syscall traffic.
+        assert!(!openat2_supported());
+    }
+}

--- a/crates/fast_io/src/secure_dir.rs
+++ b/crates/fast_io/src/secure_dir.rs
@@ -15,10 +15,12 @@
 //! # Why two code paths on Linux
 //!
 //! `openat2(2)` landed in Linux 5.6 (March 2020). On older kernels the syscall
-//! returns `ENOSYS`; we cache the first such result in a [`OnceLock`] and use
-//! plain `open(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` thereafter. The plain
-//! `open` path still rejects a symlink at the leaf - it just cannot reject
-//! `..` traversal mid-path, which is the marginal extra confinement
+//! returns `ENOSYS`; the
+//! [`openat2_supported`](crate::linux_capabilities::openat2_supported) probe
+//! caches that result and we use plain
+//! `open(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` thereafter. The plain `open`
+//! path still rejects a symlink at the leaf - it just cannot reject `..`
+//! traversal mid-path, which is the marginal extra confinement
 //! `RESOLVE_BENEATH` gives us.
 //!
 //! # Single unsafe block
@@ -110,28 +112,21 @@ mod imp {
     #[cfg(target_os = "linux")]
     pub(super) mod linux {
         use super::*;
-        use std::sync::OnceLock;
+        use crate::linux_capabilities::openat2_supported;
 
-        /// Cached `openat2` availability probe.
-        ///
-        /// `None` until the first call; `Some(true)` once we have observed a
-        /// successful `openat2` invocation; `Some(false)` once `ENOSYS` has
-        /// come back. Subsequent calls skip the syscall when this is
-        /// `Some(false)`.
-        static OPENAT2_AVAILABLE: OnceLock<bool> = OnceLock::new();
-
-        /// Attempts an `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS`.
+        /// Attempts an `openat2` with `RESOLVE_NO_SYMLINKS`.
         ///
         /// Returns:
         /// - `Ok(Some(fd))` when the call succeeded - this is the strict
         ///   confinement path.
-        /// - `Ok(None)` when the kernel does not support `openat2` (cached
-        ///   for the remainder of the process lifetime), signalling the
-        ///   caller to fall back to plain `open(O_NOFOLLOW)`.
+        /// - `Ok(None)` when the kernel does not support `openat2`,
+        ///   signalling the caller to fall back to plain `open(O_NOFOLLOW)`.
+        ///   The probe is cached by [`openat2_supported`] for the remainder
+        ///   of the process lifetime.
         /// - `Err(_)` for any other failure, including the strict-resolution
         ///   refusals (`ELOOP`, `EXDEV`) that we want callers to see.
         pub(super) fn try_openat2(c_path: &CString) -> io::Result<Option<OwnedFd>> {
-            if let Some(false) = OPENAT2_AVAILABLE.get().copied() {
+            if !openat2_supported() {
                 return Ok(None);
             }
 
@@ -177,7 +172,6 @@ mod imp {
             };
 
             if raw >= 0 {
-                let _ = OPENAT2_AVAILABLE.set(true);
                 // SAFETY: `raw` is a non-negative fd just returned by
                 // `openat2(2)` with `O_CLOEXEC`. We have not duplicated or
                 // leaked it.
@@ -188,7 +182,6 @@ mod imp {
 
             let err = io::Error::last_os_error();
             if err.raw_os_error() == Some(libc::ENOSYS) {
-                let _ = OPENAT2_AVAILABLE.set(false);
                 return Ok(None);
             }
             Err(err)

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -697,6 +697,23 @@ struct PipelineSetup {
     /// thread via `Arc` so cached ACLs can be applied after file metadata.
     /// `None` when `--acls` is not active.
     acl_cache: Option<Arc<AclCache>>,
+    /// Parent-dirfd carrier rooted at the destination tree.
+    ///
+    /// Opened once via [`fast_io::secure_open_dir`] when `setup_transfer`
+    /// resolves the destination path. Threaded through the receiver
+    /// pipeline so the SEC-1.f-j cutover sites can replace path-based
+    /// syscalls with their `*at` siblings without re-walking the path
+    /// through the kernel. This PR (SEC-1.e) wires the carrier through
+    /// to [`ReceiverContext`] but does not migrate any syscalls; the
+    /// existing path-based code paths continue to be the active code.
+    ///
+    /// `None` on Unix when the destination root cannot be opened (for
+    /// example because it does not yet exist - the receiver will create
+    /// it later and the carrier stays absent for the duration of the
+    /// transfer). `None` on Windows where the carrier is not used
+    /// (handle-based NTFS APIs, see SEC-1.l audit).
+    #[cfg(unix)]
+    sandbox: Option<Arc<fast_io::DirSandbox>>,
 }
 
 /// Applies ACLs from the receiver's ACL cache to a destination file.

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -296,6 +296,8 @@ impl ReceiverContext {
 
                 let response_ctx = ResponseContext {
                     config: &request_config,
+                    #[cfg(unix)]
+                    sandbox: setup.sandbox.as_deref(),
                 };
 
                 let xattr_list = self.resolve_xattr_list(file_entry);

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -151,6 +151,17 @@ impl ReceiverContext {
             None
         };
 
+        // SEC-1.e: open the destination root as a sandboxed dirfd carrier.
+        // The carrier rides through every per-entry operation so the
+        // SEC-1.f-j cutover sites can replace path-based syscalls with
+        // their `*at` siblings without re-walking the path through the
+        // kernel. This PR only threads the carrier; no syscalls are
+        // migrated, so a failed open is non-fatal (a brand-new
+        // destination root may not exist yet, and the existing
+        // path-based fall-backs cover that case today).
+        #[cfg(unix)]
+        let sandbox = open_sandbox_for_dest(&dest_dir);
+
         Ok((
             reader,
             file_count,
@@ -160,8 +171,37 @@ impl ReceiverContext {
                 checksum_length,
                 checksum_algorithm,
                 acl_cache,
+                #[cfg(unix)]
+                sandbox,
             },
         ))
+    }
+}
+
+/// Open the destination root as a [`fast_io::DirSandbox`] carrier.
+///
+/// Returns `Some(Arc<DirSandbox>)` when the path exists and resolves to
+/// a non-symlink directory the receiver can open. Returns `None` for any
+/// other outcome (path does not exist yet, path is a symlink, EACCES,
+/// etc.) so the receiver can keep running on the existing path-based
+/// fall-backs while the SEC-1.f-j cutover lands site by site.
+///
+/// Failures are logged at `Debug` level only; they are expected on
+/// first-run transfers where the destination is created later in
+/// `ensure_relative_parents` / `create_directories`.
+#[cfg(unix)]
+fn open_sandbox_for_dest(dest_dir: &std::path::Path) -> Option<Arc<fast_io::DirSandbox>> {
+    match fast_io::DirSandbox::open_root(dest_dir) {
+        Ok(sandbox) => Some(Arc::new(sandbox)),
+        Err(err) => {
+            logging::debug_log!(
+                Recv,
+                2,
+                "DirSandbox::open_root({}) failed: {err}; falling back to path-based syscalls",
+                dest_dir.display()
+            );
+            None
+        }
     }
 }
 

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -51,6 +51,8 @@ impl ReceiverContext {
             checksum_length,
             checksum_algorithm,
             acl_cache,
+            #[cfg(unix)]
+                sandbox: _sandbox,
         } = setup;
 
         let mut files_transferred = 0;

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -175,6 +175,16 @@ impl RequestConfig<'_> {
 pub struct ResponseContext<'a> {
     /// Protocol and checksum configuration shared with the request phase.
     pub config: &'a RequestConfig<'a>,
+    /// SEC-1.e parent-dirfd carrier rooted at the destination tree.
+    ///
+    /// Threaded through to the per-entry response processing so the
+    /// SEC-1.f-j cutover sites can resolve relative names against a
+    /// sandboxed dirfd via `*at` syscalls instead of re-walking paths
+    /// through the kernel. `None` when the receiver could not open the
+    /// destination root (e.g. it does not exist yet). This PR (SEC-1.e)
+    /// only wires the carrier; no syscalls are migrated yet.
+    #[cfg(unix)]
+    pub sandbox: Option<&'a fast_io::DirSandbox>,
 }
 
 /// Reads and validates the echoed NDX and sum_head from the sender response.

--- a/crates/transfer/tests/dir_sandbox_carrier.rs
+++ b/crates/transfer/tests/dir_sandbox_carrier.rs
@@ -1,0 +1,180 @@
+//! Integration test that exercises the SEC-1.e [`fast_io::DirSandbox`]
+//! carrier in the depth-first descent shape the receiver pipeline uses.
+//!
+//! This PR (SEC-1.e) only wires the carrier through to the receiver and
+//! does not migrate any syscalls; the existing path-based code paths
+//! remain the active code. The test therefore:
+//!
+//! 1. builds a realistic destination tree (root + nested subdirs +
+//!    files + symlink + a secondary-operand root),
+//! 2. opens a [`fast_io::DirSandbox`] at the destination root the same
+//!    way `ReceiverContext::setup_transfer` does,
+//! 3. walks the tree via `enter` / `exit`, verifying that
+//!    `current_dirfd` always tracks the depth-first cursor,
+//! 4. registers the operand root via `secondary` and confirms the
+//!    `Arc<OwnedFd>` is shared across lookups,
+//! 5. confirms the carrier refuses to descend through a symlink (the
+//!    SEC-1 confinement invariant) without disturbing the stack.
+//!
+//! No behaviour change in the receiver is asserted here - that is
+//! covered by the existing receiver integration tests in
+//! `crates/transfer/tests/` and by the parallel-receive-delta and
+//! incremental-flist test suites the workspace CI already runs. This
+//! test exists to prove the carrier shape SEC-1.f-j will consume is
+//! correct end-to-end against a real filesystem layout.
+
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::symlink;
+use std::sync::Arc;
+
+use fast_io::DirSandbox;
+use tempfile::tempdir;
+
+/// `tempdir()` paths may include a symlink prefix (macOS `/tmp ->
+/// /private/tmp`, some CI runners). [`DirSandbox::open_root`] refuses
+/// such paths under `RESOLVE_NO_SYMLINKS`, so canonicalise first.
+fn canonical_tempdir() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let canon = std::fs::canonicalize(dir.path()).expect("canonicalize");
+    (dir, canon)
+}
+
+#[test]
+fn receiver_shaped_descent_tracks_current_dirfd() {
+    let (_keep, root) = canonical_tempdir();
+
+    // Build a destination tree shaped like a typical receiver run:
+    //   root/
+    //     a/
+    //       b/
+    //         file.bin
+    //       sibling.txt
+    //     c/
+    std::fs::create_dir(root.join("a")).unwrap();
+    std::fs::create_dir(root.join("a/b")).unwrap();
+    std::fs::create_dir(root.join("c")).unwrap();
+    std::fs::write(root.join("a/b/file.bin"), b"payload").unwrap();
+    std::fs::write(root.join("a/sibling.txt"), b"x").unwrap();
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let root_raw = sandbox.current_dirfd().as_raw_fd();
+    assert_eq!(sandbox.depth(), 0);
+
+    // Descend into a/b, simulating the receiver walking a parent for a
+    // file entry. current_dirfd should hand back the b dirfd.
+    sandbox.enter(OsStr::new("a")).expect("enter a");
+    let a_raw = sandbox.current_dirfd().as_raw_fd();
+    sandbox.enter(OsStr::new("b")).expect("enter a/b");
+    let b_raw = sandbox.current_dirfd().as_raw_fd();
+
+    assert_ne!(a_raw, root_raw, "entering must hand out a fresh fd");
+    assert_ne!(b_raw, a_raw, "entering deeper must hand out a fresh fd");
+    assert_eq!(sandbox.depth(), 2);
+
+    // Pop back to a, then jump sideways into c. The carrier exposes a
+    // single descent cursor; cross-branch hops are an exit-to-parent
+    // followed by enter, which mirrors how the receiver's depth-first
+    // walker emits directory boundaries.
+    sandbox.exit();
+    assert_eq!(sandbox.current_dirfd().as_raw_fd(), a_raw);
+    sandbox.exit();
+    assert_eq!(sandbox.current_dirfd().as_raw_fd(), root_raw);
+
+    sandbox.enter(OsStr::new("c")).expect("enter c");
+    let c_raw = sandbox.current_dirfd().as_raw_fd();
+    // Note: the kernel is free to recycle the file-descriptor number
+    // that `exit()` just closed, so we can't assert `c_raw != a_raw`.
+    // What matters is that the new fd is a live, distinct kernel
+    // object - confirmed by the successful `enter` returning Ok and
+    // the depth tracking matching the expected push.
+    assert_ne!(c_raw, root_raw);
+    assert_eq!(sandbox.depth(), 1);
+
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+    assert_eq!(sandbox.current_dirfd().as_raw_fd(), root_raw);
+}
+
+#[test]
+fn descent_refuses_symlink_leaf_without_disturbing_stack() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("real")).unwrap();
+    // `link` is a symlink that resolves to `real`. Entering `link`
+    // must fail under the leaf `O_NOFOLLOW` invariant on every Unix
+    // target the carrier supports; on Linux 5.6+ the `openat2`
+    // upgrade adds `RESOLVE_NO_SYMLINKS` for the same refusal.
+    symlink(root.join("real"), root.join("link")).unwrap();
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let root_raw = sandbox.current_dirfd().as_raw_fd();
+    let depth_before = sandbox.depth();
+
+    let err = sandbox
+        .enter(OsStr::new("link"))
+        .expect_err("symlink leaf must be rejected");
+
+    // Accepted refusals across Unix variants:
+    // - Linux openat2 `RESOLVE_NO_SYMLINKS` -> ELOOP (raw 40).
+    // - Linux openat `O_NOFOLLOW | O_DIRECTORY` on a symlink leaf ->
+    //   ELOOP (raw 40).
+    // - macOS / BSD evaluate O_DIRECTORY before O_NOFOLLOW and report
+    //   ENOTDIR (raw 20) for symlink-to-directory.
+    let code = err.raw_os_error().expect("must carry an errno");
+    let accepted: &[i32] = &[
+        20, // ENOTDIR on macOS / BSD
+        40, // ELOOP on Linux
+        62, // ELOOP on macOS / BSD
+    ];
+    assert!(
+        accepted.contains(&code),
+        "expected ENOTDIR or ELOOP for symlink leaf, got errno={code} ({err})"
+    );
+
+    assert_eq!(sandbox.depth(), depth_before, "failed enter must not push");
+    assert_eq!(
+        sandbox.current_dirfd().as_raw_fd(),
+        root_raw,
+        "failed enter must not perturb the cursor"
+    );
+}
+
+#[test]
+fn secondary_operand_shares_handle_across_lookups() {
+    let (_keep_root, root) = canonical_tempdir();
+    let (_keep_op, operand) = canonical_tempdir();
+    std::fs::create_dir(operand.join("subdir")).unwrap();
+
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    assert_eq!(sandbox.secondary_count(), 0);
+
+    let fd1 = sandbox.secondary(&operand).expect("register");
+    let fd2 = sandbox.secondary(&operand).expect("re-lookup");
+    assert!(Arc::ptr_eq(&fd1, &fd2));
+    assert_eq!(sandbox.secondary_count(), 1);
+
+    // A different operand path produces a different cached handle.
+    let (_keep_op2, operand2) = canonical_tempdir();
+    let fd3 = sandbox.secondary(&operand2).expect("register second");
+    assert!(!Arc::ptr_eq(&fd1, &fd3));
+    assert_eq!(sandbox.secondary_count(), 2);
+}
+
+#[test]
+fn root_arc_outlives_borrowed_cursor() {
+    // The carrier hands callers an `Arc<OwnedFd>` for the root so a
+    // background disk-commit thread (the receiver's pipelined commit
+    // path) can hold an owner that survives the per-entry borrow
+    // lifetime. Confirm the Arc clone is a stable handle.
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    let arc = sandbox.root_arc();
+    let raw_via_arc = arc.as_raw_fd();
+    let raw_via_borrow = sandbox.root_dirfd().as_raw_fd();
+    assert_eq!(raw_via_arc, raw_via_borrow);
+    // Drop the Arc clone first; the borrowed cursor must keep working.
+    drop(arc);
+    assert!(sandbox.current_dirfd().as_raw_fd() >= 0);
+}


### PR DESCRIPTION
## Summary

Adds the parent-dirfd carrier that the SEC-1.f-j cutover sites consume
to replace path-based syscalls with their `*at` siblings. Implements
the hybrid in-tree dirfd stack plus `DashMap<PathBuf, Arc<OwnedFd>>`
side-cache shape picked in `docs/design/sec-1-b-dirfd-carrier.md`.

- `crates/fast_io/src/dir_sandbox/` - new `DirSandbox` type (Unix
  only). Holds an in-tree dirfd stack for the linear depth-first
  descent (`enter` / `exit` / `current_dirfd`) and a `DashMap` side
  cache for cross-directory operands (`--backup-dir`, `--temp-dir`,
  `--link-dest`, `--copy-dest`, `--compare-dest`) accessed via
  `secondary(path)`.
- Resolution policy: `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`
  on Linux 5.6+ (gated by `fast_io::linux_capabilities::openat2_supported()`),
  `openat(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` via `rustix`
  everywhere else. `RESOLVE_BENEATH` is correct because each `*at`
  open is anchored on a real dirfd, not `AT_FDCWD` (unlike the
  bootstrap `secure_open_dir`, where it had to be dropped per #4618).
- Threaded through `transfer::receiver::ReceiverContext`:
  `setup_transfer` opens a sandbox at the destination root, stores it
  on `PipelineSetup`, and forwards a borrow into `ResponseContext` so
  the per-entry response path sees the carrier today.

## What this does NOT do

**No syscalls are migrated in this PR.** The existing path-based code
paths remain the active code; the carrier is plumbed but currently
unused at every syscall site. The site-by-site migration is the work
of SEC-1.f-j (see breakdown in
`docs/design/sec-1-b-dirfd-carrier.md` Section 7).

## Prerequisites

- `secure_open_dir` helper (SEC-1.c) - landed via #4618.
- `openat2_supported()` probe helper (SEC-1.d) - landed via #4643;
  this PR's branch is built on top of that commit and assumes it
  reaches master first.

## Unblocks

- **SEC-1.f** - receiver in-tree leaf swaps under
  `crates/transfer/src/receiver/directory/`.
- **SEC-1.g** - engine in-tree leaf swaps under
  `crates/engine/src/local_copy/executor/` (10 sites in
  `file/guard.rs` alone).
- **SEC-1.h** - metadata-apply swaps in
  `crates/metadata/src/apply/`.
- **SEC-1.i** - cross-directory operations (`renameat` / `linkat`
  consuming the `secondary` cache).
- **SEC-1.j** - recursive `dirfd_remove_dir_all` + remaining edges.

Cross-references the 107-site inventory in
`docs/audits/sec-1-a-path-syscall-surface-2026-05-20.md`.

## Carrier shape

```rust
#[cfg(unix)]
pub struct DirSandbox {
    root: Arc<OwnedFd>,            // secure_open_dir at session start
    stack: Vec<DirFrame>,          // in-tree dirfd stack (DFS cursor)
    secondaries: DashMap<PathBuf, Arc<OwnedFd>>, // operand side cache
}

impl DirSandbox {
    pub fn open_root(root: &Path) -> io::Result<Self>;
    pub fn enter(&mut self, child_name: &OsStr) -> io::Result<()>;
    pub fn exit(&mut self);
    pub fn current_dirfd(&self) -> BorrowedFd<'_>;
    pub fn secondary(&self, path: &Path) -> io::Result<Arc<OwnedFd>>;
    // plus root_dirfd / root_arc / depth / secondary_count
}
```

The `BorrowedFd<'_>` accessor is `Copy + Send + Sync`, so rayon
worker closures capture the parent dirfd by value with zero
synchronisation cost - the pattern called out in
`docs/design/sec-1-b-dirfd-carrier.md` Section 5.

## Constraints satisfied

- Unix-only behind `#[cfg(unix)]`; Windows continues to use
  handle-based NTFS APIs (SEC-1.l audit).
- No new dependencies - reuses the existing workspace `dashmap` and
  `rustix`; only `fast_io`'s `Cargo.toml` gains a `dashmap` line.
- No `#[allow(...)]` waivers; all `#[allow(unsafe_code)]` blocks are
  inside `fast_io` per workspace policy and carry a documented
  SAFETY argument.
- Public API of `ReceiverContext` / `ParallelDeltaApplier` is
  unchanged. `ResponseContext` gains one Unix-only optional field
  (`sandbox: Option<&fast_io::DirSandbox>`) populated internally; no
  external caller touches the struct.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p fast_io --features io_uring -E 'test(dir_sandbox)'` -
      11/11 unit tests pass.
- [x] `cargo nextest run -p engine --features parallel-receive-delta` -
      4379/4379 pass (no regression).
- [x] `cargo nextest run -p transfer --features incremental-flist` -
      1611/1613 pass; the 2 failures (`files_from::relative_absolute_source_preserves_full_prefix`
      and `empty_file_checksum_verification_sha1`) reproduce on the
      base branch without this PR's changes and are unrelated.
- [x] `cargo nextest run -p transfer -E 'binary(dir_sandbox_carrier)'` -
      4/4 integration tests pass.