### PR TITLE
docs: add per-crate README files for high-priority crates

### DIFF
--- a/crates/daemon/README.md
+++ b/crates/daemon/README.md
@@ -1,0 +1,42 @@
+# daemon
+
+Rsync daemon mode (`--daemon`) - TCP listener, protocol negotiation, and
+module-based file serving.
+
+## Purpose
+
+`daemon` implements the rsync daemon process model: binding a TCP listener,
+performing `@RSYNCD:` greeting negotiation (protocol 32), authenticating clients
+via challenge/response, and executing transfers natively using the Rust transfer
+engine. It handles per-module access control, chroot, uid/gid mapping, and
+configuration via `oc-rsyncd.conf`.
+
+## Key Public Types
+
+- `run` / `run_daemon` - top-level entry points mirroring upstream `rsyncd`
+- `DaemonConfig` / `DaemonConfigBuilder` - fluent configuration assembly
+- `RsyncdConfig` - parsed `oc-rsyncd.conf` representation
+- `ModuleConfig` - per-module settings (path, auth, read-only, filters)
+- Authentication - SHA-512/256/SHA-1/MD5/MD4 challenge/response
+
+## Dependencies (upstream)
+
+`core`, `protocol`, `metadata`, `compress`, `checksums`, `fast_io`, `platform`,
+`logging-sink`
+
+## Dependents (downstream)
+
+`cli` (daemon subcommand), `embedding`
+
+## Features
+
+- `daemon-tls` - native TLS termination via rustls (alternative to stunnel)
+- `sd-notify` - systemd readiness notification (Linux)
+- `async-daemon` - tokio accept loop with sync worker dispatch
+- `concurrent-sessions` - DashMap-backed session tracking
+- `landlock` - Landlock LSM defense-in-depth (Linux 5.13+)
+
+## Platform Notes
+
+- Linux: Landlock sandboxing, systemd integration, io_uring via `fast_io`
+- Windows: Win32 service primitives via `windows` crate

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -1,0 +1,37 @@
+# engine
+
+Transfer engine - delta pipeline, local-copy executor, and sparse I/O.
+
+## Purpose
+
+`engine` implements the core transfer primitives sitting between the high-level
+`core` orchestration facade and low-level protocol/checksum/metadata crates. Both
+the CLI local-copy path and remote sender/receiver/generator roles in `transfer`
+drive file operations through this crate.
+
+## Key Public Types
+
+- `DeltaGenerator` - produces `DeltaToken` streams (LITERAL/COPY) via rolling checksum matching
+- `DeltaSignatureIndex` - block-signature index for delta matching
+- `apply_delta` / `generate_delta` / `generate_file_signature` - end-to-end delta helpers
+- `SignatureLayout` / `calculate_signature_layout` - upstream-compatible block-size heuristics
+- `LocalCopyPlan` - recursive wire-compatible local transfer executor
+- `SparseWriter` / `SparseReader` / `SparseDetector` - sparse file I/O with zero-run detection
+- `BufferPool` / `PooledBuffer` - RAII buffer reuse to eliminate per-file heap churn
+- `FuzzyMatcher` - basis-file similarity scoring for `--fuzzy`
+- `DeleteTiming` - controls before/after deletion passes
+
+## Dependencies (upstream)
+
+`protocol`, `checksums`, `metadata`, `filters`, `compress`, `bandwidth`,
+`logging`, `signature`, `matching`, `batch`, `fast_io`
+
+## Dependents (downstream)
+
+`transfer`, `core`, `cli`
+
+## Platform Notes
+
+- macOS: depends on `apple-fs` for clonefile support
+- Linux: uses `libc` for `O_NOATIME`, `posix_fadvise`, `syncfs`
+- Windows: uses `windows-sys` for `Win32_Storage_FileSystem`

