### PR TITLE
fix: build delta signature before backup rename to prevent false vanished error

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -35,6 +35,7 @@ use super::super::super::append::{AppendMode, determine_append_mode};
 use super::super::super::comparison::{
     Xxh64DedupOutcome, build_delta_signature, xxh64_dedup_check,
 };
+use super::super::super::compute_backup_path;
 use super::super::super::guard::remove_incomplete_destination;
 use super::super::super::preallocate::maybe_preallocate_destination;
 use super::TransferFlags;
@@ -119,8 +120,31 @@ pub(in crate::local_copy) fn execute_transfer(
         None
     };
 
+    // Track where the old destination ended up after a potential backup rename.
+    // When --backup renames the basis file away, the delta transfer must read
+    // matched blocks from the backup location instead of the original destination.
+    // upstream: receiver.c - the basis fd is opened before make_backup() runs;
+    // here we track the new path because we cannot hold the fd across the
+    // temp-file/inplace writer setup.
+    let mut delta_basis_override: Option<PathBuf> = None;
     if let Some(existing) = existing_metadata {
         context.backup_existing_entry(destination, relative, existing.file_type())?;
+        // When backup renamed the basis file and delta transfer will need it,
+        // record the backup path so copy_file_contents reads from the right
+        // location. The delta signature is only built for regular files, so
+        // this condition is sufficient.
+        if delta_signature.is_some()
+            && context.options().backup_enabled()
+            && !context.mode().is_dry_run()
+        {
+            delta_basis_override = Some(compute_backup_path(
+                context.destination_root(),
+                destination,
+                None,
+                context.options().backup_directory(),
+                context.options().backup_suffix(),
+            ));
+        }
     }
 
     if !file_type.is_file() {
@@ -400,6 +424,11 @@ pub(in crate::local_copy) fn execute_transfer(
         }
     );
 
+    // When backup moved the basis file, point the delta transfer at its new
+    // location so it can read matched blocks from the backup copy.
+    let delta_basis = delta_basis_override
+        .as_deref()
+        .unwrap_or(destination);
     let copy_result = context.copy_file_contents(
         &mut reader,
         &mut writer,
@@ -407,7 +436,7 @@ pub(in crate::local_copy) fn execute_transfer(
         use_sparse_writes,
         compress_enabled,
         source,
-        destination,
+        delta_basis,
         record_path,
         delta_signature.as_ref(),
         file_size,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -104,6 +104,21 @@ pub(in crate::local_copy) fn execute_transfer(
         }
     }
 
+    // Build delta signature BEFORE backup renames the destination away.
+    // upstream: receiver.c - the basis file must be read while it still exists
+    // at the destination path. If backup runs first, the rename causes ENOENT
+    // which is_vanished_error() misclassifies as a source vanish (exit 24).
+    let delta_signature = if !whole_file_enabled {
+        match existing_metadata {
+            Some(existing) if existing.is_file() => {
+                build_delta_signature(destination, existing, context.block_size_override())?
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
     if let Some(existing) = existing_metadata {
         context.backup_existing_entry(destination, relative, existing.file_type())?;
     }
@@ -233,17 +248,12 @@ pub(in crate::local_copy) fn execute_transfer(
         }
     }
 
-    // Build delta signature when a basis file exists and we are not appending.
-    // For inplace mode, delta transfer reads existing blocks before overwriting.
-    let delta_signature = if append_offset == 0 && !whole_file_enabled {
-        match existing_metadata {
-            Some(existing) if existing.is_file() => {
-                build_delta_signature(destination, existing, context.block_size_override())?
-            }
-            _ => None,
-        }
-    } else {
+    // Discard the pre-computed delta signature when appending - delta transfer
+    // is not applicable in append mode.
+    let delta_signature = if append_offset > 0 {
         None
+    } else {
+        delta_signature
     };
 
     let (mut reader, copy_source) = if let Some(ref override_path) = copy_source_override {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -426,9 +426,7 @@ pub(in crate::local_copy) fn execute_transfer(
 
     // When backup moved the basis file, point the delta transfer at its new
     // location so it can read matched blocks from the backup copy.
-    let delta_basis = delta_basis_override
-        .as_deref()
-        .unwrap_or(destination);
+    let delta_basis = delta_basis_override.as_deref().unwrap_or(destination);
     let copy_result = context.copy_file_contents(
         &mut reader,
         &mut writer,

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -2007,7 +2007,8 @@ fn symsafe_default_verbosity_suppresses_notice() {
 /// Regression test for #5405: when backup renamed the destination before
 /// `build_delta_signature` could read it, the resulting ENOENT was
 /// misclassified as a vanished source file (exit 24). The fix moves
-/// signature computation before the backup rename.
+/// signature computation before the backup rename and redirects the
+/// delta transfer to read matched blocks from the backup location.
 #[test]
 fn backup_with_no_whole_file_does_not_produce_vanished_error() {
     let ctx = test_helpers::setup_copy_test();

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -2000,3 +2000,58 @@ fn symsafe_default_verbosity_suppresses_notice() {
         "expected no SYMSAFE notice at default verbosity; got {symsafe_msgs:?}"
     );
 }
+
+/// Verifies that --backup combined with --no-whole-file (delta transfer)
+/// succeeds without false "file has vanished" errors.
+///
+/// Regression test for #5405: when backup renamed the destination before
+/// `build_delta_signature` could read it, the resulting ENOENT was
+/// misclassified as a vanished source file (exit 24). The fix moves
+/// signature computation before the backup rename.
+#[test]
+fn backup_with_no_whole_file_does_not_produce_vanished_error() {
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    // Use content large enough to produce a meaningful delta signature
+    // (must exceed the block size threshold so the delta path is exercised).
+    let old_content: Vec<u8> = (0..32_768).map(|i| (i % 251) as u8).collect();
+    let mut new_content = old_content.clone();
+    // Modify a small region so delta transfer finds partial matches.
+    for byte in new_content.iter_mut().take(256) {
+        *byte = byte.wrapping_add(1);
+    }
+
+    let source_file = ctx.source.join("delta.bin");
+    fs::write(&source_file, &new_content).expect("write source");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing = dest_root.join("delta.bin");
+    fs::write(&existing, &old_content).expect("write dest");
+
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .whole_file(false);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("backup + no-whole-file must not fail with vanished error");
+
+    let backup = dest_root.join("delta.bin~");
+    assert!(backup.exists(), "backup missing at {}", backup.display());
+    assert_eq!(
+        fs::read(&backup).expect("read backup"),
+        old_content,
+        "backup must contain original content"
+    );
+    assert_eq!(
+        fs::read(dest_root.join("delta.bin")).expect("read dest"),
+        new_content,
+        "destination must contain updated content"
+    );
+}


### PR DESCRIPTION
## Summary

- Move `build_delta_signature()` call to before `backup_existing_entry()` in `execute_transfer()`, so the destination file is read for its delta signature while it still exists at its original path
- Previously, backup renamed the destination away first, then `build_delta_signature` opened the (now-missing) path, producing ENOENT which `is_vanished_error()` misclassified as a vanished source (exit 24)
- The pre-computed delta signature is discarded if append mode is later determined to be active, preserving the original `append_offset == 0` guard semantics

Closes #5405

## Test plan

- [ ] New test `backup_with_no_whole_file_does_not_produce_vanished_error` verifies `--backup` + `--no-whole-file` succeeds with correct backup content and updated destination
- [ ] All existing backup tests continue to pass (no behavioral change for non-backup or whole-file paths)
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl