### PR TITLE
perf(daemon): close cold-start latency gap per DIS-4 audits (DIS-6)

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -20,7 +20,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use std::sync::{
-    Arc, Mutex,
+    Arc, Mutex, OnceLock,
     atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::thread;

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -43,6 +43,22 @@ pub(crate) fn legacy_daemon_greeting() -> String {
     legacy_daemon_greeting_for_protocol(ProtocolVersion::NEWEST)
 }
 
+/// Returns the cached newest-protocol greeting bytes for direct wire emission.
+///
+/// The greeting at `ProtocolVersion::NEWEST` is a pure function of the
+/// compiled-in digest list, so it is rendered once per process and reused for
+/// every accepted connection. This removes the per-accept `format!`, `pop`,
+/// and `push_str` chain identified by the DIS-4.a audit while keeping the wire
+/// bytes byte-identical to the previous per-accept builder.
+///
+/// upstream: clientserver.c:455 `output_daemon_greeting` writes the same
+/// `@RSYNCD: <ver>.<sub> <digests>\n` line from a stack buffer that is
+/// initialized once on the server.
+pub(crate) fn cached_legacy_daemon_greeting() -> &'static [u8] {
+    static GREETING: OnceLock<Box<[u8]>> = OnceLock::new();
+    GREETING.get_or_init(|| legacy_daemon_greeting().into_bytes().into_boxed_slice())
+}
+
 /// Reads one line from `reader`, stripping trailing `\r` and `\n`.
 ///
 /// Returns `Ok(None)` on EOF, or `Ok(Some(line))` with the stripped content.

--- a/crates/daemon/src/daemon/sections/legacy_messages.rs
+++ b/crates/daemon/src/daemon/sections/legacy_messages.rs
@@ -6,6 +6,10 @@
 /// messages fall back to [`format_legacy_daemon_message`], ensuring formatting
 /// parity with upstream rsync without duplicating string construction logic.
 ///
+/// The cache is hoisted to a process-wide `OnceLock` because the `OK` and
+/// `EXIT` payloads are compile-time constants; the DIS-4.a audit flagged the
+/// per-accept rebuild as wasted allocations on the cold-start critical path.
+///
 /// upstream: clientserver.c - the daemon sends `@RSYNCD: OK\n` and
 /// `@RSYNCD: EXIT\n` as protocol bookends around every module interaction.
 #[derive(Debug)]
@@ -14,21 +18,18 @@ struct LegacyMessageCache {
     exit: Box<[u8]>,
 }
 
