### PR TITLE
feat: add --server --daemon remote-shell daemon mode over stdio

### DIFF
--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -252,6 +252,13 @@ where
 
     let daemon_alias_requested = daemon_invoked_via_program_name(&args, brand);
 
+    // Check for --server --daemon (remote-shell daemon mode) BEFORE plain
+    // --server. upstream: main.c:1843-1844 dispatches start_daemon() when both
+    // am_server and am_daemon are set, before the normal server path.
+    if server::server_daemon_mode_requested(&args) {
+        return server::run_server_daemon_mode(&args, stderr);
+    }
+
     if server::server_mode_requested(&args) {
         return server::run_server_mode(&args, stdout, stderr);
     }

--- a/crates/cli/src/frontend/server/daemon.rs
+++ b/crates/cli/src/frontend/server/daemon.rs
@@ -56,6 +56,57 @@ pub(crate) fn server_mode_requested(args: &[OsString]) -> bool {
     false
 }
 
+/// Returns `true` when the invocation requests remote-shell daemon mode.
+///
+/// This is the `--server --daemon` combination where rsync serves the daemon
+/// protocol over stdin/stdout instead of binding a TCP listener. Used by
+/// remote shell wrappers (e.g., `lsh.sh`) that invoke rsync as:
+///   `rsync --config=<file> --server --daemon .`
+///
+/// upstream: main.c:1843-1844 - when both `am_server` and `am_daemon` are set,
+/// `start_daemon(STDIN_FILENO, STDOUT_FILENO)` is called.
+pub(crate) fn server_daemon_mode_requested(args: &[OsString]) -> bool {
+    let mut has_server = false;
+    let mut has_daemon = false;
+    for arg in args.iter().skip(1) {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--server" {
+            has_server = true;
+        }
+        if arg == "--daemon" {
+            has_daemon = true;
+        }
+    }
+    has_server && has_daemon
+}
+
+/// Extracts daemon arguments for the `--server --daemon` stdio path.
+///
+/// Strips `--server` and `--daemon` from the argument list, retaining any
+/// `--config=<path>` or other daemon-relevant options. The returned vector
+/// is suitable for passing to `DaemonConfig::builder().arguments(...)`.
+pub(crate) fn server_daemon_arguments(args: &[OsString]) -> Vec<OsString> {
+    let program_name = super::super::detect_program_name(args.first().map(OsString::as_os_str));
+    let daemon_program = match program_name {
+        super::super::ProgramName::Rsync => Brand::Upstream.daemon_program_name(),
+        super::super::ProgramName::OcRsync => Brand::Oc.daemon_program_name(),
+    };
+
+    let mut daemon_args = Vec::with_capacity(args.len());
+    daemon_args.push(OsString::from(daemon_program));
+
+    for arg in args.iter().skip(1) {
+        if arg == "--server" || arg == "--daemon" || arg == "." {
+            continue;
+        }
+        daemon_args.push(arg.clone());
+    }
+
+    daemon_args
+}
+
 /// Delegates execution to the daemon front-end (Unix) or reports that daemon
 /// mode is unavailable (Windows).
 #[cfg(unix)]
@@ -69,6 +120,69 @@ where
     Err: Write,
 {
     daemon::run(args, stdout, stderr)
+}
+
+/// Runs the daemon protocol over stdin/stdout for remote-shell daemon mode.
+///
+/// This is the `--server --daemon` path where the daemon protocol runs over
+/// inherited file descriptors. Used by remote shells (e.g., SSH) that invoke:
+///   `oc-rsync --config=<file> --server --daemon .`
+///
+/// upstream: main.c:1843-1844 - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
+#[cfg(unix)]
+pub(crate) fn run_server_daemon_mode<Err>(
+    args: &[OsString],
+    stderr: &mut Err,
+) -> i32
+where
+    Err: Write,
+{
+    use core::message::Role;
+    use core::rsync_error;
+    use daemon::{DaemonConfig, run_daemon_stdio};
+    use logging_sink::MessageSink;
+
+    let program_brand =
+        super::super::detect_program_name(args.first().map(OsString::as_os_str)).brand();
+
+    let daemon_args = server_daemon_arguments(args);
+
+    let config = DaemonConfig::builder()
+        .brand(program_brand)
+        .arguments(daemon_args.iter().skip(1).cloned())
+        .build();
+
+    match run_daemon_stdio(config) {
+        Ok(()) => 0,
+        Err(error) => {
+            let mut sink = MessageSink::with_brand(stderr, program_brand);
+            let mut message = rsync_error!(
+                error.exit_code(),
+                format!("{error}")
+            );
+            message = message.with_role(Role::Daemon);
+            if super::super::write_message(&message, &mut sink).is_err() {
+                let _ = writeln!(sink.writer_mut(), "{error}");
+            }
+            error.exit_code()
+        }
+    }
+}
+
+/// Reports that server-daemon mode is unavailable on Windows.
+#[cfg(windows)]
+pub(crate) fn run_server_daemon_mode<Err>(
+    args: &[OsString],
+    stderr: &mut Err,
+) -> i32
+where
+    Err: Write,
+{
+    let program_brand =
+        super::super::detect_program_name(args.first().map(OsString::as_os_str)).brand();
+
+    write_daemon_unavailable_error(stderr, program_brand);
+    1
 }
 
 /// Reports that daemon mode is unavailable on Windows.

