### PR TITLE
chore: triage environment-dependent upstream testsuite known failures

### DIFF
--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -20,25 +20,31 @@ KNOWN_FAILURES=(
   # step still fails.
   "daemon"
 
-  # --- Device / special-file tests ---
-  # Require root or CAP_MKNOD to create devices in $fromdir.
-  "devices"
-
-  # --- chown / chgrp tests ---
-  # Require root to set arbitrary uid/gid; otherwise upstream's own
-  # tests skip via test_skipped (exit 77) which the harness reports
-  # as SKIP, not FAIL.
-  "chown"
-
   # --- ssh-basic test ---
   # Requires an actual SSH-style remote shell wrapper in test fixtures.
   "ssh-basic"
 
-  # --- protected-regular ---
-  # Tests fs.protected_regular kernel feature interaction.
-  "protected-regular"
-
   # --- dir-sgid ---
-  # Setgid bit on directories; behavior is filesystem-dependent.
+  # oc-rsync gap: when creating destination directories inside a setgid
+  # parent, oc-rsync does not preserve the inherited setgid bit. Upstream
+  # rsync respects OS-level setgid inheritance on mkdir(). This test does
+  # not require root or special environment - it runs on any filesystem
+  # that supports directory setgid (ext4, xfs, etc.).
   "dir-sgid"
+
+  # -----------------------------------------------------------------------
+  # Removed entries (IFX-14 triage, 2026-06-02):
+  #
+  # "devices" - REMOVED: now passes via fakeroot on CI (UPASS). The test
+  #   re-executes itself under fakeroot when not root, and fakeroot is
+  #   pre-installed on ubuntu-latest. configure detects it via
+  #   AC_PATH_PROG(FAKEROOT_PATH, fakeroot).
+  #
+  # "chown" - REMOVED: now passes via fakeroot on CI (UPASS). Same
+  #   fakeroot re-exec mechanism as devices.test.
+  #
+  # "protected-regular" - REMOVED: self-skips (exit 77) when not root
+  #   because chown fails. Listing it here masked the natural SKIP as
+  #   XFAIL. Without the entry the harness correctly reports SKIP.
+  # -----------------------------------------------------------------------
 )


### PR DESCRIPTION
## Summary

- Remove `devices`, `chown`, and `protected-regular` from the upstream testsuite known failures list after verifying their actual CI behavior
- Update `dir-sgid` comment to document it as an actual oc-rsync gap rather than an environment issue

## Details

Triaged four environment-dependent tests (IFX-14) in `tools/ci/upstream_testsuite_known_failures.conf`:

| Test | Previous status | Action | Reason |
|------|----------------|--------|--------|
| `devices` | UPASS | Removed | Passes via fakeroot on ubuntu-latest |
| `chown` | UPASS | Removed | Passes via fakeroot on ubuntu-latest |
| `protected-regular` | XFAIL (masked SKIP) | Removed | Self-skips (exit 77) when `chown` fails as non-root; listing it masked the natural SKIP |
| `dir-sgid` | XFAIL | Retained | Actual oc-rsync gap in directory setgid inheritance, not environment-dependent |

Both `devices` and `chown` tests re-execute themselves under `fakeroot` when run as non-root. Since `fakeroot` is pre-installed on ubuntu-latest and detected by upstream's `configure` via `AC_PATH_PROG(FAKEROOT_PATH, fakeroot)`, these tests now pass.

The `protected-regular` test requires root to `chown` a file and calls `test_skipped` (exit 77) when that fails. Because exit 77 is non-zero, the harness classified it as XFAIL when listed as a known failure. Removing it lets the harness correctly report SKIP.

The `dir-sgid` test does not require root or special environment - it runs on any filesystem supporting directory setgid (ext4, xfs). The failure indicates oc-rsync does not preserve the inherited setgid bit when creating destination directories inside a setgid parent.

## Test plan

- [ ] CI upstream testsuite workflow passes without unexpected failures
- [ ] `devices` and `chown` report PASS (no longer masked as XFAIL)
- [ ] `protected-regular` reports SKIP (no longer masked as XFAIL)
- [ ] `dir-sgid` remains XFAIL with the updated comment