### PR TITLE
test(windows): add IOCP and NTFS edge-case integration tests (WTD-1/2/3)

### DIFF
--- a/crates/fast_io/tests/iocp_completion_port_integration.rs
+++ b/crates/fast_io/tests/iocp_completion_port_integration.rs
@@ -1,0 +1,432 @@
+//! IOCP completion-port integration tests for the Windows fast I/O path
+//! (WTD-2).
+//!
+//! These tests exercise IOCP code paths that existing CI does not cover:
+//!
+//! - **Concurrent reader+writer** on the same completion port via the factory
+//!   layer, verifying data round-trips through overlapped I/O end-to-end.
+//! - **Seek-then-write** to verify that IOCP writes at non-zero offsets land
+//!   at the correct file position.
+//! - **Preallocate-then-overwrite** to confirm `FileWriter::preallocate`
+//!   extends the file and subsequent writes fill the preallocated region.
+//! - **Reader factory size-threshold** to confirm that files below
+//!   `IOCP_MIN_FILE_SIZE` are served by the Std fallback while files above
+//!   the threshold use the IOCP reader.
+//! - **Writer sync durability** to verify that `FileWriter::sync` flushes
+//!   data to stable storage without error.
+//! - **Concurrent IocpDiskBatch instances** to confirm that two independent
+//!   completion ports can operate simultaneously without interference.
+//! - **IocpWriter seek to non-zero offset** exercises the `Seek` impl for
+//!   `SeekFrom::Start` and `SeekFrom::Current`.
+//! - **Error: SeekFrom::End** is unsupported and must return an error.
+//!
+//! The entire file compiles to nothing on non-Windows targets.
+
+#![cfg(all(target_os = "windows", feature = "iocp"))]
+
+use std::fs;
+use std::io::{Read, Seek, SeekFrom, Write};
+
+use fast_io::iocp::{
+    IocpConfig, IocpDiskBatch, IocpReader, IocpReaderFactory, IocpWriter, IocpWriterFactory,
+    IOCP_MIN_FILE_SIZE, is_iocp_available,
+};
+use fast_io::traits::{FileReader, FileReaderFactory, FileWriter, FileWriterFactory};
+use tempfile::tempdir;
+
+// ---------------------------------------------------------------------------
+// WTD-2.a: IOCP reader + writer round-trip via factory
+// ---------------------------------------------------------------------------
+
+/// Write data through the IOCP writer factory and read it back through the
+/// IOCP reader factory. The payload exceeds `IOCP_MIN_FILE_SIZE` so both
+/// factories select the IOCP variant.
+#[test]
+fn factory_roundtrip_above_min_size() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("factory_roundtrip.bin");
+
+    // Payload must exceed IOCP_MIN_FILE_SIZE so the reader factory picks IOCP.
+    let payload: Vec<u8> = (0..IOCP_MIN_FILE_SIZE as usize + 1024)
+        .map(|i| (i % 251) as u8)
+        .collect();
+
+    {
+        let factory = IocpWriterFactory::default();
+        assert!(factory.will_use_iocp());
+        let mut writer = factory.create(&path).unwrap();
+        writer.write_all(&payload).unwrap();
+        writer.flush().unwrap();
+    }
+
+    {
+        let factory = IocpReaderFactory::default();
+        assert!(factory.will_use_iocp());
+        let mut reader = factory.open(&path).unwrap();
+        assert_eq!(reader.size(), payload.len() as u64);
+        let data = reader.read_all().unwrap();
+        assert_eq!(data, payload);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.b: Reader factory falls back for small files
+// ---------------------------------------------------------------------------
+
+/// Files below `IOCP_MIN_FILE_SIZE` must be served by the Std reader, not
+/// the IOCP reader, because the overlapped setup cost exceeds the async
+/// benefit.
+#[test]
+fn factory_reader_uses_std_below_threshold() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("small.bin");
+    let payload = vec![0xABu8; (IOCP_MIN_FILE_SIZE as usize) - 1];
+    fs::write(&path, &payload).unwrap();
+
+    let factory = IocpReaderFactory::default();
+    let mut reader = factory.open(&path).unwrap();
+    // The Std fallback still produces correct data.
+    let data = reader.read_all().unwrap();
+    assert_eq!(data, payload);
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.c: IocpWriter seek + write at non-zero offset
+// ---------------------------------------------------------------------------
+
+/// Writing after seeking to a non-zero offset must place data at the correct
+/// file position.
+#[test]
+fn writer_seek_start_then_write() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("seek_write.bin");
+    let config = IocpConfig::default();
+
+    {
+        let mut writer = IocpWriter::create_with_size(&path, 1024, &config).unwrap();
+        // Seek to offset 512 then write 10 bytes.
+        let pos = writer.seek(SeekFrom::Start(512)).unwrap();
+        assert_eq!(pos, 512);
+        writer.write_all(b"at-offset!").unwrap();
+        writer.flush().unwrap();
+    }
+
+    let content = fs::read(&path).unwrap();
+    // File was preallocated to 1024. First 512 bytes should be zero.
+    assert!(content[..512].iter().all(|&b| b == 0));
+    assert_eq!(&content[512..522], b"at-offset!");
+}
+
+/// `SeekFrom::Current` with a positive delta must advance the offset.
+#[test]
+fn writer_seek_current_forward() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("seek_current.bin");
+    let config = IocpConfig::default();
+
+    {
+        let mut writer = IocpWriter::create_with_size(&path, 256, &config).unwrap();
+        writer.write_all(b"AAAA").unwrap();
+        writer.flush().unwrap();
+        // Current position is 4. Seek forward by 4 more.
+        let pos = writer.seek(SeekFrom::Current(4)).unwrap();
+        assert_eq!(pos, 8);
+        writer.write_all(b"BBBB").unwrap();
+        writer.flush().unwrap();
+    }
+
+    let content = fs::read(&path).unwrap();
+    assert_eq!(&content[0..4], b"AAAA");
+    // Bytes 4-7 are zero (gap from the seek).
+    assert!(content[4..8].iter().all(|&b| b == 0));
+    assert_eq!(&content[8..12], b"BBBB");
+}
+
+/// `SeekFrom::End` is explicitly unsupported and must return an error.
+#[test]
+fn writer_seek_end_returns_error() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("seek_end.bin");
+    let config = IocpConfig::default();
+    let mut writer = IocpWriter::create(&path, &config).unwrap();
+    let err = writer
+        .seek(SeekFrom::End(0))
+        .expect_err("SeekFrom::End must fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.d: FileWriter::preallocate + overwrite
+// ---------------------------------------------------------------------------
+
+/// `FileWriter::preallocate` must extend the file to the requested size.
+/// Subsequent writes must fill the preallocated region without error.
+#[test]
+fn writer_preallocate_then_fill() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("prealloc_fill.bin");
+    let config = IocpConfig::default();
+
+    let expected_size: u64 = 128 * 1024;
+    let payload: Vec<u8> = (0..expected_size as usize)
+        .map(|i| (i % 199) as u8)
+        .collect();
+
+    {
+        let mut writer = IocpWriter::create(&path, &config).unwrap();
+        writer.preallocate(expected_size).unwrap();
+        writer.write_all(&payload).unwrap();
+        writer.sync().unwrap();
+    }
+
+    let content = fs::read(&path).unwrap();
+    // The file may be larger than expected_size due to preallocate, but the
+    // first expected_size bytes must match the payload.
+    assert!(content.len() >= expected_size as usize);
+    assert_eq!(&content[..expected_size as usize], &payload[..]);
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.e: FileWriter::sync durability
+// ---------------------------------------------------------------------------
+
+/// `FileWriter::sync` must flush data to stable storage. Verify by writing,
+/// syncing, and reading back.
+#[test]
+fn writer_sync_persists_data() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("sync_persist.bin");
+    let config = IocpConfig::default();
+
+    {
+        let mut writer = IocpWriter::create(&path, &config).unwrap();
+        writer.write_all(b"durable-after-sync").unwrap();
+        writer.sync().unwrap();
+    }
+
+    let content = fs::read_to_string(&path).unwrap();
+    assert_eq!(content, "durable-after-sync");
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.f: Concurrent IocpDiskBatch instances
+// ---------------------------------------------------------------------------
+
+/// Two independent `IocpDiskBatch` instances must operate simultaneously
+/// without interfering. Each owns its own completion port and handle.
+#[test]
+fn concurrent_disk_batch_instances() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let config = IocpConfig::default();
+
+    let path_a = dir.path().join("concurrent_a.bin");
+    let path_b = dir.path().join("concurrent_b.bin");
+
+    let payload_a = vec![0xAAu8; 8192];
+    let payload_b = vec![0xBBu8; 16384];
+
+    let file_a = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path_a)
+        .unwrap();
+    let file_b = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path_b)
+        .unwrap();
+
+    let mut batch_a = IocpDiskBatch::new(&config).unwrap();
+    let mut batch_b = IocpDiskBatch::new(&config).unwrap();
+
+    batch_a.begin_file(file_a).unwrap();
+    batch_b.begin_file(file_b).unwrap();
+
+    // Interleave writes to both batches.
+    batch_a.write_data(&payload_a[..4096]).unwrap();
+    batch_b.write_data(&payload_b[..8192]).unwrap();
+    batch_a.write_data(&payload_a[4096..]).unwrap();
+    batch_b.write_data(&payload_b[8192..]).unwrap();
+
+    let (_fa, written_a) = batch_a.commit_file(false).unwrap();
+    let (_fb, written_b) = batch_b.commit_file(false).unwrap();
+
+    assert_eq!(written_a as usize, payload_a.len());
+    assert_eq!(written_b as usize, payload_b.len());
+
+    let content_a = fs::read(&path_a).unwrap();
+    let content_b = fs::read(&path_b).unwrap();
+    assert_eq!(content_a, payload_a);
+    assert_eq!(content_b, payload_b);
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.g: IocpReader read_at with explicit offset
+// ---------------------------------------------------------------------------
+
+/// `IocpReader::read_at` must read data at an arbitrary offset without
+/// affecting the sequential position.
+#[test]
+fn reader_read_at_arbitrary_offset() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("read_at.bin");
+    // Write a known pattern.
+    let payload: Vec<u8> = (0..1024).map(|i| (i % 256) as u8).collect();
+    fs::write(&path, &payload).unwrap();
+
+    let config = IocpConfig::default();
+    let mut reader = IocpReader::open(&path, &config).unwrap();
+
+    // Read 16 bytes at offset 512.
+    let mut buf = [0u8; 16];
+    let n = reader.read_at(512, &mut buf).unwrap();
+    assert_eq!(n, 16);
+    assert_eq!(&buf, &payload[512..528]);
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.h: IocpReader seek_to validates bounds
+// ---------------------------------------------------------------------------
+
+/// `IocpReader::seek_to` past the end of the file must return an error.
+#[test]
+fn reader_seek_beyond_eof_errors() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("seek_eof.bin");
+    fs::write(&path, b"short").unwrap();
+
+    let config = IocpConfig::default();
+    let mut reader = IocpReader::open(&path, &config).unwrap();
+    assert_eq!(reader.size(), 5);
+
+    let err = reader
+        .seek_to(100)
+        .expect_err("seek past EOF must fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.i: IocpWriter create_for_append preserves existing content offset
+// ---------------------------------------------------------------------------
+
+/// `IocpWriter::create_for_append` opens an existing file at offset 0.
+/// Writing appended data after a seek to the file's logical end should
+/// extend the file while preserving the original content.
+#[test]
+fn writer_create_for_append_preserves_content() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("append.bin");
+    fs::write(&path, b"existing-content").unwrap();
+
+    let config = IocpConfig::default();
+    {
+        let mut writer =
+            IocpWriter::create_for_append(&path, 8192, &config).unwrap();
+        // Seek to the end of the existing content before appending.
+        writer.seek(SeekFrom::Start(16)).unwrap();
+        writer.write_all(b"-appended").unwrap();
+        writer.flush().unwrap();
+    }
+
+    let content = fs::read_to_string(&path).unwrap();
+    assert_eq!(content, "existing-content-appended");
+}
+
+// ---------------------------------------------------------------------------
+// WTD-2.j: Large concurrent_ops IocpDiskBatch
+// ---------------------------------------------------------------------------
+
+/// Drive a moderate payload through a batch with `concurrent_ops = 64` to
+/// exercise deep in-flight queues.
+#[test]
+fn disk_batch_deep_in_flight_queue() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("deep_queue.bin");
+
+    let config = IocpConfig {
+        buffer_size: 4096,
+        concurrent_ops: 64,
+        ..IocpConfig::default()
+    };
+
+    // 64 * 4 KB = 256 KB payload to fill the entire in-flight window.
+    let payload: Vec<u8> = (0..256 * 1024).map(|i| (i % 251) as u8).collect();
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap();
+
+    let mut batch = IocpDiskBatch::new(&config).unwrap();
+    batch.begin_file(file).unwrap();
+    batch.write_data(&payload).unwrap();
+    let (_f, written) = batch.commit_file(false).unwrap();
+    assert_eq!(written as usize, payload.len());
+
+    let content = fs::read(&path).unwrap();
+    assert_eq!(content, payload);
+}

