### PR TITLE
docs(metadata): comment cleanup preserving POSIX FFI SAFETY blocks and upstream refs (CCL metadata)

### DIFF
--- a/crates/metadata/src/chmod/apply.rs
+++ b/crates/metadata/src/chmod/apply.rs
@@ -1,3 +1,9 @@
+//! Evaluator that applies parsed [`Clause`] modifiers to a mode value.
+//!
+//! Implements both numeric and symbolic chmod semantics matching GNU `chmod`,
+//! including conditional-exec (`X`), copy directives (e.g. `g=u`), and the
+//! upstream-defined target selectors (`F`, `D`).
+
 use super::spec::Clause;
 
 #[cfg(unix)]

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -1,3 +1,9 @@
+//! Parser for `--chmod` specifications.
+//!
+//! Splits comma-separated clauses, recognises optional `D`/`F` target
+//! selectors, and dispatches each clause to the numeric or symbolic
+//! parser. Errors produce [`ChmodError`] with the offending clause text.
+
 use super::{
     ChmodError,
     spec::{

--- a/crates/metadata/src/chmod/spec.rs
+++ b/crates/metadata/src/chmod/spec.rs
@@ -1,3 +1,9 @@
+//! Crate-internal representation of parsed `--chmod` clauses.
+//!
+//! Defines the [`Clause`] tree, [`Operation`] variants, [`PermSpec`] flag set,
+//! and [`TargetSelector`]/[`WhoMask`] helpers consumed by the parser and the
+//! evaluator. None of these types are exposed in the public API.
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TargetSelector {
     All,

--- a/crates/metadata/src/error.rs
+++ b/crates/metadata/src/error.rs
@@ -1,3 +1,8 @@
+//! [`MetadataError`] type used by every fallible operation in the crate.
+//!
+//! Pairs a static context string, the affected path, and the underlying
+//! [`io::Error`] so higher layers can render upstream-compatible diagnostics.
+
 use std::io;
 use std::path::{Path, PathBuf};
 

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -1,3 +1,10 @@
+//! FIFO, socket, and device-node creation helpers.
+//!
+//! Mirrors upstream rsync's `syscall.c:do_mknod()` for materialising special
+//! files before metadata is applied. Includes `--fake-super` placeholder
+//! substitution so unprivileged users can preserve privileged metadata via
+//! the `user.rsync.%stat` xattr instead of issuing `mknod(2)`.
+
 use crate::error::MetadataError;
 use std::fs;
 use std::io;

--- a/crates/metadata/src/symlink_munge.rs
+++ b/crates/metadata/src/symlink_munge.rs
@@ -1,3 +1,9 @@
+//! Symlink munging helpers for daemon-mode security.
+//!
+//! Mirrors upstream rsync's `clientserver.c:munge_symlink()` /
+//! `unmunge_symlink()` so symlink targets received over the wire cannot
+//! escape the module root when `use chroot = no`.
+
 /// Prefix prepended to symlink targets when munging is active.
 ///
 /// Upstream rsync uses this exact prefix in `clientserver.c` to prevent


### PR DESCRIPTION
## Summary

CCL (Comment Cleanup) pass on the `metadata` crate. Aligns the crate
with the rustdoc-first hygiene already applied across `checksums`,
`cli`, `compress`, `protocol`, `fast_io`, `core`, `batch`, `rsync_io`,
`logging`, `logging-sink`, `xtask`, `apple-fs`, `platform`, and
`flist`.

The `metadata` crate wraps POSIX FFI (`getpwnam_r`, `getgrnam_r`,
timestamps, ownership, xattrs, ACLs) and is one of the crates
permitted to contain `#[allow(unsafe_code)]`. Every `// SAFETY:` block
and every `// upstream:` reference was kept verbatim; counts before
and after match (71 SAFETY, 98 upstream).

## Public items that gained rustdoc

None - every `pub fn`, `pub struct`, `pub enum`, `pub trait`, and
`pub const` already had a rustdoc comment. The crate was in good
shape on this axis.

## Module-level `//!` headers added

Added concise `//!` docstrings to six true module files that lacked
them so the rendered docs surface the module's purpose:

- `crates/metadata/src/error.rs`
- `crates/metadata/src/special.rs`
- `crates/metadata/src/symlink_munge.rs`
- `crates/metadata/src/chmod/apply.rs`
- `crates/metadata/src/chmod/parse.rs`
- `crates/metadata/src/chmod/spec.rs`

## Comment categories deleted

None. The crate was already free of restatement, banner, divider,
checkpoint, and commented-out-code lines. The remaining inline `//`
comments document FFI invariants, errno handling, platform quirks,
and SAFETY continuations; they all add value beyond the code itself
and were preserved.

## Preservation confirmation

No `// SAFETY:` blocks removed (71 before, 71 after).
No `// upstream:` references removed (98 before, 98 after).
No function bodies, control flow, or `cfg`-gated logic touched.
No `#[allow(...)]` clippy waivers added.
No test files modified.

## Test plan

- [ ] `cargo fmt --all -- --check` passes (formatter ran clean before
      push; CI will reverify).
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps
      -- -D warnings` passes (CI).
- [ ] Stable nextest passes on Linux/macOS/Windows + Linux musl (CI).