### PR TITLE
feat: wire DualFileList into generator context for flat flist migration (RSS-A.6.d)

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -10,6 +10,7 @@
 //! newtype over `Vec<FileEntry>` with zero overhead - no arena fields, no
 //! conversion logic, and no extra imports.
 
+use std::fmt;
 use std::ops::{Index, IndexMut, RangeFrom};
 
 use super::FileEntry;
@@ -36,6 +37,14 @@ pub struct DualFileList {
     flat: FlatFileList,
     #[cfg(feature = "flat-flist")]
     extras: ExtrasArena,
+}
+
+impl fmt::Debug for DualFileList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DualFileList")
+            .field("len", &self.legacy.len())
+            .finish()
+    }
 }
 
 impl DualFileList {
@@ -118,6 +127,23 @@ impl DualFileList {
         self.legacy.len()
     }
 
+    /// Clears all entries from both legacy and flat stores.
+    pub fn clear(&mut self) {
+        self.legacy.clear();
+        #[cfg(feature = "flat-flist")]
+        {
+            self.flat = FlatFileList::new();
+            self.extras = ExtrasArena::new();
+        }
+    }
+
+    /// Reserves capacity for at least `additional` more entries in the
+    /// legacy Vec. The flat stores grow dynamically and do not need
+    /// explicit reservation.
+    pub fn reserve(&mut self, additional: usize) {
+        self.legacy.reserve(additional);
+    }
+
     /// Returns a shared reference to the flat file list.
     ///
     /// Available only when the `flat-flist` feature is enabled.
@@ -176,6 +202,24 @@ impl Index<RangeFrom<usize>> for DualFileList {
 impl IndexMut<usize> for DualFileList {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.legacy[index]
+    }
+}
+
+impl<'a> IntoIterator for &'a DualFileList {
+    type Item = &'a FileEntry;
+    type IntoIter = std::slice::Iter<'a, FileEntry>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.legacy.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut DualFileList {
+    type Item = &'a mut FileEntry;
+    type IntoIter = std::slice::IterMut<'a, FileEntry>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.legacy.iter_mut()
     }
 }
 

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -114,6 +114,10 @@ thread-slab-pool = ["engine/thread-slab-pool"]
 # Incremental file list processing with failed directory tracking
 incremental-flist = []
 
+# Flat file-list backing store (RSS-A.5+). Forwards to protocol's flat-flist
+# feature, enabling arena-backed dual-emit in DualFileList.
+flat-flist = ["protocol/flat-flist"]
+
 # DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
 # retained for one release to keep V61D-2 / V61D-3 interop gates
 # compilable until ISI.i.2 retires both.

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
 use ::filters::FilterChain;
-use protocol::flist::FileEntry;
+use protocol::flist::{DualFileList, FileEntry};
 use protocol::idlist::IdList;
 use protocol::stats::DeleteStats;
 use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion};
