### PR TITLE
test(filter): MDF-8 upstream --debug=FILTER diff harness

### DIFF
--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -1,0 +1,62 @@
+# MDF-8 - filter-decision diff harness
+#
+# Builds oc-rsync, runs the diff harness in scripts/mdf_8_filter_diff_harness.sh
+# against upstream rsync and the MDF-7 complex fixture, and uploads the diff
+# log as an artifact. Advisory until the default-mode diff hits zero across
+# one release cycle (see docs/design/mdf-8-filter-diff-harness.md).
+
+name: MDF-8 Filter Diff
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: 'Pass --strict to compare level-2+ FILTER traces (expected to fail today).'
+        required: false
+        default: 'false'
+
+concurrency:
+  group: mdf-8-filter-diff-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  diff:
+    name: filter-diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install upstream rsync
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsync
+          /usr/bin/rsync --version | head -n 1
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build oc-rsync (release)
+        run: cargo build --release --bin oc-rsync
+
+      - name: Run MDF-8 diff harness
+        run: |
+          ARGS=()
+          if [[ "${{ inputs.strict }}" == "true" ]]; then
+              ARGS+=(--strict)
+          fi
+          bash scripts/mdf_8_filter_diff_harness.sh \
+              --upstream /usr/bin/rsync \
+              --oc-rsync target/release/oc-rsync \
+              "${ARGS[@]}"
+
+      - name: Upload diff artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdf-8-filter-diff
+          path: /tmp/mdf-8-diff/
+          if-no-files-found: warn

