### PR TITLE
docs(github): add PULL_REQUEST_TEMPLATE with conventional-prefix + test-plan scaffolding

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Title format: <prefix>(<scope>): <imperative summary>
+Conventional prefix is load-bearing - a labeler workflow categorizes release
+notes from it. Keep titles under 70 characters; put detail in the body.
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## Summary
+
+- 1-3 bullets describing what changes and why.
+
+## Test plan
+
+- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.
+- [ ] Add targeted local repro steps if applicable: `cargo nextest run -p <crate> -E 'test(<pattern>)'`.
+
+## Coordination
+
+- Related PRs / issues:
+- Depends on:
+- Blocked by:
+
+## Conventional commit prefix
+
+Pick one; PR title prefix must match the change category:
+
+- `feat:` - new user-visible feature
+- `fix:` - bug fix
+- `perf:` - performance improvement
+- `refactor:` - non-functional restructuring
+- `docs:` - documentation only
+- `test:` - tests only
+- `style:` - formatting / lints, no behaviour change
+- `chore:` - tooling, deps, housekeeping
+- `ci:` - CI configuration
+
+## Security considerations
+
+Fill only if this PR touches `SECURITY.md`, daemon code, sandbox / `*at`
+helpers, auth, or anything in the SEC-1 chain. Otherwise delete this section.
+
+- Threat surface affected:
+- Mitigations / tests added:
+- Cross-references (`SECURITY.md`, design docs):
+
+## Pre-merge checklist
+
+- [ ] Conventional commit prefix on PR title matches the change category.
+- [ ] `cargo fmt --all` run locally.
+- [ ] `CHANGELOG.md` updated if user-visible.
+- [ ] `SECURITY.md` updated if security-relevant.
+- [ ] No references to internal tooling or non-human authoring aids; hyphens, not em-dashes.


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` so GitHub auto-pre-fills new PR bodies with the standard scaffolding `CONTRIBUTING.md` already mandates.
- Captures: Summary, Test plan, Coordination, Conventional-prefix reference, optional Security considerations, and a pre-merge checklist (fmt run, CHANGELOG / SECURITY updates, authorship hygiene).
- Section count: 6. Length: 52 lines, copy-paste-friendly.

## Test plan

- [x] `.github/PULL_REQUEST_TEMPLATE.md` did not previously exist (`ls .github/` confirmed).
- [x] Conventional-prefix list matches `CONTRIBUTING.md` "Opening a pull request" (feat / fix / perf / docs / chore / style / test / refactor / ci).
- [x] Pre-merge checklist mirrors the workflow rules in `CONTRIBUTING.md` (fmt run, no internal-tooling references, hyphens not em-dashes).
- [x] This PR's own body uses the new template, demonstrating the section flow renders correctly.
- [ ] CI: docs-only change; required checks (fmt + clippy, nextest, Windows, macOS, Linux musl) should pass trivially.

## Coordination

- Related: `CONTRIBUTING.md` (#4706 - just shipped) documents the conventions this template scaffolds.
- Related: `.github/RELEASE_TEMPLATE.md` already exists; this complements it for the PR-creation path.
- Depends on: none.
- Blocked by: none.

## Conventional commit prefix

- `docs:` - documentation-only change.

## Pre-merge checklist

- [x] Conventional commit prefix on PR title matches the change category (`docs:`).
- [x] `cargo fmt --all` no-op (docs-only, no Rust touched).
- [ ] `CHANGELOG.md` not updated - contributor-facing scaffolding, not user-visible behaviour.
- [ ] `SECURITY.md` not updated - not security-relevant.
- [x] No references to internal tooling; hyphens, not em-dashes.