### PR TITLE
refactor(engine): DeleteFs trait sandbox refactor + emitter wiring (SEC-1.q)

### DIFF
--- a/crates/engine/src/delete/emitter/fs.rs
+++ b/crates/engine/src/delete/emitter/fs.rs
@@ -5,11 +5,35 @@
 //! method per upstream-distinguishable entry kind (`delete.c:144-176`)
 //! lets unit tests assert the exact dispatch table even though all
 //! file-like kinds currently route to `unlink(2)` in production.
+//!
+//! # Sandbox-anchored dispatch (SEC-1.q)
+//!
+//! Each unlink/rmdir method ships in two shapes:
+//!
+//! - **Path-based** (`unlink_file`, `rmdir`, ...): the legacy entry
+//!   points that walk an absolute path through the kernel. Used when no
+//!   [`fast_io::DirSandbox`] has been wired to the emitter, on Windows,
+//!   and by the [`RecordingDeleteFs`] test fake which never touches the
+//!   filesystem.
+//! - **Dirfd-anchored** (`unlink_file_at`, `rmdir_at`, ...,
+//!   `#[cfg(unix)]`): the SEC-1.q entry points that resolve a
+//!   single-leaf name against a [`BorrowedFd`] for the parent directory.
+//!   These close the symlink-swap TOCTOU class on every `--delete`
+//!   syscall and route through the SEC-1.g / SEC-1.s sandbox helpers in
+//!   [`fast_io::dir_sandbox::at_syscalls`].
 
 use std::fs;
 use std::io;
+#[cfg(unix)]
+use std::os::fd::BorrowedFd;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+
+#[cfg(unix)]
+use std::ffi::OsStr;
+
+#[cfg(unix)]
+use fast_io::UnlinkFlags;
 
 use super::super::DeleteEntryKind;
 use crate::util::poison::lock_or_recover;
@@ -29,39 +53,111 @@ use crate::util::poison::lock_or_recover;
 /// across the emitter and any future helpers. The production impl is
 /// stateless; the test fake holds a `Mutex` because the recording is
 /// observable from the test thread after `emit_all` returns.
+///
+/// # Sandbox-anchored siblings (SEC-1.q)
+///
+/// Every path-based method has a unix-only `*_at` sibling that takes a
+/// parent dirfd plus a single-component leaf. When the emitter is built
+/// with [`super::DeleteEmitter::with_sandbox`], it dispatches through
+/// the `*_at` siblings; otherwise it falls back to the path-based
+/// methods. The dirfd-anchored shape pins the parent at receiver setup
+/// so a mid-syscall symlink swap on a mid-path component cannot redirect
+/// the unlink to an attacker-chosen inode beneath a different parent.
 pub trait DeleteFs: std::fmt::Debug {
-    /// Unlinks a regular file.
+    /// Unlinks a regular file by absolute path.
+    ///
+    /// Used in the no-sandbox fallback. The sandbox-anchored sibling
+    /// [`Self::unlink_file_at`] closes the symlink-swap TOCTOU class on
+    /// the parent walk; prefer it when a [`fast_io::DirSandbox`] is
+    /// available.
     fn unlink_file(&self, path: &Path) -> io::Result<()>;
 
-    /// Removes an empty directory.
+    /// Removes an empty directory by absolute path.
+    ///
+    /// See [`Self::rmdir_at`] for the sandbox-anchored sibling.
     fn rmdir(&self, path: &Path) -> io::Result<()>;
 
-    /// Unlinks a symbolic link.
+    /// Unlinks a symbolic link by absolute path.
+    ///
+    /// See [`Self::unlink_symlink_at`] for the sandbox-anchored sibling.
     fn unlink_symlink(&self, path: &Path) -> io::Result<()>;
 
-    /// Unlinks a block or character device node.
+    /// Unlinks a block or character device node by absolute path.
+    ///
+    /// See [`Self::unlink_device_at`] for the sandbox-anchored sibling.
     fn unlink_device(&self, path: &Path) -> io::Result<()>;
 
-    /// Unlinks a FIFO or socket.
+    /// Unlinks a FIFO or socket by absolute path.
+    ///
+    /// See [`Self::unlink_special_at`] for the sandbox-anchored sibling.
     fn unlink_special(&self, path: &Path) -> io::Result<()>;
 
-    /// Recursively removes a directory and everything beneath it.
+    /// Recursively removes a directory and everything beneath it by
+    /// absolute path.
     ///
     /// Invoked by the emitter when [`Self::rmdir`] returns
     /// [`io::ErrorKind::DirectoryNotEmpty`] and no nested
     /// [`super::super::DeletePlan`] has been published for the offending
     /// child (upstream `delete.c:48-122 delete_dir_contents`).
+    ///
+    /// See [`Self::remove_dir_all_at`] for the sandbox-anchored sibling.
     fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
+
+    /// Unlinks a regular file via `unlinkat(parent_fd, name, 0)`.
+    ///
+    /// SEC-1.q sandbox-anchored sibling of [`Self::unlink_file`]. The
+    /// leaf is resolved relative to `parent_fd`; a mid-syscall symlink
+    /// swap on the parent walk cannot redirect the call because the
+    /// parent is pinned by the dirfd that was opened at receiver setup.
+    #[cfg(unix)]
+    fn unlink_file_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
+
+    /// Removes an empty directory via
+    /// `unlinkat(parent_fd, name, AT_REMOVEDIR)`.
+    ///
+    /// SEC-1.q sandbox-anchored sibling of [`Self::rmdir`].
+    #[cfg(unix)]
+    fn rmdir_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
+
+    /// Unlinks a symbolic link via `unlinkat(parent_fd, name, 0)`.
+    ///
+    /// SEC-1.q sandbox-anchored sibling of [`Self::unlink_symlink`].
+    #[cfg(unix)]
+    fn unlink_symlink_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
+
+    /// Unlinks a device node via `unlinkat(parent_fd, name, 0)`.
+    ///
+    /// SEC-1.q sandbox-anchored sibling of [`Self::unlink_device`].
+    #[cfg(unix)]
+    fn unlink_device_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
+
+    /// Unlinks a FIFO or socket via `unlinkat(parent_fd, name, 0)`.
+    ///
+    /// SEC-1.q sandbox-anchored sibling of [`Self::unlink_special`].
+    #[cfg(unix)]
+    fn unlink_special_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
+
+    /// Recursively removes a directory anchored on `parent_fd`.
+    ///
+    /// SEC-1.q sandbox-anchored sibling of [`Self::remove_dir_all`].
+    /// Routes through [`fast_io::recursive_unlinkat`] (SEC-1.s) so each
+    /// per-entry descent refuses to follow a symlink at the leaf
+    /// (`O_DIRECTORY | O_NOFOLLOW`) and the final
+    /// `unlinkat(AT_REMOVEDIR)` is anchored on `parent_fd`.
+    #[cfg(unix)]
+    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()>;
 }
 
