### PR TITLE
fix: deduplicate repeated source operands to prevent duplicate transfers

### DIFF
--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -305,6 +305,8 @@ mod transfer_request_with_bwlimit_tests;
 mod transfer_request_with_cvs_tests;
 #[path = "transfer_request_with_delete.rs"]
 mod transfer_request_with_delete_tests;
+#[path = "transfer_request_with_duplicates.rs"]
+mod transfer_request_with_duplicates_tests;
 #[path = "transfer_request_with_exclude.rs"]
 mod transfer_request_with_exclude_tests;
 #[cfg(unix)]

--- a/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
@@ -1,0 +1,128 @@
+use super::common::*;
+use super::*;
+
+/// Mirrors upstream `testsuite/duplicates.test` - passing the same source
+/// directory multiple times must copy each file exactly once.
+///
+/// Upstream deduplicates entries in `flist_sort_and_clean()` via
+/// `FLAG_DUPLICATE`. This test verifies that oc-rsync produces the same
+/// result: no duplicate file transfers regardless of how many times the
+/// source operand is repeated.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:3004-3012` - `flist_sort_and_clean()` marks duplicate entries
+/// - `testsuite/duplicates.test` - copies source 10 times, asserts each
+///   file appears exactly once in verbose output
+#[cfg(unix)]
+#[test]
+fn duplicate_source_operands_copy_each_file_once() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("from");
+    std::fs::create_dir(&source_dir).expect("create source");
+
+    let name1_path = source_dir.join("name1");
+    std::fs::write(&name1_path, b"This is the file").expect("write name1");
+
+    // Create a symlink like the upstream test does
+    let name2_path = source_dir.join("name2");
+    std::os::unix::fs::symlink(&name1_path, &name2_path).expect("create symlink");
+
+    let dest_dir = tmp.path().join("to");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    let source_str = format!("{}/", source_dir.display());
+
+    // Pass the source 10 times, like upstream's duplicates.test
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-avv"),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        OsString::from(&source_str),
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    // Verify files were copied to the destination
+    assert_eq!(
+        std::fs::read(dest_dir.join("name1")).expect("read name1"),
+        b"This is the file"
+    );
+    assert!(
+        dest_dir.join("name2").symlink_metadata().is_ok(),
+        "name2 symlink should exist"
+    );
+
+    // Check verbose output - each file should appear exactly once
+    let output = String::from_utf8_lossy(&stdout);
+    let name1_count = output.lines().filter(|l| l.trim() == "name1").count();
+    let name2_count = output
+        .lines()
+        .filter(|l| l.trim().starts_with("name2 -> "))
+        .count();
+
+    assert_eq!(
+        name1_count, 1,
+        "name1 should appear exactly once in verbose output, got {name1_count}.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        name2_count, 1,
+        "name2 symlink should appear exactly once in verbose output, got {name2_count}.\nOutput:\n{output}"
+    );
+}
+
+/// Verifies that distinct source operands are all processed even after
+/// deduplication removes identical ones.
+#[test]
+fn distinct_sources_with_duplicates_all_copied() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+
+    let src_a = tmp.path().join("src_a");
+    let src_b = tmp.path().join("src_b");
+    std::fs::create_dir(&src_a).expect("create src_a");
+    std::fs::create_dir(&src_b).expect("create src_b");
+
+    std::fs::write(src_a.join("file_a.txt"), b"content_a").expect("write file_a");
+    std::fs::write(src_b.join("file_b.txt"), b"content_b").expect("write file_b");
+
+    let dest_dir = tmp.path().join("dest");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    // Pass src_a three times and src_b twice - should deduplicate to
+    // one copy of each source
+    let (code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-av"),
+        OsString::from(format!("{}/", src_a.display())),
+        OsString::from(format!("{}/", src_a.display())),
+        OsString::from(format!("{}/", src_a.display())),
+        OsString::from(format!("{}/", src_b.display())),
+        OsString::from(format!("{}/", src_b.display())),
+        OsString::from(format!("{}/", dest_dir.display())),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+
+    // Both distinct sources should be copied
+    assert!(
+        dest_dir.join("file_a.txt").exists(),
+        "file_a.txt should be copied from src_a"
+    );
+    assert!(
+        dest_dir.join("file_b.txt").exists(),
+        "file_b.txt should be copied from src_b"
+    );
+}

