### PR TITLE
perf: compact FileEntryExtras with presence bitfield for 8 Option fields

### DIFF
--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -208,12 +208,24 @@ impl FileEntry {
 
     /// Returns the device major number if this is a device.
     pub fn rdev_major(&self) -> Option<u32> {
-        self.extras.as_ref().and_then(|e| e.rdev_major)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_RDEV != 0 {
+                Some(e.rdev_major)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the device minor number if this is a device.
     pub fn rdev_minor(&self) -> Option<u32> {
-        self.extras.as_ref().and_then(|e| e.rdev_minor)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_RDEV != 0 {
+                Some(e.rdev_minor)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the wire format flags.
@@ -304,18 +316,27 @@ impl FileEntry {
     /// Sets the device numbers.
     pub fn set_rdev(&mut self, major: u32, minor: u32) {
         let e = self.extras_mut();
-        e.rdev_major = Some(major);
-        e.rdev_minor = Some(minor);
+        e.rdev_major = major;
+        e.rdev_minor = minor;
+        e.present |= super::extras::EXTRAS_PRESENT_RDEV;
     }
 
     /// Returns the hardlink index if this entry is a hardlink.
     pub fn hardlink_idx(&self) -> Option<u32> {
-        self.extras.as_ref().and_then(|e| e.hardlink_idx)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_HARDLINK_IDX != 0 {
+                Some(e.hardlink_idx)
+            } else {
+                None
+            }
+        })
     }
 
     /// Sets the hardlink index for this entry.
     pub fn set_hardlink_idx(&mut self, idx: u32) {
-        self.extras_mut().hardlink_idx = Some(idx);
+        let e = self.extras_mut();
+        e.hardlink_idx = idx;
+        e.present |= super::extras::EXTRAS_PRESENT_HARDLINK_IDX;
     }
 
     /// Returns the access time as seconds since Unix epoch.
@@ -377,23 +398,39 @@ impl FileEntry {
     /// Returns the hardlink device number (for protocol < 30).
     #[inline]
     pub fn hardlink_dev(&self) -> Option<i64> {
-        self.extras.as_ref().and_then(|e| e.hardlink_dev)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_HARDLINK_DEV != 0 {
+                Some(e.hardlink_dev)
+            } else {
+                None
+            }
+        })
     }
 
     /// Sets the hardlink device number (for protocol < 30).
     pub fn set_hardlink_dev(&mut self, dev: i64) {
-        self.extras_mut().hardlink_dev = Some(dev);
+        let e = self.extras_mut();
+        e.hardlink_dev = dev;
+        e.present |= super::extras::EXTRAS_PRESENT_HARDLINK_DEV;
     }
 
     /// Returns the hardlink inode number (for protocol < 30).
     #[inline]
     pub fn hardlink_ino(&self) -> Option<i64> {
-        self.extras.as_ref().and_then(|e| e.hardlink_ino)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_HARDLINK_DEV != 0 {
+                Some(e.hardlink_ino)
+            } else {
+                None
+            }
+        })
     }
 
     /// Sets the hardlink inode number (for protocol < 30).
     pub fn set_hardlink_ino(&mut self, ino: i64) {
-        self.extras_mut().hardlink_ino = Some(ino);
+        let e = self.extras_mut();
+        e.hardlink_ino = ino;
+        e.present |= super::extras::EXTRAS_PRESENT_HARDLINK_DEV;
     }
 
     /// Returns the file checksum if set (for --checksum mode).
@@ -410,12 +447,20 @@ impl FileEntry {
     /// Returns the access ACL index if set (for --acls mode).
     #[inline]
     pub fn acl_ndx(&self) -> Option<u32> {
-        self.extras.as_ref().and_then(|e| e.acl_ndx)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_ACL_NDX != 0 {
+                Some(e.acl_ndx)
+            } else {
+                None
+            }
+        })
     }
 
     /// Sets the access ACL index (for --acls mode).
     pub fn set_acl_ndx(&mut self, ndx: u32) {
-        self.extras_mut().acl_ndx = Some(ndx);
+        let e = self.extras_mut();
+        e.acl_ndx = ndx;
+        e.present |= super::extras::EXTRAS_PRESENT_ACL_NDX;
     }
 
     /// Returns the default ACL index if set (for directories in --acls mode).
