### PR TITLE
fix: implement -VV JSON output and remove atimes from upstream testsuite known failures

### DIFF
--- a/crates/cli/src/frontend/tests/version.rs
+++ b/crates/cli/src/frontend/tests/version.rs
@@ -64,3 +64,28 @@ fn short_version_flag_ignores_additional_operands() {
     let expected = VersionInfoReport::for_client_brand(Brand::Upstream).human_readable();
     assert_eq!(stdout, expected.into_bytes());
 }
+
+#[test]
+fn double_v_renders_json_output() {
+    let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("-VV")]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let expected = VersionInfoReport::for_client_brand(Brand::Upstream).machine_readable();
+    assert_eq!(stdout, expected.into_bytes());
+}
+
+#[test]
+fn double_v_json_contains_atimes_true() {
+    // upstream testsuite/atimes.test requires:
+    //   $RSYNC -VV | grep '"atimes": true'
+    let (code, stdout, _) = run_with_args([OsStr::new(RSYNC), OsStr::new("-VV")]);
+
+    assert_eq!(code, 0);
+    let output = String::from_utf8_lossy(&stdout);
+    assert!(
+        output.contains("\"atimes\": true"),
+        "-VV JSON must contain '\"atimes\": true' for upstream testsuite compatibility"
+    );
+}

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -49,10 +49,6 @@ KNOWN_FAILURES=(
   # paths not yet enabled by default in oc-rsync.
   "hardlinks"
 
-  # --- Time/timestamp tests ---
-  # atimes requires --atimes flag wiring on receiver side.
-  "atimes"
-
   # --- chmod-temp-dir test ---
   # Tests that --temp-dir interacts correctly with --chmod; relies on
   # specific tempfile placement that may differ from upstream.


### PR DESCRIPTION
## Summary

- Implement `-VV` (double-V) JSON output on `VersionInfoReport`, matching upstream rsync's `usage.c:print_rsync_version(FNONE)` format
- Change `-V` argument from `SetTrue` to `Count` so `-V` emits human-readable output and `-VV` emits JSON
- Remove `atimes` from `upstream_testsuite_known_failures.conf` - the test's prerequisite check (`$RSYNC -VV | grep '"atimes": true'`) now passes, and atime preservation in local copy was already implemented

## Details

The upstream `atimes.test` script first runs `$RSYNC -VV | grep '"atimes": true'` to verify atime support is compiled in. Without JSON output from `-VV`, this grep fails and the test is skipped (counted as a test failure in the harness).

Changes:
- `core_args.rs`: `-V` action changed from `ArgAction::SetTrue` to `ArgAction::Count`
- `parsed_args/mod.rs`: `show_version` type changed from `bool` to `u8`
- `parser/mod.rs`: `get_flag("version")` changed to `get_count("version")`
- `preflight.rs`: Routes `show_version >= 2` to `machine_readable()`, `== 1` to `human_readable()`
- `renderer.rs`: New `machine_readable()`, `write_machine_readable()`, `write_json_info_sections()`, `write_json_entry()`, `write_json_list()`, `section_name_to_json()` methods
- All existing tests updated for `u8` type; 7 new tests added

## Test plan

- [ ] CI fmt+clippy passes
- [ ] nextest (stable) passes with new unit tests for `machine_readable()` JSON output
- [ ] `-VV` CLI integration tests verify JSON output and `"atimes": true` presence
- [ ] Upstream testsuite `atimes` test transitions from XFAIL to PASS