### PR TITLE
ci: bump nextest job timeout to 60 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    timeout-minutes: 45
+    timeout-minutes: 60
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
     # should pin the required check to `nextest (stable)`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    timeout-minutes: 30
+    timeout-minutes: 45
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
     # should pin the required check to `nextest (stable)`.


### PR DESCRIPTION
## Summary

- Bumps the nextest CI job timeout from 30 to 60 minutes
- The full test suite consistently exceeds 30 minutes on GitHub-hosted runners, and also exceeded 45 minutes (timed out at 45m16s)
- 60 minutes provides adequate headroom while test suite optimization is tracked separately

## Test plan

- [ ] All required CI checks pass within the new timeout