### PR TITLE
feat(transfer): force-parallel env override + interop scenario crossing parallel threshold (PIP-4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4108,6 +4108,7 @@ dependencies = [
  "libc",
  "logging",
  "metadata",
+ "platform",
  "proptest",
  "protocol",
  "rand 0.10.1",

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -136,6 +136,7 @@ tracing = ["dep:tracing"]
 [dev-dependencies]
 tempfile = { workspace = true }
 test-support = { path = "../test-support" }
+platform = { path = "../platform" }
 criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -103,6 +103,19 @@ pub const PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD: usize = 100;
 /// `docs/design/parallel-receive-delta-default-on.md` section 6.2.
 pub const PARALLEL_RECEIVE_BYTES_THRESHOLD: u64 = 64 * 1024 * 1024;
 
+/// Runtime/debug override that forces [`ReceiverContext::dispatch_receiver_strategy`]
+/// onto the parallel apply path regardless of the file-count and total-bytes
+/// thresholds.
+///
+/// Set to any non-empty value (e.g. `OC_RSYNC_FORCE_PARALLEL=1`) before
+/// invoking the receiver to short-circuit the Path B heuristic. Intended for
+/// interop coverage and ad-hoc debugging; the toggle is intentionally not
+/// surfaced as a CLI flag. When the `parallel-receive-delta` feature is
+/// compiled out, the override still logs the decision under `GENR` and falls
+/// back to [`ReceiverStrategy::Sequential`] so telemetry never claims a path
+/// the binary cannot take.
+pub const FORCE_PARALLEL_RECEIVE_ENV: &str = "OC_RSYNC_FORCE_PARALLEL";
+
 pub(crate) use crate::parallel_io::ParallelThresholds;
 
 use signature;
@@ -453,11 +466,21 @@ impl ReceiverContext {
     /// `receiver_strategy=parallel_unavailable` and returns
     /// [`ReceiverStrategy::Sequential`] so telemetry never claims a path
     /// the binary cannot actually take.
+    ///
+    /// The [`FORCE_PARALLEL_RECEIVE_ENV`] env var short-circuits the heuristic
+    /// when set to a non-empty value: the function logs the override under
+    /// `GENR` and unconditionally returns [`ReceiverStrategy::Parallel`] (or
+    /// `parallel_unavailable`/Sequential when the feature is compiled out).
+    /// The override exists for interop coverage and ad-hoc debugging; it is
+    /// not surfaced as a CLI flag.
     pub(in crate::receiver) fn dispatch_receiver_strategy(
         &mut self,
         file_count: usize,
     ) -> ReceiverStrategy {
         let total_size = self.total_source_bytes();
+        if std::env::var_os(FORCE_PARALLEL_RECEIVE_ENV).is_some_and(|v| !v.is_empty()) {
+            return self.dispatch_forced_parallel(file_count, total_size);
+        }
         let want = Self::select_receiver_strategy(file_count, total_size);
         match want {
             ReceiverStrategy::Parallel => {
@@ -506,6 +529,45 @@ impl ReceiverContext {
                 );
                 ReceiverStrategy::Sequential
             }
+        }
+    }
+
+    /// Honours the [`FORCE_PARALLEL_RECEIVE_ENV`] override.
+    ///
+    /// When the `parallel-receive-delta` feature is compiled in, swaps the
+    /// delta pipeline to the parallel apply path and returns
+    /// [`ReceiverStrategy::Parallel`]. When the feature is compiled out, logs
+    /// `receiver_strategy=parallel_unavailable` and returns
+    /// [`ReceiverStrategy::Sequential`] to match the heuristic-driven
+    /// fallback at [`Self::dispatch_receiver_strategy`].
+    fn dispatch_forced_parallel(&mut self, file_count: usize, total_size: u64) -> ReceiverStrategy {
+        #[cfg(feature = "parallel-receive-delta")]
+        {
+            logging::debug_log!(
+                Genr,
+                1,
+                "receiver_strategy=parallel file_count={} total_size={} \
+                 (forced via {}=<set>)",
+                file_count,
+                total_size,
+                FORCE_PARALLEL_RECEIVE_ENV
+            );
+            self.enable_parallel_receive_delta();
+            ReceiverStrategy::Parallel
+        }
+        #[cfg(not(feature = "parallel-receive-delta"))]
+        {
+            logging::debug_log!(
+                Genr,
+                1,
+                "receiver_strategy=parallel_unavailable file_count={} total_size={} \
+                 (forced via {}=<set>); falling back to sequential because the \
+                 parallel-receive-delta feature is not compiled in",
+                file_count,
+                total_size,
+                FORCE_PARALLEL_RECEIVE_ENV
+            );
+            ReceiverStrategy::Sequential
         }
     }
 

--- a/crates/transfer/src/receiver/tests/file_list/receiver_strategy.rs
+++ b/crates/transfer/src/receiver/tests/file_list/receiver_strategy.rs
@@ -5,11 +5,22 @@
 //! [`ReceiverStrategy`] dictated by the file_count / total_size heuristic
 //! documented in `docs/design/parallel-receive-delta-default-on.md`.
 
+use std::ffi::OsStr;
+use std::sync::Mutex;
+
+use platform::env::EnvGuard;
 use protocol::flist::FileEntry;
 
 use super::super::super::ReceiverContext;
 use super::super::super::stats::ReceiverStrategy;
+use super::super::super::{FORCE_PARALLEL_RECEIVE_ENV, PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD};
 use super::super::support::{test_config, test_handshake};
+
+/// Serialises every test in this module that touches `OC_RSYNC_FORCE_PARALLEL`.
+/// `EnvGuard` requires callers to ensure no concurrent env mutations, and even
+/// tests that only *read* the variable must coordinate so a sibling test cannot
+/// flip it under them.
+static FORCE_PARALLEL_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn make_ctx_with_files(entries: Vec<FileEntry>) -> ReceiverContext {
     let handshake = test_handshake();
@@ -34,6 +45,8 @@ fn total_source_bytes_sums_file_list() {
 fn dispatch_small_transfer_picks_sequential() {
     // 5 small files at 1 KiB each = 5 KiB total. Both inputs well below
     // the Path B cutoffs.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::remove(FORCE_PARALLEL_RECEIVE_ENV);
     let entries = (0..5)
         .map(|i| FileEntry::new_file(format!("f{i}").into(), 1024, 0o644))
         .collect();
@@ -47,6 +60,8 @@ fn dispatch_small_transfer_picks_sequential() {
 fn dispatch_many_small_files_picks_parallel() {
     // 200 tiny files trips the file_count cutoff even though total_size
     // is negligible.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::remove(FORCE_PARALLEL_RECEIVE_ENV);
     let entries = (0..200)
         .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
         .collect();
@@ -60,6 +75,8 @@ fn dispatch_many_small_files_picks_parallel() {
 fn dispatch_large_bytes_picks_parallel() {
     // Single 128 MiB file - trips the 64 MiB total_size cutoff even with
     // a small file_count.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::remove(FORCE_PARALLEL_RECEIVE_ENV);
     let entries = vec![FileEntry::new_file("big".into(), 128 * 1024 * 1024, 0o644)];
     let mut ctx = make_ctx_with_files(entries);
     let strategy = ctx.dispatch_receiver_strategy(1);
@@ -71,6 +88,8 @@ fn dispatch_large_bytes_picks_parallel() {
 fn dispatch_falls_back_to_sequential_without_feature() {
     // When the feature is compiled out, even a "wants-parallel" workload
     // must report sequential so telemetry never lies about the path taken.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::remove(FORCE_PARALLEL_RECEIVE_ENV);
     let entries = (0..200)
         .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
         .collect();
@@ -81,7 +100,72 @@ fn dispatch_falls_back_to_sequential_without_feature() {
 
 #[test]
 fn dispatch_empty_file_list_picks_sequential() {
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::remove(FORCE_PARALLEL_RECEIVE_ENV);
     let mut ctx = make_ctx_with_files(Vec::new());
     let strategy = ctx.dispatch_receiver_strategy(0);
+    assert_eq!(strategy, ReceiverStrategy::Sequential);
+}
+
+#[test]
+fn dispatch_without_force_env_uses_threshold() {
+    // With the env override absent, a sub-threshold workload still picks the
+    // sequential path - the heuristic is unaffected.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::remove(FORCE_PARALLEL_RECEIVE_ENV);
+
+    let small_count = PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD / 2;
+    let entries = (0..small_count)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(small_count);
+    assert_eq!(strategy, ReceiverStrategy::Sequential);
+}
+
+#[test]
+#[cfg(feature = "parallel-receive-delta")]
+fn dispatch_force_env_overrides_threshold_to_parallel() {
+    // Sub-threshold workload with the env override set: parallel wins even
+    // though both file_count and total_size are well under the cutoffs.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set(FORCE_PARALLEL_RECEIVE_ENV, OsStr::new("1"));
+
+    let entries = (0..5)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(5);
+    assert_eq!(strategy, ReceiverStrategy::Parallel);
+}
+
+#[test]
+#[cfg(not(feature = "parallel-receive-delta"))]
+fn dispatch_force_env_falls_back_to_sequential_without_feature() {
+    // Env override is set, but the feature is compiled out. The dispatcher
+    // must log `parallel_unavailable` and return sequential so telemetry
+    // never claims a path the binary cannot take.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set(FORCE_PARALLEL_RECEIVE_ENV, OsStr::new("1"));
+
+    let entries = (0..5)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(5);
+    assert_eq!(strategy, ReceiverStrategy::Sequential);
+}
+
+#[test]
+fn dispatch_force_env_empty_value_does_not_trigger() {
+    // An empty value must not trip the override - matches `is_some_and(|v| !v.is_empty())`.
+    let _lock = FORCE_PARALLEL_ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set(FORCE_PARALLEL_RECEIVE_ENV, OsStr::new(""));
+
+    let entries = (0..5)
+        .map(|i| FileEntry::new_file(format!("f{i}").into(), 1, 0o644))
+        .collect();
+    let mut ctx = make_ctx_with_files(entries);
+    let strategy = ctx.dispatch_receiver_strategy(5);
     assert_eq!(strategy, ReceiverStrategy::Sequential);
 }

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -1172,6 +1172,18 @@ comp_run_scenario() {
       # Place a .rsync-filter merge file in source that excludes *.dat files
       printf 'exclude *.dat\n' > "$sdir/.rsync-filter"
       ;;
+    parallel-threshold)
+      # upstream: oc-rsync only. Trips PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD (100) defined
+      # in crates/transfer/src/receiver/mod.rs to exercise the parallel-receive-delta path
+      # wired by PIP-3 (#2566) / PIP-5 (#2568) and validated by this scenario (PIP-4 #2567).
+      # Keep individual files tiny so total bytes stay well under the 64 MiB
+      # PARALLEL_RECEIVE_BYTES_THRESHOLD and CI time stays low.
+      mkdir -p "$sdir/parallel_threshold"
+      local pt_i
+      for pt_i in $(seq 1 120); do
+        printf 'pt-payload-%03d\n' "$pt_i" > "$sdir/parallel_threshold/file_${pt_i}.txt"
+      done
+      ;;
   esac
 
   # shellcheck disable=SC2086
@@ -1206,6 +1218,7 @@ comp_run_scenario() {
     safe-links) rm -f "$sdir/unsafe_link.txt" ;;
     sparse) rm -f "$sdir/sparse_test.bin" ;;
     merge-filter) rm -f "$sdir/.rsync-filter" ;;
+    parallel-threshold) rm -rf "$sdir/parallel_threshold" ;;
   esac
 
   # --max-delete exits 25 when limit reached; treat as success for verification
@@ -1715,6 +1728,32 @@ comp_run_scenario() {
         echo "    --delete R-filter: unprotected file destonly.txt survived"
         return 1
       fi
+      return 0
+      ;;
+    parallel-threshold)
+      # upstream: oc-rsync only. Trips PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD (100) defined
+      # in crates/transfer/src/receiver/mod.rs to exercise the parallel-receive-delta path
+      # wired by PIP-3 (#2566) / PIP-5 (#2568) and validated by this scenario (PIP-4 #2567).
+      # Validates byte-identical destination only; internal dispatch is oc-rsync's
+      # concern, so no upstream-vs-oc comparison is performed here.
+      comp_verify_transfer "$sdir" "$ddir" || return 1
+      if [[ ! -d "$ddir/parallel_threshold" ]]; then
+        echo "    parallel-threshold: parallel_threshold/ directory missing on dest"
+        return 1
+      fi
+      local pt_received pt_i
+      pt_received=$(find "$ddir/parallel_threshold" -maxdepth 1 -type f -name 'file_*.txt' | wc -l)
+      if [[ "$pt_received" -ne 120 ]]; then
+        echo "    parallel-threshold: expected 120 files in parallel_threshold/, got ${pt_received}"
+        return 1
+      fi
+      for pt_i in $(seq 1 120); do
+        if ! cmp -s "$sdir/parallel_threshold/file_${pt_i}.txt" \
+                     "$ddir/parallel_threshold/file_${pt_i}.txt"; then
+          echo "    parallel-threshold: content mismatch for parallel_threshold/file_${pt_i}.txt"
+          return 1
+        fi
+      done
       return 0
       ;;
   esac
@@ -9621,6 +9660,10 @@ run_comprehensive_interop_case() {
     "permissions|-rlpv|perms"
     "itemize|-avi|itemize"
     "acls|-avA|acls"
+    # upstream: oc-rsync only. Trips PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD (100) defined
+    # in crates/transfer/src/receiver/mod.rs to exercise the parallel-receive-delta path
+    # wired by PIP-3 (#2566) / PIP-5 (#2568) and validated by this scenario (PIP-4 #2567).
+    "parallel-threshold-trip|-av|parallel-threshold"
   )
 
   # Extended scenarios only for the newest upstream versions (3.4.1+).


### PR DESCRIPTION
## Summary

Closes the PIP-4 validation gap for the `parallel-receive-delta` dispatch path (#2567) by adding two complementary mechanisms that, together, give the parallel apply path both an interactive debug switch and permanent CI coverage.

- **Runtime override**: `OC_RSYNC_FORCE_PARALLEL=<non-empty>` short-circuits `ReceiverContext::dispatch_receiver_strategy` and unconditionally selects `ReceiverStrategy::Parallel`. When the `parallel-receive-delta` feature is compiled out the override logs `parallel_unavailable` under GENR and falls back to Sequential so telemetry never claims a path the binary cannot take. The toggle is intentionally not surfaced on the CLI; it is a runtime/debug knob only.
- **Interop scenario**: new `parallel-threshold-trip` case in `tools/ci/run_interop.sh` augments the source tree with 120 tiny files (above `PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD = 100`, well under the 64 MiB byte cutoff, total payload < 1 MB) and validates a byte-identical destination. The existing comprehensive payload (~260 KB / 19 files) never tripped the threshold, so the parallel branch ran in zero interop transfers prior to this change.

Both pieces ship together because the env knob enables interactive debugging of the path the scenario permanently exercises in CI - one without the other leaves PIP-4 only half-validated.

## Why one PR

The env override and the interop scenario both serve the same goal: making the parallel-receive-delta dispatch path observable. The override lets engineers reproduce the path on any workload size; the scenario guarantees CI never silently regresses the path. Shipping them in a single commit keeps the validation story coherent.

## Notes

- Thresholds (`PARALLEL_RECEIVE_FILE_COUNT_THRESHOLD`, `PARALLEL_RECEIVE_BYTES_THRESHOLD`) are unchanged - PIP-4 validates the existing tuning, it does not retune.
- The new scenario validates byte-identical destination only. Internal dispatch is an oc-rsync concern; upstream's behaviour for 120 small files is identical to ours regardless of the internal pipeline choice, so no upstream-vs-oc comparison is performed.
- Unit tests use the shared `platform::env::EnvGuard` fixture (added as a dev-dependency of the `transfer` crate) plus a module-local mutex to serialise every test that touches the env var.

## Test plan

- [ ] CI: `fmt+clippy` clean
- [ ] CI: `nextest (stable)` green - new unit tests in `receiver_strategy.rs`
- [ ] CI: Windows / macOS / Linux musl matrices green
- [ ] CI: Interop Validation - new `parallel-threshold-trip` scenario passes in both directions across all upstream versions