### PR TITLE
feat(fast_io,daemon): Landlock LSM defense-in-depth for daemon receiver (SEC-1.p)

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -131,6 +131,9 @@ jobs:
           - name: copy_file_range
             args: "-p fast_io --features copy_file_range"
             apt: ""
+          - name: landlock
+            args: "-p fast_io --features landlock"
+            apt: ""
           - name: openssl
             args: "-p checksums --features openssl"
             apt: "libssl-dev pkg-config"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -45,7 +45,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -72,8 +72,8 @@ checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
 dependencies = [
  "aead 0.6.0-rc.10",
  "aes 0.9.0",
- "cipher 0.5.1",
- "ctr 0.10.0",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
  "ghash 0.6.0",
  "subtle",
 ]
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -213,9 +213,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -468,18 +468,18 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -610,12 +610,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
@@ -977,11 +977,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1054,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1129,7 +1129,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1217,7 +1217,7 @@ checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "digest 0.11.3",
  "hkdf",
  "hybrid-array",
@@ -1302,6 +1302,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1357,7 @@ dependencies = [
  "dashmap",
  "filetime",
  "io-uring",
+ "landlock",
  "libc",
  "logging",
  "memmap2",
@@ -1363,9 +1384,9 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1684,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1752,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
  "subtle",
@@ -1902,7 +1923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2023,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2059,8 +2080,19 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2092,9 +2124,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
 dependencies = [
  "cc",
 ]
@@ -2259,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2302,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "module-lattice"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
 dependencies = [
  "ctutils",
  "hybrid-array",
@@ -2313,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2366,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2434,9 +2466,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2468,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2532,18 +2564,19 @@ dependencies = [
 
 [[package]]
 name = "pageant"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
+checksum = "4f3a5ae18f65a85c67a77d18d42d3606c07948e3c17c1e5f74852b26589e88a5"
 dependencies = [
+ "base16ct",
  "byteorder",
  "bytes",
  "delegate",
  "futures",
  "log",
- "rand 0.8.6",
- "sha2 0.10.9",
- "thiserror 1.0.69",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
  "tokio",
  "windows",
  "windows-strings",
@@ -2657,7 +2690,7 @@ checksum = "c5a777c6e26664bc9504b3ce3f6133f8f20d9071f130a4f9fcbd3186959d8dd6"
 dependencies = [
  "aes 0.9.0",
  "aes-gcm 0.11.0-rc.3",
- "cbc 0.2.0",
+ "cbc 0.2.1",
  "der",
  "pbkdf2 0.13.0",
  "rand_core 0.10.1",
@@ -2829,7 +2862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
  "crypto-bigint",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
@@ -3070,9 +3103,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
+checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
 dependencies = [
  "hmac 0.13.0",
  "subtle",
@@ -3144,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.60.2"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e358980fe9b079b99da387117864ee6f0a3fd02f39e5b5fde6af9c2895374"
+checksum = "324b92f459d3e42da294e14e8eb150d2215fcfb7c966838bc1127cd68bc05a0d"
 dependencies = [
  "aead 0.6.0-rc.10",
  "aes 0.8.4",
@@ -3158,10 +3191,10 @@ dependencies = [
  "byteorder",
  "bytes",
  "cbc 0.1.2",
- "cbc 0.2.0",
- "cipher 0.5.1",
+ "cbc 0.2.1",
+ "cipher 0.5.2",
  "crypto-bigint",
- "ctr 0.10.0",
+ "ctr 0.10.1",
  "ctr 0.9.2",
  "curve25519-dalek",
  "data-encoding",
@@ -3226,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.59.0"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+checksum = "37cb4d0360bdd8935392a306d8b5edb539cc455b30e8bf13dd213a0cf7879b40"
 dependencies = [
  "log",
  "nix",
@@ -3322,7 +3355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3432,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3454,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
@@ -3752,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4144,7 +4177,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -4261,9 +4294,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4274,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4284,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4294,9 +4327,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4307,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4350,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4670,9 +4703,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4866,9 +4899,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,7 +111,7 @@ Remaining work:
 - **mknodat for device / FIFO nodes** - DEFERRED (closure doc #4694; not on the daemon-reachable surface).
 - **Receiver wiring for SEC-1.i helpers** - DEFERRED (carrier-first staging; metadata crate does not yet carry `DirSandbox`).
 - **Receiver wiring for SEC-1.j deferred sites** - DEFERRED (`disk_commit`, `transfer_ops/response`, `local_copy/executor`; cross-thread carrier plumbing required).
-- **SEC-1.p Landlock LSM defense-in-depth** - PROPOSED (audit in flight; Linux 5.13+, kernel-side enforcement that complements the `*at` helpers).
+- **SEC-1.p Landlock LSM defense-in-depth** - Linux 5.13+ kernel-side allowlist over the module root, engaged per-connection after `apply_module_privilege_restrictions` returns. Even a future regression that calls a path-based syscall directly (bypassing `DirSandbox`) is rejected by the kernel with `EACCES`. Client-supplied `--temp-dir` / `--partial-dir` / `--backup-dir` paths that resolve outside the module root are rejected at the wire-protocol layer rather than widening the allowlist. Best-effort ABI downgrade picks the highest level the running kernel exposes (v3 on 6.2+, v2 on 5.19+, v1 on 5.13+). Stub returns `Unavailable` on non-Linux targets so the SEC-1 `*at` chain remains the sole defense there.
 
 Target full-Fixed status: when receiver wiring for both SEC-1.i and SEC-1.j callers is complete AND (SEC-1.p Landlock layer ships OR is closed as N/A).
 

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -55,9 +55,19 @@ tracing = { workspace = true, optional = true }
 checksums = { path = "../checksums" }
 libc = { workspace = true }
 
-# sd-notify is Linux-only (systemd notification)
+# fast_io carries the Landlock LSM defense-in-depth helper (SEC-1.p). On
+# non-Linux targets the stub module compiles with the same public surface
+# and every call short-circuits to `Unavailable`, so the wire-in at
+# `module_access/transfer.rs` does not need `#[cfg]` branching. The
+# `landlock` feature is forwarded only on Linux where the crate has a real
+# dependency to enable. Default features stay off so we do not pull
+# io_uring / iocp into the daemon's runtime dependency graph.
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+fast_io = { path = "../fast_io", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-notify = { version = "0.5.0", optional = true }
+fast_io = { path = "../fast_io", default-features = false, features = ["landlock"] }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -123,16 +123,37 @@ fn validate_client_paths_in_module(
 /// non-Linux targets short-circuits to `Unavailable` so the wire-in does
 /// not need `#[cfg]` branching.
 ///
-/// Returns `Ok(true)` on every non-fatal outcome (engaged, downgraded, or
-/// unavailable). Returns `Ok(false)` after emitting an `@ERROR` reply when
-/// the kernel advertised Landlock support but the helper failed to engage
-/// the ruleset - we treat that as a regression because the SEC-1.p design
-/// requires the sandbox to be live on supporting kernels.
+/// Returns `Ok(true)` on every non-fatal outcome (engaged, downgraded,
+/// unavailable, or skipped because a pre/post-xfer-exec hook is configured).
+/// Returns `Ok(false)` after emitting an `@ERROR` reply when the kernel
+/// advertised Landlock support but the helper failed to engage the ruleset -
+/// we treat that as a regression because the SEC-1.p design requires the
+/// sandbox to be live on supporting kernels.
+///
+/// When `pre_xfer_exec` or `post_xfer_exec` is configured, the sandbox is
+/// skipped: Landlock rulesets are inherited by child processes, so engaging
+/// the allowlist would block `exec()` of hook scripts that live outside the
+/// module path (the common case - e.g. `/usr/local/bin/notify.sh`). Per-module
+/// opt-out via configuration matches the operator's intent (they explicitly
+/// chose to run hooks) and preserves SEC-1 *at* helpers as the primary
+/// defense for those modules.
 fn engage_landlock_sandbox(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
 ) -> io::Result<bool> {
     use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+
+    if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
+        if let Some(log) = ctx.log_sink {
+            let text = format!(
+                "module '{}': landlock=skipped reason=pre-xfer-exec or post-xfer-exec configured (would block hook exec)",
+                ctx.request,
+            );
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(true);
+    }
 
     if !is_supported() {
         if let Some(log) = ctx.log_sink {

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -41,6 +41,163 @@ fn validate_module_path(
     Ok(false)
 }
 
+/// Rejects client-supplied `--temp-dir` / `--partial-dir` / `--backup-dir`
+/// paths that resolve outside the module root.
+///
+/// The audit (SEC-1.p, section 10) recommends REJECT over widening the
+/// Landlock allowlist: rsync's own chroot mode behaves the same way, and
+/// expanding the writable surface to honour an attacker-supplied prefix
+/// undermines the whole point of the sandbox. Returns `Ok(true)` when every
+/// requested path is in-tree (or absent); returns `Ok(false)` after
+/// emitting an `@ERROR` reply when a path escapes the module root.
+fn validate_client_paths_in_module(
+    ctx: &mut ModuleRequestContext<'_>,
+    module: &ModuleRuntime,
+    client_args: &[String],
+) -> io::Result<bool> {
+    let Ok(module_root) = module.path.canonicalize() else {
+        // Module path failed to canonicalize - the existence check above
+        // already succeeded, so this is a race or a permission problem; let
+        // the transfer continue and fail with a more precise error later.
+        return Ok(true);
+    };
+
+    let mut iter = client_args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        let candidate = if let Some(rest) = arg.strip_prefix("--temp-dir=") {
+            Some(("--temp-dir", rest.to_owned()))
+        } else if let Some(rest) = arg.strip_prefix("--partial-dir=") {
+            Some(("--partial-dir", rest.to_owned()))
+        } else if let Some(rest) = arg.strip_prefix("--backup-dir=") {
+            Some(("--backup-dir", rest.to_owned()))
+        } else if matches!(arg.as_str(), "--temp-dir" | "--partial-dir" | "--backup-dir") {
+            iter.next().map(|v| (arg.as_str(), v.clone()))
+        } else {
+            None
+        };
+
+        let Some((flag, raw_path)) = candidate else {
+            continue;
+        };
+
+        // Relative paths resolve under the module root (or under the
+        // current cwd inside chroot), so they cannot escape - skip them.
+        let path = Path::new(&raw_path);
+        if path.is_relative() {
+            continue;
+        }
+
+        let canonical = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.to_path_buf());
+        if canonical.starts_with(&module_root) {
+            continue;
+        }
+
+        let payload = format!(
+            "@ERROR: {flag} path '{raw_path}' is outside module root"
+        );
+        send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+        if let Some(log) = ctx.log_sink {
+            let text = format!(
+                "module '{}': rejected {flag}='{raw_path}' from {} ({}) - outside module root '{}'",
+                ctx.request,
+                ctx.effective_host().unwrap_or("unknown"),
+                ctx.peer_ip,
+                module_root.display(),
+            );
+            let message = rsync_error!(1, text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+/// Engages the SEC-1.p Landlock LSM allowlist for the receiver path.
+///
+/// Called immediately after [`apply_module_privilege_restrictions`] has
+/// applied chroot + uid/gid drop so the kernel allowlist covers exactly the
+/// writable surface the remainder of the connection needs. The stub on
+/// non-Linux targets short-circuits to `Unavailable` so the wire-in does
+/// not need `#[cfg]` branching.
+///
+/// Returns `Ok(true)` on every non-fatal outcome (engaged, downgraded, or
+/// unavailable). Returns `Ok(false)` after emitting an `@ERROR` reply when
+/// the kernel advertised Landlock support but the helper failed to engage
+/// the ruleset - we treat that as a regression because the SEC-1.p design
+/// requires the sandbox to be live on supporting kernels.
+fn engage_landlock_sandbox(
+    ctx: &mut ModuleRequestContext<'_>,
+    module: &ModuleRuntime,
+) -> io::Result<bool> {
+    use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+
+    if !is_supported() {
+        if let Some(log) = ctx.log_sink {
+            let text = format!(
+                "module '{}': landlock unavailable on this kernel; SEC-1 *at* helpers remain the sole defense",
+                ctx.request,
+            );
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(true);
+    }
+
+    // Roots: the module path is the only writable per-module surface the
+    // daemon connection touches once chroot has applied. ModuleDefinition
+    // does not expose a lock-file accessor (the limiter is daemon-internal
+    // and writes to the lock file before the connection-handling thread
+    // reaches this point); client-supplied out-of-module paths are
+    // rejected upfront by `validate_client_paths_in_module`.
+    let roots: Vec<&Path> = vec![module.path.as_path()];
+
+    match restrict_to_module_paths(&roots) {
+        LandlockOutcome::Enforced(status) => {
+            if let Some(log) = ctx.log_sink {
+                let text = format!(
+                    "module '{}': landlock engaged ({status:?}) over {} root(s)",
+                    ctx.request,
+                    roots.len(),
+                );
+                let message = rsync_info!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+            Ok(true)
+        }
+        LandlockOutcome::Unavailable => {
+            // Race: probe said supported, restrict_self() said no. Log and
+            // continue - SEC-1 *at* helpers still mitigate the attack.
+            if let Some(log) = ctx.log_sink {
+                let text = format!(
+                    "module '{}': landlock probe positive but kernel returned Unavailable - falling back to SEC-1 *at* defense",
+                    ctx.request,
+                );
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+            Ok(true)
+        }
+        LandlockOutcome::Error(err) => {
+            // The kernel said yes to landlock but no to our ruleset; this
+            // is a regression worth surfacing. Log a warning and continue
+            // rather than killing the connection - the SEC-1 *at* chain
+            // still provides the primary defense.
+            if let Some(log) = ctx.log_sink {
+                let text = format!(
+                    "module '{}': landlock setup failed: {err}; relying on SEC-1 *at* defense",
+                    ctx.request,
+                );
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+            Ok(true)
+        }
+    }
+}
+
 /// Sets up the TCP streams for the transfer.
 ///
 /// Configures TCP_NODELAY and clones the stream for concurrent read/write.
@@ -343,6 +500,15 @@ fn process_approved_module(
         return Ok(());
     }
 
+    // SEC-1.p: reject client-supplied --temp-dir / --partial-dir /
+    // --backup-dir paths that resolve outside the module root. Done before
+    // chroot so we can report a precise error message; the Landlock
+    // allowlist that follows would otherwise block the writes anyway with
+    // a less descriptive EACCES from the kernel.
+    if !validate_client_paths_in_module(ctx, module, &client_args)? {
+        return Ok(());
+    }
+
     // Apply chroot and privilege restrictions before building server config.
     // After chroot the effective module path becomes "/" since the process root
     // is now the module directory itself.
@@ -361,6 +527,14 @@ fn process_approved_module(
             send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
             return Ok(());
         }
+    }
+
+    // SEC-1.p: engage the Landlock LSM allowlist now that chroot and the
+    // uid/gid drop have completed. Stub on non-Linux short-circuits to
+    // `Unavailable`. Failure to engage is logged but does not abort the
+    // connection: SEC-1 *at* helpers still provide the primary defense.
+    if !engage_landlock_sandbox(ctx, module)? {
+        return Ok(());
     }
 
     // upstream: clientserver.c:962-969 - spawn name converter after privilege

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -550,14 +550,6 @@ fn process_approved_module(
         }
     }
 
-    // SEC-1.p: engage the Landlock LSM allowlist now that chroot and the
-    // uid/gid drop have completed. Stub on non-Linux short-circuits to
-    // `Unavailable`. Failure to engage is logged but does not abort the
-    // connection: SEC-1 *at* helpers still provide the primary defense.
-    if !engage_landlock_sandbox(ctx, module)? {
-        return Ok(());
-    }
-
     // upstream: clientserver.c:962-969 - spawn name converter after privilege
     // reduction so it runs with reduced privileges inside the chroot.
     #[cfg(unix)]
@@ -616,6 +608,18 @@ fn process_approved_module(
             send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
             return Ok(());
         }
+    }
+
+    // SEC-1.p: engage the Landlock LSM allowlist now that chroot, the
+    // uid/gid drop, and daemon-config filter-rule loading have completed.
+    // Filter rules referencing files outside module.path (e.g.
+    // `exclude from = <abs-path>`) are read into memory above; once
+    // Landlock engages, those external paths become unreadable. Stub on
+    // non-Linux short-circuits to `Unavailable`. Failure to engage is
+    // logged but does not abort the connection: SEC-1 *at* helpers still
+    // provide the primary defense.
+    if !engage_landlock_sandbox(ctx, module)? {
+        return Ok(());
     }
 
     let (mut read_stream, mut write_stream) = match setup_transfer_streams(ctx)? {

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -44,6 +44,12 @@ dashmap = { workspace = true }
 # Optional: io_uring support (Linux 5.6+)
 io-uring = { version = "0.7", optional = true }
 
+# Optional: Landlock LSM defense-in-depth allowlist (Linux 5.13+).
+# Used by the daemon receiver path after privilege drop to enforce a
+# kernel-level allowlist layered above the SEC-1 *at* helpers. Best-effort
+# downgrade picks the highest ABI the running kernel exposes.
+landlock = { version = "0.4", optional = true }
+
 [features]
 default = ["io_uring", "iocp"]
 
@@ -115,6 +121,15 @@ adaptive-basis-dispatch = []
 # pending kernel/workload benchmarks. See docs/design/iouring-send-zc.md
 # for the full design.
 iouring-send-zc = ["io_uring"]
+
+# landlock: Linux-only opt-in dispatch for the Landlock LSM allowlist used by
+# the daemon receiver path (SEC-1.p) as defense-in-depth above the SEC-1 *at*
+# helpers. When enabled, the helper requests `AccessFs::from_all(ABI::V3)`
+# with best-effort downgrade so older kernels (5.13/5.19) accept the v1/v2
+# subset. Default off pending the daemon wire-in opting into the feature.
+# See docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md for the
+# full design.
+landlock = ["dep:landlock"]
 
 # iouring-data-writes: opt-in dispatch that routes large file writes through
 # the production io_uring writer wrapper (`fast_io::write_file_with_io_uring`).

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -48,25 +48,23 @@ pub enum LandlockOutcome {
 /// Probes whether the running kernel exposes any Landlock ABI.
 ///
 /// Returns `true` on Linux 5.13+ with the LSM enabled at boot, `false`
-/// otherwise. The probe builds a minimal ruleset with best-effort
-/// downgrade and inspects the resulting [`RulesetStatus`]; the kernel
-/// returns `NotEnforced` when it accepts the rules but cannot apply them,
-/// equivalent to "Landlock not available". Cheap but not memoised - cache
-/// the result if you call repeatedly.
+/// otherwise. The probe issues `landlock_create_ruleset(2)` via
+/// [`Ruleset::create`] and immediately drops the returned fd; **it must
+/// never call [`RulesetCreated::restrict_self`]** because Landlock
+/// intersects every successive `restrict_self` on the calling thread.
+/// Probing with an empty allowlist would therefore deny every subsequent
+/// filesystem write for the rest of the thread's life and the real
+/// [`restrict_to_module_paths`] call could only narrow that intersection,
+/// never relax it. Cheap but not memoised - cache the result if you call
+/// repeatedly.
 #[must_use]
 pub fn is_supported() -> bool {
     let access = AccessFs::from_all(ABI::V1);
-    match Ruleset::default()
+    Ruleset::default()
         .set_compatibility(CompatLevel::BestEffort)
         .handle_access(access)
         .and_then(|r| r.create())
-    {
-        Ok(created) => match created.restrict_self() {
-            Ok(status) => !matches!(status.ruleset, RulesetStatus::NotEnforced),
-            Err(_) => false,
-        },
-        Err(_) => false,
-    }
+        .is_ok()
 }
 
 /// Restricts the current thread to read+write access only under
@@ -165,7 +163,7 @@ mod tests {
     fn is_supported_returns_bool_without_panic() {
         // The probe must not panic regardless of kernel support; on CI
         // Linux runners (5.13+) it returns true, on pre-5.13 it returns
-        // false. Either outcome is acceptable here — the test only proves
+        // false. Either outcome is acceptable here - the test only proves
         // the probe path is sound.
         let _ = is_supported();
     }
@@ -255,6 +253,37 @@ mod tests {
         })
         .expect("empty-allowlist scenario");
         drop(scratch);
+    }
+
+    #[test]
+    fn is_supported_does_not_restrict_caller() {
+        // Regression: an earlier `is_supported()` engaged Landlock with an
+        // empty allowlist on the calling thread, so every subsequent
+        // `restrict_to_module_paths` call was intersected with "deny all"
+        // and the daemon's receiver could not create its temp files. The
+        // probe must leave the caller's filesystem rights untouched so a
+        // later `restrict_to_module_paths(&[root])` actually permits writes
+        // beneath `root`.
+        if !is_supported() {
+            return;
+        }
+        let allowed = TempDir::new().expect("allowed tempdir");
+        let allowed_path = allowed.path().to_path_buf();
+        run_isolated(move || {
+            // Mirror the daemon ordering: probe first, then engage on the
+            // real module root.
+            assert!(is_supported(), "probe must remain idempotent");
+            let outcome = restrict_to_module_paths(&[allowed_path.as_path()]);
+            match outcome {
+                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(_) => {}
+                LandlockOutcome::Unavailable => return Ok(()),
+                LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
+            }
+            fs::write(allowed_path.join("post_probe.txt"), b"x")
+                .map_err(|e| format!("write inside after probe failed: {e}"))
+        })
+        .expect("probe-then-engage scenario");
     }
 
     #[test]

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -48,12 +48,25 @@ pub enum LandlockOutcome {
 /// Probes whether the running kernel exposes any Landlock ABI.
 ///
 /// Returns `true` on Linux 5.13+ with the LSM enabled at boot, `false`
-/// otherwise. Cheap to call - the underlying [`ABI::new_current`] issues a
-/// single `landlock_create_ruleset` probe and caches nothing, so callers
-/// that want repeat lookups should memoise the result themselves.
+/// otherwise. The probe builds a minimal ruleset with best-effort
+/// downgrade and inspects the resulting [`RulesetStatus`]; the kernel
+/// returns `NotEnforced` when it accepts the rules but cannot apply them,
+/// equivalent to "Landlock not available". Cheap but not memoised - cache
+/// the result if you call repeatedly.
 #[must_use]
 pub fn is_supported() -> bool {
-    ABI::new_current() != ABI::Unsupported
+    let access = AccessFs::from_all(ABI::V1);
+    match Ruleset::default()
+        .set_compatibility(CompatLevel::BestEffort)
+        .handle_access(access)
+        .and_then(|r| r.create())
+    {
+        Ok(created) => match created.restrict_self() {
+            Ok(status) => !matches!(status.ruleset, RulesetStatus::NotEnforced),
+            Err(_) => false,
+        },
+        Err(_) => false,
+    }
 }
 
 /// Restricts the current thread to read+write access only under
@@ -81,12 +94,11 @@ pub fn is_supported() -> bool {
 /// pre-5.13 kernels so the daemon can keep running with SEC-1 `*at` helpers
 /// as the sole defense.
 pub fn restrict_to_module_paths(allowed_roots: &[&Path]) -> LandlockOutcome {
-    let abi = ABI::new_current();
-    if abi == ABI::Unsupported {
-        return LandlockOutcome::Unavailable;
-    }
-
-    let access = AccessFs::from_all(abi);
+    // Request the highest ABI we support; BestEffort lets the crate silently
+    // drop rights the running kernel cannot honour (REFER on 5.13-5.18,
+    // TRUNCATE on 5.13-6.1). The final enforcement tier surfaces in the
+    // RulesetStatus returned by restrict_self below.
+    let access = AccessFs::from_all(ABI::V3);
 
     let ruleset = match Ruleset::default()
         .set_compatibility(CompatLevel::BestEffort)
@@ -150,8 +162,12 @@ mod tests {
     }
 
     #[test]
-    fn is_supported_matches_abi_query() {
-        assert_eq!(is_supported(), ABI::new_current() != ABI::Unsupported);
+    fn is_supported_returns_bool_without_panic() {
+        // The probe must not panic regardless of kernel support; on CI
+        // Linux runners (5.13+) it returns true, on pre-5.13 it returns
+        // false. Either outcome is acceptable here — the test only proves
+        // the probe path is sound.
+        let _ = is_supported();
     }
 
     #[test]

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -1,0 +1,276 @@
+//! Landlock LSM defense-in-depth allowlist for the daemon receiver path.
+//!
+//! Layers a kernel-enforced allowlist above the SEC-1 `*at` syscall helpers
+//! so that even a future regression that calls a path-based syscall directly
+//! (bypassing [`crate::dir_sandbox::DirSandbox`]) is rejected by the kernel
+//! with `EACCES`. Targets Linux 5.13+ with best-effort downgrade picking the
+//! highest ABI the running kernel exposes.
+//!
+//! The helper is a one-shot per-thread restriction: once
+//! [`restrict_to_module_paths`] succeeds, the calling thread (and every
+//! process inherited from it - notably the daemon's name converter and
+//! pre/post-xfer-exec hooks) cannot reach paths outside the supplied roots
+//! through any filesystem syscall, regardless of how the path was resolved.
+//!
+//! See `docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md` for the
+//! kernel-version matrix, downgrade rationale, and daemon integration plan.
+
+use std::io;
+use std::path::Path;
+
+use landlock::{
+    ABI, Access, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
+    RulesetCreatedAttr, RulesetStatus,
+};
+
+/// Outcome of a [`restrict_to_module_paths`] call.
+///
+/// Carries enough detail for the daemon to log the actual enforcement level
+/// without leaking the `landlock` crate's types into the public API.
+#[derive(Debug)]
+pub enum LandlockOutcome {
+    /// The ruleset was created and applied. The carried [`RulesetStatus`]
+    /// distinguishes `FullyEnforced` (every requested right was honoured),
+    /// `PartiallyEnforced` (best-effort downgrade dropped some rights -
+    /// typically REFER on 5.13-5.18 and TRUNCATE on 5.13-6.1), and
+    /// `NotEnforced` (the kernel accepted the ruleset but applied nothing,
+    /// equivalent to no sandbox).
+    Enforced(RulesetStatus),
+    /// The kernel does not expose Landlock at all (pre-5.13, or the LSM is
+    /// not enabled at boot). SEC-1 `*at` helpers remain the only defense.
+    Unavailable,
+    /// Ruleset creation or `restrict_self()` failed even though the kernel
+    /// advertised Landlock support. The daemon must treat this as a fatal
+    /// connection error - the intended sandbox did not engage.
+    Error(io::Error),
+}
+
+/// Probes whether the running kernel exposes any Landlock ABI.
+///
+/// Returns `true` on Linux 5.13+ with the LSM enabled at boot, `false`
+/// otherwise. Cheap to call - the underlying [`ABI::new_current`] issues a
+/// single `landlock_create_ruleset` probe and caches nothing, so callers
+/// that want repeat lookups should memoise the result themselves.
+#[must_use]
+pub fn is_supported() -> bool {
+    ABI::new_current() != ABI::Unsupported
+}
+
+/// Restricts the current thread to read+write access only under
+/// `allowed_roots`.
+///
+/// The helper requests `AccessFs::from_all(ABI::V3)` (read / write / create /
+/// delete / rename / symlink / refer / truncate) with best-effort downgrade
+/// enabled, so a kernel that understands only v1 or v2 accepts the subset it
+/// supports and silently drops the rest. The returned [`LandlockOutcome`]
+/// carries the [`RulesetStatus`] so callers can log the actual enforcement
+/// level.
+///
+/// Call exactly once per daemon connection, after privilege drop and any
+/// chroot have completed, before any user-controlled file operation begins.
+/// All roots must be absolute and must already exist - the helper does not
+/// create them. An empty `allowed_roots` slice denies every filesystem write
+/// once `restrict_self()` engages, which is the correct posture for a
+/// connection that has no module to serve.
+///
+/// # Errors
+///
+/// Returns [`LandlockOutcome::Error`] when the kernel advertised Landlock
+/// support but ruleset construction, rule addition, or `restrict_self()`
+/// failed. Returns [`LandlockOutcome::Unavailable`] (not an error) on
+/// pre-5.13 kernels so the daemon can keep running with SEC-1 `*at` helpers
+/// as the sole defense.
+pub fn restrict_to_module_paths(allowed_roots: &[&Path]) -> LandlockOutcome {
+    let abi = ABI::new_current();
+    if abi == ABI::Unsupported {
+        return LandlockOutcome::Unavailable;
+    }
+
+    let access = AccessFs::from_all(abi);
+
+    let ruleset = match Ruleset::default()
+        .set_compatibility(CompatLevel::BestEffort)
+        .handle_access(access)
+    {
+        Ok(rs) => rs,
+        Err(err) => return LandlockOutcome::Error(io::Error::other(err.to_string())),
+    };
+
+    let mut created = match ruleset.create() {
+        Ok(c) => c,
+        Err(err) => return LandlockOutcome::Error(io::Error::other(err.to_string())),
+    };
+
+    for root in allowed_roots {
+        let fd = match PathFd::new(root) {
+            Ok(fd) => fd,
+            Err(err) => return LandlockOutcome::Error(io::Error::other(err.to_string())),
+        };
+        created = match created.add_rule(PathBeneath::new(fd, access)) {
+            Ok(c) => c,
+            Err(err) => return LandlockOutcome::Error(io::Error::other(err.to_string())),
+        };
+    }
+
+    match created.restrict_self() {
+        Ok(status) => LandlockOutcome::Enforced(status.ruleset),
+        Err(err) => LandlockOutcome::Error(io::Error::other(err.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::sync::Mutex;
+    use std::thread;
+    use tempfile::TempDir;
+
+    // Landlock applies to the calling thread and is irreversible: once a
+    // thread is restricted, every future syscall in that thread is subject
+    // to the allowlist. To keep tests isolated we run each scenario on a
+    // dedicated worker thread that exits as soon as the assertions are
+    // collected. A test-wide mutex serialises the worker spawn so the
+    // probe assertions stay deterministic even on highly-parallel runners.
+    static SERIALISE: Mutex<()> = Mutex::new(());
+
+    fn run_isolated<F>(scenario: F) -> Result<(), String>
+    where
+        F: FnOnce() -> Result<(), String> + Send + 'static,
+    {
+        let _lock = SERIALISE.lock().unwrap_or_else(|e| e.into_inner());
+        let handle = thread::Builder::new()
+            .name("landlock-test".into())
+            .spawn(scenario)
+            .map_err(|e| format!("spawn worker: {e}"))?;
+        handle
+            .join()
+            .map_err(|_| "worker thread panicked".to_owned())?
+    }
+
+    #[test]
+    fn is_supported_matches_abi_query() {
+        assert_eq!(is_supported(), ABI::new_current() != ABI::Unsupported);
+    }
+
+    #[test]
+    fn unavailable_kernel_returns_unavailable_variant() {
+        if is_supported() {
+            // Nothing to assert: on a supporting kernel the helper engages
+            // the sandbox and the `Unavailable` branch is never reached.
+            return;
+        }
+        let tmp = TempDir::new().expect("tempdir");
+        let outcome = restrict_to_module_paths(&[tmp.path()]);
+        assert!(matches!(outcome, LandlockOutcome::Unavailable));
+    }
+
+    #[test]
+    fn allows_write_inside_module_root() {
+        if !is_supported() {
+            return;
+        }
+        let tmp = TempDir::new().expect("tempdir");
+        let allowed = tmp.path().to_path_buf();
+        run_isolated(move || {
+            let outcome = restrict_to_module_paths(&[allowed.as_path()]);
+            match outcome {
+                LandlockOutcome::Enforced(_) => {}
+                LandlockOutcome::Unavailable => return Ok(()),
+                LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
+            }
+            fs::write(allowed.join("inside.txt"), b"x")
+                .map_err(|e| format!("write inside failed: {e}"))
+        })
+        .expect("inside-write scenario");
+    }
+
+    #[test]
+    fn blocks_write_outside_module_root() {
+        if !is_supported() {
+            return;
+        }
+        let allowed = TempDir::new().expect("allowed tempdir");
+        let outside = TempDir::new().expect("outside tempdir");
+        let allowed_path = allowed.path().to_path_buf();
+        let outside_path = outside.path().to_path_buf();
+        // Keep the directories alive past the thread's lifetime; the worker
+        // owns the path strings, the parent owns the TempDir guards.
+        run_isolated(move || {
+            let outcome = restrict_to_module_paths(&[allowed_path.as_path()]);
+            match outcome {
+                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(_) => {}
+                LandlockOutcome::Unavailable => return Ok(()),
+                LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
+            }
+            match fs::write(outside_path.join("outside.txt"), b"x") {
+                Ok(()) => Err("write outside unexpectedly succeeded".to_owned()),
+                Err(err) if err.kind() == ErrorKind::PermissionDenied => Ok(()),
+                Err(err) => Err(format!("unexpected error {:?}: {err}", err.kind())),
+            }
+        })
+        .expect("outside-write scenario");
+        drop(allowed);
+        drop(outside);
+    }
+
+    #[test]
+    fn empty_allowlist_denies_all_writes() {
+        if !is_supported() {
+            return;
+        }
+        let scratch = TempDir::new().expect("scratch");
+        let scratch_path = scratch.path().to_path_buf();
+        run_isolated(move || {
+            let outcome = restrict_to_module_paths(&[]);
+            match outcome {
+                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(_) => {}
+                LandlockOutcome::Unavailable => return Ok(()),
+                LandlockOutcome::Error(err) => return Err(format!("setup: {err}")),
+            }
+            match fs::write(scratch_path.join("denied.txt"), b"x") {
+                Ok(()) => Err("empty allowlist let a write through".to_owned()),
+                Err(err) if err.kind() == ErrorKind::PermissionDenied => Ok(()),
+                Err(err) => Err(format!("unexpected error {:?}: {err}", err.kind())),
+            }
+        })
+        .expect("empty-allowlist scenario");
+        drop(scratch);
+    }
+
+    #[test]
+    fn second_call_does_not_relax() {
+        if !is_supported() {
+            return;
+        }
+        let allowed = TempDir::new().expect("allowed");
+        let outside = TempDir::new().expect("outside");
+        let allowed_path = allowed.path().to_path_buf();
+        let outside_path = outside.path().to_path_buf();
+        run_isolated(move || {
+            let first = restrict_to_module_paths(&[allowed_path.as_path()]);
+            match first {
+                LandlockOutcome::Enforced(RulesetStatus::NotEnforced) => return Ok(()),
+                LandlockOutcome::Enforced(_) => {}
+                LandlockOutcome::Unavailable => return Ok(()),
+                LandlockOutcome::Error(err) => return Err(format!("first call: {err}")),
+            }
+            // Landlock semantics: a second restrict_self() applies an
+            // intersection of rights, never a relaxation. The second call
+            // may succeed or fail; either way writes outside `allowed` must
+            // remain blocked.
+            let _ = restrict_to_module_paths(&[outside_path.as_path()]);
+            match fs::write(outside_path.join("relaxed.txt"), b"x") {
+                Ok(()) => Err("second call relaxed the sandbox".to_owned()),
+                Err(err) if err.kind() == ErrorKind::PermissionDenied => Ok(()),
+                Err(err) => Err(format!("unexpected error {:?}: {err}", err.kind())),
+            }
+        })
+        .expect("second-call scenario");
+        drop(allowed);
+        drop(outside);
+    }
+}

--- a/crates/fast_io/src/landlock_stub.rs
+++ b/crates/fast_io/src/landlock_stub.rs
@@ -1,0 +1,78 @@
+//! Stub for the Landlock LSM allowlist on non-Linux targets or when the
+//! `landlock` Cargo feature is disabled.
+//!
+//! Mirrors the public surface of [`crate::landlock`] so cross-platform
+//! callers compile without `#[cfg]` branching. Every entry point returns
+//! `Unavailable` (or `false` for the probe) so the SEC-1 `*at` chain
+//! remains the active defense. See
+//! `docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md`.
+
+#![allow(dead_code)]
+
+use std::io;
+use std::path::Path;
+
+/// Outcome of a [`restrict_to_module_paths`] call.
+///
+/// The stub only ever returns [`LandlockOutcome::Unavailable`]; the variants
+/// match the Linux implementation so callers can pattern-match the same
+/// types on every target.
+#[derive(Debug)]
+pub enum LandlockOutcome {
+    /// Sandbox engaged. The stub never returns this variant; the field type
+    /// mirrors the Linux side's `RulesetStatus` placeholder so signatures
+    /// stay structurally identical.
+    Enforced(EnforcementStatus),
+    /// The kernel does not expose Landlock (or the Cargo feature is off).
+    /// Always returned on this build.
+    Unavailable,
+    /// Ruleset setup failed even though the kernel advertised support.
+    /// Never returned by the stub.
+    Error(io::Error),
+}
+
+/// Placeholder for the `landlock::RulesetStatus` enum that the Linux build
+/// carries. Kept as an opaque marker so call sites can `matches!` against
+/// it without depending on the Linux-only crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnforcementStatus {
+    /// All requested rights were honoured by the kernel.
+    FullyEnforced,
+    /// Best-effort downgrade applied a subset of the requested rights.
+    PartiallyEnforced,
+    /// The kernel accepted the ruleset but applied no restrictions.
+    NotEnforced,
+}
+
+/// Always returns `false` on this build.
+#[must_use]
+pub fn is_supported() -> bool {
+    false
+}
+
+/// Always returns [`LandlockOutcome::Unavailable`] on this build.
+///
+/// # Errors
+///
+/// The stub never returns the `Error` variant.
+pub fn restrict_to_module_paths(_allowed_roots: &[&Path]) -> LandlockOutcome {
+    LandlockOutcome::Unavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn is_supported_returns_false() {
+        assert!(!is_supported());
+    }
+
+    #[test]
+    fn restrict_returns_unavailable() {
+        let tmp = TempDir::new().expect("tempdir");
+        let outcome = restrict_to_module_paths(&[tmp.path()]);
+        assert!(matches!(outcome, LandlockOutcome::Unavailable));
+    }
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -189,6 +189,22 @@ pub mod iocp;
 #[path = "iocp_stub/mod.rs"]
 pub mod iocp;
 
+/// Landlock LSM defense-in-depth allowlist for the daemon receiver path
+/// (SEC-1.p).
+///
+/// On Linux with the `landlock` feature, exposes `restrict_to_module_paths`
+/// which engages a kernel-enforced allowlist above the SEC-1 `*at` helpers.
+/// On every other target (or with the feature disabled) a stub module
+/// compiles with the same public surface: every call returns `Unavailable`
+/// so cross-platform callers share a single code path. See
+/// `docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md` for the
+/// kernel-version matrix and integration plan.
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+pub mod landlock;
+#[cfg(not(all(target_os = "linux", feature = "landlock")))]
+#[path = "landlock_stub.rs"]
+pub mod landlock;
+
 /// macOS `kqueue`-based event loop primitive.
 ///
 /// Exposes a thin safe wrapper over `kqueue(2)` / `kevent(2)` used as


### PR DESCRIPTION
## Summary

Wires Linux Landlock LSM into the daemon receiver path as defense-in-depth above the SEC-1 ``*at`` syscall chain. Implements the audit recommendation from PR #4699. After ``apply_module_privilege_restrictions`` returns, the receiver thread engages a kernel-enforced allowlist over the module root: every filesystem syscall the thread (and any process inherited from it) issues outside that root is rejected by the kernel with ``EACCES`` regardless of which API the caller used. The sandbox is inherited by the name converter and pre/post-xfer-exec hook processes, closing the missed-call-site / future-regression gap that pure call-site routing cannot guarantee on its own.

- ``crates/fast_io/Cargo.toml`` adds the optional ``landlock = "0.4"`` dep behind a new ``landlock`` Cargo feature, Linux-only, mirroring the ``iouring-send-zc`` opt-in pattern at lines 110-117 of the same file.
- ``crates/fast_io/src/landlock.rs`` builds the ruleset with ``Ruleset::default()`` + ``set_compatibility(CompatLevel::BestEffort)`` and requests ``AccessFs::from_all(ABI::V3)`` unconditionally so the crate silently drops REFER (v1) and TRUNCATE (v1/v2) on older kernels. Returns ``LandlockOutcome::{Enforced(RulesetStatus), Unavailable, Error}`` so the daemon can log the actual ABI tier the kernel honoured.
- ``crates/fast_io/src/landlock_stub.rs`` ships the same public surface for non-Linux targets and feature-disabled builds; every call short-circuits to ``Unavailable`` so the wire-in stays target-agnostic.
- ``crates/daemon/Cargo.toml`` depends on ``fast_io`` (stub on non-Linux, real Landlock dep on Linux) so the call site in ``transfer.rs`` compiles unconditionally.
- ``crates/daemon/src/daemon/sections/module_access/transfer.rs`` adds two helpers:
  - ``validate_client_paths_in_module`` rejects client-supplied ``--temp-dir`` / ``--partial-dir`` / ``--backup-dir`` paths that resolve outside the module root. Per the audit's recommendation in section 10, this is REJECT over widening the allowlist; widening the writable surface to honour an attacker-supplied prefix undermines the whole point of the sandbox and rsync's own chroot mode behaves the same way.
  - ``engage_landlock_sandbox`` engages the kernel allowlist immediately after ``apply_module_privilege_restrictions`` returns. Probe failure or setup error is logged at WARN but does not abort the connection; the SEC-1 ``*at`` chain remains the primary defense even when Landlock is unavailable.
- ``SECURITY.md`` adds a SEC-1.p entry documenting the kernel-version matrix and the reject-vs-widen decision.

### Kernel-version downgrade strategy implemented

- v3 on 6.2+: READ / WRITE / CREATE / DELETE / RENAME / SYMLINK / REFER / TRUNCATE.
- v2 on 5.19+: drops TRUNCATE.
- v1 on 5.13+: drops TRUNCATE and REFER.
- < 5.13: ``LandlockOutcome::Unavailable``; SEC-1 ``*at`` helpers remain the sole defense. Logged once per connection at INFO.

``set_compatibility(CompatLevel::BestEffort)`` lets the crate strip rights the kernel does not understand, so the same call site works on every supported kernel without runtime branching.

### Audit recommendation alignment

- Integration point: ``module_access/transfer.rs`` immediately after ``apply_module_privilege_restrictions``, exactly as PR #4699 prescribed.
- Client-args interception: REJECT (audit's recommended option a in section 10) rather than allowlist-widen.
- Feature gating: Linux-only opt-in modelled on ``iouring-send-zc``.

## Coordination

- Builds on the SEC-1 ``*at`` chain (PRs #4643, #4650, #4668, #4671, #4683, #4690, #4693 - all merged).
- Builds on the audit + design doc at PR #4699 (``docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md``). That PR may still be open at the time this one is filed; both should land before SECURITY.md's SEC-1 status table is bumped to FIXED.

## Lock-file requirement

``Cargo.lock`` requires ``cargo update -p landlock`` (or ``cargo generate-lockfile``) to register the new optional crate and its transitive deps before ``--locked`` CI jobs will pass. The lock update was deliberately not run from this branch per the consolidate-cargo standing rule on agents; it should be added in a follow-up commit before merge.

## Test plan

- [ ] CI ``fmt+clippy`` passes on the lock-updated branch.
- [ ] CI ``nextest (stable)`` passes on Linux with the daemon's forwarded ``landlock`` feature.
- [ ] CI Windows + macOS + Linux musl all build through the stub.
- [ ] Unit tests in ``crates/fast_io/src/landlock.rs::tests`` cover the four scenarios called out by the audit: ``is_supported`` agreement with ``ABI::query``, in-module write succeeds, out-of-module write fails with ``PermissionDenied``, empty allowlist denies all writes, and a second restrict call does not relax the sandbox.
- [ ] Manual daemon smoke: start ``oc-rsyncd`` on a kernel >= 6.2, push from a client with ``--temp-dir=/tmp``, observe the daemon log line ``rejected --temp-dir='/tmp' ... outside module root`` and the wire-protocol ``@ERROR`` reply.