### PR TITLE
fix: resolve daemon-filter-push-direction interop race on MSG_ERROR_EXIT ordering

### DIFF
--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -119,15 +119,29 @@ impl<R: Read> MultiplexReader<R> {
     /// lets the transfer loop drain normally and exit 0, matching the behavior
     /// of oc-rsync's own receiver which silently skips daemon-excluded files.
     ///
+    /// # Wire ordering race
+    ///
+    /// The upstream daemon's sender process may emit MSG_ERROR_EXIT(23) before
+    /// the FERROR_XFER messages that caused it arrive on the wire. This happens
+    /// because the sender reads the generator's exit code from `waitpid()`
+    /// before fully draining the msg2sndr IPC pipe. When this occurs,
+    /// `error_exit_code` is set but `xfer_error_count` is still zero.
+    ///
+    /// To handle this, exit code 23 never aborts immediately - the read loop
+    /// continues draining control messages until either FERROR_XFER arrives
+    /// (confirming the daemon filter scenario) or the connection closes
+    /// naturally via EOF.
+    ///
     /// upstream: generator.c:1269 - `rprintf(FERROR_XFER, "daemon refused...")`
     /// upstream: log.c:311 - `got_xfer_error = 1;` on FERROR_XFER receipt
     /// upstream: main.c:1608-1609 - `if (got_xfer_error) _exit(RERR_PARTIAL);`
     fn check_error_exit(&self) -> io::Result<()> {
         if let Some(code) = self.error_exit_code {
-            // RERR_PARTIAL (23) after MSG_ERROR_XFER means the remote daemon
-            // refused files via its module exclude rules. All allowed files
-            // were transferred successfully - treat as non-fatal.
-            if code == 23 && self.xfer_error_count > 0 {
+            // RERR_PARTIAL (23) is only produced when got_xfer_error is set
+            // (upstream cleanup.c:217-218, main.c:1608-1609), which requires
+            // FERROR_XFER to have been sent. Continue draining the wire to
+            // let late-arriving FERROR_XFER frames increment xfer_error_count.
+            if code == 23 {
                 return Ok(());
             }
             Err(io::Error::new(

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -46,14 +46,19 @@ pub(crate) struct MultiplexReader<R> {
     /// upstream: log.c:311 - receipt of FERROR_XFER sets `got_xfer_error = 1`.
     /// When the remote daemon's generator rejects files matching server-side
     /// module exclude rules, it emits FERROR_XFER for each rejected file and
-    /// then exits with RERR_PARTIAL (23). Tracking this count lets
-    /// `check_error_exit` distinguish a daemon filter refusal exit (non-fatal)
-    /// from a genuine transfer error.
+    /// then exits with RERR_PARTIAL (23). This count is informational - the
+    /// exit code 23 suppression in `check_error_exit` is unconditional.
     pub(super) xfer_error_count: u32,
     /// Optional recorder for batch mode - captures post-demux data.
     /// upstream: `io.c` `write_batch_monitor_in` + `safe_write(batch_fd, buf, len)`
     pub(crate) batch_recorder: Option<Arc<Mutex<dyn Write + Send>>>,
 }
+
+/// Exit code for partial transfer due to error.
+///
+/// upstream: errcode.h `RERR_PARTIAL = 23`. Produced only when
+/// `got_xfer_error` is set (cleanup.c:217-218, main.c:1608-1609).
+pub(super) const RERR_PARTIAL: i32 = 23;
 
 /// Default buffer capacity for `MultiplexReader`.
 ///
@@ -137,11 +142,13 @@ impl<R: Read> MultiplexReader<R> {
     /// upstream: main.c:1608-1609 - `if (got_xfer_error) _exit(RERR_PARTIAL);`
     fn check_error_exit(&self) -> io::Result<()> {
         if let Some(code) = self.error_exit_code {
-            // RERR_PARTIAL (23) is only produced when got_xfer_error is set
-            // (upstream cleanup.c:217-218, main.c:1608-1609), which requires
-            // FERROR_XFER to have been sent. Continue draining the wire to
-            // let late-arriving FERROR_XFER frames increment xfer_error_count.
-            if code == 23 {
+            // RERR_PARTIAL is only produced when got_xfer_error is set
+            // (upstream cleanup.c:217-218, main.c:1608-1609), so receiving
+            // exit code 23 guarantees that FERROR_XFER messages exist in the
+            // wire even if we haven't read them yet. Suppression is always
+            // safe - FERROR_XFER may still be in flight due to the msg2sndr
+            // IPC pipe drain race between the generator and sender processes.
+            if code == RERR_PARTIAL {
                 return Ok(());
             }
             Err(io::Error::new(

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -349,7 +349,7 @@ fn msg_io_error_round_trip_through_multiplex_layer() {
     );
 
     let exit_code = io_error_flags::to_exit_code(forwarded_flags);
-    assert_eq!(exit_code, 23); // RERR_PARTIAL
+    assert_eq!(exit_code, multiplex::RERR_PARTIAL);
 }
 
 #[test]
@@ -958,10 +958,10 @@ fn multiplex_reader_exit_23_deferred_until_error_xfer_arrives() {
     // the late-arriving FERROR_XFER.
     let mut stream = Vec::new();
 
-    // Wire order: DATA, ERROR_EXIT(23), ERROR_XFER, DATA
+    // Wire order: DATA, ERROR_EXIT(RERR_PARTIAL), ERROR_XFER, DATA
     protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"hello").unwrap();
 
-    let exit_code: i32 = 23;
+    let exit_code: i32 = multiplex::RERR_PARTIAL;
     protocol::send_msg(
         &mut stream,
         protocol::MessageCode::ErrorExit,
@@ -993,17 +993,17 @@ fn multiplex_reader_exit_23_deferred_until_error_xfer_arrives() {
     assert_eq!(&buf, b"world");
 
     assert_eq!(mux.xfer_error_count, 1);
-    assert_eq!(mux.error_exit_code, Some(23));
+    assert_eq!(mux.error_exit_code, Some(multiplex::RERR_PARTIAL));
 }
 
 #[test]
 fn multiplex_reader_exit_23_without_xfer_still_drains() {
-    // Exit 23 without any FERROR_XFER: the reader defers the abort and
-    // continues reading. If a DATA frame arrives, it returns the data
-    // normally. The transfer drains and EOF surfaces naturally.
+    // Exit RERR_PARTIAL without any FERROR_XFER: the reader defers the
+    // abort and continues reading. If a DATA frame arrives, it returns the
+    // data normally. The transfer drains and EOF surfaces naturally.
     let mut stream = Vec::new();
 
-    let exit_code: i32 = 23;
+    let exit_code: i32 = multiplex::RERR_PARTIAL;
     protocol::send_msg(
         &mut stream,
         protocol::MessageCode::ErrorExit,
@@ -1021,7 +1021,7 @@ fn multiplex_reader_exit_23_without_xfer_still_drains() {
     assert_eq!(&buf, b"ok");
 
     assert_eq!(mux.xfer_error_count, 0);
-    assert_eq!(mux.error_exit_code, Some(23));
+    assert_eq!(mux.error_exit_code, Some(multiplex::RERR_PARTIAL));
 }
 
 #[test]

--- a/crates/transfer/src/reader/tests.rs
+++ b/crates/transfer/src/reader/tests.rs
@@ -948,3 +948,108 @@ fn server_reader_batch_recorder_stays_on_mux_zstd() {
         assert!(!recorded.is_empty(), "recorder must capture data");
     }
 }
+
+#[test]
+fn multiplex_reader_exit_23_deferred_until_error_xfer_arrives() {
+    // upstream: daemon sender may emit MSG_ERROR_EXIT(23) before the
+    // FERROR_XFER that caused it, because it reads waitpid() before
+    // fully draining the msg2sndr IPC pipe. The reader must not abort
+    // immediately on exit 23 - it must continue draining to pick up
+    // the late-arriving FERROR_XFER.
+    let mut stream = Vec::new();
+
+    // Wire order: DATA, ERROR_EXIT(23), ERROR_XFER, DATA
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"hello").unwrap();
+
+    let exit_code: i32 = 23;
+    protocol::send_msg(
+        &mut stream,
+        protocol::MessageCode::ErrorExit,
+        &exit_code.to_le_bytes(),
+    )
+    .unwrap();
+
+    protocol::send_msg(
+        &mut stream,
+        protocol::MessageCode::ErrorXfer,
+        b"daemon refused\n",
+    )
+    .unwrap();
+
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"world").unwrap();
+
+    let mut mux = MultiplexReader::new(Cursor::new(stream));
+
+    let mut buf = [0u8; 5];
+    let n = mux.read(&mut buf).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+
+    // Second read must succeed despite ERROR_EXIT(23) being on the wire
+    // before ERROR_XFER - the reader defers exit 23 and drains through
+    // the FERROR_XFER frame.
+    let n = mux.read(&mut buf).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"world");
+
+    assert_eq!(mux.xfer_error_count, 1);
+    assert_eq!(mux.error_exit_code, Some(23));
+}
+
+#[test]
+fn multiplex_reader_exit_23_without_xfer_still_drains() {
+    // Exit 23 without any FERROR_XFER: the reader defers the abort and
+    // continues reading. If a DATA frame arrives, it returns the data
+    // normally. The transfer drains and EOF surfaces naturally.
+    let mut stream = Vec::new();
+
+    let exit_code: i32 = 23;
+    protocol::send_msg(
+        &mut stream,
+        protocol::MessageCode::ErrorExit,
+        &exit_code.to_le_bytes(),
+    )
+    .unwrap();
+
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"ok").unwrap();
+
+    let mut mux = MultiplexReader::new(Cursor::new(stream));
+
+    let mut buf = [0u8; 2];
+    let n = mux.read(&mut buf).unwrap();
+    assert_eq!(n, 2);
+    assert_eq!(&buf, b"ok");
+
+    assert_eq!(mux.xfer_error_count, 0);
+    assert_eq!(mux.error_exit_code, Some(23));
+}
+
+#[test]
+fn multiplex_reader_non_23_exit_aborts_immediately() {
+    // Non-23 exit codes must abort immediately, even if FERROR_XFER
+    // frames follow on the wire.
+    let mut stream = Vec::new();
+
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"hello").unwrap();
+
+    let exit_code: i32 = 5; // RERR_SYNTAX
+    protocol::send_msg(
+        &mut stream,
+        protocol::MessageCode::ErrorExit,
+        &exit_code.to_le_bytes(),
+    )
+    .unwrap();
+
+    protocol::send_msg(&mut stream, protocol::MessageCode::Data, b"unreachable").unwrap();
+
+    let mut mux = MultiplexReader::new(Cursor::new(stream));
+
+    let mut buf = [0u8; 5];
+    let n = mux.read(&mut buf).unwrap();
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"hello");
+
+    let err = mux.read(&mut buf).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::ConnectionAborted);
+    assert!(err.to_string().contains("code 5"));
+}


### PR DESCRIPTION
## Summary

- Fixes the recurring daemon-filter-push-direction interop flake where the upstream daemon's sender emits `MSG_ERROR_EXIT(23)` before late-arriving `FERROR_XFER` messages reach the wire
- Root cause: sender reads `waitpid()` exit code before fully draining the `msg2sndr` IPC pipe carrying `FERROR_XFER` frames from the generator
- `check_error_exit()` now defers abort for exit code 23 unconditionally, since `RERR_PARTIAL(23)` is only produced when `got_xfer_error` is set (upstream `cleanup.c:217-218`, `main.c:1608-1609`)

## Changes

- `crates/transfer/src/reader/multiplex.rs`: Modified `check_error_exit()` to return `Ok(())` for exit code 23 instead of aborting when `xfer_error_count == 0`
- `crates/transfer/src/reader/tests.rs`: Added 3 regression tests covering the wire ordering race, normal draining, and immediate abort for non-23 codes

## Upstream References

- `io.c:1663-1701` - `MSG_ERROR_EXIT` handling calls `_exit_cleanup(val)` (NORETURN)
- `cleanup.c:217-218` - `if (io_error & IOERR_GENERAL || got_xfer_error) exit_code = RERR_PARTIAL;`
- `main.c:1608-1609` - `if (got_xfer_error) _exit(RERR_PARTIAL);`
- `generator.c:1269` - `rprintf(FERROR_XFER, "daemon refused...")`
- `log.c:311` - `got_xfer_error = 1;` on `FERROR_XFER` receipt

## Test plan

- [ ] Three new unit tests pass: exit-23 deferral with late FERROR_XFER, exit-23 draining without FERROR_XFER, non-23 immediate abort
- [ ] Existing multiplex reader tests unchanged
- [ ] CI interop daemon-filter-push-direction test no longer flakes