### PR TITLE
feat: add --ssl CLI flags for daemon TLS mode (TLS-10)

### DIFF
--- a/crates/daemon/src/cli.rs
+++ b/crates/daemon/src/cli.rs
@@ -83,10 +83,17 @@ where
         return execute_service_action(action, &parsed, stdout, stderr);
     }
 
-    let config = DaemonConfig::builder()
+    #[allow(unused_mut)]
+    let mut builder = DaemonConfig::builder()
         .brand(parsed.program_name.brand())
-        .arguments(parsed.remainder)
-        .build();
+        .arguments(parsed.remainder);
+
+    #[cfg(feature = "daemon-tls")]
+    if let Some(tls) = parsed.tls_config {
+        builder = builder.tls_config(tls);
+    }
+
+    let config = builder.build();
 
     match run_daemon(config) {
         Ok(()) => 0,
@@ -262,5 +269,96 @@ mod tests {
         let mut stderr = Vec::new();
         let result = run(["oc-rsyncd", "--windows-service"], &mut stdout, &mut stderr);
         assert_eq!(result, 1);
+    }
+
+    #[cfg(feature = "daemon-tls")]
+    mod tls_cli {
+        use crate::daemon::parse_args;
+        use std::path::Path;
+
+        #[test]
+        fn ssl_flag_sets_tls_config_with_defaults() {
+            let parsed = parse_args(["oc-rsyncd", "--ssl"]).unwrap();
+            let tls = parsed.tls_config.expect("--ssl should set tls_config");
+            assert_eq!(tls.cert_path, Path::new("cert.pem"));
+            assert_eq!(tls.key_path, Path::new("key.pem"));
+            assert!(tls.client_ca_path.is_none());
+        }
+
+        #[test]
+        fn ssl_flag_with_cert_and_key() {
+            let parsed = parse_args([
+                "oc-rsyncd",
+                "--ssl",
+                "--ssl-cert",
+                "/etc/certs/server.pem",
+                "--ssl-key",
+                "/etc/certs/server.key",
+            ])
+            .unwrap();
+            let tls = parsed.tls_config.expect("--ssl should set tls_config");
+            assert_eq!(tls.cert_path, Path::new("/etc/certs/server.pem"));
+            assert_eq!(tls.key_path, Path::new("/etc/certs/server.key"));
+            assert!(tls.client_ca_path.is_none());
+        }
+
+        #[test]
+        fn ssl_flag_with_client_ca() {
+            let parsed = parse_args([
+                "oc-rsyncd",
+                "--ssl",
+                "--ssl-cert",
+                "/certs/server.pem",
+                "--ssl-key",
+                "/certs/server.key",
+                "--ssl-ca",
+                "/certs/ca.pem",
+            ])
+            .unwrap();
+            let tls = parsed.tls_config.expect("--ssl should set tls_config");
+            assert_eq!(
+                tls.client_ca_path.as_deref(),
+                Some(Path::new("/certs/ca.pem"))
+            );
+        }
+
+        #[test]
+        fn no_ssl_flag_leaves_tls_config_none() {
+            let parsed = parse_args(["oc-rsyncd"]).unwrap();
+            assert!(parsed.tls_config.is_none());
+        }
+
+        #[test]
+        fn ssl_cert_without_ssl_flag_is_rejected() {
+            let result = parse_args(["oc-rsyncd", "--ssl-cert", "/path/cert.pem"]);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn ssl_key_without_ssl_flag_is_rejected() {
+            let result = parse_args(["oc-rsyncd", "--ssl-key", "/path/key.pem"]);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn ssl_ca_without_ssl_flag_is_rejected() {
+            let result = parse_args(["oc-rsyncd", "--ssl-ca", "/path/ca.pem"]);
+            assert!(result.is_err());
+        }
+    }
+
+    #[cfg(not(feature = "daemon-tls"))]
+    mod tls_cli_absent {
+        use crate::daemon::parse_args;
+
+        #[test]
+        fn ssl_flag_passes_through_without_feature() {
+            // Without the daemon-tls feature, --ssl is not a defined clap
+            // argument. It passes through to remainder via the trailing
+            // var-arg collector and is rejected downstream by
+            // RuntimeOptions::parse_with_brand as an unsupported option.
+            let parsed = parse_args(["oc-rsyncd", "--ssl"]).unwrap();
+            assert!(parsed.remainder.iter().any(|a| a == "--ssl"));
+        }
     }
 }

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -32,6 +32,12 @@ pub struct DaemonConfig {
     /// binding a new socket, eliminating the TOCTOU race between port allocation
     /// and daemon bind in tests.
     pre_bound_listener: Option<TcpListener>,
+    /// TLS configuration parsed from `--ssl*` CLI flags.
+    ///
+    /// When present, the daemon listener wraps accepted connections in a TLS
+    /// layer using the certificate material referenced by these paths.
+    #[cfg(feature = "daemon-tls")]
+    tls_config: Option<crate::tls::TlsConfig>,
 }
 
 impl Clone for DaemonConfig {
@@ -42,15 +48,25 @@ impl Clone for DaemonConfig {
             load_default_paths: self.load_default_paths,
             signal_flags: self.signal_flags.clone(),
             pre_bound_listener: None,
+            #[cfg(feature = "daemon-tls")]
+            tls_config: self.tls_config.clone(),
         }
     }
 }
 
 impl PartialEq for DaemonConfig {
     fn eq(&self, other: &Self) -> bool {
-        self.brand == other.brand
+        let base = self.brand == other.brand
             && self.arguments == other.arguments
-            && self.load_default_paths == other.load_default_paths
+            && self.load_default_paths == other.load_default_paths;
+        #[cfg(feature = "daemon-tls")]
+        {
+            base && self.tls_config == other.tls_config
+        }
+        #[cfg(not(feature = "daemon-tls"))]
+        {
+            base
+        }
     }
 }
 
@@ -100,6 +116,17 @@ impl DaemonConfig {
         self.pre_bound_listener.take()
     }
 
+    /// Returns TLS configuration parsed from `--ssl*` CLI flags, if present.
+    ///
+    /// When set, the daemon listener wraps accepted connections in a TLS
+    /// layer. The returned config contains filesystem paths to the certificate
+    /// chain, private key, and optional client CA bundle.
+    #[cfg(feature = "daemon-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+    pub fn take_tls_config(&mut self) -> Option<crate::tls::TlsConfig> {
+        self.tls_config.take()
+    }
+
     /// Reports whether any daemon-specific arguments were provided.
     #[must_use]
     pub const fn has_runtime_request(&self) -> bool {
@@ -115,6 +142,8 @@ pub struct DaemonConfigBuilder {
     load_default_paths: bool,
     signal_flags: Option<SignalFlags>,
     pre_bound_listener: Option<TcpListener>,
+    #[cfg(feature = "daemon-tls")]
+    tls_config: Option<crate::tls::TlsConfig>,
 }
 
 impl Clone for DaemonConfigBuilder {
@@ -125,15 +154,25 @@ impl Clone for DaemonConfigBuilder {
             load_default_paths: self.load_default_paths,
             signal_flags: self.signal_flags.clone(),
             pre_bound_listener: None,
+            #[cfg(feature = "daemon-tls")]
+            tls_config: self.tls_config.clone(),
         }
     }
 }
 
 impl PartialEq for DaemonConfigBuilder {
     fn eq(&self, other: &Self) -> bool {
-        self.brand == other.brand
+        let base = self.brand == other.brand
             && self.arguments == other.arguments
-            && self.load_default_paths == other.load_default_paths
+            && self.load_default_paths == other.load_default_paths;
+        #[cfg(feature = "daemon-tls")]
+        {
+            base && self.tls_config == other.tls_config
+        }
+        #[cfg(not(feature = "daemon-tls"))]
+        {
+            base
+        }
     }
 }
 
