### PR TITLE
bench(engine): scaffold BR-3j.f DashMap cores-vs-throughput re-bench harness

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -264,6 +264,11 @@ harness = false
 required-features = ["parallel-receive-delta"]
 
 [[bench]]
+name = "br_3j_f_dashmap_cores_vs_throughput"
+harness = false
+required-features = ["parallel-receive-delta"]
+
+[[bench]]
 name = "spill_policy_perf"
 harness = false
 required-features = ["spill-compression"]

--- a/crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs
+++ b/crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs
@@ -1,0 +1,390 @@
+//! Criterion bench: BR-3j.f post-DashMap re-bench of the BR-3i.f
+//! cores-vs-throughput sweep for [`ParallelDeltaApplier`].
+//!
+//! # Why this exists
+//!
+//! BR-3j.c/d/e (PRs #4634/#4635/#4636) replaced the applier's outer
+//! `Mutex<HashMap<FileNdx, Arc<Mutex<FileSlot>>>>` slot map with a
+//! [`DashMap`]-backed shard layout. The original BR-3i.f harness in
+//! `parallel_verify_chunk.rs` was authored against the pre-DashMap shape
+//! and produced the baseline cores-vs-throughput curve the receiver's
+//! parallel-vs-sequential gate (#4666) was sized against. BR-3j.f re-runs
+//! the same workload through the new applier so the curve can be
+//! captured after the outer-lock removal.
+//!
+//! This bench is a deliberate sibling of `parallel_verify_chunk.rs`
+//! rather than an in-place edit: keeping the BR-3i.f harness untouched
+//! means the pre-DashMap criterion baseline saved under
+//! `target/criterion/parallel_verify_chunk/` stays comparable to the
+//! BR-3j.f run saved under `target/criterion/br_3j_f_dashmap_cores_vs_throughput/`.
+//! Criterion's compare-to-baseline workflow then yields a direct
+//! before/after diff per (workload, strategy, worker_count) cell with no
+//! manual bookkeeping.
+//!
+//! # Sweep shape
+//!
+//! Identical to BR-3i.f so the cells line up cell-for-cell:
+//!
+//! 1. Worker count - `{1, 2, 4, 8, available_parallelism()}` deduplicated.
+//! 2. Checksum strategy - `{MD4, MD5, XXH3}`.
+//! 3. Workload shape - large_chunks_few_files vs small_chunks_many_files.
+//!
+//! # Outer-map probe
+//!
+//! BR-3j.f also adds a dedicated `register_finish_churn` group that
+//! exercises the path the DashMap migration most directly affects: many
+//! short-lived files being registered, immediately drained, and finished
+//! across a large rayon pool. This is the path the pre-DashMap
+//! single-mutex map serialised end-to-end; the bench surfaces whether the
+//! shard layout actually lets N workers register/finish in parallel or
+//! whether some other lock (e.g. the per-file [`SlotBarrier`]) is now the
+//! gate. Numbers from this group complement - they do not replace - the
+//! main cores-vs-throughput sweep.
+//!
+//! # Reproducibility
+//!
+//! All chunk payloads come from a seeded [`SmallRng`]; the seed varies
+//! by `(workload, file, chunk)` so the data is incompressible-looking
+//! but byte-identical across runs and machines. Per-chunk
+//! `expected_strong` digests are computed from each strategy ahead of
+//! time so the timed loop never recomputes them.
+//!
+//! # Cross-references
+//!
+//! - PR #4640 - BR-3i.c real `verify_chunk` (prerequisite shipped).
+//! - PR #4616 - BR-3i.b strategy plumbing.
+//! - PR #4634 - BR-3j.c DashMap migration under audit by this re-bench.
+//! - PR #4653 - BR-3i.f baseline harness in `parallel_verify_chunk.rs`.
+//! - `docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md` -
+//!   DashMap-vs-sharded selection audit; cells in this bench validate
+//!   the audit's "shard guard is short, never iterated in hot path"
+//!   assumptions on real workloads.
+//! - `docs/design/br-3j-f-dashmap-rebench-2026-05-21.md` - methodology,
+//!   number-capture procedure, and the deferred-numbers status.
+//! - `crates/engine/src/concurrent_delta/parallel_apply.rs` - the
+//!   implementation under measurement.
+//!
+//! Run: `cargo bench -p engine --features parallel-receive-delta \
+//!     --bench br_3j_f_dashmap_cores_vs_throughput`
+
+#![deny(unsafe_code)]
+#![cfg(feature = "parallel-receive-delta")]
+
+use std::hint::black_box;
+use std::io::{self, Write};
+use std::sync::Arc;
+use std::thread::available_parallelism;
+use std::time::Duration;
+
+use checksums::strong::strategy::{
+    ChecksumAlgorithmKind, ChecksumStrategy, ChecksumStrategySelector,
+};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use rayon::ThreadPoolBuilder;
+
+use engine::concurrent_delta::{DeltaChunk, FileNdx, ParallelDeltaApplier};
+
+/// Fixed RNG seed root. Combined with `(workload, file, chunk)` per
+/// payload so identical runs reproduce byte-for-byte. Distinct from the
+/// BR-3i.f sibling's root so post-hoc analyses cannot accidentally
+/// alias the two corpora when both criterion baselines are loaded.
+const SEED_ROOT: u64 = 0xB33D_BEEF_5EE0_C0DE;
+
+/// Workload A: large chunks, few files. 4 files x 256 chunks x 1 MiB.
+/// Matches BR-3i.f exactly so the re-bench delta is a like-for-like.
+const WORKLOAD_A_FILES: usize = 4;
+const WORKLOAD_A_CHUNKS_PER_FILE: usize = 256;
+const WORKLOAD_A_CHUNK_SIZE: usize = 1024 * 1024;
+
+/// Workload B: small chunks, many files. 256 files x 64 chunks x 16 KiB.
+/// Matches BR-3i.f exactly so the re-bench delta is a like-for-like.
+const WORKLOAD_B_FILES: usize = 256;
+const WORKLOAD_B_CHUNKS_PER_FILE: usize = 64;
+const WORKLOAD_B_CHUNK_SIZE: usize = 16 * 1024;
+
+/// Register/finish churn workload C: many files, one chunk each.
+///
+/// Selected to maximise the share of wall time spent inside
+/// `register_file` + `finish_file` so the DashMap shard layout's
+/// concurrency is the dominant signal. 4 KiB per chunk keeps the
+/// per-chunk write under a single page so the inner per-file mutex
+/// window is minimal.
+const WORKLOAD_C_FILES: usize = 4096;
+const WORKLOAD_C_CHUNKS_PER_FILE: usize = 1;
+const WORKLOAD_C_CHUNK_SIZE: usize = 4 * 1024;
+
+/// In-memory sink that discards bytes after acknowledging the write.
+///
+/// The bench measures verify+dispatch+per-file mutex cost. The applier
+/// already tracks `bytes_written` through its own counter, so the sink
+/// does not need its own bookkeeping; keeping `write` trivial avoids
+/// contaminating the cores-vs-throughput curve with allocator or
+/// shared-state pressure.
+struct CountingSink;
+
+impl Write for CountingSink {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// One named workload: a label plus the materialised chunk list and the
+/// total byte count the bench needs to report throughput.
+struct Workload {
+    label: &'static str,
+    file_count: u32,
+    chunks: Vec<DeltaChunk>,
+    total_bytes: u64,
+}
+
+/// Builds a workload's chunk list with deterministic, RNG-filled payloads.
+///
+/// `workload_tag` is folded into the per-chunk seed so workloads A, B,
+/// and C do not share payloads.
+fn build_workload(
+    label: &'static str,
+    workload_tag: u64,
+    files: usize,
+    chunks_per_file: usize,
+    chunk_size: usize,
+) -> Workload {
+    let mut chunks = Vec::with_capacity(files * chunks_per_file);
+    for file_index in 0..files {
+        for chunk_index in 0..chunks_per_file {
+            let seed = SEED_ROOT
+                ^ workload_tag.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                ^ (file_index as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9)
+                ^ (chunk_index as u64).wrapping_mul(0x94D0_49BB_1331_11EB);
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut payload = vec![0u8; chunk_size];
+            rng.fill_bytes(&mut payload);
+            let ndx = FileNdx::new(file_index as u32);
+            chunks.push(DeltaChunk::literal(ndx, chunk_index as u64, payload));
+        }
+    }
+    let total_bytes = (files as u64) * (chunks_per_file as u64) * (chunk_size as u64);
+    Workload {
+        label,
+        file_count: files as u32,
+        chunks,
+        total_bytes,
+    }
+}
+
+/// Attaches the strategy-specific `expected_strong` digest to every chunk
+/// so the timed loop exercises the real `compute + compare` path. The
+/// digest computation runs outside the criterion sample window.
+fn with_expected_digests(
+    chunks: &[DeltaChunk],
+    strategy: &dyn ChecksumStrategy,
+) -> Vec<DeltaChunk> {
+    chunks
+        .iter()
+        .map(|c| {
+            let digest = strategy.compute(&c.data);
+            DeltaChunk::literal(c.ndx, c.chunk_sequence, c.data.clone())
+                .with_expected_strong(digest)
+        })
+        .collect()
+}
+
+/// Worker counts swept per (workload, strategy) cell. Always includes 1,
+/// 2, 4, 8 and the machine's reported parallelism so 4- and 16-core
+/// hosts both produce a meaningful curve.
+fn worker_counts() -> Vec<usize> {
+    let host = available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let mut counts = vec![1usize, 2, 4, 8, host];
+    counts.sort_unstable();
+    counts.dedup();
+    counts
+}
+
+/// Strategies covered by the sweep. Mirrors BR-3i.b's supported set so
+/// this bench will fail to compile if a future change drops one of them.
+fn strategies() -> Vec<(&'static str, ChecksumAlgorithmKind)> {
+    vec![
+        ("md4", ChecksumAlgorithmKind::Md4),
+        ("md5", ChecksumAlgorithmKind::Md5),
+        ("xxh3", ChecksumAlgorithmKind::Xxh3),
+    ]
+}
+
+/// Runs one apply pass through the supplied applier, returning the total
+/// bytes routed to sinks. The applier is rebuilt per iteration so each
+/// sample starts from a clean DashMap shape - critical for BR-3j.f
+/// because the bench's claim of interest is exactly how the DashMap
+/// behaves when populated under contention from zero.
+fn run_apply(workload: &Workload, applier: &ParallelDeltaApplier) -> u64 {
+    for i in 0..workload.file_count {
+        applier
+            .register_file(FileNdx::new(i), Box::new(CountingSink))
+            .expect("register sink");
+    }
+    applier
+        .apply_batch_parallel(workload.chunks.clone())
+        .expect("batch apply");
+    let mut total = 0u64;
+    for i in 0..workload.file_count {
+        total += applier
+            .bytes_written(FileNdx::new(i))
+            .expect("bytes written");
+        let _ = applier.finish_file(FileNdx::new(i)).expect("finish file");
+    }
+    total
+}
+
+/// Drives the cores-vs-throughput sweep for a single workload. Each cell
+/// pins the applier's concurrency limit AND the ambient rayon pool to the
+/// target worker count so the dispatch surface is genuinely thread-bound,
+/// not just nominally limited.
+fn bench_workload_sweep(c: &mut Criterion, workload: Workload) {
+    let mut group = c.benchmark_group(format!(
+        "br_3j_f_dashmap_cores_vs_throughput/{}",
+        workload.label
+    ));
+    group.throughput(Throughput::Bytes(workload.total_bytes));
+    // Each iteration walks the full chunk list (potentially 1 GiB for
+    // workload A). Keep the sample budget modest so the matrix finishes
+    // in a reasonable wall-clock window; offline number-capture runs
+    // override with criterion's CLI flags when tighter confidence
+    // intervals are needed (see the BR-3j.f design doc).
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(
+        if workload.label == "large_chunks_few_files" {
+            12
+        } else {
+            6
+        },
+    ));
+
+    for (strategy_label, kind) in strategies() {
+        let strategy: Arc<dyn ChecksumStrategy> =
+            Arc::from(ChecksumStrategySelector::for_algorithm(kind, 0));
+        let prepared_chunks = with_expected_digests(&workload.chunks, strategy.as_ref());
+        let prepared_workload = Workload {
+            label: workload.label,
+            file_count: workload.file_count,
+            chunks: prepared_chunks,
+            total_bytes: workload.total_bytes,
+        };
+        let chunks_per_iter = prepared_workload.chunks.len() as u64;
+
+        for &workers in &worker_counts() {
+            let pool = ThreadPoolBuilder::new()
+                .num_threads(workers)
+                .thread_name(|i| format!("dashmap-rebench-{i}"))
+                .build()
+                .expect("rayon pool");
+
+            let id = BenchmarkId::new(
+                format!("{strategy_label}/threads={workers}"),
+                workload.label,
+            );
+            group.bench_with_input(id, &workers, |b, _| {
+                b.iter(|| {
+                    let strategy_clone = Arc::clone(&strategy);
+                    let applier = ParallelDeltaApplier::with_strategy(workers, strategy_clone);
+                    let bytes = pool.install(|| run_apply(&prepared_workload, &applier));
+                    // Group throughput reports bytes/sec. Chunks/sec is
+                    // derivable post-hoc from `chunks_per_iter` and the
+                    // reported per-iter wall time; the `black_box` here
+                    // pins the chunk count into the timed region so the
+                    // optimiser cannot fold it away.
+                    black_box((bytes, chunks_per_iter));
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+/// Drives the register/finish churn sweep for workload C. The bench
+/// measures the wall time of a full register-all + apply-all + finish-all
+/// cycle on the DashMap-backed applier; under the pre-DashMap shape this
+/// path would serialise every register and finish behind one outer
+/// mutex, so the BR-3j.f numbers should show worker scaling that the
+/// baseline would not have produced.
+///
+/// File count is the throughput unit so the criterion report yields
+/// files/sec directly; bytes are negligible in this workload.
+fn bench_register_finish_churn(c: &mut Criterion, workload: Workload) {
+    let mut group = c.benchmark_group(format!(
+        "br_3j_f_dashmap_cores_vs_throughput/register_finish_churn/{}",
+        workload.label
+    ));
+    group.throughput(Throughput::Elements(workload.file_count as u64));
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(8));
+
+    // Only MD5 here - this workload is dominated by map ops, not
+    // checksum cost, and sweeping three strategies would triple the
+    // matrix without changing the signal.
+    let strategy: Arc<dyn ChecksumStrategy> = Arc::from(ChecksumStrategySelector::for_algorithm(
+        ChecksumAlgorithmKind::Md5,
+        0,
+    ));
+    let prepared_chunks = with_expected_digests(&workload.chunks, strategy.as_ref());
+    let prepared_workload = Workload {
+        label: workload.label,
+        file_count: workload.file_count,
+        chunks: prepared_chunks,
+        total_bytes: workload.total_bytes,
+    };
+
+    for &workers in &worker_counts() {
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(workers)
+            .thread_name(|i| format!("dashmap-churn-{i}"))
+            .build()
+            .expect("rayon pool");
+
+        let id = BenchmarkId::new(format!("md5/threads={workers}"), workload.label);
+        group.bench_with_input(id, &workers, |b, _| {
+            b.iter(|| {
+                let strategy_clone = Arc::clone(&strategy);
+                let applier = ParallelDeltaApplier::with_strategy(workers, strategy_clone);
+                let files = pool.install(|| run_apply(&prepared_workload, &applier));
+                black_box(files);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_br_3j_f(c: &mut Criterion) {
+    let workload_a = build_workload(
+        "large_chunks_few_files",
+        0xA,
+        WORKLOAD_A_FILES,
+        WORKLOAD_A_CHUNKS_PER_FILE,
+        WORKLOAD_A_CHUNK_SIZE,
+    );
+    let workload_b = build_workload(
+        "small_chunks_many_files",
+        0xB,
+        WORKLOAD_B_FILES,
+        WORKLOAD_B_CHUNKS_PER_FILE,
+        WORKLOAD_B_CHUNK_SIZE,
+    );
+    let workload_c = build_workload(
+        "register_finish_churn",
+        0xC,
+        WORKLOAD_C_FILES,
+        WORKLOAD_C_CHUNKS_PER_FILE,
+        WORKLOAD_C_CHUNK_SIZE,
+    );
+    bench_workload_sweep(c, workload_a);
+    bench_workload_sweep(c, workload_b);
+    bench_register_finish_churn(c, workload_c);
+}
+
+criterion_group!(benches, bench_br_3j_f);
+criterion_main!(benches);

--- a/docs/design/br-3j-f-dashmap-rebench-2026-05-21.md
+++ b/docs/design/br-3j-f-dashmap-rebench-2026-05-21.md
@@ -1,0 +1,295 @@
+# BR-3j.f - DashMap re-bench of the BR-3i.f cores-vs-throughput sweep (2026-05-21)
+
+Date: 2026-05-21
+Scope: criterion re-bench scaffold; production number capture deferred to
+offline run on multi-core Linux hardware.
+Status: **NUMBERS DEFERRED**. Harness shipped; the actual cores-vs-throughput
+curve is captured offline on production-class hardware and appended to this
+doc once measured.
+Tracker: BR-3j.f (#2508). Predecessor harness: BR-3i.f (PR #4653) at
+`crates/engine/benches/parallel_verify_chunk.rs`.
+
+## 1. Why a re-bench
+
+BR-3j.c (PR #4634), BR-3j.d (PR #4635), and BR-3j.e (PR #4636) replaced the
+applier's outer `Mutex<HashMap<FileNdx, Arc<Mutex<FileSlot>>>>` slot map at
+`crates/engine/src/concurrent_delta/parallel_apply.rs` with a `DashMap`
+shard layout. The selection audit at
+`docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md` predicted that the
+DashMap migration would lift the outer-map contention out of the
+register/lookup/finish hot path and unblock the per-file rayon fanout that
+the rest of the applier is built around. The original BR-3i.f sweep in
+`parallel_verify_chunk.rs` produced the pre-DashMap baseline curve that
+sized the receiver's parallel-vs-sequential dispatch heuristic at PIP-3+5
+(PR #4666).
+
+BR-3j.f re-runs the same workload through the post-DashMap applier so the
+curve can be captured after the outer-lock removal. Two outcomes are
+acceptable:
+
+1. **Improvement.** The new curve scales further before saturating, or the
+   absolute throughput at every worker count rises. This is the audit's
+   directional prediction and the case the PIP-3+5 heuristic was sized
+   against.
+2. **Flat / regression.** The new curve does not improve. That is also a
+   useful conclusion: it tells us the outer map was not the binding
+   constraint on the BR-3i.f workload shape and points the next
+   investigation at the per-file `Mutex<FileSlot>` writer barrier
+   (project memory: `project_apply_batch_write_serial.md`,
+   `project_parallel_delta_apply_outer_mutex.md`).
+
+Either outcome closes the line of inquiry: the BR-3j.a audit's
+recommendation rests on the assumption that the outer map was contending.
+BR-3j.f is the test of that assumption on real workloads, not on the
+microbench shape the audit cited.
+
+## 2. Methodology
+
+### 2.1 Harness
+
+A new criterion bench at
+`crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs` registered
+under the `parallel-receive-delta` feature gate. The bench is a deliberate
+sibling of the BR-3i.f harness rather than an in-place edit so the
+criterion baseline saved under `target/criterion/parallel_verify_chunk/`
+stays comparable to the BR-3j.f run saved under
+`target/criterion/br_3j_f_dashmap_cores_vs_throughput/`. Criterion's
+compare-to-baseline workflow then yields a direct before/after diff per
+(workload, strategy, worker_count) cell without manual bookkeeping.
+
+### 2.2 Sweep cells
+
+Identical to BR-3i.f so the post-DashMap numbers line up cell-for-cell
+with the pre-DashMap baseline:
+
+| Axis | Values | Notes |
+|---|---|---|
+| Worker count | `{1, 2, 4, 8, available_parallelism()}` deduplicated | Pins both `ParallelDeltaApplier::with_strategy` concurrency and the ambient rayon pool. |
+| Checksum strategy | `{MD4, MD5, XXH3}` | Mirrors BR-3i.b's plumbed set; will fail to compile if a future change drops one. |
+| Workload A | 4 files x 256 chunks x 1 MiB = 1024 chunks / 1 GiB | Large chunks, few files. Models VM images / container layers. |
+| Workload B | 256 files x 64 chunks x 16 KiB = 16384 chunks / 256 MiB | Small chunks, many files. Models source trees / build artefact dirs. |
+| Workload C | 4096 files x 1 chunk x 4 KiB = 4096 chunks / 16 MiB | Many files, one chunk each. Register/finish churn. New for BR-3j.f. |
+
+Workload C is the BR-3j.f-specific addition. It maximises the share of
+wall time spent inside `register_file` and `finish_file` so the DashMap
+shard layout's concurrency is the dominant signal. Under the pre-DashMap
+shape this path serialised every register and finish behind one outer
+mutex, so the BR-3j.f numbers on C should show worker scaling that the
+baseline would not have produced. If they do not, the per-file
+`SlotBarrier` Mutex is the next bottleneck.
+
+### 2.3 Iteration shape
+
+Each criterion sample rebuilds the applier from scratch via
+`ParallelDeltaApplier::with_strategy(workers, strategy)`. This is
+deliberate for BR-3j.f: the bench's claim of interest is exactly how the
+DashMap behaves when populated under contention from zero. Reusing an
+applier across samples would warm the DashMap shards and mask the
+register-side scaling difference.
+
+Sink writers are `CountingSink` (no allocation, no atomic ops) so the
+bench isolates verify + dispatch + per-file mutex + outer-map cost from
+allocator pressure or shared sink state. Disk I/O is out of scope and is
+covered separately by `delta_transfer_benchmark` and `local_copy_bench`.
+
+### 2.4 Reproducibility
+
+All chunk payloads come from a seeded `SmallRng`; the seed combines a
+fixed root (`0xB33D_BEEF_5EE0_C0DE`, distinct from BR-3i.f's root so the
+two corpora cannot accidentally alias) with `(workload_tag, file_index,
+chunk_index)` triples. Per-chunk `expected_strong` digests are computed
+once per (workload, strategy) and reused across samples so the timed
+loop never recomputes them.
+
+## 3. Number capture procedure
+
+### 3.1 Target hardware
+
+The bench is meant for production-class multi-core Linux hosts. A CI
+runner is not adequate: GitHub-hosted runners typically expose 2-4 vCPUs
+and noisy neighbours skew criterion's confidence intervals beyond the
+signal this bench tries to surface.
+
+Two known-good targets in this project:
+
+1. **`oc-rsync-bench` container** (`localhost/oc-rsync-bench:latest`,
+   Arch Linux). The benchmark image the release pipeline uses. Run on a
+   bare-metal Linux host (16+ physical cores recommended) via
+   `podman run --rm -it --cpus=$(nproc) localhost/oc-rsync-bench:latest`.
+   The workspace bind-mount is intentionally **not** used here because
+   criterion baseline data lands under `target/criterion/` and we want it
+   on a dedicated benchmark volume, not the host source tree.
+2. **`rsync-profile` container** (`rsync-profile`, Debian rust:latest).
+   The persistent debug container. Exec into it with
+   `podman exec -it rsync-profile bash`; criterion output lands under
+   `/workspace/target/criterion/` (workspace bind-mount).
+
+The container choice is up to the operator. Record which one was used in
+the appended-numbers section so the cell-to-cell deltas can be replayed
+later.
+
+### 3.2 Commands
+
+From the workspace root inside the chosen target:
+
+```sh
+# Capture the post-DashMap curve as a named baseline.
+cargo bench -p engine --features parallel-receive-delta \
+    --bench br_3j_f_dashmap_cores_vs_throughput -- --save-baseline br-3j-f-post
+
+# Optional: re-run BR-3i.f against the same applier shape to refresh the
+# pre-bench baseline if the pre-DashMap data is no longer in
+# target/criterion/.
+git checkout <pre-br-3j.c-rev>
+cargo bench -p engine --features parallel-receive-delta \
+    --bench parallel_verify_chunk -- --save-baseline br-3i-f-pre
+git checkout -
+
+# Diff: criterion writes both baselines under
+# target/criterion/<group>/<id>/{br-3j-f-post,br-3i-f-pre}/. Use
+# `cargo bench ... -- --baseline br-3i-f-pre` to produce the comparison
+# report, or read the violin plots under target/criterion/report/.
+```
+
+### 3.3 Where the numbers land
+
+The actual percentile table (median / lower / upper bound per cell) is
+appended to section 6 of this doc as a markdown table. Raw criterion JSON
+under `target/criterion/br_3j_f_dashmap_cores_vs_throughput/` is the source
+of truth; the table here is a human-readable summary. Do not commit the
+raw criterion output - it is reproducible from the harness.
+
+## 4. Comparison baseline
+
+The BR-3i.f baseline ships in `parallel_verify_chunk.rs` (PR #4653) and
+was not measured to a quotable number set in any committed doc. The
+pre-DashMap absolute throughput on a given host is therefore captured
+either:
+
+- by checking out the parent of PR #4634 (BR-3j.c) and running the
+  BR-3i.f command above with `--save-baseline br-3i-f-pre`, or
+- by reading any previously-saved baseline in
+  `target/criterion/parallel_verify_chunk/` if one was preserved.
+
+The BR-3j.f re-run then uses `--baseline br-3i-f-pre` to produce the diff
+table. If neither pre-existing baseline is available, BR-3j.f stands on
+its own as the post-DashMap reference point and the directional
+improvement claim becomes "scales further at high worker count" rather
+than "X% faster than baseline".
+
+## 5. Expected directional improvement
+
+The BR-3j.a audit's predictions, lifted from
+`docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md` sections 1, 2, and
+3, applied to the BR-3j.f workload shape:
+
+1. **Workload A (large chunks, few files).** The audit predicts minimal
+   change. With 4 files and 256 chunks each, the outer-map hit rate is
+   dominated by 4 register / 4 finish calls per iteration plus 4 unique
+   `slot_for` Arc clones (after the per-file slot is warmed). The
+   pre-DashMap baseline already amortised the outer-mutex cost across
+   1024 chunks per iteration. **Expected: < 5% delta either way; this
+   workload is the noise floor for the re-bench, not the headline.**
+2. **Workload B (small chunks, many files).** Here the audit predicts the
+   largest signal. With 256 files and 16384 chunks, the pre-DashMap
+   shape forced every chunk's `slot_for` Arc clone through the outer
+   mutex. With DashMap sharding (default `4 x num_cpus.next_power_of_two()`
+   shards), 16-way concurrent `slot_for` calls hit independent shards
+   most of the time. **Expected: visible scaling improvement at workers
+   >= 4; the pre-DashMap curve should saturate earlier.**
+3. **Workload C (register/finish churn).** Brand new for BR-3j.f. The
+   pre-DashMap path serialised every register/finish behind one outer
+   mutex. DashMap's `entry` API on a sharded layout lets N workers
+   register against N different shards in parallel. **Expected: the
+   most dramatic scaling difference of the three workloads. If C does
+   not scale, the per-file `SlotBarrier::Mutex` is the next constraint
+   and the BR-3j project memory page
+   `project_parallel_delta_apply_outer_mutex.md` keeps the
+   "outer mutex" descriptor as an artefact of pre-DashMap code; the
+   real bottleneck has moved one level in.**
+
+These predictions are deliberately weak: the audit and this doc both
+recognise that the pre-DashMap baseline was already amortised by the
+per-file slot mutex for any read-heavy access pattern. The BR-3j.a audit
+selected DashMap on ergonomics and code-surface arguments at least as
+much as on raw contention. BR-3j.f's job is to quantify, not to vindicate.
+
+## 6. Captured numbers
+
+**Status:** numbers deferred. Awaiting offline run on production-class
+hardware per section 3.
+
+Once captured, the operator appends a table of the form:
+
+```
+Host: <hostname>, kernel <uname -r>, <cpu model>, <core count> cores
+Container: oc-rsync-bench:<digest> (or rsync-profile)
+Date: <YYYY-MM-DD>
+Criterion baselines: br-3i-f-pre, br-3j-f-post
+
+| Workload | Strategy | Workers | br-3i-f-pre (MiB/s) | br-3j-f-post (MiB/s) | Delta |
+|---|---|---|---|---|---|
+| large_chunks_few_files | md4 | 1 | ... | ... | ... |
+| large_chunks_few_files | md4 | 2 | ... | ... | ... |
+| ...                    | ... | ... | ... | ... | ... |
+| small_chunks_many_files | xxh3 | host | ... | ... | ... |
+
+| Workload | Strategy | Workers | Files/sec (br-3j-f-post) | Notes |
+|---|---|---|---|---|
+| register_finish_churn | md5 | 1 | ... | baseline cell |
+| register_finish_churn | md5 | 2 | ... | ... |
+| ...                   | ... | ... | ... | ... |
+```
+
+The table is the deliverable. The criterion JSON is the source of truth.
+
+## 7. Decision gate this re-bench feeds
+
+The re-bench numbers gate three downstream decisions, each tracked
+elsewhere:
+
+1. **ABW-2/3/4 (apply-batch verify/write pipelining).**
+   `docs/design/abw-2-pipelined-verify-write-deferred-2026-05-21.md`
+   section 3 holds the audit-derived condition `0.5 <= verify_wall /
+   write_wall <= 2.0` on any production-relevant cell. BR-3j.f's MiB/s
+   numbers feed that ratio when paired with the `delta_transfer_benchmark`
+   wall-clock breakdown.
+2. **RJN-3 / RJN-4 (fanout scheduler shape).**
+   `docs/design/rjn-3-4-fanout-deferred-2026-05-21.md` defers the
+   scheduler-shape design until BR-3j.f shows whether the cores-vs-
+   throughput curve still has headroom at high worker count. A saturated
+   curve closes RJN-3; a still-scaling curve keeps RJN-3 open as a
+   targeted optimisation.
+3. **Project memory `project_parallel_delta_apply_outer_mutex.md`.** If
+   the post-DashMap workload-C curve still flattens at low worker count,
+   the project page is amended with the new bottleneck name (per-file
+   `SlotBarrier::Mutex`); if it scales, the page is closed.
+
+## 8. References
+
+- `crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs` - the
+  re-bench harness this doc describes.
+- `crates/engine/benches/parallel_verify_chunk.rs` - the BR-3i.f baseline
+  harness, kept untouched so the criterion baselines stay comparable.
+- `crates/engine/src/concurrent_delta/parallel_apply.rs` - the
+  implementation under measurement; `files: DashMap<FileNdx,
+  Arc<SlotBarrier>>` field landed in BR-3j.c (PR #4634).
+- `docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md` - selection
+  audit; section 5 spells out the contention model the re-bench validates.
+- `docs/audits/br-3i-a-verify-chunk-audit-2026-05-20.md` - the
+  prerequisite verify-chunk plumbing audit; BR-3i.b/c shipped the real
+  per-chunk verify cost the cores-vs-throughput sweep measures.
+- `docs/design/abw-2-pipelined-verify-write-deferred-2026-05-21.md`,
+  `docs/design/rjn-3-4-fanout-deferred-2026-05-21.md` - downstream
+  designs blocked on this re-bench's numbers.
+- PR #4634 - BR-3j.c DashMap migration. Field swap.
+- PR #4635 - BR-3j.d DashMap wire-up. Hot-path edits.
+- PR #4636 - BR-3j.e DashMap removal of dead poisoned-error rungs.
+- PR #4653 - BR-3i.f baseline harness landed.
+- PR #4666 - PIP-3+5 receiver dispatch heuristic; sized against the
+  pre-DashMap curve, so BR-3j.f's numbers are also the input to any
+  future revision of the `file_count > 100 || total_size > 64 MiB`
+  threshold.
+- BR-3j.f tracker - #2508. Stays open with the
+  "deferred pending offline number capture" label until section 6 above
+  is populated.


### PR DESCRIPTION
## Summary

- Adds `crates/engine/benches/br_3j_f_dashmap_cores_vs_throughput.rs`, a criterion sibling of the BR-3i.f bench (`parallel_verify_chunk.rs`) that re-runs the same cores-vs-throughput sweep against the post-DashMap `ParallelDeltaApplier` so the curve can be diffed against the pre-DashMap baseline.
- Adds a third workload (`register_finish_churn`: 4096 files x 1 chunk) that maximises the share of wall time spent inside `register_file`/`finish_file`, the path BR-3j.c/d/e most directly affected.
- Documents the methodology, target hardware, command reproducer, expected directional improvement, and deferred-numbers status at `docs/design/br-3j-f-dashmap-rebench-2026-05-21.md`.
- Registers the bench in `crates/engine/Cargo.toml` under the existing `parallel-receive-delta` feature gate.

The harness is shipped here; the production cores-vs-throughput numbers are deferred to an offline capture on a production-class multi-core Linux host (per the design doc's section 3) and will be appended to section 6 of the design doc when measured. CI agents and GitHub-hosted runners do not produce statistically meaningful criterion samples for this workload.

## Test plan

- [ ] CI bench compile (`cargo bench ... --no-run` is exercised by the existing benches CI job).
- [ ] CI: fmt + clippy + nextest matrix.
- [ ] Deferred: capture numbers on `oc-rsync-bench` or `rsync-profile` container per `docs/design/br-3j-f-dashmap-rebench-2026-05-21.md` section 3 and append the comparison table to section 6.