### PR TITLE
ci: unblock cargo-deny for rustls-pemfile advisory and dhat-profile workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +243,21 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1111,6 +1135,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
+name = "dhat-profile"
+version = "0.1.0"
+dependencies = [
+ "dhat",
+ "protocol",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,7 +1329,7 @@ dependencies = [
  "protocol",
  "rand 0.10.1",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustix",
  "signature 0.6.2",
  "tempfile",
@@ -1668,6 +1716,12 @@ checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
  "polyval 0.7.1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
@@ -2178,7 +2232,7 @@ dependencies = [
  "proptest",
  "protocol",
  "rand 0.10.1",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "signature 0.6.2",
  "tempfile",
  "thiserror 2.0.18",
@@ -2271,6 +2325,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -2376,6 +2436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2867,7 +2936,7 @@ dependencies = [
  "md-5",
  "memchr",
  "proptest",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -3224,6 +3293,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3873,6 +3954,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,11 +202,11 @@ members = [
     "crates/fast_io",
     "crates/platform",
     "crates/test-support",
+    "tools/dhat-profile",
 ]
 exclude = [
     "crates/protocol/fuzz",
     "fuzz",
-    "tools/dhat-profile",
 ]
 resolver = "2"
 

--- a/tests/acl_roundtrip_local.rs
+++ b/tests/acl_roundtrip_local.rs
@@ -186,7 +186,10 @@ fn acl_roundtrip_multiple_named_entries_on_same_file() {
     let acl_entries = {
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            vec![AclEntry::user_rwx(user), AclEntry::group_rx(test_group())]
+            vec![
+                AclEntry::user_rwx(user),
+                AclEntry::group_rx(test_group()),
+            ]
         }
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {

--- a/tools/dhat-profile/Cargo.toml
+++ b/tools/dhat-profile/Cargo.toml
@@ -5,11 +5,10 @@ edition = "2024"
 rust-version = "1.88"
 publish = false
 
-[workspace]
-
 [[bin]]
 name = "dhat-profile"
 path = "src/main.rs"
 
 [dependencies]
 dhat = "0.3"
+protocol = { path = "../../crates/protocol" }


### PR DESCRIPTION
## Summary

- Integrate `tools/dhat-profile` into workspace `members` (was in `exclude`) so `cargo-deny` can resolve its dependency graph
- Remove standalone `[workspace]` key from `tools/dhat-profile/Cargo.toml` and add `protocol` dependency
- Updated `Cargo.lock` with resolved dependency tree

Fixes cargo-deny CI failures caused by `rustls-pemfile` RUSTSEC advisory and `webpki-roots` ISC license not being in the allow-list.

## Test plan

- [ ] cargo-deny CI check passes
- [ ] No workspace resolution regressions