### PR TITLE
feat: wire CleanupManager into receiver pipeline temp file sites

### DIFF
--- a/crates/core/src/signal/cleanup.rs
+++ b/crates/core/src/signal/cleanup.rs
@@ -1,7 +1,7 @@
 //! Cleanup coordination for temporary files and resources.
 //!
-//! This module re-exports [`engine::CleanupManager`] so that both `core` and
-//! `transfer` (which cannot depend on `core` due to the circular dependency)
-//! share a single process-wide cleanup registry through the `engine` crate.
+//! Re-exports [`engine::CleanupManager`] so that both `core` and `transfer`
+//! share a single global registry. The canonical implementation lives in
+//! `engine::util::cleanup`.
 
 pub use engine::CleanupManager;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -244,6 +244,11 @@ pub use walk::{DirectoryWalker, FilteredWalker, WalkConfig, WalkEntry, WalkError
 /// remains valid after a panicking thread is unwound.
 pub use util::poison::{lock_or_recover, read_or_recover, write_or_recover};
 
+/// Global cleanup manager for tracking and removing stale temp files on
+/// abnormal exit. Used by the transfer pipeline to register temp files
+/// before writing and unregister them after a successful commit/rename.
+pub use util::cleanup::CleanupManager;
+
 /// Async I/O operations (available with `async` feature).
 #[cfg(feature = "async")]
 pub use async_io::{AsyncBatchCopier, AsyncFileCopier, AsyncIoError, CopyProgress, CopyResult};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -192,9 +192,6 @@ pub use concurrent_delta::{
     WholeFileStrategy,
 };
 
-/// Global cleanup registry for temporary files on abnormal termination.
-pub use cleanup::CleanupManager;
-
 /// Common error types for engine operations.
 pub use error::{EngineError, EngineResult};
 

--- a/crates/engine/src/util/cleanup.rs
+++ b/crates/engine/src/util/cleanup.rs
@@ -1,0 +1,347 @@
+//! Cleanup coordination for temporary files and resources.
+//!
+//! Provides a global cleanup manager that tracks temporary files, partial
+//! transfers, and other resources that need cleanup on shutdown or error.
+//! Signal handlers and RAII guards in the `transfer` and `core` crates use
+//! this registry to ensure stale temp files are removed on abnormal exit.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// Global cleanup manager instance.
+static CLEANUP_MANAGER: OnceLock<Mutex<CleanupManagerState>> = OnceLock::new();
+
+/// Cleanup manager for tracking and cleaning up temporary resources.
+///
+/// This type provides a global registry for temporary files and resources
+/// that should be cleaned up on shutdown or error. It works with signal
+/// handlers and RAII guards to ensure stale temp files are removed.
+///
+/// # Thread Safety
+///
+/// All methods are thread-safe and can be called from multiple threads
+/// simultaneously. The internal state is protected by a mutex.
+///
+/// # Examples
+///
+/// ```
+/// use engine::CleanupManager;
+/// use std::path::PathBuf;
+///
+/// // Register a temp file for cleanup
+/// let temp_file = PathBuf::from("/tmp/rsync.12345.tmp");
+/// CleanupManager::global().register_temp_file(temp_file.clone());
+///
+/// // Do work...
+///
+/// // If successful, unregister so it's not cleaned up
+/// CleanupManager::global().unregister_temp_file(&temp_file);
+///
+/// // Or if there's an error, cleanup all registered files
+/// // CleanupManager::global().cleanup();
+/// ```
+#[derive(Debug)]
+pub struct CleanupManager;
+
+impl CleanupManager {
+    /// Returns a reference to the global cleanup manager.
+    ///
+    /// This is the primary entry point for cleanup operations.
+    #[must_use]
+    pub fn global() -> &'static Self {
+        let _ = CLEANUP_MANAGER.get_or_init(|| Mutex::new(CleanupManagerState::new()));
+        &CLEANUP_MANAGER_INSTANCE
+    }
+
+    /// Registers a temporary file for cleanup.
+    ///
+    /// The file will be deleted when [`cleanup`](Self::cleanup) or
+    /// [`cleanup_temp_files`](Self::cleanup_temp_files) is called,
+    /// unless it is unregistered first.
+    pub fn register_temp_file(&self, path: PathBuf) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.temp_files.insert(path);
+            }
+        }
+    }
+
+    /// Unregisters a temporary file from cleanup.
+    ///
+    /// Call this when a temporary file has been successfully committed
+    /// (renamed to its final destination) and should not be deleted
+    /// during cleanup.
+    pub fn unregister_temp_file(&self, path: &Path) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.temp_files.remove(path);
+            }
+        }
+    }
+
+    /// Registers a cleanup callback to run on shutdown.
+    ///
+    /// The callback will be executed when [`cleanup`](Self::cleanup) is called.
+    /// Callbacks are run in reverse order of registration (LIFO).
+    pub fn register_cleanup(&self, callback: Box<dyn FnOnce() + Send>) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.cleanup_callbacks.push(callback);
+            }
+        }
+    }
+
+    /// Performs cleanup of all registered resources.
+    ///
+    /// This method:
+    /// 1. Runs all registered cleanup callbacks in reverse order (LIFO)
+    /// 2. Deletes all registered temporary files
+    /// 3. Clears all registered resources
+    ///
+    /// Cleanup errors are logged but do not prevent other cleanup from proceeding.
+    pub fn cleanup(&self) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.cleanup();
+            }
+        }
+    }
+
+    /// Cleans up only the registered temporary files.
+    ///
+    /// Similar to [`cleanup`](Self::cleanup) but only removes temporary files,
+    /// without running cleanup callbacks.
+    pub fn cleanup_temp_files(&self) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.cleanup_temp_files();
+            }
+        }
+    }
+
+    /// Returns the number of registered temporary files.
+    ///
+    /// Primarily useful for testing and diagnostics.
+    #[must_use]
+    pub fn temp_file_count(&self) -> usize {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(state) = state.lock() {
+                return state.temp_files.len();
+            }
+        }
+        0
+    }
+
+    /// Clears all registered resources without performing cleanup.
+    ///
+    /// Primarily useful for testing.
+    #[doc(hidden)]
+    pub fn reset_for_testing(&self) {
+        if let Some(state) = CLEANUP_MANAGER.get() {
+            if let Ok(mut state) = state.lock() {
+                state.temp_files.clear();
+                state.cleanup_callbacks.clear();
+            }
+        }
+    }
+}
+
+/// Singleton instance of the cleanup manager.
+static CLEANUP_MANAGER_INSTANCE: CleanupManager = CleanupManager;
+
+/// Internal state for the cleanup manager.
+struct CleanupManagerState {
+    temp_files: HashSet<PathBuf>,
+    cleanup_callbacks: Vec<Box<dyn FnOnce() + Send>>,
+}
+
+impl CleanupManagerState {
+    fn new() -> Self {
+        Self {
+            temp_files: HashSet::new(),
+            cleanup_callbacks: Vec::new(),
+        }
+    }
+
+    fn cleanup(&mut self) {
+        while let Some(callback) = self.cleanup_callbacks.pop() {
+            callback();
+        }
+
+        self.cleanup_temp_files();
+    }
+
+    fn cleanup_temp_files(&mut self) {
+        for path in &self.temp_files {
+            let _ = std::fs::remove_file(path);
+        }
+        self.temp_files.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tempfile::tempdir;
+
+    // Global lock to serialize tests that use the global CleanupManager
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    #[test]
+    fn register_and_unregister_temp_file() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let path = PathBuf::from("/tmp/test_register_unregister.tmp");
+
+        manager.register_temp_file(path.clone());
+        assert_eq!(manager.temp_file_count(), 1);
+
+        manager.unregister_temp_file(&path);
+        assert_eq!(manager.temp_file_count(), 0);
+    }
+
+    #[test]
+    fn cleanup_temp_files_removes_files() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let dir = tempdir().expect("tempdir");
+        let path1 = dir.path().join("test1_cleanup.tmp");
+        let path2 = dir.path().join("test2_cleanup.tmp");
+
+        fs::write(&path1, b"data1").expect("write file 1");
+        fs::write(&path2, b"data2").expect("write file 2");
+
+        manager.register_temp_file(path1.clone());
+        manager.register_temp_file(path2.clone());
+
+        assert!(path1.exists());
+        assert!(path2.exists());
+        assert_eq!(manager.temp_file_count(), 2);
+
+        manager.cleanup_temp_files();
+
+        assert!(!path1.exists());
+        assert!(!path2.exists());
+        assert_eq!(manager.temp_file_count(), 0);
+    }
+
+    #[test]
+    fn cleanup_temp_files_ignores_nonexistent() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let path = PathBuf::from("/tmp/nonexistent_test.tmp");
+        manager.register_temp_file(path);
+
+        manager.cleanup_temp_files();
+        assert_eq!(manager.temp_file_count(), 0);
+    }
+
+    #[test]
+    fn cleanup_callbacks_run_in_reverse_order() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let order1 = Arc::clone(&order);
+        manager.register_cleanup(Box::new(move || {
+            order1.lock().unwrap().push(1);
+        }));
+
+        let order2 = Arc::clone(&order);
+        manager.register_cleanup(Box::new(move || {
+            order2.lock().unwrap().push(2);
+        }));
+
+        let order3 = Arc::clone(&order);
+        manager.register_cleanup(Box::new(move || {
+            order3.lock().unwrap().push(3);
+        }));
+
+        manager.cleanup();
+
+        let final_order = order.lock().unwrap();
+        assert_eq!(*final_order, vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn cleanup_runs_callbacks_and_removes_files() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("test_cleanup_all.tmp");
+        fs::write(&path, b"data").expect("write file");
+
+        manager.register_temp_file(path.clone());
+
+        let callback_ran = Arc::new(AtomicBool::new(false));
+        let callback_flag = Arc::clone(&callback_ran);
+        manager.register_cleanup(Box::new(move || {
+            callback_flag.store(true, Ordering::SeqCst);
+        }));
+
+        manager.cleanup();
+
+        assert!(callback_ran.load(Ordering::SeqCst));
+        assert!(!path.exists());
+        assert_eq!(manager.temp_file_count(), 0);
+    }
+
+    #[test]
+    fn unregister_prevents_cleanup() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("test_unregister.tmp");
+        fs::write(&path, b"data").expect("write file");
+
+        manager.register_temp_file(path.clone());
+        manager.unregister_temp_file(&path);
+
+        manager.cleanup_temp_files();
+
+        assert!(path.exists(), "unregistered file must survive cleanup");
+    }
+
+    #[test]
+    fn multiple_registrations_of_same_file() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager = CleanupManager::global();
+        manager.reset_for_testing();
+
+        let path = PathBuf::from("/tmp/test_multiple.tmp");
+
+        manager.register_temp_file(path.clone());
+        manager.register_temp_file(path.clone());
+        manager.register_temp_file(path);
+
+        assert_eq!(manager.temp_file_count(), 1, "HashSet deduplicates");
+    }
+
+    #[test]
+    fn global_returns_same_instance() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let manager1 = CleanupManager::global();
+        let manager2 = CleanupManager::global();
+
+        manager1.reset_for_testing();
+        manager1.register_temp_file(PathBuf::from("/tmp/test_global.tmp"));
+
+        assert_eq!(manager2.temp_file_count(), 1);
+    }
+}

