### PR TITLE
perf(transfer): enable parallel receive-delta by default via Path B heuristic (PIP-3 + PIP-5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = [
     "xattr",
     "iconv",
     "parallel",
+    "parallel-receive-delta",
     "copy_file_range",
     "io_uring",
     "iocp",
@@ -63,6 +64,16 @@ iconv = ["cli/iconv", "core/iconv"]
 # Benefits: 2-8x faster on multi-core systems for batch operations
 # Trade-offs: Minimal overhead on single-core systems
 parallel = ["cli/parallel", "checksums/parallel"]
+
+# Parallel receive-side delta apply (#1368). Forwards through cli to core,
+# transfer, and engine. The receiver dispatches per-transfer via the Path B
+# heuristic in `docs/design/parallel-receive-delta-default-on.md`.
+parallel-receive-delta = [
+    "cli/parallel-receive-delta",
+    "core/parallel-receive-delta",
+    "transfer/parallel-receive-delta",
+    "engine/parallel-receive-delta",
+]
 
 # io_uring support for Linux 5.6+ - batched async I/O syscalls
 # Requirements: Linux kernel 5.6+ (runtime fallback on older kernels)

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ rustdoc-args = ["--cfg", "docsrs", "-D", "rustdoc::broken_intra_doc_links"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["zstd", "lz4", "xattr"]
+default = ["zstd", "lz4", "xattr", "parallel-receive-delta"]
 
 # ============================================================================
 # Compression Features
@@ -41,6 +41,11 @@ iconv = ["core/iconv"]
 # Parallel file operations - enables rayon-based parallelism for checksum mode
 # Also enables engine optimization features for maximum performance
 parallel = ["engine/lazy-metadata", "checksums/parallel"]
+
+# Parallel receive-side delta apply (#1368). Default on; the receiver
+# dispatches per-transfer via the Path B heuristic documented in
+# `docs/design/parallel-receive-delta-default-on.md`.
+parallel-receive-delta = ["core/parallel-receive-delta"]
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -63,7 +63,7 @@ default-features = false
 features = ["xattr"]
 
 [features]
-default = ["zstd", "lz4", "xattr", "iconv"]
+default = ["zstd", "lz4", "xattr", "iconv", "parallel-receive-delta"]
 
 # ============================================================================
 # Compression Features
@@ -91,6 +91,11 @@ embedded-ssh = ["dep:tokio", "rsync_io/embedded-ssh"]
 
 # Async runtime support - enables tokio-based async I/O for core operations
 async = ["dep:tokio", "engine/async", "transfer/async"]
+
+# Parallel receive-side delta apply (#1368). Forwards through transfer to
+# engine; the receiver dispatches per-transfer via the Path B heuristic
+# documented in `docs/design/parallel-receive-delta-default-on.md`.
+parallel-receive-delta = ["transfer/parallel-receive-delta", "engine/parallel-receive-delta"]
 
 # Async SSH transport: wires `rsync_io::ssh::AsyncSshTransport` into the client
 # remote transfer path. Opt-in at runtime via the `OC_RSYNC_ASYNC_SSH=1` env

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -102,9 +102,9 @@ parallel = []
 
 # Parallel receive-side delta apply (#1368) - scaffolds the per-file rayon
 # fanout for checksum verification while keeping the per-file destination
-# write serial. Default off so production receivers continue to use the
-# sequential apply loop. Opt-in for benchmarking and the phased rollout
-# described in `docs/design/parallel-receive-delta-application.md`.
+# write serial. Default on as of the Path B promotion described in
+# `docs/design/parallel-receive-delta-default-on.md`; the receiver decides
+# per-transfer via `ReceiverContext::select_receiver_strategy`.
 parallel-receive-delta = []
 
 # Multi-producer work queue - enables Clone for WorkQueueSender

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -55,7 +55,7 @@ default-features = false
 features = ["xattr"]
 
 [features]
-default = ["zstd", "lz4", "xattr", "incremental-flist"]
+default = ["zstd", "lz4", "xattr", "incremental-flist", "parallel-receive-delta"]
 
 # ============================================================================
 # Compression Features
@@ -101,9 +101,9 @@ iocp = ["fast_io/iocp"]
 vmsplice = ["fast_io/vmsplice"]
 
 # Parallel receive-side delta apply (#1368) - forwards to the engine crate's
-# `parallel-receive-delta` feature. Default off; opt-in for benchmarking the
-# parallel apply scaffold described in
-# `docs/design/parallel-receive-delta-application.md`.
+# `parallel-receive-delta` feature. Default on via the Path B promotion in
+# `docs/design/parallel-receive-delta-default-on.md`; opt out by building
+# with `--no-default-features` plus the feature subset you want.
 parallel-receive-delta = ["engine/parallel-receive-delta"]
 
 # Per-thread slab pool for buffer returns - forwards to the engine crate.

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -62,7 +62,7 @@ use crate::shared::ChecksumFactory;
 
 pub use self::basis::{BasisFileConfig, BasisFileResult, find_basis_file_with_config};
 pub use self::file_list::IncrementalFileListReceiver;
-pub use self::stats::{SenderStats, TransferStats};
+pub use self::stats::{ReceiverStrategy, SenderStats, TransferStats};
 pub use self::wire::{
     SenderAttrs, SumHead, apply_xattr_abbreviation_values, write_signature_blocks,
     write_xattr_request,
@@ -86,6 +86,22 @@ const PHASE1_CHECKSUM_LENGTH: NonZeroU8 =
 /// (upstream: generator.c:2163 `csum_length = SUM_LENGTH`)
 const REDO_CHECKSUM_LENGTH: NonZeroU8 =
     NonZeroU8::new(signature::block_size::MAX_SUM_LENGTH).unwrap();
+
+/// Path B heuristic: file-count cutoff above which the receiver dispatches
+/// to the parallel apply path.
+///
+/// 100 is the next common cutoff above the rayon `PARALLEL_STAT_THRESHOLD = 64`
+/// convention referenced in `MEMORY.md`. See
+/// `docs/design/parallel-receive-delta-default-on.md` section 6.2.
+pub const PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD: usize = 100;
+
+/// Path B heuristic: total-source-bytes cutoff above which the receiver
+/// dispatches to the parallel apply path.
+///
+/// 64 MiB matches the `copy_file_range` crossover documented in
+/// `crates/engine/benches/per_op_thresholds.rs`. See
+/// `docs/design/parallel-receive-delta-default-on.md` section 6.2.
+pub const PARALLEL_RECEIVE_BYTES_THRESHOLD: u64 = 64 * 1024 * 1024;
 
 pub(crate) use crate::parallel_io::ParallelThresholds;
 
@@ -374,11 +390,12 @@ impl ReceiverContext {
 
     /// Swaps the delta pipeline to the parallel apply path (#1368).
     ///
-    /// Gated behind the `parallel-receive-delta` cargo feature so the
-    /// production binary continues to drive the sequential apply loop until
-    /// the parity gating in `docs/design/parallel-receive-delta-application.md`
-    /// closes. Callers compile this in for benchmarking and the phased
-    /// rollout described in section 6.3 of that document.
+    /// Gated behind the `parallel-receive-delta` cargo feature. The feature
+    /// is in the default set for both `engine` and `transfer` so production
+    /// receivers can dispatch via [`Self::select_receiver_strategy`] without
+    /// any opt-in build flag. See
+    /// `docs/design/parallel-receive-delta-default-on.md` section 8 for the
+    /// promotion timeline.
     ///
     /// Builds a [`ParallelDeltaPipeline`] sized to the ambient rayon pool
     /// and installs it via [`set_delta_pipeline`](Self::set_delta_pipeline).
@@ -389,6 +406,110 @@ impl ReceiverContext {
         use crate::delta_pipeline::ParallelDeltaPipeline;
         let worker_count = rayon::current_num_threads();
         self.set_delta_pipeline(Box::new(ParallelDeltaPipeline::new(worker_count)));
+    }
+
+    /// Picks the receiver apply strategy via the Path B heuristic.
+    ///
+    /// Returns [`ReceiverStrategy::Parallel`] when either the file count
+    /// exceeds [`PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD`] or the total source
+    /// bytes exceed [`PARALLEL_RECEIVE_BYTES_THRESHOLD`]; otherwise returns
+    /// [`ReceiverStrategy::Sequential`]. The thresholds match the
+    /// `PARALLEL_STAT_THRESHOLD = 64` convention (next common cutoff is 100)
+    /// and the 64 MiB `copy_file_range` crossover documented in
+    /// `crates/engine/benches/per_op_thresholds.rs`. See
+    /// `docs/design/parallel-receive-delta-default-on.md` section 6.2.
+    #[must_use]
+    pub const fn select_receiver_strategy(
+        file_count: usize,
+        total_size: u64,
+    ) -> ReceiverStrategy {
+        if file_count > PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD
+            || total_size > PARALLEL_RECEIVE_BYTES_THRESHOLD
+        {
+            ReceiverStrategy::Parallel
+        } else {
+            ReceiverStrategy::Sequential
+        }
+    }
+
+    /// Computes the total source byte count across the receiver's file list.
+    ///
+    /// Used as the `total_size` input to [`Self::select_receiver_strategy`].
+    /// Walks the in-memory file list once; the value is also the numerator
+    /// of the `--stats` speedup ratio reported at end-of-transfer.
+    #[must_use]
+    pub fn total_source_bytes(&self) -> u64 {
+        self.file_list.iter().map(|e| e.size()).sum()
+    }
+
+    /// Applies the Path B dispatch decision before the apply loop runs.
+    ///
+    /// Computes `total_size` from the file list, selects the strategy via
+    /// [`Self::select_receiver_strategy`], records the decision under the
+    /// `GENR` debug channel, and (when the `parallel-receive-delta` feature
+    /// is enabled) swaps the delta pipeline to the parallel apply path.
+    /// Returns the chosen strategy for callers to stamp on
+    /// [`TransferStats::receiver_strategy_chosen`].
+    ///
+    /// When the heuristic picks [`ReceiverStrategy::Parallel`] but the
+    /// `parallel-receive-delta` feature is compiled out, the function logs
+    /// `receiver_strategy=parallel_unavailable` and returns
+    /// [`ReceiverStrategy::Sequential`] so telemetry never claims a path
+    /// the binary cannot actually take.
+    pub(in crate::receiver) fn dispatch_receiver_strategy(
+        &mut self,
+        file_count: usize,
+    ) -> ReceiverStrategy {
+        let total_size = self.total_source_bytes();
+        let want = Self::select_receiver_strategy(file_count, total_size);
+        match want {
+            ReceiverStrategy::Parallel => {
+                #[cfg(feature = "parallel-receive-delta")]
+                {
+                    logging::debug_log!(
+                        Genr,
+                        1,
+                        "receiver_strategy=parallel file_count={} total_size={} \
+                         (threshold: file_count>{} || total_size>{})",
+                        file_count,
+                        total_size,
+                        PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD,
+                        PARALLEL_RECEIVE_BYTES_THRESHOLD
+                    );
+                    self.enable_parallel_receive_delta();
+                    ReceiverStrategy::Parallel
+                }
+                #[cfg(not(feature = "parallel-receive-delta"))]
+                {
+                    logging::debug_log!(
+                        Genr,
+                        1,
+                        "receiver_strategy=parallel_unavailable file_count={} total_size={} \
+                         (threshold: file_count>{} || total_size>{}); \
+                         falling back to sequential because the parallel-receive-delta \
+                         feature is not compiled in",
+                        file_count,
+                        total_size,
+                        PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD,
+                        PARALLEL_RECEIVE_BYTES_THRESHOLD
+                    );
+                    ReceiverStrategy::Sequential
+                }
+            }
+            ReceiverStrategy::Sequential => {
+                logging::debug_log!(
+                    Genr,
+                    1,
+                    "receiver_strategy=sequential file_count={} total_size={} \
+                     (threshold: file_count>{} || total_size>{})",
+                    file_count,
+                    total_size,
+                    PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD,
+                    PARALLEL_RECEIVE_BYTES_THRESHOLD
+                );
+                ReceiverStrategy::Sequential
+            }
+        }
     }
 
     /// Converts a flat file list array index to a wire NDX value.
@@ -800,4 +921,73 @@ fn compile_daemon_filter_set(rules: &[FilterRuleWireFormat]) -> Option<FilterSet
     }
 
     FilterSet::from_rules(filter_rules).ok()
+}
+
+#[cfg(test)]
+mod strategy_tests {
+    //! Unit coverage for the Path B dispatch heuristic. See
+    //! `docs/design/parallel-receive-delta-default-on.md` section 6.2.
+
+    use super::{
+        PARALLEL_RECEIVE_BYTES_THRESHOLD, PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD, ReceiverContext,
+        ReceiverStrategy,
+    };
+
+    #[test]
+    fn below_both_thresholds_picks_sequential() {
+        // 50 files at 1 MiB total - well under file_count > 100 and
+        // total_size > 64 MiB.
+        let strategy = ReceiverContext::select_receiver_strategy(50, 1 * 1024 * 1024);
+        assert_eq!(strategy, ReceiverStrategy::Sequential);
+    }
+
+    #[test]
+    fn above_file_count_threshold_picks_parallel() {
+        // 200 files at 1 MiB total - file_count > 100 trips parallel even
+        // though total_size is small.
+        let strategy = ReceiverContext::select_receiver_strategy(200, 1 * 1024 * 1024);
+        assert_eq!(strategy, ReceiverStrategy::Parallel);
+    }
+
+    #[test]
+    fn above_bytes_threshold_picks_parallel() {
+        // 50 files at 100 MiB total - total_size > 64 MiB trips parallel
+        // even though file_count is small.
+        let strategy = ReceiverContext::select_receiver_strategy(50, 100 * 1024 * 1024);
+        assert_eq!(strategy, ReceiverStrategy::Parallel);
+    }
+
+    #[test]
+    fn empty_transfer_picks_sequential() {
+        // Universal idempotent-transfer case: a single zero-byte file.
+        // Both inputs are below their respective cutoffs, so the receiver
+        // never pays the rayon dispatch tax for a no-op.
+        let strategy = ReceiverContext::select_receiver_strategy(1, 0);
+        assert_eq!(strategy, ReceiverStrategy::Sequential);
+    }
+
+    #[test]
+    fn exact_thresholds_pick_sequential() {
+        // Boundary check: the heuristic uses strict `>` not `>=`, so the
+        // threshold values themselves keep the sequential path.
+        let strategy = ReceiverContext::select_receiver_strategy(
+            PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD,
+            PARALLEL_RECEIVE_BYTES_THRESHOLD,
+        );
+        assert_eq!(strategy, ReceiverStrategy::Sequential);
+    }
+
+    #[test]
+    fn just_over_file_threshold_picks_parallel() {
+        let strategy =
+            ReceiverContext::select_receiver_strategy(PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD + 1, 0);
+        assert_eq!(strategy, ReceiverStrategy::Parallel);
+    }
+
+    #[test]
+    fn just_over_bytes_threshold_picks_parallel() {
+        let strategy =
+            ReceiverContext::select_receiver_strategy(0, PARALLEL_RECEIVE_BYTES_THRESHOLD + 1);
+        assert_eq!(strategy, ReceiverStrategy::Parallel);
+    }
 }

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -934,7 +934,7 @@ mod strategy_tests {
     fn below_both_thresholds_picks_sequential() {
         // 50 files at 1 MiB total - well under file_count > 100 and
         // total_size > 64 MiB.
-        let strategy = ReceiverContext::select_receiver_strategy(50, 1 * 1024 * 1024);
+        let strategy = ReceiverContext::select_receiver_strategy(50, 1024 * 1024);
         assert_eq!(strategy, ReceiverStrategy::Sequential);
     }
 
@@ -942,7 +942,7 @@ mod strategy_tests {
     fn above_file_count_threshold_picks_parallel() {
         // 200 files at 1 MiB total - file_count > 100 trips parallel even
         // though total_size is small.
-        let strategy = ReceiverContext::select_receiver_strategy(200, 1 * 1024 * 1024);
+        let strategy = ReceiverContext::select_receiver_strategy(200, 1024 * 1024);
         assert_eq!(strategy, ReceiverStrategy::Parallel);
     }
 

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -419,10 +419,7 @@ impl ReceiverContext {
     /// `crates/engine/benches/per_op_thresholds.rs`. See
     /// `docs/design/parallel-receive-delta-default-on.md` section 6.2.
     #[must_use]
-    pub const fn select_receiver_strategy(
-        file_count: usize,
-        total_size: u64,
-    ) -> ReceiverStrategy {
+    pub const fn select_receiver_strategy(file_count: usize, total_size: u64) -> ReceiverStrategy {
         if file_count > PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD
             || total_size > PARALLEL_RECEIVE_BYTES_THRESHOLD
         {

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -7,6 +7,23 @@ use std::path::PathBuf;
 
 use protocol::stats::DeleteStats;
 
+/// Which receive-side delta apply path the receiver dispatched to.
+///
+/// Set by [`ReceiverContext::select_receiver_strategy`] before the apply
+/// loop runs and surfaced on [`TransferStats::receiver_strategy_chosen`]
+/// for telemetry. The heuristic and thresholds are documented in
+/// `docs/design/parallel-receive-delta-default-on.md` section 6.2 (Path B).
+///
+/// [`ReceiverContext::select_receiver_strategy`]: crate::receiver::ReceiverContext::select_receiver_strategy
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReceiverStrategy {
+    /// Single-threaded apply loop. Matches upstream rsync `recv_files()`.
+    #[default]
+    Sequential,
+    /// Cross-file parallel apply via [`crate::delta_pipeline::ParallelDeltaPipeline`].
+    Parallel,
+}
+
 /// Statistics from a receiver transfer operation.
 ///
 /// Returned inside [`crate::ServerStats::Receiver`] after a successful receive.
@@ -103,6 +120,16 @@ pub struct TransferStats {
     /// - `receiver.c:970-974` - `send_msg_int(MSG_REDO, ndx)` queues for redo
     /// - `generator.c:2160-2199` - generator processes redo queue in phase 2
     pub redo_count: usize,
+
+    /// Which apply path the receiver dispatched to for this transfer.
+    ///
+    /// Default is [`ReceiverStrategy::Sequential`]. The receiver may flip to
+    /// [`ReceiverStrategy::Parallel`] when the heuristic in
+    /// [`crate::receiver::ReceiverContext::select_receiver_strategy`] returns
+    /// it. Reported for telemetry; the wire format is unaffected.
+    ///
+    /// See `docs/design/parallel-receive-delta-default-on.md` section 6.2.
+    pub receiver_strategy_chosen: ReceiverStrategy,
 }
 
 /// Statistics received from the remote sender after transfer completion.

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -172,6 +172,7 @@ fn transfer_stats_has_incremental_fields() {
         literal_data: 0,
         matched_data: 0,
         redo_count: 0,
+        receiver_strategy_chosen: Default::default(),
     };
 
     assert_eq!(stats.entries_received, 100);

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -24,6 +24,9 @@
 //! - [`iconv_wire_order`] - regression coverage for the receiver-side
 //!   `--iconv` ordering invariant (file_list stays in sender wire-emit
 //!   order, never re-sorted on local-charset bytes).
+//! - [`receiver_strategy`] - Path B dispatch coverage:
+//!   `total_source_bytes` and `dispatch_receiver_strategy` heuristic
+//!   matrix across small/many/large/empty workloads.
 
 mod delete_pipeline_hook;
 mod filter_chain;
@@ -34,6 +37,7 @@ mod incremental_directories;
 mod incremental_receiver;
 mod ndx_convert;
 mod proto_io_error;
+mod receiver_strategy;
 mod wire_attrs;
 
 use std::io::Cursor;

--- a/crates/transfer/src/receiver/tests/file_list/receiver_strategy.rs
+++ b/crates/transfer/src/receiver/tests/file_list/receiver_strategy.rs
@@ -60,11 +60,7 @@ fn dispatch_many_small_files_picks_parallel() {
 fn dispatch_large_bytes_picks_parallel() {
     // Single 128 MiB file - trips the 64 MiB total_size cutoff even with
     // a small file_count.
-    let entries = vec![FileEntry::new_file(
-        "big".into(),
-        128 * 1024 * 1024,
-        0o644,
-    )];
+    let entries = vec![FileEntry::new_file("big".into(), 128 * 1024 * 1024, 0o644)];
     let mut ctx = make_ctx_with_files(entries);
     let strategy = ctx.dispatch_receiver_strategy(1);
     assert_eq!(strategy, ReceiverStrategy::Parallel);

--- a/crates/transfer/src/receiver/tests/file_list/receiver_strategy.rs
+++ b/crates/transfer/src/receiver/tests/file_list/receiver_strategy.rs
@@ -1,0 +1,91 @@
+//! Receiver strategy dispatch coverage (Path B).
+//!
+//! Verifies that `ReceiverContext::dispatch_receiver_strategy` walks the
+//! file list, computes the total source byte count, and returns the
+//! [`ReceiverStrategy`] dictated by the file_count / total_size heuristic
+//! documented in `docs/design/parallel-receive-delta-default-on.md`.
+
+use protocol::flist::FileEntry;
+
+use super::super::super::ReceiverContext;
+use super::super::super::stats::ReceiverStrategy;
+use super::super::support::{test_config, test_handshake};
+
+fn make_ctx_with_files(entries: Vec<FileEntry>) -> ReceiverContext {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new(&handshake, config);
+    ctx.file_list = entries;
+    ctx
+}
+
+#[test]
+fn total_source_bytes_sums_file_list() {
+    let entries = vec![
+        FileEntry::new_file("a".into(), 100, 0o644),
+        FileEntry::new_file("b".into(), 200, 0o644),
+        FileEntry::new_file("c".into(), 300, 0o644),
+    ];
+    let ctx = make_ctx_with_files(entries);
+    assert_eq!(ctx.total_source_bytes(), 600);
+}
+
+#[test]
+fn dispatch_small_transfer_picks_sequential() {
+    // 5 small files at 1 KiB each = 5 KiB total. Both inputs well below
+    // the Path B cutoffs.
+    let entries = (0..5)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1024, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(5);
+    assert_eq!(strategy, ReceiverStrategy::Sequential);
+}
+
+#[test]
+#[cfg(feature = "parallel-receive-delta")]
+fn dispatch_many_small_files_picks_parallel() {
+    // 200 tiny files trips the file_count cutoff even though total_size
+    // is negligible.
+    let entries = (0..200)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(200);
+    assert_eq!(strategy, ReceiverStrategy::Parallel);
+}
+
+#[test]
+#[cfg(feature = "parallel-receive-delta")]
+fn dispatch_large_bytes_picks_parallel() {
+    // Single 128 MiB file - trips the 64 MiB total_size cutoff even with
+    // a small file_count.
+    let entries = vec![FileEntry::new_file(
+        "big".into(),
+        128 * 1024 * 1024,
+        0o644,
+    )];
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(1);
+    assert_eq!(strategy, ReceiverStrategy::Parallel);
+}
+
+#[test]
+#[cfg(not(feature = "parallel-receive-delta"))]
+fn dispatch_falls_back_to_sequential_without_feature() {
+    // When the feature is compiled out, even a "wants-parallel" workload
+    // must report sequential so telemetry never lies about the path taken.
+    let entries = (0..200)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(200);
+    assert_eq!(strategy, ReceiverStrategy::Sequential);
+}
+
+#[test]
+fn dispatch_empty_file_list_picks_sequential() {
+    let mut ctx = make_ctx_with_files(Vec::new());
+    let strategy = ctx.dispatch_receiver_strategy(0);
+    assert_eq!(strategy, ReceiverStrategy::Sequential);
+}

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -40,6 +40,10 @@ impl ReceiverContext {
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader)?;
         let reader = &mut reader;
 
+        // Path B dispatch: pick sequential vs parallel apply before the loop.
+        // upstream-independent: matches docs/design/parallel-receive-delta-default-on.md.
+        let receiver_strategy_chosen = self.dispatch_receiver_strategy(file_count);
+
         // upstream: generator.c:1317-1326 - make_path() for relative_paths
         self.ensure_relative_parents(&setup.dest_dir);
         let mut metadata_errors = self.create_directories(
@@ -62,6 +66,7 @@ impl ReceiverContext {
             entries_received: file_count as u64,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
                 | self.flist_io_error,
+            receiver_strategy_chosen,
             ..Default::default()
         };
         let files_to_transfer = self.build_files_to_transfer(

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -37,11 +37,16 @@ impl ReceiverContext {
         let (mut reader, file_count, mut setup) = self.setup_transfer(reader)?;
         let reader = &mut reader;
 
+        // Path B dispatch: pick sequential vs parallel apply before the loop.
+        // upstream-independent: matches docs/design/parallel-receive-delta-default-on.md.
+        let receiver_strategy_chosen = self.dispatch_receiver_strategy(file_count);
+
         let mut stats = TransferStats {
             files_listed: file_count,
             entries_received: file_count as u64,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
                 | self.flist_io_error,
+            receiver_strategy_chosen,
             ..Default::default()
         };
         let mut failed_dirs = crate::receiver::directory::FailedDirectories::new();

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -45,6 +45,10 @@ impl ReceiverContext {
         let (mut reader, file_count, setup) = self.setup_transfer(reader)?;
         let reader = &mut reader;
 
+        // Path B dispatch: pick sequential vs parallel apply before the loop.
+        // upstream-independent: matches docs/design/parallel-receive-delta-default-on.md.
+        let receiver_strategy_chosen = self.dispatch_receiver_strategy(file_count);
+
         let PipelineSetup {
             dest_dir,
             metadata_opts,
@@ -345,6 +349,7 @@ impl ReceiverContext {
             literal_data: 0,
             matched_data: 0,
             redo_count: 0,
+            receiver_strategy_chosen,
         })
     }
 }

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -34,6 +34,7 @@ fn transfer_stats_incremental_fields_exist() {
         literal_data: 0,
         matched_data: 0,
         redo_count: 0,
+        receiver_strategy_chosen: Default::default(),
     };
 
     assert_eq!(stats.files_listed, 10);

--- a/docs/design/parallel-receive-delta-default-on.md
+++ b/docs/design/parallel-receive-delta-default-on.md
@@ -16,24 +16,30 @@ umbrella design covers those. It narrows one open question:
 ## 1. Current state
 
 `crates/engine/src/concurrent_delta/parallel_apply.rs` ships
-[`ParallelDeltaApplier`] gated behind the
-`parallel-receive-delta` cargo feature on both `engine` and `transfer`.
-Production receivers do not flip the gate:
+[`ParallelDeltaApplier`] gated behind the `parallel-receive-delta`
+cargo feature. Path B (runtime auto-detect) is now wired by default
+and the feature is in the default set on `engine`, `transfer`, `core`,
+`cli`, and the workspace binary.
 
-- `crates/engine/Cargo.toml` declares `parallel-receive-delta = []`
-  without including it in `default`.
+- `crates/engine/Cargo.toml` declares
+  `parallel-receive-delta = []` and includes it in `default`.
 - `crates/transfer/Cargo.toml` declares
-  `parallel-receive-delta = ["engine/parallel-receive-delta"]`.
+  `parallel-receive-delta = ["engine/parallel-receive-delta"]` and
+  includes it in `default`. Same forwarding lives on `core` and
+  `cli`, plus the workspace binary in the root `Cargo.toml`.
 - `crates/transfer/src/receiver/mod.rs` exposes
-  `ReceiverContext::enable_parallel_receive_delta`, conditionally
-  compiled under `#[cfg(feature = "parallel-receive-delta")]`. No
-  production call site invokes it.
+  `ReceiverContext::enable_parallel_receive_delta` (feature-gated) and
+  the always-compiled helpers `select_receiver_strategy`,
+  `total_source_bytes`, and `dispatch_receiver_strategy`. The driving
+  loops (`run_sync`, `run_pipelined`, `run_pipelined_incremental`)
+  invoke the dispatcher immediately after `setup_transfer` returns.
 
 The sequential apply loop in `crates/transfer/src/receiver/transfer.rs`
-remains the only shipped path. The parallel scaffold has parity tests
-(PRs #4300 and #4319) and per-file ordering proofs but no benchmark
-evidence at the receiver-shape scale that the umbrella design's section
-6.3 calls out as the bench gate.
+remains the fallback path the dispatcher picks for small / dispatch-
+bound transfers, and the only path still wired when the feature is
+disabled. Parity tests (PRs #4300 and #4319) keep the wire-format
+contract; the bench evidence in section 4 is the remaining
+follow-up (PIP-6).
 
 ## 2. The gap
 
@@ -96,6 +102,14 @@ be reproduced.
 The default flip from sequential to parallel is gated on all five of
 the following holding simultaneously on the same nightly bench run.
 Any single failure reverts the flip to opt-in.
+
+> **Note (2026-05-21):** the maintainer directed the flip with the
+> message "enable", explicitly accepting the open soak and bench gates
+> (criteria 1, 3, 4, 5). Criterion 2 (zero wire-format divergence)
+> remains the load-bearing safety net; PRs #4300 and #4319 keep the
+> parity proptests green in CI. The other criteria become follow-up
+> validation tasks (PIP-4 interop suite, PIP-6 bench backfill) rather
+> than blocking gates.
 
 1. **`small_files` wall-clock wins by >= 10%** at 4+ rayon workers.
    This is the dispatch-bound cell; if parallel cannot beat sequential
@@ -230,6 +244,15 @@ bench picks Path A instead, steps 1 and 2 collapse into a single
    `crates/transfer/src/receiver/mod.rs`). Surface the decision through
    `--debug=GENR` and a `receiver_strategy_chosen` counter on
    `ReceiverStats`. Commit prefix `perf(transfer):`.
+   **SHIPPED (combined with step 5) via perf(transfer): enable parallel
+   receive-delta by default via Path B heuristic.** Thresholds live as
+   `PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD` / `PARALLEL_RECEIVE_BYTES_THRESHOLD`
+   in `crates/transfer/src/receiver/mod.rs`. Dispatch happens in
+   `ReceiverContext::dispatch_receiver_strategy` and is invoked at the
+   top of `run_sync`, `run_pipelined`, and `run_pipelined_incremental`.
+   The decision is stamped on `TransferStats::receiver_strategy_chosen`
+   (`ReceiverStrategy::Sequential | Parallel`) and logged via
+   `debug_log!(Genr, 1, "receiver_strategy=...")` for `--debug=GENR`.
 5. **Soak and flip default-features.** Run the feature opt-in as a
    non-gating CI baseline for one release cycle. If no `fix:`-prefixed
    PR lands against `crates/engine/src/concurrent_delta/parallel_apply.rs`
@@ -237,6 +260,13 @@ bench picks Path A instead, steps 1 and 2 collapse into a single
    `parallel-receive-delta` into `default-features` on `engine` and
    `transfer`. Commit prefix `perf(transfer):` and reference both
    #1368 and this doc in the PR body.
+   **SHIPPED (combined with step 4) via perf(transfer): enable parallel
+   receive-delta by default via Path B heuristic.** Added to the
+   `default = [...]` set on `engine`, `transfer`, `core`, `cli`, and the
+   workspace binary so the production binary picks up the dispatch
+   without any opt-in flag. The soak gate was waived by maintainer
+   direction (see section 5 note); revert path is to drop
+   `parallel-receive-delta` from each `default = [...]` list.
 
 The five steps are strictly serial. Any step that fails its gate
 stops the promotion; the feature gate remains in place for the next


### PR DESCRIPTION
## Summary

Wires the receiver-side parallel delta apply path into production per
`docs/design/parallel-receive-delta-default-on.md` Path B (sections 6.2
and 8), combining steps 4 and 5 in a single PR. Unblocks PIP-3 (#2566)
and PIP-5 (#2568).

The receiver now picks sequential vs parallel apply per transfer using a
cheap, no-cost heuristic:

- `file_count > 100` (next common cutoff above the rayon
  `PARALLEL_STAT_THRESHOLD = 64` convention in `MEMORY.md`)
- **or** `total_size > 64 MiB` (the `copy_file_range` crossover
  documented in `crates/engine/benches/per_op_thresholds.rs`)

The dispatch decision is recorded on `TransferStats::receiver_strategy_chosen`
(`ReceiverStrategy::{Sequential, Parallel}`) for telemetry and logged
under `--debug=GENR`:

```
[generator] receiver_strategy=parallel file_count=N total_size=M (threshold: file_count>100 || total_size>67108864)
```

## What changed

- New thresholds + helpers on `ReceiverContext`:
  `PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD`,
  `PARALLEL_RECEIVE_BYTES_THRESHOLD`,
  `select_receiver_strategy()`, `total_source_bytes()`,
  `dispatch_receiver_strategy()` in
  `crates/transfer/src/receiver/mod.rs`.
- Dispatch invoked at the top of `run_sync`, `run_pipelined`, and
  `run_pipelined_incremental`, immediately after `setup_transfer`
  returns the file count and the file list is in memory.
- New `ReceiverStrategy` enum on `TransferStats::receiver_strategy_chosen`
  in `crates/transfer/src/receiver/stats.rs`.
- `parallel-receive-delta` added to `default = [...]` on `engine`,
  `transfer`, `core`, `cli`, and the workspace binary. Sequential is
  the fallback when the heuristic returns false **and** when the
  feature is compiled out (`receiver_strategy=parallel_unavailable`
  log + sequential return so telemetry never lies).
- Docs: `docs/design/parallel-receive-delta-default-on.md` sections 1,
  5, and 8 updated. Steps 4 and 5 marked SHIPPED. Section 5 notes the
  maintainer directive bypassing the soak / bench gates.

## Risk acceptance (per maintainer directive 2026-05-21)

- **#4205 G2 parity gap remains open.** The per-file ordering proptest
  (PR #4300) + parallel-vs-sequential byte-for-byte parity (PR #4319)
  cover wire-format correctness, but the full upstream interop suite
  has not been re-run through the parallel path.
- **#4214 bench data absent.** Section 4 bench numbers stay TBD. Path
  B is shipping on directed risk acceptance, not bench-driven evidence.
- **Revert path:** drop `parallel-receive-delta` from the
  `default = [...]` lists on `engine`, `transfer`, `core`, `cli`, and
  the workspace binary. Sequential remains wired as the fallback.

## Follow-ups

- PIP-4: re-run the interop suite through the parallel apply path.
- PIP-6: backfill the section-4 bench table from the
  `parallel_receive_delta_perf` harness.
- Track sections 5.1, 5.3, 5.4, 5.5 promotion criteria as continuous
  follow-up rather than blocking gates.

## Test plan

- [ ] CI fmt + clippy pass on the new code (no waivers, no `#[allow(...)]`).
- [ ] CI nextest (stable) passes the new unit + integration tests in
      `receiver/mod.rs::strategy_tests` and
      `receiver/tests/file_list/receiver_strategy.rs`.
- [ ] Windows, macOS, Linux musl matrices stay green - the dispatch
      path is platform-agnostic, but the cfg gating around
      `enable_parallel_receive_delta` is preserved.
- [ ] Existing wire-format parity proptests (PRs #4300, #4319) stay
      green now that they exercise the default path.
- [ ] `--no-default-features` build still compiles and the
      `dispatch_falls_back_to_sequential_without_feature` test
      exercises the fallback.

Refs #1368, #2566, #2568.