### PR TITLE
ci(interop): cache rsync 2.6.9 build artifact (RP28.b.3)

### DIFF
--- a/.github/workflows/build-rsync-2-6-9.yml
+++ b/.github/workflows/build-rsync-2-6-9.yml
@@ -9,12 +9,12 @@
 # interop matrix consumes it.
 #
 # Parent: RP28.b (#2727). Grandparent: RP28 (#2725).
-# Follow-up: RP28.b.3 (#2962) will add artifact caching so the build
-# does not repeat on every CI run.
+# RP28.b.3 (#2962) adds the actions/cache layer below so the build does
+# not repeat on every CI run; cache key is keyed on the helper script's
+# content hash so any change to the script invalidates the artifact.
 #
 # Status: non-required. This workflow is advisory in branch protection.
-# Promotion to a required check is handled by a separate task once the
-# caching layer from RP28.b.3 lands.
+# Promotion to a required check is handled by a separate task.
 name: Build rsync 2.6.9 (smoke)
 
 on:
@@ -48,12 +48,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore rsync 2.6.9 cache
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /usr/local/bin/rsync-2.6.9
+            /tmp/rsync-2.6.9-build
+          key: rsync-2.6.9-${{ runner.os }}-${{ hashFiles('scripts/build_rsync_2_6_9.sh') }}
+          restore-keys: |
+            rsync-2.6.9-${{ runner.os }}-
+
       - name: Install build dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf
 
       - name: Build rsync 2.6.9 via helper script
+        if: steps.cache.outputs.cache-hit != 'true'
         run: sudo bash scripts/build_rsync_2_6_9.sh
 
       - name: Verify version string
@@ -70,13 +83,28 @@ jobs:
       - name: Smoke-run --help
         run: /usr/local/bin/rsync-2.6.9 --help | head -5
 
+      - name: Save rsync 2.6.9 cache
+        if: steps.cache.outputs.cache-hit != 'true' && success()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /usr/local/bin/rsync-2.6.9
+            /tmp/rsync-2.6.9-build
+          key: rsync-2.6.9-${{ runner.os }}-${{ hashFiles('scripts/build_rsync_2_6_9.sh') }}
+
       - name: Emit step summary
         run: |
+          if [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
+            CACHE_STATUS="hit (binary restored, build skipped)"
+          else
+            CACHE_STATUS="miss (built from source, artifact saved)"
+          fi
           {
             echo "### rsync 2.6.9 build smoke"
             echo ""
             echo "- Binary: \`/usr/local/bin/rsync-2.6.9\`"
             echo "- Helper: \`scripts/build_rsync_2_6_9.sh\`"
+            echo "- cache: ${CACHE_STATUS}"
             echo ""
             echo "Captured version line:"
             echo ""


### PR DESCRIPTION
## Summary

- Wraps the `build-rsync-2-6-9` smoke workflow in `actions/cache@v4` so the 2006-vintage autotools build is reused across runs instead of re-compiled every trigger.
- Restore step (`actions/cache/restore@v4`) runs before the build; install-deps and helper-script steps are gated on `steps.cache.outputs.cache-hit != 'true'` so apt-get and configure/make are skipped on a hit.
- Save step (`actions/cache/save@v4`) runs after verification, only on miss and only on success, so partial artifacts are never persisted.
- Verify and `--help` smoke steps remain unconditional so the cached binary is re-validated every run.
- Step summary now reports cache hit/miss for at-a-glance review.

## Cache key

`rsync-2.6.9-${{ runner.os }}-${{ hashFiles('scripts/build_rsync_2_6_9.sh') }}` with a `rsync-2.6.9-${{ runner.os }}-` restore-keys fallback. Any edit to the helper script invalidates the artifact and forces a rebuild.

## Paths

- `/usr/local/bin/rsync-2.6.9` (installed binary)
- `/tmp/rsync-2.6.9-build/` (intermediate sources + staging install, useful for debug rebuild scenarios)

## Lineage

- Parent: #2727 (RP28.b)
- Siblings: #4903 (RP28.b.1 - build helper script), #4941 (RP28.b.2 - smoke workflow)
- This task: #2962 (RP28.b.3)

## Test plan

- [ ] First run on this PR: cache miss, full build, save step persists artifact, step summary shows `cache: miss`.
- [ ] Re-run the workflow (or trigger on a subsequent unrelated PR touching the same paths): cache hit, install/build steps skipped, verify + smoke steps still pass, step summary shows `cache: hit`.
- [ ] Edit `scripts/build_rsync_2_6_9.sh` in a follow-up: cache key changes, fresh build runs, restore-keys fallback warms partial reuse on first run.