### PR TITLE
feat(daemon): add rsyncd.conf TLS directives (ssl cert, ssl key, ssl ca)

### DIFF
--- a/crates/daemon/src/rsyncd_config/parser.rs
+++ b/crates/daemon/src/rsyncd_config/parser.rs
@@ -110,6 +110,9 @@ impl<'a> Parser<'a> {
             modules.push(module);
         }
 
+        #[cfg(feature = "daemon-tls")]
+        self.validate_tls_config(&global)?;
+
         Ok(RsyncdConfig { global, modules })
     }
 
@@ -201,6 +204,42 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 global.daemon_chroot = Some(PathBuf::from(trimmed));
+            }
+            #[cfg(feature = "daemon-tls")]
+            "ssl cert" => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    return Err(ConfigError::parse_error(
+                        self.path,
+                        self.line_number,
+                        "'ssl cert' must not be empty",
+                    ));
+                }
+                global.ssl_cert = Some(PathBuf::from(trimmed));
+            }
+            #[cfg(feature = "daemon-tls")]
+            "ssl key" => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    return Err(ConfigError::parse_error(
+                        self.path,
+                        self.line_number,
+                        "'ssl key' must not be empty",
+                    ));
+                }
+                global.ssl_key = Some(PathBuf::from(trimmed));
+            }
+            #[cfg(feature = "daemon-tls")]
+            "ssl ca" => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    return Err(ConfigError::parse_error(
+                        self.path,
+                        self.line_number,
+                        "'ssl ca' must not be empty",
+                    ));
+                }
+                global.ssl_ca = Some(PathBuf::from(trimmed));
             }
             _ => {
                 // Unknown global directives are silently ignored for forward compatibility
@@ -377,6 +416,37 @@ impl<'a> Parser<'a> {
                 }
             })
             .collect()
