### PR TITLE
feat(daemon): wire ConnectionState FSM into connection handler

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -61,7 +61,13 @@ use protocol::{
     parse_legacy_daemon_message,
 };
 
-use crate::{config::DaemonConfig, daemon_stream::DaemonStream, error::DaemonError, systemd};
+use crate::{
+    config::DaemonConfig,
+    connection::{ConnectionState, InvalidTransition},
+    daemon_stream::DaemonStream,
+    error::DaemonError,
+    systemd,
+};
 
 mod help;
 pub(crate) mod tracing_stream;

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -8,6 +8,11 @@
 // upstream: `clientserver.c` - `rsync_module()` is the dispatcher that handles
 // module lookup, access control, authentication, and transfer setup.
 
+/// Maps an [`InvalidTransition`] to an [`io::Error`] for protocol-level reporting.
+fn transition_error(err: InvalidTransition) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, err.to_string())
+}
+
 /// Context for module request handling, passed to helper functions.
 ///
 /// Bundles the connection state (reader, bandwidth limiter, peer address)
@@ -27,6 +32,12 @@ struct ModuleRequestContext<'a> {
     /// upstream: clientserver.c:583-584 - the daemon writes `early_input` to
     /// the pre-xfer exec script's stdin.
     early_input_data: Option<Vec<u8>>,
+    /// Typed FSM state tracking the connection lifecycle phase.
+    ///
+    /// Every phase transition goes through `ConnectionState::transition()`,
+    /// which rejects invalid progressions. The field is the single source of
+    /// truth for which protocol phase the connection is in.
+    conn_state: ConnectionState,
 }
 
 impl<'a> ModuleRequestContext<'a> {
@@ -143,11 +154,16 @@ fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> i
     Ok(())
 }
 
-/// Handles module authentication flow.
+/// Handles module authentication flow with FSM transition enforcement.
 ///
 /// Returns `Some(username)` if authentication succeeded, where the username is
 /// the authenticated user (or `None` inside `Some` when auth was not required).
 /// Returns `Ok(None)` if authentication failed or was denied.
