### PR TITLE
feat: add 4-byte path interner backing flat-flist PathHandle

### DIFF
--- a/crates/protocol/src/flist/flat/intern.rs
+++ b/crates/protocol/src/flist/flat/intern.rs
@@ -104,7 +104,10 @@ impl PathArena {
         let index = u32::try_from(self.spans.len())
             .expect("PathArena exceeded u32::MAX distinct interned strings");
         // u32::MAX is the NONE sentinel and must never name a real string.
-        assert!(index != PathHandle::NONE.0, "PathArena handle space exhausted");
+        assert!(
+            index != PathHandle::NONE.0,
+            "PathArena handle space exhausted"
+        );
 
         let offset = u32::try_from(self.bytes.len()).expect("PathArena byte arena exceeded 4 GiB");
         let len = u32::try_from(s.len()).expect("interned string exceeds u32::MAX bytes");

--- a/crates/protocol/src/flist/flat/intern.rs
+++ b/crates/protocol/src/flist/flat/intern.rs
@@ -1,0 +1,171 @@
+//! Name/dirname string interner backing the flat store's [`PathHandle`].
+//!
+//! See `docs/design/flat-flist-representation.md` (RSS-A.5.c and the
+//! "Name and dirname interning vs upstream's sharing" section of RSS-A.5.f)
+//! for the design this implements.
+//!
+//! Every unique name or dirname string is stored exactly once in a
+//! contiguous byte arena; a 4-byte [`PathHandle`] indexes a side table of
+//! `(offset, len)` spans into that arena. Interning the same string twice
+//! returns the same handle, so the store gets both the dirname sharing
+//! upstream's `lastdir` cache provides (upstream: `flist.c:765-773`) and the
+//! basename deduplication upstream lacks - upstream stores each basename
+//! inline in the `file_struct` flexible array tail (upstream: `rsync.h:808`),
+//! duplicating two files named `README` in different directories. Resolving a
+//! handle is an O(1) indexed read: one table lookup plus a slice of the
+//! arena, with no hash lookup (mirroring the design's "indexed read once
+//! frozen" contract without needing a separate freeze step).
+//!
+//! The empty string is never stored; it interns to and resolves through
+//! [`PathHandle::NONE`], matching the header's null sentinel for absent
+//! name/dirname slots.
+
+use std::collections::HashMap;
+
+use super::header::PathHandle;
+
+/// Interns name/dirname strings into a compact arena keyed by [`PathHandle`].
+///
+/// The interner owns a single growable byte arena holding each unique string
+/// back to back, plus a `spans` table mapping a handle's index to the
+/// `(offset, len)` of its bytes and a `dedup` map for O(1) deduplication.
+/// Handles are dense, zero-based `u32` indices assigned in first-seen order;
+/// [`PathHandle::NONE`] (`u32::MAX`) is reserved as the empty/absent
+/// sentinel and is never assigned to a stored string.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Requires the `flat-flist` feature.
+/// use protocol::flist::{PathArena, PathHandle};
+///
+/// let mut arena = PathArena::new();
+/// let a = arena.intern("README");
+/// let b = arena.intern("README");
+/// // Identical strings share one handle and one arena copy.
+/// assert_eq!(a, b);
+/// assert_eq!(arena.resolve(a), "README");
+///
+/// // The empty string is the NONE sentinel, never stored.
+/// assert_eq!(arena.intern(""), PathHandle::NONE);
+/// assert_eq!(arena.resolve(PathHandle::NONE), "");
+/// assert_eq!(arena.len(), 1);
+/// ```
+#[derive(Debug, Default)]
+pub struct PathArena {
+    /// Contiguous bytes of every interned string, stored once each.
+    bytes: Vec<u8>,
+    /// Per-handle `(offset, len)` spans into `bytes`, indexed by handle value.
+    spans: Vec<(u32, u32)>,
+    /// Maps a string to its already-assigned handle for O(1) dedup.
+    dedup: HashMap<Box<str>, PathHandle>,
+}
+
+impl PathArena {
+    /// Creates an empty interner with no allocated arena.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates an interner pre-sized for `capacity` distinct strings.
+    ///
+    /// Reserves the span table and dedup map; the byte arena grows on
+    /// demand since per-string lengths are not known up front.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            spans: Vec::with_capacity(capacity),
+            dedup: HashMap::with_capacity(capacity),
+        }
+    }
+
+    /// Interns `s`, returning a handle that resolves back to it.
+    ///
+    /// Returns [`PathHandle::NONE`] for the empty string without storing
+    /// anything. For a non-empty string, returns the existing handle if `s`
+    /// was interned before (pointer-stable dedup), otherwise appends the
+    /// bytes to the arena, records a span, and assigns the next handle.
+    ///
+    /// # Panics
+    ///
+    /// Panics if more than `u32::MAX` distinct non-empty strings are
+    /// interned, since handles are 4-byte indices. The flat store is sized
+    /// for file lists far below this bound.
+    pub fn intern(&mut self, s: &str) -> PathHandle {
+        if s.is_empty() {
+            return PathHandle::NONE;
+        }
+        if let Some(&handle) = self.dedup.get(s) {
+            return handle;
+        }
+
+        let index = u32::try_from(self.spans.len())
+            .expect("PathArena exceeded u32::MAX distinct interned strings");
+        // u32::MAX is the NONE sentinel and must never name a real string.
+        assert!(index != PathHandle::NONE.0, "PathArena handle space exhausted");
+
+        let offset = u32::try_from(self.bytes.len()).expect("PathArena byte arena exceeded 4 GiB");
+        let len = u32::try_from(s.len()).expect("interned string exceeds u32::MAX bytes");
+        self.bytes.extend_from_slice(s.as_bytes());
+        self.spans.push((offset, len));
+
+        let handle = PathHandle(index);
+        self.dedup.insert(Box::from(s), handle);
+        handle
+    }
+
+    /// Resolves `handle` to its interned string slice.
+    ///
+    /// Returns `""` for [`PathHandle::NONE`] (the empty/absent sentinel).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `handle` was not produced by this interner (out-of-range
+    /// index). Handles are only valid for the interner that issued them.
+    #[must_use]
+    pub fn resolve(&self, handle: PathHandle) -> &str {
+        match self.get(handle) {
+            Some(s) => s,
+            None => panic!("PathHandle({}) is not valid for this PathArena", handle.0),
+        }
+    }
+
+    /// Resolves `handle` to its interned string, or `None` if absent.
+    ///
+    /// Returns `None` for [`PathHandle::NONE`] and for any handle whose index
+    /// is out of range for this interner. Non-sentinel valid handles always
+    /// resolve to a stored string.
+    #[must_use]
+    pub fn get(&self, handle: PathHandle) -> Option<&str> {
+        if handle == PathHandle::NONE {
+            return None;
+        }
+        let (offset, len) = *self.spans.get(handle.0 as usize)?;
+        let (start, end) = (offset as usize, offset as usize + len as usize);
+        // Bytes are only ever appended from valid &str, so this slice is UTF-8.
+        std::str::from_utf8(&self.bytes[start..end]).ok()
+    }
+
+    /// Returns the number of distinct non-empty strings interned.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.spans.len()
+    }
+
+    /// Returns `true` if no non-empty strings have been interned.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
+
+    /// Returns the total bytes held in the string arena.
+    ///
+    /// This is the deduplicated footprint: each unique string contributes
+    /// its length once, regardless of how many entries reference it.
+    #[must_use]
+    pub fn bytes_len(&self) -> usize {
+        self.bytes.len()
+    }
+}

