### PR TITLE
ci: fix ci-skip path filters to avoid overlap with ci.yml

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -7,9 +7,21 @@ on:
       - 'docs/**'
       - '*.md'
       - 'LICENSE'
-      - '.github/**'
+      - '.github/CODEOWNERS'
+      - '.github/dependabot.yml'
+      - '.github/FUNDING.yml'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/RELEASE_NOTES_BETA.md'
+      - '.github/RELEASE_TEMPLATE.md'
+      - '.github/release.yml'
+      - '.github/scripts/**'
       - 'scripts/**'
-      - 'tools/**'
+      - 'packaging/**'
+      - 'dist-workspace.toml'
+      - '.dockerignore'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'deny.toml'
 
 concurrency:
   group: ci-skip-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Remove `tools/**` from ci-skip.yml paths - it overlaps with ci.yml, causing both workflows to fire when tools are changed
- Replace broad `.github/**` glob with specific non-CI config files (CODEOWNERS, dependabot.yml, FUNDING.yml, PR template, release configs, scripts) to avoid overlap with the 5 specific workflow files ci.yml watches
- Add missing non-code paths (`packaging/**`, `dist-workspace.toml`, `.dockerignore`, `.gitignore`, `.gitattributes`, `deny.toml`) that previously triggered neither workflow, leaving required checks pending

## Context

The ci-skip workflow emits placeholder jobs matching the 5 required branch protection checks so docs-only PRs can merge. The path filters must be the inverse of ci.yml's paths to avoid both workflows running simultaneously for the same file changes.

Job name audit: all 5 required check names (`fmt + clippy`, `nextest (stable)`, `Windows (stable)`, `macOS (stable)`, `Linux musl (stable)`) already match between ci.yml and ci-skip.yml - no changes needed there.

## Test plan

- [ ] Verify ci-skip triggers on a docs-only PR (e.g., editing a markdown file)
- [ ] Verify ci-skip does NOT trigger when only code files (crates/src) are changed
- [ ] Verify no overlap between ci-skip.yml and ci.yml path lists