### PR TITLE
feat: implement FILE_FLAG_DELETE_ON_CLOSE temp files for Windows

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -137,8 +137,6 @@ pub mod copy_file_ex;
 pub mod copy_file_range;
 /// Anonymous temporary file creation via `O_TMPFILE` and finalization via `linkat`.
 pub mod o_tmpfile;
-/// Delete-on-close temporary file creation for Windows via `FILE_FLAG_DELETE_ON_CLOSE`.
-pub mod win_tmpfile;
 /// Platform-abstracted file copy trait with automatic optimization selection.
 pub mod platform_copy;
 /// ReFS filesystem detection for Windows reflink support.
@@ -155,6 +153,8 @@ pub mod splice;
 pub mod syscall_batch;
 /// Zero-copy file writer that pushes literal chunks via `vmsplice` + `splice`.
 pub mod vmsplice_writer;
+/// Delete-on-close temporary file creation for Windows via `FILE_FLAG_DELETE_ON_CLOSE`.
+pub mod win_tmpfile;
 
 /// macOS-optimized file writer using `F_NOCACHE` and `writev`.
 pub mod macos_io;
@@ -294,17 +294,17 @@ pub use o_tmpfile::{
     AnonymousTempFile, OTmpfileSupport, TempFileResult, link_anonymous_tmpfile,
     o_tmpfile_available, o_tmpfile_probe, open_anonymous_tmpfile, open_temp_file,
 };
-pub use win_tmpfile::{
-    WinDeleteOnCloseSupport, WinTempFileResult, WindowsTempFile, clear_delete_on_close,
-    commit_delete_on_close, delete_on_close_available, open_delete_on_close_tmpfile,
-    open_win_temp_file, rename_temp_to_dest, win_tmpfile_probe,
-};
 #[cfg(target_os = "linux")]
 pub use temp_file_strategy::AnonymousTempFileStrategy;
 #[cfg(target_os = "windows")]
 pub use temp_file_strategy::WindowsTempFileStrategy;
 pub use temp_file_strategy::{
     DefaultTempFileStrategy, NamedTempFileStrategy, TempFileHandle, TempFileKind, TempFileStrategy,
+};
+pub use win_tmpfile::{
+    WinDeleteOnCloseSupport, WinTempFileResult, WindowsTempFile, clear_delete_on_close,
+    commit_delete_on_close, delete_on_close_available, open_delete_on_close_tmpfile,
+    open_win_temp_file, rename_temp_to_dest, win_tmpfile_probe,
 };
 
 pub use io_uring::{

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -137,6 +137,8 @@ pub mod copy_file_ex;
 pub mod copy_file_range;
 /// Anonymous temporary file creation via `O_TMPFILE` and finalization via `linkat`.
 pub mod o_tmpfile;
+/// Delete-on-close temporary file creation for Windows via `FILE_FLAG_DELETE_ON_CLOSE`.
+pub mod win_tmpfile;
 /// Platform-abstracted file copy trait with automatic optimization selection.
 pub mod platform_copy;
 /// ReFS filesystem detection for Windows reflink support.
@@ -292,8 +294,15 @@ pub use o_tmpfile::{
     AnonymousTempFile, OTmpfileSupport, TempFileResult, link_anonymous_tmpfile,
     o_tmpfile_available, o_tmpfile_probe, open_anonymous_tmpfile, open_temp_file,
 };
+pub use win_tmpfile::{
+    WinDeleteOnCloseSupport, WinTempFileResult, WindowsTempFile, clear_delete_on_close,
+    commit_delete_on_close, delete_on_close_available, open_delete_on_close_tmpfile,
+    open_win_temp_file, rename_temp_to_dest, win_tmpfile_probe,
+};
 #[cfg(target_os = "linux")]
 pub use temp_file_strategy::AnonymousTempFileStrategy;
+#[cfg(target_os = "windows")]
+pub use temp_file_strategy::WindowsTempFileStrategy;
 pub use temp_file_strategy::{
     DefaultTempFileStrategy, NamedTempFileStrategy, TempFileHandle, TempFileKind, TempFileStrategy,
 };

--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -434,6 +434,7 @@ pub fn platform_io_capabilities() -> Vec<&'static str> {
     {
         caps.push("CopyFileEx");
         caps.push("ReFS reflink");
+        caps.push("FILE_FLAG_DELETE_ON_CLOSE");
         if is_iocp_available() {
             caps.push("IOCP");
         }
@@ -470,6 +471,7 @@ mod tests {
         {
             assert!(caps.contains(&"CopyFileEx"));
             assert!(caps.contains(&"ReFS reflink"));
+            assert!(caps.contains(&"FILE_FLAG_DELETE_ON_CLOSE"));
         }
     }
 

--- a/crates/fast_io/src/temp_file_strategy.rs
+++ b/crates/fast_io/src/temp_file_strategy.rs
@@ -6,18 +6,23 @@
 //!
 //! - **Linux**: [`AnonymousTempFileStrategy`] uses `O_TMPFILE` + `linkat(2)`
 //!   for zero-cleanup atomic writes. No directory entry exists until commit.
+//! - **Windows**: [`WindowsTempFileStrategy`] uses `FILE_FLAG_DELETE_ON_CLOSE`
+//!   for auto-cleanup temp files. The kernel deletes the file when the last
+//!   handle closes, providing crash-safe cleanup analogous to `O_TMPFILE`.
 //! - **All platforms**: [`NamedTempFileStrategy`] uses a uniquely-named temp
 //!   file + `rename(2)` for atomic commit, with cross-device fallback.
 //!
 //! The [`DefaultTempFileStrategy`] automatically selects the best available
-//! strategy at runtime, probing `O_TMPFILE` support on Linux and falling back
-//! to named temp files elsewhere.
+//! strategy at runtime, probing `O_TMPFILE` support on Linux,
+//! `FILE_FLAG_DELETE_ON_CLOSE` on Windows, and falling back to named temp
+//! files elsewhere.
 //!
 //! # Design
 //!
 //! This follows the Strategy Pattern (Dependency Inversion) - the engine crate
-//! depends on `TempFileStrategy` rather than on concrete `O_TMPFILE` or
-//! `rename` logic directly. Each strategy manages its own RAII cleanup.
+//! depends on `TempFileStrategy` rather than on concrete `O_TMPFILE`,
+//! `FILE_FLAG_DELETE_ON_CLOSE`, or `rename` logic directly. Each strategy
+//! manages its own RAII cleanup.
 
 use std::fs::{self, File};
 use std::io;
@@ -46,6 +51,16 @@ pub enum TempFileKind {
     Anonymous {
         /// Cloned fd for `linkat(2)` - the writer fd is returned separately.
         fd_for_link: File,
+    },
+    /// Delete-on-close temp file (Windows `FILE_FLAG_DELETE_ON_CLOSE`).
+    ///
+    /// Commit clears the delete-on-close disposition via
+    /// `SetFileInformationByHandle`, then renames to destination.
+    /// If dropped without commit, the kernel auto-deletes the file.
+    #[cfg(target_os = "windows")]
+    DeleteOnClose {
+        /// On-disk path of the delete-on-close temp file.
+        temp_path: PathBuf,
     },
     /// Named temp file - commit via `rename(2)`.
     Named {
@@ -145,6 +160,55 @@ impl TempFileStrategy for AnonymousTempFileStrategy {
     }
 }
 
+/// Strategy using Windows `FILE_FLAG_DELETE_ON_CLOSE` for auto-cleanup temp files.
+///
+/// The file is created with a unique name and the delete-on-close flag. If
+/// the process crashes before commit, the kernel deletes the file when the
+/// handle is closed. On commit, the disposition is cleared and the file is
+/// renamed to the destination.
+///
+/// # Platform support
+///
+/// Windows Vista+ with NTFS, ReFS, or FAT32. Callers should probe availability
+/// via [`delete_on_close_available`](crate::delete_on_close_available) before
+/// constructing.
+#[cfg(target_os = "windows")]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WindowsTempFileStrategy;
+
+#[cfg(target_os = "windows")]
+impl TempFileStrategy for WindowsTempFileStrategy {
+    fn create(&self, destination: &Path) -> io::Result<TempFileHandle> {
+        let dir = destination.parent().unwrap_or(Path::new("."));
+        let (file, temp_path) = crate::open_delete_on_close_tmpfile(dir)?;
+        Ok(TempFileHandle {
+            file,
+            kind: TempFileKind::DeleteOnClose { temp_path },
+        })
+    }
+
+    fn commit(&self, handle: TempFileHandle, destination: &Path) -> io::Result<()> {
+        if let TempFileKind::DeleteOnClose { temp_path } = handle.kind {
+            crate::commit_delete_on_close(handle.file, &temp_path, destination)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "expected delete-on-close temp file kind",
+            ))
+        }
+    }
+
+    fn discard(&self, _handle: TempFileHandle) {
+        // Dropping the handle triggers kernel deletion via FILE_FLAG_DELETE_ON_CLOSE.
+    }
+
+    fn is_anonymous(&self) -> bool {
+        // Delete-on-close files have a directory entry (unlike O_TMPFILE),
+        // but provide the same crash-safe auto-cleanup semantics.
+        false
+    }
+}
+
 /// Strategy using a uniquely-named temporary file + `rename(2)`.
 ///
 /// Works on all platforms. The temp file is created in the same directory as
@@ -230,6 +294,11 @@ impl TempFileStrategy for NamedTempFileStrategy {
                 io::ErrorKind::InvalidInput,
                 "expected named temp file kind",
             )),
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "expected named temp file kind",
+            )),
         }
     }
 
