### PR TITLE
feat: wire extras encoding through ExtrasArena in FlatFileList builder

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -1,10 +1,13 @@
 //! Dual file-list wrapper for the flat backing-store migration.
 //!
 //! [`DualFileList`] pushes every entry to both the legacy `Vec<FileEntry>`
-//! and (when `flat-flist` is enabled) the arena-backed [`FlatFileList`] +
-//! [`ExtrasArena`] stores. This allows production code to migrate call sites
-//! one at a time: read from either representation, compare results, and
-//! eventually drop the legacy path.
+//! and (when `flat-flist` is enabled) the arena-backed [`FlatFileList`].
+//! The [`FlatFileList`] owns its path interner and extras arena internally,
+//! so optional metadata (symlink targets, device numbers, ACL/xattr
+//! indices, checksums, user/group names, atime/crtime) is encoded through
+//! [`FlatFileList::push_with_extras`]. This allows production code to
+//! migrate call sites one at a time: read from either representation,
+//! compare results, and eventually drop the legacy path.
 //!
 //! Without the `flat-flist` feature, `DualFileList` compiles as a transparent
 //! newtype over `Vec<FileEntry>` with zero overhead - no arena fields, no
@@ -17,8 +20,8 @@ use super::FileEntry;
 
 #[cfg(feature = "flat-flist")]
 use super::flat::{
-    ExtrasArena, FileEntryHeader, FlatExtras, FlatFileList, PRESENT_CONTENT_DIR, PRESENT_GID,
-    PRESENT_LENGTH64, PRESENT_MTIME_NSEC, PRESENT_UID,
+    FileEntryHeader, FlatExtras, FlatFileList, PRESENT_CONTENT_DIR, PRESENT_GID, PRESENT_LENGTH64,
+    PRESENT_MTIME_NSEC, PRESENT_UID,
 };
 
 /// Dual file-list that maintains both legacy and flat representations.
@@ -35,8 +38,6 @@ pub struct DualFileList {
     legacy: Vec<FileEntry>,
     #[cfg(feature = "flat-flist")]
     flat: FlatFileList,
-    #[cfg(feature = "flat-flist")]
-    extras: ExtrasArena,
 }
 
 impl fmt::Debug for DualFileList {
@@ -55,8 +56,6 @@ impl DualFileList {
             legacy: Vec::new(),
             #[cfg(feature = "flat-flist")]
             flat: FlatFileList::new(),
-            #[cfg(feature = "flat-flist")]
-            extras: ExtrasArena::new(),
         }
     }
 
@@ -67,8 +66,6 @@ impl DualFileList {
             legacy: Vec::with_capacity(cap),
             #[cfg(feature = "flat-flist")]
             flat: FlatFileList::with_capacity(cap),
-            #[cfg(feature = "flat-flist")]
-            extras: ExtrasArena::new(),
         }
     }
 
