### PR TITLE
fix: parse secluded-args and capability string from compact server flags

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -10,11 +10,32 @@ use engine::{ReferenceDirectory, ReferenceDirectoryKind};
 
 /// Detects whether secluded-args mode is requested in the server arguments.
 ///
-/// In secluded-args mode, the client sends `-s` as a standalone argument
-/// on the command line (not as part of a combined flag string). The server
-/// then reads the full argument list from stdin before proceeding.
+/// Upstream rsync's `server_options()` (options.c:2604) embeds `s` in the
+/// compact flag string when `protect_args` is active - e.g.
+/// `-slogDtprze.iLsfxCIvu`. The `s` appears in the transfer-flag portion
+/// (before the first `.`), never in the capability/info suffix.
+///
+/// This function checks both standalone `-s` and `s` embedded in compact
+/// flag arguments (single-dash args that are not long flags).
+///
+/// upstream: options.c:792 - `{"secluded-args", 's', ...}`
 pub(crate) fn detect_secluded_args_flag(args: &[OsString]) -> bool {
-    args.iter().skip(1).any(|a| a == "-s")
+    args.iter().skip(1).any(|a| {
+        let s = a.to_string_lossy();
+        if s == "-s" {
+            return true;
+        }
+        // Check compact flag strings: starts with `-`, not `--`.
+        // Only scan the transfer-flag portion (before the first `.`)
+        // because `s` after the dot is the symlink-iconv capability char,
+        // not secluded-args.
+        // upstream: options.c:2604 - protect_args placed at argstr[1]
+        if s.starts_with('-') && !s.starts_with("--") && s.len() > 1 {
+            let transfer_portion = s[1..].split('.').next().unwrap_or("");
+            return transfer_portion.contains('s');
+        }
+        false
+    })
 }
 
 /// Long-form flags extracted from the server argument list.

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -204,6 +204,62 @@ fn detect_secluded_args_ignores_program_name() {
 }
 
 #[test]