--- a/docs/design/mdf-8-filter-diff-harness.md
+++ b/docs/design/mdf-8-filter-diff-harness.md
@@ -1,0 +1,109 @@
+# MDF-8 - filter-decision diff harness
+
+Companion spec for `scripts/mdf_8_filter_diff_harness.sh`. The harness
+turns the MDF-7 complex `.rsync-filter` fixture into a comparable
+upstream-vs-oc-rsync signal so MDF-* fix PRs can be graded by how much
+filter divergence they remove.
+
+## 1. Scope
+
+- Run upstream rsync with `--debug=FILTER1,2,3,4 --dry-run` against
+  `tests/fixtures/filter-rules/mdf-7-complex/source/`.
+- Run oc-rsync with the same switches against the same fixture.
+- Capture only filter-decision log lines on stderr (`[FILTER]` upstream,
+  `[Filter]` in oc-rsync's diagnostic emitter).
+- Normalise both streams to a stable form, diff them, and report the
+  line count.
+
+The harness does not transfer data (`--dry-run`) and does not exercise
+non-filter code paths. It is a tracer comparator, not a transfer
+correctness check; the latter is MDF-2 and tracked separately.
+
+## 2. What is compared
+
+Default mode (no `--strict`):
+
+- Level-1-shaped lines only: messages matching the `excluding` or
+  `including` keywords after lowercasing. This is the subset both
+  binaries are documented to emit today (see
+  `docs/user/filter-rules-status.md`).
+- Everything else (transfer summaries, timings, `sending incremental
+  file list`, `total size is N`, role banners) is dropped by the
+  initial `grep '[FILTER'` / `grep '[Filter]'` filter.
+
+`--strict` mode additionally retains level-2+ lines (rule-load echoes,
+per-decision traces). It exists so a future MDF task can flip the
+harness to required-check status once oc-rsync wires those levels
+through. The strict diff is expected to be large today.
+
+## 3. Normalisation rules
+
+The two binaries produce equivalent semantic information in slightly
+different surface forms. Normalisation strips known cosmetic
+differences without losing semantic content:
+
+- Absolute fixture path -> relative form. CI workspaces live under
+  `/home/runner/work/...`; local checkouts live elsewhere. Both must
+  reduce to the same string.
+- Destination-root prefixes (`/tmp/mdf-8/upstream-dest/`,
+  `/tmp/mdf-8/oc-rsync-dest/`) are stripped likewise.
+- Leading `[role=version]` tags (oc-rsync error-message convention,
+  not present in upstream) are removed.
+- ANSI colour escapes are removed.
+- Lines are lowercased so `[FILTER]` vs `[Filter]` and
+  `Excluding` vs `excluding` do not contribute false diff noise.
+- Output is sorted with `LC_ALL=C sort -u`. Filter order is
+  deterministic per-binary but differs across binaries (different
+  rule-evaluation walk orders); set-equality is the meaningful
+  property at this stage.
+
+A future tightening pass can switch to ordered diff once both binaries
+agree on traversal order.
+
+## 4. Expected vs known-divergent output
+
+Today's divergences (do not flag as regressions):
+
+- oc-rsync's `--debug=FILTER` only wires level 1 (audit MDF-9, doc
+  `docs/user/filter-rules-status.md`). Levels 2-4 are accepted as
+  argument values but do not produce additional log lines. The
+  default-mode harness therefore restricts comparison to level-1
+  output.
+- Several MDF-1 audit findings (#2895..#2900) are open. The diff line
+  count will be non-zero until those ship.
+
+Expected after MDF-2..MDF-6 close:
+
+- Default-mode diff line count: 0.
+- `--strict` mode diff line count: still non-zero pending the
+  level-2/3/4 wiring task.
+
+## 5. CI wiring
+
+`.github/workflows/mdf-8-filter-diff.yml` runs the harness under
+`workflow_dispatch` only. The job:
+
+1. Builds oc-rsync in release mode.
+2. Installs upstream rsync via apt.
+3. Invokes the harness with default arguments.
+4. Uploads `/tmp/mdf-8-diff/diff.txt` as an artifact.
+
+The workflow is advisory (`continue-on-error: true`). A failing diff
+does not block merges; it shows up in the workflow summary so MDF-* PR
+authors can grade their fix. The follow-up task to promote the
+workflow to required-check is gated on default-mode diff hitting zero
+and staying there for one release cycle.
+
+## 6. Acceptance for future MDF-* fix PRs
+
+Every PR that lands a fix for an MDF-1 audit finding (#2895..#2900)
+should:
+
+1. Run the harness locally (or trigger the workflow on the PR branch).
+2. Include the `diff lines` count from the harness summary in the PR
+   body, comparing pre- and post-fix.
+3. The post-fix count must be strictly less than the pre-fix count.
+   Regressions (count increases) block merge.
+4. When all MDF-1 audit findings close and the default-mode count
+   reaches zero, the harness flips to required-check and the
+   acceptance bar moves to "count must remain at zero".

--- a/scripts/mdf_8_filter_diff_harness.sh
+++ b/scripts/mdf_8_filter_diff_harness.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# MDF-8 - diff upstream rsync --debug=FILTER1,2,3,4 against oc-rsync filter output
+#
+# Runs upstream rsync and oc-rsync against the MDF-7 complex fixture with
+# the maximal `--debug=FILTER1,2,3,4` switch, captures the filter-decision
+# log lines on each side, normalises them, and diffs the two streams.
+#
+# Exit codes:
+#   0  - logs are identical after normalisation (parity).
+#   1  - logs diverge after normalisation (regression).
+#   2  - usage / argument error.
+#   77 - skipped: required binary or fixture not available.
+#
+# Defaults are tuned for local development; CI overrides via flags.
+set -euo pipefail
+
+UPSTREAM="/usr/bin/rsync"
+OC_RSYNC="target/release/oc-rsync"
+FIXTURE="tests/fixtures/filter-rules/mdf-7-complex/source"
+OUTPUT="/tmp/mdf-8-diff"
+STRICT=0
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: mdf_8_filter_diff_harness.sh [options]
+
+Options:
+  --upstream PATH   Path to upstream rsync binary (default: /usr/bin/rsync)
+  --oc-rsync PATH   Path to oc-rsync binary       (default: target/release/oc-rsync)
+  --fixture PATH    Source fixture directory      (default: tests/fixtures/filter-rules/mdf-7-complex/source)
+  --output DIR      Output directory for logs     (default: /tmp/mdf-8-diff)
+  --strict          Compare level-2+ FILTER traces as well (future work).
+  -h, --help        Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --upstream)  UPSTREAM="$2"; shift 2 ;;
+        --oc-rsync)  OC_RSYNC="$2"; shift 2 ;;
+        --fixture)   FIXTURE="$2"; shift 2 ;;
+        --output)    OUTPUT="$2"; shift 2 ;;
+        --strict)    STRICT=1; shift ;;
+        -h|--help)   usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ ! -x "$UPSTREAM" ]] && ! command -v "$UPSTREAM" >/dev/null 2>&1; then
+    echo "skip: upstream rsync not found at '$UPSTREAM'" >&2
+    exit 77
+fi
+if [[ ! -x "$OC_RSYNC" ]] && ! command -v "$OC_RSYNC" >/dev/null 2>&1; then
+    echo "skip: oc-rsync not found at '$OC_RSYNC'" >&2
+    exit 77
+fi
+if [[ ! -d "$FIXTURE" ]]; then
+    echo "skip: fixture not found at '$FIXTURE'" >&2
+    exit 77
+fi
+
+mkdir -p "$OUTPUT"
+UPSTREAM_DEST="/tmp/mdf-8/upstream-dest"
+OC_DEST="/tmp/mdf-8/oc-rsync-dest"
+mkdir -p "$UPSTREAM_DEST" "$OC_DEST"
+
+# Strip a known prefix from a stream so absolute and per-CI workspace
+# paths normalise to a stable relative form. We strip:
+#   - the fixture absolute path
+#   - the destination root prefixes
+#   - any leading "[role pid]" tag (e.g. "[receiver=3.4.1]")
+#   - terminal colour escapes
+normalise() {
+    local fixture_abs="$1"
+    sed \
+        -e "s|$fixture_abs/||g" \
+        -e "s|$fixture_abs||g" \
+        -e "s|/tmp/mdf-8/upstream-dest/||g" \
+        -e "s|/tmp/mdf-8/oc-rsync-dest/||g" \
+        -e 's/\x1b\[[0-9;]*m//g' \
+        -e 's/^\[[a-z]*=[^]]*\] //' \
+        | tr '[:upper:]' '[:lower:]' \
+        | LC_ALL=C sort -u
+}
+
+FIXTURE_ABS="$(cd "$FIXTURE" && pwd)"
+
+set +e
+"$UPSTREAM" -av --debug=FILTER1,2,3,4 --dry-run \
+    "$FIXTURE_ABS/" "$UPSTREAM_DEST/" 2>&1 \
+    | grep '\[FILTER' > "$OUTPUT/upstream-filter.log"
+UPSTREAM_RC=$?
+
+"$OC_RSYNC" -av --debug=FILTER1,2,3,4 --dry-run \
+    "$FIXTURE_ABS/" "$OC_DEST/" 2>&1 \
+    | grep -E '\[Filter\]|\[FILTER' > "$OUTPUT/oc-rsync-filter.log"
+OC_RC=$?
+set -e
+
+# grep returns 1 when no matches; in this harness "no matches" is signal
+# (level-2+ unimplemented), not failure. Capture rc but do not abort.
+if [[ "$UPSTREAM_RC" -gt 1 ]]; then
+    echo "warning: upstream rsync grep exited with $UPSTREAM_RC" >&2
+fi
+if [[ "$OC_RC" -gt 1 ]]; then
+    echo "warning: oc-rsync grep exited with $OC_RC" >&2
+fi
+
+normalise "$FIXTURE_ABS" < "$OUTPUT/upstream-filter.log" > "$OUTPUT/upstream-filter-normalised.log"
+normalise "$FIXTURE_ABS" < "$OUTPUT/oc-rsync-filter.log" > "$OUTPUT/oc-rsync-filter-normalised.log"
+
+if [[ "$STRICT" -eq 0 ]]; then
+    # Restrict comparison to level-1-shaped lines ("excluding" / "including"
+    # decisions). Level-2 rule-load echoes and level-3/4 traces are
+    # documented divergences (see docs/user/filter-rules-status.md).
+    for f in "$OUTPUT/upstream-filter-normalised.log" "$OUTPUT/oc-rsync-filter-normalised.log"; do
+        grep -E 'excluding|including' "$f" > "$f.tmp" || true
+        mv "$f.tmp" "$f"
+    done
+fi
+
+diff -u "$OUTPUT/upstream-filter-normalised.log" "$OUTPUT/oc-rsync-filter-normalised.log" \
+    > "$OUTPUT/diff.txt" || true
+
+DIFF_LINES="$(wc -l < "$OUTPUT/diff.txt" | tr -d ' ')"
+
+echo "MDF-8 filter diff harness"
+echo "  fixture           : $FIXTURE_ABS"
+echo "  upstream rsync    : $UPSTREAM"
+echo "  oc-rsync          : $OC_RSYNC"
+echo "  output dir        : $OUTPUT"
+echo "  strict mode       : $STRICT"
+echo "  upstream log lines: $(wc -l < "$OUTPUT/upstream-filter.log" | tr -d ' ')"
+echo "  oc-rsync log lines: $(wc -l < "$OUTPUT/oc-rsync-filter.log" | tr -d ' ')"
+echo "  diff lines        : $DIFF_LINES"
+
+if [[ "$DIFF_LINES" -eq 0 ]]; then
+    echo "PASS: filter-decision streams match after normalisation."
+    exit 0
+fi
+echo "FAIL: $DIFF_LINES diff lines - see $OUTPUT/diff.txt"
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/mdf_8_filter_diff_harness.sh` (mode 755). Runs upstream rsync and oc-rsync against the MDF-7 complex fixture with `--debug=FILTER1,2,3,4 --dry-run`, captures filter-decision log lines, normalises them (paths, role tags, ANSI, case, sort), and diffs the two streams. Skips with exit 77 when either binary or the fixture is missing.
- Adds `docs/design/mdf-8-filter-diff-harness.md` documenting scope, what is compared, normalisation rules, expected divergences (oc-rsync only wires level-1 today per MDF-9), CI wiring, and acceptance bar for MDF-* fix PRs.
- Adds `.github/workflows/mdf-8-filter-diff.yml`: advisory `workflow_dispatch`-only run that builds oc-rsync, installs upstream rsync, executes the harness, and uploads `/tmp/mdf-8-diff/` as an artifact. `continue-on-error: true` until the default-mode diff hits zero.

## Background

Default mode restricts comparison to level-1 (`excluding` / `including`) lines because oc-rsync's `--debug=FILTER` only emits level 1. The `--strict` flag opts into level-2+ comparison for future work after the level-2/3/4 wiring lands.

Refs: #2901 (MDF-8). Sibling PRs: #4900 (MDF-1 audit), #4919 (MDF-9 gap doc), #4946 (MDF-7 fixture).

## Test plan

- [x] `bash -n` syntax check passes.
- [x] Script exits 77 when `--upstream` path does not exist (skip convention).
- [ ] Trigger the new workflow from `Actions` to capture a baseline diff line count for the current oc-rsync.