### PR TITLE
perf: add BufReader wrapping for SSH pull read path

### DIFF
--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -20,6 +20,7 @@
 //! - `main.c:client_run()` - Role dispatch after SSH connection
 
 use std::ffi::OsString;
+use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -301,12 +302,15 @@ fn run_transfer_over_embedded_ssh(
         Some(data)
     };
 
-    let (mut reader, mut writer) = rsync_io::ssh::embedded::connect_and_exec(
+    let (reader, mut writer) = rsync_io::ssh::embedded::connect_and_exec(
         &ssh_config,
         &remote_command,
         stdin_data.as_deref(),
     )
     .map_err(|e| invalid_argument_error(&format!("embedded SSH connection failed: {e}"), 5))?;
+
+    // upstream: io.c read_buf() uses 32KB read-ahead buffering.
+    let mut reader = BufReader::with_capacity(32768, reader);
 
     let start = Instant::now();
     let batch_recording = batch_ctx.as_ref().map(|ctx| {
@@ -340,8 +344,9 @@ fn run_transfer_over_embedded_ssh(
     // transfer succeeded; a failed transfer carries the more informative
     // diagnostic and should not be masked by a shutdown-phase error.
     drop(writer);
+    let mut channel_reader = reader.into_inner();
     let goodbye_outcome =
-        reader.wait_for_eof_with_timeout(rsync_io::ssh::embedded::SSH_GOODBYE_TIMEOUT);
+        channel_reader.wait_for_eof_with_timeout(rsync_io::ssh::embedded::SSH_GOODBYE_TIMEOUT);
     let elapsed = start.elapsed();
 
     match transfer_result {

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -18,6 +18,7 @@
 //! - `options.c:server_options()` - Remote `--server` argument construction
 
 use std::ffi::{OsStr, OsString};
+use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -554,9 +555,14 @@ fn run_server_over_ssh_connection(
     progress: Option<&mut dyn crate::server::TransferProgressCallback>,
     batch_ctx: Option<BatchContext>,
 ) -> Result<crate::server::ServerStats, ClientError> {
-    let (mut reader, mut writer, mut child_handle) = connection
+    let (reader, mut writer, mut child_handle) = connection
         .split()
         .map_err(|e| invalid_argument_error(&format!("failed to split SSH connection: {e}"), 23))?;
+
+    // upstream: io.c read_buf() uses 32KB read-ahead buffering. Without this,
+    // each multiplex frame header (4 bytes) + payload triggers separate syscalls
+    // on the SSH pipe.
+    let mut reader = BufReader::with_capacity(32768, reader);
 
     let batch_recording = batch_ctx.as_ref().map(|ctx| {
         let is_sender = config.role == ServerRole::Generator;


### PR DESCRIPTION
## Summary

- Wrap SSH readers in `BufReader::with_capacity(32768)` before they reach the multiplex frame parser, matching upstream rsync's `io.c read_buf()` 32KB read-ahead buffer
- Applied to both the system SSH path (`SshReader` from `ChildStdout`) and the embedded russh path (`ChannelReader` from sync channel)
- Without this buffering, each 4-byte multiplex frame header read triggers a separate syscall on the SSH pipe, likely explaining the 1.31x SSH pull regression

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] Verify SSH pull transfers still work correctly (protocol behavior unchanged since BufReader is transparent to Read trait consumers)
- [ ] Benchmark SSH pull to confirm syscall reduction and throughput improvement