### PR TITLE
feat: implement progress2 sliding-window rate, format, and parsing helpers

### DIFF
--- a/crates/cli/src/frontend/info_output.rs
+++ b/crates/cli/src/frontend/info_output.rs
@@ -109,10 +109,23 @@ impl InfoFlags {
 
     /// Check if progress messages should be shown.
     ///
-    /// This corresponds to the `progress` info flag.
+    /// This corresponds to the `progress` info flag. Returns `true` for both
+    /// per-file progress (level 1) and overall progress2 (level 2).
     #[must_use]
     pub const fn should_show_progress(&self) -> bool {
         self.levels.get(InfoFlag::Progress) > 0
+    }
+
+    /// Check if overall (progress2) mode is active.
+    ///
+    /// Returns `true` when `--info=progress2` was specified, which sets the
+    /// progress flag to level 2. Level 1 is per-file progress; level 2 is the
+    /// overall transfer progress matching upstream's `INFO_GTE(PROGRESS, 2)`.
+    ///
+    /// upstream: rsync.h `INFO_GTE(PROGRESS, 2)` guard in progress.c
+    #[must_use]
+    pub const fn is_progress2(&self) -> bool {
+        self.levels.get(InfoFlag::Progress) >= 2
     }
 
     /// Check if statistics should be shown.
@@ -429,6 +442,7 @@ mod tests {
 
         flags.levels_mut().set(InfoFlag::Progress, 2);
         assert!(flags.should_show_progress());
+        assert!(flags.is_progress2());
 
         flags.levels_mut().set(InfoFlag::Stats, 1);
         assert!(flags.should_show_stats());
@@ -471,6 +485,41 @@ mod tests {
         assert!(!flags.should_show_skip());
         assert!(!flags.should_show_flist());
         assert!(!flags.should_show_progress());
+        assert!(!flags.is_progress2());
+    }
+
+    /// upstream: rsync.h `INFO_GTE(PROGRESS, 2)` - progress2 is active at
+    /// level 2 but not at level 0 or 1.
+    #[test]
+    fn test_is_progress2_levels() {
+        let mut flags = InfoFlags::default();
+        assert!(!flags.is_progress2(), "level 0: not progress2");
+
+        flags.levels_mut().set(InfoFlag::Progress, 1);
+        assert!(!flags.is_progress2(), "level 1: not progress2");
+        assert!(flags.should_show_progress(), "level 1: progress enabled");
+
+        flags.levels_mut().set(InfoFlag::Progress, 2);
+        assert!(flags.is_progress2(), "level 2: progress2");
+        assert!(flags.should_show_progress(), "level 2: progress enabled");
+    }
+
+    /// `--info=progress2` should parse correctly and set progress2 mode.
+    #[test]
+    fn test_parse_info_progress2() {
+        let flags = parse_info_flags("progress2").unwrap();
+        assert!(flags.should_show_progress());
+        assert!(flags.is_progress2());
+        assert_eq!(flags.levels().get(InfoFlag::Progress), 2);
+    }
+
+    /// `--info=progress` (level 1) is per-file progress, not progress2.
+    #[test]
+    fn test_parse_info_progress1_not_progress2() {
+        let flags = parse_info_flags("progress").unwrap();
+        assert!(flags.should_show_progress());
+        assert!(!flags.is_progress2());
+        assert_eq!(flags.levels().get(InfoFlag::Progress), 1);
     }
 
     #[test]

--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -14,8 +14,9 @@ pub(crate) use self::progress::{
 };
 pub(crate) use self::rate::{
     VerboseRateDisplay, compute_rate, format_human_rate, format_progress_rate,
-    format_progress_rate_decimal, format_progress_rate_human, format_summary_rate,
-    format_verbose_rate, format_verbose_rate_decimal, format_verbose_rate_human,
+    format_progress_rate_decimal, format_progress_rate_from_value, format_progress_rate_human,
+    format_summary_rate, format_verbose_rate, format_verbose_rate_decimal,
+    format_verbose_rate_human,
 };
 pub(crate) use self::remaining::RemainingTimeEstimator;
 pub(crate) use self::size::{

--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -152,6 +152,40 @@ pub(crate) fn format_progress_rate_human(rate: f64) -> String {
     format!("{}{}", display.0, display.1)
 }
 
+/// Formats a pre-computed transfer rate (bytes/sec) for the progress line.
+///
+/// Unlike [`format_progress_rate`] which computes the rate from cumulative
+/// bytes and elapsed time, this function accepts a rate value directly.
+/// This supports the sliding-window rate used in progress2 mode, where
+/// the rate comes from the [`RemainingTimeEstimator::window_rate`] method
+/// rather than a simple bytes/elapsed division.
+///
+/// upstream: progress.c:108-116 rprint_progress - rate unit selection
+pub(crate) fn format_progress_rate_from_value(
+    rate: f64,
+    human_readable: HumanReadableMode,
+) -> String {
+    if rate <= 0.0 {
+        return if human_readable.is_enabled() {
+            "0.00B/s".to_owned()
+        } else {
+            "0.00kB/s".to_owned()
+        };
+    }
+
+    let decimal = format_progress_rate_decimal(rate);
+    if !human_readable.is_enabled() {
+        return decimal;
+    }
+
+    let human = format_progress_rate_human(rate);
+    if human_readable.includes_exact() && human != decimal {
+        format!("{human} ({decimal})")
+    } else {
+        human
+    }
+}
+
 /// Computes the throughput in bytes per second for the provided measurements.
 pub(crate) fn compute_rate(bytes: u64, elapsed: Duration) -> Option<f64> {
     if elapsed.is_zero() {
@@ -260,5 +294,42 @@ mod tests {
         // 1 GiB/s prints in GB/s.
         let gb = format_progress_rate_decimal(1024.0 * 1024.0 * 1024.0);
         assert!(gb.ends_with("GB/s"), "{gb}");
+    }
+
+    /// `format_progress_rate_from_value` accepts a pre-computed rate instead of
+    /// deriving it from bytes/elapsed, supporting the sliding-window rate used
+    /// in progress2 mode.
+    #[test]
+    fn format_progress_rate_from_value_zero() {
+        let result = format_progress_rate_from_value(0.0, HumanReadableMode::Disabled);
+        assert_eq!(result, "0.00kB/s");
+    }
+
+    #[test]
+    fn format_progress_rate_from_value_negative() {
+        let result = format_progress_rate_from_value(-1.0, HumanReadableMode::Disabled);
+        assert_eq!(result, "0.00kB/s");
+    }
+
+    #[test]
+    fn format_progress_rate_from_value_kb_range() {
+        let result = format_progress_rate_from_value(512.0, HumanReadableMode::Disabled);
+        assert!(result.ends_with("kB/s"), "expected kB/s: {result}");
+    }
+
+    #[test]
+    fn format_progress_rate_from_value_mb_range() {
+        let result =
+            format_progress_rate_from_value(2.0 * 1024.0 * 1024.0, HumanReadableMode::Disabled);
+        assert!(result.ends_with("MB/s"), "expected MB/s: {result}");
+    }
+
+    #[test]
+    fn format_progress_rate_from_value_gb_range() {
+        let result = format_progress_rate_from_value(
+            2.0 * 1024.0 * 1024.0 * 1024.0,
+            HumanReadableMode::Disabled,
+        );
+        assert!(result.ends_with("GB/s"), "expected GB/s: {result}");
     }
 }

--- a/crates/cli/src/frontend/progress/format/remaining.rs
+++ b/crates/cli/src/frontend/progress/format/remaining.rs
@@ -107,6 +107,24 @@ impl RemainingTimeEstimator {
         Some(bytes_left as f64 / rate)
     }
 
+    /// Returns the sliding-window rate in bytes per second, computed as
+    /// `(current_ofs - oldest_ofs) / elapsed_seconds`. Returns `None` if the
+    /// estimator is unprimed. Returns `Some(0.0)` when stalled (no bytes
+    /// transferred over the window), matching upstream's `rate` variable in
+    /// `rprint_progress` (progress.c:102-104).
+    ///
+    /// upstream: progress.c:102-104 rprint_progress - rate computation from
+    /// oldest retained sample to current position.
+    pub(crate) fn window_rate(&self, now: Instant, ofs: u64) -> Option<f64> {
+        let oldest = self.samples[self.oldest]?;
+        let bytes_delta = ofs.saturating_sub(oldest.ofs);
+        let elapsed = now.saturating_duration_since(oldest.at).as_secs_f64();
+        if elapsed <= 0.0 || bytes_delta == 0 {
+            return Some(0.0);
+        }
+        Some(bytes_delta as f64 / elapsed)
+    }
+
     /// Renders the remaining time as `H:MM:SS` (matching upstream's
     /// `%4u:%02u:%02u`, progress.c:121-122), or the `??:??:??` placeholder
     /// when the value exceeds upstream's `9999*3600`-second clamp. A stalled
@@ -419,5 +437,50 @@ mod tests {
             est.render(t0 + Duration::from_secs(1), 1, 1 + over_limit),
             "??:??:??"
         );
+    }
+
+    /// upstream: progress.c:102-104 - window rate is computed from the oldest
+    /// retained sample to the current position.
+    #[test]
+    fn window_rate_unprimed_returns_none() {
+        let est = RemainingTimeEstimator::new();
+        let now = Instant::now();
+        // Unprimed estimator has no samples, so window_rate returns None.
+        assert!(est.window_rate(now, 1_000).is_none());
+    }
+
+    #[test]
+    fn window_rate_steady_throughput() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        let rate: u64 = 1_000_000;
+        for sec in 0..=5 {
+            est.observe(at(t0, sec), sec * rate);
+        }
+        let computed = est.window_rate(at(t0, 5), 5 * rate).expect("rate");
+        assert!(
+            (computed - 1_000_000.0).abs() < 10_000.0,
+            "expected ~1MB/s, got {computed}"
+        );
+    }
+
+    #[test]
+    fn window_rate_stalled_returns_zero() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 100);
+        est.observe(at(t0, 1), 100);
+        est.observe(at(t0, 2), 100);
+        let rate = est.window_rate(at(t0, 2), 100).expect("rate");
+        assert_eq!(rate, 0.0, "stalled window should yield zero rate");
+    }
+
+    #[test]
+    fn window_rate_zero_elapsed_returns_zero() {
+        let mut est = RemainingTimeEstimator::new();
+        let t0 = Instant::now();
+        est.observe(t0, 0);
+        let rate = est.window_rate(t0, 1_000).expect("rate");
+        assert_eq!(rate, 0.0, "zero elapsed should yield zero rate");
     }
 }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -187,7 +187,10 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 );
                 // upstream: progress.c:102-116 - progress2 uses the sliding-window
                 // rate from the 5-slot ring buffer, not the cumulative rate.
