### PR TITLE
ci: add Linux build matrix entry for landlock feature flag

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -131,6 +131,9 @@ jobs:
           - name: copy_file_range
             args: "-p fast_io --features copy_file_range"
             apt: ""
+          - name: landlock
+            args: "-p fast_io --features landlock"
+            apt: ""
           - name: openssl
             args: "-p checksums --features openssl"
             apt: "libssl-dev pkg-config"


### PR DESCRIPTION
## Summary

Adds a `landlock` row to the `feature-flags-linux` matrix in `.github/workflows/_test-features.yml` so the optional Linux-only `landlock` Cargo feature (introduced by PR #4702 / SEC-1.p) stays buildable and tested on every CI run. Without this, the feature can silently rot between releases.

- Matrix entry mirrors the existing `io_uring` and `copy_file_range` rows: `runs-on: ubuntu-latest`, scoped to `fast_io` to keep CI time low (the unit tests for the helper already live there).
- Invocation: `cargo nextest run --locked --profile ci -p fast_io --features landlock`. The row's existing `RUSTFLAGS: "-D warnings"` env enforces warnings-as-errors during the implicit build, matching the strictness the lint job applies to the rest of the workspace.
- No `apt` packages required; the `landlock` crate is pure Rust.
- Linux-only by definition (Landlock is a Linux LSM). The row lives in `feature-flags-linux`, so it never schedules on macOS or Windows runners.

## Kernel-version coverage

`set_compatibility(CompatLevel::BestEffort)` in the `fast_io` helper absorbs ABI variance, so the same row works against whatever kernel `ubuntu-latest` currently ships (5.15+ baseline through 6.x). No separate `ubuntu-24.04` cell is required to exercise the v3 ABI path - the BestEffort downgrade handles the variance, and adding a second OS image just to assert that would burn CI time without changing failure modes.

## Coordination

- Depends on PR #4702 landing first (the `landlock` Cargo feature does not exist on master yet). Until then this row will fail with `unknown feature 'landlock'`; merge order should be #4702 then this PR.
- After both land, the `landlock` row joins the other Linux-only feature rows in the `feature-flags-linux` job (visible as `landlock (linux)` in the CI run summary).

## Test plan

- [ ] After #4702 merges, rebase and confirm `landlock (linux)` cell passes on this PR's CI run.
- [ ] Confirm the row appears in the `Feature flag combinations` job summary alongside `io_uring (linux)` and `copy_file_range (linux)`.
- [ ] Verify no scheduling on macOS / Windows runners (row sits in `feature-flags-linux`, not `feature-flags-cross-os`).