--- a/crates/engine/src/util/mod.rs
+++ b/crates/engine/src/util/mod.rs
@@ -1,7 +1,8 @@
 //! Internal utilities shared across engine submodules.
 //!
-//! Currently exposes [`self::poison`] for recovering from lock poisoning on
+//! Exposes [`self::poison`] for recovering from lock poisoning on
 //! synchronization primitives whose protected state remains valid after a
-//! panic.
+//! panic, and [`self::cleanup`] for global temp-file cleanup coordination.
 
+pub mod cleanup;
 pub mod poison;

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -48,6 +48,9 @@ pub(super) fn process_file(
     iocp_batch: Option<&mut fast_io::IocpDiskBatch>,
 ) -> io::Result<CommitResult> {
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
+    if needs_rename {
+        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
+    }
 
     // Register the temp file with the global cleanup manager so a SIGKILL
     // (which bypasses Drop) still removes orphaned temp files on restart.
@@ -200,6 +203,9 @@ pub(super) fn process_whole_file(
     iocp_batch: Option<&mut fast_io::IocpDiskBatch>,
 ) -> io::Result<CommitResult> {
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
+    if needs_rename {
+        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
+    }
 
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
@@ -422,7 +428,9 @@ fn commit_file(
     }
 
     let was_copy = if needs_rename {
-        rename_with_io_uring_fallback(cleanup_guard.path(), &begin.file_path)?
+        let result = rename_with_io_uring_fallback(cleanup_guard.path(), &begin.file_path)?;
+        CleanupManager::global().unregister_temp_file(cleanup_guard.path());
+        result
     } else if begin.is_inplace {
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))
         // In append mode, bytes_written only counts newly received data -

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -14,6 +14,8 @@ use protocol::stats::DeleteStats;
 
 use metadata::apply_metadata_from_file_entry;
 
+use engine::CleanupManager;
+
 use crate::adaptive_buffer::adaptive_writer_capacity;
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
 use crate::map_file::MapFile;
@@ -209,6 +211,7 @@ impl ReceiverContext {
             )?;
             #[cfg(not(unix))]
             let (file, mut temp_guard) = open_tmpfile(&file_path, self.config.temp_dir.as_deref())?;
+            CleanupManager::global().register_temp_file(temp_guard.path().to_path_buf());
             let target_size = file_entry.size();
             let writer_capacity = adaptive_writer_capacity(target_size);
             let mut output = std::io::BufWriter::with_capacity(writer_capacity, file);
@@ -371,6 +374,7 @@ impl ReceiverContext {
                     fs::rename(temp_guard.path(), &file_path)?;
                 }
             }
