### PR TITLE
fix: round count to WINDOW multiple in reorder bench reverse-order pattern

### DIFF
--- a/crates/transfer/benches/reorder_buffer_large_scale.rs
+++ b/crates/transfer/benches/reorder_buffer_large_scale.rs
@@ -47,10 +47,7 @@ fn run_in_order(count: u64) -> u64 {
 /// because every insert must walk to a deeper internal node before the
 /// final gap-fill drains the entire range in one pass.
 fn run_reverse_order(count: u64) -> u64 {
-    assert!(
-        count % WINDOW == 0,
-        "reverse-order pattern requires count to be a multiple of WINDOW",
-    );
+    let count = (count / WINDOW) * WINDOW;
     let mut buf: BoundedReorderBuffer<u64> = BoundedReorderBuffer::new(WINDOW);
     let mut sum: u64 = 0;
     let mut base: u64 = 0;


### PR DESCRIPTION
## Summary

- Fix panic in `reorder_buffer_large_scale` benchmark's reverse-order pattern where `1,000,000 % 1024 != 0` triggered an assertion failure
- Replace the assertion with silent round-down to the nearest WINDOW multiple, so the bench runs cleanly at any count

## Test plan

- [ ] Criterion (transfer) benchmark job passes in CI without panic
- [ ] Benchmark results are stable (count rounds from 1M to 999,424 which is 976 windows - negligible difference)