### PR TITLE
docs: add README files for remaining workspace crates

### DIFF
--- a/crates/batch/README.md
+++ b/crates/batch/README.md
@@ -1,0 +1,32 @@
+# batch
+
+Batch mode support for offline/disconnected rsync transfer workflows - enables
+recording a transfer to a file and replaying it later on a different machine.
+
+## Key Public Types
+
+- `BatchConfig` - configuration for capture or replay operation
+- `BatchMode` - enum selecting `Write` (capture) or `Read` (replay)
+- `BatchHeader` - wire-format header (stream flags, protocol version, compat flags, checksum seed)
+- `BatchStats` - transfer statistics appended at end of batch file
+- `BatchFlags` - bitmap controlling which protocol features are active
+- `BatchWriter` - captures protocol stream to a batch file
+- `BatchReader` - replays a previously captured batch file
+- `BatchError` / `BatchResult` - error types for batch operations
+
+## Modules
+
+- `format` - batch file wire format parsing and serialization
+- `reader` - batch file reading and validation
+- `writer` - batch file creation
+- `script` - companion shell script generation for replay
+- `replay` - replay orchestration
+
+## Dependencies
+
+- **Upstream:** `protocol` (wire format types), `metadata` (file entry types), `filetime`
+- **Downstream:** `core` (orchestration facade)
+
+## Features
+
+- `zstd` - forwarded to `protocol` for zstd-compressed batch streams

--- a/crates/compress/README.md
+++ b/crates/compress/README.md
@@ -1,0 +1,37 @@
+# compress
+
+Compression primitives shared across the workspace - provides streaming encoders
+and decoders for zlib, zstd, and LZ4 with zero internal output allocations.
+
+## Key Public Types
+
+- `CompressionAlgorithm` - enum of supported algorithms (Zlib, Zstd, Lz4)
+- `CompressionStrategy` - trait for algorithm-specific encode/decode behavior
+- `ZlibStrategy` / `ZstdStrategy` / `Lz4Strategy` - concrete strategy implementations
+- `NegotiationPipeline<S>` - type-state pipeline for protocol-level codec negotiation
+- `CompressionStrategySelector` - selects strategy from negotiated parameters
+- `ProtocolCompressionProfile` - wire-level algorithm profile
+- `AdaptiveLevelStrategy` - trait for dynamic compression level adjustment
+- `CountingSink` - discard writer used by counting encoders
+
+## Modules
+
+- `zlib` - streaming zlib encoder/decoder (`CountingZlibEncoder`)
+- `zstd` - zstandard codec with optional multi-threaded mode
+- `lz4` - LZ4 frame codec
+- `strategy` - algorithm selection, negotiation, and adaptive level control
+- `skip_compress` - suffix-based skip list (files that compress poorly)
+- `algorithm` - `CompressionAlgorithm` enum and default level constants
+
+## Dependencies
+
+- **Upstream:** `flate2` (zlib backend), `zstd` (optional), `lz4_flex` (optional)
+- **Downstream:** `protocol`, `engine`
+
+## Features
+
+- `zstd` - Zstandard support
+- `zstdmt` - multi-threaded zstd compression
+- `lz4` - LZ4 frame support
+- `zlib-ng` - C-based zlib with SIMD (SSE2, AVX2, NEON) - fastest
+- `zlib-rs` - pure Rust zlib fallback (no C compiler required)

