### PR TITLE
bench(engine): scaffold PIP-6 end-to-end parallel-vs-sequential bench harness

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -122,3 +122,7 @@ criterion = { workspace = true }
 [[bench]]
 name = "transfer_benchmark"
 harness = false
+
+[[bench]]
+name = "pip_6_end_to_end_parallel_vs_sequential"
+harness = false

--- a/crates/core/benches/pip_6_end_to_end_parallel_vs_sequential.rs
+++ b/crates/core/benches/pip_6_end_to_end_parallel_vs_sequential.rs
@@ -1,0 +1,490 @@
+//! PIP-6 - End-to-end parallel-vs-sequential receive-delta bench.
+//!
+//! # Why this exists
+//!
+//! `crates/engine/benches/parallel_receive_delta_perf.rs` (BR-3i.f, #2502
+//! completed) drives `ParallelDeltaApplier` directly against in-memory sinks.
+//! That harness isolates apply-loop scheduling, but production receivers also
+//! pay for protocol framing, signature exchange, fsync, and the cost of the
+//! dispatch heuristic itself. BR-3j.f (#2508, pending) is the post-DashMap
+//! re-bench of the same apply loop.
+//!
+//! PIP-6 is the **end-to-end** complement: it drives a real `oc-rsync` client
+//! against a real `oc-rsync` daemon over loopback, on workload shapes
+//! calibrated to the Path B heuristic boundary
+//! (`file_count > 100 || total_size > 64 MiB`) that PIP-3+5 (PR #4666)
+//! wired into `ReceiverContext::dispatch_receiver_strategy`.
+//!
+//! The bench compares two binaries running the **same** workload:
+//!
+//! - `oc-rsync` built with default features - parallel-receive-delta is
+//!   available, dispatcher flips parallel above the heuristic thresholds.
+//! - `oc-rsync` built **without** `parallel-receive-delta` - dispatcher logs
+//!   `receiver_strategy=parallel_unavailable` per
+//!   `crates/transfer/src/receiver/mod.rs:480-494` and always picks
+//!   sequential.
+//!
+//! Same workload, same wire framing, same disk; only the apply strategy
+//! differs. The wall-clock delta is the answer the bench reports.
+//!
+//! # Workload matrix
+//!
+//! Five shapes calibrated to the dispatch boundary. See
+//! `docs/design/pip-6-end-to-end-parallel-vs-sequential-bench-2026-05-21.md`
+//! section 4 for the rationale of each shape and the heuristic decision
+//! the production dispatcher takes.
+//!
+//! | Shape              | Files  | Per-file size | Heuristic    |
+//! |--------------------|--------|---------------|--------------|
+//! | `single_large_file`| 1      | 1 GiB         | parallel     |
+//! | `many_small_files` | 10,000 | 4 KiB         | parallel     |
+//! | `boundary_under`   | 50     | ~655 KiB      | sequential   |
+//! | `boundary_over`    | 200    | 160 KiB       | parallel     |
+//! | `mixed_directory`  | 1,000  | 4 KiB - 4 MiB | parallel     |
+//!
+//! # Decision criteria
+//!
+//! Lifted from the design doc (section 7):
+//!
+//! - **Win.** `parallel_wall / sequential_wall <= 0.9` on at least 2 of 5
+//!   shapes.
+//! - **Regression budget.** No shape regresses by more than 5%.
+//! - **Boundary control.** `boundary_under` wall-clock agrees within +/-3%
+//!   (both builds dispatch sequential there).
+//!
+//! # How to run
+//!
+//! Two `oc-rsync` binaries are required. The bench resolves them via env
+//! vars; defaults match the build script convention:
+//!
+//! ```sh
+//! # Default-features build (parallel-receive-delta available)
+//! cargo build --release --bin oc-rsync
+//!
+//! # No-default-features build (parallel-receive-delta compiled out)
+//! cargo build --release \
+//!     --target-dir target/release-no-parallel \
+//!     --no-default-features \
+//!     --features 'zstd lz4 xattr iconv' \
+//!     --bin oc-rsync
+//!
+//! # Run the bench
+//! cargo bench -p core --bench pip_6_end_to_end_parallel_vs_sequential
+//! ```
+//!
+//! Env-var overrides:
+//!
+//! - `OC_RSYNC_BIN_PARALLEL` - path to the default-features binary
+//!   (default `target/release/oc-rsync`).
+//! - `OC_RSYNC_BIN_SEQUENTIAL` - path to the no-default-features binary
+//!   (default `target/release-no-parallel/oc-rsync`).
+//! - `OC_RSYNC_BENCH_LARGE_GIB` - override the `single_large_file` size in
+//!   GiB (default `1`). Useful on storage-constrained dev boxes.
+//!
+//! When either binary is missing, the bench prints a skip message and
+//! returns - matching the `BenchDaemon::start` pattern in
+//! `crates/core/benches/transfer_benchmark.rs`.
+//!
+//! # Cross-references
+//!
+//! - Design doc:
+//!   `docs/design/pip-6-end-to-end-parallel-vs-sequential-bench-2026-05-21.md`
+//! - BR-3i.f apply-loop bench:
+//!   `crates/engine/benches/parallel_receive_delta_perf.rs`
+//! - Heuristic constants and dispatch site:
+//!   `crates/transfer/src/receiver/mod.rs::PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD`,
+//!   `crates/transfer/src/receiver/mod.rs::PARALLEL_RECEIVE_BYTES_THRESHOLD`,
+//!   `crates/transfer/src/receiver/mod.rs::dispatch_receiver_strategy`.
+//! - Sibling end-to-end bench harness this scaffold mirrors:
+//!   `crates/core/benches/transfer_benchmark.rs`.
+
+#![deny(unsafe_code)]
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+/// Defaults match the build script convention documented in the module doc.
+const DEFAULT_BIN_PARALLEL: &str = "target/release/oc-rsync";
+const DEFAULT_BIN_SEQUENTIAL: &str = "target/release-no-parallel/oc-rsync";
+
+/// Daemon-port allocator. Starts above the ephemeral range used by other
+/// benches in the workspace to keep parallel bench runs from colliding.
+static NEXT_PORT: AtomicU16 = AtomicU16::new(15_200);
+
+fn next_port() -> u16 {
+    NEXT_PORT.fetch_add(1, Ordering::SeqCst)
+}
+
+/// The two build variants the bench compares.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BuildVariant {
+    /// Default features; parallel-receive-delta available; dispatcher honours
+    /// the Path B heuristic.
+    Parallel,
+    /// `parallel-receive-delta` compiled out; dispatcher logs
+    /// `parallel_unavailable` and always picks sequential.
+    Sequential,
+}
+
+impl BuildVariant {
+    fn label(self) -> &'static str {
+        match self {
+            BuildVariant::Parallel => "parallel",
+            BuildVariant::Sequential => "sequential",
+        }
+    }
+
+    fn env_var(self) -> &'static str {
+        match self {
+            BuildVariant::Parallel => "OC_RSYNC_BIN_PARALLEL",
+            BuildVariant::Sequential => "OC_RSYNC_BIN_SEQUENTIAL",
+        }
+    }
+
+    fn default_path(self) -> &'static str {
+        match self {
+            BuildVariant::Parallel => DEFAULT_BIN_PARALLEL,
+            BuildVariant::Sequential => DEFAULT_BIN_SEQUENTIAL,
+        }
+    }
+
+    /// Resolves the binary path for this variant from the env var, falling
+    /// back to the documented default. Returns `None` when neither resolves
+    /// to a regular file; callers print a skip message and return.
+    fn resolve_path(self) -> Option<PathBuf> {
+        let candidate = std::env::var_os(self.env_var())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(self.default_path()));
+        if candidate.is_file() {
+            Some(candidate)
+        } else {
+            None
+        }
+    }
+}
+
+/// Workload shapes; column 1 of the matrix in the design doc.
+#[derive(Clone, Copy, Debug)]
+enum WorkloadShape {
+    SingleLargeFile,
+    ManySmallFiles,
+    BoundaryUnder,
+    BoundaryOver,
+    MixedDirectory,
+}
+
+impl WorkloadShape {
+    const ALL: &'static [WorkloadShape] = &[
+        WorkloadShape::SingleLargeFile,
+        WorkloadShape::ManySmallFiles,
+        WorkloadShape::BoundaryUnder,
+        WorkloadShape::BoundaryOver,
+        WorkloadShape::MixedDirectory,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            WorkloadShape::SingleLargeFile => "single_large_file",
+            WorkloadShape::ManySmallFiles => "many_small_files",
+            WorkloadShape::BoundaryUnder => "boundary_under",
+            WorkloadShape::BoundaryOver => "boundary_over",
+            WorkloadShape::MixedDirectory => "mixed_directory",
+        }
+    }
+
+    /// Total source bytes for this shape; the bench reports throughput
+    /// against this number.
+    fn total_bytes(self) -> u64 {
+        match self {
+            WorkloadShape::SingleLargeFile => single_large_file_size() as u64,
+            WorkloadShape::ManySmallFiles => (10_000 * 4 * 1024) as u64,
+            WorkloadShape::BoundaryUnder => (50 * 655 * 1024) as u64,
+            WorkloadShape::BoundaryOver => (200 * 160 * 1024) as u64,
+            WorkloadShape::MixedDirectory => mixed_directory_total_bytes() as u64,
+        }
+    }
+}
+
+/// Resolves the `single_large_file` size from the env var, defaulting to
+/// 1 GiB per the design doc. Useful for storage-constrained dev boxes that
+/// cannot spare a full GiB on the bench tempdir.
+fn single_large_file_size() -> usize {
+    let gib = std::env::var("OC_RSYNC_BENCH_LARGE_GIB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(1);
+    gib * 1024 * 1024 * 1024
+}
+
+/// Sizes drawn for the `mixed_directory` shape. Mirrors the `mixed` cell in
+/// `crates/engine/benches/parallel_receive_delta_perf.rs::mixed_spec` so
+/// the apply-loop and end-to-end benches share a workload vocabulary.
+const MIXED_SIZES: &[usize] = &[
+    4 * 1024,
+    16 * 1024,
+    64 * 1024,
+    256 * 1024,
+    1024 * 1024,
+    4 * 1024 * 1024,
+];
+
+fn mixed_directory_total_bytes() -> usize {
+    (0..1_000usize)
+        .map(|i| MIXED_SIZES[i % MIXED_SIZES.len()])
+        .sum()
+}
+
+/// Writes `size` bytes of a deterministic, non-zero pattern to `path`.
+/// Non-zero so the sparse-file fast path does not skip the bytes; the
+/// pattern is keyed by the file index so different files have different
+/// content (which the delta path can actually do work against).
+fn write_pattern(path: &Path, size: usize, seed: u8) {
+    let mut file = File::create(path).expect("create source file");
+    let chunk: Vec<u8> = (0..(64 * 1024))
+        .map(|i| ((i as u8).wrapping_add(seed)) | 0x01)
+        .collect();
+    let mut remaining = size;
+    while remaining > 0 {
+        let take = remaining.min(chunk.len());
+        file.write_all(&chunk[..take]).expect("write chunk");
+        remaining -= take;
+    }
+    file.flush().expect("flush");
+}
+
+/// Populates `module_dir` with the source tree for `shape`. Idempotent:
+/// callers should `clear_module` first so each iteration sees a clean
+/// source tree (and so file mtimes are fresh, which prevents the upstream
+/// quick-check from spuriously skipping files between iterations).
+fn populate_module(module_dir: &Path, shape: WorkloadShape) {
+    match shape {
+        WorkloadShape::SingleLargeFile => {
+            write_pattern(&module_dir.join("large.dat"), single_large_file_size(), 0);
+        }
+        WorkloadShape::ManySmallFiles => {
+            for i in 0..10_000 {
+                let path = module_dir.join(format!("small_{i:05}.dat"));
+                write_pattern(&path, 4 * 1024, (i & 0xff) as u8);
+            }
+        }
+        WorkloadShape::BoundaryUnder => {
+            for i in 0..50 {
+                let path = module_dir.join(format!("file_{i:03}.dat"));
+                write_pattern(&path, 655 * 1024, (i & 0xff) as u8);
+            }
+        }
+        WorkloadShape::BoundaryOver => {
+            for i in 0..200 {
+                let path = module_dir.join(format!("file_{i:03}.dat"));
+                write_pattern(&path, 160 * 1024, (i & 0xff) as u8);
+            }
+        }
+        WorkloadShape::MixedDirectory => {
+            for i in 0..1_000 {
+                let size = MIXED_SIZES[i % MIXED_SIZES.len()];
+                let path = module_dir.join(format!("mixed_{i:04}.dat"));
+                write_pattern(&path, size, (i & 0xff) as u8);
+            }
+        }
+    }
+}
+
+/// Removes every entry in `module_dir` without removing the directory itself.
+fn clear_module(module_dir: &Path) {
+    if !module_dir.exists() {
+        return;
+    }
+    for entry in fs::read_dir(module_dir).expect("read module") {
+        let entry = entry.expect("entry");
+        let path = entry.path();
+        if path.is_dir() {
+            fs::remove_dir_all(&path).expect("remove dir");
+        } else {
+            fs::remove_file(&path).expect("remove file");
+        }
+    }
+}
+
+/// A daemon process launched from one of the two `oc-rsync` build variants.
+/// Pointed at a tempdir module so the bench can swap the source tree per
+/// workload without restarting the daemon.
+struct OcRsyncDaemon {
+    _workdir: TempDir,
+    module_path: PathBuf,
+    port: u16,
+    process: Child,
+    binary: PathBuf,
+}
+
+impl OcRsyncDaemon {
+    /// Spawns the daemon listening on a fresh port; module name is `bench`.
+    /// Returns `None` when the binary is missing - callers print a skip
+    /// message and return without panicking.
+    fn start(variant: BuildVariant) -> Option<Self> {
+        let binary = variant.resolve_path()?;
+
+        let workdir = TempDir::new().ok()?;
+        let port = next_port();
+        let config_path = workdir.path().join("oc-rsyncd.conf");
+        let pid_path = workdir.path().join("oc-rsyncd.pid");
+        let module_path = workdir.path().join("module");
+        fs::create_dir_all(&module_path).ok()?;
+
+        let config = format!(
+            "pid file = {}\nport = {}\nuse chroot = false\nnumeric ids = yes\n\n\
+             [bench]\n    path = {}\n    read only = false\n",
+            pid_path.display(),
+            port,
+            module_path.display()
+        );
+        fs::write(&config_path, &config).ok()?;
+
+        let process = Command::new(&binary)
+            .arg("--daemon")
+            .arg("--config")
+            .arg(&config_path)
+            .arg("--no-detach")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+                return Some(Self {
+                    _workdir: workdir,
+                    module_path,
+                    port,
+                    process,
+                    binary,
+                });
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        None
+    }
+
+    fn module_url(&self) -> String {
+        format!("rsync://127.0.0.1:{}/bench/", self.port)
+    }
+}
+
+impl Drop for OcRsyncDaemon {
+    fn drop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+    }
+}
+
+/// Runs the client binary against `source_url`, writing into `dest`.
+/// Returns the wall-clock duration of the transfer. Panics on transfer
+/// failure - a non-zero exit from a bench iteration is a regression that
+/// must surface, not a quiet skip.
+fn run_client(binary: &Path, source_url: &str, dest: &Path) -> Duration {
+    let start = Instant::now();
+    let status = Command::new(binary)
+        .arg("-a")
+        .arg(source_url)
+        .arg(dest)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("spawn client");
+    assert!(
+        status.success(),
+        "client transfer failed (binary={}, source={}, dest={})",
+        binary.display(),
+        source_url,
+        dest.display()
+    );
+    start.elapsed()
+}
+
+/// Runs one workload shape against one build variant. The daemon and
+/// client are both spawned from the same `variant` binary so the receiver
+/// dispatch path is the one under test (the daemon-side receiver in pull
+/// mode is the receiver whose strategy decision matters).
+fn bench_shape_variant(c: &mut Criterion, shape: WorkloadShape, variant: BuildVariant) {
+    let Some(daemon) = OcRsyncDaemon::start(variant) else {
+        eprintln!(
+            "PIP-6 skip: {} binary not found (set {}={})",
+            variant.label(),
+            variant.env_var(),
+            variant.default_path()
+        );
+        return;
+    };
+
+    clear_module(&daemon.module_path);
+    populate_module(&daemon.module_path, shape);
+
+    let total_bytes = shape.total_bytes();
+    let group_name = format!("pip_6_end_to_end/{}", shape.label());
+    let mut group = c.benchmark_group(group_name);
+    group.throughput(Throughput::Bytes(total_bytes));
+    // Bench shapes vary by ~5 orders of magnitude in wall-clock; pin sample
+    // size and measurement window per shape so the large-file cell does
+    // not blow the criterion budget while the small cells still get
+    // statistically meaningful sample counts.
+    let (samples, secs) = match shape {
+        WorkloadShape::SingleLargeFile => (10u32, 60u64),
+        WorkloadShape::ManySmallFiles => (10u32, 30u64),
+        WorkloadShape::BoundaryUnder => (15u32, 20u64),
+        WorkloadShape::BoundaryOver => (15u32, 20u64),
+        WorkloadShape::MixedDirectory => (10u32, 45u64),
+    };
+    group.sample_size(samples as usize);
+    group.measurement_time(Duration::from_secs(secs));
+
+    let binary = daemon.binary.clone();
+    let module_url = daemon.module_url();
+
+    group.bench_with_input(
+        BenchmarkId::new(variant.label(), shape.label()),
+        &shape,
+        |b, _shape| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let dest = TempDir::new().expect("dest tempdir");
+                    total += run_client(&binary, &module_url, dest.path());
+                }
+                total
+            });
+        },
+    );
+
+    group.finish();
+}
+
+/// Drives the full matrix: every shape against every variant. Each
+/// `(shape, variant)` pair gets its own daemon so daemon-side state never
+/// leaks between cells - the receiver builds its file list per transfer,
+/// not per process.
+fn bench_pip_6(c: &mut Criterion) {
+    for &shape in WorkloadShape::ALL {
+        for &variant in &[BuildVariant::Sequential, BuildVariant::Parallel] {
+            bench_shape_variant(c, shape, variant);
+        }
+    }
+}
+
+criterion_group!(
+    name = pip_6_benches;
+    config = Criterion::default()
+        // Per-cell sample/measurement overrides set inside bench_shape_variant.
+        .warm_up_time(Duration::from_secs(2));
+    targets = bench_pip_6
+);
+
+criterion_main!(pip_6_benches);

