### PR TITLE
ci(interop): build rsync 2.6.9 from source for protocol 28 interop (RP28.b)

### DIFF
--- a/docs/INTEROP.md
+++ b/docs/INTEROP.md
@@ -3,15 +3,17 @@
 **Last Updated**: 2025-11-25
 **Status**: RESTORED TO CI PIPELINE
 
-This document defines the upstream compatibility test scenarios used to validate oc-rsync's parity with rsync 3.0.9, 3.1.3, and 3.4.1.
+This document defines the upstream compatibility test scenarios used to validate oc-rsync's parity with rsync 2.6.9, 3.0.9, 3.1.3, 3.4.1, and 3.4.2.
 
 ---
 
 ## Upstream Binaries Tested
 
+- `rsync-2.6.9` (always built from source; protocol-28 cutoff peer)
 - `rsync-3.0.9` (via old-releases.ubuntu.com or source build)
 - `rsync-3.1.3` (via archive.ubuntu.com or source build)
 - `rsync-3.4.1` (via deb.debian.org or source build)
+- `rsync-3.4.2` (via deb.debian.org or source build)
 
 ---
 

--- a/docs/interop/protocol-matrix.md
+++ b/docs/interop/protocol-matrix.md
@@ -31,6 +31,7 @@ window each release will accept on the wire.
 
 | Upstream release | `PROTOCOL_VERSION` | `MIN_PROTOCOL_VERSION` | `MAX_PROTOCOL_VERSION` | Notes |
 |------------------|--------------------|------------------------|------------------------|-------|
+| rsync 2.6.9      | 29                 | 20                     | 40                     | Protocol-28 cutoff peer; advertises 29 and degrades to 28 on request. Always source-built by the harness; binary is cached but dedicated push/pull interop cells land in a follow-up task. |
 | rsync 3.0.9      | 30                 | 20                     | 40                     | First release with binary handshake; wire compat down to 28 still useful for legacy peers. |
 | rsync 3.1.3      | 31                 | 20                     | 40                     | Adds `CF_SAFE_FLIST` always-on, `--info=progress2`. |
 | rsync 3.4.1      | 32                 | 20                     | 40                     | Newest release. Adds checksum negotiation (`-e.LsfxCIvu`), `CF_ID0_NAMES`, `--crtimes`. |

--- a/docs/interop_testing.md
+++ b/docs/interop_testing.md
@@ -26,9 +26,11 @@ Both test suites use similar infrastructure:
 
 Tests verify compatibility with:
 
-- **rsync 3.4.1** - Latest stable, protocol 32
+- **rsync 3.4.2** - Latest stable, protocol 32
+- **rsync 3.4.1** - Previous stable, protocol 32
 - **rsync 3.1.3** - Common production version, protocol 30/31
 - **rsync 3.0.9** - Older widely-deployed version, protocol 30
+- **rsync 2.6.9** - Protocol-28 cutoff peer; advertises protocol 29, accepts down to 28. Always built from source by `tools/ci/run_interop.sh`.
 
 ## Prerequisites
 

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -2,6 +2,7 @@
 # Ubuntu/Debian-first rsync interop harness
 # - Detects platform architecture and aligns Debian/Ubuntu package arch names
 # - Tries real, validated package locations for:
+#     2.6.9  -> always source-built (legacy, predates per-arch .deb coverage we care about)
 #     3.0.9  -> old-releases.ubuntu.com
 #     3.1.3  -> archive.ubuntu.com
 #     3.4.1  -> deb.debian.org (3.4.1+ds1-6)
@@ -50,8 +51,12 @@ upstream_src_root="${workspace_root}/target/interop/upstream-src"
 upstream_install_root="${workspace_root}/target/interop/upstream-install"
 interop_log_dir="${workspace_root}/target/interop/logs"
 
-# Versions we test against
+# Versions we run interop scenarios against.
 versions=(3.0.9 3.1.3 3.4.1 3.4.2)
+# Versions we only build and cache (no scenarios wired up yet). 2.6.9 is the
+# protocol-28 cutoff peer (advertises protocol 29, accepts down to 28); the
+# binary is needed so follow-up tasks can wire push/pull cells against it.
+extra_build_versions=(2.6.9)
 rsync_repo_url="https://github.com/RsyncProject/rsync.git"
 rsync_tarball_base_url="${RSYNC_TARBALL_BASE_URL:-https://rsync.samba.org/ftp/rsync/src}"
 
@@ -103,11 +108,16 @@ build_jobs() {
   fi
 }
 
