### PR TITLE
fix: inherit P_LOCAL directives from global rsyncd.conf section into modules

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
@@ -794,11 +794,9 @@ fn apply_global_directive(
                 state.module_defaults.exclude.push(value.to_owned());
             }
         }
-        "include" => {
-            if !value.is_empty() {
-                state.module_defaults.include.push(value.to_owned());
-            }
-        }
+        // Note: "include" as a P_LOCAL default is not handled here because
+        // our key=value parser already claims "include" for config file
+        // inclusion (upstream uses "&include /path" which doesn't collide).
         "filter" => {
             if !value.is_empty() {
                 state.module_defaults.filter.push(value.to_owned());

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
@@ -4,6 +4,47 @@
 // (the global section), including the `include` directive that triggers
 // recursive config file parsing and result merging.
 
+/// Default values for P_LOCAL module parameters set in the global section.
+///
+/// upstream: loadparm.c - when a P_LOCAL parameter appears in the global
+/// section, it sets the default value (`def_ptr`) that all subsequently
+/// parsed modules inherit via `init_section()` / `copy_section()`.
+#[derive(Default)]
+struct GlobalModuleDefaults {
+    exclude: Vec<String>,
+    include: Vec<String>,
+    filter: Vec<String>,
+    max_verbosity: Option<i32>,
+    transfer_logging: Option<bool>,
+    log_format: Option<String>,
+    log_file: Option<PathBuf>,
+    hosts_allow: Option<Vec<HostPattern>>,
+    hosts_deny: Option<Vec<HostPattern>>,
+    timeout: Option<Option<NonZeroU64>>,
+    dont_compress: Option<String>,
+    read_only: Option<bool>,
+    write_only: Option<bool>,
+    listable: Option<bool>,
+    munge_symlinks: Option<Option<bool>>,
+    numeric_ids: Option<bool>,
+    fake_super: Option<bool>,
+    max_connections: Option<Option<NonZeroU32>>,
+    ignore_errors: Option<bool>,
+    ignore_nonreadable: Option<bool>,
+    strict_modes: Option<bool>,
+    forward_lookup: Option<bool>,
+    open_noatime: Option<bool>,
+    exclude_from: Option<PathBuf>,
+    include_from: Option<PathBuf>,
+    comment: Option<String>,
+    early_exec: Option<String>,
+    pre_xfer_exec: Option<String>,
+    post_xfer_exec: Option<String>,
+    name_converter: Option<String>,
+    temp_dir: Option<String>,
+    charset: Option<String>,
+}
+
 /// Mutable context holding all global-section state accumulated during parsing.
 ///
 /// Passed by reference into `apply_global_directive` to avoid a long parameter
@@ -31,6 +72,11 @@ struct GlobalParseState {
     rsync_port: Option<(u16, ConfigDirectiveOrigin)>,
     daemon_chroot: Option<(PathBuf, ConfigDirectiveOrigin)>,
     modules: Vec<ModuleDefinition>,
+    /// P_LOCAL parameter defaults from the global section.
+    ///
+    /// upstream: loadparm.c - P_LOCAL parameters in the global section set
+    /// defaults inherited by all modules that don't override them.
+    module_defaults: GlobalModuleDefaults,
 }
 
 impl GlobalParseState {
@@ -58,6 +104,7 @@ impl GlobalParseState {
             rsync_port: None,
             daemon_chroot: None,
             modules: Vec::new(),
+            module_defaults: GlobalModuleDefaults::default(),
         }
     }
 
@@ -737,18 +784,247 @@ fn apply_global_directive(
                 state.daemon_chroot = Some((PathBuf::from(trimmed), origin));
             }
         }
-        // upstream: loadparm.c - P_LOCAL directives in the global section are
-        // silently accepted as module defaults that apply to all modules which
-        // do not override them. We ignore them here because they are processed
-        // at the module level when the module definition inherits global defaults.
-        "munge symlinks" | "hosts allow" | "hosts deny" | "log file" | "transfer logging"
-        | "log format" | "exclude" | "exclude from" | "include from" | "max verbosity"
-        | "timeout" | "dont compress" | "pre-xfer exec" | "post-xfer exec" | "auth users"
-        | "strict modes" | "comment" | "path" | "read only" | "write only" | "list"
-        | "filter" | "charset" | "numeric ids" | "ignore errors" | "ignore nonreadable"
-        | "fake super" | "max connections" => {
-            // Silently accepted - not yet wired as inheritable module defaults.
+        // upstream: loadparm.c - P_LOCAL directives in the global section set
+        // default values inherited by all modules that don't override them.
+        // When bInGlobalSection is true, parm_ptr = def_ptr, so the value
+        // written becomes the default for all subsequent module sections
+        // (via init_section -> copy_section).
+        "exclude" => {
+            if !value.is_empty() {
+                state.module_defaults.exclude.push(value.to_owned());
+            }
         }
+        "include" => {
+            if !value.is_empty() {
+                state.module_defaults.include.push(value.to_owned());
+            }
+        }
+        "filter" => {
+            if !value.is_empty() {
+                state.module_defaults.filter.push(value.to_owned());
+            }
+        }
+        "max verbosity" => {
+            let parsed: i32 = value.parse().map_err(|_| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid integer value '{value}' for 'max verbosity'"),
+                )
+            })?;
+            state.module_defaults.max_verbosity = Some(parsed);
+        }
+        "transfer logging" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'transfer logging'"),
+                )
+            })?;
+            state.module_defaults.transfer_logging = Some(parsed);
+        }
+        "log format" => {
+            if !value.is_empty() {
+                state.module_defaults.log_format = Some(value.to_owned());
+            }
+        }
+        "log file" => {
+            if !value.is_empty() {
+                let resolved = resolve_config_relative_path(canonical, value);
+                state.module_defaults.log_file = Some(resolved);
+            }
+        }
+        "hosts allow" => {
+            let patterns = parse_host_list(value, path, line_number, "hosts allow")?;
+            state.module_defaults.hosts_allow = Some(patterns);
+        }
+        "hosts deny" => {
+            let patterns = parse_host_list(value, path, line_number, "hosts deny")?;
+            state.module_defaults.hosts_deny = Some(patterns);
+        }
+        "timeout" => {
+            let timeout = parse_timeout_seconds(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid timeout '{value}'"),
+                )
+            })?;
+            state.module_defaults.timeout = Some(timeout);
+        }
+        "dont compress" => {
+            if !value.is_empty() {
+                state.module_defaults.dont_compress = Some(value.to_owned());
+            }
+        }
+        "read only" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'read only'"),
+                )
+            })?;
+            state.module_defaults.read_only = Some(parsed);
+        }
+        "write only" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'write only'"),
+                )
+            })?;
+            state.module_defaults.write_only = Some(parsed);
+        }
+        "list" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'list'"),
+                )
+            })?;
+            state.module_defaults.listable = Some(parsed);
+        }
+        "munge symlinks" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'munge symlinks'"),
+                )
+            })?;
+            state.module_defaults.munge_symlinks = Some(Some(parsed));
+        }
+        "numeric ids" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'numeric ids'"),
+                )
+            })?;
+            state.module_defaults.numeric_ids = Some(parsed);
+        }
+        "fake super" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'fake super'"),
+                )
+            })?;
+            state.module_defaults.fake_super = Some(parsed);
+        }
+        "max connections" => {
+            let max = parse_max_connections_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid max connections value '{value}'"),
+                )
+            })?;
+            state.module_defaults.max_connections = Some(max);
+        }
+        "ignore errors" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'ignore errors'"),
+                )
+            })?;
+            state.module_defaults.ignore_errors = Some(parsed);
+        }
+        "ignore nonreadable" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'ignore nonreadable'"),
+                )
+            })?;
+            state.module_defaults.ignore_nonreadable = Some(parsed);
+        }
+        "strict modes" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'strict modes'"),
+                )
+            })?;
+            state.module_defaults.strict_modes = Some(parsed);
+        }
+        "forward lookup" => {
+            // forward lookup is both P_LOCAL and has a global handler above
+            // for reverse_lookup. This arm handles the module-default case.
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'forward lookup'"),
+                )
+            })?;
+            state.module_defaults.forward_lookup = Some(parsed);
+        }
+        "open noatime" => {
+            let parsed = parse_boolean_directive(value).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid boolean value '{value}' for 'open noatime'"),
+                )
+            })?;
+            state.module_defaults.open_noatime = Some(parsed);
+        }
+        "exclude from" => {
+            if !value.is_empty() {
+                let resolved = resolve_config_relative_path(canonical, value);
+                state.module_defaults.exclude_from = Some(resolved);
+            }
+        }
+        "include from" => {
+            if !value.is_empty() {
+                let resolved = resolve_config_relative_path(canonical, value);
+                state.module_defaults.include_from = Some(resolved);
+            }
+        }
+        "comment" => {
+            if !value.is_empty() {
+                state.module_defaults.comment = Some(value.to_owned());
+            }
+        }
+        "early exec" => {
+            if !value.is_empty() {
+                state.module_defaults.early_exec = Some(value.to_owned());
+            }
+        }
+        "pre-xfer exec" => {
+            if !value.is_empty() {
+                state.module_defaults.pre_xfer_exec = Some(value.to_owned());
+            }
+        }
+        "post-xfer exec" => {
+            if !value.is_empty() {
+                state.module_defaults.post_xfer_exec = Some(value.to_owned());
+            }
+        }
+        "name converter" => {
+            if !value.is_empty() {
+                state.module_defaults.name_converter = Some(value.to_owned());
+            }
+        }
+        "charset" => {
+            if !value.is_empty() {
+                state.module_defaults.charset = Some(value.to_owned());
+            }
+        }
+        // P_LOCAL directives that only make sense per-module - silently accepted
+        // but not stored as inheritable defaults.
+        "path" | "auth users" => {}
         _ => {
             eprintln!(
                 "warning: unknown global directive '{}' in '{}' line {} [daemon={}]",

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -124,6 +124,7 @@ fn finish_module_builder(
         default_incoming,
         default_outgoing,
         default_use_chroot,
+        &state.module_defaults,
     )
 }
 

--- a/crates/daemon/src/daemon/sections/module_definition/finish.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/finish.rs
@@ -5,6 +5,14 @@
 // (e.g., `auth users` requires `secrets file`).
 
 impl ModuleDefinitionBuilder {
+    /// Converts the accumulated builder state into a validated `ModuleDefinition`.
+    ///
+    /// Parameters not explicitly set on the module inherit from `defaults`,
+    /// which captures P_LOCAL directives from the global section of rsyncd.conf.
+    ///
+    /// upstream: loadparm.c - `init_section()` copies the current global
+    /// defaults (`Vars.l`) into each new module section. Per-module directives
+    /// then override specific fields.
     fn finish(
         self,
         config_path: &Path,
@@ -12,6 +20,7 @@ impl ModuleDefinitionBuilder {
         default_incoming_chmod: Option<&str>,
         default_outgoing_chmod: Option<&str>,
         default_use_chroot: Option<bool>,
+        defaults: &GlobalModuleDefaults,
     ) -> Result<ModuleDefinition, DaemonError> {
         let path = self.path.ok_or_else(|| {
             config_parse_error(
@@ -71,12 +80,37 @@ impl ModuleDefinitionBuilder {
             ));
         };
 
+        // upstream: loadparm.c - exclude/include/filter are STRING parameters.
+        // In the global section they set defaults; per-module directives override
+        // (not append to) the defaults. If the module has its own exclude rules,
+        // use those; otherwise inherit the global defaults.
+        let exclude = if self.exclude.is_empty() {
+            defaults.exclude.clone()
+        } else {
+            self.exclude
+        };
+        let include = if self.include.is_empty() {
+            defaults.include.clone()
+        } else {
+            self.include
+        };
+        let filter = if self.filter.is_empty() {
+            defaults.filter.clone()
+        } else {
+            self.filter
+        };
+
+        // upstream: loadparm.c - hosts_allow/hosts_deny are STRING P_LOCAL
+        // parameters with global defaults.
+        let hosts_allow = self.hosts_allow.or_else(|| defaults.hosts_allow.clone()).unwrap_or_default();
+        let hosts_deny = self.hosts_deny.or_else(|| defaults.hosts_deny.clone()).unwrap_or_default();
+
         Ok(ModuleDefinition {
             name: self.name,
             path,
-            comment: self.comment,
-            hosts_allow: self.hosts_allow.unwrap_or_default(),
-            hosts_deny: self.hosts_deny.unwrap_or_default(),
+            comment: self.comment.or_else(|| defaults.comment.clone()),
+            hosts_allow,
+            hosts_deny,
             auth_users,
             secrets_file,
             bandwidth_limit: self.bandwidth_limit,
@@ -85,46 +119,49 @@ impl ModuleDefinitionBuilder {
             bandwidth_burst_specified: self.bandwidth_burst_specified,
             bandwidth_limit_configured: self.bandwidth_limit_set,
             refuse_options: self.refuse_options.unwrap_or_default(),
-            read_only: self.read_only.unwrap_or(true),
-            write_only: self.write_only.unwrap_or(false),
-            numeric_ids: self.numeric_ids.unwrap_or(false),
+            read_only: self.read_only.or(defaults.read_only).unwrap_or(true),
+            write_only: self.write_only.or(defaults.write_only).unwrap_or(false),
+            numeric_ids: self.numeric_ids.or(defaults.numeric_ids).unwrap_or(false),
             uid: self.uid,
             gid: self.gid,
-            timeout: self.timeout.unwrap_or(None),
-            listable: self.listable.unwrap_or(true),
+            timeout: self.timeout.or(defaults.timeout).unwrap_or(None),
+            listable: self.listable.or(defaults.listable).unwrap_or(true),
             use_chroot,
-            max_connections: self.max_connections.unwrap_or(None),
+            max_connections: self.max_connections.or(defaults.max_connections).unwrap_or(None),
             incoming_chmod: self
                 .incoming_chmod
                 .unwrap_or_else(|| default_incoming_chmod.map(str::to_string)),
             outgoing_chmod: self
                 .outgoing_chmod
                 .unwrap_or_else(|| default_outgoing_chmod.map(str::to_string)),
-            fake_super: self.fake_super.unwrap_or(false),
-            munge_symlinks: self.munge_symlinks.unwrap_or(None),
-            max_verbosity: self.max_verbosity.unwrap_or(1),
-            ignore_errors: self.ignore_errors.unwrap_or(false),
-            ignore_nonreadable: self.ignore_nonreadable.unwrap_or(false),
-            transfer_logging: self.transfer_logging.unwrap_or(false),
+            fake_super: self.fake_super.or(defaults.fake_super).unwrap_or(false),
+            munge_symlinks: self.munge_symlinks.or(defaults.munge_symlinks).unwrap_or(None),
+            max_verbosity: self.max_verbosity.or(defaults.max_verbosity).unwrap_or(1),
+            ignore_errors: self.ignore_errors.or(defaults.ignore_errors).unwrap_or(false),
+            ignore_nonreadable: self.ignore_nonreadable.or(defaults.ignore_nonreadable).unwrap_or(false),
+            transfer_logging: self.transfer_logging.or(defaults.transfer_logging).unwrap_or(false),
             log_format: self
                 .log_format
-                .unwrap_or_else(|| Some("%o %h [%a] %m (%u) %f %l".to_owned())),
-            dont_compress: self.dont_compress.unwrap_or(None),
-            early_exec: self.early_exec.unwrap_or(None),
-            pre_xfer_exec: self.pre_xfer_exec.unwrap_or(None),
-            post_xfer_exec: self.post_xfer_exec.unwrap_or(None),
-            name_converter: self.name_converter.unwrap_or(None),
-            temp_dir: self.temp_dir.unwrap_or(None),
-            charset: self.charset.unwrap_or(None),
-            forward_lookup: self.forward_lookup.unwrap_or(true),
-            strict_modes: self.strict_modes.unwrap_or(true),
-            exclude_from: self.exclude_from,
-            include_from: self.include_from,
-            open_noatime: self.open_noatime.unwrap_or(false),
-            log_file: self.log_file,
-            filter: self.filter,
-            exclude: self.exclude,
-            include: self.include,
+                .unwrap_or_else(|| {
+                    defaults.log_format.clone()
+                        .or_else(|| Some("%o %h [%a] %m (%u) %f %l".to_owned()))
+                }),
+            log_file: self.log_file.or_else(|| defaults.log_file.clone()),
+            dont_compress: self.dont_compress.unwrap_or_else(|| defaults.dont_compress.clone()),
+            early_exec: self.early_exec.unwrap_or_else(|| defaults.early_exec.clone()),
+            pre_xfer_exec: self.pre_xfer_exec.unwrap_or_else(|| defaults.pre_xfer_exec.clone()),
+            post_xfer_exec: self.post_xfer_exec.unwrap_or_else(|| defaults.post_xfer_exec.clone()),
+            name_converter: self.name_converter.unwrap_or_else(|| defaults.name_converter.clone()),
+            temp_dir: self.temp_dir.unwrap_or_else(|| defaults.temp_dir.clone()),
+            charset: self.charset.unwrap_or_else(|| defaults.charset.clone()),
+            forward_lookup: self.forward_lookup.or(defaults.forward_lookup).unwrap_or(true),
+            strict_modes: self.strict_modes.or(defaults.strict_modes).unwrap_or(true),
+            exclude_from: self.exclude_from.or_else(|| defaults.exclude_from.clone()),
+            include_from: self.include_from.or_else(|| defaults.include_from.clone()),
+            open_noatime: self.open_noatime.or(defaults.open_noatime).unwrap_or(false),
+            filter,
+            exclude,
+            include,
         })
     }
 }

--- a/crates/daemon/src/daemon/sections/module_definition/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/tests.rs
@@ -525,7 +525,8 @@ fn set_open_noatime_rejects_duplicate() {
 fn finish_succeeds_with_minimal_config() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
     assert!(result.is_ok());
     let def = result.unwrap();
     assert_eq!(def.name, "testmod");
@@ -539,7 +540,8 @@ fn finish_succeeds_with_minimal_config() {
 #[test]
 fn finish_fails_without_path() {
     let builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
     assert!(result.is_err());
 }
 
@@ -548,7 +550,8 @@ fn finish_requires_absolute_path_with_chroot() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("relative/path"), &test_config_path(), 2).unwrap();
     // use_chroot defaults to true
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
     assert!(result.is_err());
 }
 
@@ -557,7 +560,8 @@ fn finish_allows_relative_path_without_chroot() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("relative/path"), &test_config_path(), 2).unwrap();
     builder.set_use_chroot(false, &test_config_path(), 3).unwrap();
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
     assert!(result.is_ok());
 }
 
@@ -567,7 +571,8 @@ fn finish_applies_default_secrets_for_auth_users() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_auth_users(vec![AuthUser::new("alice".to_owned())], &test_config_path(), 3).unwrap();
     let default_secrets = PathBuf::from("/etc/secrets");
-    let result = builder.finish(&test_config_path(), Some(&default_secrets), None, None, None);
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), Some(&default_secrets), None, None, None, &defaults);
     assert!(result.is_ok());
     let def = result.unwrap();
     assert_eq!(def.secrets_file, Some(PathBuf::from("/etc/secrets")));
