### PR TITLE
fix: preserve atime independently of mtime in local copy metadata path

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -45,8 +45,10 @@ pub fn apply_directory_metadata_with_options(
     ownership::set_owner_like(metadata, destination, true, &options, None)?;
     permissions::apply_permissions_with_chmod(destination, metadata, &options, None)?;
     if options.times() {
-        timestamps::set_timestamp_like(metadata, destination, true, None)?;
+        timestamps::set_timestamp_like(metadata, destination, true, None, Some(&options))?;
     }
+    // upstream: rsync.c:589 - directories skip atime (`ATTRS_SKIP_ATIME`)
+    // regardless of `--atimes`; only files get atime preservation.
     Ok(())
 }
 
@@ -75,8 +77,12 @@ pub fn apply_file_metadata_with_options(
 ) -> Result<(), MetadataError> {
     ownership::set_owner_like(metadata, destination, true, options, None)?;
     permissions::apply_permissions_with_chmod(destination, metadata, options, None)?;
+    // upstream: rsync.c:587-612 - mtime and atime are handled independently
     if options.times() {
-        timestamps::set_timestamp_like(metadata, destination, true, None)?;
+        timestamps::set_timestamp_like(metadata, destination, true, None, Some(options))?;
+    } else if options.atimes() {
+        // upstream: rsync.c:604-612 - atime applied when SKIP_MTIME but not SKIP_ATIME
+        timestamps::apply_atime_only_from_metadata(metadata, destination, None)?;
     }
     if options.crtimes() {
         timestamps::apply_crtime_from_source_metadata(destination, metadata)?;
@@ -99,8 +105,16 @@ pub fn apply_file_metadata_with_fd(
 ) -> Result<(), MetadataError> {
     ownership::set_owner_like_with_fd(metadata, destination, options, fd, None)?;
     permissions::apply_permissions_with_chmod_fd(destination, metadata, options, Some(fd), None)?;
+    // upstream: rsync.c:587-612 - mtime and atime are handled independently
     if options.times() {
-        timestamps::set_timestamp_with_fd(metadata, destination, fd, None)?;
+        timestamps::set_timestamp_with_fd(metadata, destination, fd, None, Some(options))?;
+    } else if options.atimes() {
+        timestamps::apply_atime_only_from_metadata_with_fd(
+            metadata,
+            destination,
+            fd,
+            None,
+        )?;
     }
     // crtime is always path-based (setattrlist on macOS) - no fd variant exists
     if options.crtimes() {
@@ -123,8 +137,17 @@ pub fn apply_file_metadata_if_changed(
 ) -> Result<(), MetadataError> {
     ownership::set_owner_like(metadata, destination, true, options, Some(existing))?;
     permissions::apply_permissions_with_chmod(destination, metadata, options, Some(existing))?;
+    // upstream: rsync.c:587-612 - mtime and atime are handled independently
     if options.times() {
-        timestamps::set_timestamp_like(metadata, destination, true, Some(existing))?;
+        timestamps::set_timestamp_like(
+            metadata,
+            destination,
+            true,
+            Some(existing),
+            Some(options),
+        )?;
+    } else if options.atimes() {
+        timestamps::apply_atime_only_from_metadata(metadata, destination, Some(existing))?;
     }
     if options.crtimes() {
         timestamps::apply_crtime_from_source_metadata(destination, metadata)?;
@@ -153,8 +176,22 @@ pub fn apply_file_metadata_with_fd_if_changed(
         Some(fd),
         Some(existing),
     )?;
+    // upstream: rsync.c:587-612 - mtime and atime are handled independently
     if options.times() {
-        timestamps::set_timestamp_with_fd(metadata, destination, fd, Some(existing))?;
+        timestamps::set_timestamp_with_fd(
+            metadata,
+            destination,
+            fd,
+            Some(existing),
+            Some(options),
+        )?;
+    } else if options.atimes() {
+        timestamps::apply_atime_only_from_metadata_with_fd(
+            metadata,
+            destination,
+            fd,
+            Some(existing),
+        )?;
     }
     // crtime is always path-based (setattrlist on macOS) - no fd variant exists
     if options.crtimes() {
@@ -186,7 +223,7 @@ pub fn apply_symlink_metadata_with_options(
 ) -> Result<(), MetadataError> {
     ownership::set_owner_like(metadata, destination, false, options, None)?;
     if options.times() {
-        timestamps::set_timestamp_like(metadata, destination, false, None)?;
+        timestamps::set_timestamp_like(metadata, destination, false, None, Some(options))?;
     }
     Ok(())
 }

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -109,12 +109,7 @@ pub fn apply_file_metadata_with_fd(
     if options.times() {
         timestamps::set_timestamp_with_fd(metadata, destination, fd, None, Some(options))?;
     } else if options.atimes() {
-        timestamps::apply_atime_only_from_metadata_with_fd(
-            metadata,
-            destination,
-            fd,
-            None,
-        )?;
+        timestamps::apply_atime_only_from_metadata_with_fd(metadata, destination, fd, None)?;
     }
     // crtime is always path-based (setattrlist on macOS) - no fd variant exists
     if options.crtimes() {
@@ -139,13 +134,7 @@ pub fn apply_file_metadata_if_changed(
     permissions::apply_permissions_with_chmod(destination, metadata, options, Some(existing))?;
     // upstream: rsync.c:587-612 - mtime and atime are handled independently
     if options.times() {
-        timestamps::set_timestamp_like(
-            metadata,
-            destination,
-            true,
-            Some(existing),
-            Some(options),
-        )?;
+        timestamps::set_timestamp_like(metadata, destination, true, Some(existing), Some(options))?;
     } else if options.atimes() {
         timestamps::apply_atime_only_from_metadata(metadata, destination, Some(existing))?;
     }

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -40,10 +40,11 @@ pub(super) fn set_timestamp_like(
     // the utimensat is only skipped when ALL relevant timestamps match.
     if let Some(existing) = existing {
         let mtime_matches = FileTime::from_last_modification_time(existing) == modified;
-        let atime_matches = options
-            .is_some_and(|o| o.atimes())
-            .then(|| FileTime::from_last_access_time(existing) == accessed)
-            .unwrap_or(true);
+        let atime_matches = if options.is_some_and(|o| o.atimes()) {
+            FileTime::from_last_access_time(existing) == accessed
+        } else {
+            true
+        };
         if mtime_matches && atime_matches {
             return Ok(());
         }
@@ -82,10 +83,11 @@ pub(super) fn set_timestamp_with_fd(
     // upstream: rsync.c:597-612 - mtime and atime are checked independently
     if let Some(existing) = existing {
         let mtime_matches = FileTime::from_last_modification_time(existing) == modified;
-        let atime_matches = options
-            .is_some_and(|o| o.atimes())
-            .then(|| FileTime::from_last_access_time(existing) == accessed)
-            .unwrap_or(true);
+        let atime_matches = if options.is_some_and(|o| o.atimes()) {
+            FileTime::from_last_access_time(existing) == accessed
+        } else {
+            true
+        };
         if mtime_matches && atime_matches {
             return Ok(());
         }

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -18,20 +18,33 @@ use std::os::fd::BorrowedFd;
 /// Applies timestamps (atime + mtime) to a path, optionally following symlinks.
 ///
 /// Uses [`set_file_times`] for regular files/directories and
-/// [`set_symlink_file_times`] for symlinks. Skips the syscall when the
-/// mtime already matches `existing`.
+/// [`set_symlink_file_times`] for symlinks. Skips the syscall when both
+/// mtime and atime already match `existing`.
+///
+/// When `options` is provided and `options.atimes()` is true, the atime
+/// comparison is included in the skip check so that atime-only changes
+/// still trigger a `utimensat` call. Without `options` (or when atimes is
+/// disabled), only the mtime is compared.
 // upstream: rsync.c:set_file_attrs() - utimensat / lutimensat based on follow flag
 pub(super) fn set_timestamp_like(
     metadata: &fs::Metadata,
     destination: &Path,
     follow_symlinks: bool,
     existing: Option<&fs::Metadata>,
+    options: Option<&MetadataOptions>,
 ) -> Result<(), MetadataError> {
     let accessed = FileTime::from_last_access_time(metadata);
     let modified = FileTime::from_last_modification_time(metadata);
 
+    // upstream: rsync.c:597-612 - mtime and atime are checked independently;
+    // the utimensat is only skipped when ALL relevant timestamps match.
     if let Some(existing) = existing {
-        if FileTime::from_last_modification_time(existing) == modified {
+        let mtime_matches = FileTime::from_last_modification_time(existing) == modified;
+        let atime_matches = options
+            .is_some_and(|o| o.atimes())
+            .then(|| FileTime::from_last_access_time(existing) == accessed)
+            .unwrap_or(true);
+        if mtime_matches && atime_matches {
             return Ok(());
         }
     }
@@ -50,7 +63,10 @@ pub(super) fn set_timestamp_like(
 /// fd-based variant of [`set_timestamp_like`] that uses `futimens` on the open fd.
 ///
 /// Avoids a path lookup by operating directly on the file descriptor.
-/// Skips the syscall when the mtime already matches `existing`.
+/// Skips the syscall when both mtime and atime already match `existing`.
+///
+/// When `options` is provided and `options.atimes()` is true, the atime
+/// comparison is included in the skip check.
 // upstream: rsync.c:set_file_attrs() - futimens path when fd is available
 #[cfg(unix)]
 pub(super) fn set_timestamp_with_fd(
@@ -58,12 +74,19 @@ pub(super) fn set_timestamp_with_fd(
     destination: &Path,
     fd: BorrowedFd<'_>,
     existing: Option<&fs::Metadata>,
+    options: Option<&MetadataOptions>,
 ) -> Result<(), MetadataError> {
     let accessed = FileTime::from_last_access_time(metadata);
     let modified = FileTime::from_last_modification_time(metadata);
 
+    // upstream: rsync.c:597-612 - mtime and atime are checked independently
     if let Some(existing) = existing {
-        if FileTime::from_last_modification_time(existing) == modified {
+        let mtime_matches = FileTime::from_last_modification_time(existing) == modified;
+        let atime_matches = options
+            .is_some_and(|o| o.atimes())
+            .then(|| FileTime::from_last_access_time(existing) == accessed)
+            .unwrap_or(true);
+        if mtime_matches && atime_matches {
             return Ok(());
         }
     }
@@ -81,6 +104,92 @@ pub(super) fn set_timestamp_with_fd(
 
     rustix::fs::futimens(fd, &timestamps).map_err(|error| {
         MetadataError::new("preserve timestamps", destination, io::Error::from(error))
+    })?;
+
+    Ok(())
+}
+
+/// Applies only the access time from source `fs::Metadata`, preserving the
+/// destination's existing mtime.
+///
+/// Used in the local copy path when `--atimes` is active but `--times` is not,
+/// mirroring upstream's `set_file_attrs()` behavior where atime and mtime are
+/// governed independently by `ATTRS_SKIP_ATIME` / `ATTRS_SKIP_MTIME`.
+// upstream: rsync.c:604-612 - atime applied independently of mtime
+pub(super) fn apply_atime_only_from_metadata(
+    metadata: &fs::Metadata,
+    destination: &Path,
+    existing: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    let source_atime = FileTime::from_last_access_time(metadata);
+
+    if let Some(existing) = existing {
+        if FileTime::from_last_access_time(existing) == source_atime {
+            return Ok(());
+        }
+    }
+
+    // Preserve the destination's current mtime - only update atime.
+    let dest_mtime = match existing {
+        Some(meta) => FileTime::from_last_modification_time(meta),
+        None => {
+            let meta = fs::metadata(destination).map_err(|error| {
+                MetadataError::new("read current timestamps", destination, error)
+            })?;
+            FileTime::from_last_modification_time(&meta)
+        }
+    };
+
+    set_file_times(destination, source_atime, dest_mtime)
+        .map_err(|error| MetadataError::new("preserve access time", destination, error))?;
+
+    Ok(())
+}
+
+/// fd-based variant of [`apply_atime_only_from_metadata`].
+///
+/// Uses `futimens` on the open fd to set only the atime while preserving the
+/// destination's existing mtime.
+// upstream: rsync.c:604-612 - atime applied independently of mtime
+#[cfg(unix)]
+pub(super) fn apply_atime_only_from_metadata_with_fd(
+    metadata: &fs::Metadata,
+    destination: &Path,
+    fd: BorrowedFd<'_>,
+    existing: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    let source_atime = FileTime::from_last_access_time(metadata);
+
+    if let Some(existing) = existing {
+        if FileTime::from_last_access_time(existing) == source_atime {
+            return Ok(());
+        }
+    }
+
+    // Preserve the destination's current mtime - only update atime.
+    let dest_mtime = match existing {
+        Some(meta) => FileTime::from_last_modification_time(meta),
+        None => {
+            let meta = fs::metadata(destination).map_err(|error| {
+                MetadataError::new("read current timestamps", destination, error)
+            })?;
+            FileTime::from_last_modification_time(&meta)
+        }
+    };
+
+    let timestamps = rustix::fs::Timestamps {
+        last_access: rustix::fs::Timespec {
+            tv_sec: source_atime.unix_seconds(),
+            tv_nsec: source_atime.nanoseconds().into(),
+        },
+        last_modification: rustix::fs::Timespec {
+            tv_sec: dest_mtime.unix_seconds(),
+            tv_nsec: dest_mtime.nanoseconds().into(),
+        },
+    };
+
+    rustix::fs::futimens(fd, &timestamps).map_err(|error| {
+        MetadataError::new("preserve access time", destination, io::Error::from(error))
     })?;
 
     Ok(())

--- a/crates/metadata/src/apply_batch.rs
+++ b/crates/metadata/src/apply_batch.rs
@@ -66,8 +66,11 @@ impl BatchMetadataContext {
     ) -> Result<(), MetadataError> {
         self.apply_ownership_cached(destination, metadata)?;
         self.apply_permissions_cached(destination, metadata)?;
+        // upstream: rsync.c:587-612 - mtime and atime are handled independently
         if self.options.times() {
             self.apply_timestamps(destination, metadata)?;
+        } else if self.options.atimes() {
+            self.apply_atime_only(destination, metadata)?;
         }
         Ok(())
     }
@@ -213,6 +216,27 @@ impl BatchMetadataContext {
 
         set_file_times(destination, accessed, modified)
             .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?;
+
+        Ok(())
+    }
+
+    /// Applies only the access time from source metadata, preserving dest mtime.
+    ///
+    /// Used when `--atimes` is active but `--times` is not, mirroring upstream's
+    /// independent atime/mtime handling.
+    // upstream: rsync.c:604-612 - atime applied independently of mtime
+    fn apply_atime_only(
+        &mut self,
+        destination: &Path,
+        metadata: &fs::Metadata,
+    ) -> Result<(), MetadataError> {
+        let source_atime = FileTime::from_last_access_time(metadata);
+        let dest_meta = fs::metadata(destination)
+            .map_err(|error| MetadataError::new("read current timestamps", destination, error))?;
+        let dest_mtime = FileTime::from_last_modification_time(&dest_meta);
+
+        set_file_times(destination, source_atime, dest_mtime)
+            .map_err(|error| MetadataError::new("preserve access time", destination, error))?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Add independent `--atimes` (`-U`) preservation in the metadata apply layer, matching upstream rsync's `set_file_attrs()` where mtime and atime are governed by separate `ATTRS_SKIP_MTIME` / `ATTRS_SKIP_ATIME` flags
- Previously, atime was only applied when `options.times()` was true; now `options.atimes()` triggers atime-only preservation (keeping destination mtime intact) even without `--times`
- Fix skip-optimization in `set_timestamp_like` and `set_timestamp_with_fd` to compare atime when `--atimes` is active, preventing atime-only changes from being silently dropped on re-sync

## Upstream Reference

- `rsync.c:597-612` - mtime and atime are checked independently; `set_times()` is called when either `UPDATED_MTIME` or `UPDATED_ATIME` is set
- `rsync.c:604-612` - atime applied when `SKIP_MTIME` but not `SKIP_ATIME`

## Files Changed

- `crates/metadata/src/apply/timestamps.rs` - Add `options` parameter to `set_timestamp_like` / `set_timestamp_with_fd` for atime-aware skip checks; add `apply_atime_only_from_metadata` and fd variant
- `crates/metadata/src/apply/mod.rs` - Wire independent atimes branches into all six public apply functions
- `crates/metadata/src/apply_batch.rs` - Same independent atime/mtime handling for batch context

## Test plan

- [ ] CI: nextest (stable) passes on all platforms
- [ ] CI: clippy clean
- [ ] CI: upstream testsuite `atimes` test passes (was IFX-8 series)
- [ ] Verify `-rtUgvvv` transfers preserve atime from source to destination
- [ ] Verify `-U` without `-t` preserves only atime, not mtime