### PR TITLE
fix: embed capability string in compact flag string for server mode interop

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -153,17 +153,20 @@ pub(super) fn build_full_daemon_args(
     }
 
     // upstream: options.c:2594-2713 - single-character flag string (e.g., "-logDtprzc").
-    let flag_string = flags::build_server_flag_string(config);
+    // upstream: options.c:2710 - maybe_add_e_option() appends the capability
+    // string directly onto the compact flag string, producing a single argument
+    // like `-logDtpre.iLsfxCIvu`. We follow the same format for interop.
+    let mut flag_string = flags::build_server_flag_string(config);
+    if protocol.as_u8() >= 30 {
+        // upstream: compat.c:177-178 daemon 'i' check, compat.c:720
+        // set_allow_inc_recurse() - capability flags for protocol 30+.
+        let capability = build_capability_string(config.inc_recursive_send());
+        if let Some(suffix) = capability.strip_prefix('-') {
+            flag_string.push_str(suffix);
+        }
+    }
     if !flag_string.is_empty() {
         args.push(flag_string);
-    }
-
-    // upstream: options.c:2707-2713 maybe_add_e_option, compat.c:177-178 daemon
-    // 'i' check, compat.c:720 set_allow_inc_recurse() - capability flags for
-    // protocol 30+; INC_RECURSE ('i') is advertised in both directions by
-    // default and `--no-inc-recursive` clears the gate.
-    if protocol.as_u8() >= 30 {
-        args.push(build_capability_string(config.inc_recursive_send()));
     }
 
     let we_are_sender = !is_sender;

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -57,14 +57,28 @@ mod protect_args_daemon_tests {
         assert_eq!(args[1], "--sender");
     }
 
+    /// Finds the compact flag string in the daemon args (starts with `-`, not `--`).
+    fn find_flag_string(args: &[String]) -> &str {
+        args.iter()
+            .find(|a| a.starts_with('-') && !a.starts_with("--"))
+            .map(|s| s.as_str())
+            .expect("flag string not found in daemon args")
+    }
+
     #[test]
     fn build_full_args_capability_flags_protocol30() {
+        // upstream: options.c:2710 - capability string is embedded in the
+        // compact flag string for protocol >= 30.
         let config = ClientConfig::default();
         let request = test_daemon_request();
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let args = build_full_daemon_args(&config, &request, protocol, false);
 
-        assert!(args.iter().any(|a| a.starts_with("-e.")));
+        let flags = find_flag_string(&args);
+        assert!(
+            flags.contains("e."),
+            "protocol 30+ must embed capability in flag string: {flags}"
+        );
     }
 
     #[test]
@@ -74,36 +88,43 @@ mod protect_args_daemon_tests {
         let protocol = ProtocolVersion::try_from(29u8).unwrap();
         let args = build_full_daemon_args(&config, &request, protocol, false);
 
-        assert!(!args.iter().any(|a| a.starts_with("-e.")));
+        let flags = find_flag_string(&args);
+        assert!(
+            !flags.contains("e."),
+            "protocol 29 must not embed capability: {flags}"
+        );
     }
 
     #[test]
     fn build_full_args_push_includes_inc_recurse_capability_by_default() {
         // ISI.h: sender-side INC_RECURSE is default-on, matching upstream
         // rsync 3.4.x. The daemon push capability includes 'i' by default.
+        // upstream: capability string is embedded in the compact flag string.
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let request = test_daemon_request();
 
         let config_default = ClientConfig::default();
         let args_default = build_full_daemon_args(&config_default, &request, protocol, false);
-        let caps_default = args_default
-            .iter()
-            .find(|a| a.starts_with("-e."))
-            .expect("capability string present");
+        let flags_default = find_flag_string(&args_default);
+        let caps_default = flags_default
+            .split("e.")
+            .nth(1)
+            .expect("capability suffix present");
         assert!(
             caps_default.contains('i'),
-            "default push capability must include 'i': {caps_default}"
+            "default push capability must include 'i': {flags_default}"
         );
 
         let config_off = ClientConfig::builder().inc_recursive_send(false).build();
         let args_off = build_full_daemon_args(&config_off, &request, protocol, false);
-        let caps_off = args_off
-            .iter()
-            .find(|a| a.starts_with("-e."))
-            .expect("capability string present");
+        let flags_off = find_flag_string(&args_off);
+        let caps_off = flags_off
+            .split("e.")
+            .nth(1)
+            .expect("capability suffix present");
         assert!(
             !caps_off.contains('i'),
-            "--no-inc-recursive must suppress 'i' on push capability: {caps_off}"
+            "--no-inc-recursive must suppress 'i' on push capability: {flags_off}"
         );
     }
 
