### PR TITLE
feat: add pre-flight spill directory writability probe

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -231,5 +231,37 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     #[must_use]
     pub fn spill_dir(&self) -> Option<&Path> {
         self.spill_dir.as_deref()
+    }
+
+    /// Probes the spill directory for writability before the transfer starts.
+    ///
+    /// Creates a small temporary file in the configured spill directory, writes
+    /// a few bytes, and removes it. This catches permission, missing-parent,
+    /// and read-only filesystem issues at transfer start rather than
+    /// mid-transfer when the first spill event fires.
+    ///
+    /// The probe is skipped (returns `Ok(())`) when:
+    /// - `in_memory_only` is `true` - no disk I/O will ever be attempted.
+    /// - No explicit `spill_dir` is configured - the buffer falls back to a
+    ///   system-managed `SpooledTempFile` whose parent is owned by the OS.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpillError::Io`](super::super::SpillError::Io) if the probe
+    /// file cannot be created, written, or removed.
+    pub fn probe_writability(&self) -> Result<(), super::super::SpillError> {
+        if self.in_memory_only {
+            return Ok(());
+        }
+        let dir = match self.spill_dir.as_deref() {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+        let probe_path = dir.join(".oc-rsync-probe");
+        let mut f = fs::File::create(&probe_path)?;
+        f.write_all(b"probe")?;
+        drop(f);
+        fs::remove_file(&probe_path)?;
+        Ok(())
     }
 }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/mod.rs
@@ -17,6 +17,7 @@ mod fault;
 mod granularity;
 mod hardening;
 mod memory_pressure;
+mod preflight;
 mod reclaim;
 
 /// Simple [`SpillCodec`] for `u64` shared across every suite.

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/preflight.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/preflight.rs
@@ -1,0 +1,89 @@
+//! Pre-flight writability probe tests.
+
+use std::fs;
+
+use super::super::super::SpillableReorderBuffer;
+
+#[test]
+fn probe_writability_succeeds_on_valid_dir() {
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let spill_dir = scratch.path().join("spill");
+    let buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_spill_dir(16, 8, &spill_dir).expect("setup spill directory");
+
+    buf.probe_writability()
+        .expect("probe must succeed on a writable directory");
+
+    // The probe file must not linger after a successful probe.
+    assert!(
+        !spill_dir.join(".oc-rsync-probe").exists(),
+        "probe file must be cleaned up"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn probe_writability_fails_on_unwritable_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Root bypasses file permission checks, so this test is meaningless
+    // when running as uid 0. Skip gracefully.
+    if rustix::process::getuid().is_root() {
+        return;
+    }
+
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let spill_dir = scratch.path().join("spill");
+    let buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_spill_dir(16, 8, &spill_dir).expect("setup spill directory");
+
+    // Revoke all permissions on the spill directory.
+    fs::set_permissions(&spill_dir, fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 spill dir");
+
+    let result = buf.probe_writability();
+
+    // Restore permissions before assertions so cleanup succeeds.
+    let _ = fs::set_permissions(&spill_dir, fs::Permissions::from_mode(0o755));
+
+    let err = result.expect_err("probe must fail on an unwritable directory");
+    match err {
+        super::super::super::SpillError::Io(ref e) => {
+            assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected PermissionDenied, got {:?}",
+                e.kind()
+            );
+        }
+        other => panic!("expected SpillError::Io(PermissionDenied), got {other:?}"),
+    }
+}
+
+#[test]
+fn probe_writability_skips_when_in_memory_only() {
+    // Create a buffer with an explicit spill dir but in-memory-only mode.
+    // The probe must return Ok without touching the filesystem.
+    let scratch = ::tempfile::tempdir().expect("create scratch root");
+    let spill_dir = scratch.path().join("spill");
+    let buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_spill_dir(16, 8, &spill_dir)
+            .expect("setup spill directory")
+            .with_in_memory_only(true);
+
+    // Remove the directory entirely - if the probe tried to touch disk it
+    // would fail, proving the skip path is taken.
+    fs::remove_dir_all(&spill_dir).expect("remove spill dir");
+
+    buf.probe_writability()
+        .expect("probe must succeed (skip) in in-memory-only mode");
+}
+
+#[test]
+fn probe_writability_skips_when_no_spill_dir() {
+    // Default buffer with no explicit spill dir - uses SpooledTempFile.
+    let buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(16, 8);
+
+    buf.probe_writability()
+        .expect("probe must succeed (skip) when no spill dir is configured");
+}


### PR DESCRIPTION
## Summary

- Add `probe_writability()` method on `SpillableReorderBuffer` that creates, writes, and removes a small temp file in the configured spill directory before the transfer starts - catching permission, missing-parent, and read-only filesystem issues early rather than mid-transfer on the first spill event.
- The probe is skipped when `in_memory_only` is `true` (no disk I/O expected) or when no explicit `spill_dir` is configured (buffer uses system-managed `SpooledTempFile`).
- Four new tests cover the happy path, unwritable directory (chmod 000, Unix only), in-memory-only skip, and no-spill-dir skip.

## Test plan

- [ ] CI: `cargo nextest run -p engine --all-features -E 'test(preflight)'` passes on Linux, macOS, Windows
- [ ] CI: fmt + clippy clean
- [ ] Verify `probe_writability_fails_on_unwritable_dir` skips gracefully on root and on Windows