### PR TITLE
feat: add SpillPolicy in-memory-only mode with SpillError::SpillDisabled

### DIFF
--- a/crates/engine/src/concurrent_delta/consumer/loops.rs
+++ b/crates/engine/src/concurrent_delta/consumer/loops.rs
@@ -144,6 +144,14 @@ pub(super) fn run_spillable_loop(
                         .send(DeltaResult::failed(ndx, format!("spill write failed: {e}")));
                     return;
                 }
+                Err(SpillError::SpillDisabled) => {
+                    let _ = result_tx.send(DeltaResult::failed(
+                        ndx,
+                        "reorder buffer exceeded capacity and spill-to-disk is disabled"
+                            .to_string(),
+                    ));
+                    return;
+                }
             }
         }
         publish_spill_events(&reorder, spill_events, &mut prev_spill);

--- a/crates/engine/src/concurrent_delta/consumer/spawn.rs
+++ b/crates/engine/src/concurrent_delta/consumer/spawn.rs
@@ -39,6 +39,7 @@ pub(super) enum ReorderMode {
         dir: Option<PathBuf>,
         granularity: spill::SpillGranularity,
         memory_pressure_bytes: Option<u64>,
+        in_memory_only: bool,
     },
 }
 
@@ -56,6 +57,7 @@ impl ReorderMode {
                 dir: cfg.spill_policy.dir,
                 granularity: cfg.spill_policy.granularity,
                 memory_pressure_bytes: cfg.spill_policy.memory_pressure_bytes,
+                in_memory_only: cfg.spill_policy.in_memory_only,
             },
             None => ReorderMode::Bare {
                 capacity: reorder_capacity,
@@ -170,9 +172,16 @@ impl ReorderBackend {
                 dir,
                 granularity,
                 memory_pressure_bytes,
+                in_memory_only,
             } => {
-                match build_spillable(capacity, threshold, dir, granularity, memory_pressure_bytes)
-                {
+                match build_spillable(
+                    capacity,
+                    threshold,
+                    dir,
+                    granularity,
+                    memory_pressure_bytes,
+                    in_memory_only,
+                ) {
                     Ok(buf) => Self::Spillable(Box::new(buf)),
                     Err(e) => Self::Failed(e),
                 }
@@ -198,6 +207,7 @@ fn build_spillable(
     dir: Option<PathBuf>,
     granularity: spill::SpillGranularity,
     memory_pressure_bytes: Option<u64>,
+    in_memory_only: bool,
 ) -> std::io::Result<SpillableReorderBuffer<DeltaResult>> {
     let buf = match dir {
         Some(d) => SpillableReorderBuffer::with_spill_dir(capacity, threshold, d)?,
@@ -205,5 +215,6 @@ fn build_spillable(
     };
     Ok(buf
         .with_granularity(granularity)
-        .with_memory_pressure_bytes(memory_pressure_bytes))
+        .with_memory_pressure_bytes(memory_pressure_bytes)
+        .with_in_memory_only(in_memory_only))
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -43,6 +43,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             compression: SpillCompression::None,
             reclaim: SpillReclaim::default(),
             memory_pressure_bytes: None,
+            in_memory_only: false,
         }
     }
 
@@ -83,6 +84,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             compression: SpillCompression::None,
             reclaim: SpillReclaim::default(),
             memory_pressure_bytes: None,
+            in_memory_only: false,
         })
     }
 
@@ -170,6 +172,21 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     #[must_use]
     pub fn memory_pressure_bytes(&self) -> Option<u64> {
         self.memory_pressure_bytes
+    }
+
+    /// Enables in-memory-only mode: the buffer returns
+    /// [`SpillError::SpillDisabled`](super::super::SpillError::SpillDisabled)
+    /// when the threshold is exceeded instead of writing to disk.
+    #[must_use]
+    pub fn with_in_memory_only(mut self, enabled: bool) -> Self {
+        self.in_memory_only = enabled;
+        self
+    }
+
+    /// Returns `true` if in-memory-only mode is active (disk spill forbidden).
+    #[must_use]
+    pub fn in_memory_only(&self) -> bool {
+        self.in_memory_only
     }
 
     /// Returns the next sequence number expected for in-order delivery.

