### PR TITLE
docs(signature): comment cleanup preserving block-size formula and phase notes (CCL signature)

### DIFF
--- a/crates/signature/src/layout.rs
+++ b/crates/signature/src/layout.rs
@@ -223,6 +223,11 @@ pub fn calculate_signature_layout(
     })
 }
 
+/// Derives a block length from file size using rsync's square-root heuristic.
+///
+/// Files at or below `BLOCK_SIZE²` use the default block size; larger files use
+/// an approximation of `sqrt(file_length)` rounded down to a multiple of 8 and
+/// clamped to the protocol-specific maximum.
 fn derive_block_length(file_length: u64, protocol: ProtocolVersion) -> u32 {
     if file_length <= u64::from(BLOCK_SIZE).saturating_mul(u64::from(BLOCK_SIZE)) {
         return BLOCK_SIZE;


### PR DESCRIPTION
## Summary

Per-crate rustdoc-first comment hygiene pass for the `signature` crate.

The crate was already in excellent shape: `#![deny(missing_docs)]` is set on the lib, all public items carry rustdoc, and substantive inline comments (block-size sqrt heuristic, phase 1 vs phase 2 redo semantics, upstream rsync references) were already in place. The only gap was a missing rustdoc on the private `derive_block_length` helper, which has been added for parity with `derive_strong_sum_length`.

## Public items that gained rustdoc

- None (all public items were already documented under `#![deny(missing_docs)]`).

## Private items that gained rustdoc

- `layout::derive_block_length` - brief description of the sqrt heuristic and protocol clamping, mirroring the existing rustdoc on `derive_strong_sum_length`.

## Categories of comments deleted

- None. All inline `//` comments in non-test code were substantive (algorithm explanations, upstream cross-references, phase semantics, ordering invariants).

## Upstream reference preservation

`upstream:` reference count before: 8
`upstream:` reference count after: 8

References preserved verbatim across `block_size.rs`, `layout.rs`, and `algorithm.rs`.

## Test plan

- [ ] CI fmt + clippy passes
- [ ] CI nextest stable passes
- [ ] CI Windows / macOS / Linux musl matrices pass