@@ -242,6 +311,10 @@ impl TempFileStrategy for NamedTempFileStrategy {
             }
             #[cfg(target_os = "linux")]
             TempFileKind::Anonymous { .. } => {}
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => {
+                // Drop triggers kernel deletion.
+            }
         }
     }
 
@@ -250,15 +323,14 @@ impl TempFileStrategy for NamedTempFileStrategy {
     }
 }
 
-/// Auto-selecting strategy that probes for `O_TMPFILE` on Linux and falls
-/// back to named temp files elsewhere.
+/// Auto-selecting strategy that probes for the best available temp file
+/// mechanism at runtime.
 ///
-/// On Linux, the first call to [`create`](TempFileStrategy::create) probes
-/// `O_TMPFILE` availability on the destination filesystem. If available, all
-/// subsequent calls use anonymous temp files. Otherwise, named temp files are
-/// used.
-///
-/// On non-Linux platforms, this always uses [`NamedTempFileStrategy`].
+/// - **Linux**: probes `O_TMPFILE` on the destination filesystem. If available,
+///   uses anonymous temp files via [`AnonymousTempFileStrategy`].
+/// - **Windows**: probes `FILE_FLAG_DELETE_ON_CLOSE`. If available, uses
+///   delete-on-close temp files via [`WindowsTempFileStrategy`].
+/// - **All platforms**: falls back to named temp files via [`NamedTempFileStrategy`].
 pub struct DefaultTempFileStrategy {
     named: NamedTempFileStrategy,
 }
@@ -289,6 +361,14 @@ impl TempFileStrategy for DefaultTempFileStrategy {
                 return anon.create(destination);
             }
         }
+        #[cfg(target_os = "windows")]
+        {
+            let dir = destination.parent().unwrap_or(Path::new("."));
+            if crate::delete_on_close_available(dir) {
+                let doc = WindowsTempFileStrategy;
+                return doc.create(destination);
+            }
+        }
         self.named.create(destination)
     }
 
@@ -299,6 +379,11 @@ impl TempFileStrategy for DefaultTempFileStrategy {
                 let anon = AnonymousTempFileStrategy;
                 anon.commit(handle, destination)
             }
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => {
+                let doc = WindowsTempFileStrategy;
+                doc.commit(handle, destination)
+            }
             TempFileKind::Named { .. } => self.named.commit(handle, destination),
         }
     }
@@ -308,6 +393,10 @@ impl TempFileStrategy for DefaultTempFileStrategy {
             #[cfg(target_os = "linux")]
             TempFileKind::Anonymous { .. } => {
                 // Drop fds - kernel reclaims inode.
+            }
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => {
+                // Drop triggers kernel deletion via FILE_FLAG_DELETE_ON_CLOSE.
             }
             TempFileKind::Named { temp_path } => {
                 let path = temp_path.clone();
@@ -395,7 +484,9 @@ mod tests {
         let temp_path = match &handle.kind {
             TempFileKind::Named { temp_path } => temp_path.clone(),
             #[cfg(target_os = "linux")]
-            _ => panic!("expected named"),
+            TempFileKind::Anonymous { .. } => panic!("expected named"),
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => panic!("expected named"),
         };
 
         assert!(temp_path.exists());
@@ -439,6 +530,8 @@ mod tests {
             }
             #[cfg(target_os = "linux")]
             TempFileKind::Anonymous { .. } => panic!("expected named"),
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => panic!("expected named"),
         }
 
         strategy.discard(handle);
@@ -456,12 +549,16 @@ mod tests {
         let p1 = match &h1.kind {
             TempFileKind::Named { temp_path } => temp_path.clone(),
             #[cfg(target_os = "linux")]
-            _ => panic!("expected named"),
+            TempFileKind::Anonymous { .. } => panic!("expected named"),
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => panic!("expected named"),
         };
         let p2 = match &h2.kind {
             TempFileKind::Named { temp_path } => temp_path.clone(),
             #[cfg(target_os = "linux")]
-            _ => panic!("expected named"),
+            TempFileKind::Anonymous { .. } => panic!("expected named"),
+            #[cfg(target_os = "windows")]
+            TempFileKind::DeleteOnClose { .. } => panic!("expected named"),
         };
 
         assert_ne!(p1, p2);
@@ -567,6 +664,73 @@ mod tests {
 
             let handle = strategy.create(&dest).expect("create");
             assert!(matches!(handle.kind, TempFileKind::Anonymous { .. }));
+            strategy.discard(handle);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    mod windows {
+        use super::*;
+
+        #[test]
+        fn delete_on_close_strategy_create_and_commit() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("doc.txt");
+            let strategy = WindowsTempFileStrategy;
+
+            let mut handle = strategy.create(&dest).expect("create");
+            assert!(!strategy.is_anonymous());
+            handle.file.write_all(b"delete-on-close data").expect("write");
+            strategy.commit(handle, &dest).expect("commit");
+
+            assert!(dest.exists());
+            assert_eq!(
+                fs::read_to_string(&dest).expect("read"),
+                "delete-on-close data"
+            );
+        }
+
+        #[test]
+        fn delete_on_close_strategy_discard_no_orphan() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("doc_discard.txt");
+            let strategy = WindowsTempFileStrategy;
+
+            let handle = strategy.create(&dest).expect("create");
+            let temp_path = match &handle.kind {
+                TempFileKind::DeleteOnClose { temp_path } => temp_path.clone(),
+                _ => panic!("expected delete-on-close"),
+            };
+
+            assert!(temp_path.exists());
+            strategy.discard(handle);
+            // Kernel should have deleted via FILE_FLAG_DELETE_ON_CLOSE.
+            assert!(!temp_path.exists());
+            assert!(!dest.exists());
+        }
+
+        #[test]
+        fn delete_on_close_strategy_commit_replaces_existing() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("doc_replace.txt");
+            fs::write(&dest, b"old").expect("write existing");
+
+            let strategy = WindowsTempFileStrategy;
+            let mut handle = strategy.create(&dest).expect("create");
+            handle.file.write_all(b"new").expect("write");
+            strategy.commit(handle, &dest).expect("commit");
+
+            assert_eq!(fs::read_to_string(&dest).expect("read"), "new");
+        }
+
+        #[test]
+        fn default_strategy_prefers_delete_on_close_on_windows() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("default_doc.txt");
+            let strategy = DefaultTempFileStrategy::default();
+
+            let handle = strategy.create(&dest).expect("create");
+            assert!(matches!(handle.kind, TempFileKind::DeleteOnClose { .. }));
             strategy.discard(handle);
         }
     }

