### PR TITLE
feat: add io_uring silent fallback observability (IKV-F.1-F.5)

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -37,6 +37,9 @@ pub struct ParsedArgs {
     /// `--version`, `-V`
     pub show_version: bool,
 
+    /// `--io-uring-status` - print the io_uring capability matrix and exit.
+    pub show_io_uring_status: bool,
+
     /// `--human-readable`, `-h` (repeatable for higher levels).
     pub human_readable: Option<HumanReadableMode>,
 

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -51,6 +51,7 @@ where
 
     let show_help = matches.get_flag("help");
     let show_version = matches.get_flag("version");
+    let show_io_uring_status = matches.get_flag("io-uring-status");
 
     // Handle human-readable: bare flags (-h, --human-readable) count occurrences
     // while explicit values (--human-readable=2) set the level directly.
@@ -703,6 +704,7 @@ where
         program_name,
         show_help,
         show_version,
+        show_io_uring_status,
         human_readable,
         dry_run,
         list_only,

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -181,6 +181,16 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .value_parser(OsStringValueParser::new()),
             )
             .arg(
+                Arg::new("io-uring-status")
+                    .long("io-uring-status")
+                    .help(
+                        "Print the io_uring capability matrix (kernel version, \
+                         availability, restriction detection, supported opcodes, \
+                         feature gates, active fallback chain) and exit.",
+                    )
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
                 Arg::new("simd")
                     .long("simd")
                     .value_name("LEVEL")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -21,7 +21,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--force, --no-force, --fuzzy/-y, --no-fuzzy, --msgs2stderr, --no-msgs2stderr, --8-bit-output, --outbuf, ",
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --xxh64-dedup, --remove-source-files, ",
-    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --io-uring-depth, --simd, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
+    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --io-uring-depth, --io-uring-status, --simd, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
     "--human-readable/-h, --no-human-readable, -P, --sparse/-S, --no-sparse/--no-S, --sparse-detect, --links/-l, --no-links/--no-l, ",
     "--copy-links/-L, ",
     "--copy-unsafe-links, --safe-links, --copy-dirlinks/-k, --keep-dirlinks/-K, ",

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -84,10 +84,12 @@ where
     }
 }
 
-/// Prints help or version text if requested, returning the exit code.
+/// Prints help, version, or io_uring status text if requested, returning
+/// the exit code.
 pub(crate) fn maybe_print_help_or_version<Out>(
     show_help: bool,
     show_version: bool,
+    show_io_uring_status: bool,
     program_name: ProgramName,
     stdout: &mut Out,
 ) -> Option<i32>