@@ -42,9 +42,13 @@ pub struct GeneratorContext {
     pub(crate) config: ServerConfig,
     /// List of files to send (contains relative paths for wire transmission).
     ///
+    /// Wraps both the legacy `Vec<FileEntry>` and (when the `flat-flist`
+    /// feature is enabled) the arena-backed `FlatFileList`, keeping both
+    /// in sync on every push. Read accessors delegate to the legacy Vec.
+    ///
     /// **Invariant**: `file_list` and `full_paths` must always have the same length.
     /// Use [`Self::push_file_item`] to add entries and [`Self::clear_file_list`] to clear.
-    pub(crate) file_list: Vec<FileEntry>,
+    pub(crate) file_list: DualFileList,
     /// Full filesystem paths for each file in `file_list` (parallel array).
     /// Used to open files for delta generation during transfer.
     ///
@@ -123,7 +127,7 @@ impl GeneratorContext {
         Self {
             protocol: handshake.protocol,
             config,
-            file_list: Vec::new(),
+            file_list: DualFileList::new(),
             full_paths: Vec::new(),
             filter_chain: FilterChain::empty(),
             negotiated_algorithms: handshake.negotiated_algorithms,
@@ -292,7 +296,7 @@ impl GeneratorContext {
             self.full_paths.len(),
             "file_list and full_paths must be kept in sync"
         );
-        &self.file_list
+        self.file_list.as_slice()
     }
 
     /// Adds a file entry and its corresponding full path to the file list.
@@ -312,8 +316,9 @@ impl GeneratorContext {
     /// Clears both the file list and full paths arrays.
     ///
     /// This method maintains the invariant that both arrays are cleared together.
+    /// The legacy Vec and flat stores (when enabled) are both cleared.
     pub(crate) fn clear_file_list(&mut self) {
-        self.file_list.clear();
+        self.file_list = DualFileList::new();
         self.full_paths.clear();
     }
 

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -149,12 +149,11 @@ impl GeneratorContext {
         } = cr;
 
         // Wrap in Option<T> for safe move-out by index.
-        let mut file_entries: Vec<Option<FileEntry>> =
-            std::mem::take(&mut self.file_list)
-                .into_vec()
-                .into_iter()
-                .map(Some)
-                .collect();
+        let mut file_entries: Vec<Option<FileEntry>> = std::mem::take(&mut self.file_list)
+            .into_vec()
+            .into_iter()
+            .map(Some)
+            .collect();
         let mut paths: Vec<Option<std::path::PathBuf>> = std::mem::take(&mut self.full_paths)
             .into_iter()
             .map(Some)

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -40,7 +40,7 @@ impl GeneratorContext {
             return;
         }
 
-        let classification = Self::classify_file_list_entries(&self.file_list);
+        let classification = Self::classify_file_list_entries(self.file_list.as_slice());
         self.reorder_and_build_segments(classification);
 
         debug_log!(
@@ -149,17 +149,19 @@ impl GeneratorContext {
         } = cr;
 
         // Wrap in Option<T> for safe move-out by index.
-        let mut file_entries: Vec<Option<FileEntry>> = std::mem::take(&mut self.file_list)
-            .into_iter()
-            .map(Some)
-            .collect();
+        let mut file_entries: Vec<Option<FileEntry>> =
+            std::mem::take(&mut self.file_list)
+                .into_vec()
+                .into_iter()
+                .map(Some)
+                .collect();
         let mut paths: Vec<Option<std::path::PathBuf>> = std::mem::take(&mut self.full_paths)
             .into_iter()
             .map(Some)
             .collect();
 
         let total = file_entries.len();
-        self.file_list = Vec::with_capacity(total);
+        self.file_list = protocol::flist::DualFileList::with_capacity(total);
         self.full_paths = Vec::with_capacity(total);
 
         // Place initial entries first (move, not clone).

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -87,15 +87,16 @@ impl GeneratorContext {
         // --qsort uses unstable sort (flist.c:2991).
         {
             let _t = PhaseTimer::new("file-list-sort");
-            let file_list_ref = &self.file_list;
+            let file_list_slice = self.file_list.as_slice();
             let mut indices: Vec<usize> = {
-                let len = self.file_list.len();
+                let len = file_list_slice.len();
                 let mut v = Vec::with_capacity(len);
                 v.extend(0..len);
                 v
             };
-            let cmp =
-                |&a: &usize, &b: &usize| compare_file_entries(&file_list_ref[a], &file_list_ref[b]);
+            let cmp = |&a: &usize, &b: &usize| {
+                compare_file_entries(&file_list_slice[a], &file_list_slice[b])
+            };
             if self.config.qsort {
                 indices.sort_unstable_by(cmp);
             } else {
@@ -104,7 +105,8 @@ impl GeneratorContext {
 
             // Apply permutation in-place using cycle-following algorithm.
             // This avoids cloning every element - O(n) swaps instead of O(n) clones.
-            apply_permutation_in_place(&mut self.file_list, &mut self.full_paths, indices);
+            let legacy = self.file_list.as_mut_vec();
+            apply_permutation_in_place(legacy.as_mut_slice(), &mut self.full_paths, indices);
         }
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
@@ -205,22 +207,24 @@ impl GeneratorContext {
         // upstream: flist.c:f_name_cmp() - sort via indirect permutation
         {
             let _t = PhaseTimer::new("file-list-sort");
-            let file_list_ref = &self.file_list;
+            let file_list_slice = self.file_list.as_slice();
             let mut indices: Vec<usize> = {
-                let len = self.file_list.len();
+                let len = file_list_slice.len();
                 let mut v = Vec::with_capacity(len);
                 v.extend(0..len);
                 v
             };
-            let cmp =
-                |&a: &usize, &b: &usize| compare_file_entries(&file_list_ref[a], &file_list_ref[b]);
+            let cmp = |&a: &usize, &b: &usize| {
+                compare_file_entries(&file_list_slice[a], &file_list_slice[b])
+            };
             if self.config.qsort {
                 indices.sort_unstable_by(cmp);
             } else {
                 indices.sort_by(cmp);
             }
 
-            apply_permutation_in_place(&mut self.file_list, &mut self.full_paths, indices);
+            let legacy = self.file_list.as_mut_vec();
+            apply_permutation_in_place(legacy.as_mut_slice(), &mut self.full_paths, indices);
         }
 
         // upstream: hlink.c:match_hard_links() - must be called after sort


### PR DESCRIPTION
## Summary

- Replace `Vec<FileEntry>` with `DualFileList` in `GeneratorContext`, the generator's local-construction emission point (point 2 from the RSS-A.6 design doc)
- Every push through `push_file_item` now dual-emits to both the legacy Vec and flat arena stores when `flat-flist` is enabled
- Add `Debug`, `IntoIterator`, `clear()`, and `reserve()` to `DualFileList` to support all existing call patterns in the generator

## Details

**Generator context field change** (`crates/transfer/src/generator/context.rs`):
- `file_list: Vec<FileEntry>` -> `file_list: DualFileList`
- Constructor: `Vec::new()` -> `DualFileList::new()`
- `file_list()` accessor: `self.file_list.as_slice()`
- `clear_file_list()`: reinitialize via `DualFileList::new()`
- `push_file_item()`: body unchanged - `DualFileList::push` has the same signature

**Sorting** (`crates/transfer/src/generator/file_list/mod.rs`):
- Comparison closure uses `as_slice()` for read access
- `apply_permutation_in_place` receives `as_mut_vec().as_mut_slice()`

**INC_RECURSE reorder** (`crates/transfer/src/generator/file_list/inc_recurse.rs`):
- `std::mem::take` + `into_vec()` for the take-and-rebuild pattern
- Reassignment uses `DualFileList::with_capacity()`

**DualFileList additions** (`crates/protocol/src/flist/dual.rs`):
- `Debug` impl (shows entry count)
- `IntoIterator` for `&DualFileList` and `&mut DualFileList`
- `clear()` - clears legacy Vec and reinitializes flat stores
- `reserve()` - reserves capacity in the legacy Vec

**Feature forwarding** (`crates/transfer/Cargo.toml`):
- `flat-flist = ["protocol/flat-flist"]` feature forwarding

## Depends on

- #5176 (`feat/dual-file-list-wrapper`) - must be merged first

## Test plan

- [ ] CI passes on all platforms (fmt, clippy, nextest, Windows, macOS, musl)
- [ ] Builds with and without `--features flat-flist`
- [ ] Existing generator tests pass unchanged (push, sort, INC_RECURSE partition, hardlinks, send_file_list)