### PR TITLE
perf: compact FileEntry layout with presence bitfield to cut flist RSS

### DIFF
--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -184,13 +184,21 @@ impl FileEntry {
     /// Returns the user ID if set.
     #[inline]
     pub const fn uid(&self) -> Option<u32> {
-        self.uid
+        if self.present & super::core::PRESENT_UID != 0 {
+            Some(self.uid)
+        } else {
+            None
+        }
     }
 
     /// Returns the group ID if set.
     #[inline]
     pub const fn gid(&self) -> Option<u32> {
-        self.gid
+        if self.present & super::core::PRESENT_GID != 0 {
+            Some(self.gid)
+        } else {
+            None
+        }
     }
 
     /// Returns the symlink target if this is a symlink.
@@ -258,12 +266,14 @@ impl FileEntry {
 
     /// Sets the user ID.
     pub const fn set_uid(&mut self, uid: u32) {
-        self.uid = Some(uid);
+        self.uid = uid;
+        self.present |= super::core::PRESENT_UID;
     }
 
     /// Sets the group ID.
     pub const fn set_gid(&mut self, gid: u32) {
-        self.gid = Some(gid);
+        self.gid = gid;
+        self.present |= super::core::PRESENT_GID;
     }
 
     /// Returns the user name if set.
@@ -350,14 +360,18 @@ impl FileEntry {
     #[inline]
     #[must_use]
     pub const fn content_dir(&self) -> bool {
-        self.content_dir
+        self.present & super::core::PRESENT_CONTENT_DIR != 0
     }
 
     /// Sets whether this directory has content to transfer.
     ///
     /// When false, XMIT_NO_CONTENT_DIR flag is set on wire.
     pub const fn set_content_dir(&mut self, has_content: bool) {
-        self.content_dir = has_content;
+        if has_content {
+            self.present |= super::core::PRESENT_CONTENT_DIR;
+        } else {
+            self.present &= !super::core::PRESENT_CONTENT_DIR;
+        }
     }
 
     /// Returns the hardlink device number (for protocol < 30).

--- a/crates/protocol/src/flist/entry/constructors.rs
+++ b/crates/protocol/src/flist/entry/constructors.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use super::FileEntry;
-use super::core::extract_dirname;
+use super::core::{PRESENT_CONTENT_DIR, extract_dirname};
 use super::extras::FileEntryExtras;
 use super::file_type::FileType;
 
@@ -35,13 +35,14 @@ impl FileEntry {
             dirname,
             size,
             mtime: 0,
-            uid: None,
-            gid: None,
             extras,
+            uid: 0,
+            gid: 0,
             mode: file_type.to_mode_bits() | (permissions & 0o7777),
             mtime_nsec: 0,
             flags: super::super::flags::FileFlags::default(),
-            content_dir: true, // Directories have content by default
+            // Directories have content by default; uid/gid start absent.
+            present: PRESENT_CONTENT_DIR,
         }
     }
 
@@ -113,13 +114,13 @@ impl FileEntry {
             dirname,
             size,
             mtime,
-            uid: None,
-            gid: None,
             extras: None,
+            uid: 0,
+            gid: 0,
             mode,
             mtime_nsec,
             flags,
-            content_dir: true,
+            present: PRESENT_CONTENT_DIR,
         }
     }
 
@@ -162,13 +163,13 @@ impl FileEntry {
             dirname,
             size,
             mtime,
-            uid: None,
-            gid: None,
             extras: None,
+            uid: 0,
+            gid: 0,
             mode,
             mtime_nsec,
             flags,
-            content_dir: true,
+            present: PRESENT_CONTENT_DIR,
         }
     }
 }

--- a/crates/protocol/src/flist/entry/core.rs
+++ b/crates/protocol/src/flist/entry/core.rs
@@ -3,6 +3,22 @@ use std::sync::Arc;
 
 use super::extras::FileEntryExtras;
 
+/// Presence bit: the `uid` field holds a meaningful value.
+///
+/// Mirrors the conditional `uid` extra in upstream rsync's `file_struct`
+/// (upstream: rsync.h `F_OWNER`). Cleared when ownership is not preserved.
+pub(super) const PRESENT_UID: u8 = 1 << 0;
+/// Presence bit: the `gid` field holds a meaningful value.
+///
+/// Mirrors the conditional `gid` extra in upstream rsync's `file_struct`
+/// (upstream: rsync.h `F_GROUP`). Cleared when ownership is not preserved.
+pub(super) const PRESENT_GID: u8 = 1 << 1;
+/// Presence bit: this directory has content to transfer (protocol 30+).
+///
+/// Set by default for directories; cleared for XMIT_NO_CONTENT_DIR (implied or
+/// content-less) directories. Non-directories report `true` via the accessor.
+pub(super) const PRESENT_CONTENT_DIR: u8 = 1 << 2;
+
 /// A single entry in the rsync file list.
 ///
 /// Contains all metadata needed to synchronize a filesystem object, including
