### PR TITLE
ci: fix daemon bench workflows using wrong package name

### DIFF
--- a/.github/workflows/bench-daemon-coldstart.yml
+++ b/.github/workflows/bench-daemon-coldstart.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install -y rsync hyperfine jq
 
       - name: Build oc-rsync (release)
-        run: cargo build --release -p oc-rsync
+        run: cargo build --release --bin oc-rsync
 
       - name: Prepare fixture and daemon configs
         id: prep

--- a/.github/workflows/bench-daemon-concurrency.yml
+++ b/.github/workflows/bench-daemon-concurrency.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get install -y rsync hyperfine jq time
 
       - name: Build oc-rsync (release)
-        run: cargo build --release -p oc-rsync
+        run: cargo build --release --bin oc-rsync
 
       - name: Prepare fixture and daemon config
         id: prep


### PR DESCRIPTION
## Summary

- Fix `cargo build --release -p oc-rsync` in `bench-daemon-coldstart.yml` and `bench-daemon-concurrency.yml` - the workspace root package is `bin`, not `oc-rsync`
- Replace with `cargo build --release --bin oc-rsync` to target the binary directly
- Both workflows have been broken since creation due to this bug

## Test plan

- [ ] Daemon cold-start benchmark workflow passes the build step
- [ ] Daemon concurrency benchmark workflow passes the build step