--- a/crates/fast_io/src/temp_file_strategy.rs
+++ b/crates/fast_io/src/temp_file_strategy.rs
@@ -680,7 +680,10 @@ mod tests {
 
             let mut handle = strategy.create(&dest).expect("create");
             assert!(!strategy.is_anonymous());
-            handle.file.write_all(b"delete-on-close data").expect("write");
+            handle
+                .file
+                .write_all(b"delete-on-close data")
+                .expect("write");
             strategy.commit(handle, &dest).expect("commit");
 
             assert!(dest.exists());

--- a/crates/fast_io/src/win_tmpfile/low_level.rs
+++ b/crates/fast_io/src/win_tmpfile/low_level.rs
@@ -328,7 +328,10 @@ mod windows {
             clear_delete_on_close(&file).expect("clear disposition");
             drop(file);
             // File should survive because we cleared the delete-on-close flag.
-            assert!(path.exists(), "file must survive after clearing disposition");
+            assert!(
+                path.exists(),
+                "file must survive after clearing disposition"
+            );
             // Clean up.
             std::fs::remove_file(&path).expect("cleanup");
         }
@@ -359,10 +362,7 @@ mod windows {
 
             commit_delete_on_close(file, &temp_path, &dest).expect("commit");
 
-            assert_eq!(
-                std::fs::read_to_string(&dest).expect("read"),
-                "new content"
-            );
+            assert_eq!(std::fs::read_to_string(&dest).expect("read"), "new content");
         }
 
         #[test]

--- a/crates/fast_io/src/win_tmpfile/low_level.rs
+++ b/crates/fast_io/src/win_tmpfile/low_level.rs
@@ -1,0 +1,446 @@
+//! Low-level Win32 wrappers for delete-on-close temporary files.
+//!
+//! On Windows, `FILE_FLAG_DELETE_ON_CLOSE` creates a named file that the
+//! kernel automatically deletes when the last handle to it is closed. This
+//! provides crash-safe cleanup semantics analogous to Linux `O_TMPFILE`:
+//! if the process crashes before commit, no orphaned temp file remains.
+//!
+//! The commit path clears the delete-on-close disposition via
+//! `SetFileInformationByHandle(FileDispositionInfo)` so the file survives
+//! handle close, then renames it to the destination.
+//!
+//! # Kernel requirements
+//!
+//! - `FILE_FLAG_DELETE_ON_CLOSE`: Windows Vista+ (all supported versions).
+//! - `SetFileInformationByHandle(FileDispositionInfo)`: Windows Vista+.
+//! - `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`: Windows NT 3.1+.
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use std::fs::File;
+    use std::io;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CREATE_NEW, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_DELETE_ON_CLOSE,
+        FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ,
+    };
+
+    /// Counter for generating unique temp file names.
+    static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Creates a delete-on-close temporary file in `dir`.
+    ///
+    /// The file is created with `FILE_FLAG_DELETE_ON_CLOSE` which instructs
+    /// the kernel to delete the file when the last handle is closed. This
+    /// provides automatic cleanup on crash or early return - no orphaned
+    /// temp files.
+    ///
+    /// The file is opened with `FILE_SHARE_READ | FILE_SHARE_DELETE` so
+    /// external processes can read it (e.g., virus scanners) and the
+    /// rename-on-commit path works.
+    ///
+    /// Returns the opened file and the path of the temp file on disk.
+    ///
+    /// # Arguments
+    ///
+    /// * `dir` - directory where the temp file is created. Must exist and
+    ///   be writable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The directory does not exist
+    /// - Permission denied
+    /// - All generated unique names collide (extremely unlikely)
+    pub fn open_delete_on_close_tmpfile(dir: &Path) -> io::Result<(File, PathBuf)> {
+        let pid = std::process::id();
+        // Retry with different unique names on collision (CREATE_NEW fails
+        // with ERROR_FILE_EXISTS if the name is taken).
+        for _ in 0..16 {
+            let unique = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let name = format!(".oc-rsync-tmp.{pid}.{unique}");
+            let temp_path = dir.join(&name);
+
+            let wide_path = to_wide_path(&temp_path)?;
+
+            // SAFETY: `wide_path` is a valid null-terminated wide string.
+            // `CREATE_NEW` fails if the file already exists, preventing
+            // races. `FILE_FLAG_DELETE_ON_CLOSE` ensures kernel-level
+            // cleanup. The returned handle is valid on success and is
+            // immediately wrapped in a `File` which owns it.
+            #[allow(unsafe_code)]
+            let handle = unsafe {
+                CreateFileW(
+                    wide_path.as_ptr(),
+                    FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_DELETE,
+                    std::ptr::null(),
+                    CREATE_NEW,
+                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                    std::ptr::null_mut(),
+                )
+            };
+
+            if handle == INVALID_HANDLE_VALUE {
+                let err = io::Error::last_os_error();
+                // ERROR_FILE_EXISTS = 80
+                if err.raw_os_error() == Some(80) {
+                    continue;
+                }
+                return Err(err);
+            }
+
+            // SAFETY: `handle` is a valid, open file handle just returned
+            // by `CreateFileW`. We transfer ownership to `File` which will
+            // close it on drop. No other code holds or aliases this handle.
+            #[allow(unsafe_code)]
+            let file = unsafe {
+                use std::os::windows::io::FromRawHandle;
+                File::from_raw_handle(handle as *mut std::ffi::c_void)
+            };
+
+            return Ok((file, temp_path));
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "failed to create unique temp file after 16 attempts",
+        ))
+    }
+
+    /// Clears the delete-on-close disposition so the file survives handle close.
+    ///
+    /// After calling this, the file will NOT be deleted when the handle is
+    /// closed. This is the first step of the commit sequence: clear the
+    /// flag, then rename to the final destination.
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - open handle to the delete-on-close temp file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `SetFileInformationByHandle` fails.
+    pub fn clear_delete_on_close(file: &File) -> io::Result<()> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FileDispositionInfo, SetFileInformationByHandle,
+        };
+
+        // FILE_DISPOSITION_INFO has a single BOOLEAN field `DeleteFile`.
+        // Setting it to FALSE (0) clears the delete-on-close flag.
+        let disposition_info: u8 = 0; // FALSE = do NOT delete on close
+
+        // SAFETY: `file.as_raw_handle()` returns a valid handle opened
+        // with `FILE_FLAG_DELETE_ON_CLOSE`. `SetFileInformationByHandle`
+        // with `FileDispositionInfo` and a `FILE_DISPOSITION_INFO` struct
+        // (which is a single BOOLEAN byte) clears the delete-on-close
+        // disposition. The buffer pointer and size match the struct layout.
+        #[allow(unsafe_code)]
+        let result = unsafe {
+            SetFileInformationByHandle(
+                file.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE,
+                FileDispositionInfo,
+                std::ptr::addr_of!(disposition_info).cast(),
+                std::mem::size_of::<u8>() as u32,
+            )
+        };
+
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+
+    /// Renames the temp file to the destination path.
+    ///
+    /// Uses `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` for atomic
+    /// replacement semantics matching upstream `util1.c:robust_rename()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `temp_path` - current path of the temp file.
+    /// * `dest` - final destination path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the rename fails.
+    pub fn rename_temp_to_dest(temp_path: &Path, dest: &Path) -> io::Result<()> {
+        use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_REPLACE_EXISTING, MoveFileExW};
+
+        let wide_src = to_wide_path(temp_path)?;
+        let wide_dst = to_wide_path(dest)?;
+
+        // SAFETY: both `wide_src` and `wide_dst` are valid null-terminated
+        // wide strings pointing to filesystem paths. `MOVEFILE_REPLACE_EXISTING`
+        // allows overwriting an existing destination.
+        #[allow(unsafe_code)]
+        let result = unsafe {
+            MoveFileExW(
+                wide_src.as_ptr(),
+                wide_dst.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING,
+            )
+        };
+
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+
+    /// Commits a delete-on-close temp file to its final destination.
+    ///
+    /// This is the full commit sequence:
+    /// 1. Flush the file to disk.
+    /// 2. Clear the delete-on-close disposition so the file survives close.
+    /// 3. Close the file handle (so the rename can proceed without sharing
+    ///    violations on the source).
+    /// 4. Rename the temp file to the destination.
+    ///
+    /// If step 2 or 4 fails, the temp file is still marked delete-on-close
+    /// and will be cleaned up when the process exits or the handle is closed.
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - open handle to the delete-on-close temp file.
+    /// * `temp_path` - on-disk path of the temp file.
+    /// * `dest` - final destination path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing, clearing the disposition, or renaming fails.
+    pub fn commit_delete_on_close(file: File, temp_path: &Path, dest: &Path) -> io::Result<()> {
+        use std::io::Write;
+
+        // Ensure all data is flushed before changing disposition.
+        let mut file = file;
+        file.flush()?;
+        file.sync_all()?;
+
+        // Clear delete-on-close so the file survives handle close.
+        clear_delete_on_close(&file)?;
+
+        // Drop the handle before renaming. Some Windows configurations
+        // (e.g., antivirus holding a read handle) may block rename while
+        // any handle is open with certain sharing modes.
+        drop(file);
+
+        // Rename to the final destination, replacing any existing file.
+        rename_temp_to_dest(temp_path, dest)
+    }
+
+    /// Probes whether delete-on-close temp files work on the filesystem
+    /// containing `dir`.
+    ///
+    /// Creates a probe file with `FILE_FLAG_DELETE_ON_CLOSE`, writes a
+    /// single byte to verify it works, then drops the handle (which
+    /// triggers deletion). The result is cached process-wide.
+    ///
+    /// # Arguments
+    ///
+    /// * `dir` - directory on the target filesystem. Must exist and be
+    ///   writable.
+    #[must_use]
+    pub fn delete_on_close_available(dir: &Path) -> bool {
+        use std::sync::atomic::AtomicU8;
+
+        static STATUS: AtomicU8 = AtomicU8::new(0);
+        const UNKNOWN: u8 = 0;
+        const AVAILABLE: u8 = 1;
+        const UNAVAILABLE: u8 = 2;
+
+        let status = STATUS.load(Ordering::Relaxed);
+        if status != UNKNOWN {
+            return status == AVAILABLE;
+        }
+
+        let available = probe_delete_on_close(dir);
+        STATUS.store(
+            if available { AVAILABLE } else { UNAVAILABLE },
+            Ordering::Relaxed,
+        );
+        available
+    }
+
+    /// Actual probe implementation.
+    fn probe_delete_on_close(dir: &Path) -> bool {
+        match open_delete_on_close_tmpfile(dir) {
+            Ok((file, _path)) => {
+                // Dropping the file triggers deletion via FILE_FLAG_DELETE_ON_CLOSE.
+                drop(file);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Converts a `Path` to a null-terminated UTF-16 wide string for Win32 APIs.
+    fn to_wide_path(path: &Path) -> io::Result<Vec<u16>> {
+        use std::os::windows::ffi::OsStrExt;
+        let wide: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        Ok(wide)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::io::Write;
+        use tempfile::tempdir;
+
+        #[test]
+        fn probe_returns_true_for_valid_directory() {
+            let dir = tempdir().expect("tempdir");
+            assert!(delete_on_close_available(dir.path()));
+        }
+
+        #[test]
+        fn open_creates_file_that_is_writable() {
+            let dir = tempdir().expect("tempdir");
+            let (mut file, path) = open_delete_on_close_tmpfile(dir.path()).expect("open");
+            file.write_all(b"test data").expect("write");
+            assert!(path.exists());
+        }
+
+        #[test]
+        fn file_deleted_on_drop() {
+            let dir = tempdir().expect("tempdir");
+            let (file, path) = open_delete_on_close_tmpfile(dir.path()).expect("open");
+            assert!(path.exists());
+            drop(file);
+            // After dropping, the kernel should have deleted the file.
+            assert!(!path.exists(), "file must be deleted after handle close");
+        }
+
+        #[test]
+        fn clear_disposition_prevents_deletion() {
+            let dir = tempdir().expect("tempdir");
+            let (file, path) = open_delete_on_close_tmpfile(dir.path()).expect("open");
+            clear_delete_on_close(&file).expect("clear disposition");
+            drop(file);
+            // File should survive because we cleared the delete-on-close flag.
+            assert!(path.exists(), "file must survive after clearing disposition");
+            // Clean up.
+            std::fs::remove_file(&path).expect("cleanup");
+        }
+
+        #[test]
+        fn commit_creates_destination_file() {
+            let dir = tempdir().expect("tempdir");
+            let (mut file, temp_path) = open_delete_on_close_tmpfile(dir.path()).expect("open");
+            file.write_all(b"commit test data").expect("write");
+
+            let dest = dir.path().join("committed.txt");
+            commit_delete_on_close(file, &temp_path, &dest).expect("commit");
+
+            assert!(dest.exists());
+            assert!(!temp_path.exists(), "temp file must be gone after rename");
+            let content = std::fs::read_to_string(&dest).expect("read");
+            assert_eq!(content, "commit test data");
+        }
+
+        #[test]
+        fn commit_replaces_existing_destination() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("existing.txt");
+            std::fs::write(&dest, b"old content").expect("create existing");
+
+            let (mut file, temp_path) = open_delete_on_close_tmpfile(dir.path()).expect("open");
+            file.write_all(b"new content").expect("write");
+
+            commit_delete_on_close(file, &temp_path, &dest).expect("commit");
+
+            assert_eq!(
+                std::fs::read_to_string(&dest).expect("read"),
+                "new content"
+            );
+        }
+
+        #[test]
+        fn unique_names_do_not_collide() {
+            let dir = tempdir().expect("tempdir");
+            let (f1, p1) = open_delete_on_close_tmpfile(dir.path()).expect("open 1");
+            let (f2, p2) = open_delete_on_close_tmpfile(dir.path()).expect("open 2");
+            assert_ne!(p1, p2);
+            drop(f1);
+            drop(f2);
+        }
+
+        #[test]
+        fn probe_returns_false_for_nonexistent_dir() {
+            // Reset static cache by using a fresh call path.
+            // Note: the static cache means this may not actually probe if
+            // a previous test already set the status. This is acceptable
+            // because the real test is the open call.
+            let result = open_delete_on_close_tmpfile(Path::new(r"Z:\nonexistent_dir_test"));
+            assert!(result.is_err());
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub use windows::{
+    clear_delete_on_close, commit_delete_on_close, delete_on_close_available,
+    open_delete_on_close_tmpfile, rename_temp_to_dest,
+};
+
+/// Stub: delete-on-close temp files are only available on Windows.
+#[cfg(not(target_os = "windows"))]
+#[must_use]
+pub fn delete_on_close_available(_dir: &std::path::Path) -> bool {
+    false
+}
+
+/// Stub: delete-on-close temp files are only available on Windows.
+#[cfg(not(target_os = "windows"))]
+pub fn open_delete_on_close_tmpfile(
+    _dir: &std::path::Path,
+) -> std::io::Result<(std::fs::File, std::path::PathBuf)> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "FILE_FLAG_DELETE_ON_CLOSE is only supported on Windows",
+    ))
+}
+
+/// Stub: delete-on-close temp files are only available on Windows.
+#[cfg(not(target_os = "windows"))]
+pub fn clear_delete_on_close(_file: &std::fs::File) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "FILE_FLAG_DELETE_ON_CLOSE is only supported on Windows",
+    ))
+}
+
+/// Stub: delete-on-close temp files are only available on Windows.
+#[cfg(not(target_os = "windows"))]
+pub fn rename_temp_to_dest(
+    _temp_path: &std::path::Path,
+    _dest: &std::path::Path,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "FILE_FLAG_DELETE_ON_CLOSE is only supported on Windows",
+    ))
+}
+
+/// Stub: delete-on-close temp files are only available on Windows.
+#[cfg(not(target_os = "windows"))]
+pub fn commit_delete_on_close(
+    _file: std::fs::File,
+    _temp_path: &std::path::Path,
+    _dest: &std::path::Path,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "FILE_FLAG_DELETE_ON_CLOSE is only supported on Windows",
+    ))
+}

