### PR TITLE
feat: add partial file retention on interrupt for --partial and --partial-dir

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -234,6 +234,7 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     server_config.qsort = config.qsort();
     server_config.write.inplace = config.inplace();
     server_config.has_partial_dir = config.partial_directory().is_some();
+    server_config.partial_dir = config.partial_directory().map(std::path::Path::to_path_buf);
     server_config.file_selection.min_file_size = config.min_file_size();
     server_config.file_selection.max_file_size = config.max_file_size();
     // upstream: options.c:2046-2048 - do_stats sets INFO_STATS to level 2+

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -77,6 +77,7 @@ pub struct ServerConfigBuilder {
     stop_at: Option<SystemTime>,
     qsort: bool,
     has_partial_dir: bool,
+    partial_dir: Option<PathBuf>,
     backup_dir: Option<String>,
     backup_suffix: Option<String>,
     daemon_filter_rules: Vec<FilterRuleWireFormat>,
@@ -113,6 +114,7 @@ impl ServerConfigBuilder {
             stop_at: None,
             qsort: false,
             has_partial_dir: false,
+            partial_dir: None,
             backup_dir: None,
             backup_suffix: None,
             daemon_filter_rules: Vec::new(),
@@ -334,6 +336,15 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Sets the directory path for storing partial files on interrupt.
+    pub fn partial_dir(&mut self, dir: Option<PathBuf>) -> &mut Self {
+        self.partial_dir = dir;
+        if self.partial_dir.is_some() {
+            self.has_partial_dir = true;
+        }
+        self
+    }
+
     /// Sets the backup directory path (`--backup-dir`).
     pub fn backup_dir(&mut self, dir: Option<String>) -> &mut Self {
         self.backup_dir = dir;
@@ -515,6 +526,7 @@ impl ServerConfigBuilder {
             stop_at: self.stop_at,
             qsort: self.qsort,
             has_partial_dir: self.has_partial_dir,
+            partial_dir: self.partial_dir.clone(),
             backup_dir: self.backup_dir.clone(),
             backup_suffix: self.backup_suffix.clone(),
             daemon_filter_rules: self.daemon_filter_rules.clone(),

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -308,6 +308,17 @@ pub struct ServerConfig {
     /// - `compat.c:777-778`: `if (compat_flags & CF_INPLACE_PARTIAL_DIR) inplace_partial = 1;`
     /// - `receiver.c:797`: `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR;`
     pub has_partial_dir: bool,
+    /// Directory path for storing partial files on interrupt (`--partial-dir=DIR`).
+    ///
+    /// When set, interrupted transfers move the incomplete temp file into this
+    /// directory instead of deleting it. On subsequent transfers, the receiver
+    /// checks this directory for a basis file to resume from.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:partial_dir` - `--partial-dir=DIR` option
+    /// - `cleanup.c:handle_partial_dir()` - moves temp to partial-dir on interrupt
+    pub partial_dir: Option<std::path::PathBuf>,
     /// Backup directory path (long-form `--backup-dir=DIR`).
     ///
     /// When set with `--backup`, displaced files are placed in this directory
@@ -418,6 +429,7 @@ impl Default for ServerConfig {
             stop_at: None,
             qsort: false,
             has_partial_dir: false,
+            partial_dir: None,
             backup_dir: None,
             backup_suffix: None,
             daemon_filter_rules: Vec::new(),

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -1,7 +1,8 @@
 //! Configuration types for the disk commit thread.
 //!
-//! Provides `DiskCommitConfig` and `BackupConfig` which control how the disk
-//! thread writes, syncs, and commits files.
+//! Provides `DiskCommitConfig`, `BackupConfig`, and `PartialMode` which
+//! control how the disk thread writes, syncs, commits files, and handles
+//! interrupted transfers.
 
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -9,6 +10,36 @@ use std::sync::Arc;
 
 use metadata::MetadataOptions;
 use protocol::acl::AclCache;
+
+/// Controls partial file retention on interrupted transfers.
+///
+/// When a transfer is interrupted (signal, connection drop, error), upstream
+/// rsync either deletes the temp file (default) or retains it for later resume
+/// via `--partial` or `--partial-dir`.
+///
+/// # Upstream Reference
+///
+/// - `cleanup.c:105-115` - `handle_partial_dir()` renames temp to partial-dir
+/// - `options.c:keep_partial` - `--partial` flag
+/// - `options.c:partial_dir` - `--partial-dir=DIR` option
+/// - `receiver.c:340-345` - `do_rename(partialptr, fname)` on interrupt
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub enum PartialMode {
+    /// No partial retention: delete temp files on interrupt (default behavior).
+    #[default]
+    None,
+    /// Retain partial files at the destination path on interrupt (`--partial`).
+    ///
+    /// The incomplete temp file is renamed to the final destination, replacing
+    /// any existing file. This allows resuming the transfer on a subsequent run.
+    Partial,
+    /// Retain partial files in a designated directory on interrupt (`--partial-dir=DIR`).
+    ///
+    /// The incomplete temp file is moved to `DIR/relative_path` instead of
+    /// being deleted. On subsequent transfers, the receiver checks this
+    /// directory for a basis file to resume from.
+    PartialDir(PathBuf),
+}
 
 /// Backup configuration for creating backup copies before overwriting.
 ///
@@ -109,6 +140,18 @@ pub struct DiskCommitConfig {
     /// `GetQueuedCompletionStatusEx`. Falls back to standard buffered
     /// I/O on non-Windows targets or when the policy is `Disabled`.
     pub iocp_policy: fast_io::IocpPolicy,
+    /// Controls partial file retention on interrupted transfers.
+    ///
+    /// When set to [`PartialMode::Partial`] or [`PartialMode::PartialDir`],
+    /// the disk thread retains temp files on shutdown/abort instead of
+    /// deleting them, matching upstream rsync's `--partial` / `--partial-dir`
+    /// behavior.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `cleanup.c:105-115` - `handle_partial_dir()` in cleanup path
+    /// - `receiver.c:340-345` - partial file rename on interrupt
+    pub partial_mode: PartialMode,
 }
 
 impl Default for DiskCommitConfig {
@@ -128,6 +171,7 @@ impl Default for DiskCommitConfig {
             io_uring_policy: fast_io::IoUringPolicy::Auto,
             io_uring_depth: None,
             iocp_policy: fast_io::IocpPolicy::Auto,
+            partial_mode: PartialMode::None,
         }
     }
 }

--- a/crates/transfer/src/disk_commit/mod.rs
+++ b/crates/transfer/src/disk_commit/mod.rs
@@ -32,5 +32,5 @@ mod writer;
 #[cfg(test)]
 mod tests;
 
-pub use self::config::{BackupConfig, DEFAULT_CHANNEL_CAPACITY, DiskCommitConfig};
+pub use self::config::{BackupConfig, DEFAULT_CHANNEL_CAPACITY, DiskCommitConfig, PartialMode};
 pub use self::thread::{DiskThreadHandle, spawn_disk_thread};

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -88,9 +88,11 @@ pub(super) fn process_file(
             Ok(m) => m,
             Err(_) => {
                 // Channel disconnected - treat as an interrupt.
-                // Flush buffered data before considering partial retention.
+                // Flush buffered data and commit any batched writes (io_uring/
+                // IOCP) before considering partial retention. flush_and_sync
+                // handles Buffered/Macos; finish handles IoUring/Iocp.
                 let _ = output.flush_and_sync(false, &begin.file_path);
-                drop(output);
+                let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
                 if bytes_written > 0 && needs_rename {
                     retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
@@ -175,10 +177,10 @@ pub(super) fn process_file(
                 });
             }
             FileMessage::Abort { reason } => {
-                // Flush buffered data before considering partial retention
-                // so the temp file contains all received data.
+                // Flush buffered data and commit any batched writes (io_uring/
+                // IOCP) so the temp file contains all received data.
                 let _ = output.flush_and_sync(false, &begin.file_path);
-                drop(output);
+                let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c:105-115 - on abort, retain temp file
                 // if partial mode is enabled and literal data was received.
                 // bytes_written > 0 is a proxy for upstream's got_literal:
@@ -191,9 +193,10 @@ pub(super) fn process_file(
                 return Err(io::Error::other(reason));
             }
             FileMessage::Shutdown => {
-                // Flush buffered data before considering partial retention.
+                // Flush buffered data and commit any batched writes (io_uring/
+                // IOCP) before considering partial retention.
                 let _ = output.flush_and_sync(false, &begin.file_path);
-                drop(output);
+                let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - same partial retention on shutdown
                 if bytes_written > 0 && needs_rename {
                     retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -25,7 +25,7 @@ use crate::temp_guard::open_tmpfile;
 #[cfg(unix)]
 use crate::temp_guard::open_tmpfile_sandboxed;
 
-use super::config::{BackupConfig, DiskCommitConfig};
+use super::config::{BackupConfig, DiskCommitConfig, PartialMode};
 use super::writer::{ReusableBufWriter, Writer};
 
 /// Processes a single file: open, write chunks, commit or abort.
@@ -84,12 +84,28 @@ pub(super) fn process_file(
     let mut bytes_written: u64 = 0;
 
     loop {
-        let msg = file_rx.recv().map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "disk thread: channel disconnected while processing file",
-            )
-        })?;
+        let msg = match file_rx.recv() {
+            Ok(m) => m,
+            Err(_) => {
+                // Channel disconnected - treat as an interrupt.
+                // Flush buffered data before considering partial retention.
+                let _ = output.flush_and_sync(false, &begin.file_path);
+                drop(output);
+                // upstream: cleanup.c - retain partial on unexpected disconnect
+                if bytes_written > 0 && needs_rename {
+                    retain_partial_file(
+                        &config.partial_mode,
+                        &mut cleanup_guard,
+                        &begin.file_path,
+                    );
+                }
+                drop(cleanup_guard);
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "disk thread: channel disconnected while processing file",
+                ));
+            }
+        };
 
         match msg {
             FileMessage::Chunk(data) => {
@@ -163,12 +179,37 @@ pub(super) fn process_file(
                 });
             }
             FileMessage::Abort { reason } => {
+                // Flush buffered data before considering partial retention
+                // so the temp file contains all received data.
+                let _ = output.flush_and_sync(false, &begin.file_path);
                 drop(output);
+                // upstream: cleanup.c:105-115 - on abort, retain temp file
+                // if partial mode is enabled and literal data was received.
+                // bytes_written > 0 is a proxy for upstream's got_literal:
+                // if any data was written, the transfer made progress worth
+                // retaining for later resume.
+                if bytes_written > 0 && needs_rename {
+                    retain_partial_file(
+                        &config.partial_mode,
+                        &mut cleanup_guard,
+                        &begin.file_path,
+                    );
+                }
                 drop(cleanup_guard);
                 return Err(io::Error::other(reason));
             }
             FileMessage::Shutdown => {
+                // Flush buffered data before considering partial retention.
+                let _ = output.flush_and_sync(false, &begin.file_path);
                 drop(output);
+                // upstream: cleanup.c - same partial retention on shutdown
+                if bytes_written > 0 && needs_rename {
+                    retain_partial_file(
+                        &config.partial_mode,
+                        &mut cleanup_guard,
+                        &begin.file_path,
+                    );
+                }
                 drop(cleanup_guard);
                 return Err(io::Error::new(
                     io::ErrorKind::Interrupted,
@@ -448,6 +489,79 @@ fn commit_file(
     };
     cleanup_guard.keep();
     Ok(was_copy)
+}
+
+/// Retains a partial temp file instead of deleting it on interrupt.
+///
+/// Depending on the `PartialMode`:
+/// - `None`: does nothing (the guard's Drop will delete the temp file).
+/// - `Partial`: renames the temp file to the final destination path, so
+///   the incomplete file is available for resume on the next run.
+/// - `PartialDir(dir)`: moves the temp file into the partial directory,
+///   using the destination filename as the target name.
+///
+/// Errors are logged and silently ignored - partial retention is best-effort.
+/// On failure, the guard's Drop will clean up the temp file.
+///
+/// # Upstream Reference
+///
+/// - `cleanup.c:105-115` - `handle_partial_dir()` moves temp to partial-dir
+/// - `cleanup.c:130-135` - `keep_partial && got_literal` guard
+/// - `receiver.c:340-345` - `do_rename(partialptr, fname)` for `--partial`
+fn retain_partial_file(
+    partial_mode: &PartialMode,
+    cleanup_guard: &mut TempFileGuard,
+    dest_path: &Path,
+) {
+    match partial_mode {
+        PartialMode::None => {}
+        PartialMode::Partial => {
+            // upstream: cleanup.c:130-135 - rename temp file directly to
+            // the destination. The incomplete content replaces any existing
+            // file at the destination path.
+            let temp_path = cleanup_guard.path().to_path_buf();
+            match rename_with_io_uring_fallback(cleanup_guard.path(), dest_path) {
+                Ok(_) => {
+                    logging::debug_log!(Io, 1, "retained partial file: {}", dest_path.display());
+                    CleanupManager::global().unregister_temp_file(&temp_path);
+                    cleanup_guard.keep();
+                }
+                Err(e) => {
+                    logging::debug_log!(
+                        Io,
+                        1,
+                        "failed to retain partial file {}: {}",
+                        dest_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+        PartialMode::PartialDir(dir) => {
+            // upstream: cleanup.c:105-115 - move temp file into partial-dir
+            let temp_path = cleanup_guard.path().to_path_buf();
+            match cleanup_guard.rename_to_partial_dir(dest_path, dir) {
+                Ok(partial_path) => {
+                    CleanupManager::global().unregister_temp_file(&temp_path);
+                    logging::debug_log!(
+                        Io,
+                        1,
+                        "retained partial file in partial-dir: {}",
+                        partial_path.display()
+                    );
+                }
+                Err(e) => {
+                    logging::debug_log!(
+                        Io,
+                        1,
+                        "failed to retain partial file in {}: {}",
+                        dir.display(),
+                        e
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Renames a temp file to its final destination, trying io_uring first.

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -93,11 +93,7 @@ pub(super) fn process_file(
                 drop(output);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(
-                        &config.partial_mode,
-                        &mut cleanup_guard,
-                        &begin.file_path,
-                    );
+                    retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::new(
@@ -189,11 +185,7 @@ pub(super) fn process_file(
                 // if any data was written, the transfer made progress worth
                 // retaining for later resume.
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(
-                        &config.partial_mode,
-                        &mut cleanup_guard,
-                        &begin.file_path,
-                    );
+                    retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::other(reason));
@@ -204,11 +196,7 @@ pub(super) fn process_file(
                 drop(output);
                 // upstream: cleanup.c - same partial retention on shutdown
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(
-                        &config.partial_mode,
-                        &mut cleanup_guard,
-                        &begin.file_path,
-                    );
+                    retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::new(

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -580,6 +580,9 @@ fn partial_mode_partial_retains_file_on_shutdown() {
     );
     assert_eq!(fs::read(&file_path).unwrap(), b"partial data");
 
+    // Drop the sender so the disk thread's recv() returns Err and exits.
+    // The Shutdown above was consumed by process_file, not disk_thread_main.
+    drop(h.file_tx);
     h.join_handle.join().unwrap();
 }
 
@@ -621,6 +624,8 @@ fn partial_mode_none_deletes_file_on_shutdown() {
         "temp file must be deleted when partial mode is None"
     );
 
+    // Drop the sender so the disk thread's recv() returns Err and exits.
+    drop(h.file_tx);
     h.join_handle.join().unwrap();
 }
 
@@ -717,6 +722,8 @@ fn partial_mode_partial_dir_retains_file_in_directory() {
         "destination file must not exist when using partial-dir"
     );
 
+    // Drop the sender so the disk thread's recv() returns Err and exits.
+    drop(h.file_tx);
     h.join_handle.join().unwrap();
 }
 
@@ -756,6 +763,8 @@ fn partial_mode_no_retention_without_data() {
         "no partial retention without literal data"
     );
 
+    // Drop the sender so the disk thread's recv() returns Err and exits.
+    drop(h.file_tx);
     h.join_handle.join().unwrap();
 }
 
@@ -842,5 +851,7 @@ fn partial_mode_relative_partial_dir() {
     );
     assert_eq!(fs::read(&partial_path).unwrap(), b"relative partial");
 
+    // Drop the sender so the disk thread's recv() returns Err and exits.
+    drop(h.file_tx);
     h.join_handle.join().unwrap();
 }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -5,7 +5,7 @@ use std::fs;
 use crate::pipeline::messages::{BeginMessage, FileMessage};
 use crate::pipeline::spsc::TryRecvError;
 
-use super::config::DiskCommitConfig;
+use super::config::{DiskCommitConfig, PartialMode};
 use super::thread::spawn_disk_thread;
 
 #[test]
@@ -530,5 +530,317 @@ fn whole_file_commit_via_io_uring_or_fallback() {
     assert_eq!(fs::read(&file_path).unwrap(), b"whole iouring");
 
     h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+// --- PIR-2: Partial file retention tests ---
+
+#[test]
+fn partial_mode_default_is_none() {
+    let config = DiskCommitConfig::default();
+    assert_eq!(config.partial_mode, PartialMode::None);
+}
+
+#[test]
+fn partial_mode_partial_retains_file_on_shutdown() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_shutdown.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"partial data".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // With PartialMode::Partial, the temp file should be renamed to dest.
+    assert!(
+        file_path.exists(),
+        "partial file must be retained at destination on shutdown"
+    );
+    assert_eq!(fs::read(&file_path).unwrap(), b"partial data");
+
+    h.join_handle.join().unwrap();
+}
+
+#[test]
+fn partial_mode_none_deletes_file_on_shutdown() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("no_partial_shutdown.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::None,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"will be deleted".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // With PartialMode::None, the temp file should be deleted.
+    assert!(
+        !file_path.exists(),
+        "temp file must be deleted when partial mode is None"
+    );
+
+    h.join_handle.join().unwrap();
+}
+
+#[test]
+fn partial_mode_partial_retains_file_on_abort() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_abort.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"abort data".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Abort {
+            reason: "test abort".into(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // With PartialMode::Partial, the temp file should be renamed to dest.
+    assert!(
+        file_path.exists(),
+        "partial file must be retained at destination on abort"
+    );
+    assert_eq!(fs::read(&file_path).unwrap(), b"abort data");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+#[test]
+fn partial_mode_partial_dir_retains_file_in_directory() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_dir_test.dat");
+    let partial_dir = dir.path().join(".rsync-partial");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::PartialDir(partial_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"partial dir data".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // The temp file should be moved to partial-dir/filename.
+    let partial_path = partial_dir.join("partial_dir_test.dat");
+    assert!(
+        partial_path.exists(),
+        "partial file must be retained in partial directory"
+    );
+    assert_eq!(fs::read(&partial_path).unwrap(), b"partial dir data");
+    // The original dest path should not exist.
+    assert!(
+        !file_path.exists(),
+        "destination file must not exist when using partial-dir"
+    );
+
+    h.join_handle.join().unwrap();
+}
+
+#[test]
+fn partial_mode_no_retention_without_data() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("no_data_partial.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    // Begin but send no chunks - upstream's got_literal would be false.
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // No data was written, so no partial retention.
+    assert!(
+        !file_path.exists(),
+        "no partial retention without literal data"
+    );
+
+    h.join_handle.join().unwrap();
+}
+
+#[test]
+fn partial_mode_channel_disconnect_retains_file() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("disconnect_partial.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"disconnect data".to_vec()))
+        .unwrap();
+
+    // Drop the sender to simulate channel disconnect.
+    drop(h.file_tx);
+
+    // The disk thread should exit and retain the partial file.
+    h.join_handle.join().unwrap();
+
+    assert!(
+        file_path.exists(),
+        "partial file must be retained on channel disconnect"
+    );
+    assert_eq!(fs::read(&file_path).unwrap(), b"disconnect data");
+}
+
+#[test]
+fn partial_mode_relative_partial_dir() {
+    let dir = test_support::create_tempdir();
+    let dest_dir = dir.path().join("dest");
+    fs::create_dir(&dest_dir).unwrap();
+    let file_path = dest_dir.join("relative_partial.dat");
+
+    // Relative partial-dir: resolved relative to the file's parent directory.
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::PartialDir(std::path::PathBuf::from(".rsync-partial")),
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"relative partial".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    let partial_path = dest_dir.join(".rsync-partial").join("relative_partial.dat");
+    assert!(
+        partial_path.exists(),
+        "partial file must be retained in relative partial directory"
+    );
+    assert_eq!(fs::read(&partial_path).unwrap(), b"relative partial");
+
     h.join_handle.join().unwrap();
 }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -50,7 +50,7 @@ impl ReceiverContext {
         total_files: usize,
         progress: &mut Option<&mut dyn crate::TransferProgressCallback>,
     ) -> io::Result<(usize, u64, u64, u64, Vec<usize>)> {
-        use crate::disk_commit::{BackupConfig, DiskCommitConfig};
+        use crate::disk_commit::{BackupConfig, DiskCommitConfig, PartialMode};
         use crate::pipeline::receiver::PipelinedReceiver;
         use crate::shared::TransferDeadline;
 
@@ -123,6 +123,14 @@ impl ReceiverContext {
             None
         };
         let file_list_arc = Arc::new(self.file_list.clone());
+        // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags
+        let partial_mode = if let Some(ref dir) = self.config.partial_dir {
+            PartialMode::PartialDir(dir.clone())
+        } else if self.config.flags.partial {
+            PartialMode::Partial
+        } else {
+            PartialMode::None
+        };
         let disk_config = DiskCommitConfig {
             do_fsync: self.config.write.fsync,
             use_sparse: self.config.flags.sparse,
@@ -136,6 +144,7 @@ impl ReceiverContext {
             acl_cache: setup.acl_cache.clone(),
             io_uring_policy: self.config.write.io_uring_policy,
             io_uring_depth: self.config.write.io_uring_depth,
+            partial_mode,
             ..DiskCommitConfig::default()
         };
         let mut pipelined_receiver = PipelinedReceiver::new(disk_config);

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -354,6 +354,79 @@ impl TempFileGuard {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Renames the temp file into a partial directory for later resume.
+    ///
+    /// Computes the target path as `partial_dir / filename` where `filename`
+    /// is derived from `dest_path` (the final destination). Creates the
+    /// partial directory if it does not exist.
+    ///
+    /// On success, marks the guard as kept (no deletion on drop) and returns
+    /// `Ok(partial_path)`. On failure, returns the I/O error - the caller
+    /// should let the guard drop normally to clean up the temp file.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `cleanup.c:105-115` - `handle_partial_dir()` constructs the partial
+    ///   path and calls `do_rename()` to move the temp file there.
+    /// - `util1.c:robust_rename()` - cross-device fallback with copy+remove.
+    pub fn rename_to_partial_dir(
+        &mut self,
+        dest_path: &Path,
+        partial_dir: &Path,
+    ) -> io::Result<PathBuf> {
+        let file_name = dest_path
+            .file_name()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "destination has no filename"))?;
+
+        // upstream: cleanup.c constructs partial path as partial_dir/filename
+        // For relative partial dirs, the path is relative to the file's parent.
+        let partial_path = if partial_dir.is_absolute() {
+            partial_dir.join(file_name)
+        } else {
+            // Relative partial-dir: place under the file's parent directory.
+            // upstream: cleanup.c uses the same parent as the destination.
+            let parent = dest_path.parent().unwrap_or(Path::new("."));
+            parent.join(partial_dir).join(file_name)
+        };
+
+        // Create the partial directory if it does not exist.
+        if let Some(parent) = partial_path.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+
+        // Rename temp file to the partial path, with cross-device fallback.
+        match fs::rename(self.path(), &partial_path) {
+            Ok(()) => {
+                self.keep_on_drop = true;
+                Ok(partial_path)
+            }
+            Err(ref e) if is_cross_device_error(e) => {
+                // upstream: util1.c:robust_rename() - copy + unlink on EXDEV
+                fs::copy(self.path(), &partial_path)?;
+                // The guard's drop will remove the source temp file.
+                self.keep_on_drop = true;
+                let _ = fs::remove_file(self.path());
+                Ok(partial_path)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Returns `true` when an I/O error represents a cross-device link (EXDEV).
+fn is_cross_device_error(e: &io::Error) -> bool {
+    match e.raw_os_error() {
+        #[cfg(unix)]
+        Some(code) => code == libc::EXDEV,
+        #[cfg(windows)]
+        Some(code) => code == 17, // ERROR_NOT_SAME_DEVICE
+        #[cfg(not(any(unix, windows)))]
+        Some(_) => false,
+        None => false,
+    }
 }
 
 impl Drop for TempFileGuard {
@@ -777,5 +850,80 @@ mod tests {
             !renamed_temp.exists(),
             "sandbox-anchored unlink must remove the original temp file"
         );
+    }
+
+    #[test]
+    fn rename_to_partial_dir_absolute() {
+        let dir = tempdir().expect("create temp dir");
+        let temp_path = dir.path().join("temp_file.tmp");
+        let partial_dir = dir.path().join("partial");
+        let dest_path = dir.path().join("final_dest.txt");
+
+        fs::write(&temp_path, b"partial content").unwrap();
+
+        let mut guard = TempFileGuard::new(temp_path.clone());
+        let result = guard.rename_to_partial_dir(&dest_path, &partial_dir);
+
+        assert!(result.is_ok());
+        let partial_path = result.unwrap();
+        assert_eq!(partial_path, partial_dir.join("final_dest.txt"));
+        assert!(partial_path.exists());
+        assert_eq!(fs::read(&partial_path).unwrap(), b"partial content");
+        assert!(!temp_path.exists());
+        // Guard should be marked kept.
+        assert!(guard.keep_on_drop);
+    }
+
+    #[test]
+    fn rename_to_partial_dir_relative() {
+        let dir = tempdir().expect("create temp dir");
+        let dest_dir = dir.path().join("dest");
+        fs::create_dir(&dest_dir).unwrap();
+        let temp_path = dir.path().join("temp_file.tmp");
+        let dest_path = dest_dir.join("file.dat");
+
+        fs::write(&temp_path, b"relative partial").unwrap();
+
+        let mut guard = TempFileGuard::new(temp_path.clone());
+        let relative_dir = Path::new(".rsync-partial");
+        let result = guard.rename_to_partial_dir(&dest_path, relative_dir);
+
+        assert!(result.is_ok());
+        let partial_path = result.unwrap();
+        assert_eq!(partial_path, dest_dir.join(".rsync-partial").join("file.dat"));
+        assert!(partial_path.exists());
+        assert_eq!(fs::read(&partial_path).unwrap(), b"relative partial");
+    }
+
+    #[test]
+    fn rename_to_partial_dir_creates_missing_directory() {
+        let dir = tempdir().expect("create temp dir");
+        let temp_path = dir.path().join("temp.tmp");
+        let partial_dir = dir.path().join("deep").join("nested").join("partial");
+        let dest_path = dir.path().join("file.txt");
+
+        fs::write(&temp_path, b"nested partial").unwrap();
+
+        let mut guard = TempFileGuard::new(temp_path.clone());
+        let result = guard.rename_to_partial_dir(&dest_path, &partial_dir);
+
+        assert!(result.is_ok());
+        let partial_path = result.unwrap();
+        assert!(partial_path.exists());
+        assert_eq!(fs::read(&partial_path).unwrap(), b"nested partial");
+    }
+
+    #[test]
+    fn rename_to_partial_dir_no_filename_returns_error() {
+        let dir = tempdir().expect("create temp dir");
+        let temp_path = dir.path().join("temp.tmp");
+        let partial_dir = dir.path().join("partial");
+
+        fs::write(&temp_path, b"data").unwrap();
+
+        let mut guard = TempFileGuard::new(temp_path);
+        let result = guard.rename_to_partial_dir(Path::new("/"), &partial_dir);
+
+        assert!(result.is_err());
     }
 }

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -375,9 +375,9 @@ impl TempFileGuard {
         dest_path: &Path,
         partial_dir: &Path,
     ) -> io::Result<PathBuf> {
-        let file_name = dest_path
-            .file_name()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "destination has no filename"))?;
+        let file_name = dest_path.file_name().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "destination has no filename")
+        })?;
 
         // upstream: cleanup.c constructs partial path as partial_dir/filename
         // For relative partial dirs, the path is relative to the file's parent.
@@ -890,7 +890,10 @@ mod tests {
 
         assert!(result.is_ok());
         let partial_path = result.unwrap();
-        assert_eq!(partial_path, dest_dir.join(".rsync-partial").join("file.dat"));
+        assert_eq!(
+            partial_path,
+            dest_dir.join(".rsync-partial").join("file.dat")
+        );
         assert!(partial_path.exists());
         assert_eq!(fs::read(&partial_path).unwrap(), b"relative partial");
     }


### PR DESCRIPTION
## Summary

- Add `PartialMode` enum (`None`/`Partial`/`PartialDir(PathBuf)`) and `partial_mode` field to `DiskCommitConfig`, controlling how the disk commit thread handles temp files on interrupted transfers
- Wire `partial_dir` path from `ClientConfig` through `ServerConfig` to `DiskCommitConfig` so the disk thread knows the retention policy
- On shutdown, abort, or channel disconnect, the disk commit thread now flushes buffered data and retains temp files per the configured mode instead of always deleting them - matching upstream rsync's `cleanup.c` behavior
- Add `TempFileGuard::rename_to_partial_dir()` helper with cross-device (EXDEV) fallback for moving temp files into partial directories
- Upstream's `got_literal` guard is approximated by `bytes_written > 0` - partial files are only retained when actual data was written

## Test plan

- [x] `partial_mode_default_is_none` - default config has no partial retention
- [x] `partial_mode_partial_retains_file_on_shutdown` - `--partial` retains temp file at dest on shutdown
- [x] `partial_mode_none_deletes_file_on_shutdown` - without `--partial`, temp file is deleted
- [x] `partial_mode_partial_retains_file_on_abort` - `--partial` retains temp file on abort
- [x] `partial_mode_partial_dir_retains_file_in_directory` - `--partial-dir` moves temp to directory
- [x] `partial_mode_no_retention_without_data` - no retention when zero bytes written (got_literal proxy)
- [x] `partial_mode_channel_disconnect_retains_file` - channel disconnect retains partial file
- [x] `partial_mode_relative_partial_dir` - relative partial-dir resolved against file parent
- [x] `rename_to_partial_dir_absolute` - absolute partial-dir rename
- [x] `rename_to_partial_dir_relative` - relative partial-dir rename
- [x] `rename_to_partial_dir_creates_missing_directory` - nested directory creation
- [x] `rename_to_partial_dir_no_filename_returns_error` - error on invalid dest path
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl