### PR TITLE
fix: preserve directory mtime after deferred deletions

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -37,7 +37,7 @@ rustc-hash = { workspace = true }
 rustix = { workspace = true, features = ["fs", "param", "process"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["fs", "io-util", "sync", "rt"] }
-filetime = { workspace = true, optional = true }
+filetime = { workspace = true }
 zstd = { version = "0.13", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -169,7 +169,7 @@ iouring-data-writes = ["fast_io/iouring-data-writes"]
 # ============================================================================
 
 # Async runtime support - enables tokio-based async I/O for file operations
-async = ["dep:tokio", "dep:filetime"]
+async = ["dep:tokio"]
 
 # ============================================================================
 # Debugging Features
@@ -179,7 +179,6 @@ async = ["dep:tokio", "dep:filetime"]
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
-filetime = { workspace = true }
 tempfile = { workspace = true }
 test-support = { path = "../test-support" }
 bandwidth = { path = "../bandwidth", features = ["test-support"] }

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -107,6 +107,13 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Executes all queued deferred deletions, unless I/O errors suppress them.
+    ///
+    /// Deletions modify the parent directory's mtime. When `-t` is active the
+    /// directory mtime was already set by `apply_final_directory_metadata`.
+    /// Capture each directory's mtime before deletion and restore it afterwards
+    /// to match upstream rsync's behaviour where the receiver sets directory
+    /// times independently of the generator's delayed-deletion phase.
+    // upstream: generator.c:2419 do_delayed_deletions() runs after generate_files()
     pub(super) fn flush_deferred_deletions(&mut self) -> Result<(), LocalCopyError> {
         if !self.deletions_allowed() {
             // I/O errors occurred and --ignore-errors is not set;
@@ -114,11 +121,25 @@ impl<'a> CopyContext<'a> {
             self.deferred_ops.deletions.clear();
             return Ok(());
         }
+        let preserve_times = self.metadata_options().times()
+            && !self.omit_dir_times_enabled();
         let pending = std::mem::take(&mut self.deferred_ops.deletions);
         for entry in pending {
             self.enforce_timeout()?;
+            // Capture directory mtime before deletion modifies it.
+            let saved_times = if preserve_times {
+                fs::metadata(&entry.destination).ok().map(|m| {
+                    filetime::FileTime::from_last_modification_time(&m)
+                })
+            } else {
+                None
+            };
             let relative = entry.relative.as_deref();
             delete_extraneous_entries(self, entry.destination.as_path(), relative, &entry.keep)?;
+            // Restore directory mtime that deletion invalidated.
+            if let Some(mtime) = saved_times {
+                let _ = filetime::set_file_mtime(&entry.destination, mtime);
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

- When `--delete-delay` or `--delete-after` is active, deferred deletions execute after `apply_final_directory_metadata` has already set directory timestamps
- The deletion modifies the parent directory's mtime, causing a visible drift (e.g., 1-second difference in the `fuzzy` and `alt-dest` upstream tests)
- Fix captures each directory's mtime before executing deferred deletions and restores it afterwards
- Makes `filetime` a non-optional dependency of the engine crate (was only available behind the `async` feature)

## Test plan

- [ ] Verify `fuzzy` upstream test passes (was failing with dir-diff due to root directory mtime)
- [ ] Verify `alt-dest` upstream test SSH copy preserves directory mtime
- [ ] No regression in existing delete-delay tests
- [ ] CI passes on all platforms

Closes #5417