### PR TITLE
feat: stamp mtime=0 on retained partial files for plain --partial

### DIFF
--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -24,6 +24,7 @@ compress = { path = "../compress" }
 logging = { path = "../logging" }
 fast_io = { path = "../fast_io", default-features = false }
 crossbeam-queue = { workspace = true }
+filetime = { workspace = true }
 getrandom = "0.4"
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -579,6 +579,22 @@ fn retain_partial_file(
             let temp_path = cleanup_guard.path().to_path_buf();
             match rename_with_io_uring_fallback(cleanup_guard.path(), dest_path) {
                 Ok(_) => {
+                    // upstream: cleanup.c:174-178 - stamp modtime=0 on
+                    // retained partial files so --update does not skip them
+                    // as "up to date" on the next run. Only for plain
+                    // --partial, not --partial-dir (upstream uses
+                    // handle_partial_dir() for --partial-dir which does not
+                    // zero the mtime).
+                    let epoch = filetime::FileTime::zero();
+                    if let Err(e) = filetime::set_file_mtime(dest_path, epoch) {
+                        logging::debug_log!(
+                            Io,
+                            1,
+                            "failed to set mtime=0 on partial file {}: {}",
+                            dest_path.display(),
+                            e
+                        );
+                    }
                     logging::debug_log!(Io, 1, "retained partial file: {}", dest_path.display());
                     CleanupManager::global().unregister_temp_file(&temp_path);
                     cleanup_guard.keep();

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -591,7 +591,15 @@ fn retain_partial_file(
                     // --partial, not --partial-dir (upstream uses
                     // handle_partial_dir() for --partial-dir which does not
                     // zero the mtime).
-                    let epoch = filetime::FileTime::zero();
+                    //
+                    // Use from_unix_time(0, 0) rather than FileTime::zero()
+                    // because on Windows, zero() maps to the Windows epoch
+                    // (1601-01-01) which becomes an all-zero FILETIME -
+                    // SetFileTime treats that as "do not change", silently
+                    // skipping the stamp. from_unix_time(0, 0) maps to
+                    // 1970-01-01 which is a non-zero FILETIME that Windows
+                    // will actually apply.
+                    let epoch = filetime::FileTime::from_unix_time(0, 0);
                     if let Err(e) = filetime::set_file_mtime(dest_path, epoch) {
                         logging::debug_log!(
                             Io,

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -92,10 +92,9 @@ pub(super) fn process_file(
                 // IOCP) before considering partial retention. flush_and_sync
                 // handles Buffered/Macos; finish handles IoUring/Iocp.
                 let _ = output.flush_and_sync(false, &begin.file_path);
+                // finish() takes `self`, closing the file handle before
+                // rename+mtime stamp (Windows resets mtime on handle close).
                 let _ = output.finish(false, &begin.file_path);
-                // Close file handle before rename+mtime stamp (Windows resets
-                // mtime on handle close).
-                drop(output);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
                 if bytes_written > 0 && needs_rename {
                     retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
@@ -191,10 +190,9 @@ pub(super) fn process_file(
                 // Flush buffered data and commit any batched writes (io_uring/
                 // IOCP) so the temp file contains all received data.
                 let _ = output.flush_and_sync(false, &begin.file_path);
+                // finish() takes `self`, closing the file handle before
+                // rename+mtime stamp (Windows resets mtime on handle close).
                 let _ = output.finish(false, &begin.file_path);
-                // Close file handle before rename+mtime stamp (Windows resets
-                // mtime on handle close).
-                drop(output);
                 // upstream: cleanup.c:105-115 - on abort, retain temp file
                 // if partial mode is enabled and literal data was received.
                 // bytes_written > 0 is a proxy for upstream's got_literal:
@@ -210,10 +208,9 @@ pub(super) fn process_file(
                 // Flush buffered data and commit any batched writes (io_uring/
                 // IOCP) before considering partial retention.
                 let _ = output.flush_and_sync(false, &begin.file_path);
+                // finish() takes `self`, closing the file handle before
+                // rename+mtime stamp (Windows resets mtime on handle close).
                 let _ = output.finish(false, &begin.file_path);
-                // Close file handle before rename+mtime stamp (Windows resets
-                // mtime on handle close).
-                drop(output);
                 // upstream: cleanup.c - same partial retention on shutdown
                 if bytes_written > 0 && needs_rename {
                     retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -93,6 +93,9 @@ pub(super) fn process_file(
                 // handles Buffered/Macos; finish handles IoUring/Iocp.
                 let _ = output.flush_and_sync(false, &begin.file_path);
                 let _ = output.finish(false, &begin.file_path);
+                // Close file handle before rename+mtime stamp (Windows resets
+                // mtime on handle close).
+                drop(output);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
                 if bytes_written > 0 && needs_rename {
                     retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
@@ -189,6 +192,9 @@ pub(super) fn process_file(
                 // IOCP) so the temp file contains all received data.
                 let _ = output.flush_and_sync(false, &begin.file_path);
                 let _ = output.finish(false, &begin.file_path);
+                // Close file handle before rename+mtime stamp (Windows resets
+                // mtime on handle close).
+                drop(output);
                 // upstream: cleanup.c:105-115 - on abort, retain temp file
                 // if partial mode is enabled and literal data was received.
                 // bytes_written > 0 is a proxy for upstream's got_literal:
@@ -205,6 +211,9 @@ pub(super) fn process_file(
                 // IOCP) before considering partial retention.
                 let _ = output.flush_and_sync(false, &begin.file_path);
                 let _ = output.finish(false, &begin.file_path);
+                // Close file handle before rename+mtime stamp (Windows resets
+                // mtime on handle close).
+                drop(output);
                 // upstream: cleanup.c - same partial retention on shutdown
                 if bytes_written > 0 && needs_rename {
                     retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2184,3 +2184,213 @@ fn delay_updates_sweep_replaces_existing_files() {
         "sweep must replace existing destination content"
     );
 }
+
+// --- PIR-3: Partial file mtime=0 stamp tests ---
+
+/// Verifies that a partial file retained via `--partial` has its mtime
+/// stamped to epoch 0. Upstream cleanup.c:174-178 does this so that a
+/// subsequent `--update` run does not skip the partial file as "up to date".
+#[test]
+fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_mtime_zero.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"partial content".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    assert!(file_path.exists(), "partial file must be retained");
+    assert_eq!(fs::read(&file_path).unwrap(), b"partial content");
+
+    // The retained partial file must have mtime=0 (epoch).
+    let mtime =
+        filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    assert_eq!(
+        mtime,
+        filetime::FileTime::zero(),
+        "partial file mtime must be stamped to epoch 0"
+    );
+
+    drop(h.file_tx);
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies that mtime=0 is also stamped on partial files retained via
+/// abort (not just shutdown). Both interrupt paths go through
+/// `retain_partial_file`.
+#[test]
+fn partial_mode_partial_stamps_mtime_zero_on_abort() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_mtime_zero_abort.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"abort partial".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Abort {
+            reason: "test abort".into(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    assert!(file_path.exists(), "partial file must be retained on abort");
+
+    let mtime =
+        filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    assert_eq!(
+        mtime,
+        filetime::FileTime::zero(),
+        "partial file mtime must be epoch 0 on abort"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies that partial files retained via `--partial-dir` do NOT have
+/// their mtime stamped to 0. Upstream only stamps mtime=0 for plain
+/// `--partial` (cleanup.c:174-178), not `--partial-dir`.
+#[test]
+fn partial_mode_partial_dir_does_not_stamp_mtime_zero() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_dir_mtime.dat");
+    let partial_dir = dir.path().join(".rsync-partial");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::PartialDir(partial_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"partial dir content".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    let partial_path = partial_dir.join("partial_dir_mtime.dat");
+    assert!(
+        partial_path.exists(),
+        "partial file must exist in partial-dir"
+    );
+
+    // partial-dir files should NOT have mtime=0.
+    let mtime =
+        filetime::FileTime::from_last_modification_time(&fs::metadata(&partial_path).unwrap());
+    assert_ne!(
+        mtime,
+        filetime::FileTime::zero(),
+        "partial-dir files must not have mtime stamped to 0"
+    );
+
+    drop(h.file_tx);
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies that mtime=0 is stamped on partial files retained via channel
+/// disconnect (connection drop). This is another interrupt path that goes
+/// through `retain_partial_file`.
+#[test]
+fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("partial_mtime_disconnect.dat");
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::Partial,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"disconnect partial".to_vec()))
+        .unwrap();
+
+    // Drop sender to simulate channel disconnect.
+    drop(h.file_tx);
+    h.join_handle.join().unwrap();
+
+    assert!(
+        file_path.exists(),
+        "partial file must be retained on disconnect"
+    );
+
+    let mtime =
+        filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    assert_eq!(
+        mtime,
+        filetime::FileTime::zero(),
+        "partial file mtime must be epoch 0 on disconnect"
+    );
+}

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2226,12 +2226,28 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
     assert_eq!(fs::read(&file_path).unwrap(), b"partial content");
 
     // The retained partial file must have mtime=0 (epoch).
+    // On Windows, NTFS cannot represent epoch 0 - set_file_mtime
+    // silently clamps to the NTFS minimum (1601-01-01). We verify that
+    // the mtime was moved far into the past rather than asserting exact
+    // zero.
     let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    #[cfg(unix)]
     assert_eq!(
         mtime,
         filetime::FileTime::zero(),
         "partial file mtime must be stamped to epoch 0"
     );
+    #[cfg(windows)]
+    {
+        let threshold = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(86400);
+        let one_day_ago = filetime::FileTime::from_system_time(threshold);
+        assert!(
+            mtime < one_day_ago,
+            "partial file mtime must be stamped to the past, got {:?}",
+            mtime,
+        );
+    }
 
     drop(h.file_tx);
     h.join_handle.join().unwrap();
@@ -2279,11 +2295,23 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
     assert!(file_path.exists(), "partial file must be retained on abort");
 
     let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    #[cfg(unix)]
     assert_eq!(
         mtime,
         filetime::FileTime::zero(),
         "partial file mtime must be epoch 0 on abort"
     );
+    #[cfg(windows)]
+    {
+        let threshold = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(86400);
+        let one_day_ago = filetime::FileTime::from_system_time(threshold);
+        assert!(
+            mtime < one_day_ago,
+            "partial file mtime must be stamped to the past on abort, got {:?}",
+            mtime,
+        );
+    }
 
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();
@@ -2385,9 +2413,21 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
     );
 
     let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    #[cfg(unix)]
     assert_eq!(
         mtime,
         filetime::FileTime::zero(),
         "partial file mtime must be epoch 0 on disconnect"
     );
+    #[cfg(windows)]
+    {
+        let threshold = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(86400);
+        let one_day_ago = filetime::FileTime::from_system_time(threshold);
+        assert!(
+            mtime < one_day_ago,
+            "partial file mtime must be stamped to the past on disconnect, got {:?}",
+            mtime,
+        );
+    }
 }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2239,8 +2239,8 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
     );
     #[cfg(windows)]
     {
-        let threshold = std::time::SystemTime::now()
-            - std::time::Duration::from_secs(86400);
+        let threshold =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
         let one_day_ago = filetime::FileTime::from_system_time(threshold);
         assert!(
             mtime < one_day_ago,
@@ -2303,8 +2303,8 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
     );
     #[cfg(windows)]
     {
-        let threshold = std::time::SystemTime::now()
-            - std::time::Duration::from_secs(86400);
+        let threshold =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
         let one_day_ago = filetime::FileTime::from_system_time(threshold);
         assert!(
             mtime < one_day_ago,
@@ -2421,8 +2421,8 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
     );
     #[cfg(windows)]
     {
-        let threshold = std::time::SystemTime::now()
-            - std::time::Duration::from_secs(86400);
+        let threshold =
+            std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
         let one_day_ago = filetime::FileTime::from_system_time(threshold);
         assert!(
             mtime < one_day_ago,

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2226,8 +2226,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
     assert_eq!(fs::read(&file_path).unwrap(), b"partial content");
 
     // The retained partial file must have mtime=0 (epoch).
-    let mtime =
-        filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
     assert_eq!(
         mtime,
         filetime::FileTime::zero(),
@@ -2279,8 +2278,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
 
     assert!(file_path.exists(), "partial file must be retained on abort");
 
-    let mtime =
-        filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
     assert_eq!(
         mtime,
         filetime::FileTime::zero(),
@@ -2386,8 +2384,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
         "partial file must be retained on disconnect"
     );
 
-    let mtime =
-        filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
+    let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
     assert_eq!(
         mtime,
         filetime::FileTime::zero(),

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2225,28 +2225,13 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
     assert!(file_path.exists(), "partial file must be retained");
     assert_eq!(fs::read(&file_path).unwrap(), b"partial content");
 
-    // The retained partial file must have mtime=0 (epoch).
-    // On Windows, NTFS cannot represent epoch 0 - set_file_mtime
-    // silently clamps to the NTFS minimum (1601-01-01). We verify that
-    // the mtime was moved far into the past rather than asserting exact
-    // zero.
+    // The retained partial file must have mtime = Unix epoch (1970-01-01).
     let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
-    #[cfg(unix)]
+    let unix_epoch = filetime::FileTime::from_unix_time(0, 0);
     assert_eq!(
-        mtime,
-        filetime::FileTime::zero(),
-        "partial file mtime must be stamped to epoch 0"
+        mtime, unix_epoch,
+        "partial file mtime must be stamped to Unix epoch"
     );
-    #[cfg(windows)]
-    {
-        let threshold = std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
-        let one_day_ago = filetime::FileTime::from_system_time(threshold);
-        assert!(
-            mtime < one_day_ago,
-            "partial file mtime must be stamped to the past, got {:?}",
-            mtime,
-        );
-    }
 
     drop(h.file_tx);
     h.join_handle.join().unwrap();
@@ -2294,22 +2279,11 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
     assert!(file_path.exists(), "partial file must be retained on abort");
 
     let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
-    #[cfg(unix)]
+    let unix_epoch = filetime::FileTime::from_unix_time(0, 0);
     assert_eq!(
-        mtime,
-        filetime::FileTime::zero(),
-        "partial file mtime must be epoch 0 on abort"
+        mtime, unix_epoch,
+        "partial file mtime must be stamped to Unix epoch on abort"
     );
-    #[cfg(windows)]
-    {
-        let threshold = std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
-        let one_day_ago = filetime::FileTime::from_system_time(threshold);
-        assert!(
-            mtime < one_day_ago,
-            "partial file mtime must be stamped to the past on abort, got {:?}",
-            mtime,
-        );
-    }
 
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();
@@ -2357,13 +2331,13 @@ fn partial_mode_partial_dir_does_not_stamp_mtime_zero() {
         "partial file must exist in partial-dir"
     );
 
-    // partial-dir files should NOT have mtime=0.
+    // partial-dir files should NOT have mtime stamped to epoch.
     let mtime =
         filetime::FileTime::from_last_modification_time(&fs::metadata(&partial_path).unwrap());
+    let unix_epoch = filetime::FileTime::from_unix_time(0, 0);
     assert_ne!(
-        mtime,
-        filetime::FileTime::zero(),
-        "partial-dir files must not have mtime stamped to 0"
+        mtime, unix_epoch,
+        "partial-dir files must not have mtime stamped to epoch"
     );
 
     drop(h.file_tx);
@@ -2411,20 +2385,9 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
     );
 
     let mtime = filetime::FileTime::from_last_modification_time(&fs::metadata(&file_path).unwrap());
-    #[cfg(unix)]
+    let unix_epoch = filetime::FileTime::from_unix_time(0, 0);
     assert_eq!(
-        mtime,
-        filetime::FileTime::zero(),
-        "partial file mtime must be epoch 0 on disconnect"
+        mtime, unix_epoch,
+        "partial file mtime must be stamped to Unix epoch on disconnect"
     );
-    #[cfg(windows)]
-    {
-        let threshold = std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
-        let one_day_ago = filetime::FileTime::from_system_time(threshold);
-        assert!(
-            mtime < one_day_ago,
-            "partial file mtime must be stamped to the past on disconnect, got {:?}",
-            mtime,
-        );
-    }
 }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2239,8 +2239,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_shutdown() {
     );
     #[cfg(windows)]
     {
-        let threshold =
-            std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
+        let threshold = std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
         let one_day_ago = filetime::FileTime::from_system_time(threshold);
         assert!(
             mtime < one_day_ago,
@@ -2303,8 +2302,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_abort() {
     );
     #[cfg(windows)]
     {
-        let threshold =
-            std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
+        let threshold = std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
         let one_day_ago = filetime::FileTime::from_system_time(threshold);
         assert!(
             mtime < one_day_ago,
@@ -2421,8 +2419,7 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
     );
     #[cfg(windows)]
     {
-        let threshold =
-            std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
+        let threshold = std::time::SystemTime::now() - std::time::Duration::from_secs(86400);
         let one_day_ago = filetime::FileTime::from_system_time(threshold);
         assert!(
             mtime < one_day_ago,


### PR DESCRIPTION
## Summary

- Stamp `mtime=0` on partial files retained via plain `--partial` on interrupt, matching upstream rsync `cleanup.c:174-178` behavior
- Prevents `--update` from skipping partial files as "up to date" on the next run, ensuring interrupted transfers resume correctly
- Only applies to `PartialMode::Partial` (plain `--partial`), not `PartialMode::PartialDir` (`--partial-dir`), matching upstream semantics

## Test plan

- [x] `partial_mode_partial_stamps_mtime_zero_on_shutdown` - mtime=0 on shutdown interrupt
- [x] `partial_mode_partial_stamps_mtime_zero_on_abort` - mtime=0 on abort interrupt
- [x] `partial_mode_partial_stamps_mtime_zero_on_disconnect` - mtime=0 on channel disconnect
- [x] `partial_mode_partial_dir_does_not_stamp_mtime_zero` - partial-dir does NOT stamp mtime=0
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl