### PR TITLE
fix(ci): use heredoc syntax for GITHUB_OUTPUT iouring_status

### DIFF
--- a/.github/workflows/iouring-kernel-compat.yml
+++ b/.github/workflows/iouring-kernel-compat.yml
@@ -133,7 +133,9 @@ jobs:
 
           # Extract io_uring status line from version output.
           IOURING_LINE=$(echo "$PROBE_OUTPUT" | grep -i 'io_uring' || echo "io_uring: not found in output")
-          echo "iouring_status=$IOURING_LINE" >> "$GITHUB_OUTPUT"
+          echo "iouring_status<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$IOURING_LINE" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Validate io_uring expectations
         env:


### PR DESCRIPTION
## Summary

- Fix `GITHUB_OUTPUT` formatting error when `iouring_status` value contains commas and parentheses (e.g., `io_uring: compiled in, available (kernel 6.8, 55 ops)`)
- Replace single-line `echo "key=value"` syntax with GitHub's heredoc/delimiter syntax which handles special characters safely

## Test plan

- [ ] Verify the `iouring-kernel-compat` workflow runs without `Invalid format` errors on ubuntu-22.04 and ubuntu-24.04 matrix cells
- [ ] Confirm the `iouring_status` output is correctly consumed by the downstream "Validate io_uring expectations" and "Generate step summary" steps