### PR TITLE
perf: batch generator flush discipline to match upstream rsync

### DIFF
--- a/crates/transfer/src/generator/diagnostics.rs
+++ b/crates/transfer/src/generator/diagnostics.rs
@@ -59,8 +59,8 @@ pub fn ndx_convert_totals() -> (u64, u64) {
 static FLUSH_CALLS: AtomicU64 = AtomicU64::new(0);
 
 /// Records a flush invocation on the generator transfer hot path. Used by the
-/// transfer loop (per-iteration, NDX_DONE echo, dry-run, final NDX_DONE) to
-/// bump [`FLUSH_CALLS`] for INC_RECURSE diagnostic I3 (#2198).
+/// transfer loop (NDX_DONE echo, phase transition, final NDX_DONE) to bump
+/// [`FLUSH_CALLS`] for INC_RECURSE diagnostic I3 (#2198).
 pub(crate) fn flush_with_count<W: Write>(writer: &mut W) -> io::Result<()> {
     FLUSH_CALLS.fetch_add(1, Ordering::Relaxed);
     writer.flush()

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -137,11 +137,13 @@ impl GeneratorContext {
                 }
             }
 
-            // upstream: io.c perform_io() flushes buffered output while waiting
-            // for input via select(). Our Read/Write traits are independent, so
-            // we must explicitly flush before blocking on read to prevent deadlock
-            // when buffered delta data hasn't reached the receiver yet.
-            flush_with_count(writer)?;
+            // upstream: io.c perform_io() uses select() to drain buffered output
+            // while waiting for input. The generator pipeline sends NDX requests
+            // independently of the sender's delta writes, so a per-file flush is
+            // unnecessary. The 64KB multiplex buffer auto-flushes when full, and
+            // phase-boundary flushes (NDX_DONE echoes, final goodbye) ensure
+            // protocol transitions are not stalled. Upstream batches ~1000 files
+            // per flush via maybe_flush_socket() with MIN_FILECNT_LOOKAHEAD.
 
             // upstream: sender.c:210-462 - read NDX request from receiver
             let ndx = match ndx_read_codec.read_ndx(&mut *reader) {
@@ -357,7 +359,6 @@ impl GeneratorContext {
                     cb.on_itemize(&format!("{name}\n"));
                 }
                 files_transferred += 1;
-                flush_with_count(writer)?;
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Remove unconditional per-file `flush_with_count()` from the generator transfer loop (top of loop, before `read_ndx()`). Upstream rsync batches ~1000 files per flush via `maybe_flush_socket()` with `MIN_FILECNT_LOOKAHEAD=1000` and a 5-second timeout (`io.c:1420-1422`, `generator.c:2214`). oc-rsync was calling `flush_with_count()` after every single file, producing 1000x more `write()` syscalls - the primary contributor to the daemon pull regression.
- Remove the redundant dry-run per-file flush, which would be followed by another flush at the top of the next loop iteration anyway.
- Phase-boundary flushes (NDX_DONE echoes, phase transitions, final goodbye NDX_DONE) are preserved to ensure protocol state machines advance without stalling.

### Why this is safe

The generator pipeline sends NDX requests independently of the sender's delta writes - the two directions of the bidirectional connection (TCP/socketpair) are independent. The generator does not wait for the sender's delta response before sending the next NDX request. Therefore, the sender can safely read multiple NDX values from the generator without flushing its write buffer between each one. The 64KB multiplex buffer (`MultiplexWriter`) auto-flushes when full, ensuring large transfers never stall.

## Test plan

- [ ] CI passes (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] Daemon pull benchmark shows reduced `write()` syscall count (expected ~1000x reduction for many-file transfers)
- [ ] Interop tests pass against all upstream versions (3.0.9, 3.1.3, 3.4.1, 3.4.2)