### PR TITLE
feat: add daemon-over-remote-shell mode for SSH with :: operands

### DIFF
--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -23,10 +23,10 @@ pub(crate) use proxy::{
 pub(crate) enum DaemonStreamReader {
     /// Cloned TCP socket used for reading.
     Tcp(TcpStream),
-    /// Connect program read half: Unix socketpair clone (Unix) or child
-    /// stdout pipe (non-Unix).
+    /// Connect program read half: Unix socketpair clone or child stdout
+    /// pipe (Unix), or child stdout pipe (non-Unix).
     #[cfg(unix)]
-    Program(std::os::unix::net::UnixStream),
+    Program(program::ProgramReader),
     #[cfg(not(unix))]
     Program(std::process::ChildStdout),
 }
@@ -44,10 +44,10 @@ impl Read for DaemonStreamReader {
 pub(crate) enum DaemonStreamWriter {
     /// Original TCP socket used for writing.
     Tcp(TcpStream),
-    /// Connect program write half: Unix socketpair clone (Unix) or child
-    /// stdin pipe (non-Unix).
+    /// Connect program write half: Unix socketpair clone or child stdin
+    /// pipe (Unix), or child stdin pipe (non-Unix).
     #[cfg(unix)]
-    Program(std::os::unix::net::UnixStream),
+    Program(program::ProgramWriter),
     #[cfg(not(unix))]
     Program(std::process::ChildStdin),
 }
@@ -189,7 +189,7 @@ impl DaemonStream {
         stdin: std::process::ChildStdin,
         stdout: std::process::ChildStdout,
     ) -> Self {
-        Self::Program(ConnectProgramStream::new(child, stdin, stdout))
+        Self::Program(ConnectProgramStream::from_pipes(child, stdin, stdout))
     }
 
     /// Returns a reference to the underlying `TcpStream` if this is a TCP

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -179,6 +179,19 @@ impl DaemonStream {
         Self::Program(stream)
     }
 
+    /// Creates a `DaemonStream` from a child process's stdio handles.
+    ///
+    /// Used by daemon-over-remote-shell mode where the caller spawns
+    /// the SSH process directly and needs to wrap its pipes as a daemon
+    /// transport.
+    pub(crate) fn from_child_process(
+        child: std::process::Child,
+        stdin: std::process::ChildStdin,
+        stdout: std::process::ChildStdout,
+    ) -> Self {
+        Self::Program(ConnectProgramStream::new(child, stdin, stdout))
+    }
+
     /// Returns a reference to the underlying `TcpStream` if this is a TCP
     /// connection. Used for applying socket-level options that only apply
     /// to real sockets (not connect programs or TLS).

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -298,8 +298,12 @@ pub(crate) struct ConnectProgramStream {
 /// (mirroring upstream rsync's `sock_exec()` which returns a single fd).
 /// On non-Unix, separate pipe handles are used.
 #[cfg(unix)]
-struct ProgramTransport {
-    socket: std::os::unix::net::UnixStream,
+enum ProgramTransport {
+    Socket(std::os::unix::net::UnixStream),
+    Pipe {
+        stdin: std::process::ChildStdin,
+        stdout: std::process::ChildStdout,
+    },
 }
 
 #[cfg(not(unix))]
@@ -314,22 +318,28 @@ impl ConnectProgramStream {
     fn from_socketpair(child: Child, parent_socket: std::os::unix::net::UnixStream) -> Self {
         Self {
             child: Some(child),
-            transport: Some(ProgramTransport {
-                socket: parent_socket,
-            }),
+            transport: Some(ProgramTransport::Socket(parent_socket)),
         }
     }
 
-    /// Creates a stream backed by OS pipes (non-Unix fallback).
-    #[cfg(not(unix))]
-    fn from_pipes(
+    /// Creates a stream backed by OS pipes.
+    ///
+    /// On non-Unix this is the only transport. On Unix this is used for
+    /// daemon-over-remote-shell where SSH pipes do not need the socketpair
+    /// trick required by `RSYNC_CONNECT_PROG` inetd detection.
+    pub(super) fn from_pipes(
         child: Child,
         stdin: std::process::ChildStdin,
         stdout: std::process::ChildStdout,
     ) -> Self {
+        #[cfg(unix)]
+        let transport = ProgramTransport::Pipe { stdin, stdout };
+        #[cfg(not(unix))]
+        let transport = ProgramTransport { stdin, stdout };
+
         Self {
             child: Some(child),
-            transport: Some(ProgramTransport { stdin, stdout }),
+            transport: Some(transport),
         }
     }
 
@@ -344,17 +354,24 @@ impl ConnectProgramStream {
 
         #[cfg(unix)]
         {
-            match transport.socket.try_clone() {
-                Ok(writer) => Ok(ConnectProgramParts {
+            match transport {
+                ProgramTransport::Socket(socket) => match socket.try_clone() {
+                    Ok(writer) => Ok(ConnectProgramParts {
+                        child,
+                        reader: ProgramReader::Socket(socket),
+                        writer: ProgramWriter::Socket(writer),
+                    }),
+                    Err(e) => {
+                        let mut child = child;
+                        let _ = child.wait();
+                        Err(e)
+                    }
+                },
+                ProgramTransport::Pipe { stdin, stdout } => Ok(ConnectProgramParts {
                     child,
-                    reader: transport.socket,
-                    writer,
+                    reader: ProgramReader::Pipe(stdout),
+                    writer: ProgramWriter::Pipe(stdin),
                 }),
-                Err(e) => {
-                    let mut child = child;
-                    let _ = child.wait();
-                    Err(e)
-                }
             }
         }
 
@@ -373,75 +390,119 @@ impl ConnectProgramStream {
 pub(super) struct ConnectProgramParts {
     /// The child process handle.
     pub(super) child: Child,
-    /// Read half: Unix socketpair clone or child stdout pipe.
+    /// Read half: Unix socketpair clone, child stdout pipe, or equivalent.
     #[cfg(unix)]
-    pub(super) reader: std::os::unix::net::UnixStream,
+    pub(super) reader: ProgramReader,
     #[cfg(not(unix))]
     pub(super) reader: std::process::ChildStdout,
-    /// Write half: Unix socketpair clone or child stdin pipe.
+    /// Write half: Unix socketpair clone, child stdin pipe, or equivalent.
     #[cfg(unix)]
-    pub(super) writer: std::os::unix::net::UnixStream,
+    pub(super) writer: ProgramWriter,
     #[cfg(not(unix))]
     pub(super) writer: std::process::ChildStdin,
 }
 
+/// Read half of a connect program stream on Unix.
+///
+/// Either a cloned socketpair end (for `RSYNC_CONNECT_PROG`) or a child
+/// stdout pipe (for daemon-over-remote-shell).
+#[cfg(unix)]
+pub(super) enum ProgramReader {
+    Socket(std::os::unix::net::UnixStream),
+    Pipe(std::process::ChildStdout),
+}
+
+#[cfg(unix)]
+impl Read for ProgramReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Socket(s) => s.read(buf),
+            Self::Pipe(p) => p.read(buf),
+        }
+    }
+}
+
+/// Write half of a connect program stream on Unix.
+///
+/// Either a cloned socketpair end (for `RSYNC_CONNECT_PROG`) or a child
+/// stdin pipe (for daemon-over-remote-shell).
+#[cfg(unix)]
+pub(super) enum ProgramWriter {
+    Socket(std::os::unix::net::UnixStream),
+    Pipe(std::process::ChildStdin),
+}
+
+#[cfg(unix)]
+impl Write for ProgramWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Socket(s) => s.write(buf),
+            Self::Pipe(p) => p.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Socket(s) => s.flush(),
+            Self::Pipe(p) => p.flush(),
+        }
+    }
+}
+
 impl Read for ConnectProgramStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let transport = self
+            .transport
+            .as_mut()
+            .expect("transport taken by into_parts");
         #[cfg(unix)]
         {
-            self.transport
-                .as_mut()
-                .expect("transport taken by into_parts")
-                .socket
-                .read(buf)
+            match transport {
+                ProgramTransport::Socket(socket) => socket.read(buf),
+                ProgramTransport::Pipe { stdout, .. } => stdout.read(buf),
+            }
         }
         #[cfg(not(unix))]
         {
-            self.transport
-                .as_mut()
-                .expect("transport taken by into_parts")
-                .stdout
-                .read(buf)
+            transport.stdout.read(buf)
         }
     }
 }
 
 impl Write for ConnectProgramStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let transport = self
+            .transport
+            .as_mut()
+            .expect("transport taken by into_parts");
         #[cfg(unix)]
         {
-            self.transport
-                .as_mut()
-                .expect("transport taken by into_parts")
-                .socket
-                .write(buf)
+            match transport {
+                ProgramTransport::Socket(socket) => socket.write(buf),
+                ProgramTransport::Pipe { stdin, .. } => stdin.write(buf),
+            }
         }
         #[cfg(not(unix))]
         {
-            self.transport
-                .as_mut()
-                .expect("transport taken by into_parts")
-                .stdin
-                .write(buf)
+            transport.stdin.write(buf)
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        let transport = self
+            .transport
+            .as_mut()
+            .expect("transport taken by into_parts");
         #[cfg(unix)]
         {
-            self.transport
-                .as_mut()
-                .expect("transport taken by into_parts")
-                .socket
-                .flush()
+            match transport {
+                ProgramTransport::Socket(socket) => socket.flush(),
+                ProgramTransport::Pipe { stdin, .. } => stdin.flush(),
+            }
         }
         #[cfg(not(unix))]
         {
-            self.transport
-                .as_mut()
-                .expect("transport taken by into_parts")
-                .stdin
-                .flush()
+            transport.stdin.flush()
         }
     }
 }

--- a/crates/core/src/client/module_list/connect/program.rs
+++ b/crates/core/src/client/module_list/connect/program.rs
@@ -407,7 +407,7 @@ pub(super) struct ConnectProgramParts {
 /// Either a cloned socketpair end (for `RSYNC_CONNECT_PROG`) or a child
 /// stdout pipe (for daemon-over-remote-shell).
 #[cfg(unix)]
-pub(super) enum ProgramReader {
+pub(in crate::client) enum ProgramReader {
     Socket(std::os::unix::net::UnixStream),
     Pipe(std::process::ChildStdout),
 }
@@ -427,7 +427,7 @@ impl Read for ProgramReader {
 /// Either a cloned socketpair end (for `RSYNC_CONNECT_PROG`) or a child
 /// stdin pipe (for daemon-over-remote-shell).
 #[cfg(unix)]
-pub(super) enum ProgramWriter {
+pub(in crate::client) enum ProgramWriter {
     Socket(std::os::unix::net::UnixStream),
     Pipe(std::process::ChildStdin),
 }

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -23,16 +23,19 @@ mod orchestration;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
+use std::ffi::OsStr;
 use std::io::BufReader;
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use engine::batch::BatchWriter;
 
-use super::super::DAEMON_SOCKET_TIMEOUT;
+use super::super::{DAEMON_SOCKET_TIMEOUT, IPC_EXIT_CODE};
 use super::super::config::ClientConfig;
 use super::super::error::{ClientError, invalid_argument_error, socket_error};
 use super::super::module_list::{
-    apply_socket_options, open_daemon_stream, resolve_connect_timeout,
+    DaemonStream, apply_socket_options, open_daemon_stream, resolve_connect_timeout,
 };
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
@@ -219,6 +222,193 @@ pub fn run_daemon_transfer(
         ),
         RemoteRole::Proxy => {
             unreachable!("Proxy transfers via daemon are rejected earlier")
+        }
+    }
+}
+
+/// Executes a daemon transfer tunneled over a remote shell (SSH with `::` syntax).
+///
+/// Mirrors upstream `main.c:1577-1586`: when `-e`/`--rsh` is active with a
+/// double-colon operand, the client spawns the remote shell with
+/// `rsync --server --daemon .` as the remote command, then speaks the
+/// `@RSYNCD:` daemon protocol over the shell's stdio pipes.
+///
+/// This avoids opening a direct TCP connection to the rsync daemon port -
+/// instead the daemon runs on the remote end as a child of the SSH session,
+/// communicating via stdin/stdout.
+#[cfg_attr(
+    feature = "tracing",
+    instrument(skip(config, _observer), name = "daemon_over_remote_shell")
+)]
+pub fn run_daemon_over_remote_shell(
+    config: &ClientConfig,
+    _observer: Option<&mut dyn ClientProgressObserver>,
+    batch_writer: Option<Arc<Mutex<BatchWriter>>>,
+) -> Result<ClientSummary, ClientError> {
+    let args = config.transfer_args();
+    if args.len() < 2 {
+        return Err(invalid_argument_error(
+            "need at least one source and one destination",
+            1,
+        ));
+    }
+
+    let (sources, destination) = args.split_at(args.len() - 1);
+    let destination = &destination[0];
+
+    let transfer_spec = determine_transfer_role(sources, destination)?;
+    let role = transfer_spec.role();
+    let local_paths = match &transfer_spec {
+        TransferSpec::Push { local_sources, .. } => local_sources.clone(),
+        TransferSpec::Pull { local_dest, .. } => vec![local_dest.clone()],
+        TransferSpec::Proxy { .. } => {
+            return Err(invalid_argument_error(
+                "remote-to-remote transfers via daemon-over-remote-shell are not supported",
+                1,
+            ));
+        }
+    };
+
+    let daemon_operand = config
+        .transfer_args()
+        .iter()
+        .find(|arg| arg.to_string_lossy().contains("::"))
+        .ok_or_else(|| invalid_argument_error("no host::module operand found", 1))?;
+    let daemon_operand_str = daemon_operand.to_string_lossy();
+    let request = DaemonTransferRequest::parse_double_colon(&daemon_operand_str)?;
+
+    // upstream: main.c:594-604 - when daemon_connection > 0, the remote
+    // command is `rsync_path --server --daemon .` with no server_options().
+    let shell_args = config.remote_shell().ok_or_else(|| {
+        invalid_argument_error("daemon-over-remote-shell requires -e/--rsh", 1)
+    })?;
+
+    let ssh_program = if shell_args.is_empty() {
+        OsStr::new("ssh")
+    } else {
+        &shell_args[0]
+    };
+    let mut cmd = Command::new(ssh_program);
+
+    for opt in shell_args.iter().skip(1) {
+        cmd.arg(opt);
+    }
+
+    if let Some(bind_addr) = config.bind_address() {
+        cmd.arg("-o")
+            .arg(format!("BindAddress={}", bind_addr.socket().ip()));
+    }
+
+    if let Some(jump) = config.jump_hosts() {
+        cmd.arg("-J").arg(jump);
+    }
+
+    if let Some(timeout) = config.connect_timeout().effective(Duration::from_secs(30)) {
+        cmd.arg("-o")
+            .arg(format!("ConnectTimeout={}", timeout.as_secs()));
+    }
+
+    if let Some(user) = &request.username {
+        cmd.arg("-l").arg(user);
+    }
+
+    cmd.arg(request.address.host());
+
+    let rsync_path = config.rsync_path().unwrap_or(OsStr::new("rsync"));
+    cmd.arg(rsync_path)
+        .arg("--server")
+        .arg("--daemon")
+        .arg(".");
+
+    // upstream: main.c:1571-1572 - set_env_num("RSYNC_PORT", env_port)
+    cmd.env("RSYNC_PORT", request.address.port().to_string());
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        invalid_argument_error(
+            &format!("failed to spawn remote shell for daemon-over-rsh: {e}"),
+            IPC_EXIT_CODE,
+        )
+    })?;
+
+    let stdin = child.stdin.take().ok_or_else(|| {
+        invalid_argument_error(
+            "remote shell process did not expose stdin",
+            IPC_EXIT_CODE,
+        )
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        invalid_argument_error(
+            "remote shell process did not expose stdout",
+            IPC_EXIT_CODE,
+        )
+    })?;
+
+    let stream = DaemonStream::from_child_process(child, stdin, stdout);
+
+    let transfer_timeout = config
+        .timeout()
+        .as_seconds()
+        .map(|s| Duration::from_secs(s.get()));
+    stream
+        .configure_transfer_options(true, transfer_timeout)
+        .map_err(|e| socket_error("configure transfer options on", "remote shell stream", e))?;
+
+    let (reader_half, mut writer_half, guard) = stream
+        .split()
+        .map_err(|e| socket_error("split remote shell stream for", "handshake", e))?;
+    let mut buf_reader = BufReader::new(reader_half);
+
+    let output_motd = !config.no_motd();
+    let protocol = perform_daemon_handshake(
+        &mut buf_reader,
+        &mut writer_half,
+        &request,
+        output_motd,
+        config.daemon_params(),
+        config.early_input(),
+        config.protocol_version(),
+    )?;
+
+    let daemon_is_sender = matches!(role, RemoteRole::Receiver);
+    send_daemon_arguments(
+        &mut writer_half,
+        config,
+        &request,
+        protocol,
+        daemon_is_sender,
+    )?;
+
+    let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
+
+    let buffered = buf_reader.buffer().to_vec();
+    let mut reader_half = buf_reader.into_inner();
+
+    match role {
+        RemoteRole::Receiver => run_pull_transfer(
+            config,
+            &mut reader_half,
+            &mut writer_half,
+            guard,
+            &local_paths,
+            protocol,
+            batch_ctx,
+            buffered,
+        ),
+        RemoteRole::Sender => run_push_transfer(
+            config,
+            &mut reader_half,
+            &mut writer_half,
+            guard,
+            &local_paths,
+            protocol,
+            batch_ctx,
+            buffered,
+        ),
+        RemoteRole::Proxy => {
+            unreachable!("Proxy transfers via daemon-over-remote-shell are rejected earlier")
         }
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -31,7 +31,6 @@ use std::time::Duration;
 
 use engine::batch::BatchWriter;
 
-use super::super::{DAEMON_SOCKET_TIMEOUT, IPC_EXIT_CODE};
 use super::super::config::ClientConfig;
 use super::super::error::{ClientError, invalid_argument_error, socket_error};
 use super::super::module_list::{
@@ -39,6 +38,7 @@ use super::super::module_list::{
 };
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
+use super::super::{DAEMON_SOCKET_TIMEOUT, IPC_EXIT_CODE};
 use super::batch_support::build_batch_context;
 use super::invocation::{RemoteRole, TransferSpec, determine_transfer_role};
 
@@ -279,9 +279,9 @@ pub fn run_daemon_over_remote_shell(
 
     // upstream: main.c:594-604 - when daemon_connection > 0, the remote
     // command is `rsync_path --server --daemon .` with no server_options().
-    let shell_args = config.remote_shell().ok_or_else(|| {
-        invalid_argument_error("daemon-over-remote-shell requires -e/--rsh", 1)
-    })?;
+    let shell_args = config
+        .remote_shell()
+        .ok_or_else(|| invalid_argument_error("daemon-over-remote-shell requires -e/--rsh", 1))?;
 
     let ssh_program = if shell_args.is_empty() {
         OsStr::new("ssh")
@@ -315,10 +315,7 @@ pub fn run_daemon_over_remote_shell(
     cmd.arg(request.address.host());
 
     let rsync_path = config.rsync_path().unwrap_or(OsStr::new("rsync"));
-    cmd.arg(rsync_path)
-        .arg("--server")
-        .arg("--daemon")
-        .arg(".");
+    cmd.arg(rsync_path).arg("--server").arg("--daemon").arg(".");
 
     // upstream: main.c:1571-1572 - set_env_num("RSYNC_PORT", env_port)
     cmd.env("RSYNC_PORT", request.address.port().to_string());
@@ -334,16 +331,10 @@ pub fn run_daemon_over_remote_shell(
     })?;
 
     let stdin = child.stdin.take().ok_or_else(|| {
-        invalid_argument_error(
-            "remote shell process did not expose stdin",
-            IPC_EXIT_CODE,
-        )
+        invalid_argument_error("remote shell process did not expose stdin", IPC_EXIT_CODE)
     })?;
     let stdout = child.stdout.take().ok_or_else(|| {
-        invalid_argument_error(
-            "remote shell process did not expose stdout",
-            IPC_EXIT_CODE,
-        )
+        invalid_argument_error("remote shell process did not expose stdout", IPC_EXIT_CODE)
     })?;
 
     let stream = DaemonStream::from_child_process(child, stdin, stdout);

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -40,7 +40,7 @@ pub use async_ssh_transport::{
     ENV_OPT_IN as ASYNC_SSH_ENV_OPT_IN, is_enabled_by_env as async_ssh_enabled,
     run_async_ssh_transfer,
 };
-pub use daemon_transfer::run_daemon_transfer;
+pub use daemon_transfer::{run_daemon_over_remote_shell, run_daemon_transfer};
 #[cfg(feature = "embedded-ssh")]
 pub(crate) use embedded_ssh_transfer::is_ssh_url;
 #[cfg(feature = "embedded-ssh")]

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -201,6 +201,12 @@ fn run_client_internal(
     });
 
     if has_daemon_url {
+        // upstream: main.c:1571-1586 - when `-e`/`--rsh` is active with `::`,
+        // the client spawns SSH with `rsync --server --daemon .` as the remote
+        // command, then speaks the daemon protocol over the SSH pipes.
+        if config.remote_shell().is_some() {
+            return remote::run_daemon_over_remote_shell(&config, observer, batch_writer);
+        }
         return remote::run_daemon_transfer(&config, observer, batch_writer);
     }
 


### PR DESCRIPTION
## Summary

- Implements `run_daemon_over_remote_shell()` mirroring upstream `main.c:1577-1586` where `-e`/`--rsh` with `::` operands spawns SSH with `rsync --server --daemon .` as the remote command, then speaks `@RSYNCD:` daemon protocol over the SSH stdio pipes
- Adds `DaemonStream::from_child_process()` constructor to wrap SSH child process stdio handles as a daemon transport without exposing private `ConnectProgramStream`
- Routes `::` operands through the remote shell path when `-e` is active in `run/mod.rs`

## Test plan

- [ ] CI passes on all required checks (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] Verify upstream testsuite daemon tests that use `-e` with `::` exercise this path
- [ ] Cross-platform compilation verified (no platform-specific code in new function)