### PR TITLE
ci: install libxxhash-dev and guard grep pipeline in upstream testsuite

### DIFF
--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
           version: ${{ env.CACHE_VERSION }}
 
       - name: Cache upstream rsync source
@@ -150,7 +150,7 @@ jobs:
             STATUS=$(echo "$line" | awk '{print $1}')
             TEST=$(echo "$line" | awk '{print $2}')
             echo "| $STATUS | $TEST |" >> "$GITHUB_STEP_SUMMARY"
-          done
+          done || true
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "</details>" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary

- Add `libxxhash-dev` to the APT packages in the upstream testsuite workflow - upstream rsync 3.4.2 requires `xxhash.h` for `./configure` to succeed
- Guard the `grep | while` pipeline in the "Generate job summary" step with `|| true` to prevent failure under `set -euo pipefail` when no test results exist

## Context

The upstream testsuite workflow has been failing on every PR and on master because:

1. `./configure` in the upstream rsync 3.4.2 source tree aborts with "Failed to find xxhash.h" since `libxxhash-dev` is not installed
2. No tests run, so the output log contains no PASS/FAIL/XFAIL/UPASS/SKIP lines
3. `grep -E` returns exit code 1 when no matches are found
4. Under `set -euo pipefail`, the "Generate job summary" step exits with code 1

## Test plan

- [ ] Verify upstream testsuite workflow runs to completion on this PR
- [ ] Verify the "Generate job summary" step no longer fails
- [ ] Verify upstream rsync 3.4.2 `./configure` succeeds with libxxhash-dev installed