@@ -106,6 +108,13 @@ where
         let report = VersionInfoReport::for_client_brand(program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {
+            Some(1)
+        } else {
+            Some(0)
+        }
+    } else if show_io_uring_status {
+        let matrix = fast_io::io_uring_capability_matrix();
+        if writeln!(stdout, "{matrix}").is_err() {
             Some(1)
         } else {
             Some(0)

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -48,6 +48,7 @@ where
         program_name,
         show_help,
         show_version,
+        show_io_uring_status,
         human_readable,
         dry_run,
         list_only,
@@ -305,7 +306,13 @@ where
         Err(message) => return fail_with_message(message, stderr),
     };
 
-    if let Some(code) = maybe_print_help_or_version(show_help, show_version, program_name, stdout) {
+    if let Some(code) = maybe_print_help_or_version(
+        show_help,
+        show_version,
+        show_io_uring_status,
+        program_name,
+        stdout,
+    ) {
         return code;
     }
 

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -145,6 +145,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --io-uring   Force io_uring for file I/O (policy=enabled); error if unavailable. Default policy is auto: probe kernel and fall back to standard I/O.\n",
             "      --no-io-uring  Disable io_uring (policy=disabled); always use standard buffered I/O even when the kernel supports io_uring.\n",
             "      --io-uring-depth=N  Override io_uring submission queue depth (default 64); must be a power of two between 1 and 32768.\n",
+            "      --io-uring-status  Print the io_uring capability matrix and exit.\n",
             "      --simd=LEVEL Force the SIMD level used by checksum dispatch (auto, avx512, avx2, sse4, neon, none).\n",
             "      --cow        Allow copy-on-write reflinks for whole-file copies (default).\n",
             "      --no-cow     Disable copy-on-write reflinks; always use the portable std::fs::copy fallback.\n",

--- a/crates/fast_io/src/io_uring/file_factory.rs
+++ b/crates/fast_io/src/io_uring/file_factory.rs
@@ -116,8 +116,14 @@ impl FileReaderFactory for IoUringReaderFactory {
         if self.will_use_io_uring() {
             match IoUringReader::open(path, &self.config) {
                 Ok(r) => return Ok(IoUringOrStdReader::IoUring(r)),
-                Err(_) => {
-                    // Fall through to standard I/O
+                Err(e) => {
+                    logging::debug_log!(
+                        Io,
+                        1,
+                        "io_uring reader open failed for {}, falling back to standard I/O: {}",
+                        path.display(),
+                        e
+                    );
                 }
             }
         }
@@ -240,8 +246,14 @@ impl FileWriterFactory for IoUringWriterFactory {
         if self.will_use_io_uring() {
             match IoUringWriter::create(path, &self.config) {
                 Ok(w) => return Ok(IoUringOrStdWriter::IoUring(w)),
-                Err(_) => {
-                    // Fall through to standard I/O
+                Err(e) => {
+                    logging::debug_log!(
+                        Io,
+                        1,
+                        "io_uring writer create failed for {}, falling back to standard I/O: {}",
+                        path.display(),
+                        e
+                    );
                 }
             }
         }
@@ -255,8 +267,16 @@ impl FileWriterFactory for IoUringWriterFactory {
         if self.will_use_io_uring() {
             match IoUringWriter::create_with_size(path, size, &self.config) {
                 Ok(w) => return Ok(IoUringOrStdWriter::IoUring(w)),
-                Err(_) => {
-                    // Fall through to standard I/O
+                Err(e) => {
+                    logging::debug_log!(
+                        Io,
+                        1,
+                        "io_uring writer create_with_size failed for {} (size={}), \
+                         falling back to standard I/O: {}",
+                        path.display(),
+                        size,
+                        e
+                    );
                 }
             }
         }

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -274,15 +274,26 @@ pub fn writer_from_file_with_depth(
             if is_io_uring_available() {
                 // Probe the per-thread ring; on setup failure `file` is still
                 // ours and we fall back to standard I/O.
-                if per_thread_ring::with_ring(|_| Ok(())).is_ok() {
-                    return Ok(IoUringOrStdWriter::IoUring(IoUringWriter::with_ring(
-                        file,
-                        buffer_capacity,
-                        config.sq_entries,
-                        batching::NO_FIXED_FD,
-                        config.register_buffers,
-                        config.registered_buffer_count,
-                    )));
+                match per_thread_ring::with_ring(|_| Ok(())) {
+                    Ok(()) => {
+                        return Ok(IoUringOrStdWriter::IoUring(IoUringWriter::with_ring(
+                            file,
+                            buffer_capacity,
+                            config.sq_entries,
+                            batching::NO_FIXED_FD,
+                            config.register_buffers,
+                            config.registered_buffer_count,
+                        )));
+                    }
+                    Err(e) => {
+                        logging::debug_log!(
+                            Io,
+                            1,
+                            "io_uring per-thread ring probe failed, \
+                             falling back to standard I/O for writer: {}",
+                            e
+                        );
+                    }
                 }
             }
             Ok(IoUringOrStdWriter::Std(
@@ -349,7 +360,16 @@ pub fn reader_from_path_with_depth<P: AsRef<std::path::Path>>(
             if is_io_uring_available() {
                 match IoUringReader::open(path.as_ref(), &config) {
                     Ok(r) => return Ok(IoUringOrStdReader::IoUring(r)),
-                    Err(_) => { /* fall through to standard I/O */ }
+                    Err(e) => {
+                        logging::debug_log!(
+                            Io,
+                            1,
+                            "io_uring reader open failed for {}, \
+                             falling back to standard I/O: {}",
+                            path.as_ref().display(),
+                            e
+                        );
+                    }
                 }
             }
             Ok(IoUringOrStdReader::Std(crate::traits::StdFileReader::open(

--- a/crates/fast_io/src/io_uring_ops.rs
+++ b/crates/fast_io/src/io_uring_ops.rs
@@ -209,6 +209,12 @@ pub fn hard_link(src: &std::path::Path, dst: &std::path::Path) -> std::io::Resul
     if let Some(result) = try_hard_link_via_io_uring(src, dst) {
         return result;
     }
+    logging::debug_log!(
+        Io,
+        2,
+        "io_uring LINKAT unavailable, falling back to std::fs::hard_link for {}",
+        dst.display()
+    );
     std::fs::hard_link(src, dst)
 }
 

--- a/crates/fast_io/src/kernel_version.rs
+++ b/crates/fast_io/src/kernel_version.rs
@@ -72,18 +72,125 @@ pub fn parse_kernel_version(release: &str) -> Option<KernelVersion> {
 /// Minimum kernel version required for io_uring (5.6).
 pub const IO_URING_MIN_KERNEL: KernelVersion = KernelVersion { major: 5, minor: 6 };
 
+/// Trait for kernel features that have a minimum version requirement.
+///
+/// Reduces maintenance surface by centralising the version-check pattern
+/// that otherwise gets duplicated across every kernel-gated feature. Each
+/// implementor declares its minimum kernel version and a human-readable
+/// feature name; the trait provides a default `is_supported` method that
+/// compares against a given `KernelVersion`.
+pub trait VersionRequirement {
+    /// Minimum kernel version required for this feature.
+    fn min_version(&self) -> KernelVersion;
+
+    /// Human-readable name for diagnostic messages (e.g. "io_uring",
+    /// "PBUF_RING", "LINKAT").
+    fn feature_name(&self) -> &str;
+
+    /// Returns `true` if `kernel` meets the minimum version requirement.
+    fn is_supported(&self, kernel: &KernelVersion) -> bool {
+        let min = self.min_version();
+        kernel.meets_minimum(min.major, min.minor)
+    }
+
+    /// Returns a diagnostic string indicating whether the feature is
+    /// supported on the given kernel, or why not.
+    fn check_message(&self, kernel: &KernelVersion) -> String {
+        let min = self.min_version();
+        if self.is_supported(kernel) {
+            format!("{}: supported (kernel {} >= {})", self.feature_name(), kernel, min)
+        } else {
+            format!(
+                "{}: unsupported (kernel {} < {} required)",
+                self.feature_name(),
+                kernel,
+                min
+            )
+        }
+    }
+}
+
+/// io_uring basic availability (Linux 5.6+).
+pub struct IoUringRequirement;
+
+impl VersionRequirement for IoUringRequirement {
+    fn min_version(&self) -> KernelVersion {
+        IO_URING_MIN_KERNEL
+    }
+    fn feature_name(&self) -> &str {
+        "io_uring"
+    }
+}
+
+/// PBUF_RING provided-buffer ring (Linux 5.19+).
+pub struct PbufRingRequirement;
+
+impl VersionRequirement for PbufRingRequirement {
+    fn min_version(&self) -> KernelVersion {
+        KernelVersion { major: 5, minor: 19 }
+    }
+    fn feature_name(&self) -> &str {
+        "PBUF_RING"
+    }
+}
+
+/// IORING_OP_LINKAT (Linux 5.15+).
+pub struct LinkatRequirement;
+
+impl VersionRequirement for LinkatRequirement {
+    fn min_version(&self) -> KernelVersion {
+        KernelVersion { major: 5, minor: 15 }
+    }
+    fn feature_name(&self) -> &str {
+        "LINKAT"
+    }
+}
+
+/// IORING_OP_STATX and IORING_OP_RENAMEAT (Linux 5.11+).
+pub struct StatxRenameatRequirement;
+
+impl VersionRequirement for StatxRenameatRequirement {
+    fn min_version(&self) -> KernelVersion {
+        KernelVersion { major: 5, minor: 11 }
+    }
+    fn feature_name(&self) -> &str {
+        "STATX/RENAMEAT"
+    }
+}
+
+/// IORING_OP_SEND_ZC zero-copy socket send (Linux 6.0+).
+pub struct SendZcRequirement;
+
+impl VersionRequirement for SendZcRequirement {
+    fn min_version(&self) -> KernelVersion {
+        KernelVersion { major: 6, minor: 0 }
+    }
+    fn feature_name(&self) -> &str {
+        "SEND_ZC"
+    }
+}
+
 /// Logs the io_uring probe result at debug level.
 ///
 /// On Linux with the `io_uring` feature enabled, this queries the kernel
 /// version and io_uring availability, emitting a `debug_log!(Io, 1, ...)`
-/// message describing the result. Callers should invoke this once during
-/// startup after the io_uring probe has been cached.
+/// message describing the result. When io_uring is unavailable, also logs
+/// the specific restriction type (seccomp, cgroup, kernel version) so
+/// operators can diagnose container or cloud environment issues.
+///
+/// Callers should invoke this once during startup after the io_uring probe
+/// has been cached.
 ///
 /// On non-Linux platforms or without the `io_uring` feature, this is a no-op.
 #[cfg(all(target_os = "linux", feature = "io_uring"))]
 pub fn log_io_uring_probe_result() {
     let reason = crate::io_uring_availability_reason();
     logging::debug_log!(Io, 1, "{reason}");
+
+    let restriction = crate::detect_io_uring_restriction();
+    if restriction != crate::IoUringRestriction::None {
+        logging::debug_log!(Io, 1, "io_uring restriction: {restriction}");
+    }
 }
 
 /// No-op stub for non-Linux platforms or when io_uring feature is disabled.
@@ -289,5 +396,85 @@ mod tests {
         // On all platforms, calling the probe log function must not panic.
         // On non-Linux, this is a no-op. On Linux, it emits a debug_log message.
         log_io_uring_probe_result();
+    }
+
+    #[test]
+    fn version_requirement_io_uring_matches_constant() {
+        let req = IoUringRequirement;
+        assert_eq!(req.min_version(), IO_URING_MIN_KERNEL);
+        assert_eq!(req.feature_name(), "io_uring");
+    }
+
+    #[test]
+    fn version_requirement_is_supported_at_exact_minimum() {
+        let req = IoUringRequirement;
+        let v = KernelVersion { major: 5, minor: 6 };
+        assert!(req.is_supported(&v));
+    }
+
+    #[test]
+    fn version_requirement_is_not_supported_below_minimum() {
+        let req = IoUringRequirement;
+        let v = KernelVersion { major: 5, minor: 5 };
+        assert!(!req.is_supported(&v));
+    }
+
+    #[test]
+    fn version_requirement_is_supported_above_minimum() {
+        let req = IoUringRequirement;
+        let v = KernelVersion { major: 6, minor: 1 };
+        assert!(req.is_supported(&v));
+    }
+
+    #[test]
+    fn version_requirement_check_message_supported() {
+        let req = IoUringRequirement;
+        let v = KernelVersion { major: 6, minor: 1 };
+        let msg = req.check_message(&v);
+        assert!(msg.contains("supported"), "got: {msg}");
+        assert!(msg.contains("io_uring"), "got: {msg}");
+        assert!(msg.contains("6.1"), "got: {msg}");
+    }
+
+    #[test]
+    fn version_requirement_check_message_unsupported() {
+        let req = IoUringRequirement;
+        let v = KernelVersion { major: 4, minor: 19 };
+        let msg = req.check_message(&v);
+        assert!(msg.contains("unsupported"), "got: {msg}");
+        assert!(msg.contains("4.19"), "got: {msg}");
+        assert!(msg.contains("5.6"), "got: {msg}");
+    }
+
+    #[test]
+    fn pbuf_ring_requirement_needs_5_19() {
+        let req = PbufRingRequirement;
+        assert_eq!(req.min_version(), KernelVersion { major: 5, minor: 19 });
+        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 18 }));
+        assert!(req.is_supported(&KernelVersion { major: 5, minor: 19 }));
+    }
+
+    #[test]
+    fn send_zc_requirement_needs_6_0() {
+        let req = SendZcRequirement;
+        assert_eq!(req.min_version(), KernelVersion { major: 6, minor: 0 });
+        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 19 }));
+        assert!(req.is_supported(&KernelVersion { major: 6, minor: 0 }));
+    }
+
+    #[test]
+    fn linkat_requirement_needs_5_15() {
+        let req = LinkatRequirement;
+        assert_eq!(req.min_version(), KernelVersion { major: 5, minor: 15 });
+        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 14 }));
+        assert!(req.is_supported(&KernelVersion { major: 5, minor: 15 }));
+    }
+
+    #[test]
+    fn statx_renameat_requirement_needs_5_11() {
+        let req = StatxRenameatRequirement;
+        assert_eq!(req.min_version(), KernelVersion { major: 5, minor: 11 });
+        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 10 }));
+        assert!(req.is_supported(&KernelVersion { major: 5, minor: 11 }));
     }
 }

--- a/crates/fast_io/src/kernel_version.rs
+++ b/crates/fast_io/src/kernel_version.rs
@@ -98,7 +98,12 @@ pub trait VersionRequirement {
     fn check_message(&self, kernel: &KernelVersion) -> String {
         let min = self.min_version();
         if self.is_supported(kernel) {
-            format!("{}: supported (kernel {} >= {})", self.feature_name(), kernel, min)
+            format!(
+                "{}: supported (kernel {} >= {})",
+                self.feature_name(),
+                kernel,
+                min
+            )
         } else {
             format!(
                 "{}: unsupported (kernel {} < {} required)",
@@ -127,7 +132,10 @@ pub struct PbufRingRequirement;
 
 impl VersionRequirement for PbufRingRequirement {
     fn min_version(&self) -> KernelVersion {
-        KernelVersion { major: 5, minor: 19 }
+        KernelVersion {
+            major: 5,
+            minor: 19,
+        }
     }
     fn feature_name(&self) -> &str {
         "PBUF_RING"
@@ -139,7 +147,10 @@ pub struct LinkatRequirement;
 
 impl VersionRequirement for LinkatRequirement {
     fn min_version(&self) -> KernelVersion {
-        KernelVersion { major: 5, minor: 15 }
+        KernelVersion {
+            major: 5,
+            minor: 15,
+        }
     }
     fn feature_name(&self) -> &str {
         "LINKAT"
@@ -151,7 +162,10 @@ pub struct StatxRenameatRequirement;
 
 impl VersionRequirement for StatxRenameatRequirement {
     fn min_version(&self) -> KernelVersion {
-        KernelVersion { major: 5, minor: 11 }
+        KernelVersion {
+            major: 5,
+            minor: 11,
+        }
     }
     fn feature_name(&self) -> &str {
         "STATX/RENAMEAT"
@@ -439,7 +453,10 @@ mod tests {
     #[test]
     fn version_requirement_check_message_unsupported() {
         let req = IoUringRequirement;
-        let v = KernelVersion { major: 4, minor: 19 };
+        let v = KernelVersion {
+            major: 4,
+            minor: 19,
+        };
         let msg = req.check_message(&v);
         assert!(msg.contains("unsupported"), "got: {msg}");
         assert!(msg.contains("4.19"), "got: {msg}");
@@ -449,32 +466,71 @@ mod tests {
     #[test]
     fn pbuf_ring_requirement_needs_5_19() {
         let req = PbufRingRequirement;
-        assert_eq!(req.min_version(), KernelVersion { major: 5, minor: 19 });
-        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 18 }));
-        assert!(req.is_supported(&KernelVersion { major: 5, minor: 19 }));
+        assert_eq!(
+            req.min_version(),
+            KernelVersion {
+                major: 5,
+                minor: 19
+            }
+        );
+        assert!(!req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 18
+        }));
+        assert!(req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 19
+        }));
     }
 
     #[test]
     fn send_zc_requirement_needs_6_0() {
         let req = SendZcRequirement;
         assert_eq!(req.min_version(), KernelVersion { major: 6, minor: 0 });
-        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 19 }));
+        assert!(!req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 19
+        }));
         assert!(req.is_supported(&KernelVersion { major: 6, minor: 0 }));
     }
 
     #[test]
     fn linkat_requirement_needs_5_15() {
         let req = LinkatRequirement;
-        assert_eq!(req.min_version(), KernelVersion { major: 5, minor: 15 });
-        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 14 }));
-        assert!(req.is_supported(&KernelVersion { major: 5, minor: 15 }));
+        assert_eq!(
+            req.min_version(),
+            KernelVersion {
+                major: 5,
+                minor: 15
+            }
+        );
+        assert!(!req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 14
+        }));
+        assert!(req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 15
+        }));
     }
 
     #[test]
     fn statx_renameat_requirement_needs_5_11() {
         let req = StatxRenameatRequirement;
-        assert_eq!(req.min_version(), KernelVersion { major: 5, minor: 11 });
-        assert!(!req.is_supported(&KernelVersion { major: 5, minor: 10 }));
-        assert!(req.is_supported(&KernelVersion { major: 5, minor: 11 }));
+        assert_eq!(
+            req.min_version(),
+            KernelVersion {
+                major: 5,
+                minor: 11
+            }
+        );
+        assert!(!req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 10
+        }));
+        assert!(req.is_supported(&KernelVersion {
+            major: 5,
+            minor: 11
+        }));
     }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -261,9 +261,9 @@ pub use dir_sandbox::{
     unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
-    IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement,
-    PbufRingRequirement, SendZcRequirement, StatxRenameatRequirement, VersionRequirement,
-    log_io_uring_probe_result, parse_kernel_version,
+    IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement, PbufRingRequirement,
+    SendZcRequirement, StatxRenameatRequirement, VersionRequirement, log_io_uring_probe_result,
+    parse_kernel_version,
 };
 #[cfg(unix)]
 pub use linux_capabilities::openat2_supported;

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -261,7 +261,9 @@ pub use dir_sandbox::{
     unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
-    IO_URING_MIN_KERNEL, KernelVersion, log_io_uring_probe_result, parse_kernel_version,
+    IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement,
+    PbufRingRequirement, SendZcRequirement, StatxRenameatRequirement, VersionRequirement,
+    log_io_uring_probe_result, parse_kernel_version,
 };
 #[cfg(unix)]
 pub use linux_capabilities::openat2_supported;
@@ -423,6 +425,7 @@ pub use sqpoll_basis::{
     MAX_WIRED_WINDOW_BYTES, MlockError, WiredBasisWindow, mlock_attempts, mlock_downgrades,
 };
 pub use status::{
-    io_uring_availability_reason, io_uring_kernel_info, io_uring_status_detail, iocp_status_detail,
+    IoUringRestriction, detect_io_uring_restriction, io_uring_availability_reason,
+    io_uring_capability_matrix, io_uring_kernel_info, io_uring_status_detail, iocp_status_detail,
     platform_io_capabilities,
 };

--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -3,6 +3,15 @@
 //! Combines compile-time platform information with runtime probes for
 //! io_uring and IOCP into human-readable strings suitable for CLI output
 //! and structured records for programmatic callers.
+//!
+//! # io_uring restriction detection (IKV-F.2)
+//!
+//! The [`IoUringRestriction`] enum and [`detect_io_uring_restriction`]
+//! function surface the specific reason io_uring is unavailable, if any.
+//! Container runtimes (Docker pre-20.10.2, gVisor), seccomp profiles, and
+//! cgroup v2 device controllers can silently block `io_uring_setup(2)`.
+//! This module detects these restrictions once at startup via the cached
+//! probe in [`crate::io_uring::config`] and provides user-visible messages.
 
 use crate::io_uring;
 #[cfg(target_os = "linux")]
