### PR TITLE
docs(release-notes): scaffold for sender INC_RECURSE default-on flip (V61D-6)

### DIFF
--- a/docs/release-notes/sender-inc-recurse-flip.md
+++ b/docs/release-notes/sender-inc-recurse-flip.md
@@ -1,0 +1,45 @@
+# Sender-side INC_RECURSE on by default (push transfers)
+
+Scaffold for the release blurb that ships with the ISI.h flip-default PR
+(#2745). Numbers and PR refs are placeholders until that PR lands.
+
+## What changed
+
+Sender-side INC_RECURSE is now enabled by default for push transfers
+(client-as-sender). The default was disabled in v0.6.2 to mitigate a
+push-path regression introduced in v0.6.1 - see
+`docs/audit/v061-daemon-push-regression.md` (V61D-1) for the root cause.
+The ISI series (#2737-#2746) re-validated the sender-INC_RECURSE path
+against upstream rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2 and closed the
+performance gap that motivated the v0.6.2 revert.
+
+## User impact
+
+Significantly faster sender-side start-time on large source trees: the
+sender no longer walks the full file list before transmitting the first
+segment. ISI.g bench (PR #4862) measured the win on a 100K-file source:
+**start-time: `<filled in at ISI.h flip>` -> `<filled in at ISI.h flip>`
+(<filled in at ISI.h flip>x faster)**. Wire bytes and final transfer
+totals are unchanged.
+
+## What to test
+
+- Daemon-push and SSH-push against upstream rsync 3.4.x on your real
+  workloads.
+- Watch for any latency, wall-clock, or wire-byte regression vs the prior
+  release.
+- Confirm `--itemize-changes` output is byte-identical.
+
+## How to revert
+
+- **Build-time:** build without the `sender-inc-recurse` cargo feature
+  (`cargo build --no-default-features --features "<other features>"`).
+- **Runtime per invocation:** pass `--no-inc-recursive` on the client.
+  There is no environment variable; the CLI flag is the runtime override.
+
+## Reference
+
+- V61D-1 audit: `docs/audit/v061-daemon-push-regression.md`
+- ISI series tracking issues: #2737-#2746 (ISI.h flip: #2745)
+- ISI.g bench (start-time win on 100K-file source): PR #4862
+- Flip PR: `<filled in at ISI.h flip>`


### PR DESCRIPTION
## Summary

- Adds `docs/release-notes/sender-inc-recurse-flip.md` as the release-notes scaffold that will ship with the eventual ISI.h flip-default PR (#2745).
- Documents the V61D-1 root cause (sender-INC_RECURSE off by default since v0.6.2), the build-time (`sender-inc-recurse` cargo feature) and runtime (`--no-inc-recursive`) revert paths, and links to the ISI.g start-time bench (PR #4862).
- Numbers and the final flip PR ref are left as `<filled in at ISI.h flip>` placeholders; this is scaffold only.

Tracking: V61D-6 (#2845). References: V61D-1 (#4873), ISI series #2737-#2746.

## Test plan

- [ ] Reviewer confirms the scaffold reads as a release blurb (terse, < 200 words of content) and not a design doc.
- [ ] Reviewer confirms all perf numbers and the flip-PR ref are placeholders, not fabricated values.
- [ ] Reviewer confirms the revert paths match the code: `sender-inc-recurse` cargo feature in `crates/core/src/client/config/builder/mod.rs:447` and `--no-inc-recursive` CLI flag.