### PR TITLE
fix: handle embedded /./ markers in --files-from entries

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/resolver.rs
+++ b/crates/cli/src/frontend/execution/file_list/resolver.rs
@@ -3,10 +3,36 @@
 //! Resolves file list entries against the source base directory, inserting
 //! `.` markers for `--files-from` to preserve relative path structure.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 use super::parser::operand_is_remote;
+
+/// Returns `true` when the operand contains a `/./` or leading `./` marker
+/// that upstream rsync uses to split the chdir prefix from the transferred
+/// relative filename.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2316` - `strstr(fbuf, "/./")` detects embedded marker
+fn entry_contains_dot_marker(operand: &OsStr) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = operand.as_bytes();
+        // Check for "/./", or a leading "./" (equivalent to no prefix)
+        if bytes.starts_with(b"./") {
+            return true;
+        }
+        bytes.windows(3).any(|w| w == b"/./")
+    }
+
+    #[cfg(not(unix))]
+    {
+        let text = operand.to_string_lossy();
+        text.starts_with("./") || text.contains("/./")
+    }
+}
 
 /// Resolves file list entries against the source base directory.
 ///
@@ -73,13 +99,27 @@ pub(crate) fn resolve_file_list_entries(
         }
 
         if files_from_active {
-            // Insert ./ marker: base/./entry - upstream rsync uses the
-            // source dir as a chdir target and entries are relative to it.
-            // The marker tells the engine where the relative portion begins.
-            let mut combined = base_path.to_path_buf();
-            combined.push(".");
-            combined.push(entry_path);
-            *entry = combined.into_os_string();
+            // upstream: flist.c:2316-2318 - when relative_paths is set and a
+            // file list entry contains "/./", upstream splits the entry at that
+            // marker: the portion before becomes a chdir prefix (relative to
+            // argv[0]), and the portion after becomes the transferred filename.
+            //
+            // If the entry already carries its own "./" marker (e.g.
+            // "from/./dir/file"), join base + entry directly so the engine's
+            // detect_marker_components finds the entry's own marker. Adding a
+            // second "./" would create base/./from/./dir/file which makes the
+            // engine split at the first marker, incorrectly keeping "from/" in
+            // the destination path.
+            if entry_contains_dot_marker(entry.as_os_str()) {
+                let mut combined = base_path.to_path_buf();
+                combined.push(entry_path);
+                *entry = combined.into_os_string();
+            } else {
+                let mut combined = base_path.to_path_buf();
+                combined.push(".");
+                combined.push(entry_path);
+                *entry = combined.into_os_string();
+            }
         } else {
             let mut combined = base_path.to_path_buf();
             combined.push(entry_path);

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -1703,8 +1703,12 @@ fn resolve_files_from_entry_with_embedded_dot_marker_skips_extra_marker() {
     let expected_1 = Path::new("/scratch").join("from/./dir/subdir/foobar.baz");
     assert_eq!(entries[1], expected_1.as_os_str());
 
-    // Entry without marker: base/./entry as before
-    let expected_2 = Path::new("/scratch/.").join("simple.txt");
+    // Entry without marker: base/./entry as before.
+    // Build expected with the same push sequence as the implementation so
+    // platform-specific separators match (Windows uses '\' between components).
+    let mut expected_2 = Path::new("/scratch").to_path_buf();
+    expected_2.push(".");
+    expected_2.push("simple.txt");
     assert_eq!(entries[2], expected_2.as_os_str());
 }
 

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -1678,3 +1678,47 @@ fn resolve_file_list_entries_with_dot_relative_paths() {
     let expected_1 = Path::new("/base").join("../parent/file.txt");
     assert_eq!(entries[1], expected_1.as_os_str());
 }
+
+#[test]
+fn resolve_files_from_entry_with_embedded_dot_marker_skips_extra_marker() {
+    use crate::frontend::execution::resolve_file_list_entries;
+
+    // upstream: flist.c:2316-2318 - entries like "from/./dir/subdir" already
+    // contain a "./" transfer root marker. The resolver must NOT add another
+    // "./" because the engine splits at the first marker, and a double marker
+    // would incorrectly keep "from/" in the destination path.
+    let mut entries = vec![
+        OsString::from("from/./dir/subdir"),
+        OsString::from("from/./dir/subdir/foobar.baz"),
+        OsString::from("simple.txt"),
+    ];
+    let operands = vec![OsString::from("/scratch"), OsString::from("/dest")];
+
+    resolve_file_list_entries(&mut entries, &operands, false, true);
+
+    // Entry with embedded marker: base joined directly, no extra "./"
+    let expected_0 = Path::new("/scratch").join("from/./dir/subdir");
+    assert_eq!(entries[0], expected_0.as_os_str());
+
+    let expected_1 = Path::new("/scratch").join("from/./dir/subdir/foobar.baz");
+    assert_eq!(entries[1], expected_1.as_os_str());
+
+    // Entry without marker: base/./entry as before
+    let expected_2 = Path::new("/scratch/.").join("simple.txt");
+    assert_eq!(entries[2], expected_2.as_os_str());
+}
+
+#[test]
+fn resolve_files_from_entry_with_leading_dot_slash_skips_extra_marker() {
+    use crate::frontend::execution::resolve_file_list_entries;
+
+    // Entry starting with "./" already has a marker at position 0.
+    let mut entries = vec![OsString::from("./dir/file.txt")];
+    let operands = vec![OsString::from("/scratch"), OsString::from("/dest")];
+
+    resolve_file_list_entries(&mut entries, &operands, false, true);
+
+    // Should join directly: /scratch/./dir/file.txt
+    let expected = Path::new("/scratch").join("./dir/file.txt");
+    assert_eq!(entries[0], expected.as_os_str());
+}

--- a/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
@@ -97,3 +97,61 @@ fn files_from_excludes_unlisted_files() {
         "file3.txt must not be copied - it is not in the --files-from list"
     );
 }
