### PR TITLE
ci: add shared-ring removal guard (IUR-6.c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
       - name: EnvGuard lint (BPF-5)
         run: bash tools/ci/check_envguard.sh
 
+      # IUR-6.c: Prevent reintroduction of Arc<Mutex<IoUring>> serialization
+      # in hot-path io_uring factory modules. The per-thread ring migration
+      # (IUR-3) eliminated this bottleneck; this lint keeps it gone.
+      - name: Shared-ring removal guard (IUR-6.c)
+        run: bash tools/ci/check_shared_ring_removal.sh
+
   # ===========================================================================
   # Unsafe SAFETY Comment Audit - Informational (non-blocking) check
   # ---------------------------------------------------------------------------

--- a/docs/design/shared-ring-removal-guard.md
+++ b/docs/design/shared-ring-removal-guard.md
@@ -1,0 +1,65 @@
+# Shared-Ring Removal Guard (IUR-6.c)
+
+## Problem
+
+The IUR-1 audit (`docs/audits/io-uring-shared-ring-audit.md`) identified that
+three io_uring factories - `file_writer`, `file_reader`, and `socket_writer` -
+serialized parallel submissions through a single `Arc<Mutex<IoUring>>` ring.
+Under rayon-parallel callers, this caused contention on the mutex and
+effectively negated the batching benefit of io_uring.
+
+IUR-3 migrated these factories to per-thread rings via `per_thread_ring.rs`,
+eliminating the serialization. Without a regression guard, future contributors
+could reintroduce the pattern unknowingly.
+
+## Solution
+
+A grep-based CI lint (`tools/ci/check_shared_ring_removal.sh`) runs in the
+`fmt + clippy` job and fails the build if `Arc<Mutex` or
+`static Mutex<IoUring>` patterns appear in the guarded factory modules.
+
+### Guarded modules
+
+| File | Role |
+|------|------|
+| `crates/fast_io/src/io_uring/file_writer.rs` | Per-file disk write SQE submission |
+| `crates/fast_io/src/io_uring/file_reader.rs` | Per-file read SQE submission |
+| `crates/fast_io/src/io_uring/socket_writer.rs` | Network send SQE submission |
+| `crates/fast_io/src/io_uring/file_factory.rs` | Factory dispatching reader/writer creation |
+| `crates/fast_io/src/io_uring/socket_factory.rs` | Factory dispatching socket reader/writer creation |
+
+### Allowlisted modules
+
+- `send_zc.rs` - Uses `Arc<Mutex<IoUring>>` for per-connection zero-copy
+  sender. This is pinned to a single connection, not a contention point for
+  parallel file I/O.
+- `shared_ring.rs` - Implements a per-session reader+writer ring topology
+  (two fds sharing one ring). This is architecturally distinct from the old
+  global bottleneck; a session ring is not shared across threads.
+
+## Checks performed
+
+1. **Arc<Mutex pattern** - Matches `Arc<Mutex` in any guarded file. Catches
+   `Arc<Mutex<IoUring>>`, `Arc<Mutex<RawIoUring>>`, and renamed variants.
+2. **Static mutex pattern** - Matches `static.*Mutex.*IoUring`,
+   `OnceLock.*Mutex.*IoUring`, or `lazy_static.*Mutex.*IoUring` to catch
+   global shared ring singletons.
+
+## Correct alternative
+
+Hot-path factories must use `per_thread_ring::with_ring()` which provides a
+thread-local `IoUring` instance. The ring is lazily constructed per thread and
+dropped on thread exit. See `docs/design/iur-2-per-thread-rings.md` for the
+full design.
+
+## Integration
+
+The check runs as a step in the `lint` job of `.github/workflows/ci.yml`,
+after clippy and before the test matrix. It requires no additional
+dependencies (uses grep) and adds negligible CI time.
+
+## Future work
+
+When IUR-6.b removes `shared_ring.rs` entirely, the guard can be extended to
+reject any `mod shared_ring` declaration in `mod.rs`, preventing the module
+from being reintroduced.

--- a/tools/ci/check_shared_ring_removal.sh
+++ b/tools/ci/check_shared_ring_removal.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# IUR-6.c: Regression guard against reintroduction of the shared-ring
+# serialization bottleneck in io_uring hot-path factories.
+#
+# Background: The IUR-1 audit identified that `file_writer`, `file_reader`,
+# and `socket_writer` factories serialized parallel submissions through a
+# single `Arc<Mutex<IoUring>>` ring. IUR-3 migrated these to per-thread rings
+# via `per_thread_ring.rs`. This script prevents the `Arc<Mutex<IoUring>>`
+# pattern from being reintroduced in those hot-path modules.
+#
+# What it checks:
+#   1. Factory modules (file_writer, file_reader, socket_writer, file_factory,
+#      socket_factory) must not contain `Arc<Mutex` wrapping an io_uring ring.
+#   2. No new `mod shared_ring` declaration in `mod.rs` that re-exports a
+#      global/static shared ring used by factories.
+#
+# Legitimate uses (allowlisted):
+#   - `send_zc.rs`: Uses `Arc<Mutex<IoUring>>` for zero-copy sender, which is
+#     pinned to a single connection - not a hot-path factory pattern.
+#   - `shared_ring.rs` itself: The module implements a per-session reader+writer
+#     ring topology (not the old global bottleneck). Once IUR-6.b removes it,
+#     this guard prevents reintroduction.
+#
+# Usage:
+#   tools/ci/check_shared_ring_removal.sh
+#
+# Exit codes:
+#   0 - No violations found.
+#   1 - Violation detected: shared-ring serialization pattern in factories.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+IO_URING_DIR="${REPO_ROOT}/crates/fast_io/src/io_uring"
+
+# Hot-path factory modules that must never contain Arc<Mutex<IoUring>>.
+GUARDED_FILES=(
+    "${IO_URING_DIR}/file_writer.rs"
+    "${IO_URING_DIR}/file_reader.rs"
+    "${IO_URING_DIR}/socket_writer.rs"
+    "${IO_URING_DIR}/file_factory.rs"
+    "${IO_URING_DIR}/socket_factory.rs"
+)
+
+# Pattern: Arc<Mutex wrapping anything ring-related. Catches:
+#   Arc<Mutex<IoUring>>
+#   Arc<Mutex<io_uring::IoUring>>
+#   Arc<Mutex<RawIoUring>>
+# The regex is intentionally broad to catch renamed variants.
+ARC_MUTEX_PATTERN='Arc<Mutex'
+
+violations=0
+
+printf '=== IUR-6.c: shared-ring removal guard ===\n'
+printf 'Checking hot-path factory modules for Arc<Mutex serialization...\n\n'
+
+for file in "${GUARDED_FILES[@]}"; do
+    if [ ! -f "$file" ]; then
+        # File might not exist on non-Linux or stub builds; skip.
+        continue
+    fi
+
+    matches=$(grep -n "$ARC_MUTEX_PATTERN" "$file" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        printf 'VIOLATION: %s contains Arc<Mutex (shared-ring serialization)\n' \
+            "$(realpath --relative-to="$REPO_ROOT" "$file" 2>/dev/null || echo "$file")"
+        printf '%s\n\n' "$matches"
+        violations=$((violations + 1))
+    fi
+done
+
+# Guard 2: Check that no static/lazy_static/OnceLock wraps a shared IoUring
+# instance in the factory modules. This catches indirect patterns like:
+#   static SHARED_RING: OnceLock<Mutex<IoUring>>
+#   lazy_static! { static ref RING: Mutex<IoUring> }
+STATIC_MUTEX_PATTERN='static.*Mutex.*[Ii]o[Uu]ring\|OnceLock.*Mutex.*[Ii]o[Uu]ring\|lazy_static.*Mutex.*[Ii]o[Uu]ring'
+
+for file in "${GUARDED_FILES[@]}"; do
+    if [ ! -f "$file" ]; then
+        continue
+    fi
+
+    matches=$(grep -n "$STATIC_MUTEX_PATTERN" "$file" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        printf 'VIOLATION: %s contains static Mutex<IoUring> (global shared ring)\n' \
+            "$(realpath --relative-to="$REPO_ROOT" "$file" 2>/dev/null || echo "$file")"
+        printf '%s\n\n' "$matches"
+        violations=$((violations + 1))
+    fi
+done
+
+if [ "$violations" -gt 0 ]; then
+    printf 'FAILED: %d violation(s) found.\n' "$violations"
+    printf 'The per-thread ring architecture (IUR-3) forbids Arc<Mutex<IoUring>>\n'
+    printf 'in hot-path factory modules. Use per_thread_ring::with_ring() instead.\n'
+    printf 'See docs/design/shared-ring-removal-guard.md for rationale.\n'
+    exit 1
+fi
+
+printf 'PASSED: No shared-ring serialization patterns in factory modules.\n'
+exit 0


### PR DESCRIPTION
## Summary

- Adds `tools/ci/check_shared_ring_removal.sh` - a grep-based lint that prevents reintroduction of `Arc<Mutex<IoUring>>` serialization in the hot-path io_uring factory modules (`file_writer`, `file_reader`, `socket_writer`, `file_factory`, `socket_factory`).
- Integrates the check as a step in the `lint` job of the CI workflow, running after clippy with zero additional dependencies.
- Documents the guard rationale and architecture in `docs/design/shared-ring-removal-guard.md`.

The per-thread ring migration (IUR-3) eliminated the shared-ring contention bottleneck where parallel submissions serialized through a single `Arc<Mutex<IoUring>>`. This guard ensures the pattern cannot be reintroduced.

Closes #2943

## Test plan

- [ ] CI lint job passes (the guard runs against the current codebase which has no violations)
- [ ] Verify the script correctly detects violations by temporarily adding `Arc<Mutex<IoUring>>` to `file_writer.rs` and confirming the lint fails
- [ ] Confirm `send_zc.rs` (legitimate `Arc<Mutex>` user) is not flagged