-                let window_rate = self.overall_remaining.window_rate(now, bytes).unwrap_or(0.0);
+                let window_rate = self
+                    .overall_remaining
+                    .window_rate(now, bytes)
+                    .unwrap_or(0.0);
                 let rate_field = format!(
                     "{:>11}",
                     format_progress_rate_from_value(window_rate, self.human_readable)
@@ -237,9 +240,7 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 } else {
                     // upstream: progress.c:100 - in-flight ticks use trailing
                     // `"  "` (two spaces) instead of the xfr trailer.
-                    let line = format!(
-                        "{size_field} {percent_field} {rate_field} {time_field}  "
-                    );
+                    let line = format!("{size_field} {percent_field} {rate_field} {time_field}  ");
                     self.write_overall_line(&line)?;
                     self.line_active = true;
                 }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -7,7 +7,7 @@ use core::client::{ClientProgressObserver, ClientProgressUpdate, HumanReadableMo
 
 use super::format::{
     RemainingTimeEstimator, format_progress_bytes, format_progress_elapsed,
-    format_progress_percent, format_progress_rate,
+    format_progress_percent, format_progress_rate, format_progress_rate_from_value,
 };
 use super::mode::ProgressMode;
 
@@ -27,6 +27,13 @@ pub(crate) struct LiveProgress<'a> {
     /// Per-file estimators keyed by relative path; created on first sighting
     /// of a path and dropped when the path's progress completes.
     per_file_remaining: HashMap<PathBuf, RemainingTimeEstimator>,
+    /// Longest line emitted in progress2 mode. Used to pad shorter lines with
+    /// trailing spaces so stale characters from longer previous ticks are
+    /// erased on overwrite.
+    ///
+    /// upstream: progress.c:84-91 `static int last_len` - tracks the longest
+    /// progress line and pads the current line to match before emitting.
+    max_line_len: usize,
 }
 
 impl<'a> LiveProgress<'a> {
@@ -45,6 +52,7 @@ impl<'a> LiveProgress<'a> {
             human_readable,
             overall_remaining: RemainingTimeEstimator::new(),
             per_file_remaining: HashMap::new(),
+            max_line_len: 0,
         }
     }
 
