### PR TITLE
ci(workflows): add parallel-receive-delta + dist profile matrix cell (PIP-9.d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,3 +569,52 @@ jobs:
     with:
       cache_version: ${{ vars.CACHE_VERSION || 'v1' }}
       timeout_minutes: 30
+
+  # ===========================================================================
+  # Parallel-receive-delta + dist profile guardrail (PIP-9.d)
+  # ---------------------------------------------------------------------------
+  # Guards against the receiver corruption surfaced by PIP-4 (#4720) where
+  # `parallel_threshold/file_1.txt` got wrong bytes when the
+  # `parallel-receive-delta` feature was active. The bug only repros under
+  # the `dist` profile (LTO + panic=abort); `release` masks it. Non-required
+  # while the cell bakes - promotion to required check tracked under PIP-9.f.
+  # Design: docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md.
+  # ===========================================================================
+  parallel-receive-delta-dist:
+    name: parallel-receive-delta (dist profile, non-required)
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 30
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-parallel-receive-delta-dist-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.toml') }}
+          key: parallel-receive-delta-dist
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2
+        with:
+          tool: cargo-nextest
+
+      # Build the workspace with `--profile dist --features parallel-receive-delta`.
+      # The dist profile (LTO + panic=abort) is the only profile under which the
+      # PIP-4 corruption surfaced; pinning it here makes regressions visible.
+      - name: Build workspace (--profile dist --features parallel-receive-delta)
+        run: cargo build --locked --workspace --profile dist --features parallel-receive-delta
+
+      # Run the `parallel_threshold` interop scenario added by PIP-9.c. If that
+      # scenario hasn't landed yet the filter matches zero tests; `--no-tests=pass`
+      # keeps the cell green on zero matches so the build alone gates regressions.
+      - name: Test parallel_threshold interop (--profile dist --features parallel-receive-delta)
+        run: cargo nextest run --locked --workspace --cargo-profile dist --features parallel-receive-delta --no-tests=pass -E 'test(parallel_threshold)'


### PR DESCRIPTION
## Summary

- Adds a non-required CI job (`parallel-receive-delta (dist profile, non-required)`) to `.github/workflows/ci.yml` that builds the workspace with `cargo build --profile dist --features parallel-receive-delta` and runs the `parallel_threshold` interop scenario (added by PIP-9.c) via `cargo nextest run --cargo-profile dist --features parallel-receive-delta --no-tests=pass -E 'test(parallel_threshold)'`.
- Guards against the receiver corruption surfaced by PIP-4 (#4720) where `parallel_threshold/file_1.txt` got wrong bytes when the feature flag was active. The bug only repros under `dist` (LTO + panic=abort); the existing `release`-profile cells silently miss it.
- Marked `continue-on-error: true` while the cell bakes. PIP-9.f tracks promotion to a required check after N consecutive green runs.

## Notes

- `[profile.dist]` already exists in workspace `Cargo.toml` (inherits release, `lto = "fat"`, `panic = "abort"`, `opt-level = "z"`), so no Cargo.toml change is required.
- The nextest step uses `--no-tests=pass` so the cell stays green during the window where PIP-9.c hasn't merged yet (zero `parallel_threshold` matches). Once PIP-9.c lands the scenario will execute under this profile and be the actual gate.
- Cell runs on `ubuntu-latest` only - the corruption is Linux-specific (io_uring + threading interaction); spreading across OS matrices is not the failure mode this guards.

## Test plan

- [ ] CI parses the new job (workflow validation).
- [ ] New `parallel-receive-delta (dist profile, non-required)` job appears in the PR's check list.
- [ ] Build step passes (no source changes; `--profile dist --features parallel-receive-delta` is currently a no-op flag per PIP-8 teardown).
- [ ] Nextest step exits 0 either by running 0 tests (pre PIP-9.c) or by running the new scenario (post PIP-9.c).
- [ ] No existing matrix cell is changed.

Design: `docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md`.