@@ -111,29 +132,32 @@ mod protect_args_daemon_tests {
     fn build_full_args_pull_includes_inc_recurse_capability_by_default() {
         // ISI.h: sender-side INC_RECURSE is default-on, matching upstream
         // rsync 3.4.x. The daemon pull capability includes 'i' by default.
+        // upstream: capability string is embedded in the compact flag string.
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let request = test_daemon_request();
 
         let config_default = ClientConfig::default();
         let args_default = build_full_daemon_args(&config_default, &request, protocol, true);
-        let caps_default = args_default
-            .iter()
-            .find(|a| a.starts_with("-e."))
-            .expect("capability string present");
+        let flags_default = find_flag_string(&args_default);
+        let caps_default = flags_default
+            .split("e.")
+            .nth(1)
+            .expect("capability suffix present");
         assert!(
             caps_default.contains('i'),
-            "default pull capability must include 'i': {caps_default}"
+            "default pull capability must include 'i': {flags_default}"
         );
 
         let config_off = ClientConfig::builder().inc_recursive_send(false).build();
         let args_off = build_full_daemon_args(&config_off, &request, protocol, true);
-        let caps_off = args_off
-            .iter()
-            .find(|a| a.starts_with("-e."))
-            .expect("capability string present");
+        let flags_off = find_flag_string(&args_off);
+        let caps_off = flags_off
+            .split("e.")
+            .nth(1)
+            .expect("capability suffix present");
         assert!(
             !caps_off.contains('i'),
-            "--no-inc-recursive must suppress 'i' on pull capability: {caps_off}"
+            "--no-inc-recursive must suppress 'i' on pull capability: {flags_off}"
         );
     }
 

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -178,7 +178,22 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from(format!("--io-uring-depth={depth}")));
         }
 
-        let flags = self.build_flag_string();
+        let mut flags = self.build_flag_string();
+
+        // upstream: options.c:2710 - maybe_add_e_option() appends the `e.xxx`
+        // capability string directly onto the compact flag string, producing a
+        // single argument like `-logDtpre.iLsfxCIvu`. Emitting it as a separate
+        // `-e.xxx` argument would confuse the server-side parser which treats
+        // only the first short-flag argument as the compact flag string.
+        // upstream: compat.c:720 set_allow_inc_recurse() - capability gate.
+        // upstream: options.c:3003-3050 maybe_add_e_option() - capability string.
+        let capability = build_capability_string(self.config.inc_recursive_send());
+        // build_capability_string returns "-e.xxx"; strip the leading '-' and
+        // append the remainder (e.g. "e.iLsfxCIvu") to the flag string.
+        if let Some(suffix) = capability.strip_prefix('-') {
+            flags.push_str(suffix);
+        }
+
         if !flags.is_empty() {
             args.push(OsString::from(flags));
         }
@@ -187,15 +202,6 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // Order mirrors upstream options.c server_options().
         self.append_long_form_args(&mut args);
 
-        // SSH transfers advertise the INC_RECURSE (`'i'`) capability in both
-        // directions by default, mirroring upstream's `allow_inc_recurse = 1`
-        // initialization. `--no-inc-recursive` clears the flag and suppresses
-        // the bit, matching `set_allow_inc_recurse()`.
-        // upstream: compat.c:720 set_allow_inc_recurse() - capability gate.
-        // upstream: options.c:3003-3050 maybe_add_e_option() - capability string.
-        args.push(OsString::from(build_capability_string(
-            self.config.inc_recursive_send(),
-        )));
         args.push(OsString::from("."));
 
         // upstream: options.c:2533 safe_arg() - when old_style_args >= 1,

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -728,8 +728,11 @@ fn includes_verbosity_flags() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
+    // Count 'v' only in the transfer-flag portion, excluding the embedded
+    // capability suffix (which contains its own 'v' in e.g. `e.iLsfxCIvu`).
     let flags = args[2].to_string_lossy();