-/// Production [`DeleteFs`] implementation backed by `std::fs`.
+/// Production [`DeleteFs`] implementation backed by `std::fs` (path
+/// fallback) and the `fast_io` `*at` syscall wrappers (sandbox path).
 ///
 /// All file-like kinds route to [`fs::remove_file`] (Unix `unlink(2)`,
-/// Windows `DeleteFileW`). Directories route to [`fs::remove_dir`]
-/// (`rmdir(2)`); the recursive fallback routes to [`fs::remove_dir_all`]
-/// to match upstream `delete_dir_contents`. This mirrors upstream
-/// `delete_item` (`delete.c:161-175`): `do_rmdir` for `S_ISDIR`,
-/// `robust_unlink` for everything else.
+/// Windows `DeleteFileW`) on the path fallback. The sandbox path routes
+/// every leaf-removal through [`fast_io::unlinkat`] for the non-recursive
+/// kinds and [`fast_io::recursive_unlinkat`] for the recursive fallback,
+/// mirroring upstream `delete_item` (`delete.c:161-175`): `do_rmdir` for
+/// `S_ISDIR`, `robust_unlink` for everything else,
+/// `delete_dir_contents` for the recursive peel.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RealDeleteFs;
 
@@ -88,6 +184,40 @@ impl DeleteFs for RealDeleteFs {
 
     fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
         fs::remove_dir_all(path)
+    }
+
+    #[cfg(unix)]
+    fn unlink_file_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        fast_io::unlinkat(parent_fd, name, UnlinkFlags::File)
+    }
+
+    #[cfg(unix)]
+    fn rmdir_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        fast_io::unlinkat(parent_fd, name, UnlinkFlags::Dir)
+    }
+
+    #[cfg(unix)]
+    fn unlink_symlink_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        fast_io::unlinkat(parent_fd, name, UnlinkFlags::File)
+    }
+
+    #[cfg(unix)]
+    fn unlink_device_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        fast_io::unlinkat(parent_fd, name, UnlinkFlags::File)
+    }
+
+    #[cfg(unix)]
+    fn unlink_special_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        fast_io::unlinkat(parent_fd, name, UnlinkFlags::File)
+    }
+
+    #[cfg(unix)]
+    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        // SEC-1.s carrier: drives the recursive peel directly off
+        // `parent_fd` with O_DIRECTORY | O_NOFOLLOW so a symlink at the
+        // root is refused and the kernel anchors every per-entry
+        // `unlinkat` on the descent dirfd.
+        fast_io::recursive_unlinkat(parent_fd, name)
     }
 }
 
@@ -118,6 +248,36 @@ impl<F: DeleteFs + ?Sized> DeleteFs for &F {
     fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
         (*self).remove_dir_all(path)
     }
+
+    #[cfg(unix)]
+    fn unlink_file_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        (*self).unlink_file_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn rmdir_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        (*self).rmdir_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn unlink_symlink_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        (*self).unlink_symlink_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn unlink_device_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        (*self).unlink_device_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn unlink_special_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        (*self).unlink_special_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        (*self).remove_dir_all_at(parent_fd, name)
+    }
 }
 
 /// Event captured by [`RecordingDeleteFs`] for each emitter dispatch.
