### PR TITLE
feat: support -VV flag for JSON capability output

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -34,8 +34,8 @@ pub struct ParsedArgs {
     /// `--help`, `-h`
     pub show_help: bool,
 
-    /// `--version`, `-V`
-    pub show_version: bool,
+    /// `--version`, `-V` (repeatable: 1 = human-readable, 2+ = JSON capabilities).
+    pub show_version: u8,
 
     /// `--io-uring-status` - print the io_uring capability matrix and exit.
     pub show_io_uring_status: bool,

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -50,7 +50,7 @@ where
     let mut matches = command.try_get_matches_from(args)?;
 
     let show_help = matches.get_flag("help");
-    let show_version = matches.get_flag("version");
+    let show_version = matches.get_count("version") as u8;
     let show_io_uring_status = matches.get_flag("io-uring-status");
 
     // Handle human-readable: bare flags (-h, --human-readable) count occurrences

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -298,7 +298,7 @@ fn version_flag() {
     let result = parse_test_args(["--version"]);
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert!(parsed.show_version);
+    assert_eq!(parsed.show_version, 1);
 }
 
 #[test]

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1728,7 +1728,7 @@ mod path_operands {
     #[test]
     fn no_operands_with_version() {
         let parsed = parse_test_args(["--version"]).expect("parse");
-        assert!(parsed.show_version);
+        assert_eq!(parsed.show_version, 1);
         assert!(parsed.remainder.is_empty());
     }
 }
@@ -1851,13 +1851,13 @@ mod help_and_version {
     #[test]
     fn version_flag() {
         let parsed = parse_test_args(["--version"]).expect("parse");
-        assert!(parsed.show_version);
+        assert_eq!(parsed.show_version, 1);
     }
 
     #[test]
     fn short_version_flag() {
         let parsed = parse_test_args(["-V"]).expect("parse");
-        assert!(parsed.show_version);
+        assert_eq!(parsed.show_version, 1);
     }
 }
 

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/core_args.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/core_args.rs
@@ -17,7 +17,7 @@ pub(super) fn add_core_args(command: ClapCommand) -> ClapCommand {
                 .long("version")
                 .short('V')
                 .help("Output version information and exit.")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::Count),
         )
         .arg(
             Arg::new("server")

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -86,9 +86,13 @@ where
 
 /// Prints help, version, or io_uring status text if requested, returning
 /// the exit code.
+///
+/// When `show_version >= 2` (i.e., `-VV`), outputs JSON-formatted capability
+/// information matching upstream rsync's `-VV` format. When `show_version == 1`,
+/// outputs the standard human-readable version banner.
 pub(crate) fn maybe_print_help_or_version<Out>(
     show_help: bool,
-    show_version: bool,
+    show_version: u8,
     show_io_uring_status: bool,
     program_name: ProgramName,
     stdout: &mut Out,
@@ -104,7 +108,17 @@ where
         } else {
             Some(0)
         }
-    } else if show_version {
+    } else if show_version >= 2 {
+        // upstream: options.c - version_opt_cnt > 1 calls print_rsync_version(FNONE)
+        // which outputs JSON capabilities.
+        let report = VersionInfoReport::for_client_brand(program_name.brand());
+        let json = report.json();
+        if stdout.write_all(json.as_bytes()).is_err() {
+            Some(1)
+        } else {
+            Some(0)
+        }
+    } else if show_version == 1 {
         let report = VersionInfoReport::for_client_brand(program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {

--- a/crates/cli/src/frontend/tests/version.rs
+++ b/crates/cli/src/frontend/tests/version.rs
@@ -74,7 +74,10 @@ fn double_version_flag_renders_json() {
     assert!(stderr.is_empty());
 
     let output = String::from_utf8(stdout).expect("valid UTF-8");
-    assert!(output.starts_with('{'), "JSON output should start with '{{'");
+    assert!(
+        output.starts_with('{'),
+        "JSON output should start with '{{'"
+    );
     assert!(output.contains("\"program\""), "should contain program key");
     assert!(output.contains("\"version\""), "should contain version key");
     assert!(output.contains("\"atimes\""), "should contain atimes key");
@@ -105,7 +108,10 @@ fn separate_version_flags_render_json() {
     assert!(stderr.is_empty());
 
     let output = String::from_utf8(stdout).expect("valid UTF-8");
-    assert!(output.starts_with('{'), "JSON output should start with '{{'");
+    assert!(
+        output.starts_with('{'),
+        "JSON output should start with '{{'"
+    );
     assert!(output.contains("\"atimes\""), "should contain atimes key");
 }
 

--- a/crates/cli/src/frontend/tests/version.rs
+++ b/crates/cli/src/frontend/tests/version.rs
@@ -64,3 +64,57 @@ fn short_version_flag_ignores_additional_operands() {
     let expected = VersionInfoReport::for_client_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
+
+// upstream: rsync -VV outputs JSON capability information
+#[test]
+fn double_version_flag_renders_json() {
+    let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("-VV")]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let output = String::from_utf8(stdout).expect("valid UTF-8");
+    assert!(output.starts_with('{'), "JSON output should start with '{{'");
+    assert!(output.contains("\"program\""), "should contain program key");
+    assert!(output.contains("\"version\""), "should contain version key");
+    assert!(output.contains("\"atimes\""), "should contain atimes key");
+    assert!(output.contains("\"crtimes\""), "should contain crtimes key");
+    assert!(output.contains("\"ACLs\""), "should contain ACLs key");
+    assert!(output.contains("\"xattrs\""), "should contain xattrs key");
+    assert!(
+        output.contains("\"capabilities\""),
+        "should contain capabilities section"
+    );
+    assert!(
+        output.contains("\"optimizations\""),
+        "should contain optimizations section"
+    );
+    assert!(
+        output.contains("\"license\": \"GPLv3\""),
+        "should contain GPLv3 license"
+    );
+}
+
+// upstream: rsync -V -V is equivalent to -VV
+#[test]
+fn separate_version_flags_render_json() {
+    let (code, stdout, stderr) =
+        run_with_args([OsStr::new(RSYNC), OsStr::new("-V"), OsStr::new("-V")]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let output = String::from_utf8(stdout).expect("valid UTF-8");
+    assert!(output.starts_with('{'), "JSON output should start with '{{'");
+    assert!(output.contains("\"atimes\""), "should contain atimes key");
+}
+
+#[test]
+fn double_version_json_matches_report() {
+    let (code, stdout, _stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("-VV")]);
+
+    assert_eq!(code, 0);
+
+    let expected = VersionInfoReport::for_client_brand(Brand::Upstream).json();
+    assert_eq!(stdout, expected.into_bytes());
+}

--- a/crates/cli/tests/argument_defaults_special.rs
+++ b/crates/cli/tests/argument_defaults_special.rs
@@ -278,9 +278,9 @@ fn test_show_help_defaults_to_false() {
 }
 
 #[test]
-fn test_show_version_defaults_to_false() {
+fn test_show_version_defaults_to_zero() {
     let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
-    assert!(!args.show_version, "show_version should default to false");
+    assert_eq!(args.show_version, 0, "show_version should default to 0");
 }
 
 #[test]

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -275,11 +275,7 @@ impl VersionInfoReport {
         // upstream: output_nno_list(FNONE, ...) outputs JSON arrays
         self.write_json_algorithm_list(writer, "checksum_list", &self.checksum_algorithms)?;
         self.write_json_algorithm_list(writer, "compress_list", &self.compress_algorithms)?;
-        self.write_json_algorithm_list(
-            writer,
-            "daemon_auth_list",
-            &self.daemon_auth_algorithms,
-        )?;
+        self.write_json_algorithm_list(writer, "daemon_auth_list", &self.daemon_auth_algorithms)?;
 
         // Closing metadata
         // upstream: usage.c - json_line("license", "GPLv3")
@@ -357,10 +353,7 @@ impl VersionInfoReport {
             super::super::SecludedArgsMode::Optional => "optional",
             super::super::SecludedArgsMode::Default => "default",
         };
-        write!(
-            writer,
-            "    \"secluded_args\": \"{secluded_value}\",\n"
-        )?;
+        write!(writer, "    \"secluded_args\": \"{secluded_value}\",\n")?;
         write!(writer, "    \"iconv\": {},\n", config.supports_iconv)?;
         write!(writer, "    \"prealloc\": {},\n", config.supports_prealloc)?;
         write!(writer, "    \"stop_at\": {},\n", config.supports_stop_at)?;
@@ -382,26 +375,14 @@ impl VersionInfoReport {
         )?;
         write!(writer, "    \"asm_MD5\": {},\n", config.supports_asm_md5)?;
         // oc-rsync-specific optimizations (not in upstream, but present in config)
-        write!(
-            writer,
-            "    \"mimalloc\": {},\n",
-            config.supports_mimalloc
-        )?;
+        write!(writer, "    \"mimalloc\": {},\n", config.supports_mimalloc)?;
         write!(
             writer,
             "    \"copy_file_range\": {},\n",
             config.supports_copy_file_range
         )?;
-        write!(
-            writer,
-            "    \"io_uring\": {},\n",
-            config.supports_io_uring
-        )?;
-        write!(
-            writer,
-            "    \"parallel\": {},\n",
-            config.supports_parallel
-        )?;
+        write!(writer, "    \"io_uring\": {},\n", config.supports_io_uring)?;
+        write!(writer, "    \"parallel\": {},\n", config.supports_parallel)?;
         write!(writer, "    \"mmap\": {}\n", config.supports_mmap)?;
         write!(writer, "  }}")?;
 

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -254,17 +254,13 @@ impl VersionInfoReport {
             meta.subprotocol_version()
         );
 
-        write!(writer, "{{\n")?;
-        write!(writer, "  \"program\": \"{}\",\n", meta.program_name())?;
-        write!(writer, "  \"version\": \"{}\",\n", meta.rust_version())?;
-        write!(writer, "  \"protocol\": \"{protocol}\",\n")?;
+        writeln!(writer, "{{")?;
+        writeln!(writer, "  \"program\": \"{}\",", meta.program_name())?;
+        writeln!(writer, "  \"version\": \"{}\",", meta.rust_version())?;
+        writeln!(writer, "  \"protocol\": \"{protocol}\",")?;
         // upstream: json_line("copyright", copyright) where copyright is just
         // "(C) YYYY-YYYY by ..." without a "Copyright" prefix
-        write!(
-            writer,
-            "  \"copyright\": \"{}\",\n",
-            meta.copyright_notice()
-        )?;
+        writeln!(writer, "  \"copyright\": \"{}\",", meta.copyright_notice())?;
         write!(writer, "  \"url\": \"{}\"", meta.source_url())?;
 
         // Capabilities section
@@ -284,7 +280,7 @@ impl VersionInfoReport {
             writer,
             ",\n  \"caveat\": \"rsync comes with ABSOLUTELY NO WARRANTY\""
         )?;
-        write!(writer, "\n}}\n")?;
+        writeln!(writer, "\n}}")?;
         Ok(())
     }
 
@@ -297,7 +293,7 @@ impl VersionInfoReport {
         let config = self.config;
 
         // upstream: "*Capabilities" becomes "capabilities": { ... }
-        write!(writer, ",\n  \"capabilities\": {{\n")?;
+        writeln!(writer, ",\n  \"capabilities\": {{")?;
 
         let file_bits = mem::size_of::<off_t>() * 8;
         let inum_bits = mem::size_of::<ino_t>() * 8;
@@ -306,84 +302,76 @@ impl VersionInfoReport {
 
         // upstream: "64-bit files" -> "file_bits": 64
         // The upstream code converts "N-bit label" to "label_bits": N
-        write!(writer, "    \"file_bits\": {file_bits},\n")?;
-        write!(writer, "    \"inum_bits\": {inum_bits},\n")?;
-        write!(writer, "    \"timestamp_bits\": {timestamp_bits},\n")?;
-        write!(writer, "    \"long_int_bits\": {long_int_bits},\n")?;
+        writeln!(writer, "    \"file_bits\": {file_bits},")?;
+        writeln!(writer, "    \"inum_bits\": {inum_bits},")?;
+        writeln!(writer, "    \"timestamp_bits\": {timestamp_bits},")?;
+        writeln!(writer, "    \"long_int_bits\": {long_int_bits},")?;
 
         // Boolean capabilities
         // upstream: "socketpairs" -> true, "no socketpairs" -> false
-        write!(
+        writeln!(
             writer,
-            "    \"socketpairs\": {},\n",
+            "    \"socketpairs\": {},",
             config.supports_socketpairs
         )?;
-        write!(writer, "    \"symlinks\": {},\n", config.supports_symlinks)?;
-        write!(writer, "    \"symtimes\": {},\n", config.supports_symtimes)?;
-        write!(
-            writer,
-            "    \"hardlinks\": {},\n",
-            config.supports_hardlinks
-        )?;
+        writeln!(writer, "    \"symlinks\": {},", config.supports_symlinks)?;
+        writeln!(writer, "    \"symtimes\": {},", config.supports_symtimes)?;
+        writeln!(writer, "    \"hardlinks\": {},", config.supports_hardlinks)?;
         // upstream: "hardlink-specials" -> "hardlink_specials"
-        write!(
+        writeln!(
             writer,
-            "    \"hardlink_specials\": {},\n",
+            "    \"hardlink_specials\": {},",
             config.supports_hardlink_specials
         )?;
-        write!(
+        writeln!(
             writer,
-            "    \"hardlink_symlinks\": {},\n",
+            "    \"hardlink_symlinks\": {},",
             config.supports_hardlink_symlinks
         )?;
         // upstream: "IPv6" -> "IPv6" (uppercase preserved, hyphens -> underscores)
-        write!(writer, "    \"IPv6\": {},\n", config.supports_ipv6)?;
-        write!(writer, "    \"atimes\": {},\n", config.supports_atimes)?;
-        write!(
+        writeln!(writer, "    \"IPv6\": {},", config.supports_ipv6)?;
+        writeln!(writer, "    \"atimes\": {},", config.supports_atimes)?;
+        writeln!(
             writer,
-            "    \"batchfiles\": {},\n",
+            "    \"batchfiles\": {},",
             config.supports_batchfiles
         )?;
-        write!(writer, "    \"inplace\": {},\n", config.supports_inplace)?;
-        write!(writer, "    \"append\": {},\n", config.supports_append)?;
-        write!(writer, "    \"ACLs\": {},\n", config.supports_acls)?;
-        write!(writer, "    \"xattrs\": {},\n", config.supports_xattrs)?;
+        writeln!(writer, "    \"inplace\": {},", config.supports_inplace)?;
+        writeln!(writer, "    \"append\": {},", config.supports_append)?;
+        writeln!(writer, "    \"ACLs\": {},", config.supports_acls)?;
+        writeln!(writer, "    \"xattrs\": {},", config.supports_xattrs)?;
         // upstream: "optional secluded-args" -> "secluded_args": "optional"
         let secluded_value = match config.secluded_args_mode {
             super::super::SecludedArgsMode::Optional => "optional",
             super::super::SecludedArgsMode::Default => "default",
         };
-        write!(writer, "    \"secluded_args\": \"{secluded_value}\",\n")?;
-        write!(writer, "    \"iconv\": {},\n", config.supports_iconv)?;
-        write!(writer, "    \"prealloc\": {},\n", config.supports_prealloc)?;
-        write!(writer, "    \"stop_at\": {},\n", config.supports_stop_at)?;
-        write!(writer, "    \"crtimes\": {}\n", config.supports_crtimes)?;
+        writeln!(writer, "    \"secluded_args\": \"{secluded_value}\",")?;
+        writeln!(writer, "    \"iconv\": {},", config.supports_iconv)?;
+        writeln!(writer, "    \"prealloc\": {},", config.supports_prealloc)?;
+        writeln!(writer, "    \"stop_at\": {},", config.supports_stop_at)?;
+        writeln!(writer, "    \"crtimes\": {}", config.supports_crtimes)?;
         write!(writer, "  }}")?;
 
         // upstream: "*Optimizations" becomes "optimizations": { ... }
-        write!(writer, ",\n  \"optimizations\": {{\n")?;
-        write!(
+        writeln!(writer, ",\n  \"optimizations\": {{")?;
+        writeln!(writer, "    \"SIMD_roll\": {},", config.supports_simd_roll)?;
+        writeln!(writer, "    \"asm_roll\": {},", config.supports_asm_roll)?;
+        writeln!(
             writer,
-            "    \"SIMD_roll\": {},\n",
-            config.supports_simd_roll
-        )?;
-        write!(writer, "    \"asm_roll\": {},\n", config.supports_asm_roll)?;
-        write!(
-            writer,
-            "    \"openssl_crypto\": {},\n",
+            "    \"openssl_crypto\": {},",
             config.supports_openssl_crypto
         )?;
-        write!(writer, "    \"asm_MD5\": {},\n", config.supports_asm_md5)?;
+        writeln!(writer, "    \"asm_MD5\": {},", config.supports_asm_md5)?;
         // oc-rsync-specific optimizations (not in upstream, but present in config)
-        write!(writer, "    \"mimalloc\": {},\n", config.supports_mimalloc)?;
-        write!(
+        writeln!(writer, "    \"mimalloc\": {},", config.supports_mimalloc)?;
+        writeln!(
             writer,
-            "    \"copy_file_range\": {},\n",
+            "    \"copy_file_range\": {},",
             config.supports_copy_file_range
         )?;
-        write!(writer, "    \"io_uring\": {},\n", config.supports_io_uring)?;
-        write!(writer, "    \"parallel\": {},\n", config.supports_parallel)?;
-        write!(writer, "    \"mmap\": {}\n", config.supports_mmap)?;
+        writeln!(writer, "    \"io_uring\": {},", config.supports_io_uring)?;
+        writeln!(writer, "    \"parallel\": {},", config.supports_parallel)?;
+        writeln!(writer, "    \"mmap\": {}", config.supports_mmap)?;
         write!(writer, "  }}")?;
 
         Ok(())

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -239,6 +239,213 @@ impl VersionInfoReport {
         rendered
     }
 
+    /// Writes the JSON capability report into the provided writer.
+    ///
+    /// This mirrors upstream rsync's `-VV` output (`print_rsync_version(FNONE)`):
+    /// a JSON object with program metadata, nested `capabilities` and
+    /// `optimizations` objects containing boolean/numeric/string values,
+    /// algorithm lists as arrays, and closing `license`/`caveat` strings.
+    pub fn write_json<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
+        // upstream: usage.c - json_line() macro opens with '{' on first line
+        let meta = &self.metadata;
+        let protocol = format!(
+            "{}.{}",
+            meta.protocol_version().as_u8(),
+            meta.subprotocol_version()
+        );
+
+        write!(writer, "{{\n")?;
+        write!(writer, "  \"program\": \"{}\",\n", meta.program_name())?;
+        write!(writer, "  \"version\": \"{}\",\n", meta.rust_version())?;
+        write!(writer, "  \"protocol\": \"{protocol}\",\n")?;
+        // upstream: json_line("copyright", copyright) where copyright is just
+        // "(C) YYYY-YYYY by ..." without a "Copyright" prefix
+        write!(
+            writer,
+            "  \"copyright\": \"{}\",\n",
+            meta.copyright_notice()
+        )?;
+        write!(writer, "  \"url\": \"{}\"", meta.source_url())?;
+
+        // Capabilities section
+        // upstream: print_info_flags(FNONE) outputs nested JSON objects
+        self.write_json_info_flags(writer)?;
+
+        // Algorithm lists
+        // upstream: output_nno_list(FNONE, ...) outputs JSON arrays
+        self.write_json_algorithm_list(writer, "checksum_list", &self.checksum_algorithms)?;
+        self.write_json_algorithm_list(writer, "compress_list", &self.compress_algorithms)?;
+        self.write_json_algorithm_list(
+            writer,
+            "daemon_auth_list",
+            &self.daemon_auth_algorithms,
+        )?;
+
+        // Closing metadata
+        // upstream: usage.c - json_line("license", "GPLv3")
+        write!(writer, ",\n  \"license\": \"GPLv3\"")?;
+        write!(
+            writer,
+            ",\n  \"caveat\": \"rsync comes with ABSOLUTELY NO WARRANTY\""
+        )?;
+        write!(writer, "\n}}\n")?;
+        Ok(())
+    }
+
+    /// Writes the capabilities and optimizations sections as nested JSON objects.
+    ///
+    /// Mirrors upstream `print_info_flags(FNONE)` which converts each info flag
+    /// into a JSON key-value pair with underscores replacing spaces/hyphens and
+    /// lowercase keys.
+    fn write_json_info_flags<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
+        let config = self.config;
+
+        // upstream: "*Capabilities" becomes "capabilities": { ... }
+        write!(writer, ",\n  \"capabilities\": {{\n")?;
+
+        let file_bits = mem::size_of::<off_t>() * 8;
+        let inum_bits = mem::size_of::<ino_t>() * 8;
+        let timestamp_bits = mem::size_of::<TimeT>() * 8;
+        let long_int_bits = mem::size_of::<i64>() * 8;
+
+        // upstream: "64-bit files" -> "file_bits": 64
+        // The upstream code converts "N-bit label" to "label_bits": N
+        write!(writer, "    \"file_bits\": {file_bits},\n")?;
+        write!(writer, "    \"inum_bits\": {inum_bits},\n")?;
+        write!(writer, "    \"timestamp_bits\": {timestamp_bits},\n")?;
+        write!(writer, "    \"long_int_bits\": {long_int_bits},\n")?;
+
+        // Boolean capabilities
+        // upstream: "socketpairs" -> true, "no socketpairs" -> false
+        write!(
+            writer,
+            "    \"socketpairs\": {},\n",
+            config.supports_socketpairs
+        )?;
+        write!(writer, "    \"symlinks\": {},\n", config.supports_symlinks)?;
+        write!(writer, "    \"symtimes\": {},\n", config.supports_symtimes)?;
+        write!(
+            writer,
+            "    \"hardlinks\": {},\n",
+            config.supports_hardlinks
+        )?;
+        // upstream: "hardlink-specials" -> "hardlink_specials"
+        write!(
+            writer,
+            "    \"hardlink_specials\": {},\n",
+            config.supports_hardlink_specials
+        )?;
+        write!(
+            writer,
+            "    \"hardlink_symlinks\": {},\n",
+            config.supports_hardlink_symlinks
+        )?;
+        // upstream: "IPv6" -> "IPv6" (uppercase preserved, hyphens -> underscores)
+        write!(writer, "    \"IPv6\": {},\n", config.supports_ipv6)?;
+        write!(writer, "    \"atimes\": {},\n", config.supports_atimes)?;
+        write!(
+            writer,
+            "    \"batchfiles\": {},\n",
+            config.supports_batchfiles
+        )?;
+        write!(writer, "    \"inplace\": {},\n", config.supports_inplace)?;
+        write!(writer, "    \"append\": {},\n", config.supports_append)?;
+        write!(writer, "    \"ACLs\": {},\n", config.supports_acls)?;
+        write!(writer, "    \"xattrs\": {},\n", config.supports_xattrs)?;
+        // upstream: "optional secluded-args" -> "secluded_args": "optional"
+        let secluded_value = match config.secluded_args_mode {
+            super::super::SecludedArgsMode::Optional => "optional",
+            super::super::SecludedArgsMode::Default => "default",
+        };
+        write!(
+            writer,
+            "    \"secluded_args\": \"{secluded_value}\",\n"
+        )?;
+        write!(writer, "    \"iconv\": {},\n", config.supports_iconv)?;
+        write!(writer, "    \"prealloc\": {},\n", config.supports_prealloc)?;
+        write!(writer, "    \"stop_at\": {},\n", config.supports_stop_at)?;
+        write!(writer, "    \"crtimes\": {}\n", config.supports_crtimes)?;
+        write!(writer, "  }}")?;
+
+        // upstream: "*Optimizations" becomes "optimizations": { ... }
+        write!(writer, ",\n  \"optimizations\": {{\n")?;
+        write!(
+            writer,
+            "    \"SIMD_roll\": {},\n",
+            config.supports_simd_roll
+        )?;
+        write!(writer, "    \"asm_roll\": {},\n", config.supports_asm_roll)?;
+        write!(
+            writer,
+            "    \"openssl_crypto\": {},\n",
+            config.supports_openssl_crypto
+        )?;
+        write!(writer, "    \"asm_MD5\": {},\n", config.supports_asm_md5)?;
+        // oc-rsync-specific optimizations (not in upstream, but present in config)
+        write!(
+            writer,
+            "    \"mimalloc\": {},\n",
+            config.supports_mimalloc
+        )?;
+        write!(
+            writer,
+            "    \"copy_file_range\": {},\n",
+            config.supports_copy_file_range
+        )?;
+        write!(
+            writer,
+            "    \"io_uring\": {},\n",
+            config.supports_io_uring
+        )?;
+        write!(
+            writer,
+            "    \"parallel\": {},\n",
+            config.supports_parallel
+        )?;
+        write!(writer, "    \"mmap\": {}\n", config.supports_mmap)?;
+        write!(writer, "  }}")?;
+
+        Ok(())
+    }
+
+    /// Writes a named algorithm list as a JSON array.
+    ///
+    /// Mirrors upstream `output_nno_list(FNONE, ...)` which outputs:
+    /// `"checksum_list": [ "xxh128", "md5", ... ]`
+    fn write_json_algorithm_list<W: FmtWrite>(
+        &self,
+        writer: &mut W,
+        name: &str,
+        entries: &[Cow<'static, str>],
+    ) -> fmt::Result {
+        write!(writer, ",\n  \"{name}\": [\n   ")?;
+        // upstream: skip entries starting with '(' (aliases)
+        let filtered: Vec<&str> = entries
+            .iter()
+            .map(|e| e.as_ref())
+            .filter(|e| !e.starts_with('('))
+            .collect();
+        for (i, entry) in filtered.iter().enumerate() {
+            if i > 0 {
+                write!(writer, ",")?;
+            }
+            write!(writer, " \"{entry}\"")?;
+        }
+        write!(writer, "\n  ]")?;
+        Ok(())
+    }
+
+    /// Returns the JSON capability report as an owned string.
+    ///
+    /// This is the `-VV` equivalent of [`human_readable`](Self::human_readable).
+    #[must_use]
+    pub fn json(&self) -> String {
+        let mut rendered = String::new();
+        self.write_json(&mut rendered)
+            .expect("writing to String cannot fail");
+        rendered
+    }
+
     fn write_info_sections<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
         let mut buffer = String::new();
         let mut items = self.info_items().into_iter().peekable();
@@ -703,5 +910,150 @@ mod tests {
             InfoItem::Entry(text) => assert_eq!(text, "no test-cap"),
             _ => panic!("Expected Entry variant"),
         }
+    }
+
+    #[test]
+    fn json_returns_non_empty_string() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(!output.is_empty());
+    }
+
+    #[test]
+    fn json_starts_with_open_brace() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.starts_with('{'));
+    }
+
+    #[test]
+    fn json_ends_with_close_brace_newline() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.ends_with("}\n"));
+    }
+
+    #[test]
+    fn json_contains_program_key() {
+        let report = VersionInfoReport::for_client_brand(Brand::Upstream);
+        let output = report.json();
+        assert!(output.contains("\"program\""));
+        assert!(output.contains(Brand::Upstream.client_program_name()));
+    }
+
+    #[test]
+    fn json_contains_version_key() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"version\""));
+    }
+
+    #[test]
+    fn json_contains_protocol_key() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"protocol\""));
+    }
+
+    #[test]
+    fn json_contains_capabilities_section() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"capabilities\""));
+    }
+
+    #[test]
+    fn json_contains_optimizations_section() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"optimizations\""));
+    }
+
+    #[test]
+    fn json_contains_atimes_key() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"atimes\""));
+    }
+
+    #[test]
+    fn json_contains_crtimes_key() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"crtimes\""));
+    }
+
+    #[test]
+    fn json_contains_acls_key() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"ACLs\""));
+    }
+
+    #[test]
+    fn json_contains_xattrs_key() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"xattrs\""));
+    }
+
+    #[test]
+    fn json_contains_license() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"license\": \"GPLv3\""));
+    }
+
+    #[test]
+    fn json_contains_checksum_list() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"checksum_list\""));
+    }
+
+    #[test]
+    fn json_contains_compress_list() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"compress_list\""));
+    }
+
+    #[test]
+    fn json_contains_daemon_auth_list() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        assert!(output.contains("\"daemon_auth_list\""));
+    }
+
+    #[test]
+    fn json_atimes_reflects_config() {
+        let config = VersionInfoConfig::builder().supports_atimes(true).build();
+        let report = VersionInfoReport::new(config);
+        let output = report.json();
+        assert!(output.contains("\"atimes\": true"));
+    }
+
+    #[test]
+    fn json_atimes_false_reflects_config() {
+        let config = VersionInfoConfig::builder().supports_atimes(false).build();
+        let report = VersionInfoReport::new(config);
+        let output = report.json();
+        assert!(output.contains("\"atimes\": false"));
+    }
+
+    #[test]
+    fn json_skips_parenthesized_checksum_aliases() {
+        let report = VersionInfoReport::default();
+        let output = report.json();
+        // The default checksum list includes "(xxhash-rust)" which should be skipped
+        assert!(!output.contains("(xxhash-rust)"));
+    }
+
+    #[test]
+    fn write_json_to_string() {
+        let report = VersionInfoReport::default();
+        let mut output = String::new();
+        report.write_json(&mut output).unwrap();
+        assert!(!output.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Change `-V`/`--version` from boolean (`SetTrue`) to count-based (`Count`) argument
- When count >= 2 (`-VV` or `-V -V`), emit JSON matching upstream rsync's `print_rsync_version(FNONE)` format
- JSON includes nested `capabilities`, `optimizations`, `checksum_list`, `compress_list`, and `daemon_auth_list` objects
- Required by the upstream testsuite which checks feature support via `$RSYNC -VV | grep '"feature": true'`

## Test plan

- [x] `double_version_flag_renders_json` - verifies `-VV` produces valid JSON with expected keys
- [x] `separate_version_flags_render_json` - verifies `-V -V` is equivalent to `-VV`
- [x] `double_version_json_matches_report` - verifies output matches `VersionInfoReport::json()` byte-for-byte
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl