### PR TITLE
fix: shell-escape filename args and parse --log-format on server side

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -92,6 +92,14 @@ pub(super) struct ServerLongFlags {
     /// the value here lets the server bypass vstring negotiation and use the
     /// same algorithm as the client.
     pub(super) compress_choice: Option<String>,
+    /// Log format forwarded by the client (upstream: `--log-format=FMT`).
+    ///
+    /// upstream: options.c:2750-2762 - the client sends `--log-format=%i`
+    /// (or `%i%I`, `%o`, `X`) so the server knows whether the generator
+    /// should produce itemize data. The server does not use the full format
+    /// string - it only inspects it for `%i` / `%o` tokens to set
+    /// `stdout_format_has_i` and `stdout_format_has_o_or_i`.
+    pub(super) log_format: Option<String>,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -132,6 +140,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         reference_directories: Vec::new(),
         info: Vec::new(),
         compress_choice: None,
+        log_format: None,
     };
 
     for arg in args {
@@ -211,6 +220,10 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         .or_else(|| s.strip_prefix("--zc="))
     {
         flags.compress_choice = Some(value.to_owned());
+    // upstream: options.c:2750-2762 - client forwards --log-format=%i (or %o,
+    // %i%I, X) so the server knows whether to generate itemize data.
+    } else if let Some(value) = s.strip_prefix("--log-format=") {
+        flags.log_format = Some(value.to_owned());
     // upstream: options.c:2928-2931 - server_options() forwards info levels.
     // Capture the raw value so run_server_mode can parse it tolerantly via
     // parse_info_flags_server (mirroring `am_server` in parse_output_words).
@@ -287,5 +300,6 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--iconv=")
         || arg.starts_with("--timeout=")
         || arg.starts_with("--io-uring-depth=")
+        || arg.starts_with("--log-format=")
         || arg.starts_with("--info=")
 }

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -121,6 +121,15 @@ where
     config.flags.delete = long_flags.delete;
     config.reference_directories = long_flags.reference_directories;
 
+    // upstream: options.c:2327-2338 - server parses --log-format to determine
+    // whether itemize data is needed. %i or %I in the format sets
+    // stdout_format_has_i, which controls generator itemize output.
+    if let Some(fmt) = &long_flags.log_format {
+        if fmt.contains("%i") || fmt.contains("%I") {
+            config.flags.info_flags.itemize = true;
+        }
+    }
+
     // upstream: rsync.c:85-147 setup_iconv() - server opens iconv against the
     // wire's UTF-8 charset using the local-side spec forwarded by the client
     // (options.c:2716-2723). Without this wiring the receiver/generator skip

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -864,3 +864,73 @@ fn parse_server_args_compress_choice_strips_from_dest() {
     assert_eq!(flags, "-vlogDtpre.iLsfxCIvuz");
     assert_eq!(pos_args, vec![OsString::from("dest/")]);
 }
+
+#[test]
+fn parse_server_long_flags_log_format_itemize() {
+    // upstream: options.c:2757 - client sends --log-format=%i for itemize
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--log-format=%i"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.log_format.as_deref(), Some("%i"));
+}
+
+#[test]
+fn parse_server_long_flags_log_format_itemize_extended() {
+    // upstream: options.c:2755 - %i%I when stdout_format_has_i > 1
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--log-format=%i%I"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.log_format.as_deref(), Some("%i%I"));
+}
+
+#[test]
+fn parse_server_long_flags_log_format_operation() {
+    // upstream: options.c:2759 - %o when stdout_format_has_o_or_i
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--log-format=%o"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.log_format.as_deref(), Some("%o"));
+}
+
+#[test]
+fn parse_server_long_flags_log_format_placeholder() {
+    // upstream: options.c:2761 - X when not verbose, no i/o tokens
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--log-format=X"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.log_format.as_deref(), Some("X"));
+}
+
+#[test]
+fn log_format_recognized_as_known_server_long_flag() {
+    assert!(is_known_server_long_flag("--log-format=%i"));
+    assert!(is_known_server_long_flag("--log-format=%i%I"));
+    assert!(is_known_server_long_flag("--log-format=%o"));
+    assert!(is_known_server_long_flag("--log-format=X"));
+}
+
+#[test]
+fn parse_server_args_log_format_strips_from_dest() {
+    // Regression: without recognizing --log-format as a known server flag,
+    // it falls through to positional args and the server tries to find a
+    // file named "--log-format=%i", reporting "file has vanished".
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-logDtpre.iLsfxCIvu"),
+        OsString::from("--log-format=%i"),
+        OsString::from("."),
+        OsString::from("/src/path/"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-logDtpre.iLsfxCIvu");
+    assert_eq!(pos_args, vec![OsString::from("/src/path/")]);
+}

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -68,6 +68,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// Builds the complete invocation argument vector with multiple remote paths.
     ///
     /// This is used for pull operations with multiple remote sources from the same host.
+    /// Filename arguments are shell-escaped for safe eval by the remote shell.
     pub fn build_with_paths(&self, remote_paths: &[&str]) -> Vec<OsString> {
         let mut args = Vec::new();
 
@@ -77,7 +78,7 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("rsync"));
         }
 
-        args.extend(self.build_args_without_program(remote_paths));
+        args.extend(self.build_args_without_program(remote_paths, true));
         args
     }
 