--- a/docs/design/pip-6-end-to-end-parallel-vs-sequential-bench-2026-05-21.md
+++ b/docs/design/pip-6-end-to-end-parallel-vs-sequential-bench-2026-05-21.md
@@ -1,0 +1,295 @@
+# PIP-6 - End-to-end parallel-vs-sequential receive-delta bench
+
+Date: 2026-05-21
+Scope: design + harness scaffold for the production-path bench that
+backs the parallel-receive-delta promotion table
+Status: scaffold only; numbers capture is the follow-up
+Predecessors:
+- PIP-3+5 (PR #4666, merged) wired the Path B heuristic
+  (`file_count > 100 || total_size > 64 MiB`) into the receiver
+  dispatch site.
+- BR-3i.f (#2502, completed) shipped the apply-loop-level bench at
+  `crates/engine/benches/parallel_receive_delta_perf.rs`.
+- BR-3j.f (#2508, pending) is the post-DashMap apply-loop re-bench.
+Tracker: PIP-6 (#2569)
+Related promotion doc: `docs/design/parallel-receive-delta-default-on.md`
+(section 4 names this bench as the remaining numbers-capture
+follow-up).
+
+## 1. The question
+
+> How much faster is parallel-receive-delta on production-shaped
+> workloads than the sequential apply path, when the production
+> heuristic gets to make the dispatch decision?
+
+PIP-3+5 already shipped the dispatch heuristic. The promotion table
+in `docs/design/parallel-receive-delta-default-on.md` section 4 is
+still empty because the apply-loop bench (BR-3i.f) measures the
+scheduling cost in isolation - in-memory sinks, no real disk I/O,
+no protocol framing, no checksum negotiation, no rayon pool warmup
+amortised against actual transfer setup. The numbers from BR-3i.f
+are necessary to gate the design (apply-loop is a winner) but not
+sufficient to gate the **production** claim that the heuristic is
+the right shape for the receivers operators actually run.
+
+PIP-6 fills the gap by driving a real `oc-rsync` sender against a
+real `oc-rsync` receiver over `rsync://` loopback, on a workload
+matrix calibrated to the heuristic's decision boundary. Wall-clock
+is the headline metric; the comparison is **same workload, parallel
+vs sequential build**, not parallel-build vs upstream-rsync.
+
+## 2. Why three benches, not one
+
+The three benches in the parallel-receive-delta chain measure
+different things; PIP-6 is the only one that exercises the
+production code path end-to-end.
+
+| Bench   | Scope                                | Drives                          | Sink         | Includes              |
+|---------|--------------------------------------|---------------------------------|--------------|-----------------------|
+| BR-3i.f | apply loop scheduling                | `ParallelDeltaApplier` directly | in-memory    | rayon dispatch only   |
+| BR-3j.f | post-DashMap apply loop              | `ParallelDeltaApplier` directly | in-memory    | post-#2508 cleanup    |
+| PIP-6   | production receiver dispatch + apply | `oc-rsync` binary over `rsync://` | real disk    | full transfer pipeline |
+
+BR-3i.f answers "does the parallel apply loop have any throughput
+to give?". BR-3j.f answers "did the DashMap rework regress the
+apply loop or unlock more headroom?". PIP-6 answers "given a real
+transfer pipeline - file-list build, signature exchange, delta
+generation, dispatch, apply, fsync - does the parallel path's
+apply-loop win translate into a wall-clock win that operators feel,
+on the workload shapes the heuristic was tuned for?".
+
+The three benches compose: if BR-3i.f shows no win, PIP-6 cannot
+show one either (the apply loop is the bottleneck the parallel
+path attacks). If BR-3i.f shows a 2x win but PIP-6 shows zero, the
+real-world bottleneck is somewhere else in the pipeline (network
+framing, signature exchange, fsync) and the dispatch decision is
+landing the parallel-apply win in a cell where the apply step is
+not the dominant cost.
+
+## 3. Scope of the production path
+
+The bench drives one full transfer per criterion iteration:
+
+1. Sender starts: `oc-rsync` client connecting to `rsync://` daemon
+   that points at the populated source tempdir as a module.
+2. Receiver starts: a second `oc-rsync` process (in daemon role) or
+   the same client when push direction; both halves are
+   process-level so they exercise the same protocol multiplex
+   framing operators see.
+3. Sender builds the file list, transmits it.
+4. Receiver decides parallel-vs-sequential via
+   `ReceiverContext::dispatch_receiver_strategy` (the Path B
+   heuristic landed in PIP-3+5).
+5. Sender computes signatures, transmits deltas.
+6. Receiver applies deltas, fsyncs, sends goodbye.
+7. Both sides exit, criterion captures the wall.
+
+The dispatch decision in step 4 is the variable PIP-6 isolates.
+The bench compares the same workload run twice: once against an
+`oc-rsync` binary built with default features (parallel-receive-
+delta on; heuristic flips parallel above its thresholds), once
+against an `oc-rsync` binary built **without** the
+`parallel-receive-delta` feature (the dispatcher logs
+`parallel_unavailable` per `crates/transfer/src/receiver/mod.rs:480`
+and always picks sequential). Same workload, same wire framing,
+same disk; only the apply strategy differs.
+
+## 4. Workload matrix
+
+Five workload shapes, calibrated to the dispatch boundary. The
+heuristic is `file_count > 100 || total_size > 64 MiB`; every
+shape is annotated with the exact decision the production
+dispatcher takes.
+
+| Shape              | Files  | Per-file size      | Total size | Heuristic decision  | Why this shape                                                                 |
+|--------------------|--------|--------------------|------------|---------------------|--------------------------------------------------------------------------------|
+| `single_large_file`| 1      | 1 GiB              | 1 GiB      | **parallel** (size) | Worst-case per-file-mutex regime; cross-file parallelism is zero, the apply loop has only one file slot. Sets the regression floor for the bench. |
+| `many_small_files` | 10,000 | 4 KiB              | 40 MiB     | **parallel** (count)| Dispatch-bound shape that BR-3i.f calls out as the headline cell; tests whether apply-loop dispatch wins survive end-to-end framing overhead. |
+| `boundary_under`   | 50     | ~655 KiB           | 32 MiB     | **sequential**      | Below both thresholds; runs the sequential path on both builds. Confirms the bench harness is comparing apples to apples (no spurious dispatch flip). |
+| `boundary_over`    | 200    | 160 KiB            | 32 MiB     | **parallel** (count)| Just over the file-count threshold; total bytes are identical to `boundary_under` so the byte-count axis is held fixed. |
+| `mixed_directory`  | 1,000  | 4 KiB - 4 MiB      | ~600 MiB   | **parallel** (both) | Typical project / media directory; sizes drawn deterministically from `{4 KiB, 16 KiB, 64 KiB, 256 KiB, 1 MiB, 4 MiB}` to match the `mixed` shape from BR-3i.f. |
+
+The `boundary_under` cell is the control: both builds dispatch
+sequential there, so wall-clock should be within bench noise.
+A delta there is a bug in the harness, not a finding about
+parallel-receive-delta.
+
+The `single_large_file` cell is the **regression sentinel**: the
+per-file `Mutex<FileSlot>` at
+`crates/engine/src/concurrent_delta/parallel_apply.rs:248-258`
+serialises all writes for the only file in the batch. The bench
+expects this cell to be within +/-5% of sequential; a worse
+showing is a finding that the heuristic should not steer
+single-file transfers to parallel even when they cross the byte
+threshold.
+
+## 5. Metrics
+
+Wall-clock is the headline number; the other four are sampled
+when the platform exposes them and reported per workload shape.
+
+| Metric                | Required | How captured                                              |
+|-----------------------|----------|-----------------------------------------------------------|
+| Wall-clock receive time | yes    | criterion `iter_custom` around the client invocation     |
+| Total bytes received  | yes      | sum of source file sizes (deterministic per workload)    |
+| Throughput (bytes/sec)| yes      | criterion `Throughput::Bytes` derives from the above     |
+| Peak RSS (MiB)        | best-effort | rusage on Unix (`getrusage(RUSAGE_CHILDREN)`), Job Object on Windows; logged as a metadata sidecar, not a criterion measurement |
+| CPU% over the run     | best-effort | rusage `utime + stime` / wall; logged as sidecar      |
+| Disk write IOPS       | best-effort | iostat sampler on Linux when `/proc/diskstats` is present; logged as sidecar |
+
+RSS, CPU%, and IOPS are sidecar metrics because criterion's
+sampling model assumes a single numeric per iteration. Sidecars
+go to a `target/pip-6-sidecar/` directory keyed by
+`(workload_shape, build_variant)`; the design doc that consumes
+the bench output (the section-4 table in
+`docs/design/parallel-receive-delta-default-on.md`) is the right
+place to surface them alongside the wall-clock table.
+
+## 6. Comparison shape
+
+Two binaries, both built locally before the bench runs:
+
+- `target/release/oc-rsync` - default features, parallel apply
+  available, heuristic flips parallel on shapes above its
+  thresholds. This is the production binary.
+- `target/release-no-parallel/oc-rsync` - built with
+  `cargo build --release --target-dir target/release-no-parallel
+  --no-default-features --features 'zstd lz4 xattr iconv'` (the
+  default set minus `parallel-receive-delta`). The dispatcher in
+  `crates/transfer/src/receiver/mod.rs:480-494` falls back to
+  sequential with a `parallel_unavailable` debug line.
+
+The bench resolves the two paths via env vars:
+
+- `OC_RSYNC_BIN_PARALLEL` (default `target/release/oc-rsync`)
+- `OC_RSYNC_BIN_SEQUENTIAL` (default
+  `target/release-no-parallel/oc-rsync`)
+
+The bench skips with a `eprintln!` and `return` (mirroring the
+`BenchDaemon::start` pattern in
+`crates/core/benches/transfer_benchmark.rs:48-51`) when either
+binary is missing, so a fresh checkout that has not built both
+variants does not panic. A README block in the bench file
+documents the two `cargo build --release` invocations.
+
+Same module path for both runs. Same workload tempdir, repopulated
+between iterations via `daemon.clear()` and re-create, so the
+receiver always sees an empty destination tree (full transfer,
+not an incremental delta). For the delta-path cells, the
+destination is pre-seeded with a deterministic basis that differs
+from the source by 50% bytes; this is how BR-3i.f's `mixed` cell
+already exercises the actual delta apply path rather than the
+whole-file fast path.
+
+## 7. Decision criteria
+
+The Path B heuristic stays the default if, on the bench numbers
+produced by this scaffold:
+
+- **Win condition.** `parallel_wall / sequential_wall <= 0.9` on
+  at least **two of the five** workload shapes. The `mixed` and
+  `many_small_files` shapes are the headline cells; if neither
+  wins by 10%+, the heuristic is steering work to a path that
+  does not pay for itself.
+- **Regression budget.** No shape regresses by more than **5%**
+  (`parallel_wall / sequential_wall <= 1.05`). The
+  `single_large_file` and `boundary_under` cells are the
+  regression sentinels; the heuristic must not steer those into a
+  worse path.
+- **Boundary control.** `boundary_under` wall-clock must agree
+  within +/-3% between the two builds (both run sequential there).
+  Wider spread points at harness bias rather than at the apply
+  strategy.
+
+A failure on **either** of the first two reverts the heuristic
+to opt-in (drops `parallel-receive-delta` from the
+`default = [...]` set on `engine`, `transfer`, `core`, `cli`, and
+the workspace binary). A failure on the third blocks the bench
+report itself and triggers a harness audit before any conclusion
+gets drawn from the cell-level numbers.
+
+## 8. Out of scope
+
+- **Numbers capture.** This PR ships the scaffold, not the
+  numbers. Bench execution is hardware-sensitive (NVMe vs HDD,
+  core count, ambient load); the right place to capture numbers
+  is the `rsync-profile` and `oc-rsync-bench` containers
+  documented in the project CLAUDE.md, on the same hardware that
+  produces the BR-3i.f and BR-3j.f baselines.
+- **SSH transport.** The bench drives `rsync://` daemon loopback
+  because the comparison is about the receiver apply path, not
+  about transport overhead. SSH adds process spawn, key
+  negotiation, and userspace encryption to every iteration; that
+  noise would mask the apply-strategy delta. A separate
+  SSH-variant bench is a possible follow-up if telemetry from
+  shipped Path B shows SSH receivers benefit differently than
+  daemon receivers do.
+- **`oc-rsync-bench` cross-version.** Comparing oc-rsync's
+  parallel path against upstream rsync 3.4.1's sequential path is
+  the job of the existing `crates/core/benches/transfer_benchmark.rs`,
+  not this bench. PIP-6 isolates the parallel-vs-sequential
+  decision inside oc-rsync; upstream comparison is a different
+  question with a different bench.
+- **Sender-side parallelism.** PIP-6 measures the receiver
+  decision only. Sender-side delta parallelism is already
+  pipelined per-file across rayon workers; that is not the path
+  the heuristic touches.
+
+## 9. Infrastructure needed before numbers can ship
+
+The scaffold compiles and runs as a criterion bench harness; the
+gating items below are about the inputs the bench needs to produce
+publishable numbers, not about the harness itself.
+
+1. **Two-variant build script.** A `tools/build_pip6_binaries.sh`
+   (or equivalent xtask) that builds the two `oc-rsync` binaries
+   into the expected target dirs. The current expectation is that
+   the operator runs the two `cargo build --release` lines from
+   the bench file's module doc; an xtask collapses the step.
+2. **Container baseline.** The bench should run on both
+   `rsync-profile` (NVMe + xxh3) and `oc-rsync-bench` (HDD-ish +
+   MD5 software-aarch64) so the result set covers the two
+   regimes the BR-3i.f cells stratify against (CPU-bound verify
+   vs I/O-bound write).
+3. **Sidecar metric collector.** RSS / CPU% / IOPS go to
+   `target/pip-6-sidecar/`. A small helper crate or script that
+   wraps the bench invocation and emits the sidecar JSON is the
+   missing piece; the scaffold writes the directory but does not
+   populate it yet (criterion does not have a hook for per-
+   iteration auxiliary metrics).
+4. **Numbers-capture commit.** The section-4 table in
+   `docs/design/parallel-receive-delta-default-on.md` is the
+   target for the wall-clock data; a follow-up `docs(design):`
+   commit lands the numbers once the bench has been run on both
+   containers.
+
+None of items 1-4 block the scaffold. They block the
+numbers-capture commit that consumes the scaffold's output.
+
+## 10. References
+
+- `docs/design/parallel-receive-delta-application.md` - umbrella
+  design for the parallel apply loop.
+- `docs/design/parallel-receive-delta-default-on.md` - promotion
+  decision doc; section 4 is the table this bench fills.
+- `docs/design/abw-2-pipelined-verify-write-deferred-2026-05-21.md` -
+  closure note that defers the verify/write pipelining design
+  pending BR-3j.f; PIP-6 is the production-path complement.
+- `crates/engine/benches/parallel_receive_delta_perf.rs` -
+  BR-3i.f apply-loop bench; PIP-6 is the end-to-end complement.
+- `crates/core/benches/transfer_benchmark.rs` - the existing
+  daemon-driven bench harness PIP-6's scaffold mirrors.
+- `crates/transfer/src/receiver/mod.rs:96-510` - the heuristic
+  constants (`PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD = 100`,
+  `PARALLEL_RECEIVE_BYTES_THRESHOLD = 64 MiB`) and the
+  `ReceiverContext::dispatch_receiver_strategy` site that PIP-6
+  exercises.
+- `crates/engine/src/concurrent_delta/parallel_apply.rs:248-258` -
+  the per-file `Mutex<FileSlot>` ingest path; the
+  `single_large_file` cell's regression sentinel.
+- PIP-3+5 (PR #4666) - heuristic wiring; the production-path
+  setup PIP-6 measures.
+- BR-3i.f (#2502, completed) - apply-loop-level bench.
+- BR-3j.f (#2508, pending) - post-DashMap apply-loop re-bench.
+- `project_parallel_delta_apply_phase2.md` - project memory page
+  tracking production cutover status.


### PR DESCRIPTION
## Summary

Adds the design doc plus criterion harness scaffold for **PIP-6** - the end-to-end production-path bench for parallel-receive-delta. This is the third bench in the parallel-receive-delta chain: BR-3i.f (#2502, completed) covers the apply-loop scheduling layer with in-memory sinks, BR-3j.f (#2508, pending) is the post-DashMap re-bench, and PIP-6 measures the receiver dispatch + apply through the full production pipeline against a real `oc-rsync` daemon over `rsync://` loopback.

The Path B heuristic landed via **PIP-3+5 (PR #4666 merged)**: `file_count > 100 || total_size > 64 MiB` dispatches the receiver to the parallel apply path. The promotion table in `docs/design/parallel-receive-delta-default-on.md` section 4 still has `TBD` cells; PIP-6 produces the numbers that fill them.

## Workload matrix

Five shapes calibrated to the dispatch boundary. Each annotated with the production heuristic's decision.

| Shape | Files | Per-file size | Total | Heuristic |
|---|---|---|---|---|
| `single_large_file` | 1 | 1 GiB | 1 GiB | parallel (size) |
| `many_small_files` | 10,000 | 4 KiB | 40 MiB | parallel (count) |
| `boundary_under` | 50 | ~655 KiB | 32 MiB | **sequential** (control) |
| `boundary_over` | 200 | 160 KiB | 32 MiB | parallel (count) |
| `mixed_directory` | 1,000 | 4 KiB - 4 MiB | ~600 MiB | parallel (both) |

`boundary_under` is the control - both builds dispatch sequential there, so wall-clock should agree within +/-3%.

## Comparison shape

Same workload, two `oc-rsync` binaries:

- `target/release/oc-rsync` - default features; parallel-receive-delta available.
- `target/release-no-parallel/oc-rsync` - built with `--no-default-features --features 'zstd lz4 xattr iconv'`; dispatcher logs `parallel_unavailable` per `crates/transfer/src/receiver/mod.rs:480-494` and always picks sequential.

Paths resolved via `OC_RSYNC_BIN_PARALLEL` / `OC_RSYNC_BIN_SEQUENTIAL`. Missing binary triggers a `eprintln!` skip rather than a panic.

## Decision criteria

- **Win.** `parallel_wall / sequential_wall <= 0.9` on at least 2 of 5 shapes.
- **Regression budget.** No shape regresses by more than 5%.
- **Boundary control.** `boundary_under` wall-clock agrees within +/-3% between the two builds.

## Bench placement

The scaffold lives in `crates/core/benches/pip_6_end_to_end_parallel_vs_sequential.rs` (not the engine crate) because the harness drives `oc-rsync` as a subprocess and `core/benches/` already hosts the daemon-driven `transfer_benchmark.rs` pattern this scaffold mirrors. The `engine` crate's deps cannot reach the daemon or the full transfer pipeline.

## Follow-up

Bench execution + numbers capture is intentionally **not** in this PR (hardware-sensitive, container-bound). The design doc section 9 lists the four follow-up items before publishable numbers can land:

1. Two-variant `cargo build` script / xtask.
2. Run on both `rsync-profile` (NVMe + xxh3) and `oc-rsync-bench` (HDD-ish + aarch64 software MD5) containers.
3. Sidecar metric collector for RSS / CPU% / IOPS.
4. `docs(design):` commit that fills section 4 of `docs/design/parallel-receive-delta-default-on.md`.

## Files

- `docs/design/pip-6-end-to-end-parallel-vs-sequential-bench-2026-05-21.md` - design doc (295 lines).
- `crates/core/benches/pip_6_end_to_end_parallel_vs_sequential.rs` - criterion bench scaffold (490 lines).
- `crates/core/Cargo.toml` - bench target registration.

## Test plan

- [ ] CI green on `fmt+clippy`, `nextest (stable)`, Windows, macOS, Linux musl.
- [ ] `cargo build -p core --benches` compiles the scaffold without warnings.
- [ ] Manual sanity: bench skips cleanly when neither binary is present.

## References

- PIP-3+5: PR #4666 (heuristic wiring, merged).
- BR-3i.f: #2502 (apply-loop bench, completed).
- BR-3j.f: #2508 (post-DashMap re-bench, pending).
- Companion design: `docs/design/parallel-receive-delta-default-on.md`.
- ABW-2/3/4 closure: `docs/design/abw-2-pipelined-verify-write-deferred-2026-05-21.md`.
- Project memory: `project_parallel_delta_apply_phase2.md`.