### PR TITLE
ci: align ci-skip interop job names with branch protection

### DIFF
--- a/.github/workflows/_ci-skip-interop-macos.yml
+++ b/.github/workflows/_ci-skip-interop-macos.yml
@@ -1,0 +1,14 @@
+name: CI skip interop (macOS)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  interop-with-upstream-macos:
+    name: interop with upstream rsync (macOS)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped — no code changes"

--- a/.github/workflows/_ci-skip-interop-windows.yml
+++ b/.github/workflows/_ci-skip-interop-windows.yml
@@ -1,0 +1,14 @@
+name: CI skip interop (Windows)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  interop-with-upstream-windows:
+    name: interop with upstream rsync (Windows, best-effort)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped — no code changes"

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -66,13 +66,9 @@ jobs:
     uses: ./.github/workflows/_ci-skip-interop.yml
 
   interop-macos:
-    name: interop with upstream rsync (macOS)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipped — no code changes"
+    name: interop (macOS)
+    uses: ./.github/workflows/_ci-skip-interop-macos.yml
 
   interop-windows:
-    name: interop with upstream rsync (Windows, best-effort)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipped — no code changes"
+    name: interop (Windows, best-effort)
+    uses: ./.github/workflows/_ci-skip-interop-windows.yml


### PR DESCRIPTION
## Summary

- Fix macOS and Windows interop skip jobs in `ci-skip.yml` to produce composite check names matching `ci.yml`
- Add `_ci-skip-interop-macos.yml` and `_ci-skip-interop-windows.yml` reusable workflows with correct inner job names
- Previously, docs-only PRs would block on interop checks that never resolved because `ci-skip.yml` emitted flat job names (e.g., `interop with upstream rsync (macOS)`) while branch protection expected composite names (e.g., `interop (macOS) / interop with upstream rsync (macOS)`)

## Test plan

- [ ] Open a docs-only PR (e.g., edit a `*.md` file) and verify all required checks resolve to "skipped" status without blocking
- [ ] Confirm the check names in the PR's status checks match the branch protection required checks exactly