### PR TITLE
docs: mark RSS arena/PathHandle design docs as not landed

### DIFF
--- a/docs/design/rss-5-fileentry-pool-shape.md
+++ b/docs/design/rss-5-fileentry-pool-shape.md
@@ -1,5 +1,15 @@
 # RSS-5: pool-allocator-backed `FileEntry` shape
 
+> **Status: prototype / not landed.** This pool-allocator shape and the
+> RSS-7 `ArenaFileEntry` prototype it references were never applied to
+> the production file list. The shipping `FileEntry` still uses `PathBuf`
+> + `Arc<Path>`, no `PathHandle`/arena type exists in the tree, and the
+> unused `bumpalo` prototype has since been removed. The only landed
+> dedup is the `Arc<Path>` dirname interner. The real arena/flat backing
+> store is designed in `docs/design/flat-flist-representation.md` and
+> built from scratch by RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-5. Branch: `docs/rss-5-fileentry-pool-shape`.
 Prerequisites: `docs/audits/rss-3-fileentry-size-breakdown.md` (cost
 analysis), `docs/design/rss-4-arena-allocator-eval.md` (recommends

--- a/docs/design/rss-8a-arena-handle-type.md
+++ b/docs/design/rss-8a-arena-handle-type.md
@@ -1,5 +1,13 @@
 # RSS-8.a: arena-handle type definition for FileEntry paths
 
+> **Status: prototype / not landed.** This `PathHandle` type was never
+> added to the tree. The production `FileEntry` still uses `PathBuf` +
+> `Arc<Path>`; no `PathHandle`/`PathArena` type exists. The only landed
+> dedup is the `Arc<Path>` dirname interner. The real arena/flat backing
+> store is designed in `docs/design/flat-flist-representation.md` and
+> built from scratch by RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-8.a. Branch: `docs/rss-8a-arena-handle-type`.
 Prerequisites: RSS-5 (pool-allocator FileEntry shape), RSS-7 (arena
 path prototype). Downstream: RSS-8.b (migration implementation),

--- a/docs/design/rss-8b-fileentry-read-path-migration.md
+++ b/docs/design/rss-8b-fileentry-read-path-migration.md
@@ -1,5 +1,14 @@
 # RSS-8.b: FileEntry read-path migration to PathHandle
 
+> **Status: prototype / not landed.** This read-path migration was never
+> applied. The production `FileEntry` still uses `PathBuf` + `Arc<Path>`,
+> and no `PathHandle`/`PathInterner`-over-arena type exists in the tree.
+> The only landed dedup is the `Arc<Path>` dirname interner. The real
+> arena/flat backing store is designed in
+> `docs/design/flat-flist-representation.md` and built from scratch by
+> RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-8.b. Branch: `docs/rss-8b-read-path-migration-spec`.
 Prerequisites: RSS-8.a (PR #4980 - defines `PathHandle` as a 4-byte
 `lasso::Spur` handle replacing `PathBuf`/`Arc<Path>` in FileEntry),

--- a/docs/design/rss-8c-fileentry-write-path-migration.md
+++ b/docs/design/rss-8c-fileentry-write-path-migration.md
@@ -1,5 +1,14 @@
 # RSS-8.c: FileEntry write-path migration to PathHandle
 
+> **Status: prototype / not landed.** This write-path migration was never
+> applied. The production `FileEntry` still uses `PathBuf` + `Arc<Path>`,
+> and no `PathHandle`/`PathArena` type exists in the tree. The only
+> landed dedup is the `Arc<Path>` dirname interner. The real arena/flat
+> backing store is designed in
+> `docs/design/flat-flist-representation.md` and built from scratch by
+> RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-8.c. Branch: `docs/rss-8c-write-path-migration-spec`.
 Prerequisites: RSS-8.a (PathHandle type definition, merged PR #4980),
 RSS-8.b (PathArena implementation over `lasso::Rodeo`/`RodeoReader`).

--- a/docs/design/rss-9a-sort-consumer-pathhandle-migration.md
+++ b/docs/design/rss-9a-sort-consumer-pathhandle-migration.md
@@ -1,5 +1,14 @@
 # RSS-9.a: sort consumer PathHandle migration spec
 
+> **Status: prototype / not landed.** This sort-consumer migration was
+> never applied. The prerequisite `PathHandle` type does not exist; the
+> production `FileEntry` still uses `PathBuf` + `Arc<Path>`. The only
+> landed dedup is the `Arc<Path>` dirname interner. The real arena/flat
+> backing store is designed in
+> `docs/design/flat-flist-representation.md` and built from scratch by
+> RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-9.a (#2925). Branch: `docs/rss-9a-sort-pathhandle`.
 Prerequisites: RSS-8.a (PathHandle type definition), RSS-8.b (read-path
 migration), RSS-8.c (write-path migration).

--- a/docs/design/rss-9b-filter-consumer-pathhandle-migration.md
+++ b/docs/design/rss-9b-filter-consumer-pathhandle-migration.md
@@ -1,5 +1,14 @@
 # RSS-9.b: filter consumer PathHandle migration
 
+> **Status: prototype / not landed.** This filter-consumer migration was
+> never applied. The prerequisite `PathHandle` type does not exist; the
+> production `FileEntry` still uses `PathBuf` + `Arc<Path>`. The only
+> landed dedup is the `Arc<Path>` dirname interner. The real arena/flat
+> backing store is designed in
+> `docs/design/flat-flist-representation.md` and built from scratch by
+> RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-9.b (#2926). Branch: `docs/rss-9b-filter-pathhandle`.
 Prerequisites: RSS-8.a (PathHandle type - 4-byte `lasso::Spur`),
 RSS-8.b (FileEntry read-path migration), RSS-8.c (FileEntry write-path

--- a/docs/design/rss-9c-transfer-consumer-pathhandle-migration.md
+++ b/docs/design/rss-9c-transfer-consumer-pathhandle-migration.md
@@ -1,5 +1,14 @@
 # RSS-9.c: transfer consumer PathHandle migration
 
+> **Status: prototype / not landed.** This transfer-consumer migration
+> was never applied. The prerequisite `PathHandle`/`PathArena` types do
+> not exist; the production `FileEntry` still uses `PathBuf` +
+> `Arc<Path>`. The only landed dedup is the `Arc<Path>` dirname interner.
+> The real arena/flat backing store is designed in
+> `docs/design/flat-flist-representation.md` and built from scratch by
+> RSS-A.5.a-f (gated on RSS-2 profiling). See
+> `docs/audit/arena-prototype-landing-gap.md`.
+
 Task: RSS-9.c (#2927). Branch: `docs/rss-9c-transfer-pathhandle`.
 Prerequisites: RSS-8.a (PathHandle type definition, PR #4980),
 RSS-8.b (read-path migration), RSS-8.c (write-path migration).


### PR DESCRIPTION
## Summary
- The RSS-5 / RSS-8.a-c / RSS-9.a-c design docs describe a `PathHandle`/arena migration of the production `FileEntry` that was never applied. The shipping `FileEntry` still uses `PathBuf` + `Arc<Path>`, no `PathHandle`/`PathArena` type exists in the tree, and the unused `bumpalo` prototype has since been removed. The only landed dedup is the `Arc<Path>` dirname interner.
- Adds a short status banner near the top of each of the seven docs so they are not mistaken for shipped state. Each banner points to `docs/design/flat-flist-representation.md` (the real backing store, built from scratch by RSS-A.5.a-f and gated on RSS-2 profiling) and to the audit `docs/audit/arena-prototype-landing-gap.md`.
- The RSS-5 banner also supersedes its now-misleading "Prototype landed in RSS-7" note.

Docs-only change. No source, build, or test files touched.

## Files annotated
- `docs/design/rss-5-fileentry-pool-shape.md`
- `docs/design/rss-8a-arena-handle-type.md`
- `docs/design/rss-8b-fileentry-read-path-migration.md`
- `docs/design/rss-8c-fileentry-write-path-migration.md`
- `docs/design/rss-9a-sort-consumer-pathhandle-migration.md`
- `docs/design/rss-9b-filter-consumer-pathhandle-migration.md`
- `docs/design/rss-9c-transfer-consumer-pathhandle-migration.md`

## Test plan
- [x] Docs-only; confirmed `git diff --name-only` lists only the seven `docs/design/rss-*.md` files.
- [x] Banner references resolve: `docs/design/flat-flist-representation.md` and `docs/audit/arena-prototype-landing-gap.md` both exist.