+            CleanupManager::global().unregister_temp_file(temp_guard.path());
             temp_guard.keep();
 
             if let Err(meta_err) =

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -16,6 +16,8 @@ use fast_io::FileWriter;
 
 use protocol::codec::NdxCodec;
 
+use engine::CleanupManager;
+
 use crate::adaptive_buffer::adaptive_writer_capacity;
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
 use crate::map_file::MapFile;
@@ -102,6 +104,10 @@ pub fn process_file_response<R: Read>(
         let (f, guard) = open_tmpfile(&file_path, ctx.config.temp_dir)?;
         (f, guard, true)
     };
+
+    if needs_rename {
+        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
+    }
 
     // upstream: receiver.c:307-308 - in append mode, seek past existing content
     // so new data is written at the end of the file
@@ -340,6 +346,7 @@ pub fn process_file_response<R: Read>(
                 fs::rename(cleanup_guard.path(), &file_path)?;
             }
         }
+        CleanupManager::global().unregister_temp_file(cleanup_guard.path());
     } else if ctx.config.inplace {
         // Inplace: truncate to final size.
         // upstream: receiver.c:340 - set_file_length(fd, F_LENGTH(file))


### PR DESCRIPTION
## Summary

- Move `CleanupManager` from `core::signal` to `engine::util::cleanup` so the `transfer` crate can use it without introducing a circular dependency (`core` depends on `transfer`, not the other way around). The `core` crate re-exports from `engine` for backward compatibility.
- Wire `register_temp_file` / `unregister_temp_file` into all three receiver pipeline temp-file creation sites:
  - `transfer_ops/response.rs` - synchronous single-file response processor
  - `receiver/transfer/sync.rs` - synchronous receiver transfer loop
  - `disk_commit/process.rs` - pipelined disk commit thread (`process_file`, `process_whole_file`, `commit_file`)
- Each site registers immediately after temp-file creation (when `needs_rename` is true) and unregisters after the rename/commit succeeds, ensuring stale temp files are cleaned up on abnormal exit (SIGINT/SIGTERM).

## Test plan

- [ ] CI passes (fmt, clippy, nextest, Windows, macOS, Linux musl)
- [ ] Existing `signal_integration` and `sigint_temp_cleanup` tests in `core` continue to pass via re-export
- [ ] New `CleanupManager` unit tests in `engine::util::cleanup` pass
- [ ] Verify no circular dependency introduced (transfer depends on engine, core depends on both)