### PR TITLE
ci: add iconv feature to CI test matrix

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -50,6 +50,8 @@ jobs:
             args: "-p daemon --features concurrent-sessions"
           - name: daemon-tls
             args: "-p daemon --features daemon-tls"
+          - name: iconv
+            args: "-p protocol -p transfer -p engine -p core -p cli -p daemon --features iconv"
 
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Add an `iconv` row to the cross-OS feature-flags matrix in `_test-features.yml`
- Covers all six crates with iconv-gated code: `protocol`, `transfer`, `engine`, `core`, `cli`, `daemon`
- Runs on Linux, macOS, and Windows since the feature depends on `encoding_rs` (pure Rust, no system library requirements)

## Test plan

- [ ] CI passes the new `iconv` matrix row on all three OS targets
- [ ] Existing feature-flag rows remain unaffected