### PR TITLE
bench(fast_io): scaffold IUS-3 SEND_ZC vs plain SEND bench harness

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -244,3 +244,18 @@ harness = false
 name = "nvme_data_path_production"
 harness = false
 required-features = ["iouring-data-writes", "iouring-data-reads"]
+
+# Linux-only bench: IORING_OP_SEND_ZC vs plain IORING_OP_SEND on a loopback
+# TCP pair across four workload shapes (16 KiB x 10000, 256 KiB x 1000,
+# 1 MiB x 100, mixed 4 KiB-1 MiB x 1000). The send_plain group needs only
+# the `io_uring` feature (default on); the send_zc group is cfg-compiled in
+# only when `iouring-send-zc` is also enabled and skips at runtime on
+# kernels < 6.0. Gated by OC_RSYNC_BENCH_IUS_3=1 because each iteration
+# rebuilds the ring + loopback pair and the full sweep runs for several
+# minutes. See docs/design/ius-3-send-zc-bench-design-2026-05-21.md for the
+# bench design + decision criteria; numbers capture on the kernel matrix
+# (5.15 / 5.19 / 6.0 / 6.6 / 6.12) is the followup PR.
+[[bench]]
+name = "ius_3_send_zc_vs_send"
+harness = false
+required-features = ["io_uring"]