@@ -578,7 +583,8 @@ fn finish_fails_auth_users_without_secrets() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_auth_users(vec![AuthUser::new("alice".to_owned())], &test_config_path(), 3).unwrap();
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
     assert!(result.is_err());
 }
 
@@ -586,12 +592,14 @@ fn finish_fails_auth_users_without_secrets() {
 fn finish_applies_default_chmod_values() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
+    let defaults = GlobalModuleDefaults::default();
     let result = builder.finish(
         &test_config_path(),
         None,
         Some("Dg+s"),
         Some("Fo-w"),
         None,
+        &defaults,
     );
     assert!(result.is_ok());
     let def = result.unwrap();
@@ -605,12 +613,14 @@ fn finish_preserves_explicit_chmod_over_defaults() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_incoming_chmod(Some("a+r".to_owned()), &test_config_path(), 3).unwrap();
     builder.set_outgoing_chmod(Some("a+x".to_owned()), &test_config_path(), 4).unwrap();
+    let defaults = GlobalModuleDefaults::default();
     let result = builder.finish(
         &test_config_path(),
         None,
         Some("default-in"),
         Some("default-out"),
         None,
+        &defaults,
     );
     assert!(result.is_ok());
     let def = result.unwrap();
@@ -639,7 +649,7 @@ fn finish_transfers_all_set_values() {
         12,
     ).unwrap();
 
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let result = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default());
     assert!(result.is_ok());
     let def = result.unwrap();
 