+fn detect_secluded_args_in_compact_flag_string() {
+    // upstream: options.c:2604 - server_options() puts 's' at argstr[1]
+    // when protect_args is active, producing e.g. `-slogDtprze.iLsfxCIvu`.
+    let args: Vec<OsString> = vec![
+        OsString::from("rsync"),
+        OsString::from("--server"),
+        OsString::from("-slogDtprze.iLsfxCIvu"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    assert!(detect_secluded_args_flag(&args));
+}
+
+#[test]
+fn detect_secluded_args_in_compact_flag_string_middle() {
+    // The 's' can appear anywhere in the transfer flags portion.
+    let args: Vec<OsString> = vec![
+        OsString::from("rsync"),
+        OsString::from("--server"),
+        OsString::from("-logDtprs"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    assert!(detect_secluded_args_flag(&args));
+}
+
+#[test]
+fn detect_secluded_args_ignores_s_in_capability_string() {
+    // The 's' after the dot is the symlink-iconv capability char,
+    // not secluded-args. Must not trigger secluded-args detection.
+    // upstream: options.c:3027 - 's' in capability string = ICONV_OPTION
+    let args: Vec<OsString> = vec![
+        OsString::from("rsync"),
+        OsString::from("--server"),
+        OsString::from("-logDtprze.iLsfxCIvu"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    assert!(!detect_secluded_args_flag(&args));
+}
+
+#[test]
+fn detect_secluded_args_both_transfer_and_capability_s() {
+    // When 's' appears in both the transfer portion (secluded-args) AND
+    // the capability string (symlink-iconv), should detect it.
+    let args: Vec<OsString> = vec![
+        OsString::from("rsync"),
+        OsString::from("--server"),
+        OsString::from("-slogDtprze.iLsfxCIvu"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    assert!(detect_secluded_args_flag(&args));
+}
+
+#[test]
 fn parse_server_args_basic() {
     let args = vec![
         OsString::from("--server"),

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -412,10 +412,20 @@ pub fn run_server_with_handshake<W: Write>(
         && (config.role == ServerRole::Generator
             || (!config.flags.delete && !config.flags.prune_empty_dirs));
 
+    // In SSH server mode (client_args is None), pass the compact flag string
+    // so setup_protocol can extract the `-e.xxx` capability string from it.
+    // upstream: compat.c:163-164 - `client_info = shell_cmd` for SSH mode.
+    let flag_str_ref = if handshake.client_args.is_none() && is_server {
+        Some(config.flag_string.as_str())
+    } else {
+        None
+    };
+
     let setup_config = setup::ProtocolSetupConfig {
         protocol: handshake.protocol,
         skip_compat_exchange: handshake.compat_exchanged,
         client_args: handshake.client_args.as_deref(),
+        flag_string: flag_str_ref,
         is_server,
         is_daemon_mode,
         do_compression,

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -224,9 +224,12 @@ fn build_our_flags<'a>(
                 // This matches upstream where `shell_cmd` is empty.
                 (build_default_flags(config.allow_inc_recurse), None)
             } else {
-                let flags = negotiator
-                    .build_flags_from_client_info(&client_info, config.allow_inc_recurse);
-                (flags, Some(std::borrow::Cow::Owned(client_info.into_owned())))
+                let flags =
+                    negotiator.build_flags_from_client_info(&client_info, config.allow_inc_recurse);
+                (
+                    flags,
+                    Some(std::borrow::Cow::Owned(client_info.into_owned())),
+                )
             }
         } else {
             // SSH server mode without flag string - use platform defaults.

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -189,11 +189,15 @@ pub fn setup_protocol_with<'a>(
 
 /// Builds compatibility flags for our side of the connection.
 ///
-/// In daemon server mode, parses the client's `-e` capability string to
-/// determine which flags to enable. In SSH/client mode, uses platform
-/// defaults.
+/// In daemon server mode, parses the client's `-e` capability string from
+/// `client_args`. In SSH server mode, extracts it from the compact
+/// `flag_string`. In SSH/client mode, uses platform defaults.
 ///
 /// Returns the flags and optionally the parsed client info string.
+///
+/// upstream: compat.c:161-179 - `set_allow_inc_recurse()` sets `client_info`
+/// from `shell_cmd` (SSH) or `maybe_add_e_option()` (local), then
+/// compat.c:712-732 uses `client_info` to build compat flags.
 fn build_our_flags<'a>(
     config: &ProtocolSetupConfig<'a>,
     negotiator: &dyn ProtocolNegotiator,
@@ -204,38 +208,72 @@ fn build_our_flags<'a>(
         let client_info = negotiator.parse_client_info(args);
         let flags = negotiator.build_flags_from_client_info(&client_info, config.allow_inc_recurse);
         (flags, Some(client_info))
+    } else if config.is_server {
+        if let Some(flag_str) = config.flag_string {
+            // SSH server mode: extract capability string from the compact
+            // flag string. Upstream sets `client_info = shell_cmd` where
+            // `shell_cmd` is the value of the `-e` option parsed from the
+            // compact flag string (compat.c:163-164).
+            //
+            // Wrap the flag string in a slice so parse_client_info can
+            // scan it for the embedded `-e.xxx` capability chars.
+            let args = [flag_str.to_owned()];
+            let client_info = negotiator.parse_client_info(&args);
+            if client_info.is_empty() {
+                // No `-e` in flag string - use platform defaults.
+                // This matches upstream where `shell_cmd` is empty.
+                (build_default_flags(config.allow_inc_recurse), None)
+            } else {
+                let flags = negotiator
+                    .build_flags_from_client_info(&client_info, config.allow_inc_recurse);
+                (flags, Some(std::borrow::Cow::Owned(client_info.into_owned())))
+            }
+        } else {
+            // SSH server mode without flag string - use platform defaults.
+            (build_default_flags(config.allow_inc_recurse), None)
+        }
     } else {
-        // SSH/client mode: set all flags we support, matching upstream
+        // Client mode: set all flags we support, matching upstream
         // compat.c:712-732 which sets flags based on compile-time features
         // and the capability string advertised to the peer.
-        let mut flags = CompatibilityFlags::CHECKSUM_SEED_FIX
-            | CompatibilityFlags::VARINT_FLIST_FLAGS
-            | CompatibilityFlags::SAFE_FILE_LIST
-            | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION
-            | CompatibilityFlags::INPLACE_PARTIAL_DIR
-            | CompatibilityFlags::ID0_NAMES;
-
-        // upstream: CAN_SET_SYMLINK_TIMES at compat.c:713-714
-        #[cfg(unix)]
-        {
-            flags |= CompatibilityFlags::SYMLINK_TIMES;
-        }
-
-        // upstream: compat.c:715-716 - CF_SYMLINK_ICONV is gated on
-        // `#ifdef ICONV_OPTION`. Mirror that with the `iconv` cargo feature
-        // so SSH/client builds without iconv neither set the flag locally
-        // nor advertise 's' to the peer (see capability::CAPABILITY_MAPPINGS).
-        #[cfg(all(unix, feature = "iconv"))]
-        {
-            flags |= CompatibilityFlags::SYMLINK_ICONV;
-        }
-
-        if config.allow_inc_recurse {
-            flags |= CompatibilityFlags::INC_RECURSE;
-        }
-
-        (flags, None)
+        (build_default_flags(config.allow_inc_recurse), None)
     }
+}
+
+/// Builds the default set of compatibility flags for our platform.
+///
+/// Used when we are the client (advertising our capabilities) or when
+/// the server has no capability string from the remote.
+///
+/// upstream: compat.c:712-732 - flags set based on compile-time features.
+fn build_default_flags(allow_inc_recurse: bool) -> CompatibilityFlags {
+    let mut flags = CompatibilityFlags::CHECKSUM_SEED_FIX
+        | CompatibilityFlags::VARINT_FLIST_FLAGS
+        | CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION
+        | CompatibilityFlags::INPLACE_PARTIAL_DIR
+        | CompatibilityFlags::ID0_NAMES;
+
+    // upstream: CAN_SET_SYMLINK_TIMES at compat.c:713-714
+    #[cfg(unix)]
+    {
+        flags |= CompatibilityFlags::SYMLINK_TIMES;
+    }
+
+    // upstream: compat.c:715-716 - CF_SYMLINK_ICONV is gated on
+    // `#ifdef ICONV_OPTION`. Mirror that with the `iconv` cargo feature
+    // so SSH/client builds without iconv neither set the flag locally
+    // nor advertise 's' to the peer (see capability::CAPABILITY_MAPPINGS).
+    #[cfg(all(unix, feature = "iconv"))]
+    {
+        flags |= CompatibilityFlags::SYMLINK_ICONV;
+    }
+
+    if allow_inc_recurse {
+        flags |= CompatibilityFlags::INC_RECURSE;
+    }
+
+    flags
 }
 
 /// Determines whether capability negotiation (vstring exchange) should occur.

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -408,7 +408,7 @@ fn setup_protocol_client_reads_compat_flags_from_server() {
         skip_compat_exchange: false,
         client_args: None, // not needed for client mode
         flag_string: None,
-        is_server: false,  // CLIENT mode
+        is_server: false, // CLIENT mode
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -29,6 +29,132 @@ fn parse_client_info_returns_empty_when_not_found() {
 }
 
 #[test]
+fn parse_client_info_from_compact_server_flag_string() {
+    // upstream: options.c:2710 - maybe_add_e_option appends -e.LsfxCIvu
+    // to the compact flag string. parse_client_info must extract it.
+    let args = vec!["-logDtprze.iLsfxCIvu".to_owned()];
+    let info = parse_client_info(&args);
+    assert_eq!(info, "iLsfxCIvu");
+}
+
+#[test]
+fn parse_client_info_from_compact_flag_string_with_secluded_args() {
+    // upstream: server_options() produces -slogDtprze.iLsfxCIvu when
+    // protect_args + all capabilities are active.
+    let args = vec!["-slogDtprze.iLsfxCIvu".to_owned()];
+    let info = parse_client_info(&args);
+    assert_eq!(info, "iLsfxCIvu");
+}
+
+#[test]
+fn parse_client_info_from_compact_flag_string_without_e() {
+    // When no -e is present (protocol < 30), returns empty.
+    let args = vec!["-logDtpr".to_owned()];
+    let info = parse_client_info(&args);
+    assert_eq!(info, "");
+}
+
+#[test]
+fn ssh_server_flag_string_limits_compat_flags() {
+    // SSH server mode: when flag_string is provided, the server extracts
+    // capabilities from the embedded `-e.xxx` and delegates to
+    // build_flags_from_client_info. The mock negotiator returns fixed
+    // flags without INC_RECURSE, confirming the flag_string path is taken
+    // instead of the default-all-flags path. Detailed capability-to-flag
+    // mapping is covered by build_compat_flags_from_client_info tests.
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let mut stdin = &b"\x03md5"[..];
+    let mut stdout = Vec::new();
+
+    let config = ProtocolSetupConfig {
+        protocol,
+        skip_compat_exchange: false,
+        client_args: None,
+        flag_string: Some("-logDtprze.LsfxCIvu"),
+        is_server: true,
+        is_daemon_mode: false,
+        do_compression: false,
+        compress_choice: None,
+        checksum_seed: Some(42),
+        allow_inc_recurse: true,
+    };
+
+    let mock = MockNegotiator::new();
+    let result = setup_protocol_with(&mut stdout, &mut stdin, &config, &mock)
+        .expect("SSH server with flag_string should succeed");
+
+    let flags = result.compat_flags.unwrap();
+    // Mock returns CHECKSUM_SEED_FIX | VARINT_FLIST_FLAGS without
+    // INC_RECURSE, confirming the flag_string code path was taken
+    // (the default-all-flags path would include INC_RECURSE when
+    // allow_inc_recurse is true).
+    assert!(
+        !flags.contains(CompatibilityFlags::INC_RECURSE),
+        "flag_string path should use negotiator's build_flags_from_client_info, not defaults"
+    );
+}
+
+#[test]
+fn ssh_server_flag_string_enables_advertised_caps() {
+    // SSH server mode: capabilities the remote advertises should be enabled.
+    let protocol = ProtocolVersion::try_from(31).unwrap();
+    let mut stdin = &b"\x03md5"[..];
+    let mut stdout = Vec::new();
+
+    let config = ProtocolSetupConfig {
+        protocol,
+        skip_compat_exchange: false,
+        client_args: None,
+        flag_string: Some("-logDtprze.iLsfxCIvu"),
+        is_server: true,
+        is_daemon_mode: false,
+        do_compression: false,
+        compress_choice: None,
+        checksum_seed: Some(42),
+        allow_inc_recurse: true,
+    };
+
+    let mock = MockNegotiator::new();
+    let result = setup_protocol_with(&mut stdout, &mut stdin, &config, &mock)
+        .expect("SSH server with full caps should succeed");
+
+    let flags = result.compat_flags.unwrap();
+    // The MockNegotiator returns its own flags, so we just verify
+    // the code path was taken without error. The detailed flag checking
+    // is covered by build_compat_flags_from_client_info tests above.
+    assert!(result.negotiated_algorithms.is_some());
+    let _ = flags;
+}
+
+#[test]
+fn ssh_server_no_flag_string_uses_defaults() {
+    // SSH server mode without flag_string falls back to platform defaults.
+    let protocol = ProtocolVersion::try_from(29).unwrap();
+    let mut stdin = &b""[..];
+    let mut stdout = Vec::new();
+
+    let config = ProtocolSetupConfig {
+        protocol,
+        skip_compat_exchange: false,
+        client_args: None,
+        flag_string: None,
+        is_server: true,
+        is_daemon_mode: false,
+        do_compression: false,
+        compress_choice: None,
+        checksum_seed: Some(42),
+        allow_inc_recurse: false,
+    };
+
+    let result = setup_protocol(&mut stdout, &mut stdin, &config)
+        .expect("SSH server without flag_string should succeed");
+
+    // Protocol 29 skips compat exchange entirely.
+    assert!(result.compat_flags.is_none());
+    assert_eq!(result.checksum_seed, 42);
+}
+
+#[test]
 #[cfg(unix)]
 fn build_compat_flags_enables_symlink_times_when_client_advertises_l() {
     let flags = build_compat_flags_from_client_info("LfxCIvu", true);
@@ -145,6 +271,7 @@ fn setup_protocol_below_30_returns_none_for_algorithms_and_compat() {
         protocol,
         skip_compat_exchange: false,
         client_args: None,
+        flag_string: None,
         is_server: true,
         is_daemon_mode: false,
         do_compression: false,
@@ -183,6 +310,7 @@ fn setup_protocol_skip_compat_exchange_skips_flags() {
         protocol,
         skip_compat_exchange: true, // SKIP
         client_args: None,
+        flag_string: None,
         is_server: true,
         is_daemon_mode: false,
         do_compression: false,
@@ -224,6 +352,7 @@ fn setup_protocol_server_writes_compat_flags_and_seed() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args), // client_args with 'v' capability
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true, // server advertises, client reads
         do_compression: false,
@@ -278,6 +407,7 @@ fn setup_protocol_client_reads_compat_flags_from_server() {
         protocol,
         skip_compat_exchange: false,
         client_args: None, // not needed for client mode
+        flag_string: None,
         is_server: false,  // CLIENT mode
         is_daemon_mode: true,
         do_compression: false,
@@ -320,6 +450,7 @@ fn setup_protocol_server_generates_deterministic_seeds() {
         protocol,
         skip_compat_exchange: false,
         client_args: None,
+        flag_string: None,
         is_server: true,
         is_daemon_mode: false,
         do_compression: false,
@@ -368,6 +499,7 @@ fn setup_protocol_ssh_mode_bidirectional_exchange() {
         protocol,
         skip_compat_exchange: false,
         client_args: None,
+        flag_string: None,
         is_server: false, // CLIENT
         is_daemon_mode: false,
         do_compression: false,
@@ -410,6 +542,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args_minimal), // Only 'v' capability
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -440,6 +573,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args_full), // Full capabilities
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -482,6 +616,7 @@ fn setup_protocol_protocol_30_minimum_for_compat_exchange() {
         protocol: protocol_30,
         skip_compat_exchange: false,
         client_args: Some(&client_args),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -512,6 +647,7 @@ fn protocol_setup_config_builder_new_sets_defaults() {
     assert!(config.is_server);
     assert!(!config.skip_compat_exchange);
     assert!(config.client_args.is_none());
+    assert!(config.flag_string.is_none());
     assert!(!config.is_daemon_mode);
     assert!(!config.do_compression);
     assert!(config.compress_choice.is_none());
@@ -552,6 +688,7 @@ fn protocol_setup_config_builder_partial_configuration() {
     // Other fields should still be at defaults
     assert!(!config.skip_compat_exchange);
     assert!(config.client_args.is_none());
+    assert!(config.flag_string.is_none());
     assert!(config.checksum_seed.is_none());
 }
 
@@ -866,6 +1003,7 @@ fn setup_protocol_server_v_flag_uses_single_byte_encoding() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -911,6 +1049,7 @@ fn setup_protocol_server_v_flag_enables_negotiation() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -942,6 +1081,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args_v),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -960,6 +1100,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args_both),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -1153,6 +1294,7 @@ fn setup_protocol_with_mock_negotiator_server_mode() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: false,
@@ -1197,6 +1339,7 @@ fn setup_protocol_with_mock_negotiator_client_mode() {
         protocol,
         skip_compat_exchange: false,
         client_args: None,
+        flag_string: None,
         is_server: false,
         is_daemon_mode: false,
         do_compression: false,
@@ -1490,6 +1633,7 @@ fn compress_choice_override_skips_vstring_and_uses_algorithm() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: true,
@@ -1523,6 +1667,7 @@ fn compress_choice_none_allows_normal_negotiation() {
         protocol,
         skip_compat_exchange: false,
         client_args: Some(&client_args),
+        flag_string: None,
         is_server: true,
         is_daemon_mode: true,
         do_compression: true,
@@ -1556,6 +1701,7 @@ fn compress_choice_zlib_override_on_legacy_protocol() {
         protocol,
         skip_compat_exchange: false,
         client_args: None,
+        flag_string: None,
         is_server: true,
         is_daemon_mode: false,
         do_compression: true,

--- a/crates/transfer/src/setup/types.rs
+++ b/crates/transfer/src/setup/types.rs
@@ -47,6 +47,19 @@ pub struct ProtocolSetupConfig<'a> {
     /// None for SSH mode or when acting as client.
     pub client_args: Option<&'a [String]>,
 
+    /// Raw compact flag string from SSH server mode (e.g. `-logDtprze.iLsfxCIvu`).
+    ///
+    /// In SSH server mode, `client_args` is `None` because the CLI frontend
+    /// has already parsed the argv into `ServerConfig`. The capability string
+    /// (`-e.xxx`) is embedded in this compact flag string. When set, the
+    /// server extracts the capability chars from it instead of unconditionally
+    /// enabling all compat flags.
+    ///
+    /// upstream: compat.c:163-164 - `client_info = shell_cmd ? shell_cmd : ""`
+    /// where `shell_cmd` is the value of the `-e` option parsed from the
+    /// compact flag string.
+    pub flag_string: Option<&'a str>,
+
     /// Whether we are the server in this connection.
     ///
     /// Controls compat flags and checksum seed direction:
@@ -121,6 +134,7 @@ impl<'a> ProtocolSetupConfig<'a> {
             protocol,
             skip_compat_exchange: false,
             client_args: None,
+            flag_string: None,
             is_server,
             is_daemon_mode: false,
             do_compression: false,
@@ -141,6 +155,13 @@ impl<'a> ProtocolSetupConfig<'a> {
     #[must_use]
     pub const fn with_client_args(mut self, args: Option<&'a [String]>) -> Self {
         self.client_args = args;
+        self
+    }
+
+    /// Sets [`Self::flag_string`].
+    #[must_use]
+    pub const fn with_flag_string(mut self, flag_string: Option<&'a str>) -> Self {
+        self.flag_string = flag_string;
         self
     }
 


### PR DESCRIPTION
## Summary

- Fix `detect_secluded_args_flag()` to detect `s` embedded in compact flag strings (e.g. `-slogDtprze.iLsfxCIvu`), not just standalone `-s`. Only scans the transfer-flag portion before the first `.` to avoid false positives from the symlink-iconv capability char `s` in the capability suffix.
- Fix SSH server mode to parse the `-e.xxx` capability string from the compact flag string instead of unconditionally enabling all compat flags. Adds `flag_string` field to `ProtocolSetupConfig` so `build_our_flags` can extract and honor the remote's advertised capabilities - matching upstream `compat.c:163-164` which sets `client_info` from `shell_cmd`.
- Extract `build_default_flags()` helper to deduplicate the platform-default flag construction shared between client mode and server-without-capability fallback.

## Test plan

- [ ] New tests verify `detect_secluded_args_flag` with compact `-slogDtprze.iLsfxCIvu` (detects `s` before dot)
- [ ] New test verifies `s` after the dot (capability string) does NOT trigger secluded-args detection
- [ ] New tests verify `parse_client_info` extracts capabilities from compact flag strings like `-logDtprze.iLsfxCIvu`
- [ ] New tests verify SSH server mode uses `flag_string` to limit compat flags to advertised capabilities
- [ ] New test verifies SSH server mode without `flag_string` falls back to platform defaults
- [ ] Existing tests updated with `flag_string: None` field - all must pass unchanged
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl