### PR TITLE
ci: increase nextest timeout to 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
     # should pin the required check to `nextest (stable)`.


### PR DESCRIPTION
## Summary

- Increase the nextest job timeout from 60 to 90 minutes to accommodate the disk-cleanup step added in #5144

## Context

The disk-cleanup step from #5144 frees ~15 GB before building to prevent link-time disk exhaustion ("No space left on device"). This cleanup adds enough overhead that the previous 60-minute timeout is now too tight, causing the nextest job to time out consistently. Increasing to 90 minutes provides sufficient headroom for both the cleanup and the full test suite.

## Test plan

- [ ] Verify the nextest job completes within the new 90-minute timeout
- [ ] Confirm no other CI jobs are affected