### PR TITLE
feat: implement --ignore-missing-args and --delete-missing-args in remote sender

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -257,6 +257,10 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // over SSH/daemon, but the in-process file-list reader and writer never
     // see a converter and silently pass raw bytes through.
     server_config.connection.iconv = config.iconv().resolve_converter();
+    // upstream: flist.c:send_file_list() - missing_args controls ENOENT handling
+    // for top-level source paths and --files-from entries.
+    server_config.file_selection.ignore_missing_args = config.ignore_missing_args();
+    server_config.file_selection.delete_missing_args = config.delete_missing_args();
 }
 
 #[cfg(test)]
@@ -341,6 +345,31 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
         assert!(!server_config.flags.info_flags.itemize);
+    }
+
+    #[test]
+    fn apply_common_server_flags_propagates_ignore_missing_args() {
+        let config = ClientConfig::builder().ignore_missing_args(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.file_selection.ignore_missing_args);
+    }
+
+    #[test]
+    fn apply_common_server_flags_propagates_delete_missing_args() {
+        let config = ClientConfig::builder().delete_missing_args(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.file_selection.delete_missing_args);
+    }
+
+    #[test]
+    fn apply_common_server_flags_missing_args_default_false() {
+        let config = ClientConfig::default();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.file_selection.ignore_missing_args);
+        assert!(!server_config.file_selection.delete_missing_args);
     }
 
     #[test]

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -366,6 +366,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--existing"));
         }
 
