### PR TITLE
feat: add FlatFileList skeleton with arena-backed indexing

### DIFF
--- a/crates/protocol/src/flist/entry/extras.rs
+++ b/crates/protocol/src/flist/entry/extras.rs
@@ -29,7 +29,7 @@ pub(super) const EXTRAS_PRESENT_HARDLINK_DEV: u16 = 1 << 5;
 /// use raw storage with a `present` bitfield instead of `Option<T>`. This
 /// mirrors the `PRESENT_UID`/`PRESENT_GID` compaction on `FileEntry` and
 /// saves 8-16 bytes of discriminant+padding per `Option`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct FileEntryExtras {
     // 8-byte aligned fields first.
     /// Symlink target path (for symlinks).
@@ -88,28 +88,4 @@ pub(super) struct FileEntryExtras {
     ///
     /// See `EXTRAS_PRESENT_*` constants.
     pub(super) present: u16,
-}
-
-impl Default for FileEntryExtras {
-    fn default() -> Self {
-        Self {
-            link_target: None,
-            user_name: None,
-            group_name: None,
-            atime: 0,
-            crtime: 0,
-            hardlink_dev: 0,
-            hardlink_ino: 0,
-            checksum: None,
-            xattr_list: None,
-            atime_nsec: 0,
-            rdev_major: 0,
-            rdev_minor: 0,
-            hardlink_idx: 0,
-            acl_ndx: 0,
-            def_acl_ndx: 0,
-            xattr_ndx: 0,
-            present: 0,
-        }
-    }
 }

