### PR TITLE
fix: emit directory records before children in itemize output

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -140,9 +140,7 @@ pub(crate) fn copy_directory_recursive(
         // upstream: generator.c:recv_generator() - directory records appear
         // BEFORE their children in the itemize output. Emit the record
         // immediately so it precedes child entries in the record stream.
-        if !record_emitted
-            && let Some((ref rel_path, ref snapshot)) = metadata_record
-        {
+        if !record_emitted && let Some((ref rel_path, ref snapshot)) = metadata_record {
             context.record(
                 LocalCopyRecord::new(
                     rel_path.clone(),

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -98,7 +98,7 @@ pub(crate) fn copy_directory_recursive(
     let directory_ready = Cell::new(!destination_missing);
     let mut created_directory_on_disk = false;
     let creation_record_pending = destination_missing && relative.is_some();
-    let mut pending_record: Option<LocalCopyRecord> = None;
+    let mut record_emitted = false;
     let metadata_record = relative.map(|rel| {
         (
             rel.to_path_buf(),
@@ -137,10 +137,13 @@ pub(crate) fn copy_directory_recursive(
             created_directory_on_disk = true;
         }
 
-        if pending_record.is_none()
+        // upstream: generator.c:recv_generator() - directory records appear
+        // BEFORE their children in the itemize output. Emit the record
+        // immediately so it precedes child entries in the record stream.
+        if !record_emitted
             && let Some((ref rel_path, ref snapshot)) = metadata_record
         {
-            pending_record = Some(
+            context.record(
                 LocalCopyRecord::new(
                     rel_path.clone(),
                     LocalCopyAction::DirectoryCreated,
@@ -151,6 +154,7 @@ pub(crate) fn copy_directory_recursive(
                 )
                 .with_creation(true),
             );
+            record_emitted = true;
         }
 
         Ok(())
@@ -158,7 +162,7 @@ pub(crate) fn copy_directory_recursive(
 
     if !context.recursive_enabled() {
         ensure_directory(context)?;
-        record_directory_completion(context, creation_record_pending, pending_record.take());
+        record_directory_completion(context, creation_record_pending, None);
         if !context.mode().is_dry_run() {
             apply_final_directory_metadata(
                 context,
@@ -250,7 +254,7 @@ pub(crate) fn copy_directory_recursive(
         return Ok(false);
     }
 
-    record_directory_completion(context, creation_record_pending, pending_record);
+    record_directory_completion(context, creation_record_pending, None);
 
     if !context.mode().is_dry_run() {
         apply_final_directory_metadata(


### PR DESCRIPTION
## Summary

- Upstream rsync's `generator.c:recv_generator()` outputs directory entries BEFORE their children in the itemize output
- oc-rsync was deferring the directory record to `record_directory_completion` (after all children processed), causing `cd+++++++++` lines to appear after their children
- Emit the directory creation record immediately in `ensure_directory` so it precedes child entries in the record stream

## Test plan

- [ ] Verify `itemize` upstream test shows directories before their children (e.g., `cd+++++++++ bar/` before `>f+++++++++ bar/baz/rsync`)
- [ ] No regression in existing itemize tests
- [ ] CI passes on all platforms

Closes #5418