--- a/crates/cli/src/frontend/server/daemon.rs
+++ b/crates/cli/src/frontend/server/daemon.rs
@@ -130,10 +130,7 @@ where
 ///
 /// upstream: main.c:1843-1844 - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
 #[cfg(unix)]
-pub(crate) fn run_server_daemon_mode<Err>(
-    args: &[OsString],
-    stderr: &mut Err,
-) -> i32
+pub(crate) fn run_server_daemon_mode<Err>(args: &[OsString], stderr: &mut Err) -> i32
 where
     Err: Write,
 {
@@ -156,10 +153,7 @@ where
         Ok(()) => 0,
         Err(error) => {
             let mut sink = MessageSink::with_brand(stderr, program_brand);
-            let mut message = rsync_error!(
-                error.exit_code(),
-                format!("{error}")
-            );
+            let mut message = rsync_error!(error.exit_code(), format!("{error}"));
             message = message.with_role(Role::Daemon);
             if super::super::write_message(&message, &mut sink).is_err() {
                 let _ = writeln!(sink.writer_mut(), "{error}");
@@ -171,10 +165,7 @@ where
 
 /// Reports that server-daemon mode is unavailable on Windows.
 #[cfg(windows)]
-pub(crate) fn run_server_daemon_mode<Err>(
-    args: &[OsString],
-    stderr: &mut Err,
-) -> i32
+pub(crate) fn run_server_daemon_mode<Err>(args: &[OsString], stderr: &mut Err) -> i32
 where
     Err: Write,
 {

--- a/crates/cli/src/frontend/server/daemon.rs
+++ b/crates/cli/src/frontend/server/daemon.rs
@@ -87,6 +87,7 @@ pub(crate) fn server_daemon_mode_requested(args: &[OsString]) -> bool {
 /// Strips `--server` and `--daemon` from the argument list, retaining any
 /// `--config=<path>` or other daemon-relevant options. The returned vector
 /// is suitable for passing to `DaemonConfig::builder().arguments(...)`.
+#[cfg(any(unix, test))]
 pub(crate) fn server_daemon_arguments(args: &[OsString]) -> Vec<OsString> {
     let program_name = super::super::detect_program_name(args.first().map(OsString::as_os_str));
     let daemon_program = match program_name {

--- a/crates/cli/src/frontend/server/mod.rs
+++ b/crates/cli/src/frontend/server/mod.rs
@@ -13,5 +13,8 @@ mod run;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use daemon::{daemon_mode_arguments, run_daemon_mode, server_mode_requested};
+pub(crate) use daemon::{
+    daemon_mode_arguments, run_daemon_mode, run_server_daemon_mode, server_daemon_mode_requested,
+    server_mode_requested,
+};
 pub(crate) use run::run_server_mode;

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1,7 +1,10 @@
 use std::ffi::OsString;
 use std::time::SystemTime;
 
-use super::daemon::{daemon_mode_arguments, server_mode_requested};
+use super::daemon::{
+    daemon_mode_arguments, server_daemon_arguments, server_daemon_mode_requested,
+    server_mode_requested,
+};
 use super::flags::{detect_secluded_args_flag, is_known_server_long_flag, parse_server_long_flags};
 use super::parse::{
     parse_server_checksum_seed, parse_server_flag_string_and_args, parse_server_size_limit,
@@ -986,4 +989,101 @@ fn parse_server_args_log_format_strips_from_dest() {
     let (flags, pos_args) = parse_server_flag_string_and_args(&args);
     assert_eq!(flags, "-logDtpre.iLsfxCIvu");
     assert_eq!(pos_args, vec![OsString::from("/src/path/")]);
+}
+
+// --- server_daemon_mode_requested tests ---
+
+#[test]
+fn server_daemon_mode_not_requested_empty() {
+    let args: Vec<OsString> = vec![];
+    assert!(!server_daemon_mode_requested(&args));
+}
+
+#[test]
+fn server_daemon_mode_not_requested_server_only() {
+    let args = vec![OsString::from("rsync"), OsString::from("--server")];
+    assert!(!server_daemon_mode_requested(&args));
+}
+
+#[test]
+fn server_daemon_mode_not_requested_daemon_only() {
+    let args = vec![OsString::from("rsync"), OsString::from("--daemon")];
+    assert!(!server_daemon_mode_requested(&args));
+}
+
+#[test]
+fn server_daemon_mode_requested_both_flags() {
+    let args = vec![
+        OsString::from("rsync"),
+        OsString::from("--server"),
+        OsString::from("--daemon"),
+        OsString::from("."),
+    ];
+    assert!(server_daemon_mode_requested(&args));
+}
+
+#[test]
+fn server_daemon_mode_requested_with_config() {
+    let args = vec![
+        OsString::from("rsync"),
+        OsString::from("--config=/etc/rsyncd.conf"),
+        OsString::from("--server"),
+        OsString::from("--daemon"),
+        OsString::from("."),
+    ];
+    assert!(server_daemon_mode_requested(&args));
+}
+
+#[test]
+fn server_daemon_mode_not_requested_after_double_dash() {
+    let args = vec![
+        OsString::from("rsync"),
+        OsString::from("--"),
+        OsString::from("--server"),
+        OsString::from("--daemon"),
+    ];
+    assert!(!server_daemon_mode_requested(&args));
+}
+
+// --- server_daemon_arguments tests ---
+
+#[test]
+fn server_daemon_arguments_strips_server_and_daemon() {
+    let args = vec![
+        OsString::from("rsync"),
+        OsString::from("--server"),
+        OsString::from("--daemon"),
+        OsString::from("."),
+    ];
+    let result = server_daemon_arguments(&args);
+    // Should not contain --server, --daemon, or "."
+    assert!(!result.iter().any(|a| a == "--server"));
+    assert!(!result.iter().any(|a| a == "--daemon"));
+    assert!(!result.iter().any(|a| a == "."));
+}
+
+#[test]
+fn server_daemon_arguments_preserves_config() {
+    let args = vec![
+        OsString::from("rsync"),
+        OsString::from("--config=/etc/rsyncd.conf"),
+        OsString::from("--server"),
+        OsString::from("--daemon"),
+        OsString::from("."),
+    ];
+    let result = server_daemon_arguments(&args);
+    assert!(result.iter().any(|a| a == "--config=/etc/rsyncd.conf"));
+}
+
+#[test]
+fn server_daemon_arguments_sets_daemon_program_name() {
+    let args = vec![
+        OsString::from("oc-rsync"),
+        OsString::from("--server"),
+        OsString::from("--daemon"),
+        OsString::from("."),
+    ];
+    let result = server_daemon_arguments(&args);
+    // First element should be the daemon program name
+    assert!(!result.is_empty());
 }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -216,9 +216,10 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
 /// Returns a `DaemonError` if configuration loading fails or the session
 /// encounters an I/O error.
 pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
+    let brand = config.brand();
     let options = RuntimeOptions::parse_with_brand(
         config.arguments(),
-        config.brand(),
+        brand,
         config.load_default_paths(),
     )?;
 
@@ -233,7 +234,7 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
     } = options;
 
     let log_sink = if let Some(path) = log_file {
-        Some(open_log_sink(&path, Brand::Oc)?)
+        Some(open_log_sink(&path, brand)?)
     } else {
         None
     };

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -217,11 +217,8 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
 /// encounters an I/O error.
 pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
     let brand = config.brand();
-    let options = RuntimeOptions::parse_with_brand(
-        config.arguments(),
-        brand,
-        config.load_default_paths(),
-    )?;
+    let options =
+        RuntimeOptions::parse_with_brand(config.arguments(), brand, config.load_default_paths())?;
 
     let RuntimeOptions {
         modules,

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -197,6 +197,100 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
     serve_connections(options, external_signal_flags, pre_bound_listener)
 }
 
+/// Runs the daemon protocol over stdin/stdout for remote-shell daemon mode.
+///
+/// This implements the `--server --daemon` path where the daemon protocol is
+/// served over inherited file descriptors instead of a TCP listener. Used when
+/// a remote shell (e.g., SSH via `lsh.sh`) invokes the daemon, matching
+/// upstream rsync's `start_daemon(STDIN_FILENO, STDOUT_FILENO)` in `main.c`.
+///
+/// The function loads configuration (from `--config` or default paths), builds
+/// the module table, and serves a single connection on the provided
+/// stdin/stdout streams. No TCP binding or signal handler registration occurs.
+///
+/// upstream: main.c:1843-1844 - `if (am_server && am_daemon) return
+/// start_daemon(STDIN_FILENO, STDOUT_FILENO);`
+///
+/// # Errors
+///
+/// Returns a `DaemonError` if configuration loading fails or the session
+/// encounters an I/O error.
+pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
+    let options = RuntimeOptions::parse_with_brand(
+        config.arguments(),
+        config.brand(),
+        config.load_default_paths(),
+    )?;
+
+    let RuntimeOptions {
+        modules,
+        motd_lines,
+        bandwidth_limit,
+        bandwidth_burst,
+        log_file,
+        reverse_lookup,
+        ..
+    } = options;
+
+    let log_sink = if let Some(path) = log_file {
+        Some(open_log_sink(&path, Brand::Oc)?)
+    } else {
+        None
+    };
+
+    let connection_limiter: Option<Arc<ConnectionLimiter>> = None;
+    let modules: Vec<ModuleRuntime> = modules
+        .into_iter()
+        .map(|definition| ModuleRuntime::new(definition, connection_limiter.clone()))
+        .collect();
+
+    // Build a DaemonStream::Stdio from process stdin/stdout.
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let pair = crate::daemon_stream::StdioPair::new(Box::new(stdin), Box::new(stdout));
+    let stream = DaemonStream::stdio(pair);
+
+    // upstream: start_daemon() with stdin/stdout fds uses 127.0.0.1:0 as the
+    // synthetic peer address. In remote-shell daemon mode the real peer address
+    // is not available since there is no TCP socket to query.
+    let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+
+    // Resolve hostname for the synthetic peer (will resolve localhost).
+    let peer_host = if reverse_lookup {
+        resolve_peer_hostname(peer_addr.ip())
+    } else {
+        None
+    };
+
+    if let Some(log) = log_sink.as_ref() {
+        log_connection(log, peer_host.as_deref(), peer_addr);
+    }
+
+    handle_legacy_session(
+        stream,
+        peer_addr,
+        LegacySessionParams {
+            modules: &modules,
+            motd_lines: &motd_lines,
+            daemon_limit: bandwidth_limit,
+            daemon_burst: bandwidth_burst,
+            log_sink,
+            peer_host,
+            reverse_lookup,
+        },
+    )
+    .map_err(|error| {
+        DaemonError::new(
+            SOCKET_IO_EXIT_CODE,
+            rsync_error!(
+                SOCKET_IO_EXIT_CODE,
+                format!("stdio daemon session failed: {error}")
+            )
+            .with_role(Role::Daemon),
+        )
+    })
+}
+
 /// Runs the daemon orchestration using the hybrid tokio listener.
 ///
 /// This is the implementation skeleton tracked under issue #1935. The

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -219,17 +219,51 @@ fn engage_landlock_sandbox(
     }
 }
 
-/// Sets up the TCP streams for the transfer.
+/// Transfer stream pair: separate read and write handles for the transfer engine.
 ///
-/// Configures TCP_NODELAY and clones the stream for concurrent read/write.
-/// Returns the read and write streams on success, or sends an error and returns `None`.
+/// For TCP connections, both sides are cloned `TcpStream` handles pointing at
+/// the same socket. For stdio connections (remote-shell daemon mode), the reader
+/// wraps stdin and the writer wraps stdout.
+struct TransferStreams {
+    read: Box<dyn Read + Send>,
+    write: Box<dyn Write + Send>,
+    /// Whether the write side supports TCP shutdown (false for stdio/pipes).
+    supports_tcp_shutdown: bool,
+}
+
+/// Sets up the transfer streams for the transfer engine.
+///
+/// For TCP/TLS connections, configures TCP_NODELAY and clones the stream to get
+/// independent read/write handles. For stdio connections (remote-shell daemon
+/// mode), opens fresh stdin/stdout handles since the original pair is consumed
+/// by the BufReader.
+///
+/// Returns the transfer streams on success, or sends an error and returns `None`.
 fn setup_transfer_streams(
     ctx: &mut ModuleRequestContext<'_>,
-) -> io::Result<Option<(TcpStream, TcpStream)>> {
+) -> io::Result<Option<TransferStreams>> {
     let stream = ctx.reader.get_mut();
     stream.set_nodelay(true)?;
 
-    let read_stream = match stream.tcp_stream().try_clone() {
+    if stream.is_stdio() {
+        // For stdio mode, the DaemonStream wraps a StdioPair (stdin + stdout).
+        // The BufReader has consumed it, but the transfer engine needs separate
+        // read/write handles. We open fresh stdin/stdout handles here - the
+        // buffered data from the BufReader is captured in HandshakeResult.buffered
+        // and chained ahead of stdin by run_server_with_handshake.
+        // upstream: start_daemon(STDIN_FILENO, STDOUT_FILENO) uses the same
+        // fds for both handshake and transfer.
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        return Ok(Some(TransferStreams {
+            read: Box::new(stdin),
+            write: Box::new(stdout),
+            supports_tcp_shutdown: false,
+        }));
+    }
+
+    let tcp = stream.tcp_stream().expect("non-stdio stream has tcp_stream");
+    let read_stream = match tcp.try_clone() {
         Ok(s) => s,
         Err(err) => {
             let payload = format!("@ERROR: failed to clone stream: {err}");
@@ -238,7 +272,7 @@ fn setup_transfer_streams(
         }
     };
 
-    let write_stream = match stream.tcp_stream().try_clone() {
+    let write_stream = match tcp.try_clone() {
         Ok(s) => s,
         Err(err) => {
             return Err(io::Error::other(format!(
@@ -247,7 +281,11 @@ fn setup_transfer_streams(
         }
     };
 
-    Ok(Some((read_stream, write_stream)))
+    Ok(Some(TransferStreams {
+        read: Box::new(read_stream),
+        write: Box::new(write_stream),
+        supports_tcp_shutdown: true,
+    }))
 }
 
 /// Builds the handshake result for the transfer.
@@ -283,8 +321,8 @@ fn execute_transfer(
     ctx: &ModuleRequestContext<'_>,
     config: ServerConfig,
     handshake: HandshakeResult,
-    read_stream: &mut TcpStream,
-    write_stream: &mut TcpStream,
+    read_stream: &mut dyn Read,
+    write_stream: &mut dyn Write,
     role: ServerRole,
     final_protocol: ProtocolVersion,
     module: &ModuleRuntime,
@@ -622,8 +660,8 @@ fn process_approved_module(
         return Ok(());
     }
 
-    let (mut read_stream, mut write_stream) = match setup_transfer_streams(ctx)? {
-        Some(streams) => streams,
+    let mut streams = match setup_transfer_streams(ctx)? {
+        Some(s) => s,
         None => return Ok(()),
     };
 
@@ -714,12 +752,13 @@ fn process_approved_module(
     let handshake = build_handshake_result(ctx.reader, negotiated_protocol, client_args, module);
     let final_protocol = handshake.protocol;
 
+    let supports_tcp_shutdown = streams.supports_tcp_shutdown;
     let exit_status = execute_transfer(
         ctx,
         config,
         handshake,
-        &mut read_stream,
-        &mut write_stream,
+        &mut *streams.read,
+        &mut *streams.write,
         role,
         final_protocol,
         module,
@@ -731,7 +770,11 @@ fn process_approved_module(
     // interprets as "connection unexpectedly closed" (exit code 12).
     // upstream: daemon child exits via exit_cleanup() which lets the kernel
     // perform clean socket shutdown with proper FIN/ACK sequence.
-    let _ = write_stream.shutdown(std::net::Shutdown::Write);
+    // For stdio streams (remote-shell daemon mode), TCP shutdown is not
+    // applicable - the pipe/fd closes naturally when dropped.
+    if supports_tcp_shutdown {
+        let _ = ctx.reader.get_mut().shutdown(std::net::Shutdown::Write);
+    }
 
     // Run post-xfer exec if configured
     // upstream: clientserver.c - post_exec() runs after the transfer, regardless of outcome

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -261,8 +261,11 @@ fn apply_client_options(
     // upstream: clientserver.c - set_socket_options() is called
     // on the accepted client fd before the session handler runs.
     if !client_socket_options.is_empty() {
+        let Some(tcp) = stream.tcp_stream() else {
+            return;
+        };
         if let Err(error) =
-            apply_socket_options_to_stream(stream.tcp_stream(), client_socket_options)
+            apply_socket_options_to_stream(tcp, client_socket_options)
         {
             if let Some(log) = log_sink {
                 let text = format!(

--- a/crates/daemon/src/daemon_stream.rs
+++ b/crates/daemon/src/daemon_stream.rs
@@ -183,7 +183,6 @@ impl DaemonStream {
             Self::Stdio(_) => panic!("cannot extract TcpStream from Stdio variant"),
         }
     }
-
 }
 
 impl Read for DaemonStream {
@@ -223,7 +222,10 @@ impl std::fmt::Debug for DaemonStream {
             Self::Plain(s) => f.debug_tuple("DaemonStream::Plain").field(s).finish(),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(_) => f.debug_tuple("DaemonStream::Tls").field(&"<tls>").finish(),
-            Self::Stdio(_) => f.debug_tuple("DaemonStream::Stdio").field(&"<stdio>").finish(),
+            Self::Stdio(_) => f
+                .debug_tuple("DaemonStream::Stdio")
+                .field(&"<stdio>")
+                .finish(),
         }
     }
 }
@@ -366,20 +368,14 @@ mod tests {
 
     #[test]
     fn stdio_is_not_tls() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         assert!(!daemon.is_tls());
     }
 
     #[test]
     fn stdio_is_stdio() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         assert!(daemon.is_stdio());
     }
@@ -393,20 +389,14 @@ mod tests {
 
     #[test]
     fn stdio_tcp_stream_is_none() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         assert!(daemon.tcp_stream().is_none());
     }
 
     #[test]
     fn stdio_set_timeouts_are_noop() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         let dur = Some(Duration::from_secs(5));
         daemon.set_read_timeout(dur).unwrap();
@@ -415,30 +405,21 @@ mod tests {
 
     #[test]
     fn stdio_set_nodelay_is_noop() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         daemon.set_nodelay(true).unwrap();
     }
 
     #[test]
     fn stdio_shutdown_is_noop() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         daemon.shutdown(Shutdown::Both).unwrap();
     }
 
     #[test]
     fn stdio_debug_format() {
-        let pair = StdioPair::new(
-            Box::new(io::Cursor::new(Vec::new())),
-            Box::new(Vec::new()),
-        );
+        let pair = StdioPair::new(Box::new(io::Cursor::new(Vec::new())), Box::new(Vec::new()));
         let daemon = DaemonStream::stdio(pair);
         let debug = format!("{daemon:?}");
         assert!(debug.contains("Stdio"), "got: {debug}");

--- a/crates/daemon/src/daemon_stream.rs
+++ b/crates/daemon/src/daemon_stream.rs
@@ -184,16 +184,6 @@ impl DaemonStream {
         }
     }
 
-    /// Consumes a `Stdio` variant and returns its reader and writer components.
-    ///
-    /// Returns `Ok((reader, writer))` for `Stdio` variants, or `Err(self)` for
-    /// TCP/TLS variants that cannot be split this way.
-    pub fn into_stdio_pair(self) -> Result<(Box<dyn Read + Send>, Box<dyn Write + Send>), Self> {
-        match self {
-            Self::Stdio(pair) => Ok((pair.reader, pair.writer)),
-            other => Err(other),
-        }
-    }
 }
 
 impl Read for DaemonStream {

--- a/crates/daemon/src/daemon_stream.rs
+++ b/crates/daemon/src/daemon_stream.rs
@@ -1,21 +1,44 @@
-//! Unified stream abstraction for plain TCP and TLS-wrapped daemon connections.
+//! Unified stream abstraction for plain TCP, TLS-wrapped, and stdio daemon
+//! connections.
 //!
-//! [`DaemonStream`] transparently handles both plain `TcpStream` and
-//! TLS-encrypted connections (via rustls) behind a single type that
-//! implements `Read + Write`. This lets the daemon's session handler,
-//! greeting exchange, and module access code operate identically
-//! regardless of whether TLS is active.
+//! [`DaemonStream`] transparently handles plain `TcpStream`, TLS-encrypted
+//! connections (via rustls), and stdio-based connections behind a single type
+//! that implements `Read + Write`. This lets the daemon's session handler,
+//! greeting exchange, and module access code operate identically regardless
+//! of the transport.
 //!
-//! The `Tls` variant is only available when the `daemon-tls` Cargo
-//! feature is enabled. Without it, `DaemonStream` is a simple wrapper
-//! around `TcpStream` with no additional dependencies.
+//! The `Tls` variant is only available when the `daemon-tls` Cargo feature is
+//! enabled. The `Stdio` variant supports the `--server --daemon` remote-shell
+//! daemon mode where stdin/stdout are used instead of a TCP socket.
+//! upstream: main.c:1843-1844 - `if (am_server && am_daemon)
+//! return start_daemon(STDIN_FILENO, STDOUT_FILENO);`
 
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpStream};
 use std::time::Duration;
 
-/// A daemon connection that is either a plain TCP stream or a
-/// TLS-encrypted stream over TCP.
+/// Joined stdin/stdout pair for daemon stdio mode.
+///
+/// Reads come from stdin, writes go to stdout. This supports the
+/// `--server --daemon` remote-shell daemon mode where the daemon protocol
+/// runs over an existing connection's stdin/stdout rather than a TCP socket.
+///
+/// upstream: clientserver.c - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`
+/// serves the daemon protocol over the inherited file descriptors.
+pub struct StdioPair {
+    reader: Box<dyn Read + Send>,
+    writer: Box<dyn Write + Send>,
+}
+
+impl StdioPair {
+    /// Creates a new stdio pair from the given reader and writer.
+    pub fn new(reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Self {
+        Self { reader, writer }
+    }
+}
+
+/// A daemon connection that is either a plain TCP stream, a TLS-encrypted
+/// stream over TCP, or a stdio pair for remote-shell daemon mode.
 ///
 /// Implements `Read` and `Write` by delegating to the inner stream,
 /// making it a drop-in replacement for `TcpStream` in the daemon's
@@ -23,11 +46,11 @@ use std::time::Duration;
 ///
 /// # Variants
 ///
-/// - `Plain` - unencrypted TCP, used when no TLS configuration is
-///   present.
-/// - `Tls` - encrypted via rustls `StreamOwned`, used when the daemon
-///   is started with `--ssl` / certificate configuration. Only
-///   available behind `#[cfg(feature = "daemon-tls")]`.
+/// - `Plain` - unencrypted TCP, used when no TLS configuration is present.
+/// - `Tls` - encrypted via rustls `StreamOwned`, used when the daemon is
+///   started with `--ssl` / certificate configuration. Only available behind
+///   `#[cfg(feature = "daemon-tls")]`.
+/// - `Stdio` - stdin/stdout pair for `--server --daemon` remote-shell mode.
 pub enum DaemonStream {
     /// Unencrypted TCP connection.
     Plain(TcpStream),
@@ -40,6 +63,13 @@ pub enum DaemonStream {
     #[cfg(feature = "daemon-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
     Tls(Box<rustls::StreamOwned<rustls::ServerConnection, TcpStream>>),
+
+    /// Stdio-based connection for remote-shell daemon mode.
+    ///
+    /// Used when the daemon is invoked via `--server --daemon` over an
+    /// existing connection (e.g., SSH). Reads from stdin, writes to stdout.
+    /// upstream: main.c - `start_daemon(STDIN_FILENO, STDOUT_FILENO)`.
+    Stdio(StdioPair),
 }
 
 impl DaemonStream {
@@ -48,34 +78,47 @@ impl DaemonStream {
         Self::Plain(stream)
     }
 
+    /// Wraps a stdio pair for remote-shell daemon mode.
+    pub fn stdio(pair: StdioPair) -> Self {
+        Self::Stdio(pair)
+    }
+
     /// Configures the read timeout on the underlying TCP socket.
     ///
     /// Delegates to `TcpStream::set_read_timeout` regardless of whether
     /// the connection is plain or TLS-wrapped - the timeout applies at the
-    /// OS socket level, beneath the TLS layer.
+    /// OS socket level, beneath the TLS layer. No-op for stdio streams
+    /// (pipes do not support socket timeouts).
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         match self {
             Self::Plain(s) => s.set_read_timeout(dur),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.sock.set_read_timeout(dur),
+            Self::Stdio(_) => Ok(()),
         }
     }
 
     /// Configures the write timeout on the underlying TCP socket.
+    ///
+    /// No-op for stdio streams.
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         match self {
             Self::Plain(s) => s.set_write_timeout(dur),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.sock.set_write_timeout(dur),
+            Self::Stdio(_) => Ok(()),
         }
     }
 
     /// Enables or disables `TCP_NODELAY` on the underlying socket.
+    ///
+    /// No-op for stdio streams.
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         match self {
             Self::Plain(s) => s.set_nodelay(nodelay),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.sock.set_nodelay(nodelay),
+            Self::Stdio(_) => Ok(()),
         }
     }
 
@@ -83,24 +126,26 @@ impl DaemonStream {
     ///
     /// For TLS streams this operates on the underlying TCP socket. The
     /// TLS `close_notify` alert should be sent (via `flush` / drop)
-    /// before calling this.
+    /// before calling this. No-op for stdio streams (stdin/stdout are
+    /// closed when the process exits).
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         match self {
             Self::Plain(s) => s.shutdown(how),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.sock.shutdown(how),
+            Self::Stdio(_) => Ok(()),
         }
     }
 
-    /// Returns a reference to the underlying `TcpStream`.
+    /// Returns a reference to the underlying `TcpStream`, if available.
     ///
-    /// Useful for operations that need the raw socket (e.g., applying
-    /// socket options, reading the peer address).
-    pub fn tcp_stream(&self) -> &TcpStream {
+    /// Returns `None` for stdio streams which have no underlying TCP socket.
+    pub fn tcp_stream(&self) -> Option<&TcpStream> {
         match self {
-            Self::Plain(s) => s,
+            Self::Plain(s) => Some(s),
             #[cfg(feature = "daemon-tls")]
-            Self::Tls(s) => &s.sock,
+            Self::Tls(s) => Some(&s.sock),
+            Self::Stdio(_) => None,
         }
     }
 
@@ -110,7 +155,13 @@ impl DaemonStream {
             Self::Plain(_) => false,
             #[cfg(feature = "daemon-tls")]
             Self::Tls(_) => true,
+            Self::Stdio(_) => false,
         }
+    }
+
+    /// Returns `true` if this is a stdio-based connection.
+    pub fn is_stdio(&self) -> bool {
+        matches!(self, Self::Stdio(_))
     }
 
     /// Consumes the `DaemonStream` and returns the inner `TcpStream`.
@@ -120,11 +171,27 @@ impl DaemonStream {
     /// discarding the TLS session state. The caller is responsible for
     /// ensuring the TLS session has been properly shut down before
     /// calling this.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `Stdio` variant, which has no `TcpStream`.
     pub fn into_tcp_stream(self) -> TcpStream {
         match self {
             Self::Plain(s) => s,
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.sock,
+            Self::Stdio(_) => panic!("cannot extract TcpStream from Stdio variant"),
+        }
+    }
+
+    /// Consumes a `Stdio` variant and returns its reader and writer components.
+    ///
+    /// Returns `Ok((reader, writer))` for `Stdio` variants, or `Err(self)` for
+    /// TCP/TLS variants that cannot be split this way.
+    pub fn into_stdio_pair(self) -> Result<(Box<dyn Read + Send>, Box<dyn Write + Send>), Self> {
+        match self {
+            Self::Stdio(pair) => Ok((pair.reader, pair.writer)),
+            other => Err(other),
         }
     }
 }
@@ -135,6 +202,7 @@ impl Read for DaemonStream {
             Self::Plain(s) => s.read(buf),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.read(buf),
+            Self::Stdio(pair) => pair.reader.read(buf),
         }
     }
 }
@@ -145,6 +213,7 @@ impl Write for DaemonStream {
             Self::Plain(s) => s.write(buf),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.write(buf),
+            Self::Stdio(pair) => pair.writer.write(buf),
         }
     }
 
@@ -153,6 +222,7 @@ impl Write for DaemonStream {
             Self::Plain(s) => s.flush(),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(s) => s.flush(),
+            Self::Stdio(pair) => pair.writer.flush(),
         }
     }
 }
@@ -163,6 +233,7 @@ impl std::fmt::Debug for DaemonStream {
             Self::Plain(s) => f.debug_tuple("DaemonStream::Plain").field(s).finish(),
             #[cfg(feature = "daemon-tls")]
             Self::Tls(_) => f.debug_tuple("DaemonStream::Tls").field(&"<tls>").finish(),
+            Self::Stdio(_) => f.debug_tuple("DaemonStream::Stdio").field(&"<stdio>").finish(),
         }
     }
 }
@@ -223,7 +294,7 @@ mod tests {
         let (_client, server) = connected_pair();
         let addr = server.local_addr().unwrap();
         let daemon = DaemonStream::plain(server);
-        assert_eq!(daemon.tcp_stream().local_addr().unwrap(), addr);
+        assert_eq!(daemon.tcp_stream().unwrap().local_addr().unwrap(), addr);
     }
 
     #[test]
@@ -284,5 +355,102 @@ mod tests {
         let daemon = DaemonStream::Plain(server);
         let debug = format!("{daemon:?}");
         assert!(debug.contains("Plain"), "got: {debug}");
+    }
+
+    #[test]
+    fn stdio_read_write_roundtrip() {
+        let input = b"hello from client";
+        let reader = io::Cursor::new(input.to_vec());
+        let writer = Vec::new();
+        let pair = StdioPair::new(Box::new(reader), Box::new(writer));
+        let mut daemon = DaemonStream::stdio(pair);
+
+        let mut buf = [0u8; 64];
+        let n = daemon.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], input);
+
+        let response = b"hello from daemon";
+        daemon.write_all(response).unwrap();
+        daemon.flush().unwrap();
+    }
+
+    #[test]
+    fn stdio_is_not_tls() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        assert!(!daemon.is_tls());
+    }
+
+    #[test]
+    fn stdio_is_stdio() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        assert!(daemon.is_stdio());
+    }
+
+    #[test]
+    fn plain_is_not_stdio() {
+        let (_client, server) = connected_pair();
+        let daemon = DaemonStream::plain(server);
+        assert!(!daemon.is_stdio());
+    }
+
+    #[test]
+    fn stdio_tcp_stream_is_none() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        assert!(daemon.tcp_stream().is_none());
+    }
+
+    #[test]
+    fn stdio_set_timeouts_are_noop() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        let dur = Some(Duration::from_secs(5));
+        daemon.set_read_timeout(dur).unwrap();
+        daemon.set_write_timeout(dur).unwrap();
+    }
+
+    #[test]
+    fn stdio_set_nodelay_is_noop() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        daemon.set_nodelay(true).unwrap();
+    }
+
+    #[test]
+    fn stdio_shutdown_is_noop() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        daemon.shutdown(Shutdown::Both).unwrap();
+    }
+
+    #[test]
+    fn stdio_debug_format() {
+        let pair = StdioPair::new(
+            Box::new(io::Cursor::new(Vec::new())),
+            Box::new(Vec::new()),
+        );
+        let daemon = DaemonStream::stdio(pair);
+        let debug = format!("{daemon:?}");
+        assert!(debug.contains("Stdio"), "got: {debug}");
     }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -202,6 +202,6 @@ pub use config::{DaemonConfig, DaemonConfigBuilder};
 #[cfg(feature = "async-daemon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-daemon")))]
 pub use daemon::run_async_daemon;
-pub use daemon::run_daemon;
-pub use daemon_stream::DaemonStream;
+pub use daemon::{run_daemon, run_daemon_stdio};
+pub use daemon_stream::{DaemonStream, StdioPair};
 pub use error::DaemonError;

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -162,16 +162,6 @@ mod exit_code_1_syntax {
     }
 
     #[test]
-    fn conflicting_server_and_daemon_returns_syntax_error() {
-        let output = run_rsync(&["--server", "--daemon"]);
-        assert_exit_code(
-            &output,
-            ExitCode::Syntax,
-            "conflicting --server and --daemon",
-        );
-    }
-
-    #[test]
     fn empty_filter_pattern_returns_syntax_error() {
         let test_dir = TestDir::new().expect("create test dir");
         let src_dir = test_dir.mkdir("src").unwrap();
@@ -1028,16 +1018,6 @@ mod binary_exit_codes {
         assert!(
             code == 1 || code == 23,
             "Missing option argument should return error, got {code}"
-        );
-    }
-
-    #[test]
-    fn conflicting_options_server_daemon_returns_syntax_error() {
-        let output = run_rsync(&["--server", "--daemon"]);
-        assert_exit_code(
-            &output,
-            ExitCode::Syntax,
-            "conflicting --server and --daemon options",
         );
     }
 

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -14,10 +14,10 @@
 
 KNOWN_FAILURES=(
   # --- Daemon-mode tests ---
-  # daemon.test uses lsh.sh (remote-shell daemon mode) for its first step
-  # which requires oc-rsync to interoperate with upstream's -e <cmd> path.
-  # Later steps use RSYNC_CONNECT_PROG which now works, but the lsh.sh
-  # step still fails.
+  # daemon.test step 1 uses lsh.sh which invokes --server --daemon over
+  # stdin/stdout. The stdio daemon path is now wired but full interop with
+  # upstream's test harness (module listing format, exclude matching, atime
+  # step 5) may still diverge. Keep listed until CI validates end-to-end.
   "daemon"
 
   # --- Device / special-file tests ---


### PR DESCRIPTION
## Summary

- Add `Stdio` variant to `DaemonStream` to support `--server --daemon` remote-shell daemon mode, where the daemon protocol runs over stdin/stdout instead of a TCP listener
- Add `run_daemon_stdio()` entry point that loads rsyncd config, builds modules, and serves a single legacy session on stdin/stdout - matching upstream `start_daemon(STDIN_FILENO, STDOUT_FILENO)` in main.c:1843-1844
- Wire CLI to detect the `--server --daemon` combination before plain `--server` dispatch and route to the stdio daemon path
- Refactor transfer stream setup to use boxed trait objects so both TCP (clone-based) and stdio (separate stdin/stdout handles) paths work through the same transfer engine

## Test plan

- [ ] CI passes: fmt+clippy, nextest, Windows/macOS/Linux builds
- [ ] New unit tests for `server_daemon_mode_requested` and `server_daemon_arguments` detection
- [ ] New unit tests for `DaemonStream::Stdio` variant (read/write, is_stdio, tcp_stream returns None, no-op timeouts/shutdown)
- [ ] Existing daemon TCP tests continue passing (no regression from `tcp_stream()` returning `Option`)
- [ ] Verify upstream testsuite daemon.test progresses further (steps 2-5 use RSYNC_CONNECT_PROG which should work)