### PR TITLE
refactor(engine): extract finish_file + flush_workers into parallel_apply/drain.rs (SPL-38.e)

### DIFF
--- a/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
@@ -1,0 +1,149 @@
+//! Per-file drain primitives for the parallel apply scaffold (SPL-38.e).
+//!
+//! Extracted from `parallel_apply/mod.rs` as part of the SPL-38 module
+//! decomposition. Sibling to [`super::slot_barrier::SlotBarrier`],
+//! [`super::decrement_guard::DecrementGuard`], and [`super::batch`]; reuses
+//! the per-slot [`std::sync::Arc<SlotBarrier>`] map maintained by
+//! [`ParallelDeltaApplier`].
+//!
+//! # Contract
+//!
+//! The two entry points are tightly paired:
+//!
+//! * [`ParallelDeltaApplier::flush_workers`] parks the caller on the slot's
+//!   [`std::sync::Condvar`] until the per-slot in-flight counter is observed
+//!   to be zero, mirroring the FFB-2 barrier wait.
+//! * [`ParallelDeltaApplier::finish_file`] bakes that barrier in front of the
+//!   [`std::sync::Arc::try_unwrap`] used to reclaim the destination writer,
+//!   so callers never have to sequence the wait + reclaim themselves.
+//!
+//! Both honour the BR-3j.c shard-discipline contract: the DashMap shard
+//! guard is dropped before the blocking wait so unrelated `FileNdx` values
+//! continue to make progress while a single file drains.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use super::super::types::FileNdx;
+use super::{ParallelApplyError, ParallelDeltaApplier};
+
+impl ParallelDeltaApplier {
+    /// Finalises a file's writer once every submitted chunk has applied.
+    ///
+    /// Returns the destination writer so the caller can run its own
+    /// finalisation step (checksum verify, temp-file rename, metadata
+    /// apply). Errors if any chunks remain buffered awaiting a missing
+    /// `chunk_sequence`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`std::io::Error`] if `ndx` is unknown, the slot is still
+    /// referenced by another caller, the slot mutex is poisoned, or the
+    /// per-file reorder buffer still holds undelivered chunks.
+    pub fn finish_file(&self, ndx: impl Into<FileNdx>) -> std::io::Result<Box<dyn Write + Send>> {
+        let ndx = ndx.into();
+        // FFB-1 Option D: bake the barrier into `finish_file` so callers
+        // never have to sequence `flush_workers` + `finish_file`
+        // themselves. The barrier waits for every outstanding
+        // `SlotHandle` clone (the unit of "in-flight" worker) to drop
+        // before we attempt the `Arc::try_unwrap` below. The lookup is
+        // a no-op if the slot is already absent, but here we know it
+        // exists or we will surface "unknown" on the subsequent remove.
+        self.flush_workers(ndx)?;
+        // `DashMap::remove` returns the owned `(K, V)` and drops the shard
+        // guard immediately; the `Arc::try_unwrap` work below happens
+        // outside the shard lock.
+        let (_, slot_arc) = self
+            .files
+            .remove(&ndx)
+            .ok_or_else(|| std::io::Error::other(format!("parallel applier file {ndx} unknown")))?;
+        // Post-barrier release-race window: `flush_workers` waits for
+        // `inflight==0` via the Condvar, which fires from
+        // `DecrementGuard::drop` *before* the guard's own
+        // `Arc<SlotBarrier>` clone has been released (the notify happens
+        // inside the drop body; the inner Arc only drops after the body
+        // returns). The window is typically nanoseconds but is reliably
+        // observable on Windows under load. Spin-then-yield until the
+        // worker's drop completes; the worker is past the notify and its
+        // drop fn is just about to return so the wait is bounded.
+        let mut spin = 0u32;
+        while Arc::strong_count(&slot_arc) > 1 {
+            spin = spin.saturating_add(1);
+            if spin >= 1_000 {
+                // Past the typical drop window - surface the typed error
+                // so a real bug (e.g. caller raced a new `slot_for`
+                // against `finish_file`) does not hide forever.
+                return Err(ParallelApplyError::ApplierStillReferenced {
+                    ndx,
+                    strong_count: Arc::strong_count(&slot_arc),
+                    kind: "finish_file",
+                }
+                .into());
+            }
+            if spin < 32 {
+                std::hint::spin_loop();
+            } else {
+                std::thread::yield_now();
+            }
+        }
+        let barrier = Arc::try_unwrap(slot_arc).map_err(|still_shared| {
+            ParallelApplyError::ApplierStillReferenced {
+                ndx,
+                strong_count: Arc::strong_count(&still_shared),
+                kind: "finish_file",
+            }
+        })?;
+        let slot = barrier
+            .slot
+            .into_inner()
+            .map_err(|_| ParallelApplyError::SlotPoisoned {
+                ndx,
+                kind: "finish_file",
+            })?;
+        if !slot.drained() {
+            return Err(ParallelApplyError::UndrainedChunks {
+                ndx,
+                buffered: slot.reorder.buffered_count(),
+                kind: "finish_file",
+            }
+            .into());
+        }
+        Ok(slot.writer)
+    }
+
+    /// Blocks the calling thread until every outstanding [`SlotHandle`]
+    /// for `ndx` has been dropped.
+    ///
+    /// Each call to [`Self::apply_one_chunk`] or
+    /// [`Self::apply_batch_parallel`] obtains a [`SlotHandle`] from
+    /// [`Self::slot_for`] that bumps the slot's in-flight counter for the
+    /// duration of the call (decrement on drop). `flush_workers` parks on
+    /// the slot's [`std::sync::Condvar`] until that counter is observed to be zero.
+    /// Spurious wakeups are filtered by the wait-while predicate.
+    ///
+    /// Returns [`Ok`] immediately if `ndx` is not registered (or has
+    /// already been finalised through [`Self::finish_file`]); the absence
+    /// of a slot is the same observable outcome as a fully-drained slot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`std::io::Error`] only if the slot's in-flight mutex was
+    /// poisoned by a panicking worker. In that case the typed
+    /// [`ParallelApplyError::SlotPoisoned`] variant carries the offending
+    /// `ndx` and the `"flush_workers"` call-site tag.
+    ///
+    /// [`SlotHandle`]: super::SlotHandle
+    /// [`Self::slot_for`]: super::ParallelDeltaApplier
+    pub fn flush_workers(&self, ndx: impl Into<FileNdx>) -> std::io::Result<()> {
+        let ndx = ndx.into();
+        // Look up the slot, clone the `Arc<SlotBarrier>`, drop the shard
+        // guard before waiting. This keeps the DashMap shard available to
+        // other NDX values while the caller blocks on the slot's own
+        // condvar, preserving the BR-3j.c shard-discipline contract.
+        let barrier = match self.files.get(&ndx) {
+            Some(guard) => Arc::clone(guard.value()),
+            None => return Ok(()),
+        };
+        barrier.wait_until_idle(ndx, "flush_workers")
+    }
+}

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -51,6 +51,7 @@ use super::types::FileNdx;
 
 mod batch;
 mod decrement_guard;