--- a/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
@@ -135,6 +135,10 @@ pub struct SpillableReorderBuffer<T: SpillCodec> {
     /// crossed. `None` preserves the historical byte-budget-only behaviour.
     /// Wired from [`SpillPolicy::memory_pressure_bytes`](super::policy::SpillPolicy::memory_pressure_bytes).
     memory_pressure_bytes: Option<u64>,
+    /// When `true`, the buffer never attempts disk I/O for spill operations
+    /// and instead returns [`SpillError::SpillDisabled`](super::SpillError::SpillDisabled).
+    /// Wired from [`SpillPolicy::in_memory_only`](super::policy::SpillPolicy::in_memory_only).
+    in_memory_only: bool,
 }
 
 impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
@@ -151,6 +155,7 @@ impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
             .field("granularity", &self.granularity)
             .field("compression", &self.compression)
             .field("reclaim", &self.reclaim)
+            .field("in_memory_only", &self.in_memory_only)
             .finish()
     }
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -24,6 +24,10 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     /// call, at least one item is spilled regardless of the byte budget so
     /// pressure is actively relieved instead of merely surveyed.
     pub(super) fn spill_excess(&mut self) -> Result<(), SpillError> {
+        if self.in_memory_only {
+            return Err(SpillError::SpillDisabled);
+        }
+
         let next = self.inner.next_expected();
         let count = self.inner.buffered_count();
         if count == 0 {

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/hardening.rs
@@ -46,6 +46,7 @@ fn enospc_during_spill_propagates_as_io_error() {
         SpillError::PriorSpillsLost { dir, count } => {
             panic!("expected I/O error, got prior-spills-lost {dir:?} count={count}")
         }
+        SpillError::SpillDisabled => panic!("expected I/O error, got SpillDisabled"),
     }
     assert!(err.is_out_of_space(), "is_out_of_space should be true");
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/in_memory_only.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/in_memory_only.rs
@@ -12,7 +12,8 @@ fn in_memory_only_returns_spill_disabled_on_threshold_breach() {
 
     // First 3 items fit within the threshold.
     for i in 0..3 {
-        buf.insert(i, i * 10).expect("should succeed under threshold");
+        buf.insert(i, i * 10)
+            .expect("should succeed under threshold");
     }
 
     // The 4th item exceeds the threshold and triggers a spill attempt,
@@ -83,7 +84,8 @@ fn in_memory_only_force_insert_returns_spill_disabled() {
     let mut buf: SpillableReorderBuffer<u64> =
         SpillableReorderBuffer::new(64, 16).with_in_memory_only(true);
 
-    buf.force_insert(0, 0).expect("first insert under threshold");
+    buf.force_insert(0, 0)
+        .expect("first insert under threshold");
     buf.force_insert(1, 10).expect("second insert at threshold");
 
     // Third force_insert exceeds the threshold.

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/in_memory_only.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/in_memory_only.rs
@@ -1,0 +1,97 @@
+//! Tests for the `in_memory_only` policy: the buffer returns
+//! [`SpillError::SpillDisabled`] when the threshold is exceeded instead
+//! of attempting disk I/O.
+
+use super::super::super::SpillableReorderBuffer;
+
+#[test]
+fn in_memory_only_returns_spill_disabled_on_threshold_breach() {
+    // Threshold of 24 bytes = 3 items of 8 bytes each.
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(64, 24).with_in_memory_only(true);
+
+    // First 3 items fit within the threshold.
+    for i in 0..3 {
+        buf.insert(i, i * 10).expect("should succeed under threshold");
+    }
+
+    // The 4th item exceeds the threshold and triggers a spill attempt,
+    // which must fail with SpillDisabled.
+    let err = buf
+        .insert(3, 30)
+        .expect_err("should fail with SpillDisabled");
+    assert!(
+        matches!(err, super::super::super::SpillError::SpillDisabled),
+        "expected SpillDisabled, got: {err:?}"
+    );
+}
+
+#[test]
+fn in_memory_only_disabled_allows_normal_spill() {
+    // Same threshold, but in_memory_only is false (default).
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(64, 24);
+    assert!(!buf.in_memory_only());
+
+    // Insert enough items to exceed the threshold - should spill to disk.
+    for i in (0..16).rev() {
+        buf.insert(i, i * 100).unwrap();
+    }
+
+    let stats = buf.spill_stats();
+    assert!(
+        stats.spill_events > 0,
+        "expected spill events with default policy"
+    );
+
+    // Items should drain correctly in order despite spilling.
+    let items = super::drain_all(&mut buf);
+    assert_eq!(items.len(), 16);
+    for (i, &val) in items.iter().enumerate() {
+        assert_eq!(val, i as u64 * 100);
+    }
+}
+
+#[test]
+fn in_memory_only_no_error_when_under_threshold() {
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(64, 1024).with_in_memory_only(true);
+
+    // All inserts stay under the 1 KB threshold.
+    for i in 0..10 {
+        buf.insert(i, i).expect("should succeed under threshold");
+    }
+
+    let stats = buf.spill_stats();
+    assert_eq!(stats.spill_events, 0);
+    assert_eq!(stats.memory_used, 80);
+}
+
+#[test]
+fn in_memory_only_accessor_reflects_builder() {
+    let buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(64, 1024).with_in_memory_only(true);
+    assert!(buf.in_memory_only());
+
+    let buf2: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(64, 1024).with_in_memory_only(false);
+    assert!(!buf2.in_memory_only());
+}
+
+#[test]
+fn in_memory_only_force_insert_returns_spill_disabled() {
+    // Threshold of 16 bytes = 2 items of 8 bytes each.
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(64, 16).with_in_memory_only(true);
+
+    buf.force_insert(0, 0).expect("first insert under threshold");
+    buf.force_insert(1, 10).expect("second insert at threshold");
+
+    // Third force_insert exceeds the threshold.
+    let err = buf
+        .force_insert(2, 20)
+        .expect_err("should fail with SpillDisabled");
+    assert!(
+        matches!(err, super::super::super::SpillError::SpillDisabled),
+        "expected SpillDisabled, got: {err:?}"
+    );
+}

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/mod.rs
@@ -16,6 +16,7 @@ mod enospc_degradation;
 mod fault;
 mod granularity;
 mod hardening;
+mod in_memory_only;
 mod memory_pressure;
 mod reclaim;
 

--- a/crates/engine/src/concurrent_delta/spill/error.rs
+++ b/crates/engine/src/concurrent_delta/spill/error.rs
@@ -52,6 +52,13 @@ pub enum SpillError {
         /// no longer be reloaded.
         count: usize,
     },
+    /// Spill-to-disk was requested but the policy forbids disk I/O.
+    ///
+    /// Returned when [`SpillPolicy::in_memory_only`](super::policy::SpillPolicy::in_memory_only)
+    /// is `true` and the reorder buffer exceeds its capacity threshold.
+    /// Callers should either increase the threshold, reduce concurrency,
+    /// or switch to a policy that permits disk spill.
+    SpillDisabled,
 }
 
 impl SpillError {
@@ -62,7 +69,8 @@ impl SpillError {
             SpillError::Io(e) => Some(e),
             SpillError::Capacity(_)
             | SpillError::UnsupportedCompression(_)
-            | SpillError::PriorSpillsLost { .. } => None,
+            | SpillError::PriorSpillsLost { .. }
+            | SpillError::SpillDisabled => None,
         }
     }
 
@@ -88,6 +96,10 @@ impl std::fmt::Display for SpillError {
                 "prior spill directory {} vanished; {count} chunk(s) cannot be recovered",
                 dir.display()
             ),
+            SpillError::SpillDisabled => write!(
+                f,
+                "reorder buffer exceeded capacity but spill-to-disk is disabled (in-memory-only policy)"
+            ),
         }
     }
 }
