### PR TITLE
feat(rsync_io): wire ssh_config Compression detection (SSC-3)

### DIFF
--- a/crates/engine/src/concurrent_delta/chunk_adapter.rs
+++ b/crates/engine/src/concurrent_delta/chunk_adapter.rs
@@ -1,0 +1,478 @@
+//! In-memory shape adapter from per-file [`DeltaWork`] to per-chunk
+//! [`DeltaChunk`].
+//!
+//! PIP-9.a substrate. The receiver pipeline today reads a per-file
+//! [`DeltaWork`] item that carries the NDX, basis path, and accumulated
+//! `literal_bytes`/`matched_bytes` counters, then streams a sequence of
+//! resolved per-chunk byte spans (either literal payloads or basis-file
+//! matches) over the existing SPSC pipe. The
+//! [`ParallelDeltaApplier`](super::ParallelDeltaApplier) on the other side
+//! expects each segment as a [`DeltaChunk`] carrying the per-file NDX, a
+//! monotonic per-file `chunk_sequence`, the resolved bytes, a literal-vs-match
+//! discriminator, and an optional strong-checksum digest the applier verifies
+//! before committing the bytes to disk.
+//!
+//! This adapter is the pure in-memory shape transformation between those two
+//! views. It performs no I/O, spawns no threads, holds no state, and does not
+//! touch the wire protocol - PIP-9.b will plug it into the production token
+//! loop without any wire-format change. PIP-7 surfaced the previous attempt's
+//! receiver corruption when scaffolding had a side-effect-only swap with no
+//! reader; the deliberate split between adapter (this file) and wire-up
+//! (PIP-9.b) keeps each step independently reviewable.
+//!
+//! # Shape
+//!
+//! - [`ChunkPayload`] - per-chunk values supplied by the receiver's wire reader
+//!   (the resolved bytes, the per-file sequence number, literal-vs-match, and
+//!   an optional strong-checksum digest derived from the basis signature).
+//! - [`ChunkSource`] - literal-vs-basis discriminator carried alongside the
+//!   payload so the adapter stays expression-equivalent to the existing
+//!   `is_literal` field on [`DeltaChunk`] without mirroring a `bool`.
+//! - [`DeltaChunkAdapter`] - zero-state struct that exposes `from_delta_work`
+//!   so callers can convert in one call without re-spelling the field map.
+//!
+//! # Invariants
+//!
+//! - `DeltaChunk::ndx == DeltaWork::ndx`. The adapter carries the NDX through
+//!   unchanged so the applier's per-file slot map keys stay correlated with
+//!   the file list index the receiver assigned at file-begin time.
+//! - `DeltaChunk::data` is moved (not cloned) from `ChunkPayload::data`. The
+//!   receiver already owns the resolved bytes; the adapter must not duplicate
+//!   them on the hot path.
+//! - `DeltaChunk::expected_strong` round-trips byte-for-byte. When the
+//!   producer attached a basis-signature-derived strong checksum (BR-3i.d),
+//!   the applier will compare it against `strategy.compute(&data)` in
+//!   [`ParallelDeltaApplier::verify_chunk`].
+//! - `DeltaChunk::chunk_sequence` is taken verbatim from
+//!   [`ChunkPayload::chunk_sequence`]; the adapter does not assign or mutate
+//!   sequence numbers (PIP-9.b is responsible for that).
+//!
+//! # Non-goals
+//!
+//! - This adapter does *not* split a `DeltaWork` into multiple chunks. The
+//!   receiver's wire reader is the source of per-chunk granularity; the
+//!   adapter is the per-chunk shape conversion. Callers loop over their own
+//!   chunk stream and invoke the adapter per segment.
+//! - This adapter does *not* touch any per-file state on the applier
+//!   ([`register_file`](super::ParallelDeltaApplier::register_file),
+//!   [`finish_file`](super::ParallelDeltaApplier::finish_file)). Those calls
+//!   remain the wire-up's responsibility in PIP-9.b.
+//!
+//! [`DeltaWork`]: super::DeltaWork
+//! [`DeltaChunk`]: super::DeltaChunk
+//! [`ParallelDeltaApplier`]: super::ParallelDeltaApplier
+//! [`ParallelDeltaApplier::verify_chunk`]: super::ParallelDeltaApplier
+//! [`register_file`]: super::ParallelDeltaApplier
+//! [`finish_file`]: super::ParallelDeltaApplier
+
+use checksums::strong::strategy::ChecksumDigest;
+
+use super::parallel_apply::DeltaChunk;
+use super::types::DeltaWork;
+
+/// Classifies a per-chunk payload as literal data or as a basis-file match.
+///
+/// Mirrors the boolean `is_literal` field that [`DeltaChunk`] exposes today
+/// but keeps the call site self-documenting. The variants map 1:1:
+/// [`ChunkSource::Literal`] -> `is_literal = true`,
+/// [`ChunkSource::Copy`] -> `is_literal = false`. The applier treats both
+/// shapes identically in the write path; the discriminator is preserved so
+/// future stats reporting can split literal vs matched bytes without
+/// changing the public chunk shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkSource {
+    /// Bytes the sender transmitted as a literal token over the wire.
+    Literal,
+    /// Bytes the receiver resolved from the basis file via a COPY token
+    /// (block-match reference).
+    Copy,
+}
+
+impl ChunkSource {
+    /// Returns the equivalent boolean form for the existing
+    /// [`DeltaChunk::is_literal`] field.
+    #[must_use]
+    pub const fn is_literal(self) -> bool {
+        matches!(self, Self::Literal)
+    }
+}
+
+/// Per-chunk values the receiver's wire reader supplies alongside the owning
+/// [`DeltaWork`].
+///
+/// Holds the resolved bytes and the metadata the
+/// [`ParallelDeltaApplier`](super::ParallelDeltaApplier) needs to verify and
+/// commit a single chunk:
+///
+/// - `chunk_sequence` - monotonic per-file submission counter the applier's
+///   reorder buffer uses to replay chunks in submission order.
+/// - `data` - resolved bytes for this chunk (literal payload or basis match).
+/// - `source` - literal-vs-copy discriminator carried through to the
+///   [`DeltaChunk::is_literal`] flag.
+/// - `expected_strong` - optional strong-checksum digest derived from the
+///   basis signature (BR-3i.d). When present, the applier verifies the
+///   digest of `data` matches before committing the bytes.
+#[derive(Debug, Clone)]
+pub struct ChunkPayload {
+    /// Monotonic per-file sequence number assigned at submission time.
+    pub chunk_sequence: u64,
+    /// Resolved bytes for this chunk.
+    pub data: Vec<u8>,
+    /// Whether the bytes came from the wire (literal) or the basis (copy).
+    pub source: ChunkSource,
+    /// Optional expected strong-checksum digest. See
+    /// [`DeltaChunk::expected_strong`] for the round-trip semantics.
+    pub expected_strong: Option<ChecksumDigest>,
+}
+
+impl ChunkPayload {
+    /// Builds a literal-data payload with no expected digest attached.
+    #[must_use]
+    pub fn literal(chunk_sequence: u64, data: Vec<u8>) -> Self {
+        Self {
+            chunk_sequence,
+            data,
+            source: ChunkSource::Literal,
+            expected_strong: None,
+        }
+    }
+
+    /// Builds a basis-match payload with no expected digest attached.
+    #[must_use]
+    pub fn copy(chunk_sequence: u64, data: Vec<u8>) -> Self {
+        Self {
+            chunk_sequence,
+            data,
+            source: ChunkSource::Copy,
+            expected_strong: None,
+        }
+    }
+
+    /// Builder-style setter that attaches an expected strong-checksum digest.
+    #[must_use]
+    pub fn with_expected_strong(mut self, expected: ChecksumDigest) -> Self {
+        self.expected_strong = Some(expected);
+        self
+    }
+}
+
+/// Zero-state shape adapter from [`DeltaWork`] + [`ChunkPayload`] to
+/// [`DeltaChunk`].
+///
+/// All methods are pure in-memory transformations. Construct one with
+/// [`DeltaChunkAdapter::new`] and call [`Self::from_delta_work`] per chunk
+/// the wire reader produces. PIP-9.b will host the per-file loop that drives
+/// this adapter from the receiver's token loop.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DeltaChunkAdapter;
+
+impl DeltaChunkAdapter {
+    /// Constructs a fresh adapter. Holds no state; provided for call-site
+    /// readability so PIP-9.b can spell the conversion as
+    /// `DeltaChunkAdapter::new().from_delta_work(...)`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Converts a [`DeltaWork`] + per-chunk [`ChunkPayload`] into a
+    /// [`DeltaChunk`] the applier can verify and commit.
+    ///
+    /// The NDX is taken from `work` so the resulting chunk slots into the
+    /// applier's per-file map. The `payload` fields are moved into the
+    /// chunk verbatim (no copies of `data`, byte-for-byte round-trip of
+    /// `expected_strong`). The conversion is total: every
+    /// `(DeltaWork, ChunkPayload)` pair yields exactly one `DeltaChunk`.
+    #[must_use]
+    pub fn from_delta_work(&self, work: &DeltaWork, payload: ChunkPayload) -> DeltaChunk {
+        DeltaChunk {
+            ndx: work.ndx(),
+            chunk_sequence: payload.chunk_sequence,
+            data: payload.data,
+            is_literal: payload.source.is_literal(),
+            expected_strong: payload.expected_strong,
+        }
+    }
+}
+
+/// Free-function form of [`DeltaChunkAdapter::from_delta_work`] for callers
+/// that prefer not to spell the zero-state struct. Behaviour is identical.
+#[must_use]
+pub fn delta_work_to_chunk(work: &DeltaWork, payload: ChunkPayload) -> DeltaChunk {
+    DeltaChunkAdapter::new().from_delta_work(work, payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use checksums::strong::strategy::{
+        ChecksumAlgorithmKind, ChecksumStrategy, ChecksumStrategySelector,
+    };
+
+    use super::super::types::FileNdx;
+    use super::*;
+
+    fn md5_strategy() -> Box<dyn ChecksumStrategy> {
+        ChecksumStrategySelector::for_algorithm(ChecksumAlgorithmKind::Md5, 0)
+    }
+
+    fn whole_file_work(ndx: u32) -> DeltaWork {
+        DeltaWork::whole_file(ndx, PathBuf::from(format!("/dest/{ndx}")), 1024)
+    }
+
+    fn delta_work(ndx: u32) -> DeltaWork {
+        DeltaWork::delta(
+            ndx,
+            PathBuf::from(format!("/dest/{ndx}")),
+            PathBuf::from(format!("/basis/{ndx}")),
+            2048,
+            512,
+            1536,
+        )
+    }
+
+    #[test]
+    fn literal_payload_preserves_bytes_byte_for_byte() {
+        let work = whole_file_work(7);
+        let bytes: Vec<u8> = (0..=255u8).collect();
+        let payload = ChunkPayload::literal(0, bytes.clone());
+        let chunk = DeltaChunkAdapter::new().from_delta_work(&work, payload);
+
+        assert_eq!(chunk.ndx, FileNdx::new(7));
+        assert_eq!(chunk.chunk_sequence, 0);
+        assert_eq!(chunk.data, bytes);
+        assert!(chunk.is_literal);
+        assert!(chunk.expected_strong.is_none());
+    }
+
+    #[test]
+    fn copy_payload_marks_chunk_as_match() {
+        let work = delta_work(3);
+        let bytes = vec![0xAB; 512];
+        let payload = ChunkPayload::copy(42, bytes.clone());
+        let chunk = delta_work_to_chunk(&work, payload);
+
+        assert_eq!(chunk.ndx, FileNdx::new(3));
+        assert_eq!(chunk.chunk_sequence, 42);
+        assert_eq!(chunk.data, bytes);
+        assert!(!chunk.is_literal);
+        assert!(chunk.expected_strong.is_none());
+    }
+
+    #[test]
+    fn expected_strong_round_trips_byte_for_byte() {
+        let work = delta_work(11);
+        let bytes = vec![0x55; 256];
+        let strategy = md5_strategy();
+        let digest = strategy.compute(&bytes);
+        let expected_bytes = digest.as_bytes().to_vec();
+
+        let payload = ChunkPayload::copy(1, bytes.clone()).with_expected_strong(digest);
+        let chunk = DeltaChunkAdapter::new().from_delta_work(&work, payload);
+
+        let attached = chunk
+            .expected_strong
+            .expect("digest must round-trip through the adapter");
+        assert_eq!(attached.as_bytes(), expected_bytes.as_slice());
+        assert_eq!(attached, strategy.compute(&chunk.data));
+    }
+
+    #[test]
+    fn expected_strong_drives_real_verify_chunk_pass() {
+        // Confirms the digest the adapter carries is the exact value the
+        // applier's verify path will accept. Computes the digest from the
+        // adapter's output chunk and compares it to the attached expectation.
+        let work = whole_file_work(0);
+        let data = b"oc-rsync pip-9.a round-trip".to_vec();
+        let strategy = md5_strategy();
+        let digest = strategy.compute(&data);
+
+        let payload = ChunkPayload::literal(0, data.clone()).with_expected_strong(digest);
+        let chunk = delta_work_to_chunk(&work, payload);
+
+        let computed = strategy.compute(&chunk.data);
+        assert_eq!(
+            chunk
+                .expected_strong
+                .as_ref()
+                .expect("expected digest attached"),
+            &computed,
+            "the digest the producer attached must equal strategy.compute(chunk.data)"
+        );
+    }
+
+    #[test]
+    fn empty_payload_yields_zero_length_chunk() {
+        let work = whole_file_work(0);
+        let payload = ChunkPayload::literal(0, Vec::new());
+        let chunk = DeltaChunkAdapter::new().from_delta_work(&work, payload);
+
+        assert_eq!(chunk.data.len(), 0);
+        assert!(chunk.is_literal);
+        assert!(chunk.expected_strong.is_none());
+    }
+
+    #[test]
+    fn empty_copy_payload_keeps_copy_discriminator() {
+        let work = delta_work(2);
+        let payload = ChunkPayload::copy(0, Vec::new());
+        let chunk = delta_work_to_chunk(&work, payload);
+
+        assert_eq!(chunk.data.len(), 0);
+        assert!(!chunk.is_literal);
+    }
+
+    #[test]
+    fn whole_file_work_routes_literal_chunk() {
+        // DeltaWork::whole_file represents a basis-less transfer; the
+        // receiver still streams the bytes as one or more literal chunks.
+        let work = whole_file_work(5);
+        let payload = ChunkPayload::literal(0, vec![0x42; 64]);
+        let chunk = DeltaChunkAdapter::new().from_delta_work(&work, payload);
+
+        assert_eq!(chunk.ndx, FileNdx::new(5));
+        assert!(chunk.is_literal);
+    }
+
+    #[test]
+    fn delta_work_can_carry_either_chunk_source() {
+        // DeltaWork::delta represents a basis-backed transfer that mixes
+        // literal tokens with basis matches; the adapter must accept both
+        // discriminators against the same work item.
+        let work = delta_work(9);
+        let adapter = DeltaChunkAdapter::new();
+
+        let literal = adapter.from_delta_work(&work, ChunkPayload::literal(0, vec![0x11; 32]));
+        assert!(literal.is_literal);
+        assert_eq!(literal.ndx, FileNdx::new(9));
+
+        let matched = adapter.from_delta_work(&work, ChunkPayload::copy(1, vec![0x22; 64]));
+        assert!(!matched.is_literal);
+        assert_eq!(matched.ndx, FileNdx::new(9));
+        assert_eq!(matched.chunk_sequence, 1);
+    }
+
+    #[test]
+    fn sequence_passes_through_unchanged() {
+        let work = whole_file_work(0);
+        let adapter = DeltaChunkAdapter::new();
+        for seq in [0u64, 1, 7, 1024, u64::MAX] {
+            let payload = ChunkPayload::literal(seq, vec![0u8; 4]);
+            let chunk = adapter.from_delta_work(&work, payload);
+            assert_eq!(chunk.chunk_sequence, seq, "seq must round-trip");
+        }
+    }
+
+    #[test]
+    fn ndx_passes_through_unchanged_across_range() {
+        let adapter = DeltaChunkAdapter::new();
+        for ndx in [0u32, 1, 42, u32::MAX] {
+            let work = whole_file_work(ndx);
+            let payload = ChunkPayload::literal(0, vec![0u8; 1]);
+            let chunk = adapter.from_delta_work(&work, payload);
+            assert_eq!(chunk.ndx, FileNdx::new(ndx));
+        }
+    }
+
+    #[test]
+    fn adapter_does_not_mutate_work() {
+        // The adapter takes `&DeltaWork` so callers can reuse the same work
+        // item for every chunk in a per-file loop. Confirm the borrow is
+        // immutable and the work item survives a chunk conversion intact.
+        let work = delta_work(4);
+        let snapshot = (
+            work.ndx(),
+            work.dest_path().to_path_buf(),
+            work.basis_path().map(std::path::Path::to_path_buf),
+            work.target_size(),
+            work.literal_bytes(),
+            work.matched_bytes(),
+            work.kind(),
+        );
+
+        let _chunk = DeltaChunkAdapter::new()
+            .from_delta_work(&work, ChunkPayload::copy(0, vec![1, 2, 3, 4]));
+
+        assert_eq!(work.ndx(), snapshot.0);
+        assert_eq!(work.dest_path(), snapshot.1);
+        assert_eq!(
+            work.basis_path().map(std::path::Path::to_path_buf),
+            snapshot.2
+        );
+        assert_eq!(work.target_size(), snapshot.3);
+        assert_eq!(work.literal_bytes(), snapshot.4);
+        assert_eq!(work.matched_bytes(), snapshot.5);
+        assert_eq!(work.kind(), snapshot.6);
+    }
+
+    #[test]
+    fn payload_constructors_build_expected_shapes() {
+        let literal = ChunkPayload::literal(3, vec![9u8; 16]);
+        assert_eq!(literal.chunk_sequence, 3);
+        assert_eq!(literal.source, ChunkSource::Literal);
+        assert!(literal.expected_strong.is_none());
+
+        let copy = ChunkPayload::copy(4, vec![8u8; 16]);
+        assert_eq!(copy.chunk_sequence, 4);
+        assert_eq!(copy.source, ChunkSource::Copy);
+        assert!(copy.expected_strong.is_none());
+    }
+
+    #[test]
+    fn chunk_source_is_literal_matches_enum_variants() {
+        assert!(ChunkSource::Literal.is_literal());
+        assert!(!ChunkSource::Copy.is_literal());
+    }
+
+    #[test]
+    fn free_function_matches_struct_method() {
+        // The free function is a thin alias; confirm both spellings produce
+        // identical output for the same inputs.
+        let work = delta_work(1);
+        let bytes = vec![0x77; 128];
+        let strategy = md5_strategy();
+        let digest = strategy.compute(&bytes);
+
+        let via_struct = DeltaChunkAdapter::new().from_delta_work(
+            &work,
+            ChunkPayload::literal(5, bytes.clone()).with_expected_strong(digest),
+        );
+        let via_free = delta_work_to_chunk(
+            &work,
+            ChunkPayload::literal(5, bytes.clone()).with_expected_strong(digest),
+        );
+
+        assert_eq!(via_struct.ndx, via_free.ndx);
+        assert_eq!(via_struct.chunk_sequence, via_free.chunk_sequence);
+        assert_eq!(via_struct.data, via_free.data);
+        assert_eq!(via_struct.is_literal, via_free.is_literal);
+        assert_eq!(via_struct.expected_strong, via_free.expected_strong);
+    }
+
+    #[test]
+    fn adapter_unit_construction_matches_new() {
+        // The unit struct has a trivial `new()` constructor for call-site
+        // readability; the bare struct literal is the equivalent shorthand.
+        // Both spellings must produce the same chunk for the same input.
+        let work = whole_file_work(0);
+        let bytes = vec![1u8, 2, 3, 4];
+        let via_new = DeltaChunkAdapter::new()
+            .from_delta_work(&work, ChunkPayload::literal(0, bytes.clone()));
+        let via_literal = DeltaChunkAdapter.from_delta_work(&work, ChunkPayload::literal(0, bytes));
+
+        assert_eq!(via_new.data, via_literal.data);
+        assert_eq!(via_new.ndx, via_literal.ndx);
+    }
+
+    #[test]
+    fn payload_with_expected_strong_overwrites_prior_value() {
+        let strategy = md5_strategy();
+        let first = strategy.compute(b"first");
+        let second = strategy.compute(b"second");
+        let payload = ChunkPayload::literal(0, vec![0u8; 4])
+            .with_expected_strong(first)
+            .with_expected_strong(second);
+        assert_eq!(payload.expected_strong.expect("digest attached"), second);
+    }
+}

--- a/crates/engine/src/concurrent_delta/mod.rs
+++ b/crates/engine/src/concurrent_delta/mod.rs
@@ -170,6 +170,8 @@
 //! - `transfer::pipeline` for the pipelined receiver architecture
 
 pub mod adaptive;
+#[cfg(feature = "parallel-receive-delta")]
+pub mod chunk_adapter;
 pub mod config;
 pub mod consumer;
 #[cfg(test)]
@@ -183,6 +185,8 @@ mod types;
 pub mod work_queue;
 
 pub use adaptive::{AdaptiveCapacityPolicy, ReorderStats};
+#[cfg(feature = "parallel-receive-delta")]
+pub use chunk_adapter::{ChunkPayload, ChunkSource, DeltaChunkAdapter, delta_work_to_chunk};
 pub use config::ConcurrentDeltaConfig;
 pub use consumer::{DeltaConsumer, DeltaConsumerStats};
 #[cfg(feature = "parallel-receive-delta")]

--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -27,10 +27,28 @@ tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [features]
+default = ["ssh-config-parse"]
 embedded-ssh = ["dep:russh", "dep:url", "dep:rpassword", "dep:is-terminal", "dep:tokio"]
 # Async SSH transport: opt-in tokio-process backing for `SshConnection`.
 # See `docs/design/async-ssh-transport.md` (#1593) for the staging plan.
 async-ssh = ["dep:tokio"]
+# ssh-config-parse:
+#   what:    Extends `SshCommand::has_ssh_compression` to consult
+#            `~/.ssh/config` and `/etc/ssh/ssh_config` for `Compression yes`
+#            at top level or under `Host *`, closing the SSC-3 gap where a
+#            user-configured default would silently double-compress when
+#            paired with rsync's `--compress`.
+#   why:     SSC-1 (argv warning) misses the case where the user sets
+#            `Compression yes` globally in ssh_config and never passes `-C`
+#            on the rsync command line.
+#   scope:   Top-level and `Host *` directives only. Per-host `Host foo`
+#            blocks and `Match` blocks are deferred because they need
+#            runtime context the warning site does not have.
+#   safety:  Pure Rust, no extra dependencies, no unsafe code.
+#   opt out: `cargo build -p rsync_io --no-default-features` (then re-add
+#            any other features you need). Without this feature the
+#            argv-only SSC-1 detection path remains in place.
+ssh-config-parse = []
 # Opt-in: exposes the standalone `socketpair_stderr` primitive
 # (SSE-3, #2372) and, when paired with `async-ssh`, the SSE-4 async
 # drain task (#2373) that funnels stderr into a bounded ring buffer

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -247,7 +247,7 @@ impl SshCommand {
         }
         #[cfg(feature = "ssh-config-parse")]
         {
-            return super::config_lookup::ssh_config_enables_compression(&self.options);
+            super::config_lookup::ssh_config_enables_compression(&self.options)
         }
         #[cfg(not(feature = "ssh-config-parse"))]
         {

--- a/crates/rsync_io/src/ssh/builder.rs
+++ b/crates/rsync_io/src/ssh/builder.rs
@@ -225,19 +225,34 @@ impl SshCommand {
     /// `--compress` is enabled: compressing twice wastes CPU and can
     /// expand already-compressed data.
     ///
-    /// Detection is conservative and inspects the explicit command-line
-    /// arguments only - it does not parse `~/.ssh/config`, since the SSH
-    /// client merges that file at spawn time and we cannot reliably read it.
-    /// `-C` and `-o Compression=...` cover the cases users set on the
-    /// rsync invocation itself (via `-e ssh -C` / `--rsh`).
+    /// Detection inspects the explicit command-line arguments first.
+    /// When the `ssh-config-parse` feature is enabled (on by default)
+    /// and the argv check is inconclusive, the lookup also consults the
+    /// user's `~/.ssh/config` (or the file supplied via `-F`) and
+    /// `/etc/ssh/ssh_config`. Only top-level directives and `Host *`
+    /// blocks are honoured - per-host `Host foo` and `Match` blocks
+    /// need runtime context the warning site does not have and are
+    /// intentionally skipped to avoid false positives.
     ///
     /// Truthy values for `Compression`: `yes`, `true`, `1`, case-insensitive.
     #[must_use]
     pub fn has_ssh_compression(&self) -> bool {
-        self.options
+        if self
+            .options
             .iter()
             .enumerate()
             .any(|(idx, opt)| arg_enables_ssh_compression(opt, self.options.get(idx + 1)))
+        {
+            return true;
+        }
+        #[cfg(feature = "ssh-config-parse")]
+        {
+            return super::config_lookup::ssh_config_enables_compression(&self.options);
+        }
+        #[cfg(not(feature = "ssh-config-parse"))]
+        {
+            false
+        }
     }
 
     /// Configures the comma-separated list of OpenSSH ProxyJump hosts.

--- a/crates/rsync_io/src/ssh/config_lookup.rs
+++ b/crates/rsync_io/src/ssh/config_lookup.rs
@@ -1,0 +1,284 @@
+//! SSH client config lookup for the `Compression` directive.
+//!
+//! Closes the SSC-3 gap: SSC-1 only inspects argv, so a user with
+//! `Compression yes` set globally in `~/.ssh/config` or
+//! `/etc/ssh/ssh_config` gets no warning when they also pass rsync's
+//! `--compress`. This module reads those files and reports whether
+//! `Compression yes` is in effect at top level or inside a `Host *`
+//! block.
+//!
+//! # Scope
+//!
+//! Top-level directives (before any `Host` block) and directives under
+//! `Host *` are honoured. Per-host blocks like `Host foo.example.com`
+//! and `Match` blocks are intentionally not evaluated here: the warning
+//! site does not know which host the user is about to connect to in a
+//! form that can drive OpenSSH's full pattern-match semantics
+//! (especially `Match exec`, which would have to run an external
+//! command). Deferring these keeps the warning conservative and free of
+//! false positives.
+//!
+//! # Failure mode
+//!
+//! Parse errors and I/O errors never propagate. A malformed file emits
+//! one `debug_log!` line and the caller falls back to the argv-only
+//! answer. Hard-failing the transfer because a user's ssh_config has a
+//! stray byte would be a worse outcome than missing a warning.
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use logging::debug_log;
+
+/// Returns `true` when `~/.ssh/config` or `/etc/ssh/ssh_config`
+/// configures `Compression yes` at top level or under `Host *`.
+///
+/// `options` is the SSH option argv; a `-F <file>` (or `-F<file>`)
+/// override is honoured first when present and the file exists. After
+/// the override, the lookup tries `~/.ssh/config`, then
+/// `/etc/ssh/ssh_config`. The first existing file wins; later files in
+/// the list are not consulted, matching OpenSSH's behaviour when `-F`
+/// is supplied.
+///
+/// Returns `false` when:
+/// - no candidate file exists,
+/// - the chosen file does not contain a matching `Compression yes`,
+/// - the chosen file fails to parse (a `debug_log!` line is emitted and
+///   the function reports `false` rather than aborting the transfer).
+pub(super) fn ssh_config_enables_compression(options: &[OsString]) -> bool {
+    for candidate in candidate_paths(options) {
+        if !candidate.is_file() {
+            continue;
+        }
+        return read_and_check(&candidate);
+    }
+    false
+}
+
+/// Returns the ordered list of ssh_config paths the caller should
+/// consult. Visible to tests so they can verify the precedence chain
+/// without touching the real filesystem.
+pub(super) fn candidate_paths(options: &[OsString]) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(override_path) = extract_dash_f_path(options) {
+        paths.push(override_path);
+    }
+    if let Some(home) = home_dir() {
+        paths.push(home.join(".ssh").join("config"));
+    }
+    paths.push(PathBuf::from("/etc/ssh/ssh_config"));
+    paths
+}
+
+/// Reads `path` and returns whether it enables compression. Parse and
+/// I/O errors are converted to `false` with a single diagnostic line.
+fn read_and_check(path: &Path) -> bool {
+    match fs::read_to_string(path) {
+        Ok(text) => parse_enables_compression(&text),
+        Err(err) => {
+            debug_log!(
+                Io,
+                1,
+                "ssh_config compression detection: failed to read {}: {}",
+                path.display(),
+                err
+            );
+            false
+        }
+    }
+}
+
+/// Parses `text` and returns `true` when `Compression yes` is in effect
+/// at top level or under `Host *`.
+///
+/// Exposed to tests so they can assert behaviour without disk I/O.
+pub(super) fn parse_enables_compression(text: &str) -> bool {
+    let mut block = Block::TopLevel;
+    let mut top_level: Option<bool> = None;
+    let mut host_star: Option<bool> = None;
+
+    for raw_line in text.lines() {
+        let line = strip_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = split_directive(line) else {
+            debug_log!(
+                Io,
+                1,
+                "ssh_config compression detection: skipping malformed line"
+            );
+            continue;
+        };
+        let key_lc = key.to_ascii_lowercase();
+        match key_lc.as_str() {
+            "host" => {
+                block = if host_patterns_include_star(value) {
+                    Block::HostStar
+                } else {
+                    Block::HostOther
+                };
+            }
+            "match" => {
+                block = Block::Match;
+            }
+            "compression" => {
+                let parsed = parse_yes_no(value);
+                match block {
+                    Block::TopLevel if top_level.is_none() => top_level = parsed,
+                    Block::HostStar if host_star.is_none() => host_star = parsed,
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    top_level.unwrap_or(false) || host_star.unwrap_or(false)
+}
+
+/// Active config block while parsing.
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum Block {
+    TopLevel,
+    HostStar,
+    HostOther,
+    Match,
+}
+
+/// Returns `true` when any token in `patterns` is exactly `*`. Matches
+/// OpenSSH's "wildcard everything" idiom, which is the only host
+/// pattern we evaluate without runtime context.
+fn host_patterns_include_star(patterns: &str) -> bool {
+    patterns
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .map(str::trim)
+        .any(|tok| tok == "*")
+}
+
+/// Walks `options` looking for `-F file` (split across two args) or
+/// `-Ffile` (concatenated). Returns the first occurrence as a
+/// [`PathBuf`].
+fn extract_dash_f_path(options: &[OsString]) -> Option<PathBuf> {
+    let mut iter = options.iter();
+    while let Some(opt) = iter.next() {
+        if opt == OsStr::new("-F") {
+            return iter.next().map(PathBuf::from);
+        }
+        let bytes = opt.to_string_lossy();
+        if let Some(rest) = bytes.strip_prefix("-F")
+            && !rest.is_empty()
+        {
+            return Some(PathBuf::from(rest));
+        }
+    }
+    None
+}
+
+/// Strips a trailing `#...` comment from a config line.
+fn strip_comment(line: &str) -> &str {
+    line.find('#').map_or(line, |idx| &line[..idx])
+}
+
+/// Splits `Key Value` (or `Key=Value`) on the first whitespace or `=`
+/// run. Returns `None` for keys with no value.
+fn split_directive(line: &str) -> Option<(&str, &str)> {
+    let (key, rest) = line.split_once(|c: char| c.is_whitespace() || c == '=')?;
+    let value = rest.trim_start_matches(|c: char| c.is_whitespace() || c == '=');
+    if value.is_empty() {
+        return None;
+    }
+    Some((key, value))
+}
+
+/// Parses a yes/no value (case-insensitive). Returns `None` for any
+/// other value so a typo cannot accidentally flip the bit.
+fn parse_yes_no(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "yes" | "true" => Some(true),
+        "no" | "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Resolves the per-user home directory. Mirrors the helper in
+/// `embedded::ssh_config` rather than reaching across module boundaries
+/// because the embedded transport is gated behind a different feature.
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+    #[cfg(windows)]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_level_compression_yes_detected() {
+        assert!(parse_enables_compression("Compression yes\n"));
+    }
+
+    #[test]
+    fn host_star_compression_yes_detected() {
+        let text = "Host *\n  Compression yes\n";
+        assert!(parse_enables_compression(text));
+    }
+
+    #[test]
+    fn per_host_compression_yes_ignored() {
+        let text = "Host foo.example.com\n  Compression yes\n";
+        assert!(!parse_enables_compression(text));
+    }
+
+    #[test]
+    fn compression_no_returns_false() {
+        assert!(!parse_enables_compression("Compression no\n"));
+    }
+
+    #[test]
+    fn match_block_compression_yes_ignored() {
+        let text = "Match host bar\n  Compression yes\n";
+        assert!(!parse_enables_compression(text));
+    }
+
+    #[test]
+    fn equals_separator_supported() {
+        assert!(parse_enables_compression("Compression=yes\n"));
+    }
+
+    #[test]
+    fn comments_stripped() {
+        assert!(parse_enables_compression(
+            "# header\nCompression yes # trailing\n"
+        ));
+    }
+
+    #[test]
+    fn extracts_split_dash_f() {
+        let opts = vec![OsString::from("-F"), OsString::from("/tmp/custom")];
+        assert_eq!(extract_dash_f_path(&opts), Some(PathBuf::from("/tmp/custom")));
+    }
+
+    #[test]
+    fn extracts_combined_dash_f() {
+        let opts = vec![OsString::from("-F/tmp/custom")];
+        assert_eq!(extract_dash_f_path(&opts), Some(PathBuf::from("/tmp/custom")));
+    }
+
+    #[test]
+    fn no_dash_f_returns_none() {
+        let opts = vec![OsString::from("-oBatchMode=yes")];
+        assert!(extract_dash_f_path(&opts).is_none());
+    }
+}

--- a/crates/rsync_io/src/ssh/config_lookup.rs
+++ b/crates/rsync_io/src/ssh/config_lookup.rs
@@ -267,13 +267,19 @@ mod tests {
     #[test]
     fn extracts_split_dash_f() {
         let opts = vec![OsString::from("-F"), OsString::from("/tmp/custom")];
-        assert_eq!(extract_dash_f_path(&opts), Some(PathBuf::from("/tmp/custom")));
+        assert_eq!(
+            extract_dash_f_path(&opts),
+            Some(PathBuf::from("/tmp/custom"))
+        );
     }
 
     #[test]
     fn extracts_combined_dash_f() {
         let opts = vec![OsString::from("-F/tmp/custom")];
-        assert_eq!(extract_dash_f_path(&opts), Some(PathBuf::from("/tmp/custom")));
+        assert_eq!(
+            extract_dash_f_path(&opts),
+            Some(PathBuf::from("/tmp/custom"))
+        );
     }
 
     #[test]

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -90,6 +90,8 @@ mod async_stderr_drain;
 mod async_transport;
 mod aux_channel;
 mod builder;
+#[cfg(feature = "ssh-config-parse")]
+mod config_lookup;
 mod connect;
 mod connection;
 /// Embedded SSH transport using the russh library.

--- a/crates/rsync_io/tests/ssh_config_compression.rs
+++ b/crates/rsync_io/tests/ssh_config_compression.rs
@@ -1,0 +1,224 @@
+//! Integration coverage for the SSC-3 `ssh_config` compression lookup.
+//!
+//! These tests drive `SshCommand::has_ssh_compression()` through the
+//! `ssh-config-parse` code path by pointing `HOME` (and `USERPROFILE`
+//! on Windows) at a temporary directory containing a synthetic
+//! `~/.ssh/config`, or by passing a `-F <override>` SSH option. They
+//! never touch the real user config.
+//!
+//! Tests share a process-global `ENV_LOCK` because they mutate
+//! environment variables, which are not thread-safe.
+
+#![cfg(feature = "ssh-config-parse")]
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::sync::Mutex;
+
+use rsync_io::ssh::SshCommand;
+use tempfile::TempDir;
+
+/// Serialises every test in this binary; environment mutation is not
+/// thread-safe in Rust 2024.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII guard that scopes an environment-variable mutation to the
+/// surrounding test. Mirrors the inline pattern used by
+/// `crates/cli/src/frontend/arguments/env.rs`.
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &OsStr) -> Self {
+        let previous = env::var_os(key);
+        // SAFETY: every caller holds `ENV_LOCK`, so no other thread can
+        // observe a torn read or invoke a concurrent setenv. set_var is
+        // unsafe in Rust 2024 only because of cross-thread races, which
+        // the mutex prevents.
+        #[allow(unsafe_code)]
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: the surrounding test still holds `ENV_LOCK` when the
+        // guard drops, so restoration cannot race a concurrent reader
+        // or writer.
+        #[allow(unsafe_code)]
+        unsafe {
+            if let Some(value) = self.previous.take() {
+                env::set_var(self.key, value);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+/// Writes `body` to `dir/.ssh/config`.
+fn write_ssh_config(dir: &TempDir, body: &str) {
+    let ssh_dir = dir.path().join(".ssh");
+    fs::create_dir_all(&ssh_dir).expect("create .ssh");
+    fs::write(ssh_dir.join("config"), body).expect("write ssh_config");
+}
+
+/// Returns an `SshCommand` carrying no SSH options so the argv check
+/// is always inconclusive and the ssh_config lookup is exercised.
+fn plain_cmd() -> SshCommand {
+    SshCommand::new("example.com")
+}
+
+#[test]
+fn top_level_compression_yes_in_home_config() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    write_ssh_config(&home, "Compression yes\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn host_star_block_compression_yes_in_home_config() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    write_ssh_config(&home, "Host *\n  Compression yes\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn per_host_block_without_host_star_returns_false() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // Deferred behaviour: per-host `Host foo` blocks need runtime
+    // context (the host we are connecting to plus full OpenSSH pattern
+    // semantics) the warning site does not have. Match blocks are
+    // skipped for the same reason. The lookup is intentionally
+    // conservative to avoid noisy false positives.
+    write_ssh_config(&home, "Host foo.example.com\n  Compression yes\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn compression_no_returns_false() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    write_ssh_config(&home, "Compression no\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn malformed_config_falls_back_to_false() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // Lines without a value, stray separators, and unrecognised
+    // Compression values must not abort the transfer. The lookup logs
+    // and returns false so the caller falls back to argv-only.
+    write_ssh_config(
+        &home,
+        "Compression\n===\nHost\n  Compression yes-but-not-quite\n",
+    );
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn empty_config_returns_false() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    write_ssh_config(&home, "");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn missing_config_returns_false() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // No .ssh directory under HOME.
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn dash_f_override_wins_over_home_config() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // `~/.ssh/config` disables compression. The `-F` override is
+    // consulted first and flips the answer to true.
+    write_ssh_config(&home, "Compression no\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    let override_dir = TempDir::new().expect("tempdir");
+    let override_path = override_dir.path().join("override.config");
+    fs::write(&override_path, "Compression yes\n").expect("write override");
+
+    let mut command = plain_cmd();
+    command.push_option("-F");
+    command.push_option(override_path.as_os_str());
+
+    assert!(command.has_ssh_compression());
+}
+
+#[test]
+fn dash_f_combined_form_is_honoured() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    let override_dir = TempDir::new().expect("tempdir");
+    let override_path = override_dir.path().join("override.config");
+    fs::write(&override_path, "Compression yes\n").expect("write override");
+
+    let mut combined = OsString::from("-F");
+    combined.push(override_path.as_os_str());
+
+    let mut command = plain_cmd();
+    command.push_option(combined);
+
+    assert!(command.has_ssh_compression());
+}
+
+#[test]
+fn argv_dash_c_still_wins_when_config_disables() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    write_ssh_config(&home, "Compression no\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    // The argv path short-circuits the config lookup, so `-C` on the
+    // rsync invocation continues to fire the SSC-1 warning even when
+    // ssh_config disables compression.
+    let mut command = plain_cmd();
+    command.push_option("-C");
+    assert!(command.has_ssh_compression());
+
+    // Sanity: without -C, the same config keeps the answer false.
+    assert!(!plain_cmd().has_ssh_compression());
+}


### PR DESCRIPTION
## Summary

- Closes the SSC-3 gap so the SSC-1 double-compression warning also fires when the user has \`Compression yes\` set in \`~/.ssh/config\` or \`/etc/ssh/ssh_config\` instead of on the rsync command line.
- Adds a small in-tree parser at \`crates/rsync_io/src/ssh/config_lookup.rs\` (no new dependencies) behind a default-on \`ssh-config-parse\` feature on the \`rsync_io\` crate.
- \`SshCommand::has_ssh_compression()\` first inspects argv (existing SSC-1 path) and, when that is inconclusive, consults the \`-F\`-supplied override, then \`~/.ssh/config\`, then \`/etc/ssh/ssh_config\`. Only top-level directives and \`Host *\` blocks are honoured.

## Scope and deferred work

- \`Host foo.example.com\` and \`Match\` blocks need runtime context (the host we are connecting to, plus full OpenSSH pattern semantics including \`Match exec\` shell-out) that the warning site does not have. These are intentionally skipped to keep the warning conservative and free of false positives - documented in code comments and in the test that pins the behaviour.

## Implementation notes

- The recommended \`ssh2-config 0.7.x\` crate was passed over in favour of a hand-rolled parser sketched in the evaluation doc. Rationale:
  - The crate cannot be promoted to a workspace dep (constraint), and adding \`ssh2-config\` plus its 5 direct deps and ~15 transitive deps just to \`rsync_io\` would expand the lockfile noticeably.
  - The \`rsync_io\` crate must contain zero unsafe code (the project coding standards), and verifying the full ssh2-config dep closure for unsafe code (and Unix-only crates that would force a \`cfg(unix)\` gate on Windows) was not feasible without running cargo locally per the standing rule.
  - The hand-rolled parser only needs to look up one directive (\`Compression\`) at top level and under \`Host *\`. ~70 LoC of pure logic, mirrors the pattern already used by \`crates/rsync_io/src/ssh/embedded/ssh_config.rs\`, no platform-specific code beyond the existing \`HOME\`/\`USERPROFILE\` split.
- Parse and I/O errors emit one \`debug_log!\` line at the existing SSH-diagnostic level and return false. The transfer is never aborted because the user's ssh_config is malformed for unrelated reasons.
- Cross-platform: uses \`std::env::var_os(\"HOME\")\` on Unix and \`USERPROFILE\` on Windows. No \`cfg(unix)\` gate on the feature itself; Windows users get the same lookup against \`%USERPROFILE%\\.ssh\\config\`.

## Follow-up

- The memory note \`project_ssh_compression_no_config_parse.md\` should be marked resolved after this lands (not modified in this PR; maintainer action).

## Test plan

- [ ] CI green on fmt+clippy, nextest stable, Windows, macOS, Linux musl.
- [ ] \`cargo nextest run -p rsync_io --all-features -E 'test(ssh_config_compression)'\` exercises the 10 new integration cases.
- [ ] Unit tests inside \`config_lookup\` exercise the parser directly (top-level yes, Host * yes, per-host ignored, Compression no, Match ignored, \`=\` separator, comments, all three \`-F\` forms).
- [ ] Existing \`has_ssh_compression_*\` tests in \`crates/rsync_io/src/ssh/tests.rs\` continue to pass; the argv path short-circuits before the new lookup runs.