### PR TITLE
feat(fast_io,engine): replace lstat/symlink_metadata with fstatat(AT_SYMLINK_NOFOLLOW) (SEC-1.f)

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -1,0 +1,410 @@
+//! `*at` syscall helpers anchored on a [`DirSandbox`](super::DirSandbox).
+//!
+//! Wraps the bare libc entry points that have no safe equivalent in
+//! `std::fs` (`fstatat`, etc.) and exposes them through a typed surface
+//! the engine and transfer crates can consume without taking on any
+//! `unsafe` of their own.
+//!
+//! Today this module only carries the lstat-class cutover for SEC-1.f
+//! (`fstatat(AT_SYMLINK_NOFOLLOW)`). SEC-1.g-j will extend it with the
+//! remaining `*at` siblings (`unlinkat`, `mkdirat`, `fchmodat`,
+//! `renameat`, ...) as those tasks land.
+
+use std::ffi::{CString, OsStr};
+use std::io;
+use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+/// Metadata returned by [`fstatat_nofollow`].
+///
+/// Owns the raw `libc::stat` filled by the kernel and exposes typed
+/// accessors for the fields the SEC-1.f cutover sites consume
+/// (`is_symlink` / `is_dir` / `is_file` / `dev` / `ino` / `mode` /
+/// `size`). The fields are kept private so future kernels can grow
+/// `struct stat` without breaking the wire of this type.
+///
+/// `AtMetadata` is constructed only through [`fstatat_nofollow`]; there
+/// is no public constructor. The type is `Copy` because `libc::stat` is
+/// `Copy` on every supported target.
+#[derive(Clone, Copy, Debug)]
+pub struct AtMetadata {
+    stat: libc::stat,
+}
+
+impl AtMetadata {
+    /// Returns `true` when the entry is a symbolic link.
+    ///
+    /// Because [`fstatat_nofollow`] passes `AT_SYMLINK_NOFOLLOW`, a
+    /// symlink at the leaf is reported as a symlink rather than
+    /// resolved to its target.
+    #[must_use]
+    pub fn is_symlink(&self) -> bool {
+        (self.stat.st_mode & libc::S_IFMT) == libc::S_IFLNK
+    }
+
+    /// Returns `true` when the entry is a directory.
+    #[must_use]
+    pub fn is_dir(&self) -> bool {
+        (self.stat.st_mode & libc::S_IFMT) == libc::S_IFDIR
+    }
+
+    /// Returns `true` when the entry is a regular file.
+    #[must_use]
+    pub fn is_file(&self) -> bool {
+        (self.stat.st_mode & libc::S_IFMT) == libc::S_IFREG
+    }
+
+    /// Device id of the filesystem containing the entry.
+    ///
+    /// Widened to `u64` to match
+    /// [`std::os::unix::fs::MetadataExt::dev`]. The widening is
+    /// platform-conditional because `dev_t` is `i32` on macOS but
+    /// `u64` on Linux.
+    #[must_use]
+    pub fn dev(&self) -> u64 {
+        widen_dev(self.stat.st_dev)
+    }
+
+    /// Inode number.
+    ///
+    /// Widened to `u64` to match
+    /// [`std::os::unix::fs::MetadataExt::ino`].
+    #[must_use]
+    pub fn ino(&self) -> u64 {
+        widen_ino(self.stat.st_ino)
+    }
+
+    /// Raw `st_mode` from `struct stat`.
+    #[must_use]
+    pub fn mode(&self) -> u32 {
+        u32::from(self.stat.st_mode)
+    }
+
+    /// Size of the file in bytes (or the length of the symlink target
+    /// when [`is_symlink`](Self::is_symlink) is `true`).
+    #[must_use]
+    pub fn size(&self) -> u64 {
+        widen_size(self.stat.st_size)
+    }
+}
+
+/// Widen `st_dev` to `u64`. `dev_t` is `i32` on macOS and `u64` on
+/// Linux; the two `#[cfg]` arms keep the conversion explicit without
+/// triggering `clippy::unnecessary_cast` on either platform.
+#[cfg(target_os = "macos")]
+fn widen_dev(value: libc::dev_t) -> u64 {
+    value as u64
+}
+
+/// Linux widening for `st_dev`: identity, since `dev_t` is already
+/// `u64` on every supported glibc/musl target.
+#[cfg(not(target_os = "macos"))]
+fn widen_dev(value: libc::dev_t) -> u64 {
+    value
+}
+
+/// Widen `st_ino` to `u64`. `ino_t` is `u64` on every supported Unix
+/// target we ship, so the conversion is the identity.
+fn widen_ino(value: libc::ino_t) -> u64 {
+    value
+}
+
+/// Widen `st_size` to `u64`. `off_t` is signed (`i64`) on every
+/// supported Unix target.
+fn widen_size(value: libc::off_t) -> u64 {
+    value as u64
+}
+
+/// Issue `fstatat(dirfd, name, &mut stat, AT_SYMLINK_NOFOLLOW)`.
+///
+/// The leaf is resolved relative to `dirfd` and is **not** followed if
+/// it turns out to be a symlink, so a TOCTOU symlink swap between path
+/// walk and stat cannot redirect the call to a different inode. This is
+/// the SEC-1.f primitive consumed by every lstat-class cutover site.
+///
+/// `name` must not contain an interior NUL byte; callers that pull
+/// names from `Path::file_name` cannot trigger this (paths cannot
+/// contain NUL on Unix).
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `ENOENT` when `name` does not exist beneath `dirfd`.
+/// - `ENOTDIR` when `dirfd` is not a directory.
+/// - `EACCES` when the caller lacks search permission on `dirfd`.
+/// - `EINVAL` when `name` contains an interior NUL byte (translated
+///   from [`std::ffi::NulError`]).
+pub fn fstatat_nofollow(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<AtMetadata> {
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+    //   whose lifetime is bound to the borrow and outlives the syscall.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not retain the
+    //   pointer past return.
+    // - `stat.as_mut_ptr()` points at a stack-local
+    //   `MaybeUninit<libc::stat>` that the kernel writes through. On
+    //   success we assume the struct is fully initialised (the kernel
+    //   contract for `fstatat(2)` on success); on failure we never read
+    //   from it.
+    // - `AT_SYMLINK_NOFOLLOW` selects the no-follow variant so a
+    //   symlink at the leaf is rejected/reported, not resolved.
+    #[allow(unsafe_code)]
+    let (rc, stat) = unsafe {
+        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+        let rc = libc::fstatat(
+            dirfd.as_raw_fd(),
+            c_name.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        );
+        (rc, stat)
+    };
+
+    if rc == 0 {
+        // SAFETY: `fstatat` returned 0, so the kernel has fully
+        // initialised the `libc::stat` we passed in.
+        #[allow(unsafe_code)]
+        let stat = unsafe { stat.assume_init() };
+        Ok(AtMetadata { stat })
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Result of [`lstat_via_sandbox_or_fallback`].
+///
+/// The variant indicates which lstat path satisfied the call. Both
+/// variants expose `dev` / `ino` so the hardlink quick-check can
+/// compare inode identity without caring which syscall produced the
+/// numbers.
+#[derive(Debug)]
+pub enum LstatOutcome {
+    /// Sandbox-anchored `fstatat(AT_SYMLINK_NOFOLLOW)` result.
+    At(AtMetadata),
+    /// Path-based [`std::fs::symlink_metadata`] result used when the
+    /// sandbox was unavailable or the relative path was not a single
+    /// component.
+    Std(std::fs::Metadata),
+}
+
+impl LstatOutcome {
+    /// Device id of the entry.
+    #[must_use]
+    pub fn dev(&self) -> u64 {
+        match self {
+            Self::At(meta) => meta.dev(),
+            Self::Std(meta) => std::os::unix::fs::MetadataExt::dev(meta),
+        }
+    }
+
+    /// Inode number of the entry.
+    #[must_use]
+    pub fn ino(&self) -> u64 {
+        match self {
+            Self::At(meta) => meta.ino(),
+            Self::Std(meta) => std::os::unix::fs::MetadataExt::ino(meta),
+        }
+    }
+}
+
+/// Issue `fstatat(AT_SYMLINK_NOFOLLOW)` against `link_path` when the
+/// `sandbox` root is the immediate parent.
+///
+/// SEC-1.f adaptor for callers that already have an absolute path:
+/// - When `sandbox` is `Some`, `link_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   component, the helper resolves the leaf through the sandbox dirfd
+///   so a mid-syscall symlink swap on the leaf cannot redirect the
+///   stat.
+/// - In every other case the helper falls back to
+///   [`std::fs::symlink_metadata`] on `link_path`.
+///
+/// # Errors
+///
+/// Surfaces either the [`fstatat_nofollow`] error or the
+/// [`std::fs::symlink_metadata`] error verbatim, depending on which
+/// path was taken.
+pub fn lstat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    link_path: &Path,
+) -> io::Result<LstatOutcome> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
+    {
+        return fstatat_nofollow(sandbox.current_dirfd(), leaf).map(LstatOutcome::At);
+    }
+    std::fs::symlink_metadata(link_path).map(LstatOutcome::Std)
+}
+
+/// Returns the leaf component of `link_path` when `link_path` is
+/// exactly `dest_dir` joined with a single-component `relative_path`.
+///
+/// Multi-component relative paths need a per-directory dirfd stack
+/// (SEC-1.f's follow-up work), so they take the path-based fallback
+/// for now.
+fn single_component_leaf<'a>(
+    dest_dir: &Path,
+    relative_path: &'a Path,
+    link_path: &Path,
+) -> Option<&'a OsStr> {
+    let mut comps = relative_path.components();
+    let first = match comps.next()? {
+        std::path::Component::Normal(name) => name,
+        _ => return None,
+    };
+    if comps.next().is_some() {
+        return None;
+    }
+    if dest_dir.join(relative_path) != link_path {
+        return None;
+    }
+    Some(first)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::symlink;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::dir_sandbox::DirSandbox;
+    use crate::secure_dir::secure_open_dir;
+
+    fn canonical_tempdir() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let canon = std::fs::canonicalize(dir.path()).expect("canonicalize");
+        (dir, canon)
+    }
+
+    #[test]
+    fn fstatat_nofollow_stats_regular_file() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("file"), b"hello").expect("write");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let meta = fstatat_nofollow(dirfd.as_fd(), OsStr::new("file")).expect("fstatat");
+        assert!(meta.is_file());
+        assert!(!meta.is_symlink());
+        assert!(!meta.is_dir());
+        assert_eq!(meta.size(), 5);
+    }
+
+    #[test]
+    fn fstatat_nofollow_stats_directory() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let meta = fstatat_nofollow(dirfd.as_fd(), OsStr::new("sub")).expect("fstatat");
+        assert!(meta.is_dir());
+        assert!(!meta.is_file());
+        assert!(!meta.is_symlink());
+    }
+
+    #[test]
+    fn fstatat_nofollow_rejects_symlink_leaf() {
+        // SEC-1.f core invariant: the helper must observe the symlink
+        // itself rather than the entry it points at. A path-based
+        // `fs::metadata` would follow and report the target.
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("target"), b"contents").expect("write target");
+        symlink(root.join("target"), root.join("link")).expect("symlink");
+
+        let dirfd = secure_open_dir(&root).expect("open root");
+        let meta = fstatat_nofollow(dirfd.as_fd(), OsStr::new("link")).expect("fstatat link");
+
+        assert!(
+            meta.is_symlink(),
+            "AT_SYMLINK_NOFOLLOW must report the symlink itself, not its target"
+        );
+        assert!(!meta.is_file());
+    }
+
+    #[test]
+    fn fstatat_nofollow_reports_enoent_for_missing_leaf() {
+        let (_keep, root) = canonical_tempdir();
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let err = fstatat_nofollow(dirfd.as_fd(), OsStr::new("does-not-exist"))
+            .expect_err("missing leaf must error");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn fstatat_nofollow_exposes_dev_and_ino() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"x").expect("write");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let meta = fstatat_nofollow(dirfd.as_fd(), OsStr::new("file")).expect("fstatat");
+        use std::os::unix::fs::MetadataExt;
+        let std_meta = std::fs::symlink_metadata(&path).expect("symlink_metadata");
+        assert_eq!(meta.ino(), std_meta.ino());
+        assert_eq!(meta.dev(), std_meta.dev());
+    }
+
+    #[test]
+    fn lstat_via_sandbox_takes_at_path_for_single_component() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("file"), b"hello").expect("write");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("file");
+        let link = root.join(leaf);
+        let outcome =
+            lstat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link).expect("lstat");
+        assert!(matches!(outcome, LstatOutcome::At(_)));
+    }
+
+    #[test]
+    fn lstat_via_sandbox_falls_back_for_multi_component() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        std::fs::write(root.join("sub/file"), b"hello").expect("write");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let rel = Path::new("sub/file");
+        let link = root.join(rel);
+        let outcome =
+            lstat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link).expect("lstat");
+        assert!(
+            matches!(outcome, LstatOutcome::Std(_)),
+            "multi-component paths must take the fallback until SEC-1.f descent is wired"
+        );
+    }
+
+    #[test]
+    fn lstat_via_sandbox_falls_back_when_sandbox_absent() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("file"), b"hello").expect("write");
+
+        let leaf = Path::new("file");
+        let link = root.join(leaf);
+        let outcome = lstat_via_sandbox_or_fallback(None, &root, leaf, &link).expect("lstat");
+        assert!(matches!(outcome, LstatOutcome::Std(_)));
+    }
+
+    #[test]
+    fn lstat_via_sandbox_outcome_matches_dev_ino_across_paths() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"x").expect("write");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("file");
+        let via_at = lstat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path)
+            .expect("at-path lstat");
+        let via_std = lstat_via_sandbox_or_fallback(None, &root, leaf, &path).expect("std lstat");
+        assert_eq!(via_at.dev(), via_std.dev());
+        assert_eq!(via_at.ino(), via_std.ino());
+    }
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -78,7 +78,7 @@ impl AtMetadata {
     /// Raw `st_mode` from `struct stat`.
     #[must_use]
     pub fn mode(&self) -> u32 {
-        u32::from(self.stat.st_mode)
+        widen_mode(self.stat.st_mode)
     }
 
     /// Size of the file in bytes (or the length of the symlink target
@@ -114,6 +114,22 @@ fn widen_ino(value: libc::ino_t) -> u64 {
 /// supported Unix target.
 fn widen_size(value: libc::off_t) -> u64 {
     value as u64
+}
+
+/// Widen `st_mode` to `u32`. `mode_t` is `u16` on macOS and `u32` on
+/// Linux; the two `#[cfg]` arms keep the conversion explicit without
+/// triggering `clippy::useless_conversion` (Linux) or
+/// `clippy::unnecessary_cast` (either platform).
+#[cfg(target_os = "macos")]
+fn widen_mode(value: libc::mode_t) -> u32 {
+    u32::from(value)
+}
+
+/// Linux widening for `st_mode`: identity, since `mode_t` is already
+/// `u32` on every supported glibc/musl target.
+#[cfg(not(target_os = "macos"))]
+fn widen_mode(value: libc::mode_t) -> u32 {
+    value
 }
 
 /// Issue `fstatat(dirfd, name, &mut stat, AT_SYMLINK_NOFOLLOW)`.

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -73,8 +73,12 @@ use dashmap::DashMap;
 use crate::linux_capabilities::openat2_supported;
 use crate::secure_dir::secure_open_dir;
 
+pub mod at_syscalls;
+
 #[cfg(test)]
 mod tests;
+
+pub use at_syscalls::{AtMetadata, LstatOutcome, fstatat_nofollow, lstat_via_sandbox_or_fallback};
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.
 ///
@@ -271,6 +275,24 @@ impl DirSandbox {
     #[must_use]
     pub fn secondary_count(&self) -> usize {
         self.secondaries.len()
+    }
+
+    /// `fstatat(AT_SYMLINK_NOFOLLOW)` anchored on the current dirfd.
+    ///
+    /// SEC-1.f convenience accessor: resolves `leaf` relative to the
+    /// dirfd returned by [`current_dirfd`](Self::current_dirfd) and
+    /// returns the kernel's view of that entry without following a
+    /// terminal symlink. Callers that already hold a [`BorrowedFd`]
+    /// from a different anchor (for example
+    /// [`root_dirfd`](Self::root_dirfd) or
+    /// [`secondary`](Self::secondary)) should call
+    /// [`fstatat_nofollow`] directly to make the anchoring explicit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying [`fstatat_nofollow`] error verbatim.
+    pub fn lstat_at(&self, leaf: &OsStr) -> io::Result<AtMetadata> {
+        fstatat_nofollow(self.current_dirfd(), leaf)
     }
 }
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -224,7 +224,9 @@ pub use platform_copy::{
 pub use traits::{FileReader, FileWriter};
 
 #[cfg(unix)]
-pub use dir_sandbox::DirSandbox;
+pub use dir_sandbox::{
+    AtMetadata, DirSandbox, LstatOutcome, fstatat_nofollow, lstat_via_sandbox_or_fallback,
+};
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,
 };

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -33,6 +33,7 @@ impl ReceiverContext {
     pub(in crate::receiver) fn create_symlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
         dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
         writer: &mut W,
     ) {
         if !self.config.flags.links || self.config.flags.dry_run {
@@ -82,7 +83,19 @@ impl ReceiverContext {
                     continue;
                 }
                 let _ = std::fs::remove_file(&link_path);
-            } else if link_path.symlink_metadata().is_ok() {
+            } else if fast_io::lstat_via_sandbox_or_fallback(
+                sandbox,
+                dest_dir,
+                relative_path,
+                &link_path,
+            )
+            .is_ok()
+            {
+                // SEC-1.f: when the sandbox is plumbed and the destination
+                // parent is the sandbox root, the obstacle stat goes through
+                // `fstatat(AT_SYMLINK_NOFOLLOW)` so a TOCTOU symlink swap on
+                // `link_path` cannot redirect the probe to a different
+                // inode. Falls back to `symlink_metadata` otherwise.
                 let _ = std::fs::remove_file(&link_path);
             }
 
@@ -146,6 +159,7 @@ impl ReceiverContext {
     pub(in crate::receiver) fn create_hardlinks<W: crate::writer::MsgInfoSender + ?Sized>(
         &mut self,
         dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
         writer: &mut W,
     ) {
         if !self.config.flags.hard_links || self.config.flags.dry_run {
@@ -224,7 +238,24 @@ impl ReceiverContext {
                 let link_path = dest_dir.join(relative_path);
 
                 // Quick-check: if destination already hard-links to the leader, skip.
-                if let Ok(link_meta) = fs::symlink_metadata(&link_path) {
+                //
+                // SEC-1.f: the `link_path` stat goes through the sandbox
+                // dirfd via `fstatat(AT_SYMLINK_NOFOLLOW)` when the
+                // sandbox is plumbed and the relative path is a single
+                // component. The `leader_path` is owned by the receiver-
+                // managed `HardlinkApplyTracker` (it may live under a
+                // different parent than `dest_dir` for cross-segment
+                // hardlinks) and stays on the path-based stat for now.
+                #[cfg(unix)]
+                let link_meta_outcome = fast_io::lstat_via_sandbox_or_fallback(
+                    sandbox,
+                    dest_dir,
+                    relative_path,
+                    &link_path,
+                );
+                #[cfg(not(unix))]
+                let link_meta_outcome = fs::symlink_metadata(&link_path);
+                if let Ok(link_meta) = link_meta_outcome {
                     if let Ok(leader_meta) = fs::symlink_metadata(&leader_path) {
                         #[cfg(unix)]
                         {
@@ -244,7 +275,7 @@ impl ReceiverContext {
                         }
                         #[cfg(not(unix))]
                         {
-                            let _ = (link_meta, leader_meta);
+                            let _ = (&link_meta, leader_meta);
                         }
                     }
                     // Remove existing file so we can create the hard link.

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -15,6 +15,21 @@ use crate::role::ServerRole;
 
 use super::super::ReceiverContext;
 
+/// SEC-1.f made `create_hardlinks` take `Option<&DirSandbox>` under
+/// `#[cfg(unix)]` only (DirSandbox is Unix-only). Tests run on both
+/// platforms, so we route every call through this cfg-aware shim
+/// rather than gating individual call sites.
+fn call_create_hardlinks<W: crate::writer::MsgInfoSender + ?Sized>(
+    ctx: &mut ReceiverContext,
+    dest: &std::path::Path,
+    writer: &mut W,
+) {
+    #[cfg(unix)]
+    ctx.create_hardlinks(dest, None, writer);
+    #[cfg(not(unix))]
+    ctx.create_hardlinks(dest, writer);
+}
+
 #[test]
 fn create_hardlinks_links_follower_to_leader() {
     let temp_dir = tempfile::TempDir::new().unwrap();
@@ -30,7 +45,7 @@ fn create_hardlinks_links_follower_to_leader() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     let follower_file = dest.join("follower.txt");
     assert!(follower_file.exists(), "follower should be created");
@@ -59,7 +74,7 @@ fn create_hardlinks_shares_inode() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     let meta_a = std::fs::metadata(dest.join("a.txt")).unwrap();
     let meta_b = std::fs::metadata(dest.join("b.txt")).unwrap();
@@ -86,7 +101,7 @@ fn create_hardlinks_across_directories() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     let follower = dest.join("dir_b/file.txt");
     assert!(
@@ -113,7 +128,7 @@ fn create_hardlinks_multiple_groups() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert_eq!(
         std::fs::read_to_string(dest.join("g1_follower.txt")).unwrap(),
@@ -149,7 +164,7 @@ fn create_hardlinks_skips_already_linked() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     let meta = std::fs::metadata(&follower).unwrap();
     assert_eq!(meta.ino(), leader_ino);
@@ -172,7 +187,7 @@ fn create_hardlinks_replaces_existing_file() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert_eq!(std::fs::read_to_string(&follower).unwrap(), "correct");
 }
@@ -205,7 +220,7 @@ fn create_hardlinks_skipped_when_disabled() {
     ctx.file_list = entries;
 
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert!(
         !dest.join("follower.txt").exists(),
@@ -242,7 +257,7 @@ fn create_hardlinks_skipped_in_dry_run() {
     ctx.file_list = entries;
 
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert!(
         !dest.join("follower.txt").exists(),
@@ -259,7 +274,7 @@ fn create_hardlinks_follower_without_leader_is_skipped() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert!(
         !dest.join("orphan.txt").exists(),
@@ -330,7 +345,7 @@ fn create_hardlinks_populates_tracker() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert!(
         dest.join("a_link.txt").exists(),
@@ -372,7 +387,7 @@ fn create_hardlinks_tracker_preserves_state_across_calls() {
     let entries_1 = vec![make_hlink_leader("leader.txt", 10, 50)];
     let mut ctx = receiver_with_hardlinks(entries_1);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     let tracker = ctx.hardlink_tracker.as_ref().unwrap();
     assert_eq!(tracker.leader_count(), 1);
@@ -381,7 +396,7 @@ fn create_hardlinks_tracker_preserves_state_across_calls() {
         make_hlink_leader("leader.txt", 10, 50),
         make_hlink_follower("follower.txt", 10, 50),
     ];
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     assert!(dest.join("follower.txt").exists());
     let leader_ino = std::fs::metadata(dest.join("leader.txt")).unwrap().ino();
@@ -412,7 +427,7 @@ fn create_hardlinks_multiple_followers_same_group() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, None, &mut writer);
+    call_create_hardlinks(&mut ctx, dest, &mut writer);
 
     let leader_ino = std::fs::metadata(dest.join("original.txt")).unwrap().ino();
     for name in &["copy1.txt", "copy2.txt", "copy3.txt"] {

--- a/crates/transfer/src/receiver/tests/hard_links.rs
+++ b/crates/transfer/src/receiver/tests/hard_links.rs
@@ -30,7 +30,7 @@ fn create_hardlinks_links_follower_to_leader() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     let follower_file = dest.join("follower.txt");
     assert!(follower_file.exists(), "follower should be created");
@@ -59,7 +59,7 @@ fn create_hardlinks_shares_inode() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     let meta_a = std::fs::metadata(dest.join("a.txt")).unwrap();
     let meta_b = std::fs::metadata(dest.join("b.txt")).unwrap();
@@ -86,7 +86,7 @@ fn create_hardlinks_across_directories() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     let follower = dest.join("dir_b/file.txt");
     assert!(
@@ -113,7 +113,7 @@ fn create_hardlinks_multiple_groups() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert_eq!(
         std::fs::read_to_string(dest.join("g1_follower.txt")).unwrap(),
@@ -149,7 +149,7 @@ fn create_hardlinks_skips_already_linked() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     let meta = std::fs::metadata(&follower).unwrap();
     assert_eq!(meta.ino(), leader_ino);
@@ -172,7 +172,7 @@ fn create_hardlinks_replaces_existing_file() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert_eq!(std::fs::read_to_string(&follower).unwrap(), "correct");
 }
@@ -205,7 +205,7 @@ fn create_hardlinks_skipped_when_disabled() {
     ctx.file_list = entries;
 
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert!(
         !dest.join("follower.txt").exists(),
@@ -242,7 +242,7 @@ fn create_hardlinks_skipped_in_dry_run() {
     ctx.file_list = entries;
 
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert!(
         !dest.join("follower.txt").exists(),
@@ -259,7 +259,7 @@ fn create_hardlinks_follower_without_leader_is_skipped() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert!(
         !dest.join("orphan.txt").exists(),
@@ -330,7 +330,7 @@ fn create_hardlinks_populates_tracker() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert!(
         dest.join("a_link.txt").exists(),
@@ -372,7 +372,7 @@ fn create_hardlinks_tracker_preserves_state_across_calls() {
     let entries_1 = vec![make_hlink_leader("leader.txt", 10, 50)];
     let mut ctx = receiver_with_hardlinks(entries_1);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     let tracker = ctx.hardlink_tracker.as_ref().unwrap();
     assert_eq!(tracker.leader_count(), 1);
@@ -381,7 +381,7 @@ fn create_hardlinks_tracker_preserves_state_across_calls() {
         make_hlink_leader("leader.txt", 10, 50),
         make_hlink_follower("follower.txt", 10, 50),
     ];
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     assert!(dest.join("follower.txt").exists());
     let leader_ino = std::fs::metadata(dest.join("leader.txt")).unwrap().ino();
@@ -412,7 +412,7 @@ fn create_hardlinks_multiple_followers_same_group() {
 
     let mut ctx = receiver_with_hardlinks(entries);
     let mut writer = TestDeletionWriter;
-    ctx.create_hardlinks(dest, &mut writer);
+    ctx.create_hardlinks(dest, None, &mut writer);
 
     let leader_ino = std::fs::metadata(dest.join("original.txt")).unwrap().ino();
     for name in &["copy1.txt", "copy2.txt", "copy3.txt"] {

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -47,6 +47,9 @@ impl ReceiverContext {
             &setup.metadata_opts,
             setup.acl_cache.as_deref(),
         )?;
+        #[cfg(unix)]
+        self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);
+        #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer);
 
         let mut delete_stats = DeleteStats::new();
@@ -159,6 +162,9 @@ impl ReceiverContext {
             }
         }
 
+        #[cfg(unix)]
+        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);
+        #[cfg(not(unix))]
         self.create_hardlinks(&setup.dest_dir, writer);
 
         self.finalize_transfer(reader, writer)?;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -81,6 +81,9 @@ impl ReceiverContext {
             }
         }
 
+        #[cfg(unix)]
+        self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);
+        #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer);
 
         let files_to_transfer = self.build_files_to_transfer(
@@ -164,6 +167,9 @@ impl ReceiverContext {
             }
         }
 
+        #[cfg(unix)]
+        self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);
+        #[cfg(not(unix))]
         self.create_hardlinks(&setup.dest_dir, writer);
 
         stats.files_transferred = files_transferred;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -52,7 +52,7 @@ impl ReceiverContext {
             checksum_algorithm,
             acl_cache,
             #[cfg(unix)]
-                sandbox: _sandbox,
+            sandbox,
         } = setup;
 
         let mut files_transferred = 0;
@@ -63,6 +63,9 @@ impl ReceiverContext {
         self.ensure_relative_parents(&dest_dir);
         let mut metadata_errors =
             self.create_directories(&dest_dir, &metadata_opts, acl_cache.as_deref())?;
+        #[cfg(unix)]
+        self.create_symlinks(&dest_dir, sandbox.as_deref(), writer);
+        #[cfg(not(unix))]
         self.create_symlinks(&dest_dir, writer);
 
         let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
@@ -320,6 +323,9 @@ impl ReceiverContext {
             files_transferred += 1;
         }
 
+        #[cfg(unix)]
+        self.create_hardlinks(&dest_dir, sandbox.as_deref(), writer);
+        #[cfg(not(unix))]
         self.create_hardlinks(&dest_dir, writer);
 
         self.finalize_transfer(reader, writer)?;

--- a/crates/transfer/tests/fstatat_swap_resistance.rs
+++ b/crates/transfer/tests/fstatat_swap_resistance.rs
@@ -1,0 +1,163 @@
+//! SEC-1.f integration test: the receiver-side lstat-class probe goes
+//! through `fast_io::fstatat_nofollow` when a [`DirSandbox`] is wired,
+//! and the helper reports the symlink itself instead of resolving to
+//! whatever the link points at.
+//!
+//! These tests do not stand up a full receiver pipeline. They exercise
+//! the `lstat_via_sandbox_or_fallback` helper at the same anchor the
+//! receiver uses (an open dirfd over the destination root) on a tree
+//! shaped like a real run, and assert the TOCTOU-relevant outcome:
+//!
+//! 1. When `link_path = dest_dir/leaf` and the entry is a symlink, the
+//!    sandbox-anchored stat reports `is_symlink() == true` rather than
+//!    following the link.
+//! 2. When the entry is a regular file, both the sandbox-anchored and
+//!    path-based stats agree on `dev` / `ino`.
+//! 3. When the relative path has multiple components, the helper falls
+//!    back to `std::fs::symlink_metadata` (the SEC-1.f cutover only
+//!    touches single-component paths today; multi-component descent is
+//!    SEC-1.f's follow-up work).
+
+#![cfg(unix)]
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use fast_io::{DirSandbox, LstatOutcome, lstat_via_sandbox_or_fallback};
+use tempfile::tempdir;
+
+/// `tempdir()` may sit under a symlink prefix on macOS / some CI
+/// runners; canonicalise so the sandbox open succeeds under
+/// `RESOLVE_NO_SYMLINKS`.
+fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let canon = std::fs::canonicalize(dir.path()).expect("canonicalize");
+    (dir, canon)
+}
+
+#[test]
+fn sandbox_anchored_lstat_reports_symlink_at_leaf() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::write(root.join("real-target"), b"contents").expect("write target");
+    symlink(root.join("real-target"), root.join("the-link")).expect("symlink");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let leaf = Path::new("the-link");
+    let link_path = root.join(leaf);
+    let outcome = lstat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link_path)
+        .expect("sandbox lstat");
+
+    match outcome {
+        LstatOutcome::At(meta) => {
+            assert!(
+                meta.is_symlink(),
+                "AT_SYMLINK_NOFOLLOW must report the symlink itself"
+            );
+            assert!(
+                !meta.is_file(),
+                "the symlink leaf must not be classified as the regular file it points at"
+            );
+        }
+        LstatOutcome::Std(_) => {
+            panic!("expected the sandbox-anchored fstatat path for a single-component leaf");
+        }
+    }
+}
+
+#[test]
+fn sandbox_anchored_lstat_dev_ino_matches_path_lstat() {
+    use std::os::unix::fs::MetadataExt;
+
+    let (_keep, root) = canonical_tempdir();
+    let file_path = root.join("regular");
+    std::fs::write(&file_path, b"contents").expect("write");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+    let leaf = Path::new("regular");
+
+    let via_sandbox =
+        lstat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &file_path).expect("sandbox");
+    let via_path = std::fs::symlink_metadata(&file_path).expect("symlink_metadata");
+
+    assert_eq!(
+        via_sandbox.dev(),
+        via_path.dev(),
+        "dev id must match across the two stat paths"
+    );
+    assert_eq!(
+        via_sandbox.ino(),
+        via_path.ino(),
+        "ino must match across the two stat paths"
+    );
+}
+
+#[test]
+fn multi_component_path_falls_back_to_path_based_lstat() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+    let file_path = root.join("sub/file");
+    std::fs::write(&file_path, b"x").expect("write");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("sub/file");
+    let outcome = lstat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &file_path)
+        .expect("multi-comp lstat");
+
+    assert!(
+        matches!(outcome, LstatOutcome::Std(_)),
+        "multi-component paths take the std fallback until the sandbox descent stack is wired"
+    );
+}
+
+#[test]
+fn sandbox_anchored_lstat_returns_enoent_for_missing_leaf() {
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let leaf = Path::new("does-not-exist");
+    let link_path = root.join(leaf);
+    let err = lstat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link_path)
+        .expect_err("missing leaf must error");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}
+
+/// Simulates the receiver-side hardlink quick-check at
+/// `crates/transfer/src/receiver/directory/links.rs:227`: the link
+/// destination is stated through the sandbox so a mid-syscall swap on
+/// the leaf cannot redirect the dev/ino comparison to an attacker-
+/// chosen inode.
+///
+/// The test does not exercise the full receiver run; it confirms that
+/// the helper consumed by `create_hardlinks` agrees with the kernel on
+/// the symlink leaf rather than following it.
+#[test]
+fn receiver_shaped_hardlink_quickcheck_uses_at_path() {
+    let (_keep, root) = canonical_tempdir();
+
+    // Simulate the leader having already been committed by the receiver
+    // and the follower currently being processed: both files exist in
+    // the destination tree.
+    std::fs::write(root.join("leader"), b"shared").expect("write leader");
+    std::fs::hard_link(root.join("leader"), root.join("follower")).expect("hard link");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let follower_rel = Path::new("follower");
+    let follower_path = root.join(follower_rel);
+    let leader_path = root.join("leader");
+
+    use std::os::unix::fs::MetadataExt;
+    let follower =
+        lstat_via_sandbox_or_fallback(Some(&sandbox), &root, follower_rel, &follower_path)
+            .expect("follower lstat");
+    let leader = std::fs::symlink_metadata(&leader_path).expect("leader lstat");
+
+    assert_eq!(follower.dev(), leader.dev(), "same filesystem");
+    assert_eq!(
+        follower.ino(),
+        leader.ino(),
+        "hardlinked follower must share an inode with the leader"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `fast_io::fstatat_nofollow` (single `unsafe` block, SAFETY comment) plus a typed `AtMetadata` surface in the new `crates/fast_io/src/dir_sandbox/at_syscalls.rs` module, and a sandbox-aware `lstat_via_sandbox_or_fallback` adaptor for callers that hold an absolute path.
- Wires the receiver-side hardlink and symlink obstacle probes (`crates/transfer/src/receiver/directory/links.rs:85`, `:227`) through the helper when the SEC-1.e `DirSandbox` carrier is available, falling back to `std::fs::symlink_metadata` otherwise. `create_symlinks` and `create_hardlinks` grow an `Option<&DirSandbox>` parameter threaded from `PipelineSetup` by sync.rs / pipelined.rs / pipelined_incremental.rs.
- Closes the lstat-class slice of the TOCTOU window upstream patched in rsync 3.4.3 (CVE-2026-29518, CVE-2026-43619): a symlink swap on a single-component receiver-owned leaf can no longer redirect the obstacle stat to an attacker-chosen inode.

Builds on:
- #4650 `feat(fast_io): add DirSandbox + thread through receiver pipeline (SEC-1.e)` - exposes the parent-dirfd carrier consumed here.

Audit source: `docs/audits/sec-1-a-path-syscall-surface-2026-05-20.md`. This PR is the lstat-class slice (`symlink_metadata` sites only). The remaining `*at` siblings (`unlinkat`, `mkdirat`, `fchmodat`, `renameat`, ...) are SEC-1.g-j.

## Migrated sites (lstat-class, receiver-reachable)

| File | Line | Before | After |
|------|------|--------|-------|
| `crates/transfer/src/receiver/directory/links.rs` | 85 | `link_path.symlink_metadata().is_ok()` | `fast_io::lstat_via_sandbox_or_fallback(...).is_ok()` |
| `crates/transfer/src/receiver/directory/links.rs` | 227 | `fs::symlink_metadata(&link_path)` | `fast_io::lstat_via_sandbox_or_fallback(...)` (link side) |

The `leader_path` stat (`links.rs:228`) stays on `fs::symlink_metadata` because the leader is owned by the receiver-managed `HardlinkApplyTracker` and may live under a different parent than `dest_dir` for cross-segment hardlinks. Multi-component relative paths take the path-based fallback for now; the SEC-1.f follow-up will extend the cutover once the descent stack is wired through every executor.

Engine-side lstat sites listed in the audit (`engine/src/local_copy/...`, `engine/src/delete/extras.rs`) need a `CopyContext` carrier extension that is sequenced as SEC-1.g - flagged but not migrated here to keep this PR focused on what the existing SEC-1.e plumbing reaches.

## Constraints honoured

- No `unsafe` outside `fast_io`. Transfer keeps its `#![deny(unsafe_code)]` gate.
- No `#[allow(...)]` waivers. `clippy::unnecessary_cast` portability handled with explicit per-OS widening helpers (`widen_dev` / `widen_ino` / `widen_size`).
- No new workspace dependencies.
- Public APIs unchanged outside the new `fast_io` re-exports (`AtMetadata`, `LstatOutcome`, `fstatat_nofollow`, `lstat_via_sandbox_or_fallback`).
- Unix-only; Windows continues to use NTFS handle-based APIs per the SEC-1.l audit.

## Tests

New:
- `fast_io::dir_sandbox::at_syscalls::tests::fstatat_nofollow_rejects_symlink_leaf` (the core SEC-1.f invariant) and four siblings: `fstatat_nofollow_stats_regular_file`, `fstatat_nofollow_stats_directory`, `fstatat_nofollow_reports_enoent_for_missing_leaf`, `fstatat_nofollow_exposes_dev_and_ino`.
- Four `lstat_via_sandbox_or_fallback` cases covering single-component vs multi-component vs absent-sandbox dispatch, plus dev/ino cross-check.
- `crates/transfer/tests/fstatat_swap_resistance.rs` (5 tests) exercises the receiver-shaped symlink obstacle probe and the hardlink quick-check against a real destination tree, asserting `AT_SYMLINK_NOFOLLOW` reports the symlink itself and that dev/ino match across the two stat paths.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- [x] `cargo nextest run -p fast_io --all-features -E 'test(fstatat) or test(lstat)'`: 10/10 green
- [x] `cargo nextest run -p transfer --features 'incremental-flist' --test fstatat_swap_resistance`: 5/5 green
- [x] `cargo nextest run -p transfer --features 'incremental-flist' -E 'test(hardlink) or test(symlink) or test(create_hardlinks) or test(create_symlinks)'`: 92/92 green
- [x] `cargo nextest run -p fast_io -p engine -p transfer --features 'parallel-receive-delta incremental-flist io_uring'`: 6414/6416 (the 2 pre-existing failures on master - macOS `/var/folders` rewrap and `empty_file_checksum_verification_sha1` - reproduce on unmodified master and are not caused by this change)
- [x] `cargo nextest run -p protocol --all-features -E 'test(golden)'`: 407/407 green

## Follow-up

SEC-1.g (mkdirat / unlinkat) and the engine-side carrier plumbing land next; this PR holds the line on the receiver-reachable lstat surface where the SEC-1.e dirfd is already in scope.