### PR TITLE
feat(fast_io): mkdirat/symlinkat/linkat sandbox helpers (SEC-1.h)

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -7,12 +7,14 @@
 //!
 //! Today this module carries:
 //! - the lstat-class cutover for SEC-1.f
-//!   (`fstatat(AT_SYMLINK_NOFOLLOW)`), and
+//!   (`fstatat(AT_SYMLINK_NOFOLLOW)`),
 //! - the unlink-class cutover for SEC-1.g
-//!   (`unlinkat(dirfd, name, 0 | AT_REMOVEDIR)`).
+//!   (`unlinkat(dirfd, name, 0 | AT_REMOVEDIR)`), and
+//! - the create-class cutover for SEC-1.h
+//!   (`mkdirat`, `symlinkat`, `linkat`).
 //!
-//! SEC-1.h-j will extend it with the remaining `*at` siblings
-//! (`mkdirat`, `fchmodat`, `renameat`, ...) as those tasks land.
+//! SEC-1.i-j will extend it with the remaining `*at` siblings
+//! (`fchmodat`, `renameat`, ...) as those tasks land.
 
 use std::ffi::{CString, OsStr};
 use std::io;
@@ -410,6 +412,287 @@ pub fn unlink_via_sandbox_or_fallback(
         UnlinkFlags::File => std::fs::remove_file(link_path),
         UnlinkFlags::Dir => std::fs::remove_dir(link_path),
     }
