### PR TITLE
fix: remove chmod-temp-dir from upstream testsuite known failures

### DIFF
--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -40,11 +40,6 @@ KNOWN_FAILURES=(
   # path does not fully transfer files via lsh.sh).
   "hardlinks"
 
-  # --- chmod-temp-dir test ---
-  # Tests that --temp-dir interacts correctly with --chmod; relies on
-  # specific tempfile placement that may differ from upstream.
-  "chmod-temp-dir"
-
   # --- ssh-basic test ---
   # Requires an actual SSH-style remote shell wrapper in test fixtures.
   "ssh-basic"


### PR DESCRIPTION
## Summary
- Remove `chmod-temp-dir` from `upstream_testsuite_known_failures.conf` so the upstream rsync testsuite harness treats it as a normal test instead of an expected failure
- The chmod-temp-dir test verifies that files with restrictive permissions (mode 440, 500, setuid/setgid) are correctly transferred when `--temp-dir` points to a different filesystem (EXDEV cross-device fallback)
- Two prior fixes resolved the underlying issues: #5326 added `unlink` before cross-device copy to handle read-only destinations, and #5314 applied metadata before rename to match upstream `finish_transfer()`

## Test plan
- [ ] CI nextest passes
- [ ] Upstream testsuite chmod-temp-dir test passes (no longer XFAIL, now PASS)
- [ ] No other upstream testsuite regressions (remaining known failures unchanged)