### PR TITLE
feat: detect and warn on Compression yes inside Match exec blocks

### DIFF
--- a/crates/rsync_io/src/ssh/config_lookup.rs
+++ b/crates/rsync_io/src/ssh/config_lookup.rs
@@ -207,21 +207,11 @@ pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> b
         eprintln!(
             "warning: ssh_config contains \"Compression yes\" inside a \"Match exec\" block."
         );
-        eprintln!(
-            "         The exec condition was not evaluated because executing arbitrary"
-        );
-        eprintln!(
-            "         commands from a config-lookup path is a security risk. If SSH"
-        );
-        eprintln!(
-            "         compression is active, oc-rsync's --compress will double-compress."
-        );
-        eprintln!(
-            "         Workaround: move \"Compression yes\" to a Host or Match host block,"
-        );
-        eprintln!(
-            "         or pass -e \"ssh -C\" explicitly so oc-rsync can detect it."
-        );
+        eprintln!("         The exec condition was not evaluated because executing arbitrary");
+        eprintln!("         commands from a config-lookup path is a security risk. If SSH");
+        eprintln!("         compression is active, oc-rsync's --compress will double-compress.");
+        eprintln!("         Workaround: move \"Compression yes\" to a Host or Match host block,");
+        eprintln!("         or pass -e \"ssh -C\" explicitly so oc-rsync can detect it.");
     }
 
     top_level.unwrap_or(false) || host_block.unwrap_or(false) || match_block.unwrap_or(false)
