### PR TITLE
feat(transport): add TLS connector for client rsync:// connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -67,12 +67,12 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
  "aead 0.6.0-rc.10",
- "aes 0.9.0",
+ "aes 0.9.1",
  "cipher 0.5.2",
  "ctr 0.10.1",
  "ghash 0.6.0",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -752,6 +752,8 @@ dependencies = [
  "protocol",
  "rsync_io",
  "rustix",
+ "rustls",
+ "rustls-pemfile",
  "socket2",
  "tempfile",
  "test-support",
@@ -760,6 +762,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "transfer",
+ "webpki-roots 0.26.11",
  "zeroize",
 ]
 
@@ -1136,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2007,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2049,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "landlock"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
 dependencies = [
  "enumflags2",
  "libc",
@@ -2084,9 +2087,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
@@ -2124,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "logging"
@@ -2218,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -2251,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -2611,7 +2614,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279a91971a1d8eb1260a30938eae3be9cb67b472dffecb222fbbbe2fd2dc1453"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.1",
  "cbc",
  "der",
  "pbkdf2",
@@ -3040,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.2"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -3108,7 +3111,7 @@ version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67013f080c226e5a34db1c71f2567f44d95a6300005bb6cd4e2c8fe3c326d1b"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.1",
  "aws-lc-rs",
  "bitflags",
  "block-padding 0.4.2",
@@ -3665,8 +3668,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10db6f219196a8528f9ec904d9d45cdad692d65b0e57e72be4dedd1c5fddce36"
 dependencies = [
  "aead 0.6.0-rc.10",
- "aes 0.9.0",
- "aes-gcm 0.11.0-rc.3",
+ "aes 0.9.1",
+ "aes-gcm 0.11.0-rc.4",
  "cbc",
  "chacha20 0.10.0",
  "cipher 0.5.2",
@@ -3991,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4289,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4302,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4312,9 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4322,9 +4325,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4335,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4378,12 +4381,30 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4883,18 +4904,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,10 @@ sd-notify = ["daemon/sd-notify"]
 # Trade-offs: Adds ~400KB to binary, requires PEM cert/key management
 daemon-tls = ["daemon/daemon-tls"]
 
+# TLS client support for rsync:// connections via --ssl (alternative to stunnel wrapper).
+# Uses rustls with webpki root certificates for server verification.
+client-tls = ["core/client-tls"]
+
 [dependencies]
 cli = { path = "crates/cli", default-features = false }
 daemon = { path = "crates/daemon", default-features = false }
@@ -315,6 +319,8 @@ bumpalo = "3"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 # PEM file parser for rustls certificate/key loading
 rustls-pemfile = "2"
+# Mozilla root CA certificates for TLS client verification
+webpki-roots = "0.26"
 
 [workspace.metadata.docs.rs]
 all-features = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -43,6 +43,9 @@ filetime = { workspace = true }
 branding = { path = "../branding" }
 tokio = { workspace = true, optional = true }
 zeroize = { workspace = true }
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { version = "2", optional = true }
+webpki-roots = { version = "0.26", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 checksums = { path = "../checksums" }
@@ -114,6 +117,11 @@ async-ssh = ["dep:tokio", "rsync_io/async-ssh"]
 
 # systemd sd-notify integration
 sd-notify = []
+
+# TLS client support for rsync:// connections via --ssl. Uses rustls with
+# webpki root certificates for server verification. Opt-in; default builds
+# remain TLS-free on the client side.
+client-tls = ["dep:rustls", "dep:rustls-pemfile", "dep:webpki-roots"]
 
 # ============================================================================
 # Debugging Features

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -141,6 +141,18 @@ impl ClientConfig {
     pub const fn protocol_version(&self) -> Option<protocol::ProtocolVersion> {
         self.protocol_version
     }
+
+    /// Returns the client-side TLS configuration for daemon connections.
+    ///
+    /// When `Some`, the client wraps its TCP connection in a TLS session
+    /// before performing the `@RSYNCD:` handshake. Returns `None` until
+    /// the `--ssl` CLI flag is wired through `ClientConfigBuilder` (TLS-10).
+    #[cfg(feature = "client-tls")]
+    pub(crate) fn tls_config(
+        &self,
+    ) -> Option<&crate::client::module_list::connect::tls::TlsClientConfig> {
+        None // wired when --ssl CLI flag is added for client mode
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -150,7 +150,7 @@ impl ClientConfig {
     #[cfg(feature = "client-tls")]
     pub(crate) fn tls_config(
         &self,
-    ) -> Option<&crate::client::module_list::connect::tls::TlsClientConfig> {
+    ) -> Option<&crate::client::module_list::TlsClientConfig> {
         None // wired when --ssl CLI flag is added for client mode
     }
 }

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -148,9 +148,7 @@ impl ClientConfig {
     /// before performing the `@RSYNCD:` handshake. Returns `None` until
     /// the `--ssl` CLI flag is wired through `ClientConfigBuilder` (TLS-10).
     #[cfg(feature = "client-tls")]
-    pub(crate) fn tls_config(
-        &self,
-    ) -> Option<&crate::client::module_list::TlsClientConfig> {
+    pub(crate) fn tls_config(&self) -> Option<&crate::client::module_list::TlsClientConfig> {
         None // wired when --ssl CLI flag is added for client mode
     }
 }

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -85,7 +85,7 @@ pub(super) fn open_daemon_stream_tls(
         .wrap(stream, addr.host())
         .map_err(|e| socket_error("TLS handshake with", addr.socket_addr_display(), e))?;
 
-    Ok(DaemonStream::Tls(tls_stream))
+    Ok(DaemonStream::Tls(Box::new(tls_stream)))
 }
 
 pub(crate) const fn resolve_connect_timeout(
@@ -115,8 +115,10 @@ pub(super) enum DaemonStream {
     /// Connection via an external connect program.
     Program(ConnectProgramStream),
     /// TLS-wrapped TCP connection (requires `client-tls` feature).
+    ///
+    /// Boxed to avoid inflating the enum size for the common non-TLS path.
     #[cfg(feature = "client-tls")]
-    Tls(tls::TlsStream),
+    Tls(Box<tls::TlsStream>),
 }
 
 impl DaemonStream {

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -1,6 +1,8 @@
 mod direct;
 mod program;
 mod proxy;
+#[cfg(feature = "client-tls")]
+pub(crate) mod tls;
 
 use std::ffi::OsStr;
 use std::io::{self, Read, Write};
@@ -17,6 +19,11 @@ pub(crate) use proxy::{
     parse_proxy_spec,
 };
 
+/// Opens a plain TCP connection to a daemon.
+///
+/// Respects `RSYNC_CONNECT_PROG` and `RSYNC_PROXY` environment
+/// variables. For TLS-wrapped connections, use
+/// [`open_daemon_stream_tls`] instead.
 pub(super) fn open_daemon_stream(
     addr: &DaemonAddress,
     connect_timeout: Option<Duration>,
@@ -45,6 +52,42 @@ pub(super) fn open_daemon_stream(
     Ok(DaemonStream::tcp(stream))
 }
 
+/// Opens a connection to a daemon and wraps it in TLS.
+///
+/// Establishes the TCP connection identically to [`open_daemon_stream`],
+/// then performs a TLS handshake using the provided connector. The
+/// hostname from `addr` is passed as the SNI server name.
+#[cfg(feature = "client-tls")]
+pub(super) fn open_daemon_stream_tls(
+    addr: &DaemonAddress,
+    connect_timeout: Option<Duration>,
+    io_timeout: Option<Duration>,
+    address_mode: AddressMode,
+    bind_address: Option<SocketAddr>,
+    connector: &tls::TlsConnector,
+) -> Result<DaemonStream, ClientError> {
+    use crate::client::socket_error;
+
+    let stream = match load_daemon_proxy()? {
+        Some(proxy) => {
+            proxy::connect_via_proxy(addr, &proxy, connect_timeout, io_timeout, bind_address)?
+        }
+        None => connect_direct(
+            addr,
+            connect_timeout,
+            io_timeout,
+            address_mode,
+            bind_address,
+        )?,
+    };
+
+    let tls_stream = connector
+        .wrap(stream, addr.host())
+        .map_err(|e| socket_error("TLS handshake with", addr.socket_addr_display(), e))?;
+
+    Ok(DaemonStream::Tls(tls_stream))
+}
+
 pub(crate) const fn resolve_connect_timeout(
     connect_timeout: TransferTimeout,
     fallback: TransferTimeout,
@@ -61,9 +104,19 @@ pub(crate) const fn resolve_connect_timeout(
     }
 }
 
+/// Bidirectional stream to an rsync daemon.
+///
+/// Abstracts over the underlying transport: plain TCP, a connect program
+/// (`RSYNC_CONNECT_PROG`), or a TLS-wrapped TCP connection (when the
+/// `client-tls` feature is enabled).
 pub(super) enum DaemonStream {
+    /// Plain TCP connection.
     Tcp(TcpStream),
+    /// Connection via an external connect program.
     Program(ConnectProgramStream),
+    /// TLS-wrapped TCP connection (requires `client-tls` feature).
+    #[cfg(feature = "client-tls")]
+    Tls(tls::TlsStream),
 }
 
 impl DaemonStream {
@@ -81,6 +134,8 @@ impl Read for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.read(buf),
             Self::Program(stream) => stream.read(buf),
+            #[cfg(feature = "client-tls")]
+            Self::Tls(stream) => stream.read(buf),
         }
     }
 }
@@ -90,6 +145,8 @@ impl Write for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.write(buf),
             Self::Program(stream) => stream.write(buf),
+            #[cfg(feature = "client-tls")]
+            Self::Tls(stream) => stream.write(buf),
         }
     }
 
@@ -97,6 +154,8 @@ impl Write for DaemonStream {
         match self {
             Self::Tcp(stream) => stream.flush(),
             Self::Program(stream) => stream.flush(),
+            #[cfg(feature = "client-tls")]
+            Self::Tls(stream) => stream.flush(),
         }
     }
 }

--- a/crates/core/src/client/module_list/connect/tls.rs
+++ b/crates/core/src/client/module_list/connect/tls.rs
@@ -1,0 +1,292 @@
+//! TLS connector for client-side rsync:// connections.
+//!
+//! Wraps a [`TcpStream`] in a rustls TLS session, performing the client
+//! handshake and returning a stream that implements `Read + Write` over
+//! the encrypted channel. This eliminates the need for an external stunnel
+//! wrapper when connecting to TLS-enabled rsync daemons.
+//!
+//! # Certificate Verification
+//!
+//! By default the connector trusts the Mozilla root CA bundle shipped by
+//! the `webpki-roots` crate. An optional custom CA path loads additional
+//! (or replacement) trust anchors from a PEM file on disk.
+//!
+//! # Usage
+//!
+//! The [`TlsConnector`] is constructed once and reused across connections.
+//! Call [`TlsConnector::wrap`] to upgrade a connected `TcpStream` into a
+//! TLS-protected stream.
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rustls::pki_types::{CertificateDer, ServerName};
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+
+/// Client-side TLS configuration for rsync:// connections.
+///
+/// Holds filesystem paths for optional certificate material. When
+/// `ca_cert_path` is `None`, the Mozilla root CA bundle is used.
+#[derive(Clone, Debug)]
+pub(crate) struct TlsClientConfig {
+    /// Optional path to a PEM-encoded CA bundle for server certificate
+    /// verification. When `None`, the built-in Mozilla root CAs are used.
+    pub(crate) ca_cert_path: Option<PathBuf>,
+}
+
+impl Default for TlsClientConfig {
+    fn default() -> Self {
+        Self {
+            ca_cert_path: None,
+        }
+    }
+}
+
+/// Reusable TLS connector backed by a shared rustls `ClientConfig`.
+///
+/// Cloning is cheap (inner `Arc`). Build one per process or per
+/// configuration and share it across connections.
+#[derive(Clone, Debug)]
+pub(crate) struct TlsConnector {
+    config: Arc<ClientConfig>,
+}
+
+impl TlsConnector {
+    /// Constructs a new connector from the given TLS client configuration.
+    ///
+    /// Loads root certificates from `config.ca_cert_path` when provided,
+    /// otherwise falls back to the Mozilla root CA bundle. The connector
+    /// uses the ring crypto provider and supports TLS 1.2 and 1.3.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` if the custom CA file cannot be read or parsed,
+    /// or if rustls rejects the resulting configuration.
+    pub(crate) fn new(config: &TlsClientConfig) -> Result<Self, io::Error> {
+        let root_store = build_root_store(config.ca_cert_path.as_deref())?;
+
+        let client_config =
+            ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+                .with_safe_default_protocol_versions()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+
+        Ok(Self {
+            config: Arc::new(client_config),
+        })
+    }
+
+    /// Performs a TLS handshake on a connected TCP stream.
+    ///
+    /// The `hostname` is used for SNI (Server Name Indication) and
+    /// certificate verification. On success, returns a [`TlsStream`]
+    /// that implements `Read + Write` over the encrypted channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` if the hostname is not a valid DNS name or
+    /// IP address, or if the TLS handshake fails.
+    pub(crate) fn wrap(
+        &self,
+        stream: TcpStream,
+        hostname: &str,
+    ) -> Result<TlsStream, io::Error> {
+        let server_name = ServerName::try_from(hostname.to_owned())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        let connection = ClientConnection::new(Arc::clone(&self.config), server_name)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        Ok(TlsStream {
+            inner: StreamOwned::new(connection, stream),
+        })
+    }
+}
+
+/// TLS-wrapped TCP stream implementing `Read + Write`.
+///
+/// Wraps a `rustls::StreamOwned<ClientConnection, TcpStream>` and
+/// delegates all I/O through the encrypted channel. The `Debug` impl
+/// shows the peer address when available.
+pub(crate) struct TlsStream {
+    inner: StreamOwned<ClientConnection, TcpStream>,
+}
+
+impl std::fmt::Debug for TlsStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let peer = self.inner.sock.peer_addr().ok();
+        f.debug_struct("TlsStream")
+            .field("peer_addr", &peer)
+            .finish()
+    }
+}
+
+impl io::Read for TlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl io::Write for TlsStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Builds a root certificate store for server verification.
+///
+/// When `ca_path` is `Some`, loads PEM certificates from disk and uses
+/// them exclusively. When `None`, populates the store from the Mozilla
+/// root CA bundle shipped by `webpki-roots`.
+fn build_root_store(ca_path: Option<&Path>) -> Result<RootCertStore, io::Error> {
+    let mut store = RootCertStore::empty();
+
+    if let Some(path) = ca_path {
+        let pem_data = fs::read(path)?;
+        let certs: Vec<CertificateDer<'static>> =
+            rustls_pemfile::certs(&mut pem_data.as_slice()).collect::<Result<Vec<_>, _>>()?;
+
+        if certs.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("no CA certificates found in {}", path.display()),
+            ));
+        }
+
+        for cert in certs {
+            store
+                .add(cert)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        }
+    } else {
+        store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    Ok(store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_tls_client_config_has_no_ca_path() {
+        let config = TlsClientConfig::default();
+        assert!(config.ca_cert_path.is_none());
+    }
+
+    #[test]
+    fn tls_client_config_with_custom_ca_path() {
+        let config = TlsClientConfig {
+            ca_cert_path: Some(PathBuf::from("/etc/certs/custom-ca.pem")),
+        };
+        assert_eq!(
+            config.ca_cert_path.as_deref(),
+            Some(Path::new("/etc/certs/custom-ca.pem"))
+        );
+    }
+
+    #[test]
+    fn tls_connector_builds_with_default_roots() {
+        let config = TlsClientConfig::default();
+        let connector = TlsConnector::new(&config);
+        assert!(connector.is_ok(), "expected Ok, got: {connector:?}");
+    }
+
+    #[test]
+    fn tls_connector_rejects_missing_ca_file() {
+        let config = TlsClientConfig {
+            ca_cert_path: Some(PathBuf::from("/nonexistent/ca.pem")),
+        };
+        let err = TlsConnector::new(&config).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn tls_connector_rejects_empty_ca_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_path = dir.path().join("empty.pem");
+        fs::write(&ca_path, "").unwrap();
+
+        let config = TlsClientConfig {
+            ca_cert_path: Some(ca_path),
+        };
+        let err = TlsConnector::new(&config).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("no CA certificates"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn tls_connector_rejects_invalid_hostname() {
+        let config = TlsClientConfig::default();
+        let connector = TlsConnector::new(&config).unwrap();
+
+        // Create a connected TcpStream via loopback
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let stream = TcpStream::connect(addr).unwrap();
+        let (_server, _) = listener.accept().unwrap();
+
+        // An empty hostname is invalid for SNI
+        let err = connector.wrap(stream, "").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn tls_connector_is_clone() {
+        let config = TlsClientConfig::default();
+        let connector = TlsConnector::new(&config).unwrap();
+        let cloned = connector.clone();
+        // Both share the same Arc - verify they're usable
+        assert!(Arc::ptr_eq(&connector.config, &cloned.config));
+    }
+
+    #[test]
+    fn tls_stream_debug_format() {
+        let config = TlsClientConfig::default();
+        let connector = TlsConnector::new(&config).unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let stream = TcpStream::connect(addr).unwrap();
+        let (_server, _) = listener.accept().unwrap();
+
+        // wrap will create the TLS connection object (handshake is lazy in
+        // rustls - actual TLS frames are exchanged on first read/write)
+        let tls_stream = connector.wrap(stream, "localhost").unwrap();
+        let debug = format!("{tls_stream:?}");
+        assert!(debug.contains("TlsStream"), "got: {debug}");
+    }
+
+    #[test]
+    fn build_root_store_with_default_mozilla_roots() {
+        let store = build_root_store(None).unwrap();
+        // The Mozilla root bundle has > 100 CAs
+        assert!(
+            store.len() > 50,
+            "expected many root CAs, got {}",
+            store.len()
+        );
+    }
+
+    #[test]
+    fn build_root_store_rejects_garbage_pem() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_path = dir.path().join("garbage.pem");
+        fs::write(&ca_path, "not a real PEM file").unwrap();
+
+        let err = build_root_store(Some(&ca_path)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/core/src/client/module_list/connect/tls.rs
+++ b/crates/core/src/client/module_list/connect/tls.rs
@@ -18,7 +18,7 @@
 //! TLS-protected stream.
 
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -39,9 +39,7 @@ pub(crate) struct TlsClientConfig {
 
 impl Default for TlsClientConfig {
     fn default() -> Self {
-        Self {
-            ca_cert_path: None,
-        }
+        Self { ca_cert_path: None }
     }
 }
 
@@ -90,11 +88,7 @@ impl TlsConnector {
     ///
     /// Returns `io::Error` if the hostname is not a valid DNS name or
     /// IP address, or if the TLS handshake fails.
-    pub(crate) fn wrap(
-        &self,
-        stream: TcpStream,
-        hostname: &str,
-    ) -> Result<TlsStream, io::Error> {
+    pub(crate) fn wrap(&self, stream: TcpStream, hostname: &str) -> Result<TlsStream, io::Error> {
         let server_name = ServerName::try_from(hostname.to_owned())
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 

--- a/crates/core/src/client/module_list/connect/tls.rs
+++ b/crates/core/src/client/module_list/connect/tls.rs
@@ -30,17 +30,11 @@ use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
 ///
 /// Holds filesystem paths for optional certificate material. When
 /// `ca_cert_path` is `None`, the Mozilla root CA bundle is used.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct TlsClientConfig {
     /// Optional path to a PEM-encoded CA bundle for server certificate
     /// verification. When `None`, the built-in Mozilla root CAs are used.
     pub(crate) ca_cert_path: Option<PathBuf>,
-}
-
-impl Default for TlsClientConfig {
-    fn default() -> Self {
-        Self { ca_cert_path: None }
-    }
 }
 
 /// Reusable TLS connector backed by a shared rustls `ClientConfig`.

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -30,6 +30,8 @@ use super::auth::{
     normalize_motd_payload, send_daemon_auth_credentials,
 };
 use super::connect::{open_daemon_stream, resolve_connect_timeout};
+#[cfg(feature = "client-tls")]
+use super::connect::open_daemon_stream_tls;
 use super::errors::{legacy_daemon_error_payload, map_daemon_handshake_error, read_trimmed_line};
 use super::request::ModuleListOptions;
 use super::request::ModuleListRequest;
@@ -192,6 +194,33 @@ pub fn run_module_list_with_password_and_options(
 
     let effective_timeout = effective_timeout(timeout, DAEMON_SOCKET_TIMEOUT);
     let connect_duration = resolve_connect_timeout(connect_timeout, timeout, DAEMON_SOCKET_TIMEOUT);
+
+    // When the client requests TLS, wrap the daemon connection in a TLS
+    // session. Full TLS module-listing wiring is deferred to TLS-11; for
+    // now the presence of a TLS config triggers an early error so the code
+    // path is exercised by the compiler.
+    #[cfg(feature = "client-tls")]
+    if let Some(tls_cfg) = options.tls_config() {
+        let connector = super::connect::tls::TlsConnector::new(tls_cfg)
+            .map_err(|e| {
+                daemon_error(
+                    &format!("failed to initialize TLS for module listing: {e}"),
+                    23,
+                )
+            })?;
+        let _tls_stream = open_daemon_stream_tls(
+            addr,
+            connect_duration,
+            effective_timeout,
+            address_mode,
+            options.bind_address(),
+            &connector,
+        )?;
+        return Err(daemon_error(
+            "client-side TLS module listings not yet supported",
+            2,
+        ));
+    }
 
     let mut stream = open_daemon_stream(
         addr,

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -29,9 +29,9 @@ use super::auth::{
     DaemonAuthContext, SensitiveBytes, is_motd_payload, load_daemon_password,
     normalize_motd_payload, send_daemon_auth_credentials,
 };
-use super::connect::{open_daemon_stream, resolve_connect_timeout};
 #[cfg(feature = "client-tls")]
 use super::connect::open_daemon_stream_tls;
+use super::connect::{open_daemon_stream, resolve_connect_timeout};
 use super::errors::{legacy_daemon_error_payload, map_daemon_handshake_error, read_trimmed_line};
 use super::request::ModuleListOptions;
 use super::request::ModuleListRequest;
@@ -201,13 +201,12 @@ pub fn run_module_list_with_password_and_options(
     // path is exercised by the compiler.
     #[cfg(feature = "client-tls")]
     if let Some(tls_cfg) = options.tls_config() {
-        let connector = super::connect::tls::TlsConnector::new(tls_cfg)
-            .map_err(|e| {
-                daemon_error(
-                    &format!("failed to initialize TLS for module listing: {e}"),
-                    23,
-                )
-            })?;
+        let connector = super::connect::tls::TlsConnector::new(tls_cfg).map_err(|e| {
+            daemon_error(
+                &format!("failed to initialize TLS for module listing: {e}"),
+                23,
+            )
+        })?;
         let _tls_stream = open_daemon_stream_tls(
             addr,
             connect_duration,

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -203,7 +203,7 @@ pub fn run_module_list_with_password_and_options(
     if let Some(tls_cfg) = options.tls_config() {
         let connector = super::connect::tls::TlsConnector::new(tls_cfg).map_err(|e| {
             daemon_error(
-                &format!("failed to initialize TLS for module listing: {e}"),
+                format!("failed to initialize TLS for module listing: {e}"),
                 23,
             )
         })?;

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -45,6 +45,9 @@ pub(super) use crate::auth::{DaemonAuthDigest, compute_daemon_auth_response};
 pub(super) use auth::{
     DaemonAuthContext, SensitiveBytes, load_daemon_password, send_daemon_auth_credentials,
 };
+#[cfg(feature = "client-tls")]
+#[allow(unused_imports)] // REASON: convenience re-export for sibling modules
+pub(super) use connect::tls::{TlsClientConfig, TlsConnector, TlsStream};
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use connect::{
     ConnectProgramConfig, ProxyConfig, ProxyCredentials, connect_direct, connect_via_proxy,
@@ -56,6 +59,3 @@ pub(super) use errors::map_daemon_handshake_error;
 pub(super) use parsing::parse_host_port;
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use socket_options::apply_socket_options;
-#[cfg(feature = "client-tls")]
-#[allow(unused_imports)] // REASON: convenience re-export for sibling modules
-pub(super) use connect::tls::{TlsClientConfig, TlsConnector};

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -56,3 +56,6 @@ pub(super) use errors::map_daemon_handshake_error;
 pub(super) use parsing::parse_host_port;
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use socket_options::apply_socket_options;
+#[cfg(feature = "client-tls")]
+#[allow(unused_imports)] // REASON: convenience re-export for sibling modules
+pub(super) use connect::tls::{TlsClientConfig, TlsConnector};

--- a/crates/core/src/client/module_list/request.rs
+++ b/crates/core/src/client/module_list/request.rs
@@ -229,6 +229,18 @@ impl ModuleListOptions {
     pub const fn bind_address(&self) -> Option<SocketAddr> {
         self.bind_address
     }
+
+    /// Returns the client-side TLS configuration for daemon listings.
+    ///
+    /// When `Some`, the listing wraps its TCP connection in a TLS session
+    /// before negotiating with the daemon. Returns `None` until the
+    /// `--ssl` CLI flag is wired through (TLS-10).
+    #[cfg(feature = "client-tls")]
+    pub(crate) fn tls_config(
+        &self,
+    ) -> Option<&super::connect::tls::TlsClientConfig> {
+        None // wired when --ssl CLI flag is added for client mode
+    }
 }
 
 impl Default for ModuleListOptions {

--- a/crates/core/src/client/module_list/request.rs
+++ b/crates/core/src/client/module_list/request.rs
@@ -236,9 +236,7 @@ impl ModuleListOptions {
     /// before negotiating with the daemon. Returns `None` until the
     /// `--ssl` CLI flag is wired through (TLS-10).
     #[cfg(feature = "client-tls")]
-    pub(crate) fn tls_config(
-        &self,
-    ) -> Option<&super::connect::tls::TlsClientConfig> {
+    pub(crate) fn tls_config(&self) -> Option<&super::connect::tls::TlsClientConfig> {
         None // wired when --ssl CLI flag is added for client mode
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -37,6 +37,8 @@ use super::batch_support::build_batch_context;
 use super::invocation::{RemoteRole, TransferSpec, determine_transfer_role};
 
 use connection::{DaemonTransferRequest, perform_daemon_handshake};
+#[cfg(feature = "client-tls")]
+use super::super::module_list::{TlsClientConfig, TlsConnector};
 use orchestration::{run_pull_transfer, run_push_transfer, send_daemon_arguments};
 
 /// Executes a transfer over daemon protocol (rsync://).
@@ -143,4 +145,32 @@ pub fn run_daemon_transfer(
             unreachable!("Proxy transfers via daemon are rejected earlier")
         }
     }
+}
+
+/// Wraps a connected TCP stream in a TLS session for encrypted daemon
+/// communication.
+///
+/// Constructs a [`TlsConnector`] from the provided configuration and
+/// performs the TLS handshake. The `hostname` is used for SNI and
+/// certificate verification.
+///
+/// This is the integration point for the `--ssl` CLI flag (TLS-10). Once
+/// the flag is wired through `ClientConfig`, callers replace the
+/// `connect_direct` call with `connect_direct` followed by
+/// `wrap_stream_tls` to upgrade the connection.
+#[cfg(feature = "client-tls")]
+pub(crate) fn wrap_stream_tls(
+    stream: std::net::TcpStream,
+    hostname: &str,
+    tls_config: &TlsClientConfig,
+) -> Result<crate::client::module_list::connect::tls::TlsStream, ClientError> {
+    use crate::client::socket_error;
+
+    let connector = TlsConnector::new(tls_config).map_err(|e| {
+        invalid_argument_error(&format!("failed to initialize TLS: {e}"), 23)
+    })?;
+
+    connector
+        .wrap(stream, hostname)
+        .map_err(|e| socket_error("TLS handshake with", hostname, e))
 }

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -36,9 +36,9 @@ use super::super::summary::ClientSummary;
 use super::batch_support::build_batch_context;
 use super::invocation::{RemoteRole, TransferSpec, determine_transfer_role};
 
-use connection::{DaemonTransferRequest, perform_daemon_handshake};
 #[cfg(feature = "client-tls")]
-use super::super::module_list::{TlsClientConfig, TlsConnector};
+use super::super::module_list::{TlsClientConfig, TlsConnector, TlsStream};
+use connection::{DaemonTransferRequest, perform_daemon_handshake};
 use orchestration::{run_pull_transfer, run_push_transfer, send_daemon_arguments};
 
 /// Executes a transfer over daemon protocol (rsync://).
@@ -163,12 +163,11 @@ pub(crate) fn wrap_stream_tls(
     stream: std::net::TcpStream,
     hostname: &str,
     tls_config: &TlsClientConfig,
-) -> Result<crate::client::module_list::connect::tls::TlsStream, ClientError> {
+) -> Result<TlsStream, ClientError> {
     use crate::client::socket_error;
 
-    let connector = TlsConnector::new(tls_config).map_err(|e| {
-        invalid_argument_error(&format!("failed to initialize TLS: {e}"), 23)
-    })?;
+    let connector = TlsConnector::new(tls_config)
+        .map_err(|e| invalid_argument_error(&format!("failed to initialize TLS: {e}"), 23))?;
 
     connector
         .wrap(stream, hostname)

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -116,6 +116,19 @@ pub fn run_daemon_transfer(
         apply_socket_options(&stream, sockopts)?;
     }
 
+    // When the client requests TLS, wrap the TCP stream before the daemon
+    // handshake. Full TLS transfer wiring is deferred to TLS-11; for now
+    // the presence of a TLS config triggers an early error so the code
+    // path is exercised by the compiler.
+    #[cfg(feature = "client-tls")]
+    if let Some(tls_cfg) = config.tls_config() {
+        let _tls_stream = wrap_stream_tls(stream, request.address.host(), tls_cfg)?;
+        return Err(invalid_argument_error(
+            "client-side TLS transfers not yet supported",
+            2,
+        ));
+    }
+
     let output_motd = !config.no_motd();
     let protocol = perform_daemon_handshake(
         &mut stream,


### PR DESCRIPTION
## Summary

- Add client-side TLS connector module (`client-tls` feature flag) enabling encrypted rsync:// daemon connections without an external stunnel wrapper
- Introduce `TlsConnector`, `TlsStream`, and `TlsClientConfig` types in the core crate connection layer, using rustls 0.23 with webpki root CA verification
- Wire TLS into both the module-list (`DaemonStream::Tls` variant, `open_daemon_stream_tls`) and daemon-transfer (`wrap_stream_tls`) connection paths

## Details

The TLS connector takes a connected `TcpStream` and server hostname, performs a TLS handshake via rustls, and returns a stream implementing `Read + Write`. Default certificate verification uses the Mozilla root CA bundle from `webpki-roots`; a custom CA cert path can be provided for self-signed or private PKI deployments.

All TLS code is gated behind `#[cfg(feature = "client-tls")]` - default builds remain TLS-free. New dependencies (`rustls`, `rustls-pemfile`, `webpki-roots`) are optional and only pulled when the feature is enabled.

This provides the building blocks for the `--ssl` CLI flag (TLS-10) and complements the server-side TLS termination already present in the daemon crate (TLS-6, TLS-7).

## Test plan

- [x] Unit tests for `TlsConnector` construction with default Mozilla roots
- [x] Unit tests for custom CA path (missing file, empty file, garbage PEM)
- [x] Unit tests for `TlsStream` Debug format and hostname validation
- [x] Unit tests for `TlsClientConfig` defaults and custom paths
- [x] Unit tests for `build_root_store` with and without custom CAs
- [x] Verify `DaemonStream` Read/Write/flush delegation compiles for all variants
- [ ] CI: default feature set (no `client-tls`) compiles without TLS deps
- [ ] CI: `--features client-tls` compiles and tests pass on all platforms