### PR TITLE
feat: add unwired flat-flist FileEntryHeader type

### DIFF
--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -31,6 +31,11 @@ async = ["bytes", "tokio", "tokio-util"]
 serde = ["dep:serde"]
 # Structured tracing for I/O operations
 tracing = ["dep:tracing"]
+# Flat file-list backing store (RSS-A.5). Opt-in, unwired phase-1 step:
+# adds the fixed-size FileEntryHeader type only. Not referenced by any
+# consumer; default builds are byte-identical to the legacy Vec<FileEntry>
+# path. Builder/consumer migration is tracked under RSS-A.6+.
+flat-flist = []
 
 [dependencies]
 bytes = { version = "1.9", optional = true }

--- a/crates/protocol/src/flist/flat/header.rs
+++ b/crates/protocol/src/flist/flat/header.rs
@@ -1,0 +1,131 @@
+//! Fixed-size header node for the flat file-list backing store.
+//!
+//! See `docs/design/flat-flist-representation.md` for the full design.
+
+/// Interned name/dirname handle for the flat file-list store.
+///
+/// A 4-byte index into the flat store's own name/dirname interner. This is
+/// a placeholder: the real interner that resolves a handle to a string is
+/// built later in RSS-A.5.c. For now the type only carries the index and a
+/// null sentinel so [`FileEntryHeader`] can name its `name`/`dirname`
+/// fields with the final shape.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct PathHandle(pub u32);
+
+impl PathHandle {
+    /// Null/empty sentinel: the entry has no interned string for this slot.
+    pub const NONE: PathHandle = PathHandle(u32::MAX);
+}
+
+/// Reference to a packed extras tail in the flat store's blob arena.
+///
+/// A 4-byte arena offset into the non-interned blob region that holds the
+/// variable-length extras record (symlink target, device numbers, hardlink
+/// data, ACL/xattr indices, checksum, user/group names). Like
+/// [`PathHandle`] this is a placeholder for the phase-1 header; the arena
+/// it indexes into is built later.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ExtrasRef(pub u32);
+
+impl ExtrasRef {
+    /// Sentinel for entries with no extras tail (the common case).
+    pub const NO_EXTRAS: ExtrasRef = ExtrasRef(u32::MAX);
+}
+
+/// Presence bit: the [`FileEntryHeader::uid`] field is meaningful.
+pub const PRESENT_UID: u16 = 1 << 0;
+/// Presence bit: the [`FileEntryHeader::gid`] field is meaningful.
+pub const PRESENT_GID: u16 = 1 << 1;
+/// Presence bit: the [`FileEntryHeader::mtime_nsec`] field is meaningful.
+pub const PRESENT_MTIME_NSEC: u16 = 1 << 2;
+/// Presence bit: the entry is a directory carrying content (protocol 30+).
+///
+/// Mirrors the legacy `FileEntry::content_dir` flag; absence corresponds to
+/// upstream's `XMIT_NO_CONTENT_DIR`.
+pub const PRESENT_CONTENT_DIR: u16 = 1 << 3;
+/// Presence bit: the size needs the full 64-bit `size` field.
+///
+/// Mirrors upstream's `FLAG_LENGTH64`; when clear, the size fits in 32 bits.
+pub const PRESENT_LENGTH64: u16 = 1 << 4;
+
+/// Fixed-size header for one file-list entry in the flat backing store.
+///
+/// Holds inline scalar metadata plus arena references to variable-length
+/// tails (name, dirname, and optional extras blob). Headers are allocated
+/// in build order and never moved after insertion; sort order is expressed
+/// through a separate `index: Vec<u32>` permutation (RSS-A.6).
+///
+/// Field order follows the design's padding-minimizing layout, yielding a
+/// 48-byte node with no tail padding on 64-bit targets - the low end of the
+/// design's 48-64 byte target.
+///
+/// The `uid`, `gid`, and `mtime_nsec` fields are meaningful only when their
+/// corresponding [`present`](FileEntryHeader::present) bit is set; read them
+/// through [`uid`](FileEntryHeader::uid) / [`gid`](FileEntryHeader::gid) /
+/// [`mtime_nsec`](FileEntryHeader::mtime_nsec), which return `None` when the
+/// bit is clear.
+#[derive(Clone, Copy)]
+pub struct FileEntryHeader {
+    /// Modification time, seconds since the Unix epoch.
+    pub mtime: i64,
+    /// File size in bytes (0 for directories and special files).
+    pub size: u64,
+    /// User ID; meaningful only when [`PRESENT_UID`] is set in `present`.
+    pub uid: u32,
+    /// Group ID; meaningful only when [`PRESENT_GID`] is set in `present`.
+    pub gid: u32,
+    /// Interned name handle, or [`PathHandle::NONE`].
+    pub name: PathHandle,
+    /// Interned dirname handle, or [`PathHandle::NONE`].
+    pub dirname: PathHandle,
+    /// Packed extras tail reference, or [`ExtrasRef::NO_EXTRAS`].
+    pub extras: ExtrasRef,
+    /// Modification time nanoseconds; meaningful only when
+    /// [`PRESENT_MTIME_NSEC`] is set in `present` (protocol 31+).
+    pub mtime_nsec: u32,
+    /// Unix mode bits (file type + permissions).
+    pub mode: u32,
+    /// Wire flags (the legacy `FileFlags` bits packed into a `u16`).
+    pub flags: u16,
+    /// Presence bitfield: which optional inline fields are set.
+    ///
+    /// See the `PRESENT_*` constants ([`PRESENT_UID`], [`PRESENT_GID`],
+    /// [`PRESENT_MTIME_NSEC`], [`PRESENT_CONTENT_DIR`], [`PRESENT_LENGTH64`]).
+    pub present: u16,
+}
+
+// The header must fit the design's 48-64 byte target. Assert the upper
+// bound rather than an exact value to stay robust to per-target padding.
+const _: () = assert!(core::mem::size_of::<FileEntryHeader>() <= 64);
+
+impl FileEntryHeader {
+    /// Returns whether the given presence `bit` is set in `present`.
+    #[must_use]
+    pub fn has(&self, bit: u16) -> bool {
+        self.present & bit != 0
+    }
+
+    /// Sets the given presence `bit` in `present`.
+    pub fn set(&mut self, bit: u16) {
+        self.present |= bit;
+    }
+
+    /// Returns the user ID, or `None` when [`PRESENT_UID`] is clear.
+    #[must_use]
+    pub fn uid(&self) -> Option<u32> {
+        self.has(PRESENT_UID).then_some(self.uid)
+    }
+
+    /// Returns the group ID, or `None` when [`PRESENT_GID`] is clear.
+    #[must_use]
+    pub fn gid(&self) -> Option<u32> {
+        self.has(PRESENT_GID).then_some(self.gid)
+    }
+
+    /// Returns the mtime nanoseconds, or `None` when [`PRESENT_MTIME_NSEC`]
+    /// is clear.
+    #[must_use]
+    pub fn mtime_nsec(&self) -> Option<u32> {
+        self.has(PRESENT_MTIME_NSEC).then_some(self.mtime_nsec)
+    }
+}

