### PR TITLE
fix: guard proactive phase transition to dirs-only transfers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    timeout-minutes: 60
+    timeout-minutes: 90
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
     # should pin the required check to `nextest (stable)`.

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -181,8 +181,19 @@ impl GeneratorContext {
                             // first_flist break), blocks waiting for receiver, which
                             // blocks waiting for our phase-transition NDX_DONE.
                             // Proactively transition when all flists are freed and
-                            // no more sub-lists are pending.
-                            if flist_done_remaining == 0 && self.incremental.flist_eof_sent {
+                            // no more sub-lists are pending, BUT only when the flist
+                            // has no regular files. When files exist, the receiver
+                            // will request them and send the normal phase-transition
+                            // NDX_DONE afterward - no deadlock occurs.
+                            let has_no_files = !self
+                                .file_list
+                                .as_slice()
+                                .iter()
+                                .any(|e| e.is_file());
+                            if flist_done_remaining == 0
+                                && self.incremental.flist_eof_sent
+                                && has_no_files
+                            {
                                 debug_log!(
                                     Send,
                                     1,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -185,11 +185,8 @@ impl GeneratorContext {
                             // has no regular files. When files exist, the receiver
                             // will request them and send the normal phase-transition
                             // NDX_DONE afterward - no deadlock occurs.
-                            let has_no_files = !self
-                                .file_list
-                                .as_slice()
-                                .iter()
-                                .any(|e| e.is_file());
+                            let has_no_files =
+                                !self.file_list.as_slice().iter().any(|e| e.is_file());
                             if flist_done_remaining == 0
                                 && self.incremental.flist_eof_sent
                                 && has_no_files


### PR DESCRIPTION
## Summary

- Fix interop regression in `standalone:empty-dir` test (exit code 23) caused by commit 0961bc01b
- The proactive phase-transition in the INC_RECURSE transfer loop now only fires when the file list contains no regular files (the deadlock-only scenario)
- When files exist, the receiver will request them and send the normal phase-transition NDX_DONE afterward - no deadlock occurs, so the proactive path must not fire

## Test plan

- [ ] CI `interop with upstream rsync` job passes `standalone:empty-dir` test
- [ ] CI nextest passes (no compile errors from the guard logic)
- [ ] Verify INC_RECURSE dirs-only transfers still complete without deadlock