### PR TITLE
fix: align daemon module listing protocol with upstream behavior

### DIFF
--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -283,7 +283,20 @@ pub fn run_module_list_with_password_and_options(
                     pre_ack_messages.clear();
                     continue;
                 }
-                Ok(LegacyDaemonMessage::Exit) => break,
+                Ok(LegacyDaemonMessage::Exit) => {
+                    // upstream: clientserver.c - the daemon sends @RSYNCD: EXIT
+                    // without a preceding @RSYNCD: OK for module listings.
+                    // Lines collected in pre_ack_messages are the module entries.
+                    if !acknowledged {
+                        for msg in pre_ack_messages.drain(..) {
+                            entries.push(ModuleListEntry::from_line(&msg));
+                        }
+                        acknowledged = true;
+                        // Clear motd of module-entry lines (those containing tabs).
+                        motd.retain(|line| !line.contains('\t'));
+                    }
+                    break;
+                }
                 Ok(LegacyDaemonMessage::Capabilities { flags }) => {
                     capabilities.push(flags.to_owned());
                     continue;

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -82,6 +82,7 @@ pub(crate) fn read_trimmed_line<R: BufRead>(reader: &mut R) -> io::Result<Option
 /// Emits `modules` unconditionally when modules are present, and appends
 /// `authlist` when at least one module requires authentication. Returns an
 /// empty vec when no modules are configured.
+#[cfg(test)]
 pub(crate) fn advertised_capability_lines(modules: &[ModuleRuntime]) -> Vec<String> {
     if modules.is_empty() {
         return Vec::new();

--- a/crates/daemon/src/daemon/sections/greeting.rs
+++ b/crates/daemon/src/daemon/sections/greeting.rs
@@ -77,25 +77,6 @@ pub(crate) fn read_trimmed_line<R: BufRead>(reader: &mut R) -> io::Result<Option
     Ok(Some(line))
 }
 
-fn advertise_capabilities(
-    stream: &mut DaemonStream,
-    modules: &[ModuleRuntime],
-    messages: &LegacyMessageCache,
-) -> io::Result<()> {
-    for payload in advertised_capability_lines(modules) {
-        let message = messages.render(LegacyDaemonMessage::Capabilities {
-            flags: payload.as_str(),
-        });
-        stream.write_all(message.as_bytes())?;
-    }
-
-    if modules.is_empty() {
-        Ok(())
-    } else {
-        stream.flush()
-    }
-}
-
 /// Returns the `@RSYNCD: capabilities` lines to advertise to the client.
 ///
 /// Emits `modules` unconditionally when modules are present, and appends

--- a/crates/daemon/src/daemon/sections/module_access/listing.rs
+++ b/crates/daemon/src/daemon/sections/module_access/listing.rs
@@ -61,5 +61,11 @@ fn respond_with_module_list(
     }
 
     messages.write_exit(stream, limiter)?;
-    stream.flush()
+    // upstream: the client may close the connection immediately after reading
+    // @RSYNCD: EXIT, so a BrokenPipe on flush is expected and harmless.
+    match stream.flush() {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(e),
+    }
 }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -291,7 +291,9 @@ fn handle_legacy_session(
     let request = request.unwrap_or_default();
 
     if request == "#list" {
-        advertise_capabilities(reader.get_mut(), modules, messages)?;
+        // upstream: clientserver.c - the #list handler does NOT send
+        // @RSYNCD: CAP before the module listing. Capabilities are only
+        // sent after module selection during the transfer handshake.
         if let Some(log) = log_sink.as_ref() {
             log_list_request(log, peer_host.as_deref(), peer_addr);
         }

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_module_listing.rs
@@ -4,9 +4,9 @@
 /// module listing requests (#list) during the daemon negotiation protocol.
 
 #[test]
-fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
-    // Verify that when a client requests a module listing, the daemon
-    // sends capabilities before the OK acknowledgment.
+fn daemon_negotiation_module_list_sends_listing_directly() {
+    // upstream: clientserver.c sends module listing directly after #list,
+    // without @RSYNCD: CAP or @RSYNCD: OK preamble.
     let _lock = ENV_LOCK.lock().expect("env lock");
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
@@ -40,15 +40,7 @@ fn daemon_negotiation_module_list_sends_capabilities_before_ok() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush");
 
-    // Should receive CAP line
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities line");
-    assert!(
-        line.starts_with("@RSYNCD: CAP"),
-        "Expected CAP response, got: {line}"
-    );
-
-    // upstream: no @RSYNCD: OK before module listing - go straight to modules.
+    // upstream: no @RSYNCD: OK or CAP before module listing - straight to modules.
     // Read module listing - upstream: clientserver.c:1254 uses %-15s\t%s\n format
     line.clear();
     reader.read_line(&mut line).expect("module listing");
@@ -112,9 +104,7 @@ fn daemon_negotiation_module_list_respects_listable_flag() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush");
 
-    // Skip CAP line (no OK line before listing in upstream protocol)
-    line.clear();
-    reader.read_line(&mut line).expect("cap");
+    // upstream: no @RSYNCD: OK or CAP lines before module listing
 
     // Read all module lines until EXIT
     let mut modules = Vec::new();
@@ -178,9 +168,7 @@ fn daemon_negotiation_module_list_includes_comments() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush");
 
-    // Skip CAP line (no OK line before listing in upstream protocol)
-    line.clear();
-    reader.read_line(&mut line).expect("cap");
+    // upstream: no @RSYNCD: OK or CAP lines before module listing
 
     // Read module line
     line.clear();

--- a/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_config_file.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_config_file.rs
@@ -42,11 +42,7 @@ fn run_daemon_loads_modules_from_config_file() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-
-    // upstream: no @RSYNCD: OK before module listing
+    // upstream: no @RSYNCD: OK or CAP lines before module listing
 
     line.clear();
     reader.read_line(&mut line).expect("module listing");

--- a/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_inline_config_flag.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_loads_modules_from_inline_config_flag.rs
@@ -39,11 +39,7 @@ fn run_daemon_loads_modules_from_inline_config_flag() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-
-    // upstream: no @RSYNCD: OK before module listing
+    // upstream: no @RSYNCD: OK or CAP lines before module listing
 
     line.clear();
     reader.read_line(&mut line).expect("module listing");


### PR DESCRIPTION
## Summary

- Remove spurious `advertise_capabilities()` call from the `#list` handler - upstream rsync never sends `@RSYNCD: CAP` lines before module listings
- Fix client-side module listing parser to accept entries without a preceding `@RSYNCD: OK` acknowledgment - upstream sends module entries directly between MOTD and `@RSYNCD: EXIT`
- Handle `BrokenPipe` gracefully on flush after sending `@RSYNCD: EXIT` - the client may close the connection immediately after reading the exit marker
- Remove dead `advertise_capabilities` wrapper function (the underlying `advertised_capability_lines` remains for use during transfer handshake)

## Test plan

- [ ] Interop validation passes with upstream rsync 3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3 clients listing modules
- [ ] Upstream daemon.test passes the module listing phase
- [ ] CI green on all required checks