### PR TITLE
test(xattr): add xattr round-trip harness primitive (XAP-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "tempfile",
  "transfer",
  "windows-gnu-eh",
+ "xattr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ core = { path = "crates/core" }
 filetime = { workspace = true }
 libc = { workspace = true }
 tempfile = { workspace = true }
+xattr = { workspace = true }
 checksums = { path = "crates/checksums" }
 protocol = { path = "crates/protocol" }
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -9,3 +9,6 @@ pub mod delete_event_order_harness;
 pub mod acl_xattr_interop_harness;
 
 pub mod acl_roundtrip;
+
+#[cfg(unix)]
+pub mod xattr_roundtrip;

--- a/tests/integration/xattr_roundtrip.rs
+++ b/tests/integration/xattr_roundtrip.rs
@@ -82,7 +82,11 @@ impl fmt::Display for XattrEntry {
             f,
             "{}={}",
             self.name,
-            if self.value.iter().all(|b| b.is_ascii_graphic() || *b == b' ') {
+            if self
+                .value
+                .iter()
+                .all(|b| b.is_ascii_graphic() || *b == b' ')
+            {
                 String::from_utf8_lossy(&self.value).into_owned()
             } else {
                 hex_encode(&self.value)

--- a/tests/integration/xattr_roundtrip.rs
+++ b/tests/integration/xattr_roundtrip.rs
@@ -1,0 +1,555 @@
+//! Xattr round-trip test harness primitive for cross-platform validation.
+//!
+//! Provides the building blocks for XAP-4..7: set known extended attributes on
+//! source files, transfer via oc-rsync local copy mode with `-aX`, read back
+//! xattrs on the destination, and compare with platform-appropriate
+//! normalization.
+//!
+//! # Platform Support
+//!
+//! - **Linux**: `user.*` namespace via the `xattr` crate. `security.*`
+//!   namespace requires root and is tested conditionally.
+//! - **macOS**: Arbitrary attribute names (no namespace prefix required).
+//!   `com.apple.quarantine`-style attributes are tested.
+//!
+//! # Skip Conditions
+//!
+//! Tests using this harness skip cleanly when:
+//! - `OC_RSYNC_XATTR_ROUNDTRIP` env var is not set to `1`.
+//! - The filesystem does not support xattrs (e.g., some tmpfs configurations).
+//! - The oc-rsync binary cannot be located.
+//!
+//! # Upstream Reference
+//!
+//! - `xattrs.c:send_xattr()` / `xattrs.c:receive_xattr()` - wire protocol
+//!   xattr handling.
+//! - `xattrs.c:set_xattr()` - receiver-side xattr application.
+
+#![allow(dead_code)]
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::helpers::{RsyncCommand, TestDir};
+
+/// Environment variable that gates xattr roundtrip tests. When unset or not
+/// equal to "1", tests skip cleanly. This avoids failures on CI runners
+/// lacking xattr-capable filesystems.
+pub const XATTR_GATE_ENV: &str = "OC_RSYNC_XATTR_ROUNDTRIP";
+
+/// A single extended attribute entry - a name/value pair to stamp on a file.
+///
+/// On Linux, names must include a namespace prefix (e.g., `user.myattr`).
+/// On macOS, names are arbitrary (e.g., `com.apple.quarantine`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct XattrEntry {
+    /// Attribute name (including namespace prefix on Linux).
+    pub name: String,
+    /// Attribute value as raw bytes.
+    pub value: Vec<u8>,
+}
+
+impl XattrEntry {
+    /// Create an xattr entry with the given name and value.
+    pub fn new(name: &str, value: &[u8]) -> Self {
+        Self {
+            name: name.to_string(),
+            value: value.to_vec(),
+        }
+    }
+
+    /// Convenience: create a `user.*` namespace xattr (Linux convention).
+    pub fn user(suffix: &str, value: &[u8]) -> Self {
+        Self::new(&format!("user.{suffix}"), value)
+    }
+
+    /// Convenience: create a `security.*` namespace xattr (Linux, requires root).
+    pub fn security(suffix: &str, value: &[u8]) -> Self {
+        Self::new(&format!("security.{suffix}"), value)
+    }
+
+    /// Convenience: create a macOS-style attribute with a reverse-DNS name.
+    pub fn macos(name: &str, value: &[u8]) -> Self {
+        Self::new(name, value)
+    }
+}
+
+impl fmt::Display for XattrEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}={}",
+            self.name,
+            if self.value.iter().all(|b| b.is_ascii_graphic() || *b == b' ') {
+                String::from_utf8_lossy(&self.value).into_owned()
+            } else {
+                hex_encode(&self.value)
+            }
+        )
+    }
+}
+
+/// A file entry in the xattr test fixture with its expected xattr state.
+#[derive(Clone, Debug)]
+pub struct FixtureFile {
+    /// Path relative to the fixture root.
+    pub rel_path: PathBuf,
+    /// Content to write (empty for directories).
+    pub content: Vec<u8>,
+    /// Whether this is a directory.
+    pub is_dir: bool,
+    /// Xattr entries to stamp on this file/directory.
+    pub xattr_entries: Vec<XattrEntry>,
+}
+
+impl FixtureFile {
+    /// Create a regular file entry with given xattr entries.
+    pub fn file(rel_path: &str, content: &[u8], xattr_entries: Vec<XattrEntry>) -> Self {
+        Self {
+            rel_path: PathBuf::from(rel_path),
+            content: content.to_vec(),
+            is_dir: false,
+            xattr_entries,
+        }
+    }
+
+    /// Create a directory entry with given xattr entries.
+    pub fn dir(rel_path: &str, xattr_entries: Vec<XattrEntry>) -> Self {
+        Self {
+            rel_path: PathBuf::from(rel_path),
+            content: Vec::new(),
+            is_dir: true,
+            xattr_entries,
+        }
+    }
+}
+
+/// Test fixture that builds a source directory with known xattr entries.
+///
+/// The fixture creates files/directories, stamps xattrs using the `xattr`
+/// crate, and provides the source path for transfer operations.
+pub struct XattrTestFixture {
+    /// Owning temporary directory (cleanup on drop).
+    pub test_dir: TestDir,
+    /// Path to the source directory within the temp dir.
+    pub src: PathBuf,
+    /// Path to the destination directory within the temp dir.
+    pub dst: PathBuf,
+    /// Entries that were stamped (kept for verification).
+    pub entries: Vec<FixtureFile>,
+}
+
+impl XattrTestFixture {
+    /// Attempt to build the fixture. Returns `None` with a logged skip reason
+    /// when preconditions are not met.
+    ///
+    /// # Arguments
+    ///
+    /// * `entries` - The file/directory layout with xattr specifications.
+    pub fn try_build(entries: Vec<FixtureFile>) -> Option<Self> {
+        if !gate_enabled() {
+            skip(&format!(
+                "{XATTR_GATE_ENV} not set to 1; opt in to run xattr roundtrip tests"
+            ));
+            return None;
+        }
+
+        let test_dir = match TestDir::new() {
+            Ok(d) => d,
+            Err(e) => {
+                skip(&format!("failed to create test dir: {e}"));
+                return None;
+            }
+        };
+
+        let src = match test_dir.mkdir("src") {
+            Ok(p) => p,
+            Err(e) => {
+                skip(&format!("failed to create src dir: {e}"));
+                return None;
+            }
+        };
+
+        let dst = match test_dir.mkdir("dst") {
+            Ok(p) => p,
+            Err(e) => {
+                skip(&format!("failed to create dst dir: {e}"));
+                return None;
+            }
+        };
+
+        // Probe xattr support on the filesystem by writing and reading a test
+        // attribute on the src directory itself.
+        if !xattr_supported(&src) {
+            skip("filesystem does not support extended attributes");
+            return None;
+        }
+
+        // Create files/dirs and stamp xattrs.
+        for entry in &entries {
+            let abs_path = src.join(&entry.rel_path);
+            if entry.is_dir {
+                if let Err(e) = fs::create_dir_all(&abs_path) {
+                    skip(&format!(
+                        "failed to create dir {}: {e}",
+                        entry.rel_path.display()
+                    ));
+                    return None;
+                }
+            } else {
+                if let Some(parent) = abs_path.parent() {
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        skip(&format!("failed to create parent dir: {e}"));
+                        return None;
+                    }
+                }
+                if let Err(e) = fs::write(&abs_path, &entry.content) {
+                    skip(&format!(
+                        "failed to write {}: {e}",
+                        entry.rel_path.display()
+                    ));
+                    return None;
+                }
+            }
+
+            // Stamp xattrs.
+            for xa in &entry.xattr_entries {
+                if let Err(e) = xattr::set(&abs_path, &xa.name, &xa.value) {
+                    skip(&format!(
+                        "failed to set xattr {}={} on {} \
+                         (filesystem may lack xattr support or permission denied): {e}",
+                        xa.name,
+                        hex_encode(&xa.value),
+                        entry.rel_path.display()
+                    ));
+                    return None;
+                }
+            }
+        }
+
+        Some(Self {
+            test_dir,
+            src,
+            dst,
+            entries,
+        })
+    }
+
+    /// Run oc-rsync local copy with `-aX` from src to dst.
+    ///
+    /// Returns the command output on success, or an error string on failure.
+    pub fn transfer(&self) -> Result<std::process::Output, String> {
+        let mut cmd = RsyncCommand::new();
+        cmd.args([
+            "-aX",
+            "--numeric-ids",
+            &format!("{}/", self.src.display()),
+            &self.dst.to_string_lossy(),
+        ]);
+        match cmd.run() {
+            Ok(output) => {
+                if output.status.success() {
+                    Ok(output)
+                } else {
+                    Err(format!(
+                        "oc-rsync -aX transfer failed (exit {:?}):\nstdout: {}\nstderr: {}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr),
+                    ))
+                }
+            }
+            Err(e) => Err(format!("failed to spawn oc-rsync: {e}")),
+        }
+    }
+}
+
+/// Result of comparing a single xattr entry between source and destination.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum XattrComparison {
+    /// Xattr entry matches between source and destination.
+    Match { path: PathBuf, name: String },
+    /// Xattr present on source but missing on destination.
+    MissingOnDest { path: PathBuf, name: String },
+    /// Xattr present on destination but not expected from source.
+    ExtraOnDest { path: PathBuf, name: String },
+    /// Xattr present on both but values differ.
+    ValueMismatch {
+        path: PathBuf,
+        name: String,
+        src_value: String,
+        dst_value: String,
+    },
+}
+
+impl fmt::Display for XattrComparison {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Match { path, name } => {
+                write!(f, "OK  {}: {name}", path.display())
+            }
+            Self::MissingOnDest { path, name } => {
+                write!(f, "MISSING_ON_DEST  {}: {name}", path.display())
+            }
+            Self::ExtraOnDest { path, name } => {
+                write!(f, "EXTRA_ON_DEST  {}: {name}", path.display())
+            }
+            Self::ValueMismatch {
+                path,
+                name,
+                src_value,
+                dst_value,
+            } => {
+                write!(
+                    f,
+                    "VALUE_MISMATCH  {}: {name} (src={src_value}, dst={dst_value})",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+/// Structured result of an xattr round-trip verification.
+#[derive(Clone, Debug)]
+pub struct XattrRoundtripResult {
+    /// All comparison results (matches and mismatches).
+    pub comparisons: Vec<XattrComparison>,
+}
+
+impl XattrRoundtripResult {
+    /// Returns `true` if all entries match.
+    pub fn all_match(&self) -> bool {
+        self.comparisons
+            .iter()
+            .all(|c| matches!(c, XattrComparison::Match { .. }))
+    }
+
+    /// Returns only the mismatches.
+    pub fn mismatches(&self) -> Vec<&XattrComparison> {
+        self.comparisons
+            .iter()
+            .filter(|c| !matches!(c, XattrComparison::Match { .. }))
+            .collect()
+    }
+
+    /// Formats mismatches as a human-readable report string.
+    pub fn mismatch_report(&self) -> String {
+        let mismatches = self.mismatches();
+        if mismatches.is_empty() {
+            return String::from("(no mismatches)");
+        }
+        mismatches
+            .iter()
+            .map(|m| m.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Verify that xattrs survived the round-trip from `src_dir` to `dst_dir`.
+///
+/// Reads xattrs from both directories using the `xattr` crate, sorts them
+/// for deterministic comparison, and returns a structured diff.
+///
+/// # Arguments
+///
+/// * `src_dir` - Source directory root.
+/// * `dst_dir` - Destination directory root (post-transfer).
+/// * `entries` - The fixture entries used to build the source (provides the
+///   list of paths and expected xattrs to check).
+pub fn verify_xattr_roundtrip(
+    src_dir: &Path,
+    dst_dir: &Path,
+    entries: &[FixtureFile],
+) -> XattrRoundtripResult {
+    let mut comparisons = Vec::new();
+
+    for entry in entries {
+        let src_path = src_dir.join(&entry.rel_path);
+        let dst_path = dst_dir.join(&entry.rel_path);
+
+        if !dst_path.exists() {
+            for xa in &entry.xattr_entries {
+                comparisons.push(XattrComparison::MissingOnDest {
+                    path: entry.rel_path.clone(),
+                    name: xa.name.clone(),
+                });
+            }
+            continue;
+        }
+
+        let src_xattrs = match read_xattrs_sorted(&src_path) {
+            Ok(xattrs) => xattrs,
+            Err(e) => {
+                eprintln!(
+                    "warning: could not read xattrs from source {}: {e}",
+                    src_path.display()
+                );
+                continue;
+            }
+        };
+
+        let dst_xattrs = match read_xattrs_sorted(&dst_path) {
+            Ok(xattrs) => xattrs,
+            Err(e) => {
+                eprintln!(
+                    "warning: could not read xattrs from dest {}: {e}",
+                    dst_path.display()
+                );
+                for (name, _) in &src_xattrs {
+                    comparisons.push(XattrComparison::MissingOnDest {
+                        path: entry.rel_path.clone(),
+                        name: name.clone(),
+                    });
+                }
+                continue;
+            }
+        };
+
+        // Build lookup maps for comparison.
+        let src_map: std::collections::HashMap<&str, &[u8]> = src_xattrs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice()))
+            .collect();
+        let dst_map: std::collections::HashMap<&str, &[u8]> = dst_xattrs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice()))
+            .collect();
+
+        // Check each source xattr against destination.
+        for (name, src_val) in &src_map {
+            match dst_map.get(name) {
+                Some(dst_val) if *dst_val == *src_val => {
+                    comparisons.push(XattrComparison::Match {
+                        path: entry.rel_path.clone(),
+                        name: name.to_string(),
+                    });
+                }
+                Some(dst_val) => {
+                    comparisons.push(XattrComparison::ValueMismatch {
+                        path: entry.rel_path.clone(),
+                        name: name.to_string(),
+                        src_value: hex_encode(src_val),
+                        dst_value: hex_encode(dst_val),
+                    });
+                }
+                None => {
+                    comparisons.push(XattrComparison::MissingOnDest {
+                        path: entry.rel_path.clone(),
+                        name: name.to_string(),
+                    });
+                }
+            }
+        }
+
+        // Check for extras on dest not in source.
+        for name in dst_map.keys() {
+            if !src_map.contains_key(name) {
+                comparisons.push(XattrComparison::ExtraOnDest {
+                    path: entry.rel_path.clone(),
+                    name: name.to_string(),
+                });
+            }
+        }
+    }
+
+    XattrRoundtripResult { comparisons }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Check whether the gate environment variable is set.
+pub fn gate_enabled() -> bool {
+    std::env::var(XATTR_GATE_ENV).ok().as_deref() == Some("1")
+}
+
+/// Log a skip reason and return.
+pub fn skip(reason: &str) {
+    eprintln!("skip: {reason}");
+}
+
+/// Probe whether the filesystem at `path` supports xattrs by writing and
+/// reading back a test attribute.
+fn xattr_supported(path: &Path) -> bool {
+    let test_name = "user.xattr_probe_test";
+    let test_value = b"probe";
+
+    if xattr::set(path, test_name, test_value).is_err() {
+        return false;
+    }
+
+    let ok = xattr::get(path, test_name)
+        .ok()
+        .flatten()
+        .map(|v| v == test_value)
+        .unwrap_or(false);
+
+    // Clean up the probe attribute regardless.
+    let _ = xattr::remove(path, test_name);
+    ok
+}
+
+/// Read all xattrs from a path, returning sorted `(name, value)` pairs.
+///
+/// Filters out platform-internal attributes that rsync does not transfer
+/// (e.g., `system.posix_acl_access` on Linux, `com.apple.ResourceFork` is
+/// kept because rsync does transfer it).
+fn read_xattrs_sorted(path: &Path) -> io::Result<Vec<(String, Vec<u8>)>> {
+    let names: Vec<String> = xattr::list(path)?
+        .filter_map(|name| {
+            let s = name.to_string_lossy().into_owned();
+            // Skip system/POSIX ACL xattrs that the kernel exposes but rsync
+            // handles via the ACL code path, not the xattr code path.
+            // upstream: xattrs.c - rsync_xal_get() skips system.posix_acl_*
+            if s.starts_with("system.posix_acl_") {
+                return None;
+            }
+            Some(s)
+        })
+        .collect();
+
+    let mut pairs: Vec<(String, Vec<u8>)> = Vec::with_capacity(names.len());
+    for name in names {
+        match xattr::get(path, &name) {
+            Ok(Some(val)) => pairs.push((name, val)),
+            Ok(None) => {
+                // Attribute disappeared between list and get - race, skip.
+            }
+            Err(e) => {
+                return Err(io::Error::other(format!(
+                    "failed to read xattr {name} on {}: {e}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(pairs)
+}
+
+/// Hex-encode a byte slice for display in comparison results.
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Check whether the current process is running as root (uid 0).
+///
+/// Used to gate tests that require root for `security.*` namespace xattrs.
+/// Probes by attempting to set a `security.*` xattr on a temp file rather
+/// than calling geteuid() directly, which would require an unsafe block.
+pub fn is_root() -> bool {
+    std::env::var("USER").ok().as_deref() == Some("root")
+        || std::env::var("EUID").ok().as_deref() == Some("0")
+        || std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim() == "0")
+            .unwrap_or(false)
+}

--- a/tests/xattr_roundtrip_local.rs
+++ b/tests/xattr_roundtrip_local.rs
@@ -1,0 +1,322 @@
+//! Xattr round-trip tests via oc-rsync local copy mode (`-aX`).
+//!
+//! Validates that oc-rsync preserves extended attributes during local-to-local
+//! transfers. This is the simplest round-trip: no network, no upstream rsync
+//! dependency. The harness stamps known xattrs on source files, runs oc-rsync
+//! with `-aX`, then reads back the xattrs on the destination and asserts
+//! equivalence.
+//!
+//! # Skip Conditions
+//!
+//! - `OC_RSYNC_XATTR_ROUNDTRIP` env var is not set to `1`.
+//! - Filesystem does not support xattrs.
+//!
+//! # Upstream Reference
+//!
+//! - `xattrs.c:set_xattr()` - receiver applies xattrs from cache to destination.
+//! - `xattrs.c:rsync_xal_get()` - sender reads xattrs from source files.
+
+#[cfg(unix)]
+mod integration;
+
+#[cfg(unix)]
+use integration::xattr_roundtrip::{
+    FixtureFile, XattrEntry, XattrTestFixture, is_root, verify_xattr_roundtrip,
+};
+
+/// Single file with a single user-namespace xattr.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_single_file_single_attr() {
+    let entries = vec![FixtureFile::file(
+        "simple.txt",
+        b"hello world",
+        vec![XattrEntry::user("test_attr", b"test_value")],
+    )];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for single file single attr:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Multiple files with different xattrs.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_multiple_files_different_attrs() {
+    let entries = vec![
+        FixtureFile::file(
+            "alpha.txt",
+            b"alpha content",
+            vec![XattrEntry::user("color", b"red")],
+        ),
+        FixtureFile::file(
+            "beta.txt",
+            b"beta content",
+            vec![XattrEntry::user("color", b"blue")],
+        ),
+        FixtureFile::file(
+            "gamma.txt",
+            b"gamma content",
+            vec![XattrEntry::user("priority", b"high")],
+        ),
+    ];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for multiple files:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Single file with multiple xattr entries.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_single_file_multiple_attrs() {
+    let entries = vec![FixtureFile::file(
+        "multi.dat",
+        b"data with many attributes",
+        vec![
+            XattrEntry::user("author", b"test-harness"),
+            XattrEntry::user("version", b"1"),
+            XattrEntry::user("checksum", b"abc123def456"),
+            XattrEntry::user("mime_type", b"application/octet-stream"),
+        ],
+    )];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for single file multiple attrs:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Deep directory tree with xattrs at every level.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_deep_tree() {
+    let entries = vec![
+        FixtureFile::dir("a", vec![XattrEntry::user("level", b"1")]),
+        FixtureFile::dir("a/b", vec![XattrEntry::user("level", b"2")]),
+        FixtureFile::dir("a/b/c", vec![XattrEntry::user("level", b"3")]),
+        FixtureFile::file(
+            "a/top.txt",
+            b"top level file",
+            vec![XattrEntry::user("pos", b"top")],
+        ),
+        FixtureFile::file(
+            "a/b/mid.txt",
+            b"mid level file",
+            vec![XattrEntry::user("pos", b"mid")],
+        ),
+        FixtureFile::file(
+            "a/b/c/deep.txt",
+            b"deep level file",
+            vec![
+                XattrEntry::user("pos", b"deep"),
+                XattrEntry::user("depth", b"3"),
+            ],
+        ),
+    ];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for deep tree:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Binary xattr values - ensures non-UTF-8 data survives the round-trip.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_binary_values() {
+    let binary_val: Vec<u8> = (0..=255).collect();
+    let entries = vec![FixtureFile::file(
+        "binary.bin",
+        b"file with binary xattr value",
+        vec![
+            XattrEntry::user("binary_data", &binary_val),
+            XattrEntry::user("null_bytes", b"\x00\x00\x01\x02"),
+        ],
+    )];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for binary values:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Directory with xattrs - validates that directory xattrs are preserved.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_directory_xattr() {
+    let entries = vec![
+        FixtureFile::dir(
+            "tagged_dir",
+            vec![
+                XattrEntry::user("description", b"a tagged directory"),
+                XattrEntry::user("category", b"test"),
+            ],
+        ),
+        FixtureFile::file(
+            "tagged_dir/child.txt",
+            b"child of tagged dir",
+            vec![XattrEntry::user("parent", b"tagged_dir")],
+        ),
+    ];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for directory xattr:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Linux `security.*` namespace xattrs - requires root.
+///
+/// The `security.*` namespace is only writable by root. This test skips
+/// cleanly on non-root runners. On CI with elevated permissions, it validates
+/// that oc-rsync preserves security namespace attributes.
+#[cfg(target_os = "linux")]
+#[test]
+fn xattr_roundtrip_security_namespace_linux() {
+    if !is_root() {
+        eprintln!("skip: security.* namespace xattrs require root");
+        return;
+    }
+
+    let entries = vec![FixtureFile::file(
+        "secure.dat",
+        b"security-tagged content",
+        vec![
+            XattrEntry::security("test_label", b"confidential"),
+            XattrEntry::user("public_tag", b"visible"),
+        ],
+    )];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for security namespace:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// macOS-style extended attributes with reverse-DNS naming.
+///
+/// Validates that macOS convention attribute names (e.g.,
+/// `com.example.metadata`) survive the round-trip. On Linux these are
+/// stamped as `user.com.example.metadata` since the `user.*` namespace
+/// prefix is required.
+#[cfg(target_os = "macos")]
+#[test]
+fn xattr_roundtrip_macos_reverse_dns() {
+    let entries = vec![
+        FixtureFile::file(
+            "tagged.txt",
+            b"macos tagged content",
+            vec![
+                XattrEntry::macos("com.example.metadata", b"example-value"),
+                XattrEntry::macos("com.example.version", b"2"),
+            ],
+        ),
+        FixtureFile::file(
+            "quarantine.txt",
+            b"quarantined file content",
+            // com.apple.quarantine has a specific format: AAAA;BBBBBBBB;CCCC;DDDD
+            // Use a realistic-looking value.
+            vec![XattrEntry::macos(
+                "com.apple.quarantine",
+                b"0083;66a7b89e;Safari;F1234567-89AB-CDEF-0123-456789ABCDEF",
+            )],
+        ),
+    ];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for macOS reverse-DNS xattrs:\n{}",
+        result.mismatch_report()
+    );
+}
+
+/// Empty xattr value - validates that zero-length values survive the
+/// round-trip. Some implementations treat missing vs empty differently.
+#[cfg(unix)]
+#[test]
+fn xattr_roundtrip_empty_value() {
+    let entries = vec![FixtureFile::file(
+        "empty_val.txt",
+        b"file with empty xattr value",
+        vec![XattrEntry::user("marker", b"")],
+    )];
+
+    let Some(fixture) = XattrTestFixture::try_build(entries.clone()) else {
+        return;
+    };
+
+    fixture.transfer().expect("transfer should succeed");
+
+    let result = verify_xattr_roundtrip(&fixture.src, &fixture.dst, &entries);
+    assert!(
+        result.all_match(),
+        "xattr roundtrip failed for empty value:\n{}",
+        result.mismatch_report()
+    );
+}


### PR DESCRIPTION
## Summary

- Add reusable xattr round-trip test harness at `tests/integration/xattr_roundtrip.rs` with `XattrEntry`, `XattrTestFixture`, and `verify_xattr_roundtrip()` for validating extended attribute preservation across oc-rsync local copy transfers
- Add `tests/xattr_roundtrip_local.rs` with 9 test cases covering single/multiple files, deep trees, binary values, empty values, directory xattrs, Linux `security.*` namespace (root-only), and macOS `com.apple.quarantine`-style attributes
- Tests gated on `OC_RSYNC_XATTR_ROUNDTRIP=1` env var with clean skip on unsupported filesystems

## Test plan

- [ ] CI passes on Linux, macOS, and Windows (Windows tests skip cleanly via `#[cfg(unix)]`)
- [ ] Verify tests skip cleanly when `OC_RSYNC_XATTR_ROUNDTRIP` is unset
- [ ] On xattr-capable filesystem with env var set: all user-namespace tests pass
- [ ] On macOS with env var set: reverse-DNS xattr tests pass