### PR TITLE
fix: support -VV JSON output and enable crtimes on macOS

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -34,8 +34,8 @@ pub struct ParsedArgs {
     /// `--help`, `-h`
     pub show_help: bool,
 
-    /// `--version`, `-V`
-    pub show_version: bool,
+    /// `--version`, `-V` (count: 1 = human-readable, 2+ = JSON)
+    pub show_version: u8,
 
     /// `--io-uring-status` - print the io_uring capability matrix and exit.
     pub show_io_uring_status: bool,

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -50,7 +50,7 @@ where
     let mut matches = command.try_get_matches_from(args)?;
 
     let show_help = matches.get_flag("help");
-    let show_version = matches.get_flag("version");
+    let show_version = matches.get_count("version");
     let show_io_uring_status = matches.get_flag("io-uring-status");
 
     // Handle human-readable: bare flags (-h, --human-readable) count occurrences

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -298,7 +298,7 @@ fn version_flag() {
     let result = parse_test_args(["--version"]);
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert!(parsed.show_version);
+    assert_eq!(parsed.show_version, 1);
 }
 
 #[test]

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1728,7 +1728,7 @@ mod path_operands {
     #[test]
     fn no_operands_with_version() {
         let parsed = parse_test_args(["--version"]).expect("parse");
-        assert!(parsed.show_version);
+        assert_eq!(parsed.show_version, 1);
         assert!(parsed.remainder.is_empty());
     }
 }
@@ -1851,13 +1851,19 @@ mod help_and_version {
     #[test]
     fn version_flag() {
         let parsed = parse_test_args(["--version"]).expect("parse");
-        assert!(parsed.show_version);
+        assert_eq!(parsed.show_version, 1);
     }
 
     #[test]
     fn short_version_flag() {
         let parsed = parse_test_args(["-V"]).expect("parse");
-        assert!(parsed.show_version);
+        assert_eq!(parsed.show_version, 1);
+    }
+
+    #[test]
+    fn double_version_flag() {
+        let parsed = parse_test_args(["-VV"]).expect("parse");
+        assert_eq!(parsed.show_version, 2);
     }
 }
 

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/core_args.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/core_args.rs
@@ -17,7 +17,7 @@ pub(super) fn add_core_args(command: ClapCommand) -> ClapCommand {
                 .long("version")
                 .short('V')
                 .help("Output version information and exit.")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::Count),
         )
         .arg(
             Arg::new("server")

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -86,9 +86,13 @@ where
 
 /// Prints help, version, or io_uring status text if requested, returning
 /// the exit code.
+///
+/// `show_version` is a count: 1 = human-readable output (upstream `-V`),
+/// 2+ = machine-readable JSON (upstream `-VV`).
+// upstream: options.c:1940-1942 - version_opt_cnt selects JSON vs human-readable
 pub(crate) fn maybe_print_help_or_version<Out>(
     show_help: bool,
-    show_version: bool,
+    show_version: u8,
     show_io_uring_status: bool,
     program_name: ProgramName,
     stdout: &mut Out,
@@ -104,7 +108,15 @@ where
         } else {
             Some(0)
         }
-    } else if show_version {
+    } else if show_version >= 2 {
+        let report = VersionInfoReport::for_client_brand(program_name.brand());
+        let json = report.machine_readable();
+        if stdout.write_all(json.as_bytes()).is_err() {
+            Some(1)
+        } else {
+            Some(0)
+        }
+    } else if show_version == 1 {
         let report = VersionInfoReport::for_client_brand(program_name.brand());
         let banner = report.human_readable();
         if stdout.write_all(banner.as_bytes()).is_err() {

--- a/crates/cli/tests/argument_defaults_special.rs
+++ b/crates/cli/tests/argument_defaults_special.rs
@@ -278,9 +278,9 @@ fn test_show_help_defaults_to_false() {
 }
 
 #[test]
-fn test_show_version_defaults_to_false() {
+fn test_show_version_defaults_to_zero() {
     let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
-    assert!(!args.show_version, "show_version should default to false");
+    assert_eq!(args.show_version, 0, "show_version should default to 0");
 }
 
 #[test]

--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -93,7 +93,7 @@ impl VersionInfoConfig {
             supports_iconv: cfg!(feature = "iconv"),
             supports_prealloc: true,
             supports_stop_at: true,
-            supports_crtimes: false,
+            supports_crtimes: cfg!(target_os = "macos"),
             supports_simd_roll: false,
             supports_asm_roll: false,
             supports_openssl_crypto: false,
@@ -410,7 +410,7 @@ mod tests {
         assert!(config.supports_append);
         assert!(config.supports_prealloc);
         assert!(config.supports_stop_at);
-        assert!(!config.supports_crtimes);
+        assert_eq!(config.supports_crtimes, cfg!(target_os = "macos"));
         assert!(!config.supports_simd_roll);
         assert!(!config.supports_asm_roll);
         assert!(!config.supports_openssl_crypto);

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -239,6 +239,129 @@ impl VersionInfoReport {
         rendered
     }
 
+    /// Writes the machine-readable JSON output produced by `-VV`.
+    ///
+    /// Mirrors upstream rsync's `print_rsync_version(FNONE)` path, which emits
+    /// a JSON object with capability flags, algorithm lists, and metadata fields.
+    // upstream: usage.c:252 - print_rsync_version with f == FNONE
+    pub fn write_machine_readable<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
+        let metadata = self.metadata;
+        let protocol = if metadata.subprotocol_version() != 0 {
+            format!(
+                "{}.{}",
+                metadata.protocol_version().as_u8(),
+                metadata.subprotocol_version()
+            )
+        } else {
+            format!("{}.0", metadata.protocol_version().as_u8())
+        };
+
+        // Preamble key-value pairs.
+        write!(writer, "{{\n  \"program\": \"{}\"", metadata.program_name())?;
+        write!(writer, ",\n  \"version\": \"{}\"", metadata.rust_version())?;
+        write!(writer, ",\n  \"protocol\": \"{protocol}\"")?;
+        write!(
+            writer,
+            ",\n  \"copyright\": \"{}\"",
+            metadata.copyright_notice()
+        )?;
+        write!(writer, ",\n  \"url\": \"{}\"", metadata.source_url())?;
+
+        // Capability and optimization sections.
+        self.write_json_info_sections(writer)?;
+
+        // Algorithm lists.
+        self.write_json_list(writer, "checksum_list", &self.checksum_algorithms)?;
+        self.write_json_list(writer, "compress_list", &self.compress_algorithms)?;
+        self.write_json_list(
+            writer,
+            "daemon_auth_list",
+            &self.daemon_auth_algorithms,
+        )?;
+
+        // Closing metadata.
+        write!(writer, ",\n  \"license\": \"GPLv3\"")?;
+        write!(
+            writer,
+            ",\n  \"caveat\": \"{} comes with ABSOLUTELY NO WARRANTY\"",
+            metadata.program_name()
+        )?;
+        writeln!(writer, "\n}}")
+    }
+
+    /// Returns the machine-readable JSON report as an owned string.
+    #[must_use]
+    pub fn machine_readable(&self) -> String {
+        let mut rendered = String::new();
+        self.write_machine_readable(&mut rendered)
+            .expect("writing to String cannot fail");
+        rendered
+    }
+
+    /// Writes JSON capability/optimization sections mirroring upstream's
+    /// `print_info_flags(FNONE)`.
+    // upstream: usage.c:37-216 - print_info_flags with as_json=true
+    fn write_json_info_sections<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
+        let items = self.info_items();
+        let mut in_section = false;
+
+        for (idx, item) in items.iter().enumerate() {
+            match item {
+                InfoItem::Section(name) => {
+                    // Close previous section if open.
+                    if in_section {
+                        write!(writer, "\n  }}")?;
+                    }
+                    // Lowercase first char, keep the rest as-is.
+                    // upstream: usage.c:206 - toLower(str+1) for first char
+                    let mut chars = name.chars();
+                    if let Some(first) = chars.next() {
+                        write!(
+                            writer,
+                            ",\n  \"{}{}\"",
+                            first.to_lowercase(),
+                            &name[first.len_utf8()..]
+                        )?;
+                    }
+                    write!(writer, ": {{")?;
+                    in_section = true;
+                }
+                InfoItem::Entry(text) => {
+                    let is_last_in_section = matches!(
+                        items.get(idx + 1),
+                        None | Some(InfoItem::Section(_))
+                    );
+
+                    write_json_entry(writer, text, !is_last_in_section)?;
+                }
+            }
+        }
+
+        // Close final section.
+        if in_section {
+            write!(writer, "\n  }}")?;
+        }
+        Ok(())
+    }
+
+    /// Writes a JSON array for an algorithm list.
+    // upstream: usage.c:218-249 - output_nno_list with f == FNONE
+    fn write_json_list<W: FmtWrite>(
+        &self,
+        writer: &mut W,
+        name: &str,
+        entries: &[Cow<'static, str>],
+    ) -> fmt::Result {
+        write!(writer, ",\n  \"{name}\": [\n   ")?;
+        for (i, entry) in entries.iter().enumerate() {
+            if i > 0 {
+                write!(writer, ",")?;
+            }
+            write!(writer, " \"{}\"", entry)?;
+        }
+        write!(writer, "\n  ]")
+    }
+
     fn write_info_sections<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
         let mut buffer = String::new();
         let mut items = self.info_items().into_iter().peekable();
@@ -460,6 +583,61 @@ fn capability_entry(label: &'static str, supported: bool) -> InfoItem {
     } else {
         InfoItem::Entry(Cow::Owned(format!("no {label}")))
     }
+}
+
+/// Converts a human-readable info entry into its JSON key-value representation.
+///
+/// Mirrors upstream `print_info_flags` JSON branch (usage.c:172-188):
+/// - `"64-bit files"` -> `"file_bits": 64`
+/// - `"no crtimes"` -> `"crtimes": false`
+/// - `"crtimes"` -> `"crtimes": true`
+/// - `"optional secluded-args"` -> `"secluded_args": "optional"`
+// upstream: usage.c:172-188 - JSON entry formatting in print_info_flags
+fn write_json_entry<W: FmtWrite>(writer: &mut W, text: &str, needs_comma: bool) -> fmt::Result {
+    let comma = if needs_comma { "," } else { "" };
+
+    if let Some(space_pos) = text.find(' ') {
+        let prefix = &text[..space_pos];
+        let suffix = &text[space_pos + 1..];
+
+        if prefix == "no" {
+            // "no crtimes" -> "crtimes": false
+            let key = json_key(suffix);
+            write!(writer, "\n    \"{key}\": false{comma}")
+        } else if prefix.starts_with(|c: char| c.is_ascii_digit()) {
+            // "64-bit files" -> "file_bits": 64
+            let val = if let Some(dash) = prefix.find('-') {
+                &prefix[..dash]
+            } else {
+                prefix
+            };
+            // Item is the word after space; drop trailing 's' and append "_bits"
+            let mut key = String::from(suffix);
+            if key.ends_with('s') {
+                key.pop();
+            }
+            key.push_str("_bits");
+            let key = json_key(&key);
+            write!(writer, "\n    \"{key}\": {val}{comma}")
+        } else {
+            // "optional secluded-args" -> "secluded_args": "optional"
+            let key = json_key(suffix);
+            write!(writer, "\n    \"{key}\": \"{prefix}\"{comma}")
+        }
+    } else {
+        // Simple boolean: "crtimes" -> "crtimes": true
+        let key = json_key(text);
+        write!(writer, "\n    \"{key}\": true{comma}")
+    }
+}
+
+/// Converts a capability name to a JSON key by replacing hyphens and spaces
+/// with underscores.
+// upstream: usage.c:187-188 - strpbrk loop replacing ' ' and '-' with '_'
+fn json_key(s: &str) -> String {
+    s.chars()
+        .map(|c| if c == '-' || c == ' ' { '_' } else { c })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/cli.rs
+++ b/crates/daemon/src/cli.rs
@@ -69,10 +69,14 @@ where
         return 0;
     }
 
-    if parsed.show_version && parsed.remainder.is_empty() {
+    if parsed.show_version > 0 && parsed.remainder.is_empty() {
         let report = VersionInfoReport::for_daemon_brand(parsed.program_name.brand());
-        let banner = report.human_readable();
-        if stdout.write_all(banner.as_bytes()).is_err() {
+        let output = if parsed.show_version >= 2 {
+            report.machine_readable()
+        } else {
+            report.human_readable()
+        };
+        if stdout.write_all(output.as_bytes()).is_err() {
             return 1;
         }
         return 0;

--- a/crates/daemon/src/daemon/sections/cli_args.rs
+++ b/crates/daemon/src/daemon/sections/cli_args.rs
@@ -53,7 +53,7 @@ pub(crate) enum ServiceAction {
 pub(crate) struct ParsedArgs {
     pub(crate) program_name: ProgramName,
     pub(crate) show_help: bool,
-    pub(crate) show_version: bool,
+    pub(crate) show_version: u8,
     pub(crate) service_action: Option<ServiceAction>,
     pub(crate) remainder: Vec<OsString>,
 }
@@ -78,7 +78,7 @@ pub(crate) fn clap_command(program_name: &'static str) -> Command {
                 .long("version")
                 .short('V')
                 .help("Output version information and exit.")
-                .action(ArgAction::SetTrue),
+                .action(ArgAction::Count),
         )
         .arg(
             Arg::new("windows-service")
@@ -132,7 +132,7 @@ where
     let mut matches = clap_command(program_name.as_str()).try_get_matches_from(args)?;
 
     let show_help = matches.get_flag("help");
-    let show_version = matches.get_flag("version");
+    let show_version = matches.get_count("version");
     let windows_service = matches.get_flag("windows-service");
     let install_service = matches.get_flag("install-service");
     let uninstall_service = matches.get_flag("uninstall-service");

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -333,7 +333,7 @@ fn parse_args_empty_defaults_to_program_name() {
     assert!(result.is_ok());
     let parsed = result.unwrap();
     assert!(!parsed.show_help);
-    assert!(!parsed.show_version);
+    assert_eq!(parsed.show_version, 0);
 }
 
 #[test]
@@ -343,7 +343,7 @@ fn parse_args_help_flag() {
     assert!(result.is_ok());
     let parsed = result.unwrap();
     assert!(parsed.show_help);
-    assert!(!parsed.show_version);
+    assert_eq!(parsed.show_version, 0);
 }
 
 #[test]
@@ -353,7 +353,7 @@ fn parse_args_version_flag_long() {
     assert!(result.is_ok());
     let parsed = result.unwrap();
     assert!(!parsed.show_help);
-    assert!(parsed.show_version);
+    assert_eq!(parsed.show_version, 1);
 }
 
 #[test]
@@ -362,7 +362,7 @@ fn parse_args_version_flag_short() {
     let result = parse_args(args);
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert!(parsed.show_version);
+    assert_eq!(parsed.show_version, 1);
 }
 
 #[test]
@@ -400,7 +400,7 @@ fn parse_args_help_and_version_together() {
     assert!(result.is_ok());
     let parsed = result.unwrap();
     assert!(parsed.show_help);
-    assert!(parsed.show_version);
+    assert_eq!(parsed.show_version, 1);
 }
 
 #[test]

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -51,10 +51,8 @@ KNOWN_FAILURES=(
   "hardlinks"
 
   # --- Time/timestamp tests ---
-  # crtimes requires platform birth-time support; atimes requires
-  # --atimes flag wiring on receiver side.
+  # atimes requires --atimes flag wiring on receiver side.
   "atimes"
-  "crtimes"
 
   # --- chmod-temp-dir test ---
   # Tests that --temp-dir interacts correctly with --chmod; relies on


### PR DESCRIPTION
## Summary

- Add machine-readable JSON output for `-VV` (double version flag), matching upstream rsync's `usage.c` format. The `--version` flag changes from boolean to counter so `-VV` yields JSON while `-V` stays human-readable.
- Enable `supports_crtimes` on macOS via `cfg!(target_os = "macos")` - the full crtime path (preserve flag, wire format, `setattrlist(2)` application) was already implemented.
- Remove `crtimes` from the upstream testsuite known-failures list. On Linux the test correctly SKIPs (exit 77) since crtimes is not advertised; on macOS it should PASS.

## Test plan

- [ ] CI nextest passes (existing tests updated for `show_version: bool` -> `u8` type change)
- [ ] New `-VV` parsing test validates `show_version == 2`
- [ ] Upstream testsuite: `crtimes` no longer listed as known failure
- [ ] macOS CI: `crtimes` test should PASS (birth time supported)
- [ ] Linux CI: `crtimes` test should SKIP (exit 77, no birth time)