### PR TITLE
ci: standardize cache keys and add missing CARGO_TERM_COLOR

### DIFF
--- a/.github/workflows/known-failures.yml
+++ b/.github/workflows/known-failures.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-D warnings"
+      CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
 
     steps:
       - name: Checkout
@@ -35,7 +36,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
-          shared-key: ci-${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci-${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           key: known-failures
 
       - name: Cache APT packages

--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -22,6 +22,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   diff:
     name: filter-diff

--- a/.github/workflows/parallel_determinism.yml
+++ b/.github/workflows/parallel_determinism.yml
@@ -28,6 +28,7 @@ env:
   CARGO_INCREMENTAL: "0"
   RUSTFLAGS: "-D warnings"
   RUST_BACKTRACE: "full"
+  CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
 
 jobs:
   determinism:
@@ -41,7 +42,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
-          shared-key: parallel-determinism
+          shared-key: parallel-determinism-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build release
         run: cargo build --locked --release


### PR DESCRIPTION
## Summary

- **known-failures.yml**: Replace hardcoded `v1` in the Rust cache shared-key with the `CACHE_VERSION` env var, matching the pattern used by all other workflows. This lets cache busting be controlled from a single GitHub Actions variable.
- **parallel_determinism.yml**: Add `CACHE_VERSION` env var and incorporate it plus the `Cargo.lock` hash into the cache shared-key. Previously the key was a bare string (`parallel-determinism`) with no version or lockfile sensitivity, meaning stale caches could persist across dependency updates.
- **mdf-8-filter-diff.yml**: Add `CARGO_TERM_COLOR: always` to the workflow-level env. This was the only workflow that runs `cargo build` without setting it.

### Audit notes (no changes needed)

- **Toolchain pins**: Required checks use `stable`; bench workflows pin `1.88.0` for reproducibility; coverage pins `nightly-2026-04-20` due to a documented llvm-cov SIGSEGV. All intentional.
- **`apt-get install rsync`**: Appears in 3 workflows with different companion packages each time. Not worth deduplicating.
- **`continue-on-error: true`**: All usages are on non-required jobs (bench, nightly/beta toolchains, informational audits, interop parity cells). All appropriate.
- **`CARGO_TERM_COLOR`**: The 5 other workflows missing it (`_ci-skip-interop.yml`, `ci-skip.yml`, `dependency-review.yml`, `labeler.yml`, `upstream-release-watch.yml`) do not run cargo commands, so the variable is not relevant.

## Test plan

- [ ] CI passes on all required checks (fmt+clippy, nextest, Windows, macOS, musl)
- [ ] Verify known-failures.yml cache key resolves correctly in a workflow run
- [ ] Verify parallel_determinism.yml cache key includes version and lockfile hash