--- a/crates/fast_io/tests/iocp_completion_port_integration.rs
+++ b/crates/fast_io/tests/iocp_completion_port_integration.rs
@@ -28,8 +28,8 @@ use std::fs;
 use std::io::{Read, Seek, SeekFrom, Write};
 
 use fast_io::iocp::{
-    IocpConfig, IocpDiskBatch, IocpReader, IocpReaderFactory, IocpWriter, IocpWriterFactory,
-    IOCP_MIN_FILE_SIZE, is_iocp_available,
+    IOCP_MIN_FILE_SIZE, IocpConfig, IocpDiskBatch, IocpReader, IocpReaderFactory, IocpWriter,
+    IocpWriterFactory, is_iocp_available,
 };
 use fast_io::traits::{FileReader, FileReaderFactory, FileWriter, FileWriterFactory};
 use tempfile::tempdir;
@@ -351,9 +351,7 @@ fn reader_seek_beyond_eof_errors() {
     let mut reader = IocpReader::open(&path, &config).unwrap();
     assert_eq!(reader.size(), 5);
 
-    let err = reader
-        .seek_to(100)
-        .expect_err("seek past EOF must fail");
+    let err = reader.seek_to(100).expect_err("seek past EOF must fail");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 }
 
@@ -377,8 +375,7 @@ fn writer_create_for_append_preserves_content() {
 
     let config = IocpConfig::default();
     {
-        let mut writer =
-            IocpWriter::create_for_append(&path, 8192, &config).unwrap();
+        let mut writer = IocpWriter::create_for_append(&path, 8192, &config).unwrap();
         // Seek to the end of the existing content before appending.
         writer.seek(SeekFrom::Start(16)).unwrap();
         writer.write_all(b"-appended").unwrap();

--- a/crates/fast_io/tests/ntfs_edge_cases.rs
+++ b/crates/fast_io/tests/ntfs_edge_cases.rs
@@ -237,10 +237,7 @@ fn case_insensitive_overwrite() {
         entries.len(),
         1,
         "case-insensitive FS should have exactly one file, got: {:?}",
-        entries
-            .iter()
-            .map(|e| e.file_name())
-            .collect::<Vec<_>>()
+        entries.iter().map(|e| e.file_name()).collect::<Vec<_>>()
     );
 
     // Content should be the second write.
@@ -337,8 +334,7 @@ fn readonly_attribute_blocks_writes() {
     fs::set_permissions(&path, perms).unwrap();
 
     // Writing must fail.
-    let err = fs::write(&path, b"overwrite")
-        .expect_err("write to read-only file must fail");
+    let err = fs::write(&path, b"overwrite").expect_err("write to read-only file must fail");
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
 
     // Clear read-only and verify write succeeds.
@@ -424,7 +420,7 @@ fn unicode_filename_roundtrip() {
     let dir = tempdir().unwrap();
 
     let names = [
-        "\u{00e9}l\u{00e8}ve.txt",     // French accents: eleve
+        "\u{00e9}l\u{00e8}ve.txt",      // French accents: eleve
         "\u{65e5}\u{672c}\u{8a9e}.txt", // Japanese: nihongo
         "\u{0410}\u{0411}\u{0412}.txt", // Cyrillic: ABV
     ];

--- a/crates/fast_io/tests/ntfs_edge_cases.rs
+++ b/crates/fast_io/tests/ntfs_edge_cases.rs
@@ -1,0 +1,547 @@
+//! NTFS edge-case integration tests for Windows-specific filesystem behaviors
+//! (WTD-3).
+//!
+//! These tests exercise NTFS semantics that differ from POSIX and can cause
+//! silent data loss or sync failures if not handled:
+//!
+//! - **Long paths (> 260 characters)**: NTFS supports paths up to ~32,767
+//!   characters when the `\\?\` prefix is used. Standard Win32 APIs without
+//!   the prefix are limited to `MAX_PATH` (260). The IOCP reader/writer use
+//!   `CreateFileW` which accepts the extended prefix.
+//! - **Case-insensitive filename matching**: NTFS is case-preserving but
+//!   case-insensitive by default. Two paths that differ only in case refer
+//!   to the same file.
+//! - **Reparse points**: NTFS junctions and directory symlinks are reparse
+//!   points. File operations that follow reparse points may land in
+//!   unexpected directories.
+//! - **File attributes**: NTFS files carry attributes (read-only, hidden,
+//!   system, archive) that affect write access and visibility.
+//! - **Alternate data streams**: Covered by the `metadata` crate's
+//!   `xattr_windows` tests and the `windows-acl-xattr` CI job.
+//!
+//! Tests that require admin privileges are marked `#[ignore]` so they do
+//! not fail on unprivileged CI runners but can be run manually with
+//! `cargo nextest run --run-ignored ignored-only`.
+//!
+//! The entire file compiles to nothing on non-Windows targets.
+
+#![cfg(windows)]
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the filesystem at `path` supports long paths (> 260).
+/// Falls back to `false` if detection fails.
+fn long_paths_supported(dir: &Path) -> bool {
+    // Try creating a directory with a name long enough to push total path
+    // length past MAX_PATH. If it succeeds, long paths are supported.
+    let long_name = "a".repeat(200);
+    let test_path = dir.join(&long_name);
+    match fs::create_dir(&test_path) {
+        Ok(()) => {
+            let _ = fs::remove_dir(&test_path);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Returns `true` if the filesystem at `path` is case-insensitive (NTFS
+/// default). Probes by creating a file with a mixed-case name and checking
+/// if the lower-case variant refers to the same file.
+fn is_case_insensitive(dir: &Path) -> bool {
+    let upper = dir.join("CaseProbe_UPPER.tmp");
+    let lower = dir.join("caseprobe_upper.tmp");
+    if fs::write(&upper, b"probe").is_err() {
+        return false;
+    }
+    let exists = lower.exists();
+    let _ = fs::remove_file(&upper);
+    exists
+}
+
+/// Returns `true` if the current process has permission to create directory
+/// junctions on the given volume. Junctions do not require admin rights on
+/// most Windows versions, but some locked-down environments block them.
+fn can_create_junctions(dir: &Path) -> bool {
+    use std::os::windows::fs as winfs;
+    let target = dir.join("junction_target_probe");
+    let link = dir.join("junction_link_probe");
+    if fs::create_dir(&target).is_err() {
+        return false;
+    }
+    let ok = winfs::symlink_dir(&target, &link).is_ok();
+    let _ = fs::remove_dir(&link);
+    let _ = fs::remove_dir(&target);
+    ok
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.a: Long paths (> MAX_PATH / 260 characters)
+// ---------------------------------------------------------------------------
+
+/// The `\\?\` extended-length path prefix lets Win32 APIs access paths
+/// longer than 260 characters. The IOCP writer opens files via
+/// `CreateFileW`, which accepts the extended prefix. This test writes
+/// and reads back a file whose total path length exceeds MAX_PATH.
+#[test]
+fn long_path_write_and_read_roundtrip() {
+    let dir = tempdir().unwrap();
+    if !long_paths_supported(dir.path()) {
+        eprintln!("skipping: filesystem does not support long paths");
+        return;
+    }
+
+    // Build a path that exceeds 260 characters using nested directories.
+    // Each segment is 50 characters; 6 levels gets us to ~300+ chars.
+    let mut deep = dir.path().to_path_buf();
+    for i in 0..6 {
+        let segment = format!("{:0>50}", i);
+        deep = deep.join(segment);
+    }
+    fs::create_dir_all(&deep).unwrap();
+
+    let file_path = deep.join("long_path_test.bin");
+    assert!(
+        file_path.to_string_lossy().len() > 260,
+        "total path must exceed MAX_PATH for this test to be meaningful, got {}",
+        file_path.to_string_lossy().len()
+    );
+
+    let payload = b"data-at-long-path";
+    fs::write(&file_path, payload).unwrap();
+    let content = fs::read(&file_path).unwrap();
+    assert_eq!(content, payload);
+}
+
+/// The `\\?\` prefix enables paths up to ~32,767 characters. Test with a
+/// path near the practical limit by using deeply nested single-char
+/// directory names.
+#[test]
+fn very_long_path_via_extended_prefix() {
+    let dir = tempdir().unwrap();
+    if !long_paths_supported(dir.path()) {
+        eprintln!("skipping: filesystem does not support long paths");
+        return;
+    }
+
+    // Use the \\?\ prefix for the base, then nest directories to push
+    // the total well past 260.
+    let base = dir.path().to_path_buf();
+
+    // 30 levels of 10-char segments = ~300 chars of nesting.
+    let mut deep = base.clone();
+    for i in 0..30 {
+        deep = deep.join(format!("d{:0>9}", i));
+    }
+
+    // Use the \\?\ prefix to create the deep path.
+    let prefixed = if deep.starts_with("\\\\?\\") {
+        deep.clone()
+    } else {
+        PathBuf::from(format!("\\\\?\\{}", deep.display()))
+    };
+
+    match fs::create_dir_all(&prefixed) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("skipping: cannot create deep directory: {e}");
+            return;
+        }
+    }
+
+    let file_path = prefixed.join("deep_file.txt");
+    fs::write(&file_path, b"deep-data").unwrap();
+    let content = fs::read(&file_path).unwrap();
+    assert_eq!(content, b"deep-data");
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.b: Case-insensitive filename matching
+// ---------------------------------------------------------------------------
+
+/// NTFS is case-preserving but case-insensitive. Writing to "File.TXT" and
+/// reading from "file.txt" must return the same content.
+#[test]
+fn case_insensitive_read_write() {
+    let dir = tempdir().unwrap();
+    if !is_case_insensitive(dir.path()) {
+        eprintln!("skipping: filesystem is case-sensitive");
+        return;
+    }
+
+    let write_path = dir.path().join("CaseSensitivity.TXT");
+    let read_path = dir.path().join("casesensitivity.txt");
+
+    fs::write(&write_path, b"case-test-data").unwrap();
+
+    // Reading via the differently-cased path must succeed.
+    let content = fs::read(&read_path).unwrap();
+    assert_eq!(content, b"case-test-data");
+}
+
+/// NTFS preserves the original case of the filename. After creating
+/// "MyFile.Txt", the directory listing should show exactly that casing.
+#[test]
+fn case_preserving_directory_listing() {
+    let dir = tempdir().unwrap();
+    if !is_case_insensitive(dir.path()) {
+        eprintln!("skipping: filesystem is case-sensitive");
+        return;
+    }
+
+    let path = dir.path().join("MyFile.Txt");
+    fs::write(&path, b"preserve-case").unwrap();
+
+    let entries: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+
+    assert!(
+        entries.iter().any(|n| n == "MyFile.Txt"),
+        "directory listing must preserve original case, got: {entries:?}"
+    );
+}
+
+/// Creating a second file with a differently-cased name on NTFS should
+/// overwrite or refer to the same file, not create a separate entry.
+#[test]
+fn case_insensitive_overwrite() {
+    let dir = tempdir().unwrap();
+    if !is_case_insensitive(dir.path()) {
+        eprintln!("skipping: filesystem is case-sensitive");
+        return;
+    }
+
+    let path_upper = dir.path().join("OVERWRITE.DAT");
+    let path_lower = dir.path().join("overwrite.dat");
+
+    fs::write(&path_upper, b"first-version").unwrap();
+    fs::write(&path_lower, b"second-version").unwrap();
+
+    // Only one file should exist in the directory.
+    let entries: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "case-insensitive FS should have exactly one file, got: {:?}",
+        entries
+            .iter()
+            .map(|e| e.file_name())
+            .collect::<Vec<_>>()
+    );
+
+    // Content should be the second write.
+    let content = fs::read(&path_upper).unwrap();
+    assert_eq!(content, b"second-version");
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.c: Reparse points (directory junctions)
+// ---------------------------------------------------------------------------
+
+/// A directory junction is an NTFS reparse point that redirects path
+/// resolution to another directory. Files accessed through the junction
+/// must be readable and writable.
+#[test]
+fn junction_target_file_roundtrip() {
+    let dir = tempdir().unwrap();
+    if !can_create_junctions(dir.path()) {
+        eprintln!("skipping: cannot create directory junctions (permissions or FS type)");
+        return;
+    }
+
+    let target_dir = dir.path().join("real_dir");
+    let junction = dir.path().join("junction_link");
+    fs::create_dir(&target_dir).unwrap();
+
+    // Create a junction pointing to target_dir.
+    // On Windows, symlink_dir creates a directory symbolic link which
+    // may require developer mode or admin rights; fall back gracefully.
+    if std::os::windows::fs::symlink_dir(&target_dir, &junction).is_err() {
+        eprintln!("skipping: symlink_dir failed (may need developer mode)");
+        return;
+    }
+
+    // Write through the junction.
+    let file_via_junction = junction.join("through_junction.txt");
+    fs::write(&file_via_junction, b"junction-data").unwrap();
+
+    // Read through the real path.
+    let file_via_real = target_dir.join("through_junction.txt");
+    let content = fs::read(&file_via_real).unwrap();
+    assert_eq!(content, b"junction-data");
+}
+
+/// Metadata on the junction link itself should report it as a symlink
+/// (reparse point), while metadata through the junction follows through.
+#[test]
+fn junction_metadata_reports_symlink() {
+    let dir = tempdir().unwrap();
+    if !can_create_junctions(dir.path()) {
+        eprintln!("skipping: cannot create directory junctions");
+        return;
+    }
+
+    let target_dir = dir.path().join("meta_target");
+    let junction = dir.path().join("meta_junction");
+    fs::create_dir(&target_dir).unwrap();
+
+    if std::os::windows::fs::symlink_dir(&target_dir, &junction).is_err() {
+        eprintln!("skipping: symlink_dir failed");
+        return;
+    }
+
+    // symlink_metadata does NOT follow the link.
+    let link_meta = fs::symlink_metadata(&junction).unwrap();
+    assert!(
+        link_meta.file_type().is_symlink(),
+        "junction must report as symlink via symlink_metadata"
+    );
+
+    // Regular metadata follows through.
+    let followed_meta = fs::metadata(&junction).unwrap();
+    assert!(
+        followed_meta.file_type().is_dir(),
+        "following the junction must yield a directory"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.d: File attributes (read-only, hidden, system, archive)
+// ---------------------------------------------------------------------------
+
+/// Setting the read-only attribute must prevent writes and clearing it
+/// must restore write access.
+#[test]
+fn readonly_attribute_blocks_writes() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("readonly.txt");
+    fs::write(&path, b"original").unwrap();
+
+    // Set read-only.
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&path, perms).unwrap();
+
+    // Writing must fail.
+    let err = fs::write(&path, b"overwrite")
+        .expect_err("write to read-only file must fail");
+    assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+
+    // Clear read-only and verify write succeeds.
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_readonly(false);
+    fs::set_permissions(&path, perms).unwrap();
+
+    fs::write(&path, b"now-writable").unwrap();
+    let content = fs::read_to_string(&path).unwrap();
+    assert_eq!(content, "now-writable");
+}
+
+/// The archive attribute is set automatically on file modification and can
+/// be queried via `GetFileAttributesW`.
+#[test]
+fn archive_attribute_set_on_modification() {
+    use std::os::windows::fs::MetadataExt;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("archive.txt");
+    fs::write(&path, b"initial-data").unwrap();
+
+    let meta = fs::metadata(&path).unwrap();
+    let attrs = meta.file_attributes();
+
+    // FILE_ATTRIBUTE_ARCHIVE = 0x20
+    const FILE_ATTRIBUTE_ARCHIVE: u32 = 0x20;
+    assert!(
+        attrs & FILE_ATTRIBUTE_ARCHIVE != 0,
+        "newly written file must have the archive attribute set, got attrs={attrs:#x}"
+    );
+}
+
+/// Hidden files are accessible via their path but may not appear in
+/// standard directory listings. This test verifies that hidden files
+/// are still readable.
+#[test]
+fn hidden_file_is_still_readable() {
+    use std::os::windows::ffi::OsStrExt;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("hidden.txt");
+    fs::write(&path, b"hidden-content").unwrap();
+
+    // Set the hidden attribute via SetFileAttributesW.
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    const FILE_ATTRIBUTE_HIDDEN: u32 = 0x02;
+    // SAFETY: `wide` is null-terminated; SetFileAttributesW is a simple
+    // metadata mutation that does not affect file data.
+    #[allow(unsafe_code)]
+    let ok = unsafe {
+        windows_sys::Win32::Storage::FileSystem::SetFileAttributesW(
+            wide.as_ptr(),
+            FILE_ATTRIBUTE_HIDDEN,
+        )
+    };
+    if ok == 0 {
+        eprintln!(
+            "skipping: SetFileAttributesW failed: {}",
+            io::Error::last_os_error()
+        );
+        return;
+    }
+
+    // File must still be readable via its exact path.
+    let content = fs::read_to_string(&path).unwrap();
+    assert_eq!(content, "hidden-content");
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.e: Unicode filenames
+// ---------------------------------------------------------------------------
+
+/// NTFS supports Unicode filenames. This test creates files with non-ASCII
+/// characters and verifies round-trip data integrity.
+#[test]
+fn unicode_filename_roundtrip() {
+    let dir = tempdir().unwrap();
+
+    let names = [
+        "\u{00e9}l\u{00e8}ve.txt",     // French accents: eleve
+        "\u{65e5}\u{672c}\u{8a9e}.txt", // Japanese: nihongo
+        "\u{0410}\u{0411}\u{0412}.txt", // Cyrillic: ABV
+    ];
+
+    for name in &names {
+        let path = dir.path().join(name);
+        let payload = format!("content-for-{name}");
+        fs::write(&path, payload.as_bytes()).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, payload, "round-trip failed for filename {name}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.f: Empty filename components and trailing dots/spaces
+// ---------------------------------------------------------------------------
+
+/// NTFS silently strips trailing dots and spaces from filenames. A file
+/// created as "test. " is stored as "test" (or "test." depending on API).
+/// This test documents the behavior for rsync's filename handling.
+#[test]
+fn trailing_dots_and_spaces_normalized() {
+    let dir = tempdir().unwrap();
+
+    // On NTFS, trailing dots and spaces are stripped by Win32 APIs.
+    // CreateFileW("test. ") actually creates "test".
+    let path_with_trailing = dir.path().join("stripped.");
+    match fs::write(&path_with_trailing, b"data") {
+        Ok(()) => {
+            // The file was created - verify what name it actually has.
+            let entries: Vec<String> = fs::read_dir(dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect();
+            // NTFS strips the trailing dot.
+            assert!(
+                entries.iter().any(|n| n == "stripped" || n == "stripped."),
+                "NTFS should normalize trailing dots, got: {entries:?}"
+            );
+        }
+        Err(_) => {
+            // Some configurations reject the name entirely.
+            eprintln!("trailing-dot filename rejected by this filesystem");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.g: Maximum filename length
+// ---------------------------------------------------------------------------
+
+/// NTFS supports filenames up to 255 characters (not bytes). This test
+/// creates a file at the limit and verifies it round-trips.
+#[test]
+fn max_filename_length_255_chars() {
+    let dir = tempdir().unwrap();
+
+    // 251 chars + ".txt" = 255 total.
+    let name = format!("{}.txt", "x".repeat(251));
+    assert_eq!(name.len(), 255);
+
+    let path = dir.path().join(&name);
+    fs::write(&path, b"max-name").unwrap();
+    let content = fs::read(&path).unwrap();
+    assert_eq!(content, b"max-name");
+}
+
+/// Filenames longer than 255 characters must fail on NTFS.
+#[test]
+fn filename_over_255_chars_fails() {
+    let dir = tempdir().unwrap();
+
+    let name = "x".repeat(256);
+    let path = dir.path().join(&name);
+    let result = fs::write(&path, b"too-long");
+    assert!(
+        result.is_err(),
+        "creating a file with a 256-char name must fail on NTFS"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WTD-3.h: Concurrent writers to the same file via sharing flags
+// ---------------------------------------------------------------------------
+
+/// Two writers with `FILE_SHARE_WRITE` can coexist. This test verifies
+/// that the IOCP writer's sharing flags allow a second handle to read
+/// the file while the first is still writing.
+#[test]
+#[cfg(feature = "iocp")]
+fn concurrent_read_during_iocp_write() {
+    use fast_io::iocp::{IocpConfig, IocpWriter, is_iocp_available};
+
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable");
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("concurrent_rw.bin");
+    let config = IocpConfig::default();
+
+    let mut writer = IocpWriter::create(&path, &config).unwrap();
+    writer.write_all(b"concurrent-data").unwrap();
+    writer.flush().unwrap();
+
+    // While the IOCP writer still has the file open, a concurrent reader
+    // must be able to open it for reading (FILE_SHARE_READ was set).
+    let content = fs::read(&path).unwrap();
+    assert_eq!(content, b"concurrent-data");
+
+    // The writer can continue writing after the concurrent read.
+    writer.write_all(b"-more").unwrap();
+    writer.flush().unwrap();
+    drop(writer);
+
+    let final_content = fs::read(&path).unwrap();
+    assert_eq!(final_content, b"concurrent-data-more");
+}


### PR DESCRIPTION
## Summary
- Audited Windows CI coverage matrix vs Linux: main Windows job runs only `core`/`engine`/`cli`; the `windows-iocp` job covers `fast_io`/`transfer` but lacked integration tests for IOCP seek/preallocate/concurrent-batch paths and NTFS filesystem edge cases
- Added 10 IOCP fast-path integration tests covering factory round-trip, seek+write, preallocate+fill, sync durability, concurrent batch instances, reader read_at/seek_to, create_for_append, and deep in-flight queues
- Added 14 NTFS edge-case tests covering long paths (>260 chars), case-insensitive matching, reparse points (junctions), file attributes (read-only/hidden/archive), Unicode filenames, trailing dot normalization, max filename length, and concurrent read during IOCP write

## Test plan
- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, musl)
- [ ] Windows-specific tests gated with `#[cfg(windows)]` or `#[cfg(all(target_os = "windows", feature = "iocp"))]`
- [ ] No compilation errors on Linux/macOS (cfg gates compile entire files to nothing)
- [ ] Tests degrade gracefully on restricted environments (skip with eprintln when features unavailable)