### PR TITLE
fix: resolve benchmark workflow failures across all three platforms

### DIFF
--- a/.github/workflows/_benchmark-macos.yml
+++ b/.github/workflows/_benchmark-macos.yml
@@ -78,10 +78,13 @@ jobs:
 
           cd rsync-3.4.2
           if [ ! -f rsync ]; then
+            BREW_PREFIX="$(brew --prefix)"
+            PKG_CONFIG_PATH="${BREW_PREFIX}/opt/openssl@3/lib/pkgconfig:${BREW_PREFIX}/opt/xxhash/lib/pkgconfig:${BREW_PREFIX}/opt/zstd/lib/pkgconfig:${BREW_PREFIX}/opt/lz4/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
             ./configure \
               --with-included-popt \
               --disable-md2man \
-              CFLAGS="-O2"
+              CFLAGS="-O2 -I${BREW_PREFIX}/include" \
+              LDFLAGS="-L${BREW_PREFIX}/lib"
             make -j$(sysctl -n hw.ncpu)
           fi
 

--- a/.github/workflows/_benchmark-windows.yml
+++ b/.github/workflows/_benchmark-windows.yml
@@ -101,16 +101,18 @@ jobs:
       - name: Build oc-rsync (release, iocp)
         run: cargo build --locked --release --features iocp --bin oc-rsync
 
-      - name: Install MSYS2 with rsync + hyperfine
+      - name: Install MSYS2 with rsync
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: MSYS
           update: false
           install: >-
             rsync
-            hyperfine
             diffutils
             coreutils
+
+      - name: Install hyperfine
+        run: cargo install hyperfine --locked
 
       - name: Run throughput benchmark
         shell: msys2 {0}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -196,18 +196,15 @@ jobs:
 
           REPORT=$(cat benchmark_report.md)
 
-          NEW_BODY=$(cat <<EOF
-          ${CURRENT_BODY}
+          {
+            printf '%s\n' "$CURRENT_BODY"
+            echo ""
+            echo "---"
+            echo ""
+            printf '%s\n' "$REPORT"
+          } > /tmp/release_body.md
 
-          ---
-
-          ${REPORT}
-          EOF
-          )
-          # Strip leading whitespace from heredoc indentation
-          NEW_BODY=$(echo "$NEW_BODY" | sed 's/^          //')
-
-          gh release edit "$TAG" --notes "$NEW_BODY"
+          gh release edit "$TAG" --notes-file /tmp/release_body.md
 
       - name: Upload benchmark assets to release
         if: steps.release_tag.outputs.tag != ''


### PR DESCRIPTION
## Summary

- **macOS**: Fix upstream rsync 3.4.2 `./configure` failure by providing Homebrew dependency paths (`PKG_CONFIG_PATH`, `CFLAGS`, `LDFLAGS`) for openssl, xxhash, zstd, and lz4
- **Windows**: Replace unavailable MSYS2 `hyperfine` package with `cargo install hyperfine --locked`
- **Linux**: Fix release notes heredoc quoting issue by writing to a temp file and using `gh release edit --notes-file` instead of `--notes` with inline content

## Test plan

- [ ] macOS benchmark workflow completes without `./configure` failures
- [ ] Windows benchmark workflow installs hyperfine via cargo and runs throughput tests
- [ ] Linux benchmark workflow correctly appends benchmark results to release notes without heredoc indentation artifacts