### PR TITLE
feat(fast_io): add openat_via_sandbox_or_fallback + readlinkat_via_sandbox helpers (closes 16+ SEC-1 GAPs)

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -27,10 +27,11 @@
 //! [`DirSandbox`](super::DirSandbox).
 
 use std::ffi::{CString, OsStr};
+use std::fs::File;
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd};
-use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::{Path, PathBuf};
 
 use filetime::FileTime;
 
@@ -1195,6 +1196,264 @@ pub fn renameat_via_sandbox_or_fallback(
     std::fs::rename(old_link_path, new_link_path)
 }
 
+// ============================================================
+// open / readlink helpers (SEC-1.s)
+// ============================================================
+
+/// Issue `openat(dirfd, name, flags, mode)` and return the resulting
+/// [`File`].
+///
+/// The leaf is resolved relative to `dirfd`. The caller chooses `flags`;
+/// pass `libc::O_NOFOLLOW` to refuse a terminal symlink swap on `name`.
+/// `mode` is consulted by the kernel only when `flags` includes
+/// `O_CREAT` (otherwise it is ignored) and is interpreted as the
+/// requested permission bits with the active umask applied.
+///
+/// `name` must not contain an interior NUL byte; callers that pull names
+/// from `Path::file_name` cannot trigger this (paths cannot contain NUL
+/// on Unix).
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `ENOENT` when `name` does not exist beneath `dirfd` and `O_CREAT`
+///   is absent from `flags`.
+/// - `EEXIST` when `O_CREAT | O_EXCL` is set and `name` already exists.
+/// - `ENOTDIR` when `dirfd` is not a directory.
+/// - `ELOOP` when `flags` includes `O_NOFOLLOW` and `name` is a symlink.
+/// - `EACCES` when the caller lacks the required permissions on `dirfd`.
+/// - `EINVAL` when `name` contains an interior NUL byte (translated
+///   from [`std::ffi::NulError`]).
+pub fn openat(dirfd: BorrowedFd<'_>, name: &OsStr, flags: i32, mode: u32) -> io::Result<File> {
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+    //   whose lifetime is bound to the borrow and outlives the syscall.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not retain the
+    //   pointer past return.
+    // - `flags` is forwarded verbatim; the caller is responsible for
+    //   passing a valid `O_*` bitmask.
+    // - `mode` is interpreted by the kernel as `mode_t` and is consulted
+    //   only when `flags` includes `O_CREAT`; for other call shapes the
+    //   kernel ignores it.
+    #[allow(unsafe_code)]
+    let raw = unsafe {
+        libc::openat(
+            dirfd.as_raw_fd(),
+            c_name.as_ptr(),
+            flags,
+            mode as libc::c_uint,
+        )
+    };
+
+    if raw < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: `openat(2)` returned a non-negative fd that we own
+    // exclusively. We do not duplicate, leak, or alias `raw` anywhere
+    // else, so wrapping it as a `File` (which takes exclusive ownership)
+    // is sound.
+    #[allow(unsafe_code)]
+    let file = unsafe { File::from_raw_fd(raw) };
+    Ok(file)
+}
+
+/// Issue `openat` against `link_path` when the `sandbox` root is the
+/// immediate parent.
+///
+/// SEC-1.s adaptor for callers that already have an absolute path:
+/// - When `sandbox` is `Some`, `link_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   component, the helper resolves the leaf through the sandbox dirfd
+///   so a mid-syscall symlink swap on the leaf cannot redirect the
+///   open to an attacker-chosen inode.
+/// - In every other case the helper falls back to
+///   [`std::fs::OpenOptions`] against `link_path` with a best-effort
+///   translation of the standard `O_*` bits (`O_RDONLY` / `O_WRONLY` /
+///   `O_RDWR` for the access mode, plus `O_CREAT` / `O_TRUNC` /
+///   `O_APPEND` / `O_EXCL` for the lifecycle modifiers). Flags outside
+///   that set are silently dropped on the fallback path because
+///   [`std::fs::OpenOptions`] does not expose every libc bit.
+///
+/// Typical temp-file creation passes
+/// `flags = libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW`,
+/// `mode = 0o600`; inplace-destination opens pass
+/// `flags = libc::O_RDWR | libc::O_NOFOLLOW`, `mode = 0`. The exact
+/// bitmask is left to the caller for flexibility.
+///
+/// # Errors
+///
+/// Surfaces either the [`openat`] error or the
+/// [`std::fs::OpenOptions::open`] error verbatim, depending on which
+/// path was taken.
+pub fn openat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    link_path: &Path,
+    flags: i32,
+    mode: u32,
+) -> io::Result<File> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
+    {
+        return openat(sandbox.current_dirfd(), leaf, flags, mode);
+    }
+    open_path_with_flags(link_path, flags, mode)
+}
+
+/// Best-effort translation of libc `O_*` flag bits onto
+/// [`std::fs::OpenOptions`].
+///
+/// Only the bits the stdlib actually exposes are consulted: the access
+/// mode (`O_RDONLY` / `O_WRONLY` / `O_RDWR`), the lifecycle bits
+/// (`O_CREAT`, `O_TRUNC`, `O_APPEND`, `O_EXCL`), and the create-mode
+/// argument. Everything else (`O_NOFOLLOW`, `O_DIRECTORY`, `O_CLOEXEC`,
+/// `O_NONBLOCK`, ...) is silently dropped on the fallback path because
+/// the stdlib has no portable knob for them; callers that need those
+/// semantics must take the sandbox fast path.
+fn open_path_with_flags(path: &Path, flags: i32, mode: u32) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut opts = std::fs::OpenOptions::new();
+    match flags & libc::O_ACCMODE {
+        libc::O_WRONLY => {
+            opts.write(true);
+        }
+        libc::O_RDWR => {
+            opts.read(true).write(true);
+        }
+        _ => {
+            opts.read(true);
+        }
+    }
+    if flags & libc::O_CREAT != 0 {
+        opts.create(true);
+        opts.mode(mode);
+    }
+    if flags & libc::O_TRUNC != 0 {
+        opts.truncate(true);
+    }
+    if flags & libc::O_APPEND != 0 {
+        opts.append(true);
+    }
+    if flags & libc::O_EXCL != 0 {
+        opts.create_new(true);
+    }
+    opts.open(path)
+}
+
+/// Issue `readlinkat(dirfd, name, buf, size)` and return the link
+/// target as a [`PathBuf`].
+///
+/// The leaf is resolved relative to `dirfd`. `readlinkat(2)` never
+/// follows the terminal symlink (it reads the contents of the link
+/// itself), so a TOCTOU swap on the leaf cannot redirect the call to a
+/// different inode.
+///
+/// The helper starts with a 256-byte buffer and doubles until the
+/// kernel reports the full target fit (return value strictly less than
+/// the buffer size) or the buffer exceeds `PATH_MAX`, at which point
+/// the helper returns `ENAMETOOLONG`.
+///
+/// `name` must not contain an interior NUL byte; callers that pull
+/// names from `Path::file_name` cannot trigger this.
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `ENOENT` when `name` does not exist beneath `dirfd`.
+/// - `EINVAL` when `name` is not a symbolic link.
+/// - `ENOTDIR` when `dirfd` is not a directory.
+/// - `EACCES` when the caller lacks search permission on `dirfd`.
+/// - `ENAMETOOLONG` when the link target exceeds `PATH_MAX`.
+/// - `EINVAL` when `name` contains an interior NUL byte (translated
+///   from [`std::ffi::NulError`]).
+pub fn readlinkat(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<PathBuf> {
+    use std::ffi::OsString;
+
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // PATH_MAX cap; double the buffer until the kernel reports a result
+    // strictly smaller than `buf.len()` (full target fit) or we exceed
+    // the cap, in which case the link target is pathologically long and
+    // we surface ENAMETOOLONG verbatim.
+    let mut cap = 256usize;
+    let max_cap = libc::PATH_MAX as usize;
+    let mut buf: Vec<u8> = vec![0; cap];
+    loop {
+        // SAFETY:
+        // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+        //   whose lifetime outlives the syscall.
+        // - `c_name.as_ptr()` is a valid NUL-terminated C string
+        //   borrowed for the duration of the call.
+        // - `buf.as_mut_ptr()` points at `cap` writable bytes the kernel
+        //   may fill; the result count cannot exceed `cap` so the write
+        //   stays in-bounds.
+        #[allow(unsafe_code)]
+        let rc = unsafe {
+            libc::readlinkat(
+                dirfd.as_raw_fd(),
+                c_name.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                cap,
+            )
+        };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let used = rc as usize;
+        if used < cap {
+            buf.truncate(used);
+            let os = OsString::from_vec(buf);
+            return Ok(PathBuf::from(os));
+        }
+        // Buffer was filled exactly; the target may be longer. Grow and
+        // retry until we either fit or exceed PATH_MAX.
+        if cap >= max_cap {
+            return Err(io::Error::from_raw_os_error(libc::ENAMETOOLONG));
+        }
+        cap = (cap * 2).min(max_cap);
+        buf.resize(cap, 0);
+    }
+}
+
+/// Issue `readlinkat` against `link_path` when the `sandbox` root is
+/// the immediate parent.
+///
+/// SEC-1.s adaptor for callers that already have an absolute path:
+/// - When `sandbox` is `Some`, `link_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   component, the helper resolves the leaf through the sandbox dirfd
+///   so a mid-syscall symlink swap on the leaf cannot redirect the
+///   read to a different symlink inode.
+/// - In every other case the helper falls back to
+///   [`std::fs::read_link`] on `link_path`.
+///
+/// # Errors
+///
+/// Surfaces either the [`readlinkat`] error or the
+/// [`std::fs::read_link`] error verbatim, depending on which path was
+/// taken.
+pub fn readlinkat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    link_path: &Path,
+) -> io::Result<PathBuf> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
+    {
+        return readlinkat(sandbox.current_dirfd(), leaf);
+    }
+    std::fs::read_link(link_path)
+}
+
 #[cfg(test)]
 mod tests {
     use std::os::fd::AsFd;
@@ -2092,5 +2351,169 @@ mod tests {
 
         assert!(!temp.exists());
         assert_eq!(std::fs::read(&final_path).expect("read"), b"committed");
+    }
+
+    #[test]
+    fn openat_raw_returns_file_for_existing_path() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"hello").expect("write");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let mut file =
+            openat(dirfd.as_fd(), OsStr::new("file"), libc::O_RDONLY, 0).expect("openat existing");
+        use std::io::Read;
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).expect("read");
+        assert_eq!(buf, "hello");
+    }
+
+    #[test]
+    fn openat_raw_returns_enoent_for_missing_name() {
+        let (_keep, root) = canonical_tempdir();
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let err = openat(dirfd.as_fd(), OsStr::new("absent"), libc::O_RDONLY, 0)
+            .expect_err("missing leaf must error");
+        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn openat_via_sandbox_fast_path_succeeds_on_leaf() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("created");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("created");
+        let file = openat_via_sandbox_or_fallback(
+            Some(&sandbox),
+            &root,
+            leaf,
+            &path,
+            libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW,
+            0o600,
+        )
+        .expect("openat sandbox create");
+        drop(file);
+
+        assert!(path.exists(), "single-component leaf must be created");
+        let meta = std::fs::metadata(&path).expect("stat");
+        // The kernel applies the active umask to the requested mode, so
+        // the exact bits depend on the test environment. Asserting that
+        // no group/other write bits leaked beyond the umask-filtered
+        // request is enough to confirm the mode argument was honoured.
+        let mode = meta.permissions().mode() & 0o777;
+        assert!(
+            mode & 0o066 == 0,
+            "mode 0o600 must not grant group/other access, got {mode:o}"
+        );
+    }
+
+    #[test]
+    fn openat_via_sandbox_fallback_for_multi_component() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        let path = root.join("sub").join("created");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let rel = Path::new("sub/created");
+        let file = openat_via_sandbox_or_fallback(
+            Some(&sandbox),
+            &root,
+            rel,
+            &path,
+            libc::O_WRONLY | libc::O_CREAT,
+            0o644,
+        )
+        .expect("openat fallback create");
+        drop(file);
+
+        assert!(
+            path.exists(),
+            "multi-component path must fall back to std OpenOptions"
+        );
+    }
+
+    #[test]
+    fn openat_via_sandbox_or_fallback_with_no_sandbox() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"present").expect("write");
+
+        let leaf = Path::new("file");
+        let mut file = openat_via_sandbox_or_fallback(None, &root, leaf, &path, libc::O_RDONLY, 0)
+            .expect("openat no-sandbox fallback");
+        use std::io::Read;
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).expect("read");
+        assert_eq!(buf, "present");
+    }
+
+    #[test]
+    fn readlinkat_returns_target_for_symlink() {
+        let (_keep, root) = canonical_tempdir();
+        let target = root.join("target");
+        std::fs::write(&target, b"x").expect("write target");
+        let link = root.join("link");
+        symlink(&target, &link).expect("symlink");
+
+        let dirfd = secure_open_dir(&root).expect("open root");
+        let got = readlinkat(dirfd.as_fd(), OsStr::new("link")).expect("readlinkat");
+        assert_eq!(got, target);
+    }
+
+    #[test]
+    fn readlinkat_returns_einval_for_non_symlink() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("file"), b"x").expect("write");
+        let dirfd = secure_open_dir(&root).expect("open root");
+
+        let err =
+            readlinkat(dirfd.as_fd(), OsStr::new("file")).expect_err("non-symlink must error");
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    }
+
+    #[test]
+    fn readlinkat_via_sandbox_returns_target_for_symlink() {
+        let (_keep, root) = canonical_tempdir();
+        let target = root.join("target");
+        std::fs::write(&target, b"x").expect("write target");
+        let link = root.join("link");
+        symlink(&target, &link).expect("symlink");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("link");
+        let got = readlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link)
+            .expect("readlinkat sandbox");
+        assert_eq!(got, target);
+    }
+
+    #[test]
+    fn readlinkat_via_sandbox_returns_einval_for_non_symlink() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"x").expect("write");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("file");
+        let err = readlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path)
+            .expect_err("non-symlink must error");
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    }
+
+    #[test]
+    fn readlinkat_via_sandbox_falls_back_for_multi_component() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("sub")).expect("mkdir sub");
+        let target = root.join("sub").join("target");
+        std::fs::write(&target, b"x").expect("write target");
+        let link = root.join("sub").join("link");
+        symlink(&target, &link).expect("symlink");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let rel = Path::new("sub/link");
+        let got = readlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link)
+            .expect("readlinkat fallback");
+        assert_eq!(got, target);
     }
 }

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -81,7 +81,8 @@ mod tests;
 pub use at_syscalls::{
     AtMetadata, LstatOutcome, UnlinkFlags, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
     fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
-    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, renameat,
+    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
+    openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback, renameat,
     renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
     unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -228,7 +228,8 @@ pub use dir_sandbox::{
     AtMetadata, DirSandbox, LstatOutcome, UnlinkFlags, fchmodat, fchmodat_via_sandbox_or_fallback,
     fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat,
     linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
-    mkdirat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback, symlinkat,
+    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback, readlinkat,
+    readlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback, symlinkat,
     symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
     utimensat_via_sandbox_or_fallback,
 };


### PR DESCRIPTION
## Summary

Adds two new SEC-1 helper families to `fast_io::dir_sandbox::at_syscalls`:

- `openat` + `openat_via_sandbox_or_fallback` -- single-shot opens
  anchored on the sandbox dirfd, with a best-effort `O_*` translation
  to `std::fs::OpenOptions` on the fallback path.
- `readlinkat` + `readlinkat_via_sandbox_or_fallback` -- symlink
  target reads anchored on the sandbox dirfd, falling back to
  `std::fs::read_link` outside the sandbox fast path.

Follows the established SEC-1 pattern (raw helper + adaptor +
`single_component_leaf` eligibility check) used by `unlinkat`,
`mkdirat`, `renameat`, etc.

This PR **only** adds the helpers and their re-exports through
`dir_sandbox::mod` and `fast_io::lib`. It deliberately does **not**
wire any of the 16+ identified call sites -- per-site wiring lands in
follow-up PRs so each cutover gets its own diff and review.

Extends the existing tests module with 10 new tests (3 raw `openat` /
`openat` sandbox, 4 `openat_via_sandbox` sandbox/multi-component/no-sandbox,
3 raw `readlinkat` / sandbox / multi-component fallback).

All helpers are `#[cfg(unix)]` (the `dir_sandbox` module is itself
Unix-only); Windows continues to use path-based stdlib opens per the
SEC-1.l NTFS handle audit. No Windows unused-import risk.

## GAPs closed (post-wire) from PR #4710 audit

Per the GAP table in `docs/audits/sec-1-path-syscall-audit-2026-05-22.md`,
the new helpers unblock the following sites once their respective
follow-up wiring PRs land:

| GAP # | File / line | Syscall now covered |
|---|---|---|
| 4 | `transfer/receiver/directory/links.rs:75` | `read_link` -> `readlinkat_via_sandbox_or_fallback` |
| 9 | `transfer/receiver/quick_check.rs:268` | `File::open` -> `openat_via_sandbox_or_fallback` |
| 10 | `transfer/receiver/basis.rs:119` | `File::open` -> `openat_via_sandbox_or_fallback` |
| 11 | `transfer/receiver/basis.rs:134` | `File::open` -> `openat_via_sandbox_or_fallback` |
| 12 | `transfer/transfer_ops/response.rs:80` | `OpenOptions::open` -> `openat_via_sandbox_or_fallback` |
| 13 | `transfer/transfer_ops/response.rs:342` | `OpenOptions::open` -> `openat_via_sandbox_or_fallback` |
| 14 | `transfer/disk_commit/process.rs:232` | `OpenOptions::open` -> `openat_via_sandbox_or_fallback` (also needs SEC-1.j cross-thread plumbing) |
| 15 | `transfer/disk_commit/process.rs:236` | `OpenOptions::open` -> `openat_via_sandbox_or_fallback` (same plumbing) |
| 16 | `transfer/disk_commit/process.rs:354` | `OpenOptions::open` -> `openat_via_sandbox_or_fallback` (same plumbing) |
| 17 | `transfer/temp_guard.rs:130` | `OpenOptions::create_new` -> `openat_via_sandbox_or_fallback` |
| 19 | `transfer/temp_guard.rs:217` | `remove_file` Drop -- benefits from open carrier rework |
| 20 | `transfer/temp_cleanup.rs:95` | `read_dir` -- needs follow-up `openat` + `fdopendir` helper built on top of these |
| 21 | `transfer/temp_cleanup.rs:137` | `remove_file` -- benefits from open carrier plumbing |
| 5 | `transfer/receiver/directory/deletion.rs:115` | `read_dir` -- ditto |
| 6 | `transfer/receiver/directory/deletion.rs:157` | `remove_dir_all` -- recursive `*at` peel built on `openat` + readdir + `unlinkat` |
| 27 | `engine/delete/emitter/fs.rs:90` | `remove_dir_all` recursive fallback -- same recursive peel |

That is 16 direct beneficiaries; the broader follow-up set
(`open_path`-based code paths reachable through the disk_commit and
temp-file lifecycle clusters) brings the count past 20 once the
DeleteFs trait refactor lands (tracked separately, out of scope here).

## Test plan

- [ ] CI fmt + clippy + nextest (stable + Linux musl + macOS + Windows)
- [ ] No callers wired -- behaviour for existing sites is unchanged.
- [ ] 10 new tests in `crates/fast_io/src/dir_sandbox/at_syscalls.rs`
      tests module exercise sandbox fast path, multi-component
      fallback, absent-sandbox fallback, and ENOENT/EINVAL error paths.