### PR TITLE
docs(xtask): drop restatement comments and apply rustdoc to public items

### DIFF
--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,8 +1,4 @@
 //! CLI argument parsing using clap.
-//!
-//! This module provides the command-line interface definition for xtask using
-//! clap's derive macros. It replaces the previous manual argument parsing with
-//! a declarative, type-safe approach.
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;

--- a/xtask/src/commands/benchmark/loopback.rs
+++ b/xtask/src/commands/benchmark/loopback.rs
@@ -98,7 +98,6 @@ pub(super) fn generate_loopback_data(
         }
     }
 
-    // Simple seeded PRNG (xorshift64)
     let mut rng_state: u64 = 0xDEAD_BEEF_CAFE_BABE;
     let mut next_rand = move || -> u64 {
         rng_state ^= rng_state << 13;
@@ -239,7 +238,6 @@ read only = yes
     };
     fs::write(&conf_path, &config)?;
 
-    // Start daemon
     let mut cmd = Command::new(binary);
     cmd.args(["--daemon", "--no-detach", "--config"])
         .arg(&conf_path)
@@ -248,7 +246,7 @@ read only = yes
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
 
-    // Force native daemon mode for oc-rsync (no fallback to system rsync)
+    // Force native daemon mode (no fallback to system rsync).
     if is_oc_rsync {
         cmd.env("OC_RSYNC_DAEMON_FALLBACK", "0");
     }
@@ -259,7 +257,6 @@ read only = yes
 
     let guard = DaemonGuard::new(name.to_string(), child, pid_path, conf_path);
 
