### PR TITLE
ci: bump nextest job timeout from 90 to 120 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    timeout-minutes: 90
+    timeout-minutes: 120
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
     # should pin the required check to `nextest (stable)`.


### PR DESCRIPTION
## Summary
- Increase nextest job timeout from 90 to 120 minutes
- The full workspace test suite with `--all-features` consistently exceeds 90 minutes on GitHub Actions ubuntu-latest runners
- Orphan process analysis from cancelled runs confirms tests are actively running (not hanging) when the timeout fires

## Test plan
- [ ] Verify nextest(stable) completes within 120 minutes on this PR's CI run
- [ ] Monitor next few master CI runs after merge