### PR TITLE
perf(checksums): implement CSM-7 fix for --checksum hot path (CSM-8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,15 @@ tempfile = { workspace = true }
 checksums = { path = "crates/checksums" }
 protocol = { path = "crates/protocol" }
 
+# CSM-8: default-enable OpenSSL EVP MD4/MD5 on Unix (G1 from CSM-7 synthesis).
+# OpenSSL ships with the system libssl on Linux and macOS and provides ~2x
+# throughput over the pure-Rust md-5/md4 crates for the --checksum hot path
+# (SHA-NI accelerated on supported x86_64 silicon, NEON crypto extensions on
+# aarch64). Windows builds keep the pure-Rust backend by default; explicit
+# `--features openssl` or `--features openssl-vendored` still works there.
+[target.'cfg(unix)'.dependencies]
+checksums = { path = "crates/checksums", default-features = false, features = ["openssl"] }
+
 # Extra deps only for Windows + GNU
 [target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
 windows-gnu-eh = { path = "crates/windows-gnu-eh" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,13 +154,15 @@ tempfile = { workspace = true }
 checksums = { path = "crates/checksums" }
 protocol = { path = "crates/protocol" }
 
-# CSM-8: default-enable OpenSSL EVP MD4/MD5 on Unix (G1 from CSM-7 synthesis).
-# OpenSSL ships with the system libssl on Linux and macOS and provides ~2x
+# CSM-8: default-enable OpenSSL EVP MD4/MD5 on glibc Linux and macOS (G1 from
+# CSM-7 synthesis). OpenSSL ships with the system libssl and provides ~2x
 # throughput over the pure-Rust md-5/md4 crates for the --checksum hot path
 # (SHA-NI accelerated on supported x86_64 silicon, NEON crypto extensions on
-# aarch64). Windows builds keep the pure-Rust backend by default; explicit
-# `--features openssl` or `--features openssl-vendored` still works there.
-[target.'cfg(unix)'.dependencies]
+# aarch64). Musl Linux and Windows builds keep the pure-Rust backend by default
+# (musl targets typically lack a system libssl, and the openssl-sys build script
+# refuses to proceed without it); explicit `--features openssl` or
+# `--features openssl-vendored` still works on every platform.
+[target.'cfg(all(unix, not(target_env = "musl")))'.dependencies]
 checksums = { path = "crates/checksums", default-features = false, features = ["openssl"] }
 
 # Extra deps only for Windows + GNU

--- a/crates/checksums/src/strong/md4.rs
+++ b/crates/checksums/src/strong/md4.rs
@@ -351,4 +351,41 @@ mod tests {
             assert_eq!(to_hex(batch), to_hex(seq), "Mismatch at index {i}");
         }
     }
+
+    // CSM-8 parity: when the OpenSSL backend is the default-selected backend on
+    // Unix (G1), every MD4 digest must be byte-identical to the pure-Rust md4
+    // crate output. Reference is taken from the pure-Rust crate directly so
+    // the assertion holds regardless of which backend `Md4::new()` selects.
+    #[test]
+    fn md4_active_backend_matches_pure_rust_reference() {
+        use md4::Md4 as Md4Reference;
+
+        let inputs: &[&[u8]] = &[
+            b"",
+            b"a",
+            b"abc",
+            b"message digest",
+            b"abcdefghijklmnopqrstuvwxyz",
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+            // span the 64-byte MD4 block boundary deterministically
+            &[0xAB_u8; 63],
+            &[0xCD_u8; 64],
+            &[0xEF_u8; 65],
+            &[0x5A_u8; 1024],
+        ];
+
+        for (i, input) in inputs.iter().enumerate() {
+            let active = Md4::digest(input);
+
+            let mut reference = Md4Reference::new();
+            reference.update(input);
+            let reference: [u8; 16] = reference.finalize().into();
+
+            assert_eq!(
+                to_hex(&active),
+                to_hex(&reference),
+                "backend digest diverged from md4 reference at input #{i}"
+            );
+        }
+    }
 }

--- a/crates/checksums/src/strong/md5.rs
+++ b/crates/checksums/src/strong/md5.rs
@@ -607,4 +607,84 @@ mod tests {
             assert_eq!(to_hex(batch), to_hex(seq), "Mismatch at index {i}");
         }
     }