--- a/crates/protocol/src/flist/flat/intern.rs
+++ b/crates/protocol/src/flist/flat/intern.rs
@@ -129,6 +129,9 @@ impl PathArena {
     /// index). Handles are only valid for the interner that issued them.
     #[must_use]
     pub fn resolve(&self, handle: PathHandle) -> &str {
+        if handle == PathHandle::NONE {
+            return "";
+        }
         match self.get(handle) {
             Some(s) => s,
             None => panic!("PathHandle({}) is not valid for this PathArena", handle.0),

--- a/crates/protocol/src/flist/flat/mod.rs
+++ b/crates/protocol/src/flist/flat/mod.rs
@@ -6,13 +6,14 @@
 //! the placeholder handle types it references.
 //!
 //! It is entirely additive and unwired. Nothing in production references
-//! these types; the legacy `Vec<FileEntry>` path is untouched. The real
-//! 4-byte path interner that backs [`PathHandle`] is built later
-//! (RSS-A.5.c), and threading `FlatFileList` through the sort, filter,
-//! transfer, and engine consumers is RSS-A.6+. All of that remains gated
-//! on RSS-2 allocation profiling per the design's validation gate.
+//! these types; the legacy `Vec<FileEntry>` path is untouched. The 4-byte
+//! path interner that backs [`PathHandle`] is [`PathArena`] (RSS-A.5.c);
+//! threading `FlatFileList` through the sort, filter, transfer, and engine
+//! consumers is RSS-A.6+. All of that remains gated on RSS-2 allocation
+//! profiling per the design's validation gate.
 
 mod header;
+mod intern;
 
 #[cfg(test)]
 mod tests;
@@ -21,3 +22,4 @@ pub use header::{
     ExtrasRef, FileEntryHeader, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
     PRESENT_MTIME_NSEC, PRESENT_UID, PathHandle,
 };
+pub use intern::PathArena;

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -105,3 +105,82 @@ fn extras_ref_no_extras_sentinel() {
     assert_eq!(h.extras, ExtrasRef::NO_EXTRAS);
     assert_ne!(ExtrasRef(0), ExtrasRef::NO_EXTRAS);
 }
+
+#[test]
+fn intern_resolve_round_trips() {
+    let mut arena = PathArena::new();
+    let h = arena.intern("src/lib.rs");
+    // A real string never collides with the empty sentinel.
+    assert_ne!(h, PathHandle::NONE);
+    assert_eq!(arena.resolve(h), "src/lib.rs");
+    assert_eq!(arena.get(h), Some("src/lib.rs"));
+}
+
+#[test]
+fn intern_dedups_to_same_handle() {
+    let mut arena = PathArena::new();
+    let a = arena.intern("README");
+    let b = arena.intern("README");
+    // Dedup yields the same handle and stores the bytes only once.
+    assert_eq!(a, b);
+    assert_eq!(arena.len(), 1);
+    assert_eq!(arena.bytes_len(), "README".len());
+}
+
+#[test]
+fn distinct_strings_get_distinct_handles() {
+    let mut arena = PathArena::new();
+    let a = arena.intern("alpha");
+    let b = arena.intern("beta");
+    let c = arena.intern("gamma");
+    assert_ne!(a, b);
+    assert_ne!(b, c);
+    assert_ne!(a, c);
+    assert_eq!(arena.len(), 3);
+    // Each resolves back to its own string regardless of insertion order.
+    assert_eq!(arena.resolve(a), "alpha");
+    assert_eq!(arena.resolve(b), "beta");
+    assert_eq!(arena.resolve(c), "gamma");
+}
+
+#[test]
+fn empty_string_is_the_none_sentinel() {
+    let mut arena = PathArena::new();
+    // The empty name/dirname slot must map to NONE and store nothing.
+    assert_eq!(arena.intern(""), PathHandle::NONE);
+    assert!(arena.is_empty());
+    assert_eq!(arena.bytes_len(), 0);
+    // NONE resolves to the empty string and to None, never to stored bytes.
+    assert_eq!(arena.resolve(PathHandle::NONE), "");
+    assert_eq!(arena.get(PathHandle::NONE), None);
+}
+
+#[test]
+fn get_returns_none_for_unknown_handle() {
+    let arena = PathArena::new();
+    // An index never issued by this arena is not a valid handle.
+    assert_eq!(arena.get(PathHandle(0)), None);
+}
+
+#[test]
+fn dedup_shares_basenames_across_dirnames() {
+    // Mirrors the design's basename-dedup goal: two identical basenames
+    // under different dirnames collapse to one arena string, which upstream
+    // (inline flexible-array basenames) cannot do.
+    let mut arena = PathArena::new();
+    let dir_a = arena.intern("a");
+    let dir_b = arena.intern("b");
+    let name_1 = arena.intern("README");
+    let name_2 = arena.intern("README");
+    assert_ne!(dir_a, dir_b);
+    assert_eq!(name_1, name_2);
+    // Two dirnames + one shared basename = three unique strings.
+    assert_eq!(arena.len(), 3);
+}
+
+#[test]
+fn with_capacity_starts_empty() {
+    let arena = PathArena::with_capacity(128);
+    assert!(arena.is_empty());
+    assert_eq!(arena.len(), 0);
+}

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -56,7 +56,7 @@ pub use flags::{FileFlags, XMIT_HLINK_FIRST, XMIT_HLINKED, XMIT_SAME_RDEV_PRE28,
 #[cfg(feature = "flat-flist")]
 pub use flat::{
     ExtrasRef, FileEntryHeader, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
-    PRESENT_MTIME_NSEC, PRESENT_UID, PathHandle,
+    PRESENT_MTIME_NSEC, PRESENT_UID, PathArena, PathHandle,
 };
 pub use hardlink::{
     DevIno, HardlinkEntry, HardlinkLookup, HardlinkTable, trace_found_flist_match,


### PR DESCRIPTION
## Summary
- Adds `PathArena`, the name/dirname string interner that backs the flat file-list store's `PathHandle` (RSS-A.5.c). It stores each unique string once in a contiguous byte arena with a `(offset, len)` span table and a `HashMap` dedup index, giving O(1) resolve and O(1) dedup with no new dependencies (std only).
- Interning identical strings returns the same handle, providing both the dirname sharing upstream's `lastdir` cache gives and the basename deduplication upstream lacks (upstream stores basenames inline per entry). `PathHandle::NONE` (`u32::MAX`) is the empty/absent sentinel: the empty string interns to it and is never stored.
- Additive and entirely feature-gated on `flat-flist`; no production code references it. Re-exported through `flat/mod.rs` (`pub use intern::PathArena;`) and the existing feature-gated block in `flist/mod.rs`, so the type is reachable public API and there is no dead-code lint.

## Test plan
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- [ ] `cargo nextest run -p protocol --all-features` (intern+resolve round-trip, dedup returns same handle, distinct strings, NONE handling, basename sharing, capacity)
- [ ] fmt + cross-platform matrices via CI