@@ -17,6 +33,12 @@ use super::extras::FileEntryExtras;
 /// that is only allocated when at least one such field is set. This reduces
 /// the common-case inline size from ~295 bytes to ~88 bytes - matching
 /// upstream rsync's conditional field allocation pattern.
+///
+/// `uid`, `gid`, and the directory content flag are packed via a `present`
+/// bitfield rather than `Option`/`bool`, reclaiming the discriminant padding
+/// that `Option<u32>` and a trailing `bool` cost. This mirrors upstream's
+/// conditional `file_extras` layout where each extra is a plain 4-byte slot
+/// gated by a presence flag.
 ///
 /// # Path Interning
 ///
@@ -44,10 +66,6 @@ pub struct FileEntry {
     pub(super) size: u64,
     /// Modification time as seconds since Unix epoch.
     pub(super) mtime: i64,
-    /// User ID (None if not preserving ownership).
-    pub(super) uid: Option<u32>,
-    /// Group ID (None if not preserving ownership).
-    pub(super) gid: Option<u32>,
     /// Rarely-used fields, boxed to reduce inline size.
     ///
     /// `None` for regular files in typical transfers (no symlinks, devices,
@@ -55,6 +73,10 @@ pub struct FileEntry {
     pub(super) extras: Option<Box<FileEntryExtras>>,
 
     // 4-byte aligned fields
+    /// User ID raw value. Meaningful only when `PRESENT_UID` is set in `present`.
+    pub(super) uid: u32,
+    /// Group ID raw value. Meaningful only when `PRESENT_GID` is set in `present`.
+    pub(super) gid: u32,
     /// Unix mode bits (type + permissions).
     pub(super) mode: u32,
     /// Modification time nanoseconds (protocol 31+).
@@ -65,10 +87,10 @@ pub struct FileEntry {
     pub(super) flags: super::super::flags::FileFlags,
 
     // 1-byte aligned fields
-    /// Whether this directory has content to transfer (protocol 30+).
+    /// Presence bitfield for `uid`, `gid`, and the directory content flag.
     ///
-    /// False indicates XMIT_NO_CONTENT_DIR - an implied or content-less directory.
-    pub(super) content_dir: bool,
+    /// See `PRESENT_UID`, `PRESENT_GID`, and `PRESENT_CONTENT_DIR`.
+    pub(super) present: u8,
 }
 
 /// Extracts the parent directory from a path.
@@ -89,13 +111,13 @@ impl Clone for FileEntry {
             dirname: Arc::clone(&self.dirname),
             size: self.size,
             mtime: self.mtime,
+            extras: self.extras.clone(),
             uid: self.uid,
             gid: self.gid,
-            extras: self.extras.clone(),
             mode: self.mode,
             mtime_nsec: self.mtime_nsec,
             flags: self.flags,
-            content_dir: self.content_dir,
+            present: self.present,
         }
     }
 }
@@ -107,12 +129,12 @@ impl std::fmt::Debug for FileEntry {
             .field("dirname", &self.dirname)
             .field("size", &self.size)
             .field("mtime", &self.mtime)
-            .field("uid", &self.uid)
-            .field("gid", &self.gid)
+            .field("uid", &self.uid())
+            .field("gid", &self.gid())
             .field("mode", &self.mode)
             .field("mtime_nsec", &self.mtime_nsec)
             .field("flags", &self.flags)
-            .field("content_dir", &self.content_dir);
+            .field("content_dir", &self.content_dir());
         if let Some(extras) = &self.extras {
             s.field("extras", extras);
         }
@@ -126,12 +148,12 @@ impl PartialEq for FileEntry {
         self.name == other.name
             && self.size == other.size
             && self.mtime == other.mtime
-            && self.uid == other.uid
-            && self.gid == other.gid
+            && self.uid() == other.uid()
+            && self.gid() == other.gid()
             && self.mode == other.mode
             && self.mtime_nsec == other.mtime_nsec
             && self.flags == other.flags
-            && self.content_dir == other.content_dir
+            && self.content_dir() == other.content_dir()
             && self.extras == other.extras
     }
 }

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -290,24 +290,66 @@ fn dirname_shared_across_entries() {
     assert!(Arc::ptr_eq(entry1.dirname(), entry2.dirname()));
 }
 
