### PR TITLE
ci: add daemon-tls feature flag CI matrix cell (TLS-14)

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -48,6 +48,8 @@ jobs:
             args: "-p logging -p protocol -p flist --features serde"
           - name: concurrent-sessions
             args: "-p daemon --features concurrent-sessions"
+          - name: daemon-tls
+            args: "-p daemon --features daemon-tls"
 
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Add `daemon-tls` entry to the cross-OS feature flag CI matrix in `_test-features.yml`
- Exercises `--features daemon-tls` for the `daemon` crate on ubuntu-latest, macos-latest, and windows-latest
- Ensures the rustls-based TLS termination feature (added in #5069) is continuously tested across all platforms

## Test plan

- [ ] CI `Test Feature Combinations` workflow passes the new `daemon-tls` cell on all three OS targets
- [ ] Existing feature flag matrix cells remain unaffected