@@ -131,9 +132,10 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// Builds the full argument list for stdin transmission in secluded-args mode.
     ///
     /// This produces the same arguments as `build_with_paths()` but as `String`
-    /// values suitable for null-separated transmission over stdin.
+    /// values suitable for null-separated transmission over stdin. No shell
+    /// escaping is applied because stdin args are null-separated, not eval'd.
     fn build_full_args_for_stdin(&self, remote_paths: &[&str]) -> Vec<String> {
-        let os_args = self.build_args_without_program(remote_paths);
+        let os_args = self.build_args_without_program(remote_paths, false);
         os_args
             .into_iter()
             .map(|a| a.to_string_lossy().into_owned())
@@ -145,7 +147,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// This is shared between normal `build_with_paths` and secluded-args
     /// `build_full_args_for_stdin`. The result includes `--server`, optional
     /// `--sender`, flags, capability string, `.`, and remote paths.
-    fn build_args_without_program(&self, remote_paths: &[&str]) -> Vec<OsString> {
+    ///
+    /// When `escape_for_shell` is true, filename arguments (remote paths) are
+    /// backslash-escaped for safe evaluation by the remote shell. This mirrors
+    /// upstream `options.c:safe_arg(NULL, path)` which escapes shell
+    /// metacharacters so that `eval "$@"` in the remote shell wrapper (e.g.,
+    /// `lsh.sh`) does not misinterpret special characters in filenames.
+    fn build_args_without_program(
+        &self,
+        remote_paths: &[&str],
+        escape_for_shell: bool,
+    ) -> Vec<OsString> {
         let mut args = Vec::new();
 
         args.push(OsString::from("--server"));
@@ -187,7 +199,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
         args.push(OsString::from("."));
 
         for path in remote_paths {
-            args.push(OsString::from(path));
+            if escape_for_shell {
+                // upstream: main.c:613 safe_arg(NULL, *remote_argv++)
+                args.push(OsString::from(shell_safe_filename_arg(path)));
+            } else {
+                args.push(OsString::from(*path));
+            }
         }
 
         args
@@ -574,6 +591,64 @@ impl<'a> RemoteInvocationBuilder<'a> {
 
         flags
     }
+}
+
+/// Shell metacharacters that upstream rsync escapes in filename arguments.
+///
+/// upstream: options.c `SHELL_CHARS` - characters requiring backslash escaping
+/// when passing filename arguments through a remote shell that evaluates them
+/// via `eval "$@"`.
+const SHELL_CHARS: &str = "!#$&;|<>(){}\"'` \t\\";
+
+/// Wildcard characters recognized by upstream rsync.
+///
+/// upstream: options.c `WILD_CHARS` - when a backslash precedes one of these
+/// characters in a filename argument, the backslash is kept as-is (it already
+/// serves as a wildcard escape), so we do not double-escape it.
+const WILD_CHARS: &str = "*?[]";
+
+/// Backslash-escapes shell metacharacters in a filename argument.
+///
+/// Mirrors upstream `options.c:safe_arg(NULL, arg)` which prepends a backslash
+/// before every character in `SHELL_CHARS`, with special handling:
+///
+/// - Backslash itself is only escaped when it does NOT precede a wildcard
+///   character (`*`, `?`, `[`, `]`), preserving intentional wildcard escapes.
+/// - A leading `-` is prefixed with `./` to prevent the remote server from
+///   interpreting the path as an option.
+///
+/// This escaping is applied when `protect_args` is not active, matching the
+/// upstream condition `!protect_args && old_style_args < 2`.
+pub(super) fn shell_safe_filename_arg(arg: &str) -> String {
+    let leading_dash = arg.starts_with('-');
+    let needs_escaping =
+        leading_dash || arg.chars().any(|c| SHELL_CHARS.contains(c));
+    if !needs_escaping {
+        return arg.to_owned();
+    }
+
+    let mut out = String::with_capacity(arg.len() + 16);
+
+    if leading_dash {
+        out.push_str("./");
+    }
+
+    let chars: Vec<char> = arg.chars().collect();
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == '\\' {
+            // upstream: backslash is only escaped when the next character is
+            // NOT a wildcard (preserving intentional wildcard escapes).
+            let next = chars.get(i + 1).copied().unwrap_or('\0');
+            if !WILD_CHARS.contains(next) {
+                out.push('\\');
+            }
+        } else if SHELL_CHARS.contains(ch) {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+
+    out
 }
 
 /// Converts a `CompressionLevel` into its numeric representation for the wire.

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2494,3 +2494,108 @@ fn iconv_explicit_single_forwards_whole_spec() {
         "Explicit single must forward the whole spec: {args:?}"
     );
 }
+
+// --- Shell-escaping of filename arguments (safe_arg) ---
+// upstream: options.c:safe_arg(NULL, path) backslash-escapes SHELL_CHARS in
+// filename args when protect_args is off. These tests verify that oc-rsync
+// produces the same escaping, matching the lsh.sh `eval "$@"` contract.
+
+use super::builder::shell_safe_filename_arg;
+
+#[test]
+fn shell_safe_simple_path_unchanged() {
+    assert_eq!(shell_safe_filename_arg("/simple/path"), "/simple/path");
+}
+
+#[test]
+fn shell_safe_escapes_parentheses() {
+    // upstream: SHELL_CHARS includes '(' and ')'
+    assert_eq!(
+        shell_safe_filename_arg("/dir/A weird)name/file"),
+        "/dir/A\\ weird\\)name/file"
+    );
+}
+
+#[test]
+fn shell_safe_escapes_spaces() {
+    assert_eq!(
+        shell_safe_filename_arg("/dir/has space/file"),
+        "/dir/has\\ space/file"
+    );
+}
+
+#[test]
+fn shell_safe_escapes_shell_metacharacters() {
+    assert_eq!(shell_safe_filename_arg("a&b"), "a\\&b");
+    assert_eq!(shell_safe_filename_arg("a;b"), "a\\;b");
+    assert_eq!(shell_safe_filename_arg("a|b"), "a\\|b");
+    assert_eq!(shell_safe_filename_arg("a<b"), "a\\<b");
+    assert_eq!(shell_safe_filename_arg("a>b"), "a\\>b");
+    assert_eq!(shell_safe_filename_arg("a{b}"), "a\\{b\\}");
+    assert_eq!(shell_safe_filename_arg("a\"b"), "a\\\"b");
+    assert_eq!(shell_safe_filename_arg("a'b"), "a\\'b");
+    assert_eq!(shell_safe_filename_arg("a`b"), "a\\`b");
+    assert_eq!(shell_safe_filename_arg("a#b"), "a\\#b");
+    assert_eq!(shell_safe_filename_arg("a$b"), "a\\$b");
+    assert_eq!(shell_safe_filename_arg("a!b"), "a\\!b");
+}
+
+#[test]
+fn shell_safe_escapes_tab() {
+    assert_eq!(shell_safe_filename_arg("a\tb"), "a\\\tb");
+}
+
+#[test]
+fn shell_safe_leading_dash_gets_dot_slash() {
+    // upstream: safe_arg prepends "./" to prevent option interpretation
+    assert_eq!(shell_safe_filename_arg("-file"), "./-file");
+}
+
+#[test]
+fn shell_safe_backslash_not_before_wildcard_is_escaped() {
+    // upstream: backslash is escaped unless followed by a wildcard char
+    assert_eq!(shell_safe_filename_arg("a\\b"), "a\\\\b");
+}
+
+#[test]
+fn shell_safe_backslash_before_wildcard_is_preserved() {
+    // upstream: backslash before wildcard chars (*?[]) is NOT escaped
+    assert_eq!(shell_safe_filename_arg("a\\*b"), "a\\*b");
+    assert_eq!(shell_safe_filename_arg("a\\?b"), "a\\?b");
+    assert_eq!(shell_safe_filename_arg("a\\[b"), "a\\[b");
+    assert_eq!(shell_safe_filename_arg("a\\]b"), "a\\]b");
+}
+
+#[test]
+fn shell_safe_no_escaping_in_secluded_mode() {
+    // When protect_args is active, stdin_args should NOT be shell-escaped
+    let config = ClientConfig::builder().protect_args(Some(true)).build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+
+    assert!(
+        secluded
+            .stdin_args
+            .iter()
+            .any(|a| a == "/path/A weird)name/"),
+        "secluded stdin_args should contain unescaped path: {:?}",
+        secluded.stdin_args
+    );
+}
+
+#[test]
+fn shell_safe_escaping_in_normal_mode() {
+    // When protect_args is off, command_line_args should have escaped paths
+    let config = ClientConfig::builder().protect_args(None).build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let secluded = builder.build_secluded(&["/path/A weird)name/"]);
+
+    assert!(
+        secluded
+            .command_line_args
+            .iter()
+            .any(|a| a.to_string_lossy() == "/path/A\\ weird\\)name/"),
+        "normal command_line_args should contain escaped path: {:?}",
+        secluded.command_line_args
+    );
+}

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -14,10 +14,9 @@
 
 KNOWN_FAILURES=(
   # --- Remote-shell tests (lsh.sh) ---
-  # These tests use upstream's support/lsh.sh as $RSYNC_RSH and invoke
-  # rsync via fake-localhost SSH. They require oc-rsync to interoperate
-  # with upstream's rsync server-side via the -e <cmd> path. Expected
-  # to need protocol-stack work to pass.
+  # Tests 1-5 pass (shell escaping + --log-format server parsing). Tests
+  # 6-7 require --old-args space-splitting of remote paths, which is not
+  # yet wired into the path-parsing layer.
   "00-hello"
 
   # --- Daemon-mode tests ---


### PR DESCRIPTION
## Summary

- Shell-escape filename arguments in remote invocations to prevent `eval` syntax errors when filenames contain shell metacharacters (parentheses, spaces, etc.). Mirrors upstream `options.c:safe_arg(NULL, path)` behavior with `SHELL_CHARS` / `WILD_CHARS` handling.
- Parse `--log-format=FMT` as a recognized server-mode long flag so the server correctly enables itemize output instead of treating the flag as a vanished filename.
- Update `upstream_testsuite_known_failures.conf` to reflect that 00-hello tests 1-5 now pass; tests 6-7 remain expected failures pending `--old-args` space-splitting support.

## Test plan

- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] New unit tests cover `shell_safe_filename_arg` escaping for all metacharacter categories
- [ ] New unit tests cover `--log-format` server flag parsing and positional arg exclusion
- [ ] Upstream testsuite 00-hello tests 1-5 pass in container with lsh.sh remote shell