### PR TITLE
fix: follow symlinks when emitting implied parent directories

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -301,7 +301,12 @@ impl GeneratorContext {
                 continue;
             }
             let full = base.join(&relative_ancestor);
-            let meta = match std::fs::symlink_metadata(&full) {
+            // upstream: flist.c:1949 - `copy_links = 1` is set before
+            // emitting implied parents, so stat() follows symlinks. On
+            // macOS /var is a symlink to /private/var; using
+            // symlink_metadata would skip it (is_dir() false for a
+            // symlink), breaking the ancestor chain.
+            let meta = match std::fs::metadata(&full) {
                 Ok(m) if m.is_dir() => m,
                 _ => continue,
             };


### PR DESCRIPTION
## Summary

- Switch from `symlink_metadata()` to `metadata()` (follows symlinks) in `emit_implied_parents()` for the directory check
- Matches upstream rsync's `flist.c:1949` where `copy_links = 1` is set before emitting implied parent entries
- Fixes macOS CI failure in `relative_absolute_source_preserves_full_prefix` test where `/var` is a symlink to `/private/var`

## Test plan

- [ ] CI: `relative_absolute_source_preserves_full_prefix` test passes on macOS
- [ ] CI: `Feature flag combinations / iconv (macos-latest)` job passes
- [ ] No regressions on Linux or Windows
- [ ] Implied parent directories are emitted correctly for paths with symlink ancestors