### PR TITLE
fix: preserve original wire NDX for INC_RECURSE gap echo-back

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -184,9 +184,14 @@ impl GeneratorContext {
     /// Updates the `NDX_CONVERT_CALLS` / `NDX_CONVERT_CMPS` counters used
     /// for INC_RECURSE diagnostic I4 (#2199).
     ///
+    /// Only used in tests after the NDX echo-back fix - the transfer loop now
+    /// preserves the original wire NDX instead of round-tripping through this
+    /// function, which avoids corrupting INC_RECURSE gap NDX values.
+    ///
     /// # Upstream Reference
     ///
     /// - `generator.c:2321` - `ndx = i + cur_flist->ndx_start`
+    #[cfg(test)]
     pub(crate) fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
         let segments = &self.incremental.ndx_segments;
         NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -306,6 +306,57 @@ fn ndx_convert_partition_point_depth_grows() {
 }
 
 #[test]
+fn inc_recurse_gap_ndx_round_trip_preserves_original() {
+    // When INC_RECURSE is active, ndx_start=1. The upstream generator sends
+    // "gap NDX" values (ndx_start - 1 = 0) to signal parent directory
+    // metadata updates. The sender must echo the original wire NDX unchanged.
+    //
+    // Before the fix, wire_to_flat_ndx(0) with ndx_start=1 computed
+    // 0 + (0 - 1) as usize = usize::MAX, and flat_to_wire_ndx(usize::MAX)
+    // produced a garbage value instead of 0.
+    //
+    // upstream: sender.c:263-266 - gap NDX echoed unchanged
+    use protocol::CompatibilityFlags;
+
+    let mut handshake = test_handshake_with_protocol(32);
+    handshake.compat_flags = Some(
+        CompatibilityFlags::INC_RECURSE
+            | CompatibilityFlags::SYMLINK_TIMES
+            | CompatibilityFlags::SYMLINK_ICONV,
+    );
+
+    let ctx = GeneratorContext::new_for_test(&handshake, test_config());
+
+    // Verify INC_RECURSE is active and ndx_start=1
+    assert!(ctx.inc_recurse());
+    assert_eq!(ctx.incremental.ndx_segments, vec![(0, 1)]);
+
+    // Gap NDX = ndx_start - 1 = 0
+    let gap_ndx: i32 = 0;
+
+    // The fix preserves wire_ndx directly, so the round-trip through
+    // wire_to_flat_ndx + flat_to_wire_ndx is no longer used in production.
+    // Verify that the gap NDX value (0) is below ndx_start (1), which is
+    // the condition under which upstream echoes the original NDX unchanged.
+    let ndx_start = ctx.incremental.ndx_segments[0].1;
+    assert!(
+        gap_ndx < ndx_start,
+        "gap NDX ({gap_ndx}) must be below ndx_start ({ndx_start})"
+    );
+
+    // Also verify that a normal NDX (at or above ndx_start) round-trips
+    // correctly through the conversion functions.
+    let normal_ndx: i32 = 1;
+    let flat = ctx.wire_to_flat_ndx(normal_ndx);
+    let back = ctx.flat_to_wire_ndx(flat);
+    assert_eq!(
+        back, normal_ndx,
+        "normal NDX round-trip: wire_to_flat_ndx({normal_ndx}) = {flat}, \
+         flat_to_wire_ndx({flat}) = {back}, expected {normal_ndx}"
+    );
+}
+
+#[test]
 fn flush_with_count_increments_global_counter() {
     // INC_RECURSE diagnostic I3 (#2198): every flush on the generator
     // transfer hot path must bump the global FLUSH_CALLS counter. The

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -273,8 +273,15 @@ impl GeneratorContext {
                 }
             }
 
+            // upstream: sender.c:263-266 - preserve the original wire NDX for
+            // echo-back. When INC_RECURSE is active, the receiver sends "gap
+            // NDX" values (ndx_start - 1 per sub-list) that fall below
+            // cur_flist->ndx_start. Upstream echoes the original NDX unchanged;
+            // converting through wire_to_flat_ndx and back via flat_to_wire_ndx
+            // corrupts these gap values (the subtraction wraps to usize::MAX).
+            let wire_ndx = ndx;
             // upstream: rsync.c:424 - i = ndx - cur_flist->ndx_start
-            let ndx = self.wire_to_flat_ndx(ndx);
+            let ndx = self.wire_to_flat_ndx(wire_ndx);
 
             // upstream: rsync.c:227 - read_ndx_and_attrs() reads iflags
             let iflags = ItemFlags::read(&mut *reader, self.protocol.as_u8())?;
@@ -309,7 +316,6 @@ impl GeneratorContext {
             // F_PATHNAME is unset for the in-band file list we build, so the
             // path/slash prefix is empty and we emit just the relative name.
             if ndx < self.file_list.len() {
-                let wire_ndx = self.flat_to_wire_ndx(ndx);
                 let entry_path = self.file_list[ndx].path().display().to_string();
                 debug_log!(Send, 1, "send_files({}, {})", wire_ndx, entry_path);
             }
@@ -321,11 +327,10 @@ impl GeneratorContext {
                 // request and apply xattr-only updates. Without this echo the
                 // wire stream stalls when ITEM_REPORT_XATTR is the only delta.
                 self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
-                let ndx_i32 = self.flat_to_wire_ndx(ndx);
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    ndx_i32,
+                    wire_ndx,
                     &iflags,
                     pending_xattr_response.as_mut(),
                 )?;
@@ -339,11 +344,10 @@ impl GeneratorContext {
             if self.config.flags.dry_run {
                 self.validate_file_index(ndx)?;
                 let file_entry = &self.file_list[ndx];
-                let ndx_i32 = self.flat_to_wire_ndx(ndx);
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    ndx_i32,
+                    wire_ndx,
                     &iflags,
                     pending_xattr_response.as_mut(),
                 )?;
@@ -385,14 +389,12 @@ impl GeneratorContext {
             }
 
             let file_size = file_entry.size();
-            // upstream: sender.c:389 - write_ndx(f_out, ndx)
-            let ndx_i32 = self.flat_to_wire_ndx(ndx);
 
             if has_basis {
                 let source: Box<dyn Read> = match self.open_source_reader(source_path, file_size) {
                     Ok(r) => r,
                     Err(e) => {
-                        self.record_open_failure(&mut *writer, ndx_i32, &e, &source_path_display)?;
+                        self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;
                     }
                 };
@@ -410,7 +412,7 @@ impl GeneratorContext {
                 self.write_ndx_and_attrs(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    ndx_i32,
+                    wire_ndx,
                     &iflags,
                     &sum_head,
                     pending_xattr_response.as_mut(),
@@ -453,7 +455,7 @@ impl GeneratorContext {
                 let source: Box<dyn Read> = match self.open_source_reader(source_path, file_size) {
                     Ok(r) => r,
                     Err(e) => {
-                        self.record_open_failure(&mut *writer, ndx_i32, &e, &source_path_display)?;
+                        self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;
                     }
                 };
@@ -461,7 +463,7 @@ impl GeneratorContext {
                 self.write_ndx_and_attrs(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    ndx_i32,
+                    wire_ndx,
                     &iflags,
                     &sum_head,
                     pending_xattr_response.as_mut(),


### PR DESCRIPTION
## Summary

- Fix INC_RECURSE NDX underflow that caused empty-dir interop failures (exit code 23)
- When INC_RECURSE is active (`ndx_start=1`), gap NDX values (`ndx_start - 1 = 0`) signal parent directory metadata updates. The transfer loop previously round-tripped these through `wire_to_flat_ndx` / `flat_to_wire_ndx`, causing `0 - 1` to wrap to `usize::MAX` and producing a garbage echo-back NDX. The upstream receiver then aborted with "File-list index N not in X - Y"
- Fix preserves the original wire NDX before conversion and uses it directly for all echo-back write points, matching upstream `sender.c:263-266`

## Test plan

- [ ] New unit test `inc_recurse_gap_ndx_round_trip_preserves_original` verifies INC_RECURSE context setup and normal NDX round-trip correctness
- [ ] CI: fmt+clippy pass (no dead_code warning since `flat_to_wire_ndx` is gated with `#[cfg(test)]`)
- [ ] CI: nextest (stable) passes on all platforms
- [ ] CI: Windows/macOS/Linux musl matrix green
- [ ] Interop: empty-dir push to upstream rsync daemon no longer exits with code 23