### PR TITLE
ci: fix push-triggered CI producing 0 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,6 @@ jobs:
     name: nextest (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
-    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 120
     # Stable gates merge; beta/nightly are informational so a churning
     # nightly compiler does not block PR throughput. Branch protection
@@ -222,8 +220,6 @@ jobs:
     name: Windows (${{ matrix.toolchain }})
     runs-on: windows-latest
     needs: lint
-    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
-    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 45
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
@@ -440,8 +436,6 @@ jobs:
     name: macOS (${{ matrix.toolchain }})
     runs-on: macos-latest
     needs: lint
-    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
-    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 30
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:
@@ -501,8 +495,6 @@ jobs:
     name: Linux musl (${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     needs: lint
-    # Skip beta/nightly on PRs - they run on schedule and workflow_dispatch only.
-    if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'
     timeout-minutes: 30
     continue-on-error: ${{ matrix.toolchain != 'stable' }}
     strategy:


### PR DESCRIPTION
## Summary

- Remove 4 job-level `if` conditions from ci.yml that caused push-triggered runs to produce 0 jobs
- Commit 2b7db94c9 added `if: github.event_name != 'pull_request' || matrix.toolchain == 'stable'` to test, windows-test, macos-test, and linux-musl jobs
- Despite appearing syntactically valid, this caused GitHub Actions to emit 0 jobs on push events (run 26792211730), breaking the master CI pipeline
- Beta/nightly matrix entries already have `continue-on-error: true` so they do not block merges

## Test plan

- [ ] Verify push-triggered CI on master produces all expected jobs (51+)
- [ ] Verify PR-triggered CI still runs all matrix entries