### PR TITLE
fix: add EACCES hardening test for spill-dir permission denied (SRO-5)

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
@@ -1,4 +1,5 @@
-//! Hardening tests for ENOSPC, temp-dir vanish, and partial writes.
+//! Hardening tests for ENOSPC, temp-dir vanish, permission denied, and
+//! partial writes.
 
 use std::fs;
 use std::io::{self, Write};
@@ -232,6 +233,60 @@ fn dir_recreate_failure_surfaces_io_error() {
     // (NotADirectory on modern Linux, Other on older toolchains, sometimes
     // AlreadyExists on macOS); any io::Error meets the contract.
     let _ = err.kind();
+}
+
+#[cfg(unix)]
+#[test]
+fn permission_denied_on_spill_dir_surfaces_io_error() {
+    // EACCES: the spill directory exists but the process cannot create files
+    // inside it. The tempfile creation in open_backend must propagate the
+    // PermissionDenied error through write_record -> spill_item ->
+    // spill_excess -> insert as SpillError::Io, never panic.
+    use std::os::unix::fs::PermissionsExt;
+
+    // Root bypasses file permission checks, so this test is meaningless
+    // when running as uid 0. Skip gracefully.
+    if rustix::process::getuid().is_root() {
+        return;
+    }
+
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let spill_dir = scratch.path().join("spill");
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_spill_dir(16, 8, &spill_dir).expect("setup spill directory");
+
+    // Revoke all permissions on the spill directory so tempfile_in fails
+    // with PermissionDenied on the next spill attempt.
+    fs::set_permissions(&spill_dir, fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 spill dir");
+
+    // Drive enough inserts to trigger a spill. The spill opens a fresh
+    // tempfile inside the now-unwritable directory and must surface
+    // SpillError::Io(PermissionDenied) cleanly.
+    let mut surfaced: Option<SpillError> = None;
+    for i in 0u64..8 {
+        match buf.insert(i, i * 41) {
+            Ok(()) => continue,
+            Err(e) => {
+                surfaced = Some(e);
+                break;
+            }
+        }
+    }
+
+    // Restore permissions before assertions so cleanup succeeds.
+    let _ = fs::set_permissions(&spill_dir, fs::Permissions::from_mode(0o755));
+
+    let err = surfaced.expect("permission-denied spill dir must surface an error");
+    match err {
+        SpillError::Io(ref e) => assert_eq!(
+            e.kind(),
+            io::ErrorKind::PermissionDenied,
+            "expected PermissionDenied, got {:?}",
+            e.kind()
+        ),
+        other => panic!("expected SpillError::Io(PermissionDenied), got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Audited all spill I/O paths in `crates/engine/src/concurrent_delta/spill/` for `.unwrap()`, `.expect()`, and `panic!()` on fallible I/O operations. Production code is clean - every disk operation (tempfile creation, write_all, seek, read_exact, create_dir_all) propagates errors via `?` and the `From<io::Error> for SpillError` conversion.
- Added a Unix-only test (`permission_denied_on_spill_dir_surfaces_io_error`) that exercises the EACCES scenario: spill directory exists but permissions are revoked mid-transfer, so `tempfile::tempfile_in()` fails with `PermissionDenied`. The test verifies the error propagates as `SpillError::Io(PermissionDenied)` without panicking. Skips gracefully when running as root (uid 0 bypasses permission checks).
- Existing SPL-33 tests already comprehensively cover ENOSPC (5-tier scenario matrix with property tests), temp-dir vanish (both recoverable and unrecoverable), partial writes (`WriteZero` via `write_all` contract), dir recreate failure, codec encode failure, and `PriorSpillsLost`. No duplication needed.

### Audit findings (no production code changes required)

All production files in the spill module were audited:

| File | I/O operations | Error handling | Status |
|------|---------------|----------------|--------|
| `tempfile.rs` | `tempfile_in()`, `SpooledTempFile::new()` | Returns `io::Result`, caller uses `?` | Clean |
| `buffer/spill.rs` | `write_all()`, `seek()`, `encode()`, `create_dir_all()` | Returns `io::Result`/`Result<_, SpillError>`, uses `?` | Clean |
| `buffer/reload.rs` | `seek()`, `read_exact()`, `decode()` | Returns `Result<_, SpillError>`, uses `?` | Clean |
| `buffer/insert.rs` | Delegates to `spill_excess()` | Returns `Result<_, SpillError>`, uses `?` | Clean |
| `buffer/lifecycle.rs` | `create_dir_all()` | Returns `io::Result`, uses `?` | Clean |
| `rss.rs` | `/proc/self/statm` read | Returns `io::Result`, caller treats `Err` as "unavailable" | Clean |
| `env.rs` | `env::var()` reads | Never panics, logs and leaves field unchanged | Clean |

No `.unwrap()` or `.expect()` on I/O operations exist in production code. The only unwrap/expect calls are in `#[cfg(test)]` modules and doc examples.

## Test plan

- [ ] CI passes on Linux, macOS, Windows (new test is `#[cfg(unix)]` only, skips on Windows)
- [ ] New `permission_denied_on_spill_dir_surfaces_io_error` test passes on Linux and macOS CI
- [ ] Existing spill hardening and ENOSPC degradation tests remain green