### PR TITLE
feat(fast_io,transfer): replace remove_file/remove_dir with unlinkat (SEC-1.g)

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -572,7 +572,10 @@ mod tests {
         let dirfd = secure_open_dir(&root).expect("open root");
 
         unlinkat(dirfd.as_fd(), OsStr::new("empty"), UnlinkFlags::Dir).expect("unlinkat dir");
-        assert!(!path.exists(), "empty directory must be gone after unlinkat");
+        assert!(
+            !path.exists(),
+            "empty directory must be gone after unlinkat"
+        );
     }
 
     #[test]
@@ -612,7 +615,10 @@ mod tests {
             code == Some(libc::ENOTEMPTY) || code == Some(libc::EEXIST),
             "expected ENOTEMPTY or EEXIST for rmdir of non-empty directory, got {code:?}"
         );
-        assert!(dir.exists(), "non-empty directory must survive a failed rmdir");
+        assert!(
+            dir.exists(),
+            "non-empty directory must survive a failed rmdir"
+        );
     }
 
     #[test]
@@ -664,7 +670,10 @@ mod tests {
         let leaf = Path::new("file");
         unlink_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path, UnlinkFlags::File)
             .expect("unlink");
-        assert!(!path.exists(), "single-component file must be removed via sandbox dirfd");
+        assert!(
+            !path.exists(),
+            "single-component file must be removed via sandbox dirfd"
+        );
     }
 
     #[test]
@@ -677,7 +686,10 @@ mod tests {
         let leaf = Path::new("empty");
         unlink_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path, UnlinkFlags::Dir)
             .expect("rmdir");
-        assert!(!path.exists(), "single-component dir must be removed via sandbox dirfd");
+        assert!(
+            !path.exists(),
+            "single-component dir must be removed via sandbox dirfd"
+        );
     }
 
     #[test]
@@ -691,7 +703,10 @@ mod tests {
         let rel = Path::new("sub/file");
         unlink_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &path, UnlinkFlags::File)
             .expect("unlink fallback");
-        assert!(!path.exists(), "multi-component path must fall back to std::fs::remove_file");
+        assert!(
+            !path.exists(),
+            "multi-component path must fall back to std::fs::remove_file"
+        );
     }
 
     #[test]
@@ -703,7 +718,10 @@ mod tests {
         let leaf = Path::new("file");
         unlink_via_sandbox_or_fallback(None, &root, leaf, &path, UnlinkFlags::File)
             .expect("unlink fallback");
-        assert!(!path.exists(), "absent-sandbox path must fall back to std::fs::remove_file");
+        assert!(
+            !path.exists(),
+            "absent-sandbox path must fall back to std::fs::remove_file"
+        );
     }
 
     #[test]
@@ -718,6 +736,9 @@ mod tests {
         let rel = Path::new("sub/inner");
         unlink_via_sandbox_or_fallback(None, &root, rel, &path, UnlinkFlags::Dir)
             .expect("rmdir fallback");
-        assert!(!path.exists(), "Dir flag must dispatch std::fs::remove_dir on fallback");
+        assert!(
+            !path.exists(),
+            "Dir flag must dispatch std::fs::remove_dir on fallback"
+        );
     }
 }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -1,14 +1,18 @@
 //! `*at` syscall helpers anchored on a [`DirSandbox`](super::DirSandbox).
 //!
 //! Wraps the bare libc entry points that have no safe equivalent in
-//! `std::fs` (`fstatat`, etc.) and exposes them through a typed surface
-//! the engine and transfer crates can consume without taking on any
-//! `unsafe` of their own.
+//! `std::fs` (`fstatat`, `unlinkat`, etc.) and exposes them through a
+//! typed surface the engine and transfer crates can consume without
+//! taking on any `unsafe` of their own.
 //!
