### PR TITLE
feat: handle progress2 interaction with --outbuf and terminal detection

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -14,7 +14,10 @@ use logging_sink::MessageSink;
 
 use crate::frontend::{
     out_format::{OutFormat, OutFormatContext},
-    progress::{LiveProgress, NameOutputLevel, ProgressMode, StderrMode, emit_transfer_summary},
+    progress::{
+        LiveProgress, NameOutputLevel, ProgressMode, ProgressOutputConfig, StderrMode,
+        emit_transfer_summary,
+    },
 };
 
 use super::messages::emit_message_with_fallback;
@@ -32,6 +35,7 @@ pub(crate) struct TransferExecutionInputs<'a> {
     pub(crate) msgs_to_stderr: bool,
     pub(crate) stderr_mode: StderrMode,
     pub(crate) progress_mode: Option<ProgressMode>,
+    pub(crate) progress_output_config: ProgressOutputConfig,
     pub(crate) human_readable_mode: HumanReadableMode,
     pub(crate) itemize_changes: bool,
     pub(crate) stats_level: u8,
@@ -59,6 +63,7 @@ where
         msgs_to_stderr,
         stderr_mode,
         progress_mode: requested_progress_mode,
+        progress_output_config,
         human_readable_mode,
         itemize_changes,
         stats_level,
@@ -78,7 +83,7 @@ where
 
     let mut live_progress = requested_progress_mode.map(|mode| {
         with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
-            LiveProgress::new(writer, mode, human_readable_mode)
+            LiveProgress::with_output_config(writer, mode, human_readable_mode, progress_output_config)
         })
     });
 

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -83,7 +83,12 @@ where
 
     let mut live_progress = requested_progress_mode.map(|mode| {
         with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
-            LiveProgress::with_output_config(writer, mode, human_readable_mode, progress_output_config)
+            LiveProgress::with_output_config(
+                writer,
+                mode,
+                human_readable_mode,
+                progress_output_config,
+            )
         })
     });
 

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -11,7 +11,8 @@ use crate::frontend::execution::drive::module_listing::{
     ModuleListingInputs, maybe_handle_module_listing,
 };
 use crate::frontend::execution::drive::{config, filters, metadata, options, summary, validation};
