### PR TITLE
fix: build all CHECK_PROGS helpers for upstream testsuite

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -77,6 +77,10 @@ build_upstream_helpers() {
     if [[ -f "${upstream_src_dir}/shconfig" && \
           -x "${upstream_src_dir}/tls" && \
           -x "${upstream_src_dir}/getgroups" && \
+          -x "${upstream_src_dir}/getfsdev" && \
+          -x "${upstream_src_dir}/trimslash" && \
+          -x "${upstream_src_dir}/t_unsafe" && \
+          -x "${upstream_src_dir}/wildtest" && \
           -x "${upstream_src_dir}/support/lsh.sh" ]]; then
         return
     fi
@@ -89,11 +93,18 @@ build_upstream_helpers() {
                 || { tail -50 configure.log; exit 1; }
         fi
         # Build the upstream rsync binary (some tests reference
-        # $TOOLDIR/rsync) plus the test helper programs (tls, getgroups)
-        # that the testsuite's check_perms and rsync_getgroups functions
-        # require. The helpers are part of CHECK_PROGS in upstream's
-        # Makefile, not the `all` target, so they must be named explicitly.
-        make all tls getgroups >make.log 2>&1 || { tail -100 make.log; exit 1; }
+        # $TOOLDIR/rsync) plus the CHECK_PROGS helper programs that
+        # various tests require:
+        #   tls        - check_perms (many tests)
+        #   getgroups  - rsync_getgroups (dir-sgid, acls tests)
+        #   getfsdev   - chmod-temp-dir (cross-filesystem temp dir)
+        #   trimslash  - trimslash test
+        #   t_unsafe   - unsafe-byname test
+        #   wildtest   - wildmatch test
+        # These are part of CHECK_PROGS in upstream's Makefile, not the
+        # `all` target, so they must be named explicitly.
+        make all tls getgroups getfsdev trimslash t_unsafe wildtest \
+            >make.log 2>&1 || { tail -100 make.log; exit 1; }
     )
 }
 


### PR DESCRIPTION
## Summary

- Build all upstream CHECK_PROGS helper binaries (getfsdev, trimslash, t_unsafe, wildtest) in addition to the existing tls and getgroups
- These helpers are required by chmod-temp-dir, trimslash, unsafe-byname, and wildmatch tests respectively
- Update the build check condition to verify all helpers are present before skipping the build step

## Root Cause

The `build_upstream_helpers()` function in `run_upstream_testsuite.sh` only built `tls` and `getgroups`, but upstream's `CHECK_PROGS` includes several more helper binaries. Tests that reference these via `$TOOLDIR/getfsdev`, `$TOOLDIR/trimslash`, `$TOOLDIR/t_unsafe`, or `$TOOLDIR/wildtest` fail with exit 127 (command not found).

## Test plan

- [x] `WHICHTESTS=chmod-temp-dir.test` should no longer exit 127
- [x] `WHICHTESTS=trimslash.test` should no longer exit 127
- [x] `WHICHTESTS=unsafe-byname.test` should no longer exit 127
- [x] `WHICHTESTS=wildmatch.test` should no longer exit 127

Closes #5408, closes #5422, closes #5424