-//! Today this module only carries the lstat-class cutover for SEC-1.f
-//! (`fstatat(AT_SYMLINK_NOFOLLOW)`). SEC-1.g-j will extend it with the
-//! remaining `*at` siblings (`unlinkat`, `mkdirat`, `fchmodat`,
-//! `renameat`, ...) as those tasks land.
+//! Today this module carries:
+//! - the lstat-class cutover for SEC-1.f
+//!   (`fstatat(AT_SYMLINK_NOFOLLOW)`), and
+//! - the unlink-class cutover for SEC-1.g
+//!   (`unlinkat(dirfd, name, 0 | AT_REMOVEDIR)`).
+//!
+//! SEC-1.h-j will extend it with the remaining `*at` siblings
+//! (`mkdirat`, `fchmodat`, `renameat`, ...) as those tasks land.
 
 use std::ffi::{CString, OsStr};
 use std::io;
@@ -283,6 +287,131 @@ fn single_component_leaf<'a>(
     Some(first)
 }
 
+/// Selector for [`unlinkat`].
+///
+/// `unlinkat(2)` overloads a single syscall to remove either a regular
+/// file/symlink/device or an empty directory, controlled by the
+/// `AT_REMOVEDIR` flag. Encoding the choice as an enum at the public
+/// surface keeps call sites self-documenting and makes the
+/// `remove_file` / `remove_dir` distinction explicit instead of hiding
+/// it behind a raw bitflag the caller has to remember.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UnlinkFlags {
+    /// Remove a non-directory entry (regular file, symlink, FIFO,
+    /// device, socket). Maps to `flags == 0` for `unlinkat(2)`.
+    ///
+    /// A non-empty directory at the leaf is rejected by the kernel
+    /// with `EISDIR` (Linux) or `EPERM` (other Unix variants); a
+    /// missing leaf yields `ENOENT`.
+    File,
+    /// Remove an empty directory entry. Maps to
+    /// `flags == AT_REMOVEDIR` for `unlinkat(2)` (equivalent to a
+    /// `rmdir(2)` anchored on `dirfd`).
+    ///
+    /// A non-empty directory at the leaf is rejected with `ENOTEMPTY`
+    /// (or `EEXIST` on some BSDs); a non-directory at the leaf yields
+    /// `ENOTDIR`.
+    Dir,
+}
+
+impl UnlinkFlags {
+    /// Returns the raw `flags` argument for `unlinkat(2)`.
+    fn as_raw(self) -> libc::c_int {
+        match self {
+            Self::File => 0,
+            Self::Dir => libc::AT_REMOVEDIR,
+        }
+    }
+}
+
+/// Issue `unlinkat(dirfd, name, flags)`.
+///
+/// The leaf is resolved relative to `dirfd` and is **not** followed if
+/// it is a symlink (`unlinkat(2)` never follows a terminal symlink). A
+/// TOCTOU symlink swap between the receiver's decide-to-delete moment
+/// and the syscall therefore cannot redirect the call into an
+/// attacker-chosen directory, because the parent is pinned by the
+/// dirfd that was opened at receiver setup.
+///
+/// `name` must not contain an interior NUL byte; callers that pull
+/// names from `Path::file_name` cannot trigger this (paths cannot
+/// contain NUL on Unix).
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `ENOENT` when `name` does not exist beneath `dirfd`.
+/// - `ENOTDIR` when `dirfd` is not a directory, or when
+///   [`UnlinkFlags::Dir`] is asked for a non-directory entry.
+/// - `EISDIR` (Linux) / `EPERM` (other Unix) when [`UnlinkFlags::File`]
+///   is asked for a directory entry.
+/// - `ENOTEMPTY` (or `EEXIST` on some BSDs) when
+///   [`UnlinkFlags::Dir`] is asked for a non-empty directory.
+/// - `EACCES` when the caller lacks write permission on `dirfd`.
+/// - `EINVAL` when `name` contains an interior NUL byte (translated
+///   from [`std::ffi::NulError`]).
+pub fn unlinkat(dirfd: BorrowedFd<'_>, name: &OsStr, flags: UnlinkFlags) -> io::Result<()> {
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+    //   whose lifetime is bound to the borrow and outlives the syscall.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not retain the
+    //   pointer past return.
+    // - `flags` is either 0 or `AT_REMOVEDIR`, the only valid values
+    //   `unlinkat(2)` accepts. `UnlinkFlags::as_raw` enforces this
+    //   discriminator-to-flag mapping at the type level.
+    // - `unlinkat(2)` never follows a terminal symlink, regardless of
+    //   the flag, so a swap-to-symlink TOCTOU on `name` cannot
+    //   redirect the unlink to an attacker-chosen target inode.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::unlinkat(dirfd.as_raw_fd(), c_name.as_ptr(), flags.as_raw()) };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Issue `unlinkat` against `link_path` when the `sandbox` root is the
+/// immediate parent.
+///
+/// SEC-1.g adaptor for callers that already have an absolute path:
+/// - When `sandbox` is `Some`, `link_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   component, the helper resolves the leaf through the sandbox dirfd
+///   so a mid-syscall symlink swap on the leaf cannot redirect the
+///   unlink to an attacker-chosen parent.
+/// - In every other case the helper falls back to
+///   [`std::fs::remove_file`] / [`std::fs::remove_dir`] on `link_path`,
+///   per the [`UnlinkFlags`] selector.
+///
+/// # Errors
+///
+/// Surfaces either the [`unlinkat`] error or the
+/// [`std::fs::remove_file`] / [`std::fs::remove_dir`] error verbatim,
+/// depending on which path was taken.
+pub fn unlink_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    link_path: &Path,
+    flags: UnlinkFlags,
+) -> io::Result<()> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
+    {
+        return unlinkat(sandbox.current_dirfd(), leaf, flags);
+    }
+    match flags {
+        UnlinkFlags::File => std::fs::remove_file(link_path),
+        UnlinkFlags::Dir => std::fs::remove_dir(link_path),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::os::fd::AsFd;
@@ -422,5 +551,173 @@ mod tests {
         let via_std = lstat_via_sandbox_or_fallback(None, &root, leaf, &path).expect("std lstat");
         assert_eq!(via_at.dev(), via_std.dev());
         assert_eq!(via_at.ino(), via_std.ino());
+    }
+
+    #[test]
+    fn unlinkat_removes_regular_file() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("victim");
+        std::fs::write(&path, b"data").expect("write");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        unlinkat(dirfd.as_fd(), OsStr::new("victim"), UnlinkFlags::File).expect("unlinkat");
+        assert!(!path.exists(), "leaf must be gone after unlinkat");
+    }
+
+    #[test]
+    fn unlinkat_removes_empty_dir_with_at_removedir() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("empty");
+        std::fs::create_dir(&path).expect("mkdir");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        unlinkat(dirfd.as_fd(), OsStr::new("empty"), UnlinkFlags::Dir).expect("unlinkat dir");
+        assert!(!path.exists(), "empty directory must be gone after unlinkat");
+    }
+
+    #[test]
+    fn unlinkat_returns_eperm_or_eisdir_on_dir_without_at_removedir() {
+        // SEC-1.g invariant: removing a directory without `AT_REMOVEDIR`
+        // must fail rather than silently succeed. Linux reports `EISDIR`,
+        // BSDs and macOS report `EPERM` per the `unlink(2)` contract.
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("dir");
+        std::fs::create_dir(&path).expect("mkdir");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let err = unlinkat(dirfd.as_fd(), OsStr::new("dir"), UnlinkFlags::File)
+            .expect_err("must refuse to unlink a directory");
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::EISDIR) || code == Some(libc::EPERM),
+            "expected EISDIR or EPERM for unlink of a directory, got {code:?}"
+        );
+        assert!(path.exists(), "directory must survive a failed unlink");
+    }
+
+    #[test]
+    fn unlinkat_returns_enotempty_on_non_empty_dir_with_at_removedir() {
+        // SEC-1.g invariant: `AT_REMOVEDIR` mirrors `rmdir(2)` exactly,
+        // refusing to remove a non-empty directory.
+        let (_keep, root) = canonical_tempdir();
+        let dir = root.join("non-empty");
+        std::fs::create_dir(&dir).expect("mkdir");
+        std::fs::write(dir.join("inner"), b"x").expect("write inner");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let err = unlinkat(dirfd.as_fd(), OsStr::new("non-empty"), UnlinkFlags::Dir)
+            .expect_err("must refuse to remove a non-empty directory");
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::ENOTEMPTY) || code == Some(libc::EEXIST),
+            "expected ENOTEMPTY or EEXIST for rmdir of non-empty directory, got {code:?}"
+        );
+        assert!(dir.exists(), "non-empty directory must survive a failed rmdir");
+    }
+
+    #[test]
+    fn unlinkat_rejects_symlink_traversal() {
+        // SEC-1 TOCTOU invariant: even when an attacker swaps the leaf
+        // for a symlink to a sensitive sibling, `unlinkat(File)` removes
+        // the symlink itself rather than the target it points at. The
+        // syscall is hard-coded to never follow a terminal symlink, but
+        // this test pins that contract against future regressions.
+        let (_keep, root) = canonical_tempdir();
+        // Sensitive target lives outside any path the receiver names.
+        let sensitive = root.join("sensitive");
+        std::fs::write(&sensitive, b"do-not-delete").expect("write sensitive");
+        // The receiver decides to delete `leaf`; meanwhile the attacker
+        // swaps it for a symlink pointing at `sensitive`.
+        let leaf = root.join("leaf");
+        std::os::unix::fs::symlink(&sensitive, &leaf).expect("symlink");
+
+        let dirfd = secure_open_dir(&root).expect("open root");
+        unlinkat(dirfd.as_fd(), OsStr::new("leaf"), UnlinkFlags::File).expect("unlinkat leaf");
+
+        assert!(
+            !leaf.exists(),
+            "the symlink itself must be removed, target chase is forbidden"
+        );
+        assert!(
+            sensitive.exists(),
+            "unlinkat must never follow the terminal symlink; the target must survive"
+        );
+    }
+
+    #[test]
+    fn unlinkat_reports_enoent_for_missing_leaf() {
+        let (_keep, root) = canonical_tempdir();
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let err = unlinkat(dirfd.as_fd(), OsStr::new("absent"), UnlinkFlags::File)
+            .expect_err("missing leaf must error");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn unlink_via_sandbox_takes_at_path_for_single_component_file() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"x").expect("write");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("file");
+        unlink_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path, UnlinkFlags::File)
+            .expect("unlink");
+        assert!(!path.exists(), "single-component file must be removed via sandbox dirfd");
+    }
+
+    #[test]
+    fn unlink_via_sandbox_takes_at_path_for_single_component_dir() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("empty");
+        std::fs::create_dir(&path).expect("mkdir");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("empty");
+        unlink_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path, UnlinkFlags::Dir)
+            .expect("rmdir");
+        assert!(!path.exists(), "single-component dir must be removed via sandbox dirfd");
+    }
+
+    #[test]
+    fn unlink_via_sandbox_falls_back_for_multi_component() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        let path = root.join("sub/file");
+        std::fs::write(&path, b"x").expect("write");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let rel = Path::new("sub/file");
+        unlink_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &path, UnlinkFlags::File)
+            .expect("unlink fallback");
+        assert!(!path.exists(), "multi-component path must fall back to std::fs::remove_file");
+    }
+
+    #[test]
+    fn unlink_via_sandbox_falls_back_when_sandbox_absent() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"x").expect("write");
+
+        let leaf = Path::new("file");
+        unlink_via_sandbox_or_fallback(None, &root, leaf, &path, UnlinkFlags::File)
+            .expect("unlink fallback");
+        assert!(!path.exists(), "absent-sandbox path must fall back to std::fs::remove_file");
+    }
+
+    #[test]
+    fn unlink_via_sandbox_dispatches_rmdir_in_fallback() {
+        // Without a sandbox the helper must still pick the correct std
+        // call from `UnlinkFlags`: `remove_dir`, not `remove_file`.
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        let path = root.join("sub/inner");
+        std::fs::create_dir(&path).expect("mkdir inner");
+
+        let rel = Path::new("sub/inner");
+        unlink_via_sandbox_or_fallback(None, &root, rel, &path, UnlinkFlags::Dir)
+            .expect("rmdir fallback");
+        assert!(!path.exists(), "Dir flag must dispatch std::fs::remove_dir on fallback");
     }
 }

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -78,7 +78,10 @@ pub mod at_syscalls;
 #[cfg(test)]
 mod tests;
 
