### PR TITLE
fix: use vendored OpenSSL for macOS x86_64 cross-compile in release workflow

### DIFF
--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -557,6 +557,11 @@ jobs:
           brew install openssl@3 || true
           echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
+      - name: Configure vendored OpenSSL for cross-compile
+        if: matrix.arch == 'x86_64'
+        shell: bash
+        run: echo "OC_RSYNC_PACKAGE_FEATURES=openssl-vendored" >> "$GITHUB_ENV"
+
       - name: Build tarball
         shell: bash
         run: cargo xtask package --tarball --tarball-target ${{ matrix.target }} --profile dist


### PR DESCRIPTION
## Summary

- The `Install OpenSSL` step in `release-cross.yml` only runs for `aarch64` builds, leaving macOS x86_64 cross-compile jobs without OpenSSL headers
- Set `OC_RSYNC_PACKAGE_FEATURES=openssl-vendored` for x86_64 jobs so OpenSSL is compiled from source targeting the correct architecture
- This fixes the `openssl-sys` build failure: `Could not find directory of OpenSSL installation` when cross-compiling from ARM64 to x86_64

## Test plan

- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] Verify release-cross workflow succeeds for macOS x86_64 target on next tag push