+}
+
+/// Issue `mkdirat(dirfd, name, mode)`.
+///
+/// The leaf is resolved relative to `dirfd`. `mkdirat(2)` creates the
+/// new directory atomically beneath the dirfd, so a TOCTOU swap on a
+/// mid-path component between the receiver's decide-to-create moment
+/// and the syscall cannot redirect the create to an attacker-chosen
+/// parent: the parent is pinned by the dirfd that was opened at
+/// receiver setup.
+///
+/// `name` must not contain an interior NUL byte; callers that pull
+/// names from `Path::file_name` cannot trigger this (paths cannot
+/// contain NUL on Unix).
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `EEXIST` when `name` already exists beneath `dirfd`.
+/// - `ENOENT` when an intermediate component of `name` is missing.
+/// - `ENOTDIR` when `dirfd` is not a directory.
+/// - `EACCES` when the caller lacks write permission on `dirfd`.
+/// - `EINVAL` when `name` contains an interior NUL byte (translated
+///   from [`std::ffi::NulError`]).
+pub fn mkdirat(dirfd: BorrowedFd<'_>, name: &OsStr, mode: u32) -> io::Result<()> {
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+    //   whose lifetime is bound to the borrow and outlives the syscall.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not retain the
+    //   pointer past return.
+    // - `mode` is the requested permission bits; the active umask is
+    //   applied by the kernel in the standard way.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::mkdirat(dirfd.as_raw_fd(), c_name.as_ptr(), mode as libc::mode_t) };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Issue `symlinkat(target, dirfd, name)`.
+///
+/// The link entry is created beneath `dirfd` so a TOCTOU swap on a
+/// mid-path component cannot redirect the create to an attacker-chosen
+/// parent. The link **target** string is written verbatim into the
+/// symlink and is never resolved by `symlinkat(2)` itself: a malicious
+/// or non-existent target is therefore not a TOCTOU concern for this
+/// helper (the receiver decides whether to follow the link later).
+///
+/// `name` and `target` must not contain interior NUL bytes; callers
+/// that pull names from `Path::file_name` cannot trigger this.
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `EEXIST` when `name` already exists beneath `dirfd`.
+/// - `ENOENT` when an intermediate component of `name` is missing.
+/// - `ENOTDIR` when `dirfd` is not a directory.
+/// - `EACCES` when the caller lacks write permission on `dirfd`.
+/// - `EINVAL` when `name` or `target` contains an interior NUL byte
+///   (translated from [`std::ffi::NulError`]).
+pub fn symlinkat(target: &Path, dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+    let c_target = CString::new(target.as_os_str().as_bytes())
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `c_target.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not resolve it.
+    // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+    //   whose lifetime is bound to the borrow and outlives the syscall.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not retain the
+    //   pointer past return.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::symlinkat(c_target.as_ptr(), dirfd.as_raw_fd(), c_name.as_ptr()) };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Issue `linkat(old_dirfd, old_name, new_dirfd, new_name, 0)`.
+///
+/// Both endpoints are resolved relative to their respective dirfds.
+/// `flags == 0` means the source must not be a symlink (the standard
+/// "follow nothing" hardlink semantics rsync uses; see `hlink.c`).
+/// Pinning the new parent to `new_dirfd` closes the TOCTOU window
+/// between leader-path resolution and link creation.
+///
+/// `old_name` and `new_name` must not contain interior NUL bytes;
+/// callers that pull names from `Path::file_name` cannot trigger this.
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `EEXIST` when `new_name` already exists beneath `new_dirfd`.
+/// - `ENOENT` when `old_name` does not exist beneath `old_dirfd`, or
+///   when an intermediate component of `new_name` is missing.
+/// - `EXDEV` when the two paths resolve to different filesystems.
+/// - `EPERM` when the underlying filesystem refuses hardlinks
+///   (e.g., directories, or filesystems without hardlink support).
+/// - `EACCES` when the caller lacks the required permissions.
+/// - `EINVAL` when either name contains an interior NUL byte
+///   (translated from [`std::ffi::NulError`]).
+pub fn linkat(
+    old_dirfd: BorrowedFd<'_>,
+    old_name: &OsStr,
+    new_dirfd: BorrowedFd<'_>,
+    new_name: &OsStr,
+) -> io::Result<()> {
+    let c_old = CString::new(old_name.as_bytes())
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let c_new = CString::new(new_name.as_bytes())
+        .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - Both `BorrowedFd<'_>` arguments outlive the syscall (lifetime
+    //   bound to the borrows passed in).
+    // - Both `CString` arguments are valid NUL-terminated C strings
+    //   borrowed for the duration of the call; the kernel does not
+    //   retain the pointers past return.
+    // - `flags == 0` is the standard rsync hardlink shape: refuse to
+    //   follow the source if it is a symlink, mirroring `link(2)`.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::linkat(
+            old_dirfd.as_raw_fd(),
+            c_old.as_ptr(),
+            new_dirfd.as_raw_fd(),
+            c_new.as_ptr(),
+            0,
+        )
+    };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Issue `mkdirat` against `dir_path` when the `sandbox` root is the
+/// immediate parent.
+///
+/// SEC-1.h adaptor for callers that already have an absolute path:
+/// - When `sandbox` is `Some`, `dir_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   component, the helper resolves the leaf through the sandbox dirfd
+///   so a mid-syscall symlink swap on the leaf cannot redirect the
+///   create to an attacker-chosen parent.
+/// - In every other case the helper falls back to
+///   [`std::fs::create_dir`] on `dir_path`.
+///
+/// # Errors
+///
+/// Surfaces either the [`mkdirat`] error or the
+/// [`std::fs::create_dir`] error verbatim, depending on which path was
+/// taken.
+pub fn mkdirat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    dir_path: &Path,
+    mode: u32,
+) -> io::Result<()> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, dir_path)
+    {
+        return mkdirat(sandbox.current_dirfd(), leaf, mode);
+    }
+    std::fs::create_dir(dir_path)
+}
+
+/// Issue `symlinkat` against `link_path` when the `sandbox` root is
+/// the immediate parent.
+///
+/// SEC-1.h adaptor for callers that already have an absolute path:
+/// - When `sandbox` is `Some`, `link_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   component, the helper resolves the leaf through the sandbox dirfd
+///   so a mid-syscall symlink swap on the leaf cannot redirect the
+///   create to an attacker-chosen parent.
+/// - In every other case the helper falls back to
+///   [`std::os::unix::fs::symlink`] on `link_path`.
+///
+/// # Errors
+///
+/// Surfaces either the [`symlinkat`] error or the
+/// [`std::os::unix::fs::symlink`] error verbatim, depending on which
+/// path was taken.
+pub fn symlinkat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    link_path: &Path,
+    target: &Path,
+) -> io::Result<()> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
+    {
+        return symlinkat(target, sandbox.current_dirfd(), leaf);
+    }
+    std::os::unix::fs::symlink(target, link_path)
+}
+
+/// Issue `linkat` against `new_path` when the `sandbox` root is the
+/// immediate parent of the new entry.
+///
+/// SEC-1.h adaptor for hardlink follower creation:
+/// - When `sandbox` is `Some`, `new_path` equals
+///   `dest_dir.join(new_relative)`, and `new_relative` has a single
+///   component, the helper anchors the **new** endpoint on the
+///   sandbox dirfd so a mid-syscall symlink swap on the follower's
+///   parent cannot redirect the create to an attacker-chosen
+///   directory. The **old** (leader) endpoint stays on `AT_FDCWD`:
+///   the leader path is tracked by the receiver-managed
+///   `HardlinkApplyTracker`, may live under a different parent than
+///   `dest_dir` for cross-segment hardlinks, and SEC-1 explicitly
+///   limits this cutover to single-component leaves under
+///   `dest_dir`.
+/// - In every other case the helper falls back to
+///   [`fast_io::hard_link`](crate::hard_link) which preserves the
+///   existing io_uring `LINKAT` fast path plus
+///   [`std::fs::hard_link`] error semantics (`EXDEV`, `EPERM`, ...).
+///
+/// # Errors
+///
+/// Surfaces either the [`linkat`] error or the
+/// [`fast_io::hard_link`](crate::hard_link) error verbatim, depending
+/// on which path was taken.
+pub fn linkat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    leader_path: &Path,
+    dest_dir: &Path,
+    new_relative: &Path,
+    new_path: &Path,
+) -> io::Result<()> {
+    if let Some(sandbox) = sandbox
+        && let Some(new_leaf) = single_component_leaf(dest_dir, new_relative, new_path)
+    {
+        // The leader endpoint is intentionally resolved against
+        // `AT_FDCWD`: SEC-1.h scopes the sandbox cutover to the
+        // receiver-managed destination parent, and the leader may
+        // live outside it. `BorrowedFd::borrow_raw(AT_FDCWD)` keeps
+        // the call shape uniform without inventing a new helper.
+        let leader_c = CString::new(leader_path.as_os_str().as_bytes())
+            .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+        let new_c = CString::new(new_leaf.as_bytes())
+            .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+        // SAFETY:
+        // - `sandbox.current_dirfd()` outlives the syscall.
+        // - Both C strings are valid NUL-terminated and borrowed for
+        //   the duration of the call.
+        // - `flags == 0` matches the standard rsync hardlink shape.
+        #[allow(unsafe_code)]
+        let rc = unsafe {
+            libc::linkat(
+                libc::AT_FDCWD,
+                leader_c.as_ptr(),
+                sandbox.current_dirfd().as_raw_fd(),
+                new_c.as_ptr(),
+                0,
+            )
+        };
+        return if rc == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        };
+    }
+    crate::hard_link(leader_path, new_path)
 }
 
 #[cfg(test)]

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -79,7 +79,9 @@ pub mod at_syscalls;
 mod tests;
 
 pub use at_syscalls::{
-    AtMetadata, LstatOutcome, UnlinkFlags, fstatat_nofollow, lstat_via_sandbox_or_fallback,
+    AtMetadata, LstatOutcome, UnlinkFlags, fstatat_nofollow, linkat,
+    linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
     unlink_via_sandbox_or_fallback, unlinkat,
 };
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -225,8 +225,10 @@ pub use traits::{FileReader, FileWriter};
 
 #[cfg(unix)]
 pub use dir_sandbox::{
-    AtMetadata, DirSandbox, LstatOutcome, UnlinkFlags, fstatat_nofollow,
-    lstat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
+    AtMetadata, DirSandbox, LstatOutcome, UnlinkFlags, fstatat_nofollow, linkat,
+    linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
+    unlink_via_sandbox_or_fallback, unlinkat,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -37,6 +37,7 @@ impl ReceiverContext {
         dest_dir: &Path,
         metadata_opts: &MetadataOptions,
         acl_cache: Option<&AclCache>,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> io::Result<Vec<(PathBuf, String)>> {
         // upstream: receiver.c:693 - dry_run skips all filesystem modifications
         if self.config.flags.dry_run {
@@ -46,7 +47,7 @@ impl ReceiverContext {
         // upstream: generator.c:1261-1262 - check_filter(&daemon_filter_list, ...)
         // skips daemon-excluded directories before creation.
         let daemon_filters = self.daemon_filter_set();
-        let dir_entries: Vec<(usize, PathBuf)> = self
+        let dir_entries: Vec<(usize, PathBuf, PathBuf)> = self
             .file_list
             .iter()
             .enumerate()
@@ -61,13 +62,13 @@ impl ReceiverContext {
                 true
             })
             .map(|(idx, entry)| {
-                let relative_path = entry.path();
+                let relative_path = entry.path().to_path_buf();
                 let dir_path = if relative_path.as_os_str() == "." {
                     dest_dir.to_path_buf()
                 } else {
-                    dest_dir.join(relative_path)
+                    dest_dir.join(&relative_path)
                 };
-                (idx, dir_path)
+                (idx, relative_path, dir_path)
             })
             .collect();
 
@@ -89,7 +90,10 @@ impl ReceiverContext {
         ))]
         let mut probed_parents: std::collections::HashSet<PathBuf> =
             std::collections::HashSet::new();
-        for (_, dir_path) in &dir_entries {
+        for (_, relative_path, dir_path) in &dir_entries {
+            // `relative_path` is only read on Unix (mkdirat fast path).
+            #[cfg(not(unix))]
+            let _ = relative_path;
             if !dir_path.exists() {
                 #[cfg(all(
                     feature = "acl",
@@ -105,7 +109,36 @@ impl ReceiverContext {
                         }
                     }
                 }
-                if let Err(e) = fs::create_dir_all(dir_path) {
+                // SEC-1.h: when the sandbox is plumbed and the new dir
+                // is a single-component leaf under the sandbox root,
+                // route through `mkdirat(dirfd, leaf, 0o777)` so a
+                // mid-syscall symlink swap on the leaf cannot redirect
+                // the create to an attacker-chosen parent. Multi-
+                // component paths fall back to `fs::create_dir_all`,
+                // which preserves the parent-walk for `--relative`
+                // shapes that `ensure_relative_parents` did not pre-
+                // create. The mode argument matches the upstream
+                // `mkdir(2)` umask-handling: pass `0o777` and let the
+                // active umask trim the bits.
+                #[cfg(unix)]
+                let create_result = fast_io::mkdirat_via_sandbox_or_fallback(
+                    sandbox,
+                    dest_dir,
+                    relative_path,
+                    dir_path,
+                    0o777,
+                )
+                .or_else(|err| {
+                    if err.kind() == io::ErrorKind::NotFound {
+                        // Multi-component path needs the parent walk.
+                        fs::create_dir_all(dir_path)
+                    } else {
+                        Err(err)
+                    }
+                });
+                #[cfg(not(unix))]
+                let create_result = fs::create_dir_all(dir_path);
+                if let Err(e) = create_result {
                     if e.kind() == io::ErrorKind::PermissionDenied {
                         // upstream: receiver.c - permission denied on mkdir is non-fatal,
                         // sets io_error and continues with remaining files.
@@ -130,8 +163,8 @@ impl ReceiverContext {
         let metadata_opts_clone = metadata_opts.clone();
         let entry_snapshots: Vec<(PathBuf, FileEntry, Option<XattrList>)> = dir_entries
             .into_iter()
-            .filter(|(_, dir_path)| !failed_dir_paths.contains(dir_path))
-            .map(|(idx, dir_path)| {
+            .filter(|(_, _, dir_path)| !failed_dir_paths.contains(dir_path))
+            .map(|(idx, _, dir_path)| {
                 let entry = &self.file_list[idx];
                 let xattr_list = self.resolve_xattr_list(entry);
                 (dir_path, entry.clone(), xattr_list)
@@ -284,6 +317,7 @@ impl ReceiverContext {
         metadata_opts: &MetadataOptions,
         failed_dirs: &mut FailedDirectories,
         acl_cache: Option<&AclCache>,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> io::Result<Option<bool>> {
         let relative_path = entry.path();
         let dir_path = if relative_path.as_os_str() == "." {
@@ -307,10 +341,35 @@ impl ReceiverContext {
             return Ok(None);
         }
 
-        // Try to create the directory
+        // Try to create the directory.
+        //
+        // SEC-1.h: when the sandbox is plumbed and the new dir is a
+        // single-component leaf under the sandbox root, route through
+        // `mkdirat(dirfd, leaf, 0o777)` so a mid-syscall symlink swap
+        // on the leaf cannot redirect the create to an attacker-chosen
+        // parent. Multi-component paths fall back to
+        // `fs::create_dir_all`, which preserves the parent-walk for
+        // `--relative` shapes.
         let is_new = !dir_path.exists();
         if is_new {
-            if let Err(e) = fs::create_dir_all(&dir_path) {
+            #[cfg(unix)]
+            let create_result = fast_io::mkdirat_via_sandbox_or_fallback(
+                sandbox,
+                dest_dir,
+                relative_path,
+                &dir_path,
+                0o777,
+            )
+            .or_else(|err| {
+                if err.kind() == io::ErrorKind::NotFound {
+                    fs::create_dir_all(&dir_path)
+                } else {
+                    Err(err)
+                }
+            });
+            #[cfg(not(unix))]
+            let create_result = fs::create_dir_all(&dir_path);
+            if let Err(e) = create_result {
                 if self.config.flags.verbose && self.config.connection.client_mode {
                     info_log!(
                         Misc,

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -128,7 +128,20 @@ impl ReceiverContext {
             }
 
             // upstream: generator.c:1591 - atomic_create() -> do_symlink()
-            if let Err(e) = std::os::unix::fs::symlink(target, &link_path) {
+            //
+            // SEC-1.h: when the sandbox is plumbed and the destination
+            // parent is the sandbox root, the create goes through
+            // `symlinkat(target, dirfd, leaf)` so a TOCTOU swap on a
+            // mid-path component cannot redirect the create to an
+            // attacker-chosen parent. Falls back to path-based
+            // `std::os::unix::fs::symlink` otherwise.
+            if let Err(e) = fast_io::symlinkat_via_sandbox_or_fallback(
+                sandbox,
+                dest_dir,
+                relative_path,
+                &link_path,
+                target,
+            ) {
                 debug_log!(
                     Recv,
                     1,
@@ -327,8 +340,30 @@ impl ReceiverContext {
                 }
 
                 // upstream: hlink.c:maybe_hard_link() -> atomic_create() -> do_link()
-                // Try io_uring LINKAT on Linux 5.15+, fall back to std::fs::hard_link.
-                if let Err(e) = fast_io::hard_link(&leader_path, &link_path) {
+                //
+                // SEC-1.h (Unix): when the sandbox is plumbed and the
+                // follower's destination parent is the sandbox root,
+                // route through `linkat(AT_FDCWD, leader, dirfd, leaf,
+                // 0)` so a mid-syscall symlink swap on the follower's
+                // parent cannot redirect the create to an
+                // attacker-chosen directory. Falls back to
+                // `fast_io::hard_link` (io_uring LINKAT on Linux 5.15+,
+                // else `std::fs::hard_link`) for the multi-component
+                // and no-sandbox cases, preserving the existing
+                // `EXDEV` / `EPERM` error semantics. Windows stays on
+                // the path-based fallback per the SEC-1.l NTFS-handle
+                // audit.
+                #[cfg(unix)]
+                let link_result = fast_io::linkat_via_sandbox_or_fallback(
+                    sandbox,
+                    &leader_path,
+                    dest_dir,
+                    relative_path,
+                    &link_path,
+                );
+                #[cfg(not(unix))]
+                let link_result = fast_io::hard_link(&leader_path, &link_path);
+                if let Err(e) = link_result {
                     debug_log!(
                         Recv,
                         1,

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -210,7 +210,15 @@ mod create_directory_incremental_tests {
         let config = test_config();
         let ctx = ReceiverContext::new(&handshake, config);
 
-        let result = ctx.create_directory_incremental(dest, &entry, &opts, &mut failed, None);
+        let result = ctx.create_directory_incremental(
+            dest,
+            &entry,
+            &opts,
+            &mut failed,
+            None,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(true)); // Returns Some(true) for new dir
@@ -232,7 +240,15 @@ mod create_directory_incremental_tests {
         let config = test_config();
         let ctx = ReceiverContext::new(&handshake, config);
 
-        let result = ctx.create_directory_incremental(dest, &entry, &opts, &mut failed, None);
+        let result = ctx.create_directory_incremental(
+            dest,
+            &entry,
+            &opts,
+            &mut failed,
+            None,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None); // Returns None for skipped
@@ -303,7 +319,15 @@ mod incremental_mode_tests {
         let config = test_config();
         let ctx = ReceiverContext::new(&handshake, config);
 
-        let result = ctx.create_directory_incremental(dest, &entry, &opts, &mut failed, None);
+        let result = ctx.create_directory_incremental(
+            dest,
+            &entry,
+            &opts,
+            &mut failed,
+            None,
+            #[cfg(unix)]
+            None,
+        );
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(true));

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -50,6 +50,8 @@ impl ReceiverContext {
             &setup.dest_dir,
             &setup.metadata_opts,
             setup.acl_cache.as_deref(),
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
         )?;
         #[cfg(unix)]
         self.create_symlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -63,6 +63,8 @@ impl ReceiverContext {
                     &setup.metadata_opts,
                     &mut failed_dirs,
                     setup.acl_cache.as_deref(),
+                    #[cfg(unix)]
+                    setup.sandbox.as_deref(),
                 )?;
                 match result {
                     Some(true) => {

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -65,8 +65,13 @@ impl ReceiverContext {
         // First pass: create directories and symlinks from file list.
         // upstream: generator.c:1317-1326 - make_path() for relative_paths
         self.ensure_relative_parents(&dest_dir);
-        let mut metadata_errors =
-            self.create_directories(&dest_dir, &metadata_opts, acl_cache.as_deref())?;
+        let mut metadata_errors = self.create_directories(
+            &dest_dir,
+            &metadata_opts,
+            acl_cache.as_deref(),
+            #[cfg(unix)]
+            sandbox.as_deref(),
+        )?;
         #[cfg(unix)]
         self.create_symlinks(&dest_dir, sandbox.as_deref(), writer);
         #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

Extends the SEC-1 dirfd-anchored carrier with the create-class siblings:

- `mkdirat(dirfd, name, mode)`
- `symlinkat(target, dirfd, name)`
- `linkat(old_dirfd, old_name, new_dirfd, new_name, 0)`
- `mkdirat_via_sandbox_or_fallback` / `symlinkat_via_sandbox_or_fallback` / `linkat_via_sandbox_or_fallback` adaptors that route a single-component leaf under the receiver's `DirSandbox` root through the `*at` variant while preserving the existing path-based fallback for multi-component paths, missing sandbox, and non-Unix targets.

Pattern source: SEC-1.g (#4671) `unlink_via_sandbox_or_fallback`.

## Receiver callers wired

- `create_symlinks` (`crates/transfer/src/receiver/directory/links.rs`) - creates symlinks via `symlinkat_via_sandbox_or_fallback`.
- `create_hardlinks` (same file) - creates follower hard links via `linkat_via_sandbox_or_fallback`. The new endpoint is anchored on the sandbox dirfd; the leader endpoint stays on `AT_FDCWD` because cross-segment hardlinks may live outside `dest_dir`. Falls back to `fast_io::hard_link` (io_uring LINKAT fast path / `std::fs::hard_link`) for multi-component / no-sandbox cases, preserving `EXDEV` / `EPERM` semantics.
- `create_directories` (`crates/transfer/src/receiver/directory/creation.rs`) - creates directories via `mkdirat_via_sandbox_or_fallback`; falls back to `fs::create_dir_all` for multi-component `--relative` shapes the parent walk did not pre-create.
- `create_directory_incremental` (same file) - same wiring for the incremental flist path.

`sandbox` is plumbed through both directory-creation entry points under `#[cfg(unix)]`, matching the SEC-1.g pattern.

## mknodat status

Deferred. Device/FIFO/socket creation is wrapped by the `metadata` crate (`create_device_node_with_fake_super`, `create_fifo_with_fake_super`, `apple_fs::mknod`) and used by the local-copy executor; the receiver pipeline reaches those paths via several abstraction layers that need a deeper refactor before the sandbox can be threaded through. Receiver-side mknod is not on the daemon-reachable TOCTOU surface that SEC-1 targets today, so the cutover is left as follow-up.

## Cross-platform

- Linux + macOS: `*at` libc syscalls are POSIX-2008, present on every supported Unix target.
- Windows: falls through to path-based stdlib per the SEC-1.l audit (NTFS uses handle-based APIs that sidestep path TOCTOU). `DirSandbox` and all `*at` helpers remain `#[cfg(unix)]`; the call sites switch on `#[cfg(unix)]` to keep the build green.

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable + Linux musl + macOS + Windows)
- [ ] Interop validation against upstream 3.4.1 / 3.4.2 (symlink, hardlink, directory tree shapes)
- [ ] SEC-1.m / SEC-1.n swap-resistance test PRs (in flight) exercise the new helpers under TOCTOU attack