### PR TITLE
docs(release): add io_uring kernel-floor disclaimer scaffold (IKV-6)

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -60,4 +60,12 @@ Status values mirror `SECURITY.md` ("Fixed", "Mostly fixed", "Mitigated", "Not v
 
 Distro packagers: see `docs/packaging/landlock-feature-guidance.md` for the per-distro `--features landlock` recommendation, runtime ABI matrix, and build-time dependency notes.
 
+### Linux io_uring requirements
+
+oc-rsync uses Linux io_uring for high-throughput I/O on supported kernels. The minimum supported kernel for the io_uring path is **Linux 5.6**; older kernels (including RHEL 8 / CentOS Stream 8 at 4.18) fall back to standard `read(2)` / `write(2)` automatically - no user action required.
+
+For the full performance tier (zero-copy `SEND_ZC`), Linux **6.0 or newer** is required AND the binary must be built with the `iouring-send-zc` cargo feature enabled. Default release builds advertise `--zero-copy` but downgrade to non-zero-copy `SEND` silently on older kernels or builds without the feature.
+
+Full per-opcode kernel-floor matrix: see `docs/audit/iouring-opcode-kernel-floor.md`.
+
 ---


### PR DESCRIPTION
## Summary

- Adds a reusable "Linux io_uring requirements" scaffold block to `.github/RELEASE_TEMPLATE.md` so every release body (starting with v0.6.3 beta and v0.7.x stable) consistently discloses:
  - Linux 5.6 minimum for the io_uring data path, with automatic fallback to standard `read(2)` / `write(2)` on older kernels (including RHEL 8 / CentOS Stream 8 at 4.18).
  - Linux 6.0+ AND the `iouring-send-zc` cargo feature required for the full performance tier (zero-copy `SEND_ZC`); default builds silently downgrade to non-zero-copy `SEND`.
  - Pointer to the per-opcode kernel-floor matrix at `docs/audit/iouring-opcode-kernel-floor.md`.
- Placed directly under the existing "Kernel / platform compatibility" table so the prose disclaimer travels with the matrix.
- No changes to released CHANGELOG entries; template-only addition.

Parent: #2866 (IKV)
Sibling: #4899 (IKV-1 audit doc)

## Test plan

- [ ] Visual review of the rendered `.github/RELEASE_TEMPLATE.md` on the PR diff.
- [ ] Confirm wording matches the IKV-1 audit's 5.6 floor and 6.0 SEND_ZC tier statements.