### PR TITLE
docs: add arena growth strategy for INC_RECURSE flat flist segment appends (RSS-A.8.b)

### DIFF
--- a/docs/design/rss-a8b-arena-growth-strategy.md
+++ b/docs/design/rss-a8b-arena-growth-strategy.md
@@ -1,349 +1,366 @@
-# RSS-A.8.b: Arena growth strategy for mid-transfer segment appends
+# RSS-A.8.b: arena growth strategy for mid-transfer segment appends
 
 Task: RSS-A.8.b. Branch: `docs/rss-a8b-arena-growth-strategy`.
 Prerequisites: RSS-A.8.a (INC_RECURSE segment append audit),
-RSS-A.5.c (PathArena), RSS-A.5.e (ExtrasArena).
+RSS-A.5.d (FlatFileList skeleton), RSS-A.5.e (ExtrasArena).
 Downstream: RSS-A.8.c (FlatFileList segment growth implementation).
 
 ## Summary
 
-When INC_RECURSE is active, the sender transmits the file list as
-multiple segments - one per directory - that arrive mid-transfer. Each
-segment appends entries to the receiver's file list, growing the
-PathArena, ExtrasArena, and header Vec. This document evaluates three
-growth strategies and recommends the one that best fits the project's
-constraints.
+This document specifies the growth strategy for the three arena-backed
+stores (`Vec<FileEntryHeader>`, `PathArena`, `ExtrasArena`) when
+INC_RECURSE segment appends arrive mid-transfer. The goal is to support
+incremental segment growth without invalidating existing handles,
+matching the single-contiguous-array-plus-segment-table model that both
+sender and receiver already use (RSS-A.8.a findings F1, F4).
 
-The critical invariant: **existing PathHandle and ExtrasRef values must
-remain valid after growth.** Every handle issued before a segment append
-must resolve to the same data after it.
+## Design decision: unified store with index-based segments
 
-## Current handle representations
+RSS-A.8.a audited the actual sender and receiver implementations and
+found that both use a single contiguous `Vec<FileEntry>` with
+`ndx_segments: Vec<(usize, i32)>` for segment boundaries (finding F1).
+The `SegmentedFileList` type (per-segment `Vec<FileEntry>` storage) is
+defined but unused in the transfer pipeline (finding F6).
 
-### PathHandle (intern.rs)
+The `flat-flist-representation.md` design proposed per-segment
+`FlatFileList` instances for INC_RECURSE, motivated by upstream's
+per-flist `pool_alloc` lifetime. However, the audit shows the actual
+oc-rsync pipeline uses a unified flat array, not per-segment containers.
+Migrating to per-segment `FlatFileList` instances would require
+restructuring the entire sender and receiver pipeline - changing NDX
+conversion, delete pipeline publication, entry access, and sort
+operations.
 
-A `u32` newtype indexing into `PathArena::spans: Vec<(u32, u32)>`.
-Each span records `(byte_offset, byte_length)` into `PathArena::bytes:
-Vec<u8>`. Resolution is O(1): look up the span by handle index, slice
-the byte arena.
+This design follows the actual implementation: **one `FlatFileList` per
+role (sender or receiver), with segment boundaries tracked by the
+existing `ndx_segments: Vec<(usize, i32)>` table.** New segments append
+entries to the tail of the same `headers` Vec, `PathArena`, and
+`ExtrasArena`. This matches the current `Vec<FileEntry>` behavior
+exactly and requires no pipeline restructuring.
 
-```
-PathHandle(3)  -->  spans[3] = (offset=42, len=8)  -->  bytes[42..50]
-```
-
-`PathHandle::NONE` is `u32::MAX`, reserved as the empty sentinel.
-
-Deduplication uses a `HashMap<Box<str>, PathHandle>` side table. Two
-entries with the same basename share one handle - upstream cannot do
-this because basenames are inline in `file_struct`.
-
-### ExtrasRef (extras.rs)
-
-A `u32` newtype storing a raw byte offset into `ExtrasArena::blobs:
-Vec<u8>`. The record at that offset starts with a 2-byte presence mask
-followed by the present fields in canonical order. Resolution is O(1):
-seek to the offset, decode the mask, read fields.
-
-```
-ExtrasRef(128)  -->  blobs[128..128+N]  (self-describing length-prefixed tail)
-```
-
-`ExtrasRef::NO_EXTRAS` is `u32::MAX`, the common-case sentinel for
-entries with no optional metadata.
-
-### FileEntryHeader (header.rs)
-
-A fixed-size (48 bytes), `Copy` struct stored in `FlatFileList::headers:
-Vec<FileEntryHeader>`. Contains inline scalars (mtime, size, uid, gid,
-mode, flags, present bitfield) plus three arena references: `name:
-PathHandle`, `dirname: PathHandle`, `extras: ExtrasRef`.
+The per-segment `FlatFileList` approach from the parent design remains
+available as a future optimization for memory reclamation (dropping
+consumed segments), but it is not required for correctness and is
+deferred.
 
 ## Handle stability under growth
 
