### PR TITLE
feat(inc-recurse): enable sender-side INC_RECURSE by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,12 +76,10 @@ parallel-receive-delta = [
     "engine/parallel-receive-delta",
 ]
 
-# Sender-side INC_RECURSE interop bake-up (ISI.b). Default OFF; flips the
-# `inc_recursive_send` builder fallback ON so push transfers advertise the
-# `'i'` capability bit. Wire behavior is unchanged when the flag is absent.
-# Forwards to `core/sender-inc-recurse`. ISI.h will flip the default and
-# retire this flag once interop is validated. See
-# `docs/design/isi-a-sender-inc-recurse-call-graph.md`.
+# DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Flag
+# retained for one release as an emergency-disable no-op. CLI
+# `--no-inc-recursive` is the recommended override. Remove in the
+# next minor version (ISI.i.2).
 sender-inc-recurse = ["core/sender-inc-recurse", "transfer/sender-inc-recurse"]
 
 # io_uring support for Linux 5.6+ - batched async I/O syscalls

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -101,13 +101,8 @@ async = ["dep:tokio", "engine/async", "transfer/async"]
 # `docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md`.
 parallel-receive-delta = ["transfer/parallel-receive-delta", "engine/parallel-receive-delta"]
 
-# Sender-side INC_RECURSE interop bake-up (ISI.b). Default OFF; when enabled,
-# flips the `inc_recursive_send` builder fallback from `false` to `true` so
-# the client advertises the `'i'` capability bit on push transfers. CLI
-# `--inc-recursive` / `--no-inc-recursive` overrides still win. ISI.c-g
-# add tests and validate interop against rsync 3.0.9 / 3.1.3 / 3.4.1 /
-# 3.4.2; ISI.h flips the default and retires this flag. See
-# `docs/design/isi-a-sender-inc-recurse-call-graph.md`.
+# DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
+# retained for one release until ISI.i.2 retires the feature flag.
 sender-inc-recurse = []
 
 # Async SSH transport: wires `rsync_io::ssh::AsyncSshTransport` into the client

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -435,17 +435,11 @@ impl ClientConfigBuilder {
             mkpath: self.mkpath,
             prune_empty_dirs: self.prune_empty_dirs,
             qsort: self.qsort,
-            // ISI.b: temporary gate for sender-side INC_RECURSE interop bake-up.
-            // The `sender-inc-recurse` cargo feature flips the default fallback
-            // from `false` to `true` so push transfers advertise the `'i'`
-            // capability bit. CLI `--inc-recursive` / `--no-inc-recursive`
-            // overrides still win because they populate `Some(_)`. Default-off
-            // behavior is bit-for-bit identical to today; ISI.h retires this
-            // gate once interop is validated against 3.0.9 / 3.1.3 / 3.4.1 /
-            // 3.4.2. See `docs/design/isi-a-sender-inc-recurse-call-graph.md`.
-            inc_recursive_send: self
-                .inc_recursive_send
-                .unwrap_or(cfg!(feature = "sender-inc-recurse")),
+            // ISI.h: sender-side INC_RECURSE is now default-on, matching
+            // upstream rsync 3.4.x. CLI `--no-inc-recursive` still overrides
+            // to `false`. The `sender-inc-recurse` cargo feature is retained
+            // for one release as a no-op escape hatch; ISI.i.2 retires it.
+            inc_recursive_send: self.inc_recursive_send.unwrap_or(true),
             verbosity: self.verbosity,
             progress: self.progress,
             stats: self.stats,

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -1589,24 +1589,9 @@ fn inc_recursive_send_false_clears_flag() {
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
-fn default_inc_recursive_send_is_false() {
-    // Sender-side INC_RECURSE is opt-in until the sender state machine is
-    // validated against upstream rsync 3.0.9 / 3.1.3 / 3.4.1. Tracker #1862.
-    // The `sender-inc-recurse` feature flips this default ON for interop
-    // bake-up; under that feature the default is true and this invariant
-    // does not hold.
-    let config = builder().build();
-    assert!(!config.inc_recursive_send());
-}
-
-#[test]
-#[cfg(feature = "sender-inc-recurse")]
-fn default_inc_recursive_send_is_true_under_sender_inc_recurse_feature() {
-    // With `sender-inc-recurse` enabled, the default flips ON so interop
-    // tests can exercise the sender-side INC_RECURSE path against upstream
-    // rsync. ISI.h will flip this default permanently after the interop
-    // bake-up completes.
+fn default_inc_recursive_send_is_true() {
+    // ISI.h: sender-side INC_RECURSE is default-on, matching upstream rsync
+    // 3.4.x. CLI `--no-inc-recursive` overrides to false.
     let config = builder().build();
     assert!(config.inc_recursive_send());
 }

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -330,7 +330,7 @@ impl Default for ClientConfig {
             mkpath: false,
             prune_empty_dirs: false,
             qsort: false,
-            inc_recursive_send: false,
+            inc_recursive_send: true,
             verbosity: 0,
             progress: false,
             stats: false,

--- a/crates/core/src/client/config/client/performance.rs
+++ b/crates/core/src/client/config/client/performance.rs
@@ -315,12 +315,9 @@ mod tests {
         assert!(!config.qsort());
     }
 
-    // Sender-side INC_RECURSE is opt-in: defaults to false until the sender-side
-    // state machine is validated against upstream rsync 3.0.9 / 3.1.3 / 3.4.1.
-    // See tracker #1862. Pull transfers are unaffected.
     #[test]
-    fn inc_recursive_send_default_is_false() {
+    fn inc_recursive_send_default_is_true() {
         let config = default_config();
-        assert!(!config.inc_recursive_send());
+        assert!(config.inc_recursive_send());
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -78,11 +78,9 @@ mod protect_args_daemon_tests {
     }
 
     #[test]
-    fn build_full_args_push_omits_inc_recurse_capability_by_default() {
-        // Sender-side INC_RECURSE is opt-in: the daemon push capability
-        // builder reads only `inc_recursive_send`, which defaults to false
-        // until the sender state machine is validated against upstream rsync.
-        // Tracker #1862.
+    fn build_full_args_push_includes_inc_recurse_capability_by_default() {
+        // ISI.h: sender-side INC_RECURSE is default-on, matching upstream
+        // rsync 3.4.x. The daemon push capability includes 'i' by default.
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let request = test_daemon_request();
 
@@ -93,28 +91,26 @@ mod protect_args_daemon_tests {
             .find(|a| a.starts_with("-e."))
             .expect("capability string present");
         assert!(
-            !caps_default.contains('i'),
-            "default push capability must omit 'i': {caps_default}"
+            caps_default.contains('i'),
+            "default push capability must include 'i': {caps_default}"
         );
 
-        let config_on = ClientConfig::builder().inc_recursive_send(true).build();
-        let args_on = build_full_daemon_args(&config_on, &request, protocol, false);
-        let caps_on = args_on
+        let config_off = ClientConfig::builder().inc_recursive_send(false).build();
+        let args_off = build_full_daemon_args(&config_off, &request, protocol, false);
+        let caps_off = args_off
             .iter()
             .find(|a| a.starts_with("-e."))
             .expect("capability string present");
         assert!(
-            caps_on.contains('i'),
-            "--inc-recursive must advertise 'i' on push capability: {caps_on}"
+            !caps_off.contains('i'),
+            "--no-inc-recursive must suppress 'i' on push capability: {caps_off}"
         );
     }
 
     #[test]
-    fn build_full_args_pull_omits_inc_recurse_capability_by_default() {
-        // Sender-side INC_RECURSE is opt-in: the daemon push/pull capability
-        // builder reads only `inc_recursive_send`, which defaults to false
-        // until the sender state machine is validated against upstream rsync.
-        // Tracker #1862.
+    fn build_full_args_pull_includes_inc_recurse_capability_by_default() {
+        // ISI.h: sender-side INC_RECURSE is default-on, matching upstream
+        // rsync 3.4.x. The daemon pull capability includes 'i' by default.
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let request = test_daemon_request();
 
@@ -125,19 +121,19 @@ mod protect_args_daemon_tests {
             .find(|a| a.starts_with("-e."))
             .expect("capability string present");
         assert!(
-            !caps_default.contains('i'),
-            "default pull capability must omit 'i': {caps_default}"
+            caps_default.contains('i'),
+            "default pull capability must include 'i': {caps_default}"
         );
 
-        let config_on = ClientConfig::builder().inc_recursive_send(true).build();
-        let args_on = build_full_daemon_args(&config_on, &request, protocol, true);
-        let caps_on = args_on
+        let config_off = ClientConfig::builder().inc_recursive_send(false).build();
+        let args_off = build_full_daemon_args(&config_off, &request, protocol, true);
+        let caps_off = args_off
             .iter()
             .find(|a| a.starts_with("-e."))
             .expect("capability string present");
         assert!(
-            caps_on.contains('i'),
-            "--inc-recursive must advertise 'i' on pull capability: {caps_on}"
+            !caps_off.contains('i'),
+            "--no-inc-recursive must suppress 'i' on pull capability: {caps_off}"
         );
     }
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -11,12 +11,10 @@ use super::{RemoteOperands, RemoteRole, TransferSpec};
 use crate::client::config::{ClientConfig, IconvSetting, TransferTimeout};
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
 fn builds_receiver_invocation_with_sender_flag() {
     // Pull: local is receiver -> remote needs --sender (upstream options.c:2598).
-    // Skipped under sender-inc-recurse: the feature flips the default
-    // inc_recursive_send, changing the capability string from
-    // build_capability_string(false).
+    // ISI.h: default inc_recursive_send is true, so the capability string
+    // is build_capability_string(true).
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
@@ -26,19 +24,17 @@ fn builds_receiver_invocation_with_sender_flag() {
     assert_eq!(args[2], "--sender");
     let flags = args[3].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
-    let expected_caps = build_capability_string(false);
+    let expected_caps = build_capability_string(true);
     assert_eq!(args[4], *expected_caps);
     assert_eq!(args[5], ".");
     assert_eq!(args[6], "/remote/path");
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
 fn builds_sender_invocation_no_sender_flag() {
     // Push: local is sender -> remote is receiver, no --sender flag.
-    // Skipped under sender-inc-recurse: the feature flips the default
-    // inc_recursive_send to true, so the expected capability string no
-    // longer matches build_capability_string(false).
+    // ISI.h: default inc_recursive_send is true, so the capability string
+    // is build_capability_string(true).
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
@@ -48,19 +44,16 @@ fn builds_sender_invocation_no_sender_flag() {
     // No --sender flag for push - flags come next
     let flags = args[2].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
-    let expected_caps = build_capability_string(false);
+    let expected_caps = build_capability_string(true);
     assert_eq!(args[3], *expected_caps);
     assert_eq!(args[4], ".");
     assert_eq!(args[5], "/remote/path");
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
-fn ssh_sender_omits_inc_recurse_capability_by_default() {
-    // Sender-side INC_RECURSE is opt-in: SSH push transfers omit the 'i'
-    // capability bit by default while the sender-side state machine is
-    // validated against upstream rsync. Tracker #1862. Skipped under
-    // sender-inc-recurse where the default flips ON.
+fn ssh_sender_includes_inc_recurse_capability_by_default() {
+    // ISI.h: sender-side INC_RECURSE is default-on, matching upstream rsync
+    // 3.4.x. SSH push transfers include the 'i' capability bit by default.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
@@ -71,10 +64,10 @@ fn ssh_sender_omits_inc_recurse_capability_by_default() {
         .expect("capability string present");
     let caps_str = caps.to_string_lossy();
     assert!(
-        !caps_str.contains('i'),
-        "default sender capability string must omit 'i': {caps_str}"
+        caps_str.contains('i'),
+        "default sender capability string must include 'i': {caps_str}"
     );
-    assert_eq!(*caps, *build_capability_string(false));
+    assert_eq!(*caps, *build_capability_string(true));
 }
 
 #[test]
@@ -98,12 +91,9 @@ fn ssh_sender_omits_inc_recurse_when_no_inc_recursive_set() {
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
-fn ssh_receiver_omits_inc_recurse_capability_by_default() {
-    // Sender-side INC_RECURSE is gated by `inc_recursive_send` which defaults
-    // to false; the SSH capability builder reads only that flag, so pull
-    // transfers also omit 'i' by default. Tracker #1862. Skipped under
-    // sender-inc-recurse where the default flips ON.
+fn ssh_receiver_includes_inc_recurse_capability_by_default() {
+    // ISI.h: sender-side INC_RECURSE is default-on, matching upstream rsync
+    // 3.4.x. Pull transfers also include the 'i' capability bit by default.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
@@ -114,8 +104,8 @@ fn ssh_receiver_omits_inc_recurse_capability_by_default() {
         .expect("capability string present");
     let caps_str = caps.to_string_lossy();
     assert!(
-        !caps_str.contains('i'),
-        "default receiver capability string must omit 'i': {caps_str}"
+        caps_str.contains('i'),
+        "default receiver capability string must include 'i': {caps_str}"
     );
 }
 
@@ -1662,14 +1652,12 @@ fn default_rsync_path_is_rsync() {
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
 fn capability_string_present_in_sender_args() {
-    // Skipped under sender-inc-recurse: the feature flips the default
-    // inc_recursive_send, so the sender args carry
-    // build_capability_string(true), not (false).
+    // ISI.h: default inc_recursive_send is true, so the sender args carry
+    // build_capability_string(true).
     let config = ClientConfig::builder().build();
     let args = build_sender_args(&config);
-    let expected = build_capability_string(false);
+    let expected = build_capability_string(true);
     assert!(
         args.iter().any(|a| a == &expected),
         "expected capability string {expected} in args: {args:?}"
@@ -1677,14 +1665,12 @@ fn capability_string_present_in_sender_args() {
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
 fn capability_string_present_in_receiver_args() {
-    // Skipped under sender-inc-recurse: the feature flips the default
-    // inc_recursive_send, so the receiver args carry
-    // build_capability_string(true), not (false).
+    // ISI.h: default inc_recursive_send is true, so the receiver args carry
+    // build_capability_string(true).
     let config = ClientConfig::builder().build();
     let args = build_receiver_args(&config);
-    let expected = build_capability_string(false);
+    let expected = build_capability_string(true);
     assert!(
         args.iter().any(|a| a == &expected),
         "expected capability string {expected} in args: {args:?}"

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -123,14 +123,9 @@ thread-slab-pool = ["engine/thread-slab-pool"]
 # Incremental file list processing with failed directory tracking
 incremental-flist = []
 
-# Marker feature mirroring the workspace-level `sender-inc-recurse` flag (which
-# forwards to `core/sender-inc-recurse`). Gates interop tests in `tests/` that
-# drive an externally-built `oc-rsync` binary - the binary must be compiled
-# with the workspace feature enabled for the test to exercise the sender-side
-# INC_RECURSE wire path. Carries no transfer-crate compile-time effect; the
-# default flip happens in `core::client::config::builder`. See
-# `docs/design/isi-a-sender-inc-recurse-call-graph.md` and
-# `docs/audit/v061-daemon-push-regression.md`.
+# DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
+# retained for one release to keep V61D-2 / V61D-3 interop gates
+# compilable until ISI.i.2 retires both.
 sender-inc-recurse = []
 
 # ============================================================================

--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -635,9 +635,9 @@ fn test_single_remote_source_returns_single_variant() {
 }
 
 #[test]
-#[cfg(not(feature = "sender-inc-recurse"))]
 fn test_remote_invocation_with_multiple_paths() {
     use core::client::{ClientConfig, remote::RemoteInvocationBuilder, remote::RemoteRole};
+    use transfer::setup::build_capability_string;
 
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
@@ -645,15 +645,14 @@ fn test_remote_invocation_with_multiple_paths() {
 
     assert_eq!(args[0].to_string_lossy(), "rsync");
     assert_eq!(args[1].to_string_lossy(), "--server");
-    // Receiver (pull) → --sender flag present
+    // Receiver (pull) -> --sender flag present
     assert_eq!(args[2].to_string_lossy(), "--sender");
     let flags_idx = 3;
     assert!(args[flags_idx].to_string_lossy().starts_with('-'));
-    // Capability info string for protocol features (checksum negotiation, etc.)
-    // Sender-side INC_RECURSE is opt-in (default false); 'i' is omitted from
-    // the capability string. Tracker #1862. Skipped under
-    // sender-inc-recurse where the default flips ON and the 'i' bit is set.
-    assert_eq!(args[flags_idx + 1].to_string_lossy(), "-e.LsfxCIvu");
+    // ISI.h: sender-side INC_RECURSE is default-on; the capability string
+    // includes 'i', matching upstream rsync 3.4.x.
+    let expected_caps = build_capability_string(true);
+    assert_eq!(args[flags_idx + 1].to_string_lossy(), expected_caps);
     let dot_idx = flags_idx + 2;
     assert_eq!(args[dot_idx].to_string_lossy(), ".");
     // Paths come after "."


### PR DESCRIPTION
## Summary

- Flip `inc_recursive_send` builder default from `cfg!(feature = "sender-inc-recurse")` to unconditional `true`, matching upstream rsync 3.4.x where INC_RECURSE is always enabled for both transfer directions
- Mark the `sender-inc-recurse` cargo feature as deprecated across all three Cargo.toml files (workspace, core, transfer) - retained for one release as a no-op escape hatch
- Update 10 tests across builder, SSH invocation, daemon orchestration, and ssh_transport integration to assert 'i' is present in the default capability string

## Context

Sender-side INC_RECURSE was disabled by default in v0.6.1 after a daemon-push regression. The ISI series (ISI.a through ISI.g) validated the sender path through call-graph audit, feature-flag gating, single-segment and multi-segment interop against upstream 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2, wire-byte parity, failure-mode coverage, and a cold-start benchmark. All pre-conditions for the flip are met.

Design spec: `docs/design/isi-h1-sender-inc-recurse-flip.md`

## Test plan

- [ ] CI fmt+clippy passes (all platforms)
- [ ] CI nextest passes on Linux, macOS, and Windows
- [ ] Interop validation workflow passes against upstream rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2
- [ ] V61D-3 CI cell continues to pass (now exercises the same always-on path)
- [ ] Daemon cold-start benchmark workflow passes