--- a/crates/fast_io/README.md
+++ b/crates/fast_io/README.md
@@ -1,0 +1,50 @@
+# fast_io
+
+High-performance I/O abstractions with platform-specific optimizations and
+safe fallback paths.
+
+## Purpose
+
+`fast_io` is the designated encapsulation layer for unsafe I/O optimizations.
+Consumer crates (`engine`, `transfer`, `core`) depend on it through safe public
+APIs only. Every unsafe optimization has a safe fallback so callers work on all
+platforms and filesystem types (NFS, FUSE, etc.).
+
+## Key Public Types and Modules
+
+- `io_uring` - Linux 5.6+ batched syscalls (statx, rename, linkat, read, write)
+- `iocp` - Windows I/O Completion Ports for overlapped async file I/O
+- `platform_copy` - trait abstracting FICLONE/copy_file_range/clonefile/CopyFileExW
+- `copy_file_range` - zero-copy file-to-file on Linux 4.5+
+- `sendfile` - zero-copy file-to-socket
+- `splice` / `vmsplice_writer` - zero-copy socket-to-file (Linux)
+- `mmap_reader` - memory-mapped basis-file access
+- `syscall_batch` - batched metadata ops with runtime threshold tuning
+- `DirSandbox` - path-traversal-safe directory operations
+- `landlock` - Landlock LSM allowlist (Linux 5.13+)
+- `kqueue` - macOS readiness-driven event loop
+- `adaptive_dispatch` - runtime I/O backend selection with throughput feedback
+- `zero_detect` - 16-byte u128 zero-run detection for sparse writes
+
+## Dependencies (upstream)
+
+`logging` (only workspace crate dependency)
+
+## Dependents (downstream)
+
+`engine`, `transfer`, `daemon`, `core`, `cli`
+
+## I/O Fallback Chain
+
+1. FICLONE - instant CoW reflink (Linux Btrfs/XFS/bcachefs)
+2. io_uring - batched syscalls (Linux 5.6+)
+3. copy_file_range - in-kernel copy (Linux 4.5+)
+4. sendfile - file-to-socket zero-copy
+5. Standard read/write - universal fallback
+
+## Platform Notes
+
+- **Linux**: io_uring (5.6+), SQPOLL (5.13+), copy_file_range, splice,
+  vmsplice, sendfile, Landlock LSM, FICLONE
+- **macOS**: clonefile, fcopyfile, F_NOCACHE, writev, kqueue
+- **Windows**: CopyFileExW, IOCP, ReFS reflink, TransmitFile

--- a/crates/filters/README.md
+++ b/crates/filters/README.md
@@ -1,0 +1,36 @@
+# filters
+
+Ordered include/exclude/protect pattern evaluation implementing the Chain of
+Responsibility pattern.
+
+## Purpose
+
+`filters` reproduces rsync's filter grammar governing `--include`/`--exclude`/
+`--filter` handling. Rules are evaluated sequentially with first-match-wins
+semantics, matching upstream `check_filter()` in `exclude.c`. Two independent
+chains are maintained: one for transfer decisions (include/exclude) and one for
+deletion protection (protect/risk).
+
+## Key Public Types
+
+- `FilterRule` - parsed rule with action (Include/Exclude/Protect/Risk/Clear/Merge/DirMerge)
+- `FilterSet` - compiled rule collection with glob matchers and deduplication
+- `FilterChain` - ordered evaluation chain (first match wins)
+- `FilterAction` - Include, Exclude, or no-match result
+- `EntryFilter` - high-level filter applied to file entries during transfer
+
+## Dependencies (upstream)
+
+`logging`, `globset`, optionally `protocol` (for flat-flist support)
+
+## Dependents (downstream)
+
+`engine`, `transfer`, `core`, `cli`, `batch`
+
+## Design Notes
+
+- Patterns honour anchored matches (leading `/`), directory-only rules
+  (trailing `/`), and recursive wildcards (`**`)
+- Protect directives prevent matched paths from deletion during `--delete`
+- Merge/DirMerge rules load per-directory `.rsync-filter` files
+- Property tests validate correctness against edge cases

