### PR TITLE
fix: add defence-in-depth bounds on wire-supplied allocation sizes

### DIFF
--- a/crates/protocol/src/acl/constants.rs
+++ b/crates/protocol/src/acl/constants.rs
@@ -71,3 +71,13 @@ pub const ACL_VALID_OBJ_BITS: u32 = 0x07;
 ///
 /// Access bits are shifted left by 2 to make room for XFLAG bits.
 pub const ACCESS_SHIFT: u32 = 2;
+
+/// Defence-in-depth cap on the number of ACL named entries from the wire.
+///
+/// POSIX ACLs typically have fewer than a dozen named entries. 4096 is
+/// well above any real-world usage while preventing a malicious peer from
+/// forcing unbounded allocations via a crafted count varint.
+///
+/// upstream: acls.c `recv_ida_entries()` uses `EXPAND_ITEM_LIST` which
+/// reallocs but has no explicit count cap.
+pub const MAX_WIRE_ACL_ENTRIES: usize = 4096;

--- a/crates/protocol/src/acl/wire/recv.rs
+++ b/crates/protocol/src/acl/wire/recv.rs
@@ -8,8 +8,8 @@ use std::io::{self, Read};
 use crate::varint::read_varint;
 
 use super::super::constants::{
-    NAME_IS_USER, NO_ENTRY, XMIT_GROUP_OBJ, XMIT_MASK_OBJ, XMIT_NAME_LIST, XMIT_OTHER_OBJ,
-    XMIT_USER_OBJ,
+    MAX_WIRE_ACL_ENTRIES, NAME_IS_USER, NO_ENTRY, XMIT_GROUP_OBJ, XMIT_MASK_OBJ, XMIT_NAME_LIST,
+    XMIT_OTHER_OBJ, XMIT_USER_OBJ,
 };
 use super::super::entry::{AclCache, IdAccess, IdaEntries, RsyncAcl};
 use super::encoding::decode_access;
@@ -26,6 +26,12 @@ use super::types::{AclType, RecvAclResult};
 /// Mirrors `recv_ida_entries()` in `acls.c` lines 697-729.
 pub fn recv_ida_entries<R: Read + ?Sized>(reader: &mut R) -> io::Result<(IdaEntries, u8)> {
     let count = read_varint(reader)? as usize;
+    if count > MAX_WIRE_ACL_ENTRIES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("ACL entry count {count} exceeds maximum {MAX_WIRE_ACL_ENTRIES}"),
+        ));
+    }
     let mut entries = IdaEntries::with_capacity(count);
     let mut computed_mask: u8 = 0;
 

--- a/crates/protocol/src/acl/wire/tests.rs
+++ b/crates/protocol/src/acl/wire/tests.rs
@@ -403,6 +403,36 @@ fn send_recv_file_acl_no_default() {
 }
 
 #[test]
+fn recv_ida_entries_exceeds_max_count() {
+    use crate::acl::constants::MAX_WIRE_ACL_ENTRIES;
+    use crate::varint::write_varint;
+
+    let mut data = Vec::new();
+    write_varint(&mut data, (MAX_WIRE_ACL_ENTRIES as i32) + 1).unwrap();
+
+    let mut cursor = Cursor::new(data);
+    let result = recv_ida_entries(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn recv_ida_entries_at_max_count_accepted() {
+    use crate::varint::write_varint;
+
+    let mut data = Vec::new();
+    // Count = 0, which is <= MAX_WIRE_ACL_ENTRIES
+    write_varint(&mut data, 0).unwrap();
+
+    let mut cursor = Cursor::new(data);
+    let (entries, mask) = recv_ida_entries(&mut cursor).unwrap();
+    assert_eq!(entries.len(), 0);
+    assert_eq!(mask, 0);
+}
+
+#[test]
 fn send_recv_acl_with_mask_obj() {
     let mut acl = RsyncAcl::new();
     acl.user_obj = 0x07;

--- a/crates/protocol/src/wire/file_entry_decode/name.rs
+++ b/crates/protocol/src/wire/file_entry_decode/name.rs
@@ -9,6 +9,14 @@ use crate::varint::{read_int, read_varint};
 
 use super::super::file_entry::{XMIT_LONG_NAME, XMIT_SAME_NAME};
 
+/// Maximum total file name length on the wire.
+///
+/// Matches upstream rsync's `MAXPATHLEN` (4096). Upstream checks
+/// `l2 >= MAXPATHLEN - l1` before allocating the name buffer.
+///
+/// upstream: rsync.h `MAXPATHLEN`, flist.c:recv_file_entry()
+const MAXPATHLEN: usize = 4096;
+
 /// Decodes a file name with prefix decompression.
 ///
 /// The rsync protocol compresses file names by sharing common prefixes with
@@ -66,6 +74,18 @@ pub fn decode_name<R: Read>(
         reader.read_exact(&mut buf)?;
         buf[0] as usize
     };
+
+    // upstream: flist.c `l2 >= MAXPATHLEN - l1` overflow exit
+    if same_len + suffix_len >= MAXPATHLEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "filename length {} exceeds maximum {}",
+                same_len + suffix_len,
+                MAXPATHLEN - 1,
+            ),
+        ));
+    }
 
     let mut suffix = vec![0u8; suffix_len];
     reader.read_exact(&mut suffix)?;