@@ -423,25 +468,41 @@ impl FileEntry {
     /// Corresponds to upstream's `F_DIR_DEFACL`. Only meaningful for directories.
     #[inline]
     pub fn def_acl_ndx(&self) -> Option<u32> {
-        self.extras.as_ref().and_then(|e| e.def_acl_ndx)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_DEF_ACL_NDX != 0 {
+                Some(e.def_acl_ndx)
+            } else {
+                None
+            }
+        })
     }
 
     /// Sets the default ACL index (for directories in --acls mode).
     ///
     /// Corresponds to upstream's `F_DIR_DEFACL`. Only meaningful for directories.
     pub fn set_def_acl_ndx(&mut self, ndx: u32) {
-        self.extras_mut().def_acl_ndx = Some(ndx);
+        let e = self.extras_mut();
+        e.def_acl_ndx = ndx;
+        e.present |= super::extras::EXTRAS_PRESENT_DEF_ACL_NDX;
     }
 
     /// Returns the extended attribute index if set (for --xattrs mode).
     #[inline]
     pub fn xattr_ndx(&self) -> Option<u32> {
-        self.extras.as_ref().and_then(|e| e.xattr_ndx)
+        self.extras.as_ref().and_then(|e| {
+            if e.present & super::extras::EXTRAS_PRESENT_XATTR_NDX != 0 {
+                Some(e.xattr_ndx)
+            } else {
+                None
+            }
+        })
     }
 
     /// Sets the extended attribute index (for --xattrs mode).
     pub fn set_xattr_ndx(&mut self, ndx: u32) {
-        self.extras_mut().xattr_ndx = Some(ndx);
+        let e = self.extras_mut();
+        e.xattr_ndx = ndx;
+        e.present |= super::extras::EXTRAS_PRESENT_XATTR_NDX;
     }
 
     /// Returns the sender-side xattr list if set (for --xattrs mode).

--- a/crates/protocol/src/flist/entry/extras.rs
+++ b/crates/protocol/src/flist/entry/extras.rs
@@ -2,6 +2,19 @@ use std::path::PathBuf;
 
 use crate::xattr::XattrList;
 
+/// Presence bit: `rdev_major` and `rdev_minor` hold meaningful values.
+pub(super) const EXTRAS_PRESENT_RDEV: u16 = 1 << 0;
+/// Presence bit: `hardlink_idx` holds a meaningful value.
+pub(super) const EXTRAS_PRESENT_HARDLINK_IDX: u16 = 1 << 1;
+/// Presence bit: `acl_ndx` holds a meaningful value.
+pub(super) const EXTRAS_PRESENT_ACL_NDX: u16 = 1 << 2;
+/// Presence bit: `def_acl_ndx` holds a meaningful value.
+pub(super) const EXTRAS_PRESENT_DEF_ACL_NDX: u16 = 1 << 3;
+/// Presence bit: `xattr_ndx` holds a meaningful value.
+pub(super) const EXTRAS_PRESENT_XATTR_NDX: u16 = 1 << 4;
+/// Presence bit: `hardlink_dev` and `hardlink_ino` hold meaningful values.
+pub(super) const EXTRAS_PRESENT_HARDLINK_DEV: u16 = 1 << 5;
+
 /// Rarely-used metadata fields for file entries.
 ///
 /// These fields are only populated when specific flags are active (e.g.
@@ -10,8 +23,15 @@ use crate::xattr::XattrList;
 /// ~200 bytes of inline overhead per entry when they're unused - matching
 /// upstream rsync's conditional field allocation in `file_struct`
 /// (upstream: flist.c:make_file()).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+///
+/// Fields that have a load-bearing `None` vs `Some(0)` distinction (rdev,
+/// hardlink_idx, acl_ndx, def_acl_ndx, xattr_ndx, hardlink_dev, hardlink_ino)
+/// use raw storage with a `present` bitfield instead of `Option<T>`. This
+/// mirrors the `PRESENT_UID`/`PRESENT_GID` compaction on `FileEntry` and
+/// saves 8-16 bytes of discriminant+padding per `Option`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct FileEntryExtras {
+    // 8-byte aligned fields first.
     /// Symlink target path (for symlinks).
     pub(super) link_target: Option<PathBuf>,
     /// User name for cross-system ownership mapping (protocol 30+).
