### PR TITLE
ci: add nextest --profile ci, --locked, and missing timeouts

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -395,7 +395,7 @@ jobs:
           set -euo pipefail
           # Ensure release oc-rsync exists for the harness.
           if [[ ! -x target/release/oc-rsync ]]; then
-            cargo build --release --bin oc-rsync
+            cargo build --locked --release --bin oc-rsync
           fi
           bash tools/ci/run_upstream_testsuite.sh
 
@@ -448,7 +448,7 @@ jobs:
           # `--features sender-inc-recurse` instead of reusing the
           # default-OFF binary from the earlier interop step.
           rm -f target/dist/oc-rsync
-          cargo build --profile dist --bin oc-rsync --features sender-inc-recurse
+          cargo build --locked --profile dist --bin oc-rsync --features sender-inc-recurse
           target/dist/oc-rsync --version 2>&1 | head -1
           bash tools/ci/run_interop.sh
 

--- a/.github/workflows/bench-checksum-throughput.yml
+++ b/.github/workflows/bench-checksum-throughput.yml
@@ -63,7 +63,7 @@ jobs:
           shared-key: bench-checksum-throughput
 
       - name: Build checksums crate (release)
-        run: cargo build --release -p checksums
+        run: cargo build --locked --release -p checksums
 
       - name: Prepare results directory
         id: prep

--- a/.github/workflows/bench-daemon-coldstart.yml
+++ b/.github/workflows/bench-daemon-coldstart.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install -y rsync hyperfine jq
 
       - name: Build oc-rsync (release)
-        run: cargo build --release --bin oc-rsync
+        run: cargo build --locked --release --bin oc-rsync
 
       - name: Prepare fixture and daemon configs
         id: prep

--- a/.github/workflows/bench-daemon-concurrency.yml
+++ b/.github/workflows/bench-daemon-concurrency.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get install -y rsync hyperfine jq time
 
       - name: Build oc-rsync (release)
-        run: cargo build --release --bin oc-rsync
+        run: cargo build --locked --release --bin oc-rsync
 
       - name: Prepare fixture and daemon config
         id: prep

--- a/.github/workflows/bench-drain-throughput.yml
+++ b/.github/workflows/bench-drain-throughput.yml
@@ -71,7 +71,7 @@ jobs:
           shared-key: bench-drain-throughput
 
       - name: Build engine (release)
-        run: cargo build --release -p engine
+        run: cargo build --locked --release -p engine
 
       - name: Prepare results directory
         id: prep

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,16 +57,16 @@ jobs:
             openssh-server libssl-dev
 
       - name: Build oc-rsync (release)
-        run: cargo build --release --workspace
+        run: cargo build --locked --release --workspace
 
       - name: Build oc-rsync with OpenSSL (release)
         run: |
-          cargo build --release --features openssl
+          cargo build --locked --release --features openssl
           cp target/release/oc-rsync target/release/oc-rsync-openssl
 
       - name: Build oc-rsync with embedded-ssh (release)
         run: |
-          cargo build --release --features embedded-ssh
+          cargo build --locked --release --features embedded-ssh
           cp target/release/oc-rsync target/release/oc-rsync-russh
 
       - name: Cache upstream rsync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Run tests
-        run: cargo nextest run --locked --workspace --all-features
+        run: cargo nextest run --locked --profile ci --workspace --all-features
 
       - name: Set up SSH loopback
         if: matrix.toolchain == 'stable'

--- a/.github/workflows/differential-fuzzer-overnight.yml
+++ b/.github/workflows/differential-fuzzer-overnight.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build oc-rsync (for differential_outcome)
         if: matrix.needs_upstream
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Detect host triple
         id: host

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -81,7 +81,7 @@ jobs:
         run: bash tools/ci/run_interop.sh build-only
 
       - name: Build oc-rsync
-        run: cargo build --release --bin oc-rsync
+        run: cargo build --locked --release --bin oc-rsync
 
       - name: Stage shared interop artifact
         run: |

--- a/.github/workflows/known-failures.yml
+++ b/.github/workflows/known-failures.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build oc-rsync
         run: |
-          cargo build --release
+          cargo build --locked --release
           mkdir -p target/dist
           cp target/release/oc-rsync target/dist/oc-rsync
 

--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build oc-rsync (release)
-        run: cargo build --release --bin oc-rsync
+        run: cargo build --locked --release --bin oc-rsync
 
       - name: Run MDF-8 diff harness
         run: |

--- a/.github/workflows/parallel_determinism.yml
+++ b/.github/workflows/parallel_determinism.yml
@@ -33,6 +33,7 @@ jobs:
   determinism:
     name: Sequential vs Parallel output
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -43,7 +44,7 @@ jobs:
           shared-key: parallel-determinism
 
       - name: Build release
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Create test fixtures
         run: |

--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           set -euo pipefail
           printf 'Building %s binary...\n' "${{ matrix.target }}"
-          cargo build --profile dist --target ${{ matrix.target }} --features openssl
+          cargo build --locked --profile dist --target ${{ matrix.target }} --features openssl
 
       - name: Build .deb package
         shell: bash

--- a/.github/workflows/ssh-smoke-bench.yml
+++ b/.github/workflows/ssh-smoke-bench.yml
@@ -99,7 +99,7 @@ jobs:
         run: sudo cp target/interop/upstream-src/rsync-3.4.2/rsync /usr/local/bin/rsync
 
       - name: Build oc-rsync (release)
-        run: cargo build --release --workspace
+        run: cargo build --locked --release --workspace
 
       - name: Set up SSH loopback
         run: |


### PR DESCRIPTION
## Summary

- **C-1**: Add `--profile ci` to nextest in `ci.yml` test job to activate the per-test 120s timeout configured in `.config/nextest.toml` - prevents the 3.5-hour hung CI runs observed twice recently.
- **C-2**: Add `--locked` to `cargo build` in `interop-validation.yml` to prevent Cargo.lock drift during CI.
- **C-3**: Not applicable - no instances of `-p oc-rsync` found in interop workflows (already using `--bin oc-rsync`).
- **M-3**: Add `timeout-minutes: 30` to the `parallel_determinism.yml` job to prevent runaway CI.
- **M-8**: Add `--locked` to both `cargo build` commands in `_interop.yml`.
- **Sweep**: Add `--locked` to all remaining `cargo build` commands missing it across 10 additional workflow files.

## Test plan

- [ ] CI passes on this PR (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] Verify `--profile ci` activates nextest CI timeout profile
- [ ] Verify `--locked` does not break any workflow (all use committed Cargo.lock)