--- a/crates/protocol/src/wire/file_entry_decode/tests.rs
+++ b/crates/protocol/src/wire/file_entry_decode/tests.rs
@@ -617,3 +617,61 @@ fn decode_symlink_target_far_exceeding_max_length() {
         assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
     }
 }
+
+#[test]
+fn decode_name_exceeds_maxpathlen() {
+    use crate::varint::write_varint;
+
+    let mut buf = Vec::new();
+    // same_len = 200 (XMIT_SAME_NAME set)
+    buf.push(200u8);
+    // suffix_len via XMIT_LONG_NAME + protocol >= 30: varint encoding of 3900
+    // same_len(200) + suffix_len(3900) = 4100 >= MAXPATHLEN(4096)
+    write_varint(&mut buf, 3900).unwrap();
+
+    let flags = (XMIT_SAME_NAME as u32) | (XMIT_LONG_NAME as u32);
+    let prev_name = vec![b'a'; 200];
+    let mut cursor = Cursor::new(buf);
+    let result = decode_name(&mut cursor, flags, &prev_name, 32);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn decode_name_at_maxpathlen_boundary() {
+    // same_len(0) + suffix_len(4095) = 4095 < MAXPATHLEN(4096) - should succeed
+    let suffix = vec![b'b'; 4095];
+    let mut buf = Vec::new();
+    buf.push(suffix.len() as u8); // Won't fit in u8, use XMIT_LONG_NAME
+
+    // Use XMIT_LONG_NAME for lengths > 255
+    let mut buf = Vec::new();
+    use crate::varint::write_varint;
+    write_varint(&mut buf, 4095).unwrap();
+    buf.extend_from_slice(&suffix);
+
+    let flags = XMIT_LONG_NAME as u32;
+    let mut cursor = Cursor::new(buf);
+    let result = decode_name(&mut cursor, flags, b"", 32);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 4095);
+}
+
+#[test]
+fn decode_name_exactly_at_maxpathlen_rejected() {
+    // same_len(0) + suffix_len(4096) = 4096 >= MAXPATHLEN(4096) - should fail
+    use crate::varint::write_varint;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 4096).unwrap();
+
+    let flags = XMIT_LONG_NAME as u32;
+    let mut cursor = Cursor::new(buf);
+    let result = decode_name(&mut cursor, flags, b"", 32);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}

