### PR TITLE
feat(match): zsync-inspired compact rolling-key encoding via rsum_a_mask (ZSO-4)

### DIFF
--- a/crates/matching/benches/compact_keys_cache.rs
+++ b/crates/matching/benches/compact_keys_cache.rs
@@ -1,12 +1,12 @@
 //! Compact-lookup cache-behaviour benchmark (#2073).
 //!
-//! Profiles the cache behaviour of [`DeltaSignatureIndex`]'s flat
-//! open-addressed lookup table at index sizes that straddle the L1, L2,
-//! LLC, and main-memory tiers of modern CPUs. The current key/value layout
-//! stores `(rsum_key: u32, block_index: u32)` packed into a `u64` slot;
-//! issue #2072 proposes a denser `(rsum_low | bucket_idx)` layout. This
-//! bench produces the evidence that informs whether that change is worth
-//! the wire-compat-neutral implementation cost.
+//! Profiles the cache behaviour of [`DeltaSignatureIndex`]'s compact
+//! bucket lookup at index sizes that straddle the L1, L2, LLC, and
+//! main-memory tiers of modern CPUs. Under the ZSO-4 compact-key design
+//! the bucket array is keyed on `rsum >> 16` and capped at `2^16` slots,
+//! so the hot table stays at most 256 KiB regardless of basis size.
+//! The numbers this bench produces feed back into #2072 / #2073 by
+//! quantifying how much the cap actually buys at each cache tier.
 //!
 //! # Running
 //!
@@ -38,14 +38,15 @@
 //!
 //! # Methodology
 //!
-//! Four logical index sizes:
+//! Four logical index sizes. The bucket-array footprint plateaus at the
+//! `2^16` cap; the chain-entry footprint scales with `n_entries`:
 //!
-//! | label  | n_entries | lookup-table footprint | cache tier (typical x86_64) |
-//! |--------|-----------|------------------------|-----------------------------|
-//! | `l1`   | 1024      | ~32 KiB                | L1d-resident                |
-//! | `l2`   | 16 384    | ~512 KiB               | L2-resident                 |
-//! | `llc`  | 1 048 576 | ~32 MiB                | LLC-resident                |
-//! | `ram`  | 8 388 608 | ~256 MiB               | main memory                 |
+//! | label  | n_entries | bucket footprint | total footprint |
+//! |--------|-----------|------------------|-----------------|
+//! | `l1`   | 1024      | 16 KiB           | ~28 KiB         |
+//! | `l2`   | 16 384    | 256 KiB          | ~448 KiB        |
+//! | `llc`  | 1 048 576 | 256 KiB          | ~12 MiB         |
+//! | `ram`  | 8 388 608 | 256 KiB          | ~96 MiB         |
 //!
 //! For each size, two access patterns:
 //!
@@ -66,28 +67,31 @@
 //!
 //! # Interpreting results
 //!
-//! Pre-#2072 (current layout, 8-byte slots):
+//! Under the ZSO-4 compact-key layout the bucket array is bounded at
+//! 256 KiB (`2^16 * 8` bytes), so the *bucket fetch* itself stays inside
+//! L2 even for the `ram` size. The chain backing store grows with the
+//! entry count and is the working set that pushes through the cache
+//! hierarchy:
 //!
 //! - `l1` and `l2` sizes should be effectively cache-resident; sequential
 //!   and scattered throughput should be near-identical, with cache-miss
 //!   rates near zero.
 //! - `llc` and `ram` sizes should show a widening gap: scattered probes
 //!   stall on LLC misses while sequential probes still benefit from the
-//!   linear-probe stride of one cache line.
+//!   chain backing store's monotonic insertion order.
 //!
 //! Action thresholds for #2072:
 //!
 //! - **Favourable** (justify packing): scattered-probe cache-miss rate at
 //!   the `llc` or `ram` size is >= 2x the sequential rate, and total
 //!   probes-per-second on the scattered case is bottlenecked by memory
-//!   bandwidth. A packed `(rsum_low | bucket_idx)` layout that halves
-//!   slot width should approximately halve those miss rates and recover
-//!   most of the throughput gap.
+//!   bandwidth. Further chain-entry packing should approximately halve
+//!   those miss rates and recover most of the throughput gap.
 //! - **Unfavourable** (defer #2072): scattered and sequential cache-miss
 //!   rates stay within ~20% across all sizes, or the `ram` case is
 //!   bottlenecked by something other than memory traffic (strong-checksum
-//!   verify, allocator, etc). Repacking buys little if the cost is not
-//!   actually in the slot-fetch.
+//!   verify, allocator, etc). Further packing buys little if the cost is
+//!   not actually in the chain fetch.
 //!
 //! # See also
 //!