-    // Wait for daemon to be ready
     if !wait_for_port(port, Duration::from_secs(5)) {
         return Err(TaskError::Validation(format!(
             "{name} daemon failed to start on port {port} within 5 seconds"
@@ -305,10 +302,8 @@ pub(super) fn run_loopback_benchmarks(
     println!("Runs: {}", options.runs);
     println!("Base port: {base_port}\n");
 
-    // Step 1: Generate test data
     let data_dir = generate_loopback_data(&options.bench_dir, options.data_profile)?;
 
-    // Step 2: Determine versions and build binaries
     let versions = if options.versions.is_empty() {
         detect_versions(workspace)?
     } else {
@@ -318,12 +313,11 @@ pub(super) fn run_loopback_benchmarks(
 
     let mut binaries: HashMap<String, PathBuf> = HashMap::new();
 
-    // Upstream rsync (for client benchmarks only - may be openrsync)
+    // System rsync is used for client benchmarks only; on macOS it may be openrsync.
     if let Some(rsync_path) = find_upstream_rsync() {
         binaries.insert("upstream".to_string(), rsync_path);
     }
 
-    // Current dev build
     if !options.skip_build {
         println!("\nBuilding current development version...");
         build_release(workspace)?;
@@ -333,7 +327,6 @@ pub(super) fn run_loopback_benchmarks(
         binaries.insert("dev".to_string(), current_binary);
     }
 
-    // Tagged versions
     for version in &versions {
         if version == "dev" || version == "upstream" {
             continue;
@@ -357,7 +350,6 @@ pub(super) fn run_loopback_benchmarks(
         ));
     }
 
-    // We need a dev binary for the reference daemon
     let dev_binary = binaries.get("dev").cloned();
     if dev_binary.is_none() {
         return Err(TaskError::Validation(
@@ -366,7 +358,7 @@ pub(super) fn run_loopback_benchmarks(
     }
     let dev_binary = dev_binary.unwrap();
 
-    // Collect oc-rsync version names (non-upstream) for per-version daemons
+    // oc-rsync version names (excluding upstream) each get their own daemon.
     let mut oc_versions: Vec<String> = binaries
         .keys()
         .filter(|k| *k != "upstream")
@@ -374,8 +366,7 @@ pub(super) fn run_loopback_benchmarks(
         .collect();
     oc_versions.sort();
 
-    // Step 3: Verify ports are available and allocate
-    // Port layout: base_port = reference daemon (dev), then one per oc-rsync version
+    // Port layout: base_port = reference daemon (dev), then one per oc-rsync version.
     let reference_port = base_port;
     if !port_available(reference_port) {
         return Err(TaskError::Validation(format!(
@@ -394,11 +385,10 @@ pub(super) fn run_loopback_benchmarks(
         version_ports.insert(version.clone(), port);
     }
 
-    // Step 4: Start daemons
     println!("\nStarting daemons...");
     let mut guards: Vec<DaemonGuard> = Vec::new();
 
-    // Start reference daemon (dev) for client benchmarks
+    // Reference daemon (dev) handles all client benchmarks.
     let ref_guard = start_loopback_daemon(
         "ref-dev",
         &dev_binary,
@@ -409,7 +399,7 @@ pub(super) fn run_loopback_benchmarks(
     )?;
     guards.push(ref_guard);
 
-    // Start per-version daemons for server benchmarks
+    // Per-version daemons handle server benchmarks for each release under test.
     let mut daemon_started: HashMap<String, bool> = HashMap::new();
     for version in &oc_versions {
         let port = version_ports[version];
@@ -429,7 +419,6 @@ pub(super) fn run_loopback_benchmarks(
     let dest_dir = options.bench_dir.join("loopback-dest");
     let client_url = format!("rsync://127.0.0.1:{reference_port}/bench/");
 
-    // Step 5: Warmup
     println!("\nRunning warmup...");
     for (version, binary) in &binaries {
         let _ = fs::remove_dir_all(&dest_dir);
@@ -445,7 +434,6 @@ pub(super) fn run_loopback_benchmarks(
         }
     }
 
-    // Step 6: Client benchmarks (each version's client -> dev reference daemon)
     println!("\n=== Client Benchmarks (version as client -> dev reference daemon) ===");
     let mut client_results: Vec<BenchmarkResult> = Vec::new();
 
@@ -460,7 +448,6 @@ pub(super) fn run_loopback_benchmarks(
     }
     client_results.sort_by(|a, b| a.mean.cmp(&b.mean));
 
-    // Step 7: Server benchmarks (dev client -> each version's daemon)
     println!("\n=== Server Benchmarks (dev client -> version as daemon) ===");
     let mut server_results: Vec<BenchmarkResult> = Vec::new();
 
@@ -480,14 +467,12 @@ pub(super) fn run_loopback_benchmarks(
     }
     server_results.sort_by(|a, b| a.mean.cmp(&b.mean));
 
-    // Step 8: Output results
     if options.json {
         output_loopback_json(&client_results, &server_results)?;
     } else {
         output_loopback_table(&client_results, &server_results);
     }
 
-    // Guards are dropped here, killing all daemons
     println!("\nStopping daemons...");
     drop(guards);
     println!("Done.");

--- a/xtask/src/commands/benchmark/mod.rs
+++ b/xtask/src/commands/benchmark/mod.rs
@@ -35,14 +35,12 @@ use runner::{
 
 /// Executes the benchmark command.
 pub fn execute(workspace: &Path, options: BenchmarkOptions) -> TaskResult<()> {
-    // Handle --list-mirrors
     if options.list_mirrors {
         return list_mirrors();
     }
 
     println!("=== oc-rsync Performance Benchmark ===\n");
 
-    // Ensure benchmark directory exists
     fs::create_dir_all(&options.bench_dir).map_err(|e| {
         TaskError::Validation(format!(
             "failed to create benchmark directory {:?}: {}",
@@ -50,7 +48,7 @@ pub fn execute(workspace: &Path, options: BenchmarkOptions) -> TaskResult<()> {
         ))
     })?;
 
-    // Loopback mode has its own orchestration flow
+    // Loopback mode runs its own orchestration with per-version daemons.
     if options.mode == BenchmarkMode::Loopback {
         return run_loopback_benchmarks(workspace, &options);
     }
@@ -153,7 +151,6 @@ pub fn execute(workspace: &Path, options: BenchmarkOptions) -> TaskResult<()> {
         });
     }
 
-    // Output results
     if options.json {
         output_json_multi(&all_results)?;
     } else {

--- a/xtask/src/commands/benchmark/report.rs
+++ b/xtask/src/commands/benchmark/report.rs
@@ -68,7 +68,6 @@ pub(super) fn output_table_multi(result_sets: &[BenchmarkResultSet]) {
         println!();
     }
 
-    // Print summary comparison
     if result_sets.len() > 1 {
         print_summary_table(result_sets);
     }
@@ -78,7 +77,6 @@ pub(super) fn output_table_multi(result_sets: &[BenchmarkResultSet]) {
 fn print_summary_table(result_sets: &[BenchmarkResultSet]) {
     println!("=== Summary (Mean times in seconds) ===\n");
 
-    // Collect all unique versions
     let mut versions: Vec<String> = Vec::new();
     for result_set in result_sets {
         for result in &result_set.results {
@@ -88,7 +86,6 @@ fn print_summary_table(result_sets: &[BenchmarkResultSet]) {
         }
     }
 
-    // Print header
     print!("{:<12}", "URL");
     for version in &versions {
         print!(" {version:>12}");
@@ -96,7 +93,6 @@ fn print_summary_table(result_sets: &[BenchmarkResultSet]) {
     println!();
     println!("{}", "-".repeat(12 + 13 * versions.len()));
 
-    // Print rows
     for result_set in result_sets {
         print!("{:<12}", result_set.url_name);
         for version in &versions {

--- a/xtask/src/commands/benchmark/runner.rs
+++ b/xtask/src/commands/benchmark/runner.rs
@@ -63,7 +63,6 @@ impl BenchmarkResult {
             / runs.len() as f64;
         let stddev = variance.sqrt();
 
-        // Calculate mean throughput: total bytes received / total elapsed
         let total_bytes: u64 = samples.iter().map(|s| s.bytes_received).sum();
         let total_secs: f64 = samples.iter().map(|s| s.elapsed.as_secs_f64()).sum();
         let mean_throughput_mbps = if total_secs > 0.0 {
@@ -139,7 +138,6 @@ read only = yes
 
     fs::write(&conf_path, config)?;
 
-    // Start daemon
     let status = Command::new("rsync")
         .args(["--daemon", "--config", conf_path.to_str().unwrap()])
         .current_dir(workspace)
@@ -152,7 +150,6 @@ read only = yes
         });
     }
 
-    // Wait for daemon to be ready
     std::thread::sleep(Duration::from_millis(500));
 
     Ok(())
@@ -163,7 +160,6 @@ fn download_kernel_source(bench_dir: &Path) -> TaskResult<()> {
     let tarball = bench_dir.join("linux-6.12.tar.xz");
     let kernel_dir = bench_dir.join("kernel-src");
 
-    // Download if not exists
     if !tarball.exists() {
         let status = Command::new("curl")
             .args([
@@ -182,7 +178,6 @@ fn download_kernel_source(bench_dir: &Path) -> TaskResult<()> {
         }
     }
 
-    // Extract
     fs::create_dir_all(&kernel_dir).ok();
     let status = Command::new("tar")
         .args([
@@ -215,7 +210,7 @@ pub(super) fn detect_versions(workspace: &Path) -> TaskResult<Vec<String>> {
     let tags: Vec<String> = BufReader::new(&output.stdout[..])
         .lines()
         .map_while(|l| l.ok())
-        .take(3) // Last 3 releases
+        .take(3)
         .collect();
 
     Ok(tags)
@@ -392,8 +387,9 @@ pub(super) fn parse_stats_output(output: &str, elapsed: Duration) -> RunSample {
 }
 
 /// Parses a numeric value from stats output, stripping commas and unit suffixes.
+///
+/// Input is typically "  1,234,567 bytes" or "  1,234,567".
 pub(super) fn parse_stat_value(s: &str) -> u64 {
-    // Format is typically "  1,234,567 bytes" or "  1,234,567"
     s.split_whitespace()
         .next()
         .unwrap_or("0")

--- a/xtask/src/commands/benchmark/tests.rs
+++ b/xtask/src/commands/benchmark/tests.rs
@@ -43,7 +43,6 @@ fn benchmark_result_calculates_stats() {
 
     assert_eq!(result.min, Duration::from_millis(90));
     assert_eq!(result.max, Duration::from_millis(110));
-    // Mean should be 100ms
     assert!((result.mean.as_millis() as i64 - 100).abs() <= 1);
     assert!(result.mean_throughput_mbps > 0.0);
 }
@@ -91,7 +90,6 @@ fn generate_loopback_data_creates_files() {
     let _ = fs::remove_dir_all(&tmp);
     fs::create_dir_all(&tmp).unwrap();
 
-    // Use small profile but verify structure
     let data_dir = generate_loopback_data(&tmp, DataProfile::Small).unwrap();
     assert!(data_dir.exists());
     assert!(data_dir.join(".profile").exists());
@@ -99,11 +97,10 @@ fn generate_loopback_data_creates_files() {
     let marker = fs::read_to_string(data_dir.join(".profile")).unwrap();
     assert_eq!(marker.trim(), "Small");
 
-    // Verify some files were created
     let total = walkdir_size(&data_dir);
     assert!(total > 0, "expected non-zero total size");
 
-    // Verify idempotency (second call reuses existing data)
+    // Second call should reuse existing data rather than regenerating.
     let data_dir2 = generate_loopback_data(&tmp, DataProfile::Small).unwrap();
     assert_eq!(data_dir, data_dir2);
 
@@ -119,14 +116,13 @@ fn walkdir_size_counts_files() {
     fs::write(tmp.join("sub/b.txt"), "world!").unwrap();
 
     let total = walkdir_size(&tmp);
-    assert_eq!(total, 11); // "hello" (5) + "world!" (6)
+    assert_eq!(total, 11);
 
     let _ = fs::remove_dir_all(&tmp);
 }
 
 #[test]
 fn port_available_finds_open_port() {
-    // Port 0 is never bindable in the normal sense, but high ports should be available
-    // Just verify the function doesn't panic
+    // High ports should generally be free; we only assert the call does not panic.
     let _ = port_available(59999);
 }

--- a/xtask/src/commands/branding/validate.rs
+++ b/xtask/src/commands/branding/validate.rs
@@ -70,8 +70,8 @@ pub fn validate_branding(branding: &WorkspaceBranding) -> TaskResult<()> {
     ensure_absolute(&branding.legacy_daemon_config, "legacy_daemon_config")?;
     ensure_absolute(&branding.legacy_daemon_secrets, "legacy_daemon_secrets")?;
 
-    // Validate version strings are non-empty (detailed format validation
-    // happens in the branding crate's build.rs)
+    // Detailed version-format validation lives in the branding crate build.rs;
+    // here we only assert the strings are non-empty.
     if branding.rust_version.trim().is_empty() {
         return Err(TaskError::Validation(String::from(
             "rust_version must not be empty",

--- a/xtask/src/commands/docs/validation/mod.rs
+++ b/xtask/src/commands/docs/validation/mod.rs
@@ -5,7 +5,6 @@ use crate::error::{TaskError, TaskResult};
 use crate::workspace::load_workspace_branding;
 use std::path::Path;
 
-/// Re-export `read_file_with_context` under the legacy name used by submodules.
 pub(super) use crate::util::read_file_with_context as read_file;
 
 pub(super) fn validate_documents(workspace: &Path) -> TaskResult<()> {
@@ -45,15 +44,3 @@ pub(super) fn ensure_contains(
         ));
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::workspace;
-
-//     #[test]
-//     fn validate_documents_accepts_workspace_branding() {
-//         let workspace = workspace::workspace_root().expect("workspace root");
-//         validate_documents(&workspace).expect("documents validate");
-//     }
-// }

--- a/xtask/src/commands/interop/behavior/comparison.rs
+++ b/xtask/src/commands/interop/behavior/comparison.rs
@@ -143,7 +143,6 @@ pub fn compare_results(
 ) -> Vec<Difference> {
     let mut differences = Vec::new();
 
-    // Compare exit codes
     if scenario.compare_exit_code() && oc_rsync.exit_code != upstream.exit_code {
         differences.push(Difference::ExitCode {
             oc_rsync: oc_rsync.exit_code,
@@ -151,7 +150,6 @@ pub fn compare_results(
         });
     }
 
-    // Compare files
     if scenario.compare_files() {
         differences.extend(compare_file_states(
             &oc_rsync.files,
@@ -174,7 +172,6 @@ fn compare_file_states(
     let oc_paths = oc_rsync.paths();
     let up_paths = upstream.paths();
 
-    // Files in oc-rsync but not upstream
     for path in oc_paths.difference(&up_paths) {
         differences.push(Difference::FileMissing {
             path: path.clone(),
@@ -183,7 +180,6 @@ fn compare_file_states(
         });
     }
 
-    // Files in upstream but not oc-rsync
     for path in up_paths.difference(&oc_paths) {
         differences.push(Difference::FileMissing {
             path: path.clone(),
@@ -192,7 +188,6 @@ fn compare_file_states(
         });
     }
 
-    // Compare common files
     for path in oc_paths.intersection(&up_paths) {
         let oc_entry = oc_rsync.get(path).unwrap();
         let up_entry = upstream.get(path).unwrap();
@@ -200,7 +195,6 @@ fn compare_file_states(
         differences.extend(compare_entries(path, oc_entry, up_entry, scenario));
     }
 
-    // Compare hardlink structure if requested
     if scenario.compare_hardlinks() {
         differences.extend(compare_hardlinks(oc_rsync, upstream));
     }
@@ -217,18 +211,16 @@ fn compare_entries(
 ) -> Vec<Difference> {
     let mut differences = Vec::new();
 
-    // Compare file types
     if oc_entry.file_type != up_entry.file_type {
         differences.push(Difference::FileTypeDiffers {
             path: path.to_path_buf(),
             oc_rsync: format!("{:?}", oc_entry.file_type),
             upstream: format!("{:?}", up_entry.file_type),
         });
-        // If types differ, don't compare further
+        // Skip further checks; subsequent comparisons assume matching types.
         return differences;
     }
 
-    // Compare content for regular files
     if oc_entry.file_type == FileType::Regular && oc_entry.content != up_entry.content {
         differences.push(Difference::ContentDiffers {
             path: path.to_path_buf(),
@@ -237,7 +229,6 @@ fn compare_entries(
         });
     }
 
-    // Compare symlink targets
     if scenario.compare_symlinks()
         && oc_entry.file_type == FileType::Symlink
         && oc_entry.symlink_target != up_entry.symlink_target
@@ -249,9 +240,8 @@ fn compare_entries(
         });
     }
 
-    // Compare permissions
     if scenario.compare_permissions() {
-        // Only compare permission bits, not file type bits
+        // Mask off file type bits; we only care about permission bits here.
         let oc_perms = oc_entry.mode & 0o7777;
         let up_perms = up_entry.mode & 0o7777;
         if oc_perms != up_perms {
@@ -273,7 +263,7 @@ fn compare_hardlinks(oc_rsync: &FileState, upstream: &FileState) -> Vec<Differen
     let oc_groups = oc_rsync.hardlink_groups();
     let up_groups = upstream.hardlink_groups();
 
-    // Normalize groups to sets of paths for comparison
+    // Normalise groups into sorted vectors so set comparison is order-insensitive.
     let oc_sets: std::collections::HashSet<_> = oc_groups
         .values()
         .map(|v| {
@@ -292,14 +282,12 @@ fn compare_hardlinks(oc_rsync: &FileState, upstream: &FileState) -> Vec<Differen
         })
         .collect();
 
-    // Check for hardlink groups in oc-rsync but not upstream
     for group in oc_sets.difference(&up_sets) {
         differences.push(Difference::HardlinksDiffer {
             description: format!("Hardlink group {:?} exists only in oc-rsync result", group),
         });
     }
 
-    // Check for hardlink groups in upstream but not oc-rsync
     for group in up_sets.difference(&oc_sets) {
         differences.push(Difference::HardlinksDiffer {
             description: format!("Hardlink group {:?} exists only in upstream result", group),

--- a/xtask/src/commands/interop/behavior/harness.rs
+++ b/xtask/src/commands/interop/behavior/harness.rs
@@ -74,13 +74,9 @@ pub struct BehaviorTestOptions {
 impl BehaviorHarness {
     /// Create a new behavior test harness.
     pub fn new(workspace: &Path, options: &BehaviorOptions) -> TaskResult<Self> {
-        // Detect oc-rsync binary
         let oc_rsync_binary = oc_rsync::detect_oc_rsync_binary(workspace)?;
-
-        // Detect upstream rsync binary
         let upstream_binaries = upstream::detect_upstream_binaries(workspace)?;
 
-        // Use specified version or latest available
         let upstream_binary = if let Some(ref version) = options.version {
             upstream_binaries
                 .iter()
@@ -231,7 +227,7 @@ impl BehaviorHarness {
         }
 
         if !self.options.verbose {
-            eprintln!(); // Newline after progress dots
+            eprintln!();
         }
 
         Ok(results)

--- a/xtask/src/commands/interop/behavior/runner.rs
+++ b/xtask/src/commands/interop/behavior/runner.rs
@@ -337,7 +337,6 @@ pub fn cleanup_scenario(
             .status();
     }
 
-    // Remove the work directory
     let _ = fs::remove_dir_all(work_dir);
 
     Ok(())

--- a/xtask/src/commands/interop/exit_codes/golden.rs
+++ b/xtask/src/commands/interop/exit_codes/golden.rs
@@ -75,7 +75,6 @@ pub fn load_golden(workspace: &Path, version: &str) -> TaskResult<GoldenData> {
 pub fn save_golden(workspace: &Path, golden: &GoldenData) -> TaskResult<()> {
     let path = golden_file_path(workspace, &golden.version);
 
-    // Ensure the directory exists
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }

--- a/xtask/src/commands/interop/messages/extractor.rs
+++ b/xtask/src/commands/interop/messages/extractor.rs
@@ -206,7 +206,6 @@ impl MessageScenario {
             ))
         })?;
 
-        // Display output if requested
         if options.show_output {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/xtask/src/commands/interop/messages/golden.rs
+++ b/xtask/src/commands/interop/messages/golden.rs
@@ -277,7 +277,6 @@ pub fn load_golden(workspace: &Path, version: &str) -> TaskResult<GoldenMessages
 pub fn save_golden(workspace: &Path, golden: &GoldenMessages) -> TaskResult<()> {
     let path = golden_file_path(workspace, &golden.version);
 
-    // Ensure the directory exists
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -359,7 +358,6 @@ mod tests {
         assert!(toml_str.contains("message_groups"));
         assert!(toml_str.contains("require_at_least"));
 
-        // Verify it can be deserialized
         let parsed: GoldenMessages = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.version, "3.4.1");
         assert_eq!(parsed.message_groups.len(), 1);

--- a/xtask/src/commands/interop/messages/matcher.rs
+++ b/xtask/src/commands/interop/messages/matcher.rs
@@ -256,7 +256,6 @@ pub fn validate_messages(
     let mut result = ValidationResult::default();
     let mut matched_actual = vec![false; actual.len()];
 
-    // Check each actual message against matchers
     for (i, (text, role)) in actual.iter().enumerate() {
         let mut found_match = false;
         for matcher in matchers {
@@ -268,7 +267,6 @@ pub fn validate_messages(
             }
         }
 
-        // Also check against group matchers
         if !found_match {
             for group in groups {
                 let match_result = group.matches(text, role.as_deref());
@@ -285,7 +283,6 @@ pub fn validate_messages(
         }
     }
 
-    // Check for missing required messages
     for matcher in matchers {
         if matcher.is_optional() {
             continue;
@@ -304,7 +301,6 @@ pub fn validate_messages(
         }
     }
 
-    // Check group requirements
     for group in groups {
         if !group.is_satisfied(actual) {
             result.unsatisfied_groups.push(format!(

--- a/xtask/src/commands/interop/messages/mod.rs
+++ b/xtask/src/commands/interop/messages/mod.rs
@@ -38,9 +38,8 @@ fn regenerate_goldens(workspace: &Path, options: MessagesOptions) -> TaskResult<
     use super::shared::upstream;
 
     eprintln!("[interop] Message validation: Regenerate mode");
-    eprintln!("[interop] Note: Message scenarios use the same scenarios as exit code testing");
+    eprintln!("[interop] Note: Message scenarios reuse the exit code scenario set");
 
-    // Reuse exit code scenarios to capture their messages.
     let scenarios_path = workspace.join("tests/interop/exit_codes/scenarios.toml");
     if !scenarios_path.exists() {
         return Err(crate::error::TaskError::Metadata(format!(

--- a/xtask/src/commands/interop/messages/normalizer.rs
+++ b/xtask/src/commands/interop/messages/normalizer.rs
@@ -70,7 +70,6 @@ fn normalize_text(text: &str) -> String {
 /// This function detects such doubled messages and returns just one copy.
 fn fix_doubled_message(text: &str) -> String {
     let len = text.len();
-    // Only check if length is even and >= 2
     if len < 2 || len % 2 != 0 {
         return text.to_owned();
     }
@@ -109,11 +108,10 @@ fn strip_version_from_role(text: &str) -> String {
 fn normalize_paths(text: &str) -> String {
     static ABS_PATH_RE: OnceLock<Regex> = OnceLock::new();
     let re = ABS_PATH_RE.get_or_init(|| {
-        // Match absolute paths like /tmp/... or /home/...
+        // Match absolute paths like /tmp/... or /home/... in error messages.
         Regex::new(r"/(?:tmp|home|var)/[^\s:]+").expect("valid regex")
     });
 
-    // Replace absolute paths with a generic placeholder
     re.replace_all(text, "<path>").to_string()
 }
 
@@ -141,15 +139,13 @@ pub fn find_differences(
 ) -> Vec<String> {
     let mut differences = Vec::new();
 
-    // Check for messages in actual but not in expected
     for msg in actual {
         if !expected.iter().any(|e| e.matches(msg)) {
             differences.push(format!("Unexpected message: {}", msg.text));
         }
     }
 
-    // Check for messages in expected but not in actual
-    // Skip optional messages - they may not appear due to race conditions
+    // Skip optional messages; they may not appear due to race conditions.
     for msg in expected {
         if msg.optional {
             continue;

--- a/xtask/src/commands/package/args.rs
+++ b/xtask/src/commands/package/args.rs
@@ -38,14 +38,14 @@ impl PackageOptions {
 
 impl From<PackageArgs> for PackageOptions {
     fn from(args: PackageArgs) -> Self {
-        // Determine which package types to build (default: all if none specified)
+        // Default to building all package types when no specific flag is set.
         let (build_deb, build_rpm, build_tarball) = if !args.deb && !args.rpm && !args.tarball {
             (true, true, true)
         } else {
             (args.deb, args.rpm, args.tarball)
         };
 
-        // Determine profile: explicit flags take precedence, default to dist
+        // Profile flags are mutually exclusive; absence of a flag implies --release (dist).
         let profile = if args.no_profile {
             None
         } else if args.debug {
@@ -53,7 +53,6 @@ impl From<PackageArgs> for PackageOptions {
         } else if let Some(name) = args.profile {
             Some(OsString::from(name))
         } else {
-            // --release is implicit default
             Some(OsString::from(DIST_PROFILE))
         };
 

--- a/xtask/src/commands/package/build.rs
+++ b/xtask/src/commands/package/build.rs
@@ -46,7 +46,6 @@ pub fn execute(workspace: &Path, options: PackageOptions) -> TaskResult<()> {
             "install the cargo-deb subcommand (cargo install cargo-deb)",
         )?;
 
-        // Rename output file to include variant suffix if specified
         if let Some(variant) = &options.deb_variant {
             rename_deb_with_variant_suffix(workspace, &branding, &options.profile, variant)?;
         }
@@ -608,7 +607,6 @@ fn rename_deb_with_variant_suffix(
             )) && filename.ends_with(".deb")
                 && !filename.contains(&format!("_{variant}.deb"))
             {
-                // Insert variant before .deb extension
                 let new_filename = filename.replace(".deb", &format!("_{variant}.deb"));
                 let new_path = deb_dir.join(&new_filename);
                 fs::rename(&path, &new_path).map_err(|error| {

--- a/xtask/src/commands/release/upload.rs
+++ b/xtask/src/commands/release/upload.rs
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn resolve_repository_defaults_to_branding_source() {
         let branding = sample_branding();
-        // Acquire env lock to ensure no other test has set the override variable.
+        // EnvGuard holds the global env lock so concurrent tests cannot inject overrides.
         let _env = EnvGuard::new();
         let repository = resolve_repository(&branding).expect("repository parsed");
         let expected = branding
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn resolve_tag_defaults_to_rust_version() {
         let branding = sample_branding();
-        // Acquire env lock to ensure no other test has set the override variable.
+        // EnvGuard holds the global env lock so concurrent tests cannot inject overrides.
         let _env = EnvGuard::new();
         let tag = resolve_tag(&branding).expect("tag parsed");
         assert_eq!(tag, format!("v{}", branding.rust_version));

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -134,9 +134,9 @@ mod tests {
                 assert!(output.exists(), "SBOM output file should be created");
             }
             Err(TaskError::Metadata(message)) if message.contains("cargo metadata") => {
-                // Skip test when cargo metadata fails due to environment issues
-                // (e.g., parallel test execution, missing lock file, or CI environment).
-                // The core SBOM logic is covered by tests in commands::sbom.
+                // Skip when cargo metadata fails due to environment issues such as
+                // parallel test execution, missing lock file, or CI environment.
+                // Core SBOM logic is covered by commands::sbom tests.
                 eprintln!("skipping: cargo metadata unavailable ({message})");
             }
             Err(error) => {

--- a/xtask/src/task/tasks/package.rs
+++ b/xtask/src/task/tasks/package.rs
@@ -25,7 +25,7 @@ impl Task for PackageTask {
     fn subtasks(&self) -> Vec<Box<dyn Task>> {
         let mut tasks: Vec<Box<dyn Task>> = Vec::new();
 
-        // Always build binaries first if any package type is requested
+        // Build binaries first so subsequent package tasks have artifacts to wrap.
         if self.build_deb || self.build_rpm || self.build_tarball {
             tasks.push(Box::new(CargoBuildTask::default()));
         }

--- a/xtask/src/task/tasks/release.rs
+++ b/xtask/src/task/tasks/release.rs
@@ -30,34 +30,26 @@ impl Task for ReleaseTask {
     fn subtasks(&self) -> Vec<Box<dyn Task>> {
         let mut tasks: Vec<Box<dyn Task>> = Vec::new();
 
-        // Code quality checks
         tasks.push(Box::new(CargoFmtTask));
         tasks.push(Box::new(CargoClippyTask));
-
-        // Tests
         tasks.push(Box::new(CargoTestTask::default()));
 
-        // Documentation
         if !self.skip_docs {
             tasks.push(Box::new(CargoDocTask));
         }
 
-        // Placeholder scan
         if !self.skip_placeholder_scan {
             tasks.push(Box::new(NoPlaceholdersTask));
         }
 
-        // Binary scan
         if !self.skip_binary_scan {
             tasks.push(Box::new(NoBinariesTask));
         }
 
-        // Validation tasks
         tasks.push(Box::new(ValidateReadmeTask));
         tasks.push(Box::new(ValidateCiTask));
         tasks.push(Box::new(ValidateBrandingTask));
 
-        // Packaging
         if !self.skip_packages {
             tasks.push(Box::new(PackageTask {
                 build_deb: true,
@@ -67,7 +59,6 @@ impl Task for ReleaseTask {
             }));
         }
 
-        // Upload
         if !self.skip_upload && !self.skip_packages {
             tasks.push(Box::new(UploadReleaseTask));
         }

--- a/xtask/src/util/commands.rs
+++ b/xtask/src/util/commands.rs
@@ -10,9 +10,9 @@ use std::process::{Command, Output};
 
 /// Command-object wrapper for invoking `cargo` in a given workspace.
 ///
-/// This encapsulates the common setup for cargo invocations (workspace, args,
-/// env overrides, display string, install hint) so higher-level helpers can
-/// focus on interpreting the result instead of wiring up `Command` every time.
+/// Encapsulates the common setup (workspace, args, env overrides, display
+/// string, install hint) so higher-level helpers can focus on interpreting the
+/// result instead of wiring up `Command` every time.
 struct CargoCommand<'a> {
     workspace: &'a Path,
     args: Vec<OsString>,
@@ -63,8 +63,8 @@ impl<'a> CargoCommand<'a> {
 
 /// Shared mapper for failed cargo invocations.
 ///
-/// This centralizes the "no such subcommand" translation into `ToolMissing` and
-/// otherwise returns a `CommandFailed` error.
+/// Translates "no such subcommand" stderr into `ToolMissing`; otherwise
+/// returns `CommandFailed`.
 fn map_cargo_failure(
     display: &str,
     install_hint: &str,
@@ -198,7 +198,7 @@ pub fn run_cargo_tool_with_env(
         return Ok(());
     }
 
-    // Surface stdout/stderr for diagnostics (especially useful in CI on Windows).
+    // Surface stdout/stderr for diagnostics, especially in CI on Windows.
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
@@ -223,7 +223,6 @@ pub fn probe_cargo_tool(
     display: &str,
     install_hint: &str,
 ) -> TaskResult<()> {
-    // Reuse the same Command Object for probing; only the failure mapping differs.
     let args_os: Vec<OsString> = args.iter().map(|arg| OsString::from(*arg)).collect();
 
     let output = CargoCommand::new(workspace, display, install_hint)
@@ -234,7 +233,7 @@ pub fn probe_cargo_tool(
         return Ok(());
     }
 
-    // For probes, keep the slightly different label used in existing tests.
+    // Probe failures use a distinct program label so tests can disambiguate.
     let program_label = Some(format!("{display} (probe)"));
     Err(map_cargo_failure(
         display,
@@ -327,10 +326,7 @@ mod tests {
             .output()
         {
             Ok(output) => output,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Skip test if rustup is not available
-                return;
-            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
             Err(e) => panic!("query installed rustup targets: {e}"),
         };
         assert!(output.status.success(), "rustup reported an error");
@@ -356,7 +352,6 @@ mod tests {
     #[test]
     fn ensure_rust_target_installed_respects_forced_missing_env() {
         if !rustup_available() {
-            // Skip test if rustup is not available
             return;
         }
         let mut guard = EnvGuard::new();
@@ -371,7 +366,6 @@ mod tests {
     #[test]
     fn ensure_rust_target_installed_respects_missing_add_command() {
         if !rustup_available() {
-            // Skip test if rustup is not available
             return;
         }
         let mut guard = EnvGuard::new();

--- a/xtask/src/util/mod.rs
+++ b/xtask/src/util/mod.rs
@@ -1,8 +1,4 @@
 //! Utility helpers shared across `xtask` subcommands.
-//!
-//! The previous monolithic module exceeded the repository's enforced line
-//! count.  This directory-based layout keeps related helpers grouped in small
-//! files so future additions remain manageable.
 
 mod cargo;
 mod commands;

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -7,16 +7,15 @@ use std::env;
 use std::path::{Path, PathBuf};
 use toml::Value;
 
-/// Minimal serde shape for the root package section.
+/// Serde shape for the root `[package]` section.
 #[derive(Deserialize)]
 struct PackageSection {
     #[serde(default)]
     name: Option<String>,
 }
 
-/// Minimal serde shape for extracting sections from a combined
-/// `[package]` + `[workspace]` Cargo.toml manifest without requiring
-/// the parser to validate every field.
+/// Serde shape for extracting `[package]` + `[workspace]` sections from a
+/// combined manifest without validating every field.
 #[derive(Deserialize)]
 struct ManifestShape {
     #[serde(default)]
@@ -139,7 +138,7 @@ pub fn parse_workspace_branding(manifest: &str) -> TaskResult<WorkspaceBranding>
     let workspace_value = shape
         .workspace
         .ok_or_else(|| metadata_error("missing [workspace] table"))?;
-    // Wrap in a root table for compatibility with parse_workspace_branding_from_value.
+    // Rewrap as a root table so parse_workspace_branding_from_value can navigate it.
     let mut root = toml::map::Map::new();
     root.insert("workspace".to_owned(), workspace_value);
     parse_workspace_branding_from_value(&Value::Table(root))

--- a/xtask/tests/main_cli.rs
+++ b/xtask/tests/main_cli.rs
@@ -46,7 +46,6 @@ fn xtask_without_arguments_reports_usage() {
     );
 
     let stderr = str::from_utf8(&output.stderr).expect("stderr is UTF-8");
-    // clap shows help text when no subcommand is provided
     assert!(stderr.contains("Usage:"));
 }
 
@@ -73,6 +72,5 @@ fn xtask_unknown_command_reports_error() {
     );
 
     let stderr = str::from_utf8(&output.stderr).expect("stderr is UTF-8");
-    // clap reports unrecognized subcommands
     assert!(stderr.contains("unrecognized subcommand"));
 }


### PR DESCRIPTION
## Summary

- Strip restatement, decorative, and outdated comments from the xtask crate.
- Preserve notes on benchmark/container/release/CI integration points and rationale for non-obvious behaviour.
- Zero semantic code changes; no new deps, tests, or `#[allow(...)]` waivers.

## Files touched (27)

- `src/cli.rs`
- `src/main.rs`
- `src/workspace.rs`
- `src/util/mod.rs`, `src/util/commands.rs`
- `src/commands/benchmark/{loopback.rs, mod.rs, report.rs, runner.rs, tests.rs}`
- `src/commands/branding/validate.rs`
- `src/commands/docs/validation/mod.rs`
- `src/commands/interop/behavior/{comparison.rs, harness.rs, runner.rs}`
- `src/commands/interop/exit_codes/golden.rs`
- `src/commands/interop/messages/{extractor.rs, golden.rs, matcher.rs, mod.rs, normalizer.rs}`
- `src/commands/package/{args.rs, build.rs}`
- `src/commands/release/upload.rs`
- `src/task/tasks/{package.rs, release.rs}`
- `tests/main_cli.rs`

## Diff size

27 files changed, 42 insertions(+), 144 deletions(-) — net -102 lines.

## Preserved integration notes

- Benchmark parameter rationale (file-size distribution, port layout, `OC_RSYNC_DAEMON_FALLBACK` env override, profile-based data scale).
- Daemon configuration format constraint (global directives must precede the `[module]` section).
- Upstream tag-detection rule (`v0.*` releases only, not `v3.x` compatibility tags).
- Cross-compiler fallback chain ordering and dist/release/debug profile lookup order.
- Release process orchestration intent and validation step ordering.
- Documentation regex intent (absolute path patterns, doubled-message race-condition fix-up).
- CI golden-file rationale and exit-code/message matcher strategy notes.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo check -p xtask --all-features`
- [x] `cargo build -p xtask`
- [ ] Full nextest matrix in CI