+
+    // CSM-8 parity: when the OpenSSL backend is the default-selected backend on
+    // Unix (G1), every digest must be byte-identical to the pure-Rust `md-5`
+    // crate output for the same input. The active backend is dictated by the
+    // build configuration; the reference value is computed from the
+    // pure-Rust crate directly to keep the comparison independent of which
+    // backend `Md5::new()` happens to pick.
+    #[test]
+    fn md5_active_backend_matches_pure_rust_reference() {
+        let inputs: &[&[u8]] = &[
+            b"",
+            b"a",
+            b"abc",
+            b"message digest",
+            b"abcdefghijklmnopqrstuvwxyz",
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+            // span the 64-byte MD5 block boundary deterministically
+            &[0xAB_u8; 63],
+            &[0xCD_u8; 64],
+            &[0xEF_u8; 65],
+            &[0x5A_u8; 1024],
+        ];
+
+        for (i, input) in inputs.iter().enumerate() {
+            let active = Md5::digest(input);
+
+            let mut reference = md5::Md5::new();
+            reference.update(input);
+            let reference: [u8; 16] = reference.finalize().into();
+
+            assert_eq!(
+                to_hex(&active),
+                to_hex(&reference),
+                "backend digest diverged from md-5 reference at input #{i}"
+            );
+        }
+    }
+
+    // CSM-8 parity: seeded hashing must also match upstream byte-for-byte
+    // regardless of backend selection. Covers the proper (protocol >= 30) and
+    // legacy (pre-CHECKSUM_SEED_FIX) seed orderings.
+    #[test]
+    fn md5_active_backend_matches_pure_rust_reference_seeded() {
+        let seed_value: i32 = 0x12345678;
+        let payloads: &[&[u8]] = &[b"", b"abc", b"message digest", &[0xAA_u8; 4096]];
+
+        for (i, data) in payloads.iter().enumerate() {
+            // proper order: seed bytes hashed before data
+            let mut proper = <Md5 as StrongDigest>::with_seed(Md5Seed::proper(seed_value));
+            proper.update(data);
+            let proper = proper.finalize();
+
+            let mut proper_ref = md5::Md5::new();
+            proper_ref.update(seed_value.to_le_bytes());
+            proper_ref.update(data);
+            let proper_ref: [u8; 16] = proper_ref.finalize().into();
+
+            assert_eq!(
+                to_hex(&proper),
+                to_hex(&proper_ref),
+                "proper-order seeded MD5 diverged at input #{i}"
+            );
+
+            // legacy order: seed bytes hashed after data
+            let mut legacy = <Md5 as StrongDigest>::with_seed(Md5Seed::legacy(seed_value));
+            legacy.update(data);
+            let legacy = legacy.finalize();
+
+            let mut legacy_ref = md5::Md5::new();
+            legacy_ref.update(data);
+            legacy_ref.update(seed_value.to_le_bytes());
+            let legacy_ref: [u8; 16] = legacy_ref.finalize().into();
+
+            assert_eq!(
+                to_hex(&legacy),
+                to_hex(&legacy_ref),
+                "legacy-order seeded MD5 diverged at input #{i}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements **G1** from the CSM-7 contributor synthesis (`docs/audits/csm-7-contributor-synthesis.md`, section 4.1 - the recommended top-of-list fix).

CSM-7 ranked the pure-Rust `md-5`/`md4` backend as the dominant contributor to the `--checksum`-mode 1.5-1.7x slowdown versus upstream rsync 3.4.1 (tracked as issue #970). Upstream's OpenSSL EVP path reaches ~1 GB/s (and ~3 GB/s with SHA-NI on supported x86_64 silicon, plus aarch64 crypto extensions). Our pure-Rust path sits at ~500 MB/s.

This PR flips the OpenSSL backend on by default for Unix targets through a `cfg(unix)`-scoped dep entry in the workspace `bin` `Cargo.toml`. Windows keeps the pure-Rust backend by default to avoid pulling in an OpenSSL build prerequisite; explicit `--features openssl` / `--features openssl-vendored` continues to work for portable opt-in.

The backend swap is wire-byte-equivalent: the existing `Md5Backend` / `Md4Backend` already produces identical RFC 1321 / RFC 1320 digests in either path. CSM-4 section 6 confirmed parity against the RFC vectors prior to this change.

## Changes

- `Cargo.toml` - add a `[target.'cfg(unix)'.dependencies]` entry that enables `checksums/openssl` so default Unix builds route MD4/MD5 through OpenSSL EVP. Windows defaults are unchanged.
- `crates/checksums/src/strong/md5.rs` - two new parity tests asserting the active backend agrees with the pure-Rust `md-5` reference for inputs that span the MD5 64-byte block boundary (63 / 64 / 65 / 1024 bytes), and for both seeded orderings (proper / legacy).
- `crates/checksums/src/strong/md4.rs` - one new parity test asserting the active backend agrees with the pure-Rust `md4` reference across the same block-boundary fixture.

## CSM-7 inputs

- `docs/audits/csm-4-strong-checksum-upstream-parity.md` (parity audit; the source of G1's CRITICAL ranking)
- `docs/audits/csm-5-c-io-pattern.md` (I/O pattern audit)
- `docs/audits/csm-6-c-simd-coverage.md` (SIMD coverage gap audit)
- `docs/audits/csm-7-contributor-synthesis.md` (synthesis + ordering; this PR implements item 1 / G1)

## Follow-ups

- **CSM-9** will re-bench against upstream rsync 3.4.1 (and against the pre-fix oc-rsync build) once this lands, and will gate the next contributor in the CSM-7 order (G2 - `simd_batch` wiring into local-copy `-c` prefetch).

## Test plan

- [ ] `cargo nextest run --workspace --all-features` (CI - default and `--all-features` rows both exercise the `openssl` backend on Linux)
- [ ] Windows CI rows (`windows-test`, `windows-iocp`) verify the pure-Rust fallback still builds and tests pass without OpenSSL
- [ ] musl release builds keep their `--features openssl-vendored` flag (no change required)
- [ ] CSM-9 bench harness (`scripts/benchmark_checksum_mode.sh`) re-runs after merge to confirm the expected ~2x improvement on MD5-heavy `-c` workloads