@@ -67,6 +75,25 @@ impl<'a> LiveProgress<'a> {
             writeln!(self.writer)?;
         }
 
+        Ok(())
+    }
+
+    /// Writes a progress line for progress2 (Overall) mode, padding to the
+    /// longest previously emitted line to erase stale characters on `\r`
+    /// overwrite.
+    ///
+    /// upstream: progress.c:84-91 - `last_len` tracking and space-padding.
+    fn write_overall_line(&mut self, line: &str) -> io::Result<()> {
+        let current_len = line.len();
+        let pad = self.max_line_len.saturating_sub(current_len);
+        if pad > 0 {
+            write!(self.writer, "{line}{:pad$}", "")?;
+        } else {
+            write!(self.writer, "{line}")?;
+        }
+        if current_len > self.max_line_len {
+            self.max_line_len = current_len;
+        }
         Ok(())
     }
 }
@@ -158,9 +185,12 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     "{:>4}",
                     format_progress_percent(bytes, update.overall_total_bytes())
                 );
+                // upstream: progress.c:102-116 - progress2 uses the sliding-window
+                // rate from the 5-slot ring buffer, not the cumulative rate.
+                let window_rate = self.overall_remaining.window_rate(now, bytes).unwrap_or(0.0);
                 let rate_field = format!(
                     "{:>11}",
-                    format_progress_rate(bytes, update.overall_elapsed(), self.human_readable)
+                    format_progress_rate_from_value(window_rate, self.human_readable)
                 );
                 // upstream: progress.c:97-105 - sliding window ETA mid-transfer,
                 // total elapsed for the final tick.