--- a/crates/fast_io/src/win_tmpfile/mod.rs
+++ b/crates/fast_io/src/win_tmpfile/mod.rs
@@ -1,0 +1,35 @@
+//! Delete-on-close temporary file creation for Windows.
+//!
+//! This module provides both low-level Win32 wrappers ([`open_delete_on_close_tmpfile`],
+//! [`clear_delete_on_close`], [`commit_delete_on_close`]) and a higher-level
+//! [`WindowsTempFile`] guard type that owns the delete-on-close handle and
+//! exposes a safe `commit_to` finalization method.
+//!
+//! The [`open_win_temp_file`] convenience function probes the filesystem once
+//! and returns either a [`WinTempFileResult::DeleteOnClose`] or
+//! [`WinTempFileResult::Unavailable`], letting callers fall back to named temp
+//! files without error handling.
+//!
+//! # Comparison with `O_TMPFILE`
+//!
+//! | Property | Linux `O_TMPFILE` | Windows `FILE_FLAG_DELETE_ON_CLOSE` |
+//! |---|---|---|
+//! | Directory entry | None until `linkat` | Visible with unique name |
+//! | Crash cleanup | Kernel reclaims inode | Kernel deletes file on close |
+//! | Commit mechanism | `linkat(2)` | Clear disposition + `MoveFileExW` |
+//! | Filesystem support | ext4, xfs, btrfs, tmpfs | NTFS, ReFS, FAT32 |
+//!
+//! Both provide the same semantic guarantee: if the process crashes before
+//! commit, no orphaned partial file remains at the destination.
+
+mod low_level;
+mod types;
+
+pub use low_level::{
+    clear_delete_on_close, commit_delete_on_close, delete_on_close_available,
+    open_delete_on_close_tmpfile, rename_temp_to_dest,
+};
+pub use types::{
+    WinDeleteOnCloseSupport, WinTempFileResult, WindowsTempFile, open_win_temp_file,
+    win_tmpfile_probe,
+};

