### PR TITLE
feat(engine): migrate ParallelDeltaApplier files map to SlotEntry (DG-3.b)

### DIFF
--- a/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
@@ -1,10 +1,15 @@
 //! Per-file drain primitives for the parallel apply scaffold (SPL-38.e).
 //!
 //! Extracted from `parallel_apply/mod.rs` as part of the SPL-38 module
-//! decomposition. Sibling to [`super::slot_barrier::SlotBarrier`],
+//! decomposition. Sibling to [`super::slot_barrier`],
 //! [`super::decrement_guard::DecrementGuard`], and [`super::batch`]; reuses
-//! the per-slot [`std::sync::Arc<SlotBarrier>`] map maintained by
-//! [`ParallelDeltaApplier`].
+//! the per-slot [`super::slot_barrier::SlotEntry`] map maintained by
+//! [`ParallelDeltaApplier`]. DG-3.b (#2569) swapped the DashMap value
+//! type from `Arc<SlotBarrier>` to `SlotEntry`; this module now clones
+//! `entry.barrier` ([`std::sync::Arc<super::slot_barrier::BarrierState>`])
+//! for the FFB-2 wait and unwraps `entry.data`
+//! ([`std::sync::Arc<super::slot_barrier::SlotData>`]) for the
+//! end-of-file writer reclaim.
 //!
 //! # Contract
 //!
@@ -25,6 +30,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use super::super::types::FileNdx;
+use super::slot_barrier::SlotEntry;
 use super::{ParallelApplyError, ParallelDeltaApplier};
 
 impl ParallelDeltaApplier {
@@ -53,21 +59,30 @@ impl ParallelDeltaApplier {
         // `DashMap::remove` returns the owned `(K, V)` and drops the shard
         // guard immediately; the `Arc::try_unwrap` work below happens
         // outside the shard lock.
-        let (_, slot_arc) = self
+        let (_, entry) = self
             .files
             .remove(&ndx)
             .ok_or_else(|| std::io::Error::other(format!("parallel applier file {ndx} unknown")))?;
+        // DG-3.b retargets the spin/unwrap from the (now-removed) single
+        // `Arc<SlotBarrier>` to the entry's payload Arc. Drop the
+        // bookkeeping Arc first so any leftover `DecrementGuard` clones
+        // are the only `BarrierState` strong references left; the
+        // payload Arc's strong-count trajectory is now what
+        // `try_unwrap` reasons about.
+        let SlotEntry { data, barrier } = entry;
+        drop(barrier);
         // Post-barrier release-race window: `flush_workers` waits for
         // `inflight==0` via the Condvar, which fires from
-        // `DecrementGuard::drop` *before* the guard's own
-        // `Arc<SlotBarrier>` clone has been released (the notify happens
-        // inside the drop body; the inner Arc only drops after the body
-        // returns). The window is typically nanoseconds but is reliably
-        // observable on Windows under load. Spin-then-yield until the
-        // worker's drop completes; the worker is past the notify and its
-        // drop fn is just about to return so the wait is bounded.
+        // `DecrementGuard::drop` *before* the guard's own adapter Arc
+        // has been released (the notify happens inside the drop body;
+        // the inner Arcs only drop after the body returns). The window
+        // is typically nanoseconds but is reliably observable on Windows
+        // under load. Spin-then-yield until the worker's drop completes;
+        // the worker is past the notify and its drop fn is just about
+        // to return so the wait is bounded. DG-3.c will retire the
+        // adapter and let DG-4 delete the spin entirely.
         let mut spin = 0u32;
-        while Arc::strong_count(&slot_arc) > 1 {
+        while Arc::strong_count(&data) > 1 {
             spin = spin.saturating_add(1);
             if spin >= 1_000 {
                 // Past the typical drop window - surface the typed error
@@ -75,7 +90,7 @@ impl ParallelDeltaApplier {
                 // against `finish_file`) does not hide forever.
                 return Err(ParallelApplyError::ApplierStillReferenced {
                     ndx,
-                    strong_count: Arc::strong_count(&slot_arc),
+                    strong_count: Arc::strong_count(&data),
                     kind: "finish_file",
                 }
                 .into());
@@ -86,20 +101,14 @@ impl ParallelDeltaApplier {
                 std::thread::yield_now();
             }
         }
-        let barrier = Arc::try_unwrap(slot_arc).map_err(|still_shared| {
+        let slot_data = Arc::try_unwrap(data).map_err(|still_shared| {
             ParallelApplyError::ApplierStillReferenced {
                 ndx,
                 strong_count: Arc::strong_count(&still_shared),
                 kind: "finish_file",
             }
         })?;
-        let slot = barrier
-            .slot
-            .into_inner()
-            .map_err(|_| ParallelApplyError::SlotPoisoned {
-                ndx,
-                kind: "finish_file",
-            })?;
+        let slot = slot_data.into_slot(ndx, "finish_file")?;
         if !slot.drained() {
             return Err(ParallelApplyError::UndrainedChunks {
                 ndx,
@@ -136,12 +145,13 @@ impl ParallelDeltaApplier {
     /// [`Self::slot_for`]: super::ParallelDeltaApplier
     pub fn flush_workers(&self, ndx: impl Into<FileNdx>) -> std::io::Result<()> {
         let ndx = ndx.into();
-        // Look up the slot, clone the `Arc<SlotBarrier>`, drop the shard
-        // guard before waiting. This keeps the DashMap shard available to
-        // other NDX values while the caller blocks on the slot's own
-        // condvar, preserving the BR-3j.c shard-discipline contract.
+        // Look up the slot, clone the `Arc<BarrierState>` from the
+        // entry, drop the shard guard before waiting. This keeps the
+        // DashMap shard available to other NDX values while the caller
+        // blocks on the slot's own condvar, preserving the BR-3j.c
+        // shard-discipline contract.
         let barrier = match self.files.get(&ndx) {
-            Some(guard) => Arc::clone(guard.value()),
+            Some(guard) => Arc::clone(&guard.value().barrier),
             None => return Ok(()),
         };
         barrier.wait_until_idle(ndx, "flush_workers")

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -1040,7 +1040,7 @@ pub(super) mod tests {
     #[test]
     fn flush_workers_survives_spurious_wakeup() {
         // Condvars are permitted to wake spuriously; the wait_while
-        // predicate in `SlotBarrier::wait_until_idle` must re-check
+        // predicate in `BarrierState::wait_until_idle` must re-check
         // under the mutex and continue waiting. We exercise the
         // predicate by notifying the slot's condvar manually while the
         // inflight counter is still > 0, then verifying flush_workers

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -55,7 +55,7 @@ mod drain;
 mod slot_barrier;
 
 use decrement_guard::DecrementGuard;
-use slot_barrier::SlotBarrier;
+use slot_barrier::{SlotBarrier, SlotEntry};
 
 /// Typed error variants for [`ParallelDeltaApplier::finish_file`] shutdown
 /// paths.
@@ -351,9 +351,16 @@ pub struct ParallelDeltaApplier {
     /// Per-file slots keyed by NDX. The outer map is a [`DashMap`] so the
     /// register/lookup path shards under a fixed number of internal locks
     /// instead of serialising every operation behind one [`std::sync::Mutex`]. Each
-    /// slot value is an [`Arc<SlotBarrier>`] that wraps the per-file
-    /// [`std::sync::Mutex<FileSlot>`] alongside the in-flight counter and [`std::sync::Condvar`]
-    /// that back FFB-2's `flush_workers` barrier. The BR-3j.a audit (see
+    /// slot value is a [`SlotEntry`] carrying the per-file payload
+    /// (an [`Arc<slot_barrier::SlotData>`] wrapping
+    /// [`std::sync::Mutex<FileSlot>`]) and the per-file bookkeeping
+    /// (an [`Arc<slot_barrier::BarrierState>`] holding the in-flight
+    /// counter and [`std::sync::Condvar`] that back FFB-2's
+    /// `flush_workers` barrier). DG-3.b (#2569) swapped the value type
+    /// from [`Arc<SlotBarrier>`] to [`SlotEntry`]; callers that still
+    /// consume [`Arc<SlotBarrier>`] adapt at the boundary via
+    /// [`SlotBarrier::from_entry`] until DG-3.c retypes the handle and
+    /// guard. The BR-3j.a audit (see
     /// `docs/audits/br-3j-a-dashmap-vs-sharded-2026-05-20.md`) selected
     /// DashMap as the right fit for the access pattern: short guard
     /// windows, no iteration in the hot path, and write rates that scale
@@ -362,13 +369,18 @@ pub struct ParallelDeltaApplier {
     /// # Locking discipline
     ///
     /// All callers below must drop the DashMap shard guard returned by
-    /// `get`/`entry` before doing any work longer than an [`Arc::clone`]
-    /// or a small struct write. Holding a shard guard across a wait,
-    /// `rayon::join`, or a per-file mutex lock would re-introduce the
-    /// outer-map contention the migration was designed to eliminate. In
-    /// particular, the barrier wait in `flush_workers` blocks on the
-    /// slot's own [`std::sync::Condvar`] and never re-acquires a shard guard.
-    files: DashMap<FileNdx, Arc<SlotBarrier>>,
+    /// `get`/`entry` before doing any work longer than an
+    /// [`SlotEntry::clone`] (two [`Arc::clone`] calls) or a small struct
+    /// write. Holding a shard guard across a wait, `rayon::join`, or a
+    /// per-file mutex lock would re-introduce the outer-map contention
+    /// the migration was designed to eliminate. In particular, the
+    /// barrier wait in `flush_workers` blocks on the slot's own
+    /// [`std::sync::Condvar`] and never re-acquires a shard guard.
+    ///
+    /// [`Arc<SlotBarrier>`]: std::sync::Arc
+    /// [`Arc<slot_barrier::SlotData>`]: std::sync::Arc
+    /// [`Arc<slot_barrier::BarrierState>`]: std::sync::Arc
+    files: DashMap<FileNdx, SlotEntry>,
     /// Reorder-buffer capacity per file. Bounded so a stalled file does not
     /// pin unbounded memory.
     per_file_reorder_capacity: usize,
@@ -482,18 +494,15 @@ impl ParallelDeltaApplier {
         // Pre-build the slot OUTSIDE the shard guard so the reorder-buffer
         // allocation never widens the lock window. Then the entry guard
         // only holds long enough to check vacancy and move the prebuilt
-        // Arc into the map. Single shard write lock; no contention on
+        // entry into the map. Single shard write lock; no contention on
         // unrelated NDX values.
-        let slot = Arc::new(SlotBarrier::new(FileSlot::new(
-            writer,
-            self.per_file_reorder_capacity,
-        )));
+        let entry = SlotEntry::new(FileSlot::new(writer, self.per_file_reorder_capacity));
         match self.files.entry(ndx) {
             Entry::Occupied(_) => Err(io::Error::other(format!(
                 "parallel applier file {ndx} already registered"
             ))),
             Entry::Vacant(vacant) => {
-                vacant.insert(slot);
+                vacant.insert(entry);
                 Ok(())
             }
         }
@@ -591,17 +600,24 @@ impl ParallelDeltaApplier {
     }
 
     fn slot_for(&self, ndx: FileNdx) -> io::Result<SlotHandle> {
-        // Clone the per-file `Arc` while the shard read guard is alive,
-        // then drop the guard at the end of this expression. Callers
-        // never see the DashMap guard, so they cannot accidentally hold
-        // it across the per-file mutex lock or a rayon dispatch. The
-        // returned [`SlotHandle`] bumps the slot's in-flight counter for
-        // the duration of its lifetime so `flush_workers` can wait on it.
-        let barrier = self
+        // Clone the per-file [`SlotEntry`] (two `Arc::clone` calls) while
+        // the shard read guard is alive, then drop the guard at the end
+        // of this expression. Callers never see the DashMap guard, so
+        // they cannot accidentally hold it across the per-file mutex lock
+        // or a rayon dispatch. The bridge below builds a fresh
+        // [`Arc<SlotBarrier>`] adapter from the entry's two inner Arcs so
+        // [`SlotHandle`] and [`DecrementGuard`] keep their
+        // [`Arc<SlotBarrier>`] field types unchanged until DG-3.c retypes
+        // them. The adapter Arc is unique to this call site; the
+        // underlying [`SlotData`] and [`BarrierState`] Arcs are shared
+        // with every other adapter minted from the same entry, so the
+        // in-flight counter and Condvar remain coherent.
+        let entry = self
             .files
             .get(&ndx)
-            .map(|guard| Arc::clone(guard.value()))
+            .map(|guard| guard.value().clone())
             .ok_or_else(|| io::Error::other(format!("parallel applier file {ndx} unknown")))?;
+        let barrier = Arc::new(SlotBarrier::from_entry(&entry));
         Ok(SlotHandle::new(barrier))
     }
 
@@ -1041,12 +1057,15 @@ pub(super) mod tests {
         // notifications to land while flush_workers is waiting.
         let handle = applier.slot_for(FileNdx::new(0)).expect("slot registered");
 
-        // Snapshot the inner Arc so a sibling thread can notify the
-        // slot's condvar without going through the apply path.
+        // Snapshot the inner `Arc<BarrierState>` so a sibling thread can
+        // notify the slot's Condvar without going through the apply
+        // path. DG-3.b stores `SlotEntry` in the DashMap; the test
+        // reads `entry.barrier` (the bookkeeping Arc) and pokes the
+        // shared Condvar through it.
         let barrier = applier
             .files
             .get(&FileNdx::new(0))
-            .map(|guard| Arc::clone(guard.value()))
+            .map(|guard| Arc::clone(&guard.value().barrier))
             .expect("slot present");
 
         let notifier_barrier = Arc::clone(&barrier);

--- a/crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs
@@ -101,12 +101,6 @@ impl SlotBarrier {
     pub(super) fn decrement_inflight(&self) {
         self.barrier.decrement_inflight();
     }
-
-    /// Blocks the calling thread until the in-flight counter reaches zero.
-    /// Spurious wakeups are filtered by the loop predicate.
-    pub(super) fn wait_until_idle(&self, ndx: FileNdx, kind: &'static str) -> io::Result<()> {
-        self.barrier.wait_until_idle(ndx, kind)
-    }
 }
 
 /// Per-slot in-flight counter and [`Condvar`] (DG-3.a, Option B).

--- a/crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs
@@ -1,21 +1,28 @@
 //! Per-slot synchronisation primitive backing FFB-1 / FFB-2.
 //!
-//! Extracted from `parallel_apply.rs` as part of SPL-38.b. Owns the
-//! [`Mutex<FileSlot>`] payload plus the in-flight worker counter and
-//! [`Condvar`] that back `flush_workers(ndx)`. The DG-2.a/DG-3 spec at
-//! `docs/design/dg-2a-option-b-spec.md` plans to rename this type to
-//! `BarrierState` and split the slot payload out; until that lands the
-//! current shape is preserved verbatim.
+//! Extracted from `parallel_apply.rs` as part of SPL-38.b. The DG-2.a/DG-3
+//! spec at `docs/design/dg-2a-option-b-spec.md` plans to split the per-slot
+//! state across [`BarrierState`] (in-flight counter + [`Condvar`]) and
+//! [`SlotData`] (per-file [`Mutex<FileSlot>`]) so [`SlotHandle`] and
+//! `finish_file` can hold independent Arc graphs.
 //!
-//! DG-3.a (this commit) adds the new Option-B types ([`BarrierState`],
-//! [`SlotData`], [`SlotEntry`], and the post-split [`SlotHandle`]) in
-//! parallel with the existing [`SlotBarrier`]. No call site has been
-//! migrated yet: that work is sequenced by DG-3.b (DashMap value swap),
-//! DG-3.c ([`super::DecrementGuard`] + the mod-level `SlotHandle`
-//! migration), and DG-3.d ([`super::ParallelDeltaApplier::finish_file`]
-//! cleanup). Until those land, the new types are unreachable from any
-//! production path and exist only to fix the compile surface they will
-//! plug into.
+//! DG-3.a (PR #4826) added the post-split types alongside the existing
+//! [`SlotBarrier`]. DG-3.b (this commit) swaps the [`super::ParallelDeltaApplier`]
+//! [`DashMap`] value type from [`Arc<SlotBarrier>`] to [`SlotEntry`] and
+//! reshapes [`SlotBarrier`] into a thin adapter that wraps shared
+//! [`Arc<SlotData>`] + [`Arc<BarrierState>`] handles. Adapter instances
+//! are minted on demand by [`super::ParallelDeltaApplier::slot_for`] so
+//! [`super::DecrementGuard`] and [`super::SlotHandle`] keep their
+//! [`Arc<SlotBarrier>`] fields unchanged until DG-3.c retypes them. Each
+//! adapter [`Arc`] is independent of the shared per-file state behind it;
+//! the next phase (DG-3.c) collapses the adapter and points the handle
+//! fields at [`Arc<SlotData>`] / [`Arc<BarrierState>`] directly.
+//!
+//! [`Arc<SlotBarrier>`]: std::sync::Arc
+//! [`Arc<SlotData>`]: std::sync::Arc
+//! [`Arc<BarrierState>`]: std::sync::Arc
+//! [`Arc`]: std::sync::Arc
+//! [`DashMap`]: dashmap::DashMap
 
 use std::io;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
@@ -23,33 +30,47 @@ use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use super::super::types::FileNdx;
 use super::{FileSlot, ParallelApplyError};
 
-/// Per-slot barrier primitive backing FFB-1 / FFB-2.
+/// DG-3.b transitional adapter that preserves the [`Arc<SlotBarrier>`] shape
+/// [`super::DecrementGuard`] and [`super::SlotHandle`] still consume.
 ///
-/// Colocates the file's [`Mutex<FileSlot>`] with an in-flight worker
-/// counter and a [`Condvar`] so `flush_workers(ndx)` can block the caller
-/// until every outstanding [`SlotHandle`] for `ndx` has been dropped. The
-/// counter sits behind its own [`Mutex`] so the barrier wait never
-/// contends with the per-file write critical section: workers take the
-/// slot mutex to write, and the counter mutex only to bump or decrement.
+/// Originally colocated the file's [`Mutex<FileSlot>`], the in-flight
+/// counter, and the [`Condvar`] in one allocation. DG-3.b moves the
+/// canonical state into [`SlotData`] + [`BarrierState`] (stored together
+/// as [`SlotEntry`] in the DashMap) and leaves this struct as a thin
+/// wrapper that forwards every method through cloned [`Arc`] handles.
+/// New instances are minted by
+/// [`super::ParallelDeltaApplier::slot_for`] on each lookup; sibling
+/// adapters share the same underlying [`Arc<SlotData>`] +
+/// [`Arc<BarrierState>`] state, so the in-flight counter and Condvar
+/// remain coherent across workers. DG-3.c retypes
+/// [`super::DecrementGuard`] / [`super::SlotHandle`] to hold the inner
+/// Arcs directly and deletes this adapter.
 ///
-/// Holding the per-slot [`Arc`] is the unit of "in-flight"; the counter
-/// tracks how many of those `Arc` clones are currently outstanding so the
-/// `Condvar` can fire deterministically the moment the last clone drops.
+/// Holding the per-slot [`Arc<SlotBarrier>`] adapter is no longer the
+/// unit of "in-flight"; the counter inside [`BarrierState`] is. The
+/// adapter's lifetime continues to bound when [`super::DecrementGuard`]
+/// runs, which is what the FFB-1 invariant cares about, so external
+/// behaviour is unchanged.
 ///
 /// [`Arc`]: std::sync::Arc
+/// [`Arc<SlotBarrier>`]: std::sync::Arc
+/// [`Arc<SlotData>`]: std::sync::Arc
+/// [`Arc<BarrierState>`]: std::sync::Arc
 /// [`SlotHandle`]: super::SlotHandle
 pub(super) struct SlotBarrier {
-    pub(super) slot: Mutex<FileSlot>,
-    pub(super) inflight: Mutex<usize>,
-    pub(super) notify: Condvar,
+    data: Arc<SlotData>,
+    barrier: Arc<BarrierState>,
 }
 
 impl SlotBarrier {
-    pub(super) fn new(slot: FileSlot) -> Self {
+    /// Builds an adapter that shares its inner state with `entry`.
+    /// Clones the entry's two Arcs so the adapter participates in the
+    /// same in-flight bookkeeping and per-file mutex as every other
+    /// adapter minted from the same entry.
+    pub(super) fn from_entry(entry: &SlotEntry) -> Self {
         Self {
-            slot: Mutex::new(slot),
-            inflight: Mutex::new(0),
-            notify: Condvar::new(),
+            data: Arc::clone(&entry.data),
+            barrier: Arc::clone(&entry.barrier),
         }
     }
 
@@ -60,57 +81,31 @@ impl SlotBarrier {
         ndx: FileNdx,
         kind: &'static str,
     ) -> io::Result<MutexGuard<'_, FileSlot>> {
-        self.slot
-            .lock()
-            .map_err(|_| ParallelApplyError::SlotPoisoned { ndx, kind }.into())
+        self.data.lock_slot(ndx, kind)
     }
 
-    /// Bumps the in-flight counter for this slot. Called by [`SlotHandle::new`]
-    /// once the caller has obtained an [`Arc<SlotBarrier>`] clone from
-    /// [`ParallelDeltaApplier::slot_for`].
+    /// Bumps the in-flight counter for this slot. Called by
+    /// [`super::SlotHandle::new`] once the caller has obtained an
+    /// [`Arc<SlotBarrier>`] clone from
+    /// [`super::ParallelDeltaApplier::slot_for`].
     ///
     /// [`Arc<SlotBarrier>`]: std::sync::Arc
-    /// [`SlotHandle::new`]: super::SlotHandle::new
-    /// [`ParallelDeltaApplier::slot_for`]: super::ParallelDeltaApplier::slot_for
     pub(super) fn increment_inflight(&self) {
-        let mut guard = self
-            .inflight
-            .lock()
-            .expect("inflight mutex poisoned on increment");
-        *guard = guard.checked_add(1).expect("inflight counter overflow");
+        self.barrier.increment_inflight();
     }
 
     /// Drops the in-flight counter back by one and wakes any waiter parked
-    /// on the [`Condvar`]. Invoked from [`DecrementGuard::drop`] so the
-    /// bookkeeping stays exception-safe across early returns and panics.
-    ///
-    /// [`DecrementGuard::drop`]: super::DecrementGuard
+    /// on the [`Condvar`]. Invoked from [`super::DecrementGuard::drop`] so
+    /// the bookkeeping stays exception-safe across early returns and
+    /// panics.
     pub(super) fn decrement_inflight(&self) {
-        let mut guard = self
-            .inflight
-            .lock()
-            .expect("inflight mutex poisoned on decrement");
-        // Saturating subtract: a poisoned-then-rebuilt path that observes
-        // zero must not panic the worker on its way out. The counter is
-        // an internal bookkeeping primitive, not a security invariant.
-        *guard = guard.saturating_sub(1);
-        // Wake every waiter; `flush_workers` re-checks the predicate under
-        // the mutex so spurious wakeups are harmless.
-        self.notify.notify_all();
+        self.barrier.decrement_inflight();
     }
 
     /// Blocks the calling thread until the in-flight counter reaches zero.
     /// Spurious wakeups are filtered by the loop predicate.
     pub(super) fn wait_until_idle(&self, ndx: FileNdx, kind: &'static str) -> io::Result<()> {
-        let guard = self
-            .inflight
-            .lock()
-            .map_err(|_| ParallelApplyError::SlotPoisoned { ndx, kind })?;
-        let _final = self
-            .notify
-            .wait_while(guard, |inflight| *inflight > 0)
-            .map_err(|_| ParallelApplyError::SlotPoisoned { ndx, kind })?;
-        Ok(())
+        self.barrier.wait_until_idle(ndx, kind)
     }
 }
 
@@ -150,20 +145,15 @@ impl SlotBarrier {
 ///
 /// `pub(super)` so the parent module (`parallel_apply`) can build
 /// [`SlotEntry`] instances without exposing the bookkeeping type to
-/// the wider engine crate. No public API is added.
-//
-// `dead_code` allow: DG-3.a is the type-definition-only step. The
-// parent module does not call into these types until DG-3.b (DashMap
-// value swap) and DG-3.c (handle/guard migration) land. The smoke
-// tests below exercise every item under `#[cfg(test)]`, but the
-// non-test build has no caller yet.
-#[allow(dead_code)]
+/// the wider engine crate. No public API is added. The [`Condvar`]
+/// field is exposed at `pub(super)` so the
+/// `flush_workers_survives_spurious_wakeup` test can fire spurious
+/// wakeups directly into the wait loop.
 pub(super) struct BarrierState {
     inflight: Mutex<usize>,
-    notify: Condvar,
+    pub(super) notify: Condvar,
 }
 
-#[allow(dead_code)]
 impl BarrierState {
     /// Constructs a fresh bookkeeping primitive with a zero in-flight
     /// counter. The counter is bumped by [`Self::increment_inflight`]
@@ -252,15 +242,10 @@ impl BarrierState {
 ///
 /// `pub(super)` so the parent module can construct [`SlotEntry`]
 /// values and read the payload back out. No public API is added.
-//
-// `dead_code` allow: same rationale as `BarrierState`. DG-3.b/c/d
-// wire up the production callers.
-#[allow(dead_code)]
 pub(super) struct SlotData {
     slot: Mutex<FileSlot>,
 }
 
-#[allow(dead_code)]
 impl SlotData {
     /// Wraps a [`FileSlot`] in its own mutex. Mirrors
     /// [`SlotBarrier::new`] for the payload half of the split.
@@ -321,11 +306,6 @@ impl SlotData {
 /// `pub(super)` so `register_file`, `slot_for`, and `finish_file` can
 /// build and decompose the entry. Not exposed beyond
 /// `parallel_apply`.
-//
-// `dead_code` allow: same rationale as `BarrierState`. The fields are
-// read by the smoke test below and will become the DashMap value type
-// in DG-3.b.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub(super) struct SlotEntry {
     /// Per-file payload Arc. `finish_file` calls [`Arc::try_unwrap`]
@@ -337,7 +317,6 @@ pub(super) struct SlotEntry {
     pub(super) barrier: Arc<BarrierState>,
 }
 
-#[allow(dead_code)]
 impl SlotEntry {
     /// Wraps a fresh [`FileSlot`] in the two Option-B Arcs. The
     /// in-flight counter starts at zero; the first [`SlotHandle`]


### PR DESCRIPTION
## Summary

DG-3.b of the Option-B migration. Swaps the `ParallelDeltaApplier::files`
DashMap value type from `Arc<SlotBarrier>` to `SlotEntry` (the carrier
type DG-3.a introduced in PR #4826). Keeps `DecrementGuard` and the
mod-level `SlotHandle` on their existing `Arc<SlotBarrier>` field
types so the structural race fix lands as an isolated, bisectable
DG-3.c change.

Sequenced per `docs/design/dg-2b-migration-order.md` step DG-3.b.

## Bridge layer (intentional)

`SlotBarrier` is reshaped into a thin transitional adapter that wraps
shared `Arc<SlotData>` + `Arc<BarrierState>` handles cloned from a
`SlotEntry`. `slot_for` mints a fresh `Arc<SlotBarrier>` adapter per
call via `SlotBarrier::from_entry`; every adapter for the same file
shares the same underlying counter, Condvar, and per-file mutex, so
the FFB-1 in-flight bookkeeping and FFB-2 barrier semantics are
unchanged.

The adapter exists only so `DecrementGuard.barrier: Arc<SlotBarrier>`
and `SlotHandle.barrier: Arc<SlotBarrier>` keep their field types
intact this PR. DG-3.c retypes those fields to the inner Arcs
directly and deletes the adapter.

## Call-site retargets

- `register_file`: builds `SlotEntry::new(...)` (no outer `Arc::new`).
- `slot_for`: clones the entry, builds the adapter Arc, returns
  `SlotHandle::new(barrier)` with the existing signature.
- `flush_workers`: clones `entry.barrier` (`Arc<BarrierState>`) and
  calls `wait_until_idle` on it directly.
- `finish_file`: retargets the spin-then-yield loop and
  `Arc::try_unwrap` onto `entry.data` (`Arc<SlotData>`); the spin loop
  body is preserved verbatim per the DG-2.b plan. `entry.barrier` is
  dropped explicitly before the spin so only `DecrementGuard` clones
  keep the bookkeeping Arc alive.
- `flush_workers_survives_spurious_wakeup` test: snapshots
  `entry.barrier` instead of the previous combined Arc; the manual
  `notify_all()` call now resolves to `BarrierState::notify`.

## Tests

The `concurrent_register_and_dispatch_on_overlapping_files` stress
test (PR #4667's SSC-1 regression guard) and every other
`parallel_apply::tests::*` case exercise the public surface only and
are unaffected by the bridge. The `flush_workers_survives_spurious_wakeup`
test was updated to use the new entry-access path.

## Linked work

- DG-3.a (#4826): added `BarrierState`, `SlotData`, `SlotEntry`,
  post-split `SlotHandle` alongside `SlotBarrier`.
- DG-3.c (next): retype `DecrementGuard.barrier` and `SlotHandle` to
  hold `Arc<BarrierState>` / `Arc<SlotData>` directly; delete the
  transitional adapter. This is the structural race fix step.
- DG-4: delete the `finish_file` spin loop once DG-3.e confirms the
  race window is closed.

## Test plan

- [ ] CI green on fmt + clippy
- [ ] CI green on nextest (stable) covering
      `parallel_apply::tests::*` and
      `parallel_apply_concurrent::*`
- [ ] CI green on Windows / macOS / Linux musl matrices