### PR TITLE
perf: add metadata_unchanged fast-path for no-change generator scan

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -243,8 +243,7 @@ pub fn metadata_unchanged(
     // upstream: generator.c:485-486 - any_time_differs(sxp, file, fname)
     if options.times() {
         let current_mtime = filetime::FileTime::from_last_modification_time(cached_meta);
-        let entry_mtime =
-            filetime::FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
+        let entry_mtime = filetime::FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
         if current_mtime != entry_mtime {
             return false;
         }

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -189,6 +189,88 @@ pub fn apply_file_metadata_with_fd_if_changed(
     Ok(())
 }
 
+/// Fast check whether all metadata attributes already match the destination.
+///
+/// Mirrors upstream `generator.c:461 unchanged_attrs()` - a pure in-memory
+/// comparison that avoids the function-call overhead of the full
+/// [`apply_metadata_with_cached_stat`] path. Returns `true` when every
+/// preserved attribute (permissions, ownership, timestamps) matches the
+/// cached stat, so the caller can skip the metadata-application chain
+/// entirely on the no-change quick-check path.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:461-502` - `unchanged_attrs()` checks `perms_differ`,
+///   `ownership_differs`, `any_time_differs`, `acls_differ`, `xattrs_differ`
+/// - `generator.c:1809-1814` - quick-check match calls `set_file_attrs` only
+///   when `unchanged_attrs` would fail (implicit - upstream always calls
+///   `set_file_attrs` but its internal guards skip every syscall when nothing
+///   differs)
+pub fn metadata_unchanged(
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    cached_meta: &fs::Metadata,
+) -> bool {
+    // upstream: generator.c:487-488 - perms_differ(file, sxp)
+    #[cfg(unix)]
+    if options.permissions() {
+        use std::os::unix::fs::MetadataExt;
+        if (cached_meta.permissions().mode() & 0o7777) != (entry.permissions() & 0o7777) {
+            return false;
+        }
+    }
+
+    // upstream: generator.c:489-490 - ownership_differs(file, sxp)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if options.owner() {
+            if let Some(uid) = entry.uid() {
+                if cached_meta.uid() != uid {
+                    return false;
+                }
+            }
+        }
+        if options.group() {
+            if let Some(gid) = entry.gid() {
+                if cached_meta.gid() != gid {
+                    return false;
+                }
+            }
+        }
+    }
+
+    // upstream: generator.c:485-486 - any_time_differs(sxp, file, fname)
+    if options.times() {
+        let current_mtime = filetime::FileTime::from_last_modification_time(cached_meta);
+        let entry_mtime =
+            filetime::FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
+        if current_mtime != entry_mtime {
+            return false;
+        }
+    }
+
+    if options.atimes() && entry.atime() != 0 {
+        let current_atime = filetime::FileTime::from_last_access_time(cached_meta);
+        let entry_atime = filetime::FileTime::from_unix_time(entry.atime(), 0);
+        if current_atime != entry_atime {
+            return false;
+        }
+    }
+
+    // chmod modifiers need the full apply path regardless of stat match
+    if options.chmod().is_some() {
+        return false;
+    }
+
+    // Owner/group overrides need the full apply path
+    if options.owner_override().is_some() || options.group_override().is_some() {
+        return false;
+    }
+
+    true
+}
+
 /// Applies metadata from `metadata` to the destination symbolic link without
 /// following the link target. Delegates to [`apply_symlink_metadata_with_options`]
 /// with default options.

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -215,7 +215,7 @@ pub fn metadata_unchanged(
     #[cfg(unix)]
     if options.permissions() {
         use std::os::unix::fs::MetadataExt;
-        if (cached_meta.permissions().mode() & 0o7777) != (entry.permissions() & 0o7777) {
+        if (cached_meta.mode() & 0o7777) != (entry.permissions() & 0o7777) {
             return false;
         }
     }

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1150,7 +1150,7 @@ fn metadata_unchanged_returns_true_when_all_attrs_match() {
     let mut entry = FileEntry::new_file(
         "unchanged.txt".into(),
         4,
-        meta.permissions().mode() & 0o7777,
+        meta.mode() & 0o7777,
     );
     entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
     entry.set_uid(meta.uid());
@@ -1181,7 +1181,7 @@ fn metadata_unchanged_returns_false_on_permission_mismatch() {
     let mtime = FileTime::from_last_modification_time(&meta);
 
     // Use different permissions than what's on disk
-    let disk_mode = meta.permissions().mode() & 0o7777;
+    let disk_mode = meta.mode() & 0o7777;
     let different_mode = disk_mode ^ 0o020; // flip group write bit
 
     let mut entry = FileEntry::new_file("perm-mismatch.txt".into(), 4, different_mode);
@@ -1215,7 +1215,7 @@ fn metadata_unchanged_returns_false_on_mtime_mismatch() {
     let mut entry = FileEntry::new_file(
         "mtime-mismatch.txt".into(),
         4,
-        meta.permissions().mode() & 0o7777,
+        meta.mode() & 0o7777,
     );
     // Set a different mtime
     entry.set_mtime(1_600_000_000, 0);

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1132,3 +1132,155 @@ fn fake_super_off_does_not_write_stat_xattr_via_local_metadata() {
         "user.rsync.%stat must not appear without --fake-super; got {raw:?}"
     );
 }
+
+// --- metadata_unchanged tests ---
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_true_when_all_attrs_match() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("unchanged.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let mut entry = FileEntry::new_file(
+        "unchanged.txt".into(),
+        4,
+        meta.permissions().mode() & 0o7777,
+    );
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .preserve_owner(true)
+        .preserve_group(true);
+
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta),
+        "should return true when all attributes match"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_false_on_permission_mismatch() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("perm-mismatch.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    // Use different permissions than what's on disk
+    let disk_mode = meta.permissions().mode() & 0o7777;
+    let different_mode = disk_mode ^ 0o020; // flip group write bit
+
+    let mut entry = FileEntry::new_file("perm-mismatch.txt".into(), 4, different_mode);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .preserve_owner(true)
+        .preserve_group(true);
+
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta),
+        "should return false when permissions differ"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_false_on_mtime_mismatch() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("mtime-mismatch.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+
+    let mut entry = FileEntry::new_file(
+        "mtime-mismatch.txt".into(),
+        4,
+        meta.permissions().mode() & 0o7777,
+    );
+    // Set a different mtime
+    entry.set_mtime(1_600_000_000, 0);
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .preserve_owner(true)
+        .preserve_group(true);
+
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta),
+        "should return false when mtime differs"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_ignores_perms_when_not_preserved() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("no-perms.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    // Permissions differ but preservation is disabled
+    let mut entry = FileEntry::new_file("no-perms.txt".into(), 4, 0o777);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(true)
+        .preserve_owner(true)
+        .preserve_group(true);
+
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta),
+        "should return true when perms differ but preservation is off"
+    );
+}
+
+#[test]
+fn metadata_unchanged_returns_false_when_chmod_active() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("chmod-active.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+
+    let entry = FileEntry::new_file("chmod-active.txt".into(), 4, 0o644);
+
+    let chmod = crate::ChmodModifiers::parse("u+x").expect("parse chmod");
+    let opts = MetadataOptions::new().with_chmod(Some(chmod));
+
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta),
+        "should return false when chmod modifiers are active"
+    );
+}

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1147,11 +1147,7 @@ fn metadata_unchanged_returns_true_when_all_attrs_match() {
     let meta = fs::metadata(&dest).expect("metadata");
     let mtime = FileTime::from_last_modification_time(&meta);
 
-    let mut entry = FileEntry::new_file(
-        "unchanged.txt".into(),
-        4,
-        meta.mode() & 0o7777,
-    );
+    let mut entry = FileEntry::new_file("unchanged.txt".into(), 4, meta.mode() & 0o7777);
     entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
     entry.set_uid(meta.uid());
     entry.set_gid(meta.gid());
@@ -1212,11 +1208,7 @@ fn metadata_unchanged_returns_false_on_mtime_mismatch() {
 
     let meta = fs::metadata(&dest).expect("metadata");
 
-    let mut entry = FileEntry::new_file(
-        "mtime-mismatch.txt".into(),
-        4,
-        meta.mode() & 0o7777,
-    );
+    let mut entry = FileEntry::new_file("mtime-mismatch.txt".into(), 4, meta.mode() & 0o7777);
     // Set a different mtime
     entry.set_mtime(1_600_000_000, 0);
     entry.set_uid(meta.uid());

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -201,6 +201,7 @@ pub use apply::{
     apply_file_metadata_if_changed, apply_file_metadata_with_options,
     apply_metadata_from_file_entry, apply_metadata_with_attrs_flags,
     apply_metadata_with_cached_stat, apply_symlink_metadata, apply_symlink_metadata_with_options,
+    metadata_unchanged,
 };
 #[cfg(unix)]
 pub use apply::{apply_file_metadata_with_fd, apply_file_metadata_with_fd_if_changed};

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use logging::{debug_gte, debug_log, info_log};
-use metadata::{MetadataOptions, apply_metadata_with_cached_stat};
+use metadata::{MetadataOptions, apply_metadata_with_cached_stat, metadata_unchanged};
 use protocol::flist::FileEntry;
 
 use crate::receiver::directory::FailedDirectories;
@@ -168,14 +168,25 @@ impl ReceiverContext {
                     size_only,
                     always_checksum,
                 ) {
+                    // upstream: generator.c:461 unchanged_attrs() - fast-path
+                    // check avoids the per-function-call overhead of the full
+                    // apply_metadata chain when all attributes already match.
+                    // On a no-change scan this eliminates ownership mapping,
+                    // permission comparison, and timestamp construction for
+                    // every file that passes quick-check.
+                    if !metadata_unchanged(entry, metadata_opts, meta) {
+                        if let Err(e) = apply_metadata_with_cached_stat(
+                            &file_path,
+                            entry,
+                            metadata_opts,
+                            dest_meta,
+                        ) {
+                            metadata_errors.push((file_path.clone(), e.to_string()));
+                        }
+                    }
                     // upstream: generator.c:2260 - itemize() for up-to-date files
                     let iflags = crate::generator::ItemFlags::from_raw(0);
                     let _ = self.emit_itemize(writer, &iflags, entry);
-                    if let Err(e) =
-                        apply_metadata_with_cached_stat(&file_path, entry, metadata_opts, dest_meta)
-                    {
-                        metadata_errors.push((file_path.clone(), e.to_string()));
-                    }
                     if let Err(e) = apply_acls_from_receiver_cache(
                         &file_path,
                         entry,


### PR DESCRIPTION
## Summary

- Add `metadata_unchanged()` to the `metadata` crate, mirroring upstream `generator.c:461 unchanged_attrs()` - a pure in-memory comparison that checks permissions, ownership, and timestamps against the cached stat result without any syscalls or function-call overhead.
- Guard the `apply_metadata_with_cached_stat()` call in `build_files_to_transfer()` behind the new `metadata_unchanged()` check, so the common no-change quick-check path skips the entire metadata application chain (ownership mapping, permission comparison, timestamp construction).
- On a no-change scan (every file passes quick-check), this eliminates per-file overhead from three sub-functions (`apply_ownership_from_entry`, `apply_permissions_from_entry`, `apply_timestamps_from_entry`) that each perform their own stat comparisons and UID/GID lookups.

## Context

BPR-3 tracks a 1.99x regression in daemon push no-change scans. Investigation found that while `emit_itemize` with iflags=0 already short-circuits (no overhead), and ACL/xattr handling returns immediately when caches are None, the `apply_metadata_with_cached_stat` call chain was running unconditionally for every unchanged file. Upstream rsync avoids this with `unchanged_attrs()` at `generator.c:461-502`.

The `metadata_unchanged()` function handles:
- Permission comparison (mode bits, unix-only)
- Ownership comparison (uid/gid, unix-only)
- Timestamp comparison (mtime with nanosecond precision)
- Access time comparison (atime when preserved)
- Short-circuit to full apply path when chmod modifiers or owner/group overrides are active

## Test plan

- [x] Unit tests for `metadata_unchanged` covering:
  - All attributes match returns true
  - Permission mismatch returns false
  - Mtime mismatch returns false
  - Permissions ignored when preservation disabled
  - Returns false when chmod modifiers active
- [ ] CI: fmt + clippy passes
- [ ] CI: nextest (stable) passes
- [ ] CI: Windows, macOS, Linux musl pass
- [ ] Linux profiling with strace/perf would confirm per-file syscall reduction on large no-change scans