### PR TITLE
feat(match): zsync-inspired hash-chain pruning via consumed-bitset (ZSO-3)

### DIFF
--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -175,6 +175,14 @@ impl DeltaGenerator {
         let prune_matched = self.prune_matched;
         #[cfg(not(any(test, feature = "bench-internal")))]
         let prune_matched = true;
+        // ZSO-3: the shared consumed-bitset on `index` survives across
+        // generator sessions when callers reuse the same index. Reset
+        // it now so each `generate()` call starts with a fresh prune
+        // state. Concurrent generators sharing the same index continue
+        // to coordinate through `mark_consumed` after this reset.
+        if prune_matched {
+            index.reset_consumed();
+        }
 
         let mut buffer = vec![0u8; self.buffer_len.max(block_len)];
         let mut buffer_pos = 0usize;
@@ -336,6 +344,15 @@ impl DeltaGenerator {
                     // later probe at a different source offset will not pick
                     // this basis index again.
                     matched_blocks.mark_matched(match_idx);
+                    // ZSO-3 hash-chain prune on the shared index. Mirrors
+                    // the per-session `matched_blocks.mark_matched` above
+                    // but uses interior mutability so the same effect
+                    // applies when the index is shared read-only across
+                    // concurrent generators
+                    // (`crates/engine/src/concurrent_delta/`).
+                    if prune_matched {
+                        index.mark_consumed(match_idx as u32);
+                    }
 
                     let last_matched = match_idx;
                     // upstream/zsync: `librcksum/rsum.c:262` advances the

--- a/crates/matching/src/index/builder.rs
+++ b/crates/matching/src/index/builder.rs
@@ -8,7 +8,10 @@ use signature::{FileSignature, SignatureAlgorithm, SignatureBlock};
 
 use super::compact_lookup::CompactLookup;
 use super::trace::{HashtableRole, trace_created, trace_growing};
-use super::{BitHash, DeltaSignatureIndex, NEXT_MATCH_NONE, TAG_TABLE_SIZE};
+use super::{
+    BitHash, CONSUMED_BITS_PER_WORD, DeltaSignatureIndex, NEXT_MATCH_NONE, TAG_TABLE_SIZE,
+    build_consumed_words,
+};
 
 /// Shared helper that indexes full-length blocks into the tag table, bithash,
 /// compact lookup table, and sequential-match successor links.
@@ -105,6 +108,7 @@ impl DeltaSignatureIndex {
         }
 
         let size = lookup.capacity();
+        let consumed = build_consumed_words(blocks.len());
         let index = Self {
             block_length,
             strong_length,
@@ -114,6 +118,7 @@ impl DeltaSignatureIndex {
             tag_table,
             bithash,
             next_match,
+            consumed,
             role,
             last_traced_size: size,
             #[cfg(any(test, feature = "bench-internal"))]
@@ -152,6 +157,15 @@ impl DeltaSignatureIndex {
         // across the per-NDX `rebuild` boundary.
         self.next_match.clear();
         self.next_match.resize(self.blocks.len(), NEXT_MATCH_NONE);
+        // ZSO-7 per-segment lifecycle: reset prune state so a new
+        // segment starts with no stale consumed bits. Resize when the
+        // new signature's block count changes the required word count.
+        let words_needed = self.blocks.len().div_ceil(CONSUMED_BITS_PER_WORD);
+        if self.consumed.len() == words_needed {
+            self.reset_consumed();
+        } else {
+            self.consumed = build_consumed_words(self.blocks.len());
+        }
         #[cfg(any(test, feature = "bench-internal"))]
         self.seq_match_counters.reset();
 

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -19,6 +19,8 @@ mod bithash_tests;
 #[cfg(test)]
 mod matched_blocks_tests;
 #[cfg(test)]
+mod prune_tests;
+#[cfg(test)]
 mod seq_match_tests;
 #[cfg(test)]
 mod sparse_match_tests;
@@ -26,6 +28,7 @@ mod sparse_match_tests;
 mod tests;
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use checksums::RollingDigest;
 
@@ -61,7 +64,7 @@ const NEXT_MATCH_NONE: u32 = u32::MAX;
 /// table indexed by `sum1` provides fast-path rejection before the hash probe,
 /// mirroring upstream rsync's `tag_table` in `match.c`. The block length is
 /// stored separately since all indexed blocks have the same canonical length.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DeltaSignatureIndex {
     block_length: usize,
     strong_length: usize,
@@ -89,6 +92,21 @@ pub struct DeltaSignatureIndex {
     /// is in-memory only and is cleared by [`Self::rebuild`] so per-segment
     /// INC_RECURSE indexes never inherit stale links.
     next_match: Vec<u32>,
+    /// Consumed-block bitset for zsync-inspired hash-chain pruning (ZSO-3).
+    ///
+    /// One bit per basis block index, sized to `(blocks.len() + 63) / 64`
+    /// `AtomicU64` words. Probes consult [`Self::is_consumed`] before the
+    /// strong-checksum verify and skip already-emitted blocks; matchers
+    /// flip the bit through [`Self::mark_consumed`] after a successful
+    /// `Copy` token emission. Atomic load/store keeps the entire match
+    /// pipeline `&self`-compatible, so the same index may be shared
+    /// read-only across concurrent generators (per
+    /// `crates/engine/src/concurrent_delta/`) without per-session
+    /// `MatchedBlocks` clones.
+    ///
+    /// Reset to all-zero by [`Self::rebuild`] so per-segment
+    /// INC_RECURSE lifecycles (ZSO-7) start with no stale prune bits.
+    consumed: Vec<AtomicU64>,
     /// Role used for `--debug=HASH` `[<role>]` prefixes on the create,
     /// grow, and destroy lifecycle emissions. Mirrors upstream
     /// `who_am_i()` (`hashtable.c:51,61,101`).
@@ -101,6 +119,50 @@ pub struct DeltaSignatureIndex {
     /// skip the field entirely so the hot path carries zero overhead.
     #[cfg(any(test, feature = "bench-internal"))]
     seq_match_counters: std::sync::Arc<SeqMatchCounters>,
+}
+
+/// Number of bits stored per `consumed` word.
+pub(super) const CONSUMED_BITS_PER_WORD: usize = u64::BITS as usize;
+
+/// Allocates the consumed-block bitset sized for `block_count` basis
+/// blocks with every bit cleared.
+pub(super) fn build_consumed_words(block_count: usize) -> Vec<AtomicU64> {
+    let words = block_count.div_ceil(CONSUMED_BITS_PER_WORD);
+    let mut v = Vec::with_capacity(words);
+    for _ in 0..words {
+        v.push(AtomicU64::new(0));
+    }
+    v
+}
+
+impl Clone for DeltaSignatureIndex {
+    /// Clones every field, snapshotting the consumed-bitset with
+    /// `Relaxed` loads. Each clone owns an independent bitset so
+    /// `mark_consumed` on the clone never races the original; this
+    /// matches the per-segment ZSO-7 lifecycle and the
+    /// per-generator-session contract from the parent design.
+    fn clone(&self) -> Self {
+        let consumed = self
+            .consumed
+            .iter()
+            .map(|word| AtomicU64::new(word.load(Ordering::Relaxed)))
+            .collect();
+        Self {
+            block_length: self.block_length,
+            strong_length: self.strong_length,
+            algorithm: self.algorithm,
+            blocks: self.blocks.clone(),
+            lookup: self.lookup.clone(),
+            tag_table: self.tag_table.clone(),
+            bithash: self.bithash.clone(),
+            next_match: self.next_match.clone(),
+            consumed,
+            role: self.role,
+            last_traced_size: self.last_traced_size,
+            #[cfg(any(test, feature = "bench-internal"))]
+            seq_match_counters: std::sync::Arc::clone(&self.seq_match_counters),
+        }
+    }
 }
 
 /// Test-only seq-match probe counters.
@@ -340,6 +402,70 @@ impl DeltaSignatureIndex {
         std::sync::Arc::clone(&self.seq_match_counters)
     }
 
+    /// Returns `true` when the basis block at `idx` has been marked as
+    /// consumed by a prior `Copy`-token emission.
+    ///
+    /// Lookups in [`Self::find_match_bytes_filtered`] and
+    /// [`Self::find_match_slices_filtered`] consult this bit before the
+    /// strong-checksum verify, skipping already-emitted basis blocks.
+    /// Out-of-range indices return `false` so probe loops do not need to
+    /// guard the call site against malformed candidate vectors.
+    ///
+    /// The load is `Relaxed`: the consumed bitset is an optimization,
+    /// not a synchronization primitive. A stale-`false` read at worst
+    /// re-verifies a basis block that has since been claimed elsewhere;
+    /// the strong-checksum step still produces a correct token. A
+    /// stale-`true` read cannot occur because each bit only ever
+    /// transitions from `0` to `1` for the lifetime of the bitset.
+    #[inline]
+    #[must_use]
+    pub fn is_consumed(&self, idx: u32) -> bool {
+        let idx = idx as usize;
+        if idx >= self.blocks.len() {
+            return false;
+        }
+        let word = idx / CONSUMED_BITS_PER_WORD;
+        let bit = idx % CONSUMED_BITS_PER_WORD;
+        (self.consumed[word].load(Ordering::Relaxed) >> bit) & 1 == 1
+    }
+
+    /// Marks the basis block at `idx` as consumed.
+    ///
+    /// Called by the matcher after emitting a `Copy` token for block
+    /// `idx`. Subsequent probes through [`Self::is_consumed`] will skip
+    /// this basis index, mirroring zsync's `remove_block_from_hash`
+    /// (`librcksum/hash.c:111-128`).
+    ///
+    /// Uses `AtomicU64::fetch_or` under `Relaxed` ordering: setting a
+    /// bit is idempotent and the bitset is a probe-side optimization,
+    /// so no happens-before edge is required. Concurrent calls on
+    /// distinct bits never conflict, and concurrent calls on the same
+    /// bit converge to the same value.
+    ///
+    /// Out-of-range indices are silently ignored.
+    #[inline]
+    pub fn mark_consumed(&self, idx: u32) {
+        let idx = idx as usize;
+        if idx >= self.blocks.len() {
+            return;
+        }
+        let word = idx / CONSUMED_BITS_PER_WORD;
+        let bit = idx % CONSUMED_BITS_PER_WORD;
+        self.consumed[word].fetch_or(1u64 << bit, Ordering::Relaxed);
+    }
+
+    /// Resets every bit in the consumed-block bitset.
+    ///
+    /// Used by [`Self::rebuild`] so per-segment INC_RECURSE lifecycles
+    /// (ZSO-7) start with no stale prune bits. Also exposed publicly so
+    /// generator-session restarts (e.g., a basis retry after a phase-2
+    /// redo) can recycle the same index without re-allocating.
+    pub fn reset_consumed(&self) {
+        for word in &self.consumed {
+            word.store(0, Ordering::Relaxed);
+        }
+    }
+
     /// Attempts to locate a matching block for a contiguous byte slice.
     #[inline]
     pub fn find_match_bytes(&self, digest: RollingDigest, window: &[u8]) -> Option<usize> {
@@ -383,6 +509,13 @@ impl DeltaSignatureIndex {
         let strong = self.algorithm.compute_truncated(window, self.strong_length);
         for index in self.lookup.find_all(digest.sum1(), digest.sum2()) {
             if matches!(matched, Some(m) if m.is_matched(index)) {
+                continue;
+            }
+            // ZSO-3 hash-chain prune: skip basis blocks the matcher has
+            // already emitted as `Copy` tokens. Atomic load keeps the
+            // probe `&self`-compatible so the index can be shared
+            // read-only across concurrent generators.
+            if self.is_consumed(index as u32) {
                 continue;
             }
             let block = &self.blocks[index];
@@ -441,6 +574,12 @@ impl DeltaSignatureIndex {
             .compute_truncated_slices(first, second, self.strong_length);
         for index in self.lookup.find_all(digest.sum1(), digest.sum2()) {
             if matches!(matched, Some(m) if m.is_matched(index)) {
+                continue;
+            }
+            // ZSO-3 hash-chain prune: see [`Self::find_match_bytes_filtered`]
+            // for the duplicate-block correctness contract; the slice
+            // variant follows the same protocol.
+            if self.is_consumed(index as u32) {
                 continue;
             }
             let block = &self.blocks[index];

--- a/crates/matching/src/index/prune_tests.rs
+++ b/crates/matching/src/index/prune_tests.rs
@@ -1,0 +1,373 @@
+//! Tests for the ZSO-3 consumed-block bitset on
+//! [`super::DeltaSignatureIndex`].
+//!
+//! Pins the contracts for the interior-mutability hash-chain prune
+//! described in `docs/design/zsync-prune.md`:
+//!
+//! - Marking a basis block flips the bit at the matching word and
+//!   offset, observable through [`super::DeltaSignatureIndex::is_consumed`].
+//! - A repeat lookup against a duplicate-content basis returns the next
+//!   surviving sibling rather than the already-consumed block.
+//! - Total emitted `Copy` tokens equal `min(source_dup, basis_dup)` for
+//!   duplicate-heavy basis files, with each token naming a distinct
+//!   basis block index.
+//! - [`super::DeltaSignatureIndex::rebuild`] resets every bit so
+//!   per-segment INC_RECURSE lifecycles (ZSO-7) start clean.
+//! - Concurrent `mark_consumed` calls on distinct bits all converge
+//!   under `Relaxed` atomics with no lost updates.
+
+use std::io::Cursor;
+use std::num::{NonZeroU8, NonZeroU32};
+use std::sync::Arc;
+use std::thread;
+
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+use super::DeltaSignatureIndex;
+use crate::generator::DeltaGenerator;
+use crate::script::DeltaToken;
+
+/// Fixed block length used by the prune tests. Small enough to keep
+/// fixtures readable, large enough that the signature layout produces
+/// at least two full-length blocks for the duplicate-bucket cases.
+const TEST_BLOCK_LENGTH: u32 = 512;
+
+/// Strong-checksum length (bytes). Matches the value used by the rest
+/// of `crates/matching/src/index/` tests so a fixed signature layout
+/// is in play.
+const TEST_STRONG_LEN: u8 = 16;
+
+/// Builds a [`DeltaSignatureIndex`] over the supplied basis bytes
+/// using the fixed test block length. Helpers downstream rely on the
+/// returned index having at least one full block (the smallest
+/// duplicate-bucket case needs two).
+fn build_index(basis: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(basis, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+/// Builds a basis composed of `n` byte-identical full-length blocks.
+/// Used by the duplicate-bucket and chain-walk cases.
+fn duplicate_basis(n: usize) -> Vec<u8> {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let pattern: Vec<u8> = (0..block_len).map(|i| ((i * 7) % 251) as u8).collect();
+    let mut basis = Vec::with_capacity(block_len * n);
+    for _ in 0..n {
+        basis.extend_from_slice(&pattern);
+    }
+    basis
+}
+
+/// Returns the number of `DeltaToken::Copy` tokens in `tokens`, the
+/// distinct basis indices they reference, and the total bytes those
+/// tokens cover. Used to assert the one-per-sibling invariant in the
+/// duplicate-bucket cases.
+fn copy_summary(tokens: &[DeltaToken]) -> (usize, Vec<u64>, u64) {
+    let mut indices = Vec::new();
+    let mut bytes = 0u64;
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    for tok in tokens {
+        if let DeltaToken::Copy { index, len } = tok {
+            // Fat `Copy` tokens cover `run_len` adjacent basis blocks;
+            // expand them so the assertion below sees one index per
+            // basis block matched.
+            let runs = (*len / block_len).max(1);
+            for r in 0..runs {
+                indices.push(index + r as u64);
+            }
+            bytes += *len as u64;
+        }
+    }
+    (indices.len(), indices, bytes)
+}
+
+#[test]
+fn prune_marks_block_consumed_after_match() {
+    // Synthetic basis with two distinct full-length blocks plus a
+    // source that exactly equals the basis. After running the
+    // generator, every basis block that produced a `Copy` token must
+    // report `is_consumed = true`.
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let basis: Vec<u8> = (0..block_len * 2).map(|i| ((i * 13) % 251) as u8).collect();
+    let source = basis.clone();
+    let index = build_index(&basis);
+    let n_blocks = index.block_count();
+    assert!(n_blocks >= 2, "fixture must produce at least two blocks");
+
+    // Sanity: no bit is set before the generator runs.
+    for i in 0..n_blocks {
+        assert!(
+            !index.is_consumed(i as u32),
+            "bit {i} should be clear at start"
+        );
+    }
+
+    let script = DeltaGenerator::new()
+        .generate(Cursor::new(source), &index)
+        .expect("script");
+
+    let (_, copy_indices, _) = copy_summary(script.tokens());
+    assert!(
+        !copy_indices.is_empty(),
+        "fixture should produce at least one Copy token"
+    );
+    for idx in &copy_indices {
+        assert!(
+            index.is_consumed(*idx as u32),
+            "block {idx} should be marked consumed after Copy emission"
+        );
+    }
+}
+
+#[test]
+fn prune_skips_consumed_block_on_repeat_lookup() {
+    // Basis with two duplicate blocks (identical content -> identical
+    // rsum -> bucket of length 2). The first lookup picks block 0;
+    // after marking it consumed, the second lookup of the same rsum
+    // must skip block 0 and return block 1 instead.
+    let basis = duplicate_basis(2);
+    let index = build_index(&basis);
+    assert_eq!(
+        index.block_count(),
+        2,
+        "fixture must produce exactly two duplicate blocks"
+    );
+    let block_len = index.block_length();
+    let window = &basis[..block_len];
+    let digest = index.block(0).rolling();
+
+    let first = index.find_match_bytes(digest, window).expect("first match");
+    assert_eq!(first, 0, "bucket walk picks block 0 in insertion order");
+
+    index.mark_consumed(first as u32);
+
+    let second = index
+        .find_match_bytes(digest, window)
+        .expect("second match should fall through to sibling");
+    assert_eq!(
+        second, 1,
+        "consumed bit on block 0 must route the probe to block 1"
+    );
+
+    index.mark_consumed(second as u32);
+
+    // Every sibling exhausted: the bucket walk now reports no match.
+    assert!(
+        index.find_match_bytes(digest, window).is_none(),
+        "with both siblings consumed, the probe must return None"
+    );
+}
+
+#[test]
+fn prune_preserves_match_correctness_under_duplicates() {
+    // Basis with N duplicate blocks, source with the same N duplicate
+    // blocks concatenated. With pruning on, the generator must emit
+    // exactly N `Copy` token-equivalents (a fat Copy expands to one
+    // wire op per basis block), each naming a distinct basis index.
+    const N: usize = 4;
+    let basis = duplicate_basis(N);
+    let source = basis.clone();
+    let index = build_index(&basis);
+    assert_eq!(index.block_count(), N);
+
+    let script = DeltaGenerator::new()
+        .generate(Cursor::new(source.clone()), &index)
+        .expect("script");
+
+    let (copy_count, mut copy_indices, copy_bytes) = copy_summary(script.tokens());
+    assert_eq!(
+        copy_count, N,
+        "expected exactly {N} Copy emissions for {N} duplicate source occurrences"
+    );
+    assert_eq!(
+        copy_bytes,
+        (N * TEST_BLOCK_LENGTH as usize) as u64,
+        "matched-byte count must equal the full basis size"
+    );
+
+    copy_indices.sort_unstable();
+    copy_indices.dedup();
+    assert_eq!(
+        copy_indices.len(),
+        N,
+        "every Copy must reference a distinct basis block index"
+    );
+}
+
+#[test]
+fn prune_state_resets_in_rebuild() {
+    // Mark every basis block consumed, then rebuild from a different
+    // signature. The reset contract from `rebuild` (ZSO-7 per-segment
+    // lifecycle) must clear every bit so the new segment starts clean.
+    let basis1: Vec<u8> = (0..2048).map(|i| ((i * 19) % 251) as u8).collect();
+    let mut index = build_index(&basis1);
+    let count1 = index.block_count();
+    assert!(count1 >= 2, "fixture must produce at least two blocks");
+    for i in 0..count1 {
+        index.mark_consumed(i as u32);
+        assert!(index.is_consumed(i as u32));
+    }
+
+    // Rebuild from a fresh basis of a different size and content so
+    // the lookup table and block list both turn over.
+    let basis2: Vec<u8> = (0..3000).map(|i| ((i * 7) % 251) as u8).collect();
+    let params = SignatureLayoutParams::new(
+        basis2.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let sig2 =
+        generate_file_signature(basis2.as_slice(), layout, SignatureAlgorithm::Md4).expect("sig2");
+    assert!(index.rebuild(&sig2, SignatureAlgorithm::Md4));
+
+    let count2 = index.block_count();
+    assert!(count2 >= 1);
+    for i in 0..count2 {
+        assert!(
+            !index.is_consumed(i as u32),
+            "bit {i} must be clear after rebuild"
+        );
+    }
+}
+
+#[test]
+fn prune_state_resets_when_rebuild_keeps_block_count() {
+    // Rebuilding with a signature whose block count fits in the same
+    // number of words must still clear every bit; the
+    // length-equal-words branch in `rebuild` is exercised here.
+    let basis: Vec<u8> = (0..2048).map(|i| ((i * 11) % 251) as u8).collect();
+    let mut index = build_index(&basis);
+    let count = index.block_count();
+    for i in 0..count {
+        index.mark_consumed(i as u32);
+    }
+
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let sig =
+        generate_file_signature(basis.as_slice(), layout, SignatureAlgorithm::Md4).expect("sig");
+    assert!(index.rebuild(&sig, SignatureAlgorithm::Md4));
+
+    for i in 0..index.block_count() {
+        assert!(
+            !index.is_consumed(i as u32),
+            "bit {i} must be clear after equal-size rebuild"
+        );
+    }
+}
+
+#[test]
+fn prune_is_thread_safe_under_concurrent_marks() {
+    // N threads each mark a disjoint range of bits via `&self`. After
+    // joining, every bit those threads claimed must be set; bits the
+    // threads did not touch must remain clear. This pins the
+    // `&self`-compatible `fetch_or` contract under load.
+    const N_BLOCKS: usize = 256;
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let basis: Vec<u8> = (0..N_BLOCKS * block_len)
+        .map(|i| (((i / block_len) * 23 + i % 251) % 251) as u8)
+        .collect();
+    let index = Arc::new(build_index(&basis));
+    let block_count = index.block_count();
+    let threads = 8;
+    let chunk = block_count / threads;
+
+    let mut handles = Vec::with_capacity(threads);
+    for t in 0..threads {
+        let idx = Arc::clone(&index);
+        let start = t * chunk;
+        let end = if t + 1 == threads {
+            block_count
+        } else {
+            (t + 1) * chunk
+        };
+        handles.push(thread::spawn(move || {
+            for i in start..end {
+                idx.mark_consumed(i as u32);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("worker thread");
+    }
+
+    for i in 0..block_count {
+        assert!(
+            index.is_consumed(i as u32),
+            "bit {i} should be set after concurrent marks"
+        );
+    }
+    // Past-the-end indices stay false (and don't panic) regardless.
+    assert!(!index.is_consumed(block_count as u32));
+    assert!(!index.is_consumed(u32::MAX));
+}
+
+#[test]
+fn mark_consumed_is_idempotent() {
+    let basis: Vec<u8> = (0..2048).map(|i| ((i * 5) % 251) as u8).collect();
+    let index = build_index(&basis);
+    let count = index.block_count();
+    assert!(count >= 1);
+    index.mark_consumed(0);
+    index.mark_consumed(0);
+    index.mark_consumed(0);
+    assert!(index.is_consumed(0));
+}
+
+#[test]
+fn mark_consumed_ignores_out_of_range() {
+    let basis: Vec<u8> = (0..2048).map(|i| ((i * 5) % 251) as u8).collect();
+    let index = build_index(&basis);
+    let count = index.block_count();
+    // Out-of-range marks must not panic, and must not flip any
+    // observable bit (the index has no slot for them).
+    index.mark_consumed(count as u32);
+    index.mark_consumed(u32::MAX);
+    for i in 0..count {
+        assert!(
+            !index.is_consumed(i as u32),
+            "no in-range bit should be set after out-of-range marks"
+        );
+    }
+    assert!(!index.is_consumed(count as u32));
+    assert!(!index.is_consumed(u32::MAX));
+}
+
+#[test]
+fn clone_snapshots_consumed_bits_independently() {
+    // Each clone must own its own consumed bitset: marking on the
+    // original must not propagate to the clone, and vice versa. This
+    // pins the per-session lifecycle contract from the parent design.
+    let basis: Vec<u8> = (0..2048).map(|i| ((i * 17) % 251) as u8).collect();
+    let index = build_index(&basis);
+    let count = index.block_count();
+    assert!(count >= 2);
+    index.mark_consumed(0);
+
+    let cloned = index.clone();
+    assert!(cloned.is_consumed(0), "clone snapshots set bits");
+    cloned.mark_consumed(1);
+
+    assert!(
+        !index.is_consumed(1),
+        "original must not see the clone's later mark"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `Vec<AtomicU64>` consumed-block bitset to `DeltaSignatureIndex` that
mirrors zsync's `librcksum/hash.c:111-128` `remove_block_from_hash`. The
matcher flips bits in the same generator hot loop that emits `Copy` tokens;
subsequent probes consult the bitset under `Relaxed` atomics and skip
already-emitted basis blocks before the strong-checksum verify. Closes ZSO-3
(#2511).

### Architectural constraint

A prior agent stalled here on a key decision: `DeltaSignatureIndex` is
intended to be shared read-only across multiple generators (per
`crates/engine/src/concurrent_delta/`), so actual chain removal cannot
mutate the shared index. Two routes were on the table:

- **Option A (chosen)**: interior mutability via `Vec<AtomicU64>` on the
  index. `AtomicU64::fetch_or` and `load(Relaxed)` keep the entire match
  pipeline `&self`-compatible.
- **Option B**: per-session owned `CompactLookup` clone. Memory-heavy; not
  pursued.

This PR implements Option A. Both `find_match_bytes_filtered` and
`find_match_slices_filtered` gain a single-word atomic load before the
strong-checksum step; the matcher adds one `fetch_or` per emitted `Copy`
token.

### ZSO-7 per-segment lifecycle

- `DeltaSignatureIndex::rebuild` resets the bitset (resizing the word
  vector when the new block count changes word capacity) so INC_RECURSE
  per-segment indexes start clean.
- `DeltaGenerator::generate` resets the bitset on entry so a single
  index instance can drive multiple sessions without leaking prune
  state across invocations.

### Wire format

Unchanged. The bitset is a probe-side optimization; the receiver applies
the same bytes regardless of which sibling index a `Copy` token names.
All 407 protocol golden tests stay green.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo nextest run -p matching --all-features` (344 passed)
- [x] `cargo nextest run -p protocol --all-features -E 'test(golden)'` (407 passed)
- [x] New `crates/matching/src/index/prune_tests.rs` covers:
  - bit set observably after a `Copy` emission
  - repeat probe of the same rsum routes to the next surviving sibling
  - N duplicate basis blocks + N duplicate source occurrences -> N
    `Copy` tokens, distinct indices
  - `rebuild` clears every bit (equal-size and resize paths)
  - 8-thread concurrent `mark_consumed` on disjoint bit ranges
    converges with no lost updates
  - idempotent marks, out-of-range no-ops, per-clone independence