### PR TITLE
fix(fast_io): gate copy_basis_range test helper to linux only

### DIFF
--- a/crates/fast_io/src/copy_basis_range.rs
+++ b/crates/fast_io/src/copy_basis_range.rs
@@ -252,7 +252,9 @@ mod imp {
 mod tests {
     use super::*;
     use std::fs::{File, OpenOptions};
-    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::io::Write;
+    #[cfg(target_os = "linux")]
+    use std::io::{Read, Seek, SeekFrom};
     use tempfile::tempdir;
 
     fn make_basis(dir: &std::path::Path, name: &str, payload: &[u8]) -> File {
@@ -274,6 +276,7 @@ mod tests {
             .unwrap()
     }
 
+    #[cfg(target_os = "linux")]
     fn read_all(dest: &mut File) -> Vec<u8> {
         dest.seek(SeekFrom::Start(0)).unwrap();
         let mut buf = Vec::new();


### PR DESCRIPTION
## Summary
- `read_all` test helper at `crates/fast_io/src/copy_basis_range.rs:277` is only used by the two `#[cfg(target_os = "linux")]` `copy_file_range` round-trip tests; on Windows IOCP CI it tripped the workspace-wide `-D dead-code` and broke the lib-test build.
- Gate the helper and its `Read/Seek/SeekFrom` imports with `#[cfg(target_os = "linux")]`. `Write` stays unconditional (used by `make_basis`).

## Test plan
- [ ] Windows IOCP `Test fast_io (--features iocp)` cell builds and passes.
- [ ] Linux + macOS test cells still compile (no regression on Read/Seek/SeekFrom imports).