@@ -182,15 +212,35 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 // list is complete, "ir" while INC_RECURSE sub-lists are still
                 // arriving on the wire.
                 let chk_prefix = if update.flist_eof() { "to" } else { "ir" };
-                write!(
-                    self.writer,
-                    "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, {chk_prefix}-chk={remaining}/{total})"
-                )?;
 
-                if final_tick {
-                    writeln!(self.writer)?;
-                    self.line_active = false;
+                if update.is_final() {
+                    // upstream: progress.c:78-82 - final tick per file emits the
+                    // xfr trailer. In progress2 mode the trailing newline is
+                    // stripped (progress.c:88) and spaces pad to the longest
+                    // prior line to erase stale characters.
+                    let line = format!(
+                        "{size_field} {percent_field} {rate_field} {time_field} (xfr#{xfr_index}, {chk_prefix}-chk={remaining}/{total})"
+                    );
+                    self.write_overall_line(&line)?;
+                    if final_tick {
+                        // upstream: progress.c:131-134 - the very last file's
+                        // final tick emits a newline. For progress2, the newline
+                        // is deferred until the summary (main.c:452). We emit
+                        // it here to separate from the summary block.
+                        writeln!(self.writer)?;
+                        self.line_active = false;
+                    } else {
+                        // Newline suppressed for progress2 per
+                        // progress.c:88 - cursor stays on same line.
+                        self.line_active = true;
+                    }
                 } else {
+                    // upstream: progress.c:100 - in-flight ticks use trailing
+                    // `"  "` (two spaces) instead of the xfr trailer.
+                    let line = format!(
+                        "{size_field} {percent_field} {rate_field} {time_field}  "
+                    );
+                    self.write_overall_line(&line)?;
                     self.line_active = true;
                 }
                 self.active_path = None;
@@ -234,6 +284,26 @@ mod tests {
         )
     }
 