--- a/crates/protocol/src/wire/file_entry_decode/tests.rs
+++ b/crates/protocol/src/wire/file_entry_decode/tests.rs
@@ -643,8 +643,6 @@ fn decode_name_exceeds_maxpathlen() {
 fn decode_name_at_maxpathlen_boundary() {
     // same_len(0) + suffix_len(4095) = 4095 < MAXPATHLEN(4096) - should succeed
     let suffix = vec![b'b'; 4095];
-    let mut buf = Vec::new();
-    buf.push(suffix.len() as u8); // Won't fit in u8, use XMIT_LONG_NAME
 
     // Use XMIT_LONG_NAME for lengths > 255
     let mut buf = Vec::new();

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -66,6 +66,36 @@ pub const RSYNC_PREFIX: &str = "user.rsync.";
 #[cfg(not(target_os = "linux"))]
 pub const RSYNC_PREFIX: &str = "rsync.";
 
+/// Defence-in-depth cap on the number of xattr entries per file from the wire.
+///
+/// Linux `listxattr(2)` returns at most `XATTR_LIST_MAX` (65536) bytes of
+/// name data. With a minimum 2-byte name per entry that is at most ~32K
+/// entries. 1024 is well above any real-world usage while preventing a
+/// malicious peer from forcing billions of allocations.
+///
+/// upstream: xattrs.c `receive_xattr()` uses `EXPAND_ITEM_LIST` which
+/// reallocs but has no explicit count cap.
+pub const MAX_WIRE_XATTR_COUNT: usize = 1024;
+
+/// Defence-in-depth cap on a single xattr name length from the wire.
+///
+/// Linux `XATTR_NAME_MAX` is 255 bytes. We allow 1024 to accommodate
+/// non-Linux platforms with longer names while still bounding allocation.
+///
+/// upstream: xattrs.c checks `name_len < 1` and NUL terminator but has
+/// no upper bound beyond the overflow check against `SIZE_MAX`.
+pub const MAX_WIRE_XATTR_NAME_LEN: usize = 1024;
+
+/// Defence-in-depth cap on a single xattr value length from the wire (64 MiB).
+///
+/// Linux `XATTR_SIZE_MAX` is 65536 bytes, but some filesystems (XFS, Btrfs)
+/// and platforms (macOS resource forks) allow larger values. 64 MiB is
+/// generous enough for any legitimate xattr while bounding allocation.
+///
+/// upstream: xattrs.c does an overflow check against `SIZE_MAX` but has
+/// no practical upper bound.
+pub const MAX_WIRE_XATTR_VALUE_LEN: usize = 64 * 1024 * 1024;
+
 /// User namespace prefix for xattrs.
 pub const USER_PREFIX: &str = "user.";
 

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -11,7 +11,10 @@
 use std::io::{self, Read};
 
 use crate::varint::read_varint;
-use crate::xattr::{MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, XattrEntry, XattrList};
+use crate::xattr::{
+    MAX_FULL_DATUM, MAX_WIRE_XATTR_COUNT, MAX_WIRE_XATTR_NAME_LEN, MAX_WIRE_XATTR_VALUE_LEN,
+    MAX_XATTR_DIGEST_LEN, XattrEntry, XattrList,
+};
 
 use super::encode::compute_xattr_checksum;
 use super::types::{RecvXattrResult, XattrDefinition, XattrSet};
@@ -58,6 +61,12 @@ pub fn read_xattr_definitions<R: Read>(reader: &mut R) -> io::Result<XattrSet> {
         ));
     }
     let count = count as usize;
+    if count > MAX_WIRE_XATTR_COUNT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("xattr count {count} exceeds maximum {MAX_WIRE_XATTR_COUNT}"),
+        ));
+    }
 
     let mut entries = Vec::with_capacity(count);
 
@@ -65,6 +74,21 @@ pub fn read_xattr_definitions<R: Read>(reader: &mut R) -> io::Result<XattrSet> {
         // upstream: name_len = read_varint(f); datum_len = read_varint(f)
         let name_len = read_varint(reader)? as usize;
         let datum_len = read_varint(reader)? as usize;
+
+        if name_len > MAX_WIRE_XATTR_NAME_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"),
+            ));
+        }
+        if datum_len > MAX_WIRE_XATTR_VALUE_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                ),
+            ));
+        }
 
         let mut name = vec![0u8; name_len];
         reader.read_exact(&mut name)?;
@@ -124,11 +148,32 @@ pub fn recv_xattr<R: Read>(reader: &mut R) -> io::Result<RecvXattrResult> {
     }
 
     let count = read_varint(reader)? as usize;
+    if count > MAX_WIRE_XATTR_COUNT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("xattr count {count} exceeds maximum {MAX_WIRE_XATTR_COUNT}"),
+        ));
+    }
     let mut list = XattrList::new();
 
     for _ in 0..count {
         let name_len = read_varint(reader)? as usize;
         let datum_len = read_varint(reader)? as usize;
+
+        if name_len > MAX_WIRE_XATTR_NAME_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("xattr name length {name_len} exceeds maximum {MAX_WIRE_XATTR_NAME_LEN}"),
+            ));
+        }
+        if datum_len > MAX_WIRE_XATTR_VALUE_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "xattr value length {datum_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                ),
+            ));
+        }
 
         // upstream: name_len includes a trailing NUL terminator on the wire
         let mut name = vec![0u8; name_len];
@@ -209,6 +254,14 @@ pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::R
     for entry in list.entries_mut() {
         if entry.state().needs_request() {
             let len = read_varint(reader)? as usize;
+            if len > MAX_WIRE_XATTR_VALUE_LEN {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "xattr value length {len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
+                    ),
+                ));
+            }
             let mut value = vec![0u8; len];
             reader.read_exact(&mut value)?;
             entry.set_full_value(value);

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -257,9 +257,7 @@ pub fn recv_xattr_values<R: Read>(reader: &mut R, list: &mut XattrList) -> io::R
             if len > MAX_WIRE_XATTR_VALUE_LEN {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!(
-                        "xattr value length {len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"
-                    ),
+                    format!("xattr value length {len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN}"),
                 ));
             }
             let mut value = vec![0u8; len];

