### PR TITLE
perf(protocol): coalesce MSG_INFO frames to reduce wire segment count

### DIFF
--- a/crates/protocol/src/envelope/message_code.rs
+++ b/crates/protocol/src/envelope/message_code.rs
@@ -172,6 +172,24 @@ impl MessageCode {
         &Self::ALL
     }
 
+    /// Returns true if this message code requires an immediate flush after
+    /// being written to the multiplexed stream.
+    ///
+    /// `MSG_INFO` and `MSG_WARNING` are batchable - they accumulate in the
+    /// write buffer and drain with the next DATA flush or explicit
+    /// `io_flush()`. All other control messages (ERROR, REDO, NO_SEND,
+    /// SUCCESS, etc.) are latency-sensitive and must be flushed immediately.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:965 send_msg()` - appends to `iobuf.msg` without flushing
+    /// - `io.c:680-716 perform_io()` - drains `iobuf.msg` opportunistically
+    #[inline]
+    #[must_use]
+    pub const fn requires_immediate_flush(self) -> bool {
+        !matches!(self, Self::Info | Self::Warning)
+    }
+
     /// Reports whether this message is a keepalive (no-op) used to prevent
     /// connection timeouts during long operations.
     ///
@@ -487,5 +505,40 @@ mod tests {
         let err = ParseMessageCodeError::new("BAD_CODE");
         let display = format!("{err}");
         assert!(display.contains("BAD_CODE"));
+    }
+
+    #[test]
+    fn info_and_warning_are_batchable() {
+        assert!(!MessageCode::Info.requires_immediate_flush());
+        assert!(!MessageCode::Warning.requires_immediate_flush());
+    }
+
+    #[test]
+    fn latency_sensitive_codes_require_flush() {
+        let must_flush = [
+            MessageCode::Data,
+            MessageCode::ErrorXfer,
+            MessageCode::Error,
+            MessageCode::ErrorSocket,
+            MessageCode::ErrorUtf8,
+            MessageCode::Redo,
+            MessageCode::Stats,
+            MessageCode::IoError,
+            MessageCode::IoTimeout,
+            MessageCode::NoOp,
+            MessageCode::ErrorExit,
+            MessageCode::Success,
+            MessageCode::Deleted,
+            MessageCode::NoSend,
+            MessageCode::Log,
+            MessageCode::Client,
+        ];
+        for code in must_flush {
+            assert!(
+                code.requires_immediate_flush(),
+                "{} should require immediate flush",
+                code.name()
+            );
+        }
     }
 }

--- a/crates/protocol/src/multiplex/writer.rs
+++ b/crates/protocol/src/multiplex/writer.rs
@@ -715,10 +715,7 @@ mod tests {
                 .write_message(MessageCode::Info, b"file2.txt")
                 .unwrap();
         }
-        assert_eq!(
-            tracker.flush_count, 0,
-            "MSG_INFO should not trigger flush"
-        );
+        assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
     }
 
     #[test]

