### PR TITLE
fix: resolve INC_RECURSE sender-side interop regressions

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -444,6 +444,12 @@ impl GeneratorContext {
     /// Body of [`Self::encode_and_send_segment`] without the timing wrapper,
     /// so the counter updates remain in a single place and the elapsed window
     /// excludes only the `Instant::now()` pair itself.
+    ///
+    /// Upstream always sends the NDX header and end-of-flist marker even for
+    /// empty directories (flist.c:2117,2139-2146). Skipping them for count==0
+    /// desynchronises `flist_done_remaining` from the receiver's NDX_DONE
+    /// stream, causing a phase-transition NDX_DONE to be consumed as a
+    /// flist-free echo.
     fn encode_and_send_segment_inner<W: Write>(
         &mut self,
         writer: &mut W,
@@ -451,10 +457,6 @@ impl GeneratorContext {
         flist_writer: &mut protocol::flist::FileListWriter,
         ndx_codec: &mut NdxCodecEnum,
     ) -> io::Result<()> {
-        if segment.count == 0 {
-            return Ok(());
-        }
-
         // Compute ndx_start for this sub-list.
         // upstream: flist.c:2931 - flist->ndx_start = prev->ndx_start + prev->used + 1
         let &(prev_flat_start, prev_ndx_start) = self
@@ -469,6 +471,7 @@ impl GeneratorContext {
             .push((segment.flist_start, seg_ndx_start));
 
         // Signal new sub-list to receiver.
+        // upstream: flist.c:2117 - write_ndx(f, NDX_FLIST_OFFSET - dir_ndx)
         ndx_codec.write_ndx(writer, NDX_FLIST_OFFSET - segment.parent_dir_ndx)?;
 
         // Set first_ndx so abbreviated vs unabbreviated followers are
@@ -485,6 +488,7 @@ impl GeneratorContext {
         }
 
         // End-of-flist marker (zero byte).
+        // upstream: flist.c:2139-2146 - always sends write_end_of_flist()
         flist_writer.write_end(writer, None)?;
 
         debug_log!(

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2846,3 +2846,214 @@ fn server_mode_flushes_writer_before_filter_list_read() {
         "writer must be flushed in server mode before reading filter list"
     );
 }
+
+// ---------------------------------------------------------------------------
+// INC_RECURSE SegmentScheduler regression tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn segment_scheduler_dispatches_when_remaining_below_threshold() {
+    // When remaining entries known to the receiver are below
+    // MIN_FILECNT_LOOKAHEAD, the scheduler should dispatch the next segment.
+    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+
+    let seg = PendingSegment {
+        parent_dir_ndx: 0,
+        flist_start: 10,
+        count: 500,
+    };
+    let mut scheduler = SegmentScheduler::new(vec![seg]);
+
+    // remaining = 13 (a small initial segment), well below 1000
+    let result = scheduler.next_if_needed(13);
+    assert!(
+        result.is_some(),
+        "scheduler must dispatch when remaining ({}) < MIN_FILECNT_LOOKAHEAD ({})",
+        13,
+        MIN_FILECNT_LOOKAHEAD,
+    );
+}
+
+#[test]
+fn segment_scheduler_blocks_when_remaining_at_threshold() {
+    // When remaining equals MIN_FILECNT_LOOKAHEAD, upstream's condition
+    // `file_total - file_old_total < at_least` is false (1000 < 1000 is false),
+    // so no dispatch should occur.
+    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+
+    let seg = PendingSegment {
+        parent_dir_ndx: 0,
+        flist_start: 10,
+        count: 500,
+    };
+    let mut scheduler = SegmentScheduler::new(vec![seg]);
+
+    let result = scheduler.next_if_needed(MIN_FILECNT_LOOKAHEAD);
+    assert!(
+        result.is_none(),
+        "scheduler must NOT dispatch when remaining == MIN_FILECNT_LOOKAHEAD"
+    );
+}
+
+#[test]
+fn segment_scheduler_blocks_when_remaining_above_threshold() {
+    // When remaining exceeds MIN_FILECNT_LOOKAHEAD, no dispatch.
+    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+
+    let seg = PendingSegment {
+        parent_dir_ndx: 0,
+        flist_start: 10,
+        count: 500,
+    };
+    let mut scheduler = SegmentScheduler::new(vec![seg]);
+
+    let result = scheduler.next_if_needed(MIN_FILECNT_LOOKAHEAD + 1);
+    assert!(
+        result.is_none(),
+        "scheduler must NOT dispatch when remaining > MIN_FILECNT_LOOKAHEAD"
+    );
+}
+
+#[test]
+fn segment_scheduler_boundary_dispatches_at_999() {
+    // remaining = 999, which is < 1000, so dispatch must occur.
+    use super::segments::{MIN_FILECNT_LOOKAHEAD, PendingSegment, SegmentScheduler};
+
+    let seg = PendingSegment {
+        parent_dir_ndx: 0,
+        flist_start: 10,
+        count: 500,
+    };
+    let mut scheduler = SegmentScheduler::new(vec![seg]);
+
+    let result = scheduler.next_if_needed(MIN_FILECNT_LOOKAHEAD - 1);
+    assert!(
+        result.is_some(),
+        "scheduler must dispatch when remaining == {} (one below threshold)",
+        MIN_FILECNT_LOOKAHEAD - 1,
+    );
+}
+
+#[test]
+fn segment_scheduler_many_files_deadlock_scenario() {
+    // Regression test for the many-files deadlock (#5085).
+    // Scenario: 1013 total entries, 13 in the initial segment, 1000 in a
+    // pending sub-list. Using dispatched_entry_count (13) instead of
+    // file_list.len() (1013) gives remaining=13 which triggers dispatch.
+    use super::segments::{PendingSegment, SegmentScheduler};
+
+    let seg = PendingSegment {
+        parent_dir_ndx: 1,
+        flist_start: 13,
+        count: 1000,
+    };
+    let mut scheduler = SegmentScheduler::new(vec![seg]);
+
+    // Bug: old code computed remaining = file_list.len() - transferred = 1013 - 0 = 1013
+    // which is >= 1000, so no dispatch occurred. Deadlock.
+    let remaining_buggy = 1013usize;
+    let result_buggy = scheduler.next_if_needed(remaining_buggy);
+    assert!(
+        result_buggy.is_none(),
+        "with total file count (buggy), scheduler incorrectly blocks"
+    );
+
+    // Fix: remaining = dispatched_entry_count - transferred = 13 - 0 = 13
+    // Reset scheduler for the corrected test.
+    let seg = PendingSegment {
+        parent_dir_ndx: 1,
+        flist_start: 13,
+        count: 1000,
+    };
+    let mut scheduler = SegmentScheduler::new(vec![seg]);
+
+    let remaining_fixed = 13usize;
+    let result_fixed = scheduler.next_if_needed(remaining_fixed);
+    assert!(
+        result_fixed.is_some(),
+        "with dispatched_entry_count (fixed), scheduler correctly dispatches"
+    );
+}
+
+#[test]
+fn empty_segment_sends_wire_bytes() {
+    // Regression test for empty-dir flist_done overcounting (#5085).
+    // An empty segment (count==0) must still produce wire output (NDX header
+    // + end-of-flist marker), matching upstream flist.c:2117,2139-2146.
+    // The old code returned early for count==0 producing zero wire bytes,
+    // which desynchronised flist_done_remaining from the receiver.
+    let handshake = test_handshake();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+
+    // Set up a minimal initial segment in ndx_segments.
+    ctx.incremental.ndx_segments = vec![(0, 0)];
+
+    // Add a dummy file entry so the file_list is non-empty (flist_start=0).
+    ctx.file_list
+        .push(protocol::flist::FileEntry::new_file("x".into(), 1, 0o644));
+    ctx.full_paths.push(PathBuf::from("x"));
+
+    let seg = super::PendingSegment {
+        parent_dir_ndx: 0,
+        flist_start: 1, // past the single entry, so count=0 segment is empty
+        count: 0,
+    };
+
+    let mut output = Vec::new();
+    let mut flist_writer = ctx.build_flist_writer();
+    let mut ndx_codec = protocol::codec::create_ndx_codec(ctx.protocol().as_u8());
+
+    ctx.encode_and_send_segment(&mut output, &seg, &mut flist_writer, &mut ndx_codec)
+        .unwrap();
+
+    // The output must contain at least the NDX header bytes and the
+    // end-of-flist zero byte. With the old early-return bug, output was empty.
+    assert!(
+        !output.is_empty(),
+        "empty segment must still produce wire output (NDX header + end marker)"
+    );
+    // The last byte should be the end-of-flist marker (0x00).
+    assert_eq!(
+        *output.last().unwrap(),
+        0u8,
+        "last wire byte must be the end-of-flist marker"
+    );
+}
+
+#[test]
+fn nonempty_segment_also_sends_wire_bytes() {
+    // Sanity check: a non-empty segment produces wire output with entries.
+    let handshake = test_handshake();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+
+    ctx.incremental.ndx_segments = vec![(0, 0)];
+    let entry = protocol::flist::FileEntry::new_file("a.txt".into(), 10, 0o644);
+    ctx.file_list.push(entry);
+    ctx.full_paths.push(PathBuf::from("a.txt"));
+
+    let seg = super::PendingSegment {
+        parent_dir_ndx: 0,
+        flist_start: 0,
+        count: 1,
+    };
+
+    let mut output_nonempty = Vec::new();
+    let mut flist_writer = ctx.build_flist_writer();
+    let mut ndx_codec = protocol::codec::create_ndx_codec(ctx.protocol().as_u8());
+
+    ctx.encode_and_send_segment(&mut output_nonempty, &seg, &mut flist_writer, &mut ndx_codec)
+        .unwrap();
+
+    // Non-empty segment output must be larger than an empty segment's output
+    // (NDX header + at least one entry + end marker).
+    assert!(
+        output_nonempty.len() > 2,
+        "non-empty segment must produce substantial wire output, got {} bytes",
+        output_nonempty.len()
+    );
+    assert_eq!(
+        *output_nonempty.last().unwrap(),
+        0u8,
+        "last wire byte must be end-of-flist marker"
+    );
+}

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3041,8 +3041,13 @@ fn nonempty_segment_also_sends_wire_bytes() {
     let mut flist_writer = ctx.build_flist_writer();
     let mut ndx_codec = protocol::codec::create_ndx_codec(ctx.protocol().as_u8());
 
-    ctx.encode_and_send_segment(&mut output_nonempty, &seg, &mut flist_writer, &mut ndx_codec)
-        .unwrap();
+    ctx.encode_and_send_segment(
+        &mut output_nonempty,
+        &seg,
+        &mut flist_writer,
+        &mut ndx_codec,
+    )
+    .unwrap();
 
     // Non-empty segment output must be larger than an empty segment's output
     // (NDX header + at least one entry + end marker).

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -98,13 +98,25 @@ impl GeneratorContext {
         // transition. This counter tracks how many flist-free echoes remain.
         let mut flist_done_remaining: usize = 0;
 
+        // upstream: flist.c:104,2160 - file_total tracks entries the receiver
+        // knows about (initial segment + dispatched sub-lists). Used for the
+        // MIN_FILECNT_LOOKAHEAD comparison in send_extra_file_list().
+        // Unlike self.file_list.len() which includes undispatched segments,
+        // this only counts entries already sent to the receiver.
+        let mut dispatched_entry_count: usize = self
+            .incremental
+            .initial_segment_count
+            .unwrap_or(self.file_list.len());
+
         // upstream: sender.c - dry-run skips data transfer; daemon may close early
         let tolerant = self.config.flags.dry_run;
 
         loop {
             // upstream: sender.c:227 - send extra file lists at top of loop
             if inc_recurse {
-                let remaining = self.file_list.len().saturating_sub(files_transferred);
+                // upstream: flist.c:2104 - file_total - file_old_total < at_least
+                // remaining = entries the receiver knows about minus transferred
+                let remaining = dispatched_entry_count.saturating_sub(files_transferred);
                 while let Some(seg) = scheduler.next_if_needed(remaining) {
                     self.encode_and_send_segment(
                         &mut *writer,
@@ -114,6 +126,7 @@ impl GeneratorContext {
                     )?;
                     segments_sent += 1;
                     flist_done_remaining += 1;
+                    dispatched_entry_count += seg.count;
                 }
 
                 // upstream: flist.c:2534-2545 - send NDX_FLIST_EOF when all sub-lists
@@ -456,7 +469,7 @@ impl GeneratorContext {
 
             // upstream: sender.c:261 - send extra file lists at bottom of loop
             if inc_recurse {
-                let remaining = self.file_list.len().saturating_sub(files_transferred);
+                let remaining = dispatched_entry_count.saturating_sub(files_transferred);
                 while let Some(seg) = scheduler.next_if_needed(remaining) {
                     self.encode_and_send_segment(
                         &mut *writer,
@@ -466,6 +479,7 @@ impl GeneratorContext {
                     )?;
                     segments_sent += 1;
                     flist_done_remaining += 1;
+                    dispatched_entry_count += seg.count;
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes two INC_RECURSE sender-side interop regressions introduced by PR #5085 (re-enabling sender-side INC_RECURSE by default):

- **many-files deadlock**: The remaining-threshold computation in the transfer loop used `file_list.len()` (all enumerated entries including undispatched segments) instead of only entries the receiver knows about. With 1013 entries and a 13-entry initial segment, `remaining = 1013 >= MIN_FILECNT_LOOKAHEAD(1000)` prevented sub-list dispatch, deadlocking against an upstream daemon waiting for sub-lists. Fixed by tracking `dispatched_entry_count` (initial + sent segment entries), matching upstream `flist.c` `file_total` semantics.

- **empty-dir flist_done overcounting**: `encode_and_send_segment_inner` returned early for `count == 0` segments without sending any wire bytes, but `flist_done_remaining` was incremented unconditionally. The overcounted counter caused the generator to consume a phase-transition `NDX_DONE` as a flist-free echo, leading to protocol desync (exit=23). Fixed by removing the early return so empty segments always send the NDX header and end-of-flist marker on the wire, matching upstream `flist.c:2117,2139-2146`.

## Test plan

- [ ] New unit tests for `SegmentScheduler` threshold boundary behavior (at, below, and above `MIN_FILECNT_LOOKAHEAD`)
- [ ] Regression test reproducing the exact many-files deadlock scenario (1013 entries, 13 initial)
- [ ] Regression test verifying empty segments produce wire output (NDX header + end marker)
- [ ] Regression test verifying non-empty segments still produce correct wire output
- [ ] CI: `standalone:many-files` interop test passes
- [ ] CI: `standalone:empty-dir` interop test passes
- [ ] All existing INC_RECURSE interop tests continue to pass