--- a/crates/flist/README.md
+++ b/crates/flist/README.md
@@ -1,0 +1,34 @@
+# flist
+
+File list generation and traversal - mirrors upstream rsync's `flist.c` for
+enumerating files, directories, and symlinks with deterministic ordering.
+
+## Key Public Types
+
+- `FileListBuilder` - configures traversal options (root emission, symlink following)
+- `FileListWalker` - `Iterator` yielding `FileListEntry` in depth-first order
+- `FileListEntry` - represents a discovered path with metadata
+- `LazyEntry` - deferred-metadata entry for large directory trees
+- `FileListError` - path-annotated I/O errors from traversal
+
+## Modules
+
+- `batched_stat` - parallel `fstatat`/`statx` batching for high file counts (Unix)
+- `parallel` - rayon-based parallel traversal
+- `symlink_safety` - cycle detection when following directory symlinks
+
+## Dependencies
+
+- **Upstream:** `logging` (diagnostics), `libc` (optional, for batched syscalls)
+- **Downstream:** `engine`, `core`
+
+## Features
+
+- `parallel` - enables rayon + batched syscalls for parallel file enumeration
+- `serde` - serialization support for file list types
+
+## Platform Notes
+
+- Unix: `batched_stat` module uses `fstatat`/`statx` for reduced syscall overhead
+- Windows: falls back to standard `std::fs::metadata` per-entry
+- All platforms: lexicographic sort ensures deterministic output regardless of FS iteration order

--- a/crates/logging-sink/README.md
+++ b/crates/logging-sink/README.md
@@ -1,0 +1,27 @@
+# logging-sink
+
+Message sink and output utilities - streams diagnostics to arbitrary writers
+while reusing scratch buffers, matching upstream rsync's `log.c` approach.
+
+## Key Public Types
+
+- `MessageSink` - wrapper around `std::io::Write` with reusable scratch buffer
+- `LineMode` - controls whether rendered messages end with a newline
+
+## Modules
+
+- `sink` - core `MessageSink` implementation
+- `line_mode` - `LineMode` enum and rendering helpers
+- `syslog` - Unix syslog backend for daemon-mode diagnostics
+
+## Dependencies
+
+- **Upstream:** `core` (provides `Message` and `MessageScratch` types)
+- **Downstream:** `daemon`, `cli`
+
+## Platform Notes
+
+- Unix: provides a syslog backend via the `syslog` crate, routing daemon diagnostics
+  through `syslog(3)` with configurable facility and tag
+- Windows: syslog module compiles out; diagnostics go to stderr or Windows Event Log
+  via the `platform` crate

--- a/crates/matching/README.md
+++ b/crates/matching/README.md
@@ -1,0 +1,32 @@
+# matching
+
+Block matching and delta generation for rsync transfers - implements the core
+rsync delta algorithm by comparing input blocks against file signatures.
+
+## Key Public Types
+
+- `DeltaGenerator` - produces delta tokens by rolling over input against a signature
+- `DeltaSignatureIndex` - hash table indexing signatures for O(1) block lookup
+- `DeltaScript` - ordered sequence of delta tokens for file reconstruction
+- `DeltaToken` - individual copy or literal operation in a delta stream
+- `FuzzyMatcher` - finds similar basis files for delta transfers (`--fuzzy`)
+- `apply_delta` - reconstructs a target file from a basis plus delta tokens
+
+## Modules
+
+- `generator` - delta generation loop (mirrors upstream `match.c`)
+- `index` - two-level hash table for signature block lookup
+- `script` - delta script types and application
+- `optimized_search` - bithash/sequential-match optimizations
+- `ring_buffer` - circular buffer for streaming delta generation
+- `fuzzy` - fuzzy basis file matching by name similarity and mtime
+
+## Dependencies
+
+- **Upstream:** `signature` (file signatures), `checksums` (rolling + strong), `logging`
+- **Downstream:** `engine` (delta pipeline)
+
+## Features
+
+- `tracing` - structured logging instrumentation for performance analysis
+- `bench-internal` - exposes internals for benchmark harnesses (never in release builds)

--- a/crates/platform/README.md
+++ b/crates/platform/README.md
@@ -1,0 +1,32 @@
+# platform
+
+Platform-specific unsafe code isolation - encapsulates all OS FFI (libc, Win32)
+behind safe public APIs so higher-level crates remain 100% safe Rust.
+
+## Modules
+
+- `daemonize` - process daemonization (fork, setsid, stdio redirection)
+- `env` - environment variable manipulation with RAII restoration
+- `error` - typed platform error variants for I/O failures
+- `group` - system group membership lookups
+- `name_resolution` - Windows account name to RID resolution
+- `privilege` - chroot, uid/gid dropping, privilege management
+- `secrets` - secrets file permission validation
+- `signal` - signal handler registration and shared atomic flags
+- `windows_service` - Windows Service Control Manager (SCM) integration
+
+## Dependencies
+
+- **Upstream (Unix):** `libc`, `nix` (safe POSIX wrappers), `signal-hook`
+- **Upstream (Windows):** `windows` crate (Win32 Foundation, Security, Services, Console)
+- **Downstream:** `daemon`, `core`, `cli`
+
+## Platform Notes
+
+- **Unix:** uses `nix` for safe wrappers where available (chroot, setuid, setgid,
+  setsid, dup2). Falls back to raw `libc` for operations not covered by nix
+  (e.g., `setgroups` on macOS, `fork`, `getgrnam_r`).
+- **Windows:** uses the `windows` crate for Win32 API bindings. Unsafe blocks are
+  scoped to individual functions with `// SAFETY:` annotations.
+- This crate uses `#![deny(unsafe_code)]` at the crate level. Individual functions
+  requiring unsafe are annotated with `#[allow(unsafe_code)]`.

--- a/crates/rsync_io/README.md
+++ b/crates/rsync_io/README.md
@@ -1,0 +1,40 @@
+# rsync_io
+
+Transport adapters for the rsync implementation - handles SSH, TCP daemon, and
+binary protocol negotiation while preserving buffered bytes across handshakes.
+
+## Key Public Types
+
+- `SessionHandshake` / `SessionHandshakeParts` - high-level session negotiation entry point
+- `NegotiatedStream` - stream wrapper that replays sniffed prologue bytes
+- `BinaryHandshake` - binary protocol (direct rsync-over-TCP) handshake
+- `LegacyDaemonHandshake` - `@RSYNCD:` ASCII daemon protocol handshake
+- `SshCommand` - SSH subprocess builder with compression detection
+- `SshConnection` - established SSH connection with read/write split
+
+## Key Functions
+
+- `sniff_negotiation_stream` - classifies prologue as binary or legacy ASCII
+- `negotiate_session` - top-level session negotiation (auto-detects transport)
+- `parse_remote_shell` - parses remote shell specification into command parts
+
+## Modules
+
+- `binary` - binary protocol handshake
+- `daemon` - legacy ASCII daemon handshake
+- `negotiation` - stream sniffing and classification
+- `session` - unified session negotiation facade
+- `ssh` - SSH transport (subprocess and embedded russh)
+- `channel_adapter` - tokio mpsc to AsyncRead/AsyncWrite bridge (async-ssh feature)
+
+## Dependencies
+
+- **Upstream:** `protocol` (wire format), `logging`, `memchr`, `shell-words`
+- **Downstream:** `core` (orchestration)
+
+## Features
+
+- `embedded-ssh` - in-process SSH via russh (no subprocess)
+- `async-ssh` - tokio-backed async SSH transport
+- `ssh-config-parse` - reads `~/.ssh/config` for compression detection (default)
+- `ssh-socketpair-stderr` - async stderr drain via Unix socketpair

