### PR TITLE
feat(engine): SpillError::PriorSpillsLost typed variant + consumer wiring (SPL-35..37)

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer/loops.rs
+++ b/crates/engine/src/concurrent_delta/consumer/loops.rs
@@ -139,6 +139,11 @@ pub(super) fn run_spillable_loop(
                     ));
                     return;
                 }
+                Err(e @ SpillError::PriorSpillsLost { .. }) => {
+                    let _ = result_tx
+                        .send(DeltaResult::failed(ndx, format!("spill write failed: {e}")));
+                    return;
+                }
             }
         }
         publish_spill_events(&reorder, spill_events, &mut prev_spill);

--- a/crates/engine/src/concurrent_delta/spill/buffer/insert.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/insert.rs
@@ -17,10 +17,11 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     ///
     /// Returns [`SpillError::Capacity`] if the sequence offset from
     /// `next_expected` exceeds the ring buffer capacity. Returns
-    /// [`SpillError::Io`] if a spill write fails (ENOSPC, missing temp
-    /// directory, partial write, encoder failure). On I/O failure the
-    /// affected item is preserved in memory; on capacity failure no
-    /// insert occurs.
+    /// [`SpillError::Io`] if a spill write fails (ENOSPC, partial write,
+    /// encoder failure) and [`SpillError::PriorSpillsLost`] when the
+    /// caller-supplied spill directory vanishes after prior records were
+    /// already on disk. On I/O failure the affected item is preserved in
+    /// memory; on capacity failure no insert occurs.
     pub fn insert(&mut self, sequence: u64, item: T) -> Result<(), SpillError> {
         let item_size = item.estimated_size();
         self.inner.insert(sequence, item)?;

--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -89,7 +89,16 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
                     Err(e) => {
                         // Re-insert the item on spill failure so the caller
                         // can retry or shut down without losing the result.
+                        // A NotFound here means spill_item refused to retry
+                        // because prior records are unrecoverable; upgrade
+                        // to the typed PriorSpillsLost variant so the
+                        // receiver can emit an actionable diagnostic.
                         self.inner.force_insert(seq, item);
+                        if e.kind() == io::ErrorKind::NotFound {
+                            if let Some(lost) = self.prior_spills_lost_error() {
+                                return Err(lost);
+                            }
+                        }
                         return Err(SpillError::Io(e));
                     }
                 }
@@ -148,8 +157,9 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             Ok(w) => w,
             Err(e) if e.kind() == io::ErrorKind::NotFound && self.spill_dir.is_some() => {
                 if !self.spill_index.is_empty() {
+                    let lost = self.prior_spills_lost_error();
                     self.restore_taken(taken);
-                    return Err(SpillError::Io(e));
+                    return Err(lost.unwrap_or(SpillError::Io(e)));
                 }
                 if let Err(retry_err) = self.recreate_spill_dir() {
                     self.restore_taken(taken);
@@ -244,8 +254,9 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
                 // safe when no prior items had been spilled - otherwise
                 // those items are lost on disk and silently continuing
                 // would corrupt the transfer. With prior items present
-                // we surface NotFound; the caller treats it as a fatal
-                // I/O error and the transfer aborts with exit 11.
+                // we surface the original NotFound here; the caller
+                // upgrades it to SpillError::PriorSpillsLost so the
+                // receiver can emit an actionable diagnostic.
                 if !self.spill_index.is_empty() {
                     return Err(e);
                 }
@@ -257,6 +268,20 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             }
             Err(e) => Err(e),
         }
+    }
+
+    /// Builds a [`SpillError::PriorSpillsLost`] for the configured directory.
+    ///
+    /// Returns `None` only when the spooled flavour (no caller-supplied
+    /// directory) somehow reached the recovery-refusal branch, in which case
+    /// callers should fall back to the original [`SpillError::Io`].
+    pub(super) fn prior_spills_lost_error(&self) -> Option<SpillError> {
+        self.spill_dir
+            .clone()
+            .map(|dir| SpillError::PriorSpillsLost {
+                dir,
+                count: self.spill_index.len(),
+            })
     }
 
     /// Applies the configured compression codec to the freshly encoded payload.

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
@@ -43,9 +43,9 @@ fn enospc_during_spill_propagates_as_io_error() {
         SpillError::UnsupportedCompression(tag) => {
             panic!("expected I/O error, got unsupported compression tag 0x{tag:02x}")
         }
-        SpillError::PriorSpillsLost { dir, count } => panic!(
-            "expected I/O error, got prior-spills-lost {dir:?} count={count}"
-        ),
+        SpillError::PriorSpillsLost { dir, count } => {
+            panic!("expected I/O error, got prior-spills-lost {dir:?} count={count}")
+        }
     }
     assert!(err.is_out_of_space(), "is_out_of_space should be true");
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
@@ -43,6 +43,9 @@ fn enospc_during_spill_propagates_as_io_error() {
         SpillError::UnsupportedCompression(tag) => {
             panic!("expected I/O error, got unsupported compression tag 0x{tag:02x}")
         }
+        SpillError::PriorSpillsLost { dir, count } => panic!(
+            "expected I/O error, got prior-spills-lost {dir:?} count={count}"
+        ),
     }
     assert!(err.is_out_of_space(), "is_out_of_space should be true");
 }
