### PR TITLE
perf: default local-copy --checksum to XXH3/128 matching upstream rsync 3.4.1 (CSM-8)

### DIFF
--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -374,9 +374,7 @@ mod tests {
 
     /// Returns the default checksum algorithm used across comparison tests.
     fn default_checksum_algorithm() -> SignatureAlgorithm {
-        SignatureAlgorithm::Md5 {
-            seed_config: checksums::strong::Md5Seed::none(),
-        }
+        SignatureAlgorithm::Xxh3_128 { seed: 0 }
     }
 
     #[test]

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -226,9 +226,7 @@ impl LocalCopyOptionsBuilder {
             sparse: false,
             sparse_detect_strategy: SparseDetectStrategy::Auto,
             checksum: false,
-            checksum_algorithm: SignatureAlgorithm::Md5 {
-                seed_config: checksums::strong::Md5Seed::none(),
-            },
+            checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
             checksum_seed: None,
             enable_xxh64_dedup: false,
             xxh64_dedup_size_limit: DEFAULT_XXH64_DEDUP_SIZE_LIMIT,

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -300,9 +300,7 @@ impl LocalCopyOptions {
             sparse: false,
             sparse_detect_strategy: SparseDetectStrategy::Auto,
             checksum: false,
-            checksum_algorithm: SignatureAlgorithm::Md5 {
-                seed_config: checksums::strong::Md5Seed::none(),
-            },
+            checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
             checksum_seed: None,
             enable_xxh64_dedup: false,
             xxh64_dedup_size_limit: DEFAULT_XXH64_DEDUP_SIZE_LIMIT,

--- a/crates/engine/src/local_copy/tests/options.rs
+++ b/crates/engine/src/local_copy/tests/options.rs
@@ -65,7 +65,7 @@ fn should_skip_copy_requires_exact_mtime_when_window_zero() {
         size_only: false,
         ignore_times: false,
         checksum: false,
-        checksum_algorithm: SignatureAlgorithm::Md5 { seed_config: checksums::strong::Md5Seed::none() },
+        checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
         modify_window: Duration::ZERO,
         prefetched_match: None,
     }));
@@ -96,7 +96,7 @@ fn should_skip_copy_allows_difference_within_window() {
         size_only: false,
         ignore_times: false,
         checksum: false,
-        checksum_algorithm: SignatureAlgorithm::Md5 { seed_config: checksums::strong::Md5Seed::none() },
+        checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
         modify_window: Duration::from_secs(5),
         prefetched_match: None,
     }));
@@ -112,7 +112,7 @@ fn should_skip_copy_allows_difference_within_window() {
         size_only: false,
         ignore_times: false,
         checksum: false,
-        checksum_algorithm: SignatureAlgorithm::Md5 { seed_config: checksums::strong::Md5Seed::none() },
+        checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
         modify_window: Duration::from_secs(5),
         prefetched_match: None,
     }));
@@ -141,7 +141,7 @@ fn should_skip_copy_skips_when_size_and_mtime_match_unless_ignored() {
         size_only: false,
         ignore_times: false,
         checksum: false,
-        checksum_algorithm: SignatureAlgorithm::Md5 { seed_config: checksums::strong::Md5Seed::none() },
+        checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
         modify_window: Duration::ZERO,
         prefetched_match: None,
     }));
@@ -154,7 +154,7 @@ fn should_skip_copy_skips_when_size_and_mtime_match_unless_ignored() {
         size_only: false,
         ignore_times: true,
         checksum: false,
-        checksum_algorithm: SignatureAlgorithm::Md5 { seed_config: checksums::strong::Md5Seed::none() },
+        checksum_algorithm: SignatureAlgorithm::Xxh3_128 { seed: 0 },
         modify_window: Duration::ZERO,
         prefetched_match: None,
     }));
@@ -204,9 +204,7 @@ fn local_copy_options_checksum_algorithm_round_trip() {
     );
     assert_eq!(
         LocalCopyOptions::default().checksum_algorithm(),
-        SignatureAlgorithm::Md5 {
-            seed_config: checksums::strong::Md5Seed::none()
-        }
+        SignatureAlgorithm::Xxh3_128 { seed: 0 }
     );
 }
 


### PR DESCRIPTION
## Summary

- Change default checksum algorithm for local-copy `--checksum` mode from MD5 to XXH3/128, matching upstream rsync 3.4.1 behavior
- XXH3/128 is 10-30x faster than MD5, eliminating the 2-3x performance gap observed in checksum mode benchmarks
- Update builder default, type default, and test expectations; no changes to wire/remote negotiation or explicit MD5-specific tests

## Test plan

- [ ] CI nextest passes on all platforms (Linux, macOS, Windows)
- [ ] `checksum_algorithm_round_trip` test verifies new default is `Xxh3_128 { seed: 0 }`
- [ ] `checksum_algorithm_behavior` tests continue to pass (they explicitly set algorithms)
- [ ] `files_checksum_match_respects_algorithm_selection` covers all algorithms including MD5
- [ ] fmt + clippy clean