--- a/crates/protocol/src/xattr/wire/tests.rs
+++ b/crates/protocol/src/xattr/wire/tests.rs
@@ -970,3 +970,127 @@ fn user_prefix_preserved_in_wire_bytes() {
     // Payload follows the name + NUL terminator.
     assert_eq!(&buf[position + needle.len()..], b"bar");
 }
+
+#[test]
+fn read_definitions_exceeds_max_count() {
+    use crate::xattr::MAX_WIRE_XATTR_COUNT;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_COUNT as i32) + 1).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = read_xattr_definitions(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn read_definitions_exceeds_max_name_len() {
+    use crate::xattr::MAX_WIRE_XATTR_NAME_LEN;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_NAME_LEN as i32) + 1).unwrap();
+    write_varint(&mut buf, 0).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = read_xattr_definitions(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn read_definitions_exceeds_max_value_len() {
+    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1).unwrap();
+    write_varint(&mut buf, 5).unwrap();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = read_xattr_definitions(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn recv_xattr_exceeds_max_count() {
+    use crate::xattr::MAX_WIRE_XATTR_COUNT;
+
+    let mut buf = Vec::new();
+    // ndx + 1 = 0 means ndx = -1, so literal path
+    write_varint(&mut buf, 0).unwrap();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_COUNT as i32) + 1).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = recv_xattr(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn recv_xattr_exceeds_max_name_len() {
+    use crate::xattr::MAX_WIRE_XATTR_NAME_LEN;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 0).unwrap();
+    write_varint(&mut buf, 1).unwrap();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_NAME_LEN as i32) + 1).unwrap();
+    write_varint(&mut buf, 0).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = recv_xattr(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn recv_xattr_exceeds_max_value_len() {
+    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 0).unwrap();
+    write_varint(&mut buf, 1).unwrap();
+    write_varint(&mut buf, 5).unwrap();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = recv_xattr(&mut cursor);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}
+
+#[test]
+fn recv_xattr_values_exceeds_max_value_len() {
+    use crate::xattr::MAX_WIRE_XATTR_VALUE_LEN;
+
+    let mut list = XattrList::new();
+    list.push(XattrEntry::abbreviated(
+        b"user.test".to_vec(),
+        vec![0u8; MAX_XATTR_DIGEST_LEN],
+        100,
+    ));
+
+    let mut buf = Vec::new();
+    write_varint(&mut buf, (MAX_WIRE_XATTR_VALUE_LEN + 1) as i32).unwrap();
+
+    let mut cursor = Cursor::new(buf);
+    let result = recv_xattr_values(&mut cursor, &mut list);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("exceeds maximum"));
+}


### PR DESCRIPTION
## Summary

- Cap xattr count, name length, and value length from untrusted wire data before allocating buffers in `read_xattr_definitions`, `recv_xattr`, and `recv_xattr_values`
- Cap ACL named-entry count in `recv_ida_entries` with `MAX_WIRE_ACL_ENTRIES = 4096`
- Cap filename total length in `decode_name` with `MAXPATHLEN = 4096` matching upstream `rsync.h`
- All bounds return `InvalidData` errors on violation

Upstream rsync lacks explicit caps on several of these paths - a malicious peer could force unbounded allocations via crafted varints. These defence-in-depth constants are set well above real-world usage while preventing denial-of-service allocations.

## Test plan

- [x] `recv_ida_entries_exceeds_max_count` - ACL count above cap rejected
- [x] `recv_ida_entries_at_max_count_accepted` - ACL count at zero accepted
- [x] `read_definitions_exceeds_max_count` - xattr definition count above cap rejected
- [x] `read_definitions_exceeds_max_name_len` - xattr name length above cap rejected
- [x] `read_definitions_exceeds_max_value_len` - xattr value length above cap rejected
- [x] `recv_xattr_exceeds_max_count` - recv_xattr count above cap rejected
- [x] `recv_xattr_exceeds_max_name_len` - recv_xattr name length above cap rejected
- [x] `recv_xattr_exceeds_max_value_len` - recv_xattr value length above cap rejected
- [x] `recv_xattr_values_exceeds_max_value_len` - recv_xattr_values length above cap rejected
- [x] `decode_name_exceeds_maxpathlen` - filename length above MAXPATHLEN rejected
- [x] `decode_name_at_maxpathlen_boundary` - filename at 4095 bytes accepted
- [x] `decode_name_exactly_at_maxpathlen_rejected` - filename at exactly 4096 bytes rejected