### PR TITLE
style: format crtime test builder chain inline

### DIFF
--- a/crates/core/src/version/report/config.rs
+++ b/crates/core/src/version/report/config.rs
@@ -627,9 +627,7 @@ mod tests {
 
     #[test]
     fn to_builder_allows_modification() {
-        let original = VersionInfoConfig::builder()
-            .supports_crtimes(false)
-            .build();
+        let original = VersionInfoConfig::builder().supports_crtimes(false).build();
         let modified = original.to_builder().supports_crtimes(true).build();
         assert!(!original.supports_crtimes);
         assert!(modified.supports_crtimes);


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` violation in crtime test builder chain introduced by #5324
- Builder chain fits on one line, so rustfmt collapses it

## Test plan
- [ ] `cargo fmt --all -- --check` passes