### PR TITLE
feat(fast_io): migrate file_writer to per-thread io_uring ring (IUR-3.b)

### DIFF
--- a/crates/fast_io/src/io_uring/file_writer.rs
+++ b/crates/fast_io/src/io_uring/file_writer.rs
@@ -1,22 +1,29 @@
 //! io_uring-based file writer with buffered batched writes.
 //!
-//! When registered buffers are available, flushes use `IORING_OP_WRITE_FIXED`
-//! which avoids per-SQE `get_user_pages()` overhead. Falls back to regular
-//! `IORING_OP_WRITE` when registration is unavailable or all slots are busy.
+//! Submissions go through the per-thread io_uring ring established by IUR-3.a
+//! ([`super::per_thread_ring::with_ring`]). The writer no longer owns a
+//! `RawIoUring` instance; one ring per OS thread is shared across every
+//! [`IoUringWriter`] that thread holds, dissolving the cross-thread
+//! contention the shared-ring layout imposed on rayon-parallel writers (IUR-2
+//! design doc section 1.1).
+//!
+//! Per-ring kernel state - fixed-file registration and registered buffers -
+//! is tied to a specific ring fd and does not survive the move to a
+//! thread-shared ring. Both are recorded as unavailable on every writer
+//! constructed through this module; IUR-3.e re-introduces them on the
+//! per-thread topology via the bgid-lease primitive.
 
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom, Write};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
-use io_uring::{IoUring as RawIoUring, opcode};
+use io_uring::opcode;
 
-use super::batching::{maybe_fixed_file, sqe_fd, submit_write_batch, try_register_fd};
+use super::batching::{NO_FIXED_FD, maybe_fixed_file, sqe_fd, submit_write_batch};
 use super::config::IoUringConfig;
-use super::registered_buffers::{
-    RegisteredBufferGroup, RegisteredBufferSlotInfo, RegisteredBufferStatus,
-    submit_write_fixed_batch,
-};
+use super::per_thread_ring::with_ring;
+use super::registered_buffers::RegisteredBufferStatus;
 use crate::traits::FileWriter;
 
 /// A file writer using io_uring for async I/O.
@@ -25,25 +32,17 @@ use crate::traits::FileWriter;
 /// fills), the buffered data is submitted as a batch of write SQEs -- up to
 /// `sq_entries` concurrent writes per `submit_and_wait` call.
 ///
