### PR TITLE
feat(daemon): log when --max-connections cap rejects a connection (DMC-5)

### DIFF
--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -74,19 +74,30 @@ fn log_module_request(log: &SharedLogSink, host: Option<&str>, peer_ip: IpAddr, 
     log_message(log, &message);
 }
 
-fn log_module_limit(
+/// Emits a structured warning when a module rejects a connection because
+/// its per-module `max connections` cap has been reached.
+///
+/// Mirrors the global cap warning emitted from
+/// [`log_max_connections_rejection`] so operators see one consistent
+/// shape across both admission paths. Fields are stable and named:
+/// `which` carries the module name (sanitised to strip control chars),
+/// `peer` records the rejected client IP, `cap` is the limit that
+/// triggered the refusal, and `current` is the active connection count
+/// observed at the refusal moment.
+pub(crate) fn log_module_limit(
     log: &SharedLogSink,
     host: Option<&str>,
     peer_ip: IpAddr,
     module: &str,
     limit: NonZeroU32,
+    current: u32,
 ) {
     let display = format_host(host, peer_ip);
     let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "refusing module '{module_display}' from {display} ({peer_ip}): max connections {limit}"
+        "max-connections cap reached: which={module_display} peer={display} ({peer_ip}) cap={limit} current={current}"
     );
-    let message = rsync_info!(text).with_role(Role::Daemon);
+    let message = rsync_warning!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -94,12 +94,23 @@ fn send_daemon_ok(
 /// Sends an error message indicating the connection limit was reached and logs the event.
 fn handle_max_connections_exceeded(
     ctx: &mut ModuleRequestContext<'_>,
+    module: &ModuleRuntime,
     limit: NonZeroU32,
 ) -> io::Result<()> {
     let payload = MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.get().to_string());
     send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
     if let Some(log) = ctx.log_sink {
-        log_module_limit(log, ctx.effective_host(), ctx.peer_ip, ctx.request, limit);
+        let current = module
+            .active_connections
+            .load(std::sync::atomic::Ordering::Acquire);
+        log_module_limit(
+            log,
+            ctx.effective_host(),
+            ctx.peer_ip,
+            ctx.request,
+            limit,
+            current,
+        );
     }
     Ok(())
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -388,7 +388,7 @@ fn process_approved_module(
     let _connection_guard = match module.try_acquire_connection() {
         Ok(guard) => guard,
         Err(ModuleConnectionError::Limit(limit)) => {
-            return handle_max_connections_exceeded(ctx, limit);
+            return handle_max_connections_exceeded(ctx, module, limit);
         }
         Err(ModuleConnectionError::Io(error)) => {
             return handle_lock_error(ctx, &error);

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -126,7 +126,8 @@ fn refuse_if_at_capacity(
         return false;
     };
 
-    if state.connection_counter.active() < limit {
+    let current = state.connection_counter.active();
+    if current < limit {
         return false;
     }
 
@@ -144,13 +145,34 @@ fn refuse_if_at_capacity(
     let _ = stream.flush();
 
     if let Some(log) = state.log_sink.as_ref() {
-        let text =
-            format!("refused connection from {peer_addr}: max connections ({limit}) reached");
-        let message = rsync_info!(text).with_role(Role::Daemon);
-        log_message(log, &message);
+        log_max_connections_rejection(log, peer_addr, "global", limit, current);
     }
 
     true
+}
+
+/// Emits a structured warning describing a connection rejected by the
+/// daemon's `--max-connections` cap.
+///
+/// Operators rely on this signal to tune the cap from observable evidence,
+/// so the fields are stable and named: `which` distinguishes the global
+/// cap from a per-module cap, `peer` records the rejected client address,
+/// `cap` is the limit that triggered the refusal, and `current` is the
+/// active connection count observed at refusal time. The line is emitted
+/// at warning level to separate it from routine connect/disconnect info
+/// chatter while staying below error severity (the daemon keeps serving).
+pub(crate) fn log_max_connections_rejection(
+    log: &SharedLogSink,
+    peer: SocketAddr,
+    which: &str,
+    cap: usize,
+    current: usize,
+) {
+    let text = format!(
+        "max-connections cap reached: which={which} peer={peer} cap={cap} current={current}"
+    );
+    let message = rsync_warning!(text).with_role(Role::Daemon);
+    log_message(log, &message);
 }
 
 /// Spawns a worker thread for an accepted connection.

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -890,7 +890,7 @@ fn refuse_if_at_capacity_emits_structured_warning() {
 
     let contents = std::fs::read_to_string(&log_path).expect("read log");
     assert!(
-        contents.starts_with("rsync warning:"),
+        contents.starts_with("oc-rsync warning:"),
         "expected warning level, got: {contents}"
     );
     assert!(

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -846,6 +846,73 @@ fn accept_loop_refuses_when_at_capacity() {
 }
 
 #[test]
+fn refuse_if_at_capacity_emits_structured_warning() {
+    // Operators need a stable, structured warning line whenever the
+    // global `--max-connections` cap rejects a connection; assert that
+    // `refuse_if_at_capacity` writes a single record with the
+    // `which=global`, `peer=`, `cap=` and `current=` fields named.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+    let client_handle =
+        thread::spawn(move || TcpStream::connect(local).expect("connect refused client"));
+    let (mut server_stream, peer) = listener.accept().expect("accept refused client");
+    let _client = client_handle.join().expect("client connect");
+
+    let log_dir = tempfile::tempdir().expect("log dir");
+    let log_path = log_dir.path().join("daemon.log");
+    let log_sink: Option<SharedLogSink> =
+        Some(open_log_sink(&log_path, Brand::Oc).expect("open log"));
+
+    let flags = no_op_signal_flags();
+    let config_path: Option<PathBuf> = None;
+    let limiter: Option<Arc<ConnectionLimiter>> = None;
+    let notifier = systemd::ServiceNotifier::new();
+    let counter = ConnectionCounter::new();
+    let _g1 = counter.acquire();
+    let _g2 = counter.acquire();
+    assert_eq!(counter.active(), 2);
+
+    let state = test_accept_loop_state(
+        &flags,
+        &config_path,
+        &limiter,
+        &log_sink,
+        &notifier,
+        counter.clone(),
+        Some(2),
+    );
+
+    assert!(refuse_if_at_capacity(&mut server_stream, peer, &state));
+    drop(server_stream);
+
+    // Drop the sink so the underlying file is flushed before we read it.
+    drop(log_sink);
+
+    let contents = std::fs::read_to_string(&log_path).expect("read log");
+    assert!(
+        contents.starts_with("rsync warning:"),
+        "expected warning level, got: {contents}"
+    );
+    assert!(
+        contents.contains("max-connections cap reached"),
+        "missing structured prefix: {contents}"
+    );
+    assert!(
+        contents.contains("which=global"),
+        "missing which=global field: {contents}"
+    );
+    assert!(
+        contents.contains(&format!("peer={peer}")),
+        "missing peer= field: {contents}"
+    );
+    assert!(contents.contains("cap=2"), "missing cap= field: {contents}");
+    assert!(
+        contents.contains("current=2"),
+        "missing current= field: {contents}"
+    );
+}
+
+#[test]
 fn accept_loop_recovers_after_disconnect() {
     // Same setup as `accept_loop_refuses_when_at_capacity`, but after
     // releasing one of the two active guards a new connection must be

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -46,6 +46,7 @@ use crate::daemon::{
     legacy_daemon_greeting,
     legacy_daemon_greeting_for_protocol,
     log_module_bandwidth_change,
+    log_module_limit,
     module_peer_hostname,
     open_log_sink,
     // From sections/config_helpers.rs
@@ -111,6 +112,7 @@ include!("tests/chunks/log_file_open_failure_returns_message_io.rs");
 include!("tests/chunks/log_module_bandwidth_change_ignores_unchanged.rs");
 include!("tests/chunks/log_module_bandwidth_change_logs_disable.rs");
 include!("tests/chunks/log_module_bandwidth_change_logs_updates.rs");
+include!("tests/chunks/log_module_limit_logs_cap_reached.rs");
 include!("tests/chunks/module_bwlimit_burst_does_not_raise_daemon_cap.rs");
 include!("tests/chunks/module_bwlimit_can_lower_daemon_cap.rs");
 include!("tests/chunks/module_bwlimit_cannot_raise_daemon_cap.rs");

--- a/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
+++ b/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
@@ -1,0 +1,45 @@
+#[test]
+fn log_module_limit_logs_cap_reached() {
+    let dir = tempdir().expect("log dir");
+    let path = dir.path().join("daemon.log");
+    let log = open_log_sink(&path, Brand::Oc).expect("open log");
+    let limit = NonZeroU32::new(4).expect("non-zero limit");
+
+    log_module_limit(
+        &log,
+        Some("client.example"),
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 17)),
+        "docs",
+        limit,
+        4,
+    );
+
+    drop(log);
+
+    let contents = fs::read_to_string(&path).expect("read log");
+    assert!(
+        contents.starts_with("rsync warning:"),
+        "expected warning-level message, got: {contents}"
+    );
+    assert!(
+        contents.contains("max-connections cap reached"),
+        "missing structured prefix: {contents}"
+    );
+    assert!(
+        contents.contains("which=docs"),
+        "missing which= field: {contents}"
+    );
+    assert!(
+        contents.contains("peer=client.example"),
+        "missing peer= field: {contents}"
+    );
+    assert!(
+        contents.contains("(192.0.2.17)"),
+        "missing peer ip: {contents}"
+    );
+    assert!(contents.contains("cap=4"), "missing cap= field: {contents}");
+    assert!(
+        contents.contains("current=4"),
+        "missing current= field: {contents}"
+    );
+}

--- a/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
+++ b/crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs
@@ -18,7 +18,7 @@ fn log_module_limit_logs_cap_reached() {
 
     let contents = fs::read_to_string(&path).expect("read log");
     assert!(
-        contents.starts_with("rsync warning:"),
+        contents.starts_with("oc-rsync warning:"),
         "expected warning-level message, got: {contents}"
     );
     assert!(


### PR DESCRIPTION
## Summary

Emit a structured warning each time the daemon refuses a connection because the global `--max-connections` cap or a per-module `max connections` cap is at the limit. Operators can now tune the cap from observable signal without sampling the wire protocol.

Both admission paths log the same shape so downstream log parsers see one format:

```
rsync warning: max-connections cap reached: which=<scope> peer=<addr> cap=<N> current=<M>
```

- `which` - `global` for the daemon-level cap, or the module name for a per-module cap.
- `peer` - the rejected client's `SocketAddr` (global path) or sanitised hostname/IP pair (per-module path).
- `cap` - the limit that triggered the refusal.
- `current` - active connection count observed at refusal time.

The refusal payload sent to the client (`@ERROR: max connections (N) reached -- try again later\n`) is unchanged - this PR only adds operator-facing log signal.

## Sites instrumented

- **Global cap** (`crates/daemon/src/daemon/sections/server_runtime/connection.rs`): `refuse_if_at_capacity` now snapshots `connection_counter.active()` and delegates to a new `log_max_connections_rejection` helper.
- **Per-module cap** (`crates/daemon/src/daemon/sections/module_access/request.rs`): `handle_max_connections_exceeded` now loads `module.active_connections` at the refusal moment and passes it through to `log_module_limit`, which was upgraded from info to warning level and reshaped to emit the same `which=/peer=/cap=/current=` field shape.

## History

- DMC-1 introduced the global `--max-connections` cap (v0.6.2).
- DMC-3 byte-pinned the refusal payload against upstream `clientserver.c:752`.
- DMC-6 added the per-module `max connections` directive (#4816).
- DMC-5 (this PR) closes the observability gap so the cap is operationally tunable.

## Test plan

- [x] New unit test `log_module_limit_logs_cap_reached` (`crates/daemon/src/tests/chunks/log_module_limit_logs_cap_reached.rs`) drives the per-module helper directly and asserts the warning level, the structured prefix, and every named field.
- [x] New integration test `refuse_if_at_capacity_emits_structured_warning` (`crates/daemon/src/daemon/sections/server_runtime/tests.rs`) exercises the full global cap-hit path end-to-end: it binds a real listener, fills the counter to the cap, calls `refuse_if_at_capacity`, drops the sink to flush, then reads the log file back and pins every field.
- [ ] CI runs the full nextest suite on stable, Windows, macOS, and Linux musl.