--- a/crates/protocol/src/flist/flat/mod.rs
+++ b/crates/protocol/src/flist/flat/mod.rs
@@ -1,0 +1,23 @@
+//! Flat file-list backing store (RSS-A.5).
+//!
+//! This module is the phase-1 step of the flat backing-store design in
+//! `docs/design/flat-flist-representation.md`: it defines the fixed-size
+//! [`FileEntryHeader`] node that a contiguous header array will hold, plus
+//! the placeholder handle types it references.
+//!
+//! It is entirely additive and unwired. Nothing in production references
+//! these types; the legacy `Vec<FileEntry>` path is untouched. The real
+//! 4-byte path interner that backs [`PathHandle`] is built later
+//! (RSS-A.5.c), and threading `FlatFileList` through the sort, filter,
+//! transfer, and engine consumers is RSS-A.6+. All of that remains gated
+//! on RSS-2 allocation profiling per the design's validation gate.
+
+mod header;
+
+#[cfg(test)]
+mod tests;
+
+pub use header::{
+    ExtrasRef, FileEntryHeader, PathHandle, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
+    PRESENT_MTIME_NSEC, PRESENT_UID,
+};

--- a/crates/protocol/src/flist/flat/mod.rs
+++ b/crates/protocol/src/flist/flat/mod.rs
@@ -18,6 +18,6 @@ mod header;
 mod tests;
 
 pub use header::{
-    ExtrasRef, FileEntryHeader, PathHandle, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
-    PRESENT_MTIME_NSEC, PRESENT_UID,
+    ExtrasRef, FileEntryHeader, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
+    PRESENT_MTIME_NSEC, PRESENT_UID, PathHandle,
 };

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+/// A blank header used as a starting point; every optional field is absent.
+fn empty_header() -> FileEntryHeader {
+    FileEntryHeader {
+        mtime: 0,
+        size: 0,
+        uid: 0,
+        gid: 0,
+        name: PathHandle::NONE,
+        dirname: PathHandle::NONE,
+        extras: ExtrasRef::NO_EXTRAS,
+        mtime_nsec: 0,
+        mode: 0,
+        flags: 0,
+        present: 0,
+    }
+}
+
+#[test]
+fn header_fits_size_target() {
+    // The design targets 48-64 bytes; the chosen field order yields 48.
+    assert!(core::mem::size_of::<FileEntryHeader>() <= 64);
+}
+
+#[test]
+fn present_bit_get_set_round_trips() {
+    let mut h = empty_header();
+    assert!(!h.has(PRESENT_UID));
+    assert!(!h.has(PRESENT_GID));
+
+    h.set(PRESENT_UID);
+    assert!(h.has(PRESENT_UID));
+    // Setting one bit must not leak into the others.
+    assert!(!h.has(PRESENT_GID));
+
+    h.set(PRESENT_GID);
+    assert!(h.has(PRESENT_GID));
+    // set() is idempotent and additive.
+    h.set(PRESENT_UID);
+    assert!(h.has(PRESENT_UID));
+    assert!(h.has(PRESENT_GID));
+}
+
+#[test]
+fn all_present_bits_are_distinct() {
+    let bits = [
+        PRESENT_UID,
+        PRESENT_GID,
+        PRESENT_MTIME_NSEC,
+        PRESENT_CONTENT_DIR,
+        PRESENT_LENGTH64,
+    ];
+    let mut acc = 0u16;
+    for bit in bits {
+        // Each flag is a single, previously-unset bit.
+        assert_eq!(bit.count_ones(), 1);
+        assert_eq!(acc & bit, 0);
+        acc |= bit;
+    }
+}
+
+#[test]
+fn uid_is_none_until_bit_set() {
+    let mut h = empty_header();
+    h.uid = 1000;
+    // Value is stored but not yet visible without the presence bit.
+    assert_eq!(h.uid(), None);
+    h.set(PRESENT_UID);
+    assert_eq!(h.uid(), Some(1000));
+}
+
+#[test]
+fn gid_is_none_until_bit_set() {
+    let mut h = empty_header();
+    h.gid = 2000;
+    assert_eq!(h.gid(), None);
+    h.set(PRESENT_GID);
+    assert_eq!(h.gid(), Some(2000));
+}
+
+#[test]
+fn mtime_nsec_is_none_until_bit_set() {
+    let mut h = empty_header();
+    h.mtime_nsec = 123_456_789;
+    assert_eq!(h.mtime_nsec(), None);
+    h.set(PRESENT_MTIME_NSEC);
+    assert_eq!(h.mtime_nsec(), Some(123_456_789));
+}
+
+#[test]
+fn path_handle_none_sentinel() {
+    assert_eq!(PathHandle::NONE, PathHandle(u32::MAX));
+    let h = empty_header();
+    assert_eq!(h.name, PathHandle::NONE);
+    assert_eq!(h.dirname, PathHandle::NONE);
+    // A real handle is distinguishable from the sentinel.
+    assert_ne!(PathHandle(0), PathHandle::NONE);
+}
+
+#[test]
+fn extras_ref_no_extras_sentinel() {
+    assert_eq!(ExtrasRef::NO_EXTRAS, ExtrasRef(u32::MAX));
+    let h = empty_header();
+    assert_eq!(h.extras, ExtrasRef::NO_EXTRAS);
+    assert_ne!(ExtrasRef(0), ExtrasRef::NO_EXTRAS);
+}

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -53,6 +53,11 @@ pub use batched_writer::{BatchConfig, BatchStats, BatchedFileListWriter};
 pub use dir_tree::{DirTreeError, DirectoryTree};
 pub use entry::{FileEntry, FileType};
 pub use flags::{FileFlags, XMIT_HLINK_FIRST, XMIT_HLINKED, XMIT_SAME_RDEV_PRE28, XMIT_TOP_DIR};
