### PR TITLE
fix: add defence-in-depth cap on accumulated compressed token data

### DIFF
--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1498,3 +1498,124 @@ fn zlib_decoder_rejects_i32_min_token() {
         .expect_err("decoder must reject i32::MIN");
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
 }
+
+/// Defence-in-depth: the zlib decoder must reject accumulated compressed
+/// data that exceeds `MAX_ACCUMULATED_COMPRESSED_BYTES` (64 MiB).
+///
+/// Rust's `usize` arithmetic prevents the integer-overflow CVE that
+/// affected upstream C (CVE-2026-43618), but an explicit cap prevents
+/// OOM from crafted input sending an unbounded chain of DEFLATED_DATA
+/// blocks.
+///
+/// upstream: token.c defence-in-depth - bound accumulated compressed data (3.4.3)
+#[test]
+fn zlib_decoder_rejects_oversized_accumulated_compressed_data() {
+    use super::zlib_codec::MAX_ACCUMULATED_COMPRESSED_BYTES;
+
+    // Build a synthetic wire stream: an initial DEFLATED_DATA block
+    // followed by enough consecutive DEFLATED_DATA blocks to breach
+    // the cap. Use a streaming reader to avoid allocating 64 MiB.
+    struct OverflowReader {
+        /// Pre-built header+payload for each DEFLATED_DATA block.
+        block: Vec<u8>,
+        /// Total bytes of compressed data emitted so far.
+        emitted: usize,
+        /// Position within the current copy of `block`.
+        pos: usize,
+        /// Whether the first flag byte (the one that enters the
+        /// DEFLATED_DATA branch in recv_token) has been emitted.
+        first_flag_emitted: bool,
+        cap: usize,
+    }
+
+    impl io::Read for OverflowReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+
+            // The very first byte the decoder reads is the flag byte
+            // that routes into the DEFLATED_DATA branch. Emit it once.
+            if !self.first_flag_emitted {
+                // DEFLATED_DATA with length = MAX_DATA_COUNT
+                let len = MAX_DATA_COUNT;
+                let flag = DEFLATED_DATA | ((len >> 8) as u8);
+                buf[0] = flag;
+                self.first_flag_emitted = true;
+                // The next read_exact(1) from the decoder will read
+                // the low-byte of the length from the block data.
+                // We set pos to 0 so the block data starts being read.
+                self.pos = 0;
+                // Prepend the low byte of the length to the block
+                // payload. We handle this by having `block` start
+                // with the low byte.
+                return Ok(1);
+            }
+
+            // Keep emitting blocks until we exceed the cap.
+            // Each "block" in self.block is: [len_low_byte, payload...]
+            // followed by the next DEFLATED_DATA header for the
+            // subsequent block (2 bytes).
+            let remaining_in_block = self.block.len() - self.pos;
+            if remaining_in_block == 0 {
+                // We just finished a block. Decide whether to emit
+                // another DEFLATED_DATA header or stop.
+                if self.emitted > self.cap {
+                    // We've exceeded the cap; the decoder should have
+                    // already errored. If we get here, something is
+                    // wrong - just return EOF to avoid infinite loops.
+                    return Ok(0);
+                }
+                self.pos = 0;
+            }
+
+            let n = buf.len().min(self.block.len() - self.pos);
+            buf[..n].copy_from_slice(&self.block[self.pos..self.pos + n]);
+            self.pos += n;
+
+            // Track emitted compressed data bytes (payload only, not
+            // headers).
+            if self.pos >= 1 {
+                // Approximate: most of what we emit is payload.
+                self.emitted += n;
+            }
+
+            Ok(n)
+        }
+    }
+
+    // Build a repeating block: low byte of length + MAX_DATA_COUNT
+    // bytes of payload + next DEFLATED_DATA header (2 bytes).
+    let payload_len = MAX_DATA_COUNT;
+    let mut block = Vec::with_capacity(1 + payload_len + 2);
+    // Low byte of the length for read_deflated_data_length
+    block.push((payload_len & 0xFF) as u8);
+    // Payload (content doesn't matter - the decoder will try to
+    // inflate it and may fail, but the cap check happens before
+    // decompression)
+    block.extend(std::iter::repeat(0xAA).take(payload_len));
+    // Next DEFLATED_DATA header (flag + low byte will be read by the
+    // next iteration of the accumulation loop)
+    let next_flag = DEFLATED_DATA | ((payload_len >> 8) as u8);
+    block.push(next_flag);
+
+    let mut reader = OverflowReader {
+        block,
+        emitted: 0,
+        pos: 0,
+        first_flag_emitted: false,
+        cap: MAX_ACCUMULATED_COMPRESSED_BYTES + MAX_DATA_COUNT,
+    };
+
+    let mut decoder = CompressedTokenDecoder::new();
+    let err = decoder
+        .recv_token(&mut reader)
+        .expect_err("decoder must reject oversized accumulated compressed data");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string()
+            .contains("accumulated compressed data exceeds"),
+        "unexpected error message: {}",
+        err
+    );
+}

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -1593,7 +1593,7 @@ fn zlib_decoder_rejects_oversized_accumulated_compressed_data() {
     // Payload (content doesn't matter - the decoder will try to
     // inflate it and may fail, but the cap check happens before
     // decompression)
-    block.extend(std::iter::repeat(0xAA).take(payload_len));
+    block.extend(std::iter::repeat_n(0xAA, payload_len));
     // Next DEFLATED_DATA header (flag + low byte will be read by the
     // next iteration of the accumulation loop)
     let next_flag = DEFLATED_DATA | ((payload_len >> 8) as u8);
@@ -1615,7 +1615,6 @@ fn zlib_decoder_rejects_oversized_accumulated_compressed_data() {
     assert!(
         err.to_string()
             .contains("accumulated compressed data exceeds"),
-        "unexpected error message: {}",
-        err
+        "unexpected error message: {err}"
     );
 }

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -357,8 +357,7 @@ impl ZlibTokenDecoder {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
                             format!(
-                                "accumulated compressed data exceeds {} byte cap",
-                                MAX_ACCUMULATED_COMPRESSED_BYTES,
+                                "accumulated compressed data exceeds {MAX_ACCUMULATED_COMPRESSED_BYTES} byte cap",
                             ),
                         ));
                     }

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -16,6 +16,18 @@ use super::{
     TOKENRUN_LONG, TOKENRUN_REL, read_deflated_data_length, write_deflated_data_pieces,
 };
 