@@ -1383,8 +1373,7 @@ mod tests {
         // block is skipped. The overall result is `false`, but the
         // warning should still fire because the exec block might enable
         // compression if evaluated.
-        let text =
-            "Compression no\nMatch exec /usr/local/bin/check-vpn\n  Compression yes\n";
+        let text = "Compression no\nMatch exec /usr/local/bin/check-vpn\n  Compression yes\n";
         assert!(!parse_enables_compression(
             text,
             &match_ctx("web1.example.com", "web1.example.com", "", "")
@@ -1465,12 +1454,7 @@ Host *\n\
         // compression fires.
         assert!(parse_enables_compression(
             text,
-            &match_ctx(
-                "db.internal.example.com",
-                "db.internal.example.com",
-                "",
-                ""
-            )
+            &match_ctx("db.internal.example.com", "db.internal.example.com", "", "")
         ));
         // Target does not match any host block with compression,
         // and the exec block is skipped.

--- a/crates/rsync_io/src/ssh/config_lookup.rs
+++ b/crates/rsync_io/src/ssh/config_lookup.rs
@@ -18,10 +18,10 @@
 //! is deliberately unsupported - executing arbitrary shell commands from
 //! a passive config-lookup path is a security risk, and the
 //! compression-detection use case does not need it. When a `Match exec`
-//! block is encountered, the parser emits a one-shot `eprintln!` warning
-//! so the user knows that compression settings inside such blocks will
-//! not be detected. The rest of the SKIP set (`canonical`, `final`,
-//! `tagged`) likewise short-circuits the block.
+//! block containing `Compression yes` is encountered, the parser emits
+//! a user-visible warning explaining that the exec condition was not
+//! evaluated and suggesting a workaround. The rest of the SKIP set
+//! (`canonical`, `final`, `tagged`) likewise short-circuits the block.
 //!
 //! # Failure mode
 //!
@@ -128,11 +128,14 @@ fn read_and_check(path: &Path, ctx: &MatchContext<'_>) -> bool {
 /// `ctx`'s fields may be empty; in that case only `Host *` and
 /// `Match all` (or other patterns that tolerate empty input) can match.
 ///
-/// When any `Match exec` block is encountered, a one-shot warning is
-/// emitted via `eprintln!` to alert the user that compression settings
-/// inside such blocks will not be detected. The warning fires at most
-/// once per parse invocation regardless of how many `Match exec` blocks
-/// appear in the file.
+/// When a `Match exec` block containing `Compression yes` is
+/// encountered, a user-visible warning is emitted explaining that the
+/// exec condition was not evaluated and suggesting a workaround (move
+/// the directive to a `Host` or `Match host` block, or pass
+/// `-e "ssh -C"` explicitly). The warning fires only when the skipped
+/// block actually contains a compression directive that would affect
+/// the detection result - bare `Match exec` blocks without compression
+/// settings produce no warning.
 ///
 /// Exposed to tests so they can assert behaviour without disk I/O.
 pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> bool {
@@ -140,7 +143,7 @@ pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> b
     let mut top_level: Option<bool> = None;
     let mut host_block: Option<bool> = None;
     let mut match_block: Option<bool> = None;
-    let mut saw_match_exec = false;
+    let mut exec_block_has_compression = false;
 
     for raw_line in text.lines() {
         let line = strip_comment(raw_line).trim();
@@ -161,7 +164,13 @@ pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> b
                 block = Block::Host(parse_pattern_list(value));
             }
             "match" => {
-                block = Block::MatchEvaluated(match_line_applies(value, ctx, &mut saw_match_exec));
+                let mut saw_exec = false;
+                let applies = match_line_applies(value, ctx, &mut saw_exec);
+                block = if saw_exec {
+                    Block::MatchExecSkipped
+                } else {
+                    Block::MatchEvaluated(applies)
+                };
             }
             "compression" => {
                 let parsed = parse_yes_no(value);
@@ -176,6 +185,11 @@ pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> b
                     Block::MatchEvaluated(true) if match_block.is_none() => {
                         match_block = parsed;
                     }
+                    Block::MatchExecSkipped => {
+                        if parsed == Some(true) {
+                            exec_block_has_compression = true;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -183,10 +197,30 @@ pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> b
         }
     }
 
-    if saw_match_exec {
+    if exec_block_has_compression {
+        debug_log!(
+            Io,
+            1,
+            "ssh_config compression detection: Match exec block contains \
+             Compression yes but the exec condition was not evaluated"
+        );
         eprintln!(
-            "warning: ssh_config Match exec blocks are not evaluated; \
-             compression settings inside them will not be detected"
+            "warning: ssh_config contains \"Compression yes\" inside a \"Match exec\" block."
+        );
+        eprintln!(
+            "         The exec condition was not evaluated because executing arbitrary"
+        );
+        eprintln!(
+            "         commands from a config-lookup path is a security risk. If SSH"
+        );
+        eprintln!(
+            "         compression is active, oc-rsync's --compress will double-compress."
+        );
+        eprintln!(
+            "         Workaround: move \"Compression yes\" to a Host or Match host block,"
+        );
+        eprintln!(
+            "         or pass -e \"ssh -C\" explicitly so oc-rsync can detect it."
         );
     }
 
@@ -207,11 +241,22 @@ pub(super) fn parse_enables_compression(text: &str, ctx: &MatchContext<'_>) -> b
 /// [`match_line_applies`] and records the boolean outcome. Subsequent
 /// `Compression` directives inside the block consult that cached
 /// decision instead of re-evaluating per directive.
+///
+/// MED-3 added [`Block::MatchExecSkipped`]: when a `Match exec` block
+/// is encountered, the parser cannot evaluate the condition (security
+/// risk - executing arbitrary commands from a passive config-lookup
+/// path). Directives inside the block are tracked separately so the
+/// parser can detect when `Compression yes` appears inside an
+/// unevaluated exec block and emit a targeted warning.
 #[derive(Clone, Eq, PartialEq)]
 enum Block {
     TopLevel,
     Host(Vec<Pattern>),
     MatchEvaluated(bool),
+    /// Block gated by a `Match exec` condition that was not evaluated.
+    /// Directives inside this block are not honoured but are inspected
+    /// for `Compression yes` to emit a targeted user warning.
+    MatchExecSkipped,
 }
 
 /// A single token from an ssh_config `Host` or `Match` pattern-list.
@@ -413,9 +458,10 @@ pub(super) fn evaluate_match(conditions: &[MatchCondition], ctx: &MatchContext<'
 /// SSC-4.a "DEFER" rationale for the full security justification.
 ///
 /// When `exec` is encountered, `*saw_exec` is set to `true` so the
-/// caller can emit a one-shot user-visible warning. The flag is only
-/// set, never cleared, so multiple `Match exec` blocks within one
-/// config file produce at most one warning.
+/// caller can distinguish an exec-skipped block from a legitimately
+/// non-matching block. The flag is only set, never cleared, so
+/// repeated calls accumulate the signal across multiple `Match exec`
+/// blocks.
 ///
 /// Recognises keys case-insensitively; arguments are split on whitespace
 /// or commas via [`parse_pattern_list`] for the keys that take a
@@ -1287,5 +1333,150 @@ mod tests {
         assert!(saw_exec);
         match_line_applies("host web1", &ctx("web1", "", ""), &mut saw_exec);
         assert!(saw_exec, "non-exec Match must not clear saw_exec flag");
+    }
+
+    // MED-6: `Match exec` warning integration tests exercising the full
+    // `parse_enables_compression` path with synthetic ssh_config fixtures.
+
+    #[test]
+    fn match_exec_with_compression_yes_returns_false() {
+        // A `Match exec` block with `Compression yes` must not contribute
+        // to the compression result - the exec condition was never
+        // evaluated, so we cannot know whether the block would apply.
+        let text = "Match exec /usr/local/bin/check-vpn\n  Compression yes\n";
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn match_exec_without_compression_does_not_warn() {
+        // A `Match exec` block that does not contain `Compression` should
+        // not trigger the warning. The warning is only relevant when
+        // compression detection may be incomplete.
+        let text = "Match exec /usr/local/bin/check-vpn\n  ForwardAgent yes\n";
+        // No assertion on stderr - we verify correctness by confirming
+        // the function returns false and does not panic.
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn match_exec_compression_no_does_not_warn() {
+        // `Compression no` inside a `Match exec` block is not actionable
+        // - even if the block were evaluated, it would not enable
+        // compression. The warning should not fire for this case.
+        let text = "Match exec /usr/local/bin/check-vpn\n  Compression no\n";
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn match_exec_with_compression_yes_alongside_top_level() {
+        // Top-level `Compression no` plus a `Match exec` block with
+        // `Compression yes`. The top-level `no` is honoured; the exec
+        // block is skipped. The overall result is `false`, but the
+        // warning should still fire because the exec block might enable
+        // compression if evaluated.
+        let text =
+            "Compression no\nMatch exec /usr/local/bin/check-vpn\n  Compression yes\n";
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn match_exec_block_does_not_affect_subsequent_blocks() {
+        // A `Match exec` block must not contaminate subsequent `Match`
+        // blocks. The `Match all` block after the exec block should be
+        // evaluated normally.
+        let text = "Match exec /usr/local/bin/check-vpn\n  Compression yes\n\
+                    Match all\n  Compression yes\n";
+        assert!(parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn match_exec_block_followed_by_host_block() {
+        // After a `Match exec` block, a `Host` block should be evaluated
+        // normally and contribute its compression setting.
+        let text = "Match exec /usr/local/bin/check-vpn\n  Compression yes\n\
+                    Host *.example.com\n  Compression yes\n";
+        assert!(parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn multiple_match_exec_blocks_with_compression() {
+        // Multiple `Match exec` blocks each containing `Compression yes`
+        // should all be skipped. The overall result is `false`.
+        let text = "Match exec /usr/local/bin/check-vpn\n  Compression yes\n\
+                    Match exec /usr/local/bin/check-lan\n  Compression yes\n";
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("web1.example.com", "web1.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn match_exec_block_with_other_directives_and_compression() {
+        // A realistic ssh_config snippet where the exec block contains
+        // multiple directives including `Compression yes`. Only the
+        // compression directive triggers the warning logic.
+        let text = "Match exec \"test -f /etc/vpn.conf\"\n\
+                    \x20 ProxyJump bastion.example.com\n\
+                    \x20 Compression yes\n\
+                    \x20 ForwardAgent yes\n";
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("internal.example.com", "internal.example.com", "", "")
+        ));
+    }
+
+    #[test]
+    fn realistic_ssh_config_with_match_exec_and_host_blocks() {
+        // A realistic multi-section ssh_config where some blocks use
+        // `Match exec` and others use `Host`. The host-block compression
+        // should be detected while the exec-block compression is skipped.
+        let text = "\
+Host bastion.example.com\n\
+  Compression no\n\
+\n\
+Match exec \"test -f /etc/vpn.conf\"\n\
+  Compression yes\n\
+  ProxyJump bastion.example.com\n\
+\n\
+Host *.internal.example.com\n\
+  Compression yes\n\
+\n\
+Host *\n\
+  ServerAliveInterval 60\n";
+        // Target matches `*.internal.example.com`, so host-block
+        // compression fires.
+        assert!(parse_enables_compression(
+            text,
+            &match_ctx(
+                "db.internal.example.com",
+                "db.internal.example.com",
+                "",
+                ""
+            )
+        ));
+        // Target does not match any host block with compression,
+        // and the exec block is skipped.
+        assert!(!parse_enables_compression(
+            text,
+            &match_ctx("external.example.com", "external.example.com", "", "")
+        ));
     }
 }

--- a/crates/rsync_io/tests/ssh_config_compression.rs
+++ b/crates/rsync_io/tests/ssh_config_compression.rs
@@ -253,3 +253,123 @@ fn argv_dash_c_still_wins_when_config_disables() {
     // Sanity: without -C, the same config keeps the answer false.
     assert!(!plain_cmd().has_ssh_compression());
 }
+
+// MED-6: integration tests for Match exec block detection via
+// `has_ssh_compression()`. These verify that the full lookup path
+// (file read -> parse -> compression check) correctly handles
+// ssh_config files containing Match exec blocks.
+
+#[test]
+fn match_exec_block_with_compression_yes_returns_false() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // A `Match exec` block containing `Compression yes` should not
+    // enable the compression flag because the exec condition is not
+    // evaluated. The function returns `false` since no other scope
+    // enables compression.
+    write_ssh_config(
+        &home,
+        "Match exec /usr/local/bin/check-vpn\n  Compression yes\n",
+    );
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn match_exec_block_compression_inside_exec_scope() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // After `Match exec`, the active block is `MatchExecSkipped` until
+    // another `Host` or `Match` directive resets it. So `Compression yes`
+    // on the following line is inside the exec block scope and should
+    // not contribute to the compression result.
+    write_ssh_config(
+        &home,
+        "Match exec /usr/local/bin/check-vpn\n  ForwardAgent yes\n\
+         Compression yes\n",
+    );
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn match_exec_with_host_star_compression_detected() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // The `Host *` block after the exec block should be evaluated
+    // normally.
+    write_ssh_config(
+        &home,
+        "Match exec /usr/local/bin/check-vpn\n  Compression yes\n\
+         Host *\n  Compression yes\n",
+    );
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn match_exec_with_match_all_compression_detected() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // A `Match all` block after a `Match exec` block should be
+    // evaluated normally and contribute its compression setting.
+    write_ssh_config(
+        &home,
+        "Match exec /usr/local/bin/check-vpn\n  Compression yes\n\
+         Match all\n  Compression yes\n",
+    );
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn match_exec_only_no_other_compression_source() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    // When the only compression setting is inside a `Match exec` block,
+    // has_ssh_compression must return false since we cannot evaluate
+    // the exec condition.
+    write_ssh_config(
+        &home,
+        "Host *\n  ServerAliveInterval 60\n\n\
+         Match exec \"test -f /etc/vpn.conf\"\n  Compression yes\n",
+    );
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    assert!(!plain_cmd().has_ssh_compression());
+}
+
+#[test]
+fn dash_f_override_with_match_exec_block() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let home = TempDir::new().expect("tempdir");
+    write_ssh_config(&home, "Compression no\n");
+    let _home_guard = EnvGuard::set("HOME", home.path().as_os_str());
+    let _userprofile_guard = EnvGuard::set("USERPROFILE", home.path().as_os_str());
+
+    // The `-F` override file contains a `Match exec` block with
+    // `Compression yes`. Since `-F` is consulted first and it only
+    // has compression inside the exec block, the result should be false.
+    let override_dir = TempDir::new().expect("tempdir");
+    let override_path = override_dir.path().join("override.config");
+    fs::write(
+        &override_path,
+        "Match exec /usr/local/bin/check-vpn\n  Compression yes\n",
+    )
+    .expect("write override");
+
+    let mut command = plain_cmd();
+    command.push_option("-F");
+    command.push_option(override_path.as_os_str());
+
+    assert!(!command.has_ssh_compression());
+}

--- a/docs/design/med-match-exec-limitation.md
+++ b/docs/design/med-match-exec-limitation.md
@@ -1,0 +1,119 @@
+# Match exec limitation in SSH config compression detection
+
+## Background
+
+`oc-rsync` detects SSH-level compression to warn when both rsync wire
+compression (`--compress`) and SSH stream compression are enabled
+simultaneously. Double-compressing wastes CPU and can expand
+already-compressed data.
+
+The detection parses `~/.ssh/config` (or the file specified via
+`-F`) and evaluates `Host` blocks, `Match host`, `Match user`,
+`Match localuser`, `Match originalhost`, and `Match all` conditions.
+This covers the majority of real-world ssh_config layouts.
+
+## Limitation: `Match exec` blocks are not evaluated
+
+OpenSSH supports `Match exec "command"` blocks that run an arbitrary
+shell command to decide whether the block applies. For example:
+
+```
+Match exec "test -f /etc/vpn.conf"
+  Compression yes
+  ProxyJump bastion.example.com
+```
+
+oc-rsync deliberately does **not** evaluate `Match exec` conditions.
+The reasons are:
+
+1. **Security** - executing user-supplied shell commands from a passive
+   config-lookup path inverts the trust model. The compression check is
+   advisory; spawning subprocesses from it is disproportionate.
+
+2. **Performance** - fork/exec on every SSH transfer adds measurable
+   overhead for a one-shot advisory warning.
+
+3. **Reproducibility** - replicating OpenSSH's exact shell selection
+   (`$SHELL`, `/bin/sh` fallback, Windows `cmd /c`) adds a surface
+   area that can diverge from OpenSSH's behavior.
+
+When a `Match exec` block contains `Compression yes`, oc-rsync emits a
+warning to stderr:
+
+```
+warning: ssh_config contains "Compression yes" inside a "Match exec" block.
+         The exec condition was not evaluated because executing arbitrary
+         commands from a config-lookup path is a security risk. If SSH
+         compression is active, oc-rsync's --compress will double-compress.
+         Workaround: move "Compression yes" to a Host or Match host block,
+         or pass -e "ssh -C" explicitly so oc-rsync can detect it.
+```
+
+## Workarounds
+
+If your ssh_config uses `Match exec` to conditionally enable compression,
+you have several options to ensure oc-rsync detects it:
+
+### Option 1: Move compression to a Host or Match host block
+
+Replace the `Match exec` block with a `Host` or `Match host` block
+that oc-rsync can evaluate:
+
+```
+# Before (not detected by oc-rsync):
+Match exec "test -f /etc/vpn.conf"
+  Compression yes
+
+# After (detected by oc-rsync):
+Host vpn-*.example.com
+  Compression yes
+```
+
+### Option 2: Pass compression explicitly on the command line
+
+Use `-e "ssh -C"` or `-e "ssh -o Compression=yes"` so the
+compression flag appears in the SSH argv where oc-rsync always
+detects it:
+
+```sh
+oc-rsync -e "ssh -C" src/ host:dest/
+```
+
+### Option 3: Separate the compression directive
+
+Move `Compression yes` out of the `Match exec` block into a scope
+that oc-rsync evaluates. Other directives can remain inside the exec
+block:
+
+```
+# oc-rsync detects this:
+Match host vpn-*.example.com
+  Compression yes
+
+# oc-rsync skips this block but the non-compression directives
+# are only relevant to OpenSSH, not to compression detection:
+Match exec "test -f /etc/vpn.conf"
+  ProxyJump bastion.example.com
+```
+
+## What is not affected
+
+- **Compression detection via argv** (`-C`, `-o Compression=yes`) is
+  always detected regardless of `Match exec` blocks.
+
+- **Top-level directives** and **Host blocks** (including glob and
+  negation patterns) are fully evaluated.
+
+- **Match host**, **Match user**, **Match localuser**,
+  **Match originalhost**, and **Match all** conditions are fully
+  evaluated.
+
+- The `Match exec` limitation only affects compression *detection*
+  for the double-compression warning. It does not affect the actual
+  SSH connection, which is established by the system `ssh` client
+  that evaluates all `Match exec` conditions normally.
+
+## References
+
+- `docs/design/ssc-4a-match-conditions.md` - DEFER decision for exec
+- `crates/rsync_io/src/ssh/config_lookup.rs` - parser implementation


### PR DESCRIPTION
## Summary

- Add runtime detection of `Match exec` blocks in the SSH config parser that contain `Compression yes` directives (MED-3)
- Emit a targeted user-visible warning with actionable workaround guidance when such blocks are found (MED-4)
- Add design documentation explaining the `Match exec` limitation and three workaround options (MED-5)
- Add comprehensive test coverage with synthetic ssh_config fixtures at both unit and integration test levels (MED-6)

The previous implementation emitted a generic warning whenever any `Match exec` block was encountered, regardless of whether it contained compression settings. The new `Block::MatchExecSkipped` variant tracks directives inside unevaluated exec blocks and only warns when `Compression yes` is actually present, reducing noise for configs that use `Match exec` for non-compression purposes like `ProxyJump`.

## Test plan

- [ ] Unit tests in `config_lookup.rs` verify the parser correctly identifies `Compression yes` inside `Match exec` blocks
- [ ] Unit tests verify `Match exec` blocks without compression or with `Compression no` do not trigger warnings
- [ ] Unit tests verify `Match exec` blocks do not contaminate subsequent `Host` or `Match` blocks
- [ ] Integration tests in `ssh_config_compression.rs` verify the full file-read-to-compression-check path
- [ ] Integration tests cover `-F` override files containing `Match exec` blocks
- [ ] CI passes on all platforms (Linux, macOS, Windows)