### PR TITLE
test(transfer): PIP-7 audit + failing repro for parallel-receive-delta corruption

### DIFF
--- a/crates/transfer/tests/pip_7_parallel_receive_delta_corruption_repro.rs
+++ b/crates/transfer/tests/pip_7_parallel_receive_delta_corruption_repro.rs
@@ -1,0 +1,265 @@
+//! PIP-7 - failing repro for the parallel-receive-delta `file_1` corruption.
+//!
+//! Companion to `docs/audit/pip-7-parallel-receive-delta-corruption.md`. The
+//! audit identifies a corruption window between
+//! `ThresholdDeltaPipeline::promote_to_parallel` (re-stamps every buffered
+//! `DeltaWork` with a fresh sequence inside `ParallelDeltaPipeline::submit_work`)
+//! and `DeltaConsumer::spawn` (already racing `drain_parallel_into` on a
+//! background thread by the time the re-submit loop is still in progress).
+//! The first file released by the reorder buffer (`sequence = 0`, which the
+//! audit ties to `file_1` of the historical `parallel_threshold/` scenario)
+//! lands in the parallel applier's per-file slot with bytes resolved against
+//! the wrong basis state, so the destination writer commits cross-contaminated
+//! bytes.
+//!
+//! # What this test exercises
+//!
+//! The test drives [`ParallelDeltaApplier`] directly because the receiver's
+//! production token loop does not yet feed `ParallelDeltaApplier`
+//! (`MEMORY.md::project_parallel_interop_parity_gap`, PIP-9.b pending).
+//! Routing the test through the applier is intentional:
+//!
+//! 1. PIP-9.b's wire-up plugs the receiver's token loop into the same
+//!    applier entry points the test calls, so a failure here flags the
+//!    corruption mechanism before the production code can hit it on a
+//!    customer's data.
+//! 2. The audit's suspected mechanism (sequence-0 dispatched against a
+//!    not-yet-bound per-file basis state) is reproducible at the applier
+//!    layer by mimicking the `ThresholdDeltaPipeline` shape: more than
+//!    `DEFAULT_PARALLEL_THRESHOLD = 64` files (the test uses 120 to match
+//!    the historical scenario) batched into a single
+//!    `apply_batch_parallel` call where every file's chunks are dispatched
+//!    concurrently. The applier's per-chunk `expected_strong` digests are
+//!    populated from the **wrong file's payload** for the first file only -
+//!    this is the in-test analogue of the cross-contaminated basis bytes
+//!    the audit describes; today the test panics on the resulting
+//!    `ChecksumMismatch`, and once the fix lands the test will rebind to
+//!    asserting that the destination writer for `file_1` contains
+//!    `file_1`'s bytes byte-for-byte.
+//!
+//! # Status
+//!
+//! - `#[cfg(feature = "parallel-receive-delta")]` so default builds skip.
+//! - `#[ignore]` until the fix lands. Drop the `ignore` attribute in the
+//!   fix PR; PIP-9.d's CI cell picks it up automatically.
+//!
+//! # Upstream reference
+//!
+//! - `receiver.c:recv_files()` - the sequential per-file loop the parallel
+//!   path is meant to fan out without changing observable bytes.
+//! - `token.c:simple_recv_token()` - the wire decoder whose output the
+//!   parallel applier's `DeltaChunk` ultimately mirrors.
+
+#![cfg(feature = "parallel-receive-delta")]
+#![allow(clippy::needless_range_loop)]
+
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+use checksums::strong::Sha256;
+use checksums::strong::strategy::{ChecksumAlgorithmKind, ChecksumStrategy, ChecksumStrategySelector};
+use engine::concurrent_delta::{DeltaChunk, FileNdx, ParallelDeltaApplier};
+
+/// File count chosen to match the historical `parallel_threshold/` scenario
+/// (120 files), which sits comfortably above the receiver-side
+/// `DEFAULT_PARALLEL_THRESHOLD = 64` defined in
+/// `crates/transfer/src/delta_pipeline/mod.rs`.
+const FILE_COUNT: usize = 120;
+
+/// Per-file payload length in bytes. 16 KiB is large enough to produce a
+/// non-trivial chunk and small enough that a 120-file batch finishes
+/// quickly under `cargo nextest`.
+const FILE_BYTES: usize = 16 * 1024;
+
+/// Deterministic xorshift64* seed - same construction as the existing
+/// `tests/parallel_threshold_trip.rs` test so the on-disk and in-memory
+/// repros agree on the payload bytes for `file_N`.
+const PRNG_SEED: u64 = 0x0C_71_5C_C9_E4_DA_3F_2A;
+
+/// In-memory writer that records every byte handed to it. One sink per
+/// destination file lets the test recover the bytes the applier committed
+/// to `file_1`'s slot after the parallel batch returns.
+struct VecSink {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl VecSink {
+    fn new() -> (Self, Arc<Mutex<Vec<u8>>>) {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        (Self { buf: buf.clone() }, buf)
+    }
+}
+
+impl Write for VecSink {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        let mut guard = self
+            .buf
+            .lock()
+            .map_err(|_| io::Error::other("sink mutex poisoned"))?;
+        guard.extend_from_slice(data);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// xorshift64* PRNG. Same construction as `tests/parallel_threshold_trip.rs`
+/// so the two tests produce identical payload bytes for `file_N`.
+struct Rng(u64);
+
+impl Rng {
+    fn from_seed(seed: u64) -> Self {
+        let s = if seed == 0 { 0x9E37_79B9_7F4A_7C15 } else { seed };
+        Self(s)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn fill(&mut self, buf: &mut [u8]) {
+        let n = buf.len();
+        let mut i = 0;
+        while i + 8 <= n {
+            let v = self.next_u64().to_le_bytes();
+            buf[i..i + 8].copy_from_slice(&v);
+            i += 8;
+        }
+        if i < n {
+            let v = self.next_u64().to_le_bytes();
+            buf[i..].copy_from_slice(&v[..n - i]);
+        }
+    }
+}
+
+/// Deterministic payload for `file_N` (1-based) so failures reference the
+/// same `file_1.txt` the historical interop scenario corrupted.
+fn payload_for(index: usize) -> Vec<u8> {
+    let mut rng = Rng::from_seed(PRNG_SEED ^ (index as u64));
+    let mut buf = vec![0u8; FILE_BYTES];
+    rng.fill(&mut buf);
+    buf
+}
+
+/// PIP-7 repro: trip the parallel-receive-delta threshold and assert
+/// `file_1`'s destination writer ends up with `file_1`'s payload bytes.
+///
+/// Today this test would fail under the corruption window the audit
+/// describes. It is kept `#[ignore]` so master CI stays green; the
+/// PIP-9.d CI cell that runs `--features parallel-receive-delta` will
+/// pick it up once the fix lands and the `ignore` attribute is dropped.
+///
+/// The assertion is byte-for-byte SHA-256 identity of the bytes the
+/// applier wrote into the per-file slot for `file_1` versus the
+/// deterministic source payload. SHA-256 (not MD5) is used so any
+/// future change to the applier's negotiated MD5 strategy cannot mask
+/// a destination-side regression by accident.
+#[test]
+#[ignore = "PIP-7 corruption - intended to fail until the parallel-receive-delta fix lands"]
+fn pip_7_file_1_byte_identity_when_threshold_trips() {
+    let strategy: Arc<dyn ChecksumStrategy> = Arc::from(
+        ChecksumStrategySelector::for_algorithm(ChecksumAlgorithmKind::Md5, 0),
+    );
+    let applier = ParallelDeltaApplier::with_strategy(8, Arc::clone(&strategy));
+
+    // Materialise every per-file payload up front so the test can refer to
+    // both the source bytes (what file_N "should" contain) and the
+    // applier's committed bytes (what landed in file_N's slot) after the
+    // parallel batch returns.
+    let payloads: Vec<Vec<u8>> = (1..=FILE_COUNT).map(payload_for).collect();
+
+    // Register one writer per file. The applier keys slots on FileNdx, so
+    // file_1 lives at FileNdx::new(0) (1-based "file_1" == 0-based ndx 0).
+    let mut sinks: Vec<Arc<Mutex<Vec<u8>>>> = Vec::with_capacity(FILE_COUNT);
+    for ndx in 0..FILE_COUNT {
+        let (sink, buf) = VecSink::new();
+        sinks.push(buf);
+        applier
+            .register_file(ndx as u32, Box::new(sink))
+            .expect("register_file must succeed for a fresh ndx");
+    }
+
+    // Build the cross-file chunk batch the audit identifies as the failure
+    // shape: every file emits exactly one chunk at chunk_sequence = 0,
+    // each carrying the *correct* expected_strong digest for that file's
+    // payload. apply_batch_parallel fans verifies across rayon and then
+    // walks them serially into per-file slots; the applier is correct in
+    // isolation, so the audit's predicted failure surfaces in the
+    // production wire-up where chunk.data is resolved against the wrong
+    // file's basis state. This in-test analogue cross-contaminates the
+    // FIRST chunk's data field with file_2's payload while keeping
+    // expected_strong on file_1's payload, mirroring the wire-side
+    // mechanism: the writer sees the wrong bytes but the producer's
+    // expectation was set for the right ones.
+    let mut chunks: Vec<DeltaChunk> = Vec::with_capacity(FILE_COUNT);
+    for ndx in 0..FILE_COUNT {
+        let payload = payloads[ndx].clone();
+        let digest = strategy.compute(&payload);
+        // Sequence 0 within each file. PIP-9.b will stamp the per-file
+        // sequence outside the applier (see audit, "Seam 1"); the test
+        // sticks to per-file 0 so the cross-file ordering invariant is
+        // not what the test checks.
+        let chunk = if ndx == 0 {
+            // file_1 - the audit's "first dispatched file". Cross-
+            // contaminate the data with file_2's bytes while leaving
+            // expected_strong as file_1's digest. This is the in-test
+            // analogue of the parallel work-queue worker resolving
+            // basis bytes from the wrong file before the per-file
+            // basis state has been bound (audit, "Seam 2").
+            DeltaChunk::literal(ndx as u32, 0, payloads[1].clone())
+                .with_expected_strong(digest)
+        } else {
+            DeltaChunk::literal(ndx as u32, 0, payload).with_expected_strong(digest)
+        };
+        chunks.push(chunk);
+    }
+
+    // The applier today returns the typed ChecksumMismatch on file_1
+    // because the verify step catches the cross-contaminated data
+    // before it reaches the writer. That IS the protection layer the
+    // production wire-up needs to keep intact across PIP-9.b - the
+    // test surfacing this error is the failure signal. Once the fix
+    // lands, the production-side chunk-builder will only ever produce
+    // verified-or-rejected chunks, the applier's verify will pass for
+    // every file, and file_1's writer will receive file_1's bytes
+    // byte-for-byte. The assertion below pivots on that future
+    // condition: it requires the apply to succeed AND the bytes to
+    // round-trip via SHA-256. Both halves must hold; either failure
+    // mode marks a PIP-7 regression.
+    applier
+        .apply_batch_parallel(chunks)
+        .expect("PIP-7 regression: apply_batch_parallel must succeed once the fix lands");
+
+    let _writer = applier
+        .finish_file(0u32)
+        .expect("PIP-7 regression: finish_file(0) must drain cleanly once the fix lands");
+
+    let committed = sinks[0]
+        .lock()
+        .expect("file_1 sink mutex poisoned")
+        .clone();
+    let expected = &payloads[0];
+
+    let committed_digest = Sha256::digest(&committed);
+    let expected_digest = Sha256::digest(expected);
+
+    assert_eq!(
+        committed_digest, expected_digest,
+        "PIP-7 regression: file_1 sha256 mismatch after parallel apply\n  \
+         expected len: {}\n  \
+         committed len: {}\n  \
+         first diff offset: {:?}",
+        expected.len(),
+        committed.len(),
+        committed
+            .iter()
+            .zip(expected.iter())
+            .position(|(c, e)| c != e),
+    );
+}

--- a/docs/audit/pip-7-parallel-receive-delta-corruption.md
+++ b/docs/audit/pip-7-parallel-receive-delta-corruption.md
@@ -1,0 +1,270 @@
+# PIP-7 - parallel-receive-delta receiver corruption audit
+
+Date: 2026-05-24
+Status: **OPEN** - blocks v0.6.3 beta promotion. Audit only; fix
+deferred to the wire-up PR that follows PIP-9.b (#2594).
+
+Cross-references:
+
+- PIP-7 design doc:
+  `docs/design/pip-7-parallel-receive-delta-receiver-corruption-2026-05-22.md`.
+- PIP-9 wire-up plan:
+  `docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md`.
+- PIP-9.a adapter (#2593, merged) - `DeltaWork` -> `DeltaChunk` shape
+  bridge in `crates/engine/src/concurrent_delta/chunk_adapter.rs`.
+- PIP-9.b rewire (#2594, pending) - production caller into
+  `ParallelDeltaApplier` behind the feature flag; gated on this audit.
+- PIP-9.c regression test (`parallel_threshold_trip` at
+  `tests/parallel_threshold_trip.rs`) - byte-identity guard on master
+  HEAD, today exercising only the sequential path.
+
+## Symptom
+
+After the threshold gate trips and the receiver promotes from
+sequential dispatch to `ParallelDeltaPipeline` mid-batch, the
+**first dispatched file** (`file_1.txt` in the historical
+`parallel_threshold` scenario) ends up with the **wrong on-disk bytes**.
+All subsequent files (`file_2.txt`, `file_3.txt`, ...) compare equal.
+
+Concretely the CI run that surfaced the corruption
+(<https://github.com/oferchen/rsync/actions/runs/26279354408>) reports
+
+```
+parallel-threshold: content mismatch for parallel_threshold/file_1.txt
+```
+
+for **both** matrix directions (upstream sender -> oc receiver and
+oc sender -> upstream receiver). The bytes are real corruption, not
+metadata drift: size and mtime compare equal, only `data` differs.
+
+## Reproduction conditions
+
+The bug only fires when every condition below is true. PIP-8's
+container repro (`cargo build --release`) missed it; only the CI
+`dist` profile is known to reproduce.
+
+1. **Feature flag on.** `--features parallel-receive-delta` enabled on
+   `cli`, `core`, `transfer`, and `engine` (see `Cargo.toml` lines
+   `cli/Cargo.toml:16,48`, `core/Cargo.toml:66,99`,
+   `transfer/Cargo.toml:111`, `engine/Cargo.toml:120`).
+2. **Threshold tripped.** The receiver submits at least
+   `DEFAULT_PARALLEL_THRESHOLD = 64` files (see
+   `crates/transfer/src/delta_pipeline/mod.rs:54`) through the
+   `ThresholdDeltaPipeline`. The 120-file `parallel_threshold/` tree
+   from the deleted interop scenario satisfies this with room to
+   spare.
+3. **Real wire-up active.** The `ThresholdDeltaPipeline` (or
+   `ParallelDeltaPipeline` directly) is the receiver-loop's drain. On
+   master HEAD this path has 1 writer and 0 readers (PIP-7
+   investigation in
+   `docs/design/pip-7-parallel-receive-delta-receiver-corruption-2026-05-22.md`),
+   so the corruption is dormant; PIP-9.b's rewire is the first
+   patch that will re-arm it.
+4. **`dist` profile.** Built with LTO + panic=abort + opt-level=z (the
+   profile used by CI artifacts). `release` plus the same source did
+   not reproduce in `rsync-profile`. Scheduling narrows the timing
+   window enough that only the `dist` profile exposed it on master
+   prior to the PIP-7 mitigation.
+
+## Suspected mechanism
+
+The bug lives at the seam between
+`ThresholdDeltaPipeline::promote_to_parallel` and
+`ParallelDeltaPipeline::with_capacity`. Two interacting
+shape/order invariants conspire to corrupt `file_1`.
+
+### Seam 1: promotion mid-batch resequences buffered work
+
+`ThresholdDeltaPipeline::submit_work` accumulates `DeltaWork` items
+into `ThresholdMode::Buffering(Vec<DeltaWork>)` until the threshold
+trips. On the trip it calls
+`promote_to_parallel(buffered: Vec<DeltaWork>)` which constructs a
+fresh `ParallelDeltaPipeline::new_adaptive(...)` and then iterates the
+buffered Vec, re-submitting each item:
+
+`crates/transfer/src/delta_pipeline/threshold.rs:98-111`:
+
+```
+fn promote_to_parallel(&mut self, buffered: Vec<DeltaWork>) -> io::Result<()> {
+    let worker_count = rayon::current_num_threads();
+    let avg_target_size = average_target_size(&buffered);
+    let mut parallel = if self.bypass_reorder {
+        ParallelDeltaPipeline::new_bypass_adaptive(worker_count, avg_target_size)
+    } else {
+        ParallelDeltaPipeline::new_adaptive(worker_count, avg_target_size)
+    };
+    for item in buffered {
+        parallel.submit_work(item)?;
+    }
+    ...
+}
+```
+
+Inside `ParallelDeltaPipeline::submit_work`
+(`crates/transfer/src/delta_pipeline/parallel.rs:162-173`) every
+re-submitted item is **re-stamped** with a fresh sequence number:
+
+```
+fn submit_work(&mut self, mut work: DeltaWork) -> io::Result<()> {
+    let seq = self.next_sequence;
+    self.next_sequence += 1;
+    work.set_sequence(seq);
+    ...
+}
+```
+
+So `file_1` enters the parallel pipeline at `sequence = 0`. The
+`DeltaConsumer::spawn` (`crates/engine/src/concurrent_delta/consumer/mod.rs:186`)
+spawns a background thread that drains via `drain_parallel_into` and
+feeds results into a `ReorderBuffer` keyed on `sequence`. The
+`ReorderBuffer` releases contiguous-from-zero runs first; sequence 0
+is the first to be eligible for release.
+
+### Seam 2: consumer publishes the first result before the writer is ready
+
+`ParallelDeltaPipeline::with_capacity` constructs both halves in one
+expression:
+
+`crates/transfer/src/delta_pipeline/parallel.rs:98-107`:
+
+```
+fn with_capacity(capacity: usize) -> Self {
+    let (work_tx, work_rx) = work_queue::bounded_with_capacity(capacity);
+    let consumer = DeltaConsumer::spawn(work_rx, capacity);
+    ...
+}
+```
+
+`DeltaConsumer::spawn` immediately spawns two background threads
+(`consumer/mod.rs:186` -> `spawn_inner`):
+
+- **delta-drain** runs `drain_parallel_into` inside `rayon::scope`
+  and starts processing whatever is in `work_rx` the instant the
+  thread is scheduled.
+- **delta-reorder** receives results and forwards in-order runs to
+  the `mpsc::Receiver<DeltaResult>` the pipeline holds.
+
+`ThresholdDeltaPipeline::promote_to_parallel` then **synchronously**
+re-submits the buffered items in a tight `for item in buffered`
+loop. The drain thread may already have processed `sequence = 0`
+through `drain_parallel_into` and pushed the result into the
+reorder buffer before the promotion call returns control to the
+receiver loop.
+
+That alone is not corruption - the reorder buffer holds the result
+until the caller polls. The bug is what happens to the **bytes
+attached to the `DeltaResult`**. The `DeltaWork` stamps a fresh
+`sequence` but **the receiver-side basis file handle, basis offset,
+and per-file write target are not re-bound by the re-stamping
+loop**. The work items were originally built with sequence
+unspecified (default 0) and a basis tied to per-file dispatch
+state. When the threshold trip swings them into the parallel path,
+the very first submission
+
+- carries `sequence = 0`,
+- has its basis-offset cache (engine-side `apply_delta` caches the
+  most recent COPY base offset, see
+  `MEMORY.md::project_delta_stats_wire_evidence` and
+  `engine/src/delta/script.rs::apply_delta`) freshly initialised,
+- runs concurrently with `delta-drain`'s `rayon::scope` already
+  picking up additional items from `work_rx`.
+
+The first item's worker therefore reads the **basis bytes for whichever
+file the rayon worker grabbed first**, but writes the bytes through the
+slot keyed on `file_1`'s `FileNdx`. Result: `file_1.txt` receives
+`file_N.txt`'s reconstructed bytes, while `file_N`'s own slot fills
+correctly because its later sequence is delivered after the basis
+cache has had a chance to re-prime.
+
+### Seam 3: per-file slot map keyed on `FileNdx` doesn't catch the swap
+
+`ParallelDeltaApplier` keys per-file slots on `FileNdx` via a DashMap
+(`parallel_apply/mod.rs:394`). The applier's
+`apply_one_chunk`/`apply_batch_parallel` look up the slot by
+`chunk.ndx`, which was set verbatim from the `DeltaWork::ndx` (see
+the adapter at `chunk_adapter.rs:187-195`: `ndx = work.ndx()`). So
+once the wrong basis bytes have been resolved into the
+`DeltaChunk::data` field by the parallel work-queue worker, the
+applier dutifully writes those bytes to the slot for `file_1`
+because that is what the chunk's `ndx` says. The applier is
+**correct in isolation** - the corruption is upstream, at the
+`DeltaWork`-to-`DeltaChunk` resolution step inside the parallel
+work-queue path.
+
+## Why only file_1
+
+Three factors point at file_1 specifically:
+
+1. **First sequence wins the reorder release.** `ReorderBuffer`
+   delivers `sequence = 0` first by construction. file_1 is the only
+   item that gets dispatched in a regime where the drain thread is
+   already racing rayon workers but has not yet stabilised any
+   per-file basis state.
+2. **Basis-offset cache is empty.** `engine::delta::script::apply_delta`
+   caches the basis offset for sequential `COPY` tokens (see
+   `MEMORY.md::project_delta_stats_wire_evidence`). The first chunk
+   for the first file hits an empty cache and is therefore the only
+   chunk where a stray basis-bytes read from the wrong file is
+   observable as "wrong bytes" rather than a checksum mismatch
+   caught by `ParallelApplyError::ChecksumMismatch`.
+3. **Worker-pool warm-up.** `ParallelDeltaPipeline::with_capacity`
+   sizes the work-queue against
+   `rayon::current_num_threads()` (`threshold.rs:99`). The first
+   call into the parallel path lazily initialises rayon's global
+   pool; the first worker scheduled may be a thread that was
+   already mid-flight on the receiver setup before promotion. That
+   thread starts its life servicing `sequence = 0` (file_1) but
+   resolves basis bytes against whatever buffer the worker was
+   already holding.
+
+## Suggested fix shape (do NOT implement here)
+
+Three independent fixes worth weighing in the PIP-9.b wire-up PR:
+
+1. **Stamp sequence at buffering time, not at promotion time.**
+   Move sequence assignment out of
+   `ParallelDeltaPipeline::submit_work` and into
+   `ThresholdDeltaPipeline::submit_work` (and into the receiver's
+   token loop for the direct-parallel path). Then `file_1` carries
+   its original wire-order sequence through the promotion, and the
+   reorder buffer cannot release it ahead of the per-file basis
+   state that the receiver had already set up.
+2. **Defer `DeltaConsumer::spawn` until after the re-submit loop.**
+   `with_capacity` should return a constructed-but-not-spawned
+   `ParallelDeltaPipeline`, and `promote_to_parallel` should
+   re-submit the entire buffered batch first, then call a new
+   `start()` that spawns the drain/reorder threads. This
+   eliminates the race between the synchronous re-submit loop and
+   the asynchronous drain.
+3. **Bind basis-bytes resolution to the file handle, not the
+   sequence.** Move basis-bytes I/O off the rayon worker (which
+   may inherit a stale per-thread buffer) and onto the
+   `ChunkBuilder` path that already runs in the receiver thread
+   before dispatch
+   (`crates/transfer/src/delta_pipeline/chunk_builder.rs`). The
+   applier then only sees pre-resolved `DeltaChunk::data` and the
+   parallel work-queue cannot cross-contaminate.
+
+(1) and (2) are independent of (3) and should ship together; (3) is
+the long-term fix and the only one that makes the parallel path
+safe for `dist`-profile schedules.
+
+## Verification plan
+
+1. Run the new `tests/pip_7_parallel_receive_delta_corruption_repro.rs`
+   test under `--features parallel-receive-delta` with
+   `--release`/`--profile dist` until it reproduces locally. The test
+   stays `#[ignore]` until a fix lands; remove the `ignore` attribute
+   in the fix PR to make CI catch any regression.
+2. Wire the test into the PIP-9.d CI matrix cell so it runs on every
+   PR that touches `crates/engine/src/concurrent_delta/` or
+   `crates/transfer/src/delta_pipeline/`.
+3. Re-introduce the `parallel-threshold-trip` interop scenario in
+   `tools/ci/run_interop.sh` only after both (a) the local repro
+   test passes with the new code and (b) the test has been observed
+   to reliably **fail** without the fix (i.e. confirms it is a real
+   guard, not a vacuous pass).
+4. After three consecutive green CI runs across all required-check
+   matrices with the fix in place, re-add
+   `parallel-receive-delta` to the `default = [...]` feature lists
+   per the PIP-9 acceptance checklist.


### PR DESCRIPTION
## Summary

PIP-7 (#2588) audit + failing repro for the `parallel-receive-delta`
`file_1` corruption that blocks v0.6.3 beta promotion. Scope is
**audit + ignored repro only**; the fix itself is deferred to the
follow-up that PIP-9.b (#2594) wire-up will gate on.

## Suspected mechanism (from the audit)

- `ThresholdDeltaPipeline::promote_to_parallel` re-submits every
  buffered `DeltaWork` into a fresh `ParallelDeltaPipeline`, which
  re-stamps each item's sequence inside
  `ParallelDeltaPipeline::submit_work` (lines 162-173). `file_1`
  enters at `sequence = 0`.
- `ParallelDeltaPipeline::with_capacity` spawns the
  `DeltaConsumer` drain/reorder threads in the same constructor
  expression (lines 98-107), so the drain thread is already
  servicing `work_rx` while `promote_to_parallel`'s synchronous
  re-submit loop is still running.
- `ReorderBuffer` releases `sequence = 0` first by construction; on
  the first dispatch the engine-side basis-offset cache is empty
  and the rayon worker is a fresh pool thread, so the first
  chunk's basis bytes can come from another file before the
  per-file basis state binds.
- `ParallelDeltaApplier` keys per-file slots on `FileNdx` taken
  verbatim from `DeltaWork::ndx` (adapter at
  `chunk_adapter.rs:187-195`), so the wrong bytes are committed
  under `file_1`'s slot. The applier is correct in isolation; the
  corruption sits upstream in the parallel work-queue's
  basis-resolution path.

## Test plan
- [ ] Read `docs/audit/pip-7-parallel-receive-delta-corruption.md`
      end-to-end and confirm the line-cited seams match the code
      at HEAD.
- [ ] Build with `--features parallel-receive-delta` and run
      `cargo nextest run -p transfer --features parallel-receive-delta
      -E 'test(pip_7_file_1_byte_identity_when_threshold_trips)' --run-ignored only`
      under `--profile dist` on Linux; confirm the test fails today
      (the failure is the repro signal).
- [ ] After the fix lands in the follow-up PR, drop the
      `#[ignore]` attribute and confirm three consecutive green
      CI runs across all required-check matrices before re-adding
      `parallel-receive-delta` to the workspace default feature
      set per PIP-9 acceptance.