### PR TITLE
feat(engine): add default 32 MiB byte budget to global BufferPool

### DIFF
--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -144,7 +144,7 @@ impl Default for GlobalBufferPoolConfig {
             .unwrap_or(auto_detected);
         let byte_budget = match parse_byte_budget_override(std::env::var(ENV_BYTE_BUDGET).ok()) {
             Some(override_val) => override_val, // Env var present: use its value (or None for 0).
-            None => Some(DEFAULT_BYTE_BUDGET), // No env var: apply the 32 MiB default.
+            None => Some(DEFAULT_BYTE_BUDGET),  // No env var: apply the 32 MiB default.
         };
         Self {
             max_buffers,

--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -143,8 +143,8 @@ impl Default for GlobalBufferPoolConfig {
         let max_buffers = parse_pool_size_override(std::env::var(ENV_BUFFER_POOL_SIZE).ok())
             .unwrap_or(auto_detected);
         let byte_budget = match parse_byte_budget_override(std::env::var(ENV_BYTE_BUDGET).ok()) {
-            Some(override_val) => override_val,  // Env var present: use its value (or None for 0).
-            None => Some(DEFAULT_BYTE_BUDGET),    // No env var: apply the 32 MiB default.
+            Some(override_val) => override_val, // Env var present: use its value (or None for 0).
+            None => Some(DEFAULT_BYTE_BUDGET), // No env var: apply the 32 MiB default.
         };
         Self {
             max_buffers,
@@ -433,9 +433,6 @@ mod tests {
 
     #[test]
     fn parse_byte_budget_negative_ignored() {
-        assert_eq!(
-            parse_byte_budget_override(Some("-1".to_string())),
-            None
-        );
+        assert_eq!(parse_byte_budget_override(Some("-1".to_string())), None);
     }
 }

--- a/crates/engine/src/local_copy/buffer_pool/global.rs
+++ b/crates/engine/src/local_copy/buffer_pool/global.rs
@@ -13,8 +13,26 @@
 //! before any subsystem acquires buffers.
 //!
 //! If [`init_global_buffer_pool`] is not called, the pool defaults to
-//! [`BufferPool::default`] - one buffer per hardware thread at
-//! [`COPY_BUFFER_SIZE`](super::super::COPY_BUFFER_SIZE).
+//! [`GlobalBufferPoolConfig::default`] - one buffer per hardware thread at
+//! [`COPY_BUFFER_SIZE`](super::super::COPY_BUFFER_SIZE) with a 32 MiB
+//! byte budget on pool retention.
+//!
+//! # Default Byte Budget
+//!
+//! The pool applies a default byte budget of [`DEFAULT_BYTE_BUDGET`] (32 MiB)
+//! on retained buffers. This prevents unbounded memory growth when adaptive
+//! buffer sizing creates large (up to 1 MiB) buffers that would otherwise
+//! accumulate in the pool. The budget is a soft cap - acquires never block,
+//! but returning buffers past the cap are deallocated instead of retained.
+//!
+//! The default can be overridden via the `OC_RSYNC_BYTE_BUDGET` environment
+//! variable or programmatically through [`GlobalBufferPoolConfig`]. Setting
+//! the env var to `0` disables the byte budget entirely.
+//!
+//! For daemon deployments serving many concurrent connections, the 32 MiB
+//! default is shared across all connections (single process-wide pool). This
+//! is appropriate because pooled buffers are reused across connections - the
+//! pool size scales with parallelism, not with connection count.
 //!
 //! # Thread Safety
 //!
@@ -57,12 +75,30 @@ pub struct GlobalBufferPoolConfig {
     pub byte_budget: Option<usize>,
 }
 
+/// Default byte budget for pool retention (32 MiB).
+///
+/// Matches the maximum pooled memory at the adaptive resizer's ceiling:
+/// 256 buffers at 128 KiB each = 32 MiB. This provides a consistent
+/// upper bound whether the pool grows by count (adaptive resizing) or
+/// by individual buffer size (adaptive buffer sizing for large files).
+///
+/// Overridden by `--max-alloc`, `OC_RSYNC_BYTE_BUDGET`, or programmatic
+/// configuration via [`GlobalBufferPoolConfig`].
+pub const DEFAULT_BYTE_BUDGET: usize = 32 * 1024 * 1024;
+
 /// Environment variable for overriding the buffer pool size (number of buffers).
 ///
 /// When set to a valid positive integer, overrides the auto-detected
 /// hardware parallelism value. Useful for tuning memory usage in
 /// constrained environments or for benchmarking.
 const ENV_BUFFER_POOL_SIZE: &str = "OC_RSYNC_BUFFER_POOL_SIZE";
+
+/// Environment variable for overriding the default byte budget.
+///
+/// When set to a valid positive integer, overrides [`DEFAULT_BYTE_BUDGET`].
+/// Set to `0` to disable the byte budget entirely (unbounded retention).
+/// Useful for memory-constrained environments or high-throughput servers.
+const ENV_BYTE_BUDGET: &str = "OC_RSYNC_BYTE_BUDGET";
 
 /// Parses an optional env-var value into a positive buffer count.
 ///
@@ -74,31 +110,56 @@ fn parse_pool_size_override(env_val: Option<String>) -> Option<usize> {
         .filter(|&n| n > 0)
 }
 
+/// Parses an optional env-var value into a byte budget.
+///
+/// Returns `Some(Some(n))` when the value is a valid positive integer (use n).
+/// Returns `Some(None)` when the value is `"0"` (disable byte budget).
+/// Returns `None` for missing or non-numeric values (use default).
+fn parse_byte_budget_override(env_val: Option<String>) -> Option<Option<usize>> {
+    let val = env_val?;
+    let n = val.parse::<usize>().ok()?;
+    if n == 0 {
+        Some(None) // Explicitly disabled.
+    } else {
+        Some(Some(n))
+    }
+}
+
 impl Default for GlobalBufferPoolConfig {
-    /// Defaults to one buffer per hardware thread at the standard copy buffer size.
+    /// Defaults to one buffer per hardware thread at the standard copy buffer
+    /// size, with a 32 MiB byte budget on pool retention.
     ///
     /// The `OC_RSYNC_BUFFER_POOL_SIZE` environment variable overrides the
     /// auto-detected hardware parallelism value when set to a valid positive
     /// integer. Invalid or non-positive values are silently ignored.
+    ///
+    /// The `OC_RSYNC_BYTE_BUDGET` environment variable overrides the default
+    /// byte budget. Set to `0` to disable the byte budget (unbounded
+    /// retention). Invalid or non-numeric values are silently ignored.
     fn default() -> Self {
         let auto_detected = std::thread::available_parallelism()
             .map(std::num::NonZero::get)
             .unwrap_or(4);
         let max_buffers = parse_pool_size_override(std::env::var(ENV_BUFFER_POOL_SIZE).ok())
             .unwrap_or(auto_detected);
+        let byte_budget = match parse_byte_budget_override(std::env::var(ENV_BYTE_BUDGET).ok()) {
+            Some(override_val) => override_val,  // Env var present: use its value (or None for 0).
+            None => Some(DEFAULT_BYTE_BUDGET),    // No env var: apply the 32 MiB default.
+        };
         Self {
             max_buffers,
             buffer_size: super::super::COPY_BUFFER_SIZE,
             memory_cap: None,
-            byte_budget: None,
+            byte_budget,
         }
     }
 }
 
 /// Returns a shared reference to the global buffer pool.
 ///
-/// Initializes the pool with [`BufferPool::default`] on first call if
-/// [`init_global_buffer_pool`] has not been called. Subsequent calls
+/// Initializes the pool from [`GlobalBufferPoolConfig::default`] on first
+/// call if [`init_global_buffer_pool`] has not been called. This applies
+/// the default 32 MiB byte budget on pool retention. Subsequent calls
 /// return a clone of the same [`Arc`].
 ///
 /// # Example
@@ -111,7 +172,14 @@ impl Default for GlobalBufferPoolConfig {
 /// ```
 #[must_use]
 pub fn global_buffer_pool() -> Arc<BufferPool> {
-    Arc::clone(GLOBAL_BUFFER_POOL.get_or_init(|| Arc::new(BufferPool::default())))
+    Arc::clone(GLOBAL_BUFFER_POOL.get_or_init(|| {
+        let config = GlobalBufferPoolConfig::default();
+        let mut pool = BufferPool::with_buffer_size(config.max_buffers, config.buffer_size);
+        if let Some(budget) = config.byte_budget.filter(|&n| n > 0) {
+            pool = pool.with_byte_budget(budget);
+        }
+        Arc::new(pool)
+    }))
 }
 
 /// Initializes the global buffer pool with custom settings.
@@ -169,7 +237,7 @@ mod tests {
         assert_eq!(config.max_buffers, expected);
         assert_eq!(config.buffer_size, super::super::super::COPY_BUFFER_SIZE);
         assert!(config.memory_cap.is_none());
-        assert!(config.byte_budget.is_none());
+        assert_eq!(config.byte_budget, Some(DEFAULT_BYTE_BUDGET));
     }
 
     #[test]
@@ -327,5 +395,47 @@ mod tests {
         // by `init_after_lazy_init_returns_err` and integration tests.
         let cap: Option<usize> = Some(0).filter(|&n| n > 0);
         assert!(cap.is_none());
+    }
+
+    #[test]
+    fn default_byte_budget_is_32_mib() {
+        assert_eq!(DEFAULT_BYTE_BUDGET, 32 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_byte_budget_positive_value() {
+        assert_eq!(
+            parse_byte_budget_override(Some("16777216".to_string())),
+            Some(Some(16_777_216))
+        );
+    }
+
+    #[test]
+    fn parse_byte_budget_zero_disables() {
+        assert_eq!(
+            parse_byte_budget_override(Some("0".to_string())),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn parse_byte_budget_non_numeric_ignored() {
+        assert_eq!(
+            parse_byte_budget_override(Some("unlimited".to_string())),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_byte_budget_missing_returns_none() {
+        assert_eq!(parse_byte_budget_override(None), None);
+    }
+
+    #[test]
+    fn parse_byte_budget_negative_ignored() {
+        assert_eq!(
+            parse_byte_budget_override(Some("-1".to_string())),
+            None
+        );
     }
 }

--- a/crates/engine/src/local_copy/buffer_pool/mod.rs
+++ b/crates/engine/src/local_copy/buffer_pool/mod.rs
@@ -108,7 +108,9 @@ pub mod throughput;
 
 pub use allocator::{BufferAllocator, DefaultAllocator};
 pub use buffer_controller::{AdaptiveBufferController, ControllerConfig};
-pub use global::{GlobalBufferPoolConfig, global_buffer_pool, init_global_buffer_pool};
+pub use global::{
+    DEFAULT_BYTE_BUDGET, GlobalBufferPoolConfig, global_buffer_pool, init_global_buffer_pool,
+};
 pub use guard::{BorrowedBufferGuard, BufferGuard};
 pub use page_aligned::{PageAlignedBufferGuard, PageAlignedBufferPool};
 pub use pool::{BufferPool, BufferPoolStats};

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -82,8 +82,8 @@ pub mod win_copy;
 
 pub use buffer_pool::{
     BorrowedBufferGuard, BufferAllocator, BufferGuard, BufferPool, BufferPoolStats,
-    DefaultAllocator, GlobalBufferPoolConfig, PageAlignedBufferGuard, PageAlignedBufferPool,
-    ThroughputTracker, global_buffer_pool, init_global_buffer_pool,
+    DEFAULT_BYTE_BUDGET, DefaultAllocator, GlobalBufferPoolConfig, PageAlignedBufferGuard,
+    PageAlignedBufferPool, ThroughputTracker, global_buffer_pool, init_global_buffer_pool,
 };
 pub use deferred_sync::{DeferredSync, SyncStrategy};
 

--- a/docs/user/buffer-pool-tuning.md
+++ b/docs/user/buffer-pool-tuning.md
@@ -1,0 +1,154 @@
+# Buffer pool tuning
+
+This guide describes the I/O buffer pool used by `oc-rsync` and `oc-rsyncd`,
+how it sizes itself by default, and how to tune it for high-concurrency
+daemon deployments.
+
+## Overview
+
+oc-rsync maintains a process-wide pool of reusable I/O buffers to reduce
+allocation overhead during file transfers. The pool uses a two-level
+architecture:
+
+1. **Thread-local fast path** - each worker thread caches one buffer with
+   zero synchronization. This absorbs 95%+ of acquire/return operations
+   under typical rayon workloads.
+2. **Central pool** - a lock-free queue stores overflow buffers. Only
+   accessed on thread-local miss.
+
+Buffers are handed out through RAII guards that automatically return them
+to the pool on drop. Callers never see raw buffers.
+
+## Default behavior
+
+| Parameter | Default | Source |
+|-----------|---------|--------|
+| Buffer count | One per hardware thread | `std::thread::available_parallelism()` |
+| Buffer size | 128 KiB | `COPY_BUFFER_SIZE` |
+| Byte budget | 32 MiB | `DEFAULT_BYTE_BUDGET` |
+| Memory cap | None (uncapped) | - |
+
+The **byte budget** is a soft cap on the total bytes of buffers retained
+in the pool. When a buffer return would push retained bytes past the
+budget, the buffer is deallocated instead of retained. Acquires never
+block - callers always get a buffer (fresh allocation on pool miss).
+
+The byte budget guards against unbounded retention when adaptive buffer
+sizing creates large buffers (up to 1 MiB for files >= 256 MiB). Without
+it, a handful of large-file transfers could leave 1 MiB buffers in the
+pool that accumulate past a reasonable memory budget.
+
+The **memory cap** (when configured via `--max-alloc`) is a hard ceiling on
+outstanding (checked-out) memory. When the cap is reached, acquires block
+until a buffer is returned. This provides backpressure for memory-constrained
+environments.
+
+## Adaptive buffer sizing
+
+The pool selects buffer sizes based on file size to balance memory
+consumption against throughput:
+
+| File size | Buffer size |
+|-----------|-------------|
+| < 64 KB | 8 KB |
+| 64 KB - 1 MB | 32 KB |
+| 1 MB - 64 MB | 128 KB |
+| 64 MB - 256 MB | 512 KB |
+| >= 256 MB | 1 MB |
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `OC_RSYNC_BUFFER_POOL_SIZE` | Override buffer count (positive integer) |
+| `OC_RSYNC_BYTE_BUDGET` | Override byte budget in bytes; `0` disables |
+| `OC_RSYNC_BUFFER_POOL_STATS` | Set to `1` to print pool telemetry on exit |
+
+## CLI flags
+
+| Flag | Effect |
+|------|--------|
+| `--max-alloc=SIZE` | Sets the byte budget on pool retention |
+
+When `--max-alloc` is specified, it overrides the default 32 MiB byte
+budget.
+
+## Daemon deployments
+
+### Shared pool architecture
+
+`oc-rsyncd` uses a thread-per-connection model. All connections share a
+single process-wide buffer pool. This is intentional - pooled buffers are
+reused across connections, so the pool size scales with the degree of
+parallelism (worker threads), not with the number of connections.
+
+### Memory impact calculation
+
+The pool's maximum retained memory is bounded by:
+
+    retained_bytes <= min(byte_budget, buffer_count * max_buffer_size)
+
+With defaults:
+
+    retained_bytes <= min(32 MiB, num_cpus * 128 KiB)
+
+On a 16-core server: `min(32 MiB, 2 MiB) = 2 MiB` retained.
+
+Outstanding (checked-out) memory scales with active I/O operations:
+
+    outstanding_bytes = active_workers * buffer_size_per_worker
+
+At 100 concurrent transfers on a 16-core server, only 16 workers run
+simultaneously (rayon thread pool), so outstanding memory is roughly:
+
+    16 * 128 KiB = 2 MiB (standard buffers)
+    16 * 1 MiB = 16 MiB (worst case with large-file adaptive buffers)
+
+### Tuning recommendations
+
+For most daemon deployments, the defaults are appropriate. The pool
+self-sizes to hardware parallelism and the 32 MiB byte budget prevents
+runaway retention.
+
+**Memory-constrained environments** (containers, VMs with < 1 GiB RAM):
+
+```ini
+# In systemd unit or container env:
+OC_RSYNC_BYTE_BUDGET=8388608     # 8 MiB byte budget
+OC_RSYNC_BUFFER_POOL_SIZE=4      # 4 buffers max
+```
+
+Or via CLI:
+
+```sh
+oc-rsyncd --max-alloc=8M ...
+```
+
+**High-throughput servers** (many large-file transfers, ample RAM):
+
+```ini
+OC_RSYNC_BYTE_BUDGET=67108864    # 64 MiB byte budget
+OC_RSYNC_BUFFER_POOL_SIZE=32     # 32 buffers max
+```
+
+**Disabling the byte budget** (not recommended, but available):
+
+```ini
+OC_RSYNC_BYTE_BUDGET=0           # Unbounded retention
+```
+
+### Monitoring
+
+Set `OC_RSYNC_BUFFER_POOL_STATS=1` to print pool telemetry to stderr
+when the process exits:
+
+```
+BufferPool stats: reuses=12345 allocations=67 growths=0 byte_overflows=3 hit_rate=99.5%
+```
+
+Key metrics:
+- **reuses** - buffer acquisitions satisfied from pool (higher is better).
+- **allocations** - fresh allocations due to pool miss.
+- **byte_overflows** - returns rejected by the byte budget (buffer
+  deallocated instead of retained).
+- **hit_rate** - reuse percentage; > 95% indicates the pool is well-sized.


### PR DESCRIPTION
## Summary

- Add a default 32 MiB byte budget (`DEFAULT_BYTE_BUDGET`) to the global buffer pool, preventing unbounded memory retention when adaptive buffer sizing creates large (up to 1 MiB) buffers for large-file transfers.
- Fix `global_buffer_pool()` lazy init to use `GlobalBufferPoolConfig::default()` instead of `BufferPool::default()`, ensuring the byte budget is applied even when `init_global_buffer_pool` is not called (daemon path).
- Add `OC_RSYNC_BYTE_BUDGET` env var override (set to `0` to disable the budget entirely).
- Add buffer pool tuning guide at `docs/user/buffer-pool-tuning.md` for high-concurrency daemon deployments.

### Audit findings (BPC-1)

The global buffer pool had three capacity mechanisms:
1. **Count cap** (soft_capacity) - enforced via atomic CAS on return. Default: `available_parallelism()`.
2. **Byte budget** (ByteBudget) - soft cap on retained bytes. Default: **None** (gap).
3. **Memory cap** (MemoryCap) - hard cap on outstanding bytes with backpressure. Default: None.

Without `--max-alloc`, the pool had no byte budget. The count cap alone (e.g., 16 buffers) at 128 KiB default buffers bounds retention to ~2 MiB, which is modest. But with adaptive buffer sizing (up to 1 MiB per buffer), the same 16 slots could retain 16 MiB. The 32 MiB default aligns with the adaptive resizer's `MAX_CAPACITY` ceiling (256 x 128 KiB) and provides a consistent byte-level guard.

Additionally, `global_buffer_pool()` used `BufferPool::default()` which bypassed `GlobalBufferPoolConfig` entirely, meaning the byte budget was never applied in the daemon lazy-init path.

## Test plan

- [ ] Existing `byte_budget` tests pass (no behavioral change for pools with explicit budgets)
- [ ] New `parse_byte_budget_*` tests cover env var parsing edge cases
- [ ] `config_default_matches_hardware_parallelism` updated to assert `Some(32 MiB)`
- [ ] `default_byte_budget_is_32_mib` validates the constant value
- [ ] CI: fmt, clippy, nextest, Windows, macOS, Linux musl