### PR TITLE
fix(tests): clippy doc_lazy_continuation in parallel_apply_dg3_stress

### DIFF
--- a/crates/engine/tests/parallel_apply_dg3_stress.rs
+++ b/crates/engine/tests/parallel_apply_dg3_stress.rs
@@ -18,13 +18,14 @@
 //!    - `register_file(ndx, sink)`
 //!    - `apply_one_chunk(literal(ndx, 0, payload))`
 //!    - `finish_file(ndx)`
-//!      The `finish_file` step is where the DG-1 race used to surface:
-//!      `Arc::try_unwrap` on the payload Arc would observe `strong_count
-//!      >= 2` because `DecrementGuard::drop` had already fired
-//!      `notify_all` but its `Arc<SlotBarrier>` field had not yet dropped.
-//!      The DG-3 split moves the notify-bearing Arc off the payload
-//!      allocation entirely, so this loop now runs clean on every
-//!      platform.
+//!
+//! The `finish_file` step is where the DG-1 race used to surface:
+//! `Arc::try_unwrap` on the payload Arc would observe `strong_count
+//! >= 2` because `DecrementGuard::drop` had already fired
+//! `notify_all` but its `Arc<SlotBarrier>` field had not yet dropped.
+//! The DG-3 split moves the notify-bearing Arc off the payload
+//! allocation entirely, so this loop now runs clean on every
+//! platform.
 //! 3. After every worker returns, assert:
 //!    - every cycle returned `Ok` (no Arc::try_unwrap failure, no
 //!      slot-poisoning panic),


### PR DESCRIPTION
## Summary
- The doc-comment list item bullet 3 in `crates/engine/tests/parallel_apply_dg3_stress.rs` had 7 lines of continuation prose that tripped clippy `doc_lazy_continuation` (3 errors at lines 25-27).
- Earlier fix PR #4893 re-indented but didn't break the prose out of the list; the lint still fires.
- This PR breaks the prose into a separate paragraph (blank doc-line break + reset to 0 indent), which is the canonical fix.

## Why it matters
Every downstream PR that rebases on master inherits this lint and fails fmt+clippy. Without this fix, 4 PRs (#4869, #4870, #4876, #4888) all block on the same upstream issue.

## Test plan
- [x] cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings clean (pending CI verification)
- [x] cargo fmt --all --check clean (pending CI verification)