--- a/crates/protocol/src/multiplex/writer.rs
+++ b/crates/protocol/src/multiplex/writer.rs
@@ -197,8 +197,15 @@ impl<W: Write> MplexWriter<W> {
     /// Writes a message with the specified message code.
     ///
     /// This is used for sending control messages (INFO, WARNING, ERROR, etc.)
-    /// or other non-DATA message types. The message is sent immediately,
-    /// flushing any buffered DATA first to maintain proper message ordering.
+    /// or other non-DATA message types. Buffered DATA is flushed first to
+    /// maintain proper message ordering.
+    ///
+    /// Batchable message codes (`MSG_INFO`, `MSG_WARNING`) skip the
+    /// immediate flush, letting the write buffer coalesce multiple
+    /// control frames into fewer TCP segments. This matches upstream
+    /// rsync's `send_msg()` in `io.c` which appends to `iobuf.msg`
+    /// without flushing. Latency-sensitive codes (ERROR, REDO, etc.)
+    /// still flush immediately.
     ///
     /// # Errors
     ///
@@ -228,7 +235,12 @@ impl<W: Write> MplexWriter<W> {
         // before data the caller has already written.
         self.flush_buffer()?;
         send_msg(&mut self.inner, code, payload)?;
-        self.inner.flush()
+        // upstream: io.c:965 send_msg() appends to iobuf.msg without flushing.
+        // Only latency-sensitive codes need an immediate flush.
+        if code.requires_immediate_flush() {
+            self.inner.flush()?;
+        }
+        Ok(())
     }
 
     /// Writes a DATA message directly without buffering.
@@ -662,5 +674,161 @@ mod tests {
         }
 
         assert_eq!(reconstructed, large_data);
+    }
+
+    /// Writer that counts flush calls to verify coalescing behavior.
+    struct FlushTracker {
+        data: Vec<u8>,
+        flush_count: usize,
+    }
+
+    impl FlushTracker {
+        fn new() -> Self {
+            Self {
+                data: Vec::new(),
+                flush_count: 0,
+            }
+        }
+    }
+
+    impl Write for FlushTracker {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.data.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flush_count += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn msg_info_does_not_flush_immediately() {
+        let mut tracker = FlushTracker::new();
+        let mut writer = MplexWriter::new(&mut tracker);
+
+        writer
+            .write_message(MessageCode::Info, b"file1.txt")
+            .unwrap();
+        assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
+
+        writer
+            .write_message(MessageCode::Info, b"file2.txt")
+            .unwrap();
+        assert_eq!(
+            tracker.flush_count, 0,
+            "second MSG_INFO should still not flush"
+        );
+    }
+
+    #[test]
+    fn msg_warning_does_not_flush_immediately() {
+        let mut tracker = FlushTracker::new();
+        let mut writer = MplexWriter::new(&mut tracker);
+
+        writer
+            .write_message(MessageCode::Warning, b"slow link")
+            .unwrap();
+        assert_eq!(
+            tracker.flush_count, 0,
+            "MSG_WARNING should not trigger flush"
+        );
+    }
+
+    #[test]
+    fn msg_error_flushes_immediately() {
+        let mut tracker = FlushTracker::new();
+        let mut writer = MplexWriter::new(&mut tracker);
+
+        writer
+            .write_message(MessageCode::Error, b"permission denied")
+            .unwrap();
+        assert_eq!(tracker.flush_count, 1, "MSG_ERROR must flush immediately");
+    }
+
+    #[test]
+    fn msg_redo_flushes_immediately() {
+        let mut tracker = FlushTracker::new();
+        let mut writer = MplexWriter::new(&mut tracker);
+
+        writer
+            .write_message(MessageCode::Redo, &42_i32.to_le_bytes())
+            .unwrap();
+        assert_eq!(tracker.flush_count, 1, "MSG_REDO must flush immediately");
+    }
+
+    #[test]
+    fn coalesced_info_frames_byte_identical_after_flush() {
+        // Send multiple MSG_INFO frames, then flush. Verify the wire bytes
+        // are identical to what individual flush-per-frame would produce.
+        let payloads: Vec<&[u8]> = vec![b"file1.txt\n", b"file2.txt\n", b"file3.txt\n"];
+
+        // Coalesced: write all, then flush once
+        let mut coalesced_output = Vec::new();
+        {
+            let mut writer = MplexWriter::new(&mut coalesced_output);
+            for payload in &payloads {
+                writer.write_message(MessageCode::Info, payload).unwrap();
+            }
+            writer.flush().unwrap();
+        }
+
+        // Reference: write each with immediate flush (old behavior)
+        let mut reference_output = Vec::new();
+        for payload in &payloads {
+            send_msg(&mut reference_output, MessageCode::Info, payload).unwrap();
+        }
+
+        assert_eq!(
+            coalesced_output, reference_output,
+            "coalesced output must be byte-identical to individual frames"
+        );
+    }
+
+    #[test]
+    fn explicit_flush_drains_buffered_info() {
+        let mut tracker = FlushTracker::new();
+        let mut writer = MplexWriter::new(&mut tracker);
+
+        writer
+            .write_message(MessageCode::Info, b"buffered")
+            .unwrap();
+        assert_eq!(tracker.flush_count, 0);
+
+        writer.flush().unwrap();
+        assert_eq!(
+            tracker.flush_count, 1,
+            "explicit flush must drain deferred MSG_INFO"
+        );
+
+        // Verify the frame is present in the output
+        let mut cursor = std::io::Cursor::new(&tracker.data);
+        let frame = recv_msg(&mut cursor).unwrap();
+        assert_eq!(frame.code(), MessageCode::Info);
+        assert_eq!(frame.payload(), b"buffered");
+    }
+
+    #[test]
+    fn data_write_after_info_preserves_ordering() {
+        // MSG_INFO followed by DATA write - verify correct frame ordering
+        let mut output = Vec::new();
+        {
+            let mut writer = MplexWriter::new(&mut output);
+            writer
+                .write_message(MessageCode::Info, b"info line")
+                .unwrap();
+            writer.write_all(b"file data").unwrap();
+            writer.flush().unwrap();
+        }
+
+        let mut cursor = std::io::Cursor::new(&output);
+        let frame1 = recv_msg(&mut cursor).unwrap();
+        assert_eq!(frame1.code(), MessageCode::Info);
+        assert_eq!(frame1.payload(), b"info line");
+
+        let frame2 = recv_msg(&mut cursor).unwrap();
+        assert_eq!(frame2.code(), MessageCode::Data);
+        assert_eq!(frame2.payload(), b"file data");
     }
 }

