### PR TITLE
fix: prevent deadlock in sync bridge multi-chunk wire parity test

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
+++ b/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
@@ -515,15 +515,31 @@ mod tests {
         // an existing runtime.
         let handle = std::thread::spawn(move || {
             let mut bridge = SyncAsyncBridge::new(client).unwrap();
-            bridge.write_all(&payload_owned).unwrap();
-            bridge.flush().unwrap();
 
-            // Read back exactly the number of bytes we wrote - the echo
-            // server sends them back 1:1.
-            let mut received = vec![0u8; payload_owned.len()];
-            if !received.is_empty() {
-                bridge.read_exact(&mut received).unwrap();
+            if payload_owned.is_empty() {
+                return Vec::new();
             }
+
+            // Interleave writes and reads in chunks to prevent deadlock:
+            // the echo server writes back inline, so both duplex buffer
+            // directions fill if we do a single large write_all before
+            // reading. Each chunk must be smaller than the duplex buffer
+            // (64 KiB) so the echo round-trip fits without blocking.
+            let chunk_size = 32 * 1024;
+            let mut received = Vec::with_capacity(payload_owned.len());
+            let mut offset = 0;
+
+            while offset < payload_owned.len() {
+                let end = (offset + chunk_size).min(payload_owned.len());
+                bridge.write_all(&payload_owned[offset..end]).unwrap();
+                bridge.flush().unwrap();
+
+                let mut buf = vec![0u8; end - offset];
+                bridge.read_exact(&mut buf).unwrap();
+                received.extend_from_slice(&buf);
+                offset = end;
+            }
+
             received
         });
 


### PR DESCRIPTION
## Summary
- Fix `wire_byte_parity_multi_chunk_payload` test hang that was failing nextest (stable) on master
- Root cause: `round_trip_via_bridge` did `write_all(256KB)` then `read_exact(256KB)` sequentially on a 64 KiB duplex buffer with an inline echo server, causing both buffer directions to fill (bidirectional deadlock)
- Fix: interleave writes and reads in 32 KiB chunks so each round-trip fits within the duplex buffer without blocking

## Test plan
- [ ] nextest (stable) passes - the timed-out test now completes
- [ ] All other wire parity tests (small, binary, empty, single-byte) continue to pass
- [ ] Windows/macOS/Linux musl CI green