### PR TITLE
fix: remove duplicate flat-flist feature key in transfer Cargo.toml

### DIFF
--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -119,10 +119,6 @@ thread-slab-pool = ["engine/thread-slab-pool"]
 # Incremental file list processing with failed directory tracking
 incremental-flist = []
 
-# Flat file-list backing store (RSS-A.5+). Forwards to protocol's flat-flist
-# feature, enabling arena-backed dual-emit in DualFileList.
-flat-flist = ["protocol/flat-flist"]
-
 # DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
 # retained for one release to keep V61D-2 / V61D-3 interop gates
 # compilable until ISI.i.2 retires both.


### PR DESCRIPTION
## Summary
- The `flat-flist` feature was defined twice in `crates/transfer/Cargo.toml` - at line 70 (Arena-backed File List Migration section) and line 122 (Protocol Features section)
- TOML rejects duplicate keys, breaking all cargo commands when the merge commit includes both definitions
- This was introduced when PR #5196 was merged, bringing in a second `flat-flist` entry that already existed from earlier PRs

## Test plan
- [ ] Verify `cargo check -p transfer --features flat-flist` succeeds
- [ ] Verify all open PRs' CI passes after this lands on master