+///
+/// FSM transitions:
+/// - When auth is required: ModuleSelect -> Authenticating -> (on grant) stays
+///   until caller transitions to Transferring.
+/// - When auth is not required: no Authenticating transition (skipped).
 fn handle_authentication(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleDefinition,
@@ -157,6 +173,12 @@ fn handle_authentication(
         send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
         return Ok(Some(None));
     }
+
+    // FSM: ModuleSelect -> Authenticating - module requires auth, challenge sent.
+    ctx.conn_state = ctx
+        .conn_state
+        .transition(ConnectionState::Authenticating)
+        .map_err(transition_error)?;
 
     match perform_module_authentication(
         ctx.reader,
@@ -170,6 +192,11 @@ fn handle_authentication(
             if let Some(log) = ctx.log_sink {
                 log_module_auth_failure(log, ctx.effective_host(), ctx.peer_ip, ctx.request);
             }
+            // FSM: -> Closing on auth failure (session ends).
+            ctx.conn_state = ctx
+                .conn_state
+                .transition(ConnectionState::Closing)
+                .map_err(transition_error)?;
             Ok(None)
         }
         AuthenticationStatus::Granted(username) => {
@@ -253,6 +280,7 @@ fn respond_with_module_request(
     messages: &LegacyMessageCache,
     negotiated_protocol: Option<ProtocolVersion>,
     early_input_data: Option<Vec<u8>>,
+    conn_state: ConnectionState,
 ) -> io::Result<()> {
     let Some(module) = modules.iter().find(|module| module.name == request) else {
         return handle_unknown_module(
@@ -302,6 +330,7 @@ fn respond_with_module_request(
         log_sink,
         messages,
         early_input_data,
+        conn_state,
     };
 
     if !module.permits(peer_ip, module_peer_host) {

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -627,11 +627,15 @@ fn process_approved_module(
         None => return Ok(()),
     };
 
+    // Extract host name before building structs that borrow ctx, so the
+    // borrow is released before the FSM transition mutates ctx.conn_state.
+    let host_name_owned = ctx.effective_host().map(str::to_owned);
+
     let xfer_ctx = XferExecContext {
         module_name: &module.name,
         module_path: &module.path,
         host_addr: ctx.peer_ip,
-        host_name: ctx.effective_host(),
+        host_name: host_name_owned.as_deref(),
         user_name: auth_user.as_deref(),
         request: ctx.request,
     };
@@ -645,7 +649,7 @@ fn process_approved_module(
         module_name: &module.name,
         username: "",
         remote_addr: &addr_str_exec,
-        hostname: ctx.effective_host().unwrap_or(""),
+        hostname: host_name_owned.as_deref().unwrap_or(""),
         pid: std::process::id(),
     };
 

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -700,6 +700,13 @@ fn process_approved_module(
         }
     }
 
+    // FSM: -> Transferring - auth passed (or was not required), all
+    // pre-transfer validation complete, transfer engine about to run.
+    ctx.conn_state = ctx
+        .conn_state
+        .transition(ConnectionState::Transferring)
+        .map_err(transition_error)?;
+
     let handshake = build_handshake_result(ctx.reader, negotiated_protocol, client_args, module);
     let final_protocol = handshake.protocol;
 
@@ -728,6 +735,12 @@ fn process_approved_module(
         let expanded_command = expand_exec_command(command, &exec_path_ctx);
         run_post_xfer_exec(&expanded_command, &xfer_ctx, exit_status, ctx.log_sink);
     }
+
+    // FSM: Transferring -> Closing - transfer and post-xfer hooks complete.
+    ctx.conn_state = ctx
+        .conn_state
+        .transition(ConnectionState::Closing)
+        .map_err(transition_error)?;
 
     Ok(())
 }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -305,7 +305,7 @@ fn handle_legacy_session(
             messages,
         )?;
         // FSM: -> Closing after sending the module list and EXIT.
-        conn_state = conn_state
+        _ = conn_state
             .transition(ConnectionState::Closing)
             .map_err(transition_error)?;
     } else if request.is_empty() {
@@ -318,7 +318,7 @@ fn handle_legacy_session(
         messages.write_exit(reader.get_mut(), &mut limiter)?;
         reader.get_mut().flush()?;
         // FSM: -> Closing after sending error and EXIT for empty request.
-        conn_state = conn_state
+        _ = conn_state
             .transition(ConnectionState::Closing)
             .map_err(transition_error)?;
     } else {

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -224,6 +224,10 @@ fn handle_legacy_session(
     // `@RSYNCD: OK\n` / `@RSYNCD: EXIT\n` boxes per accepted connection.
     let messages = LegacyMessageCache::shared();
 
+    // FSM: connection starts in Greeting - the server is about to send the
+    // @RSYNCD: greeting and wait for the client's version response.
+    let mut conn_state = ConnectionState::Greeting;
+
     // DIS-4.a R2: write the cached newest-protocol greeting bytes directly,
     // skipping the per-accept `format!`/`push_str` chain.
     // upstream: clientserver.c:455 output_daemon_greeting
@@ -242,6 +246,11 @@ fn handle_legacy_session(
                 // the version exchange. Sending OK here causes the client to misinterpret
                 // subsequent protocol messages.
                 negotiated_protocol = Some(version);
+                // FSM: Greeting -> ModuleSelect - version exchange complete,
+                // now waiting for the client to request a module name.
+                conn_state = conn_state
+                    .transition(ConnectionState::ModuleSelect)
+                    .map_err(transition_error)?;
                 continue;
             }
             Ok(LegacyDaemonMessage::Other(payload)) => {
@@ -250,7 +259,11 @@ fn handle_legacy_session(
                     continue;
                 }
             }
-            Ok(LegacyDaemonMessage::Exit) => return Ok(()),
+            Ok(LegacyDaemonMessage::Exit) => {
+                // FSM: -> Closing on client-initiated exit.
+                let _ = conn_state.transition(ConnectionState::Closing);
+                return Ok(());
+            }
             Ok(
                 LegacyDaemonMessage::Ok
                 | LegacyDaemonMessage::Capabilities { .. }
@@ -291,6 +304,10 @@ fn handle_legacy_session(
             reverse_lookup,
             messages,
         )?;
+        // FSM: -> Closing after sending the module list and EXIT.
+        conn_state = conn_state
+            .transition(ConnectionState::Closing)
+            .map_err(transition_error)?;
     } else if request.is_empty() {
         write_limited(
             reader.get_mut(),
@@ -300,6 +317,10 @@ fn handle_legacy_session(
         write_limited(reader.get_mut(), &mut limiter, b"\n")?;
         messages.write_exit(reader.get_mut(), &mut limiter)?;
         reader.get_mut().flush()?;
+        // FSM: -> Closing after sending error and EXIT for empty request.
+        conn_state = conn_state
+            .transition(ConnectionState::Closing)
+            .map_err(transition_error)?;
     } else {
         respond_with_module_request(
             &mut reader,
@@ -314,6 +335,7 @@ fn handle_legacy_session(
             messages,
             negotiated_protocol,
             early_input_data,
+            conn_state,
         )?;
     }
 
@@ -632,6 +654,91 @@ mod session_runtime_tests {
     #[test]
     fn early_input_max_size_is_5k() {
         assert_eq!(EARLY_INPUT_MAX_SIZE, 5120);
+    }
+
+    #[test]
+    fn fsm_greeting_to_module_select() {
+        let state = ConnectionState::Greeting;
+        let state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        assert_eq!(state, ConnectionState::ModuleSelect);
+    }
+
+    #[test]
+    fn fsm_module_select_to_closing_on_list() {
+        let state = ConnectionState::ModuleSelect;
+        let state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn fsm_full_lifecycle_without_auth() {
+        let mut state = ConnectionState::Greeting;
+        state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        state = state.transition(ConnectionState::Transferring).unwrap();
+        state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn fsm_full_lifecycle_with_auth() {
+        let mut state = ConnectionState::Greeting;
+        state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        state = state.transition(ConnectionState::Authenticating).unwrap();
+        state = state.transition(ConnectionState::Transferring).unwrap();
+        state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn fsm_early_close_from_module_select() {
+        let mut state = ConnectionState::Greeting;
+        state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn fsm_auth_failure_transitions_to_closing() {
+        let mut state = ConnectionState::Greeting;
+        state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        state = state.transition(ConnectionState::Authenticating).unwrap();
+        state = state.transition(ConnectionState::Closing).unwrap();
+        assert!(state.is_terminal());
+    }
+
+    #[test]
+    fn fsm_skip_auth_to_transfer() {
+        let mut state = ConnectionState::Greeting;
+        state = state.transition(ConnectionState::ModuleSelect).unwrap();
+        // When no auth required, skip Authenticating and go to Transferring.
+        state = state.transition(ConnectionState::Transferring).unwrap();
+        assert_eq!(state, ConnectionState::Transferring);
+    }
+
+    #[test]
+    fn fsm_invalid_greeting_to_transferring() {
+        let state = ConnectionState::Greeting;
+        let result = state.transition(ConnectionState::Transferring);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fsm_no_double_close() {
+        let state = ConnectionState::Closing;
+        let result = state.transition(ConnectionState::Closing);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transition_error_produces_invalid_data() {
+        let err = InvalidTransition {
+            from: ConnectionState::Greeting,
+            to: ConnectionState::Transferring,
+        };
+        let io_err = transition_error(err);
+        assert_eq!(io_err.kind(), io::ErrorKind::InvalidData);
+        assert!(io_err.to_string().contains("Greeting"));
+        assert!(io_err.to_string().contains("Transferring"));
     }
 }
 


### PR DESCRIPTION
## Summary
- Wire the existing `ConnectionState` FSM (`Greeting -> ModuleSelect -> Authenticating -> Transferring -> Closing`) into the daemon session handler as the single source of truth for connection lifecycle phase
- Add `conn_state` field to `ModuleRequestContext` and validated `transition()` calls at every protocol phase boundary in `handle_legacy_session`, `handle_authentication`, and `process_approved_module`
- Map `InvalidTransition` errors to `io::Error(InvalidData)` so invalid FSM progressions propagate through the existing error handling chain

## Test plan
- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, musl)
- [ ] FSM transitions enforced at runtime - invalid transitions produce `io::Error`
- [ ] New unit tests verify full lifecycle (with/without auth), early close, auth failure, skip-auth, invalid transitions, and `transition_error` mapping