-impl Default for LegacyMessageCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl LegacyMessageCache {
-    fn new() -> Self {
-        let ok = format_legacy_daemon_message(LegacyDaemonMessage::Ok)
-            .into_boxed_str()
-            .into_boxed_bytes();
-        let exit = format_legacy_daemon_message(LegacyDaemonMessage::Exit)
-            .into_boxed_str()
-            .into_boxed_bytes();
-        Self { ok, exit }
+    fn shared() -> &'static Self {
+        static SHARED: OnceLock<LegacyMessageCache> = OnceLock::new();
+        SHARED.get_or_init(|| {
+            let ok = format_legacy_daemon_message(LegacyDaemonMessage::Ok)
+                .into_boxed_str()
+                .into_boxed_bytes();
+            let exit = format_legacy_daemon_message(LegacyDaemonMessage::Exit)
+                .into_boxed_str()
+                .into_boxed_bytes();
+            Self { ok, exit }
+        })
     }
 
     fn render(&self, message: LegacyDaemonMessage<'_>) -> LegacyMessage<'_> {

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -219,11 +219,14 @@ fn handle_legacy_session(
     } = params;
     let mut reader = BufReader::new(stream);
     let mut limiter = BandwidthLimitComponents::new(daemon_limit, daemon_burst).into_limiter();
-    let messages = LegacyMessageCache::new();
+    // DIS-4.a R3: borrow the process-wide cache instead of rebuilding the
+    // `@RSYNCD: OK\n` / `@RSYNCD: EXIT\n` boxes per accepted connection.
+    let messages = LegacyMessageCache::shared();
 
-    let greeting = legacy_daemon_greeting();
-    write_limited(reader.get_mut(), &mut limiter, greeting.as_bytes())?;
-    reader.get_mut().flush()?;
+    // DIS-4.a R2: write the cached newest-protocol greeting bytes directly,
+    // skipping the per-accept `format!`/`push_str` chain.
+    // upstream: clientserver.c:455 output_daemon_greeting
+    write_limited(reader.get_mut(), &mut limiter, cached_legacy_daemon_greeting())?;
 
     let mut request = None;
     let mut refused_options = Vec::new();
@@ -274,7 +277,7 @@ fn handle_legacy_session(
     let request = request.unwrap_or_default();
 
     if request == "#list" {
-        advertise_capabilities(reader.get_mut(), modules, &messages)?;
+        advertise_capabilities(reader.get_mut(), modules, messages)?;
         if let Some(log) = log_sink.as_ref() {
             log_list_request(log, peer_host.as_deref(), peer_addr);
         }
@@ -285,7 +288,7 @@ fn handle_legacy_session(
             motd_lines,
             peer_addr.ip(),
             reverse_lookup,
-            &messages,
+            messages,
         )?;
     } else if request.is_empty() {
         write_limited(
@@ -307,7 +310,7 @@ fn handle_legacy_session(
             &refused_options,
             log_sink.as_ref(),
             reverse_lookup,
-            &messages,
+            messages,
             negotiated_protocol,
             early_input_data,
         )?;

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -105,6 +105,7 @@ include!("tests/chunks/first_existing_config_path_prefers_primary_candidate.rs")
 include!("tests/chunks/first_existing_config_path_returns_none_when_absent.rs");
 include!("tests/chunks/format_bandwidth_rate_prefers_largest_whole_unit.rs");
 include!("tests/chunks/help_flag_renders_static_help_snapshot.rs");
+include!("tests/chunks/cached_legacy_daemon_greeting_matches_per_call_bytes.rs");
 include!("tests/chunks/legacy_daemon_greeting_digest_list_varies_by_protocol.rs");
 include!("tests/chunks/legacy_daemon_greeting_has_single_newline.rs");
 include!("tests/chunks/legacy_daemon_greeting_includes_version_and_digests.rs");

--- a/crates/daemon/src/tests/chunks/cached_legacy_daemon_greeting_matches_per_call_bytes.rs
+++ b/crates/daemon/src/tests/chunks/cached_legacy_daemon_greeting_matches_per_call_bytes.rs
@@ -1,0 +1,10 @@
+/// Wire-byte parity check: the cached greeting bytes used on the hot accept
+/// path must be byte-identical to the per-call greeting that tests and
+/// non-hot paths still allocate. Guards against regressions in the DIS-4.a
+/// R2 hoist that powers the cold-start latency fix.
+#[test]
+fn cached_legacy_daemon_greeting_matches_per_call_bytes() {
+    let cached = cached_legacy_daemon_greeting();
+    let allocated = legacy_daemon_greeting();
+    assert_eq!(cached, allocated.as_bytes());
+}

--- a/docs/audits/dis-4a-rsyncd-greeting-overhead.md
+++ b/docs/audits/dis-4a-rsyncd-greeting-overhead.md
@@ -316,3 +316,13 @@ DIS-2 should re-run the harness with `perf record -F 999 -g
   mitigation list; R3-R5 realign with its proposals.
 - `docs/audits/binary-startup-overhead.md` - DIS-3 row 1 (out of
   DIS-4 scope).
+
+## 8. DIS-6 follow-up
+
+DIS-6 lands R2 and R3 from section 4: the newest-protocol greeting bytes
+are cached in a `OnceLock<Box<[u8]>>` (greeting.rs `cached_legacy_daemon_greeting`)
+and `LegacyMessageCache` is hoisted to a process-wide `OnceLock<LegacyMessageCache>`
+so the `@RSYNCD: OK\n` / `@RSYNCD: EXIT\n` boxes are allocated once at first
+accept and borrowed for every subsequent connection. The no-op `reader.get_mut().flush()?`
+call (R6) is dropped on the same hot path. Wire-byte parity is held by a
+test that compares the cached bytes against the per-call greeting builder.

--- a/docs/audits/dis-4a-rsyncd-greeting-overhead.md
+++ b/docs/audits/dis-4a-rsyncd-greeting-overhead.md
@@ -319,10 +319,11 @@ DIS-2 should re-run the harness with `perf record -F 999 -g
 
 ## 8. DIS-6 follow-up
 
-DIS-6 lands R2 and R3 from section 4: the newest-protocol greeting bytes
-are cached in a `OnceLock<Box<[u8]>>` (greeting.rs `cached_legacy_daemon_greeting`)
-and `LegacyMessageCache` is hoisted to a process-wide `OnceLock<LegacyMessageCache>`
-so the `@RSYNCD: OK\n` / `@RSYNCD: EXIT\n` boxes are allocated once at first
-accept and borrowed for every subsequent connection. The no-op `reader.get_mut().flush()?`
-call (R6) is dropped on the same hot path. Wire-byte parity is held by a
-test that compares the cached bytes against the per-call greeting builder.
+DIS-6 (PR #4890) lands R2, R3, and R6 from section 4: the newest-protocol
+greeting bytes are cached in a `OnceLock<Box<[u8]>>` (greeting.rs
+`cached_legacy_daemon_greeting`) and `LegacyMessageCache` is hoisted to a
+process-wide `OnceLock<LegacyMessageCache>` so the `@RSYNCD: OK\n` /
+`@RSYNCD: EXIT\n` boxes are allocated once at first accept and borrowed for
+every subsequent connection. The no-op `reader.get_mut().flush()?` call (R6)
+is dropped on the same hot path. Wire-byte parity is held by a test that
+compares the cached bytes against the per-call greeting builder.


### PR DESCRIPTION
## Summary

Implements the top wire-byte-neutral fixes flagged by the DIS-4.a cold-start
audit (#2755) and the DIS-5 wire-byte diff (#2760). All fixes ship default-on
because they preserve the daemon's wire-byte stream exactly.

- **DIS-4.a R2** - cache the newest-protocol `@RSYNCD: <ver> <digests>\n`
  greeting bytes in a process-wide `OnceLock<Box<[u8]>>`. The greeting at
  `ProtocolVersion::NEWEST` is a pure function of the compiled-in digest list,
  so every accept used to rebuild the same 41-byte string via
  `format!`/`pop`/`push_str`. Now rendered once at first accept and reused.
- **DIS-4.a R3** - hoist `LegacyMessageCache` to a process-wide
  `OnceLock<LegacyMessageCache>`. The constant `@RSYNCD: OK\n` and
  `@RSYNCD: EXIT\n` payloads were being reboxed per connection; now borrowed
  from a single shared instance.
- **DIS-4.a R6** - drop the no-op `reader.get_mut().flush()?` after the
  greeting write; `TcpStream::flush` is a no-op because the socket is
  unbuffered.

Wire-byte parity is held by a new test that asserts the cached greeting bytes
equal the per-call greeting builder. The per-call `legacy_daemon_greeting() -> String`
is preserved for the existing test surface that compares allocated strings.

## Audit findings addressed

| Recommendation | Source | Status |
|----------------|--------|--------|
| R2 - cache greeting bytes | DIS-4.a section 4 | implemented |
| R3 - hoist `LegacyMessageCache` | DIS-4.a section 4 | implemented |
| R6 - drop no-op flush | DIS-4.a section 4 | implemented |
| R1 - event-driven accept wait | DIS-4.a section 4 | deferred (touches listener) |
| R4 - pool 8 KiB `BufReader` | DIS-4.a section 4 | deferred (cross-cuts) |

## Expected impact

Per DIS-4.a section 3, R2 + R3 collectively trim ~3-5 small allocations and
~3-8 us per cold-start accept on glibc when uncontended; the larger payoff is
removed allocator jitter under load. The dominant wall-clock fixes (R1
event-driven wait, R4 buffer pool) are intentionally deferred because they
touch the listener accept loop and warrant their own PR.

upstream: `clientserver.c:455 output_daemon_greeting` writes the same greeting
from a stack buffer that is initialized once on the server.

## Test plan

- [ ] CI: nextest on stable Linux, Windows, macOS, Linux musl.
- [ ] CI: fmt + clippy clean.
- [ ] CI: new `cached_legacy_daemon_greeting_matches_per_call_bytes` test
      asserts wire-byte parity.
- [ ] CI: existing daemon golden / negotiation tests (greeting bytes,
      legacy session, listing) still pass.