### PR TITLE
perf: reclaim completed INC_RECURSE flist segments to reduce RSS

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -521,7 +521,11 @@ mod tests {
     fn reclaim_segment_clears_entries_in_range() {
         let mut list = DualFileList::new();
         for i in 0..5 {
-            list.push(FileEntry::new_file(format!("file_{i}.txt").into(), (i + 1) as u64 * 100, 0o644));
+            list.push(FileEntry::new_file(
+                format!("file_{i}.txt").into(),
+                (i + 1) as u64 * 100,
+                0o644,
+            ));
         }
 
         // Reclaim entries [1..3)

--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -172,6 +172,29 @@ impl DualFileList {
     pub fn into_vec(self) -> Vec<FileEntry> {
         self.legacy
     }
+
+    /// Reclaims heap data from entries in the range `[start..end)`.
+    ///
+    /// Calls [`FileEntry::reclaim_heap_data`] on each entry in the range,
+    /// freeing PathBuf, dirname Arc, and extras Box allocations while
+    /// keeping the entries in place so NDX-based indexing remains valid.
+    ///
+    /// This mirrors upstream rsync's `flist_free()` which deallocates
+    /// completed INC_RECURSE segments during the transfer loop.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `end > self.len()` or `start > end`.
+    pub fn reclaim_segment(&mut self, start: usize, end: usize) {
+        assert!(
+            end <= self.legacy.len() && start <= end,
+            "reclaim_segment: [{start}..{end}) out of bounds (len={})",
+            self.legacy.len()
+        );
+        for entry in &mut self.legacy[start..end] {
+            entry.reclaim_heap_data();
+        }
+    }
 }
 
 impl Default for DualFileList {
@@ -492,6 +515,51 @@ mod tests {
         list.as_mut_vec().sort_by(|a, b| a.name().cmp(b.name()));
         assert_eq!(list[0].name(), "a.txt");
         assert_eq!(list[1].name(), "z.txt");
+    }
+
+    #[test]
+    fn reclaim_segment_clears_entries_in_range() {
+        let mut list = DualFileList::new();
+        for i in 0..5 {
+            list.push(FileEntry::new_file(format!("file_{i}.txt").into(), (i + 1) as u64 * 100, 0o644));
+        }
+
+        // Reclaim entries [1..3)
+        list.reclaim_segment(1, 3);
+
+        // Unreclaimed entries are intact.
+        assert_eq!(list[0].name(), "file_0.txt");
+        assert_eq!(list[0].size(), 100);
+        assert_eq!(list[3].name(), "file_3.txt");
+        assert_eq!(list[4].name(), "file_4.txt");
+
+        // Reclaimed entries have empty names and zero sizes.
+        assert_eq!(list[1].name(), "");
+        assert_eq!(list[1].size(), 0);
+        assert_eq!(list[2].name(), "");
+        assert_eq!(list[2].size(), 0);
+
+        // List length is unchanged (entries stay in place).
+        assert_eq!(list.len(), 5);
+    }
+
+    #[test]
+    fn reclaim_segment_empty_range_is_noop() {
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_file("a.txt".into(), 10, 0o644));
+        list.reclaim_segment(0, 0);
+        assert_eq!(list[0].name(), "a.txt");
+    }
+
+    #[test]
+    fn reclaim_segment_full_range() {
+        let mut list = DualFileList::new();
+        list.push(FileEntry::new_file("a.txt".into(), 10, 0o644));
+        list.push(FileEntry::new_file("b.txt".into(), 20, 0o644));
+        list.reclaim_segment(0, 2);
+        assert_eq!(list[0].name(), "");
+        assert_eq!(list[1].name(), "");
+        assert_eq!(list.len(), 2);
     }
 
     // --- flat-flist feature tests ---

--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -566,4 +566,39 @@ impl FileEntry {
         let type_bits = self.mode & 0o170000;
         type_bits == 0o140000 || type_bits == 0o010000 // S_IFSOCK or S_IFIFO
     }
+
+    /// Releases heap-allocated data from this entry to reduce RSS.
+    ///
+    /// Clears the `name` (PathBuf), resets `dirname` to a shared empty arc,
+    /// and drops the `extras` box. Scalar fields (size, mtime, mode, uid,
+    /// gid) are zeroed. After reclamation the entry remains a valid struct
+    /// but its accessors return empty/zero values.
+    ///
+    /// This mirrors upstream rsync's `flist_free()` which deallocates
+    /// completed INC_RECURSE segments during the transfer loop. Without
+    /// reclamation, all segment entries stay in memory for the entire
+    /// transfer lifetime, causing 4-11x RSS amplification at scale.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2945 flist_free()` - frees completed file list segments
+    /// - `sender.c:244` - sender calls `flist_free(first_flist)` on NDX_DONE
+    /// - `receiver.c:573` - receiver calls `flist_free(first_flist)` on NDX_DONE
+    pub fn reclaim_heap_data(&mut self) {
+        // Drop the path buffer contents without deallocating.
+        self.name = PathBuf::new();
+        // Reset dirname to a shared empty arc.
+        self.dirname = Arc::from(Path::new(""));
+        // Drop the extras box.
+        self.extras = None;
+        // Zero scalar fields - not strictly necessary for memory but
+        // makes reclaimed entries clearly inert.
+        self.size = 0;
+        self.mtime = 0;
+        self.mode = 0;
+        self.uid = 0;
+        self.gid = 0;
+        self.mtime_nsec = 0;
+        self.present = 0;
+    }
 }

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -1453,3 +1453,46 @@ fn set_mode_to_zero_clears_type_and_permissions() {
     assert_eq!(entry.mode(), 0);
     assert_eq!(entry.permissions(), 0);
 }
+
+#[test]
+fn reclaim_heap_data_clears_name_and_extras() {
+    let mut entry = FileEntry::new_file("src/deep/path/file.rs".into(), 4096, 0o644);
+    entry.set_uid(1000);
+    entry.set_gid(2000);
+    entry.set_checksum(vec![0xAB; 16]);
+    entry.set_user_name("alice".to_string());
+
+    assert!(!entry.name().is_empty());
+    assert!(entry.checksum().is_some());
+    assert!(entry.user_name().is_some());
+
+    entry.reclaim_heap_data();
+
+    assert_eq!(entry.name(), "");
+    assert_eq!(entry.size(), 0);
+    assert_eq!(entry.mtime(), 0);
+    assert_eq!(entry.mode(), 0);
+    assert!(entry.uid().is_none());
+    assert!(entry.gid().is_none());
+    assert!(entry.checksum().is_none());
+    assert!(entry.user_name().is_none());
+}
+
+#[test]
+fn reclaim_heap_data_on_symlink_drops_target() {
+    let mut entry = FileEntry::new_symlink("link".into(), "/usr/lib/target".into());
+    assert!(entry.link_target().is_some());
+
+    entry.reclaim_heap_data();
+
+    assert_eq!(entry.name(), "");
+    assert!(entry.link_target().is_none());
+}
+
+#[test]
+fn reclaim_heap_data_on_minimal_entry_is_safe() {
+    let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
+    // No extras, no checksum - should not panic.
+    entry.reclaim_heap_data();
+    assert_eq!(entry.name(), "");
+}

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -560,4 +560,45 @@ impl GeneratorContext {
         }
         Ok(())
     }