@@ -666,7 +676,7 @@ fn finish_uses_default_values_for_unset_fields() {
     let mut builder = ModuleDefinitionBuilder::new("defaults".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
 
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let result = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default());
     assert!(result.is_ok());
     let def = result.unwrap();
 
@@ -716,7 +726,7 @@ fn finish_preserves_fake_super_when_set() {
     builder.set_path(PathBuf::from("/backup"), &test_config_path(), 2).unwrap();
     builder.set_fake_super(true, &test_config_path(), 3).unwrap();
 
-    let result = builder.finish(&test_config_path(), None, None, None, None);
+    let result = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default());
     assert!(result.is_ok());
     let def = result.unwrap();
     assert!(def.fake_super);
@@ -727,7 +737,7 @@ fn finish_munge_symlinks_default_none() {
     let mut builder = ModuleDefinitionBuilder::new("mod".to_owned(), 1);
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
 
-    let def = builder.finish(&test_config_path(), None, None, None, None).unwrap();
+    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
     assert!(def.munge_symlinks.is_none());
 }
 
@@ -737,7 +747,7 @@ fn finish_munge_symlinks_explicit_true() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_munge_symlinks(Some(true), &test_config_path(), 3).unwrap();
 
-    let def = builder.finish(&test_config_path(), None, None, None, None).unwrap();
+    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
     assert_eq!(def.munge_symlinks, Some(true));
 }
 