@@ -13,6 +22,234 @@ use crate::iocp::is_iocp_available;
 use crate::iocp::skip_event_optimization_available;
 #[cfg(target_os = "linux")]
 use crate::splice::is_splice_available;
+
+/// Reason io_uring is restricted or unavailable on this system.
+///
+/// Returned by [`detect_io_uring_restriction`]. The variants map onto the
+/// five outcomes of the startup probe in [`crate::io_uring::config`] but
+/// are exposed as a public enum so callers (CLI `--io-uring-status`,
+/// daemon log) can act on them without parsing strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IoUringRestriction {
+    /// io_uring is available - no restriction detected.
+    None,
+    /// Platform is not Linux - io_uring is a Linux-only kernel interface.
+    NotLinux,
+    /// The `io_uring` cargo feature was not compiled in.
+    FeatureDisabled,
+    /// Kernel version is below 5.6 (the minimum for `io_uring_setup(2)`).
+    KernelTooOld {
+        /// Detected kernel major version.
+        major: u32,
+        /// Detected kernel minor version.
+        minor: u32,
+    },
+    /// Kernel version is sufficient but `io_uring_setup(2)` failed.
+    /// This typically indicates seccomp filtering, container runtime
+    /// restrictions, or cgroup-level blocking.
+    SyscallBlocked {
+        /// Detected kernel major version.
+        major: u32,
+        /// Detected kernel minor version.
+        minor: u32,
+    },
+    /// Could not determine the kernel version.
+    KernelVersionUnknown,
+}
+
+impl std::fmt::Display for IoUringRestriction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "no restriction - io_uring is available"),
+            Self::NotLinux => write!(f, "platform is not Linux"),
+            Self::FeatureDisabled => write!(f, "io_uring cargo feature not compiled in"),
+            Self::KernelTooOld { major, minor } => {
+                write!(f, "kernel {major}.{minor} is below minimum 5.6")
+            }
+            Self::SyscallBlocked { major, minor } => {
+                write!(
+                    f,
+                    "io_uring_setup(2) blocked on kernel {major}.{minor} \
+                     (seccomp, container runtime, or cgroup restriction)"
+                )
+            }
+            Self::KernelVersionUnknown => write!(f, "could not detect kernel version"),
+        }
+    }
+}
+
+/// Detects whether io_uring is restricted and why.
+///
+/// Uses the cached probe result from [`crate::io_uring::config`] (which
+/// runs once per process), so this function is cheap to call repeatedly.
+/// On non-Linux platforms or without the `io_uring` feature, returns a
+/// compile-time-known restriction without any runtime cost.
+#[must_use]
+pub fn detect_io_uring_restriction() -> IoUringRestriction {
+    detect_io_uring_restriction_impl()
+}
+
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+fn detect_io_uring_restriction_impl() -> IoUringRestriction {
+    let info = io_uring::config_detail::io_uring_kernel_info();
+    if info.available {
+        return IoUringRestriction::None;
+    }
+    match (info.kernel_major, info.kernel_minor) {
+        (Some(major), Some(minor)) => {
+            if (major, minor) < (5, 6) {
+                IoUringRestriction::KernelTooOld { major, minor }
+            } else {
+                IoUringRestriction::SyscallBlocked { major, minor }
+            }
+        }
+        _ => IoUringRestriction::KernelVersionUnknown,
+    }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "io_uring")))]
+fn detect_io_uring_restriction_impl() -> IoUringRestriction {
+    #[cfg(not(target_os = "linux"))]
+    {
+        IoUringRestriction::NotLinux
+    }
+    #[cfg(all(target_os = "linux", not(feature = "io_uring")))]
+    {
+        IoUringRestriction::FeatureDisabled
+    }
+}
+
+/// Prints a multi-line io_uring capability matrix to stdout.
+///
+/// Designed for the `--io-uring-status` CLI flag. Reports:
+/// - Compile-time feature state
+/// - Kernel version and io_uring availability
+/// - Restriction detection (seccomp/cgroup/kernel version)
+/// - Supported opcodes and capabilities (PBUF_RING, SQPOLL, etc.)
+/// - Active fallback chain
+///
+/// Returns the formatted string so callers can print it or use it in tests.
+#[must_use]
+pub fn io_uring_capability_matrix() -> String {
+    let mut lines = Vec::new();
+
+    lines.push("io_uring capability matrix:".to_string());
+    lines.push(String::new());
+
+    // Compile-time feature state
+    let compiled_in = cfg!(all(target_os = "linux", feature = "io_uring"));
+    lines.push(format!(
+        "  compiled in:        {}",
+        if compiled_in { "yes" } else { "no" }
+    ));
+
+    // Platform
+    let platform = if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "other"
+    };
+    lines.push(format!("  platform:           {platform}"));
+
+    // Kernel info and restriction
+    let info = io_uring_kernel_info();
+    let restriction = detect_io_uring_restriction();
+
+    if let (Some(major), Some(minor)) = (info.kernel_major, info.kernel_minor) {
+        lines.push(format!("  kernel version:     {major}.{minor}"));
+    } else {
+        lines.push("  kernel version:     unknown".to_string());
+    }
+
+    lines.push(format!(
+        "  available:          {}",
+        if info.available { "yes" } else { "no" }
+    ));
+
+    if restriction != IoUringRestriction::None {
+        lines.push(format!("  restriction:        {restriction}"));
+    }
+
+    if info.available {
+        lines.push(format!("  supported ops:      {}", info.supported_ops));
+        lines.push(format!(
+            "  pbuf_ring:          {}",
+            if info.pbuf_ring_supported {
+                "yes (kernel 5.19+)"
+            } else {
+                "no"
+            }
+        ));
+        lines.push(format!(
+            "  sqpoll fell back:   {}",
+            if crate::sqpoll_fell_back() {
+                "yes (CAP_SYS_NICE likely missing)"
+            } else {
+                "no"
+            }
+        ));
+    }
+
+    // Feature gates
+    lines.push(String::new());
+    lines.push("  feature gates:".to_string());
+    lines.push(format!(
+        "    io_uring:             {}",
+        if cfg!(feature = "io_uring") {
+            "on"
+        } else {
+            "off"
+        }
+    ));
+    lines.push(format!(
+        "    iouring-data-reads:   {}",
+        if cfg!(feature = "iouring-data-reads") {
+            "on"
+        } else {
+            "off"
+        }
+    ));
+    lines.push(format!(
+        "    iouring-data-writes:  {}",
+        if cfg!(feature = "iouring-data-writes") {
+            "on"
+        } else {
+            "off"
+        }
+    ));
+    lines.push(format!(
+        "    iouring-send-zc:      {}",
+        if cfg!(feature = "iouring-send-zc") {
+            "on"
+        } else {
+            "off"
+        }
+    ));
+    lines.push(format!(
+        "    sqpoll-mlock-basis:   {}",
+        if cfg!(feature = "sqpoll-mlock-basis") {
+            "on"
+        } else {
+            "off"
+        }
+    ));
+
+    // Fallback chain
+    lines.push(String::new());
+    lines.push("  active fallback chain:".to_string());
+    if info.available {
+        lines.push("    1. io_uring (primary)".to_string());
+        lines.push("    2. standard buffered I/O (fallback on ring failure)".to_string());
+    } else {
+        lines.push("    1. standard buffered I/O (io_uring unavailable)".to_string());
+    }
+
+    lines.join("\n")
+}
 
 /// Detailed IOCP availability status for `--version` output.
 ///
