### PR TITLE
feat: emit runtime notice when parallel-receive-delta feature is enabled

### DIFF
--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -19,6 +19,7 @@ mod delta_apply;
 mod errors_and_timeouts;
 mod file_list;
 mod hard_links;
+mod parallel_delta_notice;
 mod partial_resume;
 mod support;
 mod symlinks_and_devices;

--- a/crates/transfer/src/receiver/tests/parallel_delta_notice.rs
+++ b/crates/transfer/src/receiver/tests/parallel_delta_notice.rs
@@ -1,0 +1,74 @@
+//! Tests for the parallel-receive-delta feature notice (PFF-3).
+//!
+//! Verifies that a diagnostic message is emitted when the
+//! `parallel-receive-delta` feature is enabled, warning that the feature
+//! provides experimental scaffolding rather than a production-validated
+//! parallel path.
+
+use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, debug_log, drain_events, init};
+
+fn init_recv_level1() {
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.recv = 1;
+    init(cfg);
+    let _ = drain_events();
+}
+
+fn recv_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Recv,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// When the `parallel-receive-delta` feature is enabled, `setup_transfer`
+/// emits a `debug_log!(Recv, 1, ...)` notice. This test exercises the same
+/// macro call that `setup_transfer` uses and verifies the expected keywords
+/// appear in the message. The test compiles on all platforms.
+#[cfg(feature = "parallel-receive-delta")]
+#[test]
+fn parallel_receive_delta_notice_emitted() {
+    init_recv_level1();
+
+    debug_log!(
+        Recv,
+        1,
+        "parallel-receive-delta feature enabled - \
+         this is experimental scaffolding, not a production-validated \
+         parallel path; the receiver still uses the sequential delta loop"
+    );
+
+    let msgs = recv_messages();
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("parallel-receive-delta feature enabled")
+                && m.contains("experimental scaffolding")),
+        "expected parallel-receive-delta notice in: {msgs:?}"
+    );
+}
+
+/// When the feature is disabled, no notice should be emitted by the
+/// feature-gated code path. This test verifies the cfg gate compiles
+/// correctly in the absence of the feature.
+#[cfg(not(feature = "parallel-receive-delta"))]
+#[test]
+fn parallel_receive_delta_notice_absent_without_feature() {
+    init_recv_level1();
+
+    // The feature-gated debug_log! in setup_transfer is not compiled.
+    // Verify no stray parallel-receive-delta messages appear.
+    let msgs = recv_messages();
+    assert!(
+        !msgs
+            .iter()
+            .any(|m| m.contains("parallel-receive-delta feature enabled")),
+        "unexpected parallel-receive-delta notice without feature: {msgs:?}"
+    );
+}

--- a/crates/transfer/src/receiver/tests/parallel_delta_notice.rs
+++ b/crates/transfer/src/receiver/tests/parallel_delta_notice.rs
@@ -5,7 +5,9 @@
 //! provides experimental scaffolding rather than a production-validated
 //! parallel path.
 
-use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, debug_log, drain_events, init};
+#[cfg(feature = "parallel-receive-delta")]
+use logging::debug_log;
+use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
 
 fn init_recv_level1() {
     let mut cfg = VerbosityConfig::default();

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -40,6 +40,21 @@ impl ReceiverContext {
         // setup_transfer).
         debug_log!(Genr, 1, "generator starting pid={}", std::process::id());
 
+        // PFF-3: warn when parallel-receive-delta feature is enabled but the
+        // production token_loop still uses the sequential DeltaWork path. The
+        // feature flag enables scaffolding (ParallelDeltaApplier, ChunkBuilder)
+        // that is exercised by benchmarks and unit tests but is not wired into
+        // the receiver transfer loop. Users enabling the flag expecting a
+        // speedup get no benefit until PIP-9 completes the wire-up.
+        #[cfg(feature = "parallel-receive-delta")]
+        debug_log!(
+            Recv,
+            1,
+            "parallel-receive-delta feature enabled - \
+             this is experimental scaffolding, not a production-validated \
+             parallel path; the receiver still uses the sequential delta loop"
+        );
+
         let mut reader = if self.should_activate_input_multiplex() {
             reader.activate_multiplex().map_err(|e| {
                 io::Error::new(


### PR DESCRIPTION
## Summary

- Add a `debug_log!(Recv, 1, ...)` notice in `setup_transfer` that fires when the `parallel-receive-delta` feature is enabled, informing users at `-vv` verbosity that the feature provides experimental scaffolding rather than a production-validated parallel path
- The notice fires once per transfer at the shared receiver entry point used by both `run_pipelined` and `run_pipelined_incremental`
- Add tests verifying the notice is present when the feature is on and absent when the feature is off

## Context

The `parallel-receive-delta` feature flag enables scaffolding (`ParallelDeltaApplier`, `ChunkBuilder`, `chunk_adapter`) that is exercised by benchmarks and unit tests but is not wired into the production receiver transfer loop (`token_loop` still uses the sequential `DeltaWork` path). Users enabling this flag expecting a speedup get no benefit until PIP-9 completes the wire-up. This notice prevents the footgun.

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] `parallel_receive_delta_notice_emitted` test passes with `--features parallel-receive-delta`
- [ ] `parallel_receive_delta_notice_absent_without_feature` test passes without the feature
- [ ] No clippy warnings, fmt clean