### PR TITLE
ci: reduce runner contention by limiting non-required jobs to schedule

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -115,9 +115,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: no-default-features
-            args: "--workspace --no-default-features"
-            apt: ""
           # PFF-6: Verify the default-features build compiles and passes
           # tests. The main CI test job uses --all-features which may mask
           # regressions in the default feature set.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ on:
       - 'docker/**'
       - 'Cross.toml'
   workflow_dispatch:
+  schedule:
+    # Run nightly to exercise beta/nightly toolchains (not run on PRs)
+    - cron: '30 3 * * *'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -142,6 +145,8 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
+    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
+    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 120
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
@@ -217,6 +222,8 @@ jobs:
     name: Windows (${{ matrix.toolchain }})
     runs-on: windows-latest
     needs: lint
+    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
+    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 45
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
@@ -433,6 +440,8 @@ jobs:
     name: macOS (${{ matrix.toolchain }})
     runs-on: macos-latest
     needs: lint
+    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
+    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 30
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
@@ -492,6 +501,8 @@ jobs:
     name: Linux musl (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
+    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
+    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 30
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,10 @@ name: Dependency Review
 
 on:
   pull_request:
+    paths:
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/*/Cargo.toml'
 
 permissions:
   contents: read

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -11,7 +11,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/interop-validation.yml'
-      - '.github/workflows/ci.yml'
   pull_request:
     paths:
       - 'crates/**'
@@ -21,7 +20,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/interop-validation.yml'
-      - '.github/workflows/ci.yml'
   workflow_dispatch:
   schedule:
     # Run nightly to catch drift in upstream versions


### PR DESCRIPTION
## Summary

- **Remove dead `no-default-features` matrix entry** from `_test-features.yml`: this row is known to fail compilation and had `continue-on-error: true` masking the failure - pure CI noise consuming a runner slot for no value.

- **Remove `ci.yml` from `interop-validation.yml` path filter**: editing `ci.yml` should not trigger the interop validation workflow. Interop tests only need to run when source code, test fixtures, or interop tooling changes.

- **Move beta/nightly toolchain jobs to schedule-only**: the `test`, `windows-test`, `macos-test`, and `linux-musl` jobs previously ran `[stable, beta, nightly]` on every PR. Beta and nightly are NOT required checks - they are informational. Now they only run on the nightly schedule (03:30 UTC) and `workflow_dispatch`, saving 8 runner slots per PR (2 non-stable toolchains x 4 job types). Stable jobs continue to run on every PR unchanged.

- **Add path filter to `dependency-review.yml`**: the dependency review action only needs to run when `Cargo.lock`, `Cargo.toml`, or crate-level `Cargo.toml` files change. Previously it ran on every PR regardless of content.

## Test plan

- [ ] Verify stable CI jobs (`nextest (stable)`, `Windows (stable)`, `macOS (stable)`, `Linux musl (stable)`) still run on this PR
- [ ] Verify beta/nightly jobs are skipped on this PR
- [ ] Verify dependency-review does not trigger (this PR has no Cargo.toml/lock changes)
- [ ] Verify interop-validation does not trigger (this PR only touches workflow YAML)