### PR TITLE
feat: implement negate modifier for filter rules

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/mod.rs
@@ -744,4 +744,45 @@ mod tests {
         let result = parse_filter_directive(OsStr::new("+   *.txt"));
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn exclude_negate_modifier_short() {
+        let result = parse_filter_directive(OsStr::new("-! */"));
+        assert!(result.is_ok());
+        match result.unwrap() {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+                assert!(spec.is_negated());
+                assert_eq!(spec.pattern(), "*/");
+            }
+            _ => panic!("expected Rule directive"),
+        }
+    }
+
+    #[test]
+    fn exclude_negate_modifier_keyword() {
+        let result = parse_filter_directive(OsStr::new("exclude,! */"));
+        assert!(result.is_ok());
+        match result.unwrap() {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+                assert!(spec.is_negated());
+                assert_eq!(spec.pattern(), "*/");
+            }
+            _ => panic!("expected Rule directive"),
+        }
+    }
+
+    #[test]
+    fn include_negate_modifier() {
+        let result = parse_filter_directive(OsStr::new("+! *.txt"));
+        assert!(result.is_ok());
+        match result.unwrap() {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Include);
+                assert!(spec.is_negated());
+            }
+            _ => panic!("expected Rule directive"),
+        }
+    }
 }

--- a/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
@@ -256,6 +256,7 @@ mod tests {
             receiver: None,
             perishable: false,
             xattr_only: false,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
         assert!(result.pattern().starts_with('/'));
@@ -270,6 +271,7 @@ mod tests {
             receiver: None,
             perishable: false,
             xattr_only: false,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
         assert!(result.applies_to_sender());
@@ -284,6 +286,7 @@ mod tests {
             receiver: Some(true),
             perishable: false,
             xattr_only: false,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
         assert!(result.applies_to_receiver());
@@ -298,6 +301,7 @@ mod tests {
             receiver: None,
             perishable: true,
             xattr_only: false,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
         assert!(result.is_perishable());
@@ -312,6 +316,7 @@ mod tests {
             receiver: None,
             perishable: false,
             xattr_only: true,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "+").expect("apply");
         assert!(result.is_xattr_only());
@@ -328,6 +333,7 @@ mod tests {
             receiver: None,
             perishable: false,
             xattr_only: true,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "-").expect("apply");
         assert!(result.is_xattr_only());
@@ -342,6 +348,7 @@ mod tests {
             receiver: None,
             perishable: false,
             xattr_only: true,
+            negate: false,
         };
         let result = apply_rule_modifiers(rule, modifiers, "P");
         assert!(result.is_err());

--- a/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
@@ -9,6 +9,7 @@ pub(super) struct RuleModifierState {
     receiver: Option<bool>,
     perishable: bool,
     xattr_only: bool,
+    negate: bool,
 }
 
 pub(super) fn parse_rule_modifiers(
@@ -36,6 +37,11 @@ pub(super) fn parse_rule_modifiers(
                 if state.sender.is_none() {
                     state.sender = Some(false);
                 }
+            }
+            '!' => {
+                // upstream: exclude.c - '!' modifier inverts the match result
+                // (FILTRULE_NEGATE). Not valid on merge-file rules.
+                state.negate = true;
             }
             'p' => {
                 if allow_perishable {
@@ -103,6 +109,10 @@ pub(super) fn apply_rule_modifiers(
 
     if modifiers.perishable {
         rule = rule.with_perishable(true);
+    }
+
+    if modifiers.negate {
+        rule = rule.with_negate(true);
     }
 
     if modifiers.xattr_only {
@@ -199,6 +209,20 @@ mod tests {
     fn parse_rule_modifiers_xattr_when_disallowed() {
         let result = parse_rule_modifiers("x", "+", true, false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_rule_modifiers_negate() {
+        let result = parse_rule_modifiers("!", "-", true, true).expect("parse");
+        assert!(result.negate);
+    }
+
+    #[test]
+    fn parse_rule_modifiers_negate_with_others() {
+        let result = parse_rule_modifiers("!s", "-", true, true).expect("parse");
+        assert!(result.negate);
+        assert_eq!(result.sender, Some(true));
+        assert_eq!(result.receiver, Some(false));
     }
 
     #[test]
@@ -321,6 +345,21 @@ mod tests {
         };
         let result = apply_rule_modifiers(rule, modifiers, "P");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn apply_rule_modifiers_negate() {
+        let rule = FilterRuleSpec::exclude("*.rs".to_owned());
+        let modifiers = RuleModifierState {
+            anchor_root: false,
+            sender: None,
+            receiver: None,
+            perishable: false,
+            xattr_only: false,
+            negate: true,
+        };
+        let result = apply_rule_modifiers(rule, modifiers, "-").expect("apply");
+        assert!(result.is_negated());
     }
 
     #[test]

--- a/crates/core/src/client/config/filters.rs
+++ b/crates/core/src/client/config/filters.rs
@@ -29,6 +29,7 @@ pub struct FilterRuleSpec {
     applies_to_receiver: bool,
     perishable: bool,
     xattr_only: bool,
+    negate: bool,
 }
 
 impl FilterRuleSpec {
@@ -44,6 +45,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -59,6 +61,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -73,6 +76,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -87,6 +91,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -101,6 +106,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -116,6 +122,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -131,6 +138,7 @@ impl FilterRuleSpec {
             applies_to_receiver: true,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -145,6 +153,7 @@ impl FilterRuleSpec {
             applies_to_receiver: false,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -159,6 +168,7 @@ impl FilterRuleSpec {
             applies_to_receiver: false,
             perishable: false,
             xattr_only: false,
+            negate: false,
         }
     }
 
@@ -263,6 +273,22 @@ impl FilterRuleSpec {
     pub const fn with_receiver(mut self, applies: bool) -> Self {
         self.applies_to_receiver = applies;
         self
+    }
+
+    /// Inverts the match result of the pattern.
+    ///
+    /// A negated exclude rule keeps paths that match the pattern instead of
+    /// excluding them. Mirrors the `!` modifier from upstream `exclude.c`.
+    #[must_use]
+    pub const fn with_negate(mut self, negate: bool) -> Self {
+        self.negate = negate;
+        self
+    }
+
+    /// Reports whether the rule inverts its match result.
+    #[must_use]
+    pub const fn is_negated(&self) -> bool {
+        self.negate
     }
 
     /// Anchors the pattern to the root of the transfer when requested.

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -172,7 +172,7 @@ pub(crate) fn build_wire_format_rules(
                     sender_side: spec.applies_to_sender(),
                     receiver_side: spec.applies_to_receiver(),
                     perishable: spec.is_perishable(),
-                    negate: false,
+                    negate: spec.is_negated(),
                 });
                 continue;
             }
@@ -192,7 +192,7 @@ pub(crate) fn build_wire_format_rules(
             sender_side: spec.applies_to_sender(),
             receiver_side: spec.applies_to_receiver(),
             perishable: spec.is_perishable(),
-            negate: false,
+            negate: spec.is_negated(),
         };
 
         if let Some(options) = spec.dir_merge_options() {

--- a/crates/core/src/client/run/filters.rs
+++ b/crates/core/src/client/run/filters.rs
@@ -25,24 +25,28 @@ pub(crate) fn compile_filter_program(
                 EngineFilterRule::include(rule.pattern().to_owned())
                     .with_sides(rule.applies_to_sender(), rule.applies_to_receiver())
                     .with_perishable(rule.is_perishable())
-                    .with_xattr_only(rule.is_xattr_only()),
+                    .with_xattr_only(rule.is_xattr_only())
+                    .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::Exclude => entries.push(FilterProgramEntry::Rule(
                 EngineFilterRule::exclude(rule.pattern().to_owned())
                     .with_sides(rule.applies_to_sender(), rule.applies_to_receiver())
                     .with_perishable(rule.is_perishable())
-                    .with_xattr_only(rule.is_xattr_only()),
+                    .with_xattr_only(rule.is_xattr_only())
+                    .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::Clear => entries.push(FilterProgramEntry::Clear),
             FilterRuleKind::Protect => entries.push(FilterProgramEntry::Rule(
                 EngineFilterRule::protect(rule.pattern().to_owned())
                     .with_sides(rule.applies_to_sender(), rule.applies_to_receiver())
-                    .with_perishable(rule.is_perishable()),
+                    .with_perishable(rule.is_perishable())
+                    .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::Risk => entries.push(FilterProgramEntry::Rule(
                 EngineFilterRule::risk(rule.pattern().to_owned())
                     .with_sides(rule.applies_to_sender(), rule.applies_to_receiver())
-                    .with_perishable(rule.is_perishable()),
+                    .with_perishable(rule.is_perishable())
+                    .with_negate(rule.is_negated()),
             )),
             FilterRuleKind::DirMerge => {
                 entries.push(FilterProgramEntry::DirMerge(DirMergeRule::new(


### PR DESCRIPTION
## Summary
- Add support for the `!` modifier on include/exclude filter rules, which inverts the match result (upstream `FILTRULE_NEGATE` in `exclude.c`)
- Without this, rules like `exclude,! */` (used by the delete and merge upstream tests) fail with "unsupported modifier '!'"
- Wire negate through `FilterRuleSpec`, `compile_filter_program()`, and the wire format encoder

## Test plan
- [x] Unit tests for parsing `!` modifier in short form (`-! */`) and keyword form (`exclude,! */`)
- [x] Unit test for `apply_rule_modifiers` with negate flag
- [ ] CI: upstream testsuite delete and merge tests should progress past the filter parse error

Closes #5410, closes #5419