### PR TITLE
ci(interop): daemon-mode rsync 2.6.9 client interop harness (RP28.e.2)

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -280,6 +280,53 @@ jobs:
           fi
           echo "PASS: rsync 2.6.9 -> oc-rsync pull produced byte-identical tree."
 
+      # RP28.e.2 - daemon-mode interop with rsync 2.6.9 as the client.
+      # Inverts the RP28.c/RP28.d topology: oc-rsync runs `--daemon
+      # --no-detach` and the 2.6.9 binary issues pulls and pushes against
+      # the `[test]` module. Exercises the D1-D10 fixture matrix from
+      # `docs/design/rp28-e-1-daemon-2-6-9-client-harness.md` (spec
+      # shipped in RP28.e.1, PR #4928). Reuses the 2.6.9 binary built
+      # by the earlier `Build upstream rsync` step under
+      # `target/interop/upstream-install/2.6.9/bin/rsync`; if absent we
+      # build it inline via the RP28.b.1 helper to keep the cell
+      # self-sufficient. The harness exits 77 when either binary is
+      # missing so the cell becomes a no-op rather than a false failure.
+      # Non-blocking via `continue-on-error: true` until RP28.k promotes
+      # pre-30 parity to a required check.
+      - name: Run rsync 2.6.9 daemon-mode client interop (RP28.e.2)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          RSYNC_269="target/interop/upstream-install/2.6.9/bin/rsync"
+          if [[ ! -x "$RSYNC_269" ]]; then
+            echo "rsync 2.6.9 binary missing at $RSYNC_269; building via RP28.b.1 helper" >&2
+            sudo bash scripts/build_rsync_2_6_9.sh
+            RSYNC_269="/usr/local/bin/rsync-2.6.9"
+          fi
+
+          OC_RSYNC="target/release/oc-rsync"
+          if [[ ! -x "$OC_RSYNC" ]]; then
+            OC_RSYNC="target/dist/oc-rsync"
+          fi
+          if [[ ! -x "$OC_RSYNC" ]]; then
+            echo "oc-rsync binary missing at target/release/oc-rsync and target/dist/oc-rsync" >&2
+            exit 1
+          fi
+
+          bash scripts/rp28_e_1_run.sh \
+            --oc-rsync "$OC_RSYNC" \
+            --rsync-2-6-9 "$RSYNC_269"
+
+      - name: Capture RP28.e.2 daemon log on failure
+        if: failure()
+        run: |
+          if [[ -f /tmp/rp28-e/daemon.log ]]; then
+            echo "--- /tmp/rp28-e/daemon.log ---"
+            cat /tmp/rp28-e/daemon.log
+          else
+            echo "no /tmp/rp28-e/daemon.log to capture"
+          fi
+
       # Drive upstream rsync's own `testsuite/*.test` corpus against
       # oc-rsync as `$RSYNC`. The harness sources upstream's `rsync.fns`
       # and reuses its helper tools (`tls`, `getgroups`, `support/lsh.sh`),