@@ -747,7 +757,7 @@ fn finish_munge_symlinks_explicit_false() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_munge_symlinks(Some(false), &test_config_path(), 3).unwrap();
 
-    let def = builder.finish(&test_config_path(), None, None, None, None).unwrap();
+    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
     assert_eq!(def.munge_symlinks, Some(false));
 }
 
@@ -757,7 +767,7 @@ fn finish_transfers_exclude_from() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_exclude_from(PathBuf::from("/etc/excludes.txt"), &test_config_path(), 3).unwrap();
 
-    let def = builder.finish(&test_config_path(), None, None, None, None).unwrap();
+    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
     assert_eq!(def.exclude_from, Some(PathBuf::from("/etc/excludes.txt")));
 }
 
@@ -767,7 +777,7 @@ fn finish_transfers_include_from() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_include_from(PathBuf::from("/etc/includes.txt"), &test_config_path(), 3).unwrap();
 
-    let def = builder.finish(&test_config_path(), None, None, None, None).unwrap();
+    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
     assert_eq!(def.include_from, Some(PathBuf::from("/etc/includes.txt")));
 }
 
@@ -777,6 +787,6 @@ fn finish_preserves_open_noatime_when_set() {
     builder.set_path(PathBuf::from("/data"), &test_config_path(), 2).unwrap();
     builder.set_open_noatime(true, &test_config_path(), 3).unwrap();
 
-    let def = builder.finish(&test_config_path(), None, None, None, None).unwrap();
+    let def = builder.finish(&test_config_path(), None, None, None, None, &GlobalModuleDefaults::default()).unwrap();
     assert!(def.open_noatime);
 }


