### PR TITLE
fix(tests): rewrap dg3_stress doc to avoid blockquote misparse

### DIFF
--- a/crates/engine/tests/parallel_apply_dg3_stress.rs
+++ b/crates/engine/tests/parallel_apply_dg3_stress.rs
@@ -20,12 +20,12 @@
 //!    - `finish_file(ndx)`
 //!
 //! The `finish_file` step is where the DG-1 race used to surface:
-//! `Arc::try_unwrap` on the payload Arc would observe `strong_count
-//! >= 2` because `DecrementGuard::drop` had already fired
-//! `notify_all` but its `Arc<SlotBarrier>` field had not yet dropped.
-//! The DG-3 split moves the notify-bearing Arc off the payload
-//! allocation entirely, so this loop now runs clean on every
-//! platform.
+//! `Arc::try_unwrap` on the payload Arc would observe a
+//! `strong_count` of two or more because `DecrementGuard::drop` had
+//! already fired `notify_all` but its `Arc<SlotBarrier>` field had
+//! not yet dropped. The DG-3 split moves the notify-bearing Arc off
+//! the payload allocation entirely, so this loop now runs clean on
+//! every platform.
 //! 3. After every worker returns, assert:
 //!    - every cycle returned `Ok` (no Arc::try_unwrap failure, no
 //!      slot-poisoning panic),


### PR DESCRIPTION
## Summary

- Line 24 of `parallel_apply_dg3_stress.rs` started with `>= 2`, which markdown parses as a blockquote marker. That caused clippy `doc_lazy_continuation` to flag lines 26-28 as missing `>` markers, breaking fmt+clippy on master.
- Rewrap the paragraph so no continuation line begins with `>`, eliminating the false-positive blockquote without touching the test logic.
- Unblocks the four PRs that rebased onto post-#4895 master and are still failing fmt+clippy on this lint (#4869 ISI.f, #4870 RP28.i, #4876 DEL-2.d, #4888 V61D-2).

## Test plan
- [x] CI fmt+clippy on this PR confirms the lint is resolved.