### PR TITLE
feat(daemon): add typed connection lifecycle state machine (FSM-1/4/6/8)

### DIFF
--- a/crates/daemon/src/connection/mod.rs
+++ b/crates/daemon/src/connection/mod.rs
@@ -1,0 +1,26 @@
+//! Typed daemon connection lifecycle management.
+//!
+//! Provides [`ConnectionState`] and transition validation for the daemon
+//! connection lifecycle: `Greeting -> ModuleSelect -> Authenticating ->
+//! Transferring -> Closing`. Every state can also transition directly to
+//! `Closing`.
+//!
+//! The state machine enforces forward-only progression through the
+//! non-terminal states. `Closing` is absorbing - once entered, no further
+//! transitions are permitted.
+//!
+//! # Usage
+//!
+//! ```
+//! use daemon::connection::ConnectionState;
+//!
+//! let state = ConnectionState::Greeting;
+//! let state = state.transition(ConnectionState::ModuleSelect).unwrap();
+//! let state = state.transition(ConnectionState::Transferring).unwrap();
+//! let state = state.transition(ConnectionState::Closing).unwrap();
+//! assert!(state.is_terminal());
+//! ```
+
+mod state;
+
+pub use state::{ConnectionState, InvalidTransition};

--- a/crates/daemon/src/connection/state.rs
+++ b/crates/daemon/src/connection/state.rs
@@ -1,0 +1,527 @@
+//! Typed state enum and transition validation for the daemon connection
+//! lifecycle.
+//!
+//! upstream: clientserver.c - the daemon connection progresses through
+//! greeting, module selection, optional authentication, transfer, and close.
+//! This module encodes those phases as a state machine with validated
+//! transitions.
+
+use std::error::Error;
+use std::fmt;
+
+/// Lifecycle state of a daemon connection.
+///
+/// Connections progress forward through the states in order. Every state
+/// can transition to [`Closing`](Self::Closing), and `Closing` is terminal
+/// - no further transitions are permitted.
+///
+/// # States
+///
+/// - **Greeting** - Server has sent the `@RSYNCD:` greeting and is waiting
+///   for the client's version response.
+/// - **ModuleSelect** - Version exchange complete; waiting for the client
+///   to request a module name or `#list`.
+/// - **Authenticating** - The requested module requires authentication;
+///   a challenge has been sent and the server is waiting for the client's
+///   response.
+/// - **Transferring** - Authentication passed (or was not required) and
+///   the transfer engine is running.
+/// - **Closing** - The session is ending. Terminal state.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ConnectionState {
+    /// Server sent `@RSYNCD: <ver>.<sub> <digests>\n`, awaiting client version.
+    Greeting,
+    /// Version exchanged; awaiting module name or `#list` from client.
+    ModuleSelect,
+    /// Module requires auth; challenge sent, awaiting client response.
+    Authenticating,
+    /// Auth passed or not required; transfer engine running.
+    Transferring,
+    /// Session ending. Terminal - no transitions out.
+    Closing,
+}
+
+/// Error returned when a state transition is not permitted.
+///
+/// Contains the source and target states so callers can inspect exactly
+/// which transition was rejected.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InvalidTransition {
+    /// The state the connection was in when the transition was attempted.
+    pub from: ConnectionState,
+    /// The target state that was rejected.
+    pub to: ConnectionState,
+}
+
+impl fmt::Display for InvalidTransition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid daemon connection transition: {:?} -> {:?}",
+            self.from, self.to
+        )
+    }
+}
+
+impl Error for InvalidTransition {}
+
+impl ConnectionState {
+    /// Returns `true` if this is a terminal state with no outgoing transitions.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Closing)
+    }
+
+    /// Returns all states reachable from the current state.
+    ///
+    /// The returned slice is static and ordered by the natural progression
+    /// of the protocol. `Closing` always appears last when present.
+    #[must_use]
+    pub const fn valid_transitions(self) -> &'static [ConnectionState] {
+        match self {
+            Self::Greeting => &[Self::ModuleSelect, Self::Closing],
+            Self::ModuleSelect => &[Self::Authenticating, Self::Transferring, Self::Closing],
+            Self::Authenticating => &[Self::Transferring, Self::Closing],
+            Self::Transferring => &[Self::Closing],
+            Self::Closing => &[],
+        }
+    }
+
+    /// Attempts to transition to `next`.
+    ///
+    /// Returns `Ok(next)` when the transition is valid, or
+    /// `Err(InvalidTransition)` when it is not. A transition is valid if
+    /// `next` appears in [`valid_transitions`](Self::valid_transitions).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use daemon::connection::ConnectionState;
+    ///
+    /// let state = ConnectionState::Greeting;
+    /// assert!(state.transition(ConnectionState::ModuleSelect).is_ok());
+    /// assert!(state.transition(ConnectionState::Transferring).is_err());
+    /// ```
+    pub const fn transition(self, next: ConnectionState) -> Result<ConnectionState, InvalidTransition> {
+        // PartialEq::eq is not available in const context for custom enums,
+        // so compare discriminants via as-cast.
+        let next_disc = next as u8;
+        let valid = self.valid_transitions();
+        let mut i = 0;
+        while i < valid.len() {
+            if valid[i] as u8 == next_disc {
+                return Ok(next);
+            }
+            i += 1;
+        }
+        Err(InvalidTransition {
+            from: self,
+            to: next,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Valid transitions -------------------------------------------------
+
+    #[test]
+    fn greeting_to_module_select() {
+        let result = ConnectionState::Greeting.transition(ConnectionState::ModuleSelect);
+        assert_eq!(result, Ok(ConnectionState::ModuleSelect));
+    }
+
+    #[test]
+    fn greeting_to_closing() {
+        let result = ConnectionState::Greeting.transition(ConnectionState::Closing);
+        assert_eq!(result, Ok(ConnectionState::Closing));
+    }
+
+    #[test]
+    fn module_select_to_authenticating() {
+        let result = ConnectionState::ModuleSelect.transition(ConnectionState::Authenticating);
+        assert_eq!(result, Ok(ConnectionState::Authenticating));
+    }
+
+    #[test]
+    fn module_select_to_transferring() {
+        let result = ConnectionState::ModuleSelect.transition(ConnectionState::Transferring);
+        assert_eq!(result, Ok(ConnectionState::Transferring));
+    }
+
+    #[test]
+    fn module_select_to_closing() {
+        let result = ConnectionState::ModuleSelect.transition(ConnectionState::Closing);
+        assert_eq!(result, Ok(ConnectionState::Closing));
+    }
+
+    #[test]
+    fn authenticating_to_transferring() {
+        let result = ConnectionState::Authenticating.transition(ConnectionState::Transferring);
+        assert_eq!(result, Ok(ConnectionState::Transferring));
+    }
+
+    #[test]
+    fn authenticating_to_closing() {
+        let result = ConnectionState::Authenticating.transition(ConnectionState::Closing);
+        assert_eq!(result, Ok(ConnectionState::Closing));
+    }
+
+    #[test]
+    fn transferring_to_closing() {
+        let result = ConnectionState::Transferring.transition(ConnectionState::Closing);
+        assert_eq!(result, Ok(ConnectionState::Closing));
+    }
+
+    // -- Invalid transitions -----------------------------------------------
+
+    #[test]
+    fn greeting_to_greeting() {
+        let result = ConnectionState::Greeting.transition(ConnectionState::Greeting);
+        assert_eq!(
+            result,
+            Err(InvalidTransition {
+                from: ConnectionState::Greeting,
+                to: ConnectionState::Greeting,
+            })
+        );
+    }
+
+    #[test]
+    fn greeting_to_authenticating() {
+        let result = ConnectionState::Greeting.transition(ConnectionState::Authenticating);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn greeting_to_transferring() {
+        let result = ConnectionState::Greeting.transition(ConnectionState::Transferring);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn module_select_to_greeting() {
+        let result = ConnectionState::ModuleSelect.transition(ConnectionState::Greeting);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn module_select_to_module_select() {
+        let result = ConnectionState::ModuleSelect.transition(ConnectionState::ModuleSelect);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn authenticating_to_greeting() {
+        let result = ConnectionState::Authenticating.transition(ConnectionState::Greeting);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn authenticating_to_module_select() {
+        let result = ConnectionState::Authenticating.transition(ConnectionState::ModuleSelect);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn authenticating_to_authenticating() {
+        let result = ConnectionState::Authenticating.transition(ConnectionState::Authenticating);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transferring_to_greeting() {
+        let result = ConnectionState::Transferring.transition(ConnectionState::Greeting);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transferring_to_module_select() {
+        let result = ConnectionState::Transferring.transition(ConnectionState::ModuleSelect);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transferring_to_authenticating() {
+        let result = ConnectionState::Transferring.transition(ConnectionState::Authenticating);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transferring_to_transferring() {
+        let result = ConnectionState::Transferring.transition(ConnectionState::Transferring);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn closing_to_greeting() {
+        let result = ConnectionState::Closing.transition(ConnectionState::Greeting);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn closing_to_module_select() {
+        let result = ConnectionState::Closing.transition(ConnectionState::ModuleSelect);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn closing_to_authenticating() {
+        let result = ConnectionState::Closing.transition(ConnectionState::Authenticating);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn closing_to_transferring() {
+        let result = ConnectionState::Closing.transition(ConnectionState::Transferring);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn closing_to_closing() {
+        let result = ConnectionState::Closing.transition(ConnectionState::Closing);
+        assert!(result.is_err());
+    }
+
+    // -- Happy-path lifecycle -----------------------------------------------
+
+    #[test]
+    fn full_lifecycle_with_auth() {
+        let state = ConnectionState::Greeting;
+        let state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        let state = state.transition(ConnectionState::Authenticating).unwrap();
+        let state = state.transition(ConnectionState::Transferring).unwrap();
+        let state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn full_lifecycle_without_auth() {
+        let state = ConnectionState::Greeting;
+        let state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        let state = state.transition(ConnectionState::Transferring).unwrap();
+        let state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    // -- Edge cases ---------------------------------------------------------
+
+    #[test]
+    fn early_close_from_greeting() {
+        let state = ConnectionState::Greeting;
+        let state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+        assert!(state.transition(ConnectionState::Greeting).is_err());
+    }
+
+    #[test]
+    fn early_close_from_module_select() {
+        let state = ConnectionState::ModuleSelect;
+        let state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn double_close_is_invalid() {
+        let state = ConnectionState::Closing;
+        assert!(state.transition(ConnectionState::Closing).is_err());
+    }
+
+    #[test]
+    fn cannot_reenter_previous_state_after_progress() {
+        let state = ConnectionState::ModuleSelect;
+        assert!(state.transition(ConnectionState::Greeting).is_err());
+
+        let state = ConnectionState::Authenticating;
+        assert!(state.transition(ConnectionState::ModuleSelect).is_err());
+        assert!(state.transition(ConnectionState::Greeting).is_err());
+
+        let state = ConnectionState::Transferring;
+        assert!(state.transition(ConnectionState::Authenticating).is_err());
+        assert!(state.transition(ConnectionState::ModuleSelect).is_err());
+        assert!(state.transition(ConnectionState::Greeting).is_err());
+    }
+
+    // -- valid_transitions --------------------------------------------------
+
+    #[test]
+    fn valid_transitions_greeting() {
+        let valid = ConnectionState::Greeting.valid_transitions();
+        assert_eq!(valid, &[ConnectionState::ModuleSelect, ConnectionState::Closing]);
+    }
+
+    #[test]
+    fn valid_transitions_module_select() {
+        let valid = ConnectionState::ModuleSelect.valid_transitions();
+        assert_eq!(
+            valid,
+            &[
+                ConnectionState::Authenticating,
+                ConnectionState::Transferring,
+                ConnectionState::Closing,
+            ]
+        );
+    }
+
+    #[test]
+    fn valid_transitions_authenticating() {
+        let valid = ConnectionState::Authenticating.valid_transitions();
+        assert_eq!(
+            valid,
+            &[ConnectionState::Transferring, ConnectionState::Closing]
+        );
+    }
+
+    #[test]
+    fn valid_transitions_transferring() {
+        let valid = ConnectionState::Transferring.valid_transitions();
+        assert_eq!(valid, &[ConnectionState::Closing]);
+    }
+
+    #[test]
+    fn valid_transitions_closing() {
+        let valid = ConnectionState::Closing.valid_transitions();
+        assert!(valid.is_empty());
+    }
+
+    // -- is_terminal --------------------------------------------------------
+
+    #[test]
+    fn only_closing_is_terminal() {
+        assert!(!ConnectionState::Greeting.is_terminal());
+        assert!(!ConnectionState::ModuleSelect.is_terminal());
+        assert!(!ConnectionState::Authenticating.is_terminal());
+        assert!(!ConnectionState::Transferring.is_terminal());
+        assert!(ConnectionState::Closing.is_terminal());
+    }
+
+    // -- InvalidTransition formatting ----------------------------------------
+
+    #[test]
+    fn invalid_transition_display() {
+        let err = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Transferring,
+        };
+        let msg = format!("{err}");
+        assert_eq!(
+            msg,
+            "invalid daemon connection transition: Greeting -> Transferring"
+        );
+    }
+
+    #[test]
+    fn invalid_transition_is_error() {
+        let err = InvalidTransition {
+            from: ConnectionState::Closing,
+            to: ConnectionState::Greeting,
+        };
+        let _: &dyn Error = &err;
+    }
+
+    #[test]
+    fn invalid_transition_debug() {
+        let err = InvalidTransition {
+            from: ConnectionState::Authenticating,
+            to: ConnectionState::Greeting,
+        };
+        let debug = format!("{err:?}");
+        assert!(debug.contains("InvalidTransition"));
+        assert!(debug.contains("Authenticating"));
+        assert!(debug.contains("Greeting"));
+    }
+
+    #[test]
+    fn invalid_transition_eq() {
+        let a = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Transferring,
+        };
+        let b = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Transferring,
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn invalid_transition_ne() {
+        let a = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Transferring,
+        };
+        let b = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Authenticating,
+        };
+        assert_ne!(a, b);
+    }
+
+    // -- Clone / Copy / Hash -----------------------------------------------
+
+    #[test]
+    fn connection_state_clone_copy() {
+        let state = ConnectionState::Greeting;
+        let cloned = state;
+        assert_eq!(state, cloned);
+    }
+
+    #[test]
+    fn connection_state_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(ConnectionState::Greeting);
+        set.insert(ConnectionState::ModuleSelect);
+        set.insert(ConnectionState::Authenticating);
+        set.insert(ConnectionState::Transferring);
+        set.insert(ConnectionState::Closing);
+        assert_eq!(set.len(), 5);
+    }
+
+    #[test]
+    fn invalid_transition_clone_copy() {
+        let err = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Closing,
+        };
+        let cloned = err;
+        assert_eq!(err, cloned);
+    }
+
+    // -- Exhaustive transition matrix ----------------------------------------
+
+    /// Verifies every possible (from, to) pair against the expected outcome.
+    #[test]
+    fn exhaustive_transition_matrix() {
+        use ConnectionState::*;
+
+        let all = [Greeting, ModuleSelect, Authenticating, Transferring, Closing];
+
+        // Expected valid transitions encoded as (from, to) pairs.
+        let valid_pairs: &[(ConnectionState, ConnectionState)] = &[
+            (Greeting, ModuleSelect),
+            (Greeting, Closing),
+            (ModuleSelect, Authenticating),
+            (ModuleSelect, Transferring),
+            (ModuleSelect, Closing),
+            (Authenticating, Transferring),
+            (Authenticating, Closing),
+            (Transferring, Closing),
+        ];
+
+        for &from in &all {
+            for &to in &all {
+                let result = from.transition(to);
+                let expected_valid = valid_pairs.iter().any(|&(f, t)| f == from && t == to);
+                assert_eq!(
+                    result.is_ok(),
+                    expected_valid,
+                    "transition {from:?} -> {to:?}: expected valid={expected_valid}, got {:?}",
+                    result
+                );
+            }
+        }
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -173,6 +173,8 @@
 #[cfg(feature = "async-daemon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-daemon")))]
 pub mod async_listener;
+/// Typed daemon connection lifecycle state machine.
+pub mod connection;
 /// Daemon mode challenge-response authentication matching upstream rsync 3.4.1.
 pub mod auth;
 mod cli;

--- a/docs/design/daemon-connection-fsm.md
+++ b/docs/design/daemon-connection-fsm.md
@@ -1,0 +1,103 @@
+# Daemon Connection Lifecycle State Machine
+
+## Overview
+
+The daemon connection handler progresses through a fixed sequence of states
+from greeting through transfer to close. Today these transitions are implicit
+in the control flow of `handle_legacy_session` and `process_approved_module`.
+This design introduces a typed `ConnectionState` enum that makes every valid
+transition explicit and prevents illegal jumps at compile time where possible
+and at runtime otherwise.
+
+## States
+
+```
+Greeting --> ModuleSelect --> Authenticating --> Transferring --> Closing
+    |             |                |                 |
+    +------+------+--------+------+---------+-------+
+           |               |                |
+           v               v                v
+        Closing          Closing          Closing
+```
+
+| State            | Description                                         |
+|------------------|-----------------------------------------------------|
+| `Greeting`       | Server sent `@RSYNCD: <ver>.<sub> <digests>\n`, waiting for client version response. |
+| `ModuleSelect`   | Version exchanged; waiting for client to send module name or `#list`. |
+| `Authenticating` | Module found and requires auth; challenge sent, waiting for response. |
+| `Transferring`   | Auth passed (or not required); transfer engine running. |
+| `Closing`        | Session ending - `@RSYNCD: EXIT` sent or connection dropped. Reachable from any state. |
+
+## Valid transitions
+
+| From             | To               | Trigger                                      |
+|------------------|------------------|----------------------------------------------|
+| `Greeting`       | `ModuleSelect`   | Client responds with `@RSYNCD: <version>`    |
+| `Greeting`       | `Closing`        | Client sends `@RSYNCD: EXIT`, EOF, or I/O error |
+| `ModuleSelect`   | `Authenticating` | Module found and requires authentication     |
+| `ModuleSelect`   | `Transferring`   | Module found, no auth required, `@RSYNCD: OK` sent |
+| `ModuleSelect`   | `Closing`        | Unknown module, access denied, `#list` served, or error |
+| `Authenticating` | `Transferring`   | Auth succeeded, `@RSYNCD: OK` sent           |
+| `Authenticating` | `Closing`        | Auth failed or denied                        |
+| `Transferring`   | `Closing`        | Transfer completes (success or failure)       |
+
+All other transitions are invalid and return `InvalidTransition`.
+
+## API surface
+
+```rust
+/// Current state of a daemon connection.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ConnectionState {
+    Greeting,
+    ModuleSelect,
+    Authenticating,
+    Transferring,
+    Closing,
+}
+
+/// Error returned when a state transition is not permitted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InvalidTransition {
+    pub from: ConnectionState,
+    pub to: ConnectionState,
+}
+
+impl ConnectionState {
+    /// Attempts to transition to `next`, returning `Ok(next)` on success
+    /// or `Err(InvalidTransition)` if the transition is illegal.
+    pub fn transition(self, next: ConnectionState)
+        -> Result<ConnectionState, InvalidTransition>;
+
+    /// Returns all states reachable from the current state.
+    pub fn valid_transitions(self) -> &'static [ConnectionState];
+
+    /// Returns `true` if the connection is in a terminal state.
+    pub fn is_terminal(self) -> bool;
+}
+```
+
+## Constraints
+
+- `Closing` is a terminal (absorbing) state - no transitions out.
+- Every state can transition to `Closing`.
+- Forward-only progression through the non-closing states: no returning to
+  a previous state.
+- The enum and transition logic live in `crates/daemon/src/connection/state.rs`
+  and are re-exported from the daemon crate.
+- This PR defines the type and validation API only. Wiring the enum into the
+  existing session handler is a follow-up to keep the change small and
+  reviewable.
+
+## Error handling
+
+`InvalidTransition` implements `Display` and `Error` manually (the daemon
+crate avoids `thiserror` because `core` shadows the primitive `core` crate).
+The display format is: `invalid daemon connection transition: {from:?} -> {to:?}`.
+
+## Testing
+
+Exhaustive matrix: every `(from, to)` pair is tested. Valid transitions
+return `Ok`, invalid transitions return `Err(InvalidTransition)`. Additional
+tests cover the full happy-path lifecycle and edge cases (double close,
+re-entering previous states).


### PR DESCRIPTION
## Summary

- Introduce a `ConnectionState` enum modelling the daemon connection lifecycle as an explicit state machine: `Greeting -> ModuleSelect -> Authenticating -> Transferring -> Closing`
- Add `InvalidTransition` error type for rejected transitions, with `Display` and `Error` implementations
- Include a design doc at `docs/design/daemon-connection-fsm.md` documenting states, valid transitions, API surface, and constraints

This PR defines the typed enum and its validation API only. Wiring the state machine into the existing `handle_legacy_session` / `process_approved_module` control flow is a separate follow-up to keep the change small and reviewable.

## Test plan

- [x] Exhaustive 5x5 transition matrix test validates every `(from, to)` pair
- [x] Happy-path lifecycle tests: with auth (`Greeting -> ModuleSelect -> Authenticating -> Transferring -> Closing`) and without auth (`Greeting -> ModuleSelect -> Transferring -> Closing`)
- [x] Edge cases: double close, re-entering previous states, early close from each non-terminal state
- [x] `valid_transitions()` returns correct successors for each state
- [x] `is_terminal()` returns true only for `Closing`
- [x] `InvalidTransition` display, debug, eq, clone/copy
- [x] `ConnectionState` hash, clone/copy