### PR TITLE
ci(bench): SSH push smoke regression cell (SSR-5)

### DIFF
--- a/.github/workflows/ssh-smoke-bench.yml
+++ b/.github/workflows/ssh-smoke-bench.yml
@@ -1,0 +1,138 @@
+name: SSH push smoke bench
+
+# SSR-5: catch SSH push wall-clock regressions like the v0.6.1 -> v0.6.2
+# subprocess-SSH goodbye-phase deadlock (~200x slower than upstream)
+# before they ship. Runs hyperfine over three file sizes (1 KB, 1 MB,
+# 100 MB) and asserts oc-rsync stays within 1.5x of upstream per size.
+#
+# Status: non-required. The bake-in plan is documented in
+# docs/ssh-transport-decision-matrix.md and the PR that introduced
+# this cell. After ~10 consecutive green runs on master with no
+# false-positive flakes, promote to the required check list in
+# branch protection.
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - 'crates/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'scripts/ci/ssh_push_smoke_bench.sh'
+      - '.github/workflows/ssh-smoke-bench.yml'
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'scripts/ci/ssh_push_smoke_bench.sh'
+      - '.github/workflows/ssh-smoke-bench.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ssh-smoke-bench-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  ssh-push-smoke:
+    name: SSH push smoke bench (1 KB / 1 MB / 100 MB)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Non-required: regression detection without gating PRs on perf
+    # flakiness. Remove this line and add to branch protection after
+    # the bake-in period described at the top of this file.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Cache cargo builds
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ssh-smoke-bench
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool \
+            libacl1-dev libattr1-dev zlib1g-dev libxxhash-dev libzstd-dev liblz4-dev \
+            openssh-server libssl-dev hyperfine jq
+
+      - name: Cache upstream rsync
+        id: cache-rsync
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: target/interop/upstream-src/rsync-3.4.2
+          key: upstream-rsync-3.4.2-${{ runner.os }}-full
+
+      - name: Build upstream rsync 3.4.2
+        if: steps.cache-rsync.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p target/interop/upstream-src
+          cd target/interop/upstream-src
+
+          if [ ! -d rsync-3.4.2 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.2.tar.gz | tar xz
+          fi
+
+          cd rsync-3.4.2
+          if [ ! -f rsync ]; then
+            ./configure
+            make -j"$(nproc)"
+          fi
+
+      - name: Install upstream rsync to PATH
+        run: sudo cp target/interop/upstream-src/rsync-3.4.2/rsync /usr/local/bin/rsync
+
+      - name: Build oc-rsync (release)
+        run: cargo build --release --workspace
+
+      - name: Set up SSH loopback
+        run: |
+          sudo systemctl start ssh
+          mkdir -p ~/.ssh
+          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ""
+          cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+          chmod 600 ~/.ssh/authorized_keys
+          ssh -o StrictHostKeyChecking=no -o BatchMode=yes localhost true
+
+      - name: Run SSH push smoke bench
+        env:
+          OC_RSYNC: ${{ github.workspace }}/target/release/oc-rsync
+          UPSTREAM_RSYNC: /usr/local/bin/rsync
+          RESULTS_DIR: ${{ github.workspace }}/ssh-smoke-results
+          HYPERFINE_RUNS: "5"
+          HYPERFINE_WARMUP: "1"
+          RATIO_LIMIT: "1.5"
+        run: |
+          export SSH_TARGET="$(whoami)@localhost"
+          bash scripts/ci/ssh_push_smoke_bench.sh
+
+      - name: Publish summary
+        if: always()
+        run: |
+          if [ -f ssh-smoke-results/summary.md ]; then
+            cat ssh-smoke-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload hyperfine results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ssh-push-smoke-results
+          retention-days: 90
+          path: ssh-smoke-results/

--- a/scripts/ci/ssh_push_smoke_bench.sh
+++ b/scripts/ci/ssh_push_smoke_bench.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SSH push smoke regression bench (SSR-5).
+#
+# Times oc-rsync and upstream rsync doing identical SSH pushes at three
+# file sizes and asserts that oc-rsync wall-clock stays within a fixed
+# multiple of upstream. Designed to catch regressions like v0.6.1's
+# subprocess SSH goodbye-phase deadlock (~200x slower) before release.
+#
+# Inputs (env):
+#   OC_RSYNC          - path to the oc-rsync binary under test (required)
+#   UPSTREAM_RSYNC    - path to upstream rsync (default: rsync on PATH)
+#   HYPERFINE_RUNS    - hyperfine --runs value (default: 5)
+#   HYPERFINE_WARMUP  - hyperfine --warmup value (default: 1)
+#   SSH_TARGET        - "user@host" for the push target (default: $USER@localhost)
+#   RESULTS_DIR       - where JSON results land (default: ./ssh-smoke-results)
+#   RATIO_LIMIT       - max oc-rsync / upstream ratio per size (default: 1.5)
+#
+# Exit 0 on success, non-zero if any size exceeds RATIO_LIMIT or a
+# transfer fails.
+
+set -euo pipefail
+
+OC_RSYNC="${OC_RSYNC:?OC_RSYNC must point at the oc-rsync binary}"
+UPSTREAM_RSYNC="${UPSTREAM_RSYNC:-rsync}"
+HYPERFINE_RUNS="${HYPERFINE_RUNS:-5}"
+HYPERFINE_WARMUP="${HYPERFINE_WARMUP:-1}"
+SSH_TARGET="${SSH_TARGET:-${USER}@localhost}"
+RESULTS_DIR="${RESULTS_DIR:-ssh-smoke-results}"
+RATIO_LIMIT="${RATIO_LIMIT:-1.5}"
+
+command -v hyperfine >/dev/null || {
+  echo "::error::hyperfine not found on PATH" >&2
+  exit 2
+}
+command -v jq >/dev/null || {
+  echo "::error::jq not found on PATH" >&2
+  exit 2
+}
+[ -x "$OC_RSYNC" ] || {
+  echo "::error::OC_RSYNC=$OC_RSYNC is not executable" >&2
+  exit 2
+}
+command -v "$UPSTREAM_RSYNC" >/dev/null || {
+  echo "::error::UPSTREAM_RSYNC=$UPSTREAM_RSYNC not found" >&2
+  exit 2
+}
+
+mkdir -p "$RESULTS_DIR"
+
+# Pre-flight: confirm SSH loopback works without a password prompt.
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no "$SSH_TARGET" true \
+  || { echo "::error::ssh to $SSH_TARGET failed (need passwordless loopback)"; exit 2; }
+
+# Sizes tested. Format: "label:bytes:destination_suffix".
+SIZES=(
+  "1KB:1024:size-1kb"
+  "1MB:1048576:size-1mb"
+  "100MB:104857600:size-100mb"
+)
+
+WORK_ROOT="$(mktemp -d -t ssh-smoke-bench-XXXXXX)"
+trap 'rm -rf "$WORK_ROOT"' EXIT
+
+declare -a SUMMARY_ROWS=()
+FAILED=0
+
+run_one_size() {
+  local label="$1" bytes="$2" dst_suffix="$3"
+  local src="$WORK_ROOT/src-$dst_suffix/payload.bin"
+  local dst_oc="$WORK_ROOT/dst-oc-$dst_suffix"
+  local dst_up="$WORK_ROOT/dst-up-$dst_suffix"
+  local json="$RESULTS_DIR/ssh-push-${label}.json"
+
+  mkdir -p "$(dirname "$src")" "$dst_oc" "$dst_up"
+  # Reproducible payload from /dev/urandom; same file for both runs.
+  head -c "$bytes" /dev/urandom > "$src"
+
+  echo "::group::SSH push smoke: $label ($bytes bytes)"
+
+  # Hyperfine resets the destination before each run so size + mtime
+  # match-skip never triggers. The --prepare hook wipes the per-size
+  # dst directory; the command itself does the push.
+  hyperfine \
+    --runs "$HYPERFINE_RUNS" \
+    --warmup "$HYPERFINE_WARMUP" \
+    --export-json "$json" \
+    --command-name "oc-rsync-$label" \
+    --prepare "rm -rf '$dst_oc' && mkdir -p '$dst_oc'" \
+    "'$OC_RSYNC' -a '$src' '$SSH_TARGET:$dst_oc/'" \
+    --command-name "upstream-$label" \
+    --prepare "rm -rf '$dst_up' && mkdir -p '$dst_up'" \
+    "'$UPSTREAM_RSYNC' -a '$src' '$SSH_TARGET:$dst_up/'"
+
+  local oc_mean up_mean ratio status
+  oc_mean=$(jq -r '.results[0].mean' "$json")
+  up_mean=$(jq -r '.results[1].mean' "$json")
+  ratio=$(awk -v a="$oc_mean" -v b="$up_mean" 'BEGIN { if (b == 0) print "inf"; else printf "%.3f", a / b }')
+  status="ok"
+  if awk -v r="$ratio" -v limit="$RATIO_LIMIT" 'BEGIN { exit !(r > limit) }'; then
+    status="FAIL"
+    FAILED=1
+    echo "::error::$label: oc-rsync ${oc_mean}s vs upstream ${up_mean}s -> ratio ${ratio} exceeds ${RATIO_LIMIT}"
+  fi
+
+  SUMMARY_ROWS+=("$label|$oc_mean|$up_mean|$ratio|$RATIO_LIMIT|$status")
+  echo "::endgroup::"
+}
+
+for entry in "${SIZES[@]}"; do
+  IFS=':' read -r label bytes suffix <<<"$entry"
+  run_one_size "$label" "$bytes" "$suffix"
+done
+
+# Markdown summary for GitHub step summary (and human readers).
+{
+  echo "## SSH push smoke bench (SSR-5)"
+  echo
+  echo "Ratio limit per size: \`${RATIO_LIMIT}x\` upstream."
+  echo
+  echo "| Size | oc-rsync (s) | upstream (s) | ratio | limit | status |"
+  echo "|------|--------------|--------------|-------|-------|--------|"
+  for row in "${SUMMARY_ROWS[@]}"; do
+    IFS='|' read -r label oc up ratio limit status <<<"$row"
+    echo "| $label | $oc | $up | ${ratio}x | ${limit}x | $status |"
+  done
+} | tee "$RESULTS_DIR/summary.md"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "::error::One or more SSH push sizes exceeded the ${RATIO_LIMIT}x upstream limit"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a non-required CI cell that catches SSH-push wall-clock regressions before release.

The motivating regression: v0.6.1 shipped a subprocess SSH push that was ~200x slower than upstream because of a goodbye-phase deadlock in the system-`ssh` stdio path. v0.6.2 fixed it via russh. Without a smoke cell that exercises a real SSH loopback on the runner, that class of regression can land again silently - existing benchmarks publish numbers but do not assert thresholds, and the interop matrix does not measure wall-clock against upstream.

## What this adds

- `.github/workflows/ssh-smoke-bench.yml` - Ubuntu runner cell that:
  - installs `openssh-server`, `hyperfine`, `jq`, builds upstream rsync 3.4.2 (cached) and `oc-rsync --release`,
  - sets up a passwordless ed25519 loopback to `localhost`,
  - calls the shared script below.
- `scripts/ci/ssh_push_smoke_bench.sh` - hyperfine harness that pushes three payloads (1 KB, 1 MB, 100 MB) over SSH with both binaries, computes `oc-rsync / upstream` ratios from the hyperfine JSON, and exits non-zero when any size exceeds `RATIO_LIMIT` (default 1.5x).

Per-size threshold (configurable via env):

| Size   | Ratio limit |
|--------|-------------|
| 1 KB   | 1.5x upstream |
| 1 MB   | 1.5x upstream |
| 100 MB | 1.5x upstream |

A future v0.6.1-class regression (~200x) would trip every cell. A 2x regression on the small-file path (which is where the goodbye-phase bug bit hardest) would also trip.

## Artifacts

Each run uploads `ssh-push-smoke-results/` containing one hyperfine JSON per size plus a markdown summary, retained 90 days for trend analysis.

## Non-required by design

The cell uses `continue-on-error: true` so perf flakiness on shared runners does not block PRs during the bake-in period. The workflow file header documents the promotion path: after ~10 consecutive green runs on master with no false positives, drop `continue-on-error` and add the check to branch protection.

## Reference

- SSH transport rationale and the russh vs subprocess choice that fixed v0.6.1: `docs/ssh-transport-decision-matrix.md`.

## Scope

- No `.rs` edits.
- No changes to existing workflows.
- Helper script is self-contained under `scripts/ci/`.

## Test plan

- [ ] Workflow parses and the job appears in the Actions tab on this PR.
- [ ] `ssh-push-smoke` job completes; markdown summary lists 1 KB / 1 MB / 100 MB rows with ratios.
- [ ] `ssh-push-smoke-results` artifact is uploaded with three JSON files plus `summary.md`.
- [ ] Manual sanity: ratios on a green master run are well under 1.5x.