### PR TITLE
test(engine): verify finish_file try_unwrap uncontended after DG-3.c (DG-3.d)

### DIFF
--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -1193,10 +1193,7 @@ pub(super) mod tests {
         let applier = ParallelDeltaApplier::new(1);
         let (sink, _) = VecSink::new();
         applier.register_file(0u32, Box::new(sink)).unwrap();
-        let entry = applier
-            .files
-            .get(&FileNdx::new(0))
-            .expect("slot present");
+        let entry = applier.files.get(&FileNdx::new(0)).expect("slot present");
         let data_addr = Arc::as_ptr(&entry.value().data).addr();
         let barrier_addr = Arc::as_ptr(&entry.value().barrier).addr();
         assert_ne!(

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -1053,6 +1053,160 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn finish_file_payload_arc_uncontended_after_worker_drop() {
+        // DG-3.d: After DG-3.c retyped `DecrementGuard` to
+        // `Arc<BarrierState>`, the worker's lingering decrement-guard
+        // clone no longer touches the payload Arc that `finish_file`
+        // calls `Arc::try_unwrap` on. Verify the strong-count trajectory
+        // claim from the DG-2.a spec section 3 at the actual try_unwrap
+        // call site: once the worker has fully released its
+        // `SlotHandle`, the entry's `Arc<SlotData>` has strong count 1
+        // (DashMap only) and `try_unwrap` would succeed deterministically
+        // without spinning.
+        //
+        // Establishing this fact in a test is the precondition for DG-4
+        // (removing the spin-then-yield workaround in
+        // `drain.rs::finish_file`). If a future change re-introduces a
+        // payload-Arc clone on the worker's drop path, this test fails
+        // before the spin can mask the regression.
+        let applier = Arc::new(ParallelDeltaApplier::new(1));
+        let (sink, _) = VecSink::new();
+        applier.register_file(0u32, Box::new(sink)).unwrap();
+
+        // Synchronisation: worker signals `acquired` after it owns the
+        // SlotHandle, then blocks on `release_rx` so the main thread
+        // controls when the handle drops. After `release_tx` fires the
+        // worker drops the handle and signals `dropped` so the main
+        // thread can observe the post-drop strong count deterministically
+        // (no time-based barrier).
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (dropped_tx, dropped_rx) = std::sync::mpsc::channel::<()>();
+        let worker_applier = Arc::clone(&applier);
+        let worker = std::thread::spawn(move || {
+            let handle = worker_applier
+                .slot_for(FileNdx::new(0))
+                .expect("slot registered");
+            acquired_tx.send(()).expect("acquired handshake");
+            release_rx.recv().expect("release handshake");
+            drop(handle);
+            dropped_tx.send(()).expect("dropped handshake");
+        });
+
+        // Wait until the worker owns the SlotHandle. While it is held the
+        // payload Arc strong count is at least 2 (DashMap + adapter's
+        // clone via SlotBarrier::from_entry) and would block `try_unwrap`.
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("worker acquired SlotHandle");
+        let while_held = applier
+            .files
+            .get(&FileNdx::new(0))
+            .map(|guard| Arc::strong_count(&guard.value().data))
+            .expect("slot present");
+        assert!(
+            while_held >= 2,
+            "payload Arc strong count while worker holds handle must be >= 2, got {while_held}"
+        );
+
+        // Release the worker, then wait for the drop to fully retire the
+        // SlotHandle (including the DecrementGuard's drop body). The
+        // dropped_tx send happens after `drop(handle)` returns, so by
+        // the time we receive on `dropped_rx` every field of the handle
+        // - including the payload Arc clone the SlotBarrier adapter
+        // carried and the bookkeeping Arc the DecrementGuard carried -
+        // has been released.
+        release_tx.send(()).expect("release send");
+        dropped_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("worker dropped SlotHandle");
+        worker.join().expect("worker thread");
+
+        // DG-3.c invariant: after the worker drops, the only remaining
+        // `Arc<SlotData>` clone is the one owned by the DashMap. The
+        // DecrementGuard's `Arc<BarrierState>` clone is irrelevant here
+        // - it lives on a disjoint allocation per the Option-B split in
+        // `docs/design/dg-2a-option-b-spec.md` section 3.
+        let after_drop = applier
+            .files
+            .get(&FileNdx::new(0))
+            .map(|guard| Arc::strong_count(&guard.value().data))
+            .expect("slot present");
+        assert_eq!(
+            after_drop, 1,
+            "payload Arc strong count after worker drop must be 1 (DashMap only), got {after_drop}"
+        );
+
+        // finish_file removes the entry from the DashMap and runs
+        // `Arc::try_unwrap` on the payload Arc. With strong_count==1 the
+        // unwrap succeeds on the first attempt; the spin-then-yield
+        // workaround in drain.rs is uncontended on this path.
+        let _writer = applier.finish_file(0u32).expect("finish_file");
+    }
+
+    #[test]
+    fn finish_file_payload_arc_uncontended_under_burst() {
+        // DG-3.d: stress variant. Drive many short-lived SlotHandles
+        // serially through the same file (mirroring the receiver
+        // pipeline's per-chunk dispatch) and verify the post-drop
+        // payload Arc strong count returns to 1 after every burst. A
+        // regression that re-introduces a payload-Arc clone on the
+        // worker drop path leaves a non-1 count visible here even
+        // before finish_file runs.
+        let applier = Arc::new(ParallelDeltaApplier::new(2));
+        let (sink, _) = VecSink::new();
+        applier.register_file(0u32, Box::new(sink)).unwrap();
+
+        for sequence in 0..32u64 {
+            applier
+                .apply_one_chunk(DeltaChunk::literal(0u32, sequence, vec![sequence as u8; 8]))
+                .expect("apply_one_chunk");
+            // After apply_one_chunk returns the SlotHandle has fully
+            // dropped (it was a local in apply_one_chunk's body). The
+            // payload Arc should be back to DashMap-only.
+            let count = applier
+                .files
+                .get(&FileNdx::new(0))
+                .map(|guard| Arc::strong_count(&guard.value().data))
+                .expect("slot present");
+            assert_eq!(
+                count, 1,
+                "payload Arc strong count after chunk {sequence} should be 1, got {count}"
+            );
+        }
+
+        // finish_file completes without hitting the spin loop's
+        // strong-count>1 branch.
+        let _writer = applier.finish_file(0u32).expect("finish_file");
+    }
+
+    #[test]
+    fn finish_file_payload_and_barrier_arcs_are_distinct_allocations() {
+        // DG-3.d: structural witness that the DG-2.a Option-B split is
+        // intact. The entry's `data: Arc<SlotData>` and
+        // `barrier: Arc<BarrierState>` Arcs point at different
+        // allocations - if a future refactor collapses them back into
+        // one (e.g. by re-introducing a combined struct behind a single
+        // Arc) the wakeup-before-drop race documented in DG-1 returns
+        // and the spin-then-yield workaround in drain.rs becomes
+        // load-bearing again.
+        let applier = ParallelDeltaApplier::new(1);
+        let (sink, _) = VecSink::new();
+        applier.register_file(0u32, Box::new(sink)).unwrap();
+        let entry = applier
+            .files
+            .get(&FileNdx::new(0))
+            .expect("slot present");
+        let data_addr = Arc::as_ptr(&entry.value().data).addr();
+        let barrier_addr = Arc::as_ptr(&entry.value().barrier).addr();
+        assert_ne!(
+            data_addr, barrier_addr,
+            "SlotEntry.data and SlotEntry.barrier must point at distinct allocations \
+             so the worker's DecrementGuard drop cannot extend the payload Arc's strong count"
+        );
+    }
+
+    #[test]
     fn flush_workers_survives_spurious_wakeup() {
         // Condvars are permitted to wake spuriously; the wait_while
         // predicate in `BarrierState::wait_until_idle` must re-check

--- a/docs/audits/dg-3d-finish-file-uncontended.md
+++ b/docs/audits/dg-3d-finish-file-uncontended.md
@@ -1,0 +1,146 @@
+# DG-3.d: `finish_file` `try_unwrap` Target Uncontended After DG-3.c
+
+Verifies the DG-2.a Option-B strong-count invariant at the actual
+`Arc::try_unwrap` call site after DG-3.c (#4845) retyped
+`DecrementGuard.barrier` from `Arc<SlotBarrier>` to `Arc<BarrierState>`.
+
+References:
+
+- Design: `docs/design/dg-2a-option-b-spec.md` sections 3 (strong-count
+  table) and 4 (race-free notify path).
+- DG-3.c PR: #4845 (DG-3.c retype).
+- Audit precursors: DG-1 release-race trace (s.5),
+  DG-2.a Option-B spec.
+
+## 1. Unwrap-target Arc identification
+
+`finish_file` lives in
+`crates/engine/src/concurrent_delta/parallel_apply/drain.rs:49-121`.
+The body extracts a `SlotEntry` via `DashMap::remove`, destructures
+into `data: Arc<SlotData>` and `barrier: Arc<BarrierState>`, drops the
+barrier Arc explicitly, then calls `Arc::try_unwrap(data)`.
+
+**Unwrap target**: `Arc<SlotData>`
+(`crates/engine/src/concurrent_delta/parallel_apply/slot_barrier.rs:261`).
+`SlotData` wraps `Mutex<FileSlot>` and is the per-file payload half of
+the DG-2.a Option-B split.
+
+## 2. Clone trajectory of `Arc<SlotData>`
+
+Every site that touches the payload Arc:
+
+| # | Site | File:line | Effect on strong count |
+|---|------|-----------|-----------------------|
+| 1 | `SlotEntry::new` | `slot_barrier.rs:341-346` | Constructs at count = 1; lives in the DashMap entry. |
+| 2 | `SlotEntry::clone` (derived) | `slot_barrier.rs:325` | Clones the inner Arc - used by `slot_for` step 3. |
+| 3 | `slot_for` local entry binding | `mod.rs:630-634` | DashMap read clones the `SlotEntry`; the local `entry` carries one cloned Arc until end-of-expression. |
+| 4 | `SlotBarrier::from_entry` | `slot_barrier.rs:76-81` | Clones `entry.data` into the transient adapter's `data` field. |
+| 5 | `SlotHandle.barrier: Arc<SlotBarrier>` | `mod.rs:298-323` | The adapter (and thus its inner `Arc<SlotData>` clone) is the only payload reference the worker carries. |
+| 6 | `finish_file` local `data` binding | `drain.rs:72` | After `DashMap::remove` the payload Arc moves out of the entry into the flusher's stack frame. |
+
+Sites the payload Arc **does not** touch after DG-3.c:
+
+- `DecrementGuard.barrier: Arc<BarrierState>` (post-DG-3.c) - the
+  retyped field lives on the bookkeeping allocation. The guard never
+  cloned the payload Arc to begin with under Option B.
+- `flush_workers` - clones `Arc<BarrierState>` only
+  (`drain.rs:146-158`).
+
+## 3. Worker drop sequence
+
+`SlotHandle` field declaration (`mod.rs:298-301`):
+
+```rust
+struct SlotHandle {
+    barrier: Arc<SlotBarrier>,
+    _decrement: DecrementGuard,
+}
+```
+
+Drop order under Rust field-drop semantics:
+
+1. `barrier: Arc<SlotBarrier>` drops. The adapter is fresh per
+   `slot_for` invocation (line 635: `Arc::new(SlotBarrier::from_entry(&entry))`),
+   so its strong count goes 1 -> 0 and the `SlotBarrier` is dropped.
+   That releases the adapter's `Arc<SlotData>` clone (site 4). Payload
+   Arc strong count: 2 -> 1 (DashMap only).
+2. `_decrement: DecrementGuard` drops. `decrement_inflight()` acquires
+   the inflight mutex, decrements, releases the mutex, fires
+   `notify_all`. The drop body returns; the contained
+   `Arc<BarrierState>` is field-dropped by implicit glue.
+
+The DG-1 wakeup-before-drop window survives between the `notify_all`
+inside `decrement_inflight` (step 2 mid-body) and the implicit drop
+of the guard's `Arc<BarrierState>` (step 2 end). The flusher's
+`flush_workers` returns the instant the Condvar predicate flips; if
+the flusher then unwrapped `Arc<BarrierState>` it would still race.
+But the flusher unwraps `Arc<SlotData>`, which was released back in
+step 1 - before the notify fired.
+
+## 4. Strong-count trajectory through `finish_file`
+
+| Step | Action | `Arc<SlotData>` count |
+|------|--------|----------------------:|
+| A | `flush_workers` returns (inflight=0). Worker has finished step 1; guard is mid-drop. | 1 (DashMap only) |
+| B | `DashMap::remove` extracts the entry; `data` moves into local. | 1 (local only) |
+| C | `drop(barrier)` releases the local `Arc<BarrierState>`. | 1 (unchanged - barrier is a different allocation) |
+| D | `Arc::try_unwrap(data)` runs. | 0 on success |
+
+The trajectory holds even if the guard's `Arc<BarrierState>` is
+arbitrarily slow to retire after step A: the payload Arc has no
+remaining reference on the worker side past step 1.
+
+## 5. Regression coverage added by DG-3.d
+
+`crates/engine/src/concurrent_delta/parallel_apply/mod.rs` test module:
+
+- `finish_file_payload_arc_uncontended_after_worker_drop` -
+  deterministic three-channel handshake (acquired / release / dropped)
+  pins the moment the worker has fully retired its `SlotHandle`,
+  reads `Arc::strong_count` on the entry's payload Arc, asserts it is
+  exactly 1, then runs `finish_file` to confirm `try_unwrap` succeeds.
+- `finish_file_payload_arc_uncontended_under_burst` - drives 32
+  serial `apply_one_chunk` calls and asserts the per-iteration
+  post-drop strong count returns to 1, catching any future change
+  that re-introduces a payload-Arc clone on the worker drop path.
+- `finish_file_payload_and_barrier_arcs_are_distinct_allocations` -
+  structural witness via `Arc::as_ptr` that the Option-B split is
+  intact at the type level; a future refactor that collapses the
+  pair behind one Arc fails here.
+
+The three tests together pin both the runtime invariant (counts) and
+the structural invariant (distinct allocations) so a regression cannot
+slip past either gate.
+
+## 6. Residual risk
+
+- `SlotHandle` retype is **deferred**. DG-3.c only retyped
+  `DecrementGuard`; `SlotHandle.barrier` is still
+  `Arc<SlotBarrier>` (the transitional adapter). Per
+  `slot_barrier.rs:48-59`, the adapter survives only as the handle's
+  bridge until a follow-on DG-3.x task collapses it. The bridge holds
+  one `Arc<SlotData>` + one `Arc<BarrierState>`, both of which drop
+  with `SlotHandle.barrier` (step 1 above) - so the deferral does
+  not regress the DG-3.d invariant, but it leaves dead code paths
+  (`SlotBarrier::lock_slot`, `SlotBarrier::increment_inflight`) that
+  the follow-on task should retire.
+- `drain.rs::finish_file` retains a spin-then-yield loop
+  (`drain.rs:84-103`) for `Arc::strong_count(&data) > 1`. After
+  DG-3.d the spin should be a no-op on every path the regression
+  tests exercise: the body executes zero iterations. **DG-4 (remove
+  the spin)** is now safe to land - the tests added here cover the
+  exact precondition DG-4 needs to assume.
+- The `dead_code`-allowed `slot_barrier::SlotHandle` (lines 391-417)
+  is the eventual replacement type. DG-3.d does not touch it; the
+  next DG-3.x task slots it into the mod-level position and deletes
+  the adapter.
+
+## 7. Conclusion
+
+After DG-3.c the `Arc<SlotData>` strong count at the `try_unwrap`
+call site is **1** on every successful path, deterministically and
+without spinning. The DG-2.a Option-B claim ("the worker's
+DecrementGuard cannot block the flusher's payload unwrap") holds at
+the source level and is now pinned by three regression tests.
+
+DG-4 (spin-loop removal) is unblocked.


### PR DESCRIPTION
## Summary

DG-3.d verification task. DG-3.c (#4845) retyped `DecrementGuard.barrier`
from `Arc<SlotBarrier>` to `Arc<BarrierState>` per the DG-2.a Option-B
spec (`docs/design/dg-2a-option-b-spec.md` section 2). This PR pins the
strong-count invariant at the actual `Arc::try_unwrap` call site in
`drain.rs::finish_file` so a future regression cannot silently
re-introduce a payload-Arc clone on the worker drop path.

The audit at `docs/audits/dg-3d-finish-file-uncontended.md`:

- Identifies the unwrap target as `Arc<SlotData>`.
- Enumerates every clone path that touches the payload Arc (6 sites).
- Traces the worker drop sequence against `SlotHandle`'s field-drop
  ordering.
- Confirms that after DG-3.c the payload Arc strong count at the
  `try_unwrap` site is deterministically 1 on every successful path.

Three regression tests cover both runtime (strong counts) and
structural (distinct allocations) gates:

- `finish_file_payload_arc_uncontended_after_worker_drop` -
  three-channel handshake pins the post-drop strong count to 1.
- `finish_file_payload_arc_uncontended_under_burst` - 32 serial
  apply_one_chunk calls confirm per-iteration return to 1.
- `finish_file_payload_and_barrier_arcs_are_distinct_allocations` -
  `Arc::as_ptr().addr()` witness that the Option-B split is intact.

## Residual risk

- `SlotHandle` retype is still deferred (`SlotHandle.barrier` remains
  `Arc<SlotBarrier>` adapter); the dead code paths
  `SlotBarrier::lock_slot` and `SlotBarrier::increment_inflight`
  should be retired by the follow-on DG-3.x task. Does not regress
  the DG-3.d invariant.
- `drain.rs::finish_file` still spins on `Arc::strong_count > 1`.
  After DG-3.d, the spin executes zero iterations on every path the
  regression tests exercise. **DG-4 (remove the spin)** is now safe
  to land - this PR provides the exact precondition DG-4 needs.

## Test plan

- [ ] CI nextest passes (new tests under
  `engine::concurrent_delta::parallel_apply::tests`).
- [ ] CI fmt+clippy passes.
- [ ] Windows / macOS / Linux musl matrices pass (the strong-count
  invariant is platform-independent).

## References

- DG-3.c PR: #4845
- DG-2.a Option-B spec: `docs/design/dg-2a-option-b-spec.md` sections
  3-6
- New audit: `docs/audits/dg-3d-finish-file-uncontended.md`