### PR TITLE
perf(fast_io): copy_file_range fast path for delta-apply COPY tokens (IUD-10)

### DIFF
--- a/crates/fast_io/src/copy_basis_range.rs
+++ b/crates/fast_io/src/copy_basis_range.rs
@@ -1,0 +1,399 @@
+//! Offset-aware basis-to-destination range copy via `copy_file_range(2)`.
+//!
+//! This module is the IUD-10 fast path for the delta-apply COPY-token branch:
+//! when the receiver replays a `COPY {index, len}` token, the contents at
+//! `basis[basis_off..basis_off+len]` must end up at
+//! `dest[dest_off..dest_off+len]`. On Linux 4.5+ with both files on the same
+//! filesystem, `copy_file_range(2)` accomplishes this entirely in the kernel
+//! without bouncing bytes through userspace - no per-byte `read(2)`/`write(2)`
+//! and, on supporting filesystems, with reflink/server-side copy acceleration.
+//!
+//! Upstream rsync 3.4.1 itself does not use `copy_file_range(2)` in the
+//! receiver - it walks `map_ptr` and `write(2)`. This is an oc-rsync
+//! optimization that produces byte-identical output; it is invisible on the
+//! wire and changes no protocol behavior.
+//!
+//! The wrapper is conservative: any kernel-reported failure on the first
+//! iteration collapses to `Ok(0)` so callers fall back to the existing
+//! read-then-write path without surfacing platform-specific errnos. Only
+//! failures after a partial copy succeed are propagated, because at that
+//! point the destination is in a state the caller must reconcile.
+//!
+//! # Bounded I/O contract
+//!
+//! Every iteration submits at most `i64::MAX` bytes and the loop terminates
+//! on three conditions: requested `len` reached, kernel returns 0 (EOF on the
+//! source), or kernel returns an error. There is no unbounded retry; the
+//! caller's `len` bounds total time.
+
+use std::fs::File;
+use std::io;
+
+/// Minimum range size for which `copy_file_range` amortizes its syscall cost.
+///
+/// Smaller ranges are cheaper to satisfy with a single `pread`/`write` pair
+/// than to round-trip through the syscall. The receiver's typical block size
+/// is well above this threshold, so the dispatch is rarely declined on real
+/// transfers; the threshold exists to keep tiny tail blocks fast.
+pub const COPY_BASIS_RANGE_MIN_BYTES: usize = 4 * 1024;
+
+/// Copies `len` bytes from `basis[basis_off..]` into `dest[dest_off..]` using
+/// `copy_file_range(2)` on Linux, or returns `Ok(0)` on every other target
+/// so callers fall back to read+write.
+///
+/// # Returns
+///
+/// - `Ok(n)` where `n == len` on full success.
+/// - `Ok(n)` where `0 < n < len` if the kernel hit EOF on the basis before
+///   the range was satisfied; the caller must reconcile the short copy
+///   (rare with a correctly sized basis).
+/// - `Ok(0)` when the syscall is unavailable, the files live on different
+///   filesystems (`EXDEV`), the kernel does not support `copy_file_range`
+///   (`ENOSYS`), or any first-iteration error. The caller must fall back to
+///   the read+write path; the destination is untouched.
+///
+/// # Errors
+///
+/// Returns `Err` only when a kernel error occurs **after** a partial copy
+/// has already succeeded. In that case the destination has been partially
+/// written and the caller cannot transparently fall back.
+///
+/// # Bounded I/O
+///
+/// Caps each iteration at `i64::MAX` and terminates on completion, EOF, or
+/// error - never hangs. Source and destination file offsets are NOT advanced
+/// (the syscall uses explicit `loff_t*` pointers).
+///
+/// # Platform support
+///
+/// - Linux 4.5+ same filesystem.
+/// - Linux 5.3+ cross filesystem (still gated to `Ok(0)` on `EXDEV` for
+///   safety on older kernels).
+/// - All other targets: returns `Ok(0)` immediately, no syscall issued.
+#[inline]
+pub fn copy_basis_range(
+    basis: &File,
+    basis_off: u64,
+    dest: &File,
+    dest_off: u64,
+    len: usize,
+) -> io::Result<usize> {
+    imp::copy_basis_range(basis, basis_off, dest, dest_off, len)
+}
+
+/// Returns `true` when the running kernel exposes a usable
+/// `copy_file_range(2)` syscall.
+///
+/// Result is cached via a process-wide `OnceLock` after the first probe so
+/// subsequent dispatch decisions are branch-only. On non-Linux targets this
+/// is a compile-time `false`.
+#[must_use]
+#[inline]
+pub fn copy_file_range_supported() -> bool {
+    imp::copy_file_range_supported()
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use std::fs::File;
+    use std::io;
+    use std::os::fd::AsRawFd;
+    use std::sync::OnceLock;
+
+    static CFR_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+    pub(super) fn copy_file_range_supported() -> bool {
+        if let Some(cached) = CFR_SUPPORTED.get().copied() {
+            return cached;
+        }
+        let result = probe();
+        let _ = CFR_SUPPORTED.set(result);
+        CFR_SUPPORTED.get().copied().unwrap_or(result)
+    }
+
+    fn probe() -> bool {
+        // Issue a zero-byte copy_file_range against /dev/null in both
+        // directions. A return of 0 with no error or any errno other than
+        // ENOSYS means the syscall reached the kernel and is available;
+        // ENOSYS means the kernel pre-dates Linux 4.5.
+        let Ok(src) = File::open("/dev/null") else {
+            return false;
+        };
+        let Ok(dst) = File::options().write(true).open("/dev/null") else {
+            return false;
+        };
+
+        let mut src_off: libc::loff_t = 0;
+        let mut dst_off: libc::loff_t = 0;
+        // SAFETY: both fds are valid for the duration of this call (owned by
+        // the local File values), the offset pointers are valid &mut local
+        // variables, len=0 is a no-op probe documented to return 0 on
+        // supported kernels. No memory is read or written.
+        #[allow(unsafe_code)]
+        let ret = unsafe {
+            libc::copy_file_range(
+                src.as_raw_fd(),
+                &mut src_off as *mut libc::loff_t,
+                dst.as_raw_fd(),
+                &mut dst_off as *mut libc::loff_t,
+                0,
+                0,
+            )
+        };
+
+        if ret >= 0 {
+            return true;
+        }
+        io::Error::last_os_error().raw_os_error() != Some(libc::ENOSYS)
+    }
+
+    pub(super) fn copy_basis_range(
+        basis: &File,
+        basis_off: u64,
+        dest: &File,
+        dest_off: u64,
+        len: usize,
+    ) -> io::Result<usize> {
+        if len == 0 {
+            return Ok(0);
+        }
+        if !copy_file_range_supported() {
+            return Ok(0);
+        }
+
+        let basis_fd = basis.as_raw_fd();
+        let dest_fd = dest.as_raw_fd();
+
+        let mut total: usize = 0;
+        let mut src_off: libc::loff_t = match libc::loff_t::try_from(basis_off) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "basis_off exceeds loff_t",
+                ));
+            }
+        };
+        let mut dst_off: libc::loff_t = match libc::loff_t::try_from(dest_off) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "dest_off exceeds loff_t",
+                ));
+            }
+        };
+
+        while total < len {
+            let remaining = len - total;
+            let chunk = remaining.min(i64::MAX as usize);
+
+            // SAFETY: both fds are valid for the call (borrowed from &File),
+            // the loff_t pointers reference valid local mutables, and the
+            // syscall does not retain any pointer past return. The kernel
+            // advances *src_off and *dst_off in place by the number of bytes
+            // copied.
+            #[allow(unsafe_code)]
+            let ret = unsafe {
+                libc::copy_file_range(
+                    basis_fd,
+                    &mut src_off as *mut libc::loff_t,
+                    dest_fd,
+                    &mut dst_off as *mut libc::loff_t,
+                    chunk,
+                    0,
+                )
+            };
+
+            if ret < 0 {
+                let err = io::Error::last_os_error();
+                if total == 0 {
+                    // First iteration: caller falls back to read+write.
+                    // EXDEV, EOPNOTSUPP, EINVAL (overlapping ranges, special
+                    // files), and EXDEV-like errors all collapse to Ok(0).
+                    return Ok(0);
+                }
+                return Err(err);
+            }
+
+            if ret == 0 {
+                // EOF on basis before len was satisfied; short copy.
+                break;
+            }
+
+            total += ret as usize;
+        }
+
+        Ok(total)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use std::fs::File;
+    use std::io;
+
+    pub(super) fn copy_file_range_supported() -> bool {
+        false
+    }
+
+    pub(super) fn copy_basis_range(
+        _basis: &File,
+        _basis_off: u64,
+        _dest: &File,
+        _dest_off: u64,
+        _len: usize,
+    ) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{File, OpenOptions};
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use tempfile::tempdir;
+
+    fn make_basis(dir: &std::path::Path, name: &str, payload: &[u8]) -> File {
+        let path = dir.join(name);
+        let mut f = File::create(&path).unwrap();
+        f.write_all(payload).unwrap();
+        f.sync_all().ok();
+        File::open(&path).unwrap()
+    }
+
+    fn make_dest(dir: &std::path::Path, name: &str) -> File {
+        let path = dir.join(name);
+        OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap()
+    }
+
+    fn read_all(dest: &mut File) -> Vec<u8> {
+        dest.seek(SeekFrom::Start(0)).unwrap();
+        let mut buf = Vec::new();
+        dest.read_to_end(&mut buf).unwrap();
+        buf
+    }
+
+    #[test]
+    fn empty_len_returns_zero_without_syscall() {
+        let dir = tempdir().unwrap();
+        let basis = make_basis(dir.path(), "b", b"abc");
+        let dest = make_dest(dir.path(), "d");
+        let copied = copy_basis_range(&basis, 0, &dest, 0, 0).unwrap();
+        assert_eq!(copied, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn same_fs_copy_produces_byte_identical_output() {
+        let dir = tempdir().unwrap();
+        let payload: Vec<u8> = (0..64 * 1024).map(|i| (i % 251) as u8).collect();
+        let basis = make_basis(dir.path(), "basis.bin", &payload);
+        let mut dest = make_dest(dir.path(), "dest.bin");
+
+        let copied = copy_basis_range(&basis, 0, &dest, 0, payload.len()).unwrap();
+        // On kernels without copy_file_range, copied == 0 and the caller
+        // would fall back. On Linux 4.5+ with a tmpfs/ext4-backed tempdir,
+        // expect a full or partial in-kernel copy.
+        if copied == 0 {
+            // Old kernel or restricted FS - production path falls back; the
+            // wrapper contract is satisfied.
+            return;
+        }
+        assert_eq!(copied, payload.len());
+
+        let out = read_all(&mut dest);
+        assert_eq!(out, payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn offset_copy_extracts_correct_window() {
+        let dir = tempdir().unwrap();
+        let payload: Vec<u8> = (0..8 * 1024).map(|i| (i % 211) as u8).collect();
+        let basis = make_basis(dir.path(), "basis.bin", &payload);
+        let mut dest = make_dest(dir.path(), "dest.bin");
+
+        let window = 4 * 1024;
+        let copied = copy_basis_range(&basis, 1024, &dest, 0, window).unwrap();
+        if copied == 0 {
+            return;
+        }
+        assert_eq!(copied, window);
+
+        let out = read_all(&mut dest);
+        assert_eq!(out, &payload[1024..1024 + window]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dest_offset_writes_at_correct_position() {
+        let dir = tempdir().unwrap();
+        let payload: Vec<u8> = (0..4 * 1024).map(|i| (i % 199) as u8).collect();
+        let basis = make_basis(dir.path(), "basis.bin", &payload);
+        let mut dest = make_dest(dir.path(), "dest.bin");
+        // Pre-fill destination with a sentinel so we can verify the write
+        // landed at the requested offset and did not clobber earlier bytes.
+        dest.write_all(&vec![0xFFu8; 2048]).unwrap();
+        dest.sync_all().ok();
+
+        let copied = copy_basis_range(&basis, 0, &dest, 2048, payload.len()).unwrap();
+        if copied == 0 {
+            return;
+        }
+        assert_eq!(copied, payload.len());
+
+        let out = read_all(&mut dest);
+        assert_eq!(&out[..2048], &vec![0xFFu8; 2048]);
+        assert_eq!(&out[2048..], payload.as_slice());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn short_copy_when_basis_eof_returns_partial_count() {
+        // Request more than the basis contains; the kernel returns 0 once it
+        // hits EOF mid-loop. The wrapper exits the loop and reports the
+        // bytes that did make it through - the receiver's checksum verifier
+        // (when sequential) will then surface the mismatch.
+        let dir = tempdir().unwrap();
+        let payload = vec![0xA5u8; 2048];
+        let basis = make_basis(dir.path(), "basis.bin", &payload);
+        let mut dest = make_dest(dir.path(), "dest.bin");
+
+        let copied = copy_basis_range(&basis, 0, &dest, 0, 8192).unwrap();
+        if copied == 0 {
+            return;
+        }
+        assert!(copied <= payload.len());
+        assert!(copied >= 1);
+
+        let out = read_all(&mut dest);
+        assert_eq!(&out[..copied], &payload[..copied]);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_stub_returns_zero_without_syscall() {
+        let dir = tempdir().unwrap();
+        let basis = make_basis(dir.path(), "b", b"abcd");
+        let dest = make_dest(dir.path(), "d");
+        let copied = copy_basis_range(&basis, 0, &dest, 0, 4).unwrap();
+        assert_eq!(copied, 0);
+        assert!(!copy_file_range_supported());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn supported_probe_is_stable_across_calls() {
+        let a = copy_file_range_supported();
+        let b = copy_file_range_supported();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -132,6 +132,9 @@ pub mod adaptive_dispatch;
 pub mod copy_file_ex;
 /// High-performance file copying with tiered fallback.
 pub mod copy_file_range;
+/// Offset-aware basis-to-destination range copy via `copy_file_range(2)` for
+/// the delta-apply COPY-token fast path (IUD-10).
+pub mod copy_basis_range;
 /// Anonymous temporary file creation via `O_TMPFILE` and finalization via `linkat`.
 pub mod o_tmpfile;
 /// Platform-abstracted file copy trait with automatic optimization selection.
@@ -230,6 +233,7 @@ mod policy;
 mod status;
 
 pub use cached_sort::{CachedSortKey, cached_sort_by};
+pub use copy_basis_range::{COPY_BASIS_RANGE_MIN_BYTES, copy_basis_range, copy_file_range_supported};
 pub use page_aligned::{PageAlignedBuffer, page_size, round_up_to_page};
 pub use parallel::{ParallelExecutor, ParallelResult};
 pub use platform_copy::{

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -128,13 +128,13 @@ pub mod zero_detect;
 #[cfg(feature = "adaptive-basis-dispatch")]
 pub mod adaptive_dispatch;
 
+/// Offset-aware basis-to-destination range copy via `copy_file_range(2)` for
+/// the delta-apply COPY-token fast path (IUD-10).
+pub mod copy_basis_range;
 /// Windows `CopyFileExW` file copy with automatic fallback.
 pub mod copy_file_ex;
 /// High-performance file copying with tiered fallback.
 pub mod copy_file_range;
-/// Offset-aware basis-to-destination range copy via `copy_file_range(2)` for
-/// the delta-apply COPY-token fast path (IUD-10).
-pub mod copy_basis_range;
 /// Anonymous temporary file creation via `O_TMPFILE` and finalization via `linkat`.
 pub mod o_tmpfile;
 /// Platform-abstracted file copy trait with automatic optimization selection.
@@ -233,7 +233,9 @@ mod policy;
 mod status;
 
 pub use cached_sort::{CachedSortKey, cached_sort_by};
-pub use copy_basis_range::{COPY_BASIS_RANGE_MIN_BYTES, copy_basis_range, copy_file_range_supported};
+pub use copy_basis_range::{
+    COPY_BASIS_RANGE_MIN_BYTES, copy_basis_range, copy_file_range_supported,
+};
 pub use page_aligned::{PageAlignedBuffer, page_size, round_up_to_page};
 pub use parallel::{ParallelExecutor, ParallelResult};
 pub use platform_copy::{

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -5,7 +5,7 @@
 //! `receiver.c:240`.
 
 use std::fs::File;
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use engine::signature::FileSignature;
@@ -19,6 +19,19 @@ use crate::map_file::AdaptiveMapStrategy;
 use crate::map_file::BufferedMap;
 use crate::map_file::MapFile;
 use crate::token_buffer::TokenBuffer;
+
+/// Same-fs detection cache for the IUD-10 `copy_file_range` fast path.
+///
+/// Resolved lazily on the first COPY token (so we don't pay a `metadata()`
+/// syscall when the receiver never produces a COPY large enough to dispatch)
+/// and cached for the remainder of the file - both fds are stable for the
+/// lifetime of `DeltaApplicator`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SameFsCache {
+    Unresolved,
+    SameFs,
+    DifferentFs,
+}
 
 /// Basis-file mapping strategy: adaptive (mmap above 1 MiB) on Unix,
 /// buffered sliding window elsewhere.
@@ -132,6 +145,9 @@ pub struct DeltaApplicator<'a> {
     basis_map: Option<MapFile<BasisMapStrategy>>,
     /// Reusable buffer for literal token data to avoid per-token allocations.
     token_buffer: TokenBuffer,
+    /// Cached same-filesystem decision for the IUD-10 `copy_file_range`
+    /// fast path. Resolved on first eligible COPY token, then reused.
+    same_fs: SameFsCache,
     stats: DeltaApplyResult,
 }
 
@@ -189,6 +205,7 @@ impl<'a> DeltaApplicator<'a> {
             basis_signature,
             basis_map,
             token_buffer: TokenBuffer::with_default_capacity(),
+            same_fs: SameFsCache::Unresolved,
             stats: DeltaApplyResult::default(),
         })
     }
@@ -301,6 +318,41 @@ impl<'a> DeltaApplicator<'a> {
             self.stats.bytes_written
         );
 
+        // IUD-10 fast path: when no checksum is being accumulated (CSUM_NONE)
+        // and no sparse rewrite is in flight, hand the basis-to-dest copy off
+        // to `copy_file_range(2)` instead of bouncing bytes through userspace.
+        // upstream rsync 3.4.1 does not use copy_file_range; this is an
+        // oc-rsync-only optimization that produces byte-identical output.
+        if Self::should_try_kernel_copy(
+            &self.checksum_verifier,
+            self.sparse_state.as_ref(),
+            bytes_to_copy,
+        ) {
+            if let Some(basis_file) = basis_map.buffered_basis_file() {
+                let dest_off = self.stats.bytes_written;
+                let dispatched = Self::try_copy_basis_range(
+                    basis_file,
+                    offset,
+                    &self.output,
+                    dest_off,
+                    bytes_to_copy,
+                    &mut self.same_fs,
+                )?;
+                if dispatched == bytes_to_copy {
+                    // Kernel honoured the full range. copy_file_range does
+                    // not advance the destination file position, so seek
+                    // forward to keep subsequent literal writes contiguous.
+                    self.output.seek(SeekFrom::Start(dest_off + dispatched as u64))?;
+                    self.stats.bytes_written += dispatched as u64;
+                    self.stats.matched_bytes += dispatched as u64;
+                    self.stats.block_tokens += 1;
+                    return Ok(());
+                }
+                // Partial or zero dispatch: fall through to read+write. The
+                // destination position has not been touched (no seek issued).
+            }
+        }
+
         let block_data = basis_map.map_ptr(offset, bytes_to_copy)?;
 
         self.checksum_verifier.update(block_data);
@@ -315,6 +367,70 @@ impl<'a> DeltaApplicator<'a> {
         self.stats.matched_bytes += bytes_to_copy as u64;
         self.stats.block_tokens += 1;
         Ok(())
+    }
+
+    /// Predicate gating the IUD-10 `copy_file_range` fast path.
+    ///
+    /// Returns `true` when in-kernel copy is safe to attempt:
+    /// - the checksum verifier is `None` (no per-byte digest to maintain),
+    /// - no sparse rewrite is active (sparse needs zero-run scanning),
+    /// - the COPY range is at least `COPY_BASIS_RANGE_MIN_BYTES` so the
+    ///   syscall overhead pays off.
+    #[inline]
+    fn should_try_kernel_copy(
+        verifier: &ChecksumVerifier,
+        sparse: Option<&SparseWriteState>,
+        bytes_to_copy: usize,
+    ) -> bool {
+        if !verifier.is_noop() {
+            return false;
+        }
+        if sparse.is_some() {
+            return false;
+        }
+        bytes_to_copy >= fast_io::COPY_BASIS_RANGE_MIN_BYTES
+    }
+
+    /// Resolves same-filesystem placement (cached) and dispatches the kernel
+    /// copy on the first call when the basis and destination share an `st_dev`.
+    ///
+    /// Returns the byte count actually written by the kernel. `Ok(0)` is the
+    /// caller's signal to fall back to read+write; the wrapper guarantees the
+    /// destination has not been mutated in that case.
+    fn try_copy_basis_range(
+        basis_file: &File,
+        basis_off: u64,
+        dest_file: &File,
+        dest_off: u64,
+        bytes_to_copy: usize,
+        cache: &mut SameFsCache,
+    ) -> io::Result<usize> {
+        if *cache == SameFsCache::Unresolved {
+            *cache = Self::resolve_same_fs(basis_file, dest_file);
+        }
+        if *cache == SameFsCache::DifferentFs {
+            return Ok(0);
+        }
+        fast_io::copy_basis_range(basis_file, basis_off, dest_file, dest_off, bytes_to_copy)
+    }
+
+    /// Computes the same-filesystem decision once per file. On non-Unix
+    /// targets the kernel-copy fast path is unreachable, so the result is
+    /// always `DifferentFs`.
+    fn resolve_same_fs(basis: &File, dest: &File) -> SameFsCache {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            match (basis.metadata(), dest.metadata()) {
+                (Ok(b), Ok(d)) if b.dev() == d.dev() => SameFsCache::SameFs,
+                _ => SameFsCache::DifferentFs,
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (basis, dest);
+            SameFsCache::DifferentFs
+        }
     }
 
     /// Reads and applies a single token from the reader.
@@ -559,5 +675,61 @@ mod tests {
             DeltaApplicator::new(out, &config, verifier, None, None).expect("construct applicator");
         assert!(!applicator.has_basis());
         assert!(!applicator.basis_uses_mmap());
+    }
+
+    #[test]
+    fn should_try_kernel_copy_requires_noop_verifier() {
+        // CSUM_NONE -> fast path eligible.
+        let none = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::None);
+        assert!(DeltaApplicator::should_try_kernel_copy(
+            &none,
+            None,
+            fast_io::COPY_BASIS_RANGE_MIN_BYTES,
+        ));
+        // Any active digest -> declined; the fast path cannot feed the
+        // verifier without re-reading the bytes it just elided.
+        let md5 = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
+        assert!(!DeltaApplicator::should_try_kernel_copy(
+            &md5,
+            None,
+            fast_io::COPY_BASIS_RANGE_MIN_BYTES,
+        ));
+    }
+
+    #[test]
+    fn should_try_kernel_copy_declines_when_sparse() {
+        let none = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::None);
+        let sparse = SparseWriteState::new();
+        // Sparse needs zero-run scanning; cannot delegate to kernel copy.
+        assert!(!DeltaApplicator::should_try_kernel_copy(
+            &none,
+            Some(&sparse),
+            fast_io::COPY_BASIS_RANGE_MIN_BYTES,
+        ));
+    }
+
+    #[test]
+    fn should_try_kernel_copy_declines_below_min_bytes() {
+        let none = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::None);
+        // Tiny ranges hit the syscall-cost wall before they amortize.
+        assert!(!DeltaApplicator::should_try_kernel_copy(
+            &none,
+            None,
+            fast_io::COPY_BASIS_RANGE_MIN_BYTES - 1,
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_same_fs_marks_two_files_in_same_tempdir() {
+        // Both files in the same tempdir live on the same filesystem under
+        // every supported test runner; the resolver must agree.
+        let dir = tempdir().expect("tempdir");
+        let a = File::create(dir.path().join("a")).expect("create a");
+        let b = File::create(dir.path().join("b")).expect("create b");
+        assert_eq!(
+            DeltaApplicator::resolve_same_fs(&a, &b),
+            SameFsCache::SameFs,
+        );
     }
 }

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -29,6 +29,7 @@ use crate::token_buffer::TokenBuffer;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SameFsCache {
     Unresolved,
+    #[cfg(target_os = "linux")]
     SameFs,
     DifferentFs,
 }
@@ -415,11 +416,11 @@ impl<'a> DeltaApplicator<'a> {
         fast_io::copy_basis_range(basis_file, basis_off, dest_file, dest_off, bytes_to_copy)
     }
 
-    /// Computes the same-filesystem decision once per file. On non-Unix
+    /// Computes the same-filesystem decision once per file. On non-Linux
     /// targets the kernel-copy fast path is unreachable, so the result is
     /// always `DifferentFs`.
     fn resolve_same_fs(basis: &File, dest: &File) -> SameFsCache {
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         {
             use std::os::unix::fs::MetadataExt;
             match (basis.metadata(), dest.metadata()) {
@@ -427,7 +428,7 @@ impl<'a> DeltaApplicator<'a> {
                 _ => SameFsCache::DifferentFs,
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(not(target_os = "linux"))]
         {
             let _ = (basis, dest);
             SameFsCache::DifferentFs
@@ -720,7 +721,7 @@ mod tests {
         ));
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn resolve_same_fs_marks_two_files_in_same_tempdir() {
         // Both files in the same tempdir live on the same filesystem under

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -342,7 +342,8 @@ impl<'a> DeltaApplicator<'a> {
                     // Kernel honoured the full range. copy_file_range does
                     // not advance the destination file position, so seek
                     // forward to keep subsequent literal writes contiguous.
-                    self.output.seek(SeekFrom::Start(dest_off + dispatched as u64))?;
+                    self.output
+                        .seek(SeekFrom::Start(dest_off + dispatched as u64))?;
                     self.stats.bytes_written += dispatched as u64;
                     self.stats.matched_bytes += dispatched as u64;
                     self.stats.block_tokens += 1;

--- a/crates/transfer/src/delta_apply/checksum.rs
+++ b/crates/transfer/src/delta_apply/checksum.rs
@@ -94,6 +94,18 @@ impl ChecksumVerifier {
         }
     }
 
+    /// Returns `true` when the verifier is the `None` variant - no whole-file
+    /// digest will be computed.
+    ///
+    /// Used by performance fast paths that can skip the per-byte `update`
+    /// callback when no checksum is being accumulated (e.g. the IUD-10
+    /// `copy_file_range` delta-apply path).
+    #[inline]
+    #[must_use]
+    pub const fn is_noop(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
     /// Returns the checksum algorithm used by this verifier.
     #[inline]
     #[must_use]

--- a/crates/transfer/src/map_file/adaptive.rs
+++ b/crates/transfer/src/map_file/adaptive.rs
@@ -107,4 +107,12 @@ impl MapStrategy for AdaptiveMapStrategy {
             Self::Mmap(m) => m.file_size(),
         }
     }
+
+    #[inline]
+    fn buffered_file(&self) -> Option<&std::fs::File> {
+        match self {
+            Self::Buffered(b) => b.buffered_file(),
+            Self::Mmap(_) => None,
+        }
+    }
 }

--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -88,6 +88,15 @@ impl BufferedMap {
         })
     }
 
+    /// Returns a shared reference to the underlying file handle.
+    ///
+    /// Exposed so optimizations like the IUD-10 `copy_file_range` fast path
+    /// can borrow the fd without disturbing the sliding-window cache state.
+    #[inline]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
     /// Returns true if the requested range is within the current window.
     #[inline]
     fn is_in_window(&self, offset: u64, len: usize) -> bool {
@@ -184,5 +193,10 @@ impl MapStrategy for BufferedMap {
     #[inline]
     fn file_size(&self) -> u64 {
         self.size
+    }
+
+    #[inline]
+    fn buffered_file(&self) -> Option<&File> {
+        Some(&self.file)
     }
 }

--- a/crates/transfer/src/map_file/mod.rs
+++ b/crates/transfer/src/map_file/mod.rs
@@ -75,4 +75,17 @@ pub trait MapStrategy: Send {
 
     /// Returns the total file size.
     fn file_size(&self) -> u64;
+
+    /// Returns the underlying basis file when the strategy is backed by a
+    /// real `File` (i.e. buffered, not mmap).
+    ///
+    /// Defaults to `None`. The buffered variants override to expose their
+    /// inner handle so the IUD-10 `copy_file_range` fast path can borrow
+    /// the fd. mmap-backed strategies must keep returning `None`: handing
+    /// an mmap-region's fd to `copy_file_range(2)` would force the kernel
+    /// to fault those pages back in through the same mapping it is reading.
+    #[inline]
+    fn buffered_file(&self) -> Option<&std::fs::File> {
+        None
+    }
 }

--- a/crates/transfer/src/map_file/wrapper.rs
+++ b/crates/transfer/src/map_file/wrapper.rs
@@ -116,6 +116,18 @@ impl MapFile<AdaptiveMapStrategy> {
     pub fn is_buffered(&self) -> bool {
         self.strategy.is_buffered()
     }
+
+    /// Returns the underlying basis file when the strategy is buffered.
+    ///
+    /// Returns `None` when mmap-backed. Used by the IUD-10 delta-apply fast
+    /// path: handing an mmap pointer to `copy_file_range(2)` would force the
+    /// kernel to fault those pages back in through the mapping it owns, so
+    /// the dispatch is restricted to the buffered variant.
+    #[must_use]
+    #[inline]
+    pub fn buffered_basis_file(&self) -> Option<&File> {
+        self.strategy.buffered_file()
+    }
 }
 
 impl<S: MapStrategy> MapFile<S> {

--- a/crates/transfer/src/map_file/wrapper.rs
+++ b/crates/transfer/src/map_file/wrapper.rs
@@ -116,21 +116,23 @@ impl MapFile<AdaptiveMapStrategy> {
     pub fn is_buffered(&self) -> bool {
         self.strategy.is_buffered()
     }
+}
 
-    /// Returns the underlying basis file when the strategy is buffered.
+impl<S: MapStrategy> MapFile<S> {
+    /// Returns the underlying basis file when the strategy is backed by a
+    /// real `File` (i.e. buffered, not mmap).
     ///
-    /// Returns `None` when mmap-backed. Used by the IUD-10 delta-apply fast
-    /// path: handing an mmap pointer to `copy_file_range(2)` would force the
-    /// kernel to fault those pages back in through the mapping it owns, so
-    /// the dispatch is restricted to the buffered variant.
+    /// Returns `None` for mmap-backed strategies. Used by the IUD-10
+    /// delta-apply fast path: handing an mmap pointer to
+    /// `copy_file_range(2)` would force the kernel to fault those pages
+    /// back in through the mapping it owns, so the dispatch is restricted
+    /// to buffered strategies.
     #[must_use]
     #[inline]
     pub fn buffered_basis_file(&self) -> Option<&File> {
         self.strategy.buffered_file()
     }
-}
 
-impl<S: MapStrategy> MapFile<S> {
     /// Creates a `MapFile` with a custom strategy.
     pub fn with_strategy(strategy: S) -> Self {
         Self { strategy }


### PR DESCRIPTION
## Summary

- Add `fast_io::copy_basis_range`, a safe wrapper over Linux `copy_file_range(2)` with `OnceLock`-cached runtime detection, EXDEV/ENOSYS fallback to `Ok(0)`, short-write looping, bounded I/O, and a non-Linux stub.
- Wire the dispatch into `transfer::delta_apply::DeltaApplicator::apply_block_ref` (the receiver's COPY-token branch) so basis-to-destination block copies on the same filesystem hand off to the kernel instead of bouncing bytes through userspace.
- Expose `MapStrategy::buffered_file()` so the dispatch can borrow the basis fd without touching the sliding-window cache; mmap-backed strategies keep returning `None` per upstream `fileio.c:214-217` rationale.
- Add `ChecksumVerifier::is_noop()` as the gate: kernel copy elides per-byte verifier updates, so dispatch only happens when `CSUM_NONE` was negotiated. Sparse rewrites are also skipped (they need zero-run scanning).

upstream rsync 3.4.1 itself does not use `copy_file_range(2)` in the receiver. This is a wire-invisible oc-rsync-only optimization that produces byte-identical output; no protocol change.

### Files of interest

- `crates/fast_io/src/copy_basis_range.rs` - safe wrapper + tests + `copy_file_range_supported()` probe.
- `crates/transfer/src/delta_apply/applicator.rs` - dispatch site at `apply_block_ref` with same-fs cache + gating predicate + helpers.
- `crates/transfer/src/map_file/{mod,buffered,adaptive,wrapper}.rs` - `buffered_file()` accessor down the stack.
- `crates/transfer/src/delta_apply/checksum.rs` - `is_noop()` predicate.

### Dispatch eligibility

All of these must hold or the code falls back to the existing read+write path with no behavior change:

1. Target is Linux (non-Linux stub returns `Ok(0)`).
2. `ChecksumVerifier` is the `None` variant (CSUM_NONE).
3. No sparse rewrite is active.
4. COPY range >= `COPY_BASIS_RANGE_MIN_BYTES` (4 KiB).
5. Basis `MapFile` is buffered, not mmap-backed.
6. Basis and destination share `st_dev` (cached on first eligible token).
7. Kernel reports a non-error full-range copy.

### Bench note

This PR adds the fast path but does not include benchmark numbers - the bench hardware setup is out of session scope. Follow-up IUD-11 should bench basis-heavy transfers before/after this change. Existing IUD-9 baseline harness can be reused.

## Test plan

- [ ] `cargo nextest run -p fast_io --all-features -E 'test(copy_basis_range)'`
- [ ] `cargo nextest run -p transfer --all-features -E 'test(should_try_kernel_copy or resolve_same_fs)'`
- [ ] Full CI matrix (fmt+clippy, nextest stable, Windows, macOS, Linux musl) green.
- [ ] No regression in existing `delta_apply` tests - both writer-kind paths (Standard, IoUring) still hold their mmap policy invariants.
- [ ] Interop suite still green - dispatch is gated by `CSUM_NONE`, which production transfers rarely hit, so the dispatch is path-additive and existing protocol-level interop coverage continues to exercise the read+write fallback unchanged.