### PR TITLE
style: comment cleanup for transfer crate

### DIFF
--- a/crates/transfer/src/generator/entry_accessor.rs
+++ b/crates/transfer/src/generator/entry_accessor.rs
@@ -26,10 +26,6 @@ use protocol::flist::FileEntryAccessor;
 use super::item_flags::ItemFlags;
 use super::itemize::ItemizeContext;
 
-// ---------------------------------------------------------------------------
-// Itemize formatting
-// ---------------------------------------------------------------------------
-
 /// Formats the 11-character itemize string from raw item flags and any entry type.
 ///
 /// Generic counterpart of [`super::itemize::format_iflags`] that accepts any
@@ -227,10 +223,6 @@ pub fn format_itemize_line_generic<T: FileEntryAccessor>(
     format!("{iflags_str} {name}{link_target}\n")
 }
 
-// ---------------------------------------------------------------------------
-// Quick-check
-// ---------------------------------------------------------------------------
-
 /// Pure-function quick-check over any `FileEntryAccessor`.
 ///
 /// Generic counterpart of [`super::super::receiver::quick_check::quick_check_matches`].
@@ -320,10 +312,6 @@ pub fn dest_mtime_newer_generic<T: FileEntryAccessor>(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Hardlink detection
-// ---------------------------------------------------------------------------
-
 /// Returns true if this entry is a hardlink follower via `FileEntryAccessor`.
 ///
 /// Generic counterpart of the concrete `is_hardlink_follower` in
@@ -338,10 +326,6 @@ pub fn dest_mtime_newer_generic<T: FileEntryAccessor>(
 pub fn is_hardlink_follower_generic<T: FileEntryAccessor>(entry: &T) -> bool {
     entry.flags().hlinked() && !entry.flags().hlink_first()
 }
-
-// ---------------------------------------------------------------------------
-// Internal helper (shared with concrete quick_check)
-// ---------------------------------------------------------------------------
 
 /// Computes a file's checksum and compares it against an expected value.
 ///
@@ -378,10 +362,6 @@ fn file_checksum_matches(
     let cmp_len = expected.len().min(len);
     digest[..cmp_len] == expected[..cmp_len]
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {

--- a/crates/transfer/src/generator/sender_accessor.rs
+++ b/crates/transfer/src/generator/sender_accessor.rs
@@ -256,10 +256,6 @@ pub fn should_skip_entry<T: FileEntryAccessor>(entry: &T) -> bool {
     !entry.is_file()
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(all(test, feature = "flat-flist"))]
 mod tests {
     use protocol::flist::{FileEntry, FileEntryAccessor};

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2898,10 +2898,6 @@ fn server_mode_flushes_writer_before_filter_list_read() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// INC_RECURSE SegmentScheduler regression tests
-// ---------------------------------------------------------------------------
-
 #[test]
 fn segment_scheduler_dispatches_when_remaining_below_threshold() {
     // When remaining entries known to the receiver are below

--- a/crates/transfer/src/receiver/entry_accessor.rs
+++ b/crates/transfer/src/receiver/entry_accessor.rs
@@ -190,10 +190,6 @@ fn file_checksum_matches(
     digest[..cmp_len] == expected[..cmp_len]
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use protocol::flist::FileEntry;

--- a/crates/transfer/src/tests/transfer_pipeline_wiring.rs
+++ b/crates/transfer/src/tests/transfer_pipeline_wiring.rs
@@ -9,10 +9,6 @@
 use crate::role::ServerRole;
 use crate::transfer_state::{TransferPhase, TransferPipeline};
 
-// ---------------------------------------------------------------------------
-// Pipeline initialization
-// ---------------------------------------------------------------------------
-
 #[test]
 fn pipeline_for_receiver_starts_at_handshake() {
     let pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -26,10 +22,6 @@ fn pipeline_for_generator_starts_at_handshake() {
     assert_eq!(pipeline.phase(), TransferPhase::Handshake);
     assert_eq!(pipeline.role(), ServerRole::Generator);
 }
-
-// ---------------------------------------------------------------------------
-// Orchestration-level transition sequence (mirrors run_server_with_handshake)
-// ---------------------------------------------------------------------------
 
 #[test]
 fn orchestration_advances_handshake_to_filter_exchange() {
@@ -107,10 +99,6 @@ fn generator_lifecycle_matches_orchestration_phases() {
     assert!(pipeline.is_complete());
 }
 
-// ---------------------------------------------------------------------------
-// Invalid transition enforcement
-// ---------------------------------------------------------------------------
-
 #[test]
 fn skipping_filter_exchange_is_rejected() {
     let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -150,10 +138,6 @@ fn advancing_past_complete_is_rejected() {
     let err = pipeline.advance().unwrap_err();
     assert_eq!(err.current, TransferPhase::Complete);
 }
-
-// ---------------------------------------------------------------------------
-// Sole state authority (FSW-7 audit)
-// ---------------------------------------------------------------------------
 
 /// Confirms that `TransferPipeline` is the sole mechanism for tracking the
 /// transfer lifecycle. No ad-hoc booleans, phase counters, or state strings
@@ -218,10 +202,6 @@ fn transfer_pipeline_is_sole_lifecycle_authority() {
     assert!(pipeline.is_complete());
 }
 
-// ---------------------------------------------------------------------------
-// fsm_error conversion
-// ---------------------------------------------------------------------------
-
 #[test]
 fn fsm_error_produces_io_error() {
     let err = crate::transfer_state::InvalidTransition {
@@ -240,10 +220,6 @@ fn fsm_error_produces_io_error() {
         "error should mention target phase: {msg}"
     );
 }
-
-// ---------------------------------------------------------------------------
-// Test helper validation
-// ---------------------------------------------------------------------------
 
 #[test]
 fn receiver_new_for_test_starts_at_filter_exchange() {
@@ -300,10 +276,6 @@ fn generator_new_for_test_starts_at_filter_exchange() {
     assert_eq!(ctx.protocol().as_u8(), 32);
 }
 
-// ---------------------------------------------------------------------------
-// Extended edge cases: skip rejection at every orchestration boundary
-// ---------------------------------------------------------------------------
-
 #[test]
 fn skipping_file_list_transfer_is_rejected() {
     let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -342,10 +314,6 @@ fn skipping_finalization_is_rejected() {
     assert_eq!(pipeline.phase(), TransferPhase::DeltaTransfer);
 }
 
-// ---------------------------------------------------------------------------
-// Extended edge cases: backward rejection at additional boundaries
-// ---------------------------------------------------------------------------
-
 #[test]
 fn backward_from_complete_to_finalization_is_rejected() {
     let mut pipeline = TransferPipeline::new(ServerRole::Generator);
@@ -369,10 +337,6 @@ fn backward_from_finalization_to_handshake_is_rejected() {
     assert_eq!(err.target, TransferPhase::Handshake);
     assert_eq!(pipeline.phase(), TransferPhase::Finalization);
 }
-
-// ---------------------------------------------------------------------------
-// Self-transition rejection at orchestration-relevant phases
-// ---------------------------------------------------------------------------
 
 #[test]
 fn self_transition_at_filter_exchange_is_rejected() {
@@ -399,10 +363,6 @@ fn self_transition_at_delta_transfer_is_rejected() {
     assert_eq!(err.target, TransferPhase::DeltaTransfer);
     assert_eq!(pipeline.phase(), TransferPhase::DeltaTransfer);
 }
-
-// ---------------------------------------------------------------------------
-// State preservation: pipeline is not mutated on failed advance
-// ---------------------------------------------------------------------------
 
 #[test]
 fn failed_advance_to_preserves_state() {
@@ -433,10 +393,6 @@ fn failed_advance_from_complete_preserves_state() {
     assert!(pipeline.is_complete());
 }
 
-// ---------------------------------------------------------------------------
-// Both roles traverse the same state sequence
-// ---------------------------------------------------------------------------
-
 #[test]
 fn both_roles_have_identical_phase_sequence() {
     let phases = [
@@ -458,10 +414,6 @@ fn both_roles_have_identical_phase_sequence() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// is_complete is false for all non-terminal phases
-// ---------------------------------------------------------------------------
-
 #[test]
 fn is_complete_false_for_all_non_terminal_phases() {
     let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -480,10 +432,6 @@ fn is_complete_false_for_all_non_terminal_phases() {
     pipeline.advance_to(TransferPhase::Complete).unwrap();
     assert!(pipeline.is_complete());
 }
-
-// ---------------------------------------------------------------------------
-// advance_through in orchestration context
-// ---------------------------------------------------------------------------
 
 #[test]
 fn advance_through_multiple_phases_is_valid() {
@@ -512,10 +460,6 @@ fn advance_through_backward_from_mid_pipeline_is_rejected() {
     assert_eq!(pipeline.phase(), TransferPhase::DeltaTransfer);
 }
 
-// ---------------------------------------------------------------------------
-// fsm_error conversion edge cases
-// ---------------------------------------------------------------------------
-
 #[test]
 fn fsm_error_forward_skip_produces_io_error() {
     let err = crate::transfer_state::InvalidTransition {
@@ -539,10 +483,6 @@ fn fsm_error_self_transition_produces_io_error() {
     assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
     assert!(io_err.to_string().contains("complete"));
 }
-
-// ---------------------------------------------------------------------------
-// Generator-specific invalid transitions mirror receiver rejections
-// ---------------------------------------------------------------------------
 
 #[test]
 fn generator_skipping_filter_exchange_is_rejected() {

--- a/crates/transfer/src/transfer_state.rs
+++ b/crates/transfer/src/transfer_state.rs
@@ -273,10 +273,6 @@ impl TransferPipeline {
 mod tests {
     use super::*;
 
-    // -----------------------------------------------------------------------
-    // TransferPhase unit tests
-    // -----------------------------------------------------------------------
-
     #[test]
     fn phase_ordinals_are_monotonically_increasing() {
         let phases = [
@@ -362,10 +358,6 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
-    // TransferPipeline - construction
-    // -----------------------------------------------------------------------
-
     #[test]
     fn new_pipeline_starts_at_handshake() {
         let pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -381,10 +373,6 @@ mod tests {
         let generator = TransferPipeline::new(ServerRole::Generator);
         assert_eq!(generator.role(), ServerRole::Generator);
     }
-
-    // -----------------------------------------------------------------------
-    // TransferPipeline::advance - happy path
-    // -----------------------------------------------------------------------
 
     #[test]
     fn advance_walks_through_all_phases() {
@@ -417,10 +405,6 @@ mod tests {
         assert_eq!(err.current, TransferPhase::Complete);
     }
 
-    // -----------------------------------------------------------------------
-    // TransferPipeline::advance_to - valid single-step transitions
-    // -----------------------------------------------------------------------
-
     #[test]
     fn advance_to_each_successor_succeeds() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -442,10 +426,6 @@ mod tests {
         pipeline.advance_to(TransferPhase::Complete).unwrap();
         assert_eq!(pipeline.phase(), TransferPhase::Complete);
     }
-
-    // -----------------------------------------------------------------------
-    // TransferPipeline::advance_to - invalid transitions
-    // -----------------------------------------------------------------------
 
     #[test]
     fn advance_to_same_phase_is_invalid() {
@@ -489,10 +469,6 @@ mod tests {
         let err = pipeline.advance_to(TransferPhase::Handshake).unwrap_err();
         assert_eq!(err.current, TransferPhase::Complete);
     }
-
-    // -----------------------------------------------------------------------
-    // TransferPipeline::advance_through
-    // -----------------------------------------------------------------------
 
     #[test]
     fn advance_through_multi_step_succeeds() {
@@ -544,10 +520,6 @@ mod tests {
         assert_eq!(pipeline.phase(), TransferPhase::DeltaTransfer);
     }
 
-    // -----------------------------------------------------------------------
-    // Full happy-path lifecycle
-    // -----------------------------------------------------------------------
-
     #[test]
     fn full_lifecycle_receiver() {
         let mut pipeline = TransferPipeline::new(ServerRole::Receiver);
@@ -586,10 +558,6 @@ mod tests {
         assert!(pipeline.is_complete());
         assert_eq!(pipeline.role(), ServerRole::Generator);
     }
-
-    // -----------------------------------------------------------------------
-    // Edge cases and error message quality
-    // -----------------------------------------------------------------------
 
     #[test]
     fn double_advance_to_same_target_fails() {


### PR DESCRIPTION
## Summary

- Removed 124 lines of decorative banner/divider comments (`// -----`) across 6 files in the transfer crate
- No code logic changes - comment-only cleanup

## Files Changed

- `generator/entry_accessor.rs` - removed 5 section banners (Itemize formatting, Quick-check, Hardlink detection, Internal helper, Tests)
- `generator/sender_accessor.rs` - removed 1 section banner (Tests)
- `generator/tests.rs` - removed 1 section banner (INC_RECURSE SegmentScheduler regression tests)
- `receiver/entry_accessor.rs` - removed 1 section banner (Tests)
- `tests/transfer_pipeline_wiring.rs` - removed 15 section banners (Pipeline initialization, Orchestration-level transition sequence, Invalid transition enforcement, Sole state authority, fsm_error conversion, Test helper validation, Extended edge cases, Self-transition rejection, State preservation, Both roles traverse, is_complete, advance_through, fsm_error edge cases, Generator-specific invalid transitions)
- `transfer_state.rs` - removed 8 section banners in test module

## What Was Preserved

- All upstream rsync source references (`// upstream:`)
- All `// SAFETY:` blocks
- All comments explaining non-obvious behavior
- All rustdoc comments (`///` and `//!`)

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)