### PR DESCRIPTION
## Summary

- Upstream `loadparm.c` treats P_LOCAL parameters in the global section of `rsyncd.conf` as defaults inherited by all modules via `init_section()`/`copy_section()`. The daemon config parser silently accepted but discarded these directives, causing global `exclude`, `include`, `filter`, `hosts allow/deny`, `max verbosity`, `transfer logging`, and 25+ other P_LOCAL parameters to have no effect on module behaviour.
- Add `GlobalModuleDefaults` struct to accumulate P_LOCAL values from the global section, thread it through `finish_module_builder()` into each module's `finish()` method, and apply the three-tier inheritance chain: module-level value > global default > hardcoded default.
- This fixes upstream testsuite `daemon-gzip-download` and `daemon-gzip-upload` failures, which depend on global `exclude = ? foobar.baz` propagating to all modules. The `daemon` test itself remains a known failure due to its use of `lsh.sh` (SSH remote shell mode), which is a separate issue.

## Test plan

- [ ] CI passes fmt+clippy, nextest, Windows, macOS, Linux musl
- [ ] Existing daemon config parsing tests pass (updated `finish()` call sites with new parameter)
- [ ] Upstream testsuite `daemon-gzip-download` and `daemon-gzip-upload` pass (manual verification with `WHICHTESTS=daemon-gzip-download.test tools/ci/run_upstream_testsuite.sh`)