### PR TITLE
docs: document russh SSH transport integration (RUSSH-15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ oc-rsync uses io_uring on Linux when the kernel and probed opcodes allow it; bel
 
 The full tier requires Linux 6.0+ together with the `iouring-send-zc` cargo feature for `SEND_ZC` dispatch; default builds downgrade to plain `SEND` even on 6.0+ kernels. See [`docs/audit/iouring-opcode-kernel-floor.md`](./docs/audit/iouring-opcode-kernel-floor.md) for the full per-opcode dispatch-site inventory.
 
+### SSH transport (russh)
+
+oc-rsync uses the Rust [`russh`](https://crates.io/crates/russh) crate for SSH transport, embedded directly in the binary. The default code path does not spawn an external `ssh` subprocess. Authentication uses key-based (RSA, ED25519, ECDSA) and password methods compatible with OpenSSH, and per-host settings are read from `~/.ssh/config` via the [`ssh2-config`](https://crates.io/crates/ssh2-config) integration (SSC-3 series).
+
+What this changes versus upstream rsync, which shells out to the system `ssh` binary:
+
+- No external `ssh` binary dependency at runtime; the SSH client lives inside the oc-rsync process.
+- All SSH state (connection, channel, auth context) lives in the oc-rsync process rather than crossing a pipe to a child.
+- `~/.ssh/config` `Match` blocks are honored for the limited subset implemented under the SSC-4 series.
+- SSH agent forwarding via `SSH_AUTH_SOCK` is honored when set.
+
+Current limitations:
+
+- Some exotic SSH features (for example SSH-2 keepalive intervals and certificate-based auth) may not be fully supported; please open an issue if you hit one.
+- The current `spawn_blocking` thread-pool bridge between the synchronous transfer pipeline and the async russh client throttles daemon concurrency at hundreds of concurrent sessions. The RUSSH-9..14 work moves the SSH transport to a fully async-native path; see [`docs/design/russh-async-native-path.md`](./docs/design/russh-async-native-path.md) for the planned evolution and [`docs/design/russh-async-native-back-compat-shim.md`](./docs/design/russh-async-native-back-compat-shim.md) for the back-compat shim.
+
+See also the `SSH TRANSPORT` section of `oc-rsync(1)` for the man-page summary.
+
 ### Performance
 
 ![Benchmark: oc-rsync vs upstream rsync](https://github.com/oferchen/rsync/releases/latest/download/benchmark.png)

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -1340,6 +1340,51 @@ Refer to **SECURITY.md** in the source distribution for full CVE status,
 including the SEC-1 (CVE-2026-29518 / CVE-2026-43619) progress matrix and
 the SEC-1.p Landlock design note.
 
+# SSH TRANSPORT
+
+**oc-rsync** uses an embedded **russh** SSH client for SSH transport. The
+default code path does not spawn an external **ssh**(1) subprocess; the
+SSH state machine (transport, channel, auth context) lives inside the
+**oc-rsync** process for the full lifetime of the transfer.
+
+**Authentication**
+:   Key-based authentication is supported for RSA, ED25519, and ECDSA key
+    types. Password authentication is also supported. Private keys are
+    read from the conventional locations under **~/.ssh/id_\***, and
+    per-host settings (**HostName**, **User**, **Port**,
+    **IdentityFile**, **ProxyJump** and the SSC-3 / SSC-4 subset of
+    other directives) are read from **~/.ssh/config** via the embedded
+    **ssh2-config** parser.
+
+**Environment**
+:   The **SSH_AUTH_SOCK** environment variable is honored, so ssh-agent
+    forwarding works for authentication when an agent socket is
+    available. See also the **ENVIRONMENT** section above.
+
+**Compression**
+:   A **Compression yes** directive in **~/.ssh/config** is honored by
+    the embedded client (SSC-4 series). When the user also requests
+    rsync wire compression via **-z** / **--compress**, a one-time
+    startup warning is emitted so the operator can pick one layer and
+    avoid double-compressing the stream (SSC-1 series). See the
+    *Performance tuning* section of the README for the operator-facing
+    guidance and the exact warning substring.
+
+**Limitations**
+:   Some SSH features are not yet fully supported by the embedded
+    client. Notable cases include certificate-based authentication, the
+    SSH-2 **ControlMaster** multiplexing feature, and exotic key
+    exchange methods outside the OpenSSH defaults. The full limitation
+    surface and migration plan are tracked under the RUSSH series; see
+    in particular **docs/design/russh-async-native-path.md** for the
+    planned async-native transport and
+    **docs/design/russh-async-native-back-compat-shim.md** for the
+    back-compat shim. If you hit an unsupported SSH feature in
+    practice, please open an issue against the project repository.
+
+See also the **SSH transport (russh)** section of the README for the
+operator-facing summary and a worked example.
+
 # LINUX IO_URING SUPPORT
 
 **oc-rsync** uses io_uring opportunistically on Linux when the running


### PR DESCRIPTION
## Summary

Adds a new `### SSH transport (russh)` section to `README.md` and a matching `# SSH TRANSPORT` section to `docs/oc-rsync.1.md`. Both describe the embedded russh SSH client model used by `oc-rsync`:

- No external `ssh` subprocess in the default code path; SSH state lives in the `oc-rsync` process.
- Key-based (RSA, ED25519, ECDSA) and password authentication; `~/.ssh/config` per-host settings via `ssh2-config` (SSC-3).
- `SSH_AUTH_SOCK` ssh-agent forwarding honored.
- `Compression yes` in `~/.ssh/config` honored (SSC-4) and one-shot warning on conflict with `-z` wire compression (SSC-1).
- Current limitations called out, including the `spawn_blocking` thread-pool bridge throttling daemon concurrency at hundreds of sessions.
- Both sections cross-link each other and the RUSSH-9 design doc.

Docs-only change; no code touched.

## Cross-references

- Parent task: #2818 (RUSSH-15)
- Sibling docs already merged:
  - #4912 (RUSSH-9) `docs/design/russh-async-native-path.md`
  - #4918 (RUSSH-10) `docs/design/russh-async-native-back-compat-shim.md`
- Related series referenced from the new prose:
  - SSC-1 (SSH + rsync double-compression warning)
  - SSC-3 (`ssh2-config` integration)
  - SSC-4 (`~/.ssh/config` `Match` / `Compression` directive handling)

## Test plan

- [ ] CI fmt + clippy + nextest pass (no code touched, expected green).
- [ ] Render `docs/oc-rsync.1.md` via the existing man-page pipeline and spot-check the new `SSH TRANSPORT` section formats cleanly (no broken definition-list items, cross-link substring matches the README heading).
- [ ] Read the rendered README on GitHub and confirm the new section sits between *Linux io_uring kernel-tier support* and *Performance* and that the design-doc links resolve.