### PR TITLE
feat: flat-flist feature flag coexistence test and CI matrix cell

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -154,6 +154,9 @@ jobs:
           - name: zlib-rs
             args: "-p compress -p protocol --no-default-features --features zlib-rs"
             apt: ""
+          - name: flat-flist
+            args: "-p protocol --features flat-flist"
+            apt: ""
 
     env:
       CARGO_TERM_COLOR: always

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -353,3 +353,36 @@ fn flat_file_list_default_is_new() {
     assert!(flist.is_empty());
     assert_eq!(flist.len(), 0);
 }
+
+// ---------------------------------------------------------------------------
+// Feature-flag coexistence (RSS-A.5.e.3)
+// ---------------------------------------------------------------------------
+
+/// Verifies that the flat-flist types and the legacy `Vec<FileEntry>` path
+/// compile and operate side-by-side in the same scope. This is the key
+/// invariant of the feature flag: enabling `flat-flist` must never shadow,
+/// conflict with, or break the legacy representation.
+#[test]
+fn flat_and_legacy_coexist_in_same_scope() {
+    use crate::flist::FileEntry;
+
+    // Legacy path: build a Vec<FileEntry> with two entries.
+    let legacy: Vec<FileEntry> = vec![
+        FileEntry::new_file("src/main.rs".into(), 2048, 0o644),
+        FileEntry::new_file("README".into(), 512, 0o644),
+    ];
+    assert_eq!(legacy.len(), 2);
+    assert_eq!(legacy[0].size(), 2048);
+
+    // Flat path: build a FlatFileList with the same logical entries.
+    let mut flat = FlatFileList::new();
+    push_entry(&mut flat, "main.rs", "src", 2048);
+    push_entry(&mut flat, "README", "", 512);
+    assert_eq!(flat.len(), 2);
+    assert_eq!(flat.get(0).unwrap().header.size, 2048);
+
+    // Both representations live in the same scope without name collisions
+    // or trait ambiguity. The legacy path is completely unaffected by the
+    // feature flag.
+    assert_eq!(legacy.len(), flat.len());
+}


### PR DESCRIPTION
## Summary

- **RSS-A.5.e.1/e.2**: Verified the `flat-flist` feature flag and cfg-gated re-exports already exist from #5168
- **RSS-A.5.e.3**: Added a compile-time coexistence test that creates both a legacy `Vec<FileEntry>` and a `FlatFileList` in the same scope, proving the feature flag does not shadow or break the legacy path
- **RSS-A.5.e.4**: Added a `flat-flist` CI matrix cell to the feature flag combinations workflow (`_test-features.yml`) that builds and tests `protocol` with `--features flat-flist`

## Test plan

- [ ] CI `flat-flist (linux)` matrix cell passes - confirms `--features flat-flist` compiles and tests pass
- [ ] Existing `no-default-features` and `default-features` matrix cells still pass - confirms no regression to the legacy path
- [ ] `flat_and_legacy_coexist_in_same_scope` test passes - both representations compile and operate side-by-side