### PR TITLE
perf: eliminate redundant stat calls in --checksum path

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use rayon::prelude::*;
 
-use checksums::strong::{Md4, Md5, Sha1, Xxh3, Xxh3_128, Xxh64};
+use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
 
 use crate::local_copy::buffer_pool::{BufferPool, global_buffer_pool};
 use crate::signature::SignatureAlgorithm;

--- a/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use rayon::prelude::*;
 
-use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
+use checksums::strong::{Md4, Md5, Sha1, Xxh3, Xxh3_128, Xxh64};
 
 use crate::local_copy::buffer_pool::{BufferPool, global_buffer_pool};
 use crate::signature::SignatureAlgorithm;
@@ -108,8 +108,15 @@ pub(crate) fn prefetch_checksums(
             let pool_dst = Arc::clone(&buffer_pool);
 
             let (source_checksum, destination_checksum) = rayon::join(
-                || compute_file_checksum(&pair.source, algorithm, &pool_src),
-                || compute_file_checksum(&pair.destination, algorithm, &pool_dst),
+                || compute_file_checksum(&pair.source, pair.source_size, algorithm, &pool_src),
+                || {
+                    compute_file_checksum(
+                        &pair.destination,
+                        pair.destination_size,
+                        algorithm,
+                        &pool_dst,
+                    )
+                },
             );
 
             (
@@ -130,18 +137,23 @@ pub(crate) fn prefetch_checksums(
 }
 
 /// Computes the checksum of a single file.
+///
+/// Uses the pre-cached `file_size` from the file list entry rather than
+/// calling `file.metadata()`, eliminating a redundant fstat syscall per file.
+/// upstream: checksum.c:402 `file_checksum()` uses the stat-cached size.
 fn compute_file_checksum(
     path: &Path,
+    file_size: u64,
     algorithm: SignatureAlgorithm,
     buffer_pool: &Arc<BufferPool>,
 ) -> Option<FileChecksum> {
     let file = File::open(path).ok()?;
-    let metadata = file.metadata().ok()?;
-    let size = metadata.len();
+    let digest = hash_file_contents(file, file_size, algorithm, buffer_pool).ok()?;
 
-    let digest = hash_file_contents(file, size, algorithm, buffer_pool).ok()?;
-
-    Some(FileChecksum { digest, size })
+    Some(FileChecksum {
+        digest,
+        size: file_size,
+    })
 }
 
 /// Hashes file contents using the specified algorithm.


### PR DESCRIPTION
## Summary

- Thread pre-cached `file_size` from `FilePair` into `compute_file_checksum` and `hash_file_contents`, removing a redundant `fstat` syscall per file in the local-copy checksum prefetch path
- Replace unbounded read-until-EOF loops with pre-sized `read_exact` calls matching upstream `checksum.c:402 file_checksum()` pattern, eliminating EOF-probe overhead
- Extract shared bounded-read logic into `feed_file` helper to reduce duplication across 7 algorithm arms

Addresses STX-7/STX-8: the 3.34x statx gap (6,691 vs 2,006 calls) traced to `compute_file_checksum` calling `file.metadata()` despite `FilePair` already carrying stat-cached sizes from prior directory traversal.

## Test plan

- [ ] CI nextest passes (existing tests in `parallel_checksum::tests` cover identical, different, size-mismatch, missing-destination, parallel-100-file, and xxh3 algorithm paths)
- [ ] Clippy clean
- [ ] Cross-platform compile (Linux, macOS, Windows)