### PR TITLE
feat: add rustls dependency to daemon crate behind daemon-tls feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
- "untrusted",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1034,6 +1034,8 @@ dependencies = [
  "metadata",
  "platform",
  "protocol",
+ "rustls",
+ "rustls-pemfile",
  "sd-notify",
  "socket2",
  "tempfile",
@@ -3022,6 +3024,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +3245,50 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4116,6 +4176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,6 +4528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,16 @@ async = ["daemon/async", "core/async"]
 # systemd sd-notify integration for daemon
 sd-notify = ["daemon/sd-notify"]
 
+# ============================================================================
+# Daemon Features
+# ============================================================================
+
+# Native TLS termination for the daemon via rustls (alternative to stunnel sidecar).
+# Requirements: None (pure Rust, no system TLS dependency)
+# Benefits: Single-binary TLS termination, no stunnel/HAProxy sidecar needed
+# Trade-offs: Adds ~400KB to binary, requires PEM cert/key management
+daemon-tls = ["daemon/daemon-tls"]
+
 [dependencies]
 cli = { path = "crates/cli", default-features = false }
 daemon = { path = "crates/daemon", default-features = false }
@@ -300,6 +310,10 @@ xattr = "1.6"
 zstd = "0.13"
 # Bump-allocator arena - used by protocol flist-arena-prototype feature (RSS-7)
 bumpalo = "3"
+# Pure-Rust TLS - daemon native TLS termination (optional, feature-gated)
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+# PEM file parser for rustls certificate/key loading
+rustls-pemfile = "2"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -33,6 +33,11 @@ tracing = ["dep:tracing", "core/tracing"]
 acl = ["core/acl", "metadata/acl"]
 # Filename charset transcoding via the module `charset =` directive (iconv).
 iconv = ["core/iconv", "protocol/iconv"]
+# Native TLS termination via rustls - single-binary alternative to stunnel/HAProxy
+# sidecar. Opt-in; default builds remain TLS-free. See
+# `docs/design/daemon-async-accept-sync-workers.md` section 11 for the integration
+# roadmap.
+daemon-tls = ["dep:rustls", "dep:rustls-pemfile"]
 
 [dependencies]
 clap = { workspace = true }
@@ -50,6 +55,8 @@ tempfile = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["net", "io-util", "sync", "rt", "rt-multi-thread", "time", "macros"] }
 dashmap = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { version = "2", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 checksums = { path = "../checksums" }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -175,10 +175,6 @@
 pub mod async_listener;
 /// Daemon mode challenge-response authentication matching upstream rsync 3.4.1.
 pub mod auth;
-/// Native TLS termination via rustls for the daemon listener.
-#[cfg(feature = "daemon-tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
-pub mod tls;
 mod cli;
 mod config;
 mod daemon;
@@ -186,6 +182,10 @@ mod error;
 /// Daemon configuration file parsing for `rsyncd.conf`.
 pub mod rsyncd_config;
 mod systemd;
+/// Native TLS termination via rustls for the daemon listener.
+#[cfg(feature = "daemon-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+pub mod tls;
 
 #[cfg(test)]
 mod test_env;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -175,6 +175,10 @@
 pub mod async_listener;
 /// Daemon mode challenge-response authentication matching upstream rsync 3.4.1.
 pub mod auth;
+/// Native TLS termination via rustls for the daemon listener.
+#[cfg(feature = "daemon-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+pub mod tls;
 mod cli;
 mod config;
 mod daemon;

--- a/crates/daemon/src/tls.rs
+++ b/crates/daemon/src/tls.rs
@@ -1,0 +1,250 @@
+//! Native TLS termination for the oc-rsync daemon via rustls.
+//!
+//! This module provides the building blocks for accepting TLS-wrapped
+//! connections in the daemon listener, eliminating the need for an external
+//! stunnel or HAProxy sidecar. It is feature-gated behind `daemon-tls` and
+//! not compiled into default builds.
+//!
+//! # Design
+//!
+//! The module exposes two operations:
+//!
+//! 1. **[`build_tls_acceptor`]** - loads PEM certificates and a private key
+//!    from disk and constructs a rustls [`TlsAcceptor`] configured with safe
+//!    defaults (TLS 1.2+, ring crypto provider).
+//! 2. **[`wrap_stream`]** - performs the TLS handshake on an accepted
+//!    [`TcpStream`], returning a [`rustls::StreamOwned`] that implements
+//!    `Read + Write` and can be handed to the synchronous per-connection
+//!    worker unchanged.
+//!
+//! Integration with the daemon listener loop is tracked as a follow-up task
+//! (TLS-7). This module contains only the TLS plumbing, not the listener
+//! wiring.
+//!
+//! # Certificate loading
+//!
+//! [`TlsConfig`] accepts filesystem paths for the certificate chain
+//! (fullchain PEM), the private key (PKCS#8 or RSA PEM), and an optional
+//! client CA bundle for mutual TLS. Certificate rotation requires a daemon
+//! restart; live reload is a future enhancement.
+//!
+//! # Security
+//!
+//! - Only TLS 1.2 and 1.3 are enabled (rustls does not support older
+//!   protocol versions).
+//! - The ring crypto provider is used by default, providing FIPS-grade
+//!   primitives without linking to OpenSSL.
+//! - Client certificate verification is opt-in via the `client_ca_path`
+//!   field on [`TlsConfig`].
+
+use std::fs;
+use std::io;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rustls::ServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::WebPkiClientVerifier;
+
+/// TLS acceptor wrapping a shared rustls [`ServerConfig`].
+///
+/// Cloning is cheap (inner `Arc`). One acceptor is built at daemon startup
+/// and shared across all connection-handling threads.
+#[derive(Clone, Debug)]
+pub struct TlsAcceptor {
+    config: Arc<ServerConfig>,
+}
+
+/// Configuration paths for TLS certificate material.
+///
+/// All paths must point at PEM-encoded files. The certificate chain file
+/// must contain the server certificate followed by any intermediate
+/// certificates, ordered leaf-first.
+#[derive(Clone, Debug)]
+pub struct TlsConfig {
+    /// Path to the PEM-encoded certificate chain (server cert + intermediates).
+    pub cert_path: PathBuf,
+    /// Path to the PEM-encoded private key (PKCS#8, PKCS#1 RSA, or SEC1 EC).
+    pub key_path: PathBuf,
+    /// Optional path to a PEM-encoded CA bundle for client certificate
+    /// verification (mutual TLS). When `None`, client certificates are not
+    /// requested.
+    pub client_ca_path: Option<PathBuf>,
+}
+
+/// Loads certificates and private key, then builds a [`TlsAcceptor`].
+///
+/// The acceptor is configured with the ring crypto provider and supports
+/// TLS 1.2 and TLS 1.3. When `config.client_ca_path` is set, client
+/// certificate verification is enabled using the provided CA bundle.
+///
+/// # Errors
+///
+/// Returns `io::Error` if any PEM file cannot be read or parsed, if no
+/// certificates or private keys are found in the provided files, or if the
+/// rustls `ServerConfig` rejects the certificate/key combination.
+pub fn build_tls_acceptor(config: &TlsConfig) -> Result<TlsAcceptor, io::Error> {
+    let certs = load_certificates(&config.cert_path)?;
+    let key = load_private_key(&config.key_path)?;
+
+    let mut server_config = if let Some(ca_path) = &config.client_ca_path {
+        let roots = load_root_store(ca_path)?;
+        let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+            .build()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(certs, key)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+    } else {
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+    };
+
+    // ALPN is not used - the rsync protocol is not registered with IANA for
+    // ALPN negotiation, and no rsync client sends ALPN extensions.
+    server_config.alpn_protocols = Vec::new();
+
+    Ok(TlsAcceptor {
+        config: Arc::new(server_config),
+    })
+}
+
+/// Performs a TLS handshake on an accepted TCP connection.
+///
+/// On success, returns a `rustls::StreamOwned` that implements `Read + Write`
+/// over the encrypted channel. The caller can pass this stream to the
+/// synchronous per-connection worker in place of a raw `TcpStream`.
+///
+/// # Errors
+///
+/// Returns `io::Error` if the TLS handshake fails (e.g., client sends an
+/// unsupported protocol version, invalid certificate, or aborts the
+/// connection).
+pub fn wrap_stream(
+    acceptor: &TlsAcceptor,
+    stream: TcpStream,
+) -> Result<rustls::StreamOwned<rustls::ServerConnection, TcpStream>, io::Error> {
+    let conn = rustls::ServerConnection::new(Arc::clone(&acceptor.config))
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(rustls::StreamOwned::new(conn, stream))
+}
+
+/// Loads PEM-encoded certificates from a file.
+fn load_certificates(path: &Path) -> Result<Vec<CertificateDer<'static>>, io::Error> {
+    let pem_data = fs::read(path)?;
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut pem_data.as_slice())
+        .collect::<Result<Vec<_>, _>>()?;
+    if certs.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("no certificates found in {}", path.display()),
+        ));
+    }
+    Ok(certs)
+}
+
+/// Loads the first PEM-encoded private key from a file.
+///
+/// Accepts PKCS#8, PKCS#1 (RSA), and SEC1 (EC) key formats.
+fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, io::Error> {
+    let pem_data = fs::read(path)?;
+    rustls_pemfile::private_key(&mut pem_data.as_slice())?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("no private key found in {}", path.display()),
+        )
+    })
+}
+
+/// Builds a root certificate store from a PEM-encoded CA bundle.
+fn load_root_store(path: &Path) -> Result<rustls::RootCertStore, io::Error> {
+    let ca_certs = load_certificates(path)?;
+    let mut store = rustls::RootCertStore::empty();
+    for cert in ca_certs {
+        store
+            .add(cert)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    }
+    if store.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("no CA certificates found in {}", path.display()),
+        ));
+    }
+    Ok(store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tls_config_holds_paths() {
+        let config = TlsConfig {
+            cert_path: PathBuf::from("/etc/certs/server.pem"),
+            key_path: PathBuf::from("/etc/certs/server.key"),
+            client_ca_path: None,
+        };
+        assert_eq!(config.cert_path.as_os_str(), "/etc/certs/server.pem");
+        assert_eq!(config.key_path.as_os_str(), "/etc/certs/server.key");
+        assert!(config.client_ca_path.is_none());
+    }
+
+    #[test]
+    fn tls_config_with_client_ca() {
+        let config = TlsConfig {
+            cert_path: PathBuf::from("/etc/certs/server.pem"),
+            key_path: PathBuf::from("/etc/certs/server.key"),
+            client_ca_path: Some(PathBuf::from("/etc/certs/ca.pem")),
+        };
+        assert_eq!(
+            config.client_ca_path.as_deref(),
+            Some(Path::new("/etc/certs/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn build_acceptor_rejects_missing_cert_file() {
+        let config = TlsConfig {
+            cert_path: PathBuf::from("/nonexistent/cert.pem"),
+            key_path: PathBuf::from("/nonexistent/key.pem"),
+            client_ca_path: None,
+        };
+        let err = build_tls_acceptor(&config).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn load_certificates_rejects_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("empty.pem");
+        fs::write(&cert_path, "").unwrap();
+        let err = load_certificates(&cert_path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("no certificates"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_private_key_rejects_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("empty.pem");
+        fs::write(&key_path, "").unwrap();
+        let err = load_private_key(&key_path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("no private key"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/daemon/src/tls.rs
+++ b/crates/daemon/src/tls.rs
@@ -140,8 +140,8 @@ pub fn wrap_stream(
 /// Loads PEM-encoded certificates from a file.
 fn load_certificates(path: &Path) -> Result<Vec<CertificateDer<'static>>, io::Error> {
     let pem_data = fs::read(path)?;
-    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut pem_data.as_slice())
-        .collect::<Result<Vec<_>, _>>()?;
+    let certs: Vec<CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut pem_data.as_slice()).collect::<Result<Vec<_>, _>>()?;
     if certs.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,


### PR DESCRIPTION
## Summary

- Adds `rustls` 0.23 (ring crypto provider) and `rustls-pemfile` 2 as optional workspace dependencies behind the `daemon-tls` feature flag
- Creates `crates/daemon/src/tls.rs` with `TlsConfig`, `build_tls_acceptor()`, and `wrap_stream()` building blocks for native TLS termination
- Feature-gated with `#[cfg(feature = "daemon-tls")]` - default builds remain TLS-free and unchanged
- No listener integration yet (tracked as TLS-7) - this PR adds only the TLS plumbing layer

## Context

The daemon currently relies on external stunnel/HAProxy/SSH sidecars for TLS termination (documented in `docs/daemon/tls-in-front.md` and `docs/deployment/daemon-tls.md`). The async-accept design doc (`docs/design/daemon-async-accept-sync-workers.md`, section 11) identifies native rustls integration as a future enhancement. This PR lays the foundation by adding the dependency and a minimal acceptor module.

## Design

- `TlsConfig` holds paths to PEM cert chain, private key, and optional client CA bundle (mTLS)
- `build_tls_acceptor()` loads PEM files, builds a rustls `ServerConfig` with safe defaults (TLS 1.2+, ring provider)
- `wrap_stream()` performs the TLS handshake on an accepted `TcpStream`, returning a `StreamOwned` that implements `Read + Write`
- The `TlsAcceptor` wrapper is `Clone` (inner `Arc<ServerConfig>`) for sharing across connection threads

## Test plan

- [x] Verify `daemon-tls` feature compiles on all CI platforms (Linux, macOS, Windows)
- [x] Unit tests cover `TlsConfig` construction, missing file rejection, and empty PEM rejection
- [x] Default build (no `daemon-tls` flag) compiles without rustls in the dependency tree
- [x] `#![deny(unsafe_code)]` on daemon crate passes - rustls is pure safe Rust