@@ -22,28 +42,14 @@ pub(super) struct FileEntryExtras {
     pub(super) atime: i64,
     /// Creation time as seconds since Unix epoch (protocol 30+, --crtimes).
     pub(super) crtime: i64,
-    /// Access time nanoseconds (protocol 32+, --atimes).
-    pub(super) atime_nsec: u32,
-    /// Device major number (for block/char devices).
-    pub(super) rdev_major: Option<u32>,
-    /// Device minor number (for block/char devices).
-    pub(super) rdev_minor: Option<u32>,
-    /// Hardlink index (for hardlink preservation).
-    pub(super) hardlink_idx: Option<u32>,
     /// Hardlink device number (for protocol < 30 hardlink deduplication).
-    pub(super) hardlink_dev: Option<i64>,
+    /// Meaningful only when `EXTRAS_PRESENT_HARDLINK_DEV` is set.
+    pub(super) hardlink_dev: i64,
     /// Hardlink inode number (for protocol < 30 hardlink deduplication).
-    pub(super) hardlink_ino: Option<i64>,
+    /// Meaningful only when `EXTRAS_PRESENT_HARDLINK_DEV` is set.
+    pub(super) hardlink_ino: i64,
     /// File checksum for --checksum mode (variable length, up to 32 bytes).
     pub(super) checksum: Option<Vec<u8>>,
-    /// Access ACL index for --acls mode (index into access ACL list, protocol 30+).
-    pub(super) acl_ndx: Option<u32>,
-    /// Default ACL index for directories in --acls mode (index into default ACL list).
-    ///
-    /// Only meaningful for directories. Corresponds to upstream's `F_DIR_DEFACL`.
-    pub(super) def_acl_ndx: Option<u32>,
-    /// Extended attribute index for --xattrs mode (index into xattr list).
-    pub(super) xattr_ndx: Option<u32>,
     /// Sender-side xattr data read from the filesystem.
     ///
     /// Populated by the generator when `--xattrs` is active. Names are in
@@ -53,4 +59,57 @@ pub(super) struct FileEntryExtras {
     /// On the receiver side this field is unused - the receiver uses
     /// `xattr_ndx` to look up data in the `XattrCache`.
     pub(super) xattr_list: Option<XattrList>,
+
+    // 4-byte aligned fields.
+    /// Access time nanoseconds (protocol 32+, --atimes).
+    pub(super) atime_nsec: u32,
+    /// Device major number (for block/char devices).
+    /// Meaningful only when `EXTRAS_PRESENT_RDEV` is set.
+    pub(super) rdev_major: u32,
+    /// Device minor number (for block/char devices).
+    /// Meaningful only when `EXTRAS_PRESENT_RDEV` is set.
+    pub(super) rdev_minor: u32,
+    /// Hardlink index (for hardlink preservation).
+    /// Meaningful only when `EXTRAS_PRESENT_HARDLINK_IDX` is set.
+    pub(super) hardlink_idx: u32,
+    /// Access ACL index for --acls mode (index into access ACL list, protocol 30+).
+    /// Meaningful only when `EXTRAS_PRESENT_ACL_NDX` is set.
+    pub(super) acl_ndx: u32,
+    /// Default ACL index for directories in --acls mode (index into default ACL list).
+    /// Meaningful only when `EXTRAS_PRESENT_DEF_ACL_NDX` is set.
+    /// Corresponds to upstream's `F_DIR_DEFACL`.
+    pub(super) def_acl_ndx: u32,
+    /// Extended attribute index for --xattrs mode (index into xattr list).
+    /// Meaningful only when `EXTRAS_PRESENT_XATTR_NDX` is set.
+    pub(super) xattr_ndx: u32,
+
+    // 2-byte aligned fields.
+    /// Presence bitfield for compacted Option fields.
+    ///
+    /// See `EXTRAS_PRESENT_*` constants.
+    pub(super) present: u16,
+}
+
+impl Default for FileEntryExtras {
+    fn default() -> Self {
+        Self {
+            link_target: None,
+            user_name: None,
+            group_name: None,
+            atime: 0,
+            crtime: 0,
+            hardlink_dev: 0,
+            hardlink_ino: 0,
+            checksum: None,
+            xattr_list: None,
+            atime_nsec: 0,
+            rdev_major: 0,
+            rdev_minor: 0,
+            hardlink_idx: 0,
+            acl_ndx: 0,
+            def_acl_ndx: 0,
+            xattr_ndx: 0,
+            present: 0,
+        }
+    }
 }

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -1329,3 +1329,109 @@ fn clone_all_extras_then_mutate() {
 
     assert_ne!(entry, cloned);
 }
+
+/// Extras presence bitfield: all compacted fields return None by default.
+#[test]
+fn extras_presence_bitfield_defaults_none() {
+    let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
+    // Force extras allocation without setting any compacted field.
+    entry.set_atime(0);
+    assert!(entry.extras.is_some());
+
+    assert_eq!(entry.rdev_major(), None);
+    assert_eq!(entry.rdev_minor(), None);
+    assert_eq!(entry.hardlink_idx(), None);
+    assert_eq!(entry.acl_ndx(), None);
+    assert_eq!(entry.def_acl_ndx(), None);
+    assert_eq!(entry.xattr_ndx(), None);
+    assert_eq!(entry.hardlink_dev(), None);
+    assert_eq!(entry.hardlink_ino(), None);
+}
+
+/// Extras presence bitfield: round-trip set/get for all compacted fields.
+#[test]
+fn extras_presence_bitfield_roundtrip() {
+    let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
+
+    entry.set_rdev(8, 1);
+    assert_eq!(entry.rdev_major(), Some(8));
+    assert_eq!(entry.rdev_minor(), Some(1));
+
+    entry.set_hardlink_idx(42);
+    assert_eq!(entry.hardlink_idx(), Some(42));
+
+    entry.set_acl_ndx(10);
+    assert_eq!(entry.acl_ndx(), Some(10));
+
+    entry.set_def_acl_ndx(20);
+    assert_eq!(entry.def_acl_ndx(), Some(20));
+
+    entry.set_xattr_ndx(30);
+    assert_eq!(entry.xattr_ndx(), Some(30));
+
+    entry.set_hardlink_dev(0xFD00);
+    assert_eq!(entry.hardlink_dev(), Some(0xFD00));
+
+    entry.set_hardlink_ino(12345);
+    assert_eq!(entry.hardlink_ino(), Some(12345));
+}
+
+/// Extras presence bitfield: Some(0) is correctly distinguished from None.
+#[test]
+fn extras_presence_bitfield_some_zero_vs_none() {
+    let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
+
+    // Before setting: None
+    assert_eq!(entry.rdev_major(), None);
+    assert_eq!(entry.hardlink_idx(), None);
+    assert_eq!(entry.acl_ndx(), None);
+    assert_eq!(entry.def_acl_ndx(), None);
+    assert_eq!(entry.xattr_ndx(), None);
+    assert_eq!(entry.hardlink_dev(), None);
+    assert_eq!(entry.hardlink_ino(), None);
+
+    // After setting to 0: Some(0)
+    entry.set_rdev(0, 0);
+    assert_eq!(entry.rdev_major(), Some(0));
+    assert_eq!(entry.rdev_minor(), Some(0));
+
+    entry.set_hardlink_idx(0);
+    assert_eq!(entry.hardlink_idx(), Some(0));
+
+    entry.set_acl_ndx(0);
+    assert_eq!(entry.acl_ndx(), Some(0));
+
+    entry.set_def_acl_ndx(0);
+    assert_eq!(entry.def_acl_ndx(), Some(0));
+
+    entry.set_xattr_ndx(0);
+    assert_eq!(entry.xattr_ndx(), Some(0));
+
+    entry.set_hardlink_dev(0);
+    assert_eq!(entry.hardlink_dev(), Some(0));
+
+    entry.set_hardlink_ino(0);
+    assert_eq!(entry.hardlink_ino(), Some(0));
+}
+
+/// Extras presence bitfield: setting one compacted field does not affect others.
+#[test]
+fn extras_presence_bitfield_independence() {
+    let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
+
+    entry.set_acl_ndx(5);
+    assert_eq!(entry.acl_ndx(), Some(5));
+    assert_eq!(entry.def_acl_ndx(), None);
+    assert_eq!(entry.xattr_ndx(), None);
+    assert_eq!(entry.rdev_major(), None);
+    assert_eq!(entry.hardlink_idx(), None);
+    assert_eq!(entry.hardlink_dev(), None);
+
+    entry.set_xattr_ndx(10);
+    assert_eq!(entry.acl_ndx(), Some(5));
+    assert_eq!(entry.xattr_ndx(), Some(10));
+    assert_eq!(entry.def_acl_ndx(), None);
+    assert_eq!(entry.rdev_major(), None);
+    assert_eq!(entry.hardlink_idx(), None);
+    assert_eq!(entry.hardlink_dev(), None);
+}


### PR DESCRIPTION
## Summary

- Replace 8 `Option<T>` fields in `FileEntryExtras` with raw `T` values gated by a `u16` presence bitfield, mirroring the `PRESENT_UID`/`PRESENT_GID` pattern already used on `FileEntry`
- Compacted fields: `rdev_major`/`rdev_minor` (shared `RDEV` bit), `hardlink_idx`, `acl_ndx`, `def_acl_ndx`, `xattr_ndx`, `hardlink_dev`/`hardlink_ino` (shared `HARDLINK_DEV` bit)
- Public API unchanged - all getters still return `Option<T>`, all setters accept the raw value

## Motivation

Each `Option<u32>` costs 8 bytes (4 discriminant + 4 padding) and each `Option<i64>` costs 16 bytes (8 discriminant + 8 padding). Replacing 8 Options with raw values plus a single `u16` bitfield saves ~72 bytes per `FileEntryExtras` allocation. At million-file scale with extras allocated (hardlinks, devices, ACLs, xattrs), this reduces heap pressure proportionally.

## Test plan

- [x] Round-trip test: set each compacted field, verify getter returns `Some(value)`
- [x] Default test: all compacted fields return `None` when presence bits are clear
- [x] `Some(0)` vs `None` test: setting a field to 0 returns `Some(0)`, not `None`
- [x] Independence test: setting one field does not affect other fields' presence
- [x] All existing tests pass unchanged (public API preserved)