-    let v_count = flags.chars().filter(|c| *c == 'v').count();
+    let transfer_portion = transfer_flags_portion(&flags);
+    let v_count = transfer_portion.chars().filter(|c| *c == 'v').count();
     assert_eq!(v_count, 3, "expected 3 'v' chars in flags: {flags}");
 }
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -22,12 +22,16 @@ fn builds_receiver_invocation_with_sender_flag() {
     assert_eq!(args[0], "rsync");
     assert_eq!(args[1], "--server");
     assert_eq!(args[2], "--sender");
+    // upstream: options.c:2710 - capability string is appended directly to
+    // the compact flag string (e.g. `-re.iLsfxCIvu`), not a separate arg.
     let flags = args[3].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
-    let expected_caps = build_capability_string(true);
-    assert_eq!(args[4], *expected_caps);
-    assert_eq!(args[5], ".");
-    assert_eq!(args[6], "/remote/path");
+    assert!(
+        flags.contains("e."),
+        "capability string must be embedded in flag string: {flags}"
+    );
+    assert_eq!(args[4], ".");
+    assert_eq!(args[5], "/remote/path");
 }
 
 #[test]
@@ -41,71 +45,81 @@ fn builds_sender_invocation_no_sender_flag() {
 
     assert_eq!(args[0], "rsync");
     assert_eq!(args[1], "--server");
-    // No --sender flag for push - flags come next
+    // No --sender flag for push - flags come next.
+    // upstream: capability string is embedded in the flag string.
     let flags = args[2].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
-    let expected_caps = build_capability_string(true);
-    assert_eq!(args[3], *expected_caps);
-    assert_eq!(args[4], ".");
-    assert_eq!(args[5], "/remote/path");
+    assert!(
+        flags.contains("e."),
+        "capability string must be embedded in flag string: {flags}"
+    );
+    assert_eq!(args[3], ".");
+    assert_eq!(args[4], "/remote/path");
 }
 
 #[test]
 fn ssh_sender_includes_inc_recurse_capability_by_default() {
     // ISI.h: sender-side INC_RECURSE is default-on, matching upstream rsync
     // 3.4.x. SSH push transfers include the 'i' capability bit by default.
+    // upstream: the capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
 
-    let caps = args
-        .iter()
-        .find(|a| a.to_string_lossy().starts_with("-e."))
-        .expect("capability string present");
-    let caps_str = caps.to_string_lossy();
+    // Capability string is now embedded in the compact flag string, not separate.
+    let flag_str = args[2].to_string_lossy();
     assert!(
-        caps_str.contains('i'),
-        "default sender capability string must include 'i': {caps_str}"
+        flag_str.contains("e."),
+        "flag string must contain embedded capability: {flag_str}"
     );
-    assert_eq!(*caps, *build_capability_string(true));
+    // Extract the capability portion after "e."
+    let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
+    assert!(
+        caps_portion.contains('i'),
+        "default sender capability string must include 'i': {flag_str}"
+    );
 }
 
 #[test]
 fn ssh_sender_omits_inc_recurse_when_no_inc_recursive_set() {
     // `--no-inc-recursive` clears `allow_inc_recurse`; the capability bit
     // is suppressed in both transfer directions. Tracker #1862.
+    // upstream: capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().inc_recursive_send(false).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
 
-    let caps = args
-        .iter()
-        .find(|a| a.to_string_lossy().starts_with("-e."))
-        .expect("capability string present");
-    let caps_str = caps.to_string_lossy();
+    let flag_str = args[2].to_string_lossy();
     assert!(
-        !caps_str.contains('i'),
-        "--no-inc-recursive must suppress 'i' on sender capability: {caps_str}"
+        flag_str.contains("e."),
+        "flag string must contain embedded capability: {flag_str}"
     );
-    assert_eq!(*caps, *build_capability_string(false));
+    let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
+    assert!(
+        !caps_portion.contains('i'),
+        "--no-inc-recursive must suppress 'i' on sender capability: {flag_str}"
+    );
 }
 
 #[test]
 fn ssh_receiver_includes_inc_recurse_capability_by_default() {
     // ISI.h: sender-side INC_RECURSE is default-on, matching upstream rsync
     // 3.4.x. Pull transfers also include the 'i' capability bit by default.
+    // upstream: capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
 
-    let caps = args
-        .iter()
-        .find(|a| a.to_string_lossy().starts_with("-e."))
-        .expect("capability string present");
-    let caps_str = caps.to_string_lossy();
+    // Pull: args[3] is the flag string (after --server, --sender)
+    let flag_str = args[3].to_string_lossy();
     assert!(
-        caps_str.contains('i'),
-        "default receiver capability string must include 'i': {caps_str}"
+        flag_str.contains("e."),
+        "flag string must contain embedded capability: {flag_str}"
+    );
+    let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
+    assert!(
+        caps_portion.contains('i'),
+        "default receiver capability string must include 'i': {flag_str}"
     );
 }
 
