### PR TITLE
chore: triage environment-dependent upstream testsuite known failures

### DIFF
--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -2,7 +2,8 @@
 # Known-failure list for tools/ci/run_upstream_testsuite.sh.
 #
 # Each entry is the basename of a *.test script in upstream's
-# target/interop/upstream-src/rsync-3.4.1/testsuite/ directory.
+# target/interop/upstream-src/rsync-${UPSTREAM_VERSION}/testsuite/ directory
+# (default UPSTREAM_VERSION=3.4.2).
 #
 # Entries here are expected to fail. The harness reports:
 #   PASS  - test passed (not in this list)
@@ -20,25 +21,60 @@ KNOWN_FAILURES=(
   # step still fails.
   "daemon"
 
-  # --- Device / special-file tests ---
-  # Require root or CAP_MKNOD to create devices in $fromdir.
-  "devices"
-
-  # --- chown / chgrp tests ---
-  # Require root to set arbitrary uid/gid; otherwise upstream's own
-  # tests skip via test_skipped (exit 77) which the harness reports
-  # as SKIP, not FAIL.
-  "chown"
-
   # --- ssh-basic test ---
   # Requires an actual SSH-style remote shell wrapper in test fixtures.
   "ssh-basic"
 
-  # --- protected-regular ---
-  # Tests fs.protected_regular kernel feature interaction.
+  # ---------------------------------------------------------------
+  # Environment-dependent tests
+  #
+  # These tests self-skip (exit 77) in unprivileged CI via
+  # test_skipped(), so they land as XFAIL, not true FAIL.
+  # They exercise oc-rsync features that ARE implemented - the
+  # failures are purely environmental, not code gaps.
+  # To validate: run in a privileged container (root or CAP_MKNOD)
+  # on a Linux filesystem that supports setgid inheritance.
+  # ---------------------------------------------------------------
+
+  # --- devices (environment: root or fakeroot or CAP_MKNOD) ---
+  # Creates char/block device nodes and FIFOs via mknod(2), then
+  # verifies rsync -D transfer, itemize output, and --link-dest
+  # hard-linking of specials. Skips with "Rsync needs root/fakeroot
+  # for device tests" when not root and $FAKEROOT_PATH is unset.
+  # oc-rsync: mknod support implemented in crates/metadata/src/special.rs.
+  # Would pass as root or under fakeroot.
+  "devices"
+
+  # --- chown (environment: root or fakeroot) ---
+  # Sets files to uid 5000/5001, gid 5002/5003 via chown(2), then
+  # verifies rsync -aHvv preserves ownership. Skips with "Can't
+  # chown (probably need root)" when chown(2) returns EPERM.
+  # oc-rsync: ownership preservation implemented in
+  # crates/metadata/src/apply/ownership.rs.
+  # Would pass as root or under fakeroot.
+  "chown"
+
+  # --- protected-regular (environment: Linux, root, fs.protected_regular>=1) ---
+  # Requires three conditions: (1) Linux with /proc/sys/fs/protected_regular,
+  # (2) sysctl fs.protected_regular set to 1 or 2, (3) root to chown a file
+  # to uid 5001 in a sticky+world-writable directory. Verifies that rsync
+  # --inplace can still write to a protected file owned by another user.
+  # Skips on non-Linux (no /proc/sys/fs/protected_regular) and when not root.
+  # oc-rsync: --inplace is implemented. Would pass as root on Linux with
+  # fs.protected_regular enabled (default on modern kernels).
   "protected-regular"
 
-  # --- dir-sgid ---
-  # Setgid bit on directories; behavior is filesystem-dependent.
+  # --- dir-sgid (environment: filesystem with setgid inheritance) ---
+  # Sets the setgid bit (chmod g+s) on a directory, creates a
+  # subdirectory inside it, and verifies the child inherits the
+  # setgid bit. Skips with "Your filesystem doesn't use directory
+  # setgid; maybe it's BSD" when the filesystem does not propagate
+  # setgid to new subdirectories (BSD semantics, some container
+  # overlay filesystems, or tmpfs with certain mount options).
+  # Does NOT require root - only a filesystem that honors setgid
+  # inheritance (standard on ext4, xfs, btrfs).
+  # oc-rsync: permission handling implemented. Would pass on Linux
+  # with a native filesystem (ext4/xfs/btrfs), may skip on macOS
+  # (BSD-style group inheritance) or overlay filesystems.
   "dir-sgid"
 )


### PR DESCRIPTION
## Summary

- Read upstream rsync 3.4.2 test scripts for the 4 environment-dependent known failures (devices, chown, protected-regular, dir-sgid) and documented exact prerequisites
- All 4 tests self-skip (exit 77) via `test_skipped()` in unprivileged CI - failures are purely environmental, not oc-rsync code gaps
- Grouped under a new "environment-dependent" section with per-test documentation of skip conditions, required privileges, and relevant oc-rsync implementation locations
- Fixed stale `rsync-3.4.1` reference in the config header to match the harness default (`UPSTREAM_VERSION=3.4.2`)

### Triage findings

| Test | Environment needed | oc-rsync code gap? | Would pass in right env? |
|------|-------------------|-------------------|------------------------|
| **devices** | Root, fakeroot, or CAP_MKNOD | No - `metadata/special.rs` | Yes |
| **chown** | Root or fakeroot | No - `metadata/apply/ownership.rs` | Yes |
| **protected-regular** | Linux + root + `fs.protected_regular>=1` | No - `--inplace` implemented | Yes |
| **dir-sgid** | Filesystem with setgid inheritance (ext4/xfs/btrfs) | No - permissions implemented | Yes (Linux native FS) |

## Test plan

- [ ] CI passes (config-only change, no code changes)
- [ ] Verify the conf file is valid bash by sourcing it: `source tools/ci/upstream_testsuite_known_failures.conf`