### PR TITLE
docs: link interop compatibility matrix from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
 ### Interop Testing
 
-Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth.
+Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
 
 ### Supported rsync protocol versions
 


### PR DESCRIPTION
## Summary

- Adds a link from the README's Interop Testing section to the full interop compatibility matrix (`docs/user/interop-compatibility-matrix.md`, merged in #5172)
- Users can now discover the per-version, per-feature, and per-platform interop detail directly from the README

## Test plan

- [ ] Verify the relative link resolves correctly on GitHub
- [ ] No functional code changes - documentation only