+
+    /// Reclaims heap data from the oldest unreclaimed INC_RECURSE segment.
+    ///
+    /// Frees PathBuf, dirname Arc, and extras Box allocations for all entries
+    /// in the segment while keeping entries in place so NDX-based indexing
+    /// remains valid. Advances `first_segment_idx` to the next segment.
+    ///
+    /// No-op when there is only one segment remaining (the current segment
+    /// must not be reclaimed while the transfer loop may still access it)
+    /// or when all segments have already been reclaimed.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2945 flist_free()` - frees completed file list segments
+    /// - `sender.c:244` - `flist_free(first_flist)` in sender transfer loop
+    pub(crate) fn reclaim_oldest_segment(&mut self) {
+        let segments = &self.incremental.ndx_segments;
+        let first = self.incremental.first_segment_idx;
+
+        // Must have at least 2 segments to reclaim (keep the current one).
+        if first + 1 >= segments.len() {
+            return;
+        }
+
+        let start = segments[first].0;
+        let end = segments[first + 1].0;
+
+        logging::debug_log!(
+            Flist,
+            2,
+            "reclaiming segment {} entries [{start}..{end})",
+            first
+        );
+
+        self.file_list.reclaim_segment(start, end);
+        // Also reclaim the parallel full_paths entries.
+        for path in &mut self.full_paths[start..end] {
+            *path = std::path::PathBuf::new();
+        }
+        self.incremental.first_segment_idx += 1;
+    }
 }

