### PR TITLE
perf: replace BufReader with pre-sized read in whole-file checksum

### DIFF
--- a/crates/checksums/src/crc32c.rs
+++ b/crates/checksums/src/crc32c.rs
@@ -35,7 +35,7 @@
 //! where the goal is fast change detection rather than protocol compatibility.
 
 use std::fs::File;
-use std::io::{self, BufReader, Read};
+use std::io::{self, Read};
 use std::path::Path;
 
 /// Buffer size for streaming file reads (64 KiB).
@@ -141,17 +141,17 @@ pub fn crc32c_bytes(data: &[u8]) -> u32 {
 /// assert_eq!(file_checksum, crc32c_bytes(b"hello world"));
 /// ```
 pub fn crc32c_file(path: &Path) -> io::Result<u32> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::with_capacity(BUF_SIZE, file);
+    let mut file = File::open(path)?;
+    let size = file.metadata()?.len();
     let mut hasher = Crc32cHasher::new();
     let mut buf = [0u8; BUF_SIZE];
+    let mut remaining = size;
 
-    loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
+    while remaining > 0 {
+        let to_read = (remaining as usize).min(BUF_SIZE);
+        file.read_exact(&mut buf[..to_read])?;
+        hasher.update(&buf[..to_read]);
+        remaining -= to_read as u64;
     }
 
     Ok(hasher.finalize())

--- a/crates/checksums/src/parallel/files.rs
+++ b/crates/checksums/src/parallel/files.rs
@@ -7,7 +7,7 @@
 use fast_io::mmap_reader::{MMAP_THRESHOLD, MmapReader};
 use rayon::prelude::*;
 use std::fs::File;
-use std::io::{self, BufReader, Read};
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use crate::rolling::RollingChecksum;
@@ -25,14 +25,13 @@ where
     D::Seed: Default,
 {
     let result = (|| -> io::Result<(D::Digest, u64)> {
-        let file = File::open(path)?;
+        let mut file = File::open(path)?;
         let metadata = file.metadata()?;
         let size = metadata.len();
 
         if size <= config.max_memory_file_size {
-            let mut data = Vec::with_capacity(size as usize);
-            let mut reader = BufReader::with_capacity(config.buffer_size, file);
-            reader.read_to_end(&mut data)?;
+            let mut data = vec![0u8; size as usize];
+            file.read_exact(&mut data)?;
             return Ok((D::digest(&data), size));
         }
 
@@ -43,16 +42,15 @@ where
             }
         }
 
+        // upstream: checksum.c - pre-sized read loop avoids trailing EOF probe
         let mut hasher = D::new();
-        let mut reader = BufReader::with_capacity(config.buffer_size, file);
         let mut buffer = vec![0u8; config.buffer_size];
-
-        loop {
-            let bytes_read = reader.read(&mut buffer)?;
-            if bytes_read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..bytes_read]);
+        let mut remaining = size;
+        while remaining > 0 {
+            let to_read = (remaining as usize).min(buffer.len());
+            file.read_exact(&mut buffer[..to_read])?;
+            hasher.update(&buffer[..to_read]);
+            remaining -= to_read as u64;
         }
 
         Ok((hasher.finalize(), size))
@@ -217,14 +215,13 @@ where
     D::Seed: Clone,
 {
     let result = (|| -> io::Result<(D::Digest, u64)> {
-        let file = File::open(path)?;
+        let mut file = File::open(path)?;
         let metadata = file.metadata()?;
         let size = metadata.len();
 
         if size <= config.max_memory_file_size {
-            let mut data = Vec::with_capacity(size as usize);
-            let mut reader = BufReader::with_capacity(config.buffer_size, file);
-            reader.read_to_end(&mut data)?;
+            let mut data = vec![0u8; size as usize];
+            file.read_exact(&mut data)?;
             return Ok((D::digest_with_seed(seed, &data), size));
         }
 
@@ -235,16 +232,15 @@ where
             }
         }
 
+        // upstream: checksum.c - pre-sized read loop avoids trailing EOF probe
         let mut hasher = D::with_seed(seed);
-        let mut reader = BufReader::with_capacity(config.buffer_size, file);
         let mut buffer = vec![0u8; config.buffer_size];
-
-        loop {
-            let bytes_read = reader.read(&mut buffer)?;
-            if bytes_read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..bytes_read]);
+        let mut remaining = size;
+        while remaining > 0 {
+            let to_read = (remaining as usize).min(buffer.len());
+            file.read_exact(&mut buffer[..to_read])?;
+            hasher.update(&buffer[..to_read]);
+            remaining -= to_read as u64;
         }
 
         Ok((hasher.finalize(), size))
@@ -323,7 +319,7 @@ where
     D::Seed: Default,
 {
     let result = (|| -> io::Result<SignatureComputeResult<D::Digest>> {
-        let file = File::open(path)?;
+        let mut file = File::open(path)?;
         let metadata = file.metadata()?;
         let size = metadata.len();
         let estimated_blocks = (size as usize).div_ceil(block_size);
@@ -351,24 +347,16 @@ where
         }
 
         let mut signatures = Vec::with_capacity(estimated_blocks);
-        let mut reader = BufReader::with_capacity(buffer_size, file);
+        let _ = buffer_size; // size known from metadata; BufReader not needed
         let mut buffer = vec![0u8; block_size];
+        let mut remaining = size;
 
-        loop {
-            let mut total_read = 0;
-            while total_read < block_size {
-                let bytes_read = reader.read(&mut buffer[total_read..])?;
-                if bytes_read == 0 {
-                    break;
-                }
-                total_read += bytes_read;
-            }
+        while remaining > 0 {
+            let to_read = (remaining as usize).min(block_size);
+            file.read_exact(&mut buffer[..to_read])?;
+            remaining -= to_read as u64;
 
-            if total_read == 0 {
-                break;
-            }
-
-            let block = &buffer[..total_read];
+            let block = &buffer[..to_read];
             let mut rolling = RollingChecksum::new();
             rolling.update(block);
 

--- a/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
@@ -139,29 +139,49 @@ fn compute_file_checksum(
     let metadata = file.metadata().ok()?;
     let size = metadata.len();
 
-    let digest = hash_file_contents(file, algorithm, buffer_pool).ok()?;
+    let digest = hash_file_contents(file, size, algorithm, buffer_pool).ok()?;
 
     Some(FileChecksum { digest, size })
 }
 
 /// Hashes file contents using the specified algorithm.
+///
+/// Uses a pre-sized read loop based on the known `file_size` to avoid
+/// the extra read() syscall that EOF-probe patterns (BufReader, loop-until-0)
+/// issue per file.
+///
+/// upstream: checksum.c - sized read loop: `while (remaining > 0) { read(); remaining -= n; }`
 fn hash_file_contents(
     mut file: File,
+    file_size: u64,
     algorithm: SignatureAlgorithm,
     buffer_pool: &Arc<BufferPool>,
 ) -> io::Result<Vec<u8>> {
     let mut buffer = BufferPool::acquire_from(Arc::clone(buffer_pool));
+    let buf_len = buffer.len();
+
+    /// Reads exactly `remaining` bytes from `file` into `hasher` using
+    /// pre-sized chunks, avoiding a trailing EOF probe syscall.
+    fn read_into_hasher(
+        file: &mut File,
+        mut remaining: u64,
+        buffer: &mut [u8],
+        buf_len: usize,
+        hasher: &mut impl checksums::strong::StrongDigest,
+    ) -> io::Result<()> {
+        while remaining > 0 {
+            let to_read = (remaining as usize).min(buf_len);
+            file.read_exact(&mut buffer[..to_read])?;
+            hasher.update(&buffer[..to_read]);
+            remaining -= to_read as u64;
+        }
+        Ok(())
+    }
 
     let digest = match algorithm {
         SignatureAlgorithm::Md4 => {
             let mut hasher = Md4::new();
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             hasher.finalize().as_ref().to_vec()
         }
         SignatureAlgorithm::Md4Seeded { seed } => {
@@ -169,13 +189,7 @@ fn hash_file_contents(
             // after the file data when seed != 0. A zero seed degenerates to
             // unseeded MD4 (preserved here for symmetry with `Md4`).
             let mut hasher = Md4::new();
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             if seed != 0 {
                 hasher.update(&seed.to_le_bytes());
             }
@@ -183,57 +197,27 @@ fn hash_file_contents(
         }
         SignatureAlgorithm::Md5 { seed_config } => {
             let mut hasher = Md5::with_seed(seed_config);
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             hasher.finalize().as_ref().to_vec()
         }
         SignatureAlgorithm::Sha1 => {
             let mut hasher = Sha1::new();
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             hasher.finalize().as_ref().to_vec()
         }
         SignatureAlgorithm::Xxh64 { seed } => {
             let mut hasher = Xxh64::new(seed);
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             hasher.finalize().as_ref().to_vec()
         }
         SignatureAlgorithm::Xxh3 { seed } => {
             let mut hasher = Xxh3::new(seed);
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             hasher.finalize().as_ref().to_vec()
         }
         SignatureAlgorithm::Xxh3_128 { seed } => {
             let mut hasher = Xxh3_128::new(seed);
-            loop {
-                let n = file.read(&mut buffer)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buffer[..n]);
-            }
+            read_into_hasher(&mut file, file_size, &mut buffer, buf_len, &mut hasher)?;
             hasher.finalize().as_ref().to_vec()
         }
     };


### PR DESCRIPTION
## Summary

- Replace `BufReader` and loop-until-0 read patterns with pre-sized read loops using `file_size` from metadata across all whole-file checksum paths
- Eliminates the extra `read()` syscall that EOF-probe patterns (BufReader, loop-until-0) issue per file, matching upstream rsync's `checksum.c` sized-read loop
- Covers `crc32c_file`, parallel file hashing (`hash_file_internal`, `hash_file_with_seed_internal`, `compute_file_signatures_internal`), and local-copy `hash_file_contents`

## Context

Root cause of STX-2/3/5/6: oc-rsync's `--checksum` mode issues 3.34x more statx calls than upstream (6,691 vs 2,006). Part of the gap comes from BufReader internally issuing a trailing `read()` returning 0 to detect EOF. Upstream rsync avoids this by using the known file size to drive a pre-sized read loop.

The fix replaces every BufReader/loop-until-0 site in the checksum path with:
```rust
// upstream: checksum.c - pre-sized read loop avoids trailing EOF probe
let mut remaining = size;
while remaining > 0 {
    let to_read = (remaining as usize).min(buf_len);
    file.read_exact(&mut buffer[..to_read])?;
    hasher.update(&buffer[..to_read]);
    remaining -= to_read as u64;
}
```

## Test plan

- [ ] CI fmt+clippy passes (no BufReader unused import warnings)
- [ ] CI nextest passes on all platforms (Linux, macOS, Windows)
- [ ] Verify no regression in existing checksum tests
- [ ] Manual strace verification that EOF-probe read(0) no longer appears in --checksum transfers