### PR TITLE
fix: correct macOS crtime test assertion in version config

### DIFF
--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -627,7 +627,9 @@ mod tests {
 
     #[test]
     fn to_builder_allows_modification() {
-        let original = VersionInfoConfig::new();
+        let original = VersionInfoConfig::builder()
+            .supports_crtimes(false)
+            .build();
         let modified = original.to_builder().supports_crtimes(true).build();
         assert!(!original.supports_crtimes);
         assert!(modified.supports_crtimes);


### PR DESCRIPTION
## Summary

- `to_builder_allows_modification` test used `VersionInfoConfig::new()` which auto-detects platform capabilities - on macOS `supports_crtimes` is `true`, causing the `assert!(!original.supports_crtimes)` assertion to fail
- Replace with explicit builder construction using `supports_crtimes(false)` since the test only verifies that `to_builder()` allows field modification

## Test plan

- [ ] macOS CI passes (previously failing)
- [ ] Linux and Windows CI unaffected