### PR TITLE
chore: triage environment-dependent upstream testsuite known failures

### DIFF
--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -25,56 +25,26 @@ KNOWN_FAILURES=(
   # Requires an actual SSH-style remote shell wrapper in test fixtures.
   "ssh-basic"
 
-  # ---------------------------------------------------------------
-  # Environment-dependent tests
-  #
-  # These tests self-skip (exit 77) in unprivileged CI via
-  # test_skipped(), so they land as XFAIL, not true FAIL.
-  # They exercise oc-rsync features that ARE implemented - the
-  # failures are purely environmental, not code gaps.
-  # To validate: run in a privileged container (root or CAP_MKNOD)
-  # on a Linux filesystem that supports setgid inheritance.
-  # ---------------------------------------------------------------
-
-  # --- devices (environment: root or fakeroot or CAP_MKNOD) ---
-  # Creates char/block device nodes and FIFOs via mknod(2), then
-  # verifies rsync -D transfer, itemize output, and --link-dest
-  # hard-linking of specials. Skips with "Rsync needs root/fakeroot
-  # for device tests" when not root and $FAKEROOT_PATH is unset.
-  # oc-rsync: mknod support implemented in crates/metadata/src/special.rs.
-  # Would pass as root or under fakeroot.
-  "devices"
-
-  # --- chown (environment: root or fakeroot) ---
-  # Sets files to uid 5000/5001, gid 5002/5003 via chown(2), then
-  # verifies rsync -aHvv preserves ownership. Skips with "Can't
-  # chown (probably need root)" when chown(2) returns EPERM.
-  # oc-rsync: ownership preservation implemented in
-  # crates/metadata/src/apply/ownership.rs.
-  # Would pass as root or under fakeroot.
-  "chown"
-
-  # --- protected-regular (environment: Linux, root, fs.protected_regular>=1) ---
-  # Requires three conditions: (1) Linux with /proc/sys/fs/protected_regular,
-  # (2) sysctl fs.protected_regular set to 1 or 2, (3) root to chown a file
-  # to uid 5001 in a sticky+world-writable directory. Verifies that rsync
-  # --inplace can still write to a protected file owned by another user.
-  # Skips on non-Linux (no /proc/sys/fs/protected_regular) and when not root.
-  # oc-rsync: --inplace is implemented. Would pass as root on Linux with
-  # fs.protected_regular enabled (default on modern kernels).
-  "protected-regular"
-
-  # --- dir-sgid (environment: filesystem with setgid inheritance) ---
-  # Sets the setgid bit (chmod g+s) on a directory, creates a
-  # subdirectory inside it, and verifies the child inherits the
-  # setgid bit. Skips with "Your filesystem doesn't use directory
-  # setgid; maybe it's BSD" when the filesystem does not propagate
-  # setgid to new subdirectories (BSD semantics, some container
-  # overlay filesystems, or tmpfs with certain mount options).
-  # Does NOT require root - only a filesystem that honors setgid
-  # inheritance (standard on ext4, xfs, btrfs).
-  # oc-rsync: permission handling implemented. Would pass on Linux
-  # with a native filesystem (ext4/xfs/btrfs), may skip on macOS
-  # (BSD-style group inheritance) or overlay filesystems.
+  # --- dir-sgid ---
+  # oc-rsync gap: when creating destination directories inside a setgid
+  # parent, oc-rsync does not preserve the inherited setgid bit. Upstream
+  # rsync respects OS-level setgid inheritance on mkdir(). This test does
+  # not require root or special environment - it runs on any filesystem
+  # that supports directory setgid (ext4, xfs, etc.).
   "dir-sgid"
+
+  # -----------------------------------------------------------------------
+  # Removed entries:
+  #
+  # "devices" - now passes via fakeroot on CI (UPASS). The test
+  #   re-executes itself under fakeroot when not root, and fakeroot is
+  #   pre-installed on ubuntu-latest.
+  #
+  # "chown" - now passes via fakeroot on CI (UPASS). Same fakeroot
+  #   re-exec mechanism as devices.test.
+  #
+  # "protected-regular" - self-skips (exit 77) when not root because
+  #   chown fails. Listing it here masked the natural SKIP as XFAIL.
+  #   Without the entry the harness correctly reports SKIP.
+  # -----------------------------------------------------------------------
 )


### PR DESCRIPTION
## Summary

- Remove `devices`, `chown`, `protected-regular` from `upstream_testsuite_known_failures.conf`
  - `devices` and `chown` now pass via fakeroot on ubuntu-latest (UPASS)
  - `protected-regular` self-skips (exit 77) when not root; listing it masked the natural SKIP as XFAIL
- Reclassify `dir-sgid` as an actual oc-rsync gap (does not preserve inherited setgid bit on mkdir) rather than environment-dependent

## Test plan

- [ ] Upstream testsuite CI passes without unexpected regressions
- [ ] `devices` and `chown` appear as PASS (not UPASS) in CI output
- [ ] `protected-regular` appears as SKIP (not XFAIL) in CI output
- [ ] `dir-sgid` continues to appear as XFAIL