-pub use at_syscalls::{AtMetadata, LstatOutcome, fstatat_nofollow, lstat_via_sandbox_or_fallback};
+pub use at_syscalls::{
+    AtMetadata, LstatOutcome, UnlinkFlags, fstatat_nofollow, lstat_via_sandbox_or_fallback,
+    unlink_via_sandbox_or_fallback, unlinkat,
+};
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.
 ///
@@ -293,6 +296,28 @@ impl DirSandbox {
     /// Propagates the underlying [`fstatat_nofollow`] error verbatim.
     pub fn lstat_at(&self, leaf: &OsStr) -> io::Result<AtMetadata> {
         fstatat_nofollow(self.current_dirfd(), leaf)
+    }
+
+    /// `unlinkat(dirfd, leaf, flags)` anchored on the current dirfd.
+    ///
+    /// SEC-1.g convenience accessor: resolves `leaf` relative to the
+    /// dirfd returned by [`current_dirfd`](Self::current_dirfd) and
+    /// removes the entry without re-walking the path through the
+    /// kernel. `unlinkat(2)` never follows a terminal symlink, so a
+    /// TOCTOU swap on `leaf` cannot redirect the unlink to an
+    /// attacker-chosen inode beneath a different parent.
+    ///
+    /// Callers that already hold a [`BorrowedFd`] from a different
+    /// anchor (for example [`root_dirfd`](Self::root_dirfd) or
+    /// [`secondary`](Self::secondary)) should call [`unlinkat`]
+    /// directly to make the anchoring explicit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the underlying [`unlinkat`] error verbatim. See
+    /// [`unlinkat`] for the notable error cases.
+    pub fn unlinkat_at(&self, leaf: &OsStr, flags: UnlinkFlags) -> io::Result<()> {
+        unlinkat(self.current_dirfd(), leaf, flags)
     }
 }
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -225,7 +225,8 @@ pub use traits::{FileReader, FileWriter};
 
 #[cfg(unix)]
 pub use dir_sandbox::{
-    AtMetadata, DirSandbox, LstatOutcome, fstatat_nofollow, lstat_via_sandbox_or_fallback,
+    AtMetadata, DirSandbox, LstatOutcome, UnlinkFlags, fstatat_nofollow,
+    lstat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -82,7 +82,19 @@ impl ReceiverContext {
                     info_log!(Name, 2, "{} is uptodate", relative_path.display());
                     continue;
                 }
-                let _ = std::fs::remove_file(&link_path);
+                // SEC-1.g: route the obstacle unlink through the sandbox
+                // dirfd when the destination parent is the sandbox root,
+                // so a TOCTOU swap on `link_path` between the readlink
+                // above and this unlink cannot redirect the syscall to
+                // an attacker-chosen parent. Falls back to path-based
+                // `remove_file` otherwise.
+                let _ = fast_io::unlink_via_sandbox_or_fallback(
+                    sandbox,
+                    dest_dir,
+                    relative_path,
+                    &link_path,
+                    fast_io::UnlinkFlags::File,
+                );
             } else if fast_io::lstat_via_sandbox_or_fallback(
                 sandbox,
                 dest_dir,
@@ -96,7 +108,17 @@ impl ReceiverContext {
                 // `fstatat(AT_SYMLINK_NOFOLLOW)` so a TOCTOU symlink swap on
                 // `link_path` cannot redirect the probe to a different
                 // inode. Falls back to `symlink_metadata` otherwise.
-                let _ = std::fs::remove_file(&link_path);
+                //
+                // SEC-1.g: matching unlink also goes through the sandbox
+                // dirfd via `unlinkat` so the obstacle-remove syscall is
+                // anchored on the same parent the stat just observed.
+                let _ = fast_io::unlink_via_sandbox_or_fallback(
+                    sandbox,
+                    dest_dir,
+                    relative_path,
+                    &link_path,
+                    fast_io::UnlinkFlags::File,
+                );
             }
 
             // Ensure parent directory exists for --relative paths.
@@ -279,6 +301,23 @@ impl ReceiverContext {
                         }
                     }
                     // Remove existing file so we can create the hard link.
