### PR TITLE
feat: wire progress tracker into daemon transfer pipeline

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -60,11 +60,11 @@ use orchestration::{run_pull_transfer, run_push_transfer, send_daemon_arguments}
 /// testsuite) and double-colon syntax (`host::module/path`).
 #[cfg_attr(
     feature = "tracing",
-    instrument(skip(config, _observer), name = "daemon_transfer")
+    instrument(skip(config, observer), name = "daemon_transfer")
 )]
 pub fn run_daemon_transfer(
     config: &ClientConfig,
-    _observer: Option<&mut dyn ClientProgressObserver>,
+    observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
@@ -209,6 +209,7 @@ pub fn run_daemon_transfer(
             protocol,
             batch_ctx,
             buffered,
+            observer,
         ),
         RemoteRole::Sender => run_push_transfer(
             config,
@@ -219,6 +220,7 @@ pub fn run_daemon_transfer(
             protocol,
             batch_ctx,
             buffered,
+            observer,
         ),
         RemoteRole::Proxy => {
             unreachable!("Proxy transfers via daemon are rejected earlier")
@@ -238,11 +240,11 @@ pub fn run_daemon_transfer(
 /// communicating via stdin/stdout.
 #[cfg_attr(
     feature = "tracing",
-    instrument(skip(config, _observer), name = "daemon_over_remote_shell")
+    instrument(skip(config, observer), name = "daemon_over_remote_shell")
 )]
 pub fn run_daemon_over_remote_shell(
     config: &ClientConfig,
-    _observer: Option<&mut dyn ClientProgressObserver>,
+    observer: Option<&mut dyn ClientProgressObserver>,
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
@@ -387,6 +389,7 @@ pub fn run_daemon_over_remote_shell(
             protocol,
             batch_ctx,
             buffered,
+            observer,
         ),
         RemoteRole::Sender => run_push_transfer(
             config,
@@ -397,6 +400,7 @@ pub fn run_daemon_over_remote_shell(
             protocol,
             batch_ctx,
             buffered,
+            observer,
         ),
         RemoteRole::Proxy => {
             unreachable!("Proxy transfers via daemon-over-remote-shell are rejected earlier")

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -1,7 +1,9 @@
 use super::super::connection::DaemonTransferRequest;
 use super::arguments::build_full_daemon_args;
 use super::server_config::{build_server_config_for_generator, build_server_config_for_receiver};
-use super::transfer::{is_dry_run_remote_close, read_files_from_for_forwarding};
+use super::transfer::{
+    DaemonProgressAdapter, is_dry_run_remote_close, read_files_from_for_forwarding,
+};
 
 use crate::client::config::ClientConfig;
 use crate::client::module_list::DaemonAddress;
@@ -771,6 +773,138 @@ mod files_from_forwarding_tests {
         let data = conn.files_from_data.take().unwrap();
         assert_eq!(data, b"file1.txt\0file2.txt\0\0");
         assert!(conn.files_from_data.is_none());
+    }
+}
+
+mod daemon_progress_adapter_tests {
+    use super::*;
+    use crate::client::progress::{ClientProgressObserver, ClientProgressUpdate};
+    use crate::server::{TransferProgressCallback, TransferProgressEvent};
+    use std::path::Path;
+    use std::time::{Duration, Instant};
+
+    /// Captures progress updates for assertion in tests.
+    struct CapturingObserver {
+        updates: Vec<(u64, usize, usize, bool)>,
+    }
+
+    impl CapturingObserver {
+        fn new() -> Self {
+            Self {
+                updates: Vec::new(),
+            }
+        }
+    }
+
+    impl ClientProgressObserver for CapturingObserver {
+        fn on_progress(&mut self, update: &ClientProgressUpdate) {
+            self.updates.push((
+                update.overall_transferred(),
+                update.index(),
+                update.total(),
+                update.flist_eof(),
+            ));
+        }
+    }
+
+    #[test]
+    fn adapter_accumulates_bytes_across_files() {
+        let mut observer = CapturingObserver::new();
+        let start = Instant::now();
+        let mut adapter = DaemonProgressAdapter::new(&mut observer, start);
+
+        let event1 = TransferProgressEvent {
+            path: Path::new("file1.txt"),
+            file_bytes: 1000,
+            total_file_bytes: Some(1000),
+            files_done: 1,
+            total_files: 3,
+            flist_eof: true,
+        };
+        adapter.on_file_transferred(&event1);
+
+        let event2 = TransferProgressEvent {
+            path: Path::new("file2.txt"),
+            file_bytes: 2000,
+            total_file_bytes: Some(2000),
+            files_done: 2,
+            total_files: 3,
+            flist_eof: true,
+        };
+        adapter.on_file_transferred(&event2);
+
+        assert_eq!(observer.updates.len(), 2);
+        // First update: 1000 bytes
+        assert_eq!(observer.updates[0].0, 1000);
+        assert_eq!(observer.updates[0].1, 1);
+        assert_eq!(observer.updates[0].2, 3);
+        // Second update: 1000 + 2000 = 3000 bytes cumulative
+        assert_eq!(observer.updates[1].0, 3000);
+        assert_eq!(observer.updates[1].1, 2);
+        assert_eq!(observer.updates[1].2, 3);
+    }
+
+    #[test]
+    fn adapter_forwards_flist_eof_flag() {
+        let mut observer = CapturingObserver::new();
+        let start = Instant::now();
+        let mut adapter = DaemonProgressAdapter::new(&mut observer, start);
+
+        let event = TransferProgressEvent {
+            path: Path::new("inc.txt"),
+            file_bytes: 500,
+            total_file_bytes: Some(500),
+            files_done: 1,
+            total_files: 2,
+            flist_eof: false,
+        };
+        adapter.on_file_transferred(&event);
+
+        assert_eq!(observer.updates.len(), 1);
+        assert!(!observer.updates[0].3, "flist_eof should be false");
+    }
+
+    #[test]
+    fn adapter_single_file_reports_correct_totals() {
+        let mut observer = CapturingObserver::new();
+        let start = Instant::now();
+        let mut adapter = DaemonProgressAdapter::new(&mut observer, start);
+
+        let event = TransferProgressEvent {
+            path: Path::new("only.bin"),
+            file_bytes: 4096,
+            total_file_bytes: Some(4096),
+            files_done: 1,
+            total_files: 1,
+            flist_eof: true,
+        };
+        adapter.on_file_transferred(&event);
+
+        assert_eq!(observer.updates.len(), 1);
+        assert_eq!(observer.updates[0].0, 4096);
+        assert_eq!(observer.updates[0].1, 1);
+        assert_eq!(observer.updates[0].2, 1);
+        assert!(observer.updates[0].3);
+    }
+
+    #[test]
+    fn adapter_zero_byte_file_handled() {
+        let mut observer = CapturingObserver::new();
+        let start = Instant::now();
+        let mut adapter = DaemonProgressAdapter::new(&mut observer, start);
+
+        let event = TransferProgressEvent {
+            path: Path::new("empty.txt"),
+            file_bytes: 0,
+            total_file_bytes: Some(0),
+            files_done: 1,
+            total_files: 2,
+            flist_eof: true,
+        };
+        adapter.on_file_transferred(&event);
+
+        assert_eq!(observer.updates.len(), 1);
+        assert_eq!(observer.updates[0].0, 0);
     }
 }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -781,7 +781,7 @@ mod daemon_progress_adapter_tests {
     use crate::client::progress::{ClientProgressObserver, ClientProgressUpdate};
     use crate::server::{TransferProgressCallback, TransferProgressEvent};
     use std::path::Path;
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
 
     /// Captures progress updates for assertion in tests.
     struct CapturingObserver {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -4,6 +4,8 @@
 //! establishing the handshake result, and delegating to `run_server_with_handshake`.
 
 use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use protocol::ProtocolVersion;
@@ -13,10 +15,12 @@ use super::stats::convert_server_stats_to_summary;
 use crate::client::config::ClientConfig;
 use crate::client::error::{ClientError, invalid_argument_error};
 use crate::client::module_list::{DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter};
+use crate::client::progress::ClientProgressObserver;
 use crate::client::remote::batch_support::{BatchContext, build_batch_recording};
 use crate::client::remote::flags;
 use crate::client::summary::ClientSummary;
 use crate::server::handshake::HandshakeResult;
+use crate::server::{TransferProgressCallback, TransferProgressEvent};
 
 /// Executes a pull transfer (remote to local).
 ///
@@ -39,6 +43,7 @@ pub(crate) fn run_pull_transfer(
     protocol: ProtocolVersion,
     batch_ctx: Option<BatchContext>,
     buffered: Vec<u8>,
+    observer: Option<&mut dyn ClientProgressObserver>,
 ) -> Result<ClientSummary, ClientError> {
     let filter_rules = flags::build_wire_format_rules(config.filter_rules())?;
 
@@ -63,12 +68,17 @@ pub(crate) fn run_pull_transfer(
         .map(|ctx| build_batch_recording(ctx, false));
 
     let start = Instant::now();
+    let mut adapter = observer.map(|obs| DaemonProgressAdapter::new(obs, start));
+    let progress: Option<&mut dyn TransferProgressCallback> = adapter
+        .as_mut()
+        .map(|a| a as &mut dyn TransferProgressCallback);
+
     let server_stats = crate::server::run_server_with_handshake(
         server_config,
         handshake,
         reader,
         writer,
-        None,
+        progress,
         batch_recording,
         None,
     )
@@ -99,6 +109,7 @@ pub(crate) fn run_push_transfer(
     protocol: ProtocolVersion,
     batch_ctx: Option<BatchContext>,
     buffered: Vec<u8>,
+    observer: Option<&mut dyn ClientProgressObserver>,
 ) -> Result<ClientSummary, ClientError> {
     let filter_rules = flags::build_wire_format_rules(config.filter_rules())?;
 
@@ -115,6 +126,10 @@ pub(crate) fn run_push_transfer(
         .map(|ctx| build_batch_recording(ctx, true));
 
     let start = Instant::now();
+    let mut adapter = observer.map(|obs| DaemonProgressAdapter::new(obs, start));
+    let progress: Option<&mut dyn TransferProgressCallback> = adapter
+        .as_mut()
+        .map(|a| a as &mut dyn TransferProgressCallback);
 
     // upstream: log.c:330-340 - when !am_server, rwrite() sends itemize to
     // FCLIENT (stdout); the callback writes directly to process stdout.
@@ -130,7 +145,7 @@ pub(crate) fn run_push_transfer(
         handshake,
         reader,
         writer,
-        None,
+        progress,
         batch_recording,
         if wants_itemize {
             Some(&mut itemize_cb as &mut dyn crate::server::ItemizeCallback)
@@ -188,6 +203,56 @@ pub(super) fn is_dry_run_remote_close(error: &std::io::Error) -> bool {
             | std::io::ErrorKind::UnexpectedEof
             | std::io::ErrorKind::WouldBlock
     )
+}
+
+/// Adapts a [`ClientProgressObserver`] to [`TransferProgressCallback`].
+///
+/// Converts server-side per-file progress events into client-side progress
+/// updates, enabling live progress display during daemon transfers. Mirrors
+/// the `ServerProgressAdapter` in the SSH transfer path.
+///
+/// upstream: progress.c - `end_progress()` is called after each file completes,
+/// updating cumulative bytes and triggering the progress display.
+pub(super) struct DaemonProgressAdapter<'a> {
+    observer: &'a mut dyn ClientProgressObserver,
+    start: Instant,
+    overall_transferred: u64,
+}
+
+impl<'a> DaemonProgressAdapter<'a> {
+    pub(super) fn new(observer: &'a mut dyn ClientProgressObserver, start: Instant) -> Self {
+        Self {
+            observer,
+            start,
+            overall_transferred: 0,
+        }
+    }
+}
+
+impl TransferProgressCallback for DaemonProgressAdapter<'_> {
+    fn on_file_transferred(&mut self, event: &TransferProgressEvent<'_>) {
+        self.overall_transferred += event.file_bytes;
+
+        let client_event = crate::client::summary::ClientEvent::from_progress(
+            event.path,
+            event.file_bytes,
+            event.total_file_bytes,
+            self.start.elapsed(),
+            Arc::from(Path::new("")),
+        );
+
+        let update = crate::client::progress::ClientProgressUpdate::from_transfer_event(
+            client_event,
+            event.files_done,
+            event.total_files,
+            event.total_file_bytes,
+            self.overall_transferred,
+            self.start.elapsed(),
+            event.flist_eof,
+        );
+
+        self.observer.on_progress(&update);
+    }
 }
 
 /// Reads the `--files-from` source and serializes it into the wire format


### PR DESCRIPTION
## Summary

- Wire the `ClientProgressObserver` through both daemon transfer paths (`rsync://` and daemon-over-remote-shell), which previously discarded the observer and passed `None` for progress to `run_server_with_handshake`
- Add `DaemonProgressAdapter` to convert per-file `TransferProgressEvent` callbacks into `ClientProgressUpdate` events with cumulative byte tracking, matching the existing `ServerProgressAdapter` pattern in the SSH transfer path
- Enables `--info=progress2` to display live transfer progress during daemon transfers

## Test plan

- [ ] `daemon_progress_adapter_tests::adapter_accumulates_bytes_across_files` - verifies cumulative byte tracking across multiple files
- [ ] `daemon_progress_adapter_tests::adapter_forwards_flist_eof_flag` - verifies INC_RECURSE flist_eof flag propagation
- [ ] `daemon_progress_adapter_tests::adapter_single_file_reports_correct_totals` - verifies correct file count and byte totals
- [ ] `daemon_progress_adapter_tests::adapter_zero_byte_file_handled` - verifies zero-byte files do not break accumulation
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl