### PR TITLE
fix: upstream testsuite hardlinks test compatibility

### DIFF
--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use std::io::{self, Write};
 
-use core::client::ClientEvent;
+use core::client::{ClientEvent, ClientEventKind};
 
 use super::tokens::{OutFormat, OutFormatContext, OutFormatToken};
 
@@ -48,6 +48,21 @@ impl OutFormat {
     }
 }
 
+/// Returns `true` when the event should be suppressed from `--out-format` output.
+///
+/// Mirrors the upstream gate in `generator.c:574-576`: when `iflags == 0`
+/// (no significant attribute changes and the file was not transferred), the
+/// itemize line is suppressed. In the local-copy path, this corresponds to
+/// `MetadataReused` events whose `change_set` reports no changes and that
+/// were not newly created.
+///
+/// upstream: generator.c:574-576 - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
+fn should_suppress_event(event: &ClientEvent) -> bool {
+    matches!(event.kind(), ClientEventKind::MetadataReused)
+        && !event.was_created()
+        && !event.change_set().has_any_change()
+}
+
 /// Emits each event using the supplied `--out-format` specification.
 pub(crate) fn emit_out_format<W: Write + ?Sized>(
     events: &[ClientEvent],
@@ -56,6 +71,9 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
     writer: &mut W,
 ) -> io::Result<()> {
     for event in events {
+        if should_suppress_event(event) {
+            continue;
+        }
         format.render(event, context, writer)?;
     }
     Ok(())

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -178,6 +178,26 @@ pub(super) fn process_links(
         // Without this check, an up-to-date hardlink emits `hf+++++++++`
         // and unnecessarily removes + re-creates the destination entry.
         if is_already_hardlinked(destination, &existing_target) {
+            if let Some(existing) = existing_metadata {
+                ::metadata::apply_file_metadata_if_changed(
+                    destination,
+                    metadata,
+                    existing,
+                    &metadata_options,
+                )
+                .map_err(map_metadata_error)?;
+            }
+            #[cfg(all(unix, feature = "xattr"))]
+            sync_xattrs_if_requested(
+                preserve_xattrs,
+                mode,
+                source,
+                destination,
+                true,
+                context.filter_program(),
+            )?;
+            #[cfg(all(any(unix, windows), feature = "acl"))]
+            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
             context.record_hard_link(metadata, destination);
             context.summary_mut().record_regular_file_matched();
             let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -31,6 +31,33 @@ use ::metadata::apply_file_metadata_with_options;
 use super::super::super::super::CROSS_DEVICE_ERROR_CODE;
 use super::super::guard::remove_existing_destination;
 
+/// Returns `true` when `destination` is already hardlinked to `target`.
+///
+/// On Unix this compares (device, inode) pairs. On non-Unix platforms
+/// (where inode-level inspection is unavailable) the function always
+/// returns `false`, causing the link to be re-created harmlessly.
+///
+/// upstream: hlink.c - `hard_link_check()` skips re-creation when the
+/// destination inode already matches the source group leader.
+fn is_already_hardlinked(destination: &Path, target: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let Ok(dest_meta) = fs::symlink_metadata(destination) else {
+            return false;
+        };
+        let Ok(target_meta) = fs::symlink_metadata(target) else {
+            return false;
+        };
+        dest_meta.dev() == target_meta.dev() && dest_meta.ino() == target_meta.ino()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (destination, target);
+        false
+    }
+}
+
 /// Result of hard-link and reference-directory processing for a file.
 pub(super) struct LinkOutcome {
     pub(super) copy_source_override: Option<PathBuf>,
@@ -146,6 +173,60 @@ pub(super) fn process_links(
 
     // 2. link to an already-copied inode we cached
     if let Some(existing_target) = context.existing_hard_link_target(metadata) {
+        // upstream: hlink.c - hard_link_check() skips re-creation when the
+        // destination already shares the same inode as the group leader.
+        // Without this check, an up-to-date hardlink emits `hf+++++++++`
+        // and unnecessarily removes + re-creates the destination entry.
+        if is_already_hardlinked(destination, &existing_target) {
+            context.record_hard_link(metadata, destination);
+            context.summary_mut().record_regular_file_matched();
+            let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+            let total_bytes = Some(metadata_snapshot.len());
+            let change_set = LocalCopyChangeSet::for_file(
+                metadata,
+                existing_metadata,
+                &metadata_options,
+                true,
+                false,
+                {
+                    #[cfg(all(unix, feature = "xattr"))]
+                    {
+                        preserve_xattrs
+                    }
+                    #[cfg(not(all(unix, feature = "xattr")))]
+                    {
+                        false
+                    }
+                },
+                {
+                    #[cfg(all(any(unix, windows), feature = "acl"))]
+                    {
+                        preserve_acls
+                    }
+                    #[cfg(not(all(any(unix, windows), feature = "acl")))]
+                    {
+                        false
+                    }
+                },
+            );
+            context.record(
+                LocalCopyRecord::new(
+                    record_path.to_path_buf(),
+                    LocalCopyAction::MetadataReused,
+                    0,
+                    total_bytes,
+                    Duration::default(),
+                    Some(metadata_snapshot),
+                )
+                .with_change_set(change_set),
+            );
+            remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
+            return Ok(LinkOutcome {
+                copy_source_override: None,
+                completed: true,
+            });
+        }
+
         let mut attempted_commit = false;
         loop {
             match create_hard_link(&existing_target, destination) {

--- a/crates/engine/src/local_copy/plan/change_set/types.rs
+++ b/crates/engine/src/local_copy/plan/change_set/types.rs
@@ -201,4 +201,28 @@ impl LocalCopyChangeSet {
     pub const fn missing_data(&self) -> bool {
         self.missing_data
     }
+
+    /// Returns `true` when at least one attribute flag is set.
+    ///
+    /// Used to gate itemize output: upstream rsync only emits an itemize line
+    /// when `iflags & SIGNIFICANT_ITEM_FLAGS` is non-zero. For up-to-date
+    /// files where no attribute differs, the line is suppressed entirely.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
+    #[must_use]
+    pub const fn has_any_change(&self) -> bool {
+        self.checksum_changed
+            || self.size_changed
+            || self.time_change.is_some()
+            || self.permissions_changed
+            || self.owner_changed
+            || self.group_changed
+            || self.access_time_changed
+            || self.create_time_changed
+            || self.acl_changed
+            || self.xattr_changed
+            || self.missing_data
+    }
 }

--- a/crates/transfer/src/generator/item_flags.rs
+++ b/crates/transfer/src/generator/item_flags.rs
@@ -123,6 +123,21 @@ impl ItemFlags {
         (self.raw & Self::SIGNIFICANT_ITEM_FLAGS) as u16
     }
 
+    /// Returns true if the item has any significant flags set.
+    ///
+    /// Used to gate itemize output: upstream only emits an itemize line when
+    /// at least one significant flag (or `ITEM_REPORT_XATTR`) is set. When
+    /// `iflags == 0` (completely unchanged file), no output is produced
+    /// unless verbosity is high or an extended name follows.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
+    #[must_use]
+    pub const fn has_significant_flags(&self) -> bool {
+        self.raw & (Self::SIGNIFICANT_ITEM_FLAGS | Self::ITEM_REPORT_XATTR) != 0
+    }
+
     /// Returns true if the item needs data transfer.
     #[must_use]
     pub const fn needs_transfer(&self) -> bool {

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -272,8 +272,13 @@ impl GeneratorContext {
     /// In client mode, writes directly to the process stdout via the
     /// itemize callback, matching upstream's `rwrite()` `FCLIENT` path.
     ///
+    /// Suppresses output when `iflags` has no significant flags set (the file
+    /// is completely unchanged), matching upstream's gate in `itemize()` at
+    /// `generator.c:574-576`.
+    ///
     /// # Upstream Reference
     ///
+    /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
     /// - `sender.c:287` - `maybe_log_item()` for non-transfer items
     /// - `sender.c:430` - `log_item()` after file transfer
     /// - `log.c:330-340` - `rwrite()`: when `am_server`, sends MSG_INFO;
@@ -286,6 +291,12 @@ impl GeneratorContext {
         itemize_cb: &mut Option<&mut dyn super::super::ItemizeCallback>,
     ) -> io::Result<()> {
         if !self.config.flags.info_flags.itemize {
+            return Ok(());
+        }
+        // upstream: generator.c:574-576 - only emit when significant flags are
+        // set. When iflags == 0 (file is completely up-to-date), no line is
+        // produced.
+        if !iflags.has_significant_flags() {
             return Ok(());
         }
         if ndx >= self.file_list.len() {

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -655,8 +655,13 @@ impl ReceiverContext {
     /// multiplexed message. Uses `is_sender: false` since the daemon is receiving
     /// files (producing `>` direction indicator).
     ///
+    /// Suppresses output when `iflags` has no significant flags set (the file is
+    /// completely unchanged), matching upstream's gate in `itemize()` at
+    /// `generator.c:574-576`.
+    ///
     /// # Upstream Reference
     ///
+    /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
     /// - `generator.c:2260` - `itemize()` in receiver's generator context
     /// - `log.c:330-340` - `rwrite()` converts to `send_msg(MSG_INFO)` when `am_server`
     fn emit_itemize<W: crate::writer::MsgInfoSender + ?Sized>(
@@ -666,6 +671,13 @@ impl ReceiverContext {
         entry: &protocol::flist::FileEntry,
     ) -> std::io::Result<()> {
         if !self.should_emit_itemize() {
+            return Ok(());
+        }
+        // upstream: generator.c:574-576 - only emit when significant flags are
+        // set. When iflags == 0 (file is completely up-to-date), no line is
+        // produced. INFO_GTE(NAME, 2) and stdout_format_has_i > 1 gates are
+        // not applicable on the server side (the client controls display).
+        if !iflags.has_significant_flags() {
             return Ok(());
         }
         let ctx = self.itemize_context();

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -115,10 +115,9 @@ fn emit_itemize_up_to_date_file() {
 
     ctx.emit_itemize(&mut writer, &iflags, &entry).unwrap();
 
-    assert_eq!(writer.messages.len(), 1);
-    let msg = String::from_utf8_lossy(&writer.messages[0]);
-    // No transfer, no changes - dots collapse to spaces
-    assert_eq!(msg, ".f          unchanged.txt\n");
+    // upstream: generator.c:574-576 - no output when iflags has no significant
+    // flags (file is completely unchanged)
+    assert_eq!(writer.messages.len(), 0);
 }
 
 #[test]

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -30,12 +30,6 @@ KNOWN_FAILURES=(
   # as SKIP, not FAIL.
   "chown"
 
-  # --- Hardlinks edge cases ---
-  # Local hardlink tests pass, but the remote-shell (lsh.sh) test at
-  # line 57 fails - same root cause as 00-hello (remote-shell transfer
-  # path does not fully transfer files via lsh.sh).
-  "hardlinks"
-
   # --- ssh-basic test ---
   # Requires an actual SSH-style remote shell wrapper in test fixtures.
   "ssh-basic"


### PR DESCRIPTION
## Summary

- Gate itemize output on significant flags to match upstream `generator.c:574-576`. Unchanged files (iflags == 0) no longer produce spurious `.f          name` lines in `--itemize-changes` output across all transfer paths (local copy, remote receiver, remote generator).
- Skip hardlink re-creation when the destination already shares the correct inode with the group leader. On Unix, compares (dev, inode) pairs before removing and re-linking, preventing unnecessary `hf+++++++++` output for already-correct hardlinks.
- Remove `hardlinks` from `upstream_testsuite_known_failures.conf`.

## Test plan

- [ ] CI upstream testsuite passes with hardlinks test no longer in known failures
- [ ] Existing hardlink interop tests continue to pass
- [ ] fmt+clippy clean
- [ ] nextest (stable) passes
- [ ] Windows/macOS CI pass (non-Unix `is_already_hardlinked` falls back to re-creation)