### PR TITLE
feat: emit one-shot warning on first reorder-buffer spill to disk

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -44,6 +44,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             reclaim: SpillReclaim::default(),
             memory_pressure_bytes: None,
             in_memory_only: false,
+            spill_warned: false,
         }
     }
 
@@ -85,6 +86,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             reclaim: SpillReclaim::default(),
             memory_pressure_bytes: None,
             in_memory_only: false,
+            spill_warned: false,
         })
     }
 
@@ -280,5 +282,15 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
         drop(f);
         fs::remove_file(&probe_path)?;
         Ok(())
+    }
+
+    /// Returns `true` if the one-shot spill-activation warning has fired.
+    ///
+    /// The warning fires exactly once per buffer lifetime - on the first
+    /// successful spill-to-disk event. Tests can inspect this flag to verify
+    /// warning behaviour without capturing log output.
+    #[must_use]
+    pub fn spill_warned(&self) -> bool {
+        self.spill_warned
     }
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
@@ -139,6 +139,10 @@ pub struct SpillableReorderBuffer<T: SpillCodec> {
     /// and instead returns [`SpillError::SpillDisabled`](super::SpillError::SpillDisabled).
     /// Wired from [`SpillPolicy::in_memory_only`](super::policy::SpillPolicy::in_memory_only).
     in_memory_only: bool,
+    /// One-shot flag that ensures the spill-activation warning fires at most
+    /// once per transfer. Set to `true` after the first successful spill
+    /// event emits a `tracing::warn!`.
+    spill_warned: bool,
 }
 
 impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
@@ -156,6 +160,7 @@ impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
             .field("compression", &self.compression)
             .field("reclaim", &self.reclaim)
             .field("in_memory_only", &self.in_memory_only)
