### PR TITLE
docs(release): v0.6.3 development cycle sprint summary

### DIFF
--- a/docs/release/v0.6.3-sprint-summary.md
+++ b/docs/release/v0.6.3-sprint-summary.md
@@ -1,0 +1,196 @@
+# v0.6.3 development cycle - sprint summary
+
+Consolidated tracking document for the audit, design, spec, and CI-tooling PRs
+merged during the v0.6.3 development cycle. PRs are grouped by topic series so
+release-notes authors and reviewers can see the full surface in one place.
+
+Range: PRs #4869, #4890-#4951 merged 2026-05-24 / 2026-05-25.
+
+## Topic series shipped in v0.6.3 development cycle
+
+### IKV - io_uring kernel-version floor
+
+Goal: Make Linux io_uring kernel-version requirements explicit at every
+documentation surface (README, man page, release notes) so operators on older
+kernels (RHEL 8 / Linux 4.18, etc.) understand the per-opcode fallback story.
+
+- PR #4899: Inventory io_uring opcodes by minimum-kernel requirement (IKV-1)
+- PR #4902: README kernel-tier support table (IKV-4)
+- PR #4904: Release-notes scaffold for io_uring kernel-floor disclaimer (IKV-6)
+- PR #4907: Man-page per-opcode fallback documentation (IKV-5)
+
+### XAP - xattr / ACL cross-platform parity
+
+Goal: Establish the direction matrix for xattr / ACL handling across
+Linux / macOS / Windows and audit known cross-platform gaps.
+
+- PR #4901: ACL / xattr cross-platform direction-matrix spec (XAP-1)
+- PR #4944: macOS-specific xattr handling audit vs upstream (XAP-8)
+
+### MDF - merge / dir-merge filter completeness
+
+Goal: Establish a regression baseline for filter-rule behavior vs upstream
+`exclude.c`, including per-modifier coverage and `.rsync-filter` discovery.
+
+- PR #4900: Per-modifier coverage audit vs upstream `exclude.c::add_rule()` (MDF-1)
+- PR #4919: Document remaining merge / dir-merge gaps (MDF-9)
+- PR #4946: Complex `.rsync-filter` fixture for every filter PR (MDF-7)
+- PR #4950: Upstream `--debug=FILTER1,2,3,4` diff harness (MDF-8)
+
+### WPC - Windows real-world parity
+
+Goal: Audit Windows-specific feature parity gaps (ADS, long paths, reparse
+points, NTFS case sensitivity, DACL round-trip, file-attribute / POSIX mode-bit
+mapping) and document the support matrix for users.
+
+- PR #4898: Alternate-data-stream handling audit vs upstream Cygwin rsync (WPC-1)
+- PR #4914: ADS strategy decision (WPC-2)
+- PR #4920: Windows support matrix user doc (WPC-13)
+- PR #4937: NTFS reparse-point classification audit (WPC-7)
+- PR #4938: DACL inherited vs explicit ACE round-trip audit (WPC-10)
+- PR #4939: Windows file-attribute / POSIX mode-bit round-trip audit (WPC-12)
+- PR #4940: Windows long-path (`\\?\`) support audit (WPC-5)
+- PR #4943: NTFS case-insensitive conflict-detection audit + test spec (WPC-11)
+
+### RP28 - rsync protocol 2.x interop
+
+Goal: Validate protocol 28 (rsync 2.6.x) interop and decide whether to keep
+or drop the wire-protocol back-negotiation path. Path A (keep + validate) was
+selected and the supporting CI harness specs and build helpers shipped.
+
+- PR #4897: Supported-protocols table in README (RP28.j.1)
+- PR #4903: rsync 2.6.9 source-build helper script (RP28.b.1)
+- PR #4913: Supported-protocols section in man page (RP28.j.2)
+- PR #4921: Drop-vs-keep decision matrix (RP28.k.1)
+- PR #4923: rsync 2.6.9 push interop fixture spec (RP28.c.a)
+- PR #4928: Daemon-mode rsync 2.6.9 client harness spec (RP28.e.1)
+- PR #4929: Client-mode rsync 2.6.9 daemon harness spec (RP28.f.1)
+- PR #4941: rsync 2.6.9 build smoke workflow (RP28.b.2)
+- PR #4942: Execute RP28.k.1 Path A decision (RP28.k.2)
+- PR #4947: Cache rsync 2.6.9 build artifact (RP28.b.3)
+- PR #4951: Daemon-mode rsync 2.6.9 client interop harness (RP28.e.2)
+
+### ISI - sender-side INC_RECURSE interop
+
+Goal: Build the evidence base for flipping sender INC_RECURSE default-on.
+Failure-mode test cases and bake-window criteria are specified; the flip
+itself is gated on bake closure.
+
+- PR #4869: Sender INC_RECURSE under flist `io_error` test (ISI.f)
+- PR #4917: Define ISI.h bake-window criteria (ISI.i.1)
+- PR #4936: Spec failure-mode test cases for sender INC_RECURSE (ISI.f.1)
+
+### V61D - daemon-push sender-INC_RECURSE matrix
+
+Goal: Cover the daemon-push sender-INC_RECURSE permutation in the interop
+matrix as a prerequisite for the ISI flip.
+
+- PR #4892: Daemon-push sender-INC_RECURSE matrix cell (V61D-3)
+
+### BPF - BufferPool factory + EnvGuard CI lint
+
+Goal: Obsolete the fragile global-`OnceLock` + `EnvGuard` test pattern with a
+per-test BufferPool factory API; add CI lint to prevent regression.
+
+- PR #4916: Spec CI lint to detect missing EnvGuard on cap-touching tests (BPF-4)
+- PR #4926: Design per-test BufferPool factory API (BPF-6)
+- PR #4930: Test-author docs on BufferPool isolation (BPF-11)
+- PR #4934: Back-compat assessment for BufferPool factory API (BPF-7)
+- PR #4945: Implement EnvGuard CI lint per BPF-4 spec (BPF-5)
+
+### DPC - drain_parallel restructure
+
+Goal: Spec the migration off `Arc<Mutex<Vec>>` drain to per-worker channels,
+including rollback runbook and throughput regression detection.
+
+- PR #4909: Design per-worker drain channels (DPC-3)
+- PR #4915: Drain-restructure rollback runbook (DPC-4)
+- PR #4948: Drain throughput regression detection workflow (DPC-8)
+
+### RUSSH - async-native russh path
+
+Goal: Spec the migration path off the current `spawn_blocking` russh bridge
+that throttles daemon concurrency at hundreds of connections, and integrate
+the russh 0.61 upgrade.
+
+- PR #4912: Design async-native russh path (RUSSH-9)
+- PR #4918: Spec back-compat shim for async-native russh (RUSSH-10)
+- PR #4933: Bump russh 0.60.3 -> 0.61.1
+- PR #4935: Document russh SSH transport integration (RUSSH-15)
+
+### PIP - parallel-receive-delta production
+
+Goal: Build the operational scaffolding (worker-pool tuning, bake criterion,
+monitor runbook) for flipping parallel-receive-delta to default-on.
+
+- PR #4906: Spec worker-pool tuning knobs (PIP-9.h.a)
+- PR #4924: Define green-CI bake criterion (PIP-9.f.1)
+- PR #4949: Bake-window monitor runbook (PIP-9.f.3)
+
+### DIS - daemon cold-start regression detection
+
+Goal: Catch daemon cold-start latency regressions in CI, including the
+DIS-6 cold-start latency closure shipped in the same window.
+
+- PR #4890: Close cold-start latency gap per DIS-4 audits (DIS-6)
+- PR #4905: CI bench cell for daemon cold-start (DIS-8.a)
+- PR #4927: Plan DIS-8.a required-check promotion (DIS-8.b)
+
+### D10K - daemon concurrency ceiling
+
+Goal: Document and detect the thread-per-connection model's operational
+ceiling (~10K concurrent connections).
+
+- PR #4908: Thread-per-connection daemon ceiling user doc (D10K-6)
+- PR #4922: Daemon concurrency ceiling regression workflow (D10K-7)
+
+### ASY-5 - tokio embeddability
+
+Goal: Set up the test framework for measuring oc-rsync's embeddability under
+tokio (current code is threaded with blocking channels; not embeddable
+without `spawn_blocking`).
+
+- PR #4911: Spec embeddability test harness (ASY-5.a)
+
+### IUB - io_uring bench coverage
+
+Goal: Spec the bench surface for the IOPS-bound workload class where io_uring
+is expected to pay off (current 148 MB bench shows ~1.00x vs standard I/O).
+
+- PR #4910: Design high-IOPS io_uring bench cells (IUB-3)
+
+### Supporting hygiene PRs
+
+The following PRs supported the sprint set above but do not belong to a single
+topic series. Listed for completeness:
+
+- PR #4891: rustfmt pass on DG-3.e stress + ACL-2.c interop tests
+- PR #4893: Clippy doc-lints in `parallel_apply_dg3_stress` + regen `Cargo.lock`
+- PR #4894: Drop unused `FileNdx` import; resolve daemon E0425
+- PR #4895: Clippy `doc_lazy_continuation` in `parallel_apply_dg3_stress`
+- PR #4896: Rewrap dg3_stress doc to avoid blockquote misparse
+
+## What's next
+
+In-flight follow-up tasks gated on the work above:
+
+- Bake window for PIP-9.f.* (bake monitor doc shipped via #4949; flip PR pending
+  until the green-CI bake criterion from #4924 is satisfied).
+- Implementation tasks for WPC-3, WPC-6, WPC-8, WPC-9 (ADS, long-path,
+  reparse-point code work pending; audits #4898, #4937, #4940 set the baseline).
+- Implementation tasks for MDF-2, MDF-3, MDF-4, MDF-5, MDF-6 (per-modifier
+  wire-byte tests, nested-depth, anchor, scope, discovery; fixture set #4946
+  and diff harness #4950 are the test substrate).
+- Bench tasks for D10K-2..D10K-5, RUSSH-4..RUSSH-7, DPC-2 / DPC-6,
+  RSS-1..RSS-12, IUR-4..IUR-5.
+- RP28.f.2 (client-mode harness implementation), RP28.b.3 cache (shipped via
+  #4947), RP28.e.3 / RP28.f.3 outcome tracking.
+- ISI.h.1, ISI.h.2, ISI.i.2 (sender INC_RECURSE default flip + bake closure
+  per criteria defined in #4917).
+- ASY-5.b..ASY-5.* (embeddability harness implementation per spec #4911).
+- IUB-4..IUB-* (high-IOPS bench cell implementation per design #4910).
+- BPF-8..BPF-10 (BufferPool factory API implementation per design #4926 and
+  back-compat assessment #4934).
+- DPC-5..DPC-7 (per-worker drain channel implementation per design #4909).
+- RUSSH-11..RUSSH-14 (async-native russh path implementation per design #4912
+  and shim spec #4918).


### PR DESCRIPTION
## Summary

Add a consolidated tracking document for the v0.6.3 development cycle so
release-notes authors and reviewers can see the full surface of the
recent audit / design / spec / CI-tooling sprint in one place.

- New file: \`docs/release/v0.6.3-sprint-summary.md\`
- Groups ~50 merged PRs (#4869, #4890-#4951) by topic series: IKV, XAP,
  MDF, WPC, RP28, ISI, V61D, BPF, DPC, RUSSH, PIP, DIS, D10K, ASY-5, IUB.
- Brief goal per series; "What's next" section enumerates in-flight
  follow-up work (PIP-9 bake, WPC implementation, MDF per-modifier tests,
  ISI flip, RUSSH async-native migration, etc.).

Intended as a release-notes input, not as user-facing documentation.

## Test plan

- [x] All PR numbers cross-checked against \`gh pr list --state merged\`.
- [x] No unverified or invented PR numbers in the doc.
- [x] Hyphens only (no em-dashes).
- [x] Doc-only change; no code paths touched.