-/// Verifies the struct size optimization: FileEntry should be <= 96 bytes
-/// inline on Unix (down from ~295 bytes before the Box<FileEntryExtras>
-/// refactor). On Windows the cap is <= 104 because `PathBuf` is 8 bytes
-/// larger than on Unix (Windows `Wtf8Buf` carries an extra `is_known_utf8`
-/// bool, which pads the inner `OsString` from 24 to 32 bytes). This guards
-/// against accidental field additions that bloat the hot path.
+/// Verifies the struct size optimization: FileEntry should be <= 88 bytes
+/// inline on Unix (down from 96 bytes before packing uid/gid/content_dir into
+/// a presence bitfield, and from ~295 bytes before the Box<FileEntryExtras>
+/// refactor). On Windows the cap is <= 96 because `PathBuf` is 8 bytes larger
+/// than on Unix (Windows `Wtf8Buf` carries an extra `is_known_utf8` bool, which
+/// pads the inner `OsString` from 24 to 32 bytes). This guards against
+/// accidental field additions that bloat the hot path.
 #[test]
 fn file_entry_size_optimized() {
     let size = std::mem::size_of::<FileEntry>();
     #[cfg(not(windows))]
-    const MAX: usize = 96;
+    const MAX: usize = 88;
     #[cfg(windows)]
-    const MAX: usize = 104;
+    const MAX: usize = 96;
     assert!(
         size <= MAX,
         "FileEntry is {size} bytes; expected <= {MAX}. \
          Did you add a field to FileEntry instead of FileEntryExtras?"
     );
+}
+
+/// RSS-A.3 regression: packing `uid`/`gid`/`content_dir` into a presence
+/// bitfield must keep the struct at or below the prior 96-byte (Unix) /
+/// 104-byte (Windows) inline size, and must round-trip the absent/present
+/// distinction the old `Option<u32>` fields encoded.
+#[test]
+fn file_entry_presence_bitfield_roundtrip() {
+    // (a) size did not regress against the pre-compaction layout.
+    #[cfg(not(windows))]
+    const PREVIOUS: usize = 96;
+    #[cfg(windows)]
+    const PREVIOUS: usize = 104;
+    let size = std::mem::size_of::<FileEntry>();
+    assert!(
+        size <= PREVIOUS,
+        "FileEntry grew to {size} bytes; pre-compaction layout was {PREVIOUS}"
+    );
+
+    // (b) building without uid/gid yields None; the directory content flag
+    // defaults to true.
+    let mut entry = FileEntry::new_directory("d".into(), 0o755);
+    assert_eq!(entry.uid(), None);
+    assert_eq!(entry.gid(), None);
+    assert!(entry.content_dir());
+
+    // Setting uid/gid flips them to Some without disturbing the other bits.
+    entry.set_uid(1000);
+    assert_eq!(entry.uid(), Some(1000));
+    assert_eq!(entry.gid(), None);
+    assert!(entry.content_dir());
+
+    entry.set_gid(0); // gid 0 must report Some(0), not None.
+    assert_eq!(entry.gid(), Some(0));
+    assert_eq!(entry.uid(), Some(1000));
+
+    // Clearing content_dir must not affect uid/gid presence.
+    entry.set_content_dir(false);
+    assert!(!entry.content_dir());
+    assert_eq!(entry.uid(), Some(1000));
+    assert_eq!(entry.gid(), Some(0));
 }
 
 /// Regular file entries should not allocate extras.


### PR DESCRIPTION
## Summary

- Pack `uid`, `gid`, and the directory content flag into a single `u8` presence bitfield, replacing two `Option<u32>` fields and a trailing `bool`. This reclaims the 4-byte discriminant each `Option<u32>` carried plus the bool's tail padding, shrinking `FileEntry` from 96 to 88 bytes on 64-bit Unix (104 to 96 on Windows). At 1M entries that saves roughly 8 MB of flist RSS.
- Reorder fields for minimal padding (8-byte aligned, then 4-byte, then the bitfield byte).
- Public accessor API is unchanged: `uid()`, `gid()`, `content_dir()`, and the `set_*` mutators keep identical `Option`/`bool` signatures and semantics, including reporting `Some(0)` for a gid of 0 and defaulting `content_dir` to true.
- Wire encoding/decoding is untouched - every codec field read already routes through the accessors, so emitted bytes are identical.

The change is confined to `crates/protocol/src/flist/entry/`. The fields are `pub(super)`, so no external call site can reach them; all builders and decoders go through the constructors and setters.

## Test plan

- [ ] `file_entry_size_optimized` enforces the new <= 88 B (Unix) / <= 96 B (Windows) cap.
- [ ] New `file_entry_presence_bitfield_roundtrip` asserts the struct did not grow past the prior layout and that the absent/present distinction round-trips (including `gid(0)` -> `Some(0)` and independence of the content-dir bit).
- [ ] Existing flist write/read, proptest round-trip, and golden-byte suites confirm wire bytes are unchanged.