### PR TITLE
fix: skip parent directory preparation in dry-run mode to prevent false vanished error

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -126,10 +126,11 @@ pub(crate) fn copy_file(
         return Ok(true);
     }
 
-    if let Some(parent) = destination.parent() {
-        context.prepare_parent_directory(parent)?;
-    }
-
+    // Dry-run check must precede parent directory preparation. When
+    // --no-implied-dirs is active, prepare_parent_directory fails with NotFound
+    // for missing parents. That NotFound error is misclassified as "file has
+    // vanished" by the caller. In dry-run mode no filesystem mutations occur,
+    // so preparing the parent is unnecessary.
     if mode.is_dry_run() {
         dry_run::handle_dry_run(
             context,
@@ -142,6 +143,10 @@ pub(crate) fn copy_file(
             },
         )?;
         return Ok(true);
+    }
+
+    if let Some(parent) = destination.parent() {
+        context.prepare_parent_directory(parent)?;
     }
 
     if existing::handle_existing_skips(

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -427,7 +427,7 @@ fn execute_without_implied_dirs_requires_existing_parent() {
 }
 
 #[test]
-fn execute_dry_run_without_implied_dirs_requires_existing_parent() {
+fn execute_dry_run_without_implied_dirs_skips_parent_check() {
     let temp = create_tempdir();
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("missing").join("dest.txt");
@@ -440,17 +440,9 @@ fn execute_dry_run_without_implied_dirs_requires_existing_parent() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().implied_dirs(false);
 
-    let error = plan
-        .execute_with_options(LocalCopyExecution::DryRun, options)
-        .expect_err("dry-run should error");
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("dry-run succeeds without checking parent");
 
-    match error.kind() {
-        LocalCopyErrorKind::Io { action, path, .. } => {
-            assert_eq!(*action, "create parent directory");
-            assert_eq!(path, destination.parent().expect("parent"));
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
     assert!(!destination.exists());
 }
 

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -1060,3 +1060,48 @@ fn dry_run_with_inplace_does_not_modify_destination() {
         "dry run with inplace must not modify destination"
     );
 }
+
+/// Regression test: dry-run with `--no-implied-dirs` must not fail with a false
+/// "file has vanished" error when the destination parent directory does not
+/// exist. The prepare_parent_directory call must be skipped entirely in
+/// dry-run mode, because no filesystem mutations are needed.
+///
+/// upstream: receiver.c:recv_files() - dry-run short-circuits before mkdir
+#[test]
+fn dry_run_with_no_implied_dirs_and_missing_parent_succeeds() {
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    let nested = source_root.join("sub").join("deep");
+    fs::create_dir_all(&nested).expect("create nested source dirs");
+    fs::write(nested.join("file.txt"), b"hello").expect("write file");
+
+    let dest_root = temp.path().join("dest");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+
+    // --relative with ./ anchor preserves sub/deep/ in the destination.
+    // With --no-implied-dirs the intermediate sub/deep/ is NOT auto-created.
+    let mut source_operand = source_root.clone().into_os_string();
+    source_operand.push("/./");
+    source_operand.push("sub/deep/file.txt");
+
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .relative_paths(true)
+        .implied_dirs(false);
+
+    // Before the fix, this returned Err with a NotFound IO error that the
+    // caller misclassified as "file has vanished".
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("dry run with --no-implied-dirs must succeed");
+
+    assert_eq!(summary.files_copied(), 1);
+    assert_eq!(summary.bytes_copied(), 5);
+    // Destination must not be created in dry-run mode.
+    assert!(
+        !dest_root.join("sub").exists(),
+        "dry run must not create directories"
+    );
+}

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -315,7 +315,7 @@ fn no_implied_dirs_recursive_copy_with_nested_structure() {
 }
 
 #[test]
-fn no_implied_dirs_dry_run_detects_missing_parents() {
+fn no_implied_dirs_dry_run_skips_parent_check() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     fs::write(&source, b"content").expect("write source");
@@ -329,17 +329,9 @@ fn no_implied_dirs_dry_run_detects_missing_parents() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
     let options = LocalCopyOptions::default().implied_dirs(false);
 
-    let error = plan
-        .execute_with_options(LocalCopyExecution::DryRun, options)
-        .expect_err("dry-run should detect missing parent");
-
-    match error.kind() {
-        LocalCopyErrorKind::Io { action, path, .. } => {
-            assert_eq!(*action, "create parent directory");
-            assert_eq!(path, destination.parent().expect("parent"));
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("dry-run succeeds without checking parent");
+    assert!(!destination.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Move the dry-run early-return check before `prepare_parent_directory()` in `copy_file()` to prevent a false "file has vanished" error when `--no-implied-dirs` is active and the destination parent directory does not exist
- In dry-run mode no filesystem mutations occur, so preparing the parent directory is unnecessary and was causing `NotFound` errors that propagated as spurious vanished-file reports
- Add regression test verifying dry-run with `--relative --no-implied-dirs` and a missing destination parent succeeds without error

Closes #5420

## Test plan

- [ ] New test `dry_run_with_no_implied_dirs_and_missing_parent_succeeds` passes in CI
- [ ] Existing dry-run tests remain green (no behavioral change for non-dry-run paths)
- [ ] Cross-platform CI (Linux, macOS, Windows) passes