### PR TITLE
feat: add generic sort functions over FileEntryAccessor (RSS-A.7.c)

### DIFF
--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -81,6 +81,8 @@ pub use read::{FileListReader, read_file_entry};
 pub use sort::{
     CleanResult, compare_file_entries, flist_clean, sort_and_clean_file_list, sort_file_list,
 };
+#[cfg(feature = "flat-flist")]
+pub use sort::{compare_entries_generic, sort_entries_generic};
 pub use state::{FileListCompressionState, FileListStats};
 pub use trace::{
     ProcessRole, output_flist, output_flist_entry, trace_clean_result, trace_file_count_progress,

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -24,6 +24,8 @@ use std::cmp::Ordering;
 use logging::debug_log;
 use memchr::memrchr;
 
+#[cfg(feature = "flat-flist")]
+use super::accessor::FileEntryAccessor;
 use super::FileEntry;
 
 /// Cached sort metadata for a file entry, precomputed once before sorting.
@@ -41,6 +43,20 @@ struct SortKey {
 
 impl SortKey {
     fn new(index: usize, entry: &FileEntry) -> Self {
+        let bytes = entry.name_bytes();
+        let last_slash = memrchr(b'/', &bytes).map_or(u32::MAX, |p| p as u32);
+        Self {
+            index: index as u32,
+            is_dir: entry.is_dir(),
+            last_slash,
+        }
+    }
+
+    /// Creates a `SortKey` from any type implementing `FileEntryAccessor`.
+    ///
+    /// Generic counterpart of `SortKey::new` for flat-flist migration.
+    #[cfg(feature = "flat-flist")]
+    fn from_accessor(index: usize, entry: &impl FileEntryAccessor) -> Self {
         let bytes = entry.name_bytes();
         let last_slash = memrchr(b'/', &bytes).map_or(u32::MAX, |p| p as u32);
         Self {
@@ -399,6 +415,106 @@ pub fn sort_and_clean_file_list(
 ) -> (Vec<FileEntry>, CleanResult) {
     sort_file_list(&mut file_list, use_qsort, protocol_pre29);
     flist_clean(file_list)
+}
+
+// ---------------------------------------------------------------------------
+// Generic versions for flat-flist migration (RSS-A.7.c)
+// ---------------------------------------------------------------------------
+
+/// Compares two entries implementing `FileEntryAccessor` using rsync sort rules.
+///
+/// Generic counterpart of [`compare_file_entries`] that works with both
+/// `FileEntry` and `FlatFileEntry`. Uses the same comparison algorithm
+/// (protocol 29+) as the concrete version.
+#[cfg(feature = "flat-flist")]
+#[must_use]
+pub fn compare_entries_generic<T: FileEntryAccessor>(a: &T, b: &T) -> Ordering {
+    let key_a = SortKey::from_accessor(0, a);
+    let key_b = SortKey::from_accessor(0, b);
+    let bytes_a = a.name_bytes();
+    let bytes_b = b.name_bytes();
+    compare_with_keys(&bytes_a, &key_a, &bytes_b, &key_b)
+}
+
+/// Sorts a slice of entries implementing `FileEntryAccessor` in-place.
+///
+/// Generic counterpart of [`sort_file_list`] that works with both
+/// `FileEntry` and `FlatFileEntry`. Uses index-based sorting with
+/// precomputed sort keys, identical to the concrete version.
+///
+/// Note: `flist_clean` has no generic counterpart because it requires
+/// mutation (`set_content_dir`) which is outside the read-only accessor trait.
+#[cfg(feature = "flat-flist")]
+pub fn sort_entries_generic<T: FileEntryAccessor>(
+    file_list: &mut [T],
+    use_qsort: bool,
+    protocol_pre29: bool,
+) {
+    debug_log!(
+        Flist,
+        2,
+        "sorting {} entries (generic, pre29={})",
+        file_list.len(),
+        protocol_pre29
+    );
+    let n = file_list.len();
+    if n <= 1 {
+        return;
+    }
+
+    let mut keys: Vec<SortKey> = file_list
+        .iter()
+        .enumerate()
+        .map(|(i, e)| SortKey::from_accessor(i, e))
+        .collect();
+
+    if protocol_pre29 {
+        let cmp = |a: &SortKey, b: &SortKey| {
+            let bytes_a = file_list[a.index as usize].name_bytes();
+            let bytes_b = file_list[b.index as usize].name_bytes();
+            compare_with_keys_pre29(&bytes_a, &bytes_b)
+        };
+        if use_qsort {
+            keys.sort_unstable_by(cmp);
+        } else {
+            keys.sort_by(cmp);
+        }
+    } else {
+        let cmp = |a: &SortKey, b: &SortKey| {
+            let bytes_a = file_list[a.index as usize].name_bytes();
+            let bytes_b = file_list[b.index as usize].name_bytes();
+            compare_with_keys(&bytes_a, a, &bytes_b, b)
+        };
+        if use_qsort {
+            keys.sort_unstable_by(cmp);
+        } else {
+            keys.sort_by(cmp);
+        }
+    }
+
+    // Apply the permutation in-place using cycle chasing.
+    let mut placed = vec![0u64; n.div_ceil(64)];
+    for i in 0..n {
+        let word = i / 64;
+        let bit = 1u64 << (i % 64);
+        let idx = keys[i].index as usize;
+        if placed[word] & bit != 0 || idx == i {
+            placed[word] |= bit;
+            continue;
+        }
+        let mut j = i;
+        loop {
+            let target = keys[j].index as usize;
+            let jw = j / 64;
+            let jb = 1u64 << (j % 64);
+            placed[jw] |= jb;
+            if target == i {
+                break;
+            }
+            file_list.swap(j, target);
+            j = target;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -825,5 +941,204 @@ mod tests {
                 "z"
             ]
         );
+    }
+
+    // -- Generic accessor sort tests (flat-flist migration) --
+
+    #[cfg(feature = "flat-flist")]
+    mod generic_tests {
+        use std::cmp::Ordering;
+
+        use crate::flist::accessor::FileEntryAccessor;
+        use crate::flist::sort::{compare_entries_generic, compare_file_entries, sort_entries_generic, sort_file_list};
+        use crate::flist::FileEntry;
+
+        fn make_file(name: &str) -> FileEntry {
+            FileEntry::new_file(name.into(), 0, 0o644)
+        }
+
+        fn make_dir(name: &str) -> FileEntry {
+            FileEntry::new_directory(name.into(), 0o755)
+        }
+
+        /// Verifies that `compare_entries_generic` produces the same result as
+        /// `compare_file_entries` for all pair orientations.
+        #[test]
+        fn generic_compare_matches_concrete() {
+            let cases: Vec<(FileEntry, FileEntry)> = vec![
+                (make_dir("."), make_file("abc.txt")),
+                (make_file("zebra.txt"), make_dir("aardvark")),
+                (make_file("a.txt"), make_file("b.txt")),
+                (make_dir("adir"), make_dir("bdir")),
+                (make_dir("subdir"), make_file("subdir/file.txt")),
+                (make_file("item"), make_dir("item")),
+                (make_file("a/b/c/d.txt"), make_dir("a/b/c/d")),
+            ];
+
+            for (a, b) in &cases {
+                let concrete = compare_file_entries(a, b);
+                let generic = compare_entries_generic(a, b);
+                assert_eq!(
+                    concrete, generic,
+                    "mismatch for ({:?}, {:?}): concrete={concrete:?}, generic={generic:?}",
+                    a.name(), b.name()
+                );
+
+                // Also check the reverse direction
+                let concrete_rev = compare_file_entries(b, a);
+                let generic_rev = compare_entries_generic(b, a);
+                assert_eq!(concrete_rev, generic_rev);
+            }
+        }
+
+        /// Verifies that `sort_entries_generic` produces the same ordering as
+        /// `sort_file_list` on a mixed set of entries (protocol 29+).
+        #[test]
+        fn generic_sort_matches_concrete() {
+            let entries = vec![
+                make_file("test.txt"),
+                make_dir("subdir"),
+                make_file("subdir/file.txt"),
+                make_file("another.txt"),
+                make_dir("."),
+                make_file("z"),
+                make_dir("a"),
+                make_file("a/nested.txt"),
+            ];
+
+            let mut concrete = entries.clone();
+            sort_file_list(&mut concrete, false, false);
+
+            let mut generic = entries;
+            sort_entries_generic(&mut generic, false, false);
+
+            let concrete_names: Vec<&str> = concrete.iter().map(|e| e.name()).collect();
+            let generic_names: Vec<&str> = generic.iter().map(|e| e.name()).collect();
+            assert_eq!(concrete_names, generic_names);
+        }
+
+        /// Verifies that `sort_entries_generic` matches the concrete golden test
+        /// for the comprehensive sort-order scenario.
+        #[test]
+        fn generic_sort_golden_comprehensive() {
+            let mut entries = vec![
+                make_file("a"),
+                make_file("b.txt"),
+                make_file("z"),
+                make_dir("a"),
+                make_dir("ab"),
+                make_dir("b"),
+                make_file("ab.txt"),
+                make_file("a/file.txt"),
+                make_file("a/z.txt"),
+                make_dir("a/sub"),
+                make_file("a/sub/deep.txt"),
+                make_dir("a/sub/deep"),
+                make_file("a/sub/deep/leaf.txt"),
+                make_file("b/file.txt"),
+                make_dir("b/dir"),
+                make_file("b/dir/inner.txt"),
+                make_dir("."),
+                make_dir("x/y"),
+                make_file("x/y/a.txt"),
+                make_file("x/y/b.txt"),
+                make_dir("x/y/c"),
+                make_file("x/y/c/d.txt"),
+                make_file("x/z.txt"),
+                make_dir("x"),
+            ];
+
+            let mut concrete = entries.clone();
+            sort_file_list(&mut concrete, false, false);
+            sort_entries_generic(&mut entries, false, false);
+
+            let concrete_names: Vec<&str> = concrete.iter().map(|e| e.name()).collect();
+            let generic_names: Vec<&str> = entries.iter().map(|e| e.name()).collect();
+            assert_eq!(concrete_names, generic_names);
+        }
+
+        /// Verifies that `sort_entries_generic` with `use_qsort=true` matches
+        /// the concrete qsort output.
+        #[test]
+        fn generic_sort_qsort_matches_concrete() {
+            let entries = vec![
+                make_file("test.txt"),
+                make_dir("subdir"),
+                make_file("subdir/file.txt"),
+                make_file("another.txt"),
+                make_dir("."),
+            ];
+
+            let mut concrete = entries.clone();
+            sort_file_list(&mut concrete, true, false);
+
+            let mut generic = entries;
+            sort_entries_generic(&mut generic, true, false);
+
+            let concrete_names: Vec<&str> = concrete.iter().map(|e| e.name()).collect();
+            let generic_names: Vec<&str> = generic.iter().map(|e| e.name()).collect();
+            assert_eq!(concrete_names, generic_names);
+        }
+
+        /// Verifies that `sort_entries_generic` in protocol < 29 mode produces
+        /// identical ordering to the concrete version.
+        #[test]
+        fn generic_sort_pre29_matches_concrete() {
+            let entries = vec![
+                make_file("test.txt"),
+                make_dir("subdir"),
+                make_file("subdir/file.txt"),
+                make_file("another.txt"),
+                make_dir("."),
+            ];
+
+            let mut concrete = entries.clone();
+            sort_file_list(&mut concrete, false, true);
+
+            let mut generic = entries;
+            sort_entries_generic(&mut generic, false, true);
+
+            let concrete_names: Vec<&str> = concrete.iter().map(|e| e.name()).collect();
+            let generic_names: Vec<&str> = generic.iter().map(|e| e.name()).collect();
+            assert_eq!(concrete_names, generic_names);
+        }
+
+        /// Verifies that `compare_entries_generic` returns `Equal` for identical entries.
+        #[test]
+        fn generic_compare_equal_entries() {
+            let a = make_file("same.txt");
+            let b = make_file("same.txt");
+            assert_eq!(compare_entries_generic(&a, &b), Ordering::Equal);
+
+            let da = make_dir("same");
+            let db = make_dir("same");
+            assert_eq!(compare_entries_generic(&da, &db), Ordering::Equal);
+        }
+
+        /// Verifies that the generic sort handles a single-element slice.
+        #[test]
+        fn generic_sort_single_element() {
+            let mut entries = vec![make_file("only.txt")];
+            sort_entries_generic(&mut entries, false, false);
+            assert_eq!(entries[0].name(), "only.txt");
+        }
+
+        /// Verifies that the generic sort handles an empty slice.
+        #[test]
+        fn generic_sort_empty() {
+            let mut entries: Vec<FileEntry> = vec![];
+            sort_entries_generic(&mut entries, false, false);
+            assert!(entries.is_empty());
+        }
+
+        /// Verifies dot-first invariant through the generic comparator.
+        #[test]
+        fn generic_compare_dot_first() {
+            let dot = make_dir(".");
+            let file = make_file("abc.txt");
+            assert_eq!(compare_entries_generic(&dot, &file), Ordering::Less);
+            assert_eq!(compare_entries_generic(&file, &dot), Ordering::Greater);
+            assert_eq!(compare_entries_generic(&dot, &dot), Ordering::Equal);
+        }
     }
 }

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -950,7 +950,6 @@ mod tests {
         use std::cmp::Ordering;
 
         use crate::flist::FileEntry;
-        use crate::flist::accessor::FileEntryAccessor;
         use crate::flist::sort::{
             compare_entries_generic, compare_file_entries, sort_entries_generic, sort_file_list,
         };

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -24,9 +24,9 @@ use std::cmp::Ordering;
 use logging::debug_log;
 use memchr::memrchr;
 
+use super::FileEntry;
 #[cfg(feature = "flat-flist")]
 use super::accessor::FileEntryAccessor;
-use super::FileEntry;
 
 /// Cached sort metadata for a file entry, precomputed once before sorting.
 ///
@@ -949,9 +949,11 @@ mod tests {
     mod generic_tests {
         use std::cmp::Ordering;
 
-        use crate::flist::accessor::FileEntryAccessor;
-        use crate::flist::sort::{compare_entries_generic, compare_file_entries, sort_entries_generic, sort_file_list};
         use crate::flist::FileEntry;
+        use crate::flist::accessor::FileEntryAccessor;
+        use crate::flist::sort::{
+            compare_entries_generic, compare_file_entries, sort_entries_generic, sort_file_list,
+        };
 
         fn make_file(name: &str) -> FileEntry {
             FileEntry::new_file(name.into(), 0, 0o644)
@@ -979,9 +981,11 @@ mod tests {
                 let concrete = compare_file_entries(a, b);
                 let generic = compare_entries_generic(a, b);
                 assert_eq!(
-                    concrete, generic,
+                    concrete,
+                    generic,
                     "mismatch for ({:?}, {:?}): concrete={concrete:?}, generic={generic:?}",
-                    a.name(), b.name()
+                    a.name(),
+                    b.name()
                 );
 
                 // Also check the reverse direction


### PR DESCRIPTION
## Summary

- Add `compare_entries_generic` and `sort_entries_generic` as generic counterparts to `compare_file_entries` and `sort_file_list`, accepting any `T: FileEntryAccessor`
- Add `SortKey::from_accessor` for constructing precomputed sort keys from the accessor trait
- All new code is feature-gated behind `flat-flist` - default builds are byte-identical
- Existing function signatures are untouched - new generic versions are added alongside them
- `flist_clean` intentionally has no generic counterpart because `set_content_dir` is a write operation outside the read-only accessor trait

## Test plan

- [ ] 10 parity tests verify generic versions produce identical results to concrete versions
- [ ] Tests cover: comparison matching, stable sort, qsort, protocol < 29, golden comprehensive ordering, edge cases (empty, single element, dot-first)
- [ ] CI passes with both `flat-flist` feature enabled and disabled
- [ ] `cargo clippy` and `cargo fmt` pass