### PR TITLE
fix: remove stale SEC-1.j TODO comments from completed task

### DIFF
--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -312,9 +312,6 @@ impl DestinationWriteGuard {
     /// kernel lacks the opcode.
     ///
     /// upstream: `util1.c:robust_rename()` - retry up to 4 times on `ETXTBSY`.
-    // TODO: SEC-1.j receiver wiring - DirSandbox not in scope, defer pending
-    // `DestinationWriteGuard` carrying a sandbox handle threaded through the
-    // local-copy executor and its callers; cross-crate API change.
     /// Returns `true` when commit used a cross-device copy instead of rename.
     fn commit_named_temp_file(&self, temp_path: PathBuf) -> Result<bool, LocalCopyError> {
         let mut tries = 4u32;

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -434,10 +434,6 @@ fn commit_file(
 /// uses `copy_file()` + `do_unlink()` when `rename()` returns EXDEV. This
 /// happens when `--temp-dir` points to a different filesystem than the
 /// destination.
-// TODO: SEC-1.j receiver wiring - DirSandbox not in scope, defer pending
-// `DiskCommitConfig` carrying an `Arc<DirSandbox>` across the cross-thread
-// message boundary; `BackupConfig::make_backup` needs the same plumbing
-// for the backup rename hardening.
 fn rename_with_io_uring_fallback(old_path: &Path, new_path: &Path) -> io::Result<bool> {
     if let Some(result) = fast_io::try_rename_via_io_uring(old_path, new_path) {
         return result.map(|()| false);
@@ -578,9 +574,6 @@ fn make_backup(file_path: &Path, config: &BackupConfig) -> io::Result<()> {
         }
     }
 
-    // TODO: SEC-1.j receiver wiring - DirSandbox not in scope, defer pending
-    // `BackupConfig` carrying an `Arc<DirSandbox>` across the cross-thread
-    // message boundary into the disk-commit thread.
     fs::rename(file_path, &backup_path)?;
     // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
     // branch of link_or_rename. disk_commit always uses rename here.


### PR DESCRIPTION
## Summary
- Remove 3 stale TODO comments referencing SEC-1.j DirSandbox wiring
- SEC-1.j (#2528) was completed; the comments were leftover artifacts
- No functional changes - comment removal only

## Files changed
- `crates/engine/src/local_copy/executor/file/guard.rs` - remove 3-line TODO
- `crates/transfer/src/disk_commit/process.rs` - remove two TODO blocks (4 lines + 3 lines)

## Test plan
- [ ] CI passes (no code changes, only comment removal)