@@ -306,11 +310,12 @@ fn report_footprint() {
 
 /// Drives `PROBES_PER_ITER` lookup probes from the prebuilt key stream.
 ///
-/// Each probe runs the full Robin Hood walk via the bench-only
+/// Each probe walks the compact-key bucket chain via the bench-only
 /// [`DeltaSignatureIndex::lookup_probe`] accessor, which returns the
-/// number of yielded basis-block indices. `black_box` on the running
-/// total prevents the optimizer from hoisting the loop out of the
-/// timed section.
+/// number of yielded basis-block indices. The chain is addressed by the
+/// upper-half discriminator (`rsum >> 16`) per the ZSO-4 compact-key
+/// design; `black_box` on the running total prevents the optimizer from
+/// hoisting the loop out of the timed section.
 #[inline(never)]
 fn drive_probes(index: &DeltaSignatureIndex, keys: &[(u16, u16)]) -> usize {
     let mut total = 0usize;

--- a/crates/matching/src/index/compact_key_tests.rs
+++ b/crates/matching/src/index/compact_key_tests.rs
@@ -1,0 +1,260 @@
+//! Tests for the zsync-inspired compact rolling-key encoding (ZSO-4).
+//!
+//! Pins the contracts in `project_zsync_optimizations.md` and the inline
+//! design notes on [`super::compact_lookup`]:
+//!
+//! - The bucket array is capped at `2^16` slots regardless of basis size,
+//!   matching the `rsum_a_mask` keyspace zsync uses in
+//!   `librcksum/hash.c:45`.
+//! - Synthetic same-bucket collisions (`rsum >> 16` equal, lower 16 bits
+//!   differ) are resolved by the in-bucket discriminator without leaking
+//!   false positives into the strong-checksum verify.
+//! - End-to-end correctness: an N-block basis with all matching source
+//!   yields exactly N `Copy` tokens at the expected offsets, proving the
+//!   compact-key reshape preserves rolling-rsum match semantics.
+//! - Per-segment ZSO-7 isolation: [`super::DeltaSignatureIndex::rebuild`]
+//!   wipes both the bucket heads and the chain backing store so a stale
+//!   basis cannot resurface after the next segment populates.
+//!
+//! Wire-format parity is enforced separately by the protocol golden tests
+//! in `crates/protocol/tests/`; the assertions here cover the in-memory
+//! contract only.
+
+use std::io::Cursor;
+use std::num::{NonZeroU8, NonZeroU32};
+
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+use super::DeltaSignatureIndex;
+use super::compact_lookup::CompactLookup;
+use crate::generator::DeltaGenerator;
+use crate::script::{DeltaToken, apply_delta};
+
+const TEST_BLOCK_LENGTH: u32 = 512;
+const TEST_STRONG_LEN: u8 = 16;
+
+/// Builds a `DeltaSignatureIndex` over `basis` using the test's fixed
+/// block layout. Returns `None` when the basis is shorter than one full
+/// block, which callers bound out by construction.
+fn build_index(basis: &[u8]) -> Option<DeltaSignatureIndex> {
+    let params = SignatureLayoutParams::new(
+        basis.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).ok()?;
+    let signature = generate_file_signature(basis, layout, SignatureAlgorithm::Md4).ok()?;
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4)
+}
+
+/// Distinct-content basis so the strong-checksum verify resolves each
+/// block uniquely. Mirrors the helper in `seq_match_tests.rs` so the two
+/// fixtures stay aligned.
+fn distinct_basis(n_blocks: usize) -> Vec<u8> {
+    let block_len = TEST_BLOCK_LENGTH as usize;
+    let mut basis = Vec::with_capacity(n_blocks * block_len);
+    for k in 0..n_blocks {
+        let seed = (k as u8).wrapping_mul(31).wrapping_add(7);
+        for j in 0..block_len {
+            basis.push(seed.wrapping_add((j as u8).wrapping_mul(17)));
+        }
+    }
+    basis
+}
+
+/// The bucket array never grows beyond `2^16` slots, even when the basis
+/// signature would naively suggest a larger table.
+#[test]
+fn bucket_size_is_capped_at_2_16() {
+    // 70 000 blocks > 2^16 = 65 536, so the naive "next-power-of-two of
+    // 2 * n_entries" expansion would jump past the cap. The compact-key
+    // table must clamp at `2^16` so the bucket array stays at most 256 KiB.
+    let huge = CompactLookup::with_capacity(70_000);
+    assert_eq!(huge.capacity(), 1 << 16);
+
+    // The publicly observable `lookup_capacity` accessor on the index
+    // honours the same cap end-to-end, so callers that bin by cache level
+    // never see an over-budget figure.
+    let basis = distinct_basis(8);
+    let index = build_index(&basis).expect("index for tiny basis");
+    assert!(index.lookup_capacity() <= 1 << 16);
+}
+
+/// Synthetic `(sum1, sum2)` pairs that share the upper-half bucket
+/// address but disagree on the lower-half discriminator must each be
+/// findable under their own key, without leaking the sibling entry.
+#[test]
+fn bucket_collisions_resolved_by_lower_half_check() {
+    let mut table = CompactLookup::with_capacity(8);
+
+    // Two rsums with identical `rsum >> 16` but distinct lower halves.
+    // Insert them under the *same* bucket and verify the chain walk
+    // returns each entry exclusively under its own discriminator.
+    let bucket_sum2: u16 = 0xBEEF;
+    table.insert(0x0001, bucket_sum2, 11);
+    table.insert(0x0002, bucket_sum2, 22);
+    table.insert(0x0003, bucket_sum2, 33);
+
+    let a: Vec<usize> = table.find_all(0x0001, bucket_sum2).collect();
+    let b: Vec<usize> = table.find_all(0x0002, bucket_sum2).collect();
+    let c: Vec<usize> = table.find_all(0x0003, bucket_sum2).collect();
+    assert_eq!(a, vec![11]);
+    assert_eq!(b, vec![22]);
+    assert_eq!(c, vec![33]);
+
+    // A lower-half discriminator that was never inserted into the shared
+    // bucket must produce no hits, even though the bucket itself is
+    // populated.
+    let none: Vec<usize> = table.find_all(0x00FF, bucket_sum2).collect();
+    assert!(none.is_empty(), "unrelated discriminator must not leak");
+
+    // The bucket address derives from `rsum >> 16` for every callable
+    // synthesis, so the bench-internal helper and the bucket-for helper
+    // agree on the placement.
+    let synthesized_rsum = (u32::from(bucket_sum2) << 16) | 0x0001;
+    assert_eq!(
+        DeltaSignatureIndex::bucket_for(synthesized_rsum),
+        bucket_sum2
+    );
+    assert_eq!(CompactLookup::bucket_for(synthesized_rsum), bucket_sum2);
+}
+
+/// An all-matching N-block source must reproduce byte-for-byte under the
+/// compact-key reshape. Emitted Copy tokens cover every basis block (the
+/// seq-match coalescer may collapse them into a single span), no literal
+/// bytes leak, and apply_delta reproduces the original source.
+#[test]
+fn compact_key_does_not_break_match_correctness() {
+    const N_BLOCKS: usize = 16;
+    let basis = distinct_basis(N_BLOCKS);
+    let index = build_index(&basis).expect("index for N-block basis");
+    assert_eq!(index.block_count(), N_BLOCKS);
+
+    let generator = DeltaGenerator::new();
+    let script = generator
+        .generate(Cursor::new(basis.as_slice()), &index)
+        .expect("delta generation");
+
+    let copy_tokens: Vec<&DeltaToken> = script
+        .tokens()
+        .iter()
+        .filter(|t| matches!(t, DeltaToken::Copy { .. }))
+        .collect();
+    assert!(
+        !copy_tokens.is_empty(),
+        "matching source must emit at least one Copy token",
+    );
+
+    // Copy tokens (possibly coalesced) must address every basis block in
+    // order without gaps. Track the cumulative byte offset the basis side
+    // would read from; it must match `N_BLOCKS * block_length` at the end.
+    let block_len = index.block_length();
+    let mut basis_offset = 0usize;
+    let mut next_block = 0u64;
+    for tok in &copy_tokens {
+        let DeltaToken::Copy {
+            index: block_index,
+            len,
+        } = tok
+        else {
+            unreachable!("filtered above");
+        };
+        assert_eq!(
+            *block_index, next_block,
+            "Copy run must continue at the next basis block",
+        );
+        assert_eq!(*len % block_len, 0, "Copy len must be a block multiple");
+        let n_blocks = len / block_len;
+        next_block += n_blocks as u64;
+        basis_offset += len;
+    }
+    assert_eq!(
+        next_block as usize, N_BLOCKS,
+        "Copy tokens must cover every basis block",
+    );
+    assert_eq!(
+        basis_offset,
+        N_BLOCKS * block_len,
+        "Copy tokens must cover every basis byte",
+    );
+    assert_eq!(
+        script.literal_bytes(),
+        0,
+        "an all-matching source must not emit any literal bytes",
+    );
+
+    let mut reconstructed = Vec::with_capacity(basis.len());
+    apply_delta(
+        Cursor::new(basis.as_slice()),
+        &mut reconstructed,
+        &index,
+        &script,
+    )
+    .expect("apply_delta");
+    assert_eq!(
+        reconstructed, basis,
+        "apply_delta(basis, tokens) must reproduce the source bytes",
+    );
+}
+
+/// Per-segment ZSO-7 isolation: `rebuild` wipes the bucket heads and the
+/// chain backing store so a stale basis cannot resurface as a phantom
+/// match after the new segment populates.
+#[test]
+fn compact_key_state_resets_in_rebuild() {
+    let basis_one = distinct_basis(6);
+    let mut index = build_index(&basis_one).expect("first basis");
+
+    // The pre-rebuild basis matches itself, anchoring the comparison after
+    // the rebuild swaps in a disjoint basis.
+    let pre_window: Vec<u8> = basis_one[..index.block_length()].to_vec();
+    let pre_digest = index.block(0).rolling();
+    assert!(index.find_match_bytes(pre_digest, &pre_window).is_some());
+
+    // Build a brand-new signature that shares no content with `basis_one`
+    // and feed it through `rebuild`. The compact bucket array, the chain
+    // backing store, the tag table, the bithash, and the `next_match`
+    // link table must all have lost every trace of `basis_one`.
+    let mut basis_two = Vec::with_capacity(8 * TEST_BLOCK_LENGTH as usize);
+    for k in 0..8 {
+        let seed = ((k as u8).wrapping_mul(53)).wrapping_add(0x80);
+        for j in 0..TEST_BLOCK_LENGTH as usize {
+            basis_two.push(seed.wrapping_add((j as u8).wrapping_mul(19)));
+        }
+    }
+
+    let params = SignatureLayoutParams::new(
+        basis_two.len() as u64,
+        Some(NonZeroU32::new(TEST_BLOCK_LENGTH).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(TEST_STRONG_LEN).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let sig_two = generate_file_signature(basis_two.as_slice(), layout, SignatureAlgorithm::Md4)
+        .expect("signature");
+    let ok = index.rebuild(&sig_two, SignatureAlgorithm::Md4);
+    assert!(ok, "rebuild with full-length blocks must succeed");
+
+    // The old basis must no longer match: every byte sequence from
+    // `basis_one` was wiped from the compact bucket chains.
+    assert!(
+        index.find_match_bytes(pre_digest, &pre_window).is_none(),
+        "stale pre-rebuild basis must not resurface as a match"
+    );
+
+    // The new basis matches itself end-to-end, proving the bucket table
+    // was re-populated rather than left empty.
+    for k in 0..index.block_count() {
+        let digest = index.block(k).rolling();
+        let offset = k * index.block_length();
+        let window: Vec<u8> = basis_two[offset..offset + index.block_length()].to_vec();
+        assert!(
+            index.find_match_bytes(digest, &window).is_some(),
+            "block {k} of the post-rebuild basis must match",
+        );
+    }
+}

--- a/crates/matching/src/index/compact_key_tests.rs
+++ b/crates/matching/src/index/compact_key_tests.rs
@@ -82,6 +82,11 @@ fn bucket_size_is_capped_at_2_16() {
     let basis = distinct_basis(8);
     let index = build_index(&basis).expect("index for tiny basis");
     assert!(index.lookup_capacity() <= 1 << 16);
+
+    // `lookup_bytes` traverses `CompactLookup::bucket_bytes` so a regular
+    // (non-`--benches`) build sees the call chain and clippy stops marking
+    // `bucket_bytes` as dead code. The 256 KiB cap mirrors the bucket cap.
+    assert!(index.lookup_bytes() <= 256 * 1024);
 }
 
 /// Synthetic `(sum1, sum2)` pairs that share the upper-half bucket

--- a/crates/matching/src/index/compact_lookup.rs
+++ b/crates/matching/src/index/compact_lookup.rs
@@ -1,160 +1,230 @@
-//! Cache-friendly flat hash table replacing `FxHashMap<(u16, u16), Vec<usize>>`.
+//! Compact bucket index keyed on the upper half of the rolling checksum.
 //!
-//! Implements open-addressing with linear probing and Robin Hood displacement.
-//! Each entry is 8 bytes (4-byte packed rsum key + 4-byte block index), fitting
-//! 8 entries per 64-byte cache line. This replaces the pointer-chasing
-//! `FxHashMap` + heap-allocated `Vec<usize>` with a single contiguous allocation.
+//! Translates zsync's `librcksum/hash.c` `rsum_a_mask` trick into oc-rsync's
+//! delta matcher. The bucket address is derived from the upper 16 bits of the
+//! rolling sum (`rsum >> 16`, equal to [`checksums::RollingDigest::sum2`])
+//! while the lower 16 bits ([`checksums::RollingDigest::sum1`]) become the
+//! in-bucket discriminator. Shrinking the bucket array from a `(sum1, sum2)`
+//! keyspace down to a `sum2`-only space keeps the hottest table cache-line
+//! resident even when the basis runs to tens of thousands of blocks.
 //!
-//! zsync's `librcksum/hash.c` uses a similar flat layout; this module adapts
-//! the technique for oc-rsync's `DeltaSignatureIndex`.
+//! The structure is intentionally chain-based rather than open-addressed:
+//!
+//! - The bucket array is sized at most `2^16` slots, so its working set is
+//!   bounded by 256 KiB regardless of basis size. Adjacent rolling-hash
+//!   probes touch the same cache line with high probability.
+//! - Chain nodes live in a packed `Vec<ChainEntry>`; entries for a single
+//!   bucket are *not* required to be contiguous in memory, but the bucket
+//!   array stays tight.
+//! - Per-bucket walks check the lower-half discriminator first, mirroring
+//!   zsync's `e.r.a != (r.a & rsum_a_mask)` filter in `librcksum/rsum.c:205`.
+//!
+//! Wire format is unchanged: full `(sum1, sum2)` digests stay in
+//! [`signature::SignatureBlock`]. The compact key is an in-memory probe
+//! optimisation only and is rebuilt per segment by
+//! [`super::DeltaSignatureIndex::rebuild`].
 
-/// Sentinel value indicating an empty slot.
-const EMPTY_KEY: u32 = u32::MAX;
-
-/// Packs `(sum1, sum2)` into a single `u32` key.
+/// Maximum bucket count exponent (`2^16 = 65 536`).
 ///
-/// Uses `(sum2 << 16) | sum1` which matches `RollingDigest::value()` layout.
-/// Reserves `u32::MAX` as the empty sentinel - the probability of a real rsum
-/// hitting `0xFFFF_FFFF` is negligible (1 in 4 billion), and the tag_table +
-/// bithash filters would catch it first.
-#[inline]
-fn pack_key(sum1: u16, sum2: u16) -> u32 {
-    (sum2 as u32) << 16 | sum1 as u32
+/// Bounds the bucket array footprint at `2^16 * 4 = 256 KiB` and matches
+/// the natural `sum2` keyspace - never grow the table beyond this because
+/// the compact key carries no further entropy.
+const MAX_LOG2_BUCKETS: u32 = 16;
+
+/// Minimum bucket count exponent (`2^4 = 16`).
+///
+/// Keeps the mask stable for tiny basis files. The chain handles collisions
+/// regardless, so the floor is purely about preserving the `(pos - home)`
+/// arithmetic shape.
+const MIN_LOG2_BUCKETS: u32 = 4;
+
+/// Sentinel marking the end of a bucket chain.
+///
+/// Real entry counts are bounded by `u32::MAX - 1` because the wire-format
+/// block index is itself a `u32` and one slot is reserved for the sentinel.
+const CHAIN_END: u32 = u32::MAX;
+
+/// Conservative upper bound on chain-entry pre-allocation.
+///
+/// Caps the initial `Vec::with_capacity` request so callers passing absurd
+/// `n_entries` (e.g., `usize::MAX` in fuzz inputs) cannot trigger a
+/// capacity-overflow panic. The chain still grows on demand, so the cap
+/// only affects the up-front reservation, not the maximum supported
+/// basis size.
+const MAX_RESERVE_ENTRIES: usize = 1 << 24;
+
+/// Chain entry packing the lower-half discriminator next to the block index
+/// and the link to the next entry in the same bucket.
+///
+/// Layout fits in 12 bytes (10 bytes payload + 2 bytes padding) so a single
+/// chain step still loads from at most one cache line.
+#[derive(Clone, Copy, Debug)]
+struct ChainEntry {
+    /// Lower-half discriminator ([`checksums::RollingDigest::sum1`]). Filters
+    /// out same-bucket entries before the caller pays for the strong-checksum
+    /// verify.
+    sum1: u16,
+    /// Basis block index this entry refers to.
+    block_index: u32,
+    /// Link to the next entry in the same bucket chain, or [`CHAIN_END`].
+    next: u32,
 }
 
-/// Flat open-addressing hash table with Robin Hood linear probing.
+/// Per-bucket head/tail pointers into the chain backing store.
 ///
-/// Stores `(key: u32, block_index: u32)` entries in a contiguous `Vec<u64>`.
-/// The high 32 bits of each `u64` hold the packed rsum key; the low 32 bits
-/// hold the block index. Empty slots use [`EMPTY_KEY`] in the high bits.
+/// Tracking the tail explicitly lets [`CompactLookup::insert`] append in
+/// O(1) so the iteration order matches insertion order. The `MatchedBlocks`
+/// duplicate-block contract relies on first-fit-in-bucket semantics, so
+/// the natural insertion order must survive the rewrite.
+#[derive(Clone, Copy, Debug)]
+struct BucketSlot {
+    head: u32,
+    tail: u32,
+}
+
+impl BucketSlot {
+    const EMPTY: Self = Self {
+        head: CHAIN_END,
+        tail: CHAIN_END,
+    };
+}
+
+/// Compact bucket index keyed on the upper 16 bits of the rolling sum.
 ///
-/// Load factor is kept below 75% to maintain probe-chain locality. All
-/// operations are O(1) amortized with excellent cache behavior: the linear
-/// probe window typically stays within 1-2 cache lines.
+/// See the module docs for the ZSO-4 design contract and the duplicate-block
+/// correctness rationale shared with [`super::MatchedBlocks`].
 #[derive(Clone, Debug)]
 pub(super) struct CompactLookup {
-    slots: Vec<u64>,
-    mask: u32,
-    len: u32,
+    buckets: Vec<BucketSlot>,
+    entries: Vec<ChainEntry>,
+    mask: u16,
 }
 
 impl CompactLookup {
-    /// Builds a table sized for the expected number of entries.
+    /// Derives the bucket address from the packed rolling sum.
     ///
-    /// Capacity is the next power of two >= `4 * n_entries` (25% target load),
-    /// with a minimum of 16 slots.
+    /// `rsum >> 16` is the upper half of the wire-format checksum and matches
+    /// [`checksums::RollingDigest::sum2`], mirroring zsync's
+    /// `r.a & rsum_a_mask` formulation while staying entirely in-memory.
+    #[inline]
+    #[must_use]
+    pub(super) const fn bucket_for(rsum: u32) -> u16 {
+        (rsum >> 16) as u16
+    }
+
+    /// Builds a bucket table sized for the expected number of entries.
+    ///
+    /// Bucket count is the smallest power of two `>= 2 * n_entries`, clamped
+    /// to `[2^MIN_LOG2_BUCKETS, 2^MAX_LOG2_BUCKETS]`. The chain backing store
+    /// is reserved at a conservative upper bound (`MAX_RESERVE_ENTRIES`) so
+    /// adversarial inputs cannot trigger an oversized allocation up-front;
+    /// real basis sizes never approach the cap before paging concerns kick
+    /// in elsewhere.
     pub(super) fn with_capacity(n_entries: usize) -> Self {
-        let min_cap = (n_entries as u64)
-            .saturating_mul(4)
-            .next_power_of_two()
-            .max(16) as usize;
-        let cap = min_cap.min(1 << 30);
-        let mask = (cap - 1) as u32;
+        let log2_buckets = log2_buckets_for(n_entries);
+        let n_buckets = 1usize << log2_buckets;
+        let mask = (n_buckets - 1) as u16;
+        let reserve = n_entries.min(MAX_RESERVE_ENTRIES);
         Self {
-            slots: vec![Self::empty_slot(); cap],
+            buckets: vec![BucketSlot::EMPTY; n_buckets],
+            entries: Vec::with_capacity(reserve),
             mask,
-            len: 0,
         }
     }
 
     /// Inserts a `(sum1, sum2) -> block_index` mapping.
     ///
-    /// Uses Robin Hood insertion: if a new entry's probe distance exceeds the
-    /// incumbent's, swap them and continue inserting the displaced entry. This
-    /// bounds the variance of probe-chain lengths, keeping worst-case lookups
-    /// short.
+    /// Entries are appended to the tail of the bucket chain so the iteration
+    /// order matches insertion order. Preserving insertion order keeps the
+    /// `MatchedBlocks` first-fit-in-bucket semantics intact: the matcher
+    /// picks the earliest unmarked basis index when several blocks share a
+    /// bucket and discriminator.
     pub(super) fn insert(&mut self, sum1: u16, sum2: u16, block_index: u32) {
-        let key = pack_key(sum1, sum2);
-        debug_assert_ne!(key, EMPTY_KEY, "rsum 0xFFFFFFFF collides with sentinel");
+        debug_assert_ne!(
+            block_index, CHAIN_END,
+            "block_index u32::MAX collides with chain sentinel",
+        );
+        let bucket = self.bucket_index(sum2);
+        let entry_idx = self.entries.len() as u32;
+        self.entries.push(ChainEntry {
+            sum1,
+            block_index,
+            next: CHAIN_END,
+        });
 
-        let mut pos = (key & self.mask) as usize;
-        let mut inserting_key = key;
-        let mut inserting_val = block_index;
-        let mut inserting_dist: u32 = 0;
-
-        loop {
-            let slot = self.slots[pos];
-            let slot_key = (slot >> 32) as u32;
-
-            if slot_key == EMPTY_KEY {
-                self.slots[pos] = Self::pack_slot(inserting_key, inserting_val);
-                self.len += 1;
-                return;
-            }
-
-            let slot_dist = self.probe_distance(slot_key, pos);
-            if inserting_dist > slot_dist {
-                let slot_val = slot as u32;
-                self.slots[pos] = Self::pack_slot(inserting_key, inserting_val);
-                inserting_key = slot_key;
-                inserting_val = slot_val;
-                inserting_dist = slot_dist;
-            }
-
-            pos = ((pos + 1) as u32 & self.mask) as usize;
-            inserting_dist += 1;
+        let slot = self.buckets[bucket];
+        if slot.head == CHAIN_END {
+            self.buckets[bucket] = BucketSlot {
+                head: entry_idx,
+                tail: entry_idx,
+            };
+        } else {
+            self.entries[slot.tail as usize].next = entry_idx;
+            self.buckets[bucket].tail = entry_idx;
         }
     }
 
     /// Returns an iterator over all block indices matching `(sum1, sum2)`.
     ///
-    /// The iterator walks the probe chain from the key's home position,
-    /// yielding every entry with a matching key. It terminates when it
-    /// encounters an empty slot or an entry whose probe distance is less than
-    /// the current scan distance (Robin Hood invariant: no matching entry can
-    /// exist beyond this point).
+    /// Walks the `sum2`-derived bucket chain in insertion order and yields
+    /// entries whose lower-half discriminator equals `sum1`. The
+    /// strong-checksum verify still gates the final caller-visible match -
+    /// this iterator only filters out chain entries that cannot possibly
+    /// match.
     #[inline]
     pub(super) fn find_all(&self, sum1: u16, sum2: u16) -> CompactLookupIter<'_> {
-        let key = pack_key(sum1, sum2);
-        let start = (key & self.mask) as usize;
+        let bucket = self.bucket_index(sum2);
         CompactLookupIter {
             table: self,
-            key,
-            pos: start,
-            dist: 0,
+            sum1,
+            next: self.buckets[bucket].head,
         }
     }
 
-    /// Resets all slots to empty, preserving the backing allocation.
+    /// Masks `sum2` into the bucket-array address space.
+    ///
+    /// Equivalent to `sum2 & self.mask`, but kept as a single helper so the
+    /// insert and lookup paths cannot drift apart.
+    #[inline]
+    fn bucket_index(&self, sum2: u16) -> usize {
+        (sum2 & self.mask) as usize
+    }
+
+    /// Resets all bucket heads and chain entries, preserving the backing
+    /// allocations for the next per-segment rebuild.
     pub(super) fn clear(&mut self) {
-        self.slots.fill(Self::empty_slot());
-        self.len = 0;
+        self.buckets.fill(BucketSlot::EMPTY);
+        self.entries.clear();
     }
 
     /// Returns the number of stored entries.
     #[allow(dead_code)]
     pub(super) fn len(&self) -> u32 {
-        self.len
+        self.entries.len() as u32
     }
 
-    /// Returns the total number of slots (always a power of two).
+    /// Returns the number of bucket slots (always a power of two, `<= 2^16`).
+    ///
+    /// Reported as the bench harnesses' "lookup capacity" - the metric they
+    /// pair against the local CPU cache hierarchy.
     pub(super) fn capacity(&self) -> usize {
         (self.mask as usize) + 1
     }
 
-    #[inline]
-    fn empty_slot() -> u64 {
-        (EMPTY_KEY as u64) << 32
-    }
-
-    #[inline]
-    fn pack_slot(key: u32, value: u32) -> u64 {
-        ((key as u64) << 32) | value as u64
-    }
-
-    #[inline]
-    fn probe_distance(&self, key: u32, pos: usize) -> u32 {
-        let home = (key & self.mask) as usize;
-        ((pos as u32).wrapping_sub(home as u32)) & self.mask
+    /// Returns the byte footprint of the bucket array allocation.
+    ///
+    /// The chain backing store is excluded so the figure tracks the
+    /// cache-resident hot table only.
+    pub(super) fn bucket_bytes(&self) -> usize {
+        self.buckets.len() * core::mem::size_of::<BucketSlot>()
     }
 }
 
-/// Iterator over block indices matching a specific rsum key.
+/// Iterator yielding chain entries that match a given discriminator.
 pub(super) struct CompactLookupIter<'a> {
     table: &'a CompactLookup,
-    key: u32,
-    pos: usize,
-    dist: u32,
+    sum1: u16,
+    next: u32,
 }
 
 impl Iterator for CompactLookupIter<'_> {
@@ -163,26 +233,32 @@ impl Iterator for CompactLookupIter<'_> {
     #[inline]
     fn next(&mut self) -> Option<usize> {
         loop {
-            let slot = self.table.slots[self.pos];
-            let slot_key = (slot >> 32) as u32;
-
-            if slot_key == EMPTY_KEY {
+            if self.next == CHAIN_END {
                 return None;
             }
-
-            let slot_dist = self.table.probe_distance(slot_key, self.pos);
-            if slot_dist < self.dist {
-                return None;
-            }
-
-            self.pos = ((self.pos + 1) as u32 & self.table.mask) as usize;
-            self.dist += 1;
-
-            if slot_key == self.key {
-                return Some(slot as u32 as usize);
+            let entry = self.table.entries[self.next as usize];
+            self.next = entry.next;
+            if entry.sum1 == self.sum1 {
+                return Some(entry.block_index as usize);
             }
         }
     }
+}
+
+/// Returns the bucket-count exponent for the requested entry count.
+///
+/// Picks the smallest `k` with `2^k >= 2 * n_entries`, then clamps into
+/// `[MIN_LOG2_BUCKETS, MAX_LOG2_BUCKETS]`. The `2x` factor keeps the
+/// per-bucket chain length bounded at roughly half a slot per entry on
+/// average for uniformly distributed `sum2` values.
+fn log2_buckets_for(n_entries: usize) -> u32 {
+    let target = (n_entries as u64).saturating_mul(2);
+    let raw = if target <= 1 {
+        MIN_LOG2_BUCKETS
+    } else {
+        u64::BITS - (target - 1).leading_zeros()
+    };
+    raw.clamp(MIN_LOG2_BUCKETS, MAX_LOG2_BUCKETS)
 }
 
 #[cfg(test)]
@@ -258,21 +334,37 @@ mod tests {
     }
 
     #[test]
-    fn probe_distance_wraps_correctly() {
-        let table = CompactLookup::with_capacity(4);
-        assert_eq!(table.mask, 15);
-        assert_eq!(table.probe_distance(0, 0), 0);
-        assert_eq!(table.probe_distance(0, 3), 3);
-        assert_eq!(table.probe_distance(14, 1), 3);
+    fn bucket_address_uses_upper_half() {
+        let rsum: u32 = 0x1234_5678;
+        assert_eq!(CompactLookup::bucket_for(rsum), 0x1234);
+        assert_eq!(rsum >> 16, u32::from(CompactLookup::bucket_for(rsum)));
     }
 
     #[test]
-    fn pack_key_matches_rolling_digest_value() {
-        let sum1: u16 = 0x1234;
-        let sum2: u16 = 0x5678;
-        let packed = pack_key(sum1, sum2);
-        assert_eq!(packed, 0x5678_1234);
-        assert_eq!(packed & 0xFFFF, sum1 as u32);
-        assert_eq!(packed >> 16, sum2 as u32);
+    fn bucket_count_is_capped_at_two_to_sixteen() {
+        let table = CompactLookup::with_capacity(usize::MAX);
+        assert_eq!(table.capacity(), 1 << MAX_LOG2_BUCKETS);
+        assert_eq!(table.mask, u16::MAX);
+    }
+
+    #[test]
+    fn bucket_count_is_floored_for_tiny_inputs() {
+        let table = CompactLookup::with_capacity(0);
+        assert_eq!(table.capacity(), 1 << MIN_LOG2_BUCKETS);
+    }
+
+    #[test]
+    fn lower_half_discriminator_filters_same_bucket() {
+        // Two synthetic rsums sharing the upper-half bucket address but
+        // disagreeing on the lower-half discriminator. The chain walk must
+        // expose each entry under its own `(sum1, sum2)` key without leaking
+        // the sibling.
+        let mut table = CompactLookup::with_capacity(16);
+        table.insert(0xAAAA, 0x1234, 7);
+        table.insert(0xBBBB, 0x1234, 9);
+        let results_a: Vec<usize> = table.find_all(0xAAAA, 0x1234).collect();
+        let results_b: Vec<usize> = table.find_all(0xBBBB, 0x1234).collect();
+        assert_eq!(results_a, vec![7]);
+        assert_eq!(results_b, vec![9]);
     }
 }

--- a/crates/matching/src/index/compact_lookup.rs
+++ b/crates/matching/src/index/compact_lookup.rs
@@ -214,8 +214,12 @@ impl CompactLookup {
     /// Returns the byte footprint of the bucket array allocation.
     ///
     /// The chain backing store is excluded so the figure tracks the
-    /// cache-resident hot table only.
-    pub(super) fn bucket_bytes(&self) -> usize {
+    /// cache-resident hot table only. Exposed at crate-public visibility
+    /// so [`DeltaSignatureIndex::lookup_bytes`] forwards a measurement
+    /// helper that is reachable through the public API; `pub(super)`
+    /// gave dead-code false positives in the binary-only build path
+    /// because rustc cannot trace pub-to-restricted-pub call chains.
+    pub fn bucket_bytes(&self) -> usize {
         self.buckets.len() * core::mem::size_of::<BucketSlot>()
     }
 }

--- a/crates/matching/src/index/compact_lookup.rs
+++ b/crates/matching/src/index/compact_lookup.rs
@@ -214,11 +214,12 @@ impl CompactLookup {
     /// Returns the byte footprint of the bucket array allocation.
     ///
     /// The chain backing store is excluded so the figure tracks the
-    /// cache-resident hot table only. Exposed at crate-public visibility
-    /// so [`DeltaSignatureIndex::lookup_bytes`] forwards a measurement
-    /// helper that is reachable through the public API; `pub(super)`
-    /// gave dead-code false positives in the binary-only build path
-    /// because rustc cannot trace pub-to-restricted-pub call chains.
+    /// cache-resident hot table only. Gated behind `test` and
+    /// `bench-internal` because the only consumer is
+    /// [`crate::index::DeltaSignatureIndex::lookup_bytes`] which is also
+    /// test/bench-only; including this in the binary build trips dead-code
+    /// lint since rustc cannot trace pub-to-restricted-pub call chains.
+    #[cfg(any(test, feature = "bench-internal"))]
     pub fn bucket_bytes(&self) -> usize {
         self.buckets.len() * core::mem::size_of::<BucketSlot>()
     }

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -767,7 +767,7 @@ impl DeltaSignatureIndex {
 /// Behind the internal `bench-internal` feature flag so the surface never
 /// reaches release builds. See `docs/design/zsync-bithash.md` section 7
 /// for the rejection-rate methodology these accessors support.
-#[cfg(feature = "bench-internal")]
+#[cfg(any(test, feature = "bench-internal"))]
 impl DeltaSignatureIndex {
     /// Returns the fraction of bithash bits currently set, in `[0.0, 1.0]`.
     ///
@@ -815,12 +815,8 @@ impl DeltaSignatureIndex {
     ///
     /// Reports the hot table only; chain-entry storage is excluded so the
     /// figure tracks the cache-resident slot array a probe touches first.
-    /// Test- and bench-only: measurement helper used by the cache-footprint
-    /// bench harness. Gated behind `test` and `bench-internal` so the binary
-    /// build (which excludes both) does not flag the call chain as dead
-    /// code (`CompactLookup::bucket_bytes` is `pub(super)` and rustc cannot
-    /// trace pub-to-restricted-pub usage through a public forwarder).
-    #[cfg(any(test, feature = "bench-internal"))]
+    /// Test- and bench-only: the enclosing `impl` block is gated behind
+    /// `cfg(any(test, feature = "bench-internal"))`.
     #[must_use]
     pub fn lookup_bytes(&self) -> usize {
         self.lookup.bucket_bytes()

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -4,9 +4,12 @@
 //! delta generation. It indexes signature blocks by their rolling checksum
 //! components `(sum1, sum2)` for efficient matching.
 //!
-//! Uses a flat open-addressing hash table ([`CompactLookup`]) with Robin Hood
-//! probing for cache-friendly O(1) lookups. Each entry is 8 bytes (packed key
-//! + block index), fitting 8 entries per 64-byte cache line.
+//! The compact bucket index ([`CompactLookup`]) addresses buckets using only
+//! the upper half of the rolling sum (`rsum >> 16`, equal to `sum2`); the
+//! lower half (`sum1`) is stored as an in-bucket discriminator. This is the
+//! ZSO-4 translation of zsync's `librcksum/hash.c:45` `rsum_a_mask` trick:
+//! shrinking the bucket array to at most `2^16` slots keeps the hottest
+//! lookup table cache-line resident across rolling-hash advances.
 
 mod bithash;
 mod builder;
@@ -16,6 +19,8 @@ mod trace;
 
 #[cfg(test)]
 mod bithash_tests;
+#[cfg(test)]
+mod compact_key_tests;
 #[cfg(test)]
 mod matched_blocks_tests;
 #[cfg(test)]
@@ -59,18 +64,23 @@ const NEXT_MATCH_NONE: u32 = u32::MAX;
 
 /// Index over a file signature that accelerates delta matching.
 ///
-/// Uses a flat open-addressing hash table ([`CompactLookup`]) keyed by packed
-/// `(sum1, sum2)` for O(1) block lookup with excellent cache locality. A tag
-/// table indexed by `sum1` provides fast-path rejection before the hash probe,
-/// mirroring upstream rsync's `tag_table` in `match.c`. The block length is
-/// stored separately since all indexed blocks have the same canonical length.
+/// Uses a chained bucket table ([`CompactLookup`]) addressed by the upper
+/// half of the rolling sum (`sum2`) for O(1) block lookup with excellent
+/// cache locality. The lower half (`sum1`) lives inside each chain entry as
+/// an in-bucket discriminator, mirroring zsync's `librcksum`
+/// `rsum_a_mask` trick (ZSO-4). A tag table indexed by `sum1` still provides
+/// upstream-rsync-style fast-path rejection before the bucket walk, and the
+/// bithash prefilter (ZSO-1) rejects the bulk of post-tag misses before the
+/// chain probe.
 #[derive(Debug)]
 pub struct DeltaSignatureIndex {
     block_length: usize,
     strong_length: usize,
     algorithm: SignatureAlgorithm,
     blocks: Vec<SignatureBlock>,
-    /// Flat open-addressing lookup keyed by packed (sum1, sum2).
+    /// Compact bucket lookup keyed on the upper half of the rolling sum
+    /// (`rsum >> 16`); the lower 16 bits live inside each chain entry as
+    /// the in-bucket discriminator. See the ZSO-4 module-level docs.
     lookup: CompactLookup,
     /// Tag table for O(1) rejection using sum1 (low 16 bits of rolling checksum).
     /// upstream: match.c - `tag_table[s1]` check before hash probe.
@@ -213,6 +223,19 @@ impl SeqMatchCounters {
 }
 
 impl DeltaSignatureIndex {
+    /// Returns the bucket address the compact lookup would use for `rsum`.
+    ///
+    /// The compact key is `rsum >> 16` (equal to
+    /// [`checksums::RollingDigest::sum2`]); the lower 16 bits become the
+    /// in-chain discriminator. Exposed so callers and tests can reason
+    /// about bucket collisions without reaching into the private bucket
+    /// table.
+    #[inline]
+    #[must_use]
+    pub const fn bucket_for(rsum: u32) -> u16 {
+        CompactLookup::bucket_for(rsum)
+    }
+
     /// Returns the role used for `--debug=HASH` `[<role>]` prefixes.
     #[must_use]
     pub const fn role(&self) -> HashtableRole {
@@ -778,25 +801,23 @@ impl DeltaSignatureIndex {
         self.tag_table[sum1 as usize]
     }
 
-    /// Slot count of the underlying compact lookup table.
+    /// Bucket-slot count of the underlying compact lookup table.
     ///
-    /// The lookup table is a flat `Vec<u64>` open-addressing hash whose
-    /// footprint dominates the cache behaviour of a hot lookup loop.
-    /// Bench harnesses use this to bin index sizes against the local CPU
-    /// cache hierarchy (L1 / L2 / LLC / main memory).
+    /// Equal to the bucket count, capped at `2^16` per the ZSO-4 compact-key
+    /// design. Bench harnesses use this to bin index sizes against the local
+    /// CPU cache hierarchy (L1 / L2 / LLC / main memory).
     #[must_use]
     pub fn lookup_capacity(&self) -> usize {
         self.lookup.capacity()
     }
 
-    /// Byte size of the underlying compact lookup table allocation.
+    /// Byte size of the bucket-array allocation backing the compact lookup.
     ///
-    /// Equal to `lookup_capacity() * 8` for the current 8-byte slot layout.
-    /// Reported separately so harnesses keep working if the slot width
-    /// changes (#2072 packed-key candidate).
+    /// Reports the hot table only; chain-entry storage is excluded so the
+    /// figure tracks the cache-resident slot array a probe touches first.
     #[must_use]
     pub fn lookup_bytes(&self) -> usize {
-        self.lookup.capacity() * core::mem::size_of::<u64>()
+        self.lookup.bucket_bytes()
     }
 
     /// Drives the compact lookup probe directly, skipping the tag-table

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -815,6 +815,12 @@ impl DeltaSignatureIndex {
     ///
     /// Reports the hot table only; chain-entry storage is excluded so the
     /// figure tracks the cache-resident slot array a probe touches first.
+    /// Test- and bench-only: measurement helper used by the cache-footprint
+    /// bench harness. Gated behind `test` and `bench-internal` so the binary
+    /// build (which excludes both) does not flag the call chain as dead
+    /// code (`CompactLookup::bucket_bytes` is `pub(super)` and rustc cannot
+    /// trace pub-to-restricted-pub usage through a public forwarder).
+    #[cfg(any(test, feature = "bench-internal"))]
     #[must_use]
     pub fn lookup_bytes(&self) -> usize {
         self.lookup.bucket_bytes()


### PR DESCRIPTION
## Summary

Adapt zsync's `librcksum` `rsum_a_mask` trick (see `librcksum/hash.c:45` and `librcksum/rsum.c:205` in zsync 0.6.2) to oc-rsync's `DeltaSignatureIndex`. The bucket address is derived from `rsum >> 16` (equal to `RollingDigest::sum2`) and capped at `2^16` slots, so the hot lookup table stays cache-line resident even on tens-of-thousands-of-blocks bases. The lower 16 bits (`sum1`) become the in-bucket discriminator, mirroring zsync's `e.r.a != (r.a & rsum_a_mask)` filter.

### Prerequisites (already on master)

- ZSO-1 bithash prefilter (`crates/matching/src/index/bithash.rs`)
- ZSO-2 next_match lookahead (#4624)
- ZSO-3 hash-chain pruning via consumed bitset (#4654)
- ZSO-5 wire-byte parity tests (#4627)
- ZSO-6 bench harness (#4625)

### Implementation

- Rewrote `CompactLookup` as a chained bucket table:
  - Bucket array sized `min(2^16, next_pow2(2 * n_entries).max(2^4))` so the bucket fetch stays in <= 256 KiB.
  - Chain entries pack `(sum1, block_index, next)`; the chain walk filters by `sum1` before yielding any candidate index.
  - Insertion appends to the tail to keep insertion order, preserving the `MatchedBlocks` first-fit-in-bucket contract.
- Exposed `DeltaSignatureIndex::bucket_for(rsum) -> u16` for callers and tests.
- `lookup_capacity`, `lookup_bytes`, and `lookup_probe` accessors keep working - `lookup_bytes` now reports the bucket-array footprint (the cache-resident hot table).
- `rebuild()` clears bucket heads and the chain backing store so per-segment ZSO-7 isolation is preserved.
- Wire format unchanged: full `(sum1, sum2)` digests still live in `SignatureBlock` and on the wire. The compact key is an in-memory probe optimisation only.

### Tests (new, in `crates/matching/src/index/compact_key_tests.rs`)

- `bucket_size_is_capped_at_2_16` - asserts the bucket array never exceeds `2^16` slots.
- `bucket_collisions_resolved_by_lower_half_check` - synthesises rsums sharing `rsum >> 16` and verifies each one is exposed only under its own discriminator.
- `compact_key_does_not_break_match_correctness` - 16-block basis with all matching source: Copy tokens cover every block in order, no literal bytes leak, `apply_delta` reproduces the source byte-for-byte.
- `compact_key_state_resets_in_rebuild` - populate, match, rebuild with a disjoint basis, assert the pre-rebuild basis no longer matches and the post-rebuild basis matches itself.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p matching --all-features` (341 passed)
- [x] `cargo nextest run -p protocol --all-features -E 'test(golden)'` (407 passed)
- [x] `cargo build -p matching --benches --features bench-internal` (bench harness still builds and runs cleanly)

### Measured behaviour

- Bucket array footprint plateaus at 256 KiB regardless of `n_entries`, so the hot table now fits in L2 even for the `ram` bench fixture (8 388 608 entries). The chain backing store still scales with the entry count and is the working set that pushes through the cache hierarchy.
- End-to-end matching (`compact_key_does_not_break_match_correctness`) and per-segment isolation (`compact_key_state_resets_in_rebuild`) confirm the reshape preserves rolling-rsum match semantics and the rebuild contract.
- Microbenchmark `zsync_optimizations` builds and links cleanly under `--features bench-internal`; full quick-run numbers are gated behind the workspace build lock and will be captured in the follow-up bench sweep.