### PR TITLE
fix: align integration-level debug flag tests with upstream clamping

### DIFF
--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -186,9 +186,10 @@ fn debug_flist_levels() {
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.flist, Some(4));
 
+    // upstream: options.c:444-445 - levels above MAX_OUT_LEVEL (4) are clamped, not rejected
     let flags = vec![OsString::from("flist5")];
-    let error = parse_debug_flags(&flags).expect_err("should reject level 5");
-    assert!(error.to_string().contains("invalid --debug flag"));
+    let settings = parse_debug_flags(&flags).expect("flags parse");
+    assert_eq!(settings.flist, Some(4));
 }
 
 #[test]
@@ -205,9 +206,10 @@ fn debug_io_levels() {
     let settings = parse_debug_flags(&flags).expect("flags parse");
     assert_eq!(settings.io, Some(4));
 
+    // upstream: options.c:444-445 - levels above MAX_OUT_LEVEL (4) are clamped, not rejected
     let flags = vec![OsString::from("io5")];
-    let error = parse_debug_flags(&flags).expect_err("should reject level 5");
-    assert!(error.to_string().contains("invalid --debug flag"));
+    let settings = parse_debug_flags(&flags).expect("flags parse");
+    assert_eq!(settings.io, Some(4));
 }
 
 #[test]

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -11,8 +11,7 @@ use protocol::ProtocolVersion;
 use protocol::nstr::{trace_daemon_auth_negotiated, trace_daemon_greeting_auth_list};
 
 use crate::auth::{
-    DaemonAuthDigest, compute_daemon_auth_response, parse_daemon_digest_list,
-    select_daemon_digest,
+    DaemonAuthDigest, compute_daemon_auth_response, parse_daemon_digest_list, select_daemon_digest,
 };
 
 use super::super::super::CLIENT_SERVER_PROTOCOL_EXIT_CODE;
@@ -74,9 +73,9 @@ impl DaemonTransferRequest {
     pub(crate) fn parse_double_colon(operand: &str) -> Result<Self, ClientError> {
         use super::super::super::module_list::parse_host_port;
 
-        let (host_part, module_path) = operand
-            .split_once("::")
-            .ok_or_else(|| invalid_argument_error(&format!("not a daemon operand: {operand}"), 1))?;
+        let (host_part, module_path) = operand.split_once("::").ok_or_else(|| {
+            invalid_argument_error(&format!("not a daemon operand: {operand}"), 1)
+        })?;
 
         let target = parse_host_port(host_part, 873)?;
 
@@ -305,9 +304,9 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
                     e,
                 )
             })?;
-            writer.flush().map_err(|e| {
-                socket_error("flush to", request.address.socket_addr_display(), e)
-            })?;
+            writer
+                .flush()
+                .map_err(|e| socket_error("flush to", request.address.socket_addr_display(), e))?;
 
             continue;
         }


### PR DESCRIPTION
## Summary
- Update `debug_flist_levels` and `debug_io_levels` integration tests to expect clamping to MAX_OUT_LEVEL (4) instead of rejection
- PR #5315 fixed the unit-level tests in `flags/tests.rs` but missed these integration tests in `info_debug.rs`
- Apply `cargo fmt` formatting to daemon connection module

## Test plan
- [ ] Verify `debug_flist_levels` and `debug_io_levels` pass on all CI platforms
- [ ] Confirm no regression in other debug flag tests