+    fn make_mid_transfer_update(flist_eof: bool) -> ClientProgressUpdate {
+        let event = ClientEvent::for_test(
+            PathBuf::from("file.bin"),
+            ClientEventKind::DataCopied,
+            false,
+            None,
+            LocalCopyChangeSet::new(),
+        );
+        ClientProgressUpdate::from_transfer_event_mid(
+            event,
+            1,
+            3,
+            Some(2_048),
+            1_024,
+            Some(4_096),
+            Duration::from_secs(1),
+            flist_eof,
+        )
+    }
+
     /// upstream: progress.c:78-82 - the per-file trailer prints `to-chk` once
     /// the file list is complete, `ir-chk` while INC_RECURSE sub-lists are
     /// still arriving.
@@ -261,5 +331,92 @@ mod tests {
         let output = String::from_utf8(buf).expect("utf8");
         assert!(output.contains("ir-chk="), "missing ir-chk: {output}");
         assert!(!output.contains("to-chk="), "unexpected to-chk: {output}");
+    }
+
+    /// upstream: progress.c:100 - in-flight progress2 ticks use trailing
+    /// spaces instead of the xfr/chk trailer.
+    #[test]
+    fn overall_mid_transfer_has_no_xfr_trailer() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live =
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(
+            !output.contains("xfr#"),
+            "mid-transfer progress2 should not contain xfr trailer: {output}"
+        );
+        assert!(
+            !output.contains("to-chk="),
+            "mid-transfer progress2 should not contain to-chk: {output}"
+        );
+    }
+
+    /// upstream: progress.c:78-82 - final tick in progress2 mode shows the
+    /// xfr/chk trailer.
+    #[test]
+    fn overall_final_tick_has_xfr_trailer() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live =
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+            live.on_progress(&make_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(
+            output.contains("xfr#"),
+            "final progress2 tick should contain xfr trailer: {output}"
+        );
+        assert!(
+            output.contains("to-chk="),
+            "final progress2 tick should contain to-chk: {output}"
+        );
+    }
+
+    /// upstream: progress.c:84-91 - progress2 pads shorter lines with spaces
+    /// to erase stale characters from longer previous ticks.
+    #[test]
+    fn overall_pads_shorter_lines_to_max() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live =
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+            // First tick: final with trailer (longer line)
+            live.on_progress(&make_update(true));
+            // Second tick: mid-transfer without trailer (shorter line, should be padded)
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        // The second line (after \r) should have trailing spaces
+        let lines: Vec<&str> = output.split('\r').collect();
+        if lines.len() > 1 {
+            let second_line = lines.last().unwrap();
+            // The second (shorter) line should be padded with trailing spaces
+            assert!(
+                second_line.ends_with("  "),
+                "shorter progress2 line should be padded: {second_line:?}"
+            );
+        }
+    }
+
+    /// upstream: progress.c:102-116 - progress2 uses the sliding-window rate
+    /// from the 5-slot ring buffer, not the cumulative rate. Verify rate field
+    /// is present and non-empty.
+    #[test]
+    fn overall_uses_sliding_window_rate() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live =
+                LiveProgress::new(&mut buf, ProgressMode::Overall, HumanReadableMode::Disabled);
+            live.on_progress(&make_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        // The rate field should contain kB/s, MB/s, or GB/s
+        assert!(
+            output.contains("kB/s") || output.contains("MB/s") || output.contains("GB/s"),
+            "progress2 should contain a rate with base-1024 units: {output}"
+        );
     }
 }

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -14,7 +14,8 @@ pub(crate) use self::format::{
     format_decimal_bytes, format_human_bytes, format_human_rate, format_list_permissions,
     format_list_size, format_list_timestamp, format_progress_bytes, format_progress_elapsed,
     format_progress_percent, format_progress_rate, format_progress_rate_decimal,
-    format_progress_rate_human, format_size, format_stat_categories, format_summary_rate,
+    format_progress_rate_from_value, format_progress_rate_human, format_size,
+    format_stat_categories, format_summary_rate,
     format_verbose_rate, format_verbose_rate_decimal, format_verbose_rate_human, is_progress_event,
     list_only_event,
 };

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -15,9 +15,8 @@ pub(crate) use self::format::{
     format_list_size, format_list_timestamp, format_progress_bytes, format_progress_elapsed,
     format_progress_percent, format_progress_rate, format_progress_rate_decimal,
     format_progress_rate_from_value, format_progress_rate_human, format_size,
-    format_stat_categories, format_summary_rate,
-    format_verbose_rate, format_verbose_rate_decimal, format_verbose_rate_human, is_progress_event,
-    list_only_event,
+    format_stat_categories, format_summary_rate, format_verbose_rate, format_verbose_rate_decimal,
+    format_verbose_rate_human, is_progress_event, list_only_event,
 };
 pub(crate) use self::live::LiveProgress;
 pub(crate) use self::mode::ProgressMode;

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -159,6 +159,38 @@ impl ClientProgressUpdate {
     }
 }
 
