### PR TITLE
ci: add --no-tests=warn to async-wire-parity workflow

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -61,4 +61,5 @@ jobs:
           cargo nextest run --locked \
             -p transfer \
             --features async \
+            --no-tests=warn \
             -E 'test(sync_async_wire_parity)'


### PR DESCRIPTION
## Summary

- The `sync_async_wire_parity` test does not yet exist in the transfer crate, causing nextest to exit with code 4 (no tests matched) on every PR touching `crates/transfer/**`, `crates/protocol/**`, or `crates/rsync_io/**`
- Adds `--no-tests=warn` so the workflow passes gracefully until the test is written

## Test plan

- [ ] Verify the async-wire-parity workflow no longer fails on PRs touching transfer/protocol/rsync_io paths