### PR TITLE
refactor(engine): extract DecrementGuard into its own submodule (SPL-38.c)

### DIFF
--- a/crates/engine/src/concurrent_delta/parallel_apply/decrement_guard.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/decrement_guard.rs
@@ -1,0 +1,33 @@
+//! RAII decrement guard for the per-slot in-flight counter (SPL-38.c).
+//!
+//! Extracted from `parallel_apply/mod.rs` as part of the SPL-38 module
+//! decomposition; sibling to [`super::slot_barrier::SlotBarrier`]. The
+//! guard is the only call site of [`SlotBarrier::decrement_inflight`]
+//! and pairs with [`SlotBarrier::increment_inflight`] in
+//! [`super::SlotHandle::new`] so the FFB-1 invariant ("every Arc
+//! outstanding is reflected in the inflight counter") holds across early
+//! returns, `?` propagations, and panics.
+//!
+//! [`SlotBarrier::decrement_inflight`]: super::slot_barrier::SlotBarrier::decrement_inflight
+//! [`SlotBarrier::increment_inflight`]: super::slot_barrier::SlotBarrier::increment_inflight
+
+use std::sync::Arc;
+
+use super::slot_barrier::SlotBarrier;
+
+/// RAII guard returned alongside a [`SlotHandle`] that decrements the
+/// per-slot in-flight counter when dropped. Keeping the decrement in a
+/// dedicated drop type makes the bookkeeping exception-safe: if the worker
+/// panics mid-write or returns early via `?`, the counter still drops
+/// back to its pre-handoff value and `flush_workers` unblocks.
+///
+/// [`SlotHandle`]: super::SlotHandle
+pub(super) struct DecrementGuard {
+    pub(super) barrier: Arc<SlotBarrier>,
+}
+
+impl Drop for DecrementGuard {
+    fn drop(&mut self) {
+        self.barrier.decrement_inflight();
+    }
+}

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -50,8 +50,10 @@ use thiserror::Error;
 use super::reorder::ReorderBuffer;
 use super::types::FileNdx;
 
+mod decrement_guard;
 mod slot_barrier;
 
+use decrement_guard::DecrementGuard;
 use slot_barrier::SlotBarrier;
 
 /// Typed error variants for [`ParallelDeltaApplier::finish_file`] shutdown
@@ -278,21 +280,6 @@ impl FileSlot {
     /// Returns true if every submitted chunk for this file has hit the writer.
     fn drained(&self) -> bool {
         self.reorder.is_empty()
-    }
-}
-
-/// RAII guard returned alongside a [`SlotHandle`] that decrements the
-/// per-slot in-flight counter when dropped. Keeping the decrement in a
-/// dedicated drop type makes the bookkeeping exception-safe: if the worker
-/// panics mid-write or returns early via `?`, the counter still drops
-/// back to its pre-handoff value and `flush_workers` unblocks.
-struct DecrementGuard {
-    barrier: Arc<SlotBarrier>,
-}
-
-impl Drop for DecrementGuard {
-    fn drop(&mut self) {
-        self.barrier.decrement_inflight();
     }
 }
 


### PR DESCRIPTION
## Summary

Continues the parallel_apply decomposition (SPL-38 series) by lifting the `DecrementGuard` RAII type and its `Drop` impl out of `parallel_apply/mod.rs` into a sibling `decrement_guard.rs` module. Mirrors the SPL-38.b precedent that extracted `SlotBarrier`.

Public-API neutral: the type was file-private and stays file-private; `SlotHandle::new` constructs the guard exactly as before through a module-level `use decrement_guard::DecrementGuard;`. No call sites change.

## Test plan

- cargo nextest run -p engine (CI verifies)