### PR TITLE
fix(tests): clippy doc-lints in parallel_apply_dg3_stress + regen Cargo.lock

### DIFF
--- a/crates/engine/tests/parallel_apply_dg3_stress.rs
+++ b/crates/engine/tests/parallel_apply_dg3_stress.rs
@@ -18,13 +18,13 @@
 //!    - `register_file(ndx, sink)`
 //!    - `apply_one_chunk(literal(ndx, 0, payload))`
 //!    - `finish_file(ndx)`
-//!    The `finish_file` step is where the DG-1 race used to surface:
-//!    `Arc::try_unwrap` on the payload Arc would observe `strong_count
-//!    >= 2` because `DecrementGuard::drop` had already fired
-//!    `notify_all` but its `Arc<SlotBarrier>` field had not yet dropped.
-//!    The DG-3 split moves the notify-bearing Arc off the payload
-//!    allocation entirely, so this loop now runs clean on every
-//!    platform.
+//!      The `finish_file` step is where the DG-1 race used to surface:
+//!      `Arc::try_unwrap` on the payload Arc would observe `strong_count
+//!      >= 2` because `DecrementGuard::drop` had already fired
+//!      `notify_all` but its `Arc<SlotBarrier>` field had not yet dropped.
+//!      The DG-3 split moves the notify-bearing Arc off the payload
+//!      allocation entirely, so this loop now runs clean on every
+//!      platform.
 //! 3. After every worker returns, assert:
 //!    - every cycle returned `Ok` (no Arc::try_unwrap failure, no
 //!      slot-poisoning panic),


### PR DESCRIPTION
## Summary

- Fixes 5 clippy `doc_lazy_continuation` errors in `crates/engine/tests/parallel_apply_dg3_stress.rs` module docstring by indenting the continuation prose under list item 2 from 4 spaces to 6 spaces. This silences both `doc list item without indentation` (lines 21-22) and `doc quote line without > marker` (lines 25-27).
- Verified `cargo metadata --locked` succeeds (Cargo.lock guard is green; no regeneration was needed in the worktree).
- Verified `cargo fmt --all -- --check` is clean.

These doc-lints were failing the `fmt + clippy` job on master under `--all-features`, which blocks every downstream PR's required check. Landing this unblocks the queue.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` no longer reports the 5 doc-lint errors against `parallel_apply_dg3_stress.rs`
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo metadata --locked --format-version 1` succeeds
- [ ] CI `fmt + clippy` job is green on this branch