+            .field("spill_warned", &self.spill_warned)
             .finish()
     }
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -11,6 +11,40 @@ use super::super::{SpillCodec, SpillCompression, SpillError, SpillGranularity, r
 use super::SPILL_TAG_ZSTD;
 use super::{HOT_ZONE, SPILL_TAG_RAW, SpillableReorderBuffer};
 
+/// Emits a one-shot `tracing::warn!` the first time the reorder buffer
+/// spills to disk. Subsequent calls with `already_warned = true` are no-ops.
+#[cfg(feature = "tracing")]
+fn emit_spill_warning(
+    spill_dir: Option<&std::path::Path>,
+    threshold: usize,
+    already_warned: bool,
+) -> bool {
+    if already_warned {
+        return true;
+    }
+    let dir_display = spill_dir
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<system tempdir>".to_string());
+    tracing::warn!(
+        spill_dir = %dir_display,
+        threshold_bytes = threshold,
+        "reorder buffer exceeded memory threshold - spilling to disk; \
+         use --spill-dir to control the spill location or \
+         OC_RSYNC_SPILL_DIR / OC_RSYNC_SPILL_THRESHOLD_BYTES to tune via environment"
+    );
+    true
+}
+
+/// No-op stub when the `tracing` feature is disabled.
+#[cfg(not(feature = "tracing"))]
+fn emit_spill_warning(
+    _spill_dir: Option<&std::path::Path>,
+    _threshold: usize,
+    _already_warned: bool,
+) -> bool {
+    true
+}
+
 impl<T: SpillCodec> SpillableReorderBuffer<T> {
     /// Spills the highest-sequence items to disk until memory usage drops
     /// below the threshold.
@@ -58,10 +92,19 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
         // demand is met automatically; the per-item path needs the explicit
         // flag.
         let rss_forced = self.should_force_spill_for_rss();
-        match self.granularity {
+        let prev_spill_count = self.spill_count;
+        let result = match self.granularity {
             SpillGranularity::PerItem => self.spill_candidates_per_item(&candidates, rss_forced),
             SpillGranularity::WholeBatch => self.spill_candidates_whole_batch(&candidates),
+        };
+        // Emit the one-shot warning after a successful spill that actually
+        // wrote at least one record. Checking spill_count > prev_spill_count
+        // avoids false positives when all candidates were in the hot zone.
+        if result.is_ok() && self.spill_count > prev_spill_count {
+            self.spill_warned =
+                emit_spill_warning(self.spill_dir.as_deref(), self.threshold, self.spill_warned);
         }
+        result
     }
 
     /// Per-item spill: each candidate becomes its own length-prefixed record.

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
@@ -240,3 +240,53 @@ fn spillable_buffer_with_delta_results() {
     assert_eq!(items[2].ndx().get(), 20);
     assert!(items[2].is_success());
 }
+
+#[test]
+fn spill_warned_flag_fires_on_first_spill() {
+    // Threshold of 24 bytes = 3 items of 8 bytes each.
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(64, 24);
+
+    // Insert 3 items - at threshold, no spill yet.
+    for i in 0..3 {
+        buf.insert(i, i * 10).unwrap();
+    }
+    assert!(!buf.spill_warned(), "warning should not fire before threshold is exceeded");
+
+    // 4th item exceeds threshold - triggers spill and warning.
+    buf.insert(3, 30).unwrap();
+    assert!(buf.spill_warned(), "warning should fire on first spill");
+    let stats = buf.spill_stats();
+    assert!(stats.spill_events > 0, "spill must have occurred");
+}
+
+#[test]
+fn spill_warned_flag_fires_only_once() {
+    // Very tight threshold: 16 bytes = 2 items.
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(64, 16);
+
+    // Fill past threshold multiple times to trigger multiple spill events.
+    for i in (0..20).rev() {
+        buf.insert(i, i * 100).unwrap();
+    }
+
+    let stats = buf.spill_stats();
+    assert!(stats.spill_events > 1, "need multiple spills for this test, got {}", stats.spill_events);
+    assert!(buf.spill_warned(), "warning flag should be set");
+
+    // Drain and verify the flag stays set.
+    let items = drain_all(&mut buf);
+    assert_eq!(items.len(), 20);
+    assert!(buf.spill_warned(), "flag must remain set after drain");
+}
+
+#[test]
+fn spill_warned_false_when_no_spill() {
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(64, 1024);
+
+    for i in 0..10 {
+        buf.insert(i, i).unwrap();
+    }
+
+    assert!(!buf.spill_warned(), "warning should not fire when under threshold");
+    assert_eq!(buf.spill_stats().spill_events, 0);
+}

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
@@ -250,7 +250,10 @@ fn spill_warned_flag_fires_on_first_spill() {
     for i in 0..3 {
         buf.insert(i, i * 10).unwrap();
     }
-    assert!(!buf.spill_warned(), "warning should not fire before threshold is exceeded");
+    assert!(
+        !buf.spill_warned(),
+        "warning should not fire before threshold is exceeded"
+    );
 
     // 4th item exceeds threshold - triggers spill and warning.
     buf.insert(3, 30).unwrap();

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
@@ -270,7 +270,11 @@ fn spill_warned_flag_fires_only_once() {
     }
 
     let stats = buf.spill_stats();
-    assert!(stats.spill_events > 1, "need multiple spills for this test, got {}", stats.spill_events);
+    assert!(
+        stats.spill_events > 1,
+        "need multiple spills for this test, got {}",
+        stats.spill_events
+    );
     assert!(buf.spill_warned(), "warning flag should be set");
 
     // Drain and verify the flag stays set.
@@ -287,6 +291,9 @@ fn spill_warned_false_when_no_spill() {
         buf.insert(i, i).unwrap();
     }
 
-    assert!(!buf.spill_warned(), "warning should not fire when under threshold");
+    assert!(
+        !buf.spill_warned(),
+        "warning should not fire when under threshold"
+    );
     assert_eq!(buf.spill_stats().spill_events, 0);
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
@@ -47,6 +47,9 @@ fn enospc_during_spill_propagates_as_io_error() {
         SpillError::PriorSpillsLost { dir, count } => {
             panic!("expected I/O error, got prior-spills-lost {dir:?} count={count}")
         }
+        SpillError::SpillDisabled => {
+            panic!("expected I/O error, got spill-disabled")
+        }
     }
     assert!(err.is_out_of_space(), "is_out_of_space should be true");
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
@@ -47,7 +47,6 @@ fn enospc_during_spill_propagates_as_io_error() {
         SpillError::PriorSpillsLost { dir, count } => {
             panic!("expected I/O error, got prior-spills-lost {dir:?} count={count}")
         }
-        SpillError::SpillDisabled => panic!("expected I/O error, got SpillDisabled"),
     }
     assert!(err.is_out_of_space(), "is_out_of_space should be true");
 }


### PR DESCRIPTION
## Summary

- Add a one-shot `tracing::warn!` that fires the first time the `SpillableReorderBuffer` spills chunks to disk during a transfer, giving users visibility into the spill activation event
- The warning includes the spill directory path, the byte threshold that was exceeded, and guidance on `--spill-dir` / `OC_RSYNC_SPILL_DIR` / `OC_RSYNC_SPILL_THRESHOLD_BYTES` for tuning
- A `spill_warned` bool flag on the buffer ensures the warning fires exactly once per buffer lifetime - subsequent spill events are silent

## Test plan

- [ ] `spill_warned_flag_fires_on_first_spill` - verifies the flag transitions from `false` to `true` on first threshold breach
- [ ] `spill_warned_flag_fires_only_once` - verifies the flag remains `true` across multiple spill events and drains
- [ ] `spill_warned_false_when_no_spill` - verifies no false positives when memory stays under threshold
- [ ] CI: fmt, clippy, nextest on all platforms (Linux, macOS, Windows)