+        // upstream: options.c:817-818 - missing_args forwarded as long-form.
+        if self.config.ignore_missing_args() {
+            args.push(OsString::from("--ignore-missing-args"));
+        }
+        if self.config.delete_missing_args() {
+            args.push(OsString::from("--delete-missing-args"));
+        }
+
         if self.config.remove_source_files() {
             args.push(OsString::from("--remove-source-files"));
         }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -454,6 +454,8 @@ const UPSTREAM_SERVER_LONG_ARGS: &[&str] = &[
     "--ignore-times",
     "--ignore-existing",
     "--existing",
+    "--ignore-missing-args",
+    "--delete-missing-args",
     "--remove-source-files",
     "--no-implied-dirs",
     "--fake-super",

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -361,6 +361,13 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) {
             "--existing" => {
                 config.file_selection.existing_only = true;
             }
+            // upstream: options.c:817-818
+            "--ignore-missing-args" => {
+                config.file_selection.ignore_missing_args = true;
+            }
+            "--delete-missing-args" => {
+                config.file_selection.delete_missing_args = true;
+            }
             // upstream: options.c:2933-2942
             "--inplace" => {
                 config.write.inplace = true;

--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -154,6 +154,19 @@ impl FileEntry {
         self.mode
     }
 
+    /// Sets the Unix mode bits (type + permissions).
+    ///
+    /// Used to create mode-0 sentinel entries for `--delete-missing-args`,
+    /// where the receiver interprets `mode == 0` as a deletion signal.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2257` - `file->mode = 0` for delete-missing-args sentinel
+    #[inline]
+    pub fn set_mode(&mut self, mode: u32) {
+        self.mode = mode;
+    }
+
     /// Returns the permission bits only (without type).
     #[inline]
     #[must_use]

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -1435,3 +1435,21 @@ fn extras_presence_bitfield_independence() {
     assert_eq!(entry.hardlink_idx(), None);
     assert_eq!(entry.hardlink_dev(), None);
 }
+
+#[test]
+fn set_mode_overrides_constructor_mode() {
+    // upstream: flist.c:2257 - delete-missing-args sets file->mode = 0
+    let mut entry = FileEntry::new_file("sentinel.txt".into(), 0, 0o644);
+    assert_eq!(entry.mode(), 0o100644); // S_IFREG | 0644
+    entry.set_mode(0);
+    assert_eq!(entry.mode(), 0);
+}
+
+#[test]
+fn set_mode_to_zero_clears_type_and_permissions() {
+    let mut entry = FileEntry::new_directory("dir".into(), 0o755);
+    assert_ne!(entry.mode(), 0);
+    entry.set_mode(0);
+    assert_eq!(entry.mode(), 0);
+    assert_eq!(entry.permissions(), 0);
+}

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -400,6 +400,18 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Enables or disables silently skipping missing source entries.
+    pub fn ignore_missing_args(&mut self, enabled: bool) -> &mut Self {
+        self.file_selection.ignore_missing_args = enabled;
+        self
+    }
+
+    /// Enables or disables deleting destination entries for missing sources.
+    pub fn delete_missing_args(&mut self, enabled: bool) -> &mut Self {
+        self.file_selection.delete_missing_args = enabled;
+        self
+    }
+
     /// Enables or disables detailed transfer statistics.
     pub fn do_stats(&mut self, enabled: bool) -> &mut Self {
         self.do_stats = enabled;

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -102,6 +102,8 @@ mod chaining {
             .existing_only(false)
             .size_only(true)
             .from0(true)
+            .ignore_missing_args(true)
+            .delete_missing_args(true)
             .build()
             .expect("valid config");
 
@@ -111,6 +113,8 @@ mod chaining {
         assert!(!config.file_selection.existing_only);
         assert!(config.file_selection.size_only);
         assert!(config.file_selection.from0);
+        assert!(config.file_selection.ignore_missing_args);
+        assert!(config.file_selection.delete_missing_args);
     }
 
     #[test]
@@ -179,6 +183,8 @@ mod defaults {
         assert!(!config.file_selection.ignore_existing);
         assert!(!config.file_selection.existing_only);
         assert!(!config.file_selection.size_only);
+        assert!(!config.file_selection.ignore_missing_args);
+        assert!(!config.file_selection.delete_missing_args);
     }
 
     #[test]

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -182,6 +182,34 @@ pub struct FileSelectionConfig {
     pub files_from_path: Option<String>,
     /// Use NUL bytes as delimiters for `--files-from` input (`--from0`).
     pub from0: bool,
+    /// Silently skip source entries that do not exist (`--ignore-missing-args`).
+    ///
+    /// When true and a top-level source path (or `--files-from` entry) returns
+    /// ENOENT during file list building, the entry is silently omitted from the
+    /// file list with no error or warning.
+    ///
+    /// Mutually exclusive with `delete_missing_args` - if both are set,
+    /// `delete_missing_args` takes precedence (upstream: `missing_args == 2`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:send_file_list()` - `missing_args == 1`
+    /// - `options.c:817` - `--ignore-missing-args`
+    pub ignore_missing_args: bool,
+    /// Delete destination entries whose source has vanished (`--delete-missing-args`).
+    ///
+    /// When true and a top-level source path (or `--files-from` entry) returns
+    /// ENOENT during file list building, a mode-0 sentinel entry is emitted into
+    /// the file list. The receiver interprets this sentinel as an instruction to
+    /// delete the corresponding destination path.
+    ///
+    /// Takes precedence over `ignore_missing_args` when both are set.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:send_file_list()` - `missing_args == 2`
+    /// - `options.c:818` - `--delete-missing-args`
+    pub delete_missing_args: bool,
 }
 
 /// Configuration supplied to the server entry point.

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -475,6 +475,28 @@ impl GeneratorContext {
         )))
     }
 
+    /// Returns the upstream `missing_args` mode for ENOENT handling.
+    ///
+    /// Maps the two boolean flags to the upstream integer convention:
+    /// - `0` (default): emit `link_stat ... failed` warning, set IOERR_GENERAL
+    /// - `1` (`--ignore-missing-args`): silently skip the entry
+    /// - `2` (`--delete-missing-args`): emit mode-0 sentinel for receiver deletion
+    ///
+    /// `delete_missing_args` takes precedence when both are set.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:send_file_list()` - `missing_args` variable (0/1/2)
+    pub(crate) fn missing_args_mode(&self) -> u8 {
+        if self.config.file_selection.delete_missing_args {
+            2
+        } else if self.config.file_selection.ignore_missing_args {
+            1
+        } else {
+            0
+        }
+    }
+
     /// Validates that a file index is within bounds of the file list.
     pub(crate) fn validate_file_index(&self, ndx: usize) -> std::io::Result<()> {
         if ndx >= self.file_list.len() {

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -77,10 +77,15 @@ impl GeneratorContext {
             } else {
                 (base_path.clone(), base_path.clone())
             };
+            // upstream: flist.c:2254-2272 - pre-stat each top-level source and
+            // apply missing_args handling. Separates "source never existed" from
+            // "source vanished during recursive walk".
+            if !self.try_walk_source_entry(&base, &path)? {
+                continue;
+            }
             if relative_paths {
                 self.emit_implied_parents(&base, &path, &mut implied_ancestors)?;
             }
-            self.walk_path(&base, path)?;
         }
 
         // upstream: flist.c:f_name_cmp() - sort both arrays via indirect permutation.
@@ -201,7 +206,13 @@ impl GeneratorContext {
         // relative paths are computed correctly (e.g., "hello.txt" instead
         // of an empty string).
         for path in file_paths {
-            self.walk_path(base_dir, path.clone())?;
+            // upstream: flist.c:2254-2272 - pre-stat each --files-from entry
+            // and apply missing_args handling before walk_path. This separates
+            // "source never existed" (ENOENT at flist time) from "source vanished
+            // during recursive walk" (ENOENT during child traversal).
+            if !self.try_walk_source_entry(base_dir, path)? {
+                continue;
+            }
         }
 
         // upstream: flist.c:f_name_cmp() - sort via indirect permutation

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -22,6 +22,85 @@ use super::super::io_error_flags;
 use super::batch_stat::{StatResult, batch_stat_dir_entries};
 
 impl GeneratorContext {
+    /// Pre-checks a top-level source entry and walks it if it exists.
+    ///
+    /// Returns `true` if the entry was processed (exists or was handled as a
+    /// mode-0 sentinel), `false` if the caller should skip to the next entry.
+    ///
+    /// This method applies `--ignore-missing-args` and `--delete-missing-args`
+    /// semantics for top-level source paths and `--files-from` entries. The
+    /// distinction from recursive children (which use [`walk_path`] directly)
+    /// is critical: a missing top-level source is "never existed at flist time"
+    /// (upstream `link_stat ... failed`, exit 23), while a missing recursive
+    /// child is "vanished during walk" (upstream `file has vanished`, exit 24).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2254-2272` - `link_stat` + `missing_args` handling per source
+    pub(in crate::generator) fn try_walk_source_entry(
+        &mut self,
+        base: &Path,
+        path: &Path,
+    ) -> io::Result<bool> {
+        // Pre-stat to detect ENOENT before walk_path processes the entry.
+        match self.resolve_symlink_metadata(path, base) {
+            Ok(_) => {
+                // Path exists - delegate to normal walk_path.
+                self.walk_path(base, path.to_path_buf())?;
+                Ok(true)
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                match self.missing_args_mode() {
+                    // upstream: flist.c:2261 - missing_args == 1: silently skip
+                    1 => Ok(false),
+                    // upstream: flist.c:2254-2258 - missing_args == 2: emit mode-0 sentinel
+                    2 => {
+                        self.emit_delete_sentinel(base, path)?;
+                        Ok(true)
+                    }
+                    // upstream: flist.c:1810 - default: link_stat failed + IOERR_GENERAL
+                    _ => {
+                        // FFV-4: emit the correct error message and error flag
+                        // for a source that never existed at flist build time.
+                        eprintln!(
+                            "rsync: [sender] link_stat \"{}\" failed: {} ({})",
+                            path.display(),
+                            e,
+                            e.raw_os_error().unwrap_or(0),
+                        );
+                        self.add_io_error(io_error_flags::IOERR_GENERAL);
+                        Ok(false)
+                    }
+                }
+            }
+            Err(e) => {
+                // Non-ENOENT error: log as link_stat failure and record.
+                self.log_stat_error(path, &e);
+                self.record_io_error(&e);
+                Ok(false)
+            }
+        }
+    }
+
+    /// Emits a mode-0 sentinel file entry for `--delete-missing-args`.
+    ///
+    /// The sentinel has `mode == 0`, which the receiver interprets as an
+    /// instruction to delete the corresponding destination path. The entry
+    /// carries the relative name so the receiver can locate the target.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2254-2258` - `missing_args == 2`: `make_file()` + `file->mode = 0`
+    fn emit_delete_sentinel(&mut self, base: &Path, path: &Path) -> io::Result<()> {
+        let relative = path.strip_prefix(base).unwrap_or(path).to_path_buf();
+        // upstream: mode=0 signals "delete this entry" to the receiver.
+        // Create a regular file entry then override mode to 0.
+        let mut entry = protocol::flist::FileEntry::new_file(relative, 0, 0);
+        entry.set_mode(0);
+        self.push_file_item(entry, path.to_path_buf());
+        Ok(())
+    }
+
     /// Recursively walks a path and adds entries to the file list.
     ///
     /// # Upstream Reference

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -93,6 +93,11 @@ impl GeneratorContext {
     /// - `flist.c:2254-2258` - `missing_args == 2`: `make_file()` + `file->mode = 0`
     fn emit_delete_sentinel(&mut self, base: &Path, path: &Path) -> io::Result<()> {
         let relative = path.strip_prefix(base).unwrap_or(path).to_path_buf();
+        let relative = if relative.as_os_str().is_empty() {
+            PathBuf::from(path.file_name().unwrap_or(path.as_os_str()))
+        } else {
+            relative
+        };
         // upstream: mode=0 signals "delete this entry" to the receiver.
         // Create a regular file entry then override mode to 0.
         let mut entry = protocol::flist::FileEntry::new_file(relative, 0, 0);

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2617,7 +2617,11 @@ mod files_from {
         assert!(!names.contains(&"missing.txt"));
 
         // No io_error flags should be set - the missing entry is silently ignored.
-        assert_eq!(ctx.io_error(), 0, "ignore-missing-args should not set io_error");
+        assert_eq!(
+            ctx.io_error(),
+            0,
+            "ignore-missing-args should not set io_error"
+        );
     }
 
     #[test]
@@ -2656,7 +2660,11 @@ mod files_from {
         assert_eq!(sentinel.size(), 0, "sentinel size should be 0");
 
         // No io_error flags should be set - exit 0.
-        assert_eq!(ctx.io_error(), 0, "delete-missing-args should not set io_error");
+        assert_eq!(
+            ctx.io_error(),
+            0,
+            "delete-missing-args should not set io_error"
+        );
     }
 
     #[test]
@@ -2728,9 +2736,7 @@ mod files_from {
         config.file_selection.ignore_missing_args = true;
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
-        let count = ctx
-            .build_file_list(&[existing.clone(), missing])
-            .unwrap();
+        let count = ctx.build_file_list(&[existing.clone(), missing]).unwrap();
 
         assert_eq!(count, 1, "only exists.txt should be in the list");
         assert_eq!(ctx.io_error(), 0, "no error for silently skipped source");
@@ -2749,9 +2755,7 @@ mod files_from {
         config.file_selection.delete_missing_args = true;
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
-        let count = ctx
-            .build_file_list(&[existing.clone(), missing])
-            .unwrap();
+        let count = ctx.build_file_list(&[existing.clone(), missing]).unwrap();
 
         // exists.txt + mode-0 sentinel for missing
         assert_eq!(count, 2, "exists.txt + sentinel");

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2559,6 +2559,7 @@ mod files_from {
 
     #[test]
     fn build_file_list_with_base_skips_missing_files() {
+        // FFV-4: default mode emits link_stat error and sets IOERR_GENERAL (exit 23).
         let temp_dir = TempDir::new().unwrap();
         let src = temp_dir.path().join("src");
         std::fs::create_dir_all(&src).unwrap();
@@ -2577,6 +2578,214 @@ mod files_from {
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
         assert!(names.contains(&"exists.txt"));
         assert!(!names.contains(&"missing.txt"));
+
+        // upstream: flist.c:1810 - ENOENT for a --files-from entry that never
+        // existed should set IOERR_GENERAL (exit 23), not IOERR_VANISHED (exit 24).
+        assert_ne!(
+            ctx.io_error() & io_error_flags::IOERR_GENERAL,
+            0,
+            "missing source should set IOERR_GENERAL"
+        );
+        assert_eq!(
+            ctx.io_error() & io_error_flags::IOERR_VANISHED,
+            0,
+            "missing source should NOT set IOERR_VANISHED"
+        );
+    }
+
+    #[test]
+    fn build_file_list_with_base_ignore_missing_args_skips_silently() {
+        // FFV-2: --ignore-missing-args silently skips missing entries with exit 0.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("exists.txt"), "data").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.file_selection.ignore_missing_args = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let file_paths = vec![src.join("exists.txt"), src.join("missing.txt")];
+        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+
+        // Dot entry + exists.txt; missing.txt silently skipped.
+        assert_eq!(count, 2, "dot + exists.txt");
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(names.contains(&"exists.txt"));
+        assert!(!names.contains(&"missing.txt"));
+
+        // No io_error flags should be set - the missing entry is silently ignored.
+        assert_eq!(ctx.io_error(), 0, "ignore-missing-args should not set io_error");
+    }
+
+    #[test]
+    fn build_file_list_with_base_delete_missing_args_emits_sentinel() {
+        // FFV-3: --delete-missing-args emits a mode-0 sentinel for receiver deletion.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("exists.txt"), "data").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.file_selection.delete_missing_args = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let file_paths = vec![src.join("exists.txt"), src.join("missing.txt")];
+        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+
+        // Dot entry + exists.txt + mode-0 sentinel for missing.txt
+        assert_eq!(count, 3, "dot + exists.txt + sentinel for missing.txt");
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(names.contains(&"exists.txt"));
+
+        // The sentinel entry should have mode == 0.
+        let sentinel = ctx
+            .file_list()
+            .iter()
+            .find(|e| e.name() == "missing.txt")
+            .expect("sentinel entry for missing.txt should be in file list");
+        assert_eq!(
+            sentinel.mode(),
+            0,
+            "delete-missing-args sentinel must have mode 0"
+        );
+        assert_eq!(sentinel.size(), 0, "sentinel size should be 0");
+
+        // No io_error flags should be set - exit 0.
+        assert_eq!(ctx.io_error(), 0, "delete-missing-args should not set io_error");
+    }
+
+    #[test]
+    fn build_file_list_with_base_delete_overrides_ignore_missing_args() {
+        // When both flags are set, delete-missing-args takes precedence.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.file_selection.ignore_missing_args = true;
+        config.file_selection.delete_missing_args = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let file_paths = vec![src.join("missing.txt")];
+        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+
+        // Dot entry + mode-0 sentinel (delete takes precedence over ignore).
+        assert_eq!(count, 2, "dot + sentinel for missing.txt");
+        let sentinel = ctx
+            .file_list()
+            .iter()
+            .find(|e| e.name() == "missing.txt")
+            .expect("sentinel should exist when delete takes precedence");
+        assert_eq!(sentinel.mode(), 0);
+    }
+
+    #[test]
+    fn missing_args_mode_returns_correct_values() {
+        let handshake = test_handshake();
+
+        // Default: mode 0
+        let config = test_config();
+        let ctx = GeneratorContext::new_for_test(&handshake, config);
+        assert_eq!(ctx.missing_args_mode(), 0);
+
+        // --ignore-missing-args: mode 1
+        let mut config = test_config();
+        config.file_selection.ignore_missing_args = true;
+        let ctx = GeneratorContext::new_for_test(&handshake, config);
+        assert_eq!(ctx.missing_args_mode(), 1);
+
+        // --delete-missing-args: mode 2
+        let mut config = test_config();
+        config.file_selection.delete_missing_args = true;
+        let ctx = GeneratorContext::new_for_test(&handshake, config);
+        assert_eq!(ctx.missing_args_mode(), 2);
+
+        // Both set: mode 2 (delete takes precedence)
+        let mut config = test_config();
+        config.file_selection.ignore_missing_args = true;
+        config.file_selection.delete_missing_args = true;
+        let ctx = GeneratorContext::new_for_test(&handshake, config);
+        assert_eq!(ctx.missing_args_mode(), 2);
+    }
+
+    #[test]
+    fn build_file_list_ignore_missing_args_top_level_source() {
+        // FFV-2 for build_file_list (non-files-from path).
+        let temp_dir = TempDir::new().unwrap();
+        let existing = temp_dir.path().join("exists.txt");
+        std::fs::write(&existing, "data").unwrap();
+        let missing = temp_dir.path().join("no_such_file.txt");
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.file_selection.ignore_missing_args = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let count = ctx
+            .build_file_list(&[existing.clone(), missing])
+            .unwrap();
+
+        assert_eq!(count, 1, "only exists.txt should be in the list");
+        assert_eq!(ctx.io_error(), 0, "no error for silently skipped source");
+    }
+
+    #[test]
+    fn build_file_list_delete_missing_args_top_level_source() {
+        // FFV-3 for build_file_list (non-files-from path).
+        let temp_dir = TempDir::new().unwrap();
+        let existing = temp_dir.path().join("exists.txt");
+        std::fs::write(&existing, "data").unwrap();
+        let missing = temp_dir.path().join("no_such_file.txt");
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.file_selection.delete_missing_args = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let count = ctx
+            .build_file_list(&[existing.clone(), missing])
+            .unwrap();
+
+        // exists.txt + mode-0 sentinel for missing
+        assert_eq!(count, 2, "exists.txt + sentinel");
+        let sentinel = ctx
+            .file_list()
+            .iter()
+            .find(|e| e.name() == "no_such_file.txt")
+            .expect("sentinel for missing source");
+        assert_eq!(sentinel.mode(), 0);
+        assert_eq!(ctx.io_error(), 0);
+    }
+
+    #[test]
+    fn build_file_list_default_missing_source_sets_general_error() {
+        // FFV-4 for build_file_list: default mode emits IOERR_GENERAL, not VANISHED.
+        let temp_dir = TempDir::new().unwrap();
+        let missing = temp_dir.path().join("nonexistent.txt");
+
+        let handshake = test_handshake();
+        let config = test_config();
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        ctx.build_file_list(&[missing]).unwrap();
+
+        assert_ne!(
+            ctx.io_error() & io_error_flags::IOERR_GENERAL,
+            0,
+            "default mode should set IOERR_GENERAL for missing source"
+        );
+        assert_eq!(
+            ctx.io_error() & io_error_flags::IOERR_VANISHED,
+            0,
+            "default mode should NOT set IOERR_VANISHED for top-level missing source"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wire `--ignore-missing-args` (FFV-2) and `--delete-missing-args` (FFV-3) flags through the full config pipeline from CLI to the remote sender's generator context
- Fix default ENOENT behavior (FFV-4) in the remote sender to emit `link_stat ... failed` with exit code 23 instead of `file has vanished` with exit code 24 for sources that never existed at flist build time
- Add `try_walk_source_entry()` to pre-stat each top-level source before `walk_path()`, separating "never existed" from "vanished during recursive walk" - matching upstream `flist.c:send_file_list()` semantics
- Add `set_mode()` accessor to `FileEntry` for creating mode-0 sentinel entries used by `--delete-missing-args`
- Add daemon-side parsing of both long-form args and SSH invocation forwarding

## Upstream Reference

- `flist.c:2254-2272` - `link_stat` + `missing_args` handling per source entry
- `flist.c:1810` - default mode emits `link_stat ... failed` via `FERROR_XFER`
- `flist.c:2257` - `file->mode = 0` sentinel for delete-missing-args
- `options.c:817-818` - `--ignore-missing-args` / `--delete-missing-args`

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] `build_file_list_with_base_skips_missing_files` - default ENOENT sets IOERR_GENERAL (exit 23), not IOERR_VANISHED (exit 24)
- [ ] `build_file_list_with_base_ignore_missing_args_skips_silently` - mode 1 silently skips, no io_error
- [ ] `build_file_list_with_base_delete_missing_args_emits_sentinel` - mode 2 emits mode-0 entry, no io_error
- [ ] `build_file_list_with_base_delete_overrides_ignore_missing_args` - delete takes precedence over ignore
- [ ] `missing_args_mode_returns_correct_values` - mode accessor returns 0/1/2
- [ ] `build_file_list_ignore_missing_args_top_level_source` - mode 1 via build_file_list
- [ ] `build_file_list_delete_missing_args_top_level_source` - mode 2 via build_file_list
- [ ] `build_file_list_default_missing_source_sets_general_error` - FFV-4 via build_file_list
- [ ] `set_mode_overrides_constructor_mode` / `set_mode_to_zero_clears_type_and_permissions` - FileEntry sentinel creation
- [ ] `apply_common_server_flags_propagates_ignore_missing_args` / `..._delete_missing_args` - config wiring
- [ ] `file_selection_setters_chain` / `default_file_selection_config` - builder integration