### PR TITLE
fix: remove erroneous CAP assertion from daemon filter list test

### DIFF
--- a/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_enforces_bwlimit_during_module_list.rs
@@ -43,11 +43,6 @@ fn run_daemon_enforces_bwlimit_during_module_list() {
 
     let mut total_bytes = 0usize;
 
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-    total_bytes += line.len();
-
     // upstream: no @RSYNCD: OK before module listing
 
     line.clear();

--- a/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_filters_modules_during_list_request.rs
@@ -39,12 +39,6 @@ fn run_daemon_filters_modules_during_list_request() {
     stream.flush().expect("flush list request");
 
     line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-
-    // upstream: no @RSYNCD: OK before module listing
-
-    line.clear();
     reader.read_line(&mut line).expect("public module");
     assert_eq!(line, "public         \t\n");
 

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_on_request.rs
@@ -31,10 +31,6 @@ fn run_daemon_lists_modules_on_request() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-
     // upstream: no @RSYNCD: OK before module listing
 
     line.clear();

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_motd_lines.rs
@@ -41,10 +41,6 @@ fn run_daemon_lists_modules_with_motd_lines() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-
     // upstream: MOTD lines are sent as raw text, not wrapped in @RSYNCD: MOTD
     line.clear();
     reader.read_line(&mut line).expect("motd line 1");

--- a/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs
@@ -38,10 +38,6 @@ fn run_daemon_omits_unlisted_modules_from_listing() {
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert_eq!(line, "@RSYNCD: CAP modules\n");
-
     // upstream: no @RSYNCD: OK before module listing
 
     line.clear();


### PR DESCRIPTION
## Summary

- Remove incorrect `@RSYNCD: CAP modules` assertion from `run_daemon_filters_modules_during_list_request` test
- Upstream rsync sends module listing lines directly after `#list` request with no CAP preamble
- Same class of fix as #5367 which corrected the identical bug in `run_daemon_config_flag_overrides_default_path`
- Fixes all 4 "Feature flag combinations" CI failures on windows-latest (async, tracing, daemon-tls, concurrent-sessions)

## Test plan

- [ ] All 6 required CI checks pass (fmt+clippy, nextest, Windows, macOS, Linux musl, interop)
- [ ] All 4 Feature flag combination jobs pass on windows-latest