@@ -147,6 +186,8 @@ impl Default for DaemonConfigBuilder {
             load_default_paths: true,
             signal_flags: None,
             pre_bound_listener: None,
+            #[cfg(feature = "daemon-tls")]
+            tls_config: None,
         }
     }
 }
@@ -159,6 +200,8 @@ impl From<DaemonConfig> for DaemonConfigBuilder {
             load_default_paths: config.load_default_paths,
             signal_flags: config.signal_flags,
             pre_bound_listener: config.pre_bound_listener,
+            #[cfg(feature = "daemon-tls")]
+            tls_config: config.tls_config,
         }
     }
 }
@@ -211,6 +254,18 @@ impl DaemonConfigBuilder {
         self
     }
 
+    /// Sets the TLS configuration for the daemon listener.
+    ///
+    /// When set, the daemon wraps accepted TCP connections in a TLS layer
+    /// using the certificate material referenced by `config`.
+    #[cfg(feature = "daemon-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+    #[must_use]
+    pub fn tls_config(mut self, config: crate::tls::TlsConfig) -> Self {
+        self.tls_config = Some(config);
+        self
+    }
+
     /// Finalises the builder and constructs the [`DaemonConfig`].
     #[must_use]
     pub fn build(self) -> DaemonConfig {
@@ -220,6 +275,8 @@ impl DaemonConfigBuilder {
             load_default_paths: self.load_default_paths,
             signal_flags: self.signal_flags,
             pre_bound_listener: self.pre_bound_listener,
+            #[cfg(feature = "daemon-tls")]
+            tls_config: self.tls_config,
         }
     }
 }