+/// Maximum aggregate size of accumulated compressed data in a single
+/// DEFLATED_DATA sequence before decompression (64 MiB).
+///
+/// Defence-in-depth: bounds the memory a peer can force the decoder to
+/// allocate by sending an unbounded chain of consecutive DEFLATED_DATA
+/// blocks. Rust's `usize` arithmetic prevents the integer-overflow CVE
+/// that affected upstream C, but an explicit cap prevents OOM from
+/// crafted input.
+///
+/// upstream: token.c defence-in-depth - bound accumulated compressed data (3.4.3)
+pub(super) const MAX_ACCUMULATED_COMPRESSED_BYTES: usize = 64 * 1024 * 1024;
+
 /// Zlib encoder state for sending compressed tokens.
 ///
 /// Manages a persistent deflate stream for compressing literal data.
@@ -332,6 +344,7 @@ impl ZlibTokenDecoder {
             reader.read_exact(&mut self.compressed_input_buf[start..start + len])?;
 
             // Accumulate consecutive DEFLATED_DATA blocks
+            // upstream: token.c defence-in-depth - bound accumulated compressed data (3.4.3)
             loop {
                 let mut peek = [0u8; 1];
                 reader.read_exact(&mut peek)?;
@@ -339,6 +352,17 @@ impl ZlibTokenDecoder {
 
                 if (next_flag & 0xC0) == DEFLATED_DATA {
                     let next_len = read_deflated_data_length(reader, next_flag)?;
+                    if self.compressed_input_buf.len() + next_len
+                        > MAX_ACCUMULATED_COMPRESSED_BYTES
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "accumulated compressed data exceeds {} byte cap",
+                                MAX_ACCUMULATED_COMPRESSED_BYTES,
+                            ),
+                        ));
+                    }
                     let s = self.compressed_input_buf.len();
                     self.compressed_input_buf.resize(s + next_len, 0);
                     reader.read_exact(&mut self.compressed_input_buf[s..s + next_len])?;

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -352,8 +352,7 @@ impl ZlibTokenDecoder {
 
                 if (next_flag & 0xC0) == DEFLATED_DATA {
                     let next_len = read_deflated_data_length(reader, next_flag)?;
-                    if self.compressed_input_buf.len() + next_len
-                        > MAX_ACCUMULATED_COMPRESSED_BYTES
+                    if self.compressed_input_buf.len() + next_len > MAX_ACCUMULATED_COMPRESSED_BYTES
                     {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,


### PR DESCRIPTION
## Summary

- Add `MAX_ACCUMULATED_COMPRESSED_BYTES` (64 MiB) constant to the zlib token decoder, capping how much compressed data the DEFLATED_DATA accumulation loop can buffer before decompression.
- A malicious peer sending an unbounded chain of consecutive DEFLATED_DATA blocks could force OOM. Rust's `usize` arithmetic prevents the integer-overflow CVE that affected upstream C (CVE-2026-43618), but the explicit cap prevents memory exhaustion from crafted input - matching the hardening added in upstream rsync 3.4.3.
- Add regression test using a streaming reader that generates oversized compressed input to verify the cap fires with `InvalidData` error.

## Test plan

- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] New test `zlib_decoder_rejects_oversized_accumulated_compressed_data` verifies cap rejection
- [ ] Existing compressed token round-trip tests continue to pass (normal transfers stay well under 64 MiB accumulated compressed data)