### PR TITLE
fix: remove erroneous CAP assertion from daemon config test

### DIFF
--- a/crates/daemon/src/tests/chunks/run_daemon_config_flag_overrides_default_path.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_config_flag_overrides_default_path.rs
@@ -53,23 +53,14 @@ fn run_daemon_config_flag_overrides_default_path() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    // Read capabilities
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
+    // upstream: no @RSYNCD: OK or CAP lines before module listing
 
-    // upstream: no @RSYNCD: OK before module listing
-
-    // Verify the custom module appears in the listing
+    // upstream: clientserver.c:1254 uses %-15s\t%s\n format
     line.clear();
     reader.read_line(&mut line).expect("module listing");
-    assert!(
-        line.contains("custom_share"),
-        "expected module 'custom_share' in listing, got: {line}"
-    );
-    assert!(
-        line.contains("Custom config test"),
-        "expected comment 'Custom config test' in listing, got: {line}"
+    assert_eq!(
+        line, "custom_share   \tCustom config test\n",
+        "Expected %-15s aligned module with comment, got: {line}"
     );
 
     // Read exit


### PR DESCRIPTION
## Summary
- Remove incorrect `@RSYNCD: CAP modules` assertion from `run_daemon_config_flag_overrides_default_path` test
- The daemon sends module listing directly after `#list` with no CAP preamble (matching upstream `clientserver.c` behavior)
- Tighten module listing assertion to exact `%-15s\t%s\n` format matching all other daemon listing tests
- Fixes 4 Windows feature-flag-combination CI failures (daemon-tls, concurrent-sessions, tracing, async)

## Test plan
- [ ] All 4 Windows feature-flag-combination jobs pass (daemon-tls, concurrent-sessions, tracing, async)
- [ ] Required CI checks remain green (fmt+clippy, nextest, Windows/macOS/musl)