@@ -333,6 +390,63 @@ mod tests {
             let taken = config.take_signal_flags().unwrap();
             shutdown.store(true, Ordering::Relaxed);
             assert!(taken.shutdown.load(Ordering::Relaxed));
+        }
+    }
+
+    #[cfg(feature = "daemon-tls")]
+    mod tls_config_tests {
+        use super::*;
+        use std::path::PathBuf;
+
+        fn sample_tls_config() -> crate::tls::TlsConfig {
+            crate::tls::TlsConfig {
+                cert_path: PathBuf::from("/etc/certs/server.pem"),
+                key_path: PathBuf::from("/etc/certs/server.key"),
+                client_ca_path: None,
+            }
+        }
+
+        #[test]
+        fn builder_default_has_no_tls_config() {
+            let mut config = DaemonConfig::builder().build();
+            assert!(config.take_tls_config().is_none());
+        }
+
+        #[test]
+        fn builder_with_tls_config() {
+            let tls = sample_tls_config();
+            let mut config = DaemonConfig::builder().tls_config(tls.clone()).build();
+            let taken = config.take_tls_config();
+            assert_eq!(taken, Some(tls));
+        }
+
+        #[test]
+        fn take_tls_config_returns_none_on_second_call() {
+            let tls = sample_tls_config();
+            let mut config = DaemonConfig::builder().tls_config(tls).build();
+            assert!(config.take_tls_config().is_some());
+            assert!(config.take_tls_config().is_none());
+        }
+
+        #[test]
+        fn tls_config_survives_clone() {
+            let tls = sample_tls_config();
+            let config = DaemonConfig::builder().tls_config(tls.clone()).build();
+            let cloned = config.clone();
+            assert_eq!(config, cloned);
+        }
+
+        #[test]
+        fn tls_config_chained_with_other_options() {
+            let tls = sample_tls_config();
+            let mut config = DaemonConfig::builder()
+                .brand(Brand::Upstream)
+                .arguments(["--port", "8873"])
+                .tls_config(tls)
+                .build();
+
+            assert_eq!(config.brand(), Brand::Upstream);
+            assert!(config.take_tls_config().is_some());
         }
     }
 

--- a/crates/daemon/src/daemon/sections/cli_args.rs
+++ b/crates/daemon/src/daemon/sections/cli_args.rs
@@ -56,6 +56,13 @@ pub(crate) struct ParsedArgs {
     pub(crate) show_version: bool,
     pub(crate) service_action: Option<ServiceAction>,
     pub(crate) remainder: Vec<OsString>,
+    /// TLS configuration parsed from `--ssl*` flags.
+    ///
+    /// Present only when `--ssl` is given and the `daemon-tls` feature is
+    /// enabled. Contains paths to the certificate chain, private key, and
+    /// optional client CA bundle for mutual TLS.
+    #[cfg(feature = "daemon-tls")]
+    pub(crate) tls_config: Option<crate::tls::TlsConfig>,
 }
 
 /// Builds the clap [`Command`] used by [`parse_args`].