+#[cfg(feature = "flat-flist")]
+pub use flat::{
+    ExtrasRef, FileEntryHeader, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
+    PRESENT_MTIME_NSEC, PRESENT_UID, PathHandle,
+};
 pub use hardlink::{
     DevIno, HardlinkEntry, HardlinkLookup, HardlinkTable, trace_found_flist_match,
     trace_hashtable_for_dev, trace_leader_is, trace_looking_for_leader, trace_virtual_first,

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -32,6 +32,8 @@
 mod batched_writer;
 mod dir_tree;
 mod entry;
+#[cfg(feature = "flat-flist")]
+mod flat;
 mod flags;
 mod hardlink;
 mod incremental;

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -32,9 +32,9 @@
 mod batched_writer;
 mod dir_tree;
 mod entry;
+mod flags;
 #[cfg(feature = "flat-flist")]
 mod flat;
-mod flags;
 mod hardlink;
 mod incremental;
 mod intern;


### PR DESCRIPTION
## Summary

Introduces the fixed-size `FileEntryHeader` type for the planned flat
file-list backing store, behind a new non-default `flat-flist` cargo
feature. This is the phase-1 step of the design in
`docs/design/flat-flist-representation.md` (RSS-A.5.a): purely additive,
feature-gated, and completely unwired. No consumer references it; the
legacy `Vec<FileEntry>` path is untouched and default builds are
byte-identical.

## What landed

- New cargo feature `flat-flist = []` in `crates/protocol/Cargo.toml`
  (not in `default`).
- New private module `crates/protocol/src/flist/flat/`, gated behind
  `#[cfg(feature = "flat-flist")]` in `flist/mod.rs`. Nothing outside the
  gated module references the new types (no `pub use flat`).
- `FileEntryHeader`: a `Copy`, 48-byte node packing inline scalars
  (`mtime`, `size`, `uid`, `gid`, `mode`, `mtime_nsec`, `flags`) plus
  placeholder 4-byte handles (`name`/`dirname: PathHandle`,
  `extras: ExtrasRef`) and a `u16` presence bitfield. Field order follows
  the design's padding-minimizing layout.
- A `u16` presence bitfield (`PRESENT_UID`, `PRESENT_GID`,
  `PRESENT_MTIME_NSEC`, `PRESENT_CONTENT_DIR`, `PRESENT_LENGTH64`)
  replacing per-field `Option` discriminants, with `has`/`set` helpers and
  typed `uid()`/`gid()`/`mtime_nsec()` accessors that return `Some` only
  when the corresponding bit is set.
- Placeholder `PathHandle(u32)` (with `NONE` sentinel) and
  `ExtrasRef(u32)` (with `NO_EXTRAS` sentinel) newtypes. The real path
  interner that resolves a handle to a string is built later (RSS-A.5.c).
- A compile-time size assertion
  `const _: () = assert!(size_of::<FileEntryHeader>() <= 64);` - the
  `<= 64` upper bound (design target 48-64 B) stays robust to per-target
  padding rather than asserting an exact value.
- Unit tests covering presence-bit get/set round-trips, `uid()`/`gid()`/
  `mtime_nsec()` returning `None` until the bit is set, the sentinel
  constants, bit distinctness, and the size bound.

## Not in scope

Not wired into `FileEntry`, `FileList`, the builder, or any consumer; no
migration. The real interner (RSS-A.5.c) and builder/consumer migration
(RSS-A.6+) remain gated on RSS-2 allocation profiling per the design's
own validation gate.

## Test plan

- [ ] CI fmt + clippy (`--all-targets --all-features -D warnings`) green;
      the gated module is compiled and linted.
- [ ] CI nextest (`--all-features`) green; flat module unit tests run.
- [ ] Windows / macOS / Linux musl stable matrices green.