### PR TITLE
fix: handle ERROR_HANDLE_EOF in Windows copy_basis_range

### DIFF
--- a/crates/fast_io/src/copy_basis_range.rs
+++ b/crates/fast_io/src/copy_basis_range.rs
@@ -317,6 +317,10 @@ mod imp {
 
             if read_ok == 0 {
                 let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(38) {
+                    // ERROR_HANDLE_EOF: normal end-of-file on basis.
+                    break;
+                }
                 if total == 0 {
                     return Ok(0);
                 }


### PR DESCRIPTION
## Summary
- Fix panic in `windows_short_copy_when_basis_eof` test on Windows IOCP CI
- `ReadFile` with `OVERLAPPED` returns FALSE with OS error 38 (`ERROR_HANDLE_EOF`) when reading at/past EOF, unlike Linux `copy_file_range` which returns 0
- Now treats error 38 as normal EOF (breaks the loop, returns bytes copied so far) matching the Linux behavior

## Test plan
- [ ] Windows IOCP CI cell passes (`windows_short_copy_when_basis_eof` no longer panics)
- [ ] Existing Linux copy_basis_range tests unaffected (no change to Linux path)