### PR TITLE
feat(transfer): thread DirSandbox through temp_guard/temp_cleanup (SEC-1.r)

### DIFF
--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -34,12 +34,12 @@ tokio-util = { workspace = true, optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-fs = { path = "../apple-fs" }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-# libc is needed for O_NOATIME flag in source-file open (upstream syscall.c:228,687).
-libc = { workspace = true }
-
 [target.'cfg(unix)'.dependencies]
 checksums = { path = "../checksums" }
+# libc is needed for O_NOATIME (Linux source-file open, upstream syscall.c:228,687)
+# and for openat flag constants (O_WRONLY/O_CREAT/O_EXCL/O_NOFOLLOW) used by the
+# SEC-1.r temp-file sandbox in temp_guard.rs.
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -44,6 +44,21 @@ pub struct DiskCommitConfig {
     pub do_fsync: bool,
     /// Whether to use sparse file writing.
     pub use_sparse: bool,
+    /// Destination tree root used to anchor SEC-1.r/SEC-1.j cross-thread
+    /// `*at` syscalls. `None` when the destination root could not be opened
+    /// at receiver setup or when running on a platform without the carrier.
+    pub dest_dir: Option<PathBuf>,
+    /// SEC-1.r parent-dirfd carrier rooted at the destination tree.
+    ///
+    /// `Arc` so the disk-commit thread can outlive the borrow on the
+    /// receiver's `PipelineSetup::sandbox`. When `Some`, the temp-file
+    /// create and the temp-file unlink-on-drop route through
+    /// `openat` / `unlinkat` instead of path-based syscalls so a TOCTOU
+    /// symlink swap on the temp parent cannot redirect the create or the
+    /// cleanup. `None` on non-Unix targets and on Unix when the receiver
+    /// could not open the destination root.
+    #[cfg(unix)]
+    pub sandbox: Option<Arc<fast_io::DirSandbox>>,
     /// Temporary directory for staging received files before final placement.
     /// Shared across all files in a transfer session.
     pub temp_dir: Option<PathBuf>,
@@ -101,6 +116,9 @@ impl Default for DiskCommitConfig {
         Self {
             do_fsync: false,
             use_sparse: false,
+            dest_dir: None,
+            #[cfg(unix)]
+            sandbox: None,
             temp_dir: None,
             file_list: None,
             metadata_opts: None,

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -14,7 +14,11 @@ use protocol::acl::AclCache;
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
 use crate::pipeline::messages::{BeginMessage, CommitResult, ComputedChecksum, FileMessage};
 use crate::pipeline::spsc;
-use crate::temp_guard::{TempFileGuard, open_tmpfile};
+use crate::temp_guard::TempFileGuard;
+#[cfg(not(unix))]
+use crate::temp_guard::open_tmpfile;
+#[cfg(unix)]
+use crate::temp_guard::open_tmpfile_sandboxed;
 
 use super::config::{BackupConfig, DiskCommitConfig};
 use super::writer::{ReusableBufWriter, Writer};
@@ -245,6 +249,20 @@ fn open_output_file(
         }
         Ok((file, TempFileGuard::new(begin.file_path.clone()), false))
     } else {
+        // SEC-1.r: when the dest_dir + sandbox carrier is plumbed, route the
+        // temp-file create through `openat(dirfd, leaf, O_WRONLY|O_CREAT|
+        // O_EXCL|O_NOFOLLOW, 0o600)` and seed the guard with a sandbox anchor
+        // so the Drop unlink uses the same dirfd. The carrier only engages
+        // for the default in-destination temp pattern (single component under
+        // dest_dir); --temp-dir routing keeps the path-based fallback.
+        #[cfg(unix)]
+        let (file, guard) = open_tmpfile_sandboxed(
+            &begin.file_path,
+            config.temp_dir.as_deref(),
+            config.sandbox.as_ref(),
+            config.dest_dir.as_deref(),
+        )?;
+        #[cfg(not(unix))]
         let (file, guard) = open_tmpfile(&begin.file_path, config.temp_dir.as_deref())?;
         Ok((file, guard, true))
     }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -126,6 +126,9 @@ impl ReceiverContext {
         let disk_config = DiskCommitConfig {
             do_fsync: self.config.write.fsync,
             use_sparse: self.config.flags.sparse,
+            dest_dir: Some(setup.dest_dir.clone()),
+            #[cfg(unix)]
+            sandbox: setup.sandbox.clone(),
             temp_dir: self.config.temp_dir.as_ref().map(PathBuf::from),
             file_list: Some(file_list_arc),
             metadata_opts: Some(setup.metadata_opts.clone()),
@@ -297,7 +300,7 @@ impl ReceiverContext {
                 let response_ctx = ResponseContext {
                     config: &request_config,
                     #[cfg(unix)]
-                    sandbox: setup.sandbox.as_deref(),
+                    sandbox: setup.sandbox.as_ref(),
                     #[cfg(unix)]
                     dest_dir: Some(setup.dest_dir.as_path()),
                 };

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -22,7 +22,10 @@ use crate::receiver::quick_check::is_hardlink_follower;
 use crate::receiver::stats::TransferStats;
 use crate::receiver::wire::{SenderAttrs, SumHead, write_signature_blocks};
 use crate::receiver::{PipelineSetup, ReceiverContext, apply_acls_from_receiver_cache};
+#[cfg(not(unix))]
 use crate::temp_guard::open_tmpfile;
+#[cfg(unix)]
+use crate::temp_guard::open_tmpfile_sandboxed;
 use crate::token_buffer::TokenBuffer;
 use crate::token_reader::{DeltaToken as TokenReaderDeltaToken, LiteralData, TokenReader};
 
@@ -198,6 +201,17 @@ impl ReceiverContext {
 
             let _echoed_sum_head = SumHead::read(reader)?;
 
+            // SEC-1.r: route temp create + drop unlink through the sandbox
+            // carrier so a TOCTOU swap on the temp parent cannot redirect
+            // the create or the unlink-on-error.
+            #[cfg(unix)]
+            let (file, mut temp_guard) = open_tmpfile_sandboxed(
+                &file_path,
+                self.config.temp_dir.as_deref(),
+                sandbox.as_ref(),
+                Some(dest_dir.as_path()),
+            )?;
+            #[cfg(not(unix))]
             let (file, mut temp_guard) = open_tmpfile(&file_path, self.config.temp_dir.as_deref())?;
             let target_size = file_entry.size();
             let writer_capacity = adaptive_writer_capacity(target_size);

--- a/crates/transfer/src/temp_cleanup.rs
+++ b/crates/transfer/src/temp_cleanup.rs
@@ -12,6 +12,8 @@
 use std::fs;
 use std::io;
 use std::path::Path;
+#[cfg(unix)]
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use logging::debug_log;
@@ -88,6 +90,29 @@ fn is_temp_file_name(name: &str) -> bool {
 /// We perform this proactively at startup rather than only on signal, since
 /// SIGKILL bypasses all cleanup handlers.
 pub fn cleanup_stale_temp_files(dest_dir: &Path, max_age: Option<Duration>) -> io::Result<usize> {
+    cleanup_stale_temp_files_sandboxed(
+        dest_dir,
+        max_age,
+        #[cfg(unix)]
+        None,
+    )
+}
+
+/// Like [`cleanup_stale_temp_files`] but routes the per-entry unlink through
+/// the SEC-1.r `DirSandbox` carrier when present.
+///
+/// The orphan scan itself stays on the path-based `fs::read_dir` (audit row
+/// #20 carrier-acceptable residual: there is no `fdopendir`-equivalent in
+/// `std` and the scan is informational, not state-changing). The per-entry
+/// `unlinkat(dirfd, leaf, 0)` (audit row #21) is anchored on the sandbox
+/// dirfd when `sandbox` and `dest_dir` reduce to a single-component leaf, so
+/// a symlink swap on the temp parent between scan and unlink cannot
+/// redirect the remove to an attacker-chosen inode.
+pub fn cleanup_stale_temp_files_sandboxed(
+    dest_dir: &Path,
+    max_age: Option<Duration>,
+    #[cfg(unix)] sandbox: Option<&Arc<fast_io::DirSandbox>>,
+) -> io::Result<usize> {
     let threshold = max_age.unwrap_or(DEFAULT_MAX_AGE);
     let now = SystemTime::now();
     let mut removed = 0;
@@ -134,7 +159,14 @@ pub fn cleanup_stale_temp_files(dest_dir: &Path, max_age: Option<Duration>) -> i
         }
 
         let path = entry.path();
-        match fs::remove_file(&path) {
+        let unlink_result = remove_temp_entry(
+            &path,
+            &file_name,
+            dest_dir,
+            #[cfg(unix)]
+            sandbox,
+        );
+        match unlink_result {
             Ok(()) => {
                 debug_log!(Exit, 2, "removed stale temp file: {}", path.display());
                 removed += 1;
@@ -144,6 +176,33 @@ pub fn cleanup_stale_temp_files(dest_dir: &Path, max_age: Option<Duration>) -> i
     }
 
     Ok(removed)
+}
+
+/// Unlinks one orphan temp-file entry, routing through the SEC-1.r sandbox
+/// carrier when present and falling back to `std::fs::remove_file` otherwise.
+fn remove_temp_entry(
+    path: &Path,
+    file_name: &std::ffi::OsStr,
+    dest_dir: &Path,
+    #[cfg(unix)] sandbox: Option<&Arc<fast_io::DirSandbox>>,
+) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        if let Some(sandbox) = sandbox {
+            let relative = Path::new(file_name);
+            return fast_io::unlink_via_sandbox_or_fallback(
+                Some(sandbox.as_ref()),
+                dest_dir,
+                relative,
+                path,
+                fast_io::UnlinkFlags::File,
+            );
+        }
+        let _ = (file_name, dest_dir);
+    }
+    #[cfg(not(unix))]
+    let _ = (file_name, dest_dir);
+    fs::remove_file(path)
 }
 
 #[cfg(test)]
@@ -323,5 +382,38 @@ mod tests {
         fs::set_permissions(&subdir, fs::Permissions::from_mode(0o755)).unwrap();
 
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sandboxed_unlink_removes_stale_entries() {
+        let dir = tempdir().expect("create temp dir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize");
+        let sandbox = Arc::new(fast_io::DirSandbox::open_root(&root).expect("sandbox"));
+
+        let temp1 = root.join(".file.txt.AbCdEf");
+        let temp2 = root.join(".data.bin.x1y2z3");
+        fs::write(&temp1, b"stale 1").unwrap();
+        fs::write(&temp2, b"stale 2").unwrap();
+
+        let count = cleanup_stale_temp_files_sandboxed(&root, Some(Duration::ZERO), Some(&sandbox))
+            .unwrap();
+        assert_eq!(count, 2);
+        assert!(!temp1.exists());
+        assert!(!temp2.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sandboxed_unlink_falls_back_when_sandbox_absent() {
+        let dir = tempdir().expect("create temp dir");
+
+        let temp = dir.path().join(".file.txt.AbCdEf");
+        fs::write(&temp, b"stale").unwrap();
+
+        let count =
+            cleanup_stale_temp_files_sandboxed(dir.path(), Some(Duration::ZERO), None).unwrap();
+        assert_eq!(count, 1);
+        assert!(!temp.exists());
     }
 }

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -13,6 +13,8 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::sync::Arc;
 
 /// Length of the random suffix including the leading dot: `.XXXXXX` = 7 bytes.
 const TMPNAME_SUFFIX_LEN: usize = 7;
@@ -120,6 +122,43 @@ fn truncate_utf8_safe(s: &str, max_len: usize) -> String {
 /// A tuple of `(File, TempFileGuard)` - the open file handle and an RAII guard
 /// that cleans up the temp file on drop unless `keep()` is called.
 pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::File, TempFileGuard)> {
+    open_tmpfile_inner(
+        dest,
+        temp_dir,
+        #[cfg(unix)]
+        None,
+        #[cfg(unix)]
+        None,
+    )
+}
+
+/// Like [`open_tmpfile`] but routes the create through the SEC-1.r
+/// `DirSandbox` carrier when both the temp parent and the temp leaf reduce
+/// to a single component beneath `dest_dir`.
+///
+/// The returned [`TempFileGuard`] inherits the same sandbox anchor so its
+/// Drop cleanup runs through `unlinkat(sandbox.current_dirfd(), leaf, 0)`,
+/// closing the symlink-swap window between the receiver's decide-to-create
+/// moment and the eventual unlink. When the sandbox is absent or the temp
+/// parent does not match `dest_dir` (for example `--temp-dir` pointing at a
+/// sibling tree), the helper falls back to the path-based open and the
+/// guard falls back to `std::fs::remove_file`.
+#[cfg(unix)]
+pub fn open_tmpfile_sandboxed(
+    dest: &Path,
+    temp_dir: Option<&Path>,
+    sandbox: Option<&Arc<fast_io::DirSandbox>>,
+    dest_dir: Option<&Path>,
+) -> io::Result<(fs::File, TempFileGuard)> {
+    open_tmpfile_inner(dest, temp_dir, sandbox, dest_dir)
+}
+
+fn open_tmpfile_inner(
+    dest: &Path,
+    temp_dir: Option<&Path>,
+    #[cfg(unix)] sandbox: Option<&Arc<fast_io::DirSandbox>>,
+    #[cfg(unix)] dest_dir: Option<&Path>,
+) -> io::Result<(fs::File, TempFileGuard)> {
     let template = get_tmpname(dest, temp_dir)?;
     let template_str = template.to_string_lossy().into_owned();
 
@@ -127,25 +166,41 @@ pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::Fil
         let concrete = fill_random_suffix(&template_str);
         let concrete_path = PathBuf::from(&concrete);
 
-        match fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&concrete_path)
-        {
+        match try_create_new(
+            &concrete_path,
+            #[cfg(unix)]
+            sandbox,
+            #[cfg(unix)]
+            dest_dir,
+        ) {
             Ok(file) => {
-                return Ok((file, TempFileGuard::new(concrete_path)));
+                #[cfg(unix)]
+                let guard = TempFileGuard::with_anchor(concrete_path.clone(), sandbox, dest_dir);
+                #[cfg(not(unix))]
+                let guard = TempFileGuard::new(concrete_path);
+                return Ok((file, guard));
             }
             Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                // upstream: receiver.c:766 - mkdir_defmode(dn) before do_mkstemp()
+                // upstream: receiver.c:766 - mkdir_defmode(dn) before do_mkstemp().
+                // SEC-1.r accepted residual: multi-component parent recovery
+                // cannot anchor on a single dirfd without an `mkpath_via_sandbox`
+                // helper; fall back to the path-based create_dir_all walk.
                 if let Some(parent) = concrete_path.parent() {
                     fs::create_dir_all(parent)?;
-                    if let Ok(file) = fs::OpenOptions::new()
-                        .write(true)
-                        .create_new(true)
-                        .open(&concrete_path)
-                    {
-                        return Ok((file, TempFileGuard::new(concrete_path)));
+                    if let Ok(file) = try_create_new(
+                        &concrete_path,
+                        #[cfg(unix)]
+                        sandbox,
+                        #[cfg(unix)]
+                        dest_dir,
+                    ) {
+                        #[cfg(unix)]
+                        let guard =
+                            TempFileGuard::with_anchor(concrete_path.clone(), sandbox, dest_dir);
+                        #[cfg(not(unix))]
+                        let guard = TempFileGuard::new(concrete_path);
+                        return Ok((file, guard));
                     }
                 }
                 return Err(io::Error::new(e.kind(), e.to_string()));
@@ -158,6 +213,43 @@ pub fn open_tmpfile(dest: &Path, temp_dir: Option<&Path>) -> io::Result<(fs::Fil
         io::ErrorKind::AlreadyExists,
         format!("failed to create temp file after {MAX_OPEN_ATTEMPTS} attempts: {template_str}"),
     ))
+}
+
+/// Atomically creates `concrete_path` with `O_RDWR | O_CREAT | O_EXCL |
+/// O_NOFOLLOW` semantics, routing through the SEC-1.r sandbox carrier when
+/// possible.
+fn try_create_new(
+    concrete_path: &Path,
+    #[cfg(unix)] sandbox: Option<&Arc<fast_io::DirSandbox>>,
+    #[cfg(unix)] dest_dir: Option<&Path>,
+) -> io::Result<fs::File> {
+    #[cfg(unix)]
+    {
+        if let (Some(sandbox), Some(dest_dir)) = (sandbox, dest_dir) {
+            if let Some(leaf_name) = concrete_path.file_name() {
+                let parent = concrete_path.parent().unwrap_or(Path::new(""));
+                if parent == dest_dir {
+                    let relative = Path::new(leaf_name);
+                    // Mirror the fallback's `OpenOptions::new().write(true).create_new(true)`
+                    // exactly: `O_WRONLY | O_CREAT | O_EXCL`, plus `O_NOFOLLOW` so a
+                    // pre-planted symlink at the leaf path cannot redirect the create.
+                    let flags = libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW;
+                    return fast_io::openat_via_sandbox_or_fallback(
+                        Some(sandbox.as_ref()),
+                        dest_dir,
+                        relative,
+                        concrete_path,
+                        flags,
+                        0o600,
+                    );
+                }
+            }
+        }
+    }
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(concrete_path)
 }
 
 /// Replaces the trailing `XXXXXX` in a template string with random alphanumeric
@@ -175,6 +267,16 @@ fn fill_random_suffix(template: &str) -> String {
     format!("{prefix}{suffix}")
 }
 
+/// SEC-1.r sandbox anchor carried by [`TempFileGuard`] so the Drop unlink
+/// runs through `unlinkat(sandbox.current_dirfd(), leaf, 0)` against the
+/// same parent the create resolved against.
+#[cfg(unix)]
+#[derive(Debug)]
+struct SandboxAnchor {
+    sandbox: Arc<fast_io::DirSandbox>,
+    dest_dir: PathBuf,
+}
+
 /// RAII guard that ensures temp files are deleted on drop.
 ///
 /// By default, the temp file is deleted when the guard is dropped (e.g., on
@@ -184,15 +286,60 @@ fn fill_random_suffix(template: &str) -> String {
 pub struct TempFileGuard {
     path: PathBuf,
     keep_on_drop: bool,
+    /// SEC-1.r sandbox anchor: when present, Drop routes the unlink through
+    /// `unlinkat(sandbox.current_dirfd(), leaf, 0)` so a symlink swap on the
+    /// temp parent between create and unlink cannot redirect the cleanup.
+    #[cfg(unix)]
+    anchor: Option<SandboxAnchor>,
 }
 
 impl TempFileGuard {
     /// Create a new guard for the given temp file path.
+    ///
+    /// The Drop cleanup uses [`std::fs::remove_file`] against the stored
+    /// path. Use [`open_tmpfile_sandboxed`] to install a SEC-1.r sandbox
+    /// anchor that routes the unlink through `unlinkat`.
     #[inline]
     pub const fn new(path: PathBuf) -> Self {
         Self {
             path,
             keep_on_drop: false,
+            #[cfg(unix)]
+            anchor: None,
+        }
+    }
+
+    /// Create a new guard with an optional SEC-1.r sandbox anchor.
+    ///
+    /// When `sandbox` and `dest_dir` are both `Some` and the temp file lives
+    /// directly beneath `dest_dir`, the guard's Drop unlinks the file through
+    /// `unlinkat(sandbox.current_dirfd(), leaf, 0)` instead of the path-based
+    /// `std::fs::remove_file`. Otherwise the guard falls back to the
+    /// path-based cleanup.
+    #[cfg(unix)]
+    fn with_anchor(
+        path: PathBuf,
+        sandbox: Option<&Arc<fast_io::DirSandbox>>,
+        dest_dir: Option<&Path>,
+    ) -> Self {
+        let anchor = match (sandbox, dest_dir) {
+            (Some(sandbox), Some(dest_dir)) => {
+                let parent = path.parent().unwrap_or(Path::new(""));
+                if parent == dest_dir {
+                    Some(SandboxAnchor {
+                        sandbox: Arc::clone(sandbox),
+                        dest_dir: dest_dir.to_path_buf(),
+                    })
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        Self {
+            path,
+            keep_on_drop: false,
+            anchor,
         }
     }
 
@@ -211,11 +358,28 @@ impl TempFileGuard {
 
 impl Drop for TempFileGuard {
     fn drop(&mut self) {
-        if !self.keep_on_drop {
-            // Best-effort: the file may never have been created, may already be renamed
-            // away, and we cannot propagate errors from drop anyway.
-            let _ = std::fs::remove_file(&self.path);
+        if self.keep_on_drop {
+            return;
         }
+        // Best-effort: the file may never have been created, may already be renamed
+        // away, and we cannot propagate errors from drop anyway.
+        #[cfg(unix)]
+        {
+            if let Some(anchor) = self.anchor.as_ref() {
+                if let Some(leaf) = self.path.file_name() {
+                    let relative = Path::new(leaf);
+                    let _ = fast_io::unlink_via_sandbox_or_fallback(
+                        Some(anchor.sandbox.as_ref()),
+                        &anchor.dest_dir,
+                        relative,
+                        &self.path,
+                        fast_io::UnlinkFlags::File,
+                    );
+                    return;
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&self.path);
     }
 }
 
@@ -503,5 +667,115 @@ mod tests {
         assert!(result.len() <= 255);
         assert!(result.ends_with(".XXXXXX"));
         assert!(!result.contains('\u{FFFD}'));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_tmpfile_sandboxed_creates_and_cleans_up_via_carrier() {
+        let dir = tempdir().expect("create temp dir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize");
+        let sandbox = Arc::new(fast_io::DirSandbox::open_root(&root).expect("open sandbox"));
+        let dest = root.join("payload.bin");
+
+        let temp_path;
+        {
+            let (_file, guard) = open_tmpfile_sandboxed(&dest, None, Some(&sandbox), Some(&root))
+                .expect("open sandboxed");
+            temp_path = guard.path().to_path_buf();
+            assert!(temp_path.exists());
+            assert_eq!(temp_path.parent().unwrap(), root);
+        }
+
+        assert!(
+            !temp_path.exists(),
+            "sandbox-anchored guard must unlink the temp file on drop"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_tmpfile_sandboxed_falls_back_when_temp_dir_differs() {
+        let dest_root = tempdir().expect("dest dir");
+        let dest_canon = std::fs::canonicalize(dest_root.path()).expect("canon dest");
+        let temp_root = tempdir().expect("temp dir");
+        let temp_canon = std::fs::canonicalize(temp_root.path()).expect("canon temp");
+        let sandbox = Arc::new(fast_io::DirSandbox::open_root(&dest_canon).expect("sandbox"));
+        let dest = dest_canon.join("file.txt");
+
+        let (_file, mut guard) =
+            open_tmpfile_sandboxed(&dest, Some(&temp_canon), Some(&sandbox), Some(&dest_canon))
+                .expect("open sandboxed with temp_dir");
+
+        let temp_path = guard.path().to_path_buf();
+        assert!(temp_path.starts_with(&temp_canon));
+        // Anchor must not engage when the temp parent differs from dest_dir.
+        assert!(guard.anchor.is_none());
+        guard.keep();
+        let _ = std::fs::remove_file(&temp_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sandbox_anchored_guard_resists_symlink_swap_on_parent() {
+        // Regression: a symlink swap on the temp file's parent between
+        // create and unlink would, via path-based remove_file, redirect
+        // the unlink to an attacker-chosen inode. The sandbox-anchored
+        // Drop unlinks via `unlinkat(dirfd, leaf, 0)`, which is pinned to
+        // the original dirfd opened at receiver setup so the swap cannot
+        // redirect the cleanup.
+        let staging = tempdir().expect("staging");
+        let staging_canon = std::fs::canonicalize(staging.path()).expect("canon staging");
+        let real_parent = staging_canon.join("real");
+        let real_aside = staging_canon.join("real.aside");
+        let attacker_parent = staging_canon.join("attacker");
+        std::fs::create_dir(&real_parent).expect("real");
+        std::fs::create_dir(&attacker_parent).expect("attacker");
+        let victim_in_attacker = attacker_parent.join("victim.bin");
+        std::fs::write(&victim_in_attacker, b"do not delete me").expect("victim");
+
+        // Open the sandbox before any swap so the dirfd points at `real`.
+        let sandbox = Arc::new(fast_io::DirSandbox::open_root(&real_parent).expect("sandbox"));
+        let dest = real_parent.join("payload.bin");
+
+        let (_file, guard) =
+            open_tmpfile_sandboxed(&dest, None, Some(&sandbox), Some(&real_parent))
+                .expect("open sandboxed");
+        let temp_path = guard.path().to_path_buf();
+        let temp_leaf = temp_path.file_name().unwrap().to_owned();
+        assert!(temp_path.exists());
+
+        // Plant a same-leaf decoy inside `attacker` so a confused
+        // path-based unlink would target the wrong inode.
+        let attacker_decoy = attacker_parent.join(&temp_leaf);
+        std::fs::write(&attacker_decoy, b"do not delete me either").expect("decoy");
+
+        // Rename the real directory aside and plant a symlink at the
+        // original location pointing at the attacker tree. The sandbox
+        // dirfd still references the (now-renamed) real directory; the
+        // attacker has overwritten the path-based `real_parent` route.
+        std::fs::rename(&real_parent, &real_aside).expect("rename real aside");
+        std::os::unix::fs::symlink(&attacker_parent, &real_parent).expect("plant symlink");
+
+        // Drop the guard - the unlinkat must run against the original
+        // dirfd, which still resolves to the moved-aside real directory.
+        drop(guard);
+
+        // The decoy under the attacker tree must survive: a path-based
+        // remove_file(real_parent/<leaf>) after the swap would have
+        // unlinked it.
+        assert!(
+            attacker_decoy.exists(),
+            "sandbox-anchored unlink must not delete the attacker-controlled decoy"
+        );
+        assert!(
+            victim_in_attacker.exists(),
+            "unrelated attacker-owned file must remain untouched"
+        );
+        // And the real temp file must be gone from its (renamed) home.
+        let renamed_temp = real_aside.join(&temp_leaf);
+        assert!(
+            !renamed_temp.exists(),
+            "sandbox-anchored unlink must remove the original temp file"
+        );
     }
 }

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -180,10 +180,13 @@ pub struct ResponseContext<'a> {
     /// Threaded through to the per-entry response processing so the
     /// SEC-1.f-j cutover sites can resolve relative names against a
     /// sandboxed dirfd via `*at` syscalls instead of re-walking paths
-    /// through the kernel. `None` when the receiver could not open the
-    /// destination root (e.g. it does not exist yet).
+    /// through the kernel. Held as `&Arc` rather than `&DirSandbox` so
+    /// SEC-1.r anchor sites (the temp-file Drop guard) can clone the
+    /// carrier into a stable handle that outlives this borrow. `None`
+    /// when the receiver could not open the destination root (e.g. it
+    /// does not exist yet).
     #[cfg(unix)]
-    pub sandbox: Option<&'a fast_io::DirSandbox>,
+    pub sandbox: Option<&'a std::sync::Arc<fast_io::DirSandbox>>,
     /// Destination tree root anchor for the SEC-1.j leaf-rename detector.
     ///
     /// `process_file_response` uses this together with `sandbox` to route

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -21,7 +21,10 @@ use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
 use crate::map_file::MapFile;
 use crate::pipeline::PendingTransfer;
 use crate::reader::ServerReader;
+#[cfg(not(unix))]
 use crate::temp_guard::open_tmpfile;
+#[cfg(unix)]
+use crate::temp_guard::open_tmpfile_sandboxed;
 use crate::token_buffer::TokenBuffer;
 use crate::token_reader::{DeltaToken, LiteralData, TokenReader};
 
@@ -88,6 +91,14 @@ pub fn process_file_response<R: Read>(
             false,
         )
     } else {
+        // SEC-1.r: route the temp-file create + drop-cleanup through the
+        // `ResponseContext` sandbox carrier when both the temp parent and
+        // the temp leaf reduce to a single component beneath `ctx.dest_dir`.
+        // --temp-dir or multi-component paths take the path-based fallback.
+        #[cfg(unix)]
+        let (f, guard) =
+            open_tmpfile_sandboxed(&file_path, ctx.config.temp_dir, ctx.sandbox, ctx.dest_dir)?;
+        #[cfg(not(unix))]
         let (f, guard) = open_tmpfile(&file_path, ctx.config.temp_dir)?;
         (f, guard, true)
     };
@@ -314,7 +325,7 @@ pub fn process_file_response<R: Read>(
                     ),
                 };
                 fast_io::renameat_via_sandbox_or_fallback(
-                    ctx.sandbox,
+                    ctx.sandbox.map(std::sync::Arc::as_ref),
                     sandbox_dest_dir,
                     &temp_rel,
                     temp_path,


### PR DESCRIPTION
## Summary

Closes 4 of the 5 SEC-1 GAP sites flagged in
`docs/audits/sec-1-path-syscall-audit-2026-05-22.md` rows #17-#21 by
threading the existing `DirSandbox` carrier into the receiver-side
temp-file lifecycle. Implements the plan in
`docs/design/sec-1-r-temp-file-sandbox-2026-05-22.md`. The 5th site
(row #20, `fs::read_dir` orphan scan) stays path-based as an audit-
acknowledged carrier-acceptable residual; see Deferred section below.

### GAP closures

| # | Site | After |
|---|------|-------|
| 17 | `temp_guard.rs:130` `OpenOptions::create_new` | `openat_via_sandbox_or_fallback(dirfd, leaf, O_WRONLY\|O_CREAT\|O_EXCL\|O_NOFOLLOW, 0o600)` |
| 18 | `temp_guard.rs:142` `create_dir_all` recovery | Unchanged (carrier-only mitigated per design; multi-component parent walk cannot anchor on a single dirfd) |
| 19 | `temp_guard.rs:217` Drop `remove_file` | `unlink_via_sandbox_or_fallback(dirfd, leaf, File)` via new `SandboxAnchor` field on `TempFileGuard` |
| 20 | `temp_cleanup.rs:95` `read_dir` orphan scan | Unchanged (no `fdopendir` equivalent in `std`; scan is read-only / informational) |
| 21 | `temp_cleanup.rs:137` `remove_file` orphan cleanup | `unlink_via_sandbox_or_fallback(dirfd, leaf, File)` via new `cleanup_stale_temp_files_sandboxed` |

### Receiver wiring (matches the established SEC-1.j pattern from #4697)

- `transfer_ops::ResponseContext` already carried `sandbox` + `dest_dir`; this PR
  flips the field type from `Option<&DirSandbox>` to `Option<&Arc<DirSandbox>>`
  so the temp-file Drop anchor can clone a stable handle that outlives the
  borrow. The synchronous `process_file_response` path calls the new
  `open_tmpfile_sandboxed`; the existing renameat call site adapts via
  `.map(Arc::as_ref)`.
- `DiskCommitConfig` gains `dest_dir: Option<PathBuf>` and
  `sandbox: Option<Arc<DirSandbox>>` so the cross-thread disk-commit worker
  carries the carrier into `process::open_output_file`'s temp-file branch.
- The non-pipelined `receiver/transfer/sync.rs` loop reuses the existing
  `setup.sandbox` to call `open_tmpfile_sandboxed` directly.

### Test plan

- [x] `cargo fmt --all` clean
- [x] New unit test `sandbox_anchored_guard_resists_symlink_swap_on_parent` -
  races a `rename + symlink` swap on the temp parent between create and Drop
  and verifies the unlinkat lands on the original dirfd (decoy survives,
  attacker-owned files untouched, real temp file removed from the renamed
  directory)
- [x] New unit tests for `open_tmpfile_sandboxed` happy path + `--temp-dir`
  fallback path + `cleanup_stale_temp_files_sandboxed` happy path + sandbox-
  absent fallback
- [ ] CI fmt+clippy
- [ ] CI nextest (stable, Windows, macOS, Linux musl)
- [ ] CI interop

### Cross-platform

- **Linux / macOS**: sandbox fast path engages via existing
  `openat_via_sandbox_or_fallback` helper.
- **Windows**: `TempFileGuard::anchor` and `open_tmpfile_sandboxed` are
  `#[cfg(unix)]`; the public `open_tmpfile` path on Windows is unchanged.
  Per SEC-1.l, Windows uses `CreateFileW` handle semantics (already in
  `fast_io`) instead of dirfd-based `*at` calls.
- **`--temp-dir` and multi-component paths**: keep the path-based fallback
  because the single-component-leaf check fails. ENOENT recovery keeps
  `create_dir_all` as accepted residual (audit row #18).

### Deferred (intentionally)

- **Audit row #20** (`fs::read_dir` orphan scan in `temp_cleanup`): closing
  this would require a `read_dir_via_sandbox_or_fallback` helper built on
  `openat(O_DIRECTORY) + fdopendir`. The design lists this as **optional,
  same PR window**; per the audit it is read-only / informational, the
  destructive op is the per-entry unlink which row #21 closes. Follow-up
  is tracked as a separate audit item if the residual is ever upgraded.
- **`SECURITY.md`**: design does not call for an update for SEC-1.r; the
  open SEC-1 follow-up entry already covers rows #17-#21. Leaving
  `SECURITY.md` untouched per the design.

### References

- Design doc: `docs/design/sec-1-r-temp-file-sandbox-2026-05-22.md`
- Audit: `docs/audits/sec-1-path-syscall-audit-2026-05-22.md` rows #17-#21
- Prerequisite helper: `openat_via_sandbox_or_fallback` (#4716)
- Receiver-wiring pattern: SEC-1.j renameat carrier (#4697)