--- a/crates/fast_io/src/win_tmpfile/types.rs
+++ b/crates/fast_io/src/win_tmpfile/types.rs
@@ -1,0 +1,276 @@
+//! Higher-level wrappers around the low-level delete-on-close syscalls.
+//!
+//! [`WindowsTempFile`] owns a delete-on-close file handle and provides a
+//! safe `commit_to` method for atomic materialization. [`open_win_temp_file`]
+//! is the recommended entry point - it probes once and returns a
+//! [`WinTempFileResult`] that callers can match on without error handling.
+
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::low_level;
+
+/// Result of probing `FILE_FLAG_DELETE_ON_CLOSE` support on a filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WinDeleteOnCloseSupport {
+    /// Delete-on-close temp files are supported.
+    Available,
+    /// Delete-on-close is not supported (non-Windows or unsupported fs).
+    Unavailable,
+}
+
+/// Probes whether delete-on-close temp files are available in `dir`.
+///
+/// This is a thin wrapper around [`low_level::delete_on_close_available`]
+/// that returns a typed enum instead of a boolean.
+#[must_use]
+pub fn win_tmpfile_probe(dir: &Path) -> WinDeleteOnCloseSupport {
+    if low_level::delete_on_close_available(dir) {
+        WinDeleteOnCloseSupport::Available
+    } else {
+        WinDeleteOnCloseSupport::Unavailable
+    }
+}
+
+/// A temporary file opened with `FILE_FLAG_DELETE_ON_CLOSE`.
+///
+/// The file is automatically deleted when dropped unless
+/// [`commit_to`](Self::commit_to) is called first, which clears the
+/// delete-on-close flag and renames the file to the destination.
+///
+/// # Platform support
+///
+/// Windows Vista+ with any NTFS, ReFS, or FAT32 filesystem.
+/// On all other platforms, [`open`](Self::open) returns
+/// `io::ErrorKind::Unsupported`.
+pub struct WindowsTempFile {
+    file: File,
+    temp_path: PathBuf,
+}
+
+impl WindowsTempFile {
+    /// Opens a delete-on-close temporary file in `dir`.
+    ///
+    /// The file is created with a unique name and `FILE_FLAG_DELETE_ON_CLOSE`.
+    /// Write data to it via [`file_mut`](Self::file_mut), then call
+    /// [`commit_to`](Self::commit_to) to atomically materialize it at the
+    /// destination path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory does not exist, is not writable,
+    /// or if temp file creation fails.
+    pub fn open(dir: &Path) -> io::Result<Self> {
+        let (file, temp_path) = low_level::open_delete_on_close_tmpfile(dir)?;
+        Ok(Self { file, temp_path })
+    }
+
+    /// Returns a mutable reference to the underlying file for writing.
+    pub fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    /// Returns the on-disk path of the temporary file.
+    ///
+    /// Unlike `O_TMPFILE` anonymous inodes, delete-on-close files have a
+    /// visible directory entry. This path is useful for diagnostics.
+    #[must_use]
+    pub fn temp_path(&self) -> &Path {
+        &self.temp_path
+    }
+
+    /// Consumes the guard and returns the underlying [`File`] and path.
+    ///
+    /// After calling this, the caller owns the raw handle. If the file is
+    /// dropped without clearing the delete-on-close disposition, the kernel
+    /// will delete it.
+    pub fn into_parts(self) -> (File, PathBuf) {
+        (self.file, self.temp_path)
+    }
+
+    /// Atomically materializes the temp file at `dest`.
+    ///
+    /// This method:
+    /// 1. Flushes and syncs the file to disk.
+    /// 2. Clears the `FILE_FLAG_DELETE_ON_CLOSE` disposition.
+    /// 3. Closes the handle.
+    /// 4. Renames the temp file to `dest`, replacing any existing file.
+    ///
+    /// If any step fails, the temp file retains its delete-on-close flag
+    /// and will be cleaned up when the handle is closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing, clearing the disposition, or renaming
+    /// fails.
+    pub fn commit_to(self, dest: &Path) -> io::Result<()> {
+        let temp_path = self.temp_path.clone();
+        low_level::commit_delete_on_close(self.file, &temp_path, dest)
+    }
+}
+
+/// Result of attempting to open a delete-on-close or named temporary file.
+///
+/// Use [`open_win_temp_file`] to obtain this. Match on the variant to
+/// determine whether the delete-on-close path is available or the caller
+/// should fall back to a named temp file.
+pub enum WinTempFileResult {
+    /// A delete-on-close file was opened successfully.
+    DeleteOnClose(WindowsTempFile),
+    /// Delete-on-close is not available; caller should use a named temp file.
+    Unavailable,
+}
+
+/// Attempts to open a delete-on-close temp file, returning
+/// [`WinTempFileResult::Unavailable`] if not supported.
+///
+/// This is the recommended entry point for the write strategy on Windows:
+/// probe once, then branch on the result without error handling.
+pub fn open_win_temp_file(dir: &Path) -> WinTempFileResult {
+    match WindowsTempFile::open(dir) {
+        Ok(wtf) => WinTempFileResult::DeleteOnClose(wtf),
+        Err(_) => WinTempFileResult::Unavailable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn probe_returns_valid_enum() {
+        let dir = tempdir().expect("tempdir");
+        let result = win_tmpfile_probe(dir.path());
+        assert!(
+            result == WinDeleteOnCloseSupport::Available
+                || result == WinDeleteOnCloseSupport::Unavailable
+        );
+    }
+
+    #[test]
+    fn probe_nonexistent_dir_is_unavailable() {
+        let result = win_tmpfile_probe(Path::new(
+            "/nonexistent_win_tmpfile_test_path_that_does_not_exist",
+        ));
+        assert_eq!(result, WinDeleteOnCloseSupport::Unavailable);
+    }
+
+    #[test]
+    fn open_win_temp_file_returns_result() {
+        let dir = tempdir().expect("tempdir");
+        let result = open_win_temp_file(dir.path());
+        match result {
+            WinTempFileResult::DeleteOnClose(_) => {}
+            WinTempFileResult::Unavailable => {}
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    mod windows {
+        use super::*;
+        use std::io::Write;
+
+        #[test]
+        fn temp_file_write_and_commit() {
+            let dir = tempdir().expect("tempdir");
+            let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+
+            wtf.file_mut().write_all(b"test data").expect("write");
+            let dest = dir.path().join("committed.txt");
+            wtf.commit_to(&dest).expect("commit");
+
+            let content = std::fs::read_to_string(&dest).expect("read");
+            assert_eq!(content, "test data");
+        }
+
+        #[test]
+        fn temp_file_drop_deletes_file() {
+            let dir = tempdir().expect("tempdir");
+            let wtf = WindowsTempFile::open(dir.path()).expect("open");
+            let path = wtf.temp_path().to_path_buf();
+            assert!(path.exists());
+            drop(wtf);
+            assert!(!path.exists(), "file must be deleted on drop");
+        }
+
+        #[test]
+        fn temp_file_into_parts() {
+            let dir = tempdir().expect("tempdir");
+            let wtf = WindowsTempFile::open(dir.path()).expect("open");
+            let (file, path) = wtf.into_parts();
+            assert!(path.exists());
+            drop(file);
+            assert!(!path.exists(), "file must be deleted when parts are dropped");
+        }
+
+        #[test]
+        fn temp_file_visible_in_directory() {
+            let dir = tempdir().expect("tempdir");
+            let wtf = WindowsTempFile::open(dir.path()).expect("open");
+            // Unlike O_TMPFILE, delete-on-close files have a directory entry.
+            let count = std::fs::read_dir(dir.path())
+                .expect("read_dir")
+                .count();
+            assert!(count >= 1, "temp file must be visible in directory");
+            drop(wtf);
+        }
+
+        #[test]
+        fn commit_replaces_existing_file() {
+            let dir = tempdir().expect("tempdir");
+            let dest = dir.path().join("existing.txt");
+            std::fs::write(&dest, b"old content").expect("create existing");
+
+            let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+            wtf.file_mut().write_all(b"new content").expect("write");
+            wtf.commit_to(&dest).expect("commit");
+
+            assert_eq!(
+                std::fs::read_to_string(&dest).expect("read"),
+                "new content"
+            );
+        }
+
+        #[test]
+        fn large_write_integrity() {
+            let dir = tempdir().expect("tempdir");
+            let size = 2 * 1024 * 1024;
+            let pattern: Vec<u8> = (0..=255u8).cycle().take(size).collect();
+
+            let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+            wtf.file_mut().write_all(&pattern).expect("write");
+
+            let dest = dir.path().join("large.bin");
+            wtf.commit_to(&dest).expect("commit");
+
+            let data = std::fs::read(&dest).expect("read");
+            assert_eq!(data.len(), size);
+            assert_eq!(data, pattern);
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    mod non_windows {
+        use super::*;
+
+        #[test]
+        fn open_returns_unsupported() {
+            let dir = tempdir().expect("tempdir");
+            match WindowsTempFile::open(dir.path()) {
+                Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::Unsupported),
+                Ok(_) => panic!("should fail on non-Windows"),
+            }
+        }
+
+        #[test]
+        fn open_win_temp_file_returns_unavailable() {
+            let dir = tempdir().expect("tempdir");
+            assert!(matches!(
+                open_win_temp_file(dir.path()),
+                WinTempFileResult::Unavailable
+            ));
+        }
+    }
+}

--- a/crates/fast_io/src/win_tmpfile/types.rs
+++ b/crates/fast_io/src/win_tmpfile/types.rs
@@ -202,7 +202,10 @@ mod tests {
             let (file, path) = wtf.into_parts();
             assert!(path.exists());
             drop(file);
-            assert!(!path.exists(), "file must be deleted when parts are dropped");
+            assert!(
+                !path.exists(),
+                "file must be deleted when parts are dropped"
+            );
         }
 
         #[test]
@@ -210,9 +213,7 @@ mod tests {
             let dir = tempdir().expect("tempdir");
             let wtf = WindowsTempFile::open(dir.path()).expect("open");
             // Unlike O_TMPFILE, delete-on-close files have a directory entry.
-            let count = std::fs::read_dir(dir.path())
-                .expect("read_dir")
-                .count();
+            let count = std::fs::read_dir(dir.path()).expect("read_dir").count();
             assert!(count >= 1, "temp file must be visible in directory");
             drop(wtf);
         }
@@ -227,10 +228,7 @@ mod tests {
             wtf.file_mut().write_all(b"new content").expect("write");
             wtf.commit_to(&dest).expect("commit");
 
-            assert_eq!(
-                std::fs::read_to_string(&dest).expect("read"),
-                "new content"
-            );
+            assert_eq!(std::fs::read_to_string(&dest).expect("read"), "new content");
         }
 
         #[test]

--- a/crates/fast_io/tests/win_tmpfile_delete_on_close.rs
+++ b/crates/fast_io/tests/win_tmpfile_delete_on_close.rs
@@ -28,9 +28,7 @@ fn probe_returns_valid_result_for_tempdir() {
 
 #[test]
 fn probe_returns_unavailable_for_missing_directory() {
-    let result = win_tmpfile_probe(Path::new(
-        "/no_such_directory_for_win_tmpfile_test_9999",
-    ));
+    let result = win_tmpfile_probe(Path::new("/no_such_directory_for_win_tmpfile_test_9999"));
     assert_eq!(result, WinDeleteOnCloseSupport::Unavailable);
 }
 
@@ -137,10 +135,7 @@ mod windows {
         wtf.file_mut().write_all(b"new content").expect("write");
         wtf.commit_to(&dest).expect("commit");
 
-        assert_eq!(
-            fs::read_to_string(&dest).expect("read"),
-            "new content"
-        );
+        assert_eq!(fs::read_to_string(&dest).expect("read"), "new content");
     }
 
     #[test]
@@ -170,7 +165,9 @@ mod windows {
 
     #[test]
     fn temp_file_strategy_create_and_commit() {
-        use fast_io::temp_file_strategy::{TempFileKind, TempFileStrategy, WindowsTempFileStrategy};
+        use fast_io::temp_file_strategy::{
+            TempFileKind, TempFileStrategy, WindowsTempFileStrategy,
+        };
 
         let dir = tempdir().expect("tempdir");
         let dest = dir.path().join("strategy.txt");
@@ -187,7 +184,9 @@ mod windows {
 
     #[test]
     fn temp_file_strategy_discard_auto_cleans() {
-        use fast_io::temp_file_strategy::{TempFileKind, TempFileStrategy, WindowsTempFileStrategy};
+        use fast_io::temp_file_strategy::{
+            TempFileKind, TempFileStrategy, WindowsTempFileStrategy,
+        };
 
         let dir = tempdir().expect("tempdir");
         let dest = dir.path().join("strategy_discard.txt");

--- a/crates/fast_io/tests/win_tmpfile_delete_on_close.rs
+++ b/crates/fast_io/tests/win_tmpfile_delete_on_close.rs
@@ -1,0 +1,261 @@
+//! Integration tests for the Windows `FILE_FLAG_DELETE_ON_CLOSE` temp file path.
+//!
+//! These tests verify that the delete-on-close temp file strategy works
+//! correctly as an alternative to named temp files for auto-cleanup writes.
+//! On non-Windows platforms, the tests verify graceful fallback.
+
+use std::path::Path;
+
+use fast_io::win_tmpfile::{
+    WinDeleteOnCloseSupport, WinTempFileResult, WindowsTempFile, open_win_temp_file,
+    win_tmpfile_probe,
+};
+use tempfile::tempdir;
+
+// ---------------------------------------------------------------------------
+// Cross-platform probe tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn probe_returns_valid_result_for_tempdir() {
+    let dir = tempdir().expect("tempdir");
+    let result = win_tmpfile_probe(dir.path());
+    assert!(
+        result == WinDeleteOnCloseSupport::Available
+            || result == WinDeleteOnCloseSupport::Unavailable
+    );
+}
+
+#[test]
+fn probe_returns_unavailable_for_missing_directory() {
+    let result = win_tmpfile_probe(Path::new(
+        "/no_such_directory_for_win_tmpfile_test_9999",
+    ));
+    assert_eq!(result, WinDeleteOnCloseSupport::Unavailable);
+}
+
+#[test]
+fn open_win_temp_file_returns_result_for_tempdir() {
+    let dir = tempdir().expect("tempdir");
+    let result = open_win_temp_file(dir.path());
+    match result {
+        WinTempFileResult::DeleteOnClose(wtf) => {
+            // Delete-on-close files are visible (unlike O_TMPFILE).
+            let count = std::fs::read_dir(dir.path()).expect("read_dir").count();
+            assert!(count >= 1, "delete-on-close file should be visible");
+            drop(wtf);
+        }
+        WinTempFileResult::Unavailable => {
+            // Expected on non-Windows.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Windows-specific tests
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    #[test]
+    fn temp_file_deleted_on_drop() {
+        let dir = tempdir().expect("tempdir");
+        let wtf = WindowsTempFile::open(dir.path()).expect("open");
+        let path = wtf.temp_path().to_path_buf();
+        assert!(path.exists());
+        drop(wtf);
+        assert!(
+            !path.exists(),
+            "temp file must be deleted when handle is dropped"
+        );
+    }
+
+    #[test]
+    fn temp_file_write_and_commit() {
+        let dir = tempdir().expect("tempdir");
+        let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+
+        let content = b"hello from FILE_FLAG_DELETE_ON_CLOSE";
+        wtf.file_mut().write_all(content).expect("write");
+
+        let dest = dir.path().join("committed.txt");
+        wtf.commit_to(&dest).expect("commit");
+
+        assert!(dest.exists());
+        assert_eq!(fs::read(&dest).expect("read"), content);
+    }
+
+    #[test]
+    fn large_write_integrity() {
+        let dir = tempdir().expect("tempdir");
+
+        // 2 MB of patterned data.
+        let size = 2 * 1024 * 1024;
+        let pattern: Vec<u8> = (0..=255u8).cycle().take(size).collect();
+
+        let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+        wtf.file_mut().write_all(&pattern).expect("write");
+
+        let dest = dir.path().join("large.bin");
+        wtf.commit_to(&dest).expect("commit");
+
+        let data = fs::read(&dest).expect("read");
+        assert_eq!(data.len(), size);
+        assert_eq!(data, pattern);
+    }
+
+    #[test]
+    fn drop_without_commit_leaves_no_orphan() {
+        let dir = tempdir().expect("tempdir");
+
+        let path;
+        {
+            let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+            wtf.file_mut()
+                .write_all(b"will be orphaned")
+                .expect("write");
+            path = wtf.temp_path().to_path_buf();
+        }
+
+        assert!(
+            !path.exists(),
+            "no orphaned files after drop without commit"
+        );
+    }
+
+    #[test]
+    fn commit_replaces_existing_file() {
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("existing.txt");
+        fs::write(&dest, b"old content").expect("create existing");
+
+        let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+        wtf.file_mut().write_all(b"new content").expect("write");
+        wtf.commit_to(&dest).expect("commit");
+
+        assert_eq!(
+            fs::read_to_string(&dest).expect("read"),
+            "new content"
+        );
+    }
+
+    #[test]
+    fn multiple_temp_files_in_same_directory() {
+        let dir = tempdir().expect("tempdir");
+
+        let mut files = Vec::new();
+        for i in 0..5 {
+            let mut wtf = WindowsTempFile::open(dir.path()).expect("open");
+            wtf.file_mut()
+                .write_all(format!("file_{i}").as_bytes())
+                .expect("write");
+            files.push(wtf);
+        }
+
+        for (i, wtf) in files.into_iter().enumerate() {
+            let dest = dir.path().join(format!("file_{i}.txt"));
+            wtf.commit_to(&dest).expect("commit");
+        }
+
+        for i in 0..5 {
+            let dest = dir.path().join(format!("file_{i}.txt"));
+            let content = fs::read_to_string(&dest).expect("read");
+            assert_eq!(content, format!("file_{i}"));
+        }
+    }
+
+    #[test]
+    fn temp_file_strategy_create_and_commit() {
+        use fast_io::temp_file_strategy::{TempFileKind, TempFileStrategy, WindowsTempFileStrategy};
+
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("strategy.txt");
+        let strategy = WindowsTempFileStrategy;
+
+        let mut handle = strategy.create(&dest).expect("create");
+        assert!(matches!(handle.kind, TempFileKind::DeleteOnClose { .. }));
+        handle.file.write_all(b"strategy data").expect("write");
+        strategy.commit(handle, &dest).expect("commit");
+
+        assert!(dest.exists());
+        assert_eq!(fs::read_to_string(&dest).expect("read"), "strategy data");
+    }
+
+    #[test]
+    fn temp_file_strategy_discard_auto_cleans() {
+        use fast_io::temp_file_strategy::{TempFileKind, TempFileStrategy, WindowsTempFileStrategy};
+
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("strategy_discard.txt");
+        let strategy = WindowsTempFileStrategy;
+
+        let handle = strategy.create(&dest).expect("create");
+        let temp_path = match &handle.kind {
+            TempFileKind::DeleteOnClose { temp_path } => temp_path.clone(),
+            _ => panic!("expected delete-on-close"),
+        };
+
+        assert!(temp_path.exists());
+        strategy.discard(handle);
+        assert!(!temp_path.exists());
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn default_strategy_uses_delete_on_close() {
+        use fast_io::temp_file_strategy::{
+            DefaultTempFileStrategy, TempFileKind, TempFileStrategy,
+        };
+
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("default.txt");
+        let strategy = DefaultTempFileStrategy::default();
+
+        let handle = strategy.create(&dest).expect("create");
+        assert!(
+            matches!(handle.kind, TempFileKind::DeleteOnClose { .. }),
+            "DefaultTempFileStrategy should prefer delete-on-close on Windows"
+        );
+        strategy.discard(handle);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-Windows fallback tests
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_os = "windows"))]
+mod non_windows {
+    use super::*;
+
+    #[test]
+    fn probe_always_unavailable() {
+        let dir = tempdir().expect("tempdir");
+        assert_eq!(
+            win_tmpfile_probe(dir.path()),
+            WinDeleteOnCloseSupport::Unavailable
+        );
+    }
+
+    #[test]
+    fn open_returns_unsupported() {
+        let dir = tempdir().expect("tempdir");
+        match WindowsTempFile::open(dir.path()) {
+            Err(err) => assert_eq!(err.kind(), std::io::ErrorKind::Unsupported),
+            Ok(_) => panic!("should fail on non-Windows"),
+        }
+    }
+
+    #[test]
+    fn open_win_temp_file_returns_unavailable() {
+        let dir = tempdir().expect("tempdir");
+        assert!(matches!(
+            open_win_temp_file(dir.path()),
+            WinTempFileResult::Unavailable
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `win_tmpfile` module to `fast_io` crate providing Windows-native crash-safe temp file creation via `FILE_FLAG_DELETE_ON_CLOSE`, analogous to Linux `O_TMPFILE`
- Implement `WindowsTempFileStrategy` integrating into the existing `TempFileStrategy` pattern alongside `AnonymousTempFileStrategy` (Linux) and `NamedTempFileStrategy` (all platforms)
- Update `DefaultTempFileStrategy` to auto-select delete-on-close on Windows, falling back to named temp files if unavailable

## Motivation

On Linux, `O_TMPFILE` creates an anonymous inode that the kernel reclaims automatically on crash - no orphaned temp files. Windows has no exact equivalent, but `FILE_FLAG_DELETE_ON_CLOSE` provides the same crash-safety guarantee: the kernel deletes the file when the last handle closes. The commit path clears the delete-on-close disposition via `SetFileInformationByHandle(FileDispositionInfo)` before renaming to the final destination.

## Design

| Property | Linux `O_TMPFILE` | Windows `FILE_FLAG_DELETE_ON_CLOSE` |
|---|---|---|
| Directory entry | None until `linkat` | Visible with unique name |
| Crash cleanup | Kernel reclaims inode | Kernel deletes file on close |
| Commit mechanism | `linkat(2)` | Clear disposition + `MoveFileExW` |
| Filesystem support | ext4, xfs, btrfs, tmpfs | NTFS, ReFS, FAT32 |

### New files

- `crates/fast_io/src/win_tmpfile/mod.rs` - module root with re-exports
- `crates/fast_io/src/win_tmpfile/low_level.rs` - Win32 FFI wrappers (`CreateFileW`, `SetFileInformationByHandle`, `MoveFileExW`) with non-Windows stubs
- `crates/fast_io/src/win_tmpfile/types.rs` - `WindowsTempFile` guard type with `commit_to` method
- `crates/fast_io/tests/win_tmpfile_delete_on_close.rs` - integration tests (Windows-specific + cross-platform fallback)

### Modified files

- `crates/fast_io/src/temp_file_strategy.rs` - add `TempFileKind::DeleteOnClose` variant, `WindowsTempFileStrategy`, update `DefaultTempFileStrategy`
- `crates/fast_io/src/lib.rs` - expose `win_tmpfile` module and `WindowsTempFileStrategy`
- `crates/fast_io/src/status.rs` - report `FILE_FLAG_DELETE_ON_CLOSE` in Windows I/O capabilities

## Test plan

- [ ] Non-Windows stubs compile and return `Unsupported` (validated by non-Windows CI jobs)
- [ ] Windows CI job validates `CreateFileW` + `FILE_FLAG_DELETE_ON_CLOSE` create/write/commit roundtrip
- [ ] Windows CI validates auto-deletion on drop without commit
- [ ] Windows CI validates `DefaultTempFileStrategy` prefers delete-on-close
- [ ] `TempFileKind` match exhaustiveness verified on all three platforms (Linux/macOS/Windows)
- [ ] Existing `O_TMPFILE` and named temp file paths unaffected (no functional changes to those code paths)