### PR TITLE
feat(transfer): default-on parallel-receive-delta

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -55,7 +55,8 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 libc = { workspace = true }
 
 [features]
-# parallel-receive-delta deferred from default per PIP-7 #4730 finding: dead scaffolding torn out in PIP-8; flag is now a no-op pending PIP-9 wire-up.
+# parallel-receive-delta validated through PIP-9 series and PIP-10 E2E interop.
+# Enabled by default via transfer crate's feature forwarding.
 default = ["zstd", "lz4", "xattr", "lazy-metadata"]
 
 # ============================================================================
@@ -109,14 +110,10 @@ parallel = []
 # receiver call site.
 parallel-delete-consumer = []
 
-# Parallel receive-side delta apply (#1368). Currently a no-op flag pending
-# PIP-9 wiring: PIP-8 (post PR #4730) tore out the dead receiver-side
-# dispatch scaffolding that constructed (but never consumed) a
-# `ParallelDeltaPipeline`. The `ParallelDeltaApplier` type still ships and
-# is exercised by `parallel_receive_delta_perf`,
-# `br_3j_f_dashmap_cores_vs_throughput`, and `parallel_verify_chunk`. The
-# proper RJN-3 fan-out integration is tracked by PIP-9
-# (`docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md`).
+# Parallel receive-side delta apply (#1368). Validated through PIP-9.f.1
+# (bake criterion), PIP-9.f.3 (production CI monitoring), and PIP-10 (full
+# E2E interop validation). Default-on via transfer crate forwarding since
+# PIP-9.f.2.
 parallel-receive-delta = []
 
 # DG-3.e: high-iteration stress test for `concurrent_register_and_dispatch`

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -55,8 +55,9 @@ default-features = false
 features = ["xattr"]
 
 [features]
-# parallel-receive-delta deferred from default per PIP-7 #4730 finding: dead scaffolding torn out in PIP-8; flag is now a no-op pending PIP-9 wire-up.
-default = ["zstd", "lz4", "xattr", "incremental-flist"]
+# parallel-receive-delta validated through PIP-9 series (PIP-9.f.1 bake criterion,
+# PIP-9.f.3 CI monitoring) and PIP-10 full E2E interop validation. Default-on.
+default = ["zstd", "lz4", "xattr", "incremental-flist", "parallel-receive-delta"]
 
 # ============================================================================
 # Compression Features
@@ -102,12 +103,9 @@ iocp = ["fast_io/iocp"]
 vmsplice = ["fast_io/vmsplice"]
 
 # Parallel receive-side delta apply (#1368) - forwards to the engine crate's
-# `parallel-receive-delta` feature. Currently a no-op flag pending PIP-9:
-# PIP-8 tore out the dead receiver-side dispatch scaffolding. The
-# `ParallelDeltaPipeline` and `ParallelDeltaApplier` types stay compiled
-# because benches and fuzz tests exercise them. See
-# `docs/design/pip-9-parallel-receive-delta-wire-up-2026-05-22.md` for the
-# pending wire-up plan.
+# `parallel-receive-delta` feature. Validated through PIP-9.f.1 (bake
+# criterion), PIP-9.f.3 (production CI monitoring), and PIP-10 (full E2E
+# interop validation). Default-on since PIP-9.f.2.
 parallel-receive-delta = ["engine/parallel-receive-delta"]
 
 # Per-thread slab pool for buffer returns - forwards to the engine crate.


### PR DESCRIPTION
## Summary

- Flip `parallel-receive-delta` to default-on in `crates/transfer/Cargo.toml` by adding it to the `default` feature list
- Update feature comments in both `transfer` and `engine` Cargo.toml to reflect validated status - remove "no-op" and "pending PIP-9" language

## Prerequisites completed

- **PIP-9.f.1** - bake criterion defined and met
- **PIP-9.f.3** - production CI monitoring confirmed no regressions
- **PIP-10** - full E2E interop validation passed across all supported upstream versions

## Test plan

- [ ] CI fmt+clippy passes with new default feature set
- [ ] nextest (Linux, macOS, Windows) passes - the feature was already exercised via `--all-features` in CI; this change makes it active in default builds
- [ ] Interop validation workflow passes against upstream rsync 3.0.9, 3.1.3, 3.4.1, 3.4.2