+mod drain;
 mod slot_barrier;
 
 use decrement_guard::DecrementGuard;
@@ -559,122 +560,6 @@ impl ParallelDeltaApplier {
         let handle = self.slot_for(ndx)?;
         let slot = handle.lock_slot(ndx, "bytes_written")?;
         Ok(slot.bytes_written())
-    }
-
-    /// Finalises a file's writer once every submitted chunk has applied.
-    ///
-    /// Returns the destination writer so the caller can run its own
-    /// finalisation step (checksum verify, temp-file rename, metadata
-    /// apply). Errors if any chunks remain buffered awaiting a missing
-    /// `chunk_sequence`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`io::Error`] if `ndx` is unknown, the slot is still
-    /// referenced by another caller, the slot mutex is poisoned, or the
-    /// per-file reorder buffer still holds undelivered chunks.
-    pub fn finish_file(&self, ndx: impl Into<FileNdx>) -> io::Result<Box<dyn Write + Send>> {
-        let ndx = ndx.into();
-        // FFB-1 Option D: bake the barrier into `finish_file` so callers
-        // never have to sequence `flush_workers` + `finish_file`
-        // themselves. The barrier waits for every outstanding
-        // `SlotHandle` clone (the unit of "in-flight" worker) to drop
-        // before we attempt the `Arc::try_unwrap` below. The lookup is
-        // a no-op if the slot is already absent, but here we know it
-        // exists or we will surface "unknown" on the subsequent remove.
-        self.flush_workers(ndx)?;
-        // `DashMap::remove` returns the owned `(K, V)` and drops the shard
-        // guard immediately; the `Arc::try_unwrap` work below happens
-        // outside the shard lock.
-        let (_, slot_arc) = self
-            .files
-            .remove(&ndx)
-            .ok_or_else(|| io::Error::other(format!("parallel applier file {ndx} unknown")))?;
-        // Post-barrier release-race window: `flush_workers` waits for
-        // `inflight==0` via the Condvar, which fires from
-        // `DecrementGuard::drop` *before* the guard's own
-        // `Arc<SlotBarrier>` clone has been released (the notify happens
-        // inside the drop body; the inner Arc only drops after the body
-        // returns). The window is typically nanoseconds but is reliably
-        // observable on Windows under load. Spin-then-yield until the
-        // worker's drop completes; the worker is past the notify and its
-        // drop fn is just about to return so the wait is bounded.
-        let mut spin = 0u32;
-        while Arc::strong_count(&slot_arc) > 1 {
-            spin = spin.saturating_add(1);
-            if spin >= 1_000 {
-                // Past the typical drop window - surface the typed error
-                // so a real bug (e.g. caller raced a new `slot_for`
-                // against `finish_file`) does not hide forever.
-                return Err(ParallelApplyError::ApplierStillReferenced {
-                    ndx,
-                    strong_count: Arc::strong_count(&slot_arc),
-                    kind: "finish_file",
-                }
-                .into());
-            }
-            if spin < 32 {
-                std::hint::spin_loop();
-            } else {
-                std::thread::yield_now();
-            }
-        }
-        let barrier = Arc::try_unwrap(slot_arc).map_err(|still_shared| {
-            ParallelApplyError::ApplierStillReferenced {
-                ndx,
-                strong_count: Arc::strong_count(&still_shared),
-                kind: "finish_file",
-            }
-        })?;
-        let slot = barrier
-            .slot
-            .into_inner()
-            .map_err(|_| ParallelApplyError::SlotPoisoned {
-                ndx,
-                kind: "finish_file",
-            })?;
-        if !slot.drained() {
-            return Err(ParallelApplyError::UndrainedChunks {
-                ndx,
-                buffered: slot.reorder.buffered_count(),
-                kind: "finish_file",
-            }
-            .into());
-        }
-        Ok(slot.writer)
-    }
-
-    /// Blocks the calling thread until every outstanding [`SlotHandle`]
-    /// for `ndx` has been dropped.
-    ///
-    /// Each call to [`Self::apply_one_chunk`] or
-    /// [`Self::apply_batch_parallel`] obtains a [`SlotHandle`] from
-    /// [`Self::slot_for`] that bumps the slot's in-flight counter for the
-    /// duration of the call (decrement on drop). `flush_workers` parks on
-    /// the slot's [`std::sync::Condvar`] until that counter is observed to be zero.
-    /// Spurious wakeups are filtered by the wait-while predicate.
-    ///
-    /// Returns [`Ok`] immediately if `ndx` is not registered (or has
-    /// already been finalised through [`Self::finish_file`]); the absence
-    /// of a slot is the same observable outcome as a fully-drained slot.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`io::Error`] only if the slot's in-flight mutex was
-    /// poisoned by a panicking worker. In that case the typed
-    /// [`ParallelApplyError::SlotPoisoned`] variant carries the offending
-    /// `ndx` and the `"flush_workers"` call-site tag.
-    pub fn flush_workers(&self, ndx: impl Into<FileNdx>) -> io::Result<()> {
-        let ndx = ndx.into();
-        // Look up the slot, clone the `Arc<SlotBarrier>`, drop the shard
-        // guard before waiting. This keeps the DashMap shard available to
-        // other NDX values while the caller blocks on the slot's own
-        // condvar, preserving the BR-3j.c shard-discipline contract.
-        let barrier = match self.files.get(&ndx) {
-            Some(guard) => Arc::clone(guard.value()),
-            None => return Ok(()),
-        };
-        barrier.wait_until_idle(ndx, "flush_workers")
     }
 
     /// Blocks until every registered slot in the applier has zero in-flight


### PR DESCRIPTION
## Summary

- Moves `ParallelDeltaApplier::finish_file` and `ParallelDeltaApplier::flush_workers` from `parallel_apply/mod.rs` into a new `parallel_apply/drain.rs` submodule, continuing the SPL-38 module decomposition kicked off by SPL-38.b/c/d.
- Adds `mod drain;` alongside the existing `batch`, `decrement_guard`, and `slot_barrier` submodules; the two methods stay on `ParallelDeltaApplier` via a sibling `impl` block so the public API is unchanged.
- Shrinks `mod.rs` by ~115 lines and groups the FFB-1/FFB-2 barrier surface (the wait + the reclaim) in one place.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - existing `finish_file_*` / `flush_workers_*` tests live in `mod.rs::tests`
- [ ] CI: Windows / macOS / Linux musl matrices