@@ -80,8 +77,8 @@ impl DualFileList {
     pub fn push(&mut self, entry: FileEntry) {
         #[cfg(feature = "flat-flist")]
         {
-            let header = file_entry_to_flat(&entry, &mut self.flat, &mut self.extras);
-            self.flat.push(header);
+            let (header, extras) = file_entry_to_flat(&entry, &mut self.flat);
+            self.flat.push_with_extras(header, &extras);
         }
         self.legacy.push(entry);
     }
@@ -155,11 +152,12 @@ impl DualFileList {
 
     /// Returns a shared reference to the extras arena.
     ///
-    /// Available only when the `flat-flist` feature is enabled.
+    /// Available only when the `flat-flist` feature is enabled. Delegates
+    /// to the [`FlatFileList`]'s own extras arena.
     #[cfg(feature = "flat-flist")]
     #[must_use]
-    pub fn extras(&self) -> &ExtrasArena {
-        &self.extras
+    pub fn extras(&self) -> &super::flat::ExtrasArena {
+        self.flat.extras()
     }
 
     /// Returns a mutable reference to the underlying legacy Vec.
@@ -223,22 +221,26 @@ impl<'a> IntoIterator for &'a mut DualFileList {
     }
 }
 
-/// Converts a [`FileEntry`] into a [`FileEntryHeader`], interning paths
-/// and encoding extras into the arena stores.
+/// Converts a [`FileEntry`] into a [`FileEntryHeader`] and [`FlatExtras`],
+/// interning paths through the [`FlatFileList`]'s [`PathArena`].
 ///
 /// The entry's name is split at the last `/` separator into dirname and
 /// basename, each interned through the [`FlatFileList`]'s [`PathArena`].
 /// Optional metadata fields (link target, device numbers, hardlink index,
 /// ACL/xattr indices, checksum, user/group names, atime/crtime) are packed
-/// into a [`FlatExtras`] record and appended to the [`ExtrasArena`].
+/// into the returned [`FlatExtras`]. The caller is responsible for encoding
+/// the extras into the arena (via [`FlatFileList::push_with_extras`]).
+///
+/// The header's [`ExtrasRef`] is set to
+/// [`ExtrasRef::NO_EXTRAS`](super::flat::ExtrasRef::NO_EXTRAS) as a
+/// placeholder - [`FlatFileList::push_with_extras`] overwrites it.
 #[cfg(feature = "flat-flist")]
 fn file_entry_to_flat(
     entry: &FileEntry,
     flist: &mut FlatFileList,
-    extras_arena: &mut ExtrasArena,
-) -> FileEntryHeader {
-    // Split the entry name into dirname and basename at the last '/'.
-    // FileEntry::name() returns the full relative path as a str.
+) -> (FileEntryHeader, FlatExtras) {
+    use super::flat::ExtrasRef;
+
     let full_name = entry.name();
     let (dirname_str, basename_str) = match full_name.rfind('/') {
         Some(pos) => (&full_name[..pos], &full_name[pos + 1..]),
@@ -249,7 +251,6 @@ fn file_entry_to_flat(
     let name_handle = paths.intern(basename_str);
     let dirname_handle = paths.intern(dirname_str);
 
-    // Build presence bitfield for inline scalar fields.
     let mut present: u16 = 0;
     if entry.uid().is_some() {
         present |= PRESENT_UID;
@@ -267,28 +268,26 @@ fn file_entry_to_flat(
         present |= PRESENT_LENGTH64;
     }
 
-    // Build the extras record from optional fields.
     let flat_extras = build_flat_extras(entry);
-    let extras_ref = extras_arena.append(&flat_extras);
 
-    // Pack FileFlags into u16 (primary + extended, dropping extended16
-    // which is rarely used and exceeds the 16-bit header field).
     let flags = entry.flags();
     let flags_u16 = u16::from(flags.primary) | (u16::from(flags.extended) << 8);
 
-    FileEntryHeader {
+    let header = FileEntryHeader {
         mtime: entry.mtime(),
         size: entry.size(),
         uid: entry.uid().unwrap_or(0),
         gid: entry.gid().unwrap_or(0),
         name: name_handle,
         dirname: dirname_handle,
-        extras: extras_ref,
+        extras: ExtrasRef::NO_EXTRAS,
         mtime_nsec: entry.mtime_nsec(),
         mode: entry.mode(),
         flags: flags_u16,
         present,
-    }
+    };
+
+    (header, flat_extras)
 }
 
 /// Builds a [`FlatExtras`] from a [`FileEntry`]'s optional metadata fields.

--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -130,7 +130,6 @@ impl DualFileList {
         #[cfg(feature = "flat-flist")]
         {
             self.flat = FlatFileList::new();
-            self.extras = ExtrasArena::new();
         }
     }
 

--- a/crates/protocol/src/flist/flat/extras.rs
+++ b/crates/protocol/src/flist/flat/extras.rs
@@ -16,12 +16,12 @@
 //! user/group names, atime/crtime/atime_nsec) - compare field-for-field
 //! against the upstream `F_*` accessors cited in the design.
 //!
-//! Like the rest of the `flat` module this is additive and unwired: nothing in
-//! production references it yet, and the legacy `Vec<FileEntry>` path is
-//! untouched. The arena follows a build-then-freeze lifecycle - append records
-//! while building, read them back by offset once frozen - and offsets are
-//! stable for the life of the arena because tails are written once and never
-//! mutated.
+//! The arena follows a build-then-freeze lifecycle - append records while
+//! building, read them back by offset once frozen - and offsets are stable
+//! for the life of the arena because tails are written once and never
+//! mutated. [`FlatFileList`](super::FlatFileList) owns an `ExtrasArena`
+//! and encodes extras through
+//! [`push_with_extras`](super::FlatFileList::push_with_extras).
 
 /// Presence bit: the [`FlatExtras::link_target`] field is present.
 pub const EXTRA_LINK_TARGET: u16 = 1 << 0;

--- a/crates/protocol/src/flist/flat/flist.rs
+++ b/crates/protocol/src/flist/flat/flist.rs
@@ -2,14 +2,11 @@
 //!
 //! [`FlatFileList`] is the top-level container for the flat backing store.
 //! It owns a contiguous `Vec<FileEntryHeader>` for scalar metadata, a
-//! [`PathArena`] for interned name/dirname strings, and provides zero-copy
-//! views ([`FlatFileEntry`]) that resolve path handles on the fly.
-//!
-//! This is the phase-1 skeleton (RSS-A.5.d): it supports push, indexed
-//! access, iteration, and sorting by resolved name. Production wiring
-//! (replacing `Vec<FileEntry>` in the transfer pipeline) is RSS-A.6+.
+//! [`PathArena`] for interned name/dirname strings, an [`ExtrasArena`] for
+//! packed optional-field tails, and provides zero-copy views
+//! ([`FlatFileEntry`]) that resolve path handles on the fly.
 
-use super::extras::ExtrasArena;
+use super::extras::{ExtrasArena, FlatExtras};
 use super::header::FileEntryHeader;
 use super::intern::PathArena;
 
@@ -39,20 +36,20 @@ pub struct FlatFileEntry<'a> {
 /// Arena-backed flat file list.
 ///
 /// Stores file-list entries as a contiguous array of [`FileEntryHeader`]
-/// nodes plus a shared [`PathArena`] for deduplicated name/dirname strings.
-/// This layout replaces the legacy `Vec<FileEntry>` with pointer-chasing
-/// flexible-array tails, providing cache-friendly iteration and O(1)
-/// indexed access with a smaller per-entry footprint.
-///
-/// The extras arena (for symlink targets, device numbers, ACL/xattr
-/// indices, and checksums) will be added once `ExtrasArena` lands
-/// (RSS-A.5.e). Until then, the `extras` field on each header is set to
-/// [`ExtrasRef::NO_EXTRAS`].
+/// nodes plus a shared [`PathArena`] for deduplicated name/dirname strings
+/// and an [`ExtrasArena`] for packed optional metadata (symlink targets,
+/// device numbers, ACL/xattr indices, checksums, user/group names,
+/// atime/crtime). This layout replaces the legacy `Vec<FileEntry>` with
+/// pointer-chasing flexible-array tails, providing cache-friendly iteration
+/// and O(1) indexed access with a smaller per-entry footprint.
 pub struct FlatFileList {
     /// Contiguous array of fixed-size entry headers.
     headers: Vec<FileEntryHeader>,
     /// Shared string interner for name and dirname handles.
     paths: PathArena,
+    /// Blob arena for packed extras tails referenced by each header's
+    /// [`ExtrasRef`](super::header::ExtrasRef).
+    extras: ExtrasArena,
 }
 
 impl FlatFileList {
@@ -62,19 +59,21 @@ impl FlatFileList {
         Self {
             headers: Vec::new(),
             paths: PathArena::new(),
+            extras: ExtrasArena::new(),
         }
     }
 
     /// Creates a flat file list pre-allocated for `cap` entries.
     ///
     /// Pre-sizes the header array and the path interner's span table.
-    /// The path interner's byte arena grows on demand since per-string
-    /// lengths are not known up front.
+    /// The path interner's byte arena and the extras arena grow on demand
+    /// since per-entry payload sizes are not known up front.
     #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
         Self {
             headers: Vec::with_capacity(cap),
             paths: PathArena::with_capacity(cap),
+            extras: ExtrasArena::new(),
         }
     }
 
@@ -126,10 +125,24 @@ impl FlatFileList {
     ///
     /// The caller must have already interned the entry's name and dirname
     /// strings into this list's [`PathArena`] (via [`paths_mut`]) and set
-    /// the resulting handles on the header before calling `push`.
-    ///
-    /// [`paths_mut`]: FlatFileList::paths_mut
+    /// the resulting handles on the header before calling `push`. The
+    /// header's [`ExtrasRef`](super::header::ExtrasRef) should already
+    /// reference a tail in this list's [`ExtrasArena`] (via
+    /// [`push_with_extras`](Self::push_with_extras)) or be
+    /// [`ExtrasRef::NO_EXTRAS`](super::header::ExtrasRef::NO_EXTRAS).
     pub fn push(&mut self, header: FileEntryHeader) {
+        self.headers.push(header);
+    }
+
+    /// Encodes `extras` into the extras arena, sets the resulting
+    /// [`ExtrasRef`](super::header::ExtrasRef) on `header`, and appends
+    /// the header to the list.
+    ///
+    /// This is the primary builder entry point when the caller has optional
+    /// metadata to attach. The caller must have already interned name and
+    /// dirname via [`paths_mut`](Self::paths_mut).
+    pub fn push_with_extras(&mut self, mut header: FileEntryHeader, extras: &FlatExtras) {
+        header.extras = self.extras.append(extras);
         self.headers.push(header);
     }
 
@@ -162,6 +175,21 @@ impl FlatFileList {
     /// the corresponding header.
     pub fn paths_mut(&mut self) -> &mut PathArena {
         &mut self.paths
+    }
+
+    /// Returns a shared reference to the extras arena.
+    #[must_use]
+    pub fn extras(&self) -> &ExtrasArena {
+        &self.extras
+    }
+
+    /// Returns a mutable reference to the extras arena.
+    ///
+    /// Used by builders that encode extras separately before pushing a
+    /// header whose [`ExtrasRef`](super::header::ExtrasRef) already
+    /// references a tail in this arena.
+    pub fn extras_mut(&mut self) -> &mut ExtrasArena {
+        &mut self.extras
     }
 }
 

--- a/crates/protocol/src/flist/flat/mod.rs
+++ b/crates/protocol/src/flist/flat/mod.rs
@@ -1,16 +1,17 @@
-//! Flat file-list backing store (RSS-A.5).
+//! Flat file-list backing store (RSS-A.5/A.6).
 //!
-//! This module is the phase-1 step of the flat backing-store design in
-//! `docs/design/flat-flist-representation.md`: it defines the fixed-size
-//! [`FileEntryHeader`] node that a contiguous header array will hold, plus
-//! the placeholder handle types it references.
+//! This module implements the flat backing-store design from
+//! `docs/design/flat-flist-representation.md`. It defines the fixed-size
+//! [`FileEntryHeader`] node, the [`PathArena`] string interner (RSS-A.5.c),
+//! the [`ExtrasArena`] blob arena for length-prefixed optional metadata
+//! tails (RSS-A.5.b), and the top-level [`FlatFileList`] container that
+//! owns all three stores.
 //!
-//! It is entirely additive and unwired. Nothing in production references
-//! these types; the legacy `Vec<FileEntry>` path is untouched. The 4-byte
-//! path interner that backs [`PathHandle`] is [`PathArena`] (RSS-A.5.c);
-//! threading `FlatFileList` through the sort, filter, transfer, and engine
-//! consumers is RSS-A.6+. All of that remains gated on RSS-2 allocation
-//! profiling per the design's validation gate.
+//! [`DualFileList`](super::DualFileList) wires the builder path: every
+//! [`FileEntry`](super::FileEntry) pushed through `DualFileList::push` is
+//! converted to a `FileEntryHeader` + `FlatExtras` and appended via
+//! [`FlatFileList::push_with_extras`]. The legacy `Vec<FileEntry>` path
+//! remains untouched and runs in parallel for migration safety.
 
 mod extras;
 mod flist;

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -355,6 +355,228 @@ fn flat_file_list_default_is_new() {
 }
 
 // ---------------------------------------------------------------------------
+// FlatFileList extras wiring (RSS-A.6.f)
+// ---------------------------------------------------------------------------
+
+/// Helper: push an entry with extras into `flist`.
+fn push_entry_with_extras(
+    flist: &mut FlatFileList,
+    name: &str,
+    dirname: &str,
+    size: u64,
+    extras: &FlatExtras,
+) {
+    let name_h = flist.paths_mut().intern(name);
+    let dirname_h = flist.paths_mut().intern(dirname);
+    let mut h = empty_header();
+    h.name = name_h;
+    h.dirname = dirname_h;
+    h.size = size;
+    flist.push_with_extras(h, extras);
+}
+
+#[test]
+fn push_with_extras_no_extras_yields_sentinel() {
+    let mut flist = FlatFileList::new();
+    push_entry_with_extras(&mut flist, "plain.txt", "", 100, &FlatExtras::default());
+
+    let h = &flist.get(0).unwrap().header;
+    assert_eq!(h.extras, ExtrasRef::NO_EXTRAS);
+    assert!(flist.extras().is_empty());
+    assert_eq!(flist.extras().decode(h.extras).unwrap(), None);
+}
+
+#[test]
+fn push_with_extras_symlink_round_trip() {
+    let mut flist = FlatFileList::new();
+    let extras = FlatExtras {
+        link_target: Some(b"../other/target".to_vec()),
+        ..FlatExtras::default()
+    };
+    push_entry_with_extras(&mut flist, "link", "src", 0, &extras);
+
+    let h = &flist.get(0).unwrap().header;
+    assert_ne!(h.extras, ExtrasRef::NO_EXTRAS);
+    let decoded = flist.extras().decode(h.extras).unwrap().unwrap();
+    assert_eq!(
+        decoded.link_target.as_deref(),
+        Some(b"../other/target" as &[u8])
+    );
+    assert_eq!(decoded.rdev_major, None);
+}
+
+#[test]
+fn push_with_extras_device_round_trip() {
+    let mut flist = FlatFileList::new();
+    let extras = FlatExtras {
+        rdev_major: Some(8),
+        rdev_minor: Some(17),
+        ..FlatExtras::default()
+    };
+    push_entry_with_extras(&mut flist, "sda", "dev", 0, &extras);
+
+    let decoded = flist
+        .extras()
+        .decode(flist.get(0).unwrap().header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded.rdev_major, Some(8));
+    assert_eq!(decoded.rdev_minor, Some(17));
+}
+
+#[test]
+fn push_with_extras_all_fields_round_trip() {
+    let mut flist = FlatFileList::new();
+    let extras = FlatExtras {
+        link_target: Some(b"target".to_vec()),
+        rdev_major: Some(1),
+        rdev_minor: Some(2),
+        hardlink_idx: Some(42),
+        acl_ndx: Some(3),
+        def_acl_ndx: Some(4),
+        xattr_ndx: Some(5),
+        checksum: Some(vec![0xDE; 16]),
+        user_name: Some(b"alice".to_vec()),
+        group_name: Some(b"staff".to_vec()),
+        atime: Some(-12345),
+        crtime: Some(987_654_321),
+        atime_nsec: Some(500),
+    };
+    push_entry_with_extras(&mut flist, "f.txt", "dir", 1024, &extras);
+
+    let decoded = flist
+        .extras()
+        .decode(flist.get(0).unwrap().header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded, extras);
+}
+
+#[test]
+fn push_with_extras_multiple_entries_independent() {
+    let mut flist = FlatFileList::new();
+
+    let symlink_extras = FlatExtras {
+        link_target: Some(b"../target".to_vec()),
+        ..FlatExtras::default()
+    };
+    push_entry_with_extras(&mut flist, "link1", "", 0, &symlink_extras);
+
+    push_entry_with_extras(&mut flist, "plain.txt", "", 256, &FlatExtras::default());
+
+    let dev_extras = FlatExtras {
+        rdev_major: Some(10),
+        rdev_minor: Some(20),
+        ..FlatExtras::default()
+    };
+    push_entry_with_extras(&mut flist, "sda", "dev", 0, &dev_extras);
+
+    let checksum_extras = FlatExtras {
+        checksum: Some(vec![0xAB; 8]),
+        user_name: Some(b"bob".to_vec()),
+        ..FlatExtras::default()
+    };
+    push_entry_with_extras(&mut flist, "data.bin", "out", 4096, &checksum_extras);
+
+    assert_eq!(flist.len(), 4);
+
+    let d0 = flist
+        .extras()
+        .decode(flist.get(0).unwrap().header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(d0, symlink_extras);
+
+    assert_eq!(flist.get(1).unwrap().header.extras, ExtrasRef::NO_EXTRAS);
+
+    let d2 = flist
+        .extras()
+        .decode(flist.get(2).unwrap().header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(d2, dev_extras);
+
+    let d3 = flist
+        .extras()
+        .decode(flist.get(3).unwrap().header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(d3, checksum_extras);
+}
+
+#[test]
+fn push_with_extras_preserves_scalar_header_fields() {
+    let mut flist = FlatFileList::new();
+    let extras = FlatExtras {
+        atime: Some(999_999),
+        crtime: Some(888_888),
+        ..FlatExtras::default()
+    };
+    let name_h = flist.paths_mut().intern("f.txt");
+    let dirname_h = flist.paths_mut().intern("dir");
+    let mut h = empty_header();
+    h.name = name_h;
+    h.dirname = dirname_h;
+    h.size = 42;
+    h.mtime = 1_000_000;
+    h.mode = 0o100644;
+    h.uid = 1000;
+    h.gid = 2000;
+    h.set(PRESENT_UID);
+    h.set(PRESENT_GID);
+    flist.push_with_extras(h, &extras);
+
+    let entry = flist.get(0).unwrap();
+    assert_eq!(entry.header.size, 42);
+    assert_eq!(entry.header.mtime, 1_000_000);
+    assert_eq!(entry.header.mode, 0o100644);
+    assert_eq!(entry.header.uid(), Some(1000));
+    assert_eq!(entry.header.gid(), Some(2000));
+    assert_eq!(entry.name, b"f.txt");
+    assert_eq!(entry.dirname, b"dir");
+
+    let decoded = flist
+        .extras()
+        .decode(entry.header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded.atime, Some(999_999));
+    assert_eq!(decoded.crtime, Some(888_888));
+}
+
+#[test]
+fn extras_accessor_starts_empty() {
+    let flist = FlatFileList::new();
+    assert!(flist.extras().is_empty());
+    assert_eq!(flist.extras().len(), 0);
+}
+
+#[test]
+fn extras_mut_allows_manual_append() {
+    let mut flist = FlatFileList::new();
+    let extras = FlatExtras {
+        hardlink_idx: Some(77),
+        ..FlatExtras::default()
+    };
+    let ext_ref = flist.extras_mut().append(&extras);
+
+    let name_h = flist.paths_mut().intern("f.txt");
+    let dirname_h = flist.paths_mut().intern("");
+    let mut h = empty_header();
+    h.name = name_h;
+    h.dirname = dirname_h;
+    h.extras = ext_ref;
+    flist.push(h);
+
+    let decoded = flist
+        .extras()
+        .decode(flist.get(0).unwrap().header.extras)
+        .unwrap()
+        .unwrap();
+    assert_eq!(decoded.hardlink_idx, Some(77));
+}
+
+// ---------------------------------------------------------------------------
 // Feature-flag coexistence (RSS-A.5.e.3)
 // ---------------------------------------------------------------------------
 

--- a/crates/protocol/src/flist/flat/tests.rs
+++ b/crates/protocol/src/flist/flat/tests.rs
@@ -535,11 +535,7 @@ fn push_with_extras_preserves_scalar_header_fields() {
     assert_eq!(entry.name, b"f.txt");
     assert_eq!(entry.dirname, b"dir");
 
-    let decoded = flist
-        .extras()
-        .decode(entry.header.extras)
-        .unwrap()
-        .unwrap();
+    let decoded = flist.extras().decode(entry.header.extras).unwrap().unwrap();
     assert_eq!(decoded.atime, Some(999_999));
     assert_eq!(decoded.crtime, Some(888_888));
 }


### PR DESCRIPTION
## Summary

- Move `ExtrasArena` ownership from `DualFileList` into `FlatFileList` so the flat file-list store is self-contained with headers, paths, and extras all under one roof.
- Add `FlatFileList::push_with_extras()` as the primary builder entry point for entries with optional metadata (symlink targets, device numbers, hardlink indices, ACL/xattr indices, checksums, user/group names, atime/crtime). It encodes the `FlatExtras` into the arena and sets the resulting `ExtrasRef` on the header.
- Add `FlatFileList::extras()` and `extras_mut()` accessors.
- Update `DualFileList` to delegate extras encoding and access through `FlatFileList`'s own arena instead of maintaining a separate `ExtrasArena` field.

Part of RSS-A.6.f (flat-flist arena allocator migration).

## Test plan

- [x] New round-trip tests in `flat/tests.rs` covering:
  - Empty extras yields `NO_EXTRAS` sentinel
  - Symlink target round-trip
  - Device numbers round-trip
  - All 13 optional fields round-trip
  - Multiple entries with mixed extras remain independently addressable
  - Scalar header fields preserved alongside extras
  - `extras()` accessor starts empty
  - Manual `extras_mut().append()` path works
- [x] Existing `DualFileList` flat-flist tests (symlink, device, checksum, user/group name, hardlink idx, ACL/xattr, atime/crtime, content_dir, length64) continue to pass through the new delegation path
- [x] CI validates across all platforms (Linux, macOS, Windows)