### PR TITLE
refactor(engine): rename apply_chunk_parallel to apply_one_chunk for clarity (RJN-2)

### DIFF
--- a/crates/engine/src/concurrent_delta/parallel_apply.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply.rs
@@ -13,7 +13,7 @@
 //! [`ParallelDeltaApplier`] owns a configurable concurrency limit and a
 //! per-file map of [`Mutex`]-guarded destination writers. Callers hand it
 //! [`DeltaChunk`] values (one literal-or-block segment for one file) through
-//! [`apply_chunk_parallel`](ParallelDeltaApplier::apply_chunk_parallel). The
+//! [`apply_one_chunk`](ParallelDeltaApplier::apply_one_chunk). The
 //! checksum verify step runs on the rayon pool; the actual file-write happens
 //! under the per-file mutex so per-file byte order is preserved.
 //!
@@ -418,7 +418,7 @@ impl ParallelDeltaApplier {
     /// Registers a destination writer for `ndx`.
     ///
     /// Must be called before the first chunk for `ndx` reaches
-    /// [`apply_chunk_parallel`](Self::apply_chunk_parallel). Returns an
+    /// [`apply_one_chunk`](Self::apply_one_chunk). Returns an
     /// error if `ndx` already has a writer (the receiver opens each file
     /// exactly once).
     ///
@@ -458,6 +458,22 @@ impl ParallelDeltaApplier {
     /// the work without spinning up a new pool. The serial write step then
     /// runs under the per-file mutex so per-file byte order is preserved.
     ///
+    /// # Scheduling shape
+    ///
+    /// This entry point schedules a single chunk's verify on a rayon worker
+    /// via `rayon::join(verify, || ())`. The second closure is a no-op, so
+    /// the caller still blocks until that one verify returns. This is a
+    /// single-chunk scheduling primitive, **not** cross-chunk parallelism.
+    /// For multi-chunk parallel verify across the rayon pool use
+    /// [`apply_batch_parallel`](Self::apply_batch_parallel), which collects a
+    /// `Vec<DeltaChunk>` through `into_par_iter` and fans the verifies out
+    /// subject to [`Self::concurrency`].
+    ///
+    /// See `docs/audits/rjn-1-apply-chunk-parallel-call-sites-2026-05-21.md`
+    /// for the call-site catalogue and design rationale behind keeping this
+    /// per-chunk shape until the receiver pipeline wires a real fan-out
+    /// caller (tracked under RJN-3).
+    ///
     /// # Errors
     ///
     /// Returns an [`io::Error`] if the file is unknown, a slot mutex is
@@ -465,7 +481,7 @@ impl ParallelDeltaApplier {
     /// buffer overflows (a stalled file with unbounded out-of-order
     /// submissions), or the per-chunk strong-checksum verification fails
     /// when [`DeltaChunk::expected_strong`] was attached.
-    pub fn apply_chunk_parallel(&self, chunk: DeltaChunk) -> io::Result<()> {
+    pub fn apply_one_chunk(&self, chunk: DeltaChunk) -> io::Result<()> {
         // `slot_for` returns an `Arc` clone and drops the DashMap shard
         // guard before returning, so the rayon verify below never blocks
         // shard-mates on unrelated NDX values.
@@ -717,7 +733,7 @@ mod tests {
         let expected = sequential_apply(&chunks);
 
         for c in chunks {
-            applier.apply_chunk_parallel(c).unwrap();
+            applier.apply_one_chunk(c).unwrap();
         }
         assert_eq!(collect_file(&applier, FileNdx::new(0), buf), expected);
     }
@@ -738,7 +754,7 @@ mod tests {
         shuffled.rotate_left(7);
 
         for c in shuffled {
-            applier.apply_chunk_parallel(c).unwrap();
+            applier.apply_one_chunk(c).unwrap();
         }
         assert_eq!(collect_file(&applier, FileNdx::new(0), buf), expected);
     }
@@ -781,7 +797,7 @@ mod tests {
     fn missing_file_registration_errors() {
         let applier = ParallelDeltaApplier::new(1);
         let err = applier
-            .apply_chunk_parallel(DeltaChunk::literal(7u32, 0, vec![1, 2, 3]))
+            .apply_one_chunk(DeltaChunk::literal(7u32, 0, vec![1, 2, 3]))
             .unwrap_err();
         assert!(err.to_string().contains("unknown"));
     }
@@ -804,7 +820,7 @@ mod tests {
 
         // Submit out-of-order chunk; sequence 0 never arrives.
         applier
-            .apply_chunk_parallel(DeltaChunk::literal(0u32, 1, vec![0u8; 4]))
+            .apply_one_chunk(DeltaChunk::literal(0u32, 1, vec![0u8; 4]))
             .unwrap();
         match applier.finish_file(0u32) {
             Ok(_) => panic!("finish_file should fail with pending chunks"),
@@ -818,11 +834,11 @@ mod tests {
         let (sink, _) = VecSink::new();
         applier.register_file(0u32, Box::new(sink)).unwrap();
         applier
-            .apply_chunk_parallel(DeltaChunk::literal(0u32, 0, vec![1u8; 100]))
+            .apply_one_chunk(DeltaChunk::literal(0u32, 0, vec![1u8; 100]))
             .unwrap();
         assert_eq!(applier.bytes_written(0u32).unwrap(), 100);
         applier
-            .apply_chunk_parallel(DeltaChunk::literal(0u32, 1, vec![2u8; 50]))
+            .apply_one_chunk(DeltaChunk::literal(0u32, 1, vec![2u8; 50]))
             .unwrap();
         assert_eq!(applier.bytes_written(0u32).unwrap(), 150);
     }
@@ -864,7 +880,7 @@ mod tests {
             let (sink, buf) = VecSink::new();
             applier.register_file(0u32, Box::new(sink)).unwrap();
             for c in permuted {
-                applier.apply_chunk_parallel(c).unwrap();
+                applier.apply_one_chunk(c).unwrap();
             }
             let actual = collect_file(&applier, FileNdx::new(0), buf);
             prop_assert_eq!(actual, expected);
@@ -878,7 +894,7 @@ mod tests {
         let cursor: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         applier.register_file(0u32, Box::new(cursor)).unwrap();
         applier
-            .apply_chunk_parallel(DeltaChunk::literal(0u32, 0, vec![9u8; 32]))
+            .apply_one_chunk(DeltaChunk::literal(0u32, 0, vec![9u8; 32]))
             .unwrap();
         let _writer = applier.finish_file(0u32).unwrap();
     }
@@ -982,7 +998,7 @@ mod tests {
         let (sink, buf) = VecSink::new();
         applier.register_file(0u32, Box::new(sink)).unwrap();
         applier
-            .apply_chunk_parallel(DeltaChunk::literal(0u32, 0, vec![0xAB; 64]))
+            .apply_one_chunk(DeltaChunk::literal(0u32, 0, vec![0xAB; 64]))
             .unwrap();
         let _writer = applier.finish_file(0u32).unwrap();
         assert_eq!(buf.lock().unwrap().len(), 64);
@@ -1012,7 +1028,7 @@ mod tests {
         let (sink, buf) = VecSink::new();
         applier.register_file(0u32, Box::new(sink)).unwrap();
         let chunk = chunk_with_correct_digest(strategy.as_ref(), 0, 0, vec![0x42; 128]);
-        applier.apply_chunk_parallel(chunk).unwrap();
+        applier.apply_one_chunk(chunk).unwrap();
         let _writer = applier.finish_file(0u32).unwrap();
         assert_eq!(buf.lock().unwrap().len(), 128);
         assert!(buf.lock().unwrap().iter().all(|&b| b == 0x42));
@@ -1030,7 +1046,7 @@ mod tests {
         let (sink, buf) = VecSink::new();
         applier.register_file(0u32, Box::new(sink)).unwrap();
         let chunk = chunk_with_correct_digest(strategy.as_ref(), 0, 0, vec![0xAA; 200]);
-        applier.apply_chunk_parallel(chunk).unwrap();
+        applier.apply_one_chunk(chunk).unwrap();
         let _writer = applier.finish_file(0u32).unwrap();
         assert_eq!(buf.lock().unwrap().len(), 200);
     }
@@ -1047,7 +1063,7 @@ mod tests {
         // non-empty payload's real digest.
         let bogus = ChecksumDigest::new(&[0u8; 16]);
         let chunk = DeltaChunk::literal(0u32, 0, vec![0x99; 64]).with_expected_strong(bogus);
-        let err = applier.apply_chunk_parallel(chunk).unwrap_err();
+        let err = applier.apply_one_chunk(chunk).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("checksum mismatch"), "msg was: {msg}");
         assert!(msg.contains("ndx=0"), "msg was: {msg}");

--- a/crates/engine/tests/arc_drain_panic_recovery.rs
+++ b/crates/engine/tests/arc_drain_panic_recovery.rs
@@ -181,8 +181,8 @@ mod parallel_apply_drain {
         let worker = thread::spawn(move || {
             let result = panic::catch_unwind(AssertUnwindSafe(|| {
                 worker_applier
-                    .apply_chunk_parallel(DeltaChunk::literal(0u32, 0, vec![0u8; 16]))
-                    .expect("apply_chunk_parallel");
+                    .apply_one_chunk(DeltaChunk::literal(0u32, 0, vec![0u8; 16]))
+                    .expect("apply_one_chunk");
             }));
             // Bubble up the panic outcome so the join site can assert
             // it stayed contained. The drain assertion already ran on
@@ -192,7 +192,7 @@ mod parallel_apply_drain {
 
         // Wait for the worker to enter `BlockingWriter::write` - by
         // that point the slot's inner Arc has a live clone held inside
-        // `apply_chunk_parallel`, so `finish_file`'s `Arc::try_unwrap`
+        // `apply_one_chunk`, so `finish_file`'s `Arc::try_unwrap`
         // will fail with the typed variant.
         started_rx
             .recv_timeout(Duration::from_secs(10))

--- a/crates/engine/tests/parallel_apply_concurrent.rs
+++ b/crates/engine/tests/parallel_apply_concurrent.rs
@@ -10,7 +10,7 @@
 //! What this test guards against:
 //!
 //! * Outer-map lock contention re-entering the design: every worker calls
-//!   `register_file` / `apply_chunk_parallel` concurrently on overlapping
+//!   `register_file` / `apply_one_chunk` concurrently on overlapping
 //!   NDX values; the DashMap shard scheme is the only thing keeping
 //!   register/lookup off a single central lock.
 //! * Per-file slot corruption: the inner `Mutex<FileSlot>` is still the
@@ -122,8 +122,8 @@ fn concurrent_files_under_dashmap_shards_match_expected_bytes() {
             expected_per_file[ndx_raw as usize].fetch_add(CHUNK_BYTES as u64, Ordering::Relaxed);
             let chunk = DeltaChunk::literal(ndx_raw, seq, vec![worker as u8; CHUNK_BYTES]);
             applier
-                .apply_chunk_parallel(chunk)
-                .expect("apply_chunk_parallel under concurrent dispatch");
+                .apply_one_chunk(chunk)
+                .expect("apply_one_chunk under concurrent dispatch");
         }
     });
     let elapsed = start.elapsed();
@@ -219,7 +219,7 @@ fn concurrent_register_and_dispatch_on_overlapping_files() {
             let ndx_raw = (rng.next_u64() % SMALL_NUM as u64) as u32;
             let seq = per_file_seq[ndx_raw as usize].fetch_add(1, Ordering::SeqCst);
             let chunk = DeltaChunk::literal(ndx_raw, seq, vec![worker as u8; CHUNK_BYTES]);
-            match applier.apply_chunk_parallel(chunk) {
+            match applier.apply_one_chunk(chunk) {
                 Ok(()) => {
                     expected.fetch_add(CHUNK_BYTES as u64, Ordering::Relaxed);
                 }

--- a/crates/transfer/src/delta_pipeline/chunk_builder.rs
+++ b/crates/transfer/src/delta_pipeline/chunk_builder.rs
@@ -92,7 +92,7 @@ pub enum ChunkBuilderError {
 /// One builder lives for the duration of a single file's delta apply. The
 /// caller bumps the sequence counter once per produced chunk, mirroring the
 /// per-file `chunk_sequence` invariant that
-/// [`ParallelDeltaApplier::apply_chunk_parallel`] documents.
+/// [`ParallelDeltaApplier::apply_one_chunk`] documents.
 ///
 /// # Per-file lifetime
 ///
@@ -408,7 +408,7 @@ mod tests {
             .expect("matched_chunk for in-bounds index");
 
         let err = applier
-            .apply_chunk_parallel(chunk)
+            .apply_one_chunk(chunk)
             .expect_err("verify must reject corrupted basis bytes");
         let msg = err.to_string();
         assert!(msg.contains("checksum mismatch"), "msg was: {msg}");


### PR DESCRIPTION
## Summary

Per the RJN-1 audit (#4656), the name \`apply_chunk_parallel\` was misleading: the function uses \`rayon::join(verify, || ())\` with a no-op second closure, which schedules a single chunk's verify on a rayon worker but does NOT parallelize across chunks. Real multi-chunk parallelism lives in \`apply_batch_parallel\`.

This PR renames to \`apply_one_chunk\` and adds a rustdoc paragraph clarifying the semantics. RJN-3 (batched fan-out at the receiver) is deferred until receiver wiring exists - per RJN-1, there are zero production callers today.

## Scope

- Rename across 17 call sites (1 definition + 12 unit tests in \`parallel_apply.rs\` + 2 stress tests in \`parallel_apply_concurrent.rs\` + 1 drop-ordering test in \`arc_drain_panic_recovery.rs\` + 1 test in \`chunk_builder.rs\`).
- No semantic code changes; no new deps; no \`#[allow(...)]\` waivers.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings\` clean
- [x] \`cargo nextest run -p engine --features parallel-receive-delta\` no regression
- [x] \`cargo nextest run -p transfer --features 'parallel-receive-delta incremental-flist'\` no regression