### PR TITLE
chore(apple-fs): audit + fix cross-platform compile hazards (XPL-1)

### DIFF
--- a/crates/apple-fs/Cargo.toml
+++ b/crates/apple-fs/Cargo.toml
@@ -8,6 +8,11 @@ version.workspace = true
 
 [dependencies]
 libc = { workspace = true }
+
+# Unix-only syscall wrappers. `nix` itself carries `#![cfg(unix)]` so it is
+# inert on Windows, but matching the per-crate convention used by `core` and
+# `platform` keeps cross-platform intent explicit at the manifest level.
+[target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
## Summary

Proactive cross-platform audit (XPL-1) of `crates/apple-fs/` per the standing rule: audit the test tree for known cross-platform CI hazards before pushing, do not wait for CI to fail.

Walked every file in the crate checking the four known hazard categories enumerated in CI history:

1. `#[cfg(unix)]` / `#[cfg(target_os = \"macos\")]` gate scope - if every test in a module is gated, the whole module should be gated instead.
2. Imports above a cfg gate used only inside it (would trigger `unused_imports` on the off-platform).
3. `let mut` bindings mutated only inside a cfg block (would trigger `unused_mut` on the off-platform).
4. Rustdoc intra-doc links that fail to resolve when the referent is re-exported through `lib.rs`.

## Files inspected

- `crates/apple-fs/Cargo.toml`
- `crates/apple-fs/README.md`
- `crates/apple-fs/src/lib.rs`
- `crates/apple-fs/src/apple_double.rs`
- `crates/apple-fs/src/resource_fork.rs`
- `crates/apple-fs/tests/apple_double_round_trip.rs`

**6 files audited.**

## Findings

### Rust sources: clean

- `src/lib.rs` - test module mixes cross-platform tests (`normalize_filename_ascii_unchanged`, `is_apple_double_name_*`, `apple_double_companion_*`) with `#[cfg(unix)]` and `#[cfg(target_os = \"macos\")]` gated tests. The mixed-platform composition means per-test gating is the right unit; whole-module gating would over-rotate. Helper-import `use super::*;` is exercised on every platform because at least one test on each platform consumes a `super` item. `unique_path` helper and its imports (`env`, `fs`, `SystemTime`, `UNIX_EPOCH`) are correctly `#[cfg(unix)]`-gated together.
- `src/apple_double.rs` - pure-data module, no cfg gates, no platform-specific surface.
- `src/resource_fork.rs` - matched `#[cfg(target_os = \"macos\")]` / `#[cfg(not(target_os = \"macos\"))]` pairs for every accessor; test module has at least one platform-specific test for each side, and the shared `use std::path::PathBuf;` is consumed on both branches (`dummy_path` on non-macOS, `make_temp_file` on macOS), so no `unused_imports` window.
- `tests/apple_double_round_trip.rs` - top-level imports (`AppleDouble`, `EntryId`) consumed by both cross-platform tests and the macOS-gated test; helper functions referenced on every platform; the macOS-only test's `use apple_fs::...` / `use std::io;` are scoped inside the gated function so they vanish cleanly on non-macOS.
- No rustdoc intra-doc links route through a `lib.rs` re-export - every `[`Type`]` link resolves inside its source module (`io::*` against `use std::io;`, `EntryId` / `FINDER_INFO_LEN` as siblings of their referrers).

### Hygiene fix applied

- `crates/apple-fs/Cargo.toml`: `nix = { workspace = true, features = [\"fs\"] }` was declared in the unconditional `[dependencies]` block. `nix` 0.31 carries `#![cfg(unix)]` so it compiles to an empty crate on Windows, but the per-crate convention used by `core/Cargo.toml` and `platform/Cargo.toml` is to put `nix` under `[target.'cfg(unix)'.dependencies]`. Moved the declaration to match that convention and added a short comment explaining the rationale. Makes cross-platform intent explicit at the manifest level and aligns the crate with the rest of the workspace.

## Cross-platform compile review (mental walkthrough)

- macOS: unchanged - `nix` still pulled in via the `cfg(unix)` target spec; `xattr` and `unicode-normalization` continue to flow through `cfg(target_os = \"macos\")`.
- Linux (gnu + musl): unchanged - `nix` still pulled in via `cfg(unix)`; the macOS-only deps stay absent.
- Windows: `nix` is now formally absent from the dep graph (previously inert via its own `#![cfg(unix)]`). Zero behaviour change, manifest is now consistent with `core` and `platform`.

## Recommended follow-ups

None. The audit recommends **no XPL-1.a / XPL-1.b follow-ups** for `apple-fs`. The crate is small, well-gated, and benefited from the recent CCL apple-fs cleanup (#4654 era). The remaining XPL-2 / XPL-3 / XPL-4 tasks already cover the other audit targets (`kqueue_stub`, `transfer` crate, ongoing macOS/Windows CI flakiness).

## Test plan

- [ ] CI: fmt + clippy on stable
- [ ] CI: nextest on stable (Linux)
- [ ] CI: Windows stable
- [ ] CI: macOS stable
- [ ] CI: Linux musl stable