--- a/crates/signature/README.md
+++ b/crates/signature/README.md
@@ -1,0 +1,39 @@
+# signature
+
+File signature layout and generation - computes rsync-compatible block signatures
+using rolling and strong checksums, with block sizing from upstream `generator.c`.
+
+## Key Public Types
+
+- `FileSignature` - complete signature for a file (collection of block checksums)
+- `SignatureLayout` - computed layout parameters (block size, checksum length, count)
+- `SignatureLayoutParams` - input parameters for layout calculation
+- `SignatureAlgorithm` - checksum algorithm selection (MD4, MD5, XXH3)
+- `SignatureBlock` - individual block's rolling + strong checksum pair
+
+## Key Functions
+
+- `calculate_signature_layout` - determines block size and checksum length from file size
+- `generate_file_signature` - reads file blocks and computes all checksums
+- `calculate_block_length` - standalone block size calculation (upstream `sum_sizes_sqroot`)
+- `calculate_checksum_length` - strong checksum length for given file/block size
+- `calculate_checksum_count` - number of blocks for a given file size
+
+## Modules
+
+- `block_size` - block sizing heuristics matching upstream rsync 3.4.1
+- `layout` - signature layout computation
+- `generation` - sequential signature generation
+- `parallel` - rayon-based parallel signature generation
+- `async_gen` - async/pipelined signature generation
+- `algorithm` - checksum algorithm selection and dispatch
+
+## Dependencies
+
+- **Upstream:** `checksums` (rolling + strong checksum implementations), `protocol` (version types)
+- **Downstream:** `matching` (delta generation), `engine`
+
+## Features
+
+- `parallel` - parallel signature generation (rayon always compiled; alias for compatibility)
+- `tracing` - structured logging for performance analysis

--- a/crates/test-support/README.md
+++ b/crates/test-support/README.md
@@ -1,0 +1,20 @@
+# test-support
+
+Shared test utilities for the oc-rsync workspace - provides helpers that multiple
+test suites need, avoiding duplicated setup boilerplate across crates.
+
+## Key Public Functions
+
+- `create_tempdir` - creates a temporary directory with retry logic for transient
+  OS errors (Windows CI antivirus/lock contention)
+
+## Dependencies
+
+- **Upstream:** `tempfile`
+- **Downstream:** used as a `dev-dependency` by crates needing reliable temp directories
+
+## Platform Notes
+
+- Windows: retries `tempdir()` up to 3 times with exponential backoff (50ms, 100ms,
+  150ms) to handle antivirus and filesystem lock contention on CI runners
+- Unix: typically succeeds on first attempt

--- a/crates/windows-gnu-eh/README.md
+++ b/crates/windows-gnu-eh/README.md
@@ -1,0 +1,34 @@
+# windows-gnu-eh
+
+Compatibility shims for `x86_64-pc-windows-gnu` DWARF exception handling - provides
+the `___register_frame_info` / `___deregister_frame_info` symbols missing from
+Zig's Windows GNU toolchain.
+
+## Purpose
+
+When cross-compiling for `x86_64-pc-windows-gnu` (e.g., with `cargo-zigbuild`),
+Zig omits legacy libgcc entry points that Rust's startup object (`rsbegin.o`)
+references. This crate provides `#[no_mangle]` shim functions that forward at
+runtime to the modern symbols from libunwind/libgcc, resolved lazily via
+`LoadLibraryA`/`GetProcAddress` and cached in atomics.
+
+## Key Functions
+
+- `force_link()` - called from `main()` behind a `#[cfg(target_env = "gnu")]` gate
+  to ensure the shim symbols are linked into the final binary. On non-GNU targets
+  this compiles to a no-op that is optimized away.
+
+## When This Crate Is Needed
+
+**Only** when targeting `x86_64-pc-windows-gnu`. On all other targets (MSVC, Unix,
+macOS) the crate compiles to nothing.
+
+## Dependencies
+
+- **Upstream:** none (uses only `core` and Windows kernel32 APIs)
+- **Downstream:** `cli` (root binary calls `force_link()`)
+
+## Maintenance
+
+Minimal - approximately 180 lines of self-contained code. No updates required
+unless Rust changes its startup object linking model for the GNU target.


### PR DESCRIPTION
## Summary

- Add README.md to the 10 workspace crates that were missing documentation: `batch`, `compress`, `flist`, `logging-sink`, `matching`, `platform`, `rsync_io`, `signature`, `test-support`, and `windows-gnu-eh`
- Each README covers purpose, key public types/traits, upstream/downstream dependencies, and platform-specific notes
- Complements the prior BF1-2 work (engine, daemon, fast_io, filters, metadata, transfer) to achieve full per-crate documentation coverage

## Test plan

- [ ] Verify READMEs render correctly on GitHub
- [ ] Confirm no build impact (documentation-only change)