### PR TITLE
fix: add wire-value cap on delete statistics for defence-in-depth

### DIFF
--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -5,6 +5,15 @@
 
 use std::io::{self, Read, Write};
 
+/// Maximum acceptable value for a single delete-stats wire field.
+///
+/// Rejects unreasonably large values from the wire to prevent signed-integer
+/// overflow when the receiver accumulates counts across multiple
+/// `NDX_DEL_STATS` messages.
+///
+/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+const MAX_WIRE_DEL_STAT: i32 = 0x3FFF_FFFF;
+
 /// Deletion statistics exchanged via `NDX_DEL_STATS`.
 ///
 /// These are sent separately from transfer stats to report deletion counts
@@ -85,17 +94,22 @@ impl DeleteStats {
 
     /// Reads delete stats from a stream in wire format.
     ///
+    /// Each field is capped at [`MAX_WIRE_DEL_STAT`] to reject unreasonably
+    /// large values from the wire before they can cause overflow during
+    /// accumulation.
+    ///
     /// # Errors
     ///
-    /// Returns an error if reading from the stream fails.
+    /// Returns an error if reading from the stream fails or if any field
+    /// exceeds [`MAX_WIRE_DEL_STAT`].
     pub fn read_from<R: Read>(reader: &mut R) -> io::Result<Self> {
         use crate::varint::read_varint;
 
-        let files = read_varint(reader)? as u32;
-        let dirs = read_varint(reader)? as u32;
-        let symlinks = read_varint(reader)? as u32;
-        let devices = read_varint(reader)? as u32;
-        let specials = read_varint(reader)? as u32;
+        let files = read_capped_del_stat(read_varint(reader)?, "files")?;
+        let dirs = read_capped_del_stat(read_varint(reader)?, "dirs")?;
+        let symlinks = read_capped_del_stat(read_varint(reader)?, "symlinks")?;
+        let devices = read_capped_del_stat(read_varint(reader)?, "devices")?;
+        let specials = read_capped_del_stat(read_varint(reader)?, "specials")?;
 
         Ok(Self {
             files,
@@ -105,4 +119,21 @@ impl DeleteStats {
             specials,
         })
     }
+}
+
+/// Validates and converts a varint-decoded delete-stat field.
+///
+/// Rejects negative values and values exceeding [`MAX_WIRE_DEL_STAT`].
+///
+/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+fn read_capped_del_stat(raw: i32, field: &str) -> io::Result<u32> {
+    if raw < 0 || raw > MAX_WIRE_DEL_STAT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "delete stat '{field}' value {raw} exceeds MAX_WIRE_DEL_STAT ({MAX_WIRE_DEL_STAT})"
+            ),
+        ));
+    }
+    Ok(raw as u32)
 }

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -127,7 +127,7 @@ impl DeleteStats {
 ///
 /// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
 fn read_capped_del_stat(raw: i32, field: &str) -> io::Result<u32> {
-    if raw < 0 || raw > MAX_WIRE_DEL_STAT {
+    if !(0..=MAX_WIRE_DEL_STAT).contains(&raw) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(

--- a/crates/protocol/src/stats/tests.rs
+++ b/crates/protocol/src/stats/tests.rs
@@ -437,6 +437,89 @@ fn delete_stats_total() {
     assert_eq!(empty.total(), 0);
 }
 
+/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+#[test]
+fn delete_stats_rejects_oversized_wire_value() {
+    use crate::varint::write_varint;
+
+    // Encode a value just above MAX_WIRE_DEL_STAT (0x3FFF_FFFF = 1_073_741_823)
+    let oversized: i32 = 0x3FFF_FFFF + 1;
+    let mut buf = Vec::new();
+    write_varint(&mut buf, oversized).unwrap();
+    // Pad with four more zero varints so read_from can attempt all 5 fields.
+    for _ in 0..4 {
+        write_varint(&mut buf, 0).unwrap();
+    }
+
+    let mut cursor = Cursor::new(&buf);
+    let err = DeleteStats::read_from(&mut cursor).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("MAX_WIRE_DEL_STAT"),
+        "error should mention MAX_WIRE_DEL_STAT, got: {err}"
+    );
+}
+
+/// upstream: io.c - MAX_WIRE_DEL_STAT defence-in-depth (3.4.3)
+#[test]
+fn delete_stats_rejects_negative_wire_value() {
+    use crate::varint::write_varint;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, -1).unwrap();
+    for _ in 0..4 {
+        write_varint(&mut buf, 0).unwrap();
+    }
+
+    let mut cursor = Cursor::new(&buf);
+    let err = DeleteStats::read_from(&mut cursor).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("MAX_WIRE_DEL_STAT"),
+        "negative value should be rejected, got: {err}"
+    );
+}
+
+/// Values at exactly MAX_WIRE_DEL_STAT must be accepted.
+#[test]
+fn delete_stats_accepts_value_at_cap() {
+    use crate::varint::write_varint;
+
+    let at_cap: i32 = 0x3FFF_FFFF;
+    let mut buf = Vec::new();
+    write_varint(&mut buf, at_cap).unwrap();
+    for _ in 0..4 {
+        write_varint(&mut buf, 0).unwrap();
+    }
+
+    let mut cursor = Cursor::new(&buf);
+    let decoded = DeleteStats::read_from(&mut cursor).unwrap();
+    assert_eq!(decoded.files, at_cap as u32);
+}
+
+/// Oversized value in a non-first field is also rejected.
+#[test]
+fn delete_stats_rejects_oversized_in_middle_field() {
+    use crate::varint::write_varint;
+
+    let oversized: i32 = 0x3FFF_FFFF + 1;
+    let mut buf = Vec::new();
+    // files=0, dirs=oversized
+    write_varint(&mut buf, 0).unwrap();
+    write_varint(&mut buf, oversized).unwrap();
+    for _ in 0..3 {
+        write_varint(&mut buf, 0).unwrap();
+    }
+
+    let mut cursor = Cursor::new(&buf);
+    let err = DeleteStats::read_from(&mut cursor).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("dirs"),
+        "error should name the 'dirs' field, got: {err}"
+    );
+}
+
 #[cfg(feature = "serde")]
 mod serde_tests {
     use crate::stats::{DeleteStats, TransferStats};


### PR DESCRIPTION
## Summary

- Port upstream rsync 3.4.3's `MAX_WIRE_DEL_STAT` (0x3FFF_FFFF) guard into `DeleteStats::read_from()` to reject unreasonably large varint values in `NDX_DEL_STATS` messages before they can cause signed-integer overflow during accumulation.
- Each of the five delete-stat fields is validated through `read_capped_del_stat()`, which rejects negative values and values exceeding the cap with an `InvalidData` error naming the offending field.
- Audited timestring/time-formatting code paths (`format_list_timestamp`, `format_out_format_mtime`) - they already handle out-of-range modtimes safely via the `time` crate's `Result`-based API and `.ok()`/`map_or_else` fallbacks. No changes needed.

## Changes

- `crates/protocol/src/stats/delete.rs`: Added `MAX_WIRE_DEL_STAT` constant and `read_capped_del_stat()` helper. Modified `read_from()` to validate each field against the cap.
- `crates/protocol/src/stats/tests.rs`: Added 4 tests covering oversized values, negative values, values at the cap boundary, and field-specific error messages.

## Test plan

- [x] Test rejects values exceeding `MAX_WIRE_DEL_STAT` (0x3FFF_FFFF + 1)
- [x] Test rejects negative wire values (-1)
- [x] Test accepts values exactly at the cap (0x3FFF_FFFF)
- [x] Test rejects oversized values in middle fields and names the correct field in the error
- [x] Verified existing proptest ranges (0..10_000) and fuzz targets won't break
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl