### PR TITLE
docs: note --zero-copy SEND_ZC build-time dependency (IUS-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ oc-rsync -avz -e 'ssh -C' user@host:/src/ /dst/
 
 `oc-rsync` emits a one-line warning when it spots `-C` (or `-o Compression=yes`) in the `--rsh` / `-e` argv it builds for the SSH child, but it does **not** parse `~/.ssh/config` or `/etc/ssh/ssh_config`, so a `Compression yes` directive set there is invisible to the warning. If throughput looks CPU-bound on an SSH transfer, check those files as well.
 
+#### `--zero-copy` and io_uring `SEND_ZC`
+
+`--zero-copy` advertises io_uring `SEND_ZC` as one of the zero-copy primitives it may dispatch on Linux, alongside `sendfile`, `splice`, and `copy_file_range`. The `SEND_ZC` dispatch itself is gated behind the `iouring-send-zc` cargo feature, which is **not** in the default feature set; the gate is documented as "Disabled by default pending kernel/workload benchmarks" in `crates/fast_io/Cargo.toml`. Default distro builds therefore use plain io_uring `SEND` even when `--zero-copy` is set; the other zero-copy primitives still kick in where the kernel supports them.
+
+To get `SEND_ZC` dispatch, build with `cargo build --features iouring-send-zc` (requires Linux 5.16+). See [`docs/design/iouring-send-zc.md`](./docs/design/iouring-send-zc.md) for the full rationale and the path to flipping this default on.
+
 ### Known Limitations / Architectural Trade-offs
 
 oc-rsync is wire-compatible with upstream rsync 3.4.1, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -866,6 +866,26 @@ exits with an error.
     even when the kernel supports io_uring. Overrides a previous
     **--io-uring** on the same command line.
 
+**--zero-copy**
+:   Allow I/O-level zero-copy primitives (**sendfile**(2), **splice**(2),
+    **copy_file_range**(2), and io_uring **SEND_ZC**) when supported by the
+    kernel. This is the default (policy *auto*/*enabled*).
+
+    **NOTE:** the io_uring **SEND_ZC** dispatch is gated behind the
+    `iouring-send-zc` cargo feature, which is **not** in the default feature
+    set; the gate is documented as "Disabled by default pending
+    kernel/workload benchmarks" in **crates/fast_io/Cargo.toml**. Default
+    distro builds therefore use plain io_uring **SEND** even when
+    **--zero-copy** is set; the other zero-copy primitives still apply where
+    the kernel supports them. To get **SEND_ZC** dispatch, build with
+    `cargo build --features iouring-send-zc` (requires Linux 5.16+). See
+    **docs/design/iouring-send-zc.md** for the full rationale.
+
+**--no-zero-copy**
+:   Disable I/O-level zero-copy and route data through portable userspace
+    read/write loops. Does not affect filesystem-level reflink / CoW cloning
+    (see **--cow** / **--no-cow**).
+
 The next two flags govern the receiver-side `SpillPolicy` that bounds the
 concurrent-delta `ReorderBuffer`'s memory footprint. Both are *planned* for
 STN-11 and will land in a future release; until then operators tune the same


### PR DESCRIPTION
## Summary

- Add a Performance tuning sibling subsection in `README.md` and a NOTE block on the `--zero-copy` entry in `docs/oc-rsync.1.md` covering the build-time dependency for io_uring `SEND_ZC` dispatch.
- The `--zero-copy` CLI help (`crates/cli/src/frontend/help.rs:151`) advertises io_uring `SEND_ZC` as one of the zero-copy primitives, but the dispatch only ships when built with `--features iouring-send-zc`, which is not in the default feature set ("Disabled by default pending kernel/workload benchmarks" in `crates/fast_io/Cargo.toml`).
- Default distro builds therefore use plain io_uring `SEND` even when `--zero-copy` is set; operators get the documented opt-in build (`cargo build --features iouring-send-zc`, requires Linux 5.16+) by reading the README / man page rather than spelunking through `Cargo.toml`.
- Cites `docs/design/iouring-send-zc.md` for the full rationale.

## Rationale

This is the IUS-1 step in the IUS-1..6 chain captured in project memory note `project_iouring_send_zc_optin_only.md`. Steps IUS-2..6 cover the longer-term work to land kernel/workload benchmarks, document the supported kernel matrix, gate behind a kernel-version probe, and finally flip the `iouring-send-zc` feature on by default for Linux targets once the data justifies it. Until that chain is complete, the user-facing `--zero-copy` flag silently downgrades to plain `SEND` on default builds; this PR is the docs-only mitigation for the discrepancy.

## Test plan

- [x] `cargo fmt --all -- --check` clean (no-op for docs-only change).
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean (no-op for docs-only change).
- [x] Visual review of the rendered README "Performance tuning" subsection and the man page `--zero-copy` entry / NOTE block.
- [ ] CI passes (fmt+clippy, nextest stable, Windows stable, macOS stable, Linux musl stable).