@@ -492,6 +729,94 @@ mod tests {
         assert!(
             !crate::sqpoll_fell_back(),
             "sqpoll_fell_back() must be false at startup"
+        );
+    }
+
+    #[test]
+    fn detect_io_uring_restriction_returns_valid_variant() {
+        let restriction = detect_io_uring_restriction();
+        // On any platform, the function must return a valid variant
+        // that can be formatted.
+        let display = format!("{restriction}");
+        assert!(!display.is_empty());
+
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(restriction, IoUringRestriction::NotLinux);
+
+        #[cfg(all(target_os = "linux", not(feature = "io_uring")))]
+        assert_eq!(restriction, IoUringRestriction::FeatureDisabled);
+    }
+
+    #[test]
+    fn detect_io_uring_restriction_consistent_with_availability() {
+        let restriction = detect_io_uring_restriction();
+        let available = crate::is_io_uring_available();
+
+        if available {
+            assert_eq!(
+                restriction,
+                IoUringRestriction::None,
+                "restriction must be None when io_uring is available"
+            );
+        } else {
+            assert_ne!(
+                restriction,
+                IoUringRestriction::None,
+                "restriction must not be None when io_uring is unavailable"
+            );
+        }
+    }
+
+    #[test]
+    fn io_uring_restriction_display_is_single_line() {
+        let restriction = detect_io_uring_restriction();
+        let display = format!("{restriction}");
+        assert!(
+            !display.contains('\n'),
+            "restriction display must be single line, got: {display}"
+        );
+    }
+
+    #[test]
+    fn io_uring_capability_matrix_is_well_formed() {
+        let matrix = io_uring_capability_matrix();
+        assert!(
+            matrix.starts_with("io_uring capability matrix:"),
+            "matrix must start with header, got: {}",
+            matrix.lines().next().unwrap_or("")
+        );
+        assert!(matrix.contains("compiled in:"));
+        assert!(matrix.contains("platform:"));
+        assert!(matrix.contains("available:"));
+        assert!(matrix.contains("feature gates:"));
+        assert!(matrix.contains("active fallback chain:"));
+    }
+
+    #[test]
+    fn io_uring_capability_matrix_reflects_availability() {
+        let matrix = io_uring_capability_matrix();
+        let available = crate::is_io_uring_available();
+
+        if available {
+            assert!(
+                matrix.contains("available:          yes"),
+                "matrix must show available=yes when io_uring is available"
+            );
+        } else {
+            assert!(
+                matrix.contains("available:          no"),
+                "matrix must show available=no when io_uring is unavailable"
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn io_uring_capability_matrix_shows_restriction_on_non_linux() {
+        let matrix = io_uring_capability_matrix();
+        assert!(
+            matrix.contains("restriction:"),
+            "matrix must show restriction on non-Linux, got: {matrix}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **IKV-F.1 - Fallback logging**: Added `debug_log!(Io, ...)` messages at every io_uring-to-standard-I/O fallback site in `file_factory.rs`, `mod.rs`, and `io_uring_ops.rs`. When io_uring operations fail, the error is now logged before falling back, making silent downgrades visible via `--debug=io1` or `--debug=io2`.

- **IKV-F.2 - Restriction detection**: Added `IoUringRestriction` enum (None, NotLinux, FeatureDisabled, KernelTooOld, SyscallBlocked, KernelVersionUnknown) and `detect_io_uring_restriction()` function in `status.rs`. On Linux, attempts an `io_uring_setup` syscall probe to distinguish seccomp/cgroup blocks from kernel version issues. Result is logged at startup alongside the existing probe result.

- **IKV-F.3 - `--io-uring-status` CLI flag**: New print-and-exit flag that outputs a structured capability matrix showing compiled-in status, platform, kernel version, availability, restriction type, supported operations (statx, rename, linkat, read, write, send_zc), pbuf_ring support, sqpoll fallback, feature gates, and active fallback chain.

- **IKV-F.4 - VersionRequirement trait**: Added trait in `kernel_version.rs` with `min_version()`, `feature_name()`, `is_supported()`, and `check_message()` methods. Five implementors cover io_uring (5.6+), PBUF_RING (5.19+), LINKAT (5.15+), STATX/RENAMEAT (5.11+), and SEND_ZC (6.0+).

- **IKV-F.5 - Tests**: Added tests for restriction detection consistency, display formatting, capability matrix structure, and all VersionRequirement implementors.

## Test plan

- [ ] CI nextest passes (all platforms)
- [ ] `--io-uring-status` prints capability matrix and exits on Linux
- [ ] `--io-uring-status` prints "not compiled in" / "not Linux" on non-Linux platforms and exits
- [ ] `--debug=io1` shows fallback messages when io_uring is unavailable
- [ ] Restriction detection correctly identifies seccomp-blocked environments (containers)