### PR TITLE
docs(release): RELEASE_TEMPLATE Security section + Landlock packaging cross-reference

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -32,3 +32,32 @@ Each release ships three Rust-toolchain variants of every binary:
 The `-beta` / `-nightly` suffix denotes the **Rust toolchain** the artifact was built with - it is **not** an indicator of oc-rsync's own release maturity (that is set in the release title and `README.md`).
 
 ---
+
+### Security
+
+See `SECURITY.md` for the canonical mitigation roster and `docs/design/sec-1-completion-summary-2026-05-22.md` for the SEC-1 sub-task (`.a`-`.p`) ship state. Release authors: copy the rows that changed this cycle from the `SECURITY.md` CVE table into the placeholder below; drop unaffected rows.
+
+**Active mitigations**
+
+| CVE | Description | Status | Cite |
+|-----|-------------|--------|------|
+| CVE-XXXX-XXXXX | _short upstream description_ | _Fixed / Mostly fixed / Mitigated / Not vulnerable_ | PR #NNNN, `SECURITY.md` |
+
+Status values mirror `SECURITY.md` ("Fixed", "Mostly fixed", "Mitigated", "Not vulnerable"). Use "Mostly fixed" when the primary syscall surface is migrated but deferred callers are tracked separately.
+
+**Defense-in-depth.** This release ships the SEC-1 `*at` syscall chain (`fstatat`, `unlinkat`, `mkdirat`, `symlinkat`, `linkat`, `fchmodat`, `fchownat`, `utimensat`, `renameat`) routed through a per-transfer `DirSandbox` carrier with `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` runtime detection. The optional `landlock` Cargo feature (Linux 5.13+) layers kernel-enforced `PathBeneath` allowlisting on top; daemons on older kernels run with the `*at` chain as the sole TOCTOU defense, which is itself sufficient against CVE-2026-29518 / CVE-2026-43619.
+
+### Kernel / platform compatibility
+
+| Layer | Minimum | Notes |
+|-------|---------|-------|
+| io_uring data path | Linux 5.6+ | Runtime-probed; falls back to standard buffered I/O. |
+| Provided buffer rings (PBUF_RING) | Linux 5.19+ | Runtime-probed; falls back to standard buffered I/O. |
+| Landlock LSM (`landlock` feature) | Linux 5.13+ | Best-effort ABI downgrade; no-op on older kernels. |
+| `IORING_OP_SEND_ZC` (`iouring-send-zc` feature) | Linux 6.0+ recommended | Opt-in; default builds use plain `IORING_OP_SEND`. |
+| macOS `*at` chain | macOS 10.10+ | BSD `*at` family verified at parity with Linux (SEC-1.k). |
+| Windows IOCP | Windows 10 1809+ | NTFS handle-based APIs sidestep path TOCTOU structurally (SEC-1.l). |
+
+Distro packagers: see `docs/packaging/landlock-feature-guidance.md` for the per-distro `--features landlock` recommendation, runtime ABI matrix, and build-time dependency notes.
+
+---


### PR DESCRIPTION
## Summary

- Adds a `## Security` section to `.github/RELEASE_TEMPLATE.md` with an active-mitigations CVE table placeholder (columns: CVE / Description / Status / Cite), a reference line pointing to `SECURITY.md` and `docs/design/sec-1-completion-summary-2026-05-22.md`, and a defense-in-depth note covering the SEC-1 `*at` syscall chain plus the optional `landlock` Cargo feature (Linux 5.13+).
- Adds a `## Kernel / platform compatibility` section enumerating the minimums for io_uring, PBUF_RING, Landlock, `IORING_OP_SEND_ZC`, the macOS `*at` chain, and the Windows IOCP path, with a pointer to `docs/packaging/landlock-feature-guidance.md` (shipped via #4709) for distro packagers.
- Generic placeholders only - downstream release notes (e.g. `.github/RELEASE_NOTES_BETA.md`) supply the actual per-CVE rows, so the template does not duplicate the beta notes.

## Test plan

- [x] `git diff --stat` confirms `.github/RELEASE_TEMPLATE.md` is the only file changed (29 insertions).
- [x] Rendered Markdown reviewed locally for correct table syntax and table alignment.
- [x] No references to AI tooling or em-dashes in the added prose.
- [x] Cross-references resolved: `SECURITY.md`, `docs/design/sec-1-completion-summary-2026-05-22.md`, `docs/packaging/landlock-feature-guidance.md` all exist on `master`.