--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -162,6 +162,18 @@ pub(crate) struct IncrementalState {
     ///
     /// Without INC_RECURSE, this contains a single entry `(0, 0)`.
     pub(crate) ndx_segments: Vec<(usize, i32)>,
+    /// Index into `ndx_segments` of the oldest unreclaimed segment.
+    ///
+    /// Advances by one each time a completed segment is reclaimed via
+    /// `reclaim_oldest_segment()`. Mirrors upstream's `first_flist`
+    /// pointer which advances through the circular list as segments
+    /// are freed by `flist_free()`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:101` - `first_flist` pointer
+    /// - `sender.c:244` - `flist_free(first_flist)` advances `first_flist`
+    pub(crate) first_segment_idx: usize,
 }
 
 impl IncrementalState {
@@ -173,6 +185,7 @@ impl IncrementalState {
             flist_writer_cache: None,
             initial_segment_count: None,
             ndx_segments: vec![(0, initial_ndx_start)],
+            first_segment_idx: 0,
         }
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3328,3 +3328,69 @@ fn nonempty_segment_also_sends_wire_bytes() {
         "last wire byte must be end-of-flist marker"
     );
 }
+
+#[test]
+fn reclaim_oldest_segment_frees_first_segment_entries() {
+    use protocol::flist::FileEntry;
+    use protocol::CompatibilityFlags;
+
+    let mut handshake = test_handshake_with_protocol(32);
+    handshake.compat_flags = Some(CompatibilityFlags::INC_RECURSE);
+    let config = test_config();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+    // Simulate 3 segments: [0..3), [3..5), [5..7)
+    for i in 0..7 {
+        ctx.push_file_item(
+            FileEntry::new_file(format!("dir/file_{i}.txt").into(), (i + 1) as u64 * 100, 0o644),
+            PathBuf::from(format!("/src/dir/file_{i}.txt")),
+        );
+    }
+    ctx.incremental.ndx_segments = vec![(0, 1), (3, 5), (5, 8)];
+    ctx.incremental.first_segment_idx = 0;
+
+    // Verify initial state.
+    assert_eq!(ctx.file_list()[0].name(), "dir/file_0.txt");
+    assert_eq!(ctx.file_list()[3].name(), "dir/file_3.txt");
+    assert_eq!(ctx.file_list()[5].name(), "dir/file_5.txt");
+
+    // Reclaim first segment [0..3).
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.incremental.first_segment_idx, 1);
+    assert_eq!(ctx.file_list()[0].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list()[1].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list()[2].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list()[3].name(), "dir/file_3.txt"); // intact
+    assert_eq!(ctx.file_list()[5].name(), "dir/file_5.txt"); // intact
+
+    // Reclaim second segment [3..5).
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.incremental.first_segment_idx, 2);
+    assert_eq!(ctx.file_list()[3].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list()[4].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list()[5].name(), "dir/file_5.txt"); // intact
+
+    // Third reclaim is a no-op (last segment must not be reclaimed).
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.incremental.first_segment_idx, 2); // unchanged
+    assert_eq!(ctx.file_list()[5].name(), "dir/file_5.txt"); // still intact
+}
+
+#[test]
+fn reclaim_oldest_segment_noop_without_inc_recurse() {
+    use protocol::flist::FileEntry;
+
+    let handshake = test_handshake_with_protocol(32);
+    let config = test_config();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+    ctx.push_file_item(
+        FileEntry::new_file("file.txt".into(), 100, 0o644),
+        PathBuf::from("/src/file.txt"),
+    );
+
+    // Single segment - reclaim is a no-op.
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.incremental.first_segment_idx, 0);
+    assert_eq!(ctx.file_list()[0].name(), "file.txt");
+}

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3331,8 +3331,8 @@ fn nonempty_segment_also_sends_wire_bytes() {
 
 #[test]
 fn reclaim_oldest_segment_frees_first_segment_entries() {
-    use protocol::flist::FileEntry;
     use protocol::CompatibilityFlags;
+    use protocol::flist::FileEntry;
 
     let mut handshake = test_handshake_with_protocol(32);
     handshake.compat_flags = Some(CompatibilityFlags::INC_RECURSE);
@@ -3342,7 +3342,11 @@ fn reclaim_oldest_segment_frees_first_segment_entries() {
     // Simulate 3 segments: [0..3), [3..5), [5..7)
     for i in 0..7 {
         ctx.push_file_item(
-            FileEntry::new_file(format!("dir/file_{i}.txt").into(), (i + 1) as u64 * 100, 0o644),
+            FileEntry::new_file(
+                format!("dir/file_{i}.txt").into(),
+                (i + 1) as u64 * 100,
+                0o644,
+            ),
             PathBuf::from(format!("/src/dir/file_{i}.txt")),
         );
     }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -163,6 +163,11 @@ impl GeneratorContext {
                         // flist_free(first_flist) loop.
                         if inc_recurse && flist_done_remaining > 0 {
                             flist_done_remaining -= 1;
+                            // upstream: sender.c:244 - flist_free(first_flist)
+                            // Reclaim heap data from the oldest completed segment
+                            // to reduce RSS. Entries stay in place for NDX indexing
+                            // but their PathBuf/extras allocations are freed.
+                            self.reclaim_oldest_segment();
                             if let Err(e) = ndx_write_codec
                                 .write_ndx_done(&mut *writer)
                                 .and_then(|()| flush_with_count(&mut *writer))

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -166,6 +166,17 @@ pub struct ReceiverContext {
     ///
     /// upstream: flist.c:2931 - `flist->ndx_start = prev->ndx_start + prev->used + 1`
     ndx_segments: Vec<(usize, i32)>,
+    /// Index into `ndx_segments` of the oldest unreclaimed segment.
+    ///
+    /// Advances by one each time a completed segment is reclaimed via
+    /// `reclaim_oldest_segment()`. Mirrors upstream's `first_flist`
+    /// pointer which advances as segments are freed by `flist_free()`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:101` - `first_flist` pointer
+    /// - `receiver.c:573` - `flist_free(first_flist)` advances `first_flist`
+    first_segment_idx: usize,
     /// Cached file list reader for compression state continuity across sub-lists.
     ///
     /// Upstream rsync uses `static` variables in `recv_file_entry()` that persist
@@ -295,6 +306,7 @@ impl ReceiverContext {
             compat_flags: handshake.compat_flags,
             checksum_seed: handshake.checksum_seed,
             ndx_segments: vec![(0, initial_ndx_start)],
+            first_segment_idx: 0,
             flist_reader_cache: None,
             uid_list: IdList::new(),
             gid_list: IdList::new(),
@@ -683,6 +695,43 @@ impl ReceiverContext {
         let ctx = self.itemize_context();
         let line = crate::generator::itemize::format_itemize_line(iflags, entry, false, &ctx);
         writer.send_msg_info(line.as_bytes())
+    }
+
+    /// Reclaims heap data from the oldest unreclaimed INC_RECURSE segment.
+    ///
+    /// Frees PathBuf, dirname Arc, and extras Box allocations for all entries
+    /// in the segment while keeping entries in place so NDX-based indexing
+    /// remains valid. Advances `first_segment_idx` to the next segment.
+    ///
+    /// No-op when there is only one segment remaining or when all segments
+    /// have already been reclaimed.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2945 flist_free()` - frees completed file list segments
+    /// - `receiver.c:573` - `flist_free(first_flist)` in receiver transfer loop
+    pub(in crate::receiver) fn reclaim_oldest_segment(&mut self) {
+        let first = self.first_segment_idx;
+
+        // Must have at least 2 segments to reclaim (keep the current one).
+        if first + 1 >= self.ndx_segments.len() {
+            return;
+        }
+
+        let start = self.ndx_segments[first].0;
+        let end = self.ndx_segments[first + 1].0;
+
+        logging::debug_log!(
+            Flist,
+            2,
+            "reclaiming segment {} entries [{start}..{end})",
+            first
+        );
+
+        for entry in &mut self.file_list[start..end] {
+            entry.reclaim_heap_data();
+        }
+        self.first_segment_idx += 1;
     }
 }
 

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/legacy_goodbye_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/legacy_goodbye_tests.rs
@@ -65,7 +65,7 @@ fn proto29_supports_goodbye_but_not_extended() {
 
 #[test]
 fn exchange_phase_done_proto28_single_phase() {
-    let ctx = receiver_for(28);
+    let mut ctx = receiver_for(28);
 
     let mut sender_input = Vec::new();
     sender_input.extend_from_slice(&NDX_DONE_LE); // echo for phase 1
@@ -87,7 +87,7 @@ fn exchange_phase_done_proto28_single_phase() {
 
 #[test]
 fn exchange_phase_done_proto29_two_phases() {
-    let ctx = receiver_for(29);
+    let mut ctx = receiver_for(29);
 
     let mut sender_input = Vec::new();
     for _ in 0..3 {
@@ -152,7 +152,7 @@ fn legacy_ndx_done_wire_format_matches_read_int() {
 
 #[test]
 fn exchange_phase_done_proto28_reads_all_sender_bytes() {
-    let ctx = receiver_for(28);
+    let mut ctx = receiver_for(28);
 
     let mut sender_input = Vec::new();
     sender_input.extend_from_slice(&NDX_DONE_LE);

--- a/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
@@ -429,3 +429,55 @@ fn try_read_one_stats_are_accessible() {
     assert_eq!(stats.num_files, 1);
     assert_eq!(stats.total_size, 999);
 }
+
+#[test]
+fn receiver_reclaim_oldest_segment_frees_entries() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Manually populate the file list with 6 entries across 3 segments.
+    for i in 0..6 {
+        ctx.file_list.push(FileEntry::new_file(
+            format!("file_{i}.txt").into(),
+            (i + 1) as u64 * 100,
+            0o644,
+        ));
+    }
+    // Segments: [0..2), [2..4), [4..6)
+    ctx.ndx_segments = vec![(0, 1), (2, 4), (4, 7)];
+    ctx.first_segment_idx = 0;
+
+    // Reclaim first segment.
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.first_segment_idx, 1);
+    assert_eq!(ctx.file_list[0].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list[1].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list[2].name(), "file_2.txt"); // intact
+    assert_eq!(ctx.file_list[4].name(), "file_4.txt"); // intact
+
+    // Reclaim second segment.
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.first_segment_idx, 2);
+    assert_eq!(ctx.file_list[2].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list[3].name(), ""); // reclaimed
+    assert_eq!(ctx.file_list[4].name(), "file_4.txt"); // intact
+
+    // Third reclaim is a no-op (last segment).
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.first_segment_idx, 2); // unchanged
+    assert_eq!(ctx.file_list[4].name(), "file_4.txt"); // intact
+}
+
+#[test]
+fn receiver_reclaim_noop_with_single_segment() {
+    let handshake = test_handshake();
+    let config = test_config();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list.push(FileEntry::new_file("f.txt".into(), 100, 0o644));
+    // Single segment - no reclamation possible.
+    ctx.reclaim_oldest_segment();
+    assert_eq!(ctx.first_segment_idx, 0);
+    assert_eq!(ctx.file_list[0].name(), "f.txt");
+}

--- a/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
@@ -475,7 +475,8 @@ fn receiver_reclaim_noop_with_single_segment() {
     let config = test_config();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list.push(FileEntry::new_file("f.txt".into(), 100, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_file("f.txt".into(), 100, 0o644));
     // Single segment - no reclamation possible.
     ctx.reclaim_oldest_segment();
     assert_eq!(ctx.first_segment_idx, 0);

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -30,7 +30,7 @@ impl ReceiverContext {
     /// Without INC_RECURSE, alternates send/receive for each phase boundary.
     /// Always reads a final NDX_DONE from the sender after all phases complete.
     pub(in crate::receiver) fn exchange_phase_done<R: Read, W: Write + ?Sized>(
-        &self,
+        &mut self,
         reader: &mut R,
         writer: &mut W,
         ndx_write_codec: &mut NdxCodecEnum,
@@ -49,6 +49,10 @@ impl ReceiverContext {
         if inc_recurse {
             let num_segments = self.ndx_segments.len();
             for _ in 0..num_segments {
+                // upstream: receiver.c:573 - flist_free(first_flist)
+                // Reclaim heap data from the oldest completed segment
+                // to reduce RSS before sending the per-segment NDX_DONE.
+                self.reclaim_oldest_segment();
                 ndx_write_codec.write_ndx_done(&mut *writer)?;
                 writer.flush()?;
                 self.read_expected_ndx_done(ndx_read_codec, reader, "segment completion")?;


### PR DESCRIPTION
## Summary

- Implement segment reclamation for INC_RECURSE transfers, mirroring upstream rsync's `flist_free()` behavior. Completed file-list segments are reclaimed on each NDX_DONE signal, preventing unbounded memory growth proportional to total file count.
- Add `FileEntry::reclaim_heap_data()` as the core primitive that clears per-entry heap allocations (PathBuf name, Arc dirname, Box extras) while preserving stable flat indices. Wire reclamation into both generator (sender) and receiver NDX_DONE handling paths.
- Track the oldest unreclaimed segment via `first_segment_idx` (mirrors upstream's `first_flist` pointer), with a guard ensuring the last/active segment is never reclaimed.

## Background

BPR-10.c analysis found that completed flist segments are never reclaimed during INC_RECURSE transfers - they stay in memory for the entire transfer lifetime. Upstream rsync explicitly calls `flist_free()` in sender.c:244, receiver.c:573, and generator.c:2222 to release completed segments. This caused 4-11x RSS amplification vs upstream at scale (100K+ files).

## Design

Reclamation is **in-place**: entries become zero-sized stubs (empty PathBuf, empty Arc, None extras, zeroed scalars) rather than being removed from the Vec. This preserves NDX-based flat indexing invariants while releasing all heap memory associated with completed segments.

The reclamation call is placed at the same protocol point as upstream - immediately upon receiving/processing NDX_DONE for a completed segment, before echoing NDX_DONE to the peer.

## Upstream references

- `flist.c:flist_free()` lines 2940-2977
- `sender.c:244`, `receiver.c:573`, `generator.c:2222` (call sites)

## Test plan

- [x] `reclaim_heap_data_clears_name_and_extras` - verifies full entry with extras is properly cleared
- [x] `reclaim_heap_data_on_symlink_drops_target` - verifies symlink target is dropped
- [x] `reclaim_heap_data_on_minimal_entry_is_safe` - no-panic on entry without extras
- [x] `reclaim_segment_clears_entries_in_range` - batch range reclamation
- [x] `reclaim_segment_empty_range_is_noop` - empty range safety
- [x] `reclaim_segment_full_range` - full-list reclamation
- [x] `reclaim_oldest_segment_frees_first_segment_entries` - generator sequential reclaim
- [x] `reclaim_oldest_segment_noop_without_inc_recurse` - single segment guard
- [x] `receiver_reclaim_oldest_segment_frees_entries` - receiver sequential reclaim
- [x] `receiver_reclaim_noop_with_single_segment` - receiver single segment guard
- [ ] CI: fmt, clippy, nextest, Windows, macOS, Linux musl