### PR TITLE
test(fast_io): reproducer + symptom doc for SQPOLL+mmap race (SQM-1.a, SQM-1.b)

### DIFF
--- a/crates/fast_io/tests/repro_sqpoll_mmap.rs
+++ b/crates/fast_io/tests/repro_sqpoll_mmap.rs
@@ -65,7 +65,7 @@ use std::io::Write;
 use std::os::unix::io::AsRawFd;
 use std::time::{Duration, Instant};
 
-use io_uring::{IoUring, opcode, types};
+use io_uring::{IoUring, cqueue, opcode, types};
 use memmap2::MmapOptions;
 use tempfile::tempdir;
 
@@ -110,8 +110,7 @@ const SQPOLL_IDLE_MS: u32 = 100;
 #[ignore = "requires CAP_SYS_NICE for SQPOLL; run with --ignored on instrumented kernels"]
 fn repro_sqpoll_mmap_race() {
     println!(
-        "repro_sqpoll_mmap: {ITERATIONS} iterations, scratch={SCRATCH_SIZE}B, read={READ_LEN}B, timeout={:?}",
-        ITER_TIMEOUT
+        "repro_sqpoll_mmap: {ITERATIONS} iterations, scratch={SCRATCH_SIZE}B, read={READ_LEN}B, timeout={ITER_TIMEOUT:?}"
     );
 
     let dir = tempdir().expect("tempdir");
@@ -119,7 +118,7 @@ fn repro_sqpoll_mmap_race() {
     let source_path = dir.path().join("source.bin");
 
     {
-        let mut f = File::create(&scratch_path).expect("create scratch");
+        let f = File::create(&scratch_path).expect("create scratch");
         f.set_len(SCRATCH_SIZE as u64).expect("set_len scratch");
         f.sync_all().expect("sync_all scratch");
     }
@@ -319,7 +318,7 @@ fn run_one_iteration(
     }
 
     let mut cq = ring.completion();
-    let cqe = match cq.next() {
+    let cqe: cqueue::Entry = match cq.next() {
         Some(c) => c,
         None => return IterStatus::Timeout,
     };
@@ -359,9 +358,9 @@ mod sanity {
 
     #[test]
     fn constants_are_sane() {
-        assert!(SCRATCH_SIZE.is_multiple_of(READ_LEN));
-        assert!(READ_LEN > 0);
-        assert!(ITERATIONS > 0 && ITERATIONS < 1024);
-        assert!(ITER_TIMEOUT.as_secs() > 0);
+        assert_eq!(SCRATCH_SIZE % READ_LEN, 0);
+        assert_eq!(READ_LEN % 4096, 0);
+        assert!(ITERATIONS.is_multiple_of(8));
+        assert_eq!(ITER_TIMEOUT, Duration::from_secs(5));
     }
 }

--- a/crates/fast_io/tests/repro_sqpoll_mmap.rs
+++ b/crates/fast_io/tests/repro_sqpoll_mmap.rs
@@ -1,0 +1,366 @@
+//! SQPOLL + mmap'd registered-buffer race reproducer (SQM-1.a).
+//!
+//! # Why this exists
+//!
+//! `crates/fast_io/src/io_uring/config.rs:336-373` defensively disables SQPOLL
+//! whenever a basis file is mmap'd into the receive pipeline because the
+//! SQPOLL kernel thread can race with userspace page-fault handling on the
+//! shared mapping. The defensive disable costs roughly 10-15% throughput on
+//! NVMe + large basis workloads (see
+//! `docs/design/sqpoll-mmap-race-symptoms.md` and
+//! `docs/audits/io_uring_sqpoll_mmap_pagefault.md`). To unlock SQM-2 (design
+//! a safe workaround) we need a minimal program that surfaces the race
+//! statistically on the kernel matrix.
+//!
+//! # What it does
+//!
+//! For each iteration:
+//!
+//! 1. Build a fresh `io_uring` with `IORING_SETUP_SQPOLL`. Skip the iteration
+//!    cleanly if the kernel refuses SQPOLL (typically `EPERM` without
+//!    `CAP_SYS_NICE`).
+//! 2. mmap a 256 MiB scratch file `READ`-only with `MAP_PRIVATE`. The mapping
+//!    is intentionally not pre-faulted - the SQPOLL kthread is expected to
+//!    drive the page-fault path while servicing a registered-buffer SQE.
+//! 3. Register the mmap'd region with the ring via `IORING_REGISTER_BUFFERS`.
+//!    Registration is the point at which the kernel calls
+//!    `get_user_pages_fast()`; one failure mode is `EFAULT` here.
+//! 4. Submit an `IORING_OP_READ_FIXED` against the registered buffer that
+//!    reads from a *separate* source file into the mmap'd region. The race
+//!    surface is the kthread touching mmap pages whose backing PTEs have not
+//!    been faulted in by the userspace task.
+//! 5. Wait for the completion with a strict per-iteration timeout so the
+//!    reproducer cannot hang even if the ring stalls. On Linux 5.11+
+//!    `submit_with_args` accepts a `Timespec` that bounds the
+//!    `io_uring_enter(GETEVENTS)` wait.
+//! 6. Classify the completion: success / short read / `-EFAULT` /
+//!    `-EAGAIN` / other negative errno / timeout. Print one status line per
+//!    iteration so external tooling can collate kernel-version coverage.
+//!
+//! # Safety profile
+//!
+//! - Bounded: `ITERATIONS` is a small constant (16). No infinite loops.
+//! - No fd leaks: every fd is owned by an `OwnedFd` or `File`. The mmap is
+//!   wrapped in [`memmap2::MmapMut`] so unmapping happens via `Drop`.
+//! - No hangs: every submit/wait uses a 5-second `Timespec` budget.
+//! - Cleanup: temporary files live under [`tempfile::tempdir`] and are
+//!   removed when the test exits, even on panic.
+//!
+//! # How to run
+//!
+//! ```sh
+//! cargo nextest run -p fast_io --features io_uring \
+//!     -E 'test(repro_sqpoll_mmap)' --no-capture
+//! ```
+//!
+//! The reproducer is `#[ignore]` by default because it requires
+//! `CAP_SYS_NICE` on most kernels to enable SQPOLL. Pass `--ignored` to run
+//! it. See `docs/design/sqpoll-mmap-race-symptoms.md` for how to interpret
+//! the per-iteration status lines and the kernel-version coverage matrix.
+
+#![cfg(all(target_os = "linux", feature = "io_uring"))]
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::unix::io::AsRawFd;
+use std::time::{Duration, Instant};
+
+use io_uring::{IoUring, opcode, types};
+use memmap2::MmapOptions;
+use tempfile::tempdir;
+
+/// Size of the mmap'd scratch region (256 MiB). Large enough to span many
+/// page-cache entries so the kthread is statistically likely to touch a
+/// non-resident page, small enough to fit in the typical CI tmpfs budget.
+const SCRATCH_SIZE: usize = 256 * 1024 * 1024;
+
+/// Size of the source file the registered-buffer read pulls bytes from.
+/// One page per submission keeps the per-op work small while still requiring
+/// the kthread to write into the mmap region (which is the trigger for the
+/// page-fault race).
+const READ_LEN: usize = 4096;
+
+/// Number of (build-ring + submit + reap) cycles to surface the race
+/// statistically. Each iteration is independent - a fresh ring and a fresh
+/// registration - so transient kernel state cannot mask the symptom across
+/// iterations.
+const ITERATIONS: usize = 16;
+
+/// Per-iteration timeout for `io_uring_enter(GETEVENTS)`. The reproducer
+/// MUST NOT hang even when the kernel stalls, so this budget is strict.
+/// Five seconds is generous for a single 4 KiB read and tight enough that
+/// a hung iteration shows up immediately.
+const ITER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// `user_data` tag on the read SQE; arbitrary but distinct so the CQE can
+/// be matched without ambiguity.
+const READ_USER_DATA: u64 = 0xC0FFEE;
+
+/// Number of SQ entries. Eight is more than enough for one read per
+/// iteration and keeps the ring small enough that SQPOLL setup succeeds on
+/// constrained CI workers.
+const SQ_ENTRIES: u32 = 8;
+
+/// SQPOLL idle window. Short enough that the kthread parks quickly on
+/// inactivity (no busy CPU in CI), long enough that a single iteration's
+/// submit + reap never races the kthread sleep.
+const SQPOLL_IDLE_MS: u32 = 100;
+
+#[test]
+#[ignore = "requires CAP_SYS_NICE for SQPOLL; run with --ignored on instrumented kernels"]
+fn repro_sqpoll_mmap_race() {
+    println!("repro_sqpoll_mmap: {ITERATIONS} iterations, scratch={SCRATCH_SIZE}B, read={READ_LEN}B, timeout={:?}", ITER_TIMEOUT);
+
+    let dir = tempdir().expect("tempdir");
+    let scratch_path = dir.path().join("scratch_mmap.bin");
+    let source_path = dir.path().join("source.bin");
+
+    {
+        let mut f = File::create(&scratch_path).expect("create scratch");
+        f.set_len(SCRATCH_SIZE as u64).expect("set_len scratch");
+        f.sync_all().expect("sync_all scratch");
+    }
+    {
+        let mut f = File::create(&source_path).expect("create source");
+        let payload: Vec<u8> = (0..READ_LEN).map(|i| (i % 251) as u8).collect();
+        f.write_all(&payload).expect("write source payload");
+        f.sync_all().expect("sync_all source");
+    }
+
+    let mut tally = StatusTally::default();
+    for iter in 0..ITERATIONS {
+        let outcome = run_one_iteration(iter, &scratch_path, &source_path);
+        println!("repro_sqpoll_mmap iter={iter:02} status={outcome}");
+        tally.record(&outcome);
+        if matches!(outcome, IterStatus::SqpollUnavailable) {
+            println!(
+                "repro_sqpoll_mmap: SQPOLL unavailable on this kernel / privilege \
+                 level; remaining iterations would be redundant"
+            );
+            break;
+        }
+    }
+
+    println!("repro_sqpoll_mmap summary: {tally}");
+}
+
+/// Result of a single reproducer iteration. Each variant maps to one cell in
+/// the failure-modes table in `docs/design/sqpoll-mmap-race-symptoms.md`.
+#[derive(Debug)]
+enum IterStatus {
+    Ok { bytes: usize, elapsed: Duration },
+    Short { bytes: usize },
+    EFault,
+    EAgain,
+    NegativeErrno(i32),
+    Timeout,
+    SqpollUnavailable,
+    RegisterFailed(std::io::Error),
+    SubmitFailed(std::io::Error),
+}
+
+impl std::fmt::Display for IterStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IterStatus::Ok { bytes, elapsed } => write!(f, "ok bytes={bytes} elapsed={elapsed:?}"),
+            IterStatus::Short { bytes } => write!(f, "short bytes={bytes}"),
+            IterStatus::EFault => write!(f, "efault"),
+            IterStatus::EAgain => write!(f, "eagain"),
+            IterStatus::NegativeErrno(e) => write!(f, "errno={e}"),
+            IterStatus::Timeout => write!(f, "timeout"),
+            IterStatus::SqpollUnavailable => write!(f, "sqpoll-unavailable"),
+            IterStatus::RegisterFailed(e) => write!(f, "register-failed: {e}"),
+            IterStatus::SubmitFailed(e) => write!(f, "submit-failed: {e}"),
+        }
+    }
+}
+
+#[derive(Default)]
+struct StatusTally {
+    ok: usize,
+    short: usize,
+    efault: usize,
+    eagain: usize,
+    other_errno: usize,
+    timeout: usize,
+    sqpoll_unavailable: usize,
+    register_failed: usize,
+    submit_failed: usize,
+}
+
+impl StatusTally {
+    fn record(&mut self, status: &IterStatus) {
+        match status {
+            IterStatus::Ok { .. } => self.ok += 1,
+            IterStatus::Short { .. } => self.short += 1,
+            IterStatus::EFault => self.efault += 1,
+            IterStatus::EAgain => self.eagain += 1,
+            IterStatus::NegativeErrno(_) => self.other_errno += 1,
+            IterStatus::Timeout => self.timeout += 1,
+            IterStatus::SqpollUnavailable => self.sqpoll_unavailable += 1,
+            IterStatus::RegisterFailed(_) => self.register_failed += 1,
+            IterStatus::SubmitFailed(_) => self.submit_failed += 1,
+        }
+    }
+}
+
+impl std::fmt::Display for StatusTally {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ok={} short={} efault={} eagain={} other_errno={} timeout={} \
+             sqpoll_unavailable={} register_failed={} submit_failed={}",
+            self.ok,
+            self.short,
+            self.efault,
+            self.eagain,
+            self.other_errno,
+            self.timeout,
+            self.sqpoll_unavailable,
+            self.register_failed,
+            self.submit_failed,
+        )
+    }
+}
+
+fn run_one_iteration(
+    iter: usize,
+    scratch_path: &std::path::Path,
+    source_path: &std::path::Path,
+) -> IterStatus {
+    let mut ring = match IoUring::builder()
+        .setup_sqpoll(SQPOLL_IDLE_MS)
+        .build(SQ_ENTRIES)
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("repro_sqpoll_mmap iter={iter:02}: SQPOLL build failed: {e}");
+            return IterStatus::SqpollUnavailable;
+        }
+    };
+
+    let scratch = match OpenOptions::new().read(true).write(true).open(scratch_path) {
+        Ok(f) => f,
+        Err(e) => return IterStatus::SubmitFailed(e),
+    };
+    let source = match File::open(source_path) {
+        Ok(f) => f,
+        Err(e) => return IterStatus::SubmitFailed(e),
+    };
+
+    // SAFETY: the test owns `scratch_path` exclusively for the duration of
+    // the iteration; no other process mutates the file while the mapping
+    // is alive, so the kernel's view stays stable as required by `MmapMut`.
+    let mut mmap = match unsafe { MmapOptions::new().len(SCRATCH_SIZE).map_mut(&scratch) } {
+        Ok(m) => m,
+        Err(e) => return IterStatus::SubmitFailed(e),
+    };
+
+    // Deliberately do NOT touch any page here. The page-fault race depends
+    // on the SQPOLL kthread being the first to write into the mapping.
+
+    let iovec = libc::iovec {
+        iov_base: mmap.as_mut_ptr().cast::<libc::c_void>(),
+        iov_len: READ_LEN,
+    };
+    // SAFETY: `iovec` points at the live `mmap` mapping which outlives the
+    // ring; the registered buffer stays valid until `unregister_buffers`
+    // runs below. The kernel's `IORING_REGISTER_BUFFERS` call only inspects
+    // the iovec during the syscall.
+    let register_result = unsafe { ring.submitter().register_buffers(&[iovec]) };
+    if let Err(e) = register_result {
+        return IterStatus::RegisterFailed(e);
+    }
+
+    let read_sqe = opcode::ReadFixed::new(
+        types::Fd(source.as_raw_fd()),
+        mmap.as_mut_ptr(),
+        READ_LEN as u32,
+        0,
+    )
+    .offset(0)
+    .build()
+    .user_data(READ_USER_DATA);
+
+    // SAFETY: `read_sqe` references `source` (live for the iteration) and
+    // the registered mmap buffer (live for the iteration); both outlast the
+    // submission + reap below.
+    unsafe {
+        if let Err(e) = ring.submission().push(&read_sqe) {
+            return IterStatus::SubmitFailed(std::io::Error::other(format!(
+                "sq push failed: {e}"
+            )));
+        }
+    }
+
+    let timeout = types::Timespec::new()
+        .sec(ITER_TIMEOUT.as_secs())
+        .nsec(ITER_TIMEOUT.subsec_nanos());
+    let args = types::SubmitArgs::new().timespec(&timeout);
+
+    let started = Instant::now();
+    let submit_result = ring.submitter().submit_with_args(1, &args);
+    match submit_result {
+        Ok(_) => {}
+        Err(e) => {
+            // ETIME (62) is the documented return when GETEVENTS times out
+            // without a completion landing. Map it to the dedicated variant
+            // so the tally separates real submit failures from kernel
+            // stalls.
+            if e.raw_os_error() == Some(libc::ETIME) {
+                return IterStatus::Timeout;
+            }
+            return IterStatus::SubmitFailed(e);
+        }
+    }
+    if started.elapsed() >= ITER_TIMEOUT {
+        return IterStatus::Timeout;
+    }
+
+    let mut cq = ring.completion();
+    let cqe = match cq.next() {
+        Some(c) => c,
+        None => return IterStatus::Timeout,
+    };
+    assert_eq!(cqe.user_data(), READ_USER_DATA, "stray CQE");
+    let result = cqe.result();
+    drop(cq);
+
+    // Drop the buffer registration before the mmap unmaps so the kernel
+    // releases its pinned references first; matches the ring-then-buffer
+    // drop-order invariant documented in
+    // `crates/fast_io/src/io_uring/registered_buffers/mod.rs`.
+    if let Err(e) = ring.submitter().unregister_buffers() {
+        eprintln!("repro_sqpoll_mmap iter={iter:02}: unregister_buffers failed: {e}");
+    }
+
+    if result < 0 {
+        let errno = -result;
+        return match errno {
+            libc::EFAULT => IterStatus::EFault,
+            libc::EAGAIN => IterStatus::EAgain,
+            other => IterStatus::NegativeErrno(other),
+        };
+    }
+    let bytes = result as usize;
+    if bytes != READ_LEN {
+        return IterStatus::Short { bytes };
+    }
+    IterStatus::Ok {
+        bytes,
+        elapsed: started.elapsed(),
+    }
+}
+
+#[cfg(test)]
+mod sanity {
+    use super::*;
+
+    #[test]
+    fn constants_are_sane() {
+        assert!(SCRATCH_SIZE.is_multiple_of(READ_LEN));
+        assert!(READ_LEN > 0);
+        assert!(ITERATIONS > 0 && ITERATIONS < 1024);
+        assert!(ITER_TIMEOUT.as_secs() > 0);
+    }
+}