--- a/crates/metadata/README.md
+++ b/crates/metadata/README.md
@@ -1,0 +1,44 @@
+# metadata
+
+Metadata preservation helpers - permissions, timestamps, ownership, ACLs,
+xattrs, and special file creation.
+
+## Purpose
+
+`metadata` centralises filesystem metadata operations for the workspace,
+reproducing upstream rsync semantics for permission bits, nanosecond timestamps,
+uid/gid ownership, ACLs, extended attributes, and special file nodes (FIFOs,
+devices, symlinks). Higher layers wire these helpers into transfer pipelines so
+metadata handling remains consistent across client and daemon roles.
+
+## Key Public Types
+
+- `apply_file_metadata` - set permissions and timestamps on regular files
+- `apply_directory_metadata` - mirror metadata for directories
+- `apply_symlink_metadata` - timestamps on symlinks without following the target
+- `create_fifo` / `create_device_node` - materialise special files
+- `MetadataError` - context-rich error with path, operation, and underlying I/O error
+- `IdLookup` - uid/gid name resolution (getpwnam_r/getgrnam_r)
+- `StatCache` - caching stat results to reduce syscall overhead
+- `apply_batch` - parallel metadata application via rayon
+
+## Dependencies (upstream)
+
+`protocol`, `logging`, `filetime`, `rustix`, `libc`
+
+## Dependents (downstream)
+
+`engine`, `transfer`, `daemon`, `core`, `cli`, `batch`
+
+## Features
+
+- `xattr` - extended attribute preservation (Linux/macOS via `xattr` crate)
+- `acl` - POSIX ACL support (Linux/macOS/FreeBSD via `exacl` crate)
+
+## Platform Notes
+
+- **Unix**: Full metadata fidelity - permissions, ownership, timestamps,
+  xattrs, ACLs, device nodes, FIFOs, symlinks
+- **macOS**: Apple-specific metadata via `apple-fs` crate (birthtime, flags)
+- **Windows**: Read-only flag, NTFS DACLs via `windows` crate, limited
+  permission round-trip

--- a/crates/transfer/README.md
+++ b/crates/transfer/README.md
@@ -1,0 +1,53 @@
+# transfer
+
+Server-side transfer coordination between sender, receiver, and generator roles.
+
+## Purpose
+
+`transfer` provides the `--server` mode entry points, implementing the rsync
+delta transfer algorithm with full protocol 32 compatibility. It orchestrates
+the pipeline of protocol phases - handshake, setup, multiplex activation, and
+role-based transfer - while overlapping network I/O with disk operations for
+maximum throughput.
+
+## Key Public Types
+
+- `GeneratorContext` - sender/generator role: walks file tree, sends file list,
+  generates and transmits delta streams
+- `ReceiverContext` - receiver role: receives file list, produces signatures,
+  applies deltas, commits metadata
+- `ServerRole` - enum selecting generator or receiver mode
+- `TransferConfig` / `TransferConfigBuilder` - transfer parameter assembly
+- `DiskCommitChannel` - SPSC channel decoupling network receives from disk writes
+- `Pipeline` - bounded-concurrency request pipeline overlapping I/O with processing
+- `AckBatcher` - amortizes per-file acknowledgment overhead
+- `TokenReader` / `TokenBuffer` - delta token stream decoding
+
+## Architecture
+
+```
+Handshake -> Protocol Setup -> Multiplex Activation -> Role Dispatch
+                                                        |
+                                          Generator (sender) or Receiver
+```
+
+## Dependencies (upstream)
+
+`protocol`, `metadata`, `engine`, `signature`, `filters`, `compress`,
+`logging`, `fast_io`, `checksums`
+
+## Dependents (downstream)
+
+`core`
+
+## Features
+
+- `io_uring` / `iocp` - async I/O forwarded to `fast_io`
+- `zstd` / `lz4` / `zlib-ng` - compression codec selection
+- `incremental-flist` - incremental file list processing (INC_RECURSE)
+- `iconv` - filename charset transcoding
+
+## Platform Notes
+
+- Unix: `O_NOATIME` for source file opens, `openat` for temp-file sandbox
+- macOS: `apple-fs` for clonefile during local operations


### PR DESCRIPTION
## Summary

- Add README.md with ownership context to 6 high-priority crates: `engine`, `daemon`, `fast_io`, `filters`, `metadata`, `transfer`
- Each README documents: purpose, key public types/traits, upstream dependencies, downstream dependents, and platform-specific notes
- Addresses BF1-2 (bus factor reduction through contributor onboarding documentation)

## Test plan

- [ ] Verify no existing README.md files were overwritten (checksums, protocol, core, cli already had them)
- [ ] Confirm each README is under 60 lines and accurately reflects Cargo.toml dependencies
- [ ] No code changes - documentation only