### PR TITLE
ci(test-features): add default-features cell for sequential path coverage

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -116,6 +116,13 @@ jobs:
           - name: no-default-features
             args: "--workspace --no-default-features"
             apt: ""
+          # PFF-6: Verify the default build (without parallel-receive-delta)
+          # exercises the sequential receive-delta path end-to-end. The main
+          # CI test job uses --all-features which enables parallel-receive-delta,
+          # masking regressions in the sequential code path that ships by default.
+          - name: default-features
+            args: "--workspace"
+            apt: ""
           - name: parallel
             args: "-p checksums -p flist --features parallel"
             apt: ""


### PR DESCRIPTION
## Summary

- Adds a `default-features` matrix row to the Linux feature-flags job in `_test-features.yml`
- Builds and tests the workspace with only default features (no `--all-features`, no `--no-default-features`)
- Catches regressions in the sequential receive-delta code path, which is the default shipped configuration

## Motivation

The main CI test job runs `--all-features`, which enables `parallel-receive-delta` and exercises the parallel code path. The existing `no-default-features` row strips all features. Neither exercises the default build configuration - which ships without `parallel-receive-delta` and uses the sequential receive-delta path. Code could accidentally depend on the parallel path being available, breaking default builds silently.

## Test plan

- [ ] New `default-features (linux)` CI cell passes
- [ ] Existing CI cells unaffected (no changes to other matrix rows)