### PR TITLE
ci: free disk space before nextest build to avoid link-time exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,17 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Free disk space
+        # The debug build statically links a large dependency closure (aws-lc,
+        # openssl, ring, zstd) into many test binaries, which can exhaust the
+        # ~14 GB free on ubuntu-latest at link time ("No space left on device").
+        # Remove preinstalled toolchains the Rust build does not use to reclaim
+        # ~15+ GB before the build.
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          df -h /
+
       - name: Run tests
         run: cargo nextest run --locked --workspace --all-features
 


### PR DESCRIPTION
## Summary
- The required `nextest (stable)` Linux job intermittently fails (and sometimes hangs then cancels) with `/usr/bin/ld: final link failed: No space left on device` during the debug-build LINK phase. The workspace statically links a large dependency closure (aws-lc-sys, openssl, ring, zstd, ...) into dozens of test binaries, which can exceed the ~14 GB free on `ubuntu-latest`.
- Adds a `Free disk space` step before the build that removes large preinstalled toolchains the Rust build never uses (`/usr/local/lib/android`, `/usr/share/dotnet`, `/opt/ghc`, `/usr/local/.ghcup`, `/opt/hostedtoolcache/CodeQL`), reclaiming ~15+ GB. Additive only - no test-logic change.

## Test plan
- [ ] This PR's own `nextest (stable)` job runs with the new step and links the full test-binary set without `No space left on device`.
- [ ] `df -h /` output in the step log shows the reclaimed headroom before the build.