@@ -113,18 +127,21 @@ fn ssh_receiver_includes_inc_recurse_capability_by_default() {
 fn ssh_receiver_omits_inc_recurse_when_no_inc_recursive_set() {
     // `--no-inc-recursive` applies to both directions, matching upstream's
     // single `allow_inc_recurse` global.
+    // upstream: capability string is embedded in the compact flag string.
     let config = ClientConfig::builder().inc_recursive_send(false).build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
 
-    let caps = args
-        .iter()
-        .find(|a| a.to_string_lossy().starts_with("-e."))
-        .expect("capability string present");
-    let caps_str = caps.to_string_lossy();
+    // Pull: args[3] is the flag string (after --server, --sender)
+    let flag_str = args[3].to_string_lossy();
     assert!(
-        !caps_str.contains('i'),
-        "--no-inc-recursive must suppress 'i' on receiver capability: {caps_str}"
+        flag_str.contains("e."),
+        "flag string must contain embedded capability: {flag_str}"
+    );
+    let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
+    assert!(
+        !caps_portion.contains('i'),
+        "--no-inc-recursive must suppress 'i' on receiver capability: {flag_str}"
     );
 }
 
@@ -183,11 +200,15 @@ fn includes_log_format_for_itemize() {
         args_str.contains(&"--log-format=%i".to_string()),
         "expected --log-format=%i in args: {args_str:?}"
     );
-    // Must NOT appear as a compact flag
+    // Itemize must NOT appear as a transfer-flag character in the compact
+    // flag string. The `i` in the capability suffix (`e.iLsfxCIvu`) is the
+    // INC_RECURSE bit, not the itemize flag - so we check only the transfer
+    // portion (before `e.`).
     let flags = args[2].to_string_lossy();
+    let transfer_portion = transfer_flags_portion(&flags);
     assert!(
-        !flags.contains(".i"),
-        "itemize should not be a compact flag: {flags}"
+        !transfer_portion.contains('i'),
+        "itemize should not be a compact transfer flag: {flags}"
     );
 }
 
