### PR TITLE
perf: eliminate redundant stat syscalls in SSH pull path

### DIFF
--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -750,7 +750,10 @@ fn apply_metadata_acls_and_xattrs(
         _ => return None,
     };
 
-    if let Err(e) = metadata::apply_metadata_from_file_entry(file_path, entry, opts) {
+    // Skip the stat inside apply_metadata_from_file_entry: the file was
+    // just renamed into place from a temp file, so its metadata will not
+    // match the desired entry. Pass None to apply unconditionally.
+    if let Err(e) = metadata::apply_metadata_with_cached_stat(file_path, entry, opts, None) {
         return Some((file_path.to_path_buf(), e.to_string()));
     }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -42,11 +42,13 @@ impl GeneratorContext {
         base: &Path,
         path: &Path,
     ) -> io::Result<bool> {
-        // Pre-stat to detect ENOENT before walk_path processes the entry.
+        // upstream: flist.c:2390 - link_stat() once, then pass &st to
+        // send_file_name(). Reuse the metadata to avoid a redundant stat
+        // inside walk_path_with_metadata.
         match self.resolve_symlink_metadata(path, base) {
-            Ok(_) => {
-                // Path exists - delegate to normal walk_path.
-                self.walk_path(base, path.to_path_buf())?;
+            Ok(metadata) => {
+                // Path exists - pass pre-resolved metadata directly.
+                self.walk_path_with_metadata(base, path.to_path_buf(), metadata, true)?;
                 Ok(true)
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
@@ -104,32 +106,6 @@ impl GeneratorContext {
         entry.set_mode(0);
         self.push_file_item(entry, path.to_path_buf());
         Ok(())
-    }
-
-    /// Recursively walks a path and adds entries to the file list.
-    ///
-    /// # Upstream Reference
-    ///
-    /// When the source path is a directory ending with '/', upstream rsync includes
-    /// the directory itself as "." entry in the file list. This allows the receiver
-    /// to create the destination directory and properly set its attributes.
-    ///
-    /// See flist.c:send_file_list() which adds "." for the top-level directory.
-    pub(in crate::generator) fn walk_path(&mut self, base: &Path, path: PathBuf) -> io::Result<()> {
-        // upstream: flist.c:readlink_stat() - resolve symlinks based on flags:
-        // --copy-links: follow ALL symlinks (stat instead of lstat)
-        // --copy-unsafe-links: follow only UNSAFE symlinks (stat if target escapes tree)
-        // otherwise: use lstat (preserve symlinks as-is)
-        let metadata = match self.resolve_symlink_metadata(&path, base) {
-            Ok(m) => m,
-            Err(e) => {
-                self.log_stat_error(&path, &e);
-                self.record_io_error(&e);
-                return Ok(());
-            }
-        };
-
-        self.walk_path_with_metadata(base, path, metadata, true)
     }
 
     /// Walks a path with pre-resolved metadata, skipping the initial stat call.

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
-use metadata::{MetadataOptions, apply_metadata_from_file_entry};
+use metadata::{MetadataOptions, apply_metadata_with_cached_stat};
 use protocol::acl::AclCache;
 use protocol::flist::FileEntry;
 use protocol::xattr::XattrList;
@@ -189,7 +189,7 @@ impl ReceiverContext {
                 .for_op(crate::parallel_io::ParallelOp::Metadata),
             move |(dir_path, entry, xattr_list)| {
                 if let Err(e) =
-                    apply_metadata_from_file_entry(&dir_path, &entry, &metadata_opts_clone)
+                    apply_metadata_with_cached_stat(&dir_path, &entry, &metadata_opts_clone, None)
                 {
                     return Some((dir_path, e.to_string()));
                 }
@@ -386,7 +386,9 @@ impl ReceiverContext {
         }
 
         // Apply metadata (non-fatal errors)
-        if let Err(e) = apply_metadata_from_file_entry(&dir_path, entry, metadata_opts) {
+        // Skip the stat inside apply_metadata_from_file_entry: the
+        // directory was just created, so pass None to apply unconditionally.
+        if let Err(e) = apply_metadata_with_cached_stat(&dir_path, entry, metadata_opts, None) {
             if self.config.flags.verbose && self.config.connection.client_mode {
                 info_log!(
                     Misc,

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -14,7 +14,7 @@ use protocol::flist::FileEntry;
 use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 use crate::delta_apply::ChecksumVerifier;
 
-use metadata::{MetadataOptions, apply_metadata_from_file_entry};
+use metadata::{MetadataOptions, apply_metadata_with_cached_stat};
 use protocol::acl::AclCache;
 
 use super::apply_acls_from_receiver_cache;
@@ -177,7 +177,11 @@ pub(super) fn try_reference_dest(
                 }
                 // Try io_uring LINKAT on Linux 5.15+, fall back to std::fs::hard_link.
                 if fast_io::hard_link(&ref_path, &dest_path).is_ok() {
-                    if let Err(e) = apply_metadata_from_file_entry(&dest_path, entry, metadata_opts)
+                    // Skip the stat syscall inside apply_metadata_from_file_entry:
+                    // the hard link shares the reference file's inode, and we
+                    // unconditionally apply the desired ownership/permissions.
+                    if let Err(e) =
+                        apply_metadata_with_cached_stat(&dest_path, entry, metadata_opts, None)
                     {
                         metadata_errors.push((dest_path.clone(), e.to_string()));
                     }
@@ -199,8 +203,12 @@ pub(super) fn try_reference_dest(
                 }
                 match fs::copy(&ref_path, &dest_path) {
                     Ok(_) => {
+                        // Skip the stat inside apply_metadata_from_file_entry:
+                        // we just created this file, so its metadata does not
+                        // match the desired entry yet. Pass None to apply
+                        // unconditionally without a redundant stat.
                         if let Err(e) =
-                            apply_metadata_from_file_entry(&dest_path, entry, metadata_opts)
+                            apply_metadata_with_cached_stat(&dest_path, entry, metadata_opts, None)
                         {
                             metadata_errors.push((dest_path.clone(), e.to_string()));
                         }

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -12,7 +12,7 @@ use logging::{PhaseTimer, info_log};
 use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
 use protocol::stats::DeleteStats;
 
-use metadata::apply_metadata_from_file_entry;
+use metadata::apply_metadata_with_cached_stat;
 
 use engine::CleanupManager;
 
@@ -377,8 +377,11 @@ impl ReceiverContext {
             CleanupManager::global().unregister_temp_file(temp_guard.path());
             temp_guard.keep();
 
+            // Skip the stat inside apply_metadata_from_file_entry: the file
+            // was just renamed from a temp file, so pass None to apply
+            // ownership/permissions/timestamps unconditionally.
             if let Err(meta_err) =
-                apply_metadata_from_file_entry(&file_path, file_entry, &metadata_opts)
+                apply_metadata_with_cached_stat(&file_path, file_entry, &metadata_opts, None)
             {
                 metadata_errors.push((file_path.clone(), meta_err.to_string()));
             } else if let Some(ref xattr_list) = self.resolve_xattr_list(file_entry) {


### PR DESCRIPTION
## Summary

- **Sender flist building**: `try_walk_source_entry` called `resolve_symlink_metadata` to check file existence, then `walk_path` called it again on the same file. Upstream `flist.c:2390` does `link_stat()` once and passes `&st` to `send_file_name()`. Now the pre-resolved metadata is passed directly to `walk_path_with_metadata`, saving one stat per top-level source entry. The now-dead `walk_path` method is removed.
- **Receiver metadata application**: Five call sites used `apply_metadata_from_file_entry` which internally calls `fs::metadata(destination)` to get cached stat before applying ownership/permissions/timestamps. For freshly created files (post-rename, hard link, copy, mkdir), this stat is wasted because the metadata never matches the desired entry anyway. Replaced with `apply_metadata_with_cached_stat(path, entry, opts, None)` to skip the redundant stat and apply unconditionally.

Affected receiver paths:
- `disk_commit/process.rs` - post-rename metadata application
- `receiver/transfer/sync.rs` - sync-mode post-rename path
- `receiver/quick_check.rs` - `--link-dest` and `--copy-dest` paths
- `receiver/directory/creation.rs` - batch and incremental dir creation

## Test plan

- [ ] CI passes (fmt, clippy, nextest, cross-platform)
- [ ] Interop tests pass against upstream rsync 3.0.9, 3.1.3, 3.4.1, 3.4.2
- [ ] Verify SSH pull initial sync produces identical output to upstream
- [ ] Benchmark SSH pull initial sync to measure stat reduction impact