### PR TITLE
docs(daemon): document --max-connections admission cap (DMC-1)

### DIFF
--- a/docs/DAEMON_PROCESS_MODEL.md
+++ b/docs/DAEMON_PROCESS_MODEL.md
@@ -137,7 +137,13 @@ providing the same isolation guarantee as the sync mode's `catch_unwind`.
 The async listener uses a `tokio::sync::Semaphore` to enforce the maximum
 connection limit.  When the semaphore has no permits, new connections are
 dropped immediately. This is analogous to upstream rsync's `max connections`
-directive.
+directive. The sync accept loop enforces the same cap via a
+`ConnectionCounter`: when `--max-connections=N` is set (or the equivalent
+`max connections` config directive), each accepted socket is refused with
+`@ERROR: max connections (N) reached -- try again later` once *N*
+concurrent sessions are in flight. The cap is unset by default; see
+**oc-rsync(1)** for the flag reference and the *Operational
+Recommendations* below for the deployment note on **v0.6.2**.
 
 ---
 
@@ -155,7 +161,7 @@ authenticate, list modules, and transfer files using the same wire protocol.
 |----------|----------------|-------------------|
 | Session crash | Only that transfer fails; other connections unaffected | Same: `catch_unwind` isolates the panic; daemon continues |
 | Memory corruption | Cannot propagate across processes | Could theoretically propagate across threads (mitigated by `deny(unsafe_code)`) |
-| `max connections` | Each child is a process; OS `ulimit` applies | Threads are lighter; semaphore or `max_sessions` config enforces the limit |
+| `max connections` | Each child is a process; OS `ulimit` applies | Threads are lighter; the `--max-connections` flag (or `max connections` directive) caps concurrent sessions and refuses excess connections with the upstream `@ERROR` reply |
 | PID in logs | Each session has its own PID | All sessions share the daemon PID; session identity is the peer address |
 | `kill <session>` | `kill <child-pid>` terminates one session | No per-session PID; the daemon must handle cancellation internally |
 | Signal delivery | SIGTERM to child kills only that child | SIGTERM to the daemon process triggers graceful shutdown of all sessions |
@@ -177,9 +183,16 @@ authenticate, list modules, and transfer files using the same wire protocol.
    the daemon stops accepting new connections and drains active sessions before
    exiting.
 
-4. **Session limits.** Use `max connections` in `oc-rsyncd.conf` (or
-   `--max-sessions` on the command line) to cap concurrent sessions, matching
-   upstream rsync's per-module `max connections` directive.
+4. **Session limits.** Use `--max-connections=N` (or `max connections = N`
+   in `oc-rsyncd.conf`) to cap concurrent sessions, matching upstream
+   rsync's per-module `max connections` directive. When the cap is hit the
+   accept loop refuses each new socket with
+   `@ERROR: max connections (N) reached -- try again later` and keeps
+   running. `--max-connections` was introduced in **v0.6.2**; older
+   releases have no admission cap, so any publicly exposed daemon should
+   run **v0.6.2** or newer. Pair with `--max-sessions=N` to bound the
+   *total* sessions served before the daemon exits (useful for periodic
+   restart under a supervisor).
 
 ---
 

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -839,6 +839,30 @@ NEON) are used where available, with automatic scalar fallbacks.
 :   Override daemon config parameter on the command line. Can be specified
     multiple times.
 
+**--max-connections**=*N*
+:   Cap the number of concurrent client connections the daemon will accept.
+    *N* must be a positive integer. When omitted the daemon imposes no
+    admission cap, so operating-system limits (file descriptors, RAM) are the
+    only ceiling. When the cap is reached the accept loop refuses each new
+    socket with the upstream-compatible greeting
+    `@ERROR: max connections (N) reached -- try again later` and closes it
+    without dispatching a session; the listener keeps running and serving
+    in-flight clients. Mirrors the per-module `max connections` directive
+    documented in **rsyncd.conf**(5); this flag enforces the same cap
+    daemon-wide from the command line. **NOTE:** publicly exposed daemons
+    SHOULD set this flag (or the equivalent `max connections` directive in
+    *oc-rsyncd.conf*). Releases prior to **v0.6.2** have no admission cap
+    and accept connections until the operating system runs out of resources.
+
+**--max-sessions**=*N*
+:   Cap the total number of sessions the daemon will serve before exiting.
+    *N* must be a positive integer. After serving *N* sessions the daemon
+    stops accepting new connections and exits once in-flight transfers
+    complete. Useful for periodic restart under a process supervisor.
+    Distinct from **--max-connections**, which caps *concurrent* sessions
+    without bounding the lifetime total. Pass **--once** as a shorthand for
+    **--max-sessions**=*1*.
+
 ## Performance Options
 
 The io_uring policy selects one of three modes for the asynchronous file I/O


### PR DESCRIPTION
## Summary

- Document **--max-connections** in the user-facing docs after it shipped in v0.6.2.
- `docs/oc-rsync.1.md`: add the flag (and related **--max-sessions**) to the man-page reference, including the upstream-compatible cap-exceeded wire string and the v0.6.2 minimum-version note for public daemons.
- `docs/DAEMON_PROCESS_MODEL.md`: refresh the Connection Limiting section, the sync-vs-async comparison table, and the Operational Recommendations to point at the flag instead of outdated --max-sessions guidance.

Cross-references upstream rsync's per-module `max connections` directive (rsyncd.conf(5)) and notes that releases prior to v0.6.2 have no admission cap.

## Test plan

- [x] No code changes — docs-only PR
- [ ] Render preview in a Markdown viewer (CI handles man-page round-trip if any)