### PR TITLE
fix: inline format arg in daemon connection state test

### DIFF
--- a/crates/daemon/src/connection/state.rs
+++ b/crates/daemon/src/connection/state.rs
@@ -530,8 +530,7 @@ mod tests {
                 assert_eq!(
                     result.is_ok(),
                     expected_valid,
-                    "transition {from:?} -> {to:?}: expected valid={expected_valid}, got {:?}",
-                    result
+                    "transition {from:?} -> {to:?}: expected valid={expected_valid}, got {result:?}"
                 );
             }
         }


### PR DESCRIPTION
## Summary
- Fix `clippy::uninlined_format_args` lint in daemon connection state exhaustive transition test

## Test plan
- CI fmt+clippy check passes