### PR TITLE
ci(interop): add rsync 2.6.9 pull matrix cell (RP28.d)

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -186,6 +186,100 @@ jobs:
           fi
           echo "PASS: oc-rsync -> rsync 2.6.9 push produced byte-identical tree."
 
+      # RP28.d - rsync 2.6.9 pull interop cell (protocol-28 cutoff peer).
+      # Symmetric to the RP28.c push cell: here rsync 2.6.9 acts as the
+      # sender daemon and oc-rsync is the receiver client pulling from it.
+      # Same small file tree (regular files, 8 KiB random blob, nested
+      # directory) to keep the matrix symmetric. Non-blocking until the
+      # RP28 series is ready to gate CI on pre-30 parity (RP28.k); promote
+      # to required by removing `continue-on-error: true` once the parity
+      # baseline is green. Exits 0 gracefully when the 2.6.9 binary is
+      # absent so the cell is a no-op without RP28.b cache.
+      - name: Run rsync 2.6.9 pull interop (RP28.d)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          UP_269="target/interop/upstream-install/2.6.9/bin/rsync"
+          if [[ ! -x "$UP_269" ]]; then
+            echo "rsync 2.6.9 binary missing at $UP_269; skipping RP28.d pull cell" >&2
+            exit 0
+          fi
+          echo "rsync 2.6.9: $($UP_269 --version 2>&1 | head -1)"
+
+          OC_RSYNC="target/dist/oc-rsync"
+          if [[ ! -x "$OC_RSYNC" ]]; then
+            echo "oc-rsync binary missing at $OC_RSYNC" >&2
+            exit 1
+          fi
+
+          WORKDIR=$(mktemp -d)
+          UP_PID=""
+          cleanup() {
+            [[ -n "$UP_PID" ]] && kill "$UP_PID" 2>/dev/null || true
+            rm -rf "$WORKDIR"
+          }
+          trap cleanup EXIT
+
+          SRC="$WORKDIR/src"
+          DST="$WORKDIR/dst"
+          mkdir -p "$SRC" "$DST"
+
+          # Same small file tree as RP28.c push cell for matrix symmetry.
+          printf 'hello 2.6.9\n' > "$SRC/hello.txt"
+          printf 'line1\nline2\n' > "$SRC/multiline.txt"
+          dd if=/dev/urandom of="$SRC/binary.dat" bs=1K count=8 2>/dev/null
+          mkdir -p "$SRC/subdir"
+          printf 'nested\n' > "$SRC/subdir/nested.txt"
+
+          # Allocate an ephemeral port for the 2.6.9 daemon.
+          UP_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+          UP_CONF="$WORKDIR/rsyncd-269.conf"
+          UP_PID_FILE="$WORKDIR/rsyncd-269.pid"
+          UP_LOG="$WORKDIR/rsyncd-269.log"
+          {
+            printf 'pid file = %s\n' "$UP_PID_FILE"
+            printf 'port = %s\n' "$UP_PORT"
+            printf 'use chroot = false\n'
+            printf '[interop]\n'
+            printf '    path = %s\n' "$SRC"
+            printf '    comment = rsync 2.6.9 sender (RP28.d)\n'
+            printf '    read only = true\n'
+          } > "$UP_CONF"
+
+          "$UP_269" --daemon --config "$UP_CONF" --no-detach --log-file "$UP_LOG" </dev/null &
+          UP_PID=$!
+
+          # Wait up to 10s for the daemon port to bind.
+          for _ in $(seq 1 20); do
+            if (echo >/dev/tcp/127.0.0.1/"$UP_PORT") 2>/dev/null; then
+              break
+            fi
+            sleep 0.5
+          done
+          if ! (echo >/dev/tcp/127.0.0.1/"$UP_PORT") 2>/dev/null; then
+            echo "FATAL: rsync 2.6.9 daemon failed to bind port $UP_PORT" >&2
+            cat "$UP_LOG" || true
+            exit 1
+          fi
+
+          echo "=== RP28.d pull: rsync 2.6.9 daemon -> oc-rsync receiver ==="
+          if ! timeout 60 "$OC_RSYNC" -av --timeout=30 \
+              "rsync://127.0.0.1:$UP_PORT/interop/" "$DST/" 2>&1; then
+            echo "FAIL: oc-rsync pull from rsync 2.6.9 daemon" >&2
+            echo "--- rsync 2.6.9 daemon log ---" >&2
+            cat "$UP_LOG" >&2 || true
+            exit 1
+          fi
+
+          if ! diff -r "$SRC" "$DST"; then
+            echo "FAIL: receiver contents diverged from sender" >&2
+            echo "--- rsync 2.6.9 daemon log ---" >&2
+            cat "$UP_LOG" >&2 || true
+            exit 1
+          fi
+          echo "PASS: rsync 2.6.9 -> oc-rsync pull produced byte-identical tree."
+
       # Drive upstream rsync's own `testsuite/*.test` corpus against
       # oc-rsync as `$RSYNC`. The harness sources upstream's `rsync.fns`
       # and reuses its helper tools (`tls`, `getgroups`, `support/lsh.sh`),


### PR DESCRIPTION
## Summary

Adds the symmetric **pull** counterpart to the RP28.c push cell merged in #4848. Exercises rsync 2.6.9 as the sender daemon with oc-rsync as the receiver client, asserting byte-identical contents on a small file tree (regular files, 8 KiB random blob, nested directory).

- Reuses the 2.6.9 binary built and cached by RP28.b at `target/interop/upstream-install/2.6.9/bin/rsync`.
- Same fixture tree as RP28.c so push and pull cells stay symmetric across the matrix.
- `continue-on-error: true` mirrors RP28.c (the RP28.k gating decision is still pending); the step also exits 0 gracefully when the 2.6.9 binary is absent so the cell is a no-op without RP28.b cache.

## Test plan

- [ ] CI Interop workflow runs the new "Run rsync 2.6.9 pull interop (RP28.d)" step
- [ ] Step passes (or surfaces a non-blocking failure under `continue-on-error: true`) without breaking the rest of the interop job
- [ ] When the 2.6.9 binary is absent, the step logs the skip and exits 0