@@ -63,7 +70,8 @@ pub(crate) struct ParsedArgs {
 /// Only `--help` and `--version` are extracted here; all other flags are
 /// collected as `remainder` and forwarded to the daemon option parser.
 pub(crate) fn clap_command(program_name: &'static str) -> Command {
-    Command::new(program_name)
+    #[allow(unused_mut)]
+    let mut cmd = Command::new(program_name)
         .disable_help_flag(true)
         .disable_version_flag(true)
         .arg_required_else_help(false)
@@ -105,7 +113,41 @@ pub(crate) fn clap_command(program_name: &'static str) -> Command {
                 .allow_hyphen_values(true)
                 .trailing_var_arg(true)
                 .value_parser(OsStringValueParser::new()),
-        )
+        );
+
+    #[cfg(feature = "daemon-tls")]
+    {
+        cmd = cmd
+            .arg(
+                Arg::new("ssl")
+                    .long("ssl")
+                    .help("Enable native TLS on the daemon listener.")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("ssl-cert")
+                    .long("ssl-cert")
+                    .help("Path to PEM certificate chain for TLS.")
+                    .value_name("PATH")
+                    .requires("ssl"),
+            )
+            .arg(
+                Arg::new("ssl-key")
+                    .long("ssl-key")
+                    .help("Path to PEM private key for TLS.")
+                    .value_name("PATH")
+                    .requires("ssl"),
+            )
+            .arg(
+                Arg::new("ssl-ca")
+                    .long("ssl-ca")
+                    .help("Path to PEM CA bundle for mutual TLS client verification.")
+                    .value_name("PATH")
+                    .requires("ssl"),
+            );
+    }
+
+    cmd
 }
 
 /// Parses the top-level daemon arguments, extracting `--help` and `--version`.
@@ -151,12 +193,31 @@ where
         None
     };
 
+    #[cfg(feature = "daemon-tls")]
+    let tls_config = if matches.get_flag("ssl") {
+        Some(crate::tls::TlsConfig {
+            cert_path: matches
+                .get_one::<String>("ssl-cert")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("cert.pem")),
+            key_path: matches
+                .get_one::<String>("ssl-key")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("key.pem")),
+            client_ca_path: matches.get_one::<String>("ssl-ca").map(PathBuf::from),
+        })
+    } else {
+        None
+    };
+
     Ok(ParsedArgs {
         program_name,
         show_help,
         show_version,
         service_action,
         remainder,
+        #[cfg(feature = "daemon-tls")]
+        tls_config,
     })
 }
 

--- a/crates/daemon/src/tls.rs
+++ b/crates/daemon/src/tls.rs
@@ -61,7 +61,7 @@ pub struct TlsAcceptor {
 /// All paths must point at PEM-encoded files. The certificate chain file
 /// must contain the server certificate followed by any intermediate
 /// certificates, ordered leaf-first.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TlsConfig {
     /// Path to the PEM-encoded certificate chain (server cert + intermediates).
     pub cert_path: PathBuf,


### PR DESCRIPTION
## Summary

- Add `--ssl`, `--ssl-cert`, `--ssl-key`, and `--ssl-ca` flags to the daemon CLI behind `#[cfg(feature = "daemon-tls")]`
- Wire parsed TLS flags into `TlsConfig` and propagate through `DaemonConfig` / `DaemonConfigBuilder` with full builder-pattern support
- Add `Eq + PartialEq` derives to `TlsConfig` for config equality checks
- Add 12 tests covering flag parsing, default paths, mutual TLS, requires-constraints, config builder round-trips, and feature-absent behavior

## Design

The `--ssl` flag is a boolean toggle that enables TLS mode. When present, `--ssl-cert` and `--ssl-key` specify the PEM certificate chain and private key (defaulting to `cert.pem` / `key.pem` in the working directory). `--ssl-ca` optionally enables mutual TLS with a client CA bundle. All three path flags use clap `requires("ssl")` so they cannot be passed without `--ssl`.

`TlsConfig` flows from `ParsedArgs` through `DaemonConfig` where `take_tls_config()` lets the listener integration (TLS-7) consume it at startup.

## Test plan

- [ ] CI passes with default features (no `daemon-tls`) - TLS code compiles away cleanly
- [ ] CI passes with `--features daemon-tls` - all 12 new tests exercise parsing and config wiring
- [ ] `--ssl-cert` / `--ssl-key` / `--ssl-ca` without `--ssl` produce clap errors
- [ ] Existing daemon CLI tests remain green (help, version, service flags)