### PR TITLE
fix: apply umask masking for chmod clauses without explicit who-specifier

### DIFF
--- a/crates/metadata/src/chmod/apply.rs
+++ b/crates/metadata/src/chmod/apply.rs
@@ -44,9 +44,42 @@ pub(crate) fn apply_clauses(_clauses: &[Clause], mode: u32, _file_type: std::fs:
     mode
 }
 
+/// Returns the process umask, cached for thread safety.
+///
+/// upstream: `main.c` stores `orig_umask` once at startup. We query it
+/// the first time a chmod clause with an implied who-specifier is applied
+/// and cache the result so the double set-and-restore syscall happens at
+/// most once per process.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn cached_umask() -> u32 {
+    use std::sync::OnceLock;
+    static UMASK: OnceLock<u32> = OnceLock::new();
+    *UMASK.get_or_init(|| {
+        // SAFETY: umask is a standard POSIX call. We set it to 0 to read
+        // the current value, then immediately restore it. This is a
+        // well-known pattern (used by upstream rsync main.c, GNU coreutils,
+        // etc.). The OnceLock ensures this pair of calls happens at most
+        // once per process, eliminating any window for concurrent umask
+        // modifications.
+        let old = unsafe { libc::umask(0) };
+        unsafe { libc::umask(old) };
+        old as u32
+    })
+}
+
 #[cfg(unix)]
 fn apply_symbolic_clause(mut mode: u32, clause: &SymbolicClause, is_dir: bool) -> u32 {
     let before = mode;
+
+    // upstream: chmod.c - when no who-specifier is given, the computed
+    // permission bits are masked by ~orig_umask. This prevents `+w` from
+    // granting world-writable when the umask forbids it.
+    let umask_mask = if clause.who_implied {
+        !cached_umask() & 0o777
+    } else {
+        0o777
+    };
 
     for dest in [Dest::User, Dest::Group, Dest::Other] {
         if !dest.includes(clause) {
@@ -83,7 +116,7 @@ fn apply_symbolic_clause(mut mode: u32, clause: &SymbolicClause, is_dir: bool) -
             }
         }
 
-        let add_bits = permission_bits(&clause.perms, dest, is_dir, before);
+        let add_bits = permission_bits(&clause.perms, dest, is_dir, before) & umask_mask;
         match clause.op {
             Operation::Add | Operation::Assign => {
                 bits |= add_bits & mask;

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -86,7 +86,8 @@ fn parse_clause(text: &str) -> Result<Clause, ChmodError> {
         }
     }
 
-    if !consumed_who {
+    let who_implied = !consumed_who;
+    if who_implied {
         who = WhoMask::new(true, true, true);
     }
 
@@ -110,6 +111,7 @@ fn parse_clause(text: &str) -> Result<Clause, ChmodError> {
             op,
             who,
             perms: spec,
+            who_implied,
         }),
     })
 }

--- a/crates/metadata/src/chmod/spec.rs
+++ b/crates/metadata/src/chmod/spec.rs
@@ -88,6 +88,9 @@ pub(crate) struct SymbolicClause {
     pub(crate) op: Operation,
     pub(crate) who: WhoMask,
     pub(crate) perms: PermSpec,
+    /// When true, no explicit who-specifier (u/g/o/a) was given.
+    /// upstream: exclude.c applies `~orig_umask` masking in this case.
+    pub(crate) who_implied: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -231,6 +234,7 @@ mod tests {
             op: Operation::Add,
             who: WhoMask::new(true, true, true),
             perms: PermSpec::default(),
+            who_implied: false,
         };
         let cloned = clause.clone();
         assert_eq!(clause, cloned);
@@ -253,6 +257,7 @@ mod tests {
             op: Operation::Assign,
             who: WhoMask::new(true, false, false),
             perms: PermSpec::default(),
+            who_implied: false,
         });
         assert!(matches!(kind, ClauseKind::Symbolic(_)));
     }

--- a/crates/metadata/src/chmod/tests.rs
+++ b/crates/metadata/src/chmod/tests.rs
@@ -106,6 +106,10 @@ fn implied_who_applies_umask_masking() {
     unsafe { libc::umask(umask) };
     if umask & 0o002 != 0 {
         // umask blocks other-write, so D+w should not grant it
-        assert_eq!(mode & 0o002, 0, "D+w should not grant other-write when umask blocks it");
+        assert_eq!(
+            mode & 0o002,
+            0,
+            "D+w should not grant other-write when umask blocks it"
+        );
     }
 }

--- a/crates/metadata/src/chmod/tests.rs
+++ b/crates/metadata/src/chmod/tests.rs
@@ -75,3 +75,37 @@ fn user_group_copy_clauses_are_respected() {
     let mode = modifiers.apply(0o640, file_type);
     assert_eq!(mode & 0o777, 0o666);
 }
+
+/// Verifies that `D+w` (no explicit who) applies umask masking.
+///
+/// upstream: chmod.c - when no who-specifier is given, `bits = (where *
+/// what) & ~orig_umask`. With a typical umask of 022, `+w` only grants
+/// owner-write (0200), NOT group-write or other-write.
+#[cfg(unix)]
+#[test]
+#[allow(unsafe_code)]
+fn implied_who_applies_umask_masking() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let dir_path = temp.path().join("testdir");
+    std::fs::create_dir(&dir_path).expect("create dir");
+    let dir_type = std::fs::metadata(&dir_path)
+        .expect("dir metadata")
+        .file_type();
+
+    // Parse the upstream testsuite spec: ug-s,a+rX,D+w
+    let modifiers = ChmodModifiers::parse("ug-s,a+rX,D+w").expect("parse");
+    // Starting from 0775 (rwxrwxr-x) which is a common directory default
+    let mode = modifiers.apply(0o2775, dir_type);
+    // After ug-s: clears setuid+setgid -> 0o775
+    // After a+rX: adds read+exec for all (dirs always get exec) -> 0o775
+    // After D+w: adds write, but masked by ~umask
+    // With umask 022: D+w adds 0o200 (user write only) -> 0o775
+    // With umask 000: D+w would add 0o222 (all write) -> 0o777
+    // The test just checks that other-write is NOT set when umask blocks it
+    let umask = unsafe { libc::umask(0) };
+    unsafe { libc::umask(umask) };
+    if umask & 0o002 != 0 {
+        // umask blocks other-write, so D+w should not grant it
+        assert_eq!(mode & 0o002, 0, "D+w should not grant other-write when umask blocks it");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `who_implied` field to `SymbolicClause` to track when no explicit who-specifier (u/g/o/a) was given in a chmod clause
- When `who_implied` is true, masks computed permission bits by `~orig_umask` matching upstream `chmod.c` behavior
- Caches process umask via `OnceLock` to avoid repeated syscalls (mirrors upstream `main.c` `orig_umask` pattern)
- Fixes `D+w` granting world-writable permissions when umask should block it

Closes #5407

## Test plan

- [x] Unit test `implied_who_applies_umask_masking` verifies `D+w` respects umask
- [x] Existing chmod tests continue to pass (explicit who-specifier cases unchanged)
- [ ] CI: upstream testsuite `chmod-option` should improve