@@ -97,7 +109,8 @@ impl std::error::Error for SpillError {
         match self {
             SpillError::Capacity(_)
             | SpillError::UnsupportedCompression(_)
-            | SpillError::PriorSpillsLost { .. } => None,
+            | SpillError::PriorSpillsLost { .. }
+            | SpillError::SpillDisabled => None,
             SpillError::Io(e) => Some(e),
         }
     }

--- a/crates/engine/src/concurrent_delta/spill/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/mod.rs
@@ -200,5 +200,15 @@ mod tests {
         assert!(std::error::Error::source(&lost).is_none());
         assert!(lost.io_error().is_none());
         assert!(!lost.is_out_of_space());
+
+        let disabled = SpillError::SpillDisabled;
+        let rendered = format!("{disabled}");
+        assert!(
+            rendered.contains("in-memory-only"),
+            "display should mention in-memory-only policy: {rendered}"
+        );
+        assert!(std::error::Error::source(&disabled).is_none());
+        assert!(disabled.io_error().is_none());
+        assert!(!disabled.is_out_of_space());
     }
 }

--- a/crates/engine/src/concurrent_delta/spill/policy.rs
+++ b/crates/engine/src/concurrent_delta/spill/policy.rs
@@ -148,6 +148,16 @@ pub struct SpillPolicy {
     /// Platforms without a supported RSS source (currently Windows) treat
     /// this knob as a no-op: the byte budget retains full control.
     pub memory_pressure_bytes: Option<u64>,
+    /// When `true`, the buffer never attempts disk I/O for spill operations.
+    ///
+    /// Instead of writing excess items to a temporary file, the buffer
+    /// returns [`SpillError::SpillDisabled`](super::SpillError::SpillDisabled)
+    /// when the memory threshold is exceeded. Use this on read-only
+    /// filesystems, in containers without writable tmpfs, or when the
+    /// caller prefers a clean error over silent disk I/O.
+    ///
+    /// Default is `false` (disk spill is permitted when a threshold is set).
+    pub in_memory_only: bool,
 }
 
 impl SpillPolicy {
@@ -213,6 +223,15 @@ impl SpillPolicy {
         self
     }
 
+    /// Enables in-memory-only mode: the buffer returns
+    /// [`SpillError::SpillDisabled`](super::SpillError::SpillDisabled) when
+    /// the threshold is exceeded instead of writing to disk.
+    #[must_use]
+    pub fn with_in_memory_only(mut self) -> Self {
+        self.in_memory_only = true;
+        self
+    }
+
     /// Returns `true` when the spill layer is configured to engage.
     #[must_use]
     pub const fn is_enabled(&self) -> bool {
@@ -265,6 +284,7 @@ mod tests {
         assert_eq!(policy.compression, SpillCompression::None);
         assert_eq!(policy.reclaim, SpillReclaim::KeepInMemory);
         assert!(policy.memory_pressure_bytes.is_none());
+        assert!(!policy.in_memory_only);
     }
 
     #[test]
@@ -278,6 +298,18 @@ mod tests {
     #[test]
     fn off_matches_default() {
         assert_eq!(SpillPolicy::off(), SpillPolicy::default());
+    }
+
+    #[test]
+    fn with_in_memory_only_sets_flag() {
+        let policy = SpillPolicy::with_threshold(4096).with_in_memory_only();
+        assert!(policy.in_memory_only);
+        assert!(policy.is_enabled());
+    }
+
+    #[test]
+    fn in_memory_only_default_is_false() {
+        assert!(!SpillPolicy::with_threshold(1024).in_memory_only);
     }
 
     #[test]

--- a/crates/engine/src/concurrent_delta/spill/tests_per_knob.rs
+++ b/crates/engine/src/concurrent_delta/spill/tests_per_knob.rs
@@ -76,11 +76,12 @@ fn build_buffer_from_policy(
             .expect("per-knob tests always opt the spill layer in"),
     )
     .unwrap_or(usize::MAX);
-    match policy.dir.clone() {
+    let buf = match policy.dir.clone() {
         Some(dir) => SpillableReorderBuffer::with_spill_dir(capacity, threshold, dir)
             .expect("spill directory must be creatable in tests"),
         None => SpillableReorderBuffer::new(capacity, threshold),
-    }
+    };
+    buf.with_in_memory_only(policy.in_memory_only)
 }
 
 fn drain_all(buf: &mut SpillableReorderBuffer<SizedItem>) -> Result<Vec<SizedItem>, SpillError> {
@@ -266,4 +267,58 @@ fn dir_override_default_none_keeps_buffer_without_a_dir() {
         buf.spill_dir().is_none(),
         "spooled backend never grows a directory"
     );
+}
+
+// ---- in_memory_only (SRO-3, wired) ----
+
+#[test]
+fn in_memory_only_returns_spill_disabled_via_policy() {
+    // When the policy sets `in_memory_only: true`, exceeding the threshold
+    // must yield `SpillError::SpillDisabled` instead of attempting disk I/O.
+    let policy = SpillPolicy {
+        threshold_bytes: Some(24),
+        in_memory_only: true,
+        ..Default::default()
+    };
+    let mut buf = build_buffer_from_policy(64, &policy);
+    assert!(buf.in_memory_only());
+
+    for i in 0..3u64 {
+        buf.insert(i, SizedItem::new(i, 8)).unwrap();
+    }
+    assert_eq!(buf.spill_stats().spill_events, 0);
+
+    let err = buf
+        .insert(3, SizedItem::new(3, 8))
+        .expect_err("should fail with SpillDisabled");
+    assert!(
+        matches!(err, SpillError::SpillDisabled),
+        "expected SpillDisabled, got: {err:?}"
+    );
+}
+
+#[test]
+fn in_memory_only_false_allows_normal_spill_via_policy() {
+    // Confirm the default `in_memory_only: false` path still spills normally.
+    let policy = SpillPolicy {
+        threshold_bytes: Some(24),
+        in_memory_only: false,
+        ..Default::default()
+    };
+    let mut buf = build_buffer_from_policy(64, &policy);
+    assert!(!buf.in_memory_only());
+
+    for i in (0..8u64).rev() {
+        buf.insert(i, SizedItem::new(i, 8)).unwrap();
+    }
+
+    let stats = buf.spill_stats();
+    assert!(
+        stats.spill_events > 0,
+        "default policy must allow disk spill"
+    );
+
+    let items = drain_all(&mut buf).unwrap();
+    let values: Vec<u64> = items.iter().map(|i| i.value).collect();
+    assert_eq!(values, (0..8u64).collect::<Vec<_>>());
 }


### PR DESCRIPTION
## Summary

- Adds `SpillPolicy::in_memory_only` field and `with_in_memory_only()` builder that configures the reorder buffer to reject disk spill with a typed error instead of attempting I/O
- Adds `SpillError::SpillDisabled` variant returned when the memory threshold is exceeded under in-memory-only policy
- Wires the flag through `ReorderMode::Spillable`, `build_spillable()`, and the consumer loop's error handler

## Motivation

On read-only filesystems, containers without writable tmpfs, or when callers prefer explicit failure over silent disk I/O, the spill-to-disk path silently fails. This adds a clean opt-in mode that surfaces a typed error immediately when the buffer exceeds capacity, letting the receiver map it to an actionable diagnostic.

## Test plan

- [x] `in_memory_only_returns_spill_disabled_on_threshold_breach` - verifies `SpillError::SpillDisabled` on threshold breach
- [x] `in_memory_only_disabled_allows_normal_spill` - verifies default behavior unchanged
- [x] `in_memory_only_no_error_when_under_threshold` - verifies no error when within budget
- [x] `in_memory_only_accessor_reflects_builder` - verifies builder/accessor round-trip
- [x] `in_memory_only_force_insert_returns_spill_disabled` - verifies force_insert path
- [x] `in_memory_only_returns_spill_disabled_via_policy` - per-knob wiring test
- [x] `in_memory_only_false_allows_normal_spill_via_policy` - per-knob default path
- [x] `SpillError::SpillDisabled` Display/source/io_error coverage in existing error test
- [x] CI: fmt, clippy, nextest, Windows, macOS, musl