### PR TITLE
fix: allow --rsync-path on local copies to match upstream behavior

### DIFF
--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -8,9 +8,6 @@ use protocol::ProtocolVersion;
 
 use super::messages::fail_with_message;
 
-/// Error message when `--rsync-path` is used without a remote connection.
-pub(crate) const RSYNC_PATH_REMOTE_ONLY_MESSAGE: &str =
-    "the --rsync-path option may only be used with remote connections";
 /// Error message when `--remote-option` is used without a remote connection.
 pub(crate) const REMOTE_OPTION_REMOTE_ONLY_MESSAGE: &str =
     "the --remote-option option may only be used with remote connections";
@@ -27,24 +24,22 @@ pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
 /// Rejects options that are only valid for remote or daemon transfers.
 ///
 /// Returns `Some(exit_code)` if a forbidden option was detected, `None` otherwise.
+///
+/// Note: `--rsync-path` is intentionally NOT rejected here. Upstream rsync
+/// silently ignores it on local copies (options.c stores the value but only
+/// uses it when spawning a remote shell). The upstream testsuite relies on
+/// this behavior (e.g., the exclude test passes `--rsync-path` on local runs).
 pub(super) fn validate_local_only_options<Err>(
     desired_protocol: Option<ProtocolVersion>,
     password_file: Option<&PathBuf>,
     connect_program: Option<&OsString>,
-    rsync_path: Option<&OsString>,
+    _rsync_path: Option<&OsString>,
     remote_options: &[OsString],
     stderr: &mut MessageSink<Err>,
 ) -> Option<i32>
 where
     Err: Write,
 {
-    if rsync_path.is_some() {
-        return Some(reject_local_only_option(
-            stderr,
-            RSYNC_PATH_REMOTE_ONLY_MESSAGE,
-        ));
-    }
-
     if !remote_options.is_empty() {
         return Some(reject_local_only_option(
             stderr,

--- a/crates/cli/src/frontend/tests/rsync.rs
+++ b/crates/cli/src/frontend/tests/rsync.rs
@@ -2,7 +2,7 @@ use super::common::*;
 use super::*;
 
 #[test]
-fn rsync_path_requires_remote_operands() {
+fn rsync_path_silently_ignored_for_local_copies() {
     use tempfile::tempdir;
 
     let temp = tempdir().expect("tempdir");
@@ -10,43 +10,15 @@ fn rsync_path_requires_remote_operands() {
     let dest = temp.path().join("dest.txt");
     std::fs::write(&source, b"content").expect("write source");
 
-    let (code, stdout, stderr) = run_with_args([
+    // upstream: options.c stores --rsync-path but only uses it when spawning
+    // a remote shell. Local copies silently ignore the option.
+    let (code, _stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--rsync-path=/opt/custom/rsync"),
         source.into_os_string(),
         dest.clone().into_os_string(),
     ]);
 
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let message = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(message.contains("the --rsync-path option may only be used with remote connections"));
-    assert!(!dest.exists());
-}
-
-#[test]
-fn rsync_path_rejected_for_batch_without_remote_operands() {
-    use tempfile::tempdir;
-
-    let temp = tempdir().expect("tempdir");
-    let source = temp.path().join("source.txt");
-    let dest = temp.path().join("dest.txt");
-    std::fs::write(&source, b"content").expect("write source");
-
-    // Test that --rsync-path requires remote operands (batch mode removed since not yet implemented)
-    let (code, stdout, stderr) = run_with_args([
-        OsString::from(RSYNC),
-        OsString::from("--rsync-path=/opt/custom/rsync"),
-        source.into_os_string(),
-        dest.clone().into_os_string(),
-    ]);
-
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    let message = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(
-        message.contains("the --rsync-path option may only be used with remote connections")
-            || message.contains("remote connections and batch modes are not yet supported")
-    );
-    assert!(!dest.exists());
+    assert_eq!(code, 0);
+    assert!(dest.exists());
 }


### PR DESCRIPTION
## Summary
- Remove the validation that rejects `--rsync-path` on local copies - upstream rsync silently ignores it
- Update tests to verify the option is silently ignored rather than rejected
- The upstream testsuite exclude and exclude-lsh tests pass `--rsync-path` even on local runs

## Test plan
- [x] Updated unit test verifies local copy succeeds with `--rsync-path`
- [ ] CI: upstream testsuite exclude and exclude-lsh tests should progress past the rsync-path error

Closes #5414, closes #5413