### PR TITLE
style: comment cleanup for daemon crate

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -272,7 +272,6 @@ impl SecretsFile {
         for raw_line in content.lines() {
             let line = raw_line.trim_end_matches('\r');
 
-            // Skip empty lines and comments
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -372,7 +372,6 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
         i += 1;
     }
 
-    // Push the last token
     let token = s[start..].trim();
     if !token.is_empty() {
         tokens.push(token.to_string());

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -691,7 +691,6 @@ fn process_approved_module(
         pid: std::process::id(),
     };
 
-    // Run pre-xfer exec if configured
     // upstream: clientserver.c - pre_exec() runs before the transfer starts.
     // Early-input data (if any) is piped to the script's stdin.
     if let Some(command) = module.pre_xfer_exec.as_deref().filter(|_| xfer_exec_enabled()) {
@@ -776,7 +775,6 @@ fn process_approved_module(
         let _ = ctx.reader.get_mut().shutdown(std::net::Shutdown::Write);
     }
 
-    // Run post-xfer exec if configured
     // upstream: clientserver.c - post_exec() runs after the transfer, regardless of outcome
     if let Some(command) = module.post_xfer_exec.as_deref().filter(|_| xfer_exec_enabled()) {
         let expanded_command = expand_exec_command(command, &exec_path_ctx);


### PR DESCRIPTION
## Summary

- Remove restatement comments that echo what the code already says across 3 files in the daemon crate
- All upstream rsync source references, SAFETY blocks, and non-obvious "why" comments are preserved
- 4 lines removed total (no logic changes)

### Changes

- `auth.rs`: Remove `// Skip empty lines and comments` above `if line.is_empty() || line.starts_with('#')`
- `helpers.rs`: Remove `// Push the last token` above `let token = s[start..].trim()`
- `transfer.rs`: Remove `// Run pre-xfer exec if configured` and `// Run post-xfer exec if configured` - the upstream reference comments immediately following these lines already provide sufficient context

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] No logic changes - comment-only deletions