### PR TITLE
fix: resolve relative OC_RSYNC_BIN path in upstream testsuite runner

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -26,6 +26,11 @@ upstream_version="${UPSTREAM_VERSION:-3.4.2}"
 upstream_src_root="${workspace_root}/target/interop/upstream-src"
 upstream_src_dir="${upstream_src_root}/rsync-${upstream_version}"
 oc_rsync_bin="${OC_RSYNC_BIN:-${workspace_root}/target/release/oc-rsync}"
+# Resolve to absolute path - test scripts cd into the upstream source tree,
+# so a relative OC_RSYNC_BIN would break.
+if [[ "$oc_rsync_bin" != /* ]]; then
+    oc_rsync_bin="${workspace_root}/${oc_rsync_bin}"
+fi
 known_failures_conf="${workspace_root}/tools/ci/upstream_testsuite_known_failures.conf"
 log_root="${workspace_root}/target/interop/upstream-testsuite"
 testrun_timeout="${TESTRUN_TIMEOUT:-300}"

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -20,10 +20,6 @@ KNOWN_FAILURES=(
   # step still fails.
   "daemon"
 
-  # --- xattr tests ---
-  # Require platform support and feature flags compiled in.
-  "xattrs"
-
   # --- Device / special-file tests ---
   # Require root or CAP_MKNOD to create devices in $fromdir.
   "devices"


### PR DESCRIPTION
## Summary

- The upstream testsuite runner (`tools/ci/run_upstream_testsuite.sh`) receives `OC_RSYNC_BIN` as a relative path from CI (`target/release/oc-rsync`). When `setup_test_env()` changes directory into the upstream source tree, the relative path becomes unresolvable, causing every test to fail with "No such file or directory".
- Added path resolution to convert relative `OC_RSYNC_BIN` to absolute using the workspace root before any directory change occurs.
- Removed `xattrs` from `upstream_testsuite_known_failures.conf` since the xattr test should now pass with the corrected binary path.

## Test plan

- [ ] CI upstream testsuite job passes with the xattrs test reporting PASS instead of XFAIL
- [ ] Other upstream testsuite tests are unaffected (same pass/fail/skip counts)
- [ ] Verify no UPASS entries appear for previously-known failures