--- a/crates/protocol/src/multiplex/writer.rs
+++ b/crates/protocol/src/multiplex/writer.rs
@@ -706,19 +706,18 @@ mod tests {
     #[test]
     fn msg_info_does_not_flush_immediately() {
         let mut tracker = FlushTracker::new();
-        let mut writer = MplexWriter::new(&mut tracker);
-
-        writer
-            .write_message(MessageCode::Info, b"file1.txt")
-            .unwrap();
-        assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
-
-        writer
-            .write_message(MessageCode::Info, b"file2.txt")
-            .unwrap();
+        {
+            let mut writer = MplexWriter::new(&mut tracker);
+            writer
+                .write_message(MessageCode::Info, b"file1.txt")
+                .unwrap();
+            writer
+                .write_message(MessageCode::Info, b"file2.txt")
+                .unwrap();
+        }
         assert_eq!(
             tracker.flush_count, 0,
-            "second MSG_INFO should still not flush"
+            "MSG_INFO should not trigger flush"
         );
     }
 
@@ -789,20 +788,18 @@ mod tests {
     #[test]
     fn explicit_flush_drains_buffered_info() {
         let mut tracker = FlushTracker::new();
-        let mut writer = MplexWriter::new(&mut tracker);
-
-        writer
-            .write_message(MessageCode::Info, b"buffered")
-            .unwrap();
-        assert_eq!(tracker.flush_count, 0);
-
-        writer.flush().unwrap();
+        {
+            let mut writer = MplexWriter::new(&mut tracker);
+            writer
+                .write_message(MessageCode::Info, b"buffered")
+                .unwrap();
+            writer.flush().unwrap();
+        }
         assert_eq!(
             tracker.flush_count, 1,
             "explicit flush must drain deferred MSG_INFO"
         );
 
-        // Verify the frame is present in the output
         let mut cursor = std::io::Cursor::new(&tracker.data);
         let frame = recv_msg(&mut cursor).unwrap();
         assert_eq!(frame.code(), MessageCode::Info);

--- a/crates/transfer/src/writer/multiplex.rs
+++ b/crates/transfer/src/writer/multiplex.rs
@@ -63,10 +63,20 @@ impl<W: Write> MultiplexWriter<W> {
     /// Unlike the `Write` trait which always sends `MSG_DATA`, this method
     /// allows sending other message types like `MSG_IO_TIMEOUT`.
     /// Flushes buffered data first to maintain message ordering.
+    ///
+    /// Batchable message codes (`MSG_INFO`, `MSG_WARNING`) skip the
+    /// immediate flush, letting the write buffer coalesce multiple
+    /// control frames into fewer TCP segments. This matches upstream
+    /// rsync's `send_msg()` in `io.c` which appends to `iobuf.msg`
+    /// without flushing. Latency-sensitive codes (ERROR, REDO, etc.)
+    /// still flush immediately.
     pub(crate) fn send_message(&mut self, code: MessageCode, payload: &[u8]) -> io::Result<()> {
         self.flush_buffer()?;
         protocol::send_msg(&mut self.inner, code, payload)?;
-        self.inner.flush()
+        if code.requires_immediate_flush() {
+            self.inner.flush()?;
+        }
+        Ok(())
     }
 
     /// Writes raw bytes directly to the inner writer, bypassing multiplex framing.

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -769,13 +769,12 @@ impl Write for FlushTracker {
 #[test]
 fn multiplex_writer_msg_info_defers_flush() {
     let mut tracker = FlushTracker::new();
-    let mut mux = MultiplexWriter::new(&mut tracker);
-
-    mux.send_message(MessageCode::Info, b"file1.txt\n").unwrap();
+    {
+        let mut mux = MultiplexWriter::new(&mut tracker);
+        mux.send_message(MessageCode::Info, b"file1.txt\n").unwrap();
+        mux.send_message(MessageCode::Info, b"file2.txt\n").unwrap();
+    }
     assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
-
-    mux.send_message(MessageCode::Info, b"file2.txt\n").unwrap();
-    assert_eq!(tracker.flush_count, 0, "second MSG_INFO should not flush");
 }
 
 #[test]
@@ -790,34 +789,34 @@ fn multiplex_writer_msg_error_flushes_immediately() {
 #[test]
 fn server_writer_msg_info_defers_flush() {
     let mut tracker = FlushTracker::new();
-    let mut writer = ServerWriter::new_plain(&mut tracker)
-        .activate_multiplex()
-        .unwrap();
+    {
+        let mut writer = ServerWriter::new_plain(&mut tracker)
+            .activate_multiplex()
+            .unwrap();
 
-    writer.send_msg_info(b"item1\n").unwrap();
-    assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
-
-    writer.send_msg_info(b"item2\n").unwrap();
-    assert_eq!(tracker.flush_count, 0, "second MSG_INFO should not flush");
-
-    // Explicit flush drains deferred MSG_INFO frames
-    writer.flush().unwrap();
-    assert_eq!(tracker.flush_count, 1);
+        writer.send_msg_info(b"item1\n").unwrap();
+        writer.send_msg_info(b"item2\n").unwrap();
+        writer.flush().unwrap();
+    }
+    assert_eq!(
+        tracker.flush_count, 1,
+        "explicit flush must drain deferred MSG_INFO"
+    );
 }
 
 #[test]
 fn server_writer_msg_error_flushes_past_deferred_info() {
     let mut tracker = FlushTracker::new();
-    let mut writer = ServerWriter::new_plain(&mut tracker)
-        .activate_multiplex()
-        .unwrap();
+    {
+        let mut writer = ServerWriter::new_plain(&mut tracker)
+            .activate_multiplex()
+            .unwrap();
 
-    writer.send_msg_info(b"info line\n").unwrap();
-    assert_eq!(tracker.flush_count, 0);
-
-    writer
-        .send_message(MessageCode::Error, b"error line\n")
-        .unwrap();
+        writer.send_msg_info(b"info line\n").unwrap();
+        writer
+            .send_message(MessageCode::Error, b"error line\n")
+            .unwrap();
+    }
     assert_eq!(
         tracker.flush_count, 1,
         "MSG_ERROR must flush even after deferred MSG_INFO"

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -736,3 +736,116 @@ fn server_writer_batch_recorder_stays_on_mux_zstd() {
         assert!(!recorded.is_empty(), "recorder must capture data");
     }
 }
+
+// MSG_INFO coalescing tests
+
+/// Writer that counts flush calls to verify coalescing behavior.
+struct FlushTracker {
+    data: Vec<u8>,
+    flush_count: usize,
+}
+
+impl FlushTracker {
+    fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            flush_count: 0,
+        }
+    }
+}
+
+impl Write for FlushTracker {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.data.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_count += 1;
+        Ok(())
+    }
+}
+
+#[test]
+fn multiplex_writer_msg_info_defers_flush() {
+    let mut tracker = FlushTracker::new();
+    let mut mux = MultiplexWriter::new(&mut tracker);
+
+    mux.send_message(MessageCode::Info, b"file1.txt\n").unwrap();
+    assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
+
+    mux.send_message(MessageCode::Info, b"file2.txt\n").unwrap();
+    assert_eq!(tracker.flush_count, 0, "second MSG_INFO should not flush");
+}
+
+#[test]
+fn multiplex_writer_msg_error_flushes_immediately() {
+    let mut tracker = FlushTracker::new();
+    let mut mux = MultiplexWriter::new(&mut tracker);
+
+    mux.send_message(MessageCode::Error, b"fatal").unwrap();
+    assert_eq!(tracker.flush_count, 1, "MSG_ERROR must flush immediately");
+}
+
+#[test]
+fn server_writer_msg_info_defers_flush() {
+    let mut tracker = FlushTracker::new();
+    let mut writer = ServerWriter::new_plain(&mut tracker)
+        .activate_multiplex()
+        .unwrap();
+
+    writer.send_msg_info(b"item1\n").unwrap();
+    assert_eq!(tracker.flush_count, 0, "MSG_INFO should not trigger flush");
+
+    writer.send_msg_info(b"item2\n").unwrap();
+    assert_eq!(tracker.flush_count, 0, "second MSG_INFO should not flush");
+
+    // Explicit flush drains deferred MSG_INFO frames
+    writer.flush().unwrap();
+    assert_eq!(tracker.flush_count, 1);
+}
+
+#[test]
+fn server_writer_msg_error_flushes_past_deferred_info() {
+    let mut tracker = FlushTracker::new();
+    let mut writer = ServerWriter::new_plain(&mut tracker)
+        .activate_multiplex()
+        .unwrap();
+
+    writer.send_msg_info(b"info line\n").unwrap();
+    assert_eq!(tracker.flush_count, 0);
+
+    writer
+        .send_message(MessageCode::Error, b"error line\n")
+        .unwrap();
+    assert_eq!(
+        tracker.flush_count, 1,
+        "MSG_ERROR must flush even after deferred MSG_INFO"
+    );
+}
+
+#[test]
+fn coalesced_msg_info_wire_bytes_identical() {
+    // Verify that coalesced MSG_INFO frames produce byte-identical output
+    // compared to the reference frame encoding (header + payload for each).
+    let payloads: Vec<&[u8]> = vec![b"file_a.txt\n", b"file_b.txt\n", b"file_c.txt\n"];
+
+    let mut coalesced = Vec::new();
+    {
+        let mut mux = MultiplexWriter::new(&mut coalesced);
+        for p in &payloads {
+            mux.send_message(MessageCode::Info, p).unwrap();
+        }
+        mux.flush().unwrap();
+    }
+
+    let mut reference = Vec::new();
+    for p in &payloads {
+        protocol::send_msg(&mut reference, MessageCode::Info, p).unwrap();
+    }
+
+    assert_eq!(
+        coalesced, reference,
+        "coalesced frames must be byte-identical to individual frames"
+    );
+}


### PR DESCRIPTION
## Summary

- Skip the immediate `inner.flush()` after writing batchable multiplex control messages (`MSG_INFO`, `MSG_WARNING`), letting them accumulate in the write buffer and drain with the next DATA flush or explicit `io_flush()` - matching upstream rsync's `send_msg()` in `io.c` which appends to `iobuf.msg` without flushing
- Add `MessageCode::requires_immediate_flush()` to classify flush discipline per message code - latency-sensitive codes (ERROR, REDO, NO_SEND, SUCCESS, etc.) retain the immediate flush
- Wire bytes are identical - only TCP segmentation changes, reducing syscall count and small-packet overhead for itemize-heavy transfers

Implements MIF-5 from the MSG_INFO frame coalescing series. Design rationale documented in `docs/design/mif-frame-coalescing.md` (MIF-3/4, PR #5105).

### Changes

| File | Change |
|------|--------|
| `crates/protocol/src/envelope/message_code.rs` | Add `requires_immediate_flush()` const method + exhaustive tests |
| `crates/protocol/src/multiplex/writer.rs` | Conditional flush in `MplexWriter::write_message()` + `FlushTracker` coalescing tests |
| `crates/transfer/src/writer/multiplex.rs` | Conditional flush in `MultiplexWriter::send_message()` |
| `crates/transfer/src/writer/tests.rs` | `FlushTracker`-based coalescing tests for `MultiplexWriter` and `ServerWriter` + wire-byte parity test |

### Expected Impact

| Metric | Before | After (Projected) |
|--------|--------|--------------------|
| TCP segments per 10K files (`-i`) | ~20,000 | ~10,000-12,000 |
| `write()` syscalls per 10K files | ~20,000 | ~2,000-4,000 |
| Wire bytes | baseline | identical |

## Test plan

- [ ] `requires_immediate_flush()` returns false for `MSG_INFO` and `MSG_WARNING` only
- [ ] All 16 latency-sensitive codes require immediate flush (exhaustive test)
- [ ] `FlushTracker` confirms zero flushes after MSG_INFO writes in both protocol and transfer crates
- [ ] `FlushTracker` confirms immediate flush after MSG_ERROR and MSG_REDO
- [ ] Coalesced MSG_INFO output is byte-identical to individual frame encoding
- [ ] `ServerWriter` defers flush through `send_msg_info()` trait path
- [ ] Existing multiplex writer tests pass unchanged (Vec<u8> flush is no-op)
- [ ] Interop CI validates upstream rsync compatibility
- [ ] Golden byte tests in `crates/protocol/tests/golden/` unaffected