--- a/scripts/rp28_e_1_run.sh
+++ b/scripts/rp28_e_1_run.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# RP28.e.2 - run daemon-mode rsync 2.6.9 client interop harness
+#
+# Orchestrates the D1-D10 fixture matrix from
+# `docs/design/rp28-e-1-daemon-2-6-9-client-harness.md`. The topology is
+# inverted relative to RP28.c/RP28.d: oc-rsync runs as
+# `--daemon --no-detach` and rsync 2.6.9 is the client.
+#
+# Usage:
+#   scripts/rp28_e_1_run.sh \
+#     [--oc-rsync target/release/oc-rsync] \
+#     [--rsync-2-6-9 /usr/local/bin/rsync-2.6.9]
+#
+# Exit codes:
+#   0  - all 10 fixtures passed
+#   1  - one or more fixtures failed
+#   77 - either required binary missing (treat as skip)
+#
+# Task: RP28.e.2 (#2964). Parent: RP28.e (#2730). Spec: RP28.e.1 (#2963).
+
+set -euo pipefail
+
+OC_RSYNC="target/release/oc-rsync"
+RSYNC_269="/usr/local/bin/rsync-2.6.9"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --oc-rsync)
+      OC_RSYNC="$2"
+      shift 2
+      ;;
+    --rsync-2-6-9)
+      RSYNC_269="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "${OC_RSYNC}" ]]; then
+  echo "RP28.e.2 skip: oc-rsync binary not found at ${OC_RSYNC}" >&2
+  exit 77
+fi
+if [[ ! -x "${RSYNC_269}" ]]; then
+  echo "RP28.e.2 skip: rsync 2.6.9 binary not found at ${RSYNC_269}" >&2
+  exit 77
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${RP28_E_ROOT:-/tmp/rp28-e}"
+export RP28_E_ROOT="${ROOT}"
+
+DAEMON_SHARE="${ROOT}/daemon-share"
+CLIENT_SRC="${ROOT}/client-src"
+CLIENT_DEST="${ROOT}/client-dest"
+DAEMON_CONF="${ROOT}/oc-rsyncd.conf"
+DAEMON_PID_FILE="${ROOT}/oc-rsyncd.pid"
+DAEMON_LOG="${ROOT}/daemon.log"
+PORT_FILE="${ROOT}/port.txt"
+
+DAEMON_PID=""
+
+cleanup() {
+  local rc=$?
+  if [[ -n "${DAEMON_PID}" ]] && kill -0 "${DAEMON_PID}" 2>/dev/null; then
+    kill -TERM "${DAEMON_PID}" 2>/dev/null || true
+    for _ in $(seq 1 10); do
+      kill -0 "${DAEMON_PID}" 2>/dev/null || break
+      sleep 0.5
+    done
+    kill -KILL "${DAEMON_PID}" 2>/dev/null || true
+  fi
+  if [[ ${rc} -ne 0 && -f "${DAEMON_LOG}" ]]; then
+    echo "--- oc-rsync daemon log (tail) ---" >&2
+    tail -n 200 "${DAEMON_LOG}" >&2 || true
+  fi
+  # Leave ROOT in place on failure for CI artifact capture; remove on success.
+  if [[ ${rc} -eq 0 ]]; then
+    rm -rf "${ROOT}"
+  fi
+}
+trap cleanup EXIT
+
+echo "RP28.e.2: oc-rsync=$(${OC_RSYNC} --version 2>&1 | head -1)"
+echo "RP28.e.2: rsync-2.6.9=$(${RSYNC_269} --version 2>&1 | head -1)"
+
+bash "${SCRIPT_DIR}/rp28_e_1_setup.sh"
+
+# Ephemeral port. Bind to verify availability then release immediately;
+# brief reuse race vs. the daemon start is the same trade-off RP28.c/d
+# accept and is tolerated by the bind-poll loop below.
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+echo "${PORT}" > "${PORT_FILE}"
+echo "RP28.e.2: daemon port ${PORT}"
+
+"${OC_RSYNC}" --daemon --no-detach --config "${DAEMON_CONF}" --port "${PORT}" \
+  > "${DAEMON_LOG}" 2>&1 &
+DAEMON_PID=$!
+
+# Wait up to 10s for the daemon to bind.
+for _ in $(seq 1 20); do
+  if (echo >/dev/tcp/127.0.0.1/"${PORT}") 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+    echo "FATAL: oc-rsync daemon exited before binding port ${PORT}" >&2
+    exit 1
+  fi
+  sleep 0.5
+done
+if ! (echo >/dev/tcp/127.0.0.1/"${PORT}") 2>/dev/null; then
+  echo "FATAL: oc-rsync daemon failed to bind port ${PORT} within 10s" >&2
+  exit 1
+fi
+echo "RP28.e.2: daemon bound 127.0.0.1:${PORT}"
+
+declare -a RESULTS
+PASS_COUNT=0
+FAIL_COUNT=0
+
+record() {
+  local name="$1" status="$2" detail="${3:-}"
+  RESULTS+=("${status} ${name} ${detail}")
+  if [[ "${status}" == "PASS" ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_client() {
+  # Runs rsync 2.6.9 against the daemon with a 60s wall-clock guard and
+  # returns its exit status. Stderr is captured per-fixture into the
+  # named file so the caller can inspect it.
+  local stderr_path="$1"
+  shift
+  set +e
+  timeout 60 "${RSYNC_269}" "$@" 2> "${stderr_path}"
+  local rc=$?
+  set -e
+  return ${rc}
+}
+
+reset_client_dest() {
+  local sub="$1"
+  rm -rf "${CLIENT_DEST}/${sub}"
+  mkdir -p "${CLIENT_DEST}/${sub}"
+}
+
+reset_daemon_share_sub() {
+  local sub="$1"
+  rm -rf "${DAEMON_SHARE}/${sub}"
+  mkdir -p "${DAEMON_SHARE}/${sub}"
+}
+
+verify_diff() {
+  # Byte-identical tree compare. `--no-dereference` keeps symlinks compared
+  # by target string rather than followed.
+  local left="$1" right="$2"
+  diff -r --no-dereference "${left}" "${right}"
+}
+
+check_daemon_quiet() {
+  # Fail if the daemon emitted panics or unexpected `error:` / `WARNING`
+  # lines. Protocol-downgrade WARNINGs at proto-28 negotiation are the
+  # only allowlisted warnings per spec section 5.
+  local label="$1"
+  local quiet=1
+  if grep -E "panicked at|thread .* panicked" "${DAEMON_LOG}" >/dev/null 2>&1; then
+    echo "FAIL ${label}: daemon log contains panic" >&2
+    quiet=0
+  fi
+  if grep -E "^error:" "${DAEMON_LOG}" >/dev/null 2>&1; then
+    echo "FAIL ${label}: daemon log contains error: line" >&2
+    quiet=0
+  fi
+  if grep -E "^WARNING" "${DAEMON_LOG}" \
+       | grep -vE "protocol downgrade|protocol version 28|protocol 28" \
+       >/dev/null 2>&1; then
+    echo "FAIL ${label}: daemon log contains unexpected WARNING" >&2
+    quiet=0
+  fi
+  [[ ${quiet} -eq 1 ]]
+}
+
+# Each fixture follows the same scaffold: prepare client side, invoke the
+# 2.6.9 client, capture rc, run the verifier, then record the result.
+fixture() {
+  local name="$1"
+  shift
+  echo "=== ${name}: $* ==="
+}
+
+URL_BASE="rsync://127.0.0.1:${PORT}/test"
+
+# ----- D1: empty dir, pull + push -----------------------------------------
+fixture D1 "empty dir pull+push"
+reset_client_dest d1
+if run_client "${ROOT}/d1.pull.err" -av "${URL_BASE}/d1/" "${CLIENT_DEST}/d1/" \
+   && verify_diff "${DAEMON_SHARE}/d1" "${CLIENT_DEST}/d1" \
+   && check_daemon_quiet D1.pull; then
+  record D1.pull PASS
+else
+  record D1.pull FAIL "see ${ROOT}/d1.pull.err"
+fi
+reset_daemon_share_sub d1_push
+if run_client "${ROOT}/d1.push.err" -av "${CLIENT_SRC}/d1/" "${URL_BASE}/d1_push/" \
+   && verify_diff "${CLIENT_SRC}/d1" "${DAEMON_SHARE}/d1_push" \
+   && check_daemon_quiet D1.push; then
+  record D1.push PASS
+else
+  record D1.push FAIL "see ${ROOT}/d1.push.err"
+fi
+
+# ----- D2: 100 small files, pull + push -----------------------------------
+fixture D2 "100 small files pull+push"
+reset_client_dest d2
+if run_client "${ROOT}/d2.pull.err" -av "${URL_BASE}/d2/" "${CLIENT_DEST}/d2/" \
+   && verify_diff "${DAEMON_SHARE}/d2" "${CLIENT_DEST}/d2" \
+   && check_daemon_quiet D2.pull; then
+  record D2.pull PASS
+else
+  record D2.pull FAIL "see ${ROOT}/d2.pull.err"
+fi
+reset_daemon_share_sub d2_push
+if run_client "${ROOT}/d2.push.err" -av "${CLIENT_SRC}/d2/" "${URL_BASE}/d2_push/" \
+   && verify_diff "${CLIENT_SRC}/d2" "${DAEMON_SHARE}/d2_push" \
+   && check_daemon_quiet D2.push; then
+  record D2.push PASS
+else
+  record D2.push FAIL "see ${ROOT}/d2.push.err"
+fi
+
+# ----- D3: zlib compression, pull -----------------------------------------
+fixture D3 "zlib -z pull"
+reset_client_dest d3
+if run_client "${ROOT}/d3.pull.err" -avz "${URL_BASE}/d3/" "${CLIENT_DEST}/d3/" \
+   && verify_diff "${DAEMON_SHARE}/d3" "${CLIENT_DEST}/d3" \
+   && check_daemon_quiet D3.pull; then
+  record D3.pull PASS
+else
+  record D3.pull FAIL "see ${ROOT}/d3.pull.err"
+fi
+
+# ----- D4: --checksum pull ------------------------------------------------
+fixture D4 "--checksum pull"
+rm -rf "${CLIENT_DEST}/d4"
+cp -a "${CLIENT_DEST}/d4_seed" "${CLIENT_DEST}/d4"
+if run_client "${ROOT}/d4.pull.err" -av --checksum \
+     "${URL_BASE}/d4/" "${CLIENT_DEST}/d4/" \
+   && verify_diff "${DAEMON_SHARE}/d4" "${CLIENT_DEST}/d4" \
+   && check_daemon_quiet D4.pull; then
+  record D4.pull PASS
+else
+  record D4.pull FAIL "see ${ROOT}/d4.pull.err"
+fi
+
+# ----- D5: --delete pull + push -------------------------------------------
+fixture D5 "--delete pull+push"
+rm -rf "${CLIENT_DEST}/d5_pull"
+cp -a "${CLIENT_DEST}/d5_pull_seed" "${CLIENT_DEST}/d5_pull"
+if run_client "${ROOT}/d5.pull.err" -av --delete \
+     "${URL_BASE}/d5_pull/" "${CLIENT_DEST}/d5_pull/" \
+   && verify_diff "${DAEMON_SHARE}/d5_pull" "${CLIENT_DEST}/d5_pull" \
+   && check_daemon_quiet D5.pull; then
+  record D5.pull PASS
+else
+  record D5.pull FAIL "see ${ROOT}/d5.pull.err"
+fi
+
+rm -rf "${DAEMON_SHARE}/d5_push"
+cp -a "${DAEMON_SHARE}/d5_push_seed" "${DAEMON_SHARE}/d5_push"
+if run_client "${ROOT}/d5.push.err" -av --delete \
+     "${CLIENT_SRC}/d5_push/" "${URL_BASE}/d5_push/" \
+   && verify_diff "${CLIENT_SRC}/d5_push" "${DAEMON_SHARE}/d5_push" \
+   && check_daemon_quiet D5.push; then
+  record D5.push PASS
+else
+  record D5.push FAIL "see ${ROOT}/d5.push.err"
+fi
+
+# ----- D6: 3-level directory tree push ------------------------------------
+fixture D6 "3-level directory tree push"
+reset_daemon_share_sub d6_push
+if run_client "${ROOT}/d6.push.err" -av "${CLIENT_SRC}/d6/" "${URL_BASE}/d6_push/" \
+   && verify_diff "${CLIENT_SRC}/d6" "${DAEMON_SHARE}/d6_push" \
+   && check_daemon_quiet D6.push; then
+  record D6.push PASS
+else
+  record D6.push FAIL "see ${ROOT}/d6.push.err"
+fi
+
+# ----- D7: extended-character filename pull + push ------------------------
+fixture D7 "extended-char filename pull+push"
+reset_client_dest d7
+if run_client "${ROOT}/d7.pull.err" -av "${URL_BASE}/d7/" "${CLIENT_DEST}/d7/" \
+   && verify_diff "${DAEMON_SHARE}/d7" "${CLIENT_DEST}/d7" \
+   && check_daemon_quiet D7.pull; then
+  record D7.pull PASS
+else
+  record D7.pull FAIL "see ${ROOT}/d7.pull.err"
+fi
+reset_daemon_share_sub d7_push
+if run_client "${ROOT}/d7.push.err" -av "${CLIENT_SRC}/d7/" "${URL_BASE}/d7_push/" \
+   && verify_diff "${CLIENT_SRC}/d7" "${DAEMON_SHARE}/d7_push" \
+   && check_daemon_quiet D7.push; then
+  record D7.push PASS
+else
+  record D7.push FAIL "see ${ROOT}/d7.push.err"
+fi
+
+# ----- D8: hardlink group pull + push -------------------------------------
+fixture D8 "hardlink group pull+push"
+reset_client_dest d8
+if run_client "${ROOT}/d8.pull.err" -avH "${URL_BASE}/d8/" "${CLIENT_DEST}/d8/" \
+   && verify_diff "${DAEMON_SHARE}/d8" "${CLIENT_DEST}/d8"; then
+  ino_a=$(stat -c '%i' "${CLIENT_DEST}/d8/a.txt")
+  ino_b=$(stat -c '%i' "${CLIENT_DEST}/d8/b.txt")
+  if [[ "${ino_a}" == "${ino_b}" ]] && check_daemon_quiet D8.pull; then
+    record D8.pull PASS
+  else
+    record D8.pull FAIL "hardlink inodes differ (${ino_a} vs ${ino_b})"
+  fi
+else
+  record D8.pull FAIL "see ${ROOT}/d8.pull.err"
+fi
+
+reset_daemon_share_sub d8_push
+if run_client "${ROOT}/d8.push.err" -avH "${CLIENT_SRC}/d8/" "${URL_BASE}/d8_push/" \
+   && verify_diff "${CLIENT_SRC}/d8" "${DAEMON_SHARE}/d8_push"; then
+  ino_a=$(stat -c '%i' "${DAEMON_SHARE}/d8_push/a.txt")
+  ino_b=$(stat -c '%i' "${DAEMON_SHARE}/d8_push/b.txt")
+  if [[ "${ino_a}" == "${ino_b}" ]] && check_daemon_quiet D8.push; then
+    record D8.push PASS
+  else
+    record D8.push FAIL "hardlink inodes differ (${ino_a} vs ${ino_b})"
+  fi
+else
+  record D8.push FAIL "see ${ROOT}/d8.push.err"
+fi
+
+# ----- D9: incremental update, pull twice ---------------------------------
+fixture D9 "incremental update (pull x2)"
+reset_client_dest d9
+if run_client "${ROOT}/d9.pull1.err" -av "${URL_BASE}/d9/" "${CLIENT_DEST}/d9/" \
+   && verify_diff "${DAEMON_SHARE}/d9" "${CLIENT_DEST}/d9" \
+   && check_daemon_quiet D9.pull1; then
+  if run_client "${ROOT}/d9.pull2.err" -av --stats \
+       "${URL_BASE}/d9/" "${CLIENT_DEST}/d9/" \
+     && verify_diff "${DAEMON_SHARE}/d9" "${CLIENT_DEST}/d9" \
+     && check_daemon_quiet D9.pull2; then
+    record D9.pull PASS
+  else
+    record D9.pull FAIL "second pull diverged - see ${ROOT}/d9.pull2.err"
+  fi
+else
+  record D9.pull FAIL "first pull diverged - see ${ROOT}/d9.pull1.err"
+fi
+
+# ----- D10: 1 MiB file with delta after modification ----------------------
+fixture D10 "1 MiB delta pull"
+reset_client_dest d10
+if run_client "${ROOT}/d10.pull1.err" -av "${URL_BASE}/d10/" "${CLIENT_DEST}/d10/" \
+   && verify_diff "${DAEMON_SHARE}/d10" "${CLIENT_DEST}/d10" \
+   && check_daemon_quiet D10.pull1; then
+  # Modify the daemon-side copy mid-stream to force the rolling+strong
+  # checksum match phase on the next pull. Touch a few hundred bytes in
+  # the middle so most of the file still matches block-for-block.
+  printf 'D10 mutation marker A\n' \
+    | dd of="${DAEMON_SHARE}/d10/payload.bin" \
+         bs=1 seek=524288 conv=notrunc 2>/dev/null
+  if run_client "${ROOT}/d10.pull2.err" -av "${URL_BASE}/d10/" "${CLIENT_DEST}/d10/" \
+     && verify_diff "${DAEMON_SHARE}/d10" "${CLIENT_DEST}/d10" \
+     && check_daemon_quiet D10.pull2; then
+    record D10.pull PASS
+  else
+    record D10.pull FAIL "delta pull diverged - see ${ROOT}/d10.pull2.err"
+  fi
+else
+  record D10.pull FAIL "first pull diverged - see ${ROOT}/d10.pull1.err"
+fi
+
+echo
+echo "RP28.e.2 summary (${PASS_COUNT} pass, ${FAIL_COUNT} fail):"
+for line in "${RESULTS[@]}"; do
+  echo "  ${line}"
+done
+
+if [[ ${FAIL_COUNT} -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/rp28_e_1_setup.sh
+++ b/scripts/rp28_e_1_setup.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# RP28.e.2 - setup harness for daemon-mode rsync 2.6.9 client interop
+#
+# Builds the deterministic fixture set described in
+# `docs/design/rp28-e-1-daemon-2-6-9-client-harness.md` section 4 (D1-D10).
+# Two trees are populated under `/tmp/rp28-e/`:
+#
+#   - `daemon-share/` - the share oc-rsync exposes via the `[test]` module;
+#     pre-seeded with the per-fixture state the client expects on pulls.
+#   - `client-src/`   - source trees the rsync 2.6.9 client pushes to the
+#     daemon. Each fixture lives in its own sub-directory.
+#
+# The script also writes the daemon config to `/tmp/rp28-e/oc-rsyncd.conf`
+# per spec section 3. All file contents use fixed bytes (no random data
+# without a fixed seed) so re-runs produce identical hashes.
+#
+# Task: RP28.e.2 (#2964). Parent: RP28.e (#2730). Spec: RP28.e.1 (#2963).
+
+set -euo pipefail
+
+ROOT="${RP28_E_ROOT:-/tmp/rp28-e}"
+DAEMON_SHARE="${ROOT}/daemon-share"
+CLIENT_SRC="${ROOT}/client-src"
+CLIENT_DEST="${ROOT}/client-dest"
+DAEMON_CONF="${ROOT}/oc-rsyncd.conf"
+DAEMON_PID_FILE="${ROOT}/oc-rsyncd.pid"
+DAEMON_LOG="${ROOT}/daemon.log"
+
+# Reset the tree so every invocation starts from a known state.
+rm -rf "${ROOT}"
+mkdir -p "${DAEMON_SHARE}" "${CLIENT_SRC}" "${CLIENT_DEST}"
+
+# Deterministic 1 KiB block used wherever a non-trivial filler is needed.
+det_block() {
+  # 1 KiB of the printable byte sequence 0..255 repeated, prefixed with a
+  # fixture-specific tag so different fixtures hash differently while still
+  # being deterministic.
+  local tag="$1"
+  printf '%s\n' "${tag}"
+  awk 'BEGIN { for (i = 0; i < 1024; i++) printf "%c", (i % 95) + 32 }'
+}
+
+# D1: empty directory (pull + push). The fixture's source directory exists
+# but holds no files; verifies greeting + module list + empty flist.
+mkdir -p "${DAEMON_SHARE}/d1"
+mkdir -p "${CLIENT_SRC}/d1"
+
+# D2: 100 small files (pull + push). Exercises proto-28 flist encoding.
+mkdir -p "${DAEMON_SHARE}/d2" "${CLIENT_SRC}/d2"
+for i in $(seq -w 1 100); do
+  printf 'd2 daemon file %s\n' "${i}" > "${DAEMON_SHARE}/d2/file_${i}.txt"
+  printf 'd2 client file %s\n' "${i}" > "${CLIENT_SRC}/d2/file_${i}.txt"
+done
+
+# D3: file with `-z` (pull). Compresses well so the proto-28 zlib codec
+# path is exercised.
+mkdir -p "${DAEMON_SHARE}/d3"
+awk 'BEGIN { for (i = 0; i < 16384; i++) printf "compressible-d3-payload\n" }' \
+  > "${DAEMON_SHARE}/d3/zlib_input.txt"
+
+# D4: file with `--checksum` (pull). Two files: one identical to what we
+# expect locally, one different, so the client's --checksum path picks up
+# at least one transfer.
+mkdir -p "${DAEMON_SHARE}/d4" "${CLIENT_DEST}/d4_seed"
+printf 'd4 identical contents\n' > "${DAEMON_SHARE}/d4/same.txt"
+printf 'd4 identical contents\n' > "${CLIENT_DEST}/d4_seed/same.txt"
+printf 'd4 daemon-side updated contents\n' > "${DAEMON_SHARE}/d4/changed.txt"
+printf 'd4 client-side older contents\n'   > "${CLIENT_DEST}/d4_seed/changed.txt"
+
+# D5: file with `--delete` on dest (pull + push). The destination starts
+# with an extra file that --delete must remove.
+mkdir -p "${DAEMON_SHARE}/d5_pull" "${CLIENT_DEST}/d5_pull_seed"
+printf 'd5 kept-pull\n' > "${DAEMON_SHARE}/d5_pull/keep.txt"
+printf 'd5 kept-pull\n' > "${CLIENT_DEST}/d5_pull_seed/keep.txt"
+printf 'd5 stale-pull (must be deleted)\n' > "${CLIENT_DEST}/d5_pull_seed/stale.txt"
+
+mkdir -p "${CLIENT_SRC}/d5_push" "${DAEMON_SHARE}/d5_push_seed"
+printf 'd5 kept-push\n' > "${CLIENT_SRC}/d5_push/keep.txt"
+printf 'd5 kept-push\n' > "${DAEMON_SHARE}/d5_push_seed/keep.txt"
+printf 'd5 stale-push (must be deleted)\n' > "${DAEMON_SHARE}/d5_push_seed/stale.txt"
+
+# D6: directory tree (3 levels deep) (push). Drives the non-INC_RECURSE
+# legacy flist walk against the daemon.
+mkdir -p "${CLIENT_SRC}/d6/lvl1/lvl2/lvl3"
+printf 'd6 top\n'  > "${CLIENT_SRC}/d6/top.txt"
+printf 'd6 lvl1\n' > "${CLIENT_SRC}/d6/lvl1/a.txt"
+printf 'd6 lvl2\n' > "${CLIENT_SRC}/d6/lvl1/lvl2/b.txt"
+printf 'd6 lvl3\n' > "${CLIENT_SRC}/d6/lvl1/lvl2/lvl3/c.txt"
+
+# D7: file with extended-character name (pull + push). The 2.6.9 build
+# disables iconv, so we stick to filename bytes only - no ACL/xattr work.
+mkdir -p "${DAEMON_SHARE}/d7" "${CLIENT_SRC}/d7"
+printf 'd7 daemon\n' > "${DAEMON_SHARE}/d7/café-naïve.txt"
+printf 'd7 client\n' > "${CLIENT_SRC}/d7/café-naïve.txt"
+
+# D8: hardlink group of two files (pull + push). The verifier asserts the
+# destination preserves the inode-identity relationship.
+mkdir -p "${DAEMON_SHARE}/d8" "${CLIENT_SRC}/d8"
+printf 'd8 daemon-shared contents\n' > "${DAEMON_SHARE}/d8/a.txt"
+ln "${DAEMON_SHARE}/d8/a.txt" "${DAEMON_SHARE}/d8/b.txt"
+printf 'd8 client-shared contents\n' > "${CLIENT_SRC}/d8/a.txt"
+ln "${CLIENT_SRC}/d8/a.txt" "${CLIENT_SRC}/d8/b.txt"
+
+# D9: incremental update (pull twice). First pull copies the file fresh;
+# second pull must hit the quick-check skip path with no transfer.
+mkdir -p "${DAEMON_SHARE}/d9"
+det_block d9-baseline > "${DAEMON_SHARE}/d9/incremental.bin"
+
+# D10: 1 MiB file modified between two pulls (delta path). Seeded with a
+# deterministic block so the rolling+strong checksum match phase has
+# something to do on the second pull.
+mkdir -p "${DAEMON_SHARE}/d10"
+awk 'BEGIN { for (i = 0; i < 1024; i++) printf "%c", (i % 95) + 32 }' \
+  > "${DAEMON_SHARE}/d10/payload.bin.chunk"
+: > "${DAEMON_SHARE}/d10/payload.bin"
+for _ in $(seq 1 1024); do
+  cat "${DAEMON_SHARE}/d10/payload.bin.chunk" >> "${DAEMON_SHARE}/d10/payload.bin"
+done
+rm -f "${DAEMON_SHARE}/d10/payload.bin.chunk"
+
+# Daemon config. The `[test]` module is read+write because the matrix
+# exercises both directions through the same module. `use chroot = no`
+# avoids needing CAP_SYS_CHROOT in CI.
+cat > "${DAEMON_CONF}" <<EOF
+use chroot = no
+address = 127.0.0.1
+pid file = ${DAEMON_PID_FILE}
+log file = ${DAEMON_LOG}
+[test]
+    path = ${DAEMON_SHARE}
+    read only = false
+    list = yes
+EOF
+
+echo "RP28.e.2 setup complete:"
+echo "  daemon share: ${DAEMON_SHARE}"
+echo "  client src:   ${CLIENT_SRC}"
+echo "  client dest:  ${CLIENT_DEST}"
+echo "  daemon conf:  ${DAEMON_CONF}"


### PR DESCRIPTION
## Summary

Wires the daemon-mode rsync 2.6.9 client interop harness specced by RP28.e.1 into the Interop Validation workflow. oc-rsync runs as `--daemon --no-detach` and rsync 2.6.9 acts as the client, inverting the RP28.c / RP28.d topology so the proto-28 pre-INC_RECURSE / pre-NDX_DEL_STATS daemon paths get exercised end-to-end.

Three artifacts ship in this PR:

- `scripts/rp28_e_1_setup.sh` - deterministic D1-D10 fixture generator (empty dir, 100 small files, `-z`, `--checksum`, `--delete`, 3-level tree, extended-char filenames, hardlink group, incremental quick-check, 1 MiB delta) and the daemon config under `/tmp/rp28-e/`.
- `scripts/rp28_e_1_run.sh` - orchestrator: ephemeral 127.0.0.1 port, daemon bind-poll, per-fixture pull/push invocations, byte-identical diff + hardlink inode parity + daemon-log quiet checks, exits 77 cleanly when either binary is missing.
- `.github/workflows/_interop.yml` - new `Run rsync 2.6.9 daemon-mode client interop (RP28.e.2)` step placed after the RP28.d pull cell. Falls back to the RP28.b.1 build helper if the 2.6.9 cache is cold. `continue-on-error: true` (advisory) per the spec; promotion to required is tracked under RP28.k.

## Cross-references

- Parent task: #2964
- Sibling: #4928 (RP28.e.1 spec)
- Upstream build helper: #4903 (RP28.b.1)
- Build smoke workflow: #4941 (RP28.b.2)
- Follow-up reporter: #2965 (RP28.e.3)

## Test plan

- [ ] CI fmt+clippy passes.
- [ ] CI nextest (stable/Windows/macOS/musl) passes.
- [ ] Interop Validation workflow runs the new step; it should either pass or fail advisory-only (`continue-on-error: true`).
- [ ] On any failure the follow-up `Capture RP28.e.2 daemon log on failure` step prints `/tmp/rp28-e/daemon.log` for RP28.e.3 triage.
- [ ] Scripts exit 77 cleanly in environments missing either binary, surfacing as workflow skip not failure.