### PR TITLE
fix(tests): drop unused FileNdx import; resolve daemon E0425

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -34,6 +34,7 @@ use crate::daemon::{
     advertised_capability_lines,
     // From sections/module_access.rs
     apply_module_bandwidth_limit,
+    cached_legacy_daemon_greeting,
     clap_command,
     clear_test_hostname_overrides,
     default_secrets_path_if_present,

--- a/crates/transfer/tests/pip_7_parallel_receive_delta_corruption_repro.rs
+++ b/crates/transfer/tests/pip_7_parallel_receive_delta_corruption_repro.rs
@@ -60,7 +60,7 @@ use checksums::strong::Sha256;
 use checksums::strong::strategy::{
     ChecksumAlgorithmKind, ChecksumStrategy, ChecksumStrategySelector,
 };
-use engine::concurrent_delta::{DeltaChunk, FileNdx, ParallelDeltaApplier};
+use engine::concurrent_delta::{DeltaChunk, ParallelDeltaApplier};
 
 /// File count chosen to match the historical `parallel_threshold/` scenario
 /// (120 files), which sits comfortably above the receiver-side


### PR DESCRIPTION
## Summary

Unblocks downstream PRs by clearing two pre-existing master CI failures.

- crates/transfer: drop the unused `FileNdx` import from `pip_7_parallel_receive_delta_corruption_repro.rs`. The slot-registration body now keys directly on `usize`, leaving `FileNdx` referenced only in comments, which trips `-D warnings`.
- crates/daemon: add `cached_legacy_daemon_greeting` to the `tests.rs` `use crate::daemon::{...}` block. The hot-path cached greeting helper landed via the DIS-4 cold-start work, and the new test chunk (`cached_legacy_daemon_greeting_matches_per_call_bytes`) is included via `include!()` from `tests.rs`, so it must see the name in the same scope. Without this, the daemon lib-test compile fails with E0425.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] CI Windows / macOS / Linux musl pass