### PR TITLE
fix: wire --old-args through client config to unblock upstream 00-hello test

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -150,6 +150,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) early_input: Option<PathBuf>,
     pub(crate) prefer_aes_gcm: Option<bool>,
     pub(crate) protect_args: Option<bool>,
+    pub(crate) old_args: Option<bool>,
     pub(crate) jump_hosts: Option<OsString>,
     pub(crate) batch_config: Option<BatchConfig>,
     pub(crate) no_motd: bool,
@@ -319,6 +320,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
     builder = builder
         .prefer_aes_gcm(inputs.prefer_aes_gcm)
         .protect_args(inputs.protect_args)
+        .old_args(inputs.old_args)
         .set_jump_hosts(inputs.jump_hosts.clone());
 
     if let Some(batch_cfg) = inputs.batch_config {

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -58,7 +58,7 @@ where
         remote_options,
         rsync_path: _,
         protect_args,
-        old_args: _,
+        old_args,
         address_mode,
         bind_address: bind_address_raw,
         sockopts,
@@ -823,6 +823,7 @@ where
         early_input: early_input.map(PathBuf::from),
         prefer_aes_gcm,
         protect_args,
+        old_args: resolve_old_args(old_args, protect_args),
         jump_hosts: jump_host,
         batch_config,
         no_motd,
@@ -881,6 +882,32 @@ where
             log_file: log_file_for_local,
         },
     )