--- a/crates/fast_io/tests/repro_sqpoll_mmap.rs
+++ b/crates/fast_io/tests/repro_sqpoll_mmap.rs
@@ -109,7 +109,10 @@ const SQPOLL_IDLE_MS: u32 = 100;
 #[test]
 #[ignore = "requires CAP_SYS_NICE for SQPOLL; run with --ignored on instrumented kernels"]
 fn repro_sqpoll_mmap_race() {
-    println!("repro_sqpoll_mmap: {ITERATIONS} iterations, scratch={SCRATCH_SIZE}B, read={READ_LEN}B, timeout={:?}", ITER_TIMEOUT);
+    println!(
+        "repro_sqpoll_mmap: {ITERATIONS} iterations, scratch={SCRATCH_SIZE}B, read={READ_LEN}B, timeout={:?}",
+        ITER_TIMEOUT
+    );
 
     let dir = tempdir().expect("tempdir");
     let scratch_path = dir.path().join("scratch_mmap.bin");
@@ -287,9 +290,7 @@ fn run_one_iteration(
     // submission + reap below.
     unsafe {
         if let Err(e) = ring.submission().push(&read_sqe) {
-            return IterStatus::SubmitFailed(std::io::Error::other(format!(
-                "sq push failed: {e}"
-            )));
+            return IterStatus::SubmitFailed(std::io::Error::other(format!("sq push failed: {e}")));
         }
     }
 

--- a/docs/design/sqpoll-mmap-race-symptoms.md
+++ b/docs/design/sqpoll-mmap-race-symptoms.md
@@ -213,10 +213,10 @@ the fallback so `--version` / diagnostics can surface it.
 This is the SMR Option 3 conservative path picked by tasks #2287..#2292
 and documented in `docs/design/mmap-vs-sqpoll-conflict-resolution.md`
 "Implementation plan (option 3)". The fallback path costs ~10-15% on NVMe
-+ large mmap'd basis workloads (per
-`/Users/ofer/.claude/projects/-Users-ofer-devel-rsync/memory/project_sqpoll_disabled_with_mmap.md`)
-but trades that for correctness: every failure mode above is sidestepped
-because the SQPOLL kthread never enters the picture.
++ large mmap'd basis workloads (per the SMR-1 bench cells in
+`crates/fast_io/benches/mmap_vs_read_fixed_basis.rs`) but trades that for
+correctness: every failure mode above is sidestepped because the SQPOLL
+kthread never enters the picture.
 
 The disable is intentionally crude. SQM-2 will use the SQM-1.a reproducer
 data to design a finer-grained workaround (candidates: `MADV_WILLNEED`

--- a/docs/design/sqpoll-mmap-race-symptoms.md
+++ b/docs/design/sqpoll-mmap-race-symptoms.md
@@ -1,0 +1,226 @@
+# SQPOLL + mmap race: symptoms and kernel-version coverage (SQM-1.b)
+
+Tracking issue: oc-rsync task #2626 (SQM-1) plus SQM-1.a (reproducer) and
+SQM-1.b (this document).
+
+Companion artefacts already in tree:
+
+- `docs/audits/io_uring_sqpoll_mmap_pagefault.md` - long-form failure-mode
+  audit covering the three kernel-side outcomes (synchronous fault, `io-wq`
+  punt, `-EFAULT`).
+- `docs/audits/mmap-page-fault-iouring-sqpoll.md` - companion three-mode
+  summary written first.
+- `docs/design/mmap-vs-sqpoll-conflict-resolution.md` - resolution-strategy
+  doc enumerating Options 1, 2, 3.
+- `docs/design/mmap-vs-sqpoll-decision.md` - the decision framework that
+  picked SMR Option 3.
+- `crates/fast_io/src/io_uring/config.rs:336-373` - the defensive disable
+  currently in production: `build_ring()` falls back to a non-SQPOLL ring
+  whenever `mmap_basis_active == true`.
+- `crates/fast_io/tests/repro_sqpoll_mmap.rs` - the SQM-1.a reproducer
+  documented below.
+
+## 1. What the race is
+
+io_uring's `IORING_SETUP_SQPOLL` mode starts a dedicated kernel thread
+(`io_sq_thread()` in `io_uring/sqpoll.c`; on kernels < 5.10 the same
+function lived in `fs/io_uring.c`) that polls the submission queue head and
+issues SQEs without the userspace task entering the kernel. The kthread
+borrows the submitter's `mm` via `kthread_use_mm()` so that user-virtual
+pointers in an SQE resolve through the right page tables. What it does not
+inherit is the userspace task's fault-handling stack, signal-delivery
+context, or scheduler class. That asymmetry is the hazard.
+
+When the SQPOLL kthread services an SQE that references a non-resident
+mmap'd user page, three outcomes are possible depending on kernel version
+and opcode:
+
+1. **Synchronous fault inside the kthread.** `io_issue_sqe()` derefs the
+   user pointer, hits a missing PTE, and `handle_mm_fault()` (in
+   `mm/memory.c`) runs inline on the kthread. For an anonymous or
+   already-resident file page this completes in microseconds. For a cold
+   file page the fault blocks on filesystem I/O. While the kthread is
+   blocked the SQ stops draining; every ring that shares this kthread
+   (post-5.11 with `wq_fd`) stalls. The latency win from SQPOLL is
+   converted into latency strictly worse than a regular ring.
+
+2. **Punt to `io-wq` task-work.** When the kernel detects the op cannot
+   complete inline it queues the request to an `io-wq` worker that re-runs
+   the op with the submitter's `mm` and takes the fault on its own stack.
+   The request now costs one SQ-poll wakeup, one work-queue dispatch, and
+   one CQE. Throughput becomes equal to (or worse than) a regular ring.
+
+3. **Short read or `-EFAULT`.** On older kernels (pre-5.12 for the
+   `IORING_OP_READ`/`WRITE` family) and on opcodes that do not punt, the
+   kthread fails the op outright. CQE returns a short result or `-EFAULT`.
+   Writers retry on short, but `-EFAULT` is fatal: it surfaces as
+   `io::Error` from `submit_and_wait` and the transfer aborts. The
+   truncate variant of this is the `SIGBUS`-on-mid-transfer-truncate case
+   upstream rsync sidesteps by never `mmap(2)`ing basis files
+   (`fileio.c:214-217`); under SQPOLL the fault is delivered in kernel
+   context, so the userspace `SIGBUS` handler upstream relies on cannot
+   run.
+
+The `IORING_REGISTER_BUFFERS` path adds a fourth surface: registration
+synchronously calls `get_user_pages_fast()` and pins each page. If the
+registered iovec is backed by an mmap, registration either eats the
+fault cost up front or returns `-EFAULT` for a hole; subsequent SQEs that
+name the registered slot are immune to faults because the pages are pinned
+until `unregister_buffers`.
+
+### Primary kernel-source citations
+
+- `io_uring/sqpoll.c::io_sq_thread()` - the polling loop. On kernels < 5.10
+  the same function lives in `fs/io_uring.c`. Upstream:
+  <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/io_uring/sqpoll.c>.
+- `io_uring/io_uring.c::io_issue_sqe()` - SQE dispatch entry that derefs
+  user pointers.
+- `mm/memory.c::handle_mm_fault()` - page-fault entry implicitly invoked
+  when the kthread derefs a non-resident page.
+- `kernel/kthread.c::kthread_use_mm()` - the `mm`-borrow primitive that
+  makes user-virtual pointers in SQEs resolve correctly under SQPOLL.
+
+### Secondary references
+
+- LWN: "The rapid growth of io_uring" - <https://lwn.net/Articles/810414/>
+  (background on SQPOLL design).
+- LWN: "Ringing in a new asynchronous I/O API" -
+  <https://lwn.net/Articles/776703/> (the original io_uring announcement
+  and `IORING_SETUP_SQPOLL` rationale).
+- man pages: `io_uring_setup(2)` (`IORING_SETUP_SQPOLL`),
+  `io_uring_register(2)` (`IORING_REGISTER_BUFFERS`),
+  `madvise(2)` (`MADV_WILLNEED`, `MADV_NOHUGEPAGE`),
+  `mmap(2)` (`MAP_POPULATE`).
+
+## 2. Reproducer how-to
+
+The reproducer lives at `crates/fast_io/tests/repro_sqpoll_mmap.rs`. It
+runs `ITERATIONS = 16` independent cycles, each one building a fresh ring,
+registering a 256 MiB mmap'd buffer, and submitting a single 4 KiB
+`READ_FIXED` against a separate source file. Every iteration has a strict
+5-second `submit_with_args` timeout so the reproducer cannot hang.
+
+The test is `#[ignore]` by default because SQPOLL requires `CAP_SYS_NICE`
+on most kernels. To run on an instrumented kernel:
+
+```sh
+cargo nextest run -p fast_io --features io_uring \
+    -E 'test(repro_sqpoll_mmap)' --ignored --no-capture
+```
+
+### Per-iteration status line format
+
+Each iteration prints exactly one line:
+
+```text
+repro_sqpoll_mmap iter=NN status=<outcome>
+```
+
+`<outcome>` is one of:
+
+| Status | Meaning |
+|---|---|
+| `ok bytes=N elapsed=...` | Iteration completed cleanly; CQE returned `READ_LEN` bytes. Race did not trip. |
+| `short bytes=N` | CQE returned `0 <= N < READ_LEN`. Maps to failure mode 3 (short read). |
+| `efault` | CQE returned `-EFAULT`. Maps to failure mode 3 (in-kernel fault refused). |
+| `eagain` | CQE returned `-EAGAIN`. Kernel asked for resubmission; recoverable but indicates the kthread could not complete inline. |
+| `errno=N` | CQE returned some other negative errno. Capture and triage. |
+| `timeout` | `submit_with_args` returned `ETIME` or the per-iteration budget elapsed without a CQE. Maps to failure mode 1 (kthread stalled). |
+| `sqpoll-unavailable` | `IoUring::builder().setup_sqpoll(...).build()` failed (typically `EPERM`). Reproducer aborts the remaining iterations. |
+| `register-failed: <err>` | `register_buffers` returned an error. Maps to the registration-path variant of failure mode 3. |
+| `submit-failed: <err>` | Setup of the read SQE failed before submission. Indicates an environment problem, not a race. |
+
+The reproducer concludes with a one-line summary tallying every status
+across iterations.
+
+### Success vs failure
+
+- **Pass condition (race did NOT trip):** every iteration reports
+  `status=ok`. This is the expected outcome on a kernel that handles
+  SQPOLL + registered mmap'd buffers correctly.
+- **Fail condition (race tripped):** any iteration reports `short`,
+  `efault`, `timeout`, `eagain`, or `errno=N`. Record the kernel version,
+  the failure-mode mapping, and the iteration count in the coverage matrix
+  below.
+
+A run that reports `sqpoll-unavailable` is inconclusive - the kernel did
+not grant SQPOLL, so the race surface was never reached. Re-run with
+`CAP_SYS_NICE` (typically via `sudo setcap cap_sys_nice=eip <bin>` on the
+test binary, or by running the test under `sudo`).
+
+## 3. Kernel-version coverage matrix
+
+Placeholder rows. Each cell is filled in when SQM-1.a runs on a fresh
+host. The kernel matrix matches the LTS line that production rsync
+deployments target plus the latest mainline.
+
+| Kernel | Major.minor | Iterations | ok | short | efault | timeout | eagain | other_errno | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| Linux 5.10 LTS | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| Linux 5.15 LTS | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| Linux 6.1 LTS  | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| Linux 6.6 LTS  | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| Linux 6.12     | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+How to populate a row:
+
+1. Boot a target kernel (KVM, hosted VPS, or bench hardware).
+2. Run the reproducer with `--ignored`. Capture stdout.
+3. Read the tally line and the per-iteration status lines.
+4. Replace the corresponding `TBD` cells. Cite the exact kernel build
+   (`uname -r`) in the `Notes` column.
+
+## 4. Failure modes seen
+
+Placeholder. SQM-1.b will be amended once the matrix above is populated.
+Categories to anticipate:
+
+- **Data corruption.** A non-`-EFAULT` short CQE that returns plausible-
+  looking bytes which do not match the source file. The reproducer does
+  not verify the bytes today; SQM-1.b round 2 will extend it to assert
+  byte equality and record this mode here.
+- **Hang.** A `submit_with_args` that exceeds the 5-second per-iteration
+  budget. Reproducer maps to `status=timeout` and continues.
+- **Kernel oops.** A panic in `dmesg` correlated with the iteration. Not
+  observable from the reproducer; capture out-of-band via `dmesg -w`.
+- **`-EFAULT` storm.** Every iteration returns `efault`. Strongest signal
+  that the registered-buffer + SQPOLL combination is structurally broken
+  on the target kernel.
+- **Throughput regression without errors.** Every iteration reports `ok`
+  but `elapsed` is much higher than a sibling non-SQPOLL run; indicates
+  failure mode 2 (silent `io-wq` punt). Not a correctness failure but
+  motivates promoting the defensive disable into a permanent policy on
+  the affected kernels.
+
+## 5. Why our current workaround works
+
+Production today disables SQPOLL whenever an mmap'd basis reader is
+active. The dispatch lives at
+`crates/fast_io/src/io_uring/config.rs:336-373`:
+
+```text
+if sqpoll_requested && !sqpoll_safe {
+    // refuse SQPOLL; fall back to a regular ring
+    SQPOLL_FALLBACK.store(true, Ordering::Relaxed);
+}
+```
+
+`sqpoll_safe = sqpoll_requested && !self.mmap_basis_active`. The flag is
+set by callers that own an `MmapReader` over the basis file. When the
+flag trips, `build_ring()` builds a regular (non-SQPOLL) ring and records
+the fallback so `--version` / diagnostics can surface it.
+
+This is the SMR Option 3 conservative path picked by tasks #2287..#2292
+and documented in `docs/design/mmap-vs-sqpoll-conflict-resolution.md`
+"Implementation plan (option 3)". The fallback path costs ~10-15% on NVMe
++ large mmap'd basis workloads (per
+`/Users/ofer/.claude/projects/-Users-ofer-devel-rsync/memory/project_sqpoll_disabled_with_mmap.md`)
+but trades that for correctness: every failure mode above is sidestepped
+because the SQPOLL kthread never enters the picture.
+
+The disable is intentionally crude. SQM-2 will use the SQM-1.a reproducer
+data to design a finer-grained workaround (candidates: `MADV_WILLNEED`
+prefault window, `mlock` the basis region for the registered-buffer
+window, or per-basis dispatch that keeps SQPOLL on for non-mmap'd basis
+paths). SQM-1.c will spec those three candidates side-by-side once this
+document's kernel-version matrix is populated.


### PR DESCRIPTION
## Summary

- SQM-1.a: standalone Linux-only reproducer at `crates/fast_io/tests/repro_sqpoll_mmap.rs` that exercises the SQPOLL + IORING_REGISTER_BUFFERS race surface against an mmap'd region. 16 bounded iterations, strict 5 s per-iteration `submit_with_args` timeout (cannot hang), one status line per iteration plus a tally.
- SQM-1.b: symptom + kernel-version coverage doc at `docs/design/sqpoll-mmap-race-symptoms.md` covering what the race is (with Linux kernel-source citations), how to read the reproducer's per-iteration status lines, a placeholder 5-row kernel matrix (5.10 / 5.15 / 6.1 / 6.6 / 6.12), and the rationale for the current defensive disable in `crates/fast_io/src/io_uring/config.rs:336-373`.
- Together: unblocks SQM-1.c (workaround spec) and SQM-2 (design SQPOLL-safe mmap basis dispatch) by giving designers a runnable signal source and a documented symptom catalogue.

## Why this exists

`crates/fast_io/src/io_uring/config.rs:336-373` defensively disables SQPOLL whenever a basis file is mmap'd because the SQPOLL kthread can race with userspace page-fault handling on the shared mapping. The disable costs ~10-15% throughput on NVMe + large basis workloads. The race itself was previously documented only in `docs/audits/io_uring_sqpoll_mmap_pagefault.md` (audit) - this PR adds an actual reproducer and a symptom-focused design doc that the SQM-2 work can build against.

## Test plan

- [ ] CI compiles the reproducer under `--features io_uring` on Linux cells. The test is `#[ignore]` by default so it does not run during normal CI; only `cargo nextest run -- --ignored` on instrumented hosts drives it.
- [ ] On non-Linux (`macos`, `windows`) the file is a no-op via `#![cfg(all(target_os = \"linux\", feature = \"io_uring\"))]` so CI must stay green.
- [ ] One sibling `#[test] fn constants_are_sane()` runs unconditionally on Linux with `io_uring` to catch trivial drift in the constants.
- [ ] Manual: run `cargo nextest run -p fast_io --features io_uring -E 'test(repro_sqpoll_mmap)' --ignored --no-capture` on a Linux host with `CAP_SYS_NICE` to confirm the reproducer can drive an SQPOLL ring end-to-end. Numbers go into the SQM-1.b matrix as a follow-up; this PR adds only the harness + placeholder rows.