### PR TITLE
ci: fix cargo-fuzz musl/ASAN build failures by passing explicit host triple

### DIFF
--- a/.github/workflows/differential-fuzzer-overnight.yml
+++ b/.github/workflows/differential-fuzzer-overnight.yml
@@ -126,6 +126,10 @@ jobs:
         if: matrix.needs_upstream
         run: cargo build --release
 
+      - name: Detect host triple
+        id: host
+        run: echo "triple=$(rustc -vV | awk '/^host:/ { print $2 }')" >>"$GITHUB_OUTPUT"
+
       - name: Run ${{ matrix.target }}
         env:
           OC_RSYNC_BIN: ${{ matrix.needs_upstream && format('{0}/target/release/oc-rsync', github.workspace) || '' }}
@@ -134,6 +138,7 @@ jobs:
           set -uo pipefail
           cd fuzz
           cargo +nightly fuzz run "${{ matrix.target }}" \
+              --target "${{ steps.host.outputs.triple }}" \
               -- -max_total_time="${FUZZ_DURATION}"
           status=$?
           echo "runner_status=${status}" >>"$GITHUB_ENV"

--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -164,15 +164,18 @@ jobs:
           echo "error: no upstream rsync binary built" >&2
           exit 1
 
+      - name: Detect host triple
+        id: host
+        run: echo "triple=$(rustc -vV | awk '/^host:/ { print $2 }')" >>"$GITHUB_OUTPUT"
+
       - name: Run cargo fuzz coverage (${{ matrix.target }})
         env:
           OC_RSYNC_UPSTREAM_BIN: ${{ steps.upstream.outputs.upstream }}
         run: |
           set -uo pipefail
           cd "${{ matrix.workspace }}"
-          # cargo fuzz coverage runs the target with a coverage-instrumented
-          # build and emits coverage/<target>/coverage.profdata.
           cargo +nightly fuzz coverage "${{ matrix.target }}" \
+              --target "${{ steps.host.outputs.triple }}" \
               -- -max_total_time="${FUZZ_DURATION}"
           status=$?
           echo "coverage_status=${status}" >>"$GITHUB_ENV"

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -81,15 +81,21 @@ jobs:
           echo "discovered ${count} fuzz target(s)"
           printf '%s\n' "${targets}"
 
+      - name: Detect host triple
+        id: host
+        run: echo "triple=$(rustc -vV | awk '/^host:/ { print $2 }')" >>"$GITHUB_OUTPUT"
+
       - name: Smoke run fuzz targets
         run: |
           set -uo pipefail
           mkdir -p coverage
+          host_triple="${{ steps.host.outputs.triple }}"
           failures=0
           while IFS= read -r target; do
               [[ -z "${target}" ]] && continue
               echo "::group::smoke ${target}"
               if ! cargo +nightly fuzz run "${target}" \
+                  --target "${host_triple}" \
                   -- -max_total_time="${FUZZ_DURATION}" -runs=0; then
                   echo "warning: smoke run failed for ${target}" >&2
                   failures=$((failures + 1))
@@ -109,7 +115,7 @@ jobs:
           while IFS= read -r target; do
               [[ -z "${target}" ]] && continue
               echo "::group::coverage ${target}"
-              if ! cargo +nightly fuzz coverage "${target}"; then
+              if ! cargo +nightly fuzz coverage "${target}" --target "${host_triple}"; then
                   echo "warning: cargo fuzz coverage failed for ${target}" >&2
                   echo "::endgroup::"
                   continue

--- a/tools/ci/run_filter_differential_fuzz.sh
+++ b/tools/ci/run_filter_differential_fuzz.sh
@@ -79,10 +79,14 @@ echo "upstream rsync: ${upstream}"
 echo "fuzz target:   ${target_name}"
 echo "duration:      ${duration}s"
 
+host_triple=$(rustc -vV | awk '/^host:/ { print $2 }')
+
 cd "${fuzz_dir}"
 set +e
 env OC_RSYNC_UPSTREAM_BIN="${upstream}" \
-    cargo +nightly fuzz run "${target_name}" -- -max_total_time="${duration}"
+    cargo +nightly fuzz run "${target_name}" \
+        --target "${host_triple}" \
+        -- -max_total_time="${duration}"
 status=$?
 set -e
 

--- a/tools/ci/run_filter_fuzz.sh
+++ b/tools/ci/run_filter_fuzz.sh
@@ -65,6 +65,10 @@ fi
 echo "fuzz target:   ${target_name}"
 echo "duration:      ${duration}s"
 
+host_triple=$(rustc -vV | awk '/^host:/ { print $2 }')
+
 cd "${fuzz_dir}"
 exec env OC_RSYNC_UPSTREAM_BIN="${upstream}" \
-    cargo +nightly fuzz run "${target_name}" -- -max_total_time="${duration}"
+    cargo +nightly fuzz run "${target_name}" \
+        --target "${host_triple}" \
+        -- -max_total_time="${duration}"


### PR DESCRIPTION
## Summary

- Fix three consecutive nightly fuzzer workflow failures caused by cargo-fuzz v0.13.x changing the default build target on Linux from gnu to musl
- ASAN (Address Sanitizer) is incompatible with musl static linking, so all `cargo fuzz run` invocations fail at link time
- Pass `--target <host-triple>` explicitly to all `cargo fuzz run` and `cargo fuzz coverage` invocations

## Files changed

- `.github/workflows/differential-fuzzer-overnight.yml` - add host triple detection step + `--target` flag
- `.github/workflows/fuzz-coverage.yml` - add host triple detection step + `--target` flag to smoke run and coverage
- `.github/workflows/fuzz-coverage-report.yml` - add host triple detection step + `--target` flag to coverage
- `tools/ci/run_filter_fuzz.sh` - add host triple detection + `--target` flag
- `tools/ci/run_filter_differential_fuzz.sh` - add host triple detection + `--target` flag

## Test plan

- [ ] Trigger `workflow_dispatch` on Differential Fuzzer Overnight with short duration to verify fix
- [ ] Trigger `workflow_dispatch` on Fuzz Coverage Smoke to verify fix
- [ ] Verify host triple detection works on both Linux and macOS runners