### PR TITLE
chore: release v0.6.3 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to oc-rsync are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-oc-rsync is wire-compatible with upstream rsync 3.4.1 (protocol 32). Release
+oc-rsync is wire-compatible with upstream rsync 3.4.3 (protocol 32). Release
 tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
 
-## [Unreleased]
+## [0.6.3] - 2026-06-03
 
 ### Security
 
@@ -231,4 +231,5 @@ tags are mirrored on GitHub at <https://github.com/oferchen/rsync/releases>.
     keyed by packed `(rsum_low, bucket_idx)` entries, giving sequential probes
     cache-friendly access and removing per-bucket heap allocations.
 
-[Unreleased]: https://github.com/oferchen/rsync/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/oferchen/rsync/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/oferchen/rsync/compare/v0.6.2...v0.6.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apple-fs"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "libc",
  "nix",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "bandwidth"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "memchr",
  "proptest",
@@ -290,7 +290,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "batch"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "filetime",
  "metadata",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "bin"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "assert_cmd",
  "checksums",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "branding"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "checksums"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "crc32c",
  "criterion",
@@ -683,7 +683,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "apple-fs",
  "assert_cmd",
@@ -740,7 +740,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compress"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "flate2",
  "lz4_flex",
@@ -756,7 +756,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bandwidth",
  "base64",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bandwidth",
  "base64",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "embedding"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "cli",
  "core",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "engine"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "apple-fs",
  "bandwidth",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "fast_io"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "filters"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "globset",
  "logging",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "flist"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "libc",
  "logging",
@@ -2189,7 +2189,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "logging"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "logging-sink"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "core",
  "syslog",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "matching"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "checksums",
  "criterion",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "metadata"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "apple-fs",
  "exacl",
@@ -2725,7 +2725,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "libc",
  "nix",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "protocol"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "compress",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "rsync_io"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aes-gcm 0.10.3",
  "chacha20poly1305",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "checksums",
  "protocol",
@@ -3896,7 +3896,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-support"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "tempfile",
 ]
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "transfer"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "apple-fs",
  "checksums",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "windows-gnu-eh"
-version = "0.6.2"
+version = "0.6.3"
 
 [[package]]
 name = "windows-implement"
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,7 +1331,7 @@ dependencies = [
  "rayon",
  "rustc-hash 2.1.2",
  "rustix",
- "signature 0.6.2",
+ "signature 0.6.3",
  "tempfile",
  "test-support",
  "thiserror 2.0.18",
@@ -2234,7 +2234,7 @@ dependencies = [
  "protocol",
  "rand 0.10.1",
  "rustc-hash 2.1.2",
- "signature 0.6.2",
+ "signature 0.6.3",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -4200,7 +4200,7 @@ dependencies = [
  "protocol",
  "rand 0.10.1",
  "rayon",
- "signature 0.6.2",
+ "signature 0.6.3",
  "tempfile",
  "test-support",
  "thiserror 2.0.18",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ edition = "2024"
 rust-version = "1.88"
 authors = ["Ofer Chen <skewers.irises.3b@icloud.com>"]
 license = "GPL-3.0-or-later"
-version = "0.6.2"
+version = "0.6.3"
 repository = "https://github.com/oferchen/rsync"
 
 [workspace.dependencies]
@@ -442,7 +442,7 @@ strip = false
 [workspace.metadata.oc_rsync]
 brand = "oc"
 upstream_version = "3.4.2"
-rust_version = "0.6.2"
+rust_version = "0.6.3"
 protocol = 32
 client_bin = "oc-rsync"
 daemon_bin = "oc-rsync"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 ## Status
 
-**Release:** 0.6.2 (alpha) - Wire-compatible drop-in replacement for rsync 3.4.3 (and 3.4.2 / 3.4.1, protocols 28-32).
+**Release:** 0.6.3 (beta) - Wire-compatible drop-in replacement for rsync 3.4.3 (and 3.4.2 / 3.4.1, protocols 28-32).
 
 All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop tested against upstream rsync 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2, and 3.4.3. Upstream rsync's own `testsuite/*.test` corpus runs in CI against `oc-rsync` as `$RSYNC` - all tests now pass (known-failures roster is empty).
 
@@ -55,6 +55,35 @@ The primary platform is Linux. macOS is well-supported with parity for all metad
 | Optimized file copy | ✓ `copy_file_range` | ✓ `fcopyfile` | ✓ `CopyFileExW` | All three are wired into the local-copy executor with standard-I/O fallback. |
 
 Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
+
+### What's New (v0.6.3)
+
+**Daemon-over-remote-shell**
+- `host::module` syntax now routes through SSH to a remote daemon (`--server --daemon` mode), matching upstream's daemon-over-remote-shell transport (#5353, #5364)
+- `RSYNC_CONNECT_PROG` support for custom connection programs (#5317)
+
+**Upstream testsuite parity**
+- All upstream `testsuite/*.test` scripts pass with zero known failures - the roster is now empty (#5342, #5346, #5355, #5358)
+- Dedicated CI workflow runs the upstream testsuite on every push with UPASS detection (#5342)
+
+**Security**
+- SEC-1 TOCTOU sandbox promoted from MOSTLY FIXED to COMPLETE - all path-based daemon syscalls now use `*at` dirfd-scoped equivalents (#4693, #4690, #4683)
+
+**Bug fixes**
+- Daemon module listing protocol aligned with upstream behavior (#5366)
+- Metadata applied before rename to match upstream `finish_transfer` semantics (#5338)
+- Secluded-args and capability string parsing from compact server flag string (#5336)
+- `P_LOCAL` directives inherited from global `rsyncd.conf` section into module context (#5334)
+- Atime preserved independently of mtime in local copy metadata path (#5328)
+- Socketpair used instead of pipes for `RSYNC_CONNECT_PROG` child stdin (#5363)
+
+**CI improvements**
+- All GitHub Actions pinned to SHA hashes for supply chain safety (#5333)
+- Nextest profiles, `--locked` builds, and standardized cache keys (#5335, #5332, #5341)
+- Non-required beta/nightly jobs moved to schedule-only to reduce runner contention (#5324)
+
+**Code quality**
+- Comment cleanup across engine, daemon, matching, and transfer crates (#5369, #5370, #5371, #5373)
 
 ### What's New (v0.6.2)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.6.x   | :white_check_mark: (current: 0.6.2) |
+| 0.6.x   | :white_check_mark: (current: 0.6.3) |
 | 0.5.x   | :warning: critical fixes only |
 | < 0.5   | :x:                |
 


### PR DESCRIPTION
## Summary

- Bump version from 0.6.2 to 0.6.3 across Cargo.toml, README, SECURITY.md, CHANGELOG
- Promote project status from alpha to beta
- Add "What's New (v0.6.3)" section to README covering daemon-over-remote-shell, upstream testsuite parity, SEC-1 sandbox completion, and CI improvements
- Promote CHANGELOG [Unreleased] to [0.6.3] - 2026-06-03

## Test plan

- [ ] CI green on all required checks (fmt+clippy, nextest stable, Windows, macOS, Linux musl)
- [ ] Verify README renders correctly on GitHub
- [ ] After merge: tag merged master commit as v0.6.3-beta