-use crate::frontend::progress::StderrMode;
+use crate::frontend::outbuf::parse_outbuf_mode;
+use crate::frontend::progress::{ProgressOutputConfig, StderrMode};
 use crate::frontend::{
     arguments::{ParsedArgs, StopRequest},
     execution::{
@@ -25,7 +26,7 @@ use core::{message::Role, rsync_error};
 use logging::VerbosityConfig;
 use logging_sink::MessageSink;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
@@ -195,7 +196,7 @@ where
         append_verify,
         msgs_to_stderr: msgs_to_stderr_option,
         stderr_mode,
-        outbuf: _,
+        outbuf,
         max_alloc,
         itemize_changes,
         whole_file,
@@ -862,6 +863,24 @@ where
 
     let config = builder.build();
 
+    // upstream: progress.c:234-238 checks `tcgetpgrp(STDOUT_FILENO)` to
+    // suppress progress when the process is not in the foreground terminal
+    // group. We detect terminal status on the output destination (stdout
+    // by default, stderr when msgs_to_stderr is active) to decide between
+    // `\r` (in-place overwrite on terminals) and `\n` (readable when piped).
+    let progress_is_terminal = if msgs_to_stderr_enabled {
+        std::io::stderr().is_terminal()
+    } else {
+        std::io::stdout().is_terminal()
+    };
+    let outbuf_mode = outbuf
+        .as_ref()
+        .and_then(|v| parse_outbuf_mode(v.as_os_str()).ok());
+    let progress_output_config = ProgressOutputConfig {
+        is_terminal: progress_is_terminal,
+        outbuf_mode,
+    };
+
     summary::execute_transfer(
         stdout,
         stderr,
@@ -870,6 +889,7 @@ where
             msgs_to_stderr: msgs_to_stderr_enabled,
             stderr_mode: stderr_mode_setting,
             progress_mode,
+            progress_output_config,
             human_readable_mode,
             itemize_changes,
             stats_level,

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -83,7 +83,7 @@ use std::io::{self, Write};
 pub mod arguments;
 mod command_builder;
 mod execution;
-mod outbuf;
+pub(crate) mod outbuf;
 
 #[cfg(test)]
 pub(crate) use command_builder::clap_command;

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -69,6 +69,7 @@ pub(crate) struct LiveProgress<'a> {
 }
 
 impl<'a> LiveProgress<'a> {
+    #[cfg(test)]
     pub(crate) fn new(
         writer: &'a mut dyn Write,
         mode: ProgressMode,

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -10,6 +10,36 @@ use super::format::{
     format_progress_percent, format_progress_rate, format_progress_rate_from_value,
 };
 use super::mode::ProgressMode;
+use crate::frontend::outbuf::OutbufMode;
+
+/// Controls how progress output adapts to terminal vs piped destinations
+/// and how buffering interacts with progress ticks.
+///
+/// upstream: progress.c uses `\r` for in-place overwrite on terminals.
+/// When piped, progress lines would overwrite each other invisibly, so
+/// upstream's `output_needs_newline` mechanism ensures a `\n` is emitted
+/// before any non-progress message. We go further: when the output is not
+/// a terminal, we use `\n` instead of `\r` so piped output is readable.
+///
+/// upstream: options.c:2012-2034 `--outbuf` controls stdout buffering via
+/// `setvbuf`. We mirror this by flushing after each progress tick when
+/// the mode is unbuffered or line-buffered.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ProgressOutputConfig {
+    /// Whether the output destination is an interactive terminal.
+    pub(crate) is_terminal: bool,
+    /// The `--outbuf` buffering mode, if specified.
+    pub(crate) outbuf_mode: Option<OutbufMode>,
+}
+
+impl Default for ProgressOutputConfig {
+    fn default() -> Self {
+        Self {
+            is_terminal: true,
+            outbuf_mode: None,
+        }
+    }
+}
 
 /// Emits verbose, statistics, and progress-oriented output derived from a
 /// [`core::client::ClientSummary`].
@@ -34,6 +64,8 @@ pub(crate) struct LiveProgress<'a> {
     /// upstream: progress.c:84-91 `static int last_len` - tracks the longest
     /// progress line and pads the current line to match before emitting.
     max_line_len: usize,
+    /// Terminal and buffering configuration for progress output.
+    output_config: ProgressOutputConfig,
 }
 
 impl<'a> LiveProgress<'a> {
@@ -41,6 +73,15 @@ impl<'a> LiveProgress<'a> {
         writer: &'a mut dyn Write,
         mode: ProgressMode,
         human_readable: HumanReadableMode,
+    ) -> Self {
+        Self::with_output_config(writer, mode, human_readable, ProgressOutputConfig::default())
+    }
+
+    pub(crate) fn with_output_config(
+        writer: &'a mut dyn Write,
+        mode: ProgressMode,
+        human_readable: HumanReadableMode,
+        output_config: ProgressOutputConfig,
     ) -> Self {
         Self {
             writer,
@@ -53,6 +94,7 @@ impl<'a> LiveProgress<'a> {
             overall_remaining: RemainingTimeEstimator::new(),
             per_file_remaining: HashMap::new(),
             max_line_len: 0,
+            output_config,
         }
     }
 
@@ -78,6 +120,31 @@ impl<'a> LiveProgress<'a> {
         Ok(())
     }
 
+    /// Returns the carriage-return prefix used to overwrite the current line.
+    ///
+    /// When the output is a terminal, returns `\r` for in-place overwrite.
+    /// When piped, returns `\n` so each progress tick appears on its own line.
+    ///
+    /// upstream: progress.c:129 uses `\r` unconditionally because upstream
+    /// relies on `output_needs_newline` + terminal process group checks in
+    /// `show_progress` to suppress output when backgrounded or piped.
+    fn line_restart(&self) -> &'static str {
+        if self.output_config.is_terminal { "\r" } else { "\n" }
+    }
+
+    /// Flushes the writer after a progress tick if the outbuf mode requires it.
+    ///
+    /// upstream: progress.c:133 calls `rflush(FCLIENT)` after every non-final
+    /// progress tick. We mirror this for unbuffered and line-buffered modes.
+    /// Block-buffered mode defers flushing to the OS or explicit flush calls.
+    fn flush_if_needed(&mut self) -> io::Result<()> {
+        match self.output_config.outbuf_mode {
+            Some(OutbufMode::None) => self.writer.flush(),
+            Some(OutbufMode::Line) => self.writer.flush(),
+            Some(OutbufMode::Block) | None => Ok(()),
+        }
+    }
+
     /// Writes a progress line for progress2 (Overall) mode, padding to the
     /// longest previously emitted line to erase stale characters on `\r`
     /// overwrite.
@@ -85,9 +152,16 @@ impl<'a> LiveProgress<'a> {
     /// upstream: progress.c:84-91 - `last_len` tracking and space-padding.
     fn write_overall_line(&mut self, line: &str) -> io::Result<()> {
         let current_len = line.len();
-        let pad = self.max_line_len.saturating_sub(current_len);
-        if pad > 0 {
-            write!(self.writer, "{line}{:pad$}", "")?;
+        // Only pad when output goes to a terminal - padding erases stale
+        // characters from longer previous `\r`-overwritten ticks. When piped,
+        // each tick is on its own line so padding is unnecessary.
+        if self.output_config.is_terminal {
+            let pad = self.max_line_len.saturating_sub(current_len);
+            if pad > 0 {
+                write!(self.writer, "{line}{:pad$}", "")?;
+            } else {
+                write!(self.writer, "{line}")?;
+            }
         } else {
             write!(self.writer, "{line}")?;
         }
@@ -153,7 +227,7 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 let xfr_index = update.index();
 
                 if self.line_active {
-                    write!(self.writer, "\r")?;
+                    write!(self.writer, "{}", self.line_restart())?;
                 }
 
                 // upstream: progress.c:80 - chk-prefix is "to" once the file
@@ -172,6 +246,9 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     self.per_file_remaining.remove(relative);
                 } else {
                     self.line_active = true;
+                    // upstream: progress.c:133 - rflush(FCLIENT) after
+                    // every non-final progress tick.
+                    self.flush_if_needed()?;
                 }
                 Ok(())
             })(),
@@ -208,7 +285,7 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                 let xfr_index = update.index();
 
                 if self.line_active {
-                    write!(self.writer, "\r")?;
+                    write!(self.writer, "{}", self.line_restart())?;
                 }
 
                 // upstream: progress.c:80 - chk-prefix is "to" once the file
@@ -236,6 +313,8 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                         // Newline suppressed for progress2 per
                         // progress.c:88 - cursor stays on same line.
                         self.line_active = true;
+                        // upstream: progress.c:133 - rflush(FCLIENT)
+                        self.flush_if_needed()?;
                     }
                 } else {
                     // upstream: progress.c:100 - in-flight ticks use trailing
@@ -243,6 +322,9 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                     let line = format!("{size_field} {percent_field} {rate_field} {time_field}  ");
                     self.write_overall_line(&line)?;
                     self.line_active = true;
+                    // upstream: progress.c:133 - rflush(FCLIENT) after
+                    // every non-final progress tick.
+                    self.flush_if_needed()?;
                 }
                 self.active_path = None;
                 Ok(())
@@ -418,6 +500,309 @@ mod tests {
         assert!(
             output.contains("kB/s") || output.contains("MB/s") || output.contains("GB/s"),
             "progress2 should contain a rate with base-1024 units: {output}"
+        );
+    }
+
+    fn piped_config() -> ProgressOutputConfig {
+        ProgressOutputConfig {
+            is_terminal: false,
+            outbuf_mode: None,
+        }
+    }
+
+    fn terminal_config() -> ProgressOutputConfig {
+        ProgressOutputConfig {
+            is_terminal: true,
+            outbuf_mode: None,
+        }
+    }
+
+    /// When output is not a terminal, progress lines should use `\n` instead
+    /// of `\r` so piped output is human-readable.
+    #[test]
+    fn per_file_uses_newline_when_piped() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::with_output_config(
+                &mut buf,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+                piped_config(),
+            );
+            live.on_progress(&make_mid_transfer_update(true));
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(
+            !output.contains('\r'),
+            "piped per-file output should not contain \\r: {output:?}"
+        );
+    }
+
+    /// When output is a terminal, progress lines should use `\r` for in-place
+    /// overwrite, matching upstream rsync behaviour.
+    #[test]
+    fn per_file_uses_cr_when_terminal() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::with_output_config(
+                &mut buf,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+                terminal_config(),
+            );
+            live.on_progress(&make_mid_transfer_update(true));
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(
+            output.contains('\r'),
+            "terminal per-file output should contain \\r: {output:?}"
+        );
+    }
+
+    /// When output is not a terminal, overall (progress2) mode should use
+    /// `\n` instead of `\r`.
+    #[test]
+    fn overall_uses_newline_when_piped() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::with_output_config(
+                &mut buf,
+                ProgressMode::Overall,
+                HumanReadableMode::Disabled,
+                piped_config(),
+            );
+            live.on_progress(&make_update(true));
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(
+            !output.contains('\r'),
+            "piped progress2 output should not contain \\r: {output:?}"
+        );
+    }
+
+    /// When output is a terminal, overall mode uses `\r` for overwrite.
+    #[test]
+    fn overall_uses_cr_when_terminal() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::with_output_config(
+                &mut buf,
+                ProgressMode::Overall,
+                HumanReadableMode::Disabled,
+                terminal_config(),
+            );
+            live.on_progress(&make_update(true));
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(
+            output.contains('\r'),
+            "terminal progress2 output should contain \\r: {output:?}"
+        );
+    }
+
+    /// When piped, overall mode should not pad shorter lines since each line
+    /// appears on its own row and there are no stale characters to erase.
+    #[test]
+    fn overall_no_padding_when_piped() {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut live = LiveProgress::with_output_config(
+                &mut buf,
+                ProgressMode::Overall,
+                HumanReadableMode::Disabled,
+                piped_config(),
+            );
+            // First tick: final with trailer (longer line)
+            live.on_progress(&make_update(true));
+            // Second tick: mid-transfer without trailer (shorter line)
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let output = String::from_utf8(buf).expect("utf8");
+        // Split on \n and look at the mid-transfer line (the last non-empty one)
+        let lines: Vec<&str> = output.lines().collect();
+        if let Some(last) = lines.last() {
+            // The mid-transfer line ends with "  " (two trailing spaces from
+            // upstream format), but should NOT have extra padding spaces beyond
+            // that since we're not in terminal mode.
+            let content = last.trim_start();
+            // Count trailing spaces beyond the two-space upstream suffix
+            let trimmed = content.trim_end();
+            let trailing_spaces = content.len() - trimmed.len();
+            assert!(
+                trailing_spaces <= 2,
+                "piped output should not pad beyond the 2-space suffix: {last:?} ({trailing_spaces} trailing spaces)"
+            );
+        }
+    }
+
+    /// Verify that `ProgressOutputConfig::default()` produces terminal mode
+    /// for backward compatibility with existing callers.
+    #[test]
+    fn default_output_config_is_terminal() {
+        let config = ProgressOutputConfig::default();
+        assert!(
+            config.is_terminal,
+            "default config should assume terminal output"
+        );
+        assert!(
+            config.outbuf_mode.is_none(),
+            "default config should have no outbuf mode"
+        );
+    }
+
+    /// Verify that `line_restart()` returns the correct character for each mode.
+    #[test]
+    fn line_restart_terminal_vs_piped() {
+        let mut buf: Vec<u8> = Vec::new();
+
+        let live_term = LiveProgress::with_output_config(
+            &mut buf,
+            ProgressMode::PerFile,
+            HumanReadableMode::Disabled,
+            terminal_config(),
+        );
+        assert_eq!(live_term.line_restart(), "\r");
+
+        let live_pipe = LiveProgress::with_output_config(
+            &mut buf,
+            ProgressMode::PerFile,
+            HumanReadableMode::Disabled,
+            piped_config(),
+        );
+        assert_eq!(live_pipe.line_restart(), "\n");
+    }
+
+    /// Flush is called for unbuffered outbuf mode on non-final ticks.
+    #[test]
+    fn flush_triggered_for_unbuffered_outbuf() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct FlushCountingWriter {
+            inner: Vec<u8>,
+            flush_count: AtomicUsize,
+        }
+        impl Write for FlushCountingWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.inner.write(buf)
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                self.flush_count.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+
+        let mut writer = FlushCountingWriter {
+            inner: Vec::new(),
+            flush_count: AtomicUsize::new(0),
+        };
+        {
+            let config = ProgressOutputConfig {
+                is_terminal: true,
+                outbuf_mode: Some(OutbufMode::None),
+            };
+            let mut live = LiveProgress::with_output_config(
+                &mut writer,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+                config,
+            );
+            // Mid-transfer tick should trigger flush
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let count = writer.flush_count.load(Ordering::Relaxed);
+        assert!(
+            count > 0,
+            "unbuffered outbuf should flush after non-final ticks, got {count} flushes"
+        );
+    }
+
+    /// Flush is NOT called for block-buffered outbuf mode.
+    #[test]
+    fn no_flush_for_block_buffered_outbuf() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct FlushCountingWriter {
+            inner: Vec<u8>,
+            flush_count: AtomicUsize,
+        }
+        impl Write for FlushCountingWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.inner.write(buf)
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                self.flush_count.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+
+        let mut writer = FlushCountingWriter {
+            inner: Vec::new(),
+            flush_count: AtomicUsize::new(0),
+        };
+        {
+            let config = ProgressOutputConfig {
+                is_terminal: true,
+                outbuf_mode: Some(OutbufMode::Block),
+            };
+            let mut live = LiveProgress::with_output_config(
+                &mut writer,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+                config,
+            );
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let count = writer.flush_count.load(Ordering::Relaxed);
+        assert_eq!(
+            count, 0,
+            "block-buffered outbuf should not flush on progress ticks, got {count} flushes"
+        );
+    }
+
+    /// Line-buffered outbuf mode should flush after non-final ticks.
+    #[test]
+    fn flush_triggered_for_line_buffered_outbuf() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct FlushCountingWriter {
+            inner: Vec<u8>,
+            flush_count: AtomicUsize,
+        }
+        impl Write for FlushCountingWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.inner.write(buf)
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                self.flush_count.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+
+        let mut writer = FlushCountingWriter {
+            inner: Vec::new(),
+            flush_count: AtomicUsize::new(0),
+        };
+        {
+            let config = ProgressOutputConfig {
+                is_terminal: true,
+                outbuf_mode: Some(OutbufMode::Line),
+            };
+            let mut live = LiveProgress::with_output_config(
+                &mut writer,
+                ProgressMode::PerFile,
+                HumanReadableMode::Disabled,
+                config,
+            );
+            live.on_progress(&make_mid_transfer_update(true));
+        }
+        let count = writer.flush_count.load(Ordering::Relaxed);
+        assert!(
+            count > 0,
+            "line-buffered outbuf should flush after non-final ticks, got {count} flushes"
         );
     }
 }

