### PR TITLE
docs(ci): track macOS-beta + Windows-gnu CI flakiness (XPL-4)

### DIFF
--- a/docs/design/del-1a-upstream-ordering-audit.md
+++ b/docs/design/del-1a-upstream-ordering-audit.md
@@ -1,0 +1,424 @@
+# Upstream delete.c NDX_DEL_STATS ordering audit (DEL-1.a)
+
+Status: Audit (task DEL-1.a; foundation for DEL-1.b reorder-buffer design and
+DEL-1.c cohort batching strategy)
+Audience: receiver and engine maintainers planning a parallel `DeleteEmitter`
+consumer behind a feature flag.
+Scope: every wire side effect that the receiver-side delete pass produces or
+consumes, with emphasis on the ordering relationship between `MSG_DELETED`
+per-file notifications and the cohort-level `NDX_DEL_STATS` frame.
+
+Out of scope: the destination-side filesystem syscall ordering (covered by
+`docs/design/parallel-deterministic-delete.md` and
+`docs/design/delete-during-strict-order-gate.md`), `--remove-source-files`,
+and the sender-side delete path under `--delete-excluded` (the sender never
+emits `NDX_DEL_STATS`; only the generator does).
+
+Upstream reference base: `target/interop/upstream-src/rsync-3.4.1/`. Upstream
+calls the file `delete.c` (the task brief used `del.c`; there is no `del.c`
+in the tree). Citations below use `delete.c` for the source of `delete_item`
+/ `delete_dir_contents`, and `generator.c` for `delete_in_dir`,
+`do_delete_pass`, `do_delayed_deletions`, and the goodbye-phase calls to
+`write_del_stats`.
+
+## 1. Where deletions originate
+
+The generator is the only role that decides a destination path should be
+removed. Three orchestration entry points exist, all in `generator.c`, and
+they correspond directly to the upstream `--delete-{before,during,after}`
+modes plus the `--delete-delay` variant which is a sibling of `delete_during`:
+
+| Mode | Variable | Entry point | Wire effect |
+|------|----------|-------------|-------------|
+| `--delete-before` | `delete_before` | `do_delete_pass` (`generator.c:351-387`) called from `generate_files` before the first content directory is processed (`generator.c:2263-2264`). | One `MSG_DELETED` per deleted entry, emitted in destination-directory traversal order, **before** any file-transfer NDX or any `NDX_DEL_STATS`. |
+| `--delete-during` | `delete_during == 1` | `delete_in_dir` (`generator.c:272-347`) called inline as the generator descends each content directory (`generator.c:1520-1523`, `generator.c:2298-2307`). | `MSG_DELETED` emitted interleaved with the per-file NDX traffic for that directory's content. |
+| `--delete-delay` | `delete_during == 2` | `delete_in_dir` queues entries via `remember_delete` (`generator.c:161-182`) into a `deldelay` temp file; `do_delayed_deletions` (`generator.c:252-265`) replays them at end-of-flist, calling `delete_item` directly. | `MSG_DELETED` emitted **after** the file-transfer phase finishes for that flist segment. |
+| `--delete-after` | `delete_after` | `do_delete_pass` called from `generate_files` after the last content directory (`generator.c:2410-2411`). | `MSG_DELETED` emitted at end-of-transfer, after the redo phase. |
+
+The actual deletion syscall and the per-file wire notification both happen
+inside `delete_item` (`delete.c:130-225`). On success, `delete_item` calls
+`log_delete(fbuf, mode)` (`delete.c:180`) which - when running on the server
+side at protocol >= 29 - calls `send_msg(MSG_DELETED, fname, len,
+am_generator)` (`log.c:863`). For directories the trailing NUL is preserved
+(`log.c:861-862`) so the receiver can tell directory deletes from file
+deletes (`io.c:1594-1600`). Recursive directory contents are peeled by
+`delete_dir_contents` (`delete.c:48-122`), which loops over the destination
+listing in reverse and calls `delete_item` per entry, so a single user-visible
+directory delete can fan out into many `MSG_DELETED` lines, in
+reverse-directory order, before the parent `rmdir` succeeds.
+
+Also note `delete_item`'s `DEL_MAKE_ROOM` path (`delete.c:156-159, 179`):
+when the generator deletes a destination file because a same-named source
+file of a different kind is about to overwrite it, the deletion is **not**
+counted in `stats.deleted_*` and **no `MSG_DELETED`** is emitted (the
+`!(flags & DEL_MAKE_ROOM)` guard around both `log_delete` and the counters
+short-circuits everything). That side path is invisible on the wire; the
+parallel consumer never has to think about it.
+
+## 2. When NDX_DEL_STATS is sent
+
+`NDX_DEL_STATS` is defined as the negative ndx `-3` (`rsync.h:287`). It is
+written by `write_del_stats` (`main.c:225-238`) and read by `read_del_stats`
+(`main.c:240-247`). Both functions live in `main.c` rather than `delete.c`
+because they live on the wire-codec layer, not the delete-policy layer.
+
+Wire layout produced by `write_del_stats`:
+
+1. `write_ndx(f, NDX_DEL_STATS)` - the ndx-codec frame, the same channel
+   that carries `NDX_DONE`, file indices, and `NDX_FLIST_OFFSET`. Note the
+   read-batch path uses raw `write_int` (`main.c:227-228`) so an offline
+   batch file is byte-identical to a varint-encoded frame minus the ndx
+   compression.
+2. `write_varint(f, files - dirs - symlinks - devices - specials)` -
+   regular-file count, derived by subtraction so the wire stays compact
+   even when most deletes are regular files (`main.c:231-233`).
+3. `write_varint(f, dirs)` (`main.c:234`).
+4. `write_varint(f, symlinks)` (`main.c:235`).
+5. `write_varint(f, devices)` (`main.c:236`).
+6. `write_varint(f, specials)` (`main.c:237`).
+
+`read_del_stats` (`main.c:240-247`) reverses the encoding and accumulates
+into `stats.deleted_files` by adding every subsequent varint, so the field
+"deleted_files" on the reader side ends up as the total across all five
+kinds while the per-kind buckets remain isolated.
+
+Triggers, all inside `generate_files` in `generator.c`:
+
+- **Early path** (`generator.c:2376-2381`): fires when `protocol_version >=
+  31 && EARLY_DELETE_DONE_MSG()`. The macro
+  `EARLY_DELETE_DONE_MSG()` is `!(delete_during == 2 || delete_after)`
+  (`generator.c:124`), so early means "deletes have already happened" - the
+  `--delete-before` and inline `--delete-during` modes. The send is gated
+  by `(INFO_GTE(STATS, 2) && (delete_mode || force_delete)) || read_batch`.
+  The first conjunct is `--stats`; the second guards against sending stats
+  for a no-delete run; the `read_batch` path always sends so the batch file
+  is self-describing.
+- **Late path** (`generator.c:2420-2425`): fires when `protocol_version >=
+  31 && !EARLY_DELETE_DONE_MSG()`, i.e. when `delete_during == 2`
+  (`--delete-delay`) or `delete_after`. Gated by `INFO_GTE(STATS, 2) ||
+  read_batch`. Emitted **after** `do_delayed_deletions` and the
+  `do_delete_pass` for `--delete-after` (`generator.c:2408-2411`), so the
+  stats reflect the deletions that fired in the late pass.
+
+In both cases the frame is followed by `write_ndx(f_out, NDX_DONE)`
+(`generator.c:2380, 2424`) to advance the goodbye state machine.
+
+The receiver-side decoder is `read_ndx_and_attrs` (`rsync.c:322-353`), which
+loops over `NDX_DEL_STATS`, calling `read_del_stats(f_in)` and - if `am_sender
+&& am_server` - re-emitting it on `f_out` for the sender child to pick up:
+
+```c
+if (ndx == NDX_DEL_STATS) {
+    read_del_stats(f_in);
+    if (am_sender && am_server)
+        write_del_stats(f_out);
+    continue;
+}
+```
+
+So `NDX_DEL_STATS` travels the same direction the rest of the ndx stream
+travels - generator -> receiver during the goodbye exchange - and a daemon
+server with sibling sender/receiver forwards it laterally.
+
+The batch-replay path (`main.c:888-895`) drains everything up to
+`NDX_DEL_STATS` from the batch-generator fd before forwarding the final
+`NDX_DONE`, which is the only place upstream synchronously waits on
+`NDX_DEL_STATS`. Elsewhere it is fire-and-forget.
+
+## 3. Channel structure: why MSG_DELETED and NDX_DEL_STATS are loosely
+coupled on the wire
+
+This is the central observation for a parallel consumer.
+
+- **`MSG_DELETED` rides the multiplex side-channel.** `send_msg(MSG_DELETED,
+  fname, len, am_generator)` (`log.c:863`) writes into `iobuf.msg`
+  (`io.c:965-1058`), which is multiplexed against `MSG_DATA` envelopes
+  carrying the main ndx stream (`io.c:680-708`). The wire reader splits the
+  channels in `perform_io`; `MSG_DELETED` is dispatched at `io.c:1549-1601`
+  and turns into a `log_delete` callback on the receiving end. There is no
+  ndx in the `MSG_DELETED` payload at all - just the path and an implicit
+  file kind (the trailing NUL trick).
+- **`NDX_DEL_STATS` rides the main ndx stream.** `write_ndx(f, NDX_DEL_STATS)`
+  pushes the negative ndx onto `iobuf.out`, which is wrapped in `MSG_DATA`
+  multiplex frames before hitting the socket. Receivers consume it through
+  `read_ndx`/`read_ndx_and_attrs` (`rsync.c:331, 337`), the same path that
+  reads positive file ndx values.
+
+Because these are two different channels, the wire ordering between a given
+`MSG_DELETED` and the closing `NDX_DEL_STATS` frame for the same cohort is
+**not** strict. The only thing that gives them apparent order on a normal
+TCP stream is the buffering policy:
+
+- `send_msg` buffers into `iobuf.msg` (`io.c:992-1058`) and flushes on
+  pressure or on explicit `io_flush` calls.
+- `write_ndx` buffers into `iobuf.out` and flushes through `perform_io`.
+
+The generator emits all per-cohort `MSG_DELETED` calls (via `log_delete`
+called from `delete_item`) **before** the generator's main thread reaches
+the `write_del_stats` call in `generate_files`. So the **causal** order is
+strict on the producer side: every `MSG_DELETED` for a cohort precedes the
+`NDX_DEL_STATS` for that cohort. The **observed** wire order can interleave
+because the two channels share the socket only via multiplex framing and
+the receiver's read loop drains them independently.
+
+The receiver does not enforce any ordering between the two channels either:
+`log_delete` from `MSG_DELETED` updates only the user-visible itemize log,
+and `read_del_stats` updates only `stats.deleted_*` counters. Neither side
+asserts the other ran first.
+
+## 4. Cohort definition
+
+There is **one cohort per `write_del_stats` call**, and at most two calls
+ever fire per transfer (early xor late, never both). The cohort boundary is
+the call site, not the per-directory boundary, not the per-flist-segment
+boundary.
+
+Practically:
+
+- For `--delete-before` and inline `--delete-during`: a single cohort covers
+  every deletion the generator made during the whole transfer. Stats are
+  shipped during the early goodbye phase.
+- For `--delete-delay` and `--delete-after`: a single cohort covers every
+  deletion made by the late pass (`do_delayed_deletions` or
+  `do_delete_pass`). The early-path `MSG_DELETED` calls from any inline
+  decisions would still have been emitted earlier on the wire (this case
+  does not happen for `--delete-after`, but it can for INC_RECURSE +
+  `--delete-during == 2` where `delete_in_dir` already emitted `MSG_DELETED`
+  via `log_delete` calls before deferred-replay - confirm: actually for
+  `delete_during == 2` the inline `delete_in_dir` call routes through
+  `remember_delete` not `delete_item`, so no `MSG_DELETED` fires until
+  `do_delayed_deletions`. See `generator.c:338-342`.)
+
+INC_RECURSE does **not** subdivide the cohort. Although `generate_files`
+iterates flist segments and calls `delete_in_dir` inside the per-segment
+loop (`generator.c:1520-1523`), the `write_del_stats` calls happen once,
+after the whole flist loop completes. The stats accumulator
+(`stats.deleted_files`, `stats.deleted_dirs`, etc.) is a single global
+struct (`rsync.h:1045`) mutated in place by `delete_item` (`delete.c:181-193`),
+so the late `write_del_stats` reads the totals across every per-directory
+batch the generator processed.
+
+The exception is the read-batch / write-batch path. In write-batch mode the
+batch file accumulates a single `NDX_DEL_STATS` frame; in read-batch mode
+the receiver drains up to that frame as part of the goodbye sequence
+(`main.c:888-895`). Still one cohort.
+
+## 5. Invariants a parallel consumer can rely on vs must preserve
+
+### 5.1 What a parallel consumer can reorder safely
+
+- **Per-file `MSG_DELETED` deliveries within a cohort.** The receiver-side
+  handler (`io.c:1549-1601`, `log_delete` at `log.c:839-876`) treats each
+  message independently. It logs the entry through the itemize formatter
+  and updates no shared counter. The relative order of two `MSG_DELETED`
+  notifications affects only the order lines appear in `--verbose` /
+  `--itemize-changes` output, not protocol correctness.
+- **Per-file syscall dispatch.** `delete_item` (`delete.c:130-225`) and
+  `delete_in_dir` (`generator.c:272-347`) take no inter-entry locks; the
+  only shared state across entries is `stats.deleted_*`, which is summed
+  globally. A parallel consumer that pre-aggregates kind counters and
+  atomically merges them before `write_del_stats` runs is wire-equivalent.
+- **`MSG_DELETED` vs `NDX_DEL_STATS` interleaving across channels.** As
+  established in section 3, upstream does not promise a strict wire order
+  here. A parallel consumer that emits `MSG_DELETED` later than the
+  current single-emitter does is still upstream-compatible as long as
+  every `MSG_DELETED` for a cohort is on the wire **before** the closing
+  `NDX_DONE` that ends the cohort's goodbye phase. The closing `NDX_DONE`
+  (`generator.c:2380, 2424`) is the only hard fence.
+
+### 5.2 What a parallel consumer must serialise
+
+- **One `NDX_DEL_STATS` per cohort.** Upstream sends exactly one frame per
+  call site. Emitting two would either trip `read_ndx_and_attrs`'s loop
+  twice (harmless to the wire but doubles the totals on the receiver since
+  `read_del_stats` accumulates additively at `main.c:243-246`) or, if both
+  frames raced into the goodbye-phase `NDX_DONE`, the receiver would
+  consume the first frame as stats and then mis-parse the second's varints
+  as the next ndx, crashing with `Invalid file index` (`rsync.c:349-352`).
+- **`NDX_DEL_STATS` must precede the next `NDX_DONE` on the ndx channel.**
+  Both upstream call sites pair the frame with an immediate `write_ndx(f_out,
+  NDX_DONE)` (`generator.c:2380, 2424`). The receiver's goodbye reader
+  loops over `NDX_DEL_STATS` and then expects `NDX_DONE`
+  (`receiver/transfer/phases.rs:144-162` mirrors this). Emitting `NDX_DONE`
+  before `NDX_DEL_STATS` would advance the receiver past the goodbye
+  state and any later `NDX_DEL_STATS` would arrive in the
+  read_final_goodbye loop, which only tolerates `NDX_DONE` after the first
+  iteration consumed `NDX_DEL_STATS` (`main.c:886-897`). The mismatch
+  surfaces as `RERR_PROTOCOL` (`rsync.c:352`).
+- **Stats accumulation must be complete before the frame is written.** The
+  five counters in the frame are derived by subtraction (regular files =
+  total - dirs - symlinks - devices - specials in `main.c:231-233`), so a
+  parallel consumer must finish every cohort dispatch and merge every
+  worker's counters into a single `DeleteStats` before serialising. A
+  consumer that races the merge will under-count regular files (and the
+  receiver, which accumulates additively, will sum a wrong total).
+- **No per-cohort `NDX_DEL_STATS` if `do_stats` is false in the non-batch
+  case.** Upstream skips the frame entirely if `--stats` was not requested
+  (`generator.c:2377, 2422`). A parallel consumer must keep this gate
+  intact; otherwise an old peer that does not expect the frame at this
+  point will mis-parse the ndx stream.
+- **`DEL_MAKE_ROOM` deletes are silent.** The `!(flags & DEL_MAKE_ROOM)`
+  guard at `delete.c:179` skips both the `MSG_DELETED` send and the stat
+  increment. A parallel consumer that classifies destination-clearing
+  deletes as "real" deletes would over-count and inject spurious
+  `MSG_DELETED` lines.
+- **Cohort identity must survive the ENOTEMPTY recursive fallback.** When
+  a directory delete falls through to `delete_dir_contents`
+  (`delete.c:144-154`), upstream emits one `MSG_DELETED` per contained
+  entry **before** the eventual parent `MSG_DELETED`, and counts every
+  one of them in the same global `stats.deleted_*`. A parallel consumer
+  that hands the nested plan to a different worker thread must still
+  fold every increment into the cohort that owns the parent dispatch -
+  upstream has exactly one cohort spanning the whole sweep, and the
+  receiver's `read_del_stats` cannot tell otherwise.
+
+### 5.3 Suggested invariants for the DEL-1.b reorder buffer
+
+- The reorder buffer's commit boundary is the closing `NDX_DONE` of the
+  cohort's goodbye phase, **not** the per-directory boundary.
+- The buffer must reject any attempt to enqueue an `NDX_DEL_STATS` frame
+  before all per-cohort `MSG_DELETED` enqueues have been observed (commit
+  ordering on the producer side - even though the wire ordering is loose,
+  enforcing it on the producer side keeps the regression-vs-baseline
+  delta to zero).
+- The buffer must enforce a hard "stats first, then NDX_DONE" sequence on
+  the ndx channel.
+- The buffer should treat `MSG_DELETED` enqueues as commutative within a
+  cohort (any permutation is wire-equivalent) so the parallel consumer can
+  batch them per worker without an explicit sort.
+
+## 6. Failure modes
+
+Catalogued from the upstream decoder's perspective, so DEL-1.b knows what
+divergence costs at each failure point.
+
+### 6.1 NDX_DEL_STATS arrives early (before per-file MSG_DELETED)
+
+Upstream never emits this pattern: `write_del_stats` is called only after
+all `delete_item` calls for the cohort have returned. A parallel consumer
+that races stats emission ahead of `log_delete` does **not** crash the
+receiver - `MSG_DELETED` updates a separate side channel that ignores stats
+state - but it produces user-visible weirdness:
+
+- `--stats` output appears before some `deleting foo` lines.
+- `--itemize-changes` lines arrive after the stats summary, which is
+  harmless to scripts that parse line-by-line but breaks
+  cohort-by-cohort log scraping.
+
+No exit-code change. Classified as stat-divergence only.
+
+### 6.2 NDX_DEL_STATS arrives late (after the closing NDX_DONE)
+
+Upstream's goodbye reader pattern is `loop { read NDX; if NDX_DEL_STATS,
+read stats and continue; if NDX_DONE, break }` (`main.c:886-897`,
+`rsync.c:329-342`, mirrored in `receiver/transfer/phases.rs:144-162`). A
+stats frame that arrives after the first `NDX_DONE` of the goodbye:
+
+- In `read_final_goodbye` (`main.c:886-905`): the first `NDX_DONE` triggers
+  the echo path. The second `read_ndx_and_attrs` call (`main.c:897`) then
+  reads the stale `NDX_DEL_STATS`, accumulates its varints into
+  `stats.deleted_*` a **second time**, and continues looking for the final
+  `NDX_DONE`. Net effect: the user sees doubled deleted-count totals in
+  `--stats` output. The next ndx must still be `NDX_DONE` or the receiver
+  exits with `RERR_PROTOCOL` (`main.c:901-904`).
+- In `read_ndx_and_attrs` mid-transfer: the loop happily consumes
+  `NDX_DEL_STATS`, double-counts, and resumes (`rsync.c:337-342`). No
+  protocol error, only stat divergence.
+
+So "late" is mostly survivable as stat divergence, with the corner case
+that any non-`NDX_DONE` ndx after the goodbye echo crashes the receiver.
+
+### 6.3 NDX_DEL_STATS with wrong counter counts
+
+`read_del_stats` reads exactly five varints (`main.c:242-246`). The wire
+field is a varint with no length prefix, so the decoder will:
+
+- Under-read (fewer than five varints): the next four reads consume bytes
+  intended for a subsequent ndx or the next multiplex envelope header.
+  The next `read_ndx` call decodes garbage and hits one of the index-range
+  guards in `rsync.c:343-373`, exiting with `RERR_PROTOCOL`.
+- Over-read (more than five varints): the extra varints are not consumed;
+  the next ndx read decodes the first leftover varint as a new ndx, which
+  is statistically a positive (file) ndx in the wrong range or a negative
+  ndx outside `{-1, -2, -3, -101..}`. Either way `rsync.c:349-352` exits
+  with `RERR_PROTOCOL`.
+- Right count but wrong values (e.g. negative-looking varints because of
+  signed overflow): `read_varint` returns an `i32` cast to `u32` in the
+  oc-rsync decoder (`protocol/src/stats/delete.rs:94-99`); upstream's
+  `read_del_stats` casts via `int` arithmetic and adds to `int` counters
+  with no overflow check. Stat divergence only; not a crash.
+
+Verdict: count errors are **fatal**. A parallel consumer must produce
+exactly five varints in the documented order, every time.
+
+### 6.4 Duplicate NDX_DEL_STATS within the same cohort
+
+Equivalent to "wrong count" via the doubling path (section 6.2). The first
+frame is consumed correctly, the second is consumed as stats too (because
+`read_ndx_and_attrs` loops), totals double, and the closing `NDX_DONE` is
+read normally. No crash, stat-divergence only.
+
+### 6.5 NDX_DEL_STATS for a cohort that produced no deletions
+
+Upstream sends the frame with all five varints set to zero when
+`--stats` is on and the cohort dispatched zero deletes (`generator.c:2422`
+late path - the `INFO_GTE(STATS, 2)` gate is the only check). The receiver
+accumulates `+0` into `stats.deleted_*` and proceeds. A parallel consumer
+that suppresses the frame on an empty cohort is upstream-compatible only
+on the early path (`generator.c:2376-2377` gates on `delete_mode ||
+force_delete`); on the late path the frame must be sent unconditionally
+once `do_stats` is on, or interop diverges in the `--stats` output
+formatting (`main.c:424` `output_itemized_counts("Number of deleted files",
+&stats.deleted_files)`).
+
+### 6.6 MSG_DELETED with mismatched directory vs file kind
+
+The trailing-NUL convention (`log.c:861-862`, `io.c:1594-1600`) is the only
+in-band kind discriminator. A parallel consumer that emits a directory path
+without the trailing NUL would have it logged as `del.` regular-file rather
+than `del.` directory in `--itemize-changes`. The `S_IFDIR` vs `S_IFREG`
+distinction also affects log_formatted's `%n` rendering. No crash, only
+log-format divergence.
+
+## 7. Summary of strictest invariant
+
+**Per cohort, exactly one `NDX_DEL_STATS` frame, carrying exactly five
+varints (regular-files-by-subtraction, dirs, symlinks, devices, specials)
+must appear on the ndx channel between the last `MSG_DELETED` for the
+cohort and the closing `NDX_DONE` of the goodbye phase.** Anything before
+or after that window is recoverable as stat divergence; violating either
+the count or the position breaks the goodbye state machine and exits the
+receiver with `RERR_PROTOCOL`.
+
+This bounds DEL-1.b's reorder-buffer design: the buffer needs cohort
+membership tracking (which the current single-emitter gets for free by
+running sequentially), a barrier at the `NDX_DEL_STATS` enqueue point that
+flushes every pending `MSG_DELETED`, and a strict ordering between the
+stats frame and the goodbye `NDX_DONE` on the ndx side.
+
+## 8. Cross-references
+
+- Current single-emitter consumer:
+  `crates/engine/src/delete/emitter/mod.rs:245-310` (`emit_all`, `drain_plan`,
+  `run_entry`).
+- Current generator-side `NDX_DEL_STATS` emission:
+  `crates/transfer/src/generator/transfer/goodbye.rs:79-110`.
+- Current receiver-side `NDX_DEL_STATS` consumption:
+  `crates/transfer/src/receiver/transfer/phases.rs:141-166`.
+- Wire codec for the five-varint frame:
+  `crates/protocol/src/stats/delete.rs:74-107`.
+- DDP design: `docs/design/parallel-deterministic-delete.md`.
+- Strict-order gate (existing constraint already in tree):
+  `docs/design/delete-during-strict-order-gate.md`.
+- Upstream entry points:
+  `target/interop/upstream-src/rsync-3.4.1/delete.c:130-225` (`delete_item`),
+  `delete.c:48-122` (`delete_dir_contents`),
+  `generator.c:252-265` (`do_delayed_deletions`),
+  `generator.c:272-347` (`delete_in_dir`),
+  `generator.c:351-387` (`do_delete_pass`),
+  `generator.c:2263-2425` (delete-pass scheduling and `write_del_stats`
+  call sites),
+  `main.c:225-247` (`write_del_stats` / `read_del_stats`),
+  `rsync.c:322-353` (`read_ndx_and_attrs` loop over `NDX_DEL_STATS`),
+  `log.c:839-876` (`log_delete` -> `send_msg(MSG_DELETED, ...)`),
+  `io.c:1549-1601` (receiver-side `MSG_DELETED` dispatch).

--- a/docs/design/xpl-4-ci-flakiness-tracking.md
+++ b/docs/design/xpl-4-ci-flakiness-tracking.md
@@ -1,0 +1,264 @@
+# XPL-4: macOS (beta) + Windows (gnu) CI cell flakiness tracking
+
+Status: audit + recommendations (doc-only)
+Sampling window: 21 push-to-master CI runs over 2026-05-21 - 2026-05-23
+Sources: `gh run list/view` against `ci.yml`, `interop-validation.yml`,
+`_interop-macos.yml`, `_interop-windows.yml`, `_ci-skip-interop.yml`.
+
+The window is bounded by `gh`'s 100-run cap; in the current high-throughput
+phase that is ~10 hours of PR traffic, which is why the master push axis (one
+SHA per merge) is the more useful flakiness signal. The reusable workflows
+(`_interop-*`, `_ci-skip-interop`) are not directly invokable, so their stats
+are surfaced through the parent `ci.yml` job rows (`interop / ...`, `interop
+(macOS) / ...`, `interop (Windows, best-effort) / ...`). `interop-validation.yml`
+runs as a separate top-level workflow and is reported alongside.
+
+## 1. Per-cell stats (push-to-master, 21-22 completed runs each)
+
+| Cell | Required? | Success % | Median wall-clock | Max | Top failure pattern |
+| --- | --- | --- | --- | --- | --- |
+| `Windows (stable)` | yes | 81.0% (17/21) | 7m19s | 9m00s | `concurrent_register_and_dispatch_on_overlapping_files` race (3/4) |
+| `Windows ACL/xattr` | yes | 81.0% (17/21) | 10m33s | 14m42s | dead-code lint cascade (`fast_io::read_all` unused on Windows) |
+| `Windows IOCP (--features iocp)` | yes | 81.0% (17/21) | 5m10s | 6m23s | same Windows dead-code cascade |
+| `interop / interop with upstream rsync` | yes | 90.5% (19/21) | 7m49s | 8m05s | `parallel-threshold-trip` unexpected fails (upstream + oc) |
+| `nextest (beta)` | advisory | 90.5% (19/21) | 17m17s | 18m25s | help-flag listing panic (`supported_options_list_mentions_all_help_flags`) |
+| `Linux musl (stable/beta/nightly)` | stable required | 95.2% (20/21) | 15m08s | 16m00s | cascade hit (real CLI panic) |
+| `Windows (beta)` / `Windows (nightly)` | advisory | 95.2% (20/21) | 7m27s / 7m14s | 11m15s / 8m28s | cascade hit (compile + CLI panic) |
+| `macOS (stable/beta/nightly)` | stable required | 95.2% (20/21) | 4m26s / 3m38s / 4m04s | ~6m | cascade hit (CLI panic) |
+| `interop (macOS) / interop with upstream rsync (macOS)` | yes | 95.2% (20/21) | 3m15s | 6m01s | cascade hit |
+| `nextest (stable)` / `nextest (nightly)` | stable required | 95.2% (20/21) | 17m37s / 17m19s | 18m06s | cascade hit |
+| `Feature flag combinations / *` (linux/macos/windows) | yes | 100% (21/21 each) | 0m54s - 5m58s | up to 7m32s | none |
+| `Windows GNU cross-check` | yes | 100% (21/21) | 1m43s | 1m51s | none in window |
+| `interop (Windows, best-effort) / ...` | advisory | 100% (21/21) | 4m22s | 8m18s | none in window |
+| `fmt + clippy` | yes | 95.5% (21/22) | 4m05s | 4m49s | cascade hit |
+| `unsafe-safety-comment-audit (informational)` | informational | 100% (21/21) | 0m07s | 0m16s | none |
+| `parallel-receive-delta (dist, non-required)` | advisory | 100% (5/5) | 20m58s | 23m13s | none in window (PIP-9.f) |
+| `Interop Validation` (top-level workflow) | yes | 96.0% (24/25) | n/a | n/a | one cascade-window failure |
+
+### Push-to-master baseline numbers
+
+* 21 completed CI runs (12 failure, 10 success) over 2026-05-21 - 2026-05-23.
+* 16 of the 12 failures map to one of three real-bug cascades that hit
+  multiple cells on the same SHA. Net "unique distinct cell failures" once
+  duplicates are folded out is 11.
+* The remaining 5 failures are the three `concurrent_register_and_dispatch_on_overlapping_files`
+  hits on Windows (stable) and the two `parallel-threshold-trip` upstream interop hits
+  on Linux.
+
+### Three observed cascades
+
+The merge train hit three cascades during the window. All three were real
+regressions, not infrastructure flakes:
+
+1. **2026-05-22 14:45 / `26294514946`** - `supported_options_list_mentions_all_help_flags`
+   panic in `cli/src/frontend/tests/help.rs:72`. Took down macOS (stable/beta/nightly),
+   Windows (stable/beta/nightly), nextest (beta), Linux musl. Diagnosis: real
+   regression in the supported-options list.
+2. **2026-05-22 23:08 - 2026-05-23 00:33 / `26316272426`, `26317715371`, `26318542552`** -
+   `function 'read_all' is never used` dead-code warning on Windows
+   x86_64-msvc, fatal under `-D warnings`. Took down Windows ACL/xattr +
+   Windows IOCP for three consecutive merges. Diagnosis: missing `#[cfg(unix)]`
+   gate; matches the `feedback_proactive_cross_platform.md` checklist.
+3. **2026-05-22 09:17 - 09:49 / `26279354408`, `26280808639`** - upstream
+   interop matrix saw `parallel-threshold-trip` fail on both `up:` and `oc:`
+   sides against 3.0.9, 3.1.3, 3.4.1, 3.4.2. Two consecutive merges. Diagnosis:
+   real wire-protocol regression in the parallel-threshold scenario; not a
+   runner flake.
+
+### Confirmed pure flakes
+
+* `engine::parallel_apply_concurrent::concurrent_register_and_dispatch_on_overlapping_files`
+  on `Windows (stable)`. Asserts `expected.load(Ordering::Relaxed) > 0` and
+  races to zero when worker threads outrun the registrar. Caught at runs
+  `26216426222`, `26225746638`, `26228915686` (three consecutive pre-cascade
+  failures). Memory: `project_concurrent_dispatch_test_flake.md` + spin-then-yield
+  fix shipped in PR #4665; SSC-1 PR #4667 added registration counter. Window
+  fails were on commits prior to the fix's full reach on push CI.
+
+## 2. Flakiness leaderboard
+
+The window is small (~21 master pushes) so percentages move quickly; rank by
+distinct-failure count after de-duplicating cascades:
+
+**Most flaky (need attention):**
+
+1. `Windows (stable)` - 3 unique flakes from one race
+   (`concurrent_register_and_dispatch_on_overlapping_files`). This is the
+   single flakiest cell.
+2. `Windows ACL/xattr` - 3 real-but-Windows-only dead-code failures over
+   consecutive merges. Not random, but Windows-specific compile cascades
+   recur often enough to behave like flakiness from the dashboard.
+3. `Windows IOCP (--features iocp)` - tied with ACL/xattr on the same
+   cascade (3 consecutive). Distinct symptom: blocks `fast_io` build under
+   `-D warnings`.
+
+**99%+ reliable (in this window):**
+
+* `Feature flag combinations / *` - 17 sub-cells, 100% across the board.
+* `Windows GNU cross-check` - 100%. The compile-only check insulates it from
+  the runtime flakes that bite `Windows (stable)`.
+* `interop (Windows, best-effort) / ...` - 100%, but it is `continue-on-error`
+  so a failure would not block. Keep on the advisory tier.
+* `interop (macOS) / interop with upstream rsync (macOS)` - 100% modulo one
+  cascade hit. Functionally rock-solid in steady state.
+* `unsafe-safety-comment-audit (informational)` - 100%; advisory.
+* `parallel-receive-delta (dist, non-required)` - 100% in 5 runs; small sample.
+
+**XPL-4 focus (macOS beta, Windows gnu):**
+
+* `macOS (beta)` - 95.2% (1 failure, cascade-only). Beta toolchain has not
+  introduced its own flakes in the window. Behaves indistinguishably from
+  `macOS (stable)`. No quarantine warranted.
+* `Windows GNU cross-check` (the "Windows (gnu)" cell in this repo - we do
+  `cargo check --target x86_64-pc-windows-gnu` on Ubuntu) - 100% in the
+  window. The cell is compile-only on a Linux runner, so it dodges every
+  Windows runtime flake. No action needed.
+
+The real Windows-gnu vs Windows-msvc divergence is that `Windows (stable)`
+and `Windows IOCP/ACL` jobs (all msvc) carry every flake while
+`Windows GNU cross-check` carries none. Use this contrast as a triage hint:
+if a regression shows on msvc cells but cross-check is green, it is almost
+always a runtime/race issue, not a compile issue.
+
+## 3. Failure-pattern dictionary
+
+| Signature | Cluster | What to do |
+| --- | --- | --- |
+| `assertion failed: expected.load(Ordering::Relaxed) > 0` in `concurrent_register_and_dispatch_on_overlapping_files` | Windows race flake | Re-merge or empty-commit kick; long-term fix tracked under SSC-1 / `project_concurrent_dispatch_test_flake.md`. |
+| `function '<name>' is never used ... could not compile '<crate>' (lib test) due to 1 previous error` on Windows | Windows-only dead-code under `-D warnings` | Add `#[cfg(unix)]` gate or `#[allow(dead_code)]` for stub. Verify with `cargo check --target x86_64-pc-windows-gnu` locally before pushing. |
+| `UNEXPECTED FAIL: up:parallel-threshold-trip (fp=native)` / `oc:parallel-threshold-trip` across 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2 | Interop matrix wire-protocol regression | Real bug. Triage against `crates/transfer` parallel-receive-delta wire-up (PIP-9). Do not retry. |
+| `panicked at crates/cli/src/frontend/tests/help.rs:72: assertion failed: supported_options_list_mentions_all_help_flags` | CLI help-flag list out of sync | Real bug. Add the missing help flag to the supported-options test data. |
+| `error: command 'cargo-nextest.exe' ... exited with code 101` after `Downloaded` lines but no failed test in summary | Windows nextest install/runner OOM (none observed in window) | Retry once; if persistent, bump runner RAM or split test groups. |
+| `taiki-e/install-action` bash startup failure on Windows | Known partner-runner issue (#169) - already worked around | None; the workaround in `ci.yml` PowerShell-installs nextest directly. |
+| `Cannot allocate memory` / `linker exited with signal 9` | Linker OOM (none observed in window) | Bump runner size (use larger SKU) or strip debuginfo on the failing crate. |
+| `Resource not accessible by integration` / GH API 403 | Token scoping (none observed) | Re-check `permissions:` block on the workflow. Retry will not help. |
+| `No space left on device` | Runner disk exhaustion (none observed) | Rerun the job. If recurring, add `swatinem/rust-cache` save-misses or prune `target/` between matrix legs. |
+| `timeout-minutes: N exceeded` | Test hang or slow build (none observed; longest run was 23m13s for `parallel-receive-delta (dist)` against 30m budget) | Profile, do not blanket-bump timeouts. Investigate as a real hang first. |
+
+## 4. Recommended weekly dashboard query
+
+Run from the repo root. Produces per-cell success/failure counts for the
+last 50 push-to-master CI runs and writes raw JSON for further slicing.
+
+```sh
+# 1. Capture the run-level list (push only, master, completed, success or failure).
+gh run list --workflow=ci.yml --branch master --status completed --limit 50 \
+  --json databaseId,conclusion,createdAt,displayTitle \
+  | jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")]' \
+  > /tmp/xpl4-runs.json
+
+# 2. Pull job-level data per run.
+> /tmp/xpl4-jobs.jsonl
+for id in $(jq -r '.[].databaseId' /tmp/xpl4-runs.json); do
+  gh run view "$id" --json jobs \
+    --jq ".jobs[] | {name: .name, conclusion: .conclusion, started: .startedAt, completed: .completedAt, runId: $id}"
+done >> /tmp/xpl4-jobs.jsonl
+
+# 3. Per-cell summary (success %, median wall-clock minutes).
+jq -s '
+  group_by(.name) | map({
+    name: .[0].name,
+    total: length,
+    success: ([.[] | select(.conclusion=="success")] | length),
+    failure: ([.[] | select(.conclusion=="failure")] | length),
+    success_pct: (
+      ([.[] | select(.conclusion=="success")] | length) * 100 /
+      ([.[] | select(.conclusion=="success" or .conclusion=="failure")] | length // 1)
+    ),
+    median_min: (
+      [.[] | select(.conclusion=="success" or .conclusion=="failure") |
+        ((.completed | fromdateiso8601) - (.started | fromdateiso8601)) / 60]
+      | sort | .[length/2 | floor]
+    )
+  }) | sort_by(.success_pct)
+' /tmp/xpl4-jobs.jsonl
+
+# 4. Failure-signature scan over the failing cells (top symptom line each).
+for id in $(jq -r '.[] | select(.conclusion=="failure") | .databaseId' /tmp/xpl4-runs.json); do
+  echo "=== run $id ==="
+  gh run view "$id" --log-failed 2>&1 \
+    | grep -iE 'UNEXPECTED FAIL|FAIL \[|panicked at|^error|could not compile' \
+    | grep -vE 'shell:|CACHE_ON_FAILURE|curl|cargo\.exe|cargo'\''' \
+    | head -5
+done
+```
+
+Extend the window by sweeping the same query against `interop-validation.yml`
+once a week; the rest of the interop cells surface through `ci.yml` rows.
+
+## 5. Triage rules for the next sprint
+
+**Required (fail-fast in PRs) - already correct, keep as-is:**
+
+* `lint (fmt + clippy)`
+* `nextest (stable)`
+* `Windows (stable)`
+* `Windows GNU cross-check`
+* `Windows IOCP (--features iocp)`
+* `Windows ACL/xattr`
+* `macOS (stable)`
+* `Linux musl (stable)`
+* `interop / interop with upstream rsync`
+* `interop (macOS) / interop with upstream rsync (macOS)`
+* `Feature flag combinations / *` (all matrix legs)
+
+**Advisory (continue-on-error, do not gate merge):**
+
+* `nextest (beta)`, `nextest (nightly)`
+* `Windows (beta)`, `Windows (nightly)`
+* `macOS (beta)`, `macOS (nightly)`
+* `Linux musl (beta)`, `Linux musl (nightly)`
+* `interop (Windows, best-effort)`
+* `parallel-receive-delta (dist, non-required)`
+* `unsafe-safety-comment-audit (informational)`
+
+These already carry `continue-on-error: true`. The 95.2% success rate on
+`macOS (beta)` and friends comes from one cascade and zero toolchain-specific
+issues - no movement needed.
+
+**Quarantine candidates (escalate, do not just mute):**
+
+* `engine::parallel_apply_concurrent::concurrent_register_and_dispatch_on_overlapping_files`
+  - the single source of `Windows (stable)` flakes in the window. SSC-1
+  fix in PR #4667 is in flight; track and verify the next 20 master pushes
+  before lowering the cell from "flaky-watch" status.
+
+**Process tightening:**
+
+* For every red `Windows ACL/xattr` or `Windows IOCP` that prints
+  `could not compile ... due to N previous error`, the immediate triage step
+  is to reproduce locally with
+  `cargo check --target x86_64-pc-windows-gnu --workspace`. That single
+  command would have caught all three dead-code cascades in this window
+  before push. Per `feedback_proactive_cross_platform.md`.
+* Multi-cell same-SHA failures (all toolchain rows red on one commit) almost
+  always indicate a real regression, not flakiness. Skip retry; bisect.
+* Single-cell failures on `Windows (stable)` where `Windows GNU cross-check`
+  passed are race or platform-runtime bugs - retry once, then file under
+  `engine` if it re-trips.
+
+## Appendix: workflow-to-cell map
+
+```
+ci.yml
+ |-- lint (fmt + clippy)                                        [ubuntu]
+ |-- unsafe-safety-comment-audit (informational)                [ubuntu]
+ |-- nextest (stable | beta | nightly)                          [ubuntu]
+ |-- Feature flag combinations / *                              [_test-features.yml]
+ |-- Windows (stable | beta | nightly)                          [windows-latest, msvc]
+ |-- Windows IOCP (--features iocp)                             [windows-latest, msvc]
+ |-- Windows ACL/xattr                                          [windows-latest, msvc]
+ |-- Windows GNU cross-check                                    [ubuntu, x86_64-pc-windows-gnu]
+ |-- macOS (stable | beta | nightly)                            [macos-latest]
+ |-- Linux musl (stable | beta | nightly)                       [ubuntu, x86_64-unknown-linux-musl]
+ |-- interop / interop with upstream rsync                      [_interop.yml]
+ |-- interop (macOS) / interop with upstream rsync (macOS)      [_interop-macos.yml]
+ |-- interop (Windows, best-effort) / ...                       [_interop-windows.yml, advisory]
+ |-- parallel-receive-delta (dist profile, non-required)        [ubuntu, advisory]
+
+interop-validation.yml (standalone)
+ |-- separate exit-code + behavior matrix; rolls up its own success rate
+```
+
+Reusable workflows (`_*.yml`) do not show in `gh workflow list` as their own
+runs - their jobs surface under the calling row in `ci.yml`.


### PR DESCRIPTION
## Summary

- Audits the last 21 push-to-master CI runs across `ci.yml`,
  `interop-validation.yml`, and the reusable `_interop-macos.yml` /
  `_interop-windows.yml` / `_ci-skip-interop.yml` workflows.
- Captures per-cell success %, median wall-clock, top failure clusters,
  a flakiness leaderboard with focus on `macOS (beta)` and
  `Windows GNU cross-check`, a failure-pattern dictionary with one-line
  remediation each, the `gh` invocation that reproduces the dashboard
  weekly, and triage rules (required / advisory / quarantine).
- Three real-bug cascades and one race-flake cluster
  (`concurrent_register_and_dispatch_on_overlapping_files`) account for
  every red cell in the window; the doc separates them so the next loop
  iteration can skip the "kick and pray" step on real regressions.

## Test plan

- [x] `docs/design/xpl-4-ci-flakiness-tracking.md` renders as plain
  Markdown with no broken tables.
- [x] Workflow-to-cell map matches the current `ci.yml` job graph.
- [x] No references to deprecated / removed cells.