+
+/// Verifies that `--files-from` entries with embedded `/./` markers produce
+/// the correct destination path structure.
+///
+/// Upstream rsync uses `/./` within a file list entry to split the path:
+/// everything before becomes a chdir prefix (relative to the source argument)
+/// and everything after becomes the transferred relative filename at the
+/// destination.
+///
+/// # Upstream Reference
+///
+/// - `testsuite/files-from.test` - tests `from/./dir/subdir` entries
+/// - `flist.c:2316-2318` - `strstr(fbuf, "/./")` splits at marker
+#[test]
+fn files_from_embedded_dot_marker_determines_destination_structure() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let scratch = tmp.path().join("scratch");
+
+    // Create: scratch/from/dir/subdir/file.txt
+    let subdir = scratch.join("from").join("dir").join("subdir");
+    std::fs::create_dir_all(&subdir).expect("create subdir");
+    std::fs::write(subdir.join("file.txt"), b"hello").expect("write file");
+
+    // File list uses "from/./dir/subdir/file.txt" - the "./" marker means
+    // "from" is the chdir prefix and "dir/subdir/file.txt" is the transfer name.
+    let list_path = tmp.path().join("filelist");
+    std::fs::write(&list_path, "from/./dir/subdir/file.txt\n").expect("write list");
+
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir(&dest).expect("create dest");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-av"),
+        OsString::from(format!("--files-from={}", list_path.display())),
+        scratch.clone().into_os_string(),
+        OsString::from(format!("{}/", dest.display())),
+    ]);
+
+    assert_eq!(code, 0, "transfer should succeed");
+
+    // The file should appear at dest/dir/subdir/file.txt (not dest/from/dir/...)
+    // because "/./'' splits the path: "from" is just a chdir prefix.
+    assert!(
+        dest.join("dir").join("subdir").join("file.txt").exists(),
+        "file should be at dir/subdir/file.txt, not from/dir/subdir/file.txt"
+    );
+    assert!(
+        !dest.join("from").exists(),
+        "the 'from' directory prefix should NOT appear at the destination"
+    );
+    assert_eq!(
+        std::fs::read(dest.join("dir").join("subdir").join("file.txt")).expect("read"),
+        b"hello"
+    );
+}


### PR DESCRIPTION
## Summary

- Fix `--files-from` path resolution when file list entries contain embedded `/./` transfer root markers (e.g., `from/./dir/subdir`)
- The resolver was adding a second `./` marker between the base directory and the entry, causing the engine to split at the wrong marker and incorrectly keeping the prefix directory in the destination path
- Entries without markers continue to get the standard `base/./entry` treatment

## Root Cause

Upstream rsync (`flist.c:2316-2318`) uses `/./` within a file list entry to split the chdir prefix from the transferred filename. For `from/./dir/subdir`, upstream does `chdir("from")` relative to the source, and sends `dir/subdir` as the file entry. The destination gets `dir/subdir`, not `from/dir/subdir`.

The oc-rsync resolver was unconditionally inserting a `./` marker (`base/./entry`), producing `base/./from/./dir/subdir`. The engine's `detect_marker_components` finds the first `./` and splits there, yielding `from/dir/subdir` as the relative path - one directory level too deep.

## Test plan

- [x] Unit test: `resolve_files_from_entry_with_embedded_dot_marker_skips_extra_marker` - verifies mixed entries with and without markers
- [x] Unit test: `resolve_files_from_entry_with_leading_dot_slash_skips_extra_marker` - verifies leading `./` entries
- [x] Integration test: `files_from_embedded_dot_marker_determines_destination_structure` - end-to-end test matching upstream `testsuite/files-from.test` scenario

Closes #5416