### PR TITLE
docs: warn users about SSH+rsync double-compression in README (SSC-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ Tested against upstream rsync **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** in 
 
 Threaded architecture replaces upstream's fork-based pipeline while keeping full protocol compatibility, reducing syscall overhead and context switches. Adaptive I/O buffers scale from 8KB to 1MB based on file size. Optional io_uring on Linux 5.6+ with three policies: *auto* (default; probe kernel and fall back to standard I/O), `--io-uring` (require io_uring; error if unavailable), `--no-io-uring` (always use standard buffered I/O). The active backend is reported by `--version` and `-vv` output. See `oc-rsync(1)` for details.
 
+### Performance tuning
+
+#### Avoid SSH + rsync double-compression
+
+SSH stream compression (`-C` on the `ssh` command line, or `Compression yes` in `~/.ssh/config` or `/etc/ssh/ssh_config`) compresses every byte the SSH session carries. The rsync wire protocol has its own compression layer, enabled with `--compress` / `-z` (and tuned with `--compress-choice`, `--compress-level`, `--compress-threads`). Running both at once feeds already-compressed bytes back into a second compressor: the second pass adds CPU on both sides and frame overhead while shrinking the stream by almost nothing, and on CPU-bound hosts throughput typically drops by 20-40%.
+
+Pick one layer. For most workloads prefer rsync's own compression: `oc-rsync` negotiates zstd when both peers support it (falling back to zlib), which is usually faster and tighter than SSH's zlib stream, and it can be skipped per file via `--skip-compress`. If you have a reason to keep SSH compression on (for example, a shared SSH config you cannot edit), drop `-z` from the rsync invocation instead.
+
+```sh
+# Good: rsync compresses, SSH carries the bytes as-is.
+oc-rsync -avz user@host:/src/ /dst/
+
+# Bad: -C on ssh re-compresses what rsync already compressed.
+oc-rsync -avz -e 'ssh -C' user@host:/src/ /dst/
+```
+
+`oc-rsync` emits a one-line warning when it spots `-C` (or `-o Compression=yes`) in the `--rsh` / `-e` argv it builds for the SSH child, but it does **not** parse `~/.ssh/config` or `/etc/ssh/ssh_config`, so a `Compression yes` directive set there is invisible to the warning. If throughput looks CPU-bound on an SSH transfer, check those files as well.
+
 ### Known Limitations / Architectural Trade-offs
 
 oc-rsync is wire-compatible with upstream rsync 3.4.1, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -647,7 +647,9 @@ NEON) are used where available, with automatic scalar fallbacks.
 ## Delta Transfer Options
 
 **-z**, **--compress**
-:   Compress file data during transfers.
+:   Compress file data during transfers. Do not combine with SSH stream
+    compression (**ssh -C** or **Compression yes** in **ssh_config**); see
+    *Avoiding double-compression over SSH* under **NOTES**.
 
 **--no-compress**
 :   Disable compression.
@@ -1077,6 +1079,31 @@ Patterns may contain wildcard characters:
 
 **[**...**]**
 :   Matches any character in the set.
+
+# NOTES
+
+## Avoiding double-compression over SSH
+
+SSH stream compression (**ssh -C**, or **Compression yes** in **~/.ssh/config**
+or **/etc/ssh/ssh_config**) compresses every byte the SSH session carries. The
+rsync wire protocol has its own compression layer, enabled with **-z** /
+**--compress** and tuned with **--compress-choice**, **--compress-level**, and
+**--compress-threads**. Running both at once feeds already-compressed bytes into
+a second compressor: the second pass burns CPU on both peers while shrinking
+the stream by almost nothing, and on CPU-bound hosts throughput typically drops
+by 20-40%.
+
+Pick one layer. For most workloads prefer rsync's own compression: **oc-rsync**
+negotiates zstd when both peers support it (falling back to zlib), which is
+usually faster and tighter than SSH's zlib stream, and individual file suffixes
+can be skipped via **--skip-compress**. If SSH compression must stay on for
+reasons outside your control, drop **-z** from the rsync invocation instead.
+
+**oc-rsync** emits a one-line warning when it detects **-C** or
+**-o Compression=yes** in the **--rsh** / **-e** argv it builds for the SSH
+child, but it does not parse **~/.ssh/config** or **/etc/ssh/ssh_config**, so a
+**Compression yes** directive set there is invisible to the warning. If
+throughput looks CPU-bound on an SSH transfer, check those files as well.
 
 # COMPATIBILITY
 


### PR DESCRIPTION
## Summary

Adds a **Performance tuning** subsection to `README.md` and a **NOTES** section to `docs/oc-rsync.1.md` explaining the SSH-plus-rsync double-compression pitfall: when SSH stream compression (`ssh -C`, or `Compression yes` in `~/.ssh/config` / `/etc/ssh/ssh_config`) runs together with `oc-rsync --compress` / `-z`, every byte gets compressed twice. The second pass burns CPU on both peers and shrinks the stream by almost nothing; on CPU-bound hosts throughput typically drops by 20-40%.

The new copy:

- Explains what each layer does and why combining them is wasteful.
- Recommends picking one layer, with a default preference for rsync's own `--compress` (zstd when negotiated, faster than SSH's zlib stream, suffix-skippable via `--skip-compress`).
- Notes that `oc-rsync` emits a one-line warning when it spots `-C` or `-o Compression=yes` in the `--rsh` / `-e` argv it builds (the SSC-1 / #2561 detector), but does **not** parse `ssh_config`, so users should also check those files when SSH transfers look CPU-bound.
- Cross-links the new NOTES section from the `-z` / `--compress` man-page entry.

Docs-only change. No code edits, no new dependencies.

### Companion tasks

- **SSC-1** (#2561, in flight) - adds the argv-side warning that this doc references.
- **SSC-3** (#2563, optional future work) - would add an actual `ssh_config` parser so the warning can also fire on the config-only case this doc has to ask users to check manually.
- Tracking note: `project_ssh_compression_no_config_parse.md` in the project memory log captures the underlying gap and why a parser is not yet on the critical path.

## Test plan

- [x] `cargo fmt --all -- --check` clean (docs-only; no-op expected).
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean (docs-only; no-op expected).
- [x] Visually inspected the README rendering and the man-page Markdown to confirm tone, formatting, and section placement match the surrounding sections.