-/// When [`RegisteredBufferGroup`] is available, the writer uses
-/// `IORING_OP_WRITE_FIXED` for flushes, eliminating kernel-side page pinning
-/// overhead on each operation.
+/// Submissions are issued against the calling thread's per-thread ring (see
+/// [`super::per_thread_ring`]). Fixed-file registration and registered-buffer
+/// fast paths are disabled on this writer until IUR-3.e wires the per-thread
+/// bgid lease; flushes always use the regular `IORING_OP_WRITE` opcode.
 pub struct IoUringWriter {
-    ring: RawIoUring,
     file: File,
     bytes_written: u64,
     buffer: Vec<u8>,
     buffer_pos: usize,
     buffer_size: usize,
     sq_entries: u32,
-    /// Fixed-file slot index, or `NO_FIXED_FD` when not registered.
-    fixed_fd_slot: i32,
-    /// Optional registered buffer group for `WRITE_FIXED` operations.
-    registered_buffers: Option<RegisteredBufferGroup>,
-    /// Provenance of `registered_buffers`: distinguishes "disabled by config"
-    /// from "kernel rejected registration" so operators can diagnose why a
-    /// transfer is using the unfixed `IORING_OP_WRITE` fallback.
-    registered_buffer_status: RegisteredBufferStatus,
 }
 
 impl IoUringWriter {
@@ -53,119 +52,58 @@ impl IoUringWriter {
     ///
     /// Returns an error if:
     /// - The file cannot be created
-    /// - io_uring initialization fails
+    /// - io_uring initialization fails on the calling thread
     pub fn create<P: AsRef<Path>>(path: P, config: &IoUringConfig) -> io::Result<Self> {
         let file = File::create(path)?;
-        let ring = config.build_ring()?;
-        let fixed_fd_slot = try_register_fd(&ring, file.as_raw_fd(), config.register_files);
-        let (registered_buffers, registered_buffer_status) =
-            RegisteredBufferGroup::try_new_with_status(
-                &ring,
-                config.buffer_size,
-                config.registered_buffer_count,
-                config.register_buffers,
-            );
-
-        Ok(Self {
-            ring,
-            file,
-            bytes_written: 0,
-            buffer: vec![0u8; config.buffer_size],
-            buffer_pos: 0,
-            buffer_size: config.buffer_size,
-            sq_entries: config.sq_entries,
-            fixed_fd_slot,
-            registered_buffers,
-            registered_buffer_status,
-        })
+        Self::new_from_file(file, config)
     }
 
     /// Wraps an existing file handle for writing with io_uring.
     pub fn from_file(file: File, config: &IoUringConfig) -> io::Result<Self> {
-        let ring = config.build_ring()?;
-        let fixed_fd_slot = try_register_fd(&ring, file.as_raw_fd(), config.register_files);
-        let (registered_buffers, registered_buffer_status) =
-            RegisteredBufferGroup::try_new_with_status(
-                &ring,
-                config.buffer_size,
-                config.registered_buffer_count,
-                config.register_buffers,
-            );
-
-        Ok(Self {
-            ring,
-            file,
-            bytes_written: 0,
-            buffer: vec![0u8; config.buffer_size],
-            buffer_pos: 0,
-            buffer_size: config.buffer_size,
-            sq_entries: config.sq_entries,
-            fixed_fd_slot,
-            registered_buffers,
-            registered_buffer_status,
-        })
+        Self::new_from_file(file, config)
     }
 
-    /// Wraps an existing file handle, io_uring ring, and fixed-fd slot.
+    /// Wraps an existing file handle for writing with the per-thread ring.
     ///
-    /// Used by [`super::writer_from_file`] which builds the ring separately
-    /// so it can fall back to standard I/O without consuming the `File`.
-    ///
-    /// Honors `register_buffers`: when `false`, skips
-    /// [`RegisteredBufferGroup`] construction entirely so flushes use the
-    /// regular `IORING_OP_WRITE` path. When `true`, allocates
-    /// `registered_buffer_count` fixed buffers (matching the pattern in
-    /// [`IoUringConfig`](super::IoUringConfig)).
+    /// Used by [`super::writer_from_file`] which previously built a ring
+    /// per call so it could fall back to standard I/O without consuming the
+    /// `File`. With the per-thread topology the writer no longer owns the
+    /// ring; this constructor is kept for API parity but is now a thin
+    /// wrapper over [`Self::new_from_file`] that ignores the
+    /// `register_buffers` / `registered_buffer_count` knobs (IUR-3.e
+    /// re-introduces buffer registration on the per-thread ring).
     pub(super) fn with_ring(
         file: File,
-        ring: RawIoUring,
         buffer_capacity: usize,
         sq_entries: u32,
-        fixed_fd_slot: i32,
-        register_buffers: bool,
-        registered_buffer_count: usize,
+        _fixed_fd_slot: i32,
+        _register_buffers: bool,
+        _registered_buffer_count: usize,
     ) -> Self {
-        let (registered_buffers, registered_buffer_status) =
-            RegisteredBufferGroup::try_new_with_status(
-                &ring,
-                buffer_capacity,
-                registered_buffer_count,
-                register_buffers,
-            );
-
-        Self {
-            ring,
-            file,
-            bytes_written: 0,
-            buffer: vec![0u8; buffer_capacity],
-            buffer_pos: 0,
-            buffer_size: buffer_capacity,
-            sq_entries,
-            fixed_fd_slot,
-            registered_buffers,
-            registered_buffer_status,
-        }
+        Self::new_with_capacity(file, buffer_capacity, sq_entries)
     }
 
     /// Returns the count of currently-registered fixed buffers, or `None` if
     /// buffer registration is not active on this writer.
     ///
-    /// Returns `None` when the caller disabled `register_buffers` or when
-    /// kernel registration failed and the writer is using the regular
-    /// `IORING_OP_WRITE` fallback path. To tell the two cases apart, call
-    /// [`registered_buffer_status`](Self::registered_buffer_status).
+    /// Always returns `None` on the per-thread topology: the per-thread ring
+    /// is shared across every writer on the same thread, so per-writer
+    /// buffer registration cannot be expressed safely. IUR-3.e re-introduces
+    /// shared per-thread buffer registration via the bgid lease; call
+    /// [`registered_buffer_status`](Self::registered_buffer_status) to tell
+    /// the post-migration state apart from a kernel-side rejection.
     #[must_use]
     pub fn registered_buffer_count(&self) -> Option<usize> {
-        self.registered_buffers.as_ref().map(|g| g.count())
+        None
     }
 
     /// Returns the provenance of fixed-buffer registration on this writer.
     ///
-    /// Use this to distinguish the two `registered_buffer_count() == None`
-    /// cases: caller disabled registration vs the kernel rejected it.
+    /// Always returns [`RegisteredBufferStatus::Disabled`] on the per-thread
+    /// topology; see [`Self::registered_buffer_count`].
     #[must_use]
     pub fn registered_buffer_status(&self) -> &RegisteredBufferStatus {
-        &self.registered_buffer_status
+        &RegisteredBufferStatus::Disabled
     }
 
     /// Creates a file with preallocated space.
@@ -176,123 +114,67 @@ impl IoUringWriter {
     ) -> io::Result<Self> {
         let file = File::create(path)?;
         file.set_len(size)?;
-        let ring = config.build_ring()?;
-        let fixed_fd_slot = try_register_fd(&ring, file.as_raw_fd(), config.register_files);
-        let (registered_buffers, registered_buffer_status) =
-            RegisteredBufferGroup::try_new_with_status(
-                &ring,
-                config.buffer_size,
-                config.registered_buffer_count,
-                config.register_buffers,
-            );
-
-        Ok(Self {
-            ring,
-            file,
-            bytes_written: 0,
-            buffer: vec![0u8; config.buffer_size],
-            buffer_pos: 0,
-            buffer_size: config.buffer_size,
-            sq_entries: config.sq_entries,
-            fixed_fd_slot,
-            registered_buffers,
-            registered_buffer_status,
-        })
+        Self::new_from_file(file, config)
     }
 
     /// Writes data at the specified offset without advancing the internal position.
     ///
-    /// Submits a single SQE and waits for completion. For bulk writes, prefer
-    /// buffered `write()` + `flush()` which batches SQEs automatically.
+    /// Submits a single SQE on the per-thread ring and waits for completion.
+    /// For bulk writes, prefer buffered `write()` + `flush()` which batches
+    /// SQEs automatically.
     pub fn write_at(&mut self, offset: u64, buf: &[u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
         }
 
-        let fd = sqe_fd(self.file.as_raw_fd(), self.fixed_fd_slot);
+        let raw_fd = self.file.as_raw_fd();
+        let fd = sqe_fd(raw_fd, NO_FIXED_FD);
 
-        let entry = opcode::Write::new(fd, buf.as_ptr(), buf.len() as u32)
-            .offset(offset)
-            .build()
-            .user_data(0);
-        let entry = maybe_fixed_file(entry, self.fixed_fd_slot);
+        with_ring(|ring| {
+            let entry = opcode::Write::new(fd, buf.as_ptr(), buf.len() as u32)
+                .offset(offset)
+                .build()
+                .user_data(0);
+            let entry = maybe_fixed_file(entry, NO_FIXED_FD);
 
-        // SAFETY: `entry` references `buf` and the file fd; both outlive
-        // `submit_and_wait` below, so the kernel can read from the buffer
-        // before we observe completion.
-        unsafe {
-            self.ring
-                .submission()
-                .push(&entry)
-                .map_err(|_| io::Error::other("submission queue full"))?;
-        }
+            // SAFETY: `entry` references `buf` and the file fd; both outlive
+            // `submit_and_wait` below, so the kernel can read from the buffer
+            // before we observe completion.
+            unsafe {
+                ring.submission()
+                    .push(&entry)
+                    .map_err(|_| io::Error::other("submission queue full"))?;
+            }
 
-        self.ring.submit_and_wait(1)?;
+            ring.submit_and_wait(1)?;
 
-        let cqe = self
-            .ring
-            .completion()
-            .next()
-            .ok_or_else(|| io::Error::other("no completion"))?;
+            let cqe = ring
+                .completion()
+                .next()
+                .ok_or_else(|| io::Error::other("no completion"))?;
 
-        let result = cqe.result();
-        if result < 0 {
-            return Err(io::Error::from_raw_os_error(-result));
-        }
+            let result = cqe.result();
+            if result < 0 {
+                return Err(io::Error::from_raw_os_error(-result));
+            }
 
-        Ok(result as usize)
+            Ok(result as usize)
+        })
     }
 
     /// Writes all of `data` starting at `offset` using batched SQEs.
     ///
-    /// Uses `WRITE_FIXED` when registered buffers are available, falling back
-    /// to regular `IORING_OP_WRITE` otherwise. Splits `data` into chunks and
-    /// submits up to `sq_entries` writes per `submit_and_wait` call.
+    /// Submits up to `sq_entries` writes per `submit_and_wait` call on the
+    /// per-thread ring.
     pub fn write_all_batched(&mut self, data: &[u8], offset: u64) -> io::Result<()> {
-        let fd = sqe_fd(self.file.as_raw_fd(), self.fixed_fd_slot);
+        let raw_fd = self.file.as_raw_fd();
+        let fd = sqe_fd(raw_fd, NO_FIXED_FD);
+        let buffer_size = self.buffer_size;
+        let sq_entries = self.sq_entries as usize;
 
-        if let Some(ref reg) = self.registered_buffers {
-            let slot_count = reg.available().min(self.sq_entries as usize);
-            if slot_count > 0 {
-                let mut slots: Vec<_> = (0..slot_count).filter_map(|_| reg.checkout()).collect();
-                if !slots.is_empty() {
-                    let slot_infos: Vec<RegisteredBufferSlotInfo> = slots
-                        .iter_mut()
-                        .map(|s| RegisteredBufferSlotInfo {
-                            ptr: s.as_mut_ptr(),
-                            buf_index: s.buf_index(),
-                            buffer_size: s.buffer_size(),
-                        })
-                        .collect();
-
-                    let written = submit_write_fixed_batch(
-                        &mut self.ring,
-                        fd,
-                        data,
-                        offset,
-                        &slot_infos,
-                        self.fixed_fd_slot,
-                    )?;
-                    if written != data.len() {
-                        return Err(io::Error::new(
-                            io::ErrorKind::WriteZero,
-                            "batched write_fixed incomplete",
-                        ));
-                    }
-                    return Ok(());
-                }
-            }
-        }
-
-        let written = submit_write_batch(
-            &mut self.ring,
-            fd,
-            data,
-            offset,
-            self.buffer_size,
-            self.sq_entries as usize,
-            self.fixed_fd_slot,
-        )?;
+        let written = with_ring(|ring| {
+            submit_write_batch(ring, fd, data, offset, buffer_size, sq_entries, NO_FIXED_FD)
+        })?;
         if written != data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::WriteZero,
@@ -302,60 +184,58 @@ impl IoUringWriter {
         Ok(())
     }
 
+    /// Builds a writer from a file handle using the configured buffer size.
+    fn new_from_file(file: File, config: &IoUringConfig) -> io::Result<Self> {
+        // Probe the per-thread ring once at construction so callers observe
+        // io_uring unavailability synchronously, matching the old behaviour
+        // where `config.build_ring()?` surfaced setup errors here.
+        with_ring(|_| Ok(()))?;
+        Ok(Self::new_with_capacity(
+            file,
+            config.buffer_size,
+            config.sq_entries,
+        ))
+    }
+
+    /// Constructs the writer state from a file, buffer capacity, and SQ depth.
+    fn new_with_capacity(file: File, buffer_capacity: usize, sq_entries: u32) -> Self {
+        Self {
+            file,
+            bytes_written: 0,
+            buffer: vec![0u8; buffer_capacity],
+            buffer_pos: 0,
+            buffer_size: buffer_capacity,
+            sq_entries,
+        }
+    }
+
     /// Flushes the internal buffer to disk using batched writes.
     ///
-    /// When registered buffers are available, uses `IORING_OP_WRITE_FIXED` to
-    /// avoid per-SQE page pinning. Falls back to regular `IORING_OP_WRITE` when
-    /// registration is unavailable or all slots are busy.
+    /// Submits the buffered region as a batch of `IORING_OP_WRITE` SQEs on
+    /// the per-thread ring.
     fn flush_buffer(&mut self) -> io::Result<()> {
         if self.buffer_pos == 0 {
             return Ok(());
         }
 
-        let fd = sqe_fd(self.file.as_raw_fd(), self.fixed_fd_slot);
+        let raw_fd = self.file.as_raw_fd();
+        let fd = sqe_fd(raw_fd, NO_FIXED_FD);
         let len = self.buffer_pos;
         let offset = self.bytes_written;
+        let buffer_size = self.buffer_size;
+        let sq_entries = self.sq_entries as usize;
 
-        if let Some(ref reg) = self.registered_buffers {
-            let slot_count = reg.available().min(self.sq_entries as usize);
-            if slot_count > 0 {
-                let mut slots: Vec<_> = (0..slot_count).filter_map(|_| reg.checkout()).collect();
-                if !slots.is_empty() {
-                    let slot_infos: Vec<RegisteredBufferSlotInfo> = slots
-                        .iter_mut()
-                        .map(|s| RegisteredBufferSlotInfo {
-                            ptr: s.as_mut_ptr(),
-                            buf_index: s.buf_index(),
-                            buffer_size: s.buffer_size(),
-                        })
-                        .collect();
-
-                    let written = submit_write_fixed_batch(
-                        &mut self.ring,
-                        fd,
-                        &self.buffer[..len],
-                        offset,
-                        &slot_infos,
-                        self.fixed_fd_slot,
-                    )?;
-                    self.bytes_written += written as u64;
-                    self.buffer_pos = 0;
-                    return Ok(());
-                }
-            }
-        }
-
-        // Safety: the buffer is not modified until submit_write_batch returns,
-        // and the kernel only reads from these pointers during submit_and_wait.
-        let written = submit_write_batch(
-            &mut self.ring,
-            fd,
-            &self.buffer[..len],
-            offset,
-            self.buffer_size,
-            self.sq_entries as usize,
-            self.fixed_fd_slot,
-        )?;
+        let written = with_ring(|ring| {
+            submit_write_batch(
+                ring,
+                fd,
+                &self.buffer[..len],
+                offset,
+                buffer_size,
+                sq_entries,
+                NO_FIXED_FD,
+            )
+        })?;
         self.bytes_written += written as u64;
         self.buffer_pos = 0;
         Ok(())
@@ -402,35 +282,36 @@ impl FileWriter for IoUringWriter {
     fn sync(&mut self) -> io::Result<()> {
         self.flush_buffer()?;
 
-        let fd = sqe_fd(self.file.as_raw_fd(), self.fixed_fd_slot);
+        let raw_fd = self.file.as_raw_fd();
+        let fd = sqe_fd(raw_fd, NO_FIXED_FD);
 
-        let entry = opcode::Fsync::new(fd).build().user_data(0);
-        let fsync_op = maybe_fixed_file(entry, self.fixed_fd_slot);
+        with_ring(|ring| {
+            let entry = opcode::Fsync::new(fd).build().user_data(0);
+            let fsync_op = maybe_fixed_file(entry, NO_FIXED_FD);
 
-        // SAFETY: `Fsync` carries only the file fd which remains valid for
-        // the duration of `submit_and_wait`; no user-space buffer is shared
-        // with the kernel.
-        unsafe {
-            self.ring
-                .submission()
-                .push(&fsync_op)
-                .map_err(|_| io::Error::other("submission queue full"))?;
-        }
+            // SAFETY: `Fsync` carries only the file fd which remains valid for
+            // the duration of `submit_and_wait`; no user-space buffer is shared
+            // with the kernel.
+            unsafe {
+                ring.submission()
+                    .push(&fsync_op)
+                    .map_err(|_| io::Error::other("submission queue full"))?;
+            }
 
-        self.ring.submit_and_wait(1)?;
+            ring.submit_and_wait(1)?;
 
-        let cqe = self
-            .ring
-            .completion()
-            .next()
-            .ok_or_else(|| io::Error::other("no completion"))?;
+            let cqe = ring
+                .completion()
+                .next()
+                .ok_or_else(|| io::Error::other("no completion"))?;
 
-        let result = cqe.result();
-        if result < 0 {
-            return Err(io::Error::from_raw_os_error(-result));
-        }
+            let result = cqe.result();
+            if result < 0 {
+                return Err(io::Error::from_raw_os_error(-result));
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 
     fn preallocate(&mut self, size: u64) -> io::Result<()> {
@@ -458,23 +339,24 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    /// Builds a writer via `with_ring` for testing. Returns `None` when the
-    /// kernel rejects `io_uring_setup(2)` (e.g., container, seccomp, or non
-    /// 5.6+ kernel) so the test skips cleanly.
+    /// Builds a writer for testing via the per-thread ring. Returns `None`
+    /// when the kernel rejects `io_uring_setup(2)` (e.g., container,
+    /// seccomp, or non-5.6+ kernel) so the test skips cleanly.
     fn make_writer(
         register_buffers: bool,
         registered_buffer_count: usize,
     ) -> Option<IoUringWriter> {
         let dir = tempdir().ok()?;
         let file = File::create(dir.path().join("out.bin")).ok()?;
-        let ring = RawIoUring::new(4).ok()?;
+        // Probe the per-thread ring; on hosts without io_uring we skip the
+        // test rather than constructing a writer that would later fail.
+        with_ring(|_| Ok(())).ok()?;
         // Keep `dir` alive for the duration of the writer by leaking it; the
         // OS reclaims the temp file at process exit. Tests are short-lived
         // and this avoids ordering the drop with the writer.
         std::mem::forget(dir);
         Some(IoUringWriter::with_ring(
             file,
-            ring,
             4096,
             4,
             -1,
@@ -484,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn with_ring_skips_registration_when_disabled() {
+    fn registered_buffers_always_disabled_on_per_thread_ring() {
         let writer = match make_writer(false, 8) {
             Some(w) => w,
             None => return,
@@ -492,20 +374,20 @@ mod tests {
         assert_eq!(
             writer.registered_buffer_count(),
             None,
-            "register_buffers=false must skip RegisteredBufferGroup construction"
+            "per-thread ring writers do not own per-writer registered buffers"
         );
         assert_eq!(
             writer.registered_buffer_status(),
             &RegisteredBufferStatus::Disabled,
-            "status must be Disabled when register_buffers=false, not RegistrationFailed"
+            "status must report Disabled on the per-thread topology until IUR-3.e wires bgid lease"
         );
     }
 
     #[test]
-    fn registered_buffer_status_failed_when_kernel_rejects() {
-        // Force registration failure by asking for more buffers than the
-        // wrapper allows. This is rejected before reaching the kernel, so the
-        // test is portable to environments without io_uring permissions.
+    fn registered_buffer_count_ignored_on_per_thread_ring() {
+        // Passing a high count must not crash and must not surface as
+        // RegistrationFailed: the per-thread topology simply ignores the
+        // per-writer registration knobs.
         let writer = match make_writer(
             true,
             super::super::registered_buffers::MAX_REGISTERED_BUFFERS + 1,
@@ -514,47 +396,33 @@ mod tests {
             None => return,
         };
         assert_eq!(writer.registered_buffer_count(), None);
-        assert!(
-            writer.registered_buffer_status().is_registration_failed(),
-            "kernel-side rejection must surface as RegistrationFailed, not Disabled"
+        assert_eq!(
+            writer.registered_buffer_status(),
+            &RegisteredBufferStatus::Disabled,
+            "per-thread topology never reports RegistrationFailed for per-writer requests"
         );
     }
 
     #[test]
-    fn with_ring_respects_configured_count() {
+    fn with_ring_returns_writer_when_io_uring_available() {
         let writer = match make_writer(true, 16) {
             Some(w) => w,
             None => return,
         };
-        // Buffer registration may fail silently inside RegisteredBufferGroup
-        // (e.g., kernel without IORING_REGISTER_BUFFERS) - skip in that case.
-        let count = match writer.registered_buffer_count() {
-            Some(c) => c,
-            None => return,
-        };
-        assert_eq!(
-            count, 16,
-            "with_ring must honor registered_buffer_count, not hard-code 8"
-        );
+        // The writer is usable; bytes_written starts at zero.
+        assert_eq!(writer.bytes_written, 0);
     }
 
     #[test]
-    fn with_ring_uses_default_count_when_unset() {
+    fn default_config_constructs_writer() {
         // `IoUringConfig::default()` sets `registered_buffer_count = 8`.
-        // Verify that wiring the config default through `with_ring` produces
-        // a writer with exactly 8 registered buffers.
+        // The per-thread topology ignores it; the writer must still
+        // construct and report Disabled.
         let config = IoUringConfig::default();
-        assert!(config.register_buffers, "default must enable registration");
-        assert_eq!(config.registered_buffer_count, 8, "default count must be 8");
-
         let writer = match make_writer(config.register_buffers, config.registered_buffer_count) {
             Some(w) => w,
             None => return,
         };
-        let count = match writer.registered_buffer_count() {
-            Some(c) => c,
-            None => return,
-        };
-        assert_eq!(count, 8, "default config must produce 8 registered buffers");
+        assert_eq!(writer.registered_buffer_count(), None);
     }
 }

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -127,7 +127,6 @@ mod tests;
 
 use std::fs::File;
 use std::io::{self, Write};
-use std::os::unix::io::AsRawFd;
 
 pub use buffer_ring::{
     BgidAllocError, BgidAllocator, BufferRing, BufferRingConfig, BufferRingError,
@@ -196,7 +195,6 @@ pub use statx::{
 
 use crate::io_uring_common::IoBackend;
 use crate::traits::{FileReader, FileReaderFactory, FileWriterFactory};
-use batching::try_register_fd;
 
 /// Marker type implementing [`IoBackend`] for the live Linux io_uring backend.
 ///
@@ -267,16 +265,14 @@ pub fn writer_from_file_with_depth(
     match policy {
         crate::IoUringPolicy::Auto => {
             if is_io_uring_available() {
-                // Build ring first - if this fails, `file` is still ours.
-                if let Ok(ring) = config.build_ring() {
-                    let fixed_fd_slot =
-                        try_register_fd(&ring, file.as_raw_fd(), config.register_files);
+                // Probe the per-thread ring; on setup failure `file` is still
+                // ours and we fall back to standard I/O.
+                if per_thread_ring::with_ring(|_| Ok(())).is_ok() {
                     return Ok(IoUringOrStdWriter::IoUring(IoUringWriter::with_ring(
                         file,
-                        ring,
                         buffer_capacity,
                         config.sq_entries,
-                        fixed_fd_slot,
+                        batching::NO_FIXED_FD,
                         config.register_buffers,
                         config.registered_buffer_count,
                     )));
@@ -293,14 +289,12 @@ pub fn writer_from_file_with_depth(
                     "io_uring requested via --io-uring but not available on this system",
                 ));
             }
-            let ring = config.build_ring()?;
-            let fixed_fd_slot = try_register_fd(&ring, file.as_raw_fd(), config.register_files);
+            per_thread_ring::with_ring(|_| Ok(()))?;
             Ok(IoUringOrStdWriter::IoUring(IoUringWriter::with_ring(
                 file,
-                ring,
                 buffer_capacity,
                 config.sq_entries,
-                fixed_fd_slot,
+                batching::NO_FIXED_FD,
                 config.register_buffers,
                 config.registered_buffer_count,
             )))

--- a/crates/fast_io/src/io_uring/registered_buffers/mod.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/mod.rs
@@ -100,6 +100,5 @@ pub(crate) fn page_size() -> usize {
 
 pub use registry::{RegisteredBufferGroup, RegisteredBufferSlot};
 pub use stats::{RegisteredBufferStats, RegisteredBufferStatus};
-pub(super) use submit::submit_write_fixed_batch;
 #[doc(hidden)]
 pub use submit::{RegisteredBufferSlotInfo, submit_read_fixed_batch};

--- a/crates/fast_io/src/io_uring/registered_buffers/submit.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/submit.rs
@@ -156,6 +156,11 @@ pub fn submit_read_fixed_batch(
 /// Writes `data` to the file starting at `base_offset`, copying chunks into
 /// registered buffers and submitting `WriteFixed` SQEs. Returns the total
 /// bytes written.
+///
+/// Gated to `#[cfg(test)]`: the per-thread-ring migration removed the
+/// production caller; the function is preserved for the existing batch
+/// tests until IUR-3.e reintroduces a bgid-lease-aware replacement.
+#[cfg(test)]
 pub(in crate::io_uring) fn submit_write_fixed_batch(
     ring: &mut RawIoUring,
     fd: io_uring::types::Fd,


### PR DESCRIPTION
## Summary

Routes `IoUringWriter` submissions through `per_thread_ring::with_ring` (IUR-3.a primitive) so every file writer on a thread shares one io_uring instance, removing the cross-thread serialisation the shared-ring layout imposed on rayon-parallel writers. The public `IoUringWriter::create` / `create_with_size` / `from_file` factory surface is preserved; only the `pub(super) with_ring` constructor loses its caller-supplied `RawIoUring` parameter (no longer needed once the ring is fetched per call from thread-local storage). Per-ring fixed-file registration and registered-buffer fast paths are disabled on writers built through this module - both are kernel state keyed to a specific ring fd and cannot survive the move to a thread-shared ring; IUR-3.e re-introduces per-thread buffer registration via the bgid lease.

## Status

**BEHIND** IUR-3.a (PR #4793). This branch carries the three IUR-3.a commits ahead of the migration so it builds in isolation; once PR #4793 lands, those commits become identical history and the branch rebases cleanly.

## Test plan

- `cargo nextest run -p fast_io --features io_uring` (CI verifies)