### PR TITLE
style: format transfer_state.rs and daemon state machine files

### DIFF
--- a/crates/daemon/src/connection/state.rs
+++ b/crates/daemon/src/connection/state.rs
@@ -102,7 +102,10 @@ impl ConnectionState {
     /// assert!(state.transition(ConnectionState::ModuleSelect).is_ok());
     /// assert!(state.transition(ConnectionState::Transferring).is_err());
     /// ```
-    pub const fn transition(self, next: ConnectionState) -> Result<ConnectionState, InvalidTransition> {
+    pub const fn transition(
+        self,
+        next: ConnectionState,
+    ) -> Result<ConnectionState, InvalidTransition> {
         // PartialEq::eq is not available in const context for custom enums,
         // so compare discriminants via as-cast.
         let next_disc = next as u8;
@@ -349,7 +352,10 @@ mod tests {
     #[test]
     fn valid_transitions_greeting() {
         let valid = ConnectionState::Greeting.valid_transitions();
-        assert_eq!(valid, &[ConnectionState::ModuleSelect, ConnectionState::Closing]);
+        assert_eq!(
+            valid,
+            &[ConnectionState::ModuleSelect, ConnectionState::Closing]
+        );
     }
 
     #[test]
@@ -497,7 +503,13 @@ mod tests {
     fn exhaustive_transition_matrix() {
         use ConnectionState::*;
 
-        let all = [Greeting, ModuleSelect, Authenticating, Transferring, Closing];
+        let all = [
+            Greeting,
+            ModuleSelect,
+            Authenticating,
+            Transferring,
+            Closing,
+        ];
 
         // Expected valid transitions encoded as (from, to) pairs.
         let valid_pairs: &[(ConnectionState, ConnectionState)] = &[

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -173,12 +173,12 @@
 #[cfg(feature = "async-daemon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-daemon")))]
 pub mod async_listener;
-/// Typed daemon connection lifecycle state machine.
-pub mod connection;
 /// Daemon mode challenge-response authentication matching upstream rsync 3.4.1.
 pub mod auth;
 mod cli;
 mod config;
+/// Typed daemon connection lifecycle state machine.
+pub mod connection;
 mod daemon;
 /// Unified stream abstraction for plain TCP and TLS-wrapped connections.
 pub mod daemon_stream;

--- a/crates/transfer/src/transfer_state.rs
+++ b/crates/transfer/src/transfer_state.rs
@@ -425,9 +425,7 @@ mod tests {
     fn advance_to_each_successor_succeeds() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
 
-        pipeline
-            .advance_to(TransferPhase::FilterExchange)
-            .unwrap();
+        pipeline.advance_to(TransferPhase::FilterExchange).unwrap();
         assert_eq!(pipeline.phase(), TransferPhase::FilterExchange);
 
         pipeline
@@ -452,9 +450,7 @@ mod tests {
     #[test]
     fn advance_to_same_phase_is_invalid() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
-        let err = pipeline
-            .advance_to(TransferPhase::Handshake)
-            .unwrap_err();
+        let err = pipeline.advance_to(TransferPhase::Handshake).unwrap_err();
         assert_eq!(err.current, TransferPhase::Handshake);
         assert_eq!(err.target, TransferPhase::Handshake);
         // Phase should not change on error
@@ -464,13 +460,9 @@ mod tests {
     #[test]
     fn advance_to_prior_phase_is_invalid() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
-        pipeline
-            .advance_to(TransferPhase::FilterExchange)
-            .unwrap();
+        pipeline.advance_to(TransferPhase::FilterExchange).unwrap();
 
-        let err = pipeline
-            .advance_to(TransferPhase::Handshake)
-            .unwrap_err();
+        let err = pipeline.advance_to(TransferPhase::Handshake).unwrap_err();
         assert_eq!(err.current, TransferPhase::FilterExchange);
         assert_eq!(err.target, TransferPhase::Handshake);
         assert_eq!(pipeline.phase(), TransferPhase::FilterExchange);
@@ -494,9 +486,7 @@ mod tests {
         for _ in 0..5 {
             pipeline.advance().unwrap();
         }
-        let err = pipeline
-            .advance_to(TransferPhase::Handshake)
-            .unwrap_err();
+        let err = pipeline.advance_to(TransferPhase::Handshake).unwrap_err();
         assert_eq!(err.current, TransferPhase::Complete);
     }
 
@@ -525,9 +515,7 @@ mod tests {
     #[test]
     fn advance_through_to_complete() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
-        pipeline
-            .advance_through(TransferPhase::Complete)
-            .unwrap();
+        pipeline.advance_through(TransferPhase::Complete).unwrap();
         assert!(pipeline.is_complete());
     }
 
@@ -587,9 +575,7 @@ mod tests {
     fn full_lifecycle_generator() {
         let mut pipeline = TransferPipeline::new(ServerRole::Generator);
 
-        pipeline
-            .advance_to(TransferPhase::FilterExchange)
-            .unwrap();
+        pipeline.advance_to(TransferPhase::FilterExchange).unwrap();
         pipeline
             .advance_to(TransferPhase::FileListTransfer)
             .unwrap();
@@ -608,9 +594,7 @@ mod tests {
     #[test]
     fn double_advance_to_same_target_fails() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
-        pipeline
-            .advance_to(TransferPhase::FilterExchange)
-            .unwrap();
+        pipeline.advance_to(TransferPhase::FilterExchange).unwrap();
         let err = pipeline
             .advance_to(TransferPhase::FilterExchange)
             .unwrap_err();
@@ -679,19 +663,14 @@ mod tests {
             }
 
             let result = pipeline.advance_to(phase);
-            assert!(
-                result.is_err(),
-                "self-transition at {phase} should fail"
-            );
+            assert!(result.is_err(), "self-transition at {phase} should fail");
         }
     }
 
     #[test]
     fn advance_through_from_complete_is_invalid() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
-        pipeline
-            .advance_through(TransferPhase::Complete)
-            .unwrap();
+        pipeline.advance_through(TransferPhase::Complete).unwrap();
 
         // Every phase target should fail from Complete
         let all_phases = [
@@ -716,9 +695,7 @@ mod tests {
     #[test]
     fn advance_past_complete_is_idempotently_rejected() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
-        pipeline
-            .advance_through(TransferPhase::Complete)
-            .unwrap();
+        pipeline.advance_through(TransferPhase::Complete).unwrap();
 
         // Multiple attempts to advance past Complete all fail
         for _ in 0..3 {


### PR DESCRIPTION
## Summary
- Fix cargo fmt violations in `crates/transfer/src/transfer_state.rs`, `crates/daemon/src/connection/state.rs`, and `crates/daemon/src/lib.rs` introduced by PR #5088

## Test plan
- CI fmt+clippy check passes