### PR TITLE
perf: increase checksum read buffer from 64KB to 256KB

### DIFF
--- a/crates/transfer/src/generator/entry_accessor.rs
+++ b/crates/transfer/src/generator/entry_accessor.rs
@@ -347,7 +347,8 @@ fn file_checksum_matches(
         return false;
     };
     let mut hasher = ChecksumVerifier::for_algorithm(algorithm);
-    let mut buf = [0u8; 64 * 1024];
+    // upstream: rsync.h:159 MAX_MAP_SIZE = 256*1024
+    let mut buf = vec![0u8; 256 * 1024];
     let mut remaining = file_size;
     while remaining > 0 {
         let to_read = buf.len().min(remaining as usize);

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -269,7 +269,8 @@ fn file_checksum_matches(
         return false;
     };
     let mut hasher = ChecksumVerifier::for_algorithm(algorithm);
-    let mut buf = [0u8; 64 * 1024];
+    // upstream: rsync.h:159 MAX_MAP_SIZE = 256*1024
+    let mut buf = vec![0u8; 256 * 1024];
     let mut remaining = file_size;
     while remaining > 0 {
         let to_read = buf.len().min(remaining as usize);


### PR DESCRIPTION
## Summary

- Increase the whole-file checksum read buffer from 64 KB to 256 KB in both the receiver and generator `file_checksum_matches()` functions, matching upstream rsync's `MAX_MAP_SIZE` (rsync.h:159)
- Reduces read syscalls by 4x during `--checksum` mode, closing ~2-3% residual overhead identified in BPR-7.b audit
- Uses heap allocation (`vec!`) instead of stack array to avoid 256 KB stack pressure

## Test plan
- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] Verify `--checksum` mode transfers produce identical results