### PR TITLE
feat(core): add sender-inc-recurse feature flag for INC_RECURSE interop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,14 @@ parallel-receive-delta = [
     "engine/parallel-receive-delta",
 ]
 
+# Sender-side INC_RECURSE interop bake-up (ISI.b). Default OFF; flips the
+# `inc_recursive_send` builder fallback ON so push transfers advertise the
+# `'i'` capability bit. Wire behavior is unchanged when the flag is absent.
+# Forwards to `core/sender-inc-recurse`. ISI.h will flip the default and
+# retire this flag once interop is validated. See
+# `docs/design/isi-a-sender-inc-recurse-call-graph.md`.
+sender-inc-recurse = ["core/sender-inc-recurse"]
+
 # io_uring support for Linux 5.6+ - batched async I/O syscalls
 # Requirements: Linux kernel 5.6+ (runtime fallback on older kernels)
 # Benefits: 20-40% faster I/O on supported systems via syscall batching

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -98,6 +98,15 @@ async = ["dep:tokio", "engine/async", "transfer/async"]
 # `docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md`.
 parallel-receive-delta = ["transfer/parallel-receive-delta", "engine/parallel-receive-delta"]
 
+# Sender-side INC_RECURSE interop bake-up (ISI.b). Default OFF; when enabled,
+# flips the `inc_recursive_send` builder fallback from `false` to `true` so
+# the client advertises the `'i'` capability bit on push transfers. CLI
+# `--inc-recursive` / `--no-inc-recursive` overrides still win. ISI.c-g
+# add tests and validate interop against rsync 3.0.9 / 3.1.3 / 3.4.1 /
+# 3.4.2; ISI.h flips the default and retires this flag. See
+# `docs/design/isi-a-sender-inc-recurse-call-graph.md`.
+sender-inc-recurse = []
+
 # Async SSH transport: wires `rsync_io::ssh::AsyncSshTransport` into the client
 # remote transfer path. Opt-in at runtime via the `OC_RSYNC_ASYNC_SSH=1` env
 # var until the CLI flag lands (#1806).

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -434,7 +434,17 @@ impl ClientConfigBuilder {
             mkpath: self.mkpath,
             prune_empty_dirs: self.prune_empty_dirs,
             qsort: self.qsort,
-            inc_recursive_send: self.inc_recursive_send.unwrap_or(false),
+            // ISI.b: temporary gate for sender-side INC_RECURSE interop bake-up.
+            // The `sender-inc-recurse` cargo feature flips the default fallback
+            // from `false` to `true` so push transfers advertise the `'i'`
+            // capability bit. CLI `--inc-recursive` / `--no-inc-recursive`
+            // overrides still win because they populate `Some(_)`. Default-off
+            // behavior is bit-for-bit identical to today; ISI.h retires this
+            // gate once interop is validated against 3.0.9 / 3.1.3 / 3.4.1 /
+            // 3.4.2. See `docs/design/isi-a-sender-inc-recurse-call-graph.md`.
+            inc_recursive_send: self
+                .inc_recursive_send
+                .unwrap_or(cfg!(feature = "sender-inc-recurse")),
             verbosity: self.verbosity,
             progress: self.progress,
             stats: self.stats,

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1589,11 +1589,26 @@ fn inc_recursive_send_false_clears_flag() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn default_inc_recursive_send_is_false() {
     // Sender-side INC_RECURSE is opt-in until the sender state machine is
     // validated against upstream rsync 3.0.9 / 3.1.3 / 3.4.1. Tracker #1862.
+    // The `sender-inc-recurse` feature flips this default ON for interop
+    // bake-up; under that feature the default is true and this invariant
+    // does not hold.
     let config = builder().build();
     assert!(!config.inc_recursive_send());
+}
+
+#[test]
+#[cfg(feature = "sender-inc-recurse")]
+fn default_inc_recursive_send_is_true_under_sender_inc_recurse_feature() {
+    // With `sender-inc-recurse` enabled, the default flips ON so interop
+    // tests can exercise the sender-side INC_RECURSE path against upstream
+    // rsync. ISI.h will flip this default permanently after the interop
+    // bake-up completes.
+    let config = builder().build();
+    assert!(config.inc_recursive_send());
 }
 
 #[test]

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -11,8 +11,12 @@ use super::{RemoteOperands, RemoteRole, TransferSpec};
 use crate::client::config::{ClientConfig, IconvSetting, TransferTimeout};
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn builds_receiver_invocation_with_sender_flag() {
-    // Pull: local is receiver -> remote needs --sender (upstream options.c:2598)
+    // Pull: local is receiver -> remote needs --sender (upstream options.c:2598).
+    // Skipped under sender-inc-recurse: the feature flips the default
+    // inc_recursive_send, changing the capability string from
+    // build_capability_string(false).
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
@@ -29,8 +33,12 @@ fn builds_receiver_invocation_with_sender_flag() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn builds_sender_invocation_no_sender_flag() {
-    // Push: local is sender -> remote is receiver, no --sender flag
+    // Push: local is sender -> remote is receiver, no --sender flag.
+    // Skipped under sender-inc-recurse: the feature flips the default
+    // inc_recursive_send to true, so the expected capability string no
+    // longer matches build_capability_string(false).
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
@@ -47,10 +55,12 @@ fn builds_sender_invocation_no_sender_flag() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn ssh_sender_omits_inc_recurse_capability_by_default() {
     // Sender-side INC_RECURSE is opt-in: SSH push transfers omit the 'i'
     // capability bit by default while the sender-side state machine is
-    // validated against upstream rsync. Tracker #1862.
+    // validated against upstream rsync. Tracker #1862. Skipped under
+    // sender-inc-recurse where the default flips ON.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
@@ -1661,7 +1671,11 @@ fn capability_string_present_in_sender_args() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn capability_string_present_in_receiver_args() {
+    // Skipped under sender-inc-recurse: the feature flips the default
+    // inc_recursive_send, so the receiver args carry
+    // build_capability_string(true), not (false).
     let config = ClientConfig::builder().build();
     let args = build_receiver_args(&config);
     let expected = build_capability_string(false);

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1660,7 +1660,11 @@ fn default_rsync_path_is_rsync() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn capability_string_present_in_sender_args() {
+    // Skipped under sender-inc-recurse: the feature flips the default
+    // inc_recursive_send, so the sender args carry
+    // build_capability_string(true), not (false).
     let config = ClientConfig::builder().build();
     let args = build_sender_args(&config);
     let expected = build_capability_string(false);

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -98,10 +98,12 @@ fn ssh_sender_omits_inc_recurse_when_no_inc_recursive_set() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn ssh_receiver_omits_inc_recurse_capability_by_default() {
     // Sender-side INC_RECURSE is gated by `inc_recursive_send` which defaults
     // to false; the SSH capability builder reads only that flag, so pull
-    // transfers also omit 'i' by default. Tracker #1862.
+    // transfers also omit 'i' by default. Tracker #1862. Skipped under
+    // sender-inc-recurse where the default flips ON.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");

--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -635,6 +635,7 @@ fn test_single_remote_source_returns_single_variant() {
 }
 
 #[test]
+#[cfg(not(feature = "sender-inc-recurse"))]
 fn test_remote_invocation_with_multiple_paths() {
     use core::client::{ClientConfig, remote::RemoteInvocationBuilder, remote::RemoteRole};
 
@@ -650,7 +651,8 @@ fn test_remote_invocation_with_multiple_paths() {
     assert!(args[flags_idx].to_string_lossy().starts_with('-'));
     // Capability info string for protocol features (checksum negotiation, etc.)
     // Sender-side INC_RECURSE is opt-in (default false); 'i' is omitted from
-    // the capability string. Tracker #1862.
+    // the capability string. Tracker #1862. Skipped under
+    // sender-inc-recurse where the default flips ON and the 'i' bit is set.
     assert_eq!(args[flags_idx + 1].to_string_lossy(), "-e.LsfxCIvu");
     let dot_idx = flags_idx + 2;
     assert_eq!(args[dot_idx].to_string_lossy(), ".");


### PR DESCRIPTION
## Summary

- Adds a default-off `sender-inc-recurse` cargo feature (top-level + `crates/core`) that gates the `inc_recursive_send` builder fallback at `crates/core/src/client/config/builder/mod.rs:437`. The fallback flips from `unwrap_or(false)` to `unwrap_or(cfg!(feature = \"sender-inc-recurse\"))`, so when the feature is enabled the client advertises the `'i'` capability bit on push transfers (both SSH invocation and daemon transfer arg builders consume this single source of truth).
- Default-off behavior is bit-for-bit identical to today - the fallback evaluates to `false` without the feature, and CLI `--inc-recursive` / `--no-inc-recursive` tri-state overrides still win because they populate `Some(_)` before the fallback runs.
- Follow-up ISI.c / ISI.d / ISI.e tasks add sender-direction integration tests, invert hard-coded `inc_recursive_send(off)` expectations, and validate interop against rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2; ISI.h flips the default and retires the flag. See `docs/design/isi-a-sender-inc-recurse-call-graph.md` for the call-graph audit.

## Test plan

- [ ] cargo nextest run --workspace (CI verifies)
- [ ] CI matrix cell will be added by ISI.d