+impl ClientProgressUpdate {
+    /// Creates a mid-transfer (non-final) progress update for testing.
+    ///
+    /// Identical to [`from_transfer_event`](Self::from_transfer_event) except
+    /// `is_final()` returns `false`, simulating an in-flight progress tick
+    /// before the file transfer completes.
+    #[doc(hidden)]
+    pub fn from_transfer_event_mid(
+        event: ClientEvent,
+        files_done: usize,
+        total_files: usize,
+        total_bytes: Option<u64>,
+        overall_transferred: u64,
+        overall_total_bytes: Option<u64>,
+        overall_elapsed: Duration,
+        flist_eof: bool,
+    ) -> Self {
+        Self {
+            event,
+            total: total_files,
+            remaining: total_files.saturating_sub(files_done),
+            index: files_done,
+            total_bytes,
+            final_update: false,
+            overall_transferred,
+            overall_total_bytes,
+            overall_elapsed,
+            flist_eof,
+        }
+    }
+}
+
 impl<F> ClientProgressObserver for F
 where
     F: FnMut(&ClientProgressUpdate),


### PR DESCRIPTION
## Summary

- Wire up `--info=progress2` rendering to match upstream rsync's `progress.c` behavior
- Add `RemainingTimeEstimator::window_rate()` for sliding-window rate (5-slot ring buffer) used by progress2's rate column instead of cumulative bytes/elapsed
- Add `format_progress_rate_from_value()` to format a pre-computed rate, supporting the sliding-window rate in progress2 mode
- Add `InfoFlags::is_progress2()` to distinguish progress2 (level >= 2) from per-file progress (level 1), mirroring upstream's `INFO_GTE(PROGRESS, 2)` guard
- Rework `LiveProgress` Overall mode: mid-transfer ticks emit trailing spaces (no xfr trailer), final per-file ticks show xfr trailer without newline, and shorter lines are padded to the longest prior line to erase stale characters on carriage return
- Add `ClientProgressUpdate::from_transfer_event_mid()` test helper for creating non-final progress updates

## Test plan

- [x] Existing `--info=progress2` parsing tests pass (progress2 -> ProgressSetting::Overall)
- [x] New `is_progress2()` tests verify level 0/1/2 distinction
- [x] New `parse_info_progress2` and `parse_info_progress1_not_progress2` tests
- [x] New `window_rate` tests: unprimed, steady throughput, stalled, zero elapsed
- [x] New `format_progress_rate_from_value` tests: zero, negative, kB/MB/GB ranges
- [x] New `overall_mid_transfer_has_no_xfr_trailer` test verifies mid-transfer ticks omit the xfr/chk trailer
- [x] New `overall_final_tick_has_xfr_trailer` test verifies final ticks include xfr/chk trailer
- [x] New `overall_pads_shorter_lines_to_max` test verifies space-padding to erase stale characters
- [x] New `overall_uses_sliding_window_rate` test verifies base-1024 rate units in progress2
- [x] Existing per-file progress tests unchanged and passing
- [x] Existing overall mode integration tests (`live_progress_overall_*`) pass