### PR TITLE
fix: resolve INC_RECURSE empty-dir 3-way deadlock on push

### DIFF
--- a/crates/fast_io/src/copy_basis_range.rs
+++ b/crates/fast_io/src/copy_basis_range.rs
@@ -317,6 +317,10 @@ mod imp {
 
             if read_ok == 0 {
                 let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(38) {
+                    // ERROR_HANDLE_EOF: normal end-of-file on basis.
+                    break;
+                }
                 if total == 0 {
                     return Ok(0);
                 }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -172,6 +172,41 @@ impl GeneratorContext {
                                 }
                                 return Err(e);
                             }
+
+                            // upstream: sender.c:242-250 - when flist_free() frees
+                            // the last flist (first_flist becomes NULL), the sender
+                            // falls through to the phase transition immediately.
+                            // Without this, empty-dir pushes deadlock: the generator
+                            // frees all flists except the last (cur_flist ==
+                            // first_flist break), blocks waiting for receiver, which
+                            // blocks waiting for our phase-transition NDX_DONE.
+                            // Proactively transition when all flists are freed and
+                            // no more sub-lists are pending.
+                            if flist_done_remaining == 0
+                                && self.incremental.flist_eof_sent
+                            {
+                                debug_log!(
+                                    Send,
+                                    1,
+                                    "all flists freed with eof sent, \
+                                     proactive phase transition"
+                                );
+                                phase += 1;
+                                if phase > max_phase {
+                                    break;
+                                }
+                                debug_log!(Send, 1, "send_files phase={}", phase);
+                                if let Err(e) = ndx_write_codec
+                                    .write_ndx_done(&mut *writer)
+                                    .and_then(|()| flush_with_count(&mut *writer))
+                                {
+                                    if tolerant && is_early_close_error(&e) {
+                                        break;
+                                    }
+                                    return Err(e);
+                                }
+                            }
+
                             continue;
                         }
 

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -182,9 +182,7 @@ impl GeneratorContext {
                             // blocks waiting for our phase-transition NDX_DONE.
                             // Proactively transition when all flists are freed and
                             // no more sub-lists are pending.
-                            if flist_done_remaining == 0
-                                && self.incremental.flist_eof_sent
-                            {
+                            if flist_done_remaining == 0 && self.incremental.flist_eof_sent {
                                 debug_log!(
                                     Send,
                                     1,


### PR DESCRIPTION
## Summary

- Fixes a protocol deadlock when oc-rsync pushes a directory tree containing only empty subdirectories to an upstream rsync daemon with INC_RECURSE enabled
- The upstream generator frees all sub-list flists immediately (empty dirs have in_progress == 0) but cannot free the last one, creating a 3-way deadlock between generator, receiver, and sender
- Mirrors upstream sender.c:242-250 behavior: proactively send phase-transition NDX_DONE when all flist-free echoes are sent and all sub-lists dispatched

## Test plan

- [ ] Verify `standalone:empty-dir` interop test passes (direction 2: oc-rsync client to upstream daemon)
- [ ] Verify existing INC_RECURSE push tests still pass (non-empty dir trees)
- [ ] Verify non-INC_RECURSE transfers unaffected