### PR TITLE
fix(cli): drop --features token from --zero-copy help text

### DIFF
--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -148,7 +148,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --simd=LEVEL Force the SIMD level used by checksum dispatch (auto, avx512, avx2, sse4, neon, none).\n",
             "      --cow        Allow copy-on-write reflinks for whole-file copies (default).\n",
             "      --no-cow     Disable copy-on-write reflinks; always use the portable std::fs::copy fallback.\n",
-            "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range; io_uring SEND_ZC only when built with --features iouring-send-zc, otherwise downgrades to plain io_uring SEND) when supported by the kernel. This is the default (policy=auto/enabled).\n",
+            "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range; io_uring SEND_ZC only when built with the iouring-send-zc cargo feature, otherwise downgrades to plain io_uring SEND) when supported by the kernel. This is the default (policy=auto/enabled).\n",
             "      --no-zero-copy  Disable I/O-level zero-copy; route through portable userspace read/write loops. Does not affect filesystem-level reflink/CoW cloning.\n",
             "      --inplace    Write updated data directly to destination files.\n",
             "      --no-inplace Use temporary files when updating regular files.\n",


### PR DESCRIPTION
## Summary
- PR #4733 (IUS-6) embedded a literal `--features iouring-send-zc` inside the `--zero-copy` long-help string.
- `supported_options_list_mentions_all_help_flags` scans rendered help for `--FOO` tokens and matched `--features`, which is not in `SUPPORTED_OPTIONS_LIST`.
- Replace the substring with prose (`the iouring-send-zc cargo feature`) so the help no longer forges a fake oc-rsync option, while keeping the same constraint visible to readers.

## Test plan
- [x] master regression: `supported_options_list_mentions_all_help_flags` failing on `d658fb7dc` reproduced via PR #4736 and PR #4738 nextest/Windows logs
- [ ] CI fmt + clippy
- [ ] CI nextest (stable) — confirms the failing test now passes
- [ ] CI Windows (stable) — same test ran here too