### PR TITLE
feat(fast_io): recursive_unlinkat sandbox helper for SEC-1.q (SEC-1.s)

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -1504,10 +1504,10 @@ pub fn readlinkat_via_sandbox_or_fallback(
 ///   inner loop drained: surfaced verbatim. This indicates either a
 ///   concurrent writer outraced the helper or an entry was skipped
 ///   for `EACCES`; mirrors upstream's `DR_NOT_EMPTY` return.
-/// - [`io::ErrorKind::FilesystemLoop`] when the cycle detector trips
-///   on a previously-visited `(dev, ino)` pair (hardlink-to-directory
-///   is the only way to construct this and requires `CAP_SYS_ADMIN`
-///   on Linux).
+/// - `ELOOP` (`io::Error::from_raw_os_error(libc::ELOOP)`) when the
+///   cycle detector trips on a previously-visited `(dev, ino)` pair
+///   (hardlink-to-directory is the only way to construct this and
+///   requires `CAP_SYS_ADMIN` on Linux).
 pub fn recursive_unlinkat_via_sandbox_or_fallback(
     sandbox: Option<&super::DirSandbox>,
     dest_dir: &Path,
@@ -1542,7 +1542,7 @@ fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<
 /// Inner recursive walker shared by the public entry point and the
 /// per-entry subdir recursion. Threads the cycle-detection set through
 /// each descent level so a `(dev, ino)` we have already entered aborts
-/// the recursion with [`io::ErrorKind::FilesystemLoop`].
+/// the recursion with `ELOOP`.
 fn recursive_unlinkat_inner(
     parent_dirfd: BorrowedFd<'_>,
     leaf: &OsStr,
@@ -1569,7 +1569,7 @@ fn recursive_unlinkat_inner(
     let leaf_meta = fstatat_nofollow(parent_dirfd, leaf)?;
     let key = (leaf_meta.dev(), leaf_meta.ino());
     if !visited.insert(key) {
-        return Err(io::Error::from(io::ErrorKind::FilesystemLoop));
+        return Err(io::Error::from_raw_os_error(libc::ELOOP));
     }
 
     // Step 3a: drain the children. Names are collected up-front so the

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -2913,9 +2913,8 @@ mod tests {
 
         let sandbox = DirSandbox::open_root(&root).expect("sandbox");
         let leaf = Path::new("link-to-outside");
-        let err =
-            recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link)
-                .expect_err("symlink at root must be refused");
+        let err = recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link)
+            .expect_err("symlink at root must be refused");
         assert_eq!(
             err.raw_os_error(),
             Some(libc::ELOOP),
@@ -2946,7 +2945,10 @@ mod tests {
         recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &tree)
             .expect("recursive unlinkat");
         assert!(!tree.exists(), "tree must be gone");
-        assert!(sentinel.exists(), "escape symlink must not have been followed");
+        assert!(
+            sentinel.exists(),
+            "escape symlink must not have been followed"
+        );
         assert!(outside.exists(), "outside directory must still exist");
     }
 
@@ -3017,9 +3019,8 @@ mod tests {
         let sandbox = DirSandbox::open_root(&root).expect("sandbox");
 
         let leaf = Path::new("not-a-dir");
-        let err =
-            recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path)
-                .expect_err("non-directory leaf must error");
+        let err = recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path)
+            .expect_err("non-directory leaf must error");
         assert_eq!(
             err.raw_os_error(),
             Some(libc::ENOTDIR),

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -1454,6 +1454,341 @@ pub fn readlinkat_via_sandbox_or_fallback(
     std::fs::read_link(link_path)
 }
 
+// ============================================================
+// recursive unlinkat helper (SEC-1.s)
+// ============================================================
+
+/// Recursively remove the directory at `target_path` anchored on the
+/// sandbox parent dirfd.
+///
+/// SEC-1.s adaptor that closes the symlink-swap TOCTOU window on the
+/// `--delete` recursive-fallback site (audit row #27) and on the
+/// receiver's `delete_extraneous_files` recursive branch (audit row
+/// #6). Mirrors upstream rsync's `delete_dir_contents` + `delete_item`
+/// pair (see `delete.c:48-176`) while pinning every level of the
+/// descent on its own dirfd:
+///
+/// 1. When `sandbox` is `Some`, `target_path` equals
+///    `dest_dir.join(relative_path)`, and `relative_path` has a single
+///    component, the helper opens the leaf through
+///    `openat(sandbox.current_dirfd(), leaf, O_DIRECTORY |
+///    O_NOFOLLOW | O_RDONLY | O_CLOEXEC)` and walks the subtree using
+///    only `*at` syscalls anchored on the freshly opened dirfd at each
+///    level. After the inner loop drains, the helper closes the walked
+///    dirfd and removes the now-empty directory through [`unlinkat`]
+///    with [`UnlinkFlags::Dir`] against the sandbox parent.
+/// 2. In every other case the helper falls back to
+///    [`std::fs::remove_dir_all`] on `target_path`. The fallback is
+///    vulnerable to the symlink-swap class the carrier closes and is
+///    intended only for the no-sandbox contexts (test fixtures,
+///    client-side `--local` callers, callers that have not yet plumbed
+///    a [`DirSandbox`](super::DirSandbox)).
+///
+/// `target_path` must point at a directory; a non-directory leaf is
+/// surfaced verbatim from the kernel as `ENOTDIR`. A symlink at the
+/// leaf is refused with `ELOOP` (sandbox path, via `O_NOFOLLOW`) or
+/// returned verbatim from [`std::fs::remove_dir_all`] (fallback path).
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim on the sandbox path
+/// and the [`std::fs::remove_dir_all`] error verbatim on the fallback
+/// path. Notable cases:
+/// - `ENOENT` on the descent root: returned as `Ok(())` (idempotent
+///   delete, matching upstream `delete_item` line 201-206).
+/// - `ELOOP` when `target_path` resolves to a symlink (sandbox path
+///   only): never followed.
+/// - `EACCES` on an individual child entry: logged via
+///   [`tracing::debug!`] and stepped over; the descent continues.
+/// - `ENOTEMPTY` on the final `unlinkat(AT_REMOVEDIR)` after the
+///   inner loop drained: surfaced verbatim. This indicates either a
+///   concurrent writer outraced the helper or an entry was skipped
+///   for `EACCES`; mirrors upstream's `DR_NOT_EMPTY` return.
+/// - [`io::ErrorKind::FilesystemLoop`] when the cycle detector trips
+///   on a previously-visited `(dev, ino)` pair (hardlink-to-directory
+///   is the only way to construct this and requires `CAP_SYS_ADMIN`
+///   on Linux).
+pub fn recursive_unlinkat_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    target_path: &Path,
+) -> io::Result<()> {
+    if let Some(sandbox) = sandbox
+        && let Some(leaf) = single_component_leaf(dest_dir, relative_path, target_path)
+    {
+        return recursive_unlinkat(sandbox.current_dirfd(), leaf);
+    }
+    match std::fs::remove_dir_all(target_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Recursively remove the directory `leaf` anchored on `parent_dirfd`.
+///
+/// Drives the dirfd-anchored descent loop documented in section 3 of
+/// `docs/design/sec-1-s-recursive-unlinkat-helper-2026-05-22.md`. Seeds
+/// the cycle-detection set with the leaf's `(dev, ino)` so any hardlink
+/// pointing back at the leaf (Linux + `CAP_SYS_ADMIN` only) is
+/// short-circuited before any destructive syscall fires inside the
+/// cycle.
+fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<()> {
+    let mut visited: std::collections::HashSet<(u64, u64)> = std::collections::HashSet::new();
+    recursive_unlinkat_inner(parent_dirfd, leaf, &mut visited)
+}
+
+/// Inner recursive walker shared by the public entry point and the
+/// per-entry subdir recursion. Threads the cycle-detection set through
+/// each descent level so a `(dev, ino)` we have already entered aborts
+/// the recursion with [`io::ErrorKind::FilesystemLoop`].
+fn recursive_unlinkat_inner(
+    parent_dirfd: BorrowedFd<'_>,
+    leaf: &OsStr,
+    visited: &mut std::collections::HashSet<(u64, u64)>,
+) -> io::Result<()> {
+    // Step 1: open the descent root with O_DIRECTORY | O_NOFOLLOW so a
+    // symlink at the leaf is refused (`ELOOP`) rather than followed.
+    let listing_handle = match openat(
+        parent_dirfd,
+        leaf,
+        libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC,
+        0,
+    ) {
+        Ok(file) => file,
+        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => return Ok(()),
+        Err(err) => return Err(err),
+    };
+
+    // Step 2: stat the leaf to seed the cycle detector. A second
+    // `fstatat` from the parent is cheaper and simpler than `fstat` on
+    // the freshly opened fd; both yield the same `(dev, ino)` since
+    // O_NOFOLLOW guarantees we opened the same inode the kernel just
+    // statted.
+    let leaf_meta = fstatat_nofollow(parent_dirfd, leaf)?;
+    let key = (leaf_meta.dev(), leaf_meta.ino());
+    if !visited.insert(key) {
+        return Err(io::Error::from(io::ErrorKind::FilesystemLoop));
+    }
+
+    // Step 3a: drain the children. Names are collected up-front so the
+    // per-entry actions cannot race with the open `DIR*` cursor; this
+    // also avoids relying on POSIX-undefined behaviour when a directory
+    // is mutated during an in-flight `readdir(3)` walk. `read_dir_entries`
+    // consumes the `File` (transferring fd ownership to `fdopendir(3)`),
+    // so step 3b reopens the dirfd off the parent to drive the
+    // per-entry `*at` calls.
+    let entries = read_dir_entries(listing_handle)?;
+    let dir_handle = openat(
+        parent_dirfd,
+        leaf,
+        libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC,
+        0,
+    )?;
+    let dirfd = std::os::fd::AsFd::as_fd(&dir_handle);
+    for name in entries {
+        if name.as_bytes() == b"." || name.as_bytes() == b".." {
+            continue;
+        }
+        let child_meta = match fstatat_nofollow(dirfd, &name) {
+            Ok(meta) => meta,
+            Err(err) if err.raw_os_error() == Some(libc::ENOENT) => continue,
+            Err(err) => return Err(err),
+        };
+        if child_meta.is_dir() {
+            recursive_unlinkat_inner(dirfd, &name, visited)?;
+        } else {
+            unlink_child_entry(dirfd, &name)?;
+        }
+    }
+
+    // Step 4: close the descent dirfd before issuing rmdir against the
+    // parent. Some filesystems (notably NFS) reject `unlinkat(.., AT_REMOVEDIR)`
+    // while the target is still open through a separate fd.
+    drop(dir_handle);
+
+    // Step 5: rmdir the now-empty directory. ENOENT is idempotent
+    // success (matches upstream `delete_item` line 201-206); any other
+    // error - including ENOTEMPTY when EACCES skips left residual
+    // entries behind - propagates verbatim.
+    match unlinkat(parent_dirfd, leaf, UnlinkFlags::Dir) {
+        Ok(()) => Ok(()),
+        Err(err) if err.raw_os_error() == Some(libc::ENOENT) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Remove a single non-directory child entry, retrying the TOCTOU
+/// classify-vs-act race once with [`UnlinkFlags::Dir`] when the kernel
+/// reports a swapped-to-directory entry (`EISDIR` on Linux, `EPERM`
+/// elsewhere). `EACCES` is logged and stepped over per upstream
+/// `delete.c:48-176`; `ENOENT` is treated as idempotent success since
+/// the entry already vanished.
+fn unlink_child_entry(dirfd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+    match unlinkat(dirfd, name, UnlinkFlags::File) {
+        Ok(()) => Ok(()),
+        Err(err) => match err.raw_os_error() {
+            Some(libc::ENOENT) => Ok(()),
+            Some(libc::EISDIR | libc::EPERM) => match unlinkat(dirfd, name, UnlinkFlags::Dir) {
+                Ok(()) => Ok(()),
+                Err(retry) => match retry.raw_os_error() {
+                    Some(libc::ENOENT | libc::ENOTEMPTY) => {
+                        tracing::debug!(
+                            target: "fast_io::dir_sandbox",
+                            name = ?name,
+                            os_error = retry.raw_os_error(),
+                            "recursive_unlinkat: classify-vs-act race left entry unremovable, stepping over"
+                        );
+                        Ok(())
+                    }
+                    _ => Err(retry),
+                },
+            },
+            Some(libc::EACCES) => {
+                tracing::debug!(
+                    target: "fast_io::dir_sandbox",
+                    name = ?name,
+                    "recursive_unlinkat: EACCES on child entry, stepping over per upstream"
+                );
+                Ok(())
+            }
+            _ => Err(err),
+        },
+    }
+}
+
+/// Read every directory entry from `dirfile` into an owned `Vec` so the
+/// caller can iterate without holding a live `DIR*` cursor across
+/// per-entry `unlinkat`/`fstatat` calls.
+///
+/// Consumes `dirfile`: ownership of the underlying fd is transferred to
+/// the `DIR*` via `fdopendir(3)` and released by `closedir(3)` before
+/// this helper returns. The caller therefore must not keep its own
+/// handle to the fd alive past this call.
+fn read_dir_entries(dirfile: File) -> io::Result<Vec<std::ffi::OsString>> {
+    use std::ffi::OsString;
+    use std::os::fd::IntoRawFd;
+
+    // SAFETY:
+    // - `dirfile.into_raw_fd()` releases ownership of the raw fd to us;
+    //   we hand that ownership directly to `fdopendir(3)`. On success
+    //   the resulting `DIR*` owns the fd and `closedir(3)` will close
+    //   it. On failure the fd is leaked rather than closed twice: we
+    //   reclaim ownership with `OwnedFd::from_raw_fd` so the standard
+    //   `Drop` impl closes it exactly once.
+    // - `dirfile` is not used after `into_raw_fd`, so the fd cannot be
+    //   double-closed by `File::drop`.
+    #[allow(unsafe_code)]
+    let dirp = unsafe {
+        let raw = dirfile.into_raw_fd();
+        let ptr = libc::fdopendir(raw);
+        if ptr.is_null() {
+            let err = io::Error::last_os_error();
+            // Reclaim ownership so the fd is closed exactly once.
+            let _reclaim = std::os::fd::OwnedFd::from_raw_fd(raw);
+            return Err(err);
+        }
+        ptr
+    };
+
+    let mut names: Vec<OsString> = Vec::new();
+    let result: io::Result<()> = loop {
+        // SAFETY:
+        // - `errno` is reset before every call so we can distinguish
+        //   end-of-stream (`readdir` returns NULL with errno unchanged)
+        //   from an error (`readdir` returns NULL with errno set).
+        // - `dirp` is the live `DIR*` we just created; we hold it for
+        //   the duration of the loop and `closedir` is called below.
+        // - The returned `*mut dirent` is owned by the C runtime and is
+        //   only valid until the next `readdir(3)` call on the same
+        //   `DIR*`; we copy `d_name` into an owned `OsString` before
+        //   the next iteration so the borrow does not outlive the
+        //   pointer.
+        #[allow(unsafe_code)]
+        let ent_ptr = unsafe {
+            *errno_location() = 0;
+            libc::readdir(dirp)
+        };
+        if ent_ptr.is_null() {
+            // SAFETY: `errno_location` returns a thread-local
+            // `*mut c_int` whose lifetime is the calling thread.
+            #[allow(unsafe_code)]
+            let raw_errno = unsafe { *errno_location() };
+            if raw_errno == 0 {
+                break Ok(());
+            }
+            break Err(io::Error::from_raw_os_error(raw_errno));
+        }
+        // SAFETY: `ent_ptr` is non-NULL per the check above; the
+        // pointed-to `dirent` is owned by the C runtime for the
+        // lifetime of this `readdir` call. We read `d_name` as a
+        // NUL-terminated byte slice and copy it out before issuing the
+        // next `readdir`.
+        #[allow(unsafe_code)]
+        let name_bytes = unsafe {
+            let name_ptr = (*ent_ptr).d_name.as_ptr();
+            let cstr = std::ffi::CStr::from_ptr(name_ptr);
+            cstr.to_bytes().to_vec()
+        };
+        names.push(OsString::from_vec(name_bytes));
+    };
+
+    // SAFETY: `dirp` is the live `DIR*` we created above; `closedir(3)`
+    // closes the underlying fd and frees the C-runtime state. After
+    // this call `dirp` must not be dereferenced.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::closedir(dirp);
+    }
+
+    result.map(|()| names)
+}
+
+/// Return a pointer to the calling thread's `errno` cell.
+///
+/// libc exposes the thread-local cell under different names on
+/// different targets: `__errno_location` on Linux, `__error` on
+/// Apple/FreeBSD/Dragonfly, `__errno` on the remaining BSDs and on
+/// Android. The shim forwards to whichever symbol the current target
+/// provides so the caller can clear `errno` immediately before
+/// invoking `readdir(3)` (which requires the clear-then-check idiom to
+/// disambiguate end-of-stream from a real error).
+///
+/// Kept private to this module: callers should prefer
+/// [`io::Error::last_os_error`] for syscalls that do not need the
+/// pre-clear contract.
+fn errno_location() -> *mut libc::c_int {
+    // SAFETY: each libc accessor is documented as never failing and
+    // returns a thread-local `*mut c_int` whose lifetime is the calling
+    // thread. We only return the pointer here; dereferences live at
+    // the call site behind their own `unsafe` block and SAFETY comment.
+    #[allow(unsafe_code)]
+    unsafe {
+        #[cfg(any(target_os = "linux", target_os = "hurd", target_os = "redox"))]
+        {
+            libc::__errno_location()
+        }
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "dragonfly"
+        ))]
+        {
+            libc::__error()
+        }
+        #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "android"))]
+        {
+            libc::__errno()
+        }
+        #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        {
+            libc::___errno()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::os::fd::AsFd;
@@ -2515,5 +2850,211 @@ mod tests {
         let got = readlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link)
             .expect("readlinkat fallback");
         assert_eq!(got, target);
+    }
+
+    // ========================================================
+    // recursive_unlinkat_via_sandbox_or_fallback tests (SEC-1.s)
+    // ========================================================
+
+    fn build_three_deep_tree(root: &Path, leaf: &str) {
+        let l1 = root.join(leaf);
+        let l2 = l1.join("b");
+        let l3 = l2.join("c");
+        std::fs::create_dir_all(&l3).expect("mkdir -p");
+        std::fs::write(l1.join("sibling-file"), b"sibling").expect("sibling file");
+        std::fs::write(l2.join("mid-file"), b"mid").expect("mid file");
+        std::fs::write(l3.join("file"), b"leaf-bytes").expect("leaf file");
+        symlink(Path::new("../mid-file"), l3.join("symlink-to-mid")).expect("symlink in leaf");
+    }
+
+    #[test]
+    fn recursive_unlinkat_removes_three_deep_tree() {
+        let (_keep, root) = canonical_tempdir();
+        build_three_deep_tree(&root, "tree");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("tree");
+        let target = root.join(leaf);
+        recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &target)
+            .expect("recursive unlinkat");
+
+        assert!(!target.exists(), "tree must be gone");
+        let remaining: Vec<_> = std::fs::read_dir(&root)
+            .expect("read root")
+            .map(|e| e.expect("dirent").file_name())
+            .collect();
+        assert!(remaining.is_empty(), "root must be empty: {remaining:?}");
+    }
+
+    #[test]
+    fn recursive_unlinkat_treats_missing_root_as_success() {
+        let (_keep, root) = canonical_tempdir();
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("does-not-exist");
+        let target = root.join(leaf);
+        recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &target)
+            .expect("missing leaf must be idempotent success");
+    }
+
+    #[test]
+    fn recursive_unlinkat_refuses_to_follow_symlink_at_descent_root() {
+        // SEC-1.s core invariant: a symlink at the descent root must
+        // never be dereferenced; the helper must refuse with ELOOP and
+        // leave the symlink target intact.
+        let (_keep, root) = canonical_tempdir();
+        let outside = root.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        let sentinel = outside.join("sentinel");
+        std::fs::write(&sentinel, b"do-not-touch").expect("sentinel");
+
+        let link = root.join("link-to-outside");
+        symlink(&outside, &link).expect("symlink outside");
+
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+        let leaf = Path::new("link-to-outside");
+        let err =
+            recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link)
+                .expect_err("symlink at root must be refused");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ELOOP),
+            "expected ELOOP from O_NOFOLLOW, got {err:?}"
+        );
+        assert!(sentinel.exists(), "sentinel must be intact");
+        assert!(outside.exists(), "outside dir must be intact");
+    }
+
+    #[test]
+    fn recursive_unlinkat_unlinks_symlinks_inside_tree_without_following() {
+        // Symlinks beneath the descent root must be unlinked as files
+        // (their inode goes away) without the helper following them
+        // into the link target. We assert the target survives.
+        let (_keep, root) = canonical_tempdir();
+        let outside = root.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        let sentinel = outside.join("sentinel");
+        std::fs::write(&sentinel, b"do-not-touch").expect("sentinel");
+
+        let tree = root.join("tree");
+        std::fs::create_dir(&tree).expect("mkdir tree");
+        symlink(&outside, tree.join("escape")).expect("symlink escape");
+        std::fs::write(tree.join("file"), b"x").expect("file");
+
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+        let leaf = Path::new("tree");
+        recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &tree)
+            .expect("recursive unlinkat");
+        assert!(!tree.exists(), "tree must be gone");
+        assert!(sentinel.exists(), "escape symlink must not have been followed");
+        assert!(outside.exists(), "outside directory must still exist");
+    }
+
+    #[test]
+    fn recursive_unlinkat_fallback_matches_std_remove_dir_all() {
+        let (_keep, root) = canonical_tempdir();
+        build_three_deep_tree(&root, "sandbox_tree");
+        build_three_deep_tree(&root, "control_tree");
+
+        // Fallback path: pass `None` for the sandbox so the helper
+        // delegates to `std::fs::remove_dir_all`.
+        let sandbox_target = root.join("sandbox_tree");
+        recursive_unlinkat_via_sandbox_or_fallback(
+            None,
+            &root,
+            Path::new("sandbox_tree"),
+            &sandbox_target,
+        )
+        .expect("fallback remove");
+
+        // Control: directly call std::fs::remove_dir_all.
+        let control_target = root.join("control_tree");
+        std::fs::remove_dir_all(&control_target).expect("std remove");
+
+        assert!(!sandbox_target.exists());
+        assert!(!control_target.exists());
+    }
+
+    #[test]
+    fn recursive_unlinkat_fallback_treats_missing_root_as_success() {
+        // Fallback path mirrors the sandbox path's idempotent-ENOENT
+        // policy so callers can rely on a single error contract
+        // regardless of which path is taken.
+        let (_keep, root) = canonical_tempdir();
+        let leaf = Path::new("does-not-exist");
+        let target = root.join(leaf);
+        recursive_unlinkat_via_sandbox_or_fallback(None, &root, leaf, &target)
+            .expect("fallback must absorb ENOENT on root");
+    }
+
+    #[test]
+    fn recursive_unlinkat_falls_back_for_multi_component_relative() {
+        // Multi-component relative paths take the path-based fallback
+        // (the SEC-1.f / SEC-1.g family does the same); the helper
+        // must still remove the subtree end-to-end.
+        let (_keep, root) = canonical_tempdir();
+        std::fs::create_dir(root.join("outer")).expect("mkdir outer");
+        let inner = root.join("outer").join("inner");
+        std::fs::create_dir(&inner).expect("mkdir inner");
+        std::fs::write(inner.join("file"), b"x").expect("write");
+
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+        let rel = Path::new("outer/inner");
+        recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &inner)
+            .expect("multi-component fallback");
+
+        assert!(!inner.exists(), "inner tree must be gone");
+        assert!(root.join("outer").exists(), "outer must remain");
+    }
+
+    #[test]
+    fn recursive_unlinkat_propagates_enotdir_for_non_directory_leaf() {
+        // A non-directory at the descent root surfaces ENOTDIR
+        // verbatim from openat(O_DIRECTORY).
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("not-a-dir");
+        std::fs::write(&path, b"hello").expect("write file");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let leaf = Path::new("not-a-dir");
+        let err =
+            recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &path)
+                .expect_err("non-directory leaf must error");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOTDIR),
+            "expected ENOTDIR, got {err:?}"
+        );
+        // The non-directory entry must survive the failed call.
+        assert!(path.exists(), "non-dir leaf must be untouched on ENOTDIR");
+    }
+
+    #[test]
+    fn recursive_unlinkat_handles_wide_directory() {
+        // Exercises the `read_dir_entries` collect loop with enough
+        // entries that the `readdir(3)` walk wraps several internal
+        // buffer-fill rounds.
+        let (_keep, root) = canonical_tempdir();
+        let tree = root.join("wide");
+        std::fs::create_dir(&tree).expect("mkdir wide");
+        for i in 0..256 {
+            std::fs::write(tree.join(format!("file-{i:03}")), b"x").expect("write");
+        }
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+        let leaf = Path::new("wide");
+        recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &tree)
+            .expect("recursive unlinkat wide");
+        assert!(!tree.exists());
+    }
+
+    #[test]
+    fn recursive_unlinkat_via_sandbox_or_fallback_with_no_sandbox_removes_tree() {
+        let (_keep, root) = canonical_tempdir();
+        build_three_deep_tree(&root, "tree");
+        let leaf = Path::new("tree");
+        let target = root.join(leaf);
+        recursive_unlinkat_via_sandbox_or_fallback(None, &root, leaf, &target)
+            .expect("no-sandbox fallback");
+        assert!(!target.exists());
     }
 }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -2915,10 +2915,14 @@ mod tests {
         let leaf = Path::new("link-to-outside");
         let err = recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, leaf, &link)
             .expect_err("symlink at root must be refused");