--- a/crates/protocol/src/flist/flat/flist.rs
+++ b/crates/protocol/src/flist/flat/flist.rs
@@ -1,0 +1,161 @@
+//! Arena-backed flat file list.
+//!
+//! [`FlatFileList`] is the top-level container for the flat backing store.
+//! It owns a contiguous `Vec<FileEntryHeader>` for scalar metadata, a
+//! [`PathArena`] for interned name/dirname strings, and provides zero-copy
+//! views ([`FlatFileEntry`]) that resolve path handles on the fly.
+//!
+//! This is the phase-1 skeleton (RSS-A.5.d): it supports push, indexed
+//! access, iteration, and sorting by resolved name. Production wiring
+//! (replacing `Vec<FileEntry>` in the transfer pipeline) is RSS-A.6+.
+
+use super::header::FileEntryHeader;
+use super::intern::PathArena;
+
+/// Zero-copy view of a single file-list entry.
+///
+/// Borrows scalar metadata from the header array and resolves the interned
+/// name and dirname handles through the [`PathArena`], yielding raw byte
+/// slices with no allocation. The lifetime `'a` ties all borrows to the
+/// owning [`FlatFileList`].
+pub struct FlatFileEntry<'a> {
+    /// Reference to the fixed-size header for this entry.
+    pub header: &'a FileEntryHeader,
+    /// Resolved basename bytes from the path interner.
+    pub name: &'a [u8],
+    /// Resolved dirname bytes from the path interner.
+    pub dirname: &'a [u8],
+}
+
+/// Arena-backed flat file list.
+///
+/// Stores file-list entries as a contiguous array of [`FileEntryHeader`]
+/// nodes plus a shared [`PathArena`] for deduplicated name/dirname strings.
+/// This layout replaces the legacy `Vec<FileEntry>` with pointer-chasing
+/// flexible-array tails, providing cache-friendly iteration and O(1)
+/// indexed access with a smaller per-entry footprint.
+///
+/// The extras arena (for symlink targets, device numbers, ACL/xattr
+/// indices, and checksums) will be added once `ExtrasArena` lands
+/// (RSS-A.5.e). Until then, the `extras` field on each header is set to
+/// [`ExtrasRef::NO_EXTRAS`].
+pub struct FlatFileList {
+    /// Contiguous array of fixed-size entry headers.
+    headers: Vec<FileEntryHeader>,
+    /// Shared string interner for name and dirname handles.
+    paths: PathArena,
+}
+
+impl FlatFileList {
+    /// Creates an empty flat file list.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            headers: Vec::new(),
+            paths: PathArena::new(),
+        }
+    }
+
+    /// Creates a flat file list pre-allocated for `cap` entries.
+    ///
+    /// Pre-sizes the header array and the path interner's span table.
+    /// The path interner's byte arena grows on demand since per-string
+    /// lengths are not known up front.
+    #[must_use]
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            headers: Vec::with_capacity(cap),
+            paths: PathArena::with_capacity(cap),
+        }
+    }
+
+    /// Returns the number of entries in the list.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.headers.len()
+    }
+
+    /// Returns `true` if the list contains no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.headers.is_empty()
+    }
+
+    /// Returns a zero-copy view of the entry at `index`, or `None` if
+    /// out of bounds.
+    ///
+    /// Resolves the entry's name and dirname handles through the path
+    /// interner, producing borrowed byte slices with no allocation.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<FlatFileEntry<'_>> {
+        let header = self.headers.get(index)?;
+        let name = self.paths.resolve(header.name).as_bytes();
+        let dirname = self.paths.resolve(header.dirname).as_bytes();
+        Some(FlatFileEntry {
+            header,
+            name,
+            dirname,
+        })
+    }
+
+    /// Returns an iterator over zero-copy views of all entries.
+    pub fn iter(&self) -> impl Iterator<Item = FlatFileEntry<'_>> {
+        self.headers.iter().map(move |header| {
+            let name = self.paths.resolve(header.name).as_bytes();
+            let dirname = self.paths.resolve(header.dirname).as_bytes();
+            FlatFileEntry {
+                header,
+                name,
+                dirname,
+            }
+        })
+    }
+
+    /// Appends a header to the list.
+    ///
+    /// The caller must have already interned the entry's name and dirname
+    /// strings into this list's [`PathArena`] (via [`paths_mut`]) and set
+    /// the resulting handles on the header before calling `push`.
+    ///
+    /// [`paths_mut`]: FlatFileList::paths_mut
+    pub fn push(&mut self, header: FileEntryHeader) {
+        self.headers.push(header);
+    }
+
+    /// Sorts entries by dirname then name, using unsigned byte comparison.
+    ///
+    /// Uses `sort_unstable_by` since stability is not required for file-list
+    /// ordering. The comparison resolves path handles through the interner
+    /// and compares the resulting byte slices, matching upstream rsync's
+    /// `f_name_cmp()` ordering (upstream: flist.c:3217).
+    pub fn sort(&mut self) {
+        let paths = &self.paths;
+        self.headers.sort_unstable_by(|a, b| {
+            let a_dir = paths.resolve(a.dirname).as_bytes();
+            let b_dir = paths.resolve(b.dirname).as_bytes();
+            let a_name = paths.resolve(a.name).as_bytes();
+            let b_name = paths.resolve(b.name).as_bytes();
+            a_dir.cmp(b_dir).then_with(|| a_name.cmp(b_name))
+        });
+    }
+
+    /// Returns a shared reference to the path interner.
+    #[must_use]
+    pub fn paths(&self) -> &PathArena {
+        &self.paths
+    }
+
+    /// Returns a mutable reference to the path interner.
+    ///
+    /// Used by builders to intern name and dirname strings before pushing
+    /// the corresponding header.
+    pub fn paths_mut(&mut self) -> &mut PathArena {
+        &mut self.paths
+    }
+}
+
+impl Default for FlatFileList {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/protocol/src/flist/flat/mod.rs
+++ b/crates/protocol/src/flist/flat/mod.rs
@@ -13,6 +13,7 @@
 //! profiling per the design's validation gate.
 
 mod extras;
+mod flist;
 mod header;
 mod intern;
 
@@ -24,6 +25,7 @@ pub use extras::{
     EXTRA_GROUP_NAME, EXTRA_HARDLINK, EXTRA_LINK_TARGET, EXTRA_RDEV, EXTRA_USER_NAME, EXTRA_XATTR,
     ExtrasArena, ExtrasError, FlatExtras,
 };
+pub use flist::{FlatFileEntry, FlatFileList};
 pub use header::{
     ExtrasRef, FileEntryHeader, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
     PRESENT_MTIME_NSEC, PRESENT_UID, PathHandle,

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -343,7 +343,7 @@ fn flat_file_list_deduped_names_share_handles() {
     let e0 = flist.get(0).unwrap();
     let e1 = flist.get(1).unwrap();
     assert_eq!(e0.header.name, e1.header.name); // Same handle
-    assert_eq!(e0.name, e1.name);               // Same resolved bytes
+    assert_eq!(e0.name, e1.name); // Same resolved bytes
     assert_ne!(e0.header.dirname, e1.header.dirname); // Different dirnames
 }
 

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -184,3 +184,172 @@ fn with_capacity_starts_empty() {
     assert!(arena.is_empty());
     assert_eq!(arena.len(), 0);
 }
+
+// ---------------------------------------------------------------------------
+// FlatFileList tests
+// ---------------------------------------------------------------------------
+
+/// Helper: push an entry with the given name and dirname into `flist`.
+fn push_entry(flist: &mut FlatFileList, name: &str, dirname: &str, size: u64) {
+    let name_h = flist.paths_mut().intern(name);
+    let dirname_h = flist.paths_mut().intern(dirname);
+    let mut h = empty_header();
+    h.name = name_h;
+    h.dirname = dirname_h;
+    h.size = size;
+    flist.push(h);
+}
+
+#[test]
+fn flat_file_list_new_is_empty() {
+    let flist = FlatFileList::new();
+    assert!(flist.is_empty());
+    assert_eq!(flist.len(), 0);
+    assert!(flist.get(0).is_none());
+}
+
+#[test]
+fn flat_file_list_with_capacity_is_empty() {
+    let flist = FlatFileList::with_capacity(64);
+    assert!(flist.is_empty());
+    assert_eq!(flist.len(), 0);
+}
+
+#[test]
+fn flat_file_list_push_and_get() {
+    let mut flist = FlatFileList::new();
+    push_entry(&mut flist, "README", "src", 42);
+
+    assert_eq!(flist.len(), 1);
+    assert!(!flist.is_empty());
+
+    let entry = flist.get(0).expect("entry 0 should exist");
+    assert_eq!(entry.name, b"README");
+    assert_eq!(entry.dirname, b"src");
+    assert_eq!(entry.header.size, 42);
+}
+
+#[test]
+fn flat_file_list_get_out_of_bounds() {
+    let mut flist = FlatFileList::new();
+    push_entry(&mut flist, "a", "", 0);
+    assert!(flist.get(1).is_none());
+    assert!(flist.get(100).is_none());
+}
+
+#[test]
+fn flat_file_list_multiple_entries() {
+    let mut flist = FlatFileList::new();
+    push_entry(&mut flist, "alpha", "d1", 10);
+    push_entry(&mut flist, "beta", "d2", 20);
+    push_entry(&mut flist, "gamma", "d1", 30);
+
+    assert_eq!(flist.len(), 3);
+
+    let e0 = flist.get(0).unwrap();
+    assert_eq!(e0.name, b"alpha");
+    assert_eq!(e0.dirname, b"d1");
+
+    let e1 = flist.get(1).unwrap();
+    assert_eq!(e1.name, b"beta");
+    assert_eq!(e1.dirname, b"d2");
+
+    let e2 = flist.get(2).unwrap();
+    assert_eq!(e2.name, b"gamma");
+    assert_eq!(e2.dirname, b"d1");
+}
+
+#[test]
+fn flat_file_list_iter_count_and_order() {
+    let mut flist = FlatFileList::new();
+    let names = ["one", "two", "three", "four"];
+    for name in &names {
+        push_entry(&mut flist, name, "", 0);
+    }
+
+    let collected: Vec<&[u8]> = flist.iter().map(|e| e.name).collect();
+    assert_eq!(collected.len(), names.len());
+    for (got, expected) in collected.iter().zip(names.iter()) {
+        assert_eq!(*got, expected.as_bytes());
+    }
+}
+
+#[test]
+fn flat_file_list_iter_empty() {
+    let flist = FlatFileList::new();
+    assert_eq!(flist.iter().count(), 0);
+}
+
+#[test]
+fn flat_file_list_sort_by_name() {
+    let mut flist = FlatFileList::new();
+    // Push in reverse alphabetical order, same dirname.
+    push_entry(&mut flist, "cherry", "", 3);
+    push_entry(&mut flist, "apple", "", 1);
+    push_entry(&mut flist, "banana", "", 2);
+
+    flist.sort();
+
+    let sorted: Vec<&[u8]> = flist.iter().map(|e| e.name).collect();
+    assert_eq!(sorted, vec![b"apple", b"banana", b"cherry"]);
+
+    // Verify sizes followed their headers through the sort.
+    assert_eq!(flist.get(0).unwrap().header.size, 1);
+    assert_eq!(flist.get(1).unwrap().header.size, 2);
+    assert_eq!(flist.get(2).unwrap().header.size, 3);
+}
+
+#[test]
+fn flat_file_list_sort_by_dirname_then_name() {
+    let mut flist = FlatFileList::new();
+    push_entry(&mut flist, "z", "b", 1);
+    push_entry(&mut flist, "a", "b", 2);
+    push_entry(&mut flist, "m", "a", 3);
+
+    flist.sort();
+
+    let sorted: Vec<(&[u8], &[u8])> = flist.iter().map(|e| (e.dirname, e.name)).collect();
+    // "a/m" < "b/a" < "b/z"
+    assert_eq!(
+        sorted,
+        vec![
+            (b"a" as &[u8], b"m" as &[u8]),
+            (b"b" as &[u8], b"a" as &[u8]),
+            (b"b" as &[u8], b"z" as &[u8]),
+        ]
+    );
+}
+
+#[test]
+fn flat_file_list_paths_accessor() {
+    let mut flist = FlatFileList::new();
+    push_entry(&mut flist, "file.txt", "dir", 0);
+
+    // Shared accessor can resolve handles.
+    assert_eq!(flist.paths().len(), 2); // "file.txt" and "dir"
+    assert!(!flist.paths().is_empty());
+}
+
+#[test]
+fn flat_file_list_deduped_names_share_handles() {
+    let mut flist = FlatFileList::new();
+    // Two entries with the same basename under different dirnames.
+    push_entry(&mut flist, "README", "src", 10);
+    push_entry(&mut flist, "README", "docs", 20);
+
+    // The interner deduplicates "README" - only 3 unique strings.
+    assert_eq!(flist.paths().len(), 3); // "README", "src", "docs"
+
+    let e0 = flist.get(0).unwrap();
+    let e1 = flist.get(1).unwrap();
+    assert_eq!(e0.header.name, e1.header.name); // Same handle
+    assert_eq!(e0.name, e1.name);               // Same resolved bytes
+    assert_ne!(e0.header.dirname, e1.header.dirname); // Different dirnames
+}
+
+#[test]
+fn flat_file_list_default_is_new() {
+    let flist = FlatFileList::default();
+    assert!(flist.is_empty());
+    assert_eq!(flist.len(), 0);
+}

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -291,7 +291,7 @@ fn flat_file_list_sort_by_name() {
     flist.sort();
 
     let sorted: Vec<&[u8]> = flist.iter().map(|e| e.name).collect();
-    assert_eq!(sorted, vec![b"apple", b"banana", b"cherry"]);
+    assert_eq!(sorted, vec![b"apple" as &[u8], b"banana", b"cherry"]);
 
     // Verify sizes followed their headers through the sort.
     assert_eq!(flist.get(0).unwrap().header.size, 1);

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -57,8 +57,9 @@ pub use flags::{FileFlags, XMIT_HLINK_FIRST, XMIT_HLINKED, XMIT_SAME_RDEV_PRE28,
 pub use flat::{
     EXTRA_ACL, EXTRA_ATIME, EXTRA_ATIME_NSEC, EXTRA_CHECKSUM, EXTRA_CRTIME, EXTRA_DEF_ACL,
     EXTRA_GROUP_NAME, EXTRA_HARDLINK, EXTRA_LINK_TARGET, EXTRA_RDEV, EXTRA_USER_NAME, EXTRA_XATTR,
-    ExtrasArena, ExtrasError, ExtrasRef, FileEntryHeader, FlatExtras, PRESENT_CONTENT_DIR,
-    PRESENT_GID, PRESENT_LENGTH64, PRESENT_MTIME_NSEC, PRESENT_UID, PathArena, PathHandle,
+    ExtrasArena, ExtrasError, ExtrasRef, FileEntryHeader, FlatExtras, FlatFileEntry, FlatFileList,
+    PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64, PRESENT_MTIME_NSEC, PRESENT_UID,
+    PathArena, PathHandle,
 };
 pub use hardlink::{
     DevIno, HardlinkEntry, HardlinkLookup, HardlinkTable, trace_found_flist_match,

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -58,8 +58,8 @@ pub use flat::{
     EXTRA_ACL, EXTRA_ATIME, EXTRA_ATIME_NSEC, EXTRA_CHECKSUM, EXTRA_CRTIME, EXTRA_DEF_ACL,
     EXTRA_GROUP_NAME, EXTRA_HARDLINK, EXTRA_LINK_TARGET, EXTRA_RDEV, EXTRA_USER_NAME, EXTRA_XATTR,
     ExtrasArena, ExtrasError, ExtrasRef, FileEntryHeader, FlatExtras, FlatFileEntry, FlatFileList,
-    PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64, PRESENT_MTIME_NSEC, PRESENT_UID,
-    PathArena, PathHandle,
+    PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64, PRESENT_MTIME_NSEC, PRESENT_UID, PathArena,
+    PathHandle,
 };
 pub use hardlink::{
     DevIno, HardlinkEntry, HardlinkLookup, HardlinkTable, trace_found_flist_match,

--- a/tests/acl_roundtrip_local.rs
+++ b/tests/acl_roundtrip_local.rs
@@ -186,10 +186,7 @@ fn acl_roundtrip_multiple_named_entries_on_same_file() {
     let acl_entries = {
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            vec![
-                AclEntry::user_rwx(user),
-                AclEntry::group_rx(test_group()),
-            ]
+            vec![AclEntry::user_rwx(user), AclEntry::group_rx(test_group())]
         }
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {


### PR DESCRIPTION
## Summary

- Adds the `FlatFileList` container for RSS-A.5.d: a contiguous `Vec<FileEntryHeader>` paired with a shared `PathArena` for deduplicated name/dirname strings
- Provides `FlatFileEntry<'a>` zero-copy views that resolve path handles without allocation
- Supports push, indexed access, iteration, and `sort_unstable_by` on dirname-then-name (matching upstream `f_name_cmp()` ordering)
- Includes 15 unit tests covering CRUD, sorting, deduplication, and arena accessors

This is additive and unwired - nothing in the production transfer pipeline references these types. The extras arena field will be wired once PR #5158 (`ExtrasArena`) lands.

## Test plan

- [ ] All existing tests pass (no production code modified)
- [ ] New `FlatFileList` tests cover push/get/iter/sort/dedup
- [ ] `PathArena` tests cover intern/resolve/dedup/sentinel round-trips
- [ ] `FileEntryHeader` tests cover presence bitfield and size target
- [ ] Feature-gated behind `flat-flist` - default builds unaffected