### PR TITLE
ci: pin all GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build-rsync-2-6-9.yml
+++ b/.github/workflows/build-rsync-2-6-9.yml
@@ -46,11 +46,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore rsync 2.6.9 cache
         id: cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             /usr/local/bin/rsync-2.6.9
@@ -85,7 +85,7 @@ jobs:
 
       - name: Save rsync 2.6.9 cache
         if: steps.cache.outputs.cache-hit != 'true' && success()
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             /usr/local/bin/rsync-2.6.9

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install upstream rsync
         run: |
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y rsync
           /usr/bin/rsync --version | head -n 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       - name: Build oc-rsync (release)
         run: cargo build --release --bin oc-rsync
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload diff artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mdf-8-filter-diff
           path: /tmp/mdf-8-diff/


### PR DESCRIPTION
## Summary

- **build-rsync-2-6-9.yml**: Pin `actions/checkout@v6` to `@de0fac2e...` (v6.0.2), `actions/cache/restore@v5` and `actions/cache/save@v5` to `@27d5ce7f...` (v5.0.5)
- **labeler.yml**: Pin `actions/github-script@v9` to `@3a2844b7...` (v9.0.0)
- **mdf-8-filter-diff.yml**: Pin `actions/checkout@v6` to `@de0fac2e...` (v6.0.2), `dtolnay/rust-toolchain@stable` to `@4be9e76f...`, `actions/upload-artifact@v7` to `@043fb46d...` (v7.0.1)

All SHA hashes match those already used in other workflow files across the repository. No functional changes - only tag references replaced with immutable SHA pins for supply chain hardening.

## Test plan

- [ ] CI workflows continue to resolve the correct action versions
- [ ] No workflow regressions from the pin changes