### PR TITLE
perf: remove hardcoded TCP_NODELAY from daemon connections

### DIFF
--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -244,17 +244,15 @@ impl DaemonStream {
 
     /// Configures TCP-specific socket options for the transfer phase.
     ///
-    /// Sets TCP_NODELAY and applies read/write timeouts. No-op for
-    /// non-TCP transports (connect programs, TLS).
+    /// Applies read/write timeouts. No-op for non-TCP transports (connect
+    /// programs, TLS). TCP_NODELAY is intentionally not set - upstream rsync
+    /// does not set it on daemon connections (clientserver.c:1346 only sets
+    /// SO_KEEPALIVE).
     pub(crate) fn configure_transfer_options(
         &self,
-        nodelay: bool,
         timeout: Option<Duration>,
     ) -> io::Result<()> {
         if let Self::Tcp(stream) = self {
-            if nodelay {
-                stream.set_nodelay(true)?;
-            }
             stream.set_read_timeout(timeout)?;
             stream.set_write_timeout(timeout)?;
         }

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -248,10 +248,7 @@ impl DaemonStream {
     /// programs, TLS). TCP_NODELAY is intentionally not set - upstream rsync
     /// does not set it on daemon connections (clientserver.c:1346 only sets
     /// SO_KEEPALIVE).
-    pub(crate) fn configure_transfer_options(
-        &self,
-        timeout: Option<Duration>,
-    ) -> io::Result<()> {
+    pub(crate) fn configure_transfer_options(&self, timeout: Option<Duration>) -> io::Result<()> {
         if let Self::Tcp(stream) = self {
             stream.set_read_timeout(timeout)?;
             stream.set_write_timeout(timeout)?;

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -147,15 +147,17 @@ pub fn run_daemon_transfer(
     }
 
     // upstream: io.c - select_timeout() uses io_timeout for all transfer I/O.
-    // Configure TCP_NODELAY and transfer-phase timeouts before splitting.
+    // Configure transfer-phase timeouts before splitting.
     // For TCP, settings apply to both halves (shared underlying socket).
     // For connect programs, this is a no-op.
+    // TCP_NODELAY is intentionally not set - upstream rsync does not set it on
+    // daemon connections (clientserver.c:1346 only sets SO_KEEPALIVE).
     let transfer_timeout = config
         .timeout()
         .as_seconds()
         .map(|s| std::time::Duration::from_secs(s.get()));
     stream
-        .configure_transfer_options(true, transfer_timeout)
+        .configure_transfer_options(transfer_timeout)
         .map_err(|e| socket_error("configure transfer options on", "daemon socket", e))?;
 
     // Split the stream into read/write halves for the handshake. The line-based
@@ -346,7 +348,7 @@ pub fn run_daemon_over_remote_shell(
         .as_seconds()
         .map(|s| Duration::from_secs(s.get()));
     stream
-        .configure_transfer_options(true, transfer_timeout)
+        .configure_transfer_options(transfer_timeout)
         .map_err(|e| socket_error("configure transfer options on", "remote shell stream", e))?;
 
     let (reader_half, mut writer_half, guard) = stream

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -233,17 +233,20 @@ struct TransferStreams {
 
 /// Sets up the transfer streams for the transfer engine.
 ///
-/// For TCP/TLS connections, configures TCP_NODELAY and clones the stream to get
-/// independent read/write handles. For stdio connections (remote-shell daemon
-/// mode), opens fresh stdin/stdout handles since the original pair is consumed
-/// by the BufReader.
+/// For TCP/TLS connections, clones the stream to get independent read/write
+/// handles. For stdio connections (remote-shell daemon mode), opens fresh
+/// stdin/stdout handles since the original pair is consumed by the BufReader.
+///
+/// TCP_NODELAY is intentionally not set - upstream rsync does not set it on
+/// daemon connections (clientserver.c:1346 only sets SO_KEEPALIVE). Leaving
+/// Nagle's algorithm enabled allows the kernel to coalesce small writes into
+/// fewer TCP segments.
 ///
 /// Returns the transfer streams on success, or sends an error and returns `None`.
 fn setup_transfer_streams(
     ctx: &mut ModuleRequestContext<'_>,
 ) -> io::Result<Option<TransferStreams>> {
     let stream = ctx.reader.get_mut();
-    stream.set_nodelay(true)?;
 
     if stream.is_stdio() {
         // For stdio mode, the DaemonStream wraps a StdioPair (stdin + stdout).


### PR DESCRIPTION
## Summary

- Remove hardcoded `TCP_NODELAY` from all 3 daemon connection sites (server-side `setup_transfer_streams`, client-side `run_daemon_transfer`, and `run_daemon_over_remote_shell`)
- Upstream rsync does not set `TCP_NODELAY` on daemon connections - `clientserver.c:1346` only sets `SO_KEEPALIVE`
- The hardcoded `TCP_NODELAY` disables Nagle's algorithm, forcing every per-file flush to emit a separate TCP segment instead of allowing the kernel to coalesce small writes - this contributes to excess wire segments in daemon transfers
- Simplify `DaemonStream::configure_transfer_options()` by removing the now-unused `nodelay` parameter

## Changes

**`crates/daemon/src/daemon/sections/module_access/transfer.rs`** - Remove `stream.set_nodelay(true)?` call from `setup_transfer_streams()`

**`crates/core/src/client/remote/daemon_transfer/mod.rs`** - Remove `nodelay` argument from both `configure_transfer_options()` calls (direct daemon and daemon-over-remote-shell paths)

**`crates/core/src/client/module_list/connect/mod.rs`** - Remove `nodelay` parameter from `configure_transfer_options()` method signature and body

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] Daemon interop tests pass against upstream rsync 3.0.9, 3.1.3, 3.4.1, 3.4.2
- [ ] Verify daemon pull/push performance improvement via benchmarks