@@ -958,20 +979,39 @@ fn build_sender_args(config: &ClientConfig) -> Vec<String> {
 
 /// Helper: finds the compact flag string in an args vector.
 ///
-/// The flag string starts with `-` but not `--`, and is not the capability
-/// string (`-e.xxx`). This handles variable positioning caused by
-/// `--ignore-errors` and `--fsync` appearing before the flag string.
+/// The flag string starts with `-` but not `--`. Since the capability string
+/// is now embedded in the flag string (e.g. `-re.iLsfxCIvu`), this returns
+/// the combined string. Variable positioning is handled by skipping `--xxx` args.
 fn find_flag_string(args: &[String]) -> &str {
     args.iter()
-        .find(|a| a.starts_with('-') && !a.starts_with("--") && !a.starts_with("-e."))
+        .find(|a| a.starts_with('-') && !a.starts_with("--"))
         .map(|s| s.as_str())
         .expect("flag string not found in args")
 }
 
-/// Helper: extracts the compact flag string from a push (Sender) invocation.
+/// Helper: extracts the transfer-flag portion of the compact flag string
+/// (everything before `e.`), excluding the embedded capability suffix.
+///
+/// upstream: the compact flag string is `-<transfer-flags>e.<capabilities>`.
+/// This returns only the `<transfer-flags>` portion so counting and negative
+/// assertions are not affected by the capability characters.
+fn transfer_flags_portion(flag_string: &str) -> &str {
+    // The capability string starts at the first 'e.' after the leading '-'.
+    if let Some(pos) = flag_string[1..].find("e.") {
+        &flag_string[..pos + 1]
+    } else {
+        flag_string
+    }
+}
+
+/// Helper: extracts the transfer-flag portion from a push (Sender) invocation.
+///
+/// Returns only the transfer flags (before `e.`), excluding the embedded
+/// capability suffix, so that per-flag assertions are not affected by
+/// capability characters like `v`, `x`, `L`.
 fn sender_flag_string(config: &ClientConfig) -> String {
     let args = build_sender_args(config);
-    find_flag_string(&args).to_owned()
+    transfer_flags_portion(find_flag_string(&args)).to_owned()
 }
 
 /// Helper: builds a pull (Receiver) invocation and returns the args vector.
@@ -984,10 +1024,13 @@ fn build_receiver_args(config: &ClientConfig) -> Vec<String> {
         .collect()
 }
 
-/// Helper: extracts the compact flag string from a pull (Receiver) invocation.
+/// Helper: extracts the transfer-flag portion from a pull (Receiver) invocation.
+///
+/// Returns only the transfer flags (before `e.`), excluding the embedded
+/// capability suffix.
 fn receiver_flag_string(config: &ClientConfig) -> String {
     let args = build_receiver_args(config);
-    find_flag_string(&args).to_owned()
+    transfer_flags_portion(find_flag_string(&args)).to_owned()
 }
 
 #[test]
@@ -1652,28 +1695,43 @@ fn default_rsync_path_is_rsync() {
 }
 
 #[test]
-fn capability_string_present_in_sender_args() {
-    // ISI.h: default inc_recursive_send is true, so the sender args carry
-    // build_capability_string(true).
+fn capability_string_embedded_in_sender_flag_string() {
+    // upstream: options.c:2710 - capability string is appended directly to
+    // the compact flag string, not emitted as a separate argument.
     let config = ClientConfig::builder().build();
     let args = build_sender_args(&config);
     let expected = build_capability_string(true);
+    // The capability string (e.g. "-e.iLsfxCIvu") with leading '-' stripped
+    // should be embedded in the compact flag string.
+    let suffix = expected.strip_prefix('-').unwrap();
+    let flag_str = find_flag_string(&args);
     assert!(
-        args.iter().any(|a| a == &expected),
-        "expected capability string {expected} in args: {args:?}"
+        flag_str.ends_with(suffix),
+        "expected capability suffix {suffix} embedded in flag string {flag_str}"
+    );
+    // Must NOT appear as a standalone argument.
+    assert!(
+        !args.iter().any(|a| a == &expected),
+        "capability string must not be a separate argument: {args:?}"
     );
 }
 
 #[test]
-fn capability_string_present_in_receiver_args() {
-    // ISI.h: default inc_recursive_send is true, so the receiver args carry
-    // build_capability_string(true).
+fn capability_string_embedded_in_receiver_flag_string() {
+    // upstream: options.c:2710 - capability string is appended directly to
+    // the compact flag string, not emitted as a separate argument.
     let config = ClientConfig::builder().build();
     let args = build_receiver_args(&config);
     let expected = build_capability_string(true);
+    let suffix = expected.strip_prefix('-').unwrap();
+    let flag_str = find_flag_string(&args);
     assert!(
-        args.iter().any(|a| a == &expected),
-        "expected capability string {expected} in args: {args:?}"
+        flag_str.ends_with(suffix),
+        "expected capability suffix {suffix} embedded in flag string {flag_str}"
+    );
+    assert!(
+        !args.iter().any(|a| a == &expected),
+        "capability string must not be a separate argument: {args:?}"
     );
 }
 
@@ -2067,7 +2125,8 @@ fn all_flags_enabled_produces_valid_invocation() {
     assert!(args.contains(&"--ignore-errors".to_owned()));
     assert!(args.contains(&"--fsync".to_owned()));
 
-    let flags = find_flag_string(&args);
+    let full_flags = find_flag_string(&args);
+    let flags = transfer_flags_portion(full_flags);
     for (ch, name) in [
         ('l', "links"),
         ('L', "copy_links"),
@@ -2171,7 +2230,14 @@ fn all_flags_enabled_produces_valid_invocation() {
         );
     }
 
-    assert!(args.contains(&build_capability_string(true)));
+    // upstream: capability string is embedded in the flag string, not separate.
+    let caps = build_capability_string(true);
+    let caps_suffix = caps.strip_prefix('-').unwrap();
+    let flag_str = find_flag_string(&args);
+    assert!(
+        flag_str.ends_with(caps_suffix),
+        "all-flags test: capability suffix {caps_suffix} must be in flag string {flag_str}"
+    );
     assert!(args.contains(&".".to_owned()));
     assert!(args.contains(&"/path".to_owned()));
 }

--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -648,12 +648,17 @@ fn test_remote_invocation_with_multiple_paths() {
     // Receiver (pull) -> --sender flag present
     assert_eq!(args[2].to_string_lossy(), "--sender");
     let flags_idx = 3;
-    assert!(args[flags_idx].to_string_lossy().starts_with('-'));
-    // ISI.h: sender-side INC_RECURSE is default-on; the capability string
-    // includes 'i', matching upstream rsync 3.4.x.
+    let flags = args[flags_idx].to_string_lossy();
+    assert!(flags.starts_with('-'));
+    // upstream: options.c:2710 - capability string is now embedded in the
+    // compact flag string (e.g. `-re.iLsfxCIvu`), not a separate argument.
     let expected_caps = build_capability_string(true);
-    assert_eq!(args[flags_idx + 1].to_string_lossy(), expected_caps);
-    let dot_idx = flags_idx + 2;
+    let caps_suffix = expected_caps.strip_prefix('-').unwrap();
+    assert!(
+        flags.ends_with(caps_suffix),
+        "capability suffix {caps_suffix} must be embedded in flag string: {flags}"
+    );
+    let dot_idx = flags_idx + 1;
     assert_eq!(args[dot_idx].to_string_lossy(), ".");
     // Paths come after "."
     assert_eq!(args[dot_idx + 1].to_string_lossy(), "/path1");


### PR DESCRIPTION
## Summary

- Upstream rsync's `maybe_add_e_option()` concatenates the capability string (e.g. `e.iLsfxCIvu`) directly onto the compact flag string, producing a single argument like `-logDtpre.iLsfxCIvu`. oc-rsync was emitting it as a separate `-e.iLsfxCIvu` argument, which the server-side parser treats as a positional arg rather than flags - losing capability negotiation and corrupting path arguments.
- Fix both the SSH invocation builder and daemon argument builder to concatenate the capability suffix onto the flag string, matching upstream's wire format exactly.
- This enables upstream rsync's `00-hello.test` to pass when using oc-rsync as the remote shell binary.

## Details

The root cause was in `RemoteInvocationBuilder::build_args_without_program` (SSH path) and `build_full_daemon_args` (daemon path). Both were pushing `build_capability_string()` as a separate argument. The server-side parser `parse_server_flag_string_and_args` only recognizes the first short-flag argument as the compact flag string; any subsequent `-xxx` arguments become positional args, losing the capability info and shifting path arguments.

The fix strips the leading `-` from the capability string (e.g. `-e.iLsfxCIvu` becomes `e.iLsfxCIvu`) and appends it directly to the compact flag string, matching upstream `options.c:2710 maybe_add_e_option()`.

## Test plan

- [ ] Existing invocation builder tests updated to verify capability string is embedded in the flag string rather than emitted as a separate argument
- [ ] Daemon argument builder tests updated with the same verification
- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] Upstream testsuite `00-hello.test` passes with oc-rsync as remote shell binary