### PR TITLE
fix: remove clippy::ptr_arg waivers in flist sort functions

### DIFF
--- a/crates/flist/src/sort.rs
+++ b/crates/flist/src/sort.rs
@@ -2,20 +2,17 @@
 
 /// Sorts file list entries by relative path in lexicographic order.
 #[cfg(feature = "parallel")]
-#[allow(clippy::ptr_arg)]
-pub(crate) fn sort_file_entries(entries: &mut Vec<crate::entry::FileListEntry>) {
+pub(crate) fn sort_file_entries(entries: &mut [crate::entry::FileListEntry]) {
     entries.sort_unstable_by(|a, b| a.relative_path.cmp(&b.relative_path));
 }
 
 /// Sorts directory entries by file name in lexicographic order.
 #[cfg(feature = "parallel")]
-#[allow(clippy::ptr_arg)]
-pub(crate) fn sort_dir_entries(entries: &mut Vec<std::fs::DirEntry>) {
+pub(crate) fn sort_dir_entries(entries: &mut [std::fs::DirEntry]) {
     entries.sort_unstable_by_key(|e| e.file_name());
 }
 
 /// Sorts OS strings in lexicographic order.
-#[allow(clippy::ptr_arg)]
-pub(crate) fn sort_os_strings(entries: &mut Vec<std::ffi::OsString>) {
+pub(crate) fn sort_os_strings(entries: &mut [std::ffi::OsString]) {
     entries.sort_unstable();
 }


### PR DESCRIPTION
## Summary
- Change sort function signatures from `&mut Vec<T>` to `&mut [T]` in `crates/flist/src/sort.rs`
- All three functions (`sort_file_entries`, `sort_dir_entries`, `sort_os_strings`) only call slice methods, never resize the Vec
- Removes 3 `#[allow(clippy::ptr_arg)]` attributes that suppressed valid lints

## Test plan
- [ ] CI fmt+clippy passes (the lint is now satisfied, no suppression needed)
- [ ] All callers pass `&mut Vec<T>` which auto-derefs to `&mut [T]` - no caller changes needed
- [ ] nextest passes (sort behavior unchanged)