### PR TITLE
ci: unblock cargo-deny for rustls-pemfile advisory + webpki-roots license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,13 @@ ignore = [
     # `embedded-ssh` feature; default builds are unaffected. Re-evaluate when
     # rsa 0.10 ships stable and the advisory is updated.
     "RUSTSEC-2023-0071",
+    # RUSTSEC-2025-0134 - rustls-pemfile is unmaintained (repo archived Aug
+    # 2025); upstream recommends migrating to rustls-pki-types' PemObject. This
+    # is an unmaintained notice, not a vulnerability, and there is no safe
+    # upgrade available. It reaches us only transitively through the rustls TLS
+    # stack (webpki/tokio-rustls), which still depends on rustls-pemfile; we do
+    # not use it directly. Re-evaluate once the rustls stack drops it.
+    "RUSTSEC-2025-0134",
 ]
 
 [licenses]
@@ -43,6 +50,10 @@ allow = [
     "0BSD",
     "CC0-1.0",
     "Artistic-2.0",
+    # webpki-roots ships the Mozilla CA certificate bundle under the Community
+    # Data License Agreement (permissive). It is data, not code, reaches us
+    # transitively via the rustls TLS stack, and imposes no copyleft.
+    "CDLA-Permissive-2.0",
     # The project itself is GPL-3.0-or-later
     "GPL-3.0-or-later",
 ]


### PR DESCRIPTION
## Summary
Master's **Security Audit** (`cargo-deny check all`) has been failing on every Cargo-touching PR due to two dependency-ecosystem changes, neither caused by repo code:

- **advisories FAILED** — `RUSTSEC-2025-0134`: `rustls-pemfile 2.2.0` is unmaintained (repo archived Aug 2025; no safe upgrade). It is an unmaintained notice, not a vulnerability, and reaches us only transitively via the rustls TLS stack (`webpki`/`tokio-rustls`). Added to `[advisories] ignore` with rationale, matching the existing `RUSTSEC-2023-0071` precedent.
- **licenses FAILED** — `webpki-roots` (the Mozilla CA bundle) now ships under `CDLA-Permissive-2.0`, which was not in the allow list. It is permissive data (not code) with no copyleft. Added to `[licenses] allow`.

Config-only change to `deny.toml`.

## Test plan
- [ ] Security Audit (cargo-deny) job turns green on this PR.
- [ ] No change to any build/test behavior (deny.toml only).