### PR TITLE
fix: export setfacl_nodef in upstream testsuite harness for ACL tests

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool acl libacl1-dev libattr1-dev libzstd-dev liblz4-dev
           version: ${{ inputs.cache_version }}
 
       - name: Cache upstream rsync

--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool acl libacl1-dev libattr1-dev libzstd-dev liblz4-dev
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool acl libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
           version: ${{ inputs.cache_version }}
 
       - name: Cache upstream rsync

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -90,6 +90,22 @@ build_upstream_helpers() {
     )
 }
 
+find_setfacl_nodef() {
+    # upstream: runtests.sh:205-215 - detect the platform's command for
+    # removing default ACLs from a directory.  The ACL tests rely on this
+    # variable being exported into their environment.
+    local probe_dir=$1
+    if setacl -k u::7,g::5,o:5 "$probe_dir" 2>/dev/null; then
+        echo 'setacl -k'
+    elif setfacl --help 2>&1 | grep -E ' -k,|\[-[a-z]*k' >/dev/null 2>&1; then
+        echo 'setfacl -k'
+    elif setfacl -s u::7,g::5,o:5 "$probe_dir" 2>/dev/null; then
+        echo 'setfacl -s u::7,g::5,o:5'
+    else
+        echo 'true'
+    fi
+}
+
 setup_test_env() {
     cd "$upstream_src_dir"
     TOOLDIR="$upstream_src_dir"
@@ -120,6 +136,10 @@ prep_scratch() {
     local sd=$1
     [[ -d "$sd" ]] && chmod -R u+rwX "$sd" 2>/dev/null && rm -rf "$sd"
     mkdir -p "$sd"
+    # upstream: runtests.sh:254 - clear default ACLs and setgid to avoid
+    # confusing tests that depend on inheritable permission state.
+    $setfacl_nodef "$sd" 2>/dev/null || true
+    chmod g-s "$sd" 2>/dev/null || true
     ln -sfn "$srcdir" "$sd/src"
 }
 
@@ -196,6 +216,11 @@ main() {
     mkdir -p "$log_root"
     scratchbase="${log_root}/scratch"
     mkdir -p "$scratchbase"
+
+    # upstream: runtests.sh:205-217 - detect and export setfacl_nodef so
+    # ACL tests can clear default ACLs from directories.
+    setfacl_nodef=$(find_setfacl_nodef "$scratchbase")
+    export setfacl_nodef
 
     passed=0
     failed=0

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -20,10 +20,8 @@ KNOWN_FAILURES=(
   # step still fails.
   "daemon"
 
-  # --- ACL / xattr tests ---
+  # --- xattr tests ---
   # Require platform support and feature flags compiled in.
-  "acls"
-  "acls-default"
   "xattrs"
 
   # --- Device / special-file tests ---


### PR DESCRIPTION
## Summary
- Add `find_setfacl_nodef()` to the upstream testsuite harness, mirroring upstream `runtests.sh:205-215`, so the `setfacl_nodef` variable is detected and exported before ACL tests run
- Update `prep_scratch()` to clear default ACLs and setgid bits on scratch directories, matching upstream `runtests.sh:254`
- Add the `acl` APT package to CI dependencies to ensure `setfacl`/`getfacl` commands are available
- Remove `acls` and `acls-default` from the upstream testsuite known failures list

## Test plan
- [ ] CI nextest passes
- [ ] Upstream testsuite `acls` and `acls-default` tests pass (no longer XFAIL)
- [ ] No regressions in other upstream testsuite tests