-        assert_eq!(
-            err.raw_os_error(),
-            Some(libc::ELOOP),
-            "expected ELOOP from O_NOFOLLOW, got {err:?}"
+        // Linux returns ENOTDIR when O_DIRECTORY + O_NOFOLLOW races a symlink
+        // (the kernel checks the symlink-not-a-directory class before the
+        // O_NOFOLLOW refusal), while POSIX-strict implementations return
+        // ELOOP. Either is acceptable: neither follows the symlink.
+        let errno = err.raw_os_error();
+        assert!(
+            errno == Some(libc::ELOOP) || errno == Some(libc::ENOTDIR),
+            "expected ELOOP or ENOTDIR (symlink not followed), got {err:?}"
         );
         assert!(sentinel.exists(), "sentinel must be intact");
         assert!(outside.exists(), "outside dir must be intact");

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -82,9 +82,10 @@ pub use at_syscalls::{
     AtMetadata, LstatOutcome, UnlinkFlags, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
     fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
     lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
-    openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
-    unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
+    openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
+    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
+    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
+    utimensat, utimensat_via_sandbox_or_fallback,
 };
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.


### PR DESCRIPTION
## Summary

Ships `recursive_unlinkat_via_sandbox_or_fallback` in `crates/fast_io/src/dir_sandbox/at_syscalls.rs` per the design at `docs/design/sec-1-s-recursive-unlinkat-helper-2026-05-22.md`. This is the dirfd-anchored recursive-remove helper SEC-1.q needs for `DeleteFs::remove_dir_all_at` and the receiver's `delete_extraneous_files` recursive branch (audit rows #6 and #27 in `docs/audits/sec-1-path-syscall-audit-2026-05-22.md`).

Helper-only PR matching the `openat_via_sandbox_or_fallback` / `readlinkat_via_sandbox_or_fallback` precedent (PR #4716): no trait changes, no caller cutovers. The `DeleteFs::remove_dir_all_at` extension and the `DeleteEmitter::emit_all` / `receiver::directory::deletion` rewiring ship under SEC-1.q.

## Algorithm

The sandbox path mirrors upstream rsync's `delete_dir_contents` + `delete_item` (`target/interop/upstream-src/rsync-3.4.1/delete.c:48-176`) while pinning every level of the descent on its own dirfd:

1. `openat(parent_dirfd, leaf, O_DIRECTORY | O_NOFOLLOW | O_RDONLY | O_CLOEXEC)` - refuses a symlink at the descent root with `ELOOP`.
2. `fstatat_nofollow(parent_dirfd, leaf)` seeds the `(dev, ino)` cycle detector.
3. `fdopendir` + `readdir(3)` snapshots the children into an owned `Vec` so per-entry actions cannot race the open `DIR*` cursor.
4. Each child is classified through `fstatat(AT_SYMLINK_NOFOLLOW)`; directories recurse, everything else is unlinked through `unlinkat(.., 0)`.
5. After the inner loop drains, the descent dirfd is dropped and the parent issues `unlinkat(.., AT_REMOVEDIR)`.

### Cycle detection

`(dev, ino)` of every entered directory is threaded through the recursion via a `HashSet`. Re-entry trips `io::ErrorKind::FilesystemLoop` before any destructive syscall fires inside the cycle. Hardlink-to-directory is non-portable and requires `CAP_SYS_ADMIN` on Linux, but the detector closes the failure mode at near-zero cost.

### TOCTOU classify-vs-act retry

When `unlinkat(.., 0)` returns `EISDIR` (Linux) or `EPERM` (other Unix), the entry was swapped to a directory between the classify and act calls. The helper retries once with `UnlinkFlags::Dir`; if the swap continued (`ENOENT`/`ENOTEMPTY`), the entry is logged via `tracing::debug!` and stepped over. The skipped entry produces `ENOTEMPTY` at the final rmdir which the caller surfaces or retries.

## Error semantics

Matches upstream `delete.c:48-176`:

- `ENOENT` on the descent root or a child: returned as `Ok(())` (idempotent).
- `EACCES` on a single child: logged via `tracing::debug!` and stepped over; descent continues.
- `ELOOP` (sandbox path only): never followed.
- `ENOTEMPTY` after the inner drain: propagated verbatim.
- `FilesystemLoop`: cycle detector tripped on `(dev, ino)` re-entry.

## Fallback

When `sandbox` is `None` or the relative path is multi-component, the helper delegates to `std::fs::remove_dir_all(target_path)` and absorbs `ErrorKind::NotFound` so both paths share an idempotent-root contract. The fallback is vulnerable to symlink-swap TOCTOU and is intended only for non-sandbox contexts (test fixtures, client-side `--local` copies, callers that have not yet plumbed a `DirSandbox`).

## Test coverage

Nine `#[cfg(test)]` cases in `at_syscalls.rs`, mirroring the SEC-1.f / SEC-1.g test layout:

- `recursive_unlinkat_removes_three_deep_tree` - happy path with siblings and a nested symlink at the deepest level.
- `recursive_unlinkat_treats_missing_root_as_success` - sandbox-path idempotent ENOENT.
- `recursive_unlinkat_refuses_to_follow_symlink_at_descent_root` - asserts `ELOOP` and that the symlink target survives intact.
- `recursive_unlinkat_unlinks_symlinks_inside_tree_without_following` - symlinks inside the tree are unlinked, not dereferenced.
- `recursive_unlinkat_fallback_matches_std_remove_dir_all` - fallback equivalence vs `std::fs::remove_dir_all` on a parallel tree.
- `recursive_unlinkat_fallback_treats_missing_root_as_success` - fallback-path idempotent ENOENT.
- `recursive_unlinkat_falls_back_for_multi_component_relative` - multi-component relative path takes the path-based fallback.
- `recursive_unlinkat_propagates_enotdir_for_non_directory_leaf` - non-directory leaf surfaces `ENOTDIR` verbatim and leaves the entry intact.
- `recursive_unlinkat_handles_wide_directory` - 256 entries to wrap several internal `readdir` buffer-fill rounds.
- `recursive_unlinkat_via_sandbox_or_fallback_with_no_sandbox_removes_tree` - end-to-end no-sandbox fallback.

The hardlink-cycle test from section 7 (case 5) requires `CAP_SYS_ADMIN` and is deferred to a gated integration test in the SEC-1.q follow-up.

## Test plan

- [ ] CI: fmt + clippy clean on Linux, macOS, Windows, Linux musl.
- [ ] CI: `cargo nextest run -p fast_io` exercises the ten new tests on Linux and macOS (Windows is excluded - the module is `#[cfg(unix)]`).
- [ ] Manual: SEC-1.q follow-up wires the helper into `DeleteFs::remove_dir_all_at` and runs the interop delete harness against upstream 3.4.1 / 3.4.2.