--- a/crates/fast_io/benches/ius_3_send_zc_vs_send.rs
+++ b/crates/fast_io/benches/ius_3_send_zc_vs_send.rs
@@ -1,0 +1,468 @@
+//! IUS-3: `IORING_OP_SEND_ZC` vs plain `IORING_OP_SEND` socket-send bench.
+//!
+//! See `docs/design/ius-3-send-zc-bench-design-2026-05-21.md` for the bench
+//! design, kernel matrix, workload matrix, and decision criteria that feed
+//! IUS-4 (the default-on / opt-in decision for the `iouring-send-zc` cargo
+//! feature). The kernel-compat matrix this bench operates against is
+//! enumerated in `docs/audits/ius-2-send-zc-kernel-compat-matrix.md` (PR
+//! #4664, merged).
+//!
+//! # Topology
+//!
+//! Both bench groups drive a single TCP loopback pair (`127.0.0.1`) and
+//! submit identical payloads through one freshly-built `IoUring`. The plain
+//! `send_plain` group uses `IORING_OP_SEND`; the `send_zc` group dispatches
+//! through [`fast_io::io_uring::try_send_zc`] which submits
+//! `IORING_OP_SEND_ZC` and drains both CQEs (transfer + notification) before
+//! returning, matching the production buffer-lifetime contract documented at
+//! `crates/fast_io/src/io_uring/send_zc.rs:130`.
+//!
+//! Loopback isolates the syscall/CPU cost of the two primitives without
+//! depending on a NIC, switch, or peer host. The followup numbers-capture PR
+//! adds a `tc qdisc`-based bandwidth-shape wrapper script
+//! (`scripts/bench-ius-3-tc-setup.sh`) that applies `netem` to the loopback
+//! interface for the 1 Gbps and 10 Gbps shapes; the harness itself is
+//! unchanged. tc-based bandwidth shapes are therefore out of scope for the
+//! scaffold; followup PR adds the tc setup script.
+//!
+//! # Feature gating
+//!
+//! - The `send_plain` group needs only the `io_uring` feature (default on).
+//! - The `send_zc` group additionally requires the `iouring-send-zc` cargo
+//!   feature and runtime probe success
+//!   ([`fast_io::io_uring::send_zc_supported`]). Without the feature the
+//!   group is `cfg`-compiled out; with the feature but no kernel support,
+//!   the group skips cleanly with a stderr notice rather than panicking.
+//!
+//! # When to run
+//!
+//! ```sh
+//! # default build (send_plain only): never useful, opt out via env gate
+//! OC_RSYNC_BENCH_IUS_3=1 \
+//!   cargo bench -p fast_io --bench ius_3_send_zc_vs_send
+//!
+//! # full bench with both groups (Linux 6.0+ required for send_zc rows)
+//! OC_RSYNC_BENCH_IUS_3=1 \
+//!   cargo bench -p fast_io --features iouring-send-zc \
+//!     --bench ius_3_send_zc_vs_send
+//! ```
+//!
+//! The env-var gate matches the convention in other `fast_io` benches
+//! (`iouring_per_file_vs_shared`, `nvme_data_path`) so a default
+//! `cargo bench -p fast_io` does not pick up the IUS-3 work by accident.
+//!
+//! # What the numbers inform
+//!
+//! Decision criteria (see design doc section 7): SEND_ZC is promoted to
+//! `ZeroCopyPolicy::Auto` (IUS-4) only when
+//!
+//! - `send_zc_throughput / send_throughput >= 1.1` on at least 3 of 4
+//!   workload shapes for kernels >= 6.0, **and**
+//! - user+system CPU% reduction >= 10% on at least 2 workload shapes for
+//!   kernels >= 6.0.
+//!
+//! Only the throughput half is reported by this criterion harness; the
+//! CPU%, syscall-count, and `copy_to_user`-bytes metrics are layered on
+//! out-of-band by the numbers-capture followup PR (criterion does not
+//! expose per-iteration sys CPU and does not own the strace pid).
+
+#[cfg(target_os = "linux")]
+use std::env;
+#[cfg(target_os = "linux")]
+use std::io::Read;
+#[cfg(target_os = "linux")]
+use std::net::{TcpListener, TcpStream};
+#[cfg(target_os = "linux")]
+use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "linux")]
+use std::thread;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(target_os = "linux")]
+use io_uring::{IoUring, opcode, types};
+
+/// Env-var gate: set to `1` to actually run the bench; otherwise the
+/// harness prints a skip line and exits 0 so default `cargo bench -p
+/// fast_io` is cheap. Matches the convention in `iouring_per_file_vs_shared`.
+#[cfg(target_os = "linux")]
+const ENABLE_ENV: &str = "OC_RSYNC_BENCH_IUS_3";
+
+/// Submission-queue depth. SEND_ZC posts two CQEs per submission so we
+/// keep the SQ shallow enough to drain in lockstep without queue
+/// pressure obscuring the per-call cost.
+#[cfg(target_os = "linux")]
+const SQ_ENTRIES: u32 = 16;
+
+/// Sentinel byte used to fill bench payloads. The bench measures the
+/// send-side primitive only, so the receiver discards the bytes without
+/// verifying them; the actual byte value is therefore arbitrary.
+#[cfg(target_os = "linux")]
+const FILL_BYTE: u8 = 0xa5;
+
+/// Loopback bind address. Port `0` lets the kernel assign a free port so
+/// concurrent bench runs do not collide.
+#[cfg(target_os = "linux")]
+const LOOPBACK_BIND: &str = "127.0.0.1:0";
+
+/// LCG state for the deterministic `mixed_chunks` workload. Same seed
+/// every bench invocation so the size distribution is reproducible and
+/// the SEND vs SEND_ZC delta is not buried in seed jitter.
+#[cfg(target_os = "linux")]
+const MIXED_LCG_SEED: u64 = 0x_b1ef_2026_05_21_u64;
+
+/// Workload spec: a label, the per-call payload size in bytes, and the
+/// call count per criterion iter. The four shapes match the matrix in
+/// the IUS-3 design doc section 4 (`small_chunks`, `medium_chunks`,
+/// `large_chunks`, `mixed`).
+#[cfg(target_os = "linux")]
+#[derive(Copy, Clone)]
+struct Workload {
+    label: &'static str,
+    chunk_bytes: usize,
+    calls: usize,
+}
+
+#[cfg(target_os = "linux")]
+const SMALL_CHUNKS: Workload = Workload {
+    label: "small_chunks_16KiB_x_10000",
+    chunk_bytes: 16 * 1024,
+    calls: 10_000,
+};
+
+#[cfg(target_os = "linux")]
+const MEDIUM_CHUNKS: Workload = Workload {
+    label: "medium_chunks_256KiB_x_1000",
+    chunk_bytes: 256 * 1024,
+    calls: 1_000,
+};
+
+#[cfg(target_os = "linux")]
+const LARGE_CHUNKS: Workload = Workload {
+    label: "large_chunks_1MiB_x_100",
+    chunk_bytes: 1024 * 1024,
+    calls: 100,
+};
+
+/// Marker for the mixed workload: chunk size is per-call random in
+/// `[MIXED_MIN, MIXED_MAX]`; `chunk_bytes` here is the upper bound used
+/// to size the payload buffer.
+#[cfg(target_os = "linux")]
+const MIXED_CHUNKS: Workload = Workload {
+    label: "mixed_chunks_4KiB_to_1MiB_x_1000",
+    chunk_bytes: 1024 * 1024,
+    calls: 1_000,
+};
+
+#[cfg(target_os = "linux")]
+const MIXED_MIN: usize = 4 * 1024;
+#[cfg(target_os = "linux")]
+const MIXED_MAX: usize = 1024 * 1024;
+
+/// Returns the deterministic size for the `i`-th mixed-workload chunk.
+///
+/// Knuth LCG seeded with [`MIXED_LCG_SEED`]; the modulus picks a value
+/// in `[MIXED_MIN, MIXED_MAX]`. Same `i` always returns the same size so
+/// the SEND and SEND_ZC bench groups are byte-identical workloads.
+#[cfg(target_os = "linux")]
+fn mixed_chunk_size(i: usize) -> usize {
+    let mut state = MIXED_LCG_SEED.wrapping_add(i as u64);
+    state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let span = (MIXED_MAX - MIXED_MIN) as u64;
+    MIXED_MIN + ((state >> 33) % (span + 1)) as usize
+}
+
+/// All four workloads in iteration order. The criterion bench groups
+/// loop over this slice so `send_plain` and `send_zc` produce
+/// directly-comparable rows in the criterion report.
+#[cfg(target_os = "linux")]
+const WORKLOADS: &[Workload] = &[SMALL_CHUNKS, MEDIUM_CHUNKS, LARGE_CHUNKS, MIXED_CHUNKS];
+
+/// Probes `io_uring_setup(2)` with a small ring so an unsupported host
+/// (locked-down container, kernel < 5.6, seccomp filter) gives a clean
+/// skip rather than a panic mid-iter.
+#[cfg(target_os = "linux")]
+fn io_uring_usable() -> bool {
+    IoUring::new(SQ_ENTRIES).is_ok()
+}
+
+/// Returns `true` when the bench should actually run. False when either
+/// the env var is unset or the kernel rejects io_uring.
+#[cfg(target_os = "linux")]
+fn bench_enabled() -> bool {
+    match env::var(ENABLE_ENV) {
+        Ok(v) if v == "1" => io_uring_usable(),
+        _ => false,
+    }
+}
+
+/// Loopback peer: holds the listener, the sender-side `TcpStream` (the
+/// bench writes to this), and the drain thread that reads until the
+/// sender closes. Drop order is sender-then-thread so the thread
+/// observes EOF cleanly and joins without timing out.
+#[cfg(target_os = "linux")]
+struct Loopback {
+    sender: TcpStream,
+    drain: Option<thread::JoinHandle<()>>,
+}
+
+#[cfg(target_os = "linux")]
+impl Loopback {
+    /// Binds a fresh loopback pair, spawns a drain thread, and returns
+    /// the sender stream + join handle. The drain thread reads
+    /// indefinitely (until the sender closes) so the bench never blocks
+    /// on a back-pressured socket.
+    fn new() -> std::io::Result<Self> {
+        let listener = TcpListener::bind(LOOPBACK_BIND)?;
+        let addr = listener.local_addr()?;
+        let drain = thread::spawn(move || {
+            let (mut peer, _) = match listener.accept() {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            // 30 s timeout so a misbehaving bench iter cannot hang the
+            // drain thread indefinitely. Loopback receives should
+            // satisfy in microseconds.
+            let _ = peer.set_read_timeout(Some(Duration::from_secs(30)));
+            let mut sink = [0u8; 64 * 1024];
+            loop {
+                match peer.read(&mut sink) {
+                    Ok(0) => break,
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+        });
+        let sender = TcpStream::connect(addr)?;
+        Ok(Self {
+            sender,
+            drain: Some(drain),
+        })
+    }
+
+    /// Raw fd for io_uring SQE construction.
+    fn fd(&self) -> std::os::unix::io::RawFd {
+        self.sender.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for Loopback {
+    fn drop(&mut self) {
+        // Closing the sender lets the drain thread observe EOF on the
+        // peer fd; without this step the thread blocks in `read` until
+        // the read timeout fires.
+        let _ = self.sender.shutdown(std::net::Shutdown::Both);
+        if let Some(handle) = self.drain.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Submits one `IORING_OP_SEND` SQE for `buf` and drains the single CQE.
+///
+/// Mirrors the production batched-SEND path in
+/// `crates/fast_io/src/io_uring/batching.rs:272` (`submit_send_batch`)
+/// reduced to one call so the bench measures the per-submission cost
+/// without batching artifacts. Short sends are reported as an error so
+/// the bench skips that iter rather than looping internally - the
+/// loopback peer has 30 s of read timeout, so short sends would indicate
+/// a real failure rather than back-pressure.
+#[cfg(target_os = "linux")]
+fn submit_send_one(
+    ring: &mut IoUring,
+    fd: std::os::unix::io::RawFd,
+    buf: &[u8],
+) -> std::io::Result<usize> {
+    let entry = opcode::Send::new(types::Fd(fd), buf.as_ptr(), buf.len() as u32)
+        .build()
+        .user_data(0);
+    // SAFETY: `buf` is borrowed for the full lifetime of this call; the
+    // kernel reads the pointer only between push and the matching CQE
+    // arrival, which is fully contained by `submit_and_wait` below.
+    unsafe {
+        ring.submission()
+            .push(&entry)
+            .map_err(|_| std::io::Error::other("submission queue full"))?;
+    }
+    ring.submit_and_wait(1)?;
+    let cqe = ring
+        .completion()
+        .next()
+        .ok_or_else(|| std::io::Error::other("no completion"))?;
+    let result = cqe.result();
+    if result < 0 {
+        return Err(std::io::Error::from_raw_os_error(-result));
+    }
+    Ok(result as usize)
+}
+
+/// Sums the byte counts that one workload would dispatch in a single
+/// criterion iter. Used as the `Throughput::Bytes` hint so criterion
+/// reports MiB/s in addition to ns/iter.
+#[cfg(target_os = "linux")]
+fn workload_bytes(workload: &Workload) -> u64 {
+    if workload.label == MIXED_CHUNKS.label {
+        (0..workload.calls).map(mixed_chunk_size).sum::<usize>() as u64
+    } else {
+        (workload.chunk_bytes * workload.calls) as u64
+    }
+}
+
+/// Runs `workload` against the plain SEND primitive: pre-fills one
+/// max-size buffer (reused across the inner loop) and submits one
+/// `IORING_OP_SEND` per call. Reports any send error to the caller so
+/// criterion drops the iter rather than reporting noise.
+#[cfg(target_os = "linux")]
+fn run_send_plain(
+    ring: &mut IoUring,
+    fd: std::os::unix::io::RawFd,
+    buf: &[u8],
+    workload: &Workload,
+) -> std::io::Result<()> {
+    for i in 0..workload.calls {
+        let chunk = if workload.label == MIXED_CHUNKS.label {
+            &buf[..mixed_chunk_size(i)]
+        } else {
+            &buf[..workload.chunk_bytes]
+        };
+        let n = submit_send_one(ring, fd, chunk)?;
+        if n != chunk.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "short SEND on loopback",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Bench group: plain `IORING_OP_SEND` against a fresh ring + loopback
+/// pair per criterion iter. The ring and loopback are reconstructed
+/// inside `iter_with_setup` so per-iter cost reflects the production
+/// "one-shot writer" lifecycle; the long-lived shared-ring case is
+/// covered by `iouring_per_file_vs_shared.rs` for the file-write path
+/// and is out of scope for IUS-3.
+#[cfg(target_os = "linux")]
+fn bench_send_plain(c: &mut Criterion) {
+    if !bench_enabled() {
+        eprintln!(
+            "Skipping ius_3_send_zc_vs_send::send_plain: set {ENABLE_ENV}=1 on a Linux 5.6+ \
+             host with io_uring_setup(2) reachable to enable."
+        );
+        return;
+    }
+
+    let mut group = c.benchmark_group("ius_3_send_plain");
+    group.sample_size(10);
+
+    let payload = vec![FILL_BYTE; MIXED_MAX];
+
+    for workload in WORKLOADS {
+        group.throughput(Throughput::Bytes(workload_bytes(workload)));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(workload.label),
+            workload,
+            |b, workload| {
+                b.iter_with_setup(
+                    || {
+                        let ring = IoUring::new(SQ_ENTRIES).expect("ring");
+                        let loopback = Loopback::new().expect("loopback");
+                        (ring, loopback)
+                    },
+                    |(mut ring, loopback)| {
+                        let fd = loopback.fd();
+                        run_send_plain(&mut ring, fd, &payload, workload).expect("send_plain");
+                        drop(loopback);
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Bench group: `IORING_OP_SEND_ZC` via [`fast_io::io_uring::try_send_zc`].
+///
+/// Only compiled when the `iouring-send-zc` cargo feature is enabled.
+/// Runtime probe ([`fast_io::io_uring::send_zc_supported`]) gates the
+/// per-iter dispatch; on kernels < 6.0 the group skips cleanly so the
+/// build still succeeds.
+#[cfg(all(target_os = "linux", feature = "iouring-send-zc"))]
+fn bench_send_zc(c: &mut Criterion) {
+    if !bench_enabled() {
+        eprintln!(
+            "Skipping ius_3_send_zc_vs_send::send_zc: set {ENABLE_ENV}=1 on a Linux 6.0+ host \
+             with IORING_OP_SEND_ZC support to enable."
+        );
+        return;
+    }
+    if !fast_io::io_uring::send_zc_supported() {
+        eprintln!(
+            "Skipping ius_3_send_zc_vs_send::send_zc: kernel does not advertise \
+             IORING_OP_SEND_ZC (requires Linux 6.0+; see \
+             docs/audits/ius-2-send-zc-kernel-compat-matrix.md)."
+        );
+        return;
+    }
+
+    let mut group = c.benchmark_group("ius_3_send_zc");
+    group.sample_size(10);
+
+    let payload = vec![FILL_BYTE; MIXED_MAX];
+
+    for workload in WORKLOADS {
+        group.throughput(Throughput::Bytes(workload_bytes(workload)));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(workload.label),
+            workload,
+            |b, workload| {
+                b.iter_with_setup(
+                    || {
+                        let ring = IoUring::new(SQ_ENTRIES).expect("ring");
+                        let loopback = Loopback::new().expect("loopback");
+                        (ring, loopback)
+                    },
+                    |(mut ring, loopback)| {
+                        let fd = loopback.fd();
+                        for i in 0..workload.calls {
+                            let chunk = if workload.label == MIXED_CHUNKS.label {
+                                &payload[..mixed_chunk_size(i)]
+                            } else {
+                                &payload[..workload.chunk_bytes]
+                            };
+                            let n = fast_io::io_uring::try_send_zc(&mut ring, fd, chunk, 0)
+                                .expect("send_zc");
+                            assert_eq!(n, chunk.len(), "short SEND_ZC on loopback");
+                        }
+                        drop(loopback);
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring-send-zc"))]
+criterion_group!(ius_3_send_zc_vs_send, bench_send_plain, bench_send_zc);
+
+#[cfg(all(target_os = "linux", not(feature = "iouring-send-zc")))]
+criterion_group!(ius_3_send_zc_vs_send, bench_send_plain);
+
+#[cfg(target_os = "linux")]
+criterion_main!(ius_3_send_zc_vs_send);
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!(
+        "ius_3_send_zc_vs_send: skipped (Linux-only bench; IORING_OP_SEND / IORING_OP_SEND_ZC \
+         require io_uring)"
+    );
+}

--- a/crates/fast_io/benches/ius_3_send_zc_vs_send.rs
+++ b/crates/fast_io/benches/ius_3_send_zc_vs_send.rs
@@ -111,7 +111,7 @@ const LOOPBACK_BIND: &str = "127.0.0.1:0";
 /// every bench invocation so the size distribution is reproducible and
 /// the SEND vs SEND_ZC delta is not buried in seed jitter.
 #[cfg(target_os = "linux")]
-const MIXED_LCG_SEED: u64 = 0x_b1ef_2026_05_21_u64;
+const MIXED_LCG_SEED: u64 = 0xb1ef_2026_0521_u64;
 
 /// Workload spec: a label, the per-call payload size in bytes, and the
 /// call count per criterion iter. The four shapes match the matrix in

--- a/docs/design/ius-3-send-zc-bench-design-2026-05-21.md
+++ b/docs/design/ius-3-send-zc-bench-design-2026-05-21.md
@@ -1,0 +1,247 @@
+# IUS-3 - `IORING_OP_SEND_ZC` vs plain `IORING_OP_SEND` bench design
+
+Date: 2026-05-21
+Scope: bench plan + harness scaffold; numbers capture is the followup
+Status: scaffold ships; multi-kernel execution requires hardware
+Predecessor: `docs/audits/ius-2-send-zc-kernel-compat-matrix.md` (PR #4664, merged)
+Successor: IUS-4 (default-on / opt-in decision); IUS-5 (`ZeroCopyPolicy::Auto` runtime probe wiring)
+Tracker: IUS-3 (#2584); IUS-4 (#2585); IUS-5 (#2586)
+
+## 1. Bench question
+
+**Is `IORING_OP_SEND_ZC` enough of a win to justify promoting the
+`iouring-send-zc` cargo feature to default-on?**
+
+The decision is binary: the IUS-4 default-on flip either keeps the
+feature opt-in (today's state, captured in IUS-1 PR #4661 docs and the
+upstream IUS-2 audit) or promotes `ZeroCopyPolicy::Auto` to consume
+SEND_ZC when both the build-time feature and the runtime probe at
+[`crates/fast_io/src/io_uring/send_zc.rs:77`](../../crates/fast_io/src/io_uring/send_zc.rs#L77)
+agree.
+
+This document specifies the bench harness, the kernel x workload matrix
+the bench has to span, the metrics the bench reports, and the decision
+criteria that feed IUS-4. The harness scaffold ships in
+`crates/fast_io/benches/ius_3_send_zc_vs_send.rs`; the numbers capture
+is a followup PR because the bench needs multi-kernel hardware that the
+default CI runner cannot provide.
+
+## 2. Why a dedicated bench (instead of reusing the daemon harness)
+
+The IUS-2 audit at section 4 already enumerates the workload-sensitivity
+axes informally (large-NIC win, small-file regression guard). The
+`docs/design/iouring-send-zc.md` bench plan at section 5 sketches a
+two-workload daemon-driven benchmark (1 GiB transfer + 10 000 x 4 KiB
+storm). That plan suffices for go/no-go on the production daemon path
+but is too coarse to attribute the result to `IORING_OP_SEND_ZC` vs
+ambient noise (compression, checksum, basis-read, sparse-write).
+
+IUS-3 isolates the socket-send primitive. The bench drives a TCP
+loopback pair on the same host and dispatches identical payloads through
+either `try_send_zc` (SEND_ZC) or `opcode::Send` (plain SEND), both
+against a freshly-built `IoUring`. No daemon, no filesystem I/O, no
+compression. The delta the bench reports is attributable to the
+SEND_ZC vs SEND primitive only.
+
+## 3. Kernel matrix
+
+The IUS-2 audit table at section 1.3 enumerates the distro x default
+kernel landscape. The bench-relevant rows are the kernels that
+materially affect the SEND_ZC dispatch:
+
+| Kernel | Representative distro | SEND_ZC support | Why this row |
+|--------|-----------------------|-----------------|--------------|
+| 5.15 | Ubuntu 22.04 (default), Debian 11 backports | **No** | Floor for "io_uring present, SEND_ZC absent". The probe at `send_zc::is_supported` must return false and the writer must stay on the batched-SEND path. |
+| 5.19 | Transient (few production distros) | **Partial** | `IORING_OP_SEND_ZC` is in the 5.20 merge window, renamed to 6.0 before release; some 5.19 prerelease kernels carry the opcode but lack the notification-CQE accounting. The probe should reject these as unsupported. |
+| 6.0 | Debian 12 (6.1), Amazon Linux 2023 (6.1) | **Yes** | First stable kernel exposing `IORING_OP_SEND_ZC`. Registered-buffer fast path is unavailable (lands in 6.2); bench must run the unregistered SEND_ZC path here. |
+| 6.6 LTS | First long-term-support kernel with SEND_ZC | **Yes (stable)** | The realistic deployment target for the next 2-3 years. Registered-buffer pool from [`send_zc::ZeroCopySender`](../../crates/fast_io/src/io_uring/send_zc.rs#L282) is fully usable. |
+| 6.12 | Ubuntu 24.10 (6.11), RHEL 10 ETA (6.12) | **Yes (mature)** | Current LTS; demonstrates the steady-state performance once `IORING_RECVSEND_FIXED_BUF` and SEND_ZC have been in-tree long enough for the corner-case bugfixes to settle. |
+
+Two rows the bench does **not** target:
+
+- **< 5.6** (RHEL 8 4.18, Ubuntu 18.04 4.15): io_uring itself is
+  unavailable; the writer falls back to standard `write(2)`. SEND_ZC is
+  irrelevant.
+- **6.2 - 6.5** (SLES 15 SP6 6.4, openSUSE Leap 15.6 6.4): in the
+  audit's "best CPU-savings region" but not the bench's reference
+  rows. If hardware is available, run as a bonus row; not gating.
+
+## 4. Workload matrix
+
+| Workload | Chunk size | Calls per iter | Why |
+|----------|-----------|----------------|-----|
+| `small_chunks` | 16 KiB | 10 000 | Dispatch-overhead-dominated. SEND_ZC's two-CQE drain doubles the kernel/userspace round-trip count; if SEND_ZC wins here, it wins everywhere. The 16 KiB floor matches the production `SEND_ZC_MIN_BYTES` constant at [`socket_writer.rs:25-28`](../../crates/fast_io/src/io_uring/socket_writer.rs#L25). |
+| `medium_chunks` | 256 KiB | 1 000 | Matches the upstream-rsync 256 KiB literal-token chunk; also the per-slot size of the [`ZeroCopySender`](../../crates/fast_io/src/io_uring/send_zc.rs#L245) registered-buffer pool. This is the production daemon shape. |
+| `large_chunks` | 1 MiB | 100 | Bulk-transfer regime. SEND_ZC's per-byte savings dominate fixed CQE-drain overhead; if SEND_ZC fails to win here, the feature has no path forward. |
+| `mixed` | random 4 KiB to 1 MiB | ~1 000 | Production-shape: real rsync transfers interleave control frames, literal tokens, and `MSG_DATA` chunks of varying sizes. Driven by a deterministic LCG (no `rand` workspace dep) so reruns are byte-identical. |
+
+The mixed workload uses an LCG seeded with a constant so the size
+distribution is identical across runs and the SEND vs SEND_ZC delta is
+not buried in seed jitter.
+
+## 5. Network shape
+
+The scaffold ships with **loopback** as the default (no real network
+latency). Loopback isolates the syscall/CPU cost of SEND vs SEND_ZC
+without depending on a NIC, switch, or peer host. The bench binds a
+`TcpListener` on `127.0.0.1`, accepts a connection, and drives the
+sender/receiver pair from the same process.
+
+Two additional network shapes are out of scope for the scaffold but
+covered in a followup PR:
+
+- **1 Gbps via `tc qdisc`** - applies `tc qdisc add dev lo root netem
+  rate 1gbit` before the bench; `netem` injects synthetic bandwidth and
+  latency on the loopback interface so the bench captures the "slow NIC"
+  regime where SEND_ZC's reduced kernel CPU should not change wall time
+  but should reduce sys CPU.
+- **10 Gbps via `tc qdisc`** - same primitive at 10 gbit. Closer to the
+  production daemon-on-fast-NIC regime where SEND_ZC's CPU savings
+  matter most.
+
+The followup PR adds a `scripts/bench-ius-3-tc-setup.sh` that wraps the
+`tc` calls with cleanup-on-exit guards. The bench itself remains
+unchanged; the script wraps `cargo bench` with `tc qdisc add` ...
+`cargo bench` ... `tc qdisc del`.
+
+## 6. Measured metrics
+
+The criterion harness reports wall-clock throughput by default
+(`Throughput::Bytes` on each bench group). The followup numbers-capture
+PR layers on the additional metrics out-of-band:
+
+| Metric | Source | Interpretation |
+|--------|--------|---------------|
+| Wall-clock bytes/sec | criterion `Throughput::Bytes` | First-order go/no-go. SEND_ZC wins if `send_zc_throughput / send_throughput >= 1.1` on the bench. |
+| User + system CPU% | `time -v` wrapper around the bench binary | Second-order signal. SEND_ZC's documented benefit is "25-40% sys CPU reduction" (per the kernel `io_uring-net` benchmarks cited in `docs/design/iouring-send-zc.md` section 5). Captures the case where wall time does not move on loopback but sys CPU drops. |
+| Syscalls per second | `strace -c -p <bench_pid>` for the steady-state window | Disambiguates SEND_ZC's two-CQE drain vs SEND's one-CQE drain. Expected: SEND_ZC submits the same number of SQEs but drains 2x CQEs per submission. |
+| `copy_to_user` bytes | `/proc/<bench_pid>/io` `rchar`/`wchar` deltas on Linux 6.x | The smoking gun: SEND_ZC's whole purpose is to avoid the kernel-to-user page copy. If `wchar` does not drop for SEND_ZC vs SEND on identical workloads, the kernel is not exercising the zero-copy path. |
+
+The bench scaffold reports only the wall-clock signal. The other three
+are layered on by the numbers-capture wrapper script (followup PR);
+they are out of scope for the criterion harness because criterion does
+not expose per-iteration sys CPU and does not own the strace pid.
+
+## 7. Decision criteria
+
+The IUS-4 default-on flip is gated on **both** of the following:
+
+1. **Throughput**: `send_zc_throughput / send_throughput >= 1.1` on
+   **at least 3 of 4 workload shapes** for kernels >= 6.0.
+2. **CPU**: user+system CPU% reduction >= 10% on **at least 2 workload
+   shapes** for kernels >= 6.0.
+
+The asymmetry between the two thresholds reflects the documented
+SEND_ZC benefit. SEND_ZC is primarily a CPU optimisation, not a
+throughput optimisation - on loopback and slow NICs the wall-clock
+delta is often noise while sys CPU drops materially. The throughput
+criterion rejects "free 10% headroom on the host" claims that do not
+also translate into observable speedup; the CPU criterion catches the
+"SEND_ZC saves CPU but wall time is flat" cells which are still wins
+on a CPU-bound host.
+
+Negative outcomes and their IUS-4 implications:
+
+- **Throughput fails, CPU passes**: SEND_ZC is a CPU optimisation only.
+  Keep opt-in; the feature ships for operators who want the CPU
+  headroom on CPU-bound hosts, but the default flip is not justified.
+- **CPU fails, throughput passes**: anomalous; investigate before
+  flipping. Most likely cause: bench captured wall-clock noise that
+  did not reproduce in CPU accounting.
+- **Both fail on `small_chunks`, both pass on the others**: confirm
+  the production `SEND_ZC_MIN_BYTES` threshold at
+  [`socket_writer.rs:25-28`](../../crates/fast_io/src/io_uring/socket_writer.rs#L25)
+  rejects small payloads correctly; the bench result should match the
+  threshold's intent.
+- **Both fail across the matrix**: file IUS-4 as "decision: stay
+  opt-in". The feature continues to ship; the README / man-page note
+  from IUS-1 (PR #4661) documents the opt-in path. No code changes.
+
+## 8. Runtime probe vs build flag interaction
+
+Even when the bench passes the thresholds, the `iouring-send-zc` cargo
+feature remains the build-time gate. The runtime probe at
+[`crates/fast_io/src/io_uring/send_zc.rs:77`](../../crates/fast_io/src/io_uring/send_zc.rs#L77)
+(`is_supported`) is the kernel-time gate that handles distros where
+the operator built the binary on a 6.x host and runs it on a 5.x host
+(or vice versa) without rebuilding.
+
+The IUS-2 audit at section 2.4 enumerates the gating contract:
+
+- Build-time gate (`iouring-send-zc` cargo feature): controls whether
+  `ZeroCopySender` and the registered-buffer fast path compile in.
+  Default-off today; IUS-4 may flip to default-on.
+- Runtime gate (`send_zc::is_supported()`): cached in a process-wide
+  `AtomicI8`; one-shot `IORING_REGISTER_PROBE` against a throwaway
+  ring. Returns true only on kernels that advertise the opcode.
+
+IUS-5 wires `ZeroCopyPolicy::Auto` to consult the runtime probe. Today
+`allow_send_zc()` at
+[`crates/fast_io/src/io_uring_common.rs:183`](../../crates/fast_io/src/io_uring_common.rs#L183)
+returns true only for `ZeroCopyPolicy::Enabled`; `Auto` collapses to
+false, which means flipping the cargo feature alone today does not
+enable SEND_ZC dispatch.
+
+The bench scaffold therefore tests the dispatch primitive
+(`try_send_zc`) directly, not the policy-gated entry point. The
+production wiring decision is IUS-5's concern; IUS-3 produces the
+evidence that informs IUS-4 (default-on decision) which in turn
+unblocks IUS-5 (policy wiring).
+
+## 9. Out-of-scope (deliberate)
+
+The scaffold does not measure:
+
+- **Multi-sender concurrency on a shared ring**. The IUS-2 audit at
+  section 3.5 flags the `user_data` mask at
+  [`send_zc.rs:61`](../../crates/fast_io/src/io_uring/send_zc.rs#L61)
+  as single-sender-only; multi-sender SEND_ZC needs a CQE demuxing
+  layer that does not yet exist. Bench fixtures stay single-sender.
+- **Registered-buffer vs unregistered SEND_ZC**. Both paths are
+  zero-copy at the socket layer; the difference is the per-page
+  pinning saving. Reported by
+  [`ZeroCopySender::registered_buffers_active`](../../crates/fast_io/src/io_uring/send_zc.rs#L447)
+  but not split out by the bench. A followup can add a `[bench]`
+  group for it once the registered-buffer fast path is the production
+  default.
+- **Non-blocking sockets / `EAGAIN` handling**. The bench uses
+  blocking loopback sockets; SEND_ZC's `EAGAIN` propagation is not
+  exercised. Production daemon sockets are blocking; this matches the
+  shape that matters.
+- **Real-NIC bench between two hosts**. Captured in the
+  `docs/design/iouring-send-zc.md` section 5 plan as workload C
+  ("recorded but not gating"). The numbers-capture followup may add
+  this if hardware is available; not required for the IUS-4 decision.
+
+## 10. Followups
+
+Tracked separately so this PR stays scoped to the design + scaffold:
+
+- **Numbers capture on real hardware** (multi-kernel rsync-profile
+  container fleet on Linux 6.0 / 6.6 / 6.12). Requires bare-metal or
+  multi-VM hosts. Gated on hardware availability; not blocking IUS-4.
+- **`tc qdisc` bandwidth-shape wrapper script**
+  (`scripts/bench-ius-3-tc-setup.sh`). One-off operator script; does
+  not change the bench source.
+- **Registered-buffer split** (IUS-3b). Add a bench group that
+  enforces `registered_buffers_active() == true` and reports the
+  pinned-page benefit separately from the socket-layer benefit.
+- **IUS-4** (default-on / opt-in decision). Consumes the bench
+  numbers from this followup; updates the IUS-1 README / man-page
+  wording and (if the decision is to flip) updates
+  `crates/fast_io/Cargo.toml` to add `iouring-send-zc` to `default`
+  on Linux targets.
+- **IUS-5** (runtime probe wiring into `ZeroCopyPolicy::Auto`). Wires
+  `allow_send_zc()` to consult `send_zc::is_supported()` so flipping
+  the cargo feature also flips the default policy.
+
+## 11. References
+
+- Audit: `docs/audits/ius-2-send-zc-kernel-compat-matrix.md` (PR #4664, merged)
+- IUS-1 README + man-page note: PR #4661 (merged)
+- Design: `docs/design/iouring-send-zc.md`
+- Runtime probe: `crates/fast_io/src/io_uring/send_zc.rs:77` (`is_supported()`)
+- Dispatch primitive: `crates/fast_io/src/io_uring/send_zc.rs:130` (`try_send_zc()`)
+- Production caller: `crates/fast_io/src/io_uring/socket_writer.rs:91-104`
+- Policy resolution: `crates/fast_io/src/io_uring_common.rs:183` (`allow_send_zc()`)
+- Project memory: `project_iouring_send_zc_optin_only.md`


### PR DESCRIPTION
## Summary

Scaffold the IUS-3 bench that compares `IORING_OP_SEND_ZC` against
plain `IORING_OP_SEND` on a loopback TCP pair across four workload
shapes. This is the gate for IUS-4 (the default-on / opt-in decision
for the `iouring-send-zc` cargo feature).

- **Design doc** (`docs/design/ius-3-send-zc-bench-design-2026-05-21.md`):
  bench question, kernel matrix, workload matrix, decision criteria
  feeding IUS-4, runtime-probe vs build-flag interaction.
- **Bench scaffold** (`crates/fast_io/benches/ius_3_send_zc_vs_send.rs`):
  criterion harness with `send_plain` and `send_zc` bench groups;
  loopback TCP pair; deterministic LCG for the `mixed` workload so reruns
  are byte-identical. Env-gated by `OC_RSYNC_BENCH_IUS_3=1` so default
  `cargo bench -p fast_io` does not pick up the work.

## Kernel x workload matrix

Cited from `docs/audits/ius-2-send-zc-kernel-compat-matrix.md` (PR #4664, merged):

| Kernel | SEND_ZC | Representative distro |
|--------|---------|-----------------------|
| 5.15 | No | Ubuntu 22.04 default; runtime probe rejects |
| 5.19 | Partial | Transient; probe rejects |
| 6.0 | Yes | Debian 12 (6.1), AL 2023 (6.1); first stable |
| 6.6 LTS | Yes (stable) | Production target |
| 6.12 | Yes (mature) | Ubuntu 24.10 (6.11), RHEL 10 ETA |

Workloads: `small_chunks` (16 KiB x 10000), `medium_chunks` (256 KiB x
1000), `large_chunks` (1 MiB x 100), `mixed` (random 4 KiB - 1 MiB x
1000 via deterministic LCG).

## Feature gating

- `send_plain` group: needs only the default `io_uring` feature.
- `send_zc` group: `#[cfg(all(target_os = \"linux\", feature = \"iouring-send-zc\"))]`
  - the runtime probe at
  [`crates/fast_io/src/io_uring/send_zc.rs:77`](https://github.com/oferchen/oc-rsync/blob/master/crates/fast_io/src/io_uring/send_zc.rs#L77)
  (`is_supported()`, identified in the IUS-2 audit section 2.2) further
  gates per-iter dispatch, skipping with a stderr notice on kernels
  < 6.0 rather than panicking.

Cargo.toml declares `required-features = [\"io_uring\"]` so the bench
is excluded from builds that turn the feature off; the `send_zc` group
inside the source is independently cfg-gated.

## Decision criteria for IUS-4 (design doc section 7)

SEND_ZC is promoted to default-on (`ZeroCopyPolicy::Auto` consumes it)
only when both:

1. `send_zc_throughput / send_throughput >= 1.1` on >= 3 of 4 workload
   shapes for kernels >= 6.0, **and**
2. user+system CPU% reduction >= 10% on >= 2 workload shapes for
   kernels >= 6.0.

The criterion harness reports the throughput half; CPU%, syscalls/sec,
and `copy_to_user` bytes are layered on out-of-band by the followup
numbers-capture wrapper.

## Followups (hardware-dependent)

- **Numbers capture** on multi-kernel rsync-profile fleet
  (Linux 6.0 / 6.6 / 6.12 minimum). Gated on hardware availability;
  not blocking IUS-4 design work.
- **`tc qdisc` bandwidth-shape wrapper** (`scripts/bench-ius-3-tc-setup.sh`)
  for the 1 Gbps / 10 Gbps loopback shapes flagged in the bench's
  module doc as out of scope for the scaffold.
- **IUS-4** consumes the bench numbers; IUS-5 wires
  `ZeroCopyPolicy::Auto` to consult `send_zc::is_supported()`.

References: IUS-2 audit (PR #4664, merged), IUS-1 README + man-page
note (PR #4661, merged), `docs/design/iouring-send-zc.md`.

## Test plan

- [ ] CI: workspace builds with default features (bench compiles with `send_plain` group only)
- [ ] CI: workspace builds with `--features iouring-send-zc` (bench compiles with both groups)
- [ ] Manual on Linux 6.6+: `OC_RSYNC_BENCH_IUS_3=1 cargo bench -p fast_io --features iouring-send-zc --bench ius_3_send_zc_vs_send` produces criterion output for all eight rows (4 workloads x 2 groups)
- [ ] Manual on Linux 5.15: the `send_zc` group skips with the expected stderr message; `send_plain` runs to completion