@@ -114,8 +117,9 @@ fn temp_dir_vanish_recreates_when_no_prior_spills() {
 #[test]
 fn temp_dir_vanish_after_prior_spills_returns_error() {
     // Vanish after prior spills is unrecoverable: those items live
-    // only on the now-missing disk. We surface the I/O error rather
-    // than silently lose them.
+    // only on the now-missing disk. We surface the typed
+    // PriorSpillsLost variant so the receiver can emit an actionable
+    // diagnostic instead of a generic NotFound.
     let scratch = ::tempfile::tempdir().expect("create scratch root");
     let spill_dir = scratch.path().join("spill");
     let mut buf: SpillableReorderBuffer<u64> =
@@ -132,18 +136,78 @@ fn temp_dir_vanish_after_prior_spills_returns_error() {
     buf.spill_file = None;
     fs::remove_dir_all(&spill_dir).expect("remove spill dir");
 
-    // The next insert that triggers a spill should surface NotFound
-    // (or another io::Error) without panicking and without recreating
-    // the directory: prior items are unrecoverable.
+    // The next insert that triggers a spill should surface
+    // PriorSpillsLost without panicking and without recreating the
+    // directory: prior items are unrecoverable.
     let mut saw_error = false;
     for i in 2u64..6 {
         if let Err(e) = buf.insert(i, i * 100) {
-            assert!(matches!(e, SpillError::Io(_)), "expected I/O error");
+            match e {
+                SpillError::PriorSpillsLost { ref dir, count } => {
+                    assert_eq!(dir, &spill_dir, "variant must carry the vanished dir");
+                    assert!(count >= 1, "expected at least one lost chunk, got {count}");
+                }
+                other => panic!("expected PriorSpillsLost, got {other:?}"),
+            }
             saw_error = true;
             break;
         }
     }
     assert!(saw_error, "expected spill failure after dir vanish");
+    assert_eq!(
+        buf.spill_stats().dir_recreate_events,
+        0,
+        "must not silently recreate when prior items exist"
+    );
+}
+
+#[test]
+fn prior_spills_lost_surfaces_typed_variant_on_dir_wipe() {
+    // SPL-37: a wipe of the spill directory after items are already on
+    // disk must surface PriorSpillsLost with the configured dir and a
+    // non-zero count of unrecoverable chunks. Forces enough inserts to
+    // trip the byte threshold so spill_excess writes real records, then
+    // wipes the directory and drives the reload-or-spill path until the
+    // typed variant surfaces.
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let spill_dir = scratch.path().join("spill");
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_spill_dir(32, 16, &spill_dir).expect("setup spill directory");
+
+    // Seed enough items to comfortably exceed the 16-byte threshold so
+    // spill_excess fires and persists at least one record on disk.
+    for i in 0u64..6 {
+        buf.insert(i, i * 17).expect("seed insert must succeed");
+    }
+    let seeded = buf.spill_stats().spilled_items;
+    assert!(
+        seeded >= 1,
+        "expected at least one item on disk before wipe, got {seeded}"
+    );
+
+    // Wipe the directory mid-transfer. Drop the cached file handle so the
+    // next write reopens against the missing parent.
+    buf.spill_file = None;
+    fs::remove_dir_all(&spill_dir).expect("remove spill dir");
+
+    let mut surfaced: Option<SpillError> = None;
+    for i in 6u64..32 {
+        match buf.insert(i, i * 23) {
+            Ok(()) => continue,
+            Err(e) => {
+                surfaced = Some(e);
+                break;
+            }
+        }
+    }
+    let err = surfaced.expect("expected spill to surface an error after wipe");
+    match err {
+        SpillError::PriorSpillsLost { dir, count } => {
+            assert_eq!(dir, spill_dir, "variant must carry the vanished directory");
+            assert!(count >= 1, "expected count >= 1, got {count}");
+        }
+        other => panic!("expected PriorSpillsLost, got {other:?}"),
+    }
     assert_eq!(
         buf.spill_stats().dir_recreate_events,
         0,

--- a/crates/engine/src/concurrent_delta/spill/error.rs
+++ b/crates/engine/src/concurrent_delta/spill/error.rs
@@ -9,6 +9,7 @@
 //! [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
 
 use std::io;
+use std::path::PathBuf;
 
 use super::super::reorder::CapacityExceeded;
 
@@ -25,6 +26,12 @@ use super::super::reorder::CapacityExceeded;
 /// build that has no codec available - the on-disk tag byte advertises the
 /// algorithm so we fail loudly rather than decode garbage.
 ///
+/// [`PriorSpillsLost`](Self::PriorSpillsLost) is surfaced when the spill
+/// directory vanishes mid-transfer after one or more records were already
+/// written to disk. Recovery is refused because those records cannot be
+/// reconstructed; the typed variant lets the receiver emit an actionable
+/// diagnostic for the operator instead of a generic `NotFound`.
+///
 /// [`FileIo`]: https://github.com/RsyncProject/rsync/blob/master/errcode.h
 #[derive(Debug)]
 pub enum SpillError {
@@ -35,6 +42,16 @@ pub enum SpillError {
     /// On-disk record advertises a compression algorithm this build cannot
     /// decode. Holds the unknown tag byte for diagnostics.
     UnsupportedCompression(u8),
+    /// Caller-supplied spill directory vanished mid-transfer after prior
+    /// records were already on disk. Carries the directory that vanished
+    /// and the count of records known to be unrecoverable.
+    PriorSpillsLost {
+        /// Directory that disappeared after prior spill writes had committed.
+        dir: PathBuf,
+        /// Number of records (sequences) that were spilled to disk and can
+        /// no longer be reloaded.
+        count: usize,
+    },
 }
 
 impl SpillError {
@@ -43,7 +60,9 @@ impl SpillError {
     pub fn io_error(&self) -> Option<&io::Error> {
         match self {
             SpillError::Io(e) => Some(e),
-            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
+            SpillError::Capacity(_)
+            | SpillError::UnsupportedCompression(_)
+            | SpillError::PriorSpillsLost { .. } => None,
         }
     }
 
@@ -64,6 +83,11 @@ impl std::fmt::Display for SpillError {
                 f,
                 "reorder spill record uses compression tag 0x{tag:02x} not supported by this build"
             ),
+            SpillError::PriorSpillsLost { dir, count } => write!(
+                f,
+                "prior spill directory {} vanished; {count} chunk(s) cannot be recovered",
+                dir.display()
+            ),
         }
     }
 }
@@ -71,7 +95,9 @@ impl std::fmt::Display for SpillError {
 impl std::error::Error for SpillError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            SpillError::Capacity(_) | SpillError::UnsupportedCompression(_) => None,
+            SpillError::Capacity(_)
+            | SpillError::UnsupportedCompression(_)
+            | SpillError::PriorSpillsLost { .. } => None,
             SpillError::Io(e) => Some(e),
         }
     }

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -187,5 +187,18 @@ mod tests {
         assert!(std::error::Error::source(&unsupported).is_none());
         assert!(unsupported.io_error().is_none());
         assert!(!unsupported.is_out_of_space());
+
+        let lost = SpillError::PriorSpillsLost {
+            dir: std::path::PathBuf::from("/tmp/spill-vanished"),
+            count: 3,
+        };
+        let rendered = format!("{lost}");
+        assert!(
+            rendered.contains("/tmp/spill-vanished") && rendered.contains("3 chunk"),
+            "display should mention dir and count: {rendered}"
+        );
+        assert!(std::error::Error::source(&lost).is_none());
+        assert!(lost.io_error().is_none());
+        assert!(!lost.is_out_of_space());
     }
 }


### PR DESCRIPTION
## Summary

Implements SPL-32's top hardening recommendation: distinguish "prior spills lost" from a generic NotFound at the reorder spill recovery-refusal sites.

- **SPL-35** - Add `SpillError::PriorSpillsLost { dir, count }` variant in `crates/engine/src/concurrent_delta/spill/error.rs`. The variant carries the spill directory that vanished and the count of records known to be unrecoverable. `Display` renders the recommended message `"prior spill directory <dir> vanished; <count> chunk(s) cannot be recovered"`. `io_error()` and `is_out_of_space()` correctly classify it as a non-I/O failure.
- **SPL-36** - Wire the typed variant through the spill writer.
  - `spill_candidates_per_item` (per-item path): on `NotFound` returned from the inner refusal branch, calls the new `prior_spills_lost_error()` helper and surfaces `PriorSpillsLost` rather than `Io(NotFound)`.
  - `spill_candidates_whole_batch` (whole-batch path): same upgrade in its refusal arm before `restore_taken`.
  - Consumer `run_spillable_loop` (`consumer/loops.rs`) adds the missing match arm so the variant funnels into `DeltaResult::failed` with the actionable diagnostic for the receiver (still mapped to upstream exit code 11).
- **SPL-37** - Regression coverage.
  - The pre-existing `temp_dir_vanish_after_prior_spills_returns_error` assertion was tightened to require `SpillError::PriorSpillsLost { dir, count }` with `dir == spill_dir` and `count >= 1`.
  - New `prior_spills_lost_surfaces_typed_variant_on_dir_wipe` explicitly drives the SPL-37 contract: seeds enough inserts to commit real records to disk, force-wipes the spill directory, then drains the buffer and asserts the surfaced error is exactly `PriorSpillsLost` with the configured dir and a non-zero count. `dir_recreate_events` must remain `0`.

The variant is added in a way that is non-breaking only at the variant-set level; every existing exhaustive `match SpillError` in the workspace (consumer loop, hardening tests, top-level Display/source test) was updated to handle the new arm.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest stable (Linux, macOS, Windows, Linux musl) passes
- [ ] Existing temp-dir-vanish hardening tests still pass with the tightened typed-variant assertion
- [ ] New `prior_spills_lost_surfaces_typed_variant_on_dir_wipe` test passes