--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -75,7 +75,12 @@ impl<'a> LiveProgress<'a> {
         mode: ProgressMode,
         human_readable: HumanReadableMode,
     ) -> Self {
-        Self::with_output_config(writer, mode, human_readable, ProgressOutputConfig::default())
+        Self::with_output_config(
+            writer,
+            mode,
+            human_readable,
+            ProgressOutputConfig::default(),
+        )
     }
 
     pub(crate) fn with_output_config(
@@ -130,7 +135,11 @@ impl<'a> LiveProgress<'a> {
     /// relies on `output_needs_newline` + terminal process group checks in
     /// `show_progress` to suppress output when backgrounded or piped.
     fn line_restart(&self) -> &'static str {
-        if self.output_config.is_terminal { "\r" } else { "\n" }
+        if self.output_config.is_terminal {
+            "\r"
+        } else {
+            "\n"
+        }
     }
 
     /// Flushes the writer after a progress tick if the outbuf mode requires it.

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use self::format::{
     format_stat_categories, format_summary_rate, format_verbose_rate, format_verbose_rate_decimal,
     format_verbose_rate_human, is_progress_event, list_only_event,
 };
-pub(crate) use self::live::LiveProgress;
+pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;
 pub use self::mode::{NameOutputLevel, ProgressSetting, StderrMode}; // Changed to pub for test_utils
 pub(crate) use self::render::emit_transfer_summary;


### PR DESCRIPTION
## Summary

- Adapt progress output line separators based on terminal detection: `\r` for in-place overwrite on terminals, `\n` when piped so output is readable
- Skip line padding in piped mode since each tick appears on its own line
- Wire `--outbuf` mode into `LiveProgress` for flush control: unbuffered and line-buffered modes flush after each non-final tick, block-buffered defers
- Terminal detection uses `std::io::IsTerminal` on stdout (or stderr when `--msgs2stderr` is active), mirroring upstream's `tcgetpgrp` check in `progress.c:234-238`

## Test plan

- [x] Unit tests for `\r` vs `\n` selection in both PerFile and Overall modes
- [x] Unit tests for padding suppression when piped
- [x] Unit tests for flush behavior with each outbuf mode (None/Line/Block)
- [x] `ProgressOutputConfig::default()` backward compatibility test
- [x] `line_restart()` direct assertion test
- [x] Existing progress tests continue to pass (use `LiveProgress::new()` which defaults to terminal mode)
- [ ] CI validates all platforms (Linux, macOS, Windows)