-Both handle types are **index-based**, not pointer-based:
+RSS-A.8.a finding F4 established that arena handles survive Vec
+reallocation because they are index-based, not pointer-based:
 
-- `PathHandle` is an index into the `spans` Vec. When `bytes` or `spans`
-  reallocates (moves to a larger buffer), the index remains valid because
-  Vec reallocation preserves element order and index semantics. The span's
-  `(offset, len)` pair still points to the correct byte range within the
-  (possibly relocated) `bytes` buffer.
+- **`PathHandle`**: a `u32` index into `PathArena.spans`, which is a
+  `Vec<(u32, u32)>`. Appending new strings may reallocate the underlying
+  `bytes: Vec<u8>` and `spans: Vec<(u32, u32)>`, but existing handles
+  remain valid - they index into the span table, and spans reference
+  byte offsets that do not change when the arena grows (append-only).
+- **`ExtrasRef`**: a `u32` byte offset into `ExtrasArena.blobs`. New
+  tails are appended; existing offsets remain valid because the arena
+  never mutates written bytes.
+- **`FileEntryHeader` indices**: flat indices into `headers: Vec<FileEntryHeader>`.
+  Vec reallocation preserves index-based access.
 
-- `ExtrasRef` is a byte offset into the `blobs` Vec. Reallocation
-  preserves byte order and offset semantics. An `ExtrasRef(128)` still
-  addresses byte 128 in the (possibly relocated) buffer.
+No handle invalidation occurs during segment growth. The invariant is
+structural: all three stores are append-only, and all references are
+index/offset-based. This is tested by the handle-stability test
+specified in the verification section below.
 
-- `FileEntryHeader` values in the `headers` Vec are `Copy` and
-  self-contained. Reallocation moves headers but their arena references
-  are value types (u32 indices/offsets), not pointers.
+## Growth policies
 
-**Conclusion: Vec reallocation does not invalidate any existing handle.**
-This was identified in RSS-A.8.a finding F4 and is the foundation for
-the recommended strategy.
+### 1. `Vec<FileEntryHeader>` (header array)
 
-## Upstream rsync's approach
+**Policy: Rust `Vec` default doubling with optional pre-reservation.**
 
-Upstream rsync uses `lib/pool_alloc.c` - a chunk-based pool allocator.
-Each `file_list` has its own pool from which `file_struct` nodes
-(variable-size because of the flexible array basename tail) are
-allocated. The pool grows by allocating new chunks from `malloc`:
+The header array uses standard `Vec::push` semantics. `Vec` doubles its
+capacity when it runs out of space, giving amortized O(1) append. This
+matches the current `Vec<FileEntry>` behavior.
 
