### PR TITLE
feat: implement --delay-updates final rename sweep in remote receiver

### DIFF
--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -152,6 +152,16 @@ pub struct DiskCommitConfig {
     /// - `cleanup.c:105-115` - `handle_partial_dir()` in cleanup path
     /// - `receiver.c:340-345` - partial file rename on interrupt
     pub partial_mode: PartialMode,
+    /// When true, files are staged to a `.~tmp~` partial directory instead
+    /// of being renamed to their final destination immediately. The caller
+    /// must perform a final rename sweep at the phase 2 boundary.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:546-547`: `delayed_bits = bitbag_create()`
+    /// - `receiver.c:906-929`: staging to partial dir when `delay_updates`
+    /// - `receiver.c:584-585`: `handle_delayed_updates()` at phase 2
+    pub delay_updates: bool,
 }
 
 impl Default for DiskCommitConfig {
@@ -172,6 +182,7 @@ impl Default for DiskCommitConfig {
             io_uring_depth: None,
             iocp_policy: fast_io::IocpPolicy::Auto,
             partial_mode: PartialMode::None,
+            delay_updates: false,
         }
     }
 }

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -142,7 +142,7 @@ pub(super) fn process_file(
                     None
                 };
 
-                let was_copy = commit_file(
+                let outcome = commit_file(
                     &begin,
                     config,
                     &mut cleanup_guard,
@@ -153,7 +153,7 @@ pub(super) fn process_file(
                 // Temp file has been renamed to its final destination (or
                 // kept via guard.keep()), so remove it from the global
                 // cleanup registry - it is no longer an orphan candidate.
-                if needs_rename {
+                if needs_rename && outcome.delayed_path.is_none() {
                     CleanupManager::global().unregister_temp_file(cleanup_guard.path());
                 }
 
@@ -161,7 +161,14 @@ pub(super) fn process_file(
                 // (no pre-rename step), or re-apply after cross-device
                 // copy since fs::copy does not preserve ownership,
                 // timestamps, ACLs, or xattrs.
-                let metadata_error = if needs_rename && !was_copy {
+                // When delay_updates staged the file, apply metadata to
+                // the staging path (it will be renamed to final later).
+                let metadata_error = if outcome.delayed_path.is_some() {
+                    // upstream: receiver.c:924 - finish_transfer(partialptr, ...)
+                    // applies metadata to the staged partial file.
+                    let staged = outcome.delayed_path.as_ref().unwrap();
+                    apply_file_metadata(staged, &begin, config)
+                } else if needs_rename && !outcome.was_copy {
                     pre_meta_error
                 } else {
                     apply_file_metadata(&begin.file_path, &begin, config)
@@ -174,6 +181,7 @@ pub(super) fn process_file(
                     file_entry_index: begin.file_entry_index,
                     metadata_error,
                     computed_checksum,
+                    delayed_path: outcome.delayed_path,
                 });
             }
             FileMessage::Abort { reason } => {
@@ -280,7 +288,7 @@ pub(super) fn process_whole_file(
         None
     };
 
-    let was_copy = commit_file(
+    let outcome = commit_file(
         &begin,
         config,
         &mut cleanup_guard,
@@ -288,11 +296,14 @@ pub(super) fn process_whole_file(
         bytes_written,
     )?;
 
-    if needs_rename {
+    if needs_rename && outcome.delayed_path.is_none() {
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
     }
 
-    let metadata_error = if needs_rename && !was_copy {
+    let metadata_error = if outcome.delayed_path.is_some() {
+        let staged = outcome.delayed_path.as_ref().unwrap();
+        apply_file_metadata(staged, &begin, config)
+    } else if needs_rename && !outcome.was_copy {
         pre_meta_error
     } else {
         apply_file_metadata(&begin.file_path, &begin, config)
@@ -305,6 +316,7 @@ pub(super) fn process_whole_file(
         file_entry_index: begin.file_entry_index,
         metadata_error,
         computed_checksum,
+        delayed_path: outcome.delayed_path,
     })
 }
 
@@ -437,26 +449,60 @@ fn make_writer<'a>(
     Ok(Writer::Buffered(ReusableBufWriter::new(file, write_buf)))
 }
 
+/// Commit result indicating whether a cross-device copy occurred and
+/// whether the file was staged to the partial dir for delayed updates.
+struct CommitOutcome {
+    /// True when a cross-device copy was needed (EXDEV fallback).
+    was_copy: bool,
+    /// When `--delay-updates` staged the file to `.~tmp~`, holds the
+    /// staging path. `None` for immediate commits and inplace writes.
+    delayed_path: Option<PathBuf>,
+}
+
 /// Performs backup, atomic rename, and inplace truncation after writing.
 ///
-/// Returns `true` when a cross-device copy was needed (EXDEV fallback),
-/// `false` otherwise. Callers use this to decide whether metadata must be
-/// re-applied to the final path.
+/// When `delay_updates` is true and the file uses temp+rename, stages the
+/// file to `.~tmp~/<filename>` in the same parent directory instead of
+/// renaming to the final destination. The caller reports the staging path
+/// back so the receiver can perform a bulk rename sweep at phase 2.
 ///
 /// When io_uring is available (Linux 5.11+ with `IORING_OP_RENAMEAT`), the
 /// temp-file rename is submitted as an io_uring SQE instead of a synchronous
 /// `rename(2)` syscall. Falls back to `std::fs::rename` on all other
 /// platforms or when the kernel lacks the opcode.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:906-929`: delay_updates stages to partial dir
+/// - `receiver.c:422-450`: `handle_delayed_updates()` bulk rename
 fn commit_file(
     begin: &BeginMessage,
     config: &DiskCommitConfig,
     cleanup_guard: &mut TempFileGuard,
     needs_rename: bool,
     bytes_written: u64,
-) -> io::Result<bool> {
+) -> io::Result<CommitOutcome> {
     // upstream: backup.c:make_backup() - rename existing file before overwrite
-    if let Some(ref backup_config) = config.backup {
-        make_backup(&begin.file_path, backup_config)?;
+    // With delay_updates, backup happens during the sweep, not here.
+    if !config.delay_updates {
+        if let Some(ref backup_config) = config.backup {
+            make_backup(&begin.file_path, backup_config)?;
+        }
+    }
+
+    if needs_rename && config.delay_updates {
+        // upstream: receiver.c:916-929 - stage to partial dir (.~tmp~)
+        let staging_path = partial_dir_path(&begin.file_path);
+        if let Some(parent) = staging_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let result = rename_with_io_uring_fallback(cleanup_guard.path(), &staging_path)?;
+        CleanupManager::global().unregister_temp_file(cleanup_guard.path());
+        cleanup_guard.keep();
+        return Ok(CommitOutcome {
+            was_copy: result,
+            delayed_path: Some(staging_path),
+        });
     }
 
     let was_copy = if needs_rename {
@@ -479,7 +525,27 @@ fn commit_file(
         false
     };
     cleanup_guard.keep();
-    Ok(was_copy)
+    Ok(CommitOutcome {
+        was_copy,
+        delayed_path: None,
+    })
+}
+
+/// Upstream partial dir name for `--delay-updates` staging.
+///
+/// upstream: options.c - `static char tmp_partialdir[] = ".~tmp~";`
+const DELAY_UPDATES_PARTIAL_DIR: &str = ".~tmp~";
+
+/// Computes the `.~tmp~/<filename>` staging path for a destination file.
+///
+/// upstream: receiver.c:430 - `partial_dir_fname(fname)` returns
+/// `<parent>/.~tmp~/<basename>`.
+fn partial_dir_path(file_path: &Path) -> PathBuf {
+    let parent = file_path.parent().unwrap_or(Path::new("."));
+    let basename = file_path
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("unknown"));
+    parent.join(DELAY_UPDATES_PARTIAL_DIR).join(basename)
 }
 
 /// Retains a partial temp file instead of deleting it on interrupt.
@@ -886,5 +952,22 @@ mod tests {
             first, second,
             "io_uring RENAMEAT2 availability must be consistent"
         );
+    }
+
+    /// Verifies `partial_dir_path` constructs `.~tmp~/<basename>` under the
+    /// file's parent directory, matching upstream `options.c:tmp_partialdir`.
+    #[test]
+    fn partial_dir_path_constructs_staging_path() {
+        let path = Path::new("/dest/subdir/file.txt");
+        let staging = partial_dir_path(path);
+        assert_eq!(staging, PathBuf::from("/dest/subdir/.~tmp~/file.txt"));
+    }
+
+    /// Verifies `partial_dir_path` handles files directly in the root dest dir.
+    #[test]
+    fn partial_dir_path_root_level_file() {
+        let path = Path::new("/dest/file.txt");
+        let staging = partial_dir_path(path);
+        assert_eq!(staging, PathBuf::from("/dest/.~tmp~/file.txt"));
     }
 }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -12,6 +12,7 @@ use super::thread::spawn_disk_thread;
 fn default_config() {
     let config = DiskCommitConfig::default();
     assert!(!config.do_fsync);
+    assert!(!config.delay_updates);
     assert_eq!(
         config.channel_capacity,
         super::config::DEFAULT_CHANNEL_CAPACITY
@@ -492,6 +493,117 @@ fn commit_file_rename_replaces_existing_via_io_uring_or_fallback() {
     let result = h.result_rx.recv().unwrap().unwrap();
     assert_eq!(result.bytes_written, 11);
     assert_eq!(fs::read(&file_path).unwrap(), b"new content");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies that with `delay_updates` enabled, the disk thread stages files
+/// to `.~tmp~/<filename>` instead of renaming to the final destination.
+/// The final rename is deferred to the receiver's phase 2 sweep.
+///
+/// upstream: receiver.c:906-929 - delay_updates stages to partial dir
+#[test]
+fn delay_updates_stages_to_partial_dir() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("delayed.dat");
+
+    let config = DiskCommitConfig {
+        delay_updates: true,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 13,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"delayed write".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Commit).unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 13);
+
+    // File should NOT be at the final path yet.
+    assert!(
+        !file_path.exists(),
+        "final path should not exist when delay_updates is active"
+    );
+
+    // File should be staged in the .~tmp~ partial dir.
+    let staging_path = dir.path().join(".~tmp~").join("delayed.dat");
+    assert!(
+        staging_path.exists(),
+        "file should be staged at .~tmp~/<basename>"
+    );
+    assert_eq!(fs::read(&staging_path).unwrap(), b"delayed write");
+
+    // CommitResult should report the delayed path.
+    assert_eq!(
+        result.delayed_path,
+        Some(staging_path.clone()),
+        "CommitResult must report the staging path"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+
+    // Cleanup: remove .~tmp~ dir
+    let _ = fs::remove_file(&staging_path);
+    let _ = fs::remove_dir(dir.path().join(".~tmp~"));
+}
+
+/// Verifies that the coalesced WholeFile path also stages to `.~tmp~`
+/// when `delay_updates` is enabled.
+#[test]
+fn delay_updates_whole_file_stages_to_partial_dir() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("whole_delayed.dat");
+
+    let config = DiskCommitConfig {
+        delay_updates: true,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config);
+
+    h.file_tx
+        .send(FileMessage::WholeFile {
+            begin: Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: 14,
+                file_entry_index: 0,
+                checksum_verifier: None,
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            }),
+            data: b"whole delayed!".to_vec(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    assert_eq!(result.bytes_written, 14);
+    assert!(
+        !file_path.exists(),
+        "final path should not exist with delay_updates"
+    );
+
+    let staging_path = dir.path().join(".~tmp~").join("whole_delayed.dat");
+    assert!(staging_path.exists(), "file staged at .~tmp~/<basename>");
+    assert_eq!(fs::read(&staging_path).unwrap(), b"whole delayed!");
+    assert_eq!(result.delayed_path, Some(staging_path));
 
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -99,6 +99,7 @@ pub struct BeginMessage {
 }
 
 /// Computed checksum digest returned by the disk thread.
+#[derive(Debug)]
 pub struct ComputedChecksum {
     /// Digest bytes (only `len` bytes are valid).
     pub bytes: [u8; ChecksumVerifier::MAX_DIGEST_LEN],

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -116,4 +116,14 @@ pub struct CommitResult {
     pub metadata_error: Option<(PathBuf, String)>,
     /// Computed per-file checksum, if verification was deferred to the disk thread.
     pub computed_checksum: Option<ComputedChecksum>,
+    /// When `--delay-updates` is active, the staging path where the file was
+    /// placed instead of its final destination. The receiver collects these
+    /// and performs a bulk rename sweep at the phase 2 boundary.
+    ///
+    /// `None` when delay-updates is off or for inplace/device writes.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:927-928`: `bitbag_set_bit(delayed_bits, ndx)`
+    pub delayed_path: Option<PathBuf>,
 }

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -71,6 +71,15 @@ pub struct PipelinedReceiver {
     /// The caller retrieves these via [`Self::drain_warnings`] and routes
     /// them through the multiplexed protocol writer.
     warnings: Vec<String>,
+    /// Files staged to `.~tmp~` partial dir when `--delay-updates` is active.
+    /// Each entry is `(staging_path, final_path)`. The receiver performs a
+    /// bulk rename sweep at the phase 2 boundary.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:546-547`: `delayed_bits = bitbag_create()`
+    /// - `receiver.c:584-585`: `handle_delayed_updates()` sweep
+    delayed_updates: Vec<(PathBuf, PathBuf)>,
 }
 
 impl PipelinedReceiver {
@@ -88,6 +97,7 @@ impl PipelinedReceiver {
             redo_enabled: true,
             permission_error_count: 0,
             warnings: Vec::new(),
+            delayed_updates: Vec::new(),
         }
     }
 
@@ -147,6 +157,7 @@ impl PipelinedReceiver {
         loop {
             match self.result_rx.try_recv() {
                 Ok(Ok(result)) => {
+                    self.collect_delayed_update(&result);
                     self.verify_checksum(&result)?;
                     bytes += result.bytes_written;
                     if let Some(err) = result.metadata_error {
@@ -206,6 +217,7 @@ impl PipelinedReceiver {
         while self.pending_commits > 0 {
             match self.result_rx.recv() {
                 Ok(Ok(result)) => {
+                    self.collect_delayed_update(&result);
                     self.verify_checksum(&result)?;
                     bytes += result.bytes_written;
                     if let Some(err) = result.metadata_error {
@@ -296,6 +308,35 @@ impl PipelinedReceiver {
         }
 
         Ok(())
+    }
+
+    /// Collects a delayed update entry from a commit result, if present.
+    ///
+    /// Uses the pending checksum queue to recover the final destination path
+    /// (which is stored there as `file_path`). The staging path comes from
+    /// `CommitResult::delayed_path`.
+    fn collect_delayed_update(&mut self, result: &CommitResult) {
+        if let Some(ref staged) = result.delayed_path {
+            // The expected_checksums queue is FIFO and hasn't been popped
+            // yet (verify_checksum pops it). Peek at the front entry.
+            if let Some(pending) = self.expected_checksums.front() {
+                self.delayed_updates
+                    .push((staged.clone(), pending.file_path.clone()));
+            }
+        }
+    }
+
+    /// Returns and clears the accumulated delayed update entries.
+    ///
+    /// Each entry is `(staging_path, final_path)`. The receiver calls this
+    /// at the phase 2 boundary and renames each file from its staging
+    /// location to the final destination.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:584-585`: `handle_delayed_updates()` at phase 2
+    pub fn take_delayed_updates(&mut self) -> Vec<(PathBuf, PathBuf)> {
+        std::mem::take(&mut self.delayed_updates)
     }
 
     /// Drains newly detected redo indices without disabling redo mode.
@@ -497,6 +538,7 @@ mod tests {
                 bytes: computed_bytes,
                 len: 4,
             }),
+            delayed_path: None,
         };
 
         // In phase 1 (redo_enabled=true), this should NOT return an error.
@@ -544,6 +586,7 @@ mod tests {
                 bytes: computed_bytes,
                 len: 4,
             }),
+            delayed_path: None,
         };
 
         // In phase 2, mismatch should still return Ok (error is logged, not fatal).
@@ -581,6 +624,7 @@ mod tests {
                 bytes: expected,
                 len: 4,
             }),
+            delayed_path: None,
         };
 
         pr.verify_checksum(&result).unwrap();
@@ -677,5 +721,104 @@ mod tests {
             msg,
             "ERROR: /tmp/a/b failed verification -- update discarded."
         );
+    }
+
+    /// Verifies `collect_delayed_update` captures the staging path from
+    /// `CommitResult::delayed_path` paired with the final destination from
+    /// the pending checksum queue.
+    #[test]
+    fn collect_delayed_update_tracks_staging_and_final_path() {
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig::default());
+
+        // Simulate a pending checksum entry (which carries the final path).
+        pr.expected_checksums.push_back(PendingChecksum {
+            expected: [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
+            len: 0,
+            file_path: PathBuf::from("/dest/file.txt"),
+            file_index: 0,
+        });
+
+        let result = CommitResult {
+            bytes_written: 42,
+            file_entry_index: 0,
+            metadata_error: None,
+            computed_checksum: None,
+            delayed_path: Some(PathBuf::from("/dest/.~tmp~/file.txt")),
+        };
+
+        pr.collect_delayed_update(&result);
+
+        let updates = pr.take_delayed_updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].0, PathBuf::from("/dest/.~tmp~/file.txt"));
+        assert_eq!(updates[0].1, PathBuf::from("/dest/file.txt"));
+
+        drop(pr);
+    }
+
+    /// Verifies that `take_delayed_updates` returns empty when no files
+    /// were staged.
+    #[test]
+    fn take_delayed_updates_empty_when_no_delays() {
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig::default());
+        assert!(pr.take_delayed_updates().is_empty());
+        drop(pr);
+    }
+
+    /// End-to-end: disk thread with `delay_updates` stages a file, and
+    /// `PipelinedReceiver` captures the delayed path through the result
+    /// drain.
+    #[test]
+    fn delay_updates_end_to_end_through_mediator() {
+        let dir = test_support::create_tempdir();
+        let file_path = dir.path().join("e2e.dat");
+
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig {
+            delay_updates: true,
+            ..DiskCommitConfig::default()
+        });
+
+        pr.file_sender()
+            .send(FileMessage::WholeFile {
+                begin: Box::new(BeginMessage {
+                    file_path: file_path.clone(),
+                    target_size: 10,
+                    file_entry_index: 0,
+                    checksum_verifier: None,
+                    is_device_target: false,
+                    is_inplace: false,
+                    append_offset: 0,
+                    xattr_list: None,
+                }),
+                data: b"e2e staged".to_vec(),
+            })
+            .unwrap();
+
+        pr.note_commit_sent(
+            [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
+            0,
+            file_path.clone(),
+            0,
+        );
+
+        let (bytes, errors) = pr.drain_all_results().unwrap();
+        assert_eq!(bytes, 10);
+        assert!(errors.is_empty());
+
+        // Final path should NOT exist - file is staged.
+        assert!(!file_path.exists());
+
+        // Staging path should exist.
+        let staging = dir.path().join(".~tmp~").join("e2e.dat");
+        assert!(staging.exists());
+        assert_eq!(std::fs::read(&staging).unwrap(), b"e2e staged");
+
+        // PipelinedReceiver tracked the delayed update.
+        let updates = pr.take_delayed_updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].0, staging);
+        assert_eq!(updates[0].1, file_path);
+
+        drop(pr);
     }
 }

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -101,10 +101,7 @@ pub(in crate::receiver) fn handle_delayed_updates(
                     }
                 }
                 if let Err(e) = fs::rename(final_path, &backup_path) {
-                    eprintln!(
-                        "rsync: backup failed for {}: {e}",
-                        final_path.display()
-                    );
+                    eprintln!("rsync: backup failed for {}: {e}", final_path.display());
                 }
             }
         }

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -22,6 +22,9 @@ mod setup;
 mod sync;
 
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+use logging::debug_log;
 
 use crate::receiver::ReceiverContext;
 use crate::receiver::stats::TransferStats;
@@ -57,5 +60,198 @@ impl ReceiverContext {
             let _ = progress;
             self.run_pipelined(reader, writer, crate::pipeline::PipelineConfig::default())
         }
+    }
+}
+
+/// Renames all delayed-update files from their `.~tmp~` staging paths to
+/// their final destinations, then removes the empty `.~tmp~` directories.
+///
+/// Mirrors upstream `receiver.c:422-450 handle_delayed_updates()` which
+/// iterates `delayed_bits`, renames each file from its `partial_dir_fname()`
+/// path to the final destination, and calls `handle_partial_dir(PDIR_DELETE)`.
+///
+/// When `backup_config` is `Some`, backs up the existing destination file
+/// before the rename (upstream: `receiver.c:431 make_backup(fname, False)`).
+///
+/// Rename failures are logged but do not abort the transfer, matching
+/// upstream which calls `rsyserr(FERROR_XFER, ...)` and continues.
+pub(in crate::receiver) fn handle_delayed_updates(
+    delayed: &[(PathBuf, PathBuf)],
+    backup_config: Option<crate::disk_commit::BackupConfig>,
+) {
+    use std::collections::HashSet;
+    use std::fs;
+
+    let mut staging_dirs: HashSet<PathBuf> = HashSet::new();
+
+    for (staging_path, final_path) in delayed {
+        // upstream: receiver.c:431-432 - make_backup(fname, False)
+        if let Some(ref bc) = backup_config {
+            if final_path.exists() {
+                let backup_path = engine::compute_backup_path(
+                    &bc.dest_dir,
+                    final_path,
+                    None,
+                    bc.backup_dir.as_deref(),
+                    &bc.suffix,
+                );
+                if let Some(parent) = backup_path.parent() {
+                    if !parent.exists() {
+                        let _ = fs::create_dir_all(parent);
+                    }
+                }
+                if let Err(e) = fs::rename(final_path, &backup_path) {
+                    eprintln!(
+                        "rsync: backup failed for {}: {e}",
+                        final_path.display()
+                    );
+                }
+            }
+        }
+
+        // upstream: receiver.c:433-435 - DEBUG_GTE(RECV, 1) rename notice
+        debug_log!(
+            Recv,
+            1,
+            "renaming {} to {}",
+            staging_path.display(),
+            final_path.display()
+        );
+
+        // upstream: receiver.c:439 - do_rename(partialptr, fname)
+        if let Err(e) = fs::rename(staging_path, final_path) {
+            eprintln!(
+                "rsync: rename failed for {} (from {}): {e}",
+                final_path.display(),
+                staging_path.display()
+            );
+            continue;
+        }
+
+        // Track parent staging directories for cleanup.
+        if let Some(parent) = staging_path.parent() {
+            staging_dirs.insert(parent.to_path_buf());
+        }
+    }
+
+    // upstream: receiver.c:446 - handle_partial_dir(partialptr, PDIR_DELETE)
+    // Remove empty .~tmp~ staging directories.
+    for dir in &staging_dirs {
+        let _ = fs::remove_dir(dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    /// Verifies the delayed rename sweep moves files from staging paths to
+    /// final destinations, matching upstream `receiver.c:422-450`.
+    #[test]
+    fn handle_delayed_updates_renames_staged_files() {
+        let dir = test_support::create_tempdir();
+        let staging_dir = dir.path().join(".~tmp~");
+        fs::create_dir(&staging_dir).unwrap();
+
+        // Create two staged files.
+        let staged_a = staging_dir.join("a.txt");
+        let staged_b = staging_dir.join("b.txt");
+        fs::write(&staged_a, b"content-a").unwrap();
+        fs::write(&staged_b, b"content-b").unwrap();
+
+        let final_a = dir.path().join("a.txt");
+        let final_b = dir.path().join("b.txt");
+
+        let delayed = vec![
+            (staged_a.clone(), final_a.clone()),
+            (staged_b.clone(), final_b.clone()),
+        ];
+
+        handle_delayed_updates(&delayed, None);
+
+        // Files should be at final paths.
+        assert_eq!(fs::read_to_string(&final_a).unwrap(), "content-a");
+        assert_eq!(fs::read_to_string(&final_b).unwrap(), "content-b");
+
+        // Staging paths should no longer exist.
+        assert!(!staged_a.exists());
+        assert!(!staged_b.exists());
+
+        // The empty .~tmp~ directory should have been cleaned up.
+        assert!(
+            !staging_dir.exists(),
+            "empty .~tmp~ dir should be removed after sweep"
+        );
+    }
+
+    /// Verifies that the sweep cleans up the `.~tmp~` directory even when
+    /// it contained multiple files across different parent directories.
+    #[test]
+    fn handle_delayed_updates_cleans_multiple_staging_dirs() {
+        let dir = test_support::create_tempdir();
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+
+        let tmp1 = dir.path().join(".~tmp~");
+        let tmp2 = sub.join(".~tmp~");
+        fs::create_dir(&tmp1).unwrap();
+        fs::create_dir(&tmp2).unwrap();
+
+        let staged1 = tmp1.join("f1.txt");
+        let staged2 = tmp2.join("f2.txt");
+        fs::write(&staged1, b"one").unwrap();
+        fs::write(&staged2, b"two").unwrap();
+
+        let final1 = dir.path().join("f1.txt");
+        let final2 = sub.join("f2.txt");
+
+        let delayed = vec![
+            (staged1.clone(), final1.clone()),
+            (staged2.clone(), final2.clone()),
+        ];
+
+        handle_delayed_updates(&delayed, None);
+
+        assert_eq!(fs::read_to_string(&final1).unwrap(), "one");
+        assert_eq!(fs::read_to_string(&final2).unwrap(), "two");
+        assert!(!tmp1.exists());
+        assert!(!tmp2.exists());
+    }
+
+    /// Verifies the sweep continues past rename failures (matching upstream
+    /// which logs errors but does not abort).
+    #[test]
+    fn handle_delayed_updates_continues_on_rename_failure() {
+        let dir = test_support::create_tempdir();
+        let staging_dir = dir.path().join(".~tmp~");
+        fs::create_dir(&staging_dir).unwrap();
+
+        // Create one valid staged file and one that points to a missing source.
+        let staged_good = staging_dir.join("good.txt");
+        fs::write(&staged_good, b"good").unwrap();
+        let staged_bad = PathBuf::from("/nonexistent/path/.~tmp~/bad.txt");
+
+        let final_good = dir.path().join("good.txt");
+        let final_bad = PathBuf::from("/nonexistent/path/bad.txt");
+
+        let delayed = vec![
+            (staged_bad, final_bad),
+            (staged_good.clone(), final_good.clone()),
+        ];
+
+        // Should not panic or abort.
+        handle_delayed_updates(&delayed, None);
+
+        // The good file should still be renamed successfully.
+        assert_eq!(fs::read_to_string(&final_good).unwrap(), "good");
+        assert!(!staged_good.exists());
+    }
+
+    /// Verifies the sweep handles an empty delayed list gracefully.
+    #[test]
+    fn handle_delayed_updates_empty_is_noop() {
+        handle_delayed_updates(&[], None);
     }
 }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -54,7 +54,7 @@ impl ReceiverContext {
         is_redo_pass: bool,
         total_files: usize,
         progress: &mut Option<&mut dyn crate::TransferProgressCallback>,
-    ) -> io::Result<(usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>)> {
+    ) -> io::Result<PipelineResult> {
         use crate::disk_commit::{BackupConfig, DiskCommitConfig, PartialMode};
         use crate::pipeline::receiver::PipelinedReceiver;
         use crate::shared::TransferDeadline;

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -33,7 +33,8 @@ impl ReceiverContext {
     ///
     /// Fills a sliding window of file requests, computes signatures in parallel
     /// when the batch exceeds the configured signature threshold, then processes responses
-    /// with a background disk commit thread. Returns `(files_transferred, bytes, redo_indices)`.
+    /// with a background disk commit thread. Returns
+    /// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
     #[allow(clippy::too_many_arguments)]
     pub(in crate::receiver) fn run_pipeline_loop_decoupled<
         R: Read,
@@ -49,7 +50,7 @@ impl ReceiverContext {
         is_redo_pass: bool,
         total_files: usize,
         progress: &mut Option<&mut dyn crate::TransferProgressCallback>,
-    ) -> io::Result<(usize, u64, u64, u64, Vec<usize>)> {
+    ) -> io::Result<(usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>)> {
         use crate::disk_commit::{BackupConfig, DiskCommitConfig, PartialMode};
         use crate::pipeline::receiver::PipelinedReceiver;
         use crate::shared::TransferDeadline;
@@ -61,7 +62,7 @@ impl ReceiverContext {
         // upstream: generator.c sends itemize immediately per-file via rwrite()
         if files_to_transfer.is_empty() {
             writer.flush()?;
-            return Ok((0, 0, 0, 0, Vec::new()));
+            return Ok((0, 0, 0, 0, Vec::new(), Vec::new()));
         }
 
         let deadline = TransferDeadline::from_system_time(self.config.stop_at);
@@ -145,6 +146,7 @@ impl ReceiverContext {
             io_uring_policy: self.config.write.io_uring_policy,
             io_uring_depth: self.config.write.io_uring_depth,
             partial_mode,
+            delay_updates: self.config.write.delay_updates,
             ..DiskCommitConfig::default()
         };
         let mut pipelined_receiver = PipelinedReceiver::new(disk_config);
@@ -152,7 +154,7 @@ impl ReceiverContext {
             let _ = pipelined_receiver.take_redo_indices();
         }
 
-        let result = (|| -> io::Result<(usize, u64, u64, u64, Vec<usize>)> {
+        let result = (|| -> io::Result<(usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>)> {
             // Track how many requests the sender has received (flushed) but
             // not yet responded to. We only flush the write buffer when this
             // drops to zero - otherwise the sender already has queued requests.
@@ -394,6 +396,7 @@ impl ReceiverContext {
             }
 
             let redo_indices = pipelined_receiver.take_redo_indices();
+            let delayed = pipelined_receiver.take_delayed_updates();
 
             Ok((
                 files_transferred,
@@ -401,6 +404,7 @@ impl ReceiverContext {
                 total_literal_bytes,
                 total_matched_bytes,
                 redo_indices,
+                delayed,
             ))
         })();
 

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -28,6 +28,10 @@ use crate::transfer_ops::{
     RequestConfig, ResponseContext, process_file_response_streaming, send_file_request,
 };
 
+/// Result type for the pipelined transfer closure:
+/// `(files_transferred, bytes, literal, matched, redo_indices, delayed_updates)`.
+type PipelineResult = (usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>);
+
 impl ReceiverContext {
     /// Pipelined transfer loop with decoupled network/disk I/O.
     ///
@@ -154,7 +158,7 @@ impl ReceiverContext {
             let _ = pipelined_receiver.take_redo_indices();
         }
 
-        let result = (|| -> io::Result<(usize, u64, u64, u64, Vec<usize>, Vec<(PathBuf, PathBuf)>)> {
+        let result = (|| -> io::Result<PipelineResult> {
             // Track how many requests the sender has received (flushed) but
             // not yet responded to. We only flush the write buffer when this
             // drops to zero - otherwise the sender already has queued requests.

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -89,6 +89,7 @@ impl ReceiverContext {
         let mut literal_data: u64 = 0;
         let mut matched_data: u64 = 0;
         let mut redo_count: usize = 0;
+        let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
 
         // upstream: generator.c:1845 - dry_run sends NDX requests without data
         if self.config.flags.dry_run {
@@ -98,12 +99,14 @@ impl ReceiverContext {
             let redo_config = pipeline_config.clone();
             let mut no_progress: Option<&mut dyn crate::TransferProgressCallback> = None;
             let redo_indices;
+            let delayed;
             (
                 files_transferred,
                 bytes_received,
                 literal_data,
                 matched_data,
                 redo_indices,
+                delayed,
             ) = self.run_pipeline_loop_decoupled(
                 reader,
                 writer,
@@ -115,6 +118,7 @@ impl ReceiverContext {
                 total_files,
                 &mut no_progress,
             )?;
+            all_delayed_updates.extend(delayed);
 
             // Phase 2: redo pass for files that failed checksum verification.
             redo_count = redo_indices.len();
@@ -136,8 +140,8 @@ impl ReceiverContext {
                     })
                     .collect();
 
-                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _) = self
-                    .run_pipeline_loop_decoupled(
+                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _, redo_delayed) =
+                    self.run_pipeline_loop_decoupled(
                         reader,
                         writer,
                         redo_config,
@@ -153,6 +157,7 @@ impl ReceiverContext {
                 bytes_received += redo_bytes;
                 literal_data += redo_literal;
                 matched_data += redo_matched;
+                all_delayed_updates.extend(redo_delayed);
             }
         }
 
@@ -173,6 +178,20 @@ impl ReceiverContext {
         self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);
         #[cfg(not(unix))]
         self.create_hardlinks(&setup.dest_dir, writer);
+
+        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
+        if !all_delayed_updates.is_empty() {
+            let backup_cfg = if self.config.flags.backup {
+                Some(crate::disk_commit::BackupConfig {
+                    dest_dir: setup.dest_dir.clone(),
+                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
+                    suffix: self.config.effective_backup_suffix().into(),
+                })
+            } else {
+                None
+            };
+            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
+        }
 
         self.finalize_transfer(reader, writer)?;
 

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -103,6 +103,7 @@ impl ReceiverContext {
         let mut literal_data: u64 = 0;
         let mut matched_data: u64 = 0;
         let mut redo_count: usize = 0;
+        let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
 
         // upstream: generator.c:1845 - dry_run sends NDX requests without data
         if self.config.flags.dry_run {
@@ -111,12 +112,14 @@ impl ReceiverContext {
             let total_files = files_to_transfer.len();
             let redo_config = pipeline_config.clone();
             let redo_indices;
+            let delayed;
             (
                 files_transferred,
                 bytes_received,
                 literal_data,
                 matched_data,
                 redo_indices,
+                delayed,
             ) = self.run_pipeline_loop_decoupled(
                 reader,
                 writer,
@@ -128,6 +131,7 @@ impl ReceiverContext {
                 total_files,
                 &mut progress,
             )?;
+            all_delayed_updates.extend(delayed);
 
             // Phase 2: redo pass for files that failed checksum verification.
             redo_count = redo_indices.len();
@@ -149,8 +153,8 @@ impl ReceiverContext {
                     })
                     .collect();
 
-                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _) = self
-                    .run_pipeline_loop_decoupled(
+                let (redo_transferred, redo_bytes, redo_literal, redo_matched, _, redo_delayed) =
+                    self.run_pipeline_loop_decoupled(
                         reader,
                         writer,
                         redo_config,
@@ -166,6 +170,7 @@ impl ReceiverContext {
                 bytes_received += redo_bytes;
                 literal_data += redo_literal;
                 matched_data += redo_matched;
+                all_delayed_updates.extend(redo_delayed);
             }
         }
 
@@ -173,6 +178,20 @@ impl ReceiverContext {
         self.create_hardlinks(&setup.dest_dir, setup.sandbox.as_deref(), writer);
         #[cfg(not(unix))]
         self.create_hardlinks(&setup.dest_dir, writer);
+
+        // upstream: receiver.c:584-585 - handle_delayed_updates() at phase 2
+        if !all_delayed_updates.is_empty() {
+            let backup_cfg = if self.config.flags.backup {
+                Some(crate::disk_commit::BackupConfig {
+                    dest_dir: setup.dest_dir.clone(),
+                    backup_dir: self.config.backup_dir.as_ref().map(PathBuf::from),
+                    suffix: self.config.effective_backup_suffix().into(),
+                })
+            } else {
+                None
+            };
+            super::handle_delayed_updates(&all_delayed_updates, backup_cfg);
+        }
 
         stats.files_transferred = files_transferred;
         stats.bytes_received = bytes_received;


### PR DESCRIPTION
## Summary

- Wire `--delay-updates` staging into the remote receiver's disk commit thread: when active, files are staged to `.~tmp~/<filename>` instead of being renamed directly to the final destination
- Add `handle_delayed_updates()` bulk rename sweep at the phase 2 boundary, matching upstream `receiver.c:422-450`
- Thread delayed update tracking through `PipelinedReceiver` and `run_pipeline_loop_decoupled` so both pipelined and incremental receiver paths perform the sweep

## Test plan

- [ ] `delay_updates_stages_to_partial_dir` - disk thread stages chunked file to `.~tmp~/<basename>` when `delay_updates: true`
- [ ] `delay_updates_whole_file_stages_to_partial_dir` - coalesced WholeFile path also stages correctly
- [ ] `handle_delayed_updates_renames_staged_files` - sweep moves files from staging to final and cleans up `.~tmp~` dirs
- [ ] `handle_delayed_updates_cleans_multiple_staging_dirs` - sweep handles files across different parent directories
- [ ] `handle_delayed_updates_continues_on_rename_failure` - sweep continues past individual rename failures (matching upstream)
- [ ] `handle_delayed_updates_empty_is_noop` - empty list is handled gracefully
- [ ] `collect_delayed_update_tracks_staging_and_final_path` - mediator tracks staging/final path pairs
- [ ] `delay_updates_end_to_end_through_mediator` - full end-to-end: disk thread stages, mediator captures, paths verified
- [ ] `partial_dir_path_constructs_staging_path` - `.~tmp~/<basename>` path construction
- [ ] `default_config` updated to verify `delay_updates: false` default
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl