### PR TITLE
docs: document ssh-socketpair-stderr feature and fallback warnings (SSF-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,26 @@ oc-rsync -avz -e 'ssh -C' user@host:/src/ /dst/
 
 To get `SEND_ZC` dispatch, build with `cargo build --features iouring-send-zc` (requires Linux 5.16+). See [`docs/design/iouring-send-zc.md`](./docs/design/iouring-send-zc.md) for the full rationale and the path to flipping this default on.
 
+#### SSH stderr socketpair channel
+
+Default builds drain the SSH child's stderr through an anonymous pipe on a dedicated reader thread. The `ssh-socketpair-stderr` cargo feature swaps that pipe for a `socketpair(AF_UNIX, SOCK_STREAM)` and, on the async transport, hands the parent end to an epoll/kqueue-integrated tokio drain. The wake-up and shutdown paths become event-driven instead of timeout-bounded, and the larger socket buffer absorbs bursty remote shells without dropping lines.
+
+Operators benefit when SSH stderr is chatty (banners, MOTDs, `ssh -v`), the network is high-latency, or many parallel transfers are in flight. In those workloads the pipe-based drain delays or truncates diagnostic output and can leave drain threads parked past child exit. The socketpair path keeps stderr capture deterministic at session boundaries.
+
+Build with:
+
+```sh
+cargo build --features ssh-socketpair-stderr
+```
+
+Linux is the recommended target; the Windows shim is tracked separately (SSE-5). See [`docs/ssh-transport.md`](./docs/ssh-transport.md) and [`docs/design/socketpair-stderr-channel.md`](./docs/design/socketpair-stderr-channel.md).
+
+Three one-shot warnings may appear on stderr (sync path) or via `tracing` target `ssh::stderr` (async path) when the runtime cannot honour the feature. Each fires at most once per process; the substrings are the operator-grep contract:
+
+- `SSH stderr async drain unavailable on this platform` - the kernel rejected `socketpair(AF_UNIX, SOCK_STREAM, 0)` (typically `EMFILE`, `ENFILE`, `EPERM`, or `ENOSYS` under seccomp). The session falls back to `Stdio::piped()`. Raise the per-process fd limit or relax the sandbox if you want the socketpair drain back.
+- `SSH stderr socketpair partially set up` - the socketpair allocated but `dup(2)` on the parent half failed (usually `EMFILE`). The drain still reads from the socketpair, but `shutdown_read` becomes a no-op and the drain thread relies on a 50 ms timeout at child exit. Investigate fd pressure in the parent process.
+- `SSH stderr async drain falling back to Stdio::inherit()` - the async transport could not stand up the socketpair, so the SSH child's stderr is wired straight to the parent terminal. `stderr_capture()` returns empty for this session; consume diagnostics from the parent's own stderr instead.
+
 ### Known Limitations / Architectural Trade-offs
 
 oc-rsync is wire-compatible with upstream rsync 3.4.1, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -1125,6 +1125,45 @@ child, but it does not parse **~/.ssh/config** or **/etc/ssh/ssh_config**, so a
 **Compression yes** directive set there is invisible to the warning. If
 throughput looks CPU-bound on an SSH transfer, check those files as well.
 
+## SSH stderr socketpair channel
+
+Default builds drain the SSH child's stderr through an anonymous pipe on a
+dedicated reader thread. The **ssh-socketpair-stderr** cargo feature swaps the
+pipe for a **socketpair(AF_UNIX, SOCK_STREAM)** and, when the async transport
+is in use, hands the parent end to an epoll/kqueue-integrated drain. Wake-up
+and shutdown become event-driven instead of timeout-bounded, and the larger
+socket buffer absorbs bursty remote shells without dropping diagnostic lines.
+
+Enable it with:
+
+    cargo build --features ssh-socketpair-stderr
+
+Linux is the supported target; the Windows shim is pending. See
+**docs/design/socketpair-stderr-channel.md** in the source distribution.
+
+When the runtime cannot honour the feature, **oc-rsync** emits one of three
+one-shot warnings. Each fires at most once per process; the substrings below
+are the operator-grep contract. Sync-path warnings go to stderr; async-path
+warnings go to the **tracing** target **ssh::stderr**.
+
+**SSH stderr async drain unavailable on this platform**
+:   The kernel rejected **socketpair(AF_UNIX, SOCK_STREAM, 0)** - typically
+    **EMFILE**, **ENFILE**, **EPERM**, or **ENOSYS** under seccomp. The session
+    falls back to **Stdio::piped()**. Raise the per-process fd limit or relax
+    the sandbox to restore the socketpair drain.
+
+**SSH stderr socketpair partially set up**
+:   The socketpair allocated but **dup(2)** on the parent half failed, usually
+    **EMFILE**. The drain still reads from the socketpair, but **shutdown_read**
+    becomes a no-op and the drain thread is bounded by a 50 ms timeout at
+    child exit. Investigate fd pressure in the parent process.
+
+**SSH stderr async drain falling back to Stdio::inherit()**
+:   The async transport could not stand up the socketpair, so the SSH child's
+    stderr is wired straight to the parent terminal. **stderr_capture()**
+    returns empty for this session; consume diagnostics from the parent's own
+    stderr instead.
+
 # COMPATIBILITY
 
 **oc-rsync** is wire-compatible with upstream rsync and can operate with:


### PR DESCRIPTION
## Summary

User-facing documentation for the `ssh-socketpair-stderr` cargo feature, completing the SSF track started by the SSF-1 audit (PR #4658) and the SSF-2 warning wiring (PR #4663, in-flight).

- **README.md** - new `#### SSH stderr socketpair channel` subsection under `### Performance tuning`, alongside the SSC-2 (double-compression) and IUS-1 (`SEND_ZC`) subsections.
- **docs/oc-rsync.1.md** - new `## SSH stderr socketpair channel` block under `# NOTES`, mirroring the README content in man-page form.

Both cover:
- What the feature swaps in (socketpair-backed async drain vs the default anonymous-pipe drain).
- When operators benefit (chatty SSH stderr, slow networks, mass-parallel transfers).
- How to build (`cargo build --features ssh-socketpair-stderr`).
- The three one-shot runtime warnings from SSF-2, cited verbatim by their grep-marker substrings:
  - `SSH stderr async drain unavailable on this platform`
  - `SSH stderr socketpair partially set up`
  - `SSH stderr async drain falling back to Stdio::inherit()`

The marker substrings are the operator-grep contract - they match the `pub(super) const *_MARKER` strings introduced by PR #4663.

## Follow-up dependency

PR #4663 (SSF-2, in-flight) introduces the warning markers. Ordering notes:

- If #4663 merges first, this PR is text-only and merges as-is.
- If #4663 merges after, the substrings here will already be the contract once #4663 lands - no rebase needed.
- If #4663 is reverted or its marker strings change, this PR must be amended to drop or update the bullet list referencing them.

## References

- SSF-1 audit doc: `docs/audits/ssf-1-socketpair-fallback-sites-2026-05-21.md` (merged via PR #4658).
- SSF-2 warning wiring: PR #4663 (in-flight).
- Feature design: `docs/design/socketpair-stderr-channel.md`, `docs/ssh-transport.md`.

## Test plan

- [ ] CI fmt, clippy, nextest matrices pass (docs-only change, no code touched).
- [ ] Man-page renders cleanly under `pandoc` in the docs workflow.