@@ -136,6 +296,11 @@ pub struct DeleteEvent {
 /// staging real files. The recorded sequence is the ground truth for the
 /// "syscall order matches upstream" check that section 9.1 of the design
 /// elevates to a release-gating interop test.
+///
+/// The SEC-1.q `*_at` impls discard `parent_fd` and record only the leaf
+/// name so the existing emitter unit tests, which assert on absolute
+/// paths, keep working unchanged when the emitter dispatches through the
+/// dirfd-anchored siblings (the path is provided by the dispatcher).
 #[derive(Debug, Default)]
 pub struct RecordingDeleteFs {
     events: Mutex<Vec<DeleteEvent>>,
@@ -197,6 +362,42 @@ impl DeleteFs for RecordingDeleteFs {
         // unit tests can assert "the emitter fell back to recursion for
         // this path".
         self.record(path, DeleteEntryKind::Dir);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn unlink_file_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        self.record(Path::new(name), DeleteEntryKind::File);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn rmdir_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        self.record(Path::new(name), DeleteEntryKind::Dir);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn unlink_symlink_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        self.record(Path::new(name), DeleteEntryKind::Symlink);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn unlink_device_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        self.record(Path::new(name), DeleteEntryKind::Device);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn unlink_special_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        self.record(Path::new(name), DeleteEntryKind::Special);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn remove_dir_all_at(&self, _parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        self.record(Path::new(name), DeleteEntryKind::Dir);
         Ok(())
     }
 }

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -48,6 +48,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(unix)]
+use fast_io::DirSandbox;
+
 use protocol::DeleteStats;
 
 use super::cohort_index::CohortIndex;
@@ -106,6 +109,16 @@ pub struct DeleteEmitter<F: DeleteFs> {
     /// arrives. `None` while the cursor is fully drained or not yet
     /// blocked.
     pending: Option<PathBuf>,
+    /// Optional [`DirSandbox`] anchor for the SEC-1.q sandbox-anchored
+    /// dispatch. When `Some`, every entry is removed through the
+    /// dirfd-bearing `*_at` trait methods so the parent walk cannot be
+    /// redirected by a mid-syscall symlink swap. The dirfd for each
+    /// plan directory is opened against [`DirSandbox::root_dirfd`] just
+    /// before dispatch; on open failure the emitter falls back to the
+    /// path-based methods so the drain stays compatible with the
+    /// pre-SEC-1.q caller contract.
+    #[cfg(unix)]
+    sandbox: Option<Arc<DirSandbox>>,
 }
 
 impl<F: DeleteFs> DeleteEmitter<F> {
@@ -133,7 +146,34 @@ impl<F: DeleteFs> DeleteEmitter<F> {
             cohort_log: Vec::new(),
             io_error: 0,
             pending: None,
+            #[cfg(unix)]
+            sandbox: None,
         }
+    }
+
+    /// Attaches a [`DirSandbox`] to this emitter so every subsequent
+    /// dispatch routes through the SEC-1.q dirfd-anchored trait methods.
+    ///
+    /// The dirfd for each plan directory is opened against
+    /// [`DirSandbox::root_dirfd`] just before dispatch and dropped after
+    /// the plan drains. On open failure (the plan directory was already
+    /// removed by an earlier plan, for example) the dispatcher falls
+    /// back to the path-based methods so callers that mix planned and
+    /// recursive deletes still make forward progress.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn with_sandbox(mut self, sandbox: Arc<DirSandbox>) -> Self {
+        self.sandbox = Some(sandbox);
+        self
+    }
+
+    /// Returns the attached [`DirSandbox`], if any. Used by tests that
+    /// assert the emitter is consulting the sandbox carrier the caller
+    /// handed it.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn sandbox(&self) -> Option<&Arc<DirSandbox>> {
+        self.sandbox.as_ref()
     }
 
     /// Builds an emitter that consults a hardlink-cohort snapshot for
@@ -269,11 +309,41 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// iterates the dirlist and keeps going after each per-entry
     /// failure.
     fn drain_plan(&mut self, plan: &DeletePlan) -> io::Result<()> {
+        // SEC-1.q: open the plan directory once via the sandbox so every
+        // entry under it can dispatch through the `*_at` trait methods.
+        // A failure to open the dirfd leaves `parent_fd` as `None` and
+        // each entry transparently falls back to the path-based methods.
+        #[cfg(unix)]
+        let parent_handle = self.open_plan_dirfd(&plan.directory);
         for entry in &plan.extras {
             let full = plan.directory.join(&entry.name);
-            self.run_entry(entry.kind, &full, entry.hardlink_cohort)?;
+            #[cfg(unix)]
+            let parent_fd = parent_handle.as_ref().map(std::os::fd::AsFd::as_fd);
+            #[cfg(not(unix))]
+            let parent_fd = None::<()>;
+            self.run_entry(
+                entry.kind,
+                &full,
+                &entry.name,
+                parent_fd,
+                entry.hardlink_cohort,
+            )?;
         }
         Ok(())
+    }
+
+    /// Opens a dirfd for `plan_directory` against the attached
+    /// [`DirSandbox`]'s root for SEC-1.q dispatch.
+    ///
+    /// Returns `None` when no sandbox is attached, when the plan
+    /// directory cannot be opened (already-removed parent during an
+    /// in-flight recursive drain), or when the platform does not expose
+    /// the `*at` syscall family.
+    #[cfg(unix)]
+    fn open_plan_dirfd(&self, plan_directory: &Path) -> Option<std::os::fd::OwnedFd> {
+        let sandbox = self.sandbox.as_ref()?;
+        let relative = plan_directory_to_relative(plan_directory);
+        open_dir_at(sandbox.root_dirfd(), relative).ok()
     }
 
     /// Issues one [`DeleteFs`] call, updates stats on success, and
