### PR TITLE
style: collapse debug_log macro calls per rustfmt

### DIFF
--- a/crates/transfer/src/receiver/tests/parallel_delta_notice.rs
+++ b/crates/transfer/src/receiver/tests/parallel_delta_notice.rs
@@ -34,11 +34,7 @@ fn recv_messages() -> Vec<String> {
 fn parallel_receive_delta_notice_emitted() {
     init_recv_level1();
 
-    debug_log!(
-        Recv,
-        1,
-        "parallel receive-delta path active"
-    );
+    debug_log!(Recv, 1, "parallel receive-delta path active");
 
     let msgs = recv_messages();
     assert!(

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -42,11 +42,7 @@ impl ReceiverContext {
         debug_log!(Genr, 1, "generator starting pid={}", std::process::id());
 
         // Parallel receive-side delta apply is unconditionally compiled (PFF-7).
-        debug_log!(
-            Recv,
-            1,
-            "parallel receive-delta path active"
-        );
+        debug_log!(Recv, 1, "parallel receive-delta path active");
 
         let mut reader = if self.should_activate_input_multiplex() {
             reader.activate_multiplex().map_err(|e| {


### PR DESCRIPTION
## Summary
- Collapse multi-line `debug_log!` macro calls that rustfmt expects on a single line
- Fixes fmt+clippy CI failure on master

## Test plan
- CI fmt+clippy check passes