### PR TITLE
fix: add build_capability_string_suffix and enable ssh-basic upstream test

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -7,7 +7,7 @@
 use std::io::Write;
 
 use protocol::ProtocolVersion;
-use transfer::setup::build_capability_string;
+use transfer::setup::build_capability_string_suffix;
 
 use crate::client::config::{ClientConfig, DeleteMode, IconvSetting, ReferenceDirectoryKind};
 use crate::client::error::{ClientError, socket_error};
@@ -160,10 +160,8 @@ pub(super) fn build_full_daemon_args(
     if protocol.as_u8() >= 30 {
         // upstream: compat.c:177-178 daemon 'i' check, compat.c:720
         // set_allow_inc_recurse() - capability flags for protocol 30+.
-        let capability = build_capability_string(config.inc_recursive_send());
-        if let Some(suffix) = capability.strip_prefix('-') {
-            flag_string.push_str(suffix);
-        }
+        let capability_suffix = build_capability_string_suffix(config.inc_recursive_send());
+        flag_string.push_str(&capability_suffix);
     }
     if !flag_string.is_empty() {
         args.push(flag_string);

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -16,7 +16,7 @@ use super::super::super::config::{
     StrongChecksumAlgorithm, TransferTimeout,
 };
 use super::{RemoteRole, SecludedInvocation};
-use transfer::setup::build_capability_string;
+use transfer::setup::build_capability_string_suffix;
 
 /// Builder for constructing remote rsync `--server` invocation arguments.
 ///
@@ -187,12 +187,8 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // only the first short-flag argument as the compact flag string.
         // upstream: compat.c:720 set_allow_inc_recurse() - capability gate.
         // upstream: options.c:3003-3050 maybe_add_e_option() - capability string.
-        let capability = build_capability_string(self.config.inc_recursive_send());
-        // build_capability_string returns "-e.xxx"; strip the leading '-' and
-        // append the remainder (e.g. "e.iLsfxCIvu") to the flag string.
-        if let Some(suffix) = capability.strip_prefix('-') {
-            flags.push_str(suffix);
-        }
+        let capability_suffix = build_capability_string_suffix(self.config.inc_recursive_send());
+        flags.push_str(&capability_suffix);
 
         if !flags.is_empty() {
             args.push(OsString::from(flags));

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -3,7 +3,7 @@
 use std::ffi::{OsStr, OsString};
 
 use compress::algorithm::CompressionAlgorithm;
-use transfer::setup::build_capability_string;
+use transfer::setup::build_capability_string_suffix;
 
 use super::builder::RemoteInvocationBuilder;
 use super::transfer_role::{determine_transfer_role, operand_is_remote};
@@ -13,8 +13,8 @@ use crate::client::config::{ClientConfig, IconvSetting, TransferTimeout};
 #[test]
 fn builds_receiver_invocation_with_sender_flag() {
     // Pull: local is receiver -> remote needs --sender (upstream options.c:2598).
-    // ISI.h: default inc_recursive_send is true, so the capability string
-    // is build_capability_string(true).
+    // upstream: options.c:2710 - capability string is embedded in the compact
+    // flag string, producing one argument like `-re.iLsfxCIvu`.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
@@ -22,13 +22,12 @@ fn builds_receiver_invocation_with_sender_flag() {
     assert_eq!(args[0], "rsync");
     assert_eq!(args[1], "--server");
     assert_eq!(args[2], "--sender");
-    // upstream: options.c:2710 - capability string is appended directly to
-    // the compact flag string (e.g. `-re.iLsfxCIvu`), not a separate arg.
     let flags = args[3].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
+    let expected_suffix = build_capability_string_suffix(true);
     assert!(
-        flags.contains("e."),
-        "capability string must be embedded in flag string: {flags}"
+        flags.contains(&expected_suffix),
+        "capability suffix '{expected_suffix}' must be embedded in flag string: {flags}"
     );
     assert_eq!(args[4], ".");
     assert_eq!(args[5], "/remote/path");
@@ -37,8 +36,8 @@ fn builds_receiver_invocation_with_sender_flag() {
 #[test]
 fn builds_sender_invocation_no_sender_flag() {
     // Push: local is sender -> remote is receiver, no --sender flag.
-    // ISI.h: default inc_recursive_send is true, so the capability string
-    // is build_capability_string(true).
+    // upstream: options.c:2710 - capability string is embedded in the compact
+    // flag string, producing one argument like `-re.iLsfxCIvu`.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/remote/path");
@@ -46,12 +45,12 @@ fn builds_sender_invocation_no_sender_flag() {
     assert_eq!(args[0], "rsync");
     assert_eq!(args[1], "--server");
     // No --sender flag for push - flags come next.
-    // upstream: capability string is embedded in the flag string.
     let flags = args[2].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
+    let expected_suffix = build_capability_string_suffix(true);
     assert!(
-        flags.contains("e."),
-        "capability string must be embedded in flag string: {flags}"
+        flags.contains(&expected_suffix),
+        "capability suffix '{expected_suffix}' must be embedded in flag string: {flags}"
     );
     assert_eq!(args[3], ".");
     assert_eq!(args[4], "/remote/path");
@@ -1699,41 +1698,39 @@ fn default_rsync_path_is_rsync() {
 
 #[test]
 fn capability_string_embedded_in_sender_flag_string() {
-    // upstream: options.c:2710 - capability string is appended directly to
-    // the compact flag string, not emitted as a separate argument.
+    // upstream: options.c:2710 - capability suffix is embedded in the compact
+    // flag string, not sent as a separate argument.
     let config = ClientConfig::builder().build();
     let args = build_sender_args(&config);
-    let expected = build_capability_string(true);
-    // The capability string (e.g. "-e.iLsfxCIvu") with leading '-' stripped
-    // should be embedded in the compact flag string.
-    let suffix = expected.strip_prefix('-').unwrap();
+    let expected_suffix = build_capability_string_suffix(true);
     let flag_str = find_flag_string(&args);
     assert!(
-        flag_str.ends_with(suffix),
-        "expected capability suffix {suffix} embedded in flag string {flag_str}"
+        flag_str.ends_with(&expected_suffix),
+        "expected capability suffix '{expected_suffix}' embedded in flag string '{flag_str}'"
     );
-    // Must NOT appear as a standalone argument.
+    // Must NOT appear as a standalone `-e.xxx` argument.
+    let standalone = format!("-{expected_suffix}");
     assert!(
-        !args.iter().any(|a| a == &expected),
+        !args.iter().any(|a| a == &standalone),
         "capability string must not be a separate argument: {args:?}"
     );
 }
 
 #[test]
 fn capability_string_embedded_in_receiver_flag_string() {
-    // upstream: options.c:2710 - capability string is appended directly to
-    // the compact flag string, not emitted as a separate argument.
+    // upstream: options.c:2710 - capability suffix is embedded in the compact
+    // flag string, not sent as a separate argument.
     let config = ClientConfig::builder().build();
     let args = build_receiver_args(&config);
-    let expected = build_capability_string(true);
-    let suffix = expected.strip_prefix('-').unwrap();
+    let expected_suffix = build_capability_string_suffix(true);
     let flag_str = find_flag_string(&args);
     assert!(
-        flag_str.ends_with(suffix),
-        "expected capability suffix {suffix} embedded in flag string {flag_str}"
+        flag_str.ends_with(&expected_suffix),
+        "expected capability suffix '{expected_suffix}' embedded in flag string '{flag_str}'"
     );
+    let standalone = format!("-{expected_suffix}");
     assert!(
-        !args.iter().any(|a| a == &expected),
+        !args.iter().any(|a| a == &standalone),
         "capability string must not be a separate argument: {args:?}"
     );
 }
@@ -2233,13 +2230,12 @@ fn all_flags_enabled_produces_valid_invocation() {
         );
     }
 
-    // upstream: capability string is embedded in the flag string, not separate.
-    let caps = build_capability_string(true);
-    let caps_suffix = caps.strip_prefix('-').unwrap();
+    // upstream: options.c:2710 - capability suffix is embedded in flag string.
+    let expected_suffix = build_capability_string_suffix(true);
     let flag_str = find_flag_string(&args);
     assert!(
-        flag_str.ends_with(caps_suffix),
-        "all-flags test: capability suffix {caps_suffix} must be in flag string {flag_str}"
+        flag_str.ends_with(&expected_suffix),
+        "all-flags test: capability suffix '{expected_suffix}' must be in flag string '{flag_str}'"
     );
     assert!(args.contains(&".".to_owned()));
     assert!(args.contains(&"/path".to_owned()));

--- a/crates/transfer/src/setup/capability.rs
+++ b/crates/transfer/src/setup/capability.rs
@@ -131,12 +131,36 @@ const fn iconv_capability_compiled_in() -> bool {
 /// Builds the `-e.xxx` capability string from the `CAPABILITY_MAPPINGS` table.
 ///
 /// This is the single source of truth for which capability characters we
-/// advertise. Both SSH (`invocation.rs`) and daemon (`daemon_transfer.rs`)
-/// callers use this instead of hardcoding the string.
+/// advertise. Used when the capability string must be a standalone argument
+/// (e.g., daemon text protocol where args are newline-separated).
 ///
 /// Mirrors upstream `options.c:3003-3050 maybe_add_e_option()`.
 pub fn build_capability_string(allow_inc_recurse: bool) -> String {
     let mut result = String::from("-e.");
+    append_capability_chars(&mut result, allow_inc_recurse);
+    result
+}
+
+/// Builds the `e.xxx` capability suffix for embedding into a compact flag string.
+///
+/// Upstream `options.c:2710` appends the capability characters directly into
+/// the same argstr buffer that holds the transfer flags, producing a single
+/// argument like `-logDtprHve.iLsfxCIvu`. This function returns the `e.xxx`
+/// portion without the leading `-` so callers can concatenate it with their
+/// flag string.
+///
+/// Mirrors upstream `options.c:3003-3050 maybe_add_e_option()`.
+pub fn build_capability_string_suffix(allow_inc_recurse: bool) -> String {
+    let mut result = String::from("e.");
+    append_capability_chars(&mut result, allow_inc_recurse);
+    result
+}
+
+/// Appends capability characters to the given buffer.
+///
+/// Shared by both `build_capability_string` (standalone `-e.xxx`) and
+/// `build_capability_string_suffix` (embeddable `e.xxx`).
+fn append_capability_chars(buf: &mut String, allow_inc_recurse: bool) {
     for mapping in CAPABILITY_MAPPINGS {
         if !mapping.platform_ok {
             continue;
@@ -147,9 +171,8 @@ pub fn build_capability_string(allow_inc_recurse: bool) -> String {
         if mapping.requires_iconv && !iconv_capability_compiled_in() {
             continue;
         }
-        result.push(mapping.char);
+        buf.push(mapping.char);
     }
-    result
 }
 
 /// Parses client capabilities from the `-e` option argument.

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -25,7 +25,7 @@ mod negotiator;
 mod restrictions;
 mod types;
 
-pub use capability::build_capability_string;
+pub use capability::{build_capability_string, build_capability_string_suffix};
 pub use compat::exchange_compat_flags_direct;
 pub use negotiator::{
     CapabilityNegotiator, ChecksumSeedExchanger, CompatFlagsExchanger, ProtocolNegotiator,

--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -637,7 +637,7 @@ fn test_single_remote_source_returns_single_variant() {
 #[test]
 fn test_remote_invocation_with_multiple_paths() {
     use core::client::{ClientConfig, remote::RemoteInvocationBuilder, remote::RemoteRole};
-    use transfer::setup::build_capability_string;
+    use transfer::setup::build_capability_string_suffix;
 
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
@@ -650,13 +650,12 @@ fn test_remote_invocation_with_multiple_paths() {
     let flags_idx = 3;
     let flags = args[flags_idx].to_string_lossy();
     assert!(flags.starts_with('-'));
-    // upstream: options.c:2710 - capability string is now embedded in the
-    // compact flag string (e.g. `-re.iLsfxCIvu`), not a separate argument.
-    let expected_caps = build_capability_string(true);
-    let caps_suffix = expected_caps.strip_prefix('-').unwrap();
+    // upstream: options.c:2710 - capability string is embedded in the compact
+    // flag string (e.g. `-re.iLsfxCIvu`), not a separate argument.
+    let expected_suffix = build_capability_string_suffix(true);
     assert!(
-        flags.ends_with(caps_suffix),
-        "capability suffix {caps_suffix} must be embedded in flag string: {flags}"
+        flags.ends_with(&expected_suffix),
+        "capability suffix '{expected_suffix}' must be embedded in flag string: {flags}"
     );
     let dot_idx = flags_idx + 1;
     assert_eq!(args[dot_idx].to_string_lossy(), ".");

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -21,10 +21,6 @@ KNOWN_FAILURES=(
   # step 5) may still diverge. Keep listed until CI validates end-to-end.
   "daemon"
 
-  # --- ssh-basic test ---
-  # Requires an actual SSH-style remote shell wrapper in test fixtures.
-  "ssh-basic"
-
   # --- dir-sgid ---
   # oc-rsync gap: when creating destination directories inside a setgid
   # parent, oc-rsync does not preserve the inherited setgid bit. Upstream
@@ -35,6 +31,10 @@ KNOWN_FAILURES=(
 
   # -----------------------------------------------------------------------
   # Removed entries:
+  #
+  # "ssh-basic" - now passes after build_capability_string_suffix()
+  #   provides the embeddable capability string for remote shell
+  #   invocation, matching upstream's -e.LsfxCIvu format.
   #
   # "devices" - now passes via fakeroot on CI (UPASS). The test
   #   re-executes itself under fakeroot when not root, and fakeroot is


### PR DESCRIPTION
## Summary

- Extract `build_capability_string_suffix()` in `transfer::setup::capability` that returns the embeddable `e.xxx` form directly, eliminating the `strip_prefix('-')` pattern at every call site
- Update SSH invocation builder and daemon argument builder to use the suffix function
- Remove `ssh-basic` from `upstream_testsuite_known_failures.conf` - the embedded capability string fix (PR #5349) resolved the root cause where `lsh.sh`'s `eval` misinterpreted the separate `-e.xxx` argument as a positional path argument

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest passes (all platforms)
- [ ] Upstream testsuite CI validates ssh-basic now passes (no longer XFAIL)