### PR TITLE
fix: force dry-run mode for --only-write-batch local transfers

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -299,7 +299,14 @@ fn run_client_internal(
         options = options.batch_writer(Some(writer_arc.clone()));
     }
 
-    let mode = if config.dry_run() || config.list_only() {
+    // upstream: main.c:1817-1818 - `--only-write-batch` forces dry_run=1 so
+    // that the transfer runs (populating the batch file) without creating the
+    // destination directory or writing any files.
+    let is_only_write_batch = config
+        .batch_config()
+        .is_some_and(|bc| !bc.should_transfer());
+
+    let mode = if config.dry_run() || config.list_only() || is_only_write_batch {
         LocalCopyExecution::DryRun
     } else {
         LocalCopyExecution::Apply


### PR DESCRIPTION
## Summary

- Forces `LocalCopyExecution::DryRun` when `--only-write-batch` is active, matching upstream `main.c:1817-1818` which sets `dry_run=1` for `write_batch < 0`
- The batch writer still captures transfer data since it operates independently of the execution mode
- Prevents spurious destination directory creation that caused the upstream testsuite `batch-mode` test to fail

Closes #5406

## Test plan

- [ ] CI: upstream testsuite `batch-mode` test should pass
- [ ] Existing batch tests continue to pass (write-batch and read-batch unaffected)