### PR TITLE
feat(transfer): thread DirSandbox through receiver --delete path (SEC-1.q2)

### DIFF
--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -575,13 +575,17 @@ fn is_not_empty(err: &io::Error) -> bool {
 #[cfg(unix)]
 fn plan_directory_to_relative(plan_directory: &Path) -> &Path {
     use std::path::Component;
-    let stripped = plan_directory.components().skip_while(|c| {
-        matches!(
-            c,
-            Component::RootDir | Component::Prefix(_) | Component::CurDir
-        )
-    });
-    let original = stripped.as_path();
+    let mut components = plan_directory.components();
+    loop {
+        let mut peek = components.clone();
+        match peek.next() {
+            Some(Component::Prefix(_)) | Some(Component::RootDir) | Some(Component::CurDir) => {
+                components.next();
+            }
+            _ => break,
+        }
+    }
+    let original = components.as_path();
     if original.as_os_str().is_empty() {
         Path::new(".")
     } else {

--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -1806,6 +1806,357 @@ fn errno_location() -> *mut libc::c_int {
     }
 }
 
+// ============================================================
+// read_dir helper (SEC-1.q2)
+// ============================================================
+
+/// File-type discriminator returned by [`DirEntryView::file_type`].
+///
+/// The receiver-side `--delete` loop only needs to distinguish
+/// directories, symlinks, and everything else (regular files, devices,
+/// FIFOs, sockets); the kernel `d_type` field exposes the same shape
+/// when available and [`fstatat_nofollow`] backfills it when the
+/// underlying filesystem reports [`libc::DT_UNKNOWN`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EntryKind {
+    /// Directory entry.
+    Dir,
+    /// Symbolic link (never followed by the sandbox helpers).
+    Symlink,
+    /// Regular file, device, FIFO, socket, or unknown non-directory.
+    Other,
+}
+
+impl EntryKind {
+    fn from_dt(dt: u8) -> Option<Self> {
+        match dt {
+            libc::DT_DIR => Some(Self::Dir),
+            libc::DT_LNK => Some(Self::Symlink),
+            libc::DT_UNKNOWN => None,
+            _ => Some(Self::Other),
+        }
+    }
+
+    fn from_mode(mode: u32) -> Self {
+        // `libc::S_IFMT` is `mode_t`: `u16` on macOS, `u32` on Linux.
+        // [`widen_mode`] keeps the comparison portable without tripping
+        // `clippy::unnecessary_cast` on either target.
+        let masked = mode & widen_mode(libc::S_IFMT);
+        if masked == widen_mode(libc::S_IFDIR) {
+            Self::Dir
+        } else if masked == widen_mode(libc::S_IFLNK) {
+            Self::Symlink
+        } else {
+            Self::Other
+        }
+    }
+
+    /// Returns `true` when the entry is a directory.
+    #[must_use]
+    pub fn is_dir(self) -> bool {
+        matches!(self, Self::Dir)
+    }
+
+    /// Returns `true` when the entry is a symbolic link.
+    #[must_use]
+    pub fn is_symlink(self) -> bool {
+        matches!(self, Self::Symlink)
+    }
+}
+
+/// One entry from [`ReadDirOutcome`] exposing the leaf name and the
+/// classify bits the receiver-side `--delete` loop needs.
+///
+/// The view is produced by both the sandbox-anchored and the path-based
+/// branches so the caller can swap on [`ReadDirOutcome`] without
+/// branching on the underlying syscall family. The leaf name is owned so
+/// the caller can hold it across further `*at` calls without keeping the
+/// directory cursor live.
+#[derive(Clone, Debug)]
+pub struct DirEntryView {
+    name: std::ffi::OsString,
+    kind: Option<EntryKind>,
+}
+
+impl DirEntryView {
+    /// The leaf name of this directory entry.
+    #[must_use]
+    pub fn file_name(&self) -> &std::ffi::OsStr {
+        &self.name
+    }
+
+    /// Consume the view and return the owned leaf name.
+    #[must_use]
+    pub fn into_file_name(self) -> std::ffi::OsString {
+        self.name
+    }
+
+    /// Classifies the entry without following symlinks, or `None` when
+    /// the underlying filesystem reported [`libc::DT_UNKNOWN`] and the
+    /// caller chose not to stat the leaf.
+    #[must_use]
+    pub fn file_type(&self) -> Option<EntryKind> {
+        self.kind
+    }
+}
+
+/// Result of [`read_dir_via_sandbox_or_fallback`].
+///
+/// The variant indicates which read path satisfied the call. Both
+/// variants iterate as `io::Result<DirEntryView>` so the caller can swap
+/// on the variant without branching on the per-entry shape.
+#[derive(Debug)]
+pub enum ReadDirOutcome {
+    /// Sandbox-anchored listing collected via `openat(O_DIRECTORY |
+    /// O_NOFOLLOW)` + `fdopendir`. The whole listing is materialised up
+    /// front so the dirfd is released before the caller starts issuing
+    /// per-entry actions (matches the `recursive_unlinkat` invariant).
+    At(std::vec::IntoIter<DirEntryView>),
+    /// Path-based [`std::fs::read_dir`] iterator used when the sandbox
+    /// was unavailable or the relative path was not a single component.
+    Std(std::fs::ReadDir),
+}
+
+impl Iterator for ReadDirOutcome {
+    type Item = io::Result<DirEntryView>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::At(iter) => iter.next().map(Ok),
+            Self::Std(iter) => iter.next().map(|res| {
+                res.map(|entry| {
+                    let kind = entry.file_type().ok().map(|ft| {
+                        if ft.is_dir() {
+                            EntryKind::Dir
+                        } else if ft.is_symlink() {
+                            EntryKind::Symlink
+                        } else {
+                            EntryKind::Other
+                        }
+                    });
+                    DirEntryView {
+                        name: entry.file_name(),
+                        kind,
+                    }
+                })
+            }),
+        }
+    }
+}
+
+/// Open `target_path` as a directory and list its entries, anchoring on
+/// the sandbox dirfd when possible.
+///
+/// SEC-1.q2 adaptor for the receiver-side `--delete` scan (audit row #5).
+/// Mirrors the existing `*_via_sandbox_or_fallback` shape:
+/// - When `sandbox` is `Some` and `relative_path` is empty or `.`, the
+///   listing targets `dest_dir` itself; the helper opens a fresh
+///   `openat(dirfd, ".", O_DIRECTORY | O_RDONLY | O_CLOEXEC)` against
+///   the sandbox dirfd so `fdopendir(3)` receives its own owned fd and
+///   the caller's sandbox handle stays intact.
+/// - When `sandbox` is `Some`, `target_path` equals
+///   `dest_dir.join(relative_path)`, and `relative_path` has a single
+///   `Component::Normal`, the helper opens the leaf through
+///   `openat(sandbox.current_dirfd(), leaf, O_DIRECTORY | O_NOFOLLOW |
+///   O_RDONLY | O_CLOEXEC)` so a TOCTOU symlink swap on the leaf cannot
+///   redirect the listing into an attacker-chosen directory.
+/// - In every other case the helper falls back to
+///   [`std::fs::read_dir`] on `target_path`. The fallback is vulnerable
+///   to the symlink-swap class the carrier closes; it is intended only
+///   for the no-sandbox contexts and multi-component descents that the
+///   SEC-1.f-q chain has not yet plumbed.
+///
+/// The sandbox-anchored branch materialises the full listing up front
+/// (matching the `recursive_unlinkat` invariant) so the dirfd is closed
+/// before per-entry `unlinkat`/`fstatat` syscalls fire. The std branch
+/// lazily iterates as today.
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `ELOOP` or `ENOTDIR` when the leaf is a symlink and the sandbox
+///   path was selected (`O_NOFOLLOW`).
+/// - `ENOENT` when `target_path` does not exist.
+/// - `EACCES` when the caller lacks search permission on the leaf or
+///   the parent dirfd.
+pub fn read_dir_via_sandbox_or_fallback(
+    sandbox: Option<&super::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &Path,
+    target_path: &Path,
+) -> io::Result<ReadDirOutcome> {
+    if let Some(sandbox) = sandbox {
+        if relative_path.as_os_str().is_empty() || relative_path == Path::new(".") {
+            if dest_dir == target_path {
+                let parent = sandbox.current_dirfd();
+                let dir_handle = openat_dot(parent)?;
+                let entries = read_dir_entry_views(dir_handle, parent, None)?;
+                return Ok(ReadDirOutcome::At(entries.into_iter()));
+            }
+        } else if let Some(leaf) = single_component_leaf(dest_dir, relative_path, target_path) {
+            let parent = sandbox.current_dirfd();
+            let dir_handle = openat(
+                parent,
+                leaf,
+                libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC,
+                0,
+            )?;
+            let entries = read_dir_entry_views(dir_handle, parent, Some(leaf))?;
+            return Ok(ReadDirOutcome::At(entries.into_iter()));
+        }
+    }
+    std::fs::read_dir(target_path).map(ReadDirOutcome::Std)
+}
+
+/// Open the directory the supplied dirfd refers to as a fresh `File`
+/// suitable for handing to `fdopendir(3)`.
+///
+/// `openat(dirfd, ".", ...)` returns a fresh fd that points at the same
+/// inode as `dirfd` without aliasing the caller's borrowed handle.
+/// `O_NOFOLLOW` is omitted because the leaf is `.` (a directory by
+/// definition); `O_DIRECTORY` is set so a kernel race that swapped the
+/// inode to a non-directory between `openat` and the kernel reaching it
+/// would surface as `ENOTDIR`.
+fn openat_dot(dirfd: BorrowedFd<'_>) -> io::Result<File> {
+    openat(
+        dirfd,
+        OsStr::new("."),
+        libc::O_DIRECTORY | libc::O_RDONLY | libc::O_CLOEXEC,
+        0,
+    )
+}
+
+/// Materialise the full listing for the directory `dirfile` refers to,
+/// classifying each entry by `d_type` when the filesystem provides it
+/// and falling back to [`fstatat_nofollow`] off `parent_dirfd` when it
+/// reports [`libc::DT_UNKNOWN`].
+///
+/// Consumes `dirfile`: ownership of the underlying fd is transferred to
+/// the `DIR*` via `fdopendir(3)` and released by `closedir(3)` before
+/// this helper returns. `parent_dirfd` plus `leaf_in_parent` describe
+/// where to reopen the directory when a DT_UNKNOWN backfill is needed;
+/// `leaf_in_parent == None` means `parent_dirfd` itself is the listing
+/// target (the `dest_dir == target_path` branch).
+fn read_dir_entry_views(
+    dirfile: File,
+    parent_dirfd: BorrowedFd<'_>,
+    leaf_in_parent: Option<&OsStr>,
+) -> io::Result<Vec<DirEntryView>> {
+    use std::ffi::OsString;
+    use std::os::fd::IntoRawFd;
+
+    // SAFETY:
+    // - `dirfile.into_raw_fd()` releases ownership of the raw fd to us;
+    //   we hand that ownership directly to `fdopendir(3)`. On success
+    //   the resulting `DIR*` owns the fd and `closedir(3)` will close
+    //   it. On failure we reclaim ownership with `OwnedFd::from_raw_fd`
+    //   so the standard `Drop` impl closes it exactly once.
+    // - `dirfile` is not used after `into_raw_fd`, so the fd cannot be
+    //   double-closed by `File::drop`.
+    #[allow(unsafe_code)]
+    let dirp = unsafe {
+        let raw = dirfile.into_raw_fd();
+        let ptr = libc::fdopendir(raw);
+        if ptr.is_null() {
+            let err = io::Error::last_os_error();
+            let _reclaim = std::os::fd::OwnedFd::from_raw_fd(raw);
+            return Err(err);
+        }
+        ptr
+    };
+
+    let mut entries: Vec<DirEntryView> = Vec::new();
+    let mut needs_backfill = false;
+    let result: io::Result<()> = loop {
+        // SAFETY:
+        // - `errno` is reset before every call so we can distinguish
+        //   end-of-stream (`readdir` returns NULL with errno unchanged)
+        //   from an error (`readdir` returns NULL with errno set).
+        // - `dirp` is the live `DIR*` we just created; we hold it for
+        //   the duration of the loop and `closedir` is called below.
+        // - The returned `*mut dirent` is owned by the C runtime and is
+        //   only valid until the next `readdir(3)` call on the same
+        //   `DIR*`; we copy `d_name` into an owned `OsString` before
+        //   the next iteration so the borrow does not outlive the
+        //   pointer.
+        #[allow(unsafe_code)]
+        let ent_ptr = unsafe {
+            *errno_location() = 0;
+            libc::readdir(dirp)
+        };
+        if ent_ptr.is_null() {
+            // SAFETY: `errno_location` returns a thread-local
+            // `*mut c_int` whose lifetime is the calling thread.
+            #[allow(unsafe_code)]
+            let raw_errno = unsafe { *errno_location() };
+            if raw_errno == 0 {
+                break Ok(());
+            }
+            break Err(io::Error::from_raw_os_error(raw_errno));
+        }
+        // SAFETY: `ent_ptr` is non-NULL per the check above; the
+        // pointed-to `dirent` is owned by the C runtime for the
+        // lifetime of this `readdir` call. We read `d_name` and
+        // `d_type` and copy `d_name` out before issuing the next
+        // `readdir`.
+        #[allow(unsafe_code)]
+        let (name_bytes, dt) = unsafe {
+            let name_ptr = (*ent_ptr).d_name.as_ptr();
+            let cstr = std::ffi::CStr::from_ptr(name_ptr);
+            let dt = (*ent_ptr).d_type;
+            (cstr.to_bytes().to_vec(), dt)
+        };
+        let name = OsString::from_vec(name_bytes);
+        if name.as_bytes() == b"." || name.as_bytes() == b".." {
+            continue;
+        }
+        let kind = EntryKind::from_dt(dt);
+        if kind.is_none() {
+            needs_backfill = true;
+        }
+        entries.push(DirEntryView { name, kind });
+    };
+
+    // SAFETY: `dirp` is the live `DIR*` we created above; `closedir(3)`
+    // closes the underlying fd and frees the C-runtime state. After
+    // this call `dirp` must not be dereferenced.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::closedir(dirp);
+    }
+
+    result?;
+
+    // Backfill DT_UNKNOWN entries with `fstatat` against a freshly
+    // opened dirfd. Filesystems such as XFS and many FUSE mounts always
+    // report DT_UNKNOWN; without the backfill the receiver cannot
+    // distinguish a directory from a regular file and would mis-dispatch
+    // the unlink. The reopen anchors on the same parent that produced
+    // the listing so the stat is consistent with the directory we just
+    // read.
+    if needs_backfill {
+        let backfill_dir = match leaf_in_parent {
+            Some(leaf) => openat(
+                parent_dirfd,
+                leaf,
+                libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC,
+                0,
+            )?,
+            None => openat_dot(parent_dirfd)?,
+        };
+        let backfill_fd = std::os::fd::AsFd::as_fd(&backfill_dir);
+        for entry in entries.iter_mut().filter(|e| e.kind.is_none()) {
+            entry.kind = match fstatat_nofollow(backfill_fd, &entry.name) {
+                Ok(meta) => Some(EntryKind::from_mode(meta.mode())),
+                Err(err) if err.raw_os_error() == Some(libc::ENOENT) => None,
+                Err(err) => return Err(err),
+            };
+        }
+    }
+
+    Ok(entries)
+}
+
 #[cfg(test)]
 mod tests {
     use std::os::fd::AsFd;
@@ -3078,5 +3429,145 @@ mod tests {
         recursive_unlinkat_via_sandbox_or_fallback(None, &root, leaf, &target)
             .expect("no-sandbox fallback");
         assert!(!target.exists());
+    }
+
+    // ========================================================
+    // read_dir_via_sandbox_or_fallback tests (SEC-1.q2)
+    // ========================================================
+
+    fn collect_names(outcome: ReadDirOutcome) -> Vec<std::ffi::OsString> {
+        outcome
+            .map(|res| res.expect("dir entry").into_file_name())
+            .collect()
+    }
+
+    #[test]
+    fn read_dir_via_sandbox_lists_root_when_relative_is_empty() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("a"), b"x").expect("write a");
+        std::fs::create_dir(root.join("b")).expect("mkdir b");
+        symlink(root.join("a"), root.join("c")).expect("symlink c");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let outcome = read_dir_via_sandbox_or_fallback(Some(&sandbox), &root, Path::new(""), &root)
+            .expect("read_dir");
+        assert!(matches!(outcome, ReadDirOutcome::At(_)));
+
+        let mut names: Vec<_> = collect_names(outcome)
+            .into_iter()
+            .map(|n| n.to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn read_dir_via_sandbox_lists_single_component_subdir() {
+        let (_keep, root) = canonical_tempdir();
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).expect("mkdir sub");
+        std::fs::write(sub.join("file"), b"x").expect("write file");
+        std::fs::create_dir(sub.join("nested")).expect("mkdir nested");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let outcome =
+            read_dir_via_sandbox_or_fallback(Some(&sandbox), &root, Path::new("sub"), &sub)
+                .expect("read_dir");
+        assert!(matches!(outcome, ReadDirOutcome::At(_)));
+
+        let entries: Vec<_> = outcome.map(|res| res.expect("entry")).collect();
+        assert_eq!(entries.len(), 2);
+        let mut by_name: std::collections::HashMap<_, _> = entries
+            .into_iter()
+            .map(|e| (e.file_name().to_os_string(), e.file_type()))
+            .collect();
+        let file_kind = by_name.remove(OsStr::new("file")).expect("file present");
+        let nested_kind = by_name
+            .remove(OsStr::new("nested"))
+            .expect("nested present");
+        assert_eq!(file_kind, Some(EntryKind::Other));
+        assert_eq!(nested_kind, Some(EntryKind::Dir));
+    }
+
+    #[test]
+    fn read_dir_via_sandbox_falls_back_for_multi_component() {
+        let (_keep, root) = canonical_tempdir();
+        let nested = root.join("a/b");
+        std::fs::create_dir_all(&nested).expect("mkdir -p");
+        std::fs::write(nested.join("leaf"), b"x").expect("write leaf");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let outcome =
+            read_dir_via_sandbox_or_fallback(Some(&sandbox), &root, Path::new("a/b"), &nested)
+                .expect("read_dir");
+        assert!(
+            matches!(outcome, ReadDirOutcome::Std(_)),
+            "multi-component path must take the path-based fallback"
+        );
+        let names = collect_names(outcome);
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0], OsStr::new("leaf"));
+    }
+
+    #[test]
+    fn read_dir_via_sandbox_falls_back_when_sandbox_absent() {
+        let (_keep, root) = canonical_tempdir();
+        std::fs::write(root.join("file"), b"x").expect("write");
+
+        let outcome =
+            read_dir_via_sandbox_or_fallback(None, &root, Path::new(""), &root).expect("read_dir");
+        assert!(matches!(outcome, ReadDirOutcome::Std(_)));
+        let names = collect_names(outcome);
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0], OsStr::new("file"));
+    }
+
+    #[test]
+    fn read_dir_via_sandbox_refuses_symlink_at_leaf() {
+        // SEC-1.q2 core invariant: when an attacker swaps a subdir for a
+        // symlink to an outside directory between the receiver's
+        // decide-to-list moment and the syscall, the sandbox-anchored
+        // helper must refuse with ELOOP/ENOTDIR rather than redirect the
+        // listing to the attacker-chosen tree.
+        let (_keep, root) = canonical_tempdir();
+        let outside = root.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        std::fs::write(outside.join("sentinel"), b"do-not-touch").expect("sentinel");
+        let link = root.join("link");
+        symlink(&outside, &link).expect("symlink");
+
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+        let err = read_dir_via_sandbox_or_fallback(Some(&sandbox), &root, Path::new("link"), &link)
+            .expect_err("symlink leaf must be refused");
+        let errno = err.raw_os_error();
+        assert!(
+            errno == Some(libc::ELOOP) || errno == Some(libc::ENOTDIR),
+            "expected ELOOP or ENOTDIR (symlink not followed), got {err:?}"
+        );
+        assert!(outside.exists(), "symlink target outside must survive");
+    }
+
+    #[test]
+    fn read_dir_view_via_sandbox_matches_std_for_subdir_listing() {
+        let (_keep, root) = canonical_tempdir();
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).expect("mkdir sub");
+        std::fs::write(sub.join("a"), b"a").expect("write a");
+        std::fs::write(sub.join("b"), b"b").expect("write b");
+        std::fs::create_dir(sub.join("c")).expect("mkdir c");
+        let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+        let via_at =
+            read_dir_via_sandbox_or_fallback(Some(&sandbox), &root, Path::new("sub"), &sub)
+                .expect("via at");
+        let mut at_names = collect_names(via_at);
+        at_names.sort();
+
+        let via_std =
+            read_dir_via_sandbox_or_fallback(None, &root, Path::new("sub"), &sub).expect("via std");
+        let mut std_names = collect_names(via_std);
+        std_names.sort();
+
+        assert_eq!(at_names, std_names, "sandbox and std listings must agree");
     }
 }

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -79,10 +79,11 @@ pub mod at_syscalls;
 mod tests;
 
 pub use at_syscalls::{
-    AtMetadata, LstatOutcome, UnlinkFlags, fchmodat, fchmodat_via_sandbox_or_fallback, fchownat,
-    fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback,
-    lstat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, openat,
-    openat_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
+    AtMetadata, DirEntryView, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags, fchmodat,
+    fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow,
+    linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
+    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
+    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
     recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
     renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
     unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -241,14 +241,14 @@ pub use traits::{FileReader, FileWriter};
 
 #[cfg(unix)]
 pub use dir_sandbox::{
-    AtMetadata, DirSandbox, LstatOutcome, UnlinkFlags, fchmodat, fchmodat_via_sandbox_or_fallback,
-    fchownat, fchownat_via_sandbox_or_fallback, fstatat_nofollow, linkat,
-    linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback, mkdirat,
-    mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback, readlinkat,
-    readlinkat_via_sandbox_or_fallback, recursive_unlinkat,
-    recursive_unlinkat_via_sandbox_or_fallback, renameat, renameat_via_sandbox_or_fallback,
-    symlinkat, symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat,
-    utimensat, utimensat_via_sandbox_or_fallback,
+    AtMetadata, DirEntryView, DirSandbox, EntryKind, LstatOutcome, ReadDirOutcome, UnlinkFlags,
+    fchmodat, fchmodat_via_sandbox_or_fallback, fchownat, fchownat_via_sandbox_or_fallback,
+    fstatat_nofollow, linkat, linkat_via_sandbox_or_fallback, lstat_via_sandbox_or_fallback,
+    mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
+    read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
+    recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
+    renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
+    unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -5,8 +5,14 @@
 //! removes them. Parallel scanning via `map_blocking` when directory count
 //! exceeds threshold. Respects `--max-delete` via an atomic counter shared
 //! across workers, and `FilterChain::allows_deletion()` for protect/risk rules.
+//!
+//! SEC-1.q2: when the receiver carries a [`fast_io::DirSandbox`], the scan
+//! and removal syscalls route through the `*_via_sandbox_or_fallback`
+//! helpers so a TOCTOU symlink swap on a top-level entry cannot redirect
+//! the listing or the unlink to an attacker-chosen inode. Multi-component
+//! relative paths take the documented path-based fallback (see
+//! `crates/fast_io/src/dir_sandbox/at_syscalls.rs::single_component_leaf`).
 
-use std::fs;
 use std::io;
 use std::path::Path;
 
@@ -28,6 +34,12 @@ impl ReceiverContext {
     /// enforces the deletion limit across all parallel workers. Protect/risk filter
     /// rules are evaluated via `FilterChain::allows_deletion()` before each deletion.
     ///
+    /// `sandbox` is the SEC-1.e parent-dirfd carrier opened at setup time. When
+    /// `Some`, the scan and per-entry deletions route through the sandbox-anchored
+    /// `*_via_sandbox_or_fallback` helpers (audit rows #5, #6, #7); when `None`
+    /// every site falls back to the path-based `std::fs` syscalls and is
+    /// byte-identical to the pre-SEC-1.q2 behaviour.
+    ///
     /// Returns `(stats, limit_exceeded)` where `limit_exceeded` is true when deletions
     /// were stopped due to `--max-delete`.
     ///
@@ -40,6 +52,7 @@ impl ReceiverContext {
     pub(in crate::receiver) fn delete_extraneous_files<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
         dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&std::sync::Arc<fast_io::DirSandbox>>,
         writer: &mut W,
     ) -> io::Result<(DeleteStats, bool)> {
         use std::collections::{HashMap, HashSet};
@@ -92,6 +105,15 @@ impl ReceiverContext {
         let dir_children = Arc::new(dir_children);
         let filter_chain = Arc::new(self.filter_chain.clone());
         let dest_dir_owned = dest_dir.to_path_buf();
+        // SEC-1.q2: clone the sandbox `Arc` into the worker closure so
+        // every per-directory job can route its scan and per-entry
+        // deletions through the sandbox-anchored `*at` helpers without
+        // contending on a mutex. The carrier is `None` when the
+        // destination dir could not be opened at setup time, and on
+        // Windows where the carrier is not used (NTFS handle semantics
+        // already close the symlink-swap window, per the SEC-1.l audit).
+        #[cfg(unix)]
+        let sandbox_for_workers = sandbox.cloned();
 
         // Collect deleted relative paths for post-parallel itemize emission.
         // The writer is not Send, so MSG_INFO frames are emitted sequentially
@@ -112,19 +134,63 @@ impl ReceiverContext {
                     None => return (DeleteStats::new(), Vec::new()),
                 };
 
-                let read_dir = match fs::read_dir(&dest_path) {
+                #[cfg(unix)]
+                let sandbox_ref = sandbox_for_workers.as_deref();
+                #[cfg(unix)]
+                let read_dir_iter = {
+                    // SEC-1.q2 audit row #5: anchor the directory listing
+                    // on the sandbox dirfd when the scan target is the
+                    // root or a single-component subdir; the helper falls
+                    // back to `std::fs::read_dir` for multi-component
+                    // descents and the sandbox-off case.
+                    let scan_rel: &Path = if dir_relative.as_os_str() == "." {
+                        Path::new("")
+                    } else {
+                        dir_relative.as_path()
+                    };
+                    match fast_io::read_dir_via_sandbox_or_fallback(
+                        sandbox_ref,
+                        &dest_dir_owned,
+                        scan_rel,
+                        &dest_path,
+                    ) {
+                        Ok(iter) => iter,
+                        Err(_) => return (DeleteStats::new(), Vec::new()),
+                    }
+                };
+                #[cfg(not(unix))]
+                let read_dir_iter = match std::fs::read_dir(&dest_path) {
                     Ok(iter) => iter,
                     Err(_) => return (DeleteStats::new(), Vec::new()),
                 };
 
                 let mut stats = DeleteStats::new();
                 let mut deleted_paths = Vec::new();
-                for entry in read_dir {
+                for entry in read_dir_iter {
+                    #[cfg(unix)]
+                    let (name, kind) = match entry {
+                        Ok(view) => (view.file_name().to_os_string(), view.file_type()),
+                        Err(_) => continue,
+                    };
+                    #[cfg(unix)]
+                    let is_dir = kind.is_some_and(fast_io::EntryKind::is_dir);
+                    #[cfg(unix)]
+                    let is_symlink = kind.is_some_and(fast_io::EntryKind::is_symlink);
+
+                    #[cfg(not(unix))]
                     let entry = match entry {
                         Ok(e) => e,
                         Err(_) => continue,
                     };
+                    #[cfg(not(unix))]
                     let name = entry.file_name();
+                    #[cfg(not(unix))]
+                    let file_type = entry.file_type().ok();
+                    #[cfg(not(unix))]
+                    let is_dir = file_type.as_ref().is_some_and(|ft| ft.is_dir());
+                    #[cfg(not(unix))]
+                    let is_symlink = file_type.as_ref().is_some_and(|ft| ft.is_symlink());
+
                     let normalized = normalize_filename_for_compare(&name);
                     if keep.contains(&normalized) {
                         continue;
@@ -134,9 +200,7 @@ impl ReceiverContext {
                     // check before deletion. allows_deletion() evaluates
                     // protect/risk rules from the global filter chain.
                     let rel_for_filter = dir_relative.join(&name);
-                    let file_type = entry.file_type().ok();
-                    let is_dir_for_filter = file_type.as_ref().is_some_and(|ft| ft.is_dir());
-                    if !filter_chain.allows_deletion(&rel_for_filter, is_dir_for_filter) {
+                    if !filter_chain.allows_deletion(&rel_for_filter, is_dir) {
                         continue;
                     }
 
@@ -150,13 +214,53 @@ impl ReceiverContext {
                     }
 
                     let path = dest_path.join(&name);
-                    let is_dir = file_type.as_ref().is_some_and(|ft| ft.is_dir());
-                    let is_symlink = file_type.as_ref().is_some_and(|ft| ft.is_symlink());
+                    // SEC-1.q2: the unlink/rmdir-all also routes through
+                    // the sandbox helpers so the deletion is anchored on
+                    // the same parent the scan observed. The relative
+                    // path passed here is rooted at the receiver's
+                    // sandbox base (`dest_dir_owned`); top-level
+                    // entries take the sandbox-anchored fast path and
+                    // deeper entries fall back to the path-based
+                    // `std::fs::remove_*` helpers via the same
+                    // `single_component_leaf` precondition the existing
+                    // SEC-1.f-j helpers use.
+                    let rel_for_unlink = if dir_relative.as_os_str() == "." {
+                        std::path::PathBuf::from(&name)
+                    } else {
+                        dir_relative.join(&name)
+                    };
 
                     let result = if is_dir {
-                        fs::remove_dir_all(&path)
+                        // SEC-1.q2 audit row #6
+                        #[cfg(unix)]
+                        {
+                            fast_io::recursive_unlinkat_via_sandbox_or_fallback(
+                                sandbox_ref,
+                                &dest_dir_owned,
+                                &rel_for_unlink,
+                                &path,
+                            )
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            std::fs::remove_dir_all(&path)
+                        }
                     } else {
-                        fs::remove_file(&path)
+                        // SEC-1.q2 audit row #7
+                        #[cfg(unix)]
+                        {
+                            fast_io::unlink_via_sandbox_or_fallback(
+                                sandbox_ref,
+                                &dest_dir_owned,
+                                &rel_for_unlink,
+                                &path,
+                                fast_io::UnlinkFlags::File,
+                            )
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            std::fs::remove_file(&path)
+                        }
                     };
 
                     match result {

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -224,6 +224,7 @@ impl ReceiverContext {
                     // `std::fs::remove_*` helpers via the same
                     // `single_component_leaf` precondition the existing
                     // SEC-1.f-j helpers use.
+                    #[cfg(unix)]
                     let rel_for_unlink = if dir_relative.as_os_str() == "." {
                         std::path::PathBuf::from(&name)
                     } else {

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -39,7 +39,14 @@ fn receiver_filter_chain_protects_from_deletion() {
     ctx.set_filter_chain(::filters::FilterChain::new(global));
 
     let mut writer = TestDeletionWriter;
-    let (stats, _) = ctx.delete_extraneous_files(dest, &mut writer).unwrap();
+    let (stats, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
 
     // normal.txt should be deleted (not in file list, not protected)
     assert!(
@@ -84,7 +91,14 @@ fn receiver_filter_chain_empty_allows_all_deletions() {
 
     // Empty filter chain - all deletions should proceed
     let mut writer = TestDeletionWriter;
-    let (stats, _) = ctx.delete_extraneous_files(dest, &mut writer).unwrap();
+    let (stats, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
 
     assert!(!dest.join("file1.txt").exists());
     assert!(!dest.join("file2.log").exists());

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -61,7 +61,12 @@ impl ReceiverContext {
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
         if self.config.flags.delete {
-            let (ds, exceeded) = self.delete_extraneous_files(&setup.dest_dir, writer)?;
+            let (ds, exceeded) = self.delete_extraneous_files(
+                &setup.dest_dir,
+                #[cfg(unix)]
+                setup.sandbox.as_ref(),
+                writer,
+            )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
         }

--- a/crates/transfer/tests/delete_sandbox_swap.rs
+++ b/crates/transfer/tests/delete_sandbox_swap.rs
@@ -1,0 +1,237 @@
+//! SEC-1.q2 integration tests: the receiver-side `--delete` scan and
+//! per-entry removal route through the `fast_io::*_via_sandbox_or_fallback`
+//! helpers when a [`DirSandbox`] is wired, so a TOCTOU symlink swap at
+//! the top of the destination tree cannot redirect either the listing
+//! or the unlink to an attacker-chosen inode outside the destination.
+//!
+//! These tests do not stand up a full receiver pipeline. They exercise
+//! the three sandbox helpers the receiver-deletion loop now consumes
+//! (`read_dir_via_sandbox_or_fallback`, `unlink_via_sandbox_or_fallback`,
+//! `recursive_unlinkat_via_sandbox_or_fallback`) at the same anchor the
+//! receiver uses (an open dirfd over the destination root), on a tree
+//! shaped like an attacker-controlled extraneous-files scenario, and
+//! assert the TOCTOU-relevant outcomes:
+//!
+//! 1. A symlink at the deletion target is removed itself rather than
+//!    followed to its target outside the sandbox.
+//! 2. A swapped-to-symlink subdirectory refuses to list via the sandbox
+//!    helper (`ELOOP` / `ENOTDIR`), leaving the outside tree intact.
+//! 3. With the sandbox absent, the helpers fall back to the path-based
+//!    `std::fs` syscalls and produce byte-identical observable behaviour
+//!    for the legitimate (non-swapped) case.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use fast_io::{
+    DirSandbox, EntryKind, ReadDirOutcome, UnlinkFlags, read_dir_via_sandbox_or_fallback,
+    recursive_unlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback,
+};
+use tempfile::tempdir;
+
+/// `tempdir()` may sit under a symlink prefix on macOS / some CI
+/// runners; canonicalise so the sandbox open succeeds under
+/// `RESOLVE_NO_SYMLINKS`.
+fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempdir().expect("tempdir");
+    let canon = std::fs::canonicalize(dir.path()).expect("canonicalize");
+    (dir, canon)
+}
+
+/// Simulates the attack the receiver-side `--delete` loop defends
+/// against on its symlink-removal branch: between the receiver's
+/// decide-to-delete moment and the syscall, an attacker swaps the
+/// extraneous file for a symlink to a sensitive target outside the
+/// destination. The sandbox-anchored unlink removes the symlink itself;
+/// the sensitive target must survive.
+#[test]
+fn delete_symlink_extraneous_does_not_follow_swap() {
+    let (_keep, parent) = canonical_tempdir();
+
+    // Sensitive tree outside the destination the attacker wants the
+    // unlink to land on.
+    let sensitive_dir = parent.join("sensitive");
+    std::fs::create_dir(&sensitive_dir).expect("mkdir sensitive");
+    let sensitive_file = sensitive_dir.join("secret");
+    std::fs::write(&sensitive_file, b"do-not-delete").expect("write secret");
+
+    let dest = parent.join("dest");
+    std::fs::create_dir(&dest).expect("mkdir dest");
+    // Receiver decides `dest/extraneous` is not in the sender's file
+    // list; the attacker has swapped it for a symlink to the sensitive
+    // tree above.
+    let extraneous = dest.join("extraneous");
+    symlink(&sensitive_dir, &extraneous).expect("symlink swap");
+
+    let sandbox = DirSandbox::open_root(&dest).expect("sandbox");
+
+    let leaf = Path::new("extraneous");
+    unlink_via_sandbox_or_fallback(Some(&sandbox), &dest, leaf, &extraneous, UnlinkFlags::File)
+        .expect("unlink leaf");
+
+    assert!(
+        !extraneous.exists(),
+        "swapped symlink must be removed itself, not followed"
+    );
+    assert!(
+        sensitive_dir.is_dir(),
+        "sensitive directory outside the sandbox must survive"
+    );
+    assert!(
+        sensitive_file.is_file(),
+        "file inside sensitive directory must survive"
+    );
+}
+
+/// Simulates the attack the receiver-side recursive-delete branch
+/// defends against: the attacker swaps an extraneous subdirectory for a
+/// symlink to a sensitive directory outside the destination. The
+/// sandbox-anchored recursive unlink must refuse to follow the symlink
+/// and leave the sensitive directory intact.
+#[test]
+fn delete_directory_swap_to_symlink_refuses_descent() {
+    let (_keep, parent) = canonical_tempdir();
+
+    let sensitive_dir = parent.join("sensitive");
+    std::fs::create_dir(&sensitive_dir).expect("mkdir sensitive");
+    std::fs::write(sensitive_dir.join("secret"), b"do-not-delete").expect("write secret");
+
+    let dest = parent.join("dest");
+    std::fs::create_dir(&dest).expect("mkdir dest");
+    let swapped = dest.join("swapped");
+    symlink(&sensitive_dir, &swapped).expect("symlink swap");
+
+    let sandbox = DirSandbox::open_root(&dest).expect("sandbox");
+    let leaf = Path::new("swapped");
+    let err = recursive_unlinkat_via_sandbox_or_fallback(Some(&sandbox), &dest, leaf, &swapped)
+        .expect_err("recursive unlinkat must refuse a symlinked descent root");
+    let errno = err.raw_os_error();
+    assert!(
+        errno == Some(libc::ELOOP) || errno == Some(libc::ENOTDIR),
+        "expected ELOOP or ENOTDIR (symlink not followed), got {err:?}"
+    );
+    assert!(
+        sensitive_dir.is_dir(),
+        "sensitive directory must survive the refused descent"
+    );
+    assert!(
+        sensitive_dir.join("secret").is_file(),
+        "secret file must survive"
+    );
+}
+
+/// The receiver's scan of the destination root must refuse to list a
+/// symlink that has been swapped in place of a subdirectory. The
+/// `read_dir_via_sandbox_or_fallback` helper surfaces ELOOP / ENOTDIR,
+/// which the receiver translates into a "skip this directory" branch
+/// (it cannot enumerate what to delete and so deletes nothing inside),
+/// and the outside tree is untouched.
+#[test]
+fn read_dir_swap_to_symlink_refuses_listing() {
+    let (_keep, parent) = canonical_tempdir();
+
+    let outside = parent.join("outside");
+    std::fs::create_dir(&outside).expect("mkdir outside");
+    std::fs::write(outside.join("sentinel"), b"do-not-touch").expect("sentinel");
+
+    let dest = parent.join("dest");
+    std::fs::create_dir(&dest).expect("mkdir dest");
+    let scan_target = dest.join("subdir");
+    symlink(&outside, &scan_target).expect("symlink swap");
+
+    let sandbox = DirSandbox::open_root(&dest).expect("sandbox");
+
+    let err =
+        read_dir_via_sandbox_or_fallback(Some(&sandbox), &dest, Path::new("subdir"), &scan_target)
+            .expect_err("symlink at listing leaf must be refused");
+    let errno = err.raw_os_error();
+    assert!(
+        errno == Some(libc::ELOOP) || errno == Some(libc::ENOTDIR),
+        "expected ELOOP or ENOTDIR (symlink not followed), got {err:?}"
+    );
+    assert!(
+        outside.join("sentinel").is_file(),
+        "outside sentinel must survive"
+    );
+}
+
+/// Sandbox-anchored read_dir at the destination root reports every
+/// extraneous entry with the correct classify bits the receiver uses to
+/// dispatch between `unlink_via_sandbox_or_fallback` (files / symlinks /
+/// devices) and `recursive_unlinkat_via_sandbox_or_fallback`
+/// (directories).
+#[test]
+fn read_dir_at_root_classifies_entries_for_dispatch() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::write(root.join("file"), b"x").expect("write file");
+    std::fs::create_dir(root.join("dir")).expect("mkdir dir");
+    symlink(root.join("file"), root.join("link")).expect("symlink link");
+
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let outcome = read_dir_via_sandbox_or_fallback(Some(&sandbox), &root, Path::new(""), &root)
+        .expect("read_dir at root");
+    assert!(matches!(outcome, ReadDirOutcome::At(_)));
+
+    let mut by_name: std::collections::HashMap<_, _> = outcome
+        .map(|res| {
+            let view = res.expect("entry");
+            (
+                view.file_name().to_string_lossy().into_owned(),
+                view.file_type(),
+            )
+        })
+        .collect();
+    assert_eq!(by_name.remove("file"), Some(Some(EntryKind::Other)));
+    assert_eq!(by_name.remove("dir"), Some(Some(EntryKind::Dir)));
+    assert_eq!(by_name.remove("link"), Some(Some(EntryKind::Symlink)));
+    assert!(
+        by_name.is_empty(),
+        "no extra entries should remain: {by_name:?}"
+    );
+}
+
+/// Sandbox-off behaviour: the helpers must produce byte-identical
+/// observable outcomes to the pre-SEC-1.q2 path-based syscalls. Pins
+/// the documented identical-behaviour-fallback contract so a future
+/// regression cannot silently change the `None`-carrier semantics that
+/// every existing `delete_extraneous_files` test relies on.
+#[test]
+fn sandbox_off_fallback_matches_std_for_legitimate_delete() {
+    let (_keep, root) = canonical_tempdir();
+    let dir = root.join("subdir");
+    std::fs::create_dir(&dir).expect("mkdir subdir");
+    std::fs::write(dir.join("a"), b"a").expect("write a");
+    std::fs::write(dir.join("b"), b"b").expect("write b");
+
+    let outcome =
+        read_dir_via_sandbox_or_fallback(None, &root, Path::new("subdir"), &dir).expect("read_dir");
+    assert!(matches!(outcome, ReadDirOutcome::Std(_)));
+    let mut names: Vec<_> = outcome
+        .map(|r| r.expect("entry").file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["a", "b"]);
+
+    let leaf = Path::new("a");
+    let leaf_path = dir.join(leaf);
+    // Multi-component path forces the path-based fallback even with a
+    // sandbox; without a sandbox the helper takes the same branch
+    // unconditionally.
+    unlink_via_sandbox_or_fallback(
+        None,
+        &root,
+        Path::new("subdir/a"),
+        &leaf_path,
+        UnlinkFlags::File,
+    )
+    .expect("unlink fallback");
+    assert!(!leaf_path.exists(), "fallback unlink must remove file");
+    assert!(dir.join("b").is_file(), "sibling file must survive");
+
+    recursive_unlinkat_via_sandbox_or_fallback(None, &root, Path::new("subdir"), &dir)
+        .expect("recursive unlink fallback");
+    assert!(!dir.exists(), "fallback recursive unlink must remove dir");
+}


### PR DESCRIPTION
## Summary

Closes the SEC-1.q2 receiver-side wiring gap left by PR #4728. The
`DeleteEmitter::with_sandbox` carrier slot landed but the production
receiver-deletion loop in `crates/transfer/src/receiver/directory/deletion.rs`
still called `std::fs::read_dir`, `std::fs::remove_dir_all`, and
`std::fs::remove_file` directly under `--delete`, leaving audit rows
#5, #6, #7 (from `docs/audits/sec-1-path-syscall-audit-2026-05-22.md`)
open. Implements Option B from the design doc shipped in PR #4729
(`docs/design/sec-1-q2-receiver-deletion-sandbox-2026-05-22.md`).

GAP sites closed by this PR:
- `deletion.rs:115` (audit row #5): `fs::read_dir(&dest_path)` swapped
  for the new `fast_io::read_dir_via_sandbox_or_fallback` helper.
- `deletion.rs:157` (audit row #6): `fs::remove_dir_all(&path)`
  swapped for `fast_io::recursive_unlinkat_via_sandbox_or_fallback`
  (added in SEC-1.s PR #4726).
- `deletion.rs:159` (audit row #7): `fs::remove_file(&path)` swapped
  for `fast_io::unlink_via_sandbox_or_fallback` (existing SEC-1.g
  helper).

New `fast_io` helper:
- `read_dir_via_sandbox_or_fallback` mirrors the existing
  `*_via_sandbox_or_fallback` signature shape. When the sandbox is
  present and the listing target is the root or a single-component
  subdir, the helper opens through `openat(O_DIRECTORY | O_NOFOLLOW)` +
  `fdopendir`, materialises the entries into an owned `Vec` (matching
  the `recursive_unlinkat` invariant so per-entry `*at` calls do not
  race the live `DIR*` cursor), and reports per-entry classify bits
  via `DirEntryView::file_type` (backfilling `DT_UNKNOWN` via
  `fstatat_nofollow` against the same parent dirfd). Multi-component
  and sandbox-absent paths fall back to `std::fs::read_dir` so the
  pre-SEC-1.q2 behaviour is preserved byte-for-byte.

Mirrors the SEC-1.r `temp_guard` / `temp_cleanup` precedent (PR #4723):
`Option<&Arc<DirSandbox>>` is plumbed through the existing call shape
without restructuring the surrounding parallel-iteration. The carrier
is cloned once into the `map_blocking` worker closure and forwarded
into every helper call. No transfer-crate `unsafe` is introduced; all
`unsafe` stays behind the existing `fast_io` safe wrappers.

Cross-platform: all new code is `#[cfg(unix)]`. Windows continues
through `std::fs::remove_file` / `remove_dir_all` / `read_dir` per the
SEC-1.l audit conclusion on NTFS handle semantics.

## Test plan

- [x] Unit tests in `crates/fast_io/src/dir_sandbox/at_syscalls.rs`:
  sandbox lists the root when relative is empty, sandbox lists a
  single-component subdir with correct file-type classification,
  sandbox falls back for multi-component descents, sandbox-absent
  fallback, symlink-at-leaf refused with `ELOOP` / `ENOTDIR`, sandbox
  and std listings agree byte-for-byte.
- [x] New integration regressions in
  `crates/transfer/tests/delete_sandbox_swap.rs`: symlink swap on a
  file deletion, symlink swap on a directory deletion (recursive),
  symlink swap on the directory listing target, sandbox-on root
  listing classifies entries correctly, sandbox-off fallback matches
  `std::fs` behaviour byte-for-byte.
- [x] Existing `crates/transfer/src/receiver/tests/file_list/filter_chain.rs`
  cases updated to pass the new `sandbox: None` argument and continue
  to pass.
- [ ] CI: full nextest matrix (Linux musl, macOS, Windows) plus
  fmt+clippy on the worktree-blocking platforms.