-```c
-// upstream: lib/pool_alloc.c
-// pool_alloc() bumps a pointer within the current chunk.
-// When the current chunk is exhausted, a new chunk is malloc'd.
-// Old chunks are never freed until pool_destroy().
+Pre-reservation is available when the segment's entry count is known
+ahead of time. The receiver learns the count from the wire (the segment
+end marker), so it cannot pre-reserve. The sender knows the count from
+the partition step and can call `reserve(count)` before pushing. In
+practice, the doubling strategy is sufficient for both cases and the
+capacity slack is bounded (at most 50% waste on the header array, which
+at 48 bytes per entry is 24 MB for 1M entries - acceptable).
+
+Growth bound: at most `2 * N * 48` bytes for N entries, where the
+factor of 2 accounts for Vec capacity slack.
+
+### 2. `PathArena` (interned name/dirname strings)
+
+**Policy: standard Vec doubling on both `bytes` and `spans`, with
+deduplication absorbing growth.**
+
+`PathArena` holds three allocations:
+- `bytes: Vec<u8>` - the string arena, grows by `extend_from_slice`.
+- `spans: Vec<(u32, u32)>` - per-handle span table, grows by `push`.
+- `dedup: HashMap<Box<str>, PathHandle>` - dedup map, grows by `insert`.
+
+New segments add entries whose names and dirnames are interned through
+the same `PathArena`. Because the interner deduplicates, identical
+strings across segments share one arena copy and one handle. In
+INC_RECURSE transfers, the dirname sharing is particularly effective:
+each sub-list corresponds to one directory, and all entries in that
+sub-list share the same dirname handle.
+
+The `bytes` arena grows only for genuinely new strings. The `spans`
+table grows by one entry per new unique string. The `dedup` HashMap
+follows its standard rehash-at-load-factor growth. None of these
+invalidate existing handles.
+
+Growth bound: `bytes` is bounded by the total unique string bytes across
+all segments. For a transfer with D unique directories of average name
+length L_d, and F unique basenames of average length L_b, the arena
+holds `D * L_d + F * L_b` bytes. At 1M files with 10K directories,
+average dirname 30 bytes, average basename 15 bytes:
+`10K * 30 + 1M * 15 = 15.3 MB`. This is much smaller than the
+per-entry `PathBuf` allocations it replaces (~46 MB at 1M entries per
+the RSS-A.2 audit).
+
+### 3. `ExtrasArena` (packed extras tails)
+
+**Policy: standard Vec doubling on `blobs: Vec<u8>`.**
+
+Each entry with non-empty extras (symlink targets, device numbers,
+checksums, ACL/xattr indices, user/group names, atime/crtime) appends a
+self-describing tail to the `blobs` arena. Entries without extras
+(the common case for regular files) get `ExtrasRef::NO_EXTRAS` and
+consume zero arena bytes.
+
+The arena is append-only and references are byte offsets. Growth does
+not invalidate existing offsets. There is no deduplication (extras tails
+are per-entry-unique), so the arena grows linearly with the number of
+entries that have extras.
+
+Growth bound: for a transfer of N entries where fraction P have extras
+with average tail size T bytes, the arena holds `N * P * T` bytes. In
+the common case (regular files, uid+gid preserved but stored inline,
+no symlinks/devices/ACLs), P is near zero and the arena stays empty.
+Worst case (every entry has a symlink target or checksum): T is roughly
+25 bytes (2-byte mask + 2-byte len + ~20-byte path), giving `N * 25`
+bytes.
+
+## Segment boundary tracking
+
+The `ndx_segments: Vec<(usize, i32)>` table tracks segment boundaries
+in the same way for both `Vec<FileEntry>` and `FlatFileList`. Each entry
+is `(flat_start, ndx_start)`:
+
+- `flat_start` is the index in the header array where the segment
+  begins.
+- `ndx_start` is the wire NDX value for the first entry in the segment.
+
+For the initial segment, `flat_start = 0` and `ndx_start = 1` (with
+INC_RECURSE). For subsequent segments:
+
+```
+seg_ndx_start = prev_ndx_start + prev_used + 1   // +1 gap sentinel
+flat_start = headers.len()                        // append position
 ```
 
-Key properties of the upstream model:
+This formula matches upstream `flist.c:2931` and the current oc-rsync
+implementation (RSS-A.8.a audit, line 94). The NDX segment table is
+independent of the backing store format - it works identically whether
+the store is `Vec<FileEntry>` or `Vec<FileEntryHeader>`.
 
-- **No reallocation.** Individual nodes are never moved. The pool grows
-  by adding new chunks, and `file_struct` pointers remain stable.
-- **Per-flist lifetime.** With INC_RECURSE, each sub-list gets its own
-  `file_list` with its own pool. When a sub-list is fully consumed, the
-  entire pool is destroyed in one call (`pool_destroy`), freeing all
-  nodes at once with no per-entry destructor.
-- **The `files[]` pointer array.** A separate `realloc`-grown array of
-  `file_struct*` pointers provides indexed and sorted access. This array
-  can move, but the nodes it points to do not.
+## Segment lifecycle
 
-The oc-rsync flat-flist design doc (`flat-flist-representation.md`)
-proposes a per-segment `FlatFileList` model that mirrors this: each
-INC_RECURSE segment owns an independent `FlatFileList` with its own
-`headers`, `PathArena`, and `ExtrasArena`, droppable as a unit.
+### Receiver (append-and-sort)
 
-However, the actual receiver implementation (RSS-A.8.a finding F1) uses
-a **single contiguous** `Vec<FileEntry>` (or `DualFileList`) with
-index-based segment boundaries (`ndx_segments: Vec<(usize, i32)>`), not
-per-segment containers. This document evaluates growth strategies for
-that single-container model, since the implementation must work with the
-code as it exists today.
+1. Record `flat_start = flist.len()`.
+2. Compute `seg_ndx_start` from `ndx_segments.last()`.
+3. For each entry on the wire:
+   a. Intern name/dirname into `PathArena` via `flist.paths_mut().intern()`.
+   b. Encode extras into `ExtrasArena` via `extras_arena.append()`.
+   c. Push the `FileEntryHeader` to `flist` via `flist.push()`.
+4. Sort the segment range `headers[flat_start..]` via `sort_range()`.
+5. Match hardlinks within the segment range.
+6. Push `(flat_start, seg_ndx_start)` to `ndx_segments`.
+7. Publish segment to the delete pipeline.
 
-## Strategy evaluation
+Step 4 requires a `sort_range(range)` method on `FlatFileList` (action
+item 1 from RSS-A.8.a). Sorting reorders headers within the range but
+does not move any headers outside it, so handles from prior segments
+remain valid. The sort resolves path handles through the shared
+`PathArena`, which is safe because all handles reference the same arena.
 
-### Strategy A: Pre-allocate generously
+### Sender (partition-then-dispatch)
 
-Reserve a large initial capacity for all three backing stores based on
-an estimate of the total file count.
+1. Build the full file list into `FlatFileList` (all entries).
+2. Sort the full list.
+3. Partition into segments by reordering the header array in-place:
+   initial entries at `[0..N)`, sub-directory entries at `[N..)`.
+4. Record segment boundaries via `PendingSegment` structs referencing
+   `(flist_start, count)` ranges.
+5. Dispatch segments lazily during the transfer loop.
 
-**Mechanism:**
-- At the start of a transfer, estimate total files (from the sender's
-  hint or a heuristic like 2x the initial segment count).
-- Call `Vec::with_capacity(estimate)` on `headers`, `bytes`, `spans`,
-  and `blobs`.
-- Subsequent pushes within capacity do not reallocate.
+Step 3 requires a `reorder_by_permutation(perm: &[usize])` or
+equivalent mutation on the header array (action item 4 from RSS-A.8.a).
+This reorders headers but does not change path or extras handles - the
+handles are embedded in the headers and move with them.
 
-**Handle stability:** Trivially satisfied - no reallocation occurs as
-long as the estimate holds. If the estimate is exceeded, Vec grows
-normally with the same index stability as Strategy B.
+## DualFileList synchronization
 
-**Tradeoffs:**
+During the migration, `DualFileList` maintains both `Vec<FileEntry>` and
+`FlatFileList`. For INC_RECURSE segment growth:
 
-| Dimension | Assessment |
-|-----------|------------|
-| Memory overhead | High. Over-estimation wastes memory. A 2x estimate for 1M files wastes 48 MB in headers alone. Under-estimation gains nothing - Vec falls back to doubling. |
-| Fragmentation | Low during growth (no reallocation churn). |
-| Implementation complexity | Low - one `with_capacity` call per arena. |
-| Upstream parity | Poor. Upstream does not pre-allocate; it grows chunk by chunk. |
-| Predictability | Poor. File counts are often unknown before traversal, especially with INC_RECURSE where segments arrive incrementally. The sender does not communicate total count ahead of the sub-lists. |
+- **Push**: `DualFileList::push(entry)` already pushes to both stores.
+  Segment growth uses the same `push` path. No change needed.
+- **Sort**: The receiver sorts each segment via
+  `sort_file_list(&mut self.file_list[flat_start..], ...)` on the legacy
+  Vec. The flat store must be sorted in sync. **Strategy: sort both
+  stores independently** (RSS-A.8.a finding F5, option 1). The legacy
+  Vec sorts via `compare_file_entries()`, the flat store sorts via
+  `sort_range()` with its own comparator that resolves path handles.
+  Both comparators produce the same order (unsigned byte comparison on
+  dirname then name). A parity test verifies identical ordering.
+- **Segment boundaries**: `DualFileList::segment_start()` already
+  returns `legacy.len()`, which equals `flat.len()` because push
+  maintains both in lockstep.
 
-**Verdict:** Not recommended as a primary strategy. The file count is
-inherently unknown with INC_RECURSE. Pre-allocation is a useful
-optimization hint (e.g., sizing PathArena for expected dirname
-cardinality) but cannot serve as the growth strategy itself.
+## Required FlatFileList additions
 
-### Strategy B: Grow-on-demand with Vec (index-based handles)
+These are the API additions identified in RSS-A.8.a's action items,
+needed for segment growth support:
 
-Use the standard `Vec` growth policy (amortized doubling) for all three
-backing stores. Handles are indices/offsets that survive reallocation.
+### 1. `sort_range(range: Range<usize>)`
 
-**Mechanism:**
-- `PathArena::intern()` pushes to `bytes` and `spans`. Vec doubles
-  capacity when full.
-- `ExtrasArena::append()` pushes to `blobs`. Same Vec growth.
-- `FlatFileList::push()` pushes to `headers`. Same Vec growth.
-- No special action needed on segment boundaries.
+Sorts a sub-range of the header array by dirname-then-name, resolving
+path handles through the shared `PathArena`. Used by the receiver to
+sort each INC_RECURSE segment independently.
 
-**Handle stability:** Inherently satisfied by the index-based handle
-design. As analyzed above, `PathHandle` (span index) and `ExtrasRef`
-(byte offset) are value types that do not reference memory addresses.
-Vec reallocation changes the buffer address but not the logical
-index/offset semantics.
+```rust
+impl FlatFileList {
+    pub fn sort_range(&mut self, range: std::ops::Range<usize>) {
+        let paths = &self.paths;
+        self.headers[range].sort_unstable_by(|a, b| {
+            let a_dir = paths.resolve(a.dirname).as_bytes();
+            let b_dir = paths.resolve(b.dirname).as_bytes();
+            let a_name = paths.resolve(a.name).as_bytes();
+            let b_name = paths.resolve(b.name).as_bytes();
+            a_dir.cmp(b_dir).then_with(|| a_name.cmp(b_name))
+        });
+    }
+}
+```
 
-**Tradeoffs:**
+### 2. `headers_slice(range: Range<usize>) -> &[FileEntryHeader]`
 
-| Dimension | Assessment |
-|-----------|------------|
-| Memory overhead | Standard Vec overhead: up to 2x capacity vs used at any point. Amortized O(1) push. Identical to the current `Vec<FileEntry>` model. |
-| Fragmentation | Moderate. Each doubling allocates a new buffer and copies, leaving the old buffer for the allocator to reclaim. Standard Vec behavior - well-understood and optimized by system allocators. |
-| Implementation complexity | Minimal. No new data structures. The current PathArena and ExtrasArena already use this pattern. No code changes needed for growth behavior. |
-| Upstream parity | Reasonable. Upstream uses chunk-based growth (no copying), but the practical outcome is similar: O(1) amortized append, bounded overhead. The Vec model trades copy cost for simpler layout and better cache locality. |
-| Predictability | High. Vec growth is deterministic and well-characterized. No heuristics or estimates needed. |
+Returns a slice of headers for segment-scoped operations (hardlink
+matching, delete pipeline publication, iteration).
 
-**Verdict:** Recommended. The index-based handle design was specifically
-chosen to tolerate Vec reallocation. This strategy requires zero new
-code for growth behavior - it is what the current implementation already
-does.
+```rust
+impl FlatFileList {
+    pub fn headers_slice(&self, range: std::ops::Range<usize>) -> &[FileEntryHeader] {
+        &self.headers[range]
+    }
+}
+```
 
-### Strategy C: Chain of fixed-size arena blocks
+### 3. `reorder_by_permutation(perm: &[usize])`
 
-Allocate arenas as a linked list (or Vec) of fixed-size blocks. Handles
-encode `(block_index, offset_within_block)`.
+Reorders the header array according to a permutation vector. Used by
+the sender's INC_RECURSE partition step. The permutation is computed
+from the legacy Vec's partition and applied to the flat store.
 
-**Mechanism:**
-- `PathArena` would store `blocks: Vec<Vec<u8>>` instead of a single
-  `bytes: Vec<u8>`. When the current block fills, allocate a new one.
-- Handles become `(u16 block_idx, u16 offset)` or similar compound
-  encodings.
-- Resolution: `blocks[handle.block_idx][handle.offset..handle.offset + len]`.
+```rust
+impl FlatFileList {
+    pub fn reorder_by_permutation(&mut self, perm: &[usize]) {
+        assert_eq!(perm.len(), self.headers.len());
+        let mut reordered = Vec::with_capacity(perm.len());
+        for &idx in perm {
+            reordered.push(self.headers[idx]);
+        }
+        self.headers = reordered;
+    }
+}
+```
 
-**Handle stability:** Fully stable. New blocks do not move old blocks.
-The `blocks` Vec itself may reallocate, but that moves the block
-pointers, not the block contents (blocks are heap-allocated via inner
-Vec). Handles reference block contents via two-level indirection.
+Path handles and extras refs are embedded in the headers and move with
+them. The `PathArena` and `ExtrasArena` are unaffected.
 
-**Tradeoffs:**
+## Memory reclamation (future optimization)
 
-| Dimension | Assessment |
-|-----------|------------|
-| Memory overhead | Low per-block waste (only the last block has unused capacity). But each block is a separate allocation with its own malloc header. |
-| Fragmentation | Low. Blocks are never moved or copied after allocation. No reallocation churn. |
-| Implementation complexity | High. Requires redesigning PathHandle and ExtrasRef to encode block coordinates. The dedup HashMap in PathArena needs to resolve handles through the block chain. Resolution becomes two-level indirection instead of one array index. Sorting comparators become slower (two lookups per resolve). |
-| Upstream parity | Good. Mirrors upstream's `pool_alloc` chunk model. |
-| Predictability | High. Growth is bounded per-block. |
-| Handle encoding | The 4-byte handle budget is tight. Encoding both block index and offset in 32 bits limits either the block count or the per-block capacity. For example, 12-bit block index (4096 blocks) + 20-bit offset (1 MB per block) fits u32 but constrains the design. |
+The unified-store model does not reclaim memory as segments are consumed.
+In the legacy `Vec<FileEntry>` model, consumed entries stay in the Vec
+and are simply skipped by the transfer loop. The flat store follows the
+same pattern: consumed headers, interned strings, and extras tails stay
+allocated until the entire file list is dropped.
 
-**Verdict:** Not recommended. The complexity cost is high and the
-benefit (avoiding Vec copy on reallocation) is marginal. The Vec copy
-cost is amortized O(1) and happens infrequently. The cache-friendly
-contiguous layout of a single Vec outweighs the zero-copy advantage of
-chained blocks for the access patterns in this codebase (sequential
-scan during sort, random access during transfer). The 4-byte handle
-encoding constraint adds fragility.
+For long INC_RECURSE transfers with many small segments, this means the
+store grows monotonically. This is acceptable because:
 
-## Recommendation
+1. It matches the current behavior (no memory reclamation today).
+2. The flat store's per-entry footprint is 2-3x smaller than the legacy
+   store (48 bytes vs 96-160 bytes per entry), so the peak RSS is
+   smaller even without reclamation.
+3. Upstream rsync uses per-flist `pool_destroy()` to reclaim memory, but
+   oc-rsync's pipeline is designed around a single flat array. Changing
+   to per-segment ownership would require restructuring NDX conversion,
+   delete pipeline, and entry access.
 
-**Strategy B: Grow-on-demand with Vec** is the recommended approach.
+A future optimization can introduce per-segment ownership by:
+- Splitting the store into per-segment `FlatFileList` instances.
+- Changing NDX lookup to search across segment containers.
+- Dropping consumed segments to reclaim their headers, paths, and extras.
 
-### Rationale
-
-1. **Already working.** The current PathArena and ExtrasArena
-   implementations use exactly this strategy. No new growth code is
-   needed. The index-based handle types (PathHandle as span index,
-   ExtrasRef as byte offset) were designed for this.
-
-2. **Handle stability is inherent.** Unlike pointer-based handles that
-   break on reallocation, index-based handles are value types that
-   survive any number of Vec reallocations. This is the core insight
-   from RSS-A.8.a finding F4.
-
-3. **Minimal complexity.** No new data structures, no handle encoding
-   changes, no two-level indirection. The implementation stays simple
-   and auditable.
-
-4. **Performance characteristics are well-understood.** Vec's amortized
-   O(1) push with geometric growth is the standard Rust growth strategy.
-   The copy cost during reallocation is bounded (each element is copied
-   at most O(log N) times total across all reallocations). For the
-   access patterns in this codebase - sequential scan during sort,
-   random access during transfer - contiguous memory is optimal.
-
-5. **Compatible with both receiver models.** Whether the receiver uses
-   a single `Vec<FileEntry>` (current implementation) or per-segment
-   `FlatFileList` containers (design doc proposal), Vec growth works
-   identically. The strategy does not constrain the segment ownership
-   model.
-
-### Combining with pre-allocation hints
-
-Strategy A (pre-allocation) is complementary as an optimization:
-
-- `PathArena::with_capacity(estimated_unique_paths)` pre-sizes the span
-  table and dedup map, reducing early reallocation churn. This already
-  exists.
-- `FlatFileList::with_capacity(estimated_entries)` pre-sizes the header
-  Vec. This already exists.
-- For the byte arenas (`PathArena::bytes`, `ExtrasArena::blobs`), a
-  heuristic like `estimated_entries * avg_name_len` could pre-size the
-  byte buffer. This is a minor optimization for a future task.
-
-These hints reduce the number of reallocations but are not required for
-correctness. If the estimate is wrong, Vec grows normally.
-
-## Per-segment vs single-container model
-
-The flat-flist design doc proposes per-segment `FlatFileList` ownership:
-each INC_RECURSE segment gets its own `FlatFileList` with independent
-arenas, droppable as a unit. This mirrors upstream's per-flist pool
-destroy.
-
-The current receiver implementation uses a single contiguous
-`Vec<FileEntry>` with index-based segment boundaries. RSS-A.8.a
-confirmed this in finding F1.
-
-The recommended growth strategy (B) works with both models:
-
-- **Single container:** One PathArena, one ExtrasArena, one headers Vec
-  grow throughout the transfer. Handles from all segments share the same
-  arena and remain valid. Segment boundaries are tracked by
-  `ndx_segments` indices into the single array.
-
-- **Per-segment containers:** Each segment's FlatFileList has its own
-  arenas. Handles are only valid within their segment. No cross-segment
-  handle comparison is needed (RSS-A.8.a finding, flat-flist design doc
-  section "INC_RECURSE incremental segment growth").
-
-The choice between these models is a separate design decision (RSS-A.8.c
-scope). The growth strategy is orthogonal: Vec growth works in both.
-
-## Design doc vs implementation gap
-
-The flat-flist design doc describes per-segment FlatFileList ownership
-with segment-scoped arenas. The current implementation uses a single
-flat Vec across all segments. This gap is documented in RSS-A.8.a
-findings F1 and F5. The migration path is:
-
-1. **Phase 1 (current):** DualFileList pushes to both legacy Vec and
-   FlatFileList. Growth is Vec-based. Single container.
-2. **Phase 2 (RSS-A.8.c):** Add `sort_range()`, `headers_slice()`, and
-   segment-aware accessors to FlatFileList so segment operations work
-   on the single container.
-3. **Phase 3 (optional, RSS-A.9+):** If per-segment ownership proves
-   beneficial (memory reclaim, cache pressure), refactor to per-segment
-   FlatFileList containers. The growth strategy remains Vec-based within
-   each segment.
+This is tracked separately and is not required for the initial flat
+store migration.
 
 ## Verification plan
 
-The following properties should be tested when RSS-A.8.c implements
-segment growth:
+### T1: handle stability across segment growth
 
-1. **Handle stability across segment appends.** Push entries in segment
-   0, record their PathHandles and ExtrasRefs, then push segment 1
-   entries. Verify all segment 0 handles still resolve correctly.
+Push entries for segment 0, record their `PathHandle`s and
+`ExtrasRef`s. Then push entries for segment 1 (causing potential Vec
+reallocation). Verify that resolving the segment-0 handles still
+returns the correct values. Cover all three stores: headers (by index),
+`PathArena` (by `PathHandle`), `ExtrasArena` (by `ExtrasRef`).
 
-2. **Cross-segment deduplication.** Intern "README" in segment 0, intern
-   "README" in segment 1 (same PathArena). Verify same handle returned
-   (single-container model only).
+### T2: sort_range does not disturb other segments
 
-3. **Sort within segment range.** Push entries for two segments, sort
-   only the second segment's range. Verify segment 0 entries are
-   untouched and segment 1 is correctly sorted.
+Push entries for two segments. Sort segment 1 via `sort_range()`. Verify
+that segment 0 entries remain in their original order and their handles
+still resolve correctly.
 
-4. **Large-scale growth.** Push 100K entries across 1K segments. Verify
-   no handle corruption and O(1) amortized push cost.
+### T3: DualFileList sort parity
 
-## References
+Push entries via `DualFileList`, sort a segment range on the legacy Vec
+and independently on the flat store. Verify that both stores produce the
+same entry order (compare by name/dirname).
 
-- `crates/protocol/src/flist/flat/intern.rs` - PathArena implementation
-- `crates/protocol/src/flist/flat/extras.rs` - ExtrasArena implementation
-- `crates/protocol/src/flist/flat/header.rs` - PathHandle, ExtrasRef types
-- `crates/protocol/src/flist/flat/flist.rs` - FlatFileList container
-- `crates/protocol/src/flist/dual.rs` - DualFileList migration wrapper
-- `crates/transfer/src/receiver/file_list/receive.rs` - receiver segment
-  append (`receive_extra_file_lists`)
-- `docs/design/flat-flist-representation.md` - flat-flist design doc
-  (INC_RECURSE section)
-- `docs/design/rss-a8a-inc-recurse-segment-audit.md` - prior audit
-- upstream: `lib/pool_alloc.c` - chunk-based pool allocator
-- upstream: `flist.c:flist_new()`, `flist.c:send_extra_file_list()` -
-  per-segment file list allocation
+### T4: ndx_segments consistency
+
+Simulate multi-segment append (3+ segments) with the +1 gap formula.
+Verify that `wire_to_flat_ndx` and `flat_to_wire_ndx` produce correct
+conversions for entries in each segment.
+
+### T5: reorder_by_permutation preserves handles
+
+Apply a permutation to the header array. Verify that each header's
+`PathHandle` and `ExtrasRef` still resolve to the correct name,
+dirname, and extras after reordering.
+
+## Cross-references
+
+- `docs/design/flat-flist-representation.md` - parent design for the
+  flat backing store (RSS-A.4).
+- `docs/design/rss-a8a-inc-recurse-segment-audit.md` - prerequisite
+  audit documenting how `Vec<FileEntry>` handles INC_RECURSE segments
+  (findings F1-F9 and action items referenced throughout).
+- `docs/design/rss-5-fileentry-pool-shape.md` - earlier pool shape
+  design (prototype, not landed).
+- `crates/protocol/src/flist/flat/flist.rs` - `FlatFileList`
+  implementation (RSS-A.5.d skeleton).
+- `crates/protocol/src/flist/flat/intern.rs` - `PathArena`
+  implementation (RSS-A.5.c).
+- `crates/protocol/src/flist/flat/extras.rs` - `ExtrasArena`
+  implementation (RSS-A.5.e).
+- `crates/protocol/src/flist/dual.rs` - `DualFileList` migration
+  wrapper.
+- `crates/transfer/src/receiver/mod.rs` - receiver segment tracking
+  (`ndx_segments`).
+- `crates/transfer/src/generator/segments.rs` - sender segment
+  scheduling (`IncrementalState`, `SegmentScheduler`).
+- upstream: `flist.c:2923-2931` (ndx_start computation),
+  `flist.c:flist_new()` (per-flist allocation),
+  `lib/pool_alloc.c` (pool allocate/destroy).


### PR DESCRIPTION
## Summary
- Specifies growth strategy for FlatFileList's three arena-backed stores during INC_RECURSE mid-transfer segment appends
- Chooses unified store with index-based segments over per-segment FlatFileList instances, matching the actual sender/receiver implementation from RSS-A.8.a audit
- Documents handle stability guarantees, growth policies, segment lifecycle, and DualFileList synchronization

## Test plan
- [ ] docs-only change, no code modifications
- [ ] Downstream task RSS-A.8.c will implement this design