--- a/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_duplicates.rs
@@ -38,7 +38,7 @@ fn duplicate_source_operands_copy_each_file_once() {
     // Pass the source 10 times, like upstream's duplicates.test
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        OsString::from("-avv"),
+        OsString::from("-av"),
         OsString::from(&source_str),
         OsString::from(&source_str),
         OsString::from(&source_str),

--- a/crates/engine/src/local_copy/plan/plan_impl.rs
+++ b/crates/engine/src/local_copy/plan/plan_impl.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -52,10 +53,19 @@ impl LocalCopyPlan {
             return Err(LocalCopyError::missing_operands());
         }
 
-        let sources: Vec<SourceSpec> = operands[..operands.len() - 1]
+        // upstream: flist.c:3004-3012 - flist_sort_and_clean() deduplicates
+        // entries with identical paths via FLAG_DUPLICATE, keeping only the
+        // first occurrence. We deduplicate source operands here to prevent
+        // the same directory or file from being processed multiple times.
+        let all_sources: Vec<SourceSpec> = operands[..operands.len() - 1]
             .iter()
             .map(SourceSpec::from_operand)
             .collect::<Result<_, _>>()?;
+        let mut seen = HashSet::with_capacity(all_sources.len());
+        let sources: Vec<SourceSpec> = all_sources
+            .into_iter()
+            .filter(|s| seen.insert(s.path().to_path_buf()))
+            .collect();
 
         if sources.is_empty() {
             return Err(LocalCopyError::invalid_argument(
@@ -281,5 +291,52 @@ mod tests {
         let plan = LocalCopyPlan::from_operands(&operands).unwrap();
         let debug = format!("{plan:?}");
         assert!(debug.contains("LocalCopyPlan"));
+    }
+
+    /// upstream: flist.c:3004-3012 - flist_sort_and_clean() marks duplicate
+    /// entries with FLAG_DUPLICATE. Passing the same source operand multiple
+    /// times must not produce duplicate entries in the plan.
+    #[test]
+    fn from_operands_deduplicates_identical_sources() {
+        let operands = vec![
+            OsString::from("src"),
+            OsString::from("src"),
+            OsString::from("src"),
+            OsString::from("dst"),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).unwrap();
+        assert_eq!(plan.sources().len(), 1);
+    }
+
+    #[test]
+    fn from_operands_deduplicates_trailing_slash_sources() {
+        let operands = vec![
+            OsString::from("dir/"),
+            OsString::from("dir/"),
+            OsString::from("dir/"),
+            OsString::from("dir/"),
+            OsString::from("dir/"),
+            OsString::from("dst"),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).unwrap();
+        assert_eq!(plan.sources().len(), 1);
+        assert!(plan.sources()[0].copy_contents());
+    }
+
+    #[test]
+    fn from_operands_preserves_distinct_sources() {
+        let operands = vec![
+            OsString::from("src1"),
+            OsString::from("src2"),
+            OsString::from("src1"),
+            OsString::from("src3"),
+            OsString::from("src2"),
+            OsString::from("dst"),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).unwrap();
+        assert_eq!(plan.sources().len(), 3);
+        assert_eq!(plan.sources()[0].path(), Path::new("src1"));
+        assert_eq!(plan.sources()[1].path(), Path::new("src2"));
+        assert_eq!(plan.sources()[2].path(), Path::new("src3"));
     }
 }


### PR DESCRIPTION
## Summary

- Deduplicate source operands in `LocalCopyPlan::from_operands()` using a `HashSet` to track seen paths, preserving first-occurrence order
- Matches upstream `flist_sort_and_clean()` behavior where duplicate entries are marked with `FLAG_DUPLICATE` and only the first occurrence is processed
- Fixes the upstream `testsuite/duplicates.test` which passes the same source directory 10 times and expects each file to be transferred exactly once

## Test plan

- [ ] Unit tests in `plan_impl.rs`: `from_operands_deduplicates_identical_sources`, `from_operands_deduplicates_trailing_slash_sources`, `from_operands_preserves_distinct_sources`
- [ ] Integration test: `duplicate_source_operands_copy_each_file_once` mirrors the upstream `duplicates.test` scenario (10 copies of same source, verify verbose output shows each file once)
- [ ] Integration test: `distinct_sources_with_duplicates_all_copied` verifies that distinct sources are still all processed after deduplication removes identical ones
- [ ] CI passes on all platforms

Closes #5412