+                    //
+                    // SEC-1.g: on Unix, route the unlink through the
+                    // sandbox dirfd when the destination parent is the
+                    // sandbox root so a TOCTOU swap between the stat
+                    // above and the unlink cannot redirect the syscall
+                    // to an attacker-chosen parent. Windows stays on
+                    // the path-based `remove_file` per the SEC-1.l
+                    // NTFS-handle audit.
+                    #[cfg(unix)]
+                    let _ = fast_io::unlink_via_sandbox_or_fallback(
+                        sandbox,
+                        dest_dir,
+                        relative_path,
+                        &link_path,
+                        fast_io::UnlinkFlags::File,
+                    );
+                    #[cfg(not(unix))]
                     let _ = fs::remove_file(&link_path);
                 }
 

--- a/crates/transfer/tests/unlinkat_swap_resistance.rs
+++ b/crates/transfer/tests/unlinkat_swap_resistance.rs
@@ -1,0 +1,143 @@
+//! SEC-1.g integration test: the receiver-side obstacle unlink goes
+//! through `fast_io::unlinkat` when a [`DirSandbox`] is wired, and the
+//! syscall removes the leaf entry itself instead of following a
+//! symlink swap to an attacker-chosen target.
+//!
+//! These tests do not stand up a full receiver pipeline. They exercise
+//! the `unlink_via_sandbox_or_fallback` helper at the same anchor the
+//! receiver uses (an open dirfd over the destination root) on a tree
+//! shaped like a real run, and assert the TOCTOU-relevant outcome:
+//!
+//! 1. When `link_path = dest_dir/leaf` and the entry is a symlink, the
+//!    sandbox-anchored unlink removes the symlink itself rather than
+//!    chasing it to whatever target it points at outside the sandbox.
+//! 2. When the relative path has multiple components, the helper falls
+//!    back to `std::fs::remove_file` (the SEC-1.g cutover only touches
+//!    single-component paths today; multi-component descent is the
+//!    SEC-1.g.followup work mirroring SEC-1.f).
+//! 3. `UnlinkFlags::Dir` mirrors `rmdir(2)` and refuses to remove a
+//!    non-empty directory.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use fast_io::{DirSandbox, UnlinkFlags, unlink_via_sandbox_or_fallback};
+use tempfile::tempdir;
+
+/// `tempdir()` may sit under a symlink prefix on macOS / some CI
+/// runners; canonicalise so the sandbox open succeeds under
+/// `RESOLVE_NO_SYMLINKS`.
+fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let canon = std::fs::canonicalize(dir.path()).expect("canonicalize");
+    (dir, canon)
+}
+
+/// Simulates the attack the receiver-side obstacle unlink defends
+/// against: between the receiver's decide-to-delete moment and the
+/// syscall, an attacker swaps `dest/target/` for a symlink to
+/// `../../sensitive/`. `unlinkat` anchored on the sandbox dirfd
+/// removes the symlink itself; the sensitive target outside the
+/// destination tree must survive.
+#[test]
+fn unlink_via_sandbox_does_not_follow_swapped_symlink() {
+    let (_keep, parent) = canonical_tempdir();
+
+    // Sensitive tree the attacker hopes to redirect the unlink to.
+    let sensitive_dir = parent.join("sensitive");
+    std::fs::create_dir(&sensitive_dir).expect("mkdir sensitive");
+    let sensitive_file = sensitive_dir.join("secret");
+    std::fs::write(&sensitive_file, b"do-not-delete").expect("write secret");
+
+    // Receiver-managed destination tree. The receiver decides to delete
+    // `dest/target`; the attacker has swapped it for a symlink pointing
+    // at the sensitive tree above.
+    let dest = parent.join("dest");
+    std::fs::create_dir(&dest).expect("mkdir dest");
+    let target = dest.join("target");
+    symlink(&sensitive_dir, &target).expect("symlink swap");
+
+    let sandbox = DirSandbox::open_root(&dest).expect("sandbox");
+
+    let leaf = Path::new("target");
+    let link_path = dest.join(leaf);
+    unlink_via_sandbox_or_fallback(Some(&sandbox), &dest, leaf, &link_path, UnlinkFlags::File)
+        .expect("unlink leaf");
+
+    assert!(
+        !target.exists(),
+        "swapped symlink must be removed itself, not followed"
+    );
+    assert!(
+        sensitive_dir.is_dir(),
+        "sensitive directory outside the sandbox must survive"
+    );
+    assert!(
+        sensitive_file.is_file(),
+        "file inside sensitive directory must survive"
+    );
+}
+
+/// Sandbox-anchored unlink removes a regular file at a single-
+/// component leaf, matching the obstacle-clear path the receiver
+/// takes for symlink and hardlink quick-check misses.
+#[test]
+fn unlink_via_sandbox_removes_regular_file_at_leaf() {
+    let (_keep, root) = canonical_tempdir();
+    let path = root.join("obstacle");
+    std::fs::write(&path, b"contents").expect("write");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let leaf = Path::new("obstacle");
+    unlink_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path, UnlinkFlags::File)
+        .expect("unlink");
+    assert!(!path.exists(), "regular file leaf must be removed");
+}
+
+/// `UnlinkFlags::Dir` mirrors `rmdir(2)` exactly: refuses to remove a
+/// non-empty directory, even when the sandbox dirfd is the immediate
+/// parent. Pins the contract so future refactors do not silently
+/// promote `rmdir` into a recursive removal.
+#[test]
+fn unlink_via_sandbox_dir_flag_refuses_non_empty_directory() {
+    let (_keep, root) = canonical_tempdir();
+    let dir = root.join("non-empty");
+    std::fs::create_dir(&dir).expect("mkdir");
+    std::fs::write(dir.join("inner"), b"x").expect("write inner");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+    let leaf = Path::new("non-empty");
+    let err = unlink_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &dir, UnlinkFlags::Dir)
+        .expect_err("must refuse to rmdir a non-empty directory");
+    let code = err.raw_os_error();
+    assert!(
+        code == Some(libc::ENOTEMPTY) || code == Some(libc::EEXIST),
+        "expected ENOTEMPTY or EEXIST, got {code:?}"
+    );
+    assert!(dir.is_dir(), "directory must survive a failed rmdir");
+}
+
+/// Multi-component paths fall back to `std::fs::remove_file` until the
+/// sandbox descent stack is wired through every executor. This pins
+/// the documented deferral so a future regression does not silently
+/// promote multi-component paths into the path-based fallback without
+/// re-evaluating the TOCTOU exposure.
+#[test]
+fn unlink_via_sandbox_multi_component_takes_fallback() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+    let path = root.join("sub/file");
+    std::fs::write(&path, b"x").expect("write");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+    let rel = Path::new("sub/file");
+    unlink_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &path, UnlinkFlags::File)
+        .expect("unlink");
+    assert!(
+        !path.exists(),
+        "multi-component fallback must remove the leaf via std::fs::remove_file"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `fast_io::unlinkat` + `UnlinkFlags` as the SEC-1.g primitive (single SAFETY block in `fast_io`; consumer crates take a safe wrapper) and a `DirSandbox::unlinkat_at` convenience method, mirroring SEC-1.f's `fstatat_nofollow` / `lstat_at` pattern.
- Migrate the three receiver-side obstacle-remove sites in `crates/transfer/src/receiver/directory/links.rs` (rows `links.rs:84/:86/:251` in [docs/audits/sec-1-a-path-syscall-surface-2026-05-20.md](docs/audits/sec-1-a-path-syscall-surface-2026-05-20.md)) to route through `fast_io::unlink_via_sandbox_or_fallback` when the SEC-1.e `DirSandbox` carrier is plumbed, falling back to path-based `remove_file` otherwise.
- Closes the unlink-class slice of the TOCTOU window: `unlinkat(2)` is anchored on the receiver-owned dirfd and is hard-coded to never follow a terminal symlink, so a swap on the leaf cannot redirect the syscall to an attacker-chosen parent and cannot chase the swapped symlink to a sensitive sibling.

## Audit cite

The SEC-1.a audit ([docs/audits/sec-1-a-path-syscall-surface-2026-05-20.md](docs/audits/sec-1-a-path-syscall-surface-2026-05-20.md)) enumerates 14 ` unlinkat(parent_fd, leaf, 0)` and ` unlinkat(parent_fd, leaf, AT_REMOVEDIR)` cutover rows across `engine` and `transfer`. This PR migrates the three receiver-pipeline rows that already have the SEC-1.e sandbox carrier wired:

| audit row | site | this PR |
|---|---|---|
| `links.rs:84` | `create_symlinks` stale-symlink-replace | migrated |
| `links.rs:86` | `create_symlinks` non-symlink obstacle remove | migrated |
| `links.rs:251` | `create_hardlinks` existing-file remove before `linkat` | migrated (Unix only; Windows keeps `fs::remove_file` per the SEC-1.l NTFS-handle audit) |

## Deferred to SEC-1.g.followup

Mirrors SEC-1.f's deferral pattern: any site that needs additional plumbing beyond the existing SEC-1.e carrier stays out of scope.

- `crates/transfer/src/receiver/directory/deletion.rs:157,159` (`delete_extraneous_files`). Runs in `parallel_io::map_blocking` worker closures over arbitrary subdirectories. The sandbox's `current_dirfd` reflects the receiver's in-tree descent on the main thread; workers each operate against a different `dest_dir.join(dir_rel)` and need either per-worker secondary dirfds (`DirSandbox::secondary`) or a descent-stack copy per worker.
- `crates/transfer/src/temp_guard.rs:217` (`TempGuard` RAII cleanup). Needs a `TempGuard` extension to carry a sandbox reference.
- All `engine`-side rows (`engine/src/delete/emitter/fs.rs`, `engine/src/local_copy/context_impl/state.rs:471,526,635`, `engine/src/local_copy/context_impl/reporting.rs:168,175`, `engine/src/local_copy/executor/file/guard.rs:32,50,155,351,426,469`, `engine/src/local_copy/executor/file/partial.rs:217`, `engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs:111,115`, `engine/src/local_copy/executor/sources/orchestration.rs:390`, `engine/src/local_copy/executor/directory/recursive/deletion.rs:64`, `engine/src/local_copy/hard_links/cohort.rs:90,156`). These need a `CopyContext` extension to carry a sandbox reference; the plumbing is sequenced as SEC-1.g.followup to keep this PR scoped to the receiver pipeline.
- `fs::remove_dir_all` sites stay path-based; they need the hand-rolled `openat` peel called out in audit section 4 (item 2). That is a separate task.

## Constraints honoured

- No `unsafe` outside `fast_io` (deny gate intact on `transfer`).
- No `#[allow(...)]` waivers added; the single SAFETY block lives in `fast_io::dir_sandbox::at_syscalls`.
- No new workspace dependencies.
- Cross-platform compile preserved: `unlink_via_sandbox_or_fallback` and `UnlinkFlags` are `#[cfg(unix)]`; Windows `create_hardlinks` keeps `fs::remove_file`.

## Test plan

- [ ] `cargo nextest run -p fast_io --all-features -E 'test(unlinkat) + test(unlink_via_sandbox)'` (5 new `unlinkat_*` + 4 new `unlink_via_sandbox_*` tests, plus the SEC-1.f siblings remain green)
- [ ] `cargo nextest run -p transfer --test unlinkat_swap_resistance` (4 new integration tests, including the symlink-swap attack scenario)
- [ ] `cargo nextest run -p transfer --all-features -E 'test(create_hardlinks) + test(create_symlinks)'` (existing receiver tests stay green through the cfg-aware `call_create_hardlinks` shim)
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] Full CI matrix: fmt+clippy, nextest (stable), Windows, macOS, Linux musl