+    }
+
+    /// Validates that `ssl cert` and `ssl key` are either both set or both absent.
+    ///
+    /// `ssl ca` is independently optional. Setting `ssl ca` without the cert/key
+    /// pair is also an error - a CA bundle is meaningless without a server identity.
+    #[cfg(feature = "daemon-tls")]
+    fn validate_tls_config(&self, global: &GlobalConfig) -> Result<(), ConfigError> {
+        let has_cert = global.ssl_cert.is_some();
+        let has_key = global.ssl_key.is_some();
+        let has_ca = global.ssl_ca.is_some();
+
+        if has_cert && !has_key {
+            return Err(ConfigError::cross_field_error(
+                self.path,
+                "'ssl cert' requires 'ssl key' to also be set",
+            ));
+        }
+        if has_key && !has_cert {
+            return Err(ConfigError::cross_field_error(
+                self.path,
+                "'ssl key' requires 'ssl cert' to also be set",
+            ));
+        }
+        if has_ca && !has_cert {
+            return Err(ConfigError::cross_field_error(
+                self.path,
+                "'ssl ca' requires 'ssl cert' and 'ssl key' to also be set",
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/crates/daemon/src/rsyncd_config/sections.rs
+++ b/crates/daemon/src/rsyncd_config/sections.rs
@@ -37,6 +37,24 @@ pub struct GlobalConfig {
     ///
     /// upstream: daemon-parm.h - `daemon chroot` STRING, P_GLOBAL.
     pub(crate) daemon_chroot: Option<PathBuf>,
+    /// Path to the PEM-encoded TLS certificate chain file.
+    ///
+    /// upstream: stunnel-era `ssl cert` global directive. Must be set together
+    /// with `ssl_key`.
+    #[cfg(feature = "daemon-tls")]
+    pub(crate) ssl_cert: Option<PathBuf>,
+    /// Path to the PEM-encoded TLS private key file.
+    ///
+    /// upstream: stunnel-era `ssl key` global directive. Must be set together
+    /// with `ssl_cert`.
+    #[cfg(feature = "daemon-tls")]
+    pub(crate) ssl_key: Option<PathBuf>,
+    /// Path to the PEM-encoded CA certificate file for client verification.
+    ///
+    /// upstream: stunnel-era `ssl ca` global directive. Optional - when absent,
+    /// client certificates are not requested.
+    #[cfg(feature = "daemon-tls")]
+    pub(crate) ssl_ca: Option<PathBuf>,
 }
 
 impl GlobalConfig {
@@ -127,6 +145,55 @@ impl GlobalConfig {
     /// upstream: daemon-parm.h - `daemon chroot` STRING, P_GLOBAL.
     pub fn daemon_chroot(&self) -> Option<&Path> {
         self.daemon_chroot.as_deref()
+    }
+
+    /// Returns the path to the PEM-encoded TLS certificate chain file, if configured.
+    ///
+    /// upstream: stunnel-era `ssl cert` global directive. When set, `ssl_key`
+    /// must also be present.
+    #[cfg(feature = "daemon-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+    pub fn ssl_cert(&self) -> Option<&Path> {
+        self.ssl_cert.as_deref()
+    }
+
+    /// Returns the path to the PEM-encoded TLS private key file, if configured.
+    ///
+    /// upstream: stunnel-era `ssl key` global directive. When set, `ssl_cert`
+    /// must also be present.
+    #[cfg(feature = "daemon-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+    pub fn ssl_key(&self) -> Option<&Path> {
+        self.ssl_key.as_deref()
+    }
+
+    /// Returns the path to the PEM-encoded CA certificate file for client
+    /// verification, if configured.
+    ///
+    /// upstream: stunnel-era `ssl ca` global directive. Optional - only needed
+    /// for mutual TLS.
+    #[cfg(feature = "daemon-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+    pub fn ssl_ca(&self) -> Option<&Path> {
+        self.ssl_ca.as_deref()
+    }
+
+    /// Builds a [`TlsConfig`](crate::tls::TlsConfig) from the parsed global
+    /// TLS directives, if both `ssl cert` and `ssl key` are configured.
+    ///
+    /// Returns `None` when TLS is not configured (neither directive is set).
+    /// The caller receives a ready-to-use `TlsConfig` that can be passed
+    /// directly to [`build_tls_acceptor`](crate::tls::build_tls_acceptor).
+    #[cfg(feature = "daemon-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
+    pub fn tls_config(&self) -> Option<crate::tls::TlsConfig> {
+        let cert_path = self.ssl_cert.clone()?;
+        let key_path = self.ssl_key.clone()?;
+        Some(crate::tls::TlsConfig {
+            cert_path,
+            key_path,
+            client_ca_path: self.ssl_ca.clone(),
+        })
     }
 }
 

--- a/crates/daemon/src/rsyncd_config/tests.rs
+++ b/crates/daemon/src/rsyncd_config/tests.rs
@@ -867,3 +867,229 @@ fn module_fake_super_yes_parses_to_true_for_am_root_demotion() {
         "module 'plain' must default to fake_super() == false when the directive is absent"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TLS directive tests - gated behind `daemon-tls` feature
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "daemon-tls")]
+mod tls_directives {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_ssl_cert_and_key() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             ssl key = /etc/ssl/server.key\n\
+             [m]\npath = /srv/m\n",
+        );
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        assert_eq!(
+            config.global().ssl_cert(),
+            Some(Path::new("/etc/ssl/server.pem"))
+        );
+        assert_eq!(
+            config.global().ssl_key(),
+            Some(Path::new("/etc/ssl/server.key"))
+        );
+        assert!(config.global().ssl_ca().is_none());
+    }
+
+    #[test]
+    fn parse_ssl_cert_key_and_ca() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             ssl key = /etc/ssl/server.key\n\
+             ssl ca = /etc/ssl/ca.pem\n\
+             [m]\npath = /srv/m\n",
+        );
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        assert_eq!(
+            config.global().ssl_cert(),
+            Some(Path::new("/etc/ssl/server.pem"))
+        );
+        assert_eq!(
+            config.global().ssl_key(),
+            Some(Path::new("/etc/ssl/server.key"))
+        );
+        assert_eq!(
+            config.global().ssl_ca(),
+            Some(Path::new("/etc/ssl/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn tls_defaults_are_none() {
+        let file = write_config("[m]\npath = /srv/m\n");
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        assert!(config.global().ssl_cert().is_none());
+        assert!(config.global().ssl_key().is_none());
+        assert!(config.global().ssl_ca().is_none());
+    }
+
+    #[test]
+    fn tls_config_returns_none_when_not_configured() {
+        let file = write_config("[m]\npath = /srv/m\n");
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        assert!(config.global().tls_config().is_none());
+    }
+
+    #[test]
+    fn tls_config_returns_some_when_configured() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             ssl key = /etc/ssl/server.key\n\
+             [m]\npath = /srv/m\n",
+        );
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        let tls = config.global().tls_config().expect("tls_config is Some");
+        assert_eq!(tls.cert_path, Path::new("/etc/ssl/server.pem"));
+        assert_eq!(tls.key_path, Path::new("/etc/ssl/server.key"));
+        assert!(tls.client_ca_path.is_none());
+    }
+
+    #[test]
+    fn tls_config_includes_ca_when_set() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             ssl key = /etc/ssl/server.key\n\
+             ssl ca = /etc/ssl/ca.pem\n\
+             [m]\npath = /srv/m\n",
+        );
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        let tls = config.global().tls_config().expect("tls_config is Some");
+        assert_eq!(tls.cert_path, Path::new("/etc/ssl/server.pem"));
+        assert_eq!(tls.key_path, Path::new("/etc/ssl/server.key"));
+        assert_eq!(
+            tls.client_ca_path.as_deref(),
+            Some(Path::new("/etc/ssl/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn error_ssl_cert_without_key() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             [m]\npath = /srv/m\n",
+        );
+        let err = RsyncdConfig::from_file(file.path()).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'ssl cert' requires 'ssl key'"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_ssl_key_without_cert() {
+        let file = write_config(
+            "ssl key = /etc/ssl/server.key\n\
+             [m]\npath = /srv/m\n",
+        );
+        let err = RsyncdConfig::from_file(file.path()).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'ssl key' requires 'ssl cert'"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_ssl_ca_without_cert_and_key() {
+        let file = write_config(
+            "ssl ca = /etc/ssl/ca.pem\n\
+             [m]\npath = /srv/m\n",
+        );
+        let err = RsyncdConfig::from_file(file.path()).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'ssl ca' requires 'ssl cert' and 'ssl key'"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_ssl_cert_empty_value() {
+        let file = write_config(
+            "ssl cert = \n\
+             ssl key = /etc/ssl/server.key\n\
+             [m]\npath = /srv/m\n",
+        );
+        let err = RsyncdConfig::from_file(file.path()).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'ssl cert' must not be empty"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_ssl_key_empty_value() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             ssl key = \n\
+             [m]\npath = /srv/m\n",
+        );
+        let err = RsyncdConfig::from_file(file.path()).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'ssl key' must not be empty"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_ssl_ca_empty_value() {
+        let file = write_config(
+            "ssl cert = /etc/ssl/server.pem\n\
+             ssl key = /etc/ssl/server.key\n\
+             ssl ca = \n\
+             [m]\npath = /srv/m\n",
+        );
+        let err = RsyncdConfig::from_file(file.path()).expect_err("should fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'ssl ca' must not be empty"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn ssl_directives_inside_module_are_ignored() {
+        let file = write_config(
+            "[mod]\n\
+             path = /data\n\
+             ssl cert = /etc/ssl/server.pem\n\
+             ssl key = /etc/ssl/server.key\n\
+             ssl ca = /etc/ssl/ca.pem\n",
+        );
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        assert!(config.global().ssl_cert().is_none());
+        assert!(config.global().ssl_key().is_none());
+        assert!(config.global().ssl_ca().is_none());
+    }
+
+    #[test]
+    fn ssl_directives_with_whitespace_trimmed() {
+        let file = write_config(
+            "ssl cert =   /etc/ssl/server.pem  \n\
+             ssl key =   /etc/ssl/server.key  \n\
+             ssl ca =   /etc/ssl/ca.pem  \n\
+             [m]\npath = /srv/m\n",
+        );
+        let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+        assert_eq!(
+            config.global().ssl_cert(),
+            Some(Path::new("/etc/ssl/server.pem"))
+        );
+        assert_eq!(
+            config.global().ssl_key(),
+            Some(Path::new("/etc/ssl/server.key"))
+        );
+        assert_eq!(
+            config.global().ssl_ca(),
+            Some(Path::new("/etc/ssl/ca.pem"))
+        );
+    }
+}

--- a/crates/daemon/src/rsyncd_config/tests.rs
+++ b/crates/daemon/src/rsyncd_config/tests.rs
@@ -913,10 +913,7 @@ mod tls_directives {
             config.global().ssl_key(),
             Some(Path::new("/etc/ssl/server.key"))
         );
-        assert_eq!(
-            config.global().ssl_ca(),
-            Some(Path::new("/etc/ssl/ca.pem"))
-        );
+        assert_eq!(config.global().ssl_ca(), Some(Path::new("/etc/ssl/ca.pem")));
     }
 
     #[test]