-# Build the most realistic URL for this version+arch using actual distro naming
+# Build the most realistic URL for this version+arch using actual distro naming.
+# Returns an empty string for versions that have no usable .deb (e.g. 2.6.9);
+# ensure_upstream_build treats an empty URL as "skip deb fetch, build from source".
 build_version_url() {
   local version=$1
   local arch=$2
   case "$version" in
+    2.6.9)
+      echo ""
+      ;;
     3.0.9)
       echo "${OLD_UBUNTU_MIRROR}/pool/main/r/rsync/rsync_3.0.9-1ubuntu1.3_${arch}.deb"
       ;;
@@ -185,6 +195,11 @@ try_fetch_deb_generic() {
   local candidates=()
 
   case "$version" in
+    2.6.9)
+      # No usable per-arch generic-pool .deb for rsync 2.6.9; skip straight to source build.
+      rm -f "$tmp_deb"
+      return 1
+      ;;
     3.0.9)
       candidates+=(
         "${OLD_UBUNTU_MIRROR}/pool/main/r/rsync/rsync_3.0.9-1ubuntu1_${arch}.deb"
@@ -336,6 +351,17 @@ build_upstream_from_source() {
     exit 1
   fi
 
+  # Refresh ancient autotools helper scripts when the system provides newer ones.
+  # rsync 2.6.9 ships a 2006-vintage config.guess/config.sub that does not
+  # recognise aarch64, riscv64, or modern Linux triples; Debian's autotools
+  # package keeps current copies in /usr/share/misc/ that we can drop in.
+  local helper
+  for helper in config.guess config.sub; do
+    if [[ -f "$helper" && -f "/usr/share/misc/${helper}" ]]; then
+      cp "/usr/share/misc/${helper}" "$helper"
+    fi
+  done
+
   local configure_help
   configure_help=$(./configure --help)
   local -a configure_args=("--prefix=${install_dir}")
@@ -356,8 +382,20 @@ build_upstream_from_source() {
   if grep -q -- "--enable-xattr-support" <<<"$configure_help"; then
     configure_args+=("--enable-xattr-support")
   fi
+  # rsync 2.6.9 predates the bundled-popt-by-default era; without this the
+  # build links against system libpopt, which may not be present on minimal
+  # CI images. The flag is silently absent on newer rsync, so gate on help.
+  if grep -q -- "--with-included-popt" <<<"$configure_help"; then
+    configure_args+=("--with-included-popt")
+  fi
 
-  if ! ./configure "${configure_args[@]}" >"${build_log}" 2>&1; then
+  # gcc >= 14 makes implicit function declarations and implicit int errors by
+  # default, which breaks autoconf feature-probes in rsync 2.6.9 (every check
+  # silently reports "no", leading to a build that calls gettimeofday with the
+  # wrong arity etc.). Restoring the historical "warn, don't error" defaults
+  # keeps the conftest results accurate without touching newer rsync builds.
+  local extra_cflags="-O2 -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion"
+  if ! CFLAGS="${CFLAGS:-} ${extra_cflags}" ./configure "${configure_args[@]}" >"${build_log}" 2>&1; then
     echo "Upstream rsync ${version} configure failed; see ${build_log}" >&2
     tail -n 50 "${build_log}" >&2 || true
     exit 1
@@ -395,6 +433,11 @@ ensure_upstream_build() {
 
   local url
   url=$(build_version_url "$version" "$arch")
+  if [[ -z "$url" ]]; then
+    echo "No .deb candidate for rsync ${version}; building from source ..."
+    build_upstream_from_source "$version"
+    return
+  fi
   echo "Trying ${url}"
   if try_fetch_deb "$url" "$install_dir"; then
     if "${install_dir}/bin/rsync" --version | head -n1 | grep -q "rsync\s\+version\s\+${version}\b"; then
@@ -9813,16 +9856,18 @@ for arg in "$@"; do
   esac
 done
 
-# Build upstream binaries first (always needed)
+# Build upstream binaries first (always needed). Includes versions cached for
+# follow-up tasks (extra_build_versions) so the binary is on disk and on PATH
+# even when no scenarios reference it yet.
 mkdir -p "$upstream_src_root" "$upstream_install_root"
-for version in "${versions[@]}"; do
+for version in "${versions[@]}" "${extra_build_versions[@]}"; do
   ensure_upstream_build "$version"
 done
 
 # If build-only mode, exit after building upstream binaries
 if [[ "$build_only" == "true" ]]; then
   echo "Built upstream rsync binaries (build-only mode)"
-  for version in "${versions[@]}"; do
+  for version in "${versions[@]}" "${extra_build_versions[@]}"; do
     binary="${upstream_install_root}/${version}/bin/rsync"
     if [[ -x "$binary" ]]; then
       echo "  - ${version}: $binary"


### PR DESCRIPTION
## Summary

- Caches rsync 2.6.9 as the fifth upstream binary built by `tools/ci/run_interop.sh`, alongside the existing 3.0.9, 3.1.3, 3.4.1, 3.4.2. 2.6.9 is the protocol-28 cutoff peer (advertises protocol 29, accepts down to 28) and exercises the bottom of oc-rsync's claimed protocol range.
- Version-matrix change: `versions=` (the iterators that drive interop scenarios) stays at `(3.0.9 3.1.3 3.4.1 3.4.2)`. A new `extra_build_versions=(2.6.9)` array drives the build/cache loop only; no scenario cells are added in this PR.
- RP28.c (push interop) and RP28.d (pull interop) will land the actual interop cells against 2.6.9 in follow-up PRs; this PR just makes the binary buildable, cached, and on the harness PATH.

## Build quirks handled

rsync 2.6.9 predates several modern toolchain assumptions, so `build_upstream_from_source` was extended (all changes are gated on configure-help probing or `/usr/share/misc/` presence, so they remain no-ops or harmless for newer rsync builds):

- **`config.guess` / `config.sub` refresh** - 2.6.9 ships 2006-vintage helper scripts that reject `aarch64`, `riscv64`, and modern Linux triples. The harness now copies Debian's `/usr/share/misc/config.{guess,sub}` over them when present.
- **`--with-included-popt`** - 2.6.9 predates the bundled-popt-by-default era. Appended when `configure --help` advertises it; silent for newer rsync where it is a no-op opt-in.
- **`CFLAGS=-Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion`** - gcc >= 14 promotes these to errors by default, which silently makes every autoconf feature-probe in 2.6.9 return "no" (e.g. the script then compiles a `gettimeofday(&tv)` call with the wrong arity). Restoring the historical "warn, don't error" defaults keeps the conftest results accurate.
- **No usable per-arch .deb** - `build_version_url` returns empty for 2.6.9 and `try_fetch_deb_generic` short-circuits, so `ensure_upstream_build` skips straight to the source build.

## Configure flags used for 2.6.9

```
CFLAGS="-O2 -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion" \
  ./configure --prefix=<install_dir> --with-included-popt
```

(`--disable-xxhash`, `--disable-md2man`, `--enable-acl-support`, `--enable-xattr-support` are not present in 2.6.9's `configure --help`, so the existing grep-gated logic skips them.)

## Smoke test

Built end-to-end inside the `rsync-profile` podman container on aarch64 with `tools/ci/run_interop.sh build-only`:

```
Built upstream rsync binaries (build-only mode)
  - 3.0.9: .../target/interop/upstream-install/3.0.9/bin/rsync
  - 3.1.3: .../target/interop/upstream-install/3.1.3/bin/rsync
  - 3.4.1: .../target/interop/upstream-install/3.4.1/bin/rsync
  - 3.4.2: .../target/interop/upstream-install/3.4.2/bin/rsync
  - 2.6.9: .../target/interop/upstream-install/2.6.9/bin/rsync

$ rsync --version | head -2
rsync  version 2.6.9  protocol version 29
Copyright (C) 1996-2006 by Andrew Tridgell, Wayne Davison, and others.
```

3.4.2 source-build re-verified separately with the same new CFLAGS + `--with-included-popt` (clean build, `rsync  version 3.4.2  protocol version 32`).

## Docs touched

- `docs/INTEROP.md` - upstream-binaries list now enumerates 2.6.9 and 3.4.2.
- `docs/interop_testing.md` - supported-versions list adds 2.6.9 with a note that it is source-built.
- `docs/interop/protocol-matrix.md` - protocol-to-release table adds a 2.6.9 row that calls out the cached-only status.

## Test plan

- [ ] `tools/ci/run_interop.sh build-only` succeeds on the CI runner and produces the 2.6.9 binary at `target/interop/upstream-install/2.6.9/bin/rsync`.
- [ ] Full `tools/ci/run_interop.sh` run still passes for 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2 (scenario matrix unchanged).
- [ ] Interop Validation workflow stays green; 2.6.9 build is additive only and does not gate any scenario yet.