### PR TITLE
docs: document supported rsync wire-protocol version matrix (RP28.j)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
 Tested against upstream rsync **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth.
 
+### Supported rsync wire protocol versions
+
+| upstream rsync version | protocol | mode (push/pull/daemon)  | status (CI-verified) |
+|------------------------|----------|--------------------------|----------------------|
+| 2.6.9                  | 29       | push (daemon)            | non-blocking (RP28.c) |
+| 2.6.9                  | 29       | pull (daemon)            | non-blocking (RP28.d) |
+| 3.0.9                  | 30       | push, pull, daemon       | gating |
+| 3.1.3                  | 31       | push, pull, daemon       | gating |
+| 3.4.1                  | 32       | push, pull, daemon, SSH  | gating |
+| 3.4.2                  | 32       | push, pull, daemon       | gating |
+
+Wire format is verified byte-identical to upstream rsync via CI golden-byte tests for the listed versions. Other versions may work but are not regression-tested.
+
 ### Performance
 
 ![Benchmark: oc-rsync vs upstream rsync](https://github.com/oferchen/rsync/releases/latest/download/benchmark.png)

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -46,9 +46,25 @@ rsync without conflict.
 ## Protocol Compatibility
 
 **oc-rsync** supports rsync protocol versions 28 through 32 and has been
-validated against upstream rsync versions 3.0.9, 3.1.3, and 3.4.1.
+validated against upstream rsync versions 3.0.9, 3.1.3, 3.4.1, and 3.4.2.
 Incremental recursion, checksum negotiation (including XXH3 and XXH128),
 and all standard wire-format features are supported.
+
+The CI interop matrix covers the following upstream rsync version, protocol,
+and transfer-mode combinations:
+
+| upstream rsync | protocol | mode (push/pull/daemon)  | status (CI-verified) |
+|----------------|----------|--------------------------|----------------------|
+| 2.6.9          | 29       | push (daemon)            | non-blocking (RP28.c) |
+| 2.6.9          | 29       | pull (daemon)            | non-blocking (RP28.d) |
+| 3.0.9          | 30       | push, pull, daemon       | gating |
+| 3.1.3          | 31       | push, pull, daemon       | gating |
+| 3.4.1          | 32       | push, pull, daemon, SSH  | gating |
+| 3.4.2          | 32       | push, pull, daemon       | gating |
+
+Wire format is verified byte-identical to upstream rsync via CI golden-byte
+tests for the listed versions. Other versions may work but are not
+regression-tested.
 
 ## Performance
 


### PR DESCRIPTION
## Summary

- Add a "Supported rsync wire protocol versions" table to README.md covering upstream rsync 2.6.9 (proto 29, RP28.c/RP28.d non-blocking cells), 3.0.9 (proto 30), 3.1.3 (proto 31), 3.4.1 (proto 32), and 3.4.2 (proto 32).
- Mirror the same matrix into the Protocol Compatibility section of `docs/oc-rsync.1.md`.
- Footnote documents that the wire format is verified byte-identical to upstream via CI golden-byte tests for the listed versions.

Source of truth for the matrix is `.github/workflows/_interop.yml` (RP28.c push + RP28.d pull cells for 2.6.9) and `tools/ci/run_interop.sh` (the `versions=(3.0.9 3.1.3 3.4.1 3.4.2)` gating loop covering push/pull/daemon scenarios).

Closes RP28.j (#2735).

## Test plan

- [ ] CI docs/lint passes
- [ ] Manual review of rendered README table
- [ ] Manual review of generated man page (`oc-rsync(1)` Protocol Compatibility section)