@@ -1087,9 +1084,6 @@ mod tls_directives {
             config.global().ssl_key(),
             Some(Path::new("/etc/ssl/server.key"))
         );
-        assert_eq!(
-            config.global().ssl_ca(),
-            Some(Path::new("/etc/ssl/ca.pem"))
-        );
+        assert_eq!(config.global().ssl_ca(), Some(Path::new("/etc/ssl/ca.pem")));
     }
 }

--- a/crates/daemon/src/rsyncd_config/validation.rs
+++ b/crates/daemon/src/rsyncd_config/validation.rs
@@ -53,6 +53,20 @@ impl ConfigError {
         }
     }
 
+    /// Cross-field validation error not tied to a specific line.
+    ///
+    /// Used for post-parse checks that span multiple directives (e.g., `ssl cert`
+    /// requires `ssl key`).
+    #[cfg(feature = "daemon-tls")]
+    pub(crate) fn cross_field_error(path: &Path, message: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::Validation,
+            line: None,
+            message: message.into(),
+            path: Some(path.to_path_buf()),
+        }
+    }
+
     /// Returns the line number where the error occurred, if available.
     pub fn line(&self) -> Option<usize> {
         self.line


### PR DESCRIPTION
## Summary

- Add parsing support for `ssl cert`, `ssl key`, and `ssl ca` global directives in the rsyncd.conf parser, matching upstream rsync's stunnel-era naming convention
- All TLS config code is feature-gated behind `daemon-tls` - default builds are unaffected
- Cross-field validation ensures `ssl cert` and `ssl key` are always set together, and `ssl ca` requires the cert/key pair
- Convenience `tls_config()` method on `GlobalConfig` bridges parsed directives directly to the existing `TlsConfig` struct from TLS-6

## Details

**New directives (global-only):**

| Directive | Type | Required | Description |
|-----------|------|----------|-------------|
| `ssl cert` | path | With `ssl key` | PEM certificate chain |
| `ssl key` | path | With `ssl cert` | PEM private key |
| `ssl ca` | path | Optional | CA bundle for client cert verification (mTLS) |

**Files changed:**
- `sections.rs` - TLS fields on `GlobalConfig`, accessor methods, `tls_config()` bridge
- `parser.rs` - `ssl cert`/`ssl key`/`ssl ca` match arms in `parse_global_directive`, post-parse `validate_tls_config`
- `validation.rs` - `cross_field_error` constructor for line-independent validation errors
- `tests.rs` - 14 tests covering parsing, defaults, validation errors, empty values, whitespace trimming, module-scope isolation

## Test plan

- [ ] CI passes with default features (TLS code compiled out, no regressions)
- [ ] CI passes with `daemon-tls` feature (TLS parsing and validation exercised)
- [ ] Verify `ssl cert` without `ssl key` produces a validation error
- [ ] Verify `ssl key` without `ssl cert` produces a validation error
- [ ] Verify `ssl ca` alone produces a validation error
- [ ] Verify empty values for each directive produce parse errors
- [ ] Verify TLS directives inside module sections are silently ignored (global-only)