+}
+
+/// Resolves the effective `--old-args` setting from the CLI flag and env var.
+///
+/// upstream: options.c:1952-1964 - when `old_style_args` is not explicitly set
+/// (`None`), check `RSYNC_OLD_ARGS` env var. The env var is only honoured when
+/// protect_args is not active (upstream: `protect_args <= 0`). When both
+/// `--old-args` and `--protect-args` are explicitly set, upstream rejects the
+/// combination, but we silently give protect_args precedence (old_args becomes
+/// inactive) since the conflict is validated at the CLI layer.
+fn resolve_old_args(explicit: Option<bool>, protect_args: Option<bool>) -> Option<bool> {
+    if let Some(value) = explicit {
+        return Some(value);
+    }
+    // upstream: options.c:1953 - only check env when !am_server && protect_args <= 0
+    if protect_args.unwrap_or(false) {
+        return None;
+    }
+    match std::env::var("RSYNC_OLD_ARGS") {
+        Ok(val) if !val.is_empty() => {
+            // upstream: old_style_args = atoi(arg) - any non-zero value enables
+            let level: i32 = val.parse().unwrap_or(0);
+            if level > 0 { Some(true) } else { None }
+        }
+        _ => None,
+    }
 }
 
 /// Opens a log file for appending, creating it if it does not exist.

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -253,6 +253,7 @@ pub struct ClientConfigBuilder {
     early_input: Option<PathBuf>,
     prefer_aes_gcm: Option<bool>,
     protect_args: Option<bool>,
+    old_args: Option<bool>,
     jump_hosts: Option<OsString>,
     batch_config: Option<engine::batch::BatchConfig>,
     files_from: FilesFromSource,
@@ -297,6 +298,14 @@ impl ClientConfigBuilder {
         &self,
         caps: protocol::CompatibilityFlags,
     ) -> Result<(), ConfigConflict> {
+        // upstream: options.c:1958-1961 - --old-args conflicts with --protect-args.
+        if self.old_args == Some(true) && self.protect_args == Some(true) {
+            return Err(ConfigConflict {
+                option1: "old-args",
+                option2: "secluded-args",
+            });
+        }
+
         // upstream: options.c:2382 - --append cannot be used with --whole-file.
         // Only an explicit `--whole-file` (Some(true)) conflicts; the default
         // (None) and `--no-whole-file` (Some(false)) are accepted.
@@ -476,6 +485,7 @@ impl ClientConfigBuilder {
             early_input: self.early_input,
             prefer_aes_gcm: self.prefer_aes_gcm,
             protect_args: self.protect_args,
+            old_args: self.old_args,
             jump_hosts: self.jump_hosts,
             batch_config: self.batch_config,
             files_from: self.files_from,

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -54,6 +54,20 @@ impl ClientConfigBuilder {
         #[doc(alias = "--secluded-args")]
         #[doc(alias = "-s")]
         protect_args: Option<bool>,
+
+        /// Enables or disables old-style argument passing for remote shells.
+        ///
+        /// When `Some(true)`, filename arguments are not shell-escaped before
+        /// being passed to the remote shell, preserving pre-3.0 behaviour where
+        /// spaces in a remote path are split by `eval` into separate args.
+        /// When `Some(false)`, old-args is explicitly disabled.
+        /// When `None`, the default behavior applies (disabled unless
+        /// `RSYNC_OLD_ARGS` is set).
+        ///
+        /// upstream: options.c - `old_style_args`, `RSYNC_OLD_ARGS`.
+        #[doc(alias = "--old-args")]
+        #[doc(alias = "--no-old-args")]
+        old_args: Option<bool>,
     }
 
     /// Configures the embedded SSH transport options.

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -194,6 +194,12 @@ pub struct ClientConfig {
     pub(super) early_input: Option<PathBuf>,
     pub(super) prefer_aes_gcm: Option<bool>,
     pub(super) protect_args: Option<bool>,
+    /// `--old-args` / `--no-old-args` - pre-3.0 argument passing.
+    ///
+    /// When `Some(true)`, filename arguments are passed unescaped to the remote
+    /// shell, allowing space-separated paths to be split by `eval`.
+    /// upstream: options.c - `old_style_args`, `RSYNC_OLD_ARGS` env var.
+    pub(super) old_args: Option<bool>,
     pub(super) jump_hosts: Option<OsString>,
     pub(super) batch_config: Option<engine::batch::BatchConfig>,
     pub(super) files_from: FilesFromSource,
@@ -375,6 +381,7 @@ impl Default for ClientConfig {
             early_input: None,
             prefer_aes_gcm: None,
             protect_args: None,
+            old_args: None,
             jump_hosts: None,
             batch_config: None,
             files_from: FilesFromSource::None,

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -110,6 +110,22 @@ impl ClientConfig {
         self.protect_args
     }
 
+    /// Returns the old-args preference for remote shell transfers.
+    ///
+    /// When `Some(true)`, filename arguments are passed unescaped to the remote
+    /// shell, preserving the pre-3.0 behaviour where spaces in a remote path
+    /// cause `eval` to split them into separate arguments.
+    ///
+    /// `Some(false)` explicitly disables old-args. `None` uses the default
+    /// behaviour (disabled unless `RSYNC_OLD_ARGS` is set in the environment).
+    ///
+    /// upstream: options.c - `old_style_args`, `RSYNC_OLD_ARGS` env var.
+    #[doc(alias = "--old-args")]
+    #[doc(alias = "--no-old-args")]
+    pub const fn old_args(&self) -> Option<bool> {
+        self.old_args
+    }
+
     /// Returns the configured OpenSSH ProxyJump hosts, if any.
     ///
     /// The returned value is a comma-separated list of `[user@]host[:port]`

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -198,8 +198,13 @@ impl<'a> RemoteInvocationBuilder<'a> {
         )));
         args.push(OsString::from("."));
 
+        // upstream: options.c:2533 safe_arg() - when old_style_args >= 1,
+        // filename arguments (is_filename_arg=true) skip shell escaping so
+        // the remote shell's eval naturally splits space-separated paths.
+        let old_args_active = self.config.old_args().unwrap_or(false);
+
         for path in remote_paths {
-            if escape_for_shell {
+            if escape_for_shell && !old_args_active {
                 // upstream: main.c:613 safe_arg(NULL, *remote_argv++)
                 args.push(OsString::from(shell_safe_filename_arg(path)));
             } else {

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -13,12 +13,6 @@
 # When adding entries, include a one-line reason. Group by category.
 
 KNOWN_FAILURES=(
-  # --- Remote-shell tests (lsh.sh) ---
-  # Tests 1-5 pass (shell escaping + --log-format server parsing). Tests
-  # 6-7 require --old-args space-splitting of remote paths, which is not
-  # yet wired into the path-parsing layer.
-  "00-hello"
-
   # --- Daemon-mode tests ---
   # daemon.test uses lsh.sh (remote-shell daemon mode) for its first step
   # which requires oc-rsync to interoperate with upstream's -e <cmd> path.


### PR DESCRIPTION
## Summary

- Wires the `--old-args` / `--no-old-args` flag from CLI parsing through `ClientConfig` to the `RemoteInvocationBuilder`, enabling pre-3.0 argument passing where filename args skip shell escaping
- Resolves `RSYNC_OLD_ARGS` environment variable when the flag is not explicitly set, matching upstream `options.c:1952-1964`
- Validates the `--old-args` / `--protect-args` mutual exclusion (upstream `options.c:1958-1961`)
- Removes `00-hello` from the upstream testsuite known failures list

## Context

The upstream testsuite `00-hello.test` validates basic remote shell interop via `lsh.sh`. Tests 1-5 already pass (shell escaping and `--log-format` server parsing). Tests 6-7 use `--old-args` and `RSYNC_OLD_ARGS=1` respectively, which require the client to pass filename arguments unescaped so the remote shell's `eval` naturally splits space-separated paths into separate arguments.

Previously, `old_args` was parsed by the CLI but immediately dropped (`old_args: _`). This PR threads it through the full config chain and modifies `RemoteInvocationBuilder::build_args_without_program` to skip `shell_safe_filename_arg` escaping when old-args is active, mirroring upstream `safe_arg()` behavior at `options.c:2533`.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest passes (existing `old_args_tests` in `arguments/tests.rs` verify CLI parsing)
- [ ] Upstream testsuite `00-hello` should now pass (removed from known failures)
- [ ] Verify `--old-args` + `--protect-args` produces a conflict error