### PR TITLE
fix: implement dest_mode() computation for non-preserve-perms transfers

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn copy_file(
     relative: Option<&Path>,
 ) -> Result<bool, LocalCopyError> {
     context.enforce_timeout()?;
-    let metadata_options = context.metadata_options();
+    let mut metadata_options = context.metadata_options();
     let mode = context.mode();
     let file_type = metadata.file_type();
 
@@ -173,6 +173,10 @@ pub(crate) fn copy_file(
     let whole_file_enabled = context.whole_file_enabled();
     let compress_enabled = context.should_compress(record_path.as_path());
     let relative_for_link = relative.unwrap_or(record_path.as_path());
+
+    // upstream: rsync.c:dest_mode() uses `exists` to apply umask-masked source
+    // permissions for new files vs keeping existing permissions for updates.
+    metadata_options = metadata_options.with_destination_is_new(!destination_previously_existed);
 
     let link_outcome = links::process_links(
         context,

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -16,6 +16,78 @@ use std::io;
 #[cfg(unix)]
 use std::os::fd::BorrowedFd;
 
+/// Returns the process umask, cached for thread safety.
+///
+/// upstream: `main.c` stores `orig_umask` once at startup. We query it
+/// the first time a permission application needs the umask and cache the
+/// result so the double set-and-restore syscall happens at most once per
+/// process.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn cached_umask() -> u32 {
+    use std::sync::OnceLock;
+    static UMASK: OnceLock<u32> = OnceLock::new();
+    *UMASK.get_or_init(|| {
+        // SAFETY: umask is a standard POSIX call. We set it to 0 to read
+        // the current value, then immediately restore it. This is a
+        // well-known pattern (used by upstream rsync main.c, GNU coreutils,
+        // etc.). The OnceLock ensures this pair of calls happens at most
+        // once per process, eliminating any window for concurrent umask
+        // modifications.
+        let old = unsafe { libc::umask(0) };
+        unsafe { libc::umask(old) };
+        old as u32
+    })
+}
+
+/// Computes the destination file mode matching upstream `rsync.c:dest_mode()`.
+///
+/// When `-p` (preserve permissions) is not active, upstream rsync still applies
+/// the source mode masked by the umask-derived default permissions. This ensures
+/// that execute bits from the source are preserved (masked by umask) instead of
+/// being lost to `open()`'s default `0o666 & ~umask`.
+///
+/// For new files: `source_mode & (~0o7777 | dflt_perms)`
+/// For existing files: keeps existing permissions (returns `None`)
+///
+/// upstream: rsync.c:449-472 `dest_mode()`
+/// upstream: generator.c:2280 `dflt_perms = (ACCESSPERMS & ~orig_umask)`
+#[cfg(unix)]
+fn compute_dest_mode(
+    source_mode: u32,
+    is_new: bool,
+    existing: Option<&fs::Metadata>,
+) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if is_new {
+        // upstream: dest_mode() for new files:
+        // new_mode = flist_mode & (~CHMOD_BITS | dflt_perms)
+        let dflt_perms = 0o777 & !cached_umask();
+        let new_mode = source_mode & (!0o7777 | dflt_perms);
+        // Skip the chmod if the mode already matches
+        if let Some(existing) = existing {
+            if (existing.permissions().mode() & 0o7777) == (new_mode & 0o7777) {
+                return None;
+            }
+        }
+        Some(new_mode)
+    } else if let Some(existing) = existing {
+        // upstream: dest_mode() for existing files returns
+        // (flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS)
+        // which keeps existing permissions. No chmod needed.
+        let stat_mode = existing.permissions().mode();
+        let new_mode = (source_mode & !0o7777) | (stat_mode & 0o7777);
+        if (new_mode & 0o7777) != (stat_mode & 0o7777) {
+            Some(new_mode)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
 /// Sets permissions on `destination` to match `metadata` (full mode on Unix,
 /// read-only flag on Windows).
 ///
@@ -96,6 +168,24 @@ pub(super) fn apply_permissions_with_chmod(
 
     if options.permissions() || options.executability() {
         apply_permissions_without_chmod(destination, metadata, options, existing)?;
+        return Ok(());
+    }
+
+    // upstream: rsync.c:dest_mode() - when no explicit permission option is
+    // active, still apply source-mode-based permissions masked by umask.
+    // Without this, newly created files get `0o666 & ~umask` from open()
+    // instead of `source_mode & (~CHMOD_BITS | dflt_perms)`.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let source_mode = metadata.permissions().mode();
+        if let Some(new_mode) =
+            compute_dest_mode(source_mode, options.destination_is_new(), existing)
+        {
+            let permissions = PermissionsExt::from_mode(new_mode);
+            fs::set_permissions(destination, permissions)
+                .map_err(|error| MetadataError::new("apply dest_mode", destination, error))?;
+        }
     }
 
     Ok(())
@@ -168,6 +258,28 @@ pub(super) fn apply_permissions_with_chmod_fd(
 
     if options.executability() && metadata.is_file() {
         apply_permissions_without_chmod(destination, metadata, options, existing)?;
+        return Ok(());
+    }
+
+    // upstream: rsync.c:dest_mode() - when no explicit permission option is
+    // active, still apply source-mode-based permissions masked by umask.
+    let source_mode = metadata.permissions().mode();
+    if let Some(new_mode) =
+        compute_dest_mode(source_mode, options.destination_is_new(), existing)
+    {
+        if let Some(fd) = fd {
+            unix_fs::fchmod(
+                fd,
+                unix_fs::Mode::from_raw_mode(new_mode as rustix::fs::RawMode),
+            )
+            .map_err(|error| {
+                MetadataError::new("apply dest_mode", destination, io::Error::from(error))
+            })?;
+        } else {
+            let permissions = PermissionsExt::from_mode(new_mode);
+            fs::set_permissions(destination, permissions)
+                .map_err(|error| MetadataError::new("apply dest_mode", destination, error))?;
+        }
     }
 
     Ok(())

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -264,9 +264,7 @@ pub(super) fn apply_permissions_with_chmod_fd(
     // upstream: rsync.c:dest_mode() - when no explicit permission option is
     // active, still apply source-mode-based permissions masked by umask.
     let source_mode = metadata.permissions().mode();
-    if let Some(new_mode) =
-        compute_dest_mode(source_mode, options.destination_is_new(), existing)
-    {
+    if let Some(new_mode) = compute_dest_mode(source_mode, options.destination_is_new(), existing) {
         if let Some(fd) = fd {
             unix_fs::fchmod(
                 fd,

--- a/crates/metadata/src/options/accessors.rs
+++ b/crates/metadata/src/options/accessors.rs
@@ -88,4 +88,12 @@ impl MetadataOptions {
     pub const fn group_mapping(&self) -> Option<&GroupMapping> {
         self.group_mapping.as_ref()
     }
+
+    /// Reports whether the destination file was newly created during this transfer.
+    ///
+    /// upstream: rsync.c:dest_mode() distinguishes new vs existing files.
+    #[must_use]
+    pub const fn destination_is_new(&self) -> bool {
+        self.destination_is_new
+    }
 }

--- a/crates/metadata/src/options/mod.rs
+++ b/crates/metadata/src/options/mod.rs
@@ -34,6 +34,10 @@ pub struct MetadataOptions {
     pub(crate) chmod: Option<ChmodModifiers>,
     pub(crate) user_mapping: Option<UserMapping>,
     pub(crate) group_mapping: Option<GroupMapping>,
+    /// When true, the destination file was newly created during this transfer.
+    /// upstream: rsync.c:dest_mode() uses `exists` parameter to distinguish
+    /// between new and existing files for permission computation.
+    pub(crate) destination_is_new: bool,
 }
 
 impl MetadataOptions {
@@ -58,6 +62,7 @@ impl MetadataOptions {
             chmod: None,
             user_mapping: None,
             group_mapping: None,
+            destination_is_new: false,
         }
     }
 }

--- a/crates/metadata/src/options/setters.rs
+++ b/crates/metadata/src/options/setters.rs
@@ -144,4 +144,15 @@ impl MetadataOptions {
         self.group_mapping = mapping;
         self
     }
+
+    /// Marks the destination as newly created during this transfer.
+    ///
+    /// upstream: rsync.c:dest_mode() uses `exists` to determine whether to
+    /// apply umask-masked source permissions (new file) or keep existing
+    /// permissions (existing file).
+    #[must_use]
+    pub const fn with_destination_is_new(mut self, is_new: bool) -> Self {
+        self.destination_is_new = is_new;
+        self
+    }
 }

--- a/crates/metadata/src/options/tests.rs
+++ b/crates/metadata/src/options/tests.rs
@@ -166,6 +166,8 @@ fn defaults_match_expected_configuration() {
     assert!(options.user_mapping().is_none());
     assert!(options.group_mapping().is_none());
 
+    assert!(!options.destination_is_new());
+
     assert_eq!(MetadataOptions::default(), options);
 }
 
@@ -201,6 +203,18 @@ fn builder_methods_apply_requested_flags() {
     assert_eq!(options.chmod(), Some(&modifiers));
     assert_eq!(options.user_mapping(), Some(&user_map));
     assert_eq!(options.group_mapping(), Some(&group_map));
+}
+
+#[test]
+fn destination_is_new_defaults_to_false_and_can_be_set() {
+    let options = MetadataOptions::new();
+    assert!(!options.destination_is_new());
+
+    let options = options.with_destination_is_new(true);
+    assert!(options.destination_is_new());
+
+    let options = options.with_destination_is_new(false);
+    assert!(!options.destination_is_new());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Implements upstream rsync's `dest_mode()` function (rsync.c:449-472) for the local copy engine
- When neither `-p` (preserve permissions) nor `-E` (preserve executability) is active, upstream rsync still applies `source_mode & (~CHMOD_BITS | dflt_perms)` to newly created files, where `dflt_perms = ACCESSPERMS & ~orig_umask`
- Without this, newly created files get `0o666 & ~umask` from `open()` instead of preserving source execute bits masked by umask
- Adds `destination_is_new` tracking to `MetadataOptions` so `compute_dest_mode()` can distinguish new files (apply umask-masked source perms) from existing files (keep existing perms)

## Test plan

- [ ] Verify `executability` upstream test passes (was showing `rw-r--r--` instead of `rwx------`)
- [ ] Verify `dir-sgid` upstream test passes (was showing `rw-------` instead of `rwx------`)
- [ ] Verify `acls-default` upstream test passes (was showing `rw-r--r--` instead of `rw-rw-rw-`)
- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] No regression in existing permission-preservation tests

Closes #5403, closes #5411, closes #5415