### PR TITLE
ci: add disk cleanup step to nextest job to prevent linker ENOSPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,15 @@ jobs:
         toolchain: [stable, beta, nightly]
 
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          sudo apt-get remove -y '^dotnet-.*' '^llvm-.*' 'php.*' azure-cli google-chrome-stable \
+            firefox powershell mono-devel libgl1-mesa-dri google-cloud-cli 2>/dev/null || true
+          sudo apt-get autoremove -y 2>/dev/null || true
+          sudo apt-get clean
+          df -h /
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

- Add a disk cleanup step at the start of the nextest job that removes pre-installed packages (Android SDK, .NET, LLVM, PHP, etc.) from the ubuntu-latest runner
- Frees ~15 GB of disk space, preventing the recurring `No space left on device` linker failure on nextest(nightly)

## Test plan

- [ ] nextest(nightly) completes without `No space left on device` errors
- [ ] nextest(stable) and nextest(beta) unaffected
- [ ] No regression in build times (cleanup step adds ~30s)