@@ -281,13 +351,29 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// returning `Err`; non-fatal failures under the default policy
     /// record `io_error` and return `Ok(())` so the caller's loop
     /// continues.
+    ///
+    /// `parent_fd` carries the SEC-1.q sandbox dirfd anchor for the
+    /// containing plan directory. When `Some`, the dispatcher routes
+    /// through the dirfd-anchored `*_at` trait methods; when `None`,
+    /// the dispatcher uses the path-based fallback. `leaf` is the
+    /// single-component leaf name (`entry.name`); `path` is the
+    /// absolute reconstruction used by the path-based fallback and by
+    /// the cohort log.
     fn run_entry(
         &mut self,
         kind: DeleteEntryKind,
         path: &Path,
+        #[cfg(unix)] leaf: &std::ffi::OsStr,
+        #[cfg(not(unix))] _leaf: &std::ffi::OsStr,
+        #[cfg(unix)] parent_fd: Option<std::os::fd::BorrowedFd<'_>>,
+        #[cfg(not(unix))] _parent_fd: Option<()>,
         cohort: Option<HardlinkCohortId>,
     ) -> io::Result<()> {
-        match self.dispatch(kind, path) {
+        #[cfg(unix)]
+        let outcome = self.dispatch(kind, path, parent_fd, leaf);
+        #[cfg(not(unix))]
+        let outcome = self.dispatch(kind, path);
+        match outcome {
             Ok(()) => {
                 Self::increment_stat(&mut self.stats, kind);
                 self.record_cohort_dispatch(path, kind, cohort);
@@ -335,6 +421,33 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// Dispatches one planned entry. Directories route through
     /// [`Self::dispatch_dir`] so the `ENOTEMPTY` fallback can recurse via
     /// a nested plan or [`DeleteFs::remove_dir_all`].
+    ///
+    /// On Unix, `parent_fd` and `leaf` together carry the SEC-1.q
+    /// sandbox anchor: when `parent_fd` is `Some`, the dispatcher
+    /// routes through the dirfd-anchored `*_at` trait methods,
+    /// otherwise it uses the path-based fallback.
+    #[cfg(unix)]
+    fn dispatch(
+        &mut self,
+        kind: DeleteEntryKind,
+        path: &Path,
+        parent_fd: Option<std::os::fd::BorrowedFd<'_>>,
+        leaf: &std::ffi::OsStr,
+    ) -> io::Result<()> {
+        match (kind, parent_fd) {
+            (DeleteEntryKind::File, Some(fd)) => self.fs.unlink_file_at(fd, leaf),
+            (DeleteEntryKind::Symlink, Some(fd)) => self.fs.unlink_symlink_at(fd, leaf),
+            (DeleteEntryKind::Device, Some(fd)) => self.fs.unlink_device_at(fd, leaf),
+            (DeleteEntryKind::Special, Some(fd)) => self.fs.unlink_special_at(fd, leaf),
+            (DeleteEntryKind::Dir, _) => self.dispatch_dir(path, parent_fd, leaf),
+            (DeleteEntryKind::File, None) => self.fs.unlink_file(path),
+            (DeleteEntryKind::Symlink, None) => self.fs.unlink_symlink(path),
+            (DeleteEntryKind::Device, None) => self.fs.unlink_device(path),
+            (DeleteEntryKind::Special, None) => self.fs.unlink_special(path),
+        }
+    }
+
+    #[cfg(not(unix))]
     fn dispatch(&mut self, kind: DeleteEntryKind, path: &Path) -> io::Result<()> {
         match kind {
             DeleteEntryKind::File => self.fs.unlink_file(path),
@@ -352,13 +465,45 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// [`DeleteFs::remove_dir_all`] when no plan was published (upstream
     /// `delete.c:48-122 delete_dir_contents`). The retried `rmdir` after
     /// a successful drain matches `delete_item`'s second pass.
+    #[cfg(unix)]
+    fn dispatch_dir(
+        &mut self,
+        path: &Path,
+        parent_fd: Option<std::os::fd::BorrowedFd<'_>>,
+        leaf: &std::ffi::OsStr,
+    ) -> io::Result<()> {
+        let rmdir_result = match parent_fd {
+            Some(fd) => self.fs.rmdir_at(fd, leaf),
+            None => self.fs.rmdir(path),
+        };
+        match rmdir_result {
+            Ok(()) => Ok(()),
+            Err(err) if is_not_empty(&err) => {
+                if let Some(plan) = self.plans.take(path) {
+                    self.drain_plan(&plan)?;
+                    // Retry the rmdir now that the contents are gone.
+                    match parent_fd {
+                        Some(fd) => self.fs.rmdir_at(fd, leaf),
+                        None => self.fs.rmdir(path),
+                    }
+                } else {
+                    match parent_fd {
+                        Some(fd) => self.fs.remove_dir_all_at(fd, leaf),
+                        None => self.fs.remove_dir_all(path),
+                    }
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    #[cfg(not(unix))]
     fn dispatch_dir(&mut self, path: &Path) -> io::Result<()> {
         match self.fs.rmdir(path) {
             Ok(()) => Ok(()),
             Err(err) if is_not_empty(&err) => {
                 if let Some(plan) = self.plans.take(path) {
                     self.drain_plan(&plan)?;
-                    // Retry the rmdir now that the contents are gone.
                     self.fs.rmdir(path)
                 } else {
                     self.fs.remove_dir_all(path)
@@ -417,4 +562,76 @@ fn is_not_empty(err: &io::Error) -> bool {
     // ENOTEMPTY is 39 on Linux, 66 on BSD/macOS. Keep the check raw so
     // it works on any platform without a libc dep.
     matches!(err.raw_os_error(), Some(39) | Some(66))
+}
+
+/// Strips any leading path separators from `plan_directory` so it can be
+/// passed to a sandbox-anchored `openat(2)`.
+///
+/// Plan directories are constructed as destination-relative paths in the
+/// receiver, but emitter unit tests build them as plain `PathBuf`s that
+/// may or may not include a leading separator. The sandbox `openat`
+/// helpers require a relative path; an absolute leaf bypasses the
+/// dirfd anchor and would defeat the security posture.
+#[cfg(unix)]
+fn plan_directory_to_relative(plan_directory: &Path) -> &Path {
+    use std::path::Component;
+    let stripped = plan_directory.components().skip_while(|c| {
+        matches!(
+            c,
+            Component::RootDir | Component::Prefix(_) | Component::CurDir
+        )
+    });
+    let original = stripped.as_path();
+    if original.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        original
+    }
+}
+
+/// Open `relative` as a directory off `parent_fd` using
+/// [`fast_io::openat`] with `O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC`.
+///
+/// Multi-component `relative` paths walk component-by-component so each
+/// step refuses to follow a terminal symlink, matching the SEC-1.s
+/// recursive peel's descent policy. An empty or `.` relative re-opens
+/// `parent_fd` itself via `openat(parent_fd, ".", O_DIRECTORY)` so the
+/// caller always receives an `OwnedFd` it can borrow uniformly.
+#[cfg(unix)]
+fn open_dir_at(
+    parent_fd: std::os::fd::BorrowedFd<'_>,
+    relative: &Path,
+) -> io::Result<std::os::fd::OwnedFd> {
+    use std::ffi::OsStr;
+    use std::os::fd::{AsFd, OwnedFd};
+    use std::path::Component;
+
+    let flags = libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC;
+
+    let mut current: Option<OwnedFd> = None;
+    let mut walked = false;
+    for component in relative.components() {
+        match component {
+            Component::Normal(name) => {
+                walked = true;
+                let anchor = current.as_ref().map_or(parent_fd, |fd| fd.as_fd());
+                let file = fast_io::openat(anchor, name, flags, 0)?;
+                current = Some(file.into());
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
+            }
+        }
+    }
+
+    if !walked {
+        // No real descent: re-open `parent_fd` as "." so the caller's
+        // borrow signature is uniform whether or not descent happened.
+        let dot = OsStr::new(".");
+        let file = fast_io::openat(parent_fd, dot, flags, 0)?;
+        return Ok(file.into());
+    }
+
+    Ok(current.expect("walked descent always produces a dirfd"))
 }

--- a/crates/engine/src/delete/emitter/tests/mod.rs
+++ b/crates/engine/src/delete/emitter/tests/mod.rs
@@ -9,8 +9,12 @@
 //! Shared helpers (synthetic plan/entry builders, the [`ScriptedDeleteFs`]
 //! failure fake) live here.
 
+#[cfg(unix)]
+use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::io;
+#[cfg(unix)]
+use std::os::fd::BorrowedFd;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -23,6 +27,8 @@ use crate::util::poison::lock_or_recover;
 mod cohort;
 mod dispatch;
 mod error_policy;
+#[cfg(unix)]
+mod sandbox;
 
 pub(super) fn entry(name: &str, kind: DeleteEntryKind) -> DeleteEntry {
     DeleteEntry::new(OsString::from(name), kind)
@@ -113,5 +119,53 @@ impl DeleteFs for ScriptedDeleteFs {
             return Err(err);
         }
         self.inner.remove_dir_all(path)
+    }
+
+    #[cfg(unix)]
+    fn unlink_file_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        if let Some(err) = self.maybe_fail(Path::new(name)) {
+            return Err(err);
+        }
+        self.inner.unlink_file_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn rmdir_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        if let Some(err) = self.maybe_fail(Path::new(name)) {
+            return Err(err);
+        }
+        self.inner.rmdir_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn unlink_symlink_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        if let Some(err) = self.maybe_fail(Path::new(name)) {
+            return Err(err);
+        }
+        self.inner.unlink_symlink_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn unlink_device_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        if let Some(err) = self.maybe_fail(Path::new(name)) {
+            return Err(err);
+        }
+        self.inner.unlink_device_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn unlink_special_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        if let Some(err) = self.maybe_fail(Path::new(name)) {
+            return Err(err);
+        }
+        self.inner.unlink_special_at(parent_fd, name)
+    }
+
+    #[cfg(unix)]
+    fn remove_dir_all_at(&self, parent_fd: BorrowedFd<'_>, name: &OsStr) -> io::Result<()> {
+        if let Some(err) = self.maybe_fail(Path::new(name)) {
+            return Err(err);
+        }
+        self.inner.remove_dir_all_at(parent_fd, name)
     }
 }

--- a/crates/engine/src/delete/emitter/tests/sandbox.rs
+++ b/crates/engine/src/delete/emitter/tests/sandbox.rs
@@ -1,0 +1,212 @@
+//! SEC-1.q sandbox-anchored dispatch tests for the delete emitter.
+//!
+//! Each test exercises a real on-disk layout under a [`tempfile::TempDir`]
+//! so the dirfd-anchored `*_at` trait methods route through the live
+//! `unlinkat(2)` / SEC-1.s `recursive_unlinkat_via_sandbox_or_fallback`
+//! helpers from `fast_io::dir_sandbox::at_syscalls`.
+
+use std::os::unix::fs::symlink;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use fast_io::DirSandbox;
+
+use super::super::super::{DeleteEntryKind, DeletePlanMap, DirTraversalCursor};
+use super::super::{DeleteEmitter, RealDeleteFs};
+use super::{entry, plan};
+
+/// Open a sandbox at `root` so the emitter's `*_at` dispatch can anchor
+/// per-plan `openat` calls against it.
+fn sandbox_for(root: &std::path::Path) -> Arc<DirSandbox> {
+    Arc::new(DirSandbox::open_root(root).expect("open sandbox root"))
+}
+
+#[test]
+fn unlink_file_at_removes_regular_file_under_sandbox() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("d");
+    std::fs::create_dir(&dir).expect("mkdir d");
+    let file = dir.join("victim");
+    std::fs::write(&file, b"x").expect("write victim");
+    assert!(file.exists());
+
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("victim", DeleteEntryKind::File)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter =
+        DeleteEmitter::new(RealDeleteFs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("drain succeeds");
+
+    assert!(!file.exists(), "sandbox unlinkat removed the file");
+    assert_eq!(emitter.stats().files, 1);
+    assert!(emitter.sandbox().is_some());
+}
+
+#[test]
+fn rmdir_at_removes_empty_directory_under_sandbox() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("d");
+    std::fs::create_dir(&dir).expect("mkdir d");
+    let inner = dir.join("empty-child");
+    std::fs::create_dir(&inner).expect("mkdir empty-child");
+
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("empty-child", DeleteEntryKind::Dir)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter =
+        DeleteEmitter::new(RealDeleteFs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("drain succeeds");
+
+    assert!(!inner.exists(), "sandbox rmdir removed the directory");
+    assert_eq!(emitter.stats().dirs, 1);
+}
+
+#[test]
+fn unlink_symlink_at_removes_symlink_without_following_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("d");
+    std::fs::create_dir(&dir).expect("mkdir d");
+    let target = tmp.path().join("outside");
+    std::fs::write(&target, b"do-not-touch").expect("write outside target");
+    let link = dir.join("link");
+    symlink(&target, &link).expect("symlink");
+
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("link", DeleteEntryKind::Symlink)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter =
+        DeleteEmitter::new(RealDeleteFs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("drain succeeds");
+
+    assert!(!link.exists(), "sandbox unlinkat removed the symlink");
+    assert!(
+        target.exists(),
+        "symlink unlink must never follow the link to the outside target",
+    );
+    assert_eq!(emitter.stats().symlinks, 1);
+}
+
+#[test]
+fn remove_dir_all_at_peels_nested_tree_without_following_symlinks() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("d");
+    std::fs::create_dir(&dir).expect("mkdir d");
+    let tree = dir.join("tree");
+    std::fs::create_dir_all(tree.join("level-1/level-2")).expect("nest dirs");
+    std::fs::write(tree.join("level-1/file"), b"x").expect("write file");
+    let outside_target = tmp.path().join("outside-tree");
+    std::fs::write(&outside_target, b"do-not-touch").expect("write outside");
+    symlink(&outside_target, tree.join("level-1/escape-link")).expect("symlink");
+
+    // No nested plan for "d/tree"; ENOTEMPTY fallback routes through
+    // remove_dir_all_at -> SEC-1.s recursive helper.
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("tree", DeleteEntryKind::Dir)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter =
+        DeleteEmitter::new(RealDeleteFs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("drain succeeds");
+
+    assert!(!tree.exists(), "recursive peel removed the tree");
+    assert!(
+        outside_target.exists(),
+        "recursive peel must never follow the escape symlink to the outside target",
+    );
+    assert_eq!(emitter.stats().dirs, 1);
+}
+
+#[test]
+fn sandbox_off_falls_back_to_path_based_methods() {
+    // No sandbox attached: dispatch must use the path-based methods so
+    // every existing caller stays on the legacy fallback. This is the
+    // baseline contract for SEC-1.q's "additive" trait extension.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("d");
+    std::fs::create_dir(&dir).expect("mkdir d");
+    let file = dir.join("victim");
+    std::fs::write(&file, b"x").expect("write");
+
+    let plans = DeletePlanMap::new();
+    plans.insert(plan(
+        dir.to_str().expect("path utf-8"),
+        vec![entry("victim", DeleteEntryKind::File)],
+    ));
+    let mut cursor = DirTraversalCursor::new(dir.clone());
+    cursor.observe_segment(dir.clone(), &[]);
+
+    let mut emitter = DeleteEmitter::new(RealDeleteFs, plans, cursor);
+    assert!(emitter.sandbox().is_none());
+    emitter.emit_all().expect("drain succeeds");
+
+    assert!(!file.exists(), "path-based fallback removed the file");
+    assert_eq!(emitter.stats().files, 1);
+}
+
+#[test]
+fn sandbox_dispatch_handles_device_and_special_leaves() {
+    // Devices and FIFOs both route through unlinkat with UnlinkFlags::File;
+    // the kinds are distinguished only for the stats counters and the
+    // dispatch matrix in unit tests. Using a regular file as the on-disk
+    // backing entry keeps the test portable across platforms that gate
+    // mknod behind elevated capabilities.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("d");
+    std::fs::create_dir(&dir).expect("mkdir d");
+    let dev = dir.join("dev-entry");
+    let fifo = dir.join("fifo-entry");
+    std::fs::write(&dev, b"x").expect("write dev");
+    std::fs::write(&fifo, b"y").expect("write fifo");
+
+    let plans = DeletePlanMap::new();
+    plans.insert(plan(
+        "d",
+        vec![
+            entry("dev-entry", DeleteEntryKind::Device),
+            entry("fifo-entry", DeleteEntryKind::Special),
+        ],
+    ));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter =
+        DeleteEmitter::new(RealDeleteFs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter.emit_all().expect("drain succeeds");
+
+    assert!(!dev.exists() && !fifo.exists());
+    assert_eq!(emitter.stats().devices, 1);
+    assert_eq!(emitter.stats().specials, 1);
+}
+
+#[test]
+fn sandbox_with_missing_plan_directory_falls_back_to_path_dispatch() {
+    // The plan references a directory that no longer exists on disk
+    // (a concurrent removal raced the emitter). The sandbox dirfd open
+    // fails; the dispatcher must still attempt the path-based methods
+    // so the standard NotFound-vs-IO error policy applies uniformly.
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("absent", vec![entry("victim", DeleteEntryKind::File)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("absent"));
+    cursor.observe_segment(PathBuf::from("absent"), &[]);
+
+    let mut emitter =
+        DeleteEmitter::new(RealDeleteFs, plans, cursor).with_sandbox(sandbox_for(tmp.path()));
+    emitter
+        .emit_all()
+        .expect("drain returns ok under default policy");
+
+    // The directory does not exist, so the path-based fallback's
+    // remove_file returns NotFound which the policy records as a
+    // vanished race rather than a fatal abort.
+    assert_eq!(emitter.stats().files, 0);
+    assert_ne!(emitter.io_error(), 0);
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -1534,7 +1534,24 @@ pub fn recursive_unlinkat_via_sandbox_or_fallback(
 /// pointing back at the leaf (Linux + `CAP_SYS_ADMIN` only) is
 /// short-circuited before any destructive syscall fires inside the
 /// cycle.
-fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<()> {
+///
+/// Direct-dirfd entry point for callers that already hold the parent
+/// dirfd and a single-component leaf (SEC-1.q `DeleteFs::remove_dir_all_at`
+/// is the first consumer). Callers that come in with absolute paths
+/// should prefer
+/// [`recursive_unlinkat_via_sandbox_or_fallback`] which selects between
+/// this dirfd-anchored path and the [`std::fs::remove_dir_all`]
+/// fallback based on whether the supplied sandbox can resolve the
+/// leaf as a single component.
+///
+/// # Errors
+///
+/// Surfaces the same error set as
+/// [`recursive_unlinkat_via_sandbox_or_fallback`]: `ENOENT` on the
+/// descent root is folded into `Ok(())`, `ELOOP` is returned for a
+/// symlink at the root or a hardlink cycle, and `ENOTEMPTY` is surfaced
+/// when an `EACCES` skip left residual entries behind.
+pub fn recursive_unlinkat(parent_dirfd: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<()> {
     let mut visited: std::collections::HashSet<(u64, u64)> = std::collections::HashSet::new();
     recursive_unlinkat_inner(parent_dirfd, leaf, &mut visited)
 }

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -83,9 +83,9 @@ pub use at_syscalls::{
     fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
     lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
     openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
-    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
-    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
+    renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
+    unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -245,9 +245,10 @@ pub use dir_sandbox::{
     fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat,
     linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
     mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback, readlinkat,
-    readlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback, symlinkat,
-    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
-    utimensat_via_sandbox_or_fallback,
+    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
+    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
+    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
+    utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,

--- a/docs/design/sec-1-q-delete-emitter-sandbox-2026-05-22.md
+++ b/docs/design/sec-1-q-delete-emitter-sandbox-2026-05-22.md
@@ -157,6 +157,26 @@ Promote OPEN to IN-PROGRESS when any of the following lands:
 - A CVE-class disclosure targets the `--delete` traversal rather
   than the per-entry unlink.
 
+## Deferred follow-up: receiver-deletion integration
+
+The initial SEC-1.q implementation lands the trait extension, the
+`RealDeleteFs` sandbox routes, and the `DeleteEmitter` sandbox carrier
+slot. The receiver-deletion call sites in `crates/transfer/` (PR #4710
+rows #5-#7) are **not** wired in the same PR because the receiver's
+delete traversal does not yet route through `DeleteEmitter`: it issues
+its own per-entry unlink/rmdir loop in
+`crates/transfer/src/receiver/directory/`. Threading the sandbox through
+that loop is a separate refactor (collapsing the receiver loop onto the
+emitter, or shimming the sandbox into the loop directly) and ships as a
+follow-up task once the architectural mismatch is resolved.
+
+Until that follow-up lands, `DeleteEmitter::with_sandbox` is exercised
+only from unit tests and from any future caller that builds the emitter
+directly. The path-based fallback methods remain the production code
+path for the existing receiver loop, so this PR is a net-positive
+defense-in-depth change with zero behavioural regression for the live
+receiver.
+
 ## References
 
 - PR #4710 -


### PR DESCRIPTION
## Summary

Implements **SEC-1.q** per `docs/design/sec-1-q-delete-emitter-sandbox-2026-05-22.md`. Closes 6 GAP sites from the SEC-1 audit (PR #4710 rows 22-27): daemon-reachable `unlink`/`rmdir`/`remove_dir_all` calls in the engine `DeleteFs` impl that weren't anchored on `DirSandbox`.

This was previously opened as PR #4727 stacked on SEC-1.s (PR #4726). #4726 merged at sha `2a5d119`, GitHub auto-closed #4727 when its base branch was deleted, and reopen is blocked. Re-opening here against `master` with the same source branch.

## Changes

1. **Trait extension** (`crates/engine/src/delete/emitter/fs.rs`): six new unix-only `*_at` siblings taking `BorrowedFd<'_> + &OsStr`. Path-based methods preserved as no-sandbox/Windows fallback.
2. **Implementations**: `RealDeleteFs` routes through `fast_io::unlinkat` and `fast_io::recursive_unlinkat` (SEC-1.s helper); `RecordingDeleteFs` and `ScriptedDeleteFs` discard `parent_fd` and record the leaf name so existing emitter tests pass unchanged; `&F` blanket impl mirrors the six methods.
3. **Emitter wiring**: `Option<Arc<DirSandbox>>` carrier field on `DeleteEmitter` plus `with_sandbox()` builder and `sandbox()` accessor. `drain_plan` opens a per-plan dirfd against `sandbox.root_dirfd()`; `dispatch` and `dispatch_dir` route through the `*_at` methods when the dirfd is available, otherwise transparently fall back to path-based methods. All cross-platform via `#[cfg(unix)]` gates.
4. **Tests** (`crates/engine/src/delete/emitter/tests/sandbox.rs`): seven tests covering per-method sandbox dispatch, symlink-swap resistance (regular file, symlink, recursive peel against escape symlinks), sandbox-off fallback, device/special leaf dispatch, missing-plan-directory fallback.
5. **Helper exposure**: `recursive_unlinkat(parent_dirfd, leaf)` promoted from private to `pub` and re-exported, so engine can drive the recursive peel directly.

## Deferred

Receiver loop in `crates/transfer/` doesn't route through `DeleteEmitter` yet; wiring that path is a separate follow-up (noted in the design doc).

## Constraints

- No unsafe added to engine crate (still denies unsafe).
- Cross-platform: unix gates the new methods; Windows path unchanged.
- Conventional commit prefix `refactor:` per PR title.