### PR TITLE
perf: eliminate redundant file reads in SSH push sender path

### DIFF
--- a/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
+++ b/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
@@ -189,41 +189,92 @@ impl io::Read for SyncReader {
     }
 }
 
+/// Internal write buffer capacity for [`SyncWriter`].
+///
+/// Small writes (4-byte multiplex headers, NDX values, etc.) are coalesced
+/// into this staging buffer instead of allocating a `Vec` per write and
+/// sending it over the channel. The buffer is flushed when full or when
+/// `flush()` is called. Sized to match upstream rsync's `IO_BUFFER_SIZE`
+/// (32 KB) - large enough to batch a full multiplex frame's header + data.
+const SYNC_WRITER_BUF_SIZE: usize = 32 * 1024;
+
 /// Synchronous writer half returned by [`into_sync_halves`].
 ///
-/// Forwards each `write` call as a single message on a bounded
-/// `tokio::sync::mpsc::Sender` via `blocking_send`, which honors
+/// Coalesces small writes into an internal staging buffer to reduce
+/// per-write heap allocations and channel sends. Data is flushed to the
+/// channel when the buffer fills or when `flush()` is called explicitly.
+/// Each channel message still uses `blocking_send` which honors
 /// backpressure: when the channel is full the calling thread blocks until
 /// the async side drains capacity. A closed receiver surfaces as
 /// [`io::ErrorKind::BrokenPipe`].
 pub struct SyncWriter {
     tx: Option<tokio_mpsc::Sender<Vec<u8>>>,
+    /// Staging buffer for small writes. Avoids allocating a `Vec<u8>` per
+    /// `write()` call and amortizes the channel-send overhead across many
+    /// small writes (4-byte headers, varint NDX values, etc.).
+    buf: Vec<u8>,
 }
 
 impl SyncWriter {
     fn new(tx: tokio_mpsc::Sender<Vec<u8>>) -> Self {
-        Self { tx: Some(tx) }
+        Self {
+            tx: Some(tx),
+            buf: Vec::with_capacity(SYNC_WRITER_BUF_SIZE),
+        }
+    }
+
+    /// Sends the staging buffer contents through the channel and clears it.
+    fn flush_buf(&mut self) -> io::Result<()> {
+        if self.buf.is_empty() {
+            return Ok(());
+        }
+        let tx = self
+            .tx
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "writer shut down"))?;
+        let chunk = std::mem::replace(&mut self.buf, Vec::with_capacity(SYNC_WRITER_BUF_SIZE));
+        tx.blocking_send(chunk)
+            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
+        Ok(())
     }
 }
 
 impl io::Write for SyncWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let tx = self
-            .tx
-            .as_ref()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "writer shut down"))?;
-        tx.blocking_send(buf.to_vec())
-            .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        // Large writes bypass the staging buffer to avoid an extra memcpy.
+        if buf.len() >= SYNC_WRITER_BUF_SIZE {
+            self.flush_buf()?;
+            let tx = self
+                .tx
+                .as_ref()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "writer shut down"))?;
+            tx.blocking_send(buf.to_vec())
+                .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
+            return Ok(buf.len());
+        }
+
+        // Flush if appending would exceed capacity.
+        if self.buf.len() + buf.len() > SYNC_WRITER_BUF_SIZE {
+            self.flush_buf()?;
+        }
+
+        self.buf.extend_from_slice(buf);
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        Ok(())
+        self.flush_buf()
     }
 }
 
 impl Drop for SyncWriter {
     fn drop(&mut self) {
+        // Best-effort flush of any remaining buffered data before closing.
+        let _ = self.flush_buf();
         // Dropping the sender signals EOF to the outbound pump, which then
         // closes the async write half cleanly.
         self.tx = None;
@@ -402,7 +453,7 @@ mod tests {
     }
 
     /// `SyncWriter` returns `BrokenPipe` once the downstream receiver is
-    /// gone.
+    /// gone. Small writes are buffered, so the error surfaces on `flush()`.
     #[test]
     fn sync_writer_to_closed_channel_is_broken_pipe() {
         // Build the channel outside a runtime - blocking_send must not be
@@ -410,7 +461,10 @@ mod tests {
         let (tx, rx) = tokio_mpsc::channel::<Vec<u8>>(1);
         drop(rx);
         let mut writer = SyncWriter::new(tx);
-        let err = writer.write_all(b"x").unwrap_err();
+        // Small write succeeds because it stays in the staging buffer.
+        writer.write_all(b"x").unwrap();
+        // Flush forces the channel send, which detects the closed receiver.
+        let err = writer.flush().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
     }
 
@@ -434,10 +488,14 @@ mod tests {
         let mut writer = SyncWriter::new(tx);
         let (signal_tx, signal_rx) = std_mpsc::channel::<()>();
 
+        // Write data larger than the staging buffer to force a flush,
+        // which will block because the channel is full.
+        let large_payload = vec![0x42u8; SYNC_WRITER_BUF_SIZE + 1];
+
         let handle = std::thread::spawn(move || {
             // Notify that the writer is about to block.
             signal_tx.send(()).unwrap();
-            writer.write_all(b"second").unwrap();
+            writer.write_all(&large_payload).unwrap();
         });
 
         // Wait for the writer thread to be ready and prove the second write
@@ -447,9 +505,9 @@ mod tests {
         let first = rt.block_on(rx.recv()).unwrap();
         assert_eq!(first, b"first");
 
-        // Once a slot is free the second write should complete promptly.
+        // Once a slot is free the large write should complete promptly.
         let second = rt.block_on(rx.recv()).unwrap();
-        assert_eq!(second, b"second");
+        assert_eq!(second.len(), SYNC_WRITER_BUF_SIZE + 1);
         handle.join().unwrap();
     }
 

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -11,14 +11,18 @@
 //! - `sender.c:354-430` - File transfer with delta or whole-file paths
 //! - `token.c` - Token encoding with optional compression
 
+#[cfg(test)]
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use logging::debug_log;
 use protocol::wire::{
-    CHUNK_SIZE, CompressedTokenEncoder, DeltaOp, write_token_end, write_token_stream,
+    CHUNK_SIZE, CompressedTokenEncoder, DeltaOp, write_token_block_match, write_token_end,
+    write_token_literal,
 };
+#[cfg(test)]
+use protocol::wire::write_token_stream;
 use protocol::{ChecksumAlgorithm, CompressionAlgorithm};
 
 use engine::delta::{DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken};
@@ -280,12 +284,18 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
 /// byte that will appear in the reconstructed file through `sum_update()`,
 /// including matched-block data read back from the source via `map_ptr()`.
 ///
+/// Superseded by [`write_delta_with_inline_checksum`] which computes the
+/// checksum in the same pass as the wire write, eliminating a second file
+/// open+read. Retained for tests that need to verify the checksum
+/// independently of the wire write.
+///
 /// # Upstream Reference
 ///
 /// - `match.c:370` - `sum_init(xfer_sum_nni, checksum_seed)`
 /// - `match.c:383-385` - `sum_update()` on literal data
 /// - `match.c:matched():131-135` - `sum_update()` on matched block data
 /// - `checksum.c:686` - `sum_end(char *sum)` finalizes into caller buffer
+#[cfg(test)]
 pub(super) fn compute_file_checksum(
     script: &DeltaScript,
     algorithm: ChecksumAlgorithm,
@@ -381,28 +391,16 @@ pub(super) fn script_to_wire_delta(script: DeltaScript, block_length: u32) -> Ve
 
 /// Writes delta tokens to the wire, using compression if enabled.
 ///
-/// When compression is None or `CompressionAlgorithm::None`, uses the plain
-/// token format (`write_token_stream`). Otherwise, uses the compressed token
-/// format with DEFLATED_DATA headers as expected by upstream rsync.
-///
-/// For CPRES_ZLIB mode, after each block match token the matched block's data
-/// is fed to the compressor dictionary via `see_token()`, keeping the deflate
-/// stream synchronized between sender and receiver. The receiver performs the
-/// corresponding `see_deflate_token()` call. CPRES_ZLIBX skips this step.
-///
-/// # Arguments
-///
-/// * `writer` - Output stream for compressed tokens
-/// * `ops` - Delta operations to encode
-/// * `compression` - Negotiated compression algorithm
-/// * `source_path` - Path to the source file, needed to re-read matched block
-///   data for CPRES_ZLIB dictionary synchronization
+/// Superseded by [`write_delta_with_inline_checksum`] which merges checksum
+/// computation into the same pass. Retained for tests that verify compression
+/// independently of checksumming.
 ///
 /// # Upstream Reference
 ///
 /// - `token.c:send_token()` - switches between simple and deflated token sending
 /// - `token.c:send_deflated_token()` lines 460-484 - dictionary sync after block match
 /// - `token.c:see_deflate_token()` lines 631-670 - receiver-side dictionary sync
+#[cfg(test)]
 pub(super) fn write_delta_with_compression<W: Write>(
     writer: &mut W,
     ops: &[DeltaOp],
@@ -462,4 +460,126 @@ pub(super) fn write_delta_with_compression<W: Write>(
         }
         None => write_token_stream(writer, ops),
     }
+}
+
+/// Result of writing a delta to the wire with inline checksum computation.
+pub(super) struct InlineChecksumResult {
+    /// Whole-file checksum computed during the wire-write pass.
+    pub checksum_buf: [u8; ChecksumVerifier::MAX_DIGEST_LEN],
+    /// Number of valid bytes in `checksum_buf`.
+    pub checksum_len: usize,
+}
+
+/// Writes delta tokens to the wire and computes the file checksum in a single pass.
+///
+/// Merges the work of `write_delta_with_compression` and `compute_file_checksum`
+/// into one iteration over the delta ops. For Copy tokens, source data is read
+/// once and fed to both the checksum verifier and (for CPRES_ZLIB) the compressor
+/// dictionary, eliminating the extra file open+read pass that
+/// `compute_file_checksum` previously performed.
+///
+/// # Upstream Reference
+///
+/// Mirrors upstream `match.c:matched()` where `sum_update()` and `send_token()`
+/// operate on the same `map_ptr()` data in a single pass, and
+/// `token.c:send_deflated_token()` feeds the same data to the compressor
+/// dictionary.
+pub(super) fn write_delta_with_inline_checksum<W: Write>(
+    writer: &mut W,
+    ops: &[DeltaOp],
+    encoder: Option<&mut CompressedTokenEncoder>,
+    is_zlib: bool,
+    source_path: &Path,
+    use_noatime: bool,
+    checksum_algorithm: ChecksumAlgorithm,
+) -> io::Result<InlineChecksumResult> {
+    let mut verifier = ChecksumVerifier::for_algorithm(checksum_algorithm);
+
+    // Lazily open source file only when Copy tokens are present.
+    // A single file handle serves both checksum and dictionary sync.
+    let has_copies = ops.iter().any(|op| matches!(op, DeltaOp::Copy { .. }));
+    let mut source_file = if has_copies {
+        Some(io::BufReader::new(
+            super::open_source::open_source_with_noatime(source_path, use_noatime)?,
+        ))
+    } else {
+        None
+    };
+    let mut source_offset: u64 = 0;
+    let mut read_buf = Vec::new();
+
+    match encoder {
+        Some(encoder) => {
+            let needs_dict_sync = is_zlib && has_copies;
+
+            for op in ops {
+                match op {
+                    DeltaOp::Literal(data) => {
+                        verifier.update(data);
+                        encoder.send_literal(writer, data)?;
+                        source_offset += data.len() as u64;
+                    }
+                    DeltaOp::Copy {
+                        block_index,
+                        length,
+                    } => {
+                        encoder.send_block_match(writer, *block_index)?;
+
+                        // Read block data once, feed to both checksum and dict sync.
+                        let len = *length as usize;
+                        read_buf.clear();
+                        read_buf.resize(len, 0);
+                        if let Some(ref mut file) = source_file {
+                            file.seek(SeekFrom::Start(source_offset))?;
+                            file.read_exact(&mut read_buf)?;
+                        }
+                        verifier.update(&read_buf);
+                        if needs_dict_sync {
+                            encoder.see_token(&read_buf)?;
+                        }
+                        source_offset += u64::from(*length);
+                    }
+                }
+            }
+
+            encoder.finish(writer)?;
+        }
+        None => {
+            // Uncompressed path: write tokens and compute checksum in one pass.
+            for op in ops {
+                match op {
+                    DeltaOp::Literal(data) => {
+                        verifier.update(data);
+                        write_token_literal(writer, data)?;
+                    }
+                    DeltaOp::Copy {
+                        block_index,
+                        length,
+                    } => {
+                        write_token_block_match(writer, *block_index)?;
+
+                        // Read block data for checksum computation.
+                        let len = *length as usize;
+                        read_buf.clear();
+                        read_buf.resize(len, 0);
+                        if let Some(ref mut file) = source_file {
+                            file.seek(SeekFrom::Start(source_offset))?;
+                            file.read_exact(&mut read_buf)?;
+                        }
+                        verifier.update(&read_buf);
+                        source_offset += u64::from(*length);
+                    }
+                }
+            }
+            write_token_end(writer)?;
+        }
+    }
+
+    let mut checksum_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+    let checksum_len = verifier.finalize_into(&mut checksum_buf);
+
+    Ok(InlineChecksumResult {
+        checksum_buf,
+        checksum_len,
+    })
 }

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -11,8 +11,6 @@
 //! - `sender.c:354-430` - File transfer with delta or whole-file paths
 //! - `token.c` - Token encoding with optional compression
 
-#[cfg(test)]
-use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -275,72 +273,6 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
         checksum_buf,
         checksum_len,
     })
-}
-
-/// Computes the file transfer checksum from delta script data.
-///
-/// Hashes ALL bytes described by the delta script - both literal data and
-/// block-reference data read from the source file. Upstream rsync feeds every
-/// byte that will appear in the reconstructed file through `sum_update()`,
-/// including matched-block data read back from the source via `map_ptr()`.
-///
-/// Superseded by [`write_delta_with_inline_checksum`] which computes the
-/// checksum in the same pass as the wire write, eliminating a second file
-/// open+read. Retained for tests that need to verify the checksum
-/// independently of the wire write.
-///
-/// # Upstream Reference
-///
-/// - `match.c:370` - `sum_init(xfer_sum_nni, checksum_seed)`
-/// - `match.c:383-385` - `sum_update()` on literal data
-/// - `match.c:matched():131-135` - `sum_update()` on matched block data
-/// - `checksum.c:686` - `sum_end(char *sum)` finalizes into caller buffer
-#[cfg(test)]
-pub(super) fn compute_file_checksum(
-    script: &DeltaScript,
-    algorithm: ChecksumAlgorithm,
-    _seed: i32,
-    _compat_flags: Option<&protocol::CompatibilityFlags>,
-    source_path: &Path,
-    block_length: u32,
-    use_noatime: bool,
-) -> io::Result<([u8; ChecksumVerifier::MAX_DIGEST_LEN], usize)> {
-    let mut verifier = ChecksumVerifier::for_algorithm(algorithm);
-
-    // Lazily open source file only when Copy tokens are present.
-    let mut source_file: Option<fs::File> = None;
-    let mut read_buf = Vec::new();
-
-    for token in script.tokens() {
-        match token {
-            DeltaToken::Literal(data) => {
-                verifier.update(data);
-            }
-            DeltaToken::Copy { index, len } => {
-                // upstream: match.c:matched() - re-reads block data from source
-                // and feeds it through sum_update() for whole-file checksum.
-                let file = match source_file.as_mut() {
-                    Some(f) => f,
-                    None => {
-                        source_file = Some(super::open_source::open_source_with_noatime(
-                            source_path,
-                            use_noatime,
-                        )?);
-                        source_file.as_mut().unwrap()
-                    }
-                };
-                let offset = *index * u64::from(block_length);
-                file.seek(SeekFrom::Start(offset))?;
-                read_buf.resize(*len, 0);
-                file.read_exact(&mut read_buf)?;
-                verifier.update(&read_buf);
-            }
-        }
-    }
-
-    let mut buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
-    let len = verifier.finalize_into(&mut buf);
-    Ok((buf, len))
 }
 
 /// Converts engine delta script to wire protocol delta operations.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -15,12 +15,12 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use logging::debug_log;
+#[cfg(test)]
+use protocol::wire::write_token_stream;
 use protocol::wire::{
     CHUNK_SIZE, CompressedTokenEncoder, DeltaOp, write_token_block_match, write_token_end,
     write_token_literal,
 };
-#[cfg(test)]
-use protocol::wire::write_token_stream;
 use protocol::{ChecksumAlgorithm, CompressionAlgorithm};
 
 use engine::delta::{DeltaGenerator, DeltaScript, DeltaSignatureIndex, DeltaToken};

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -17,8 +17,8 @@ use protocol::codec::{
 use protocol::stats::DeleteStats;
 
 use super::super::delta::{
-    compute_file_checksum, create_token_encoder, script_to_wire_delta, stream_whole_file_transfer,
-    write_delta_with_compression,
+    create_token_encoder, script_to_wire_delta, stream_whole_file_transfer,
+    write_delta_with_inline_checksum,
 };
 use super::super::item_flags::ItemFlags;
 use super::super::{
@@ -420,15 +420,6 @@ impl GeneratorContext {
 
                 let checksum_algorithm = self.get_checksum_algorithm();
                 let use_noatime = self.config.write.open_noatime;
-                let (checksum_buf, checksum_len) = compute_file_checksum(
-                    &delta_script,
-                    checksum_algorithm,
-                    self.checksum_seed,
-                    self.compat_flags.as_ref(),
-                    source_path,
-                    block_length,
-                    use_noatime,
-                )?;
                 let delta_total_bytes = delta_script.total_bytes();
                 let wire_ops = script_to_wire_delta(delta_script, block_length);
                 let use_compression = self.file_compression(source_path).is_some();
@@ -436,7 +427,11 @@ impl GeneratorContext {
                     negotiated_compression,
                     Some(protocol::CompressionAlgorithm::Zlib)
                 );
-                write_delta_with_compression(
+                // upstream: match.c:matched() - compute file checksum inline
+                // during the wire-write pass, eliminating the separate
+                // compute_file_checksum() call that re-opened and re-read the
+                // source file.
+                let result = write_delta_with_inline_checksum(
                     &mut *writer,
                     &wire_ops,
                     if use_compression {
@@ -447,8 +442,9 @@ impl GeneratorContext {
                     is_zlib,
                     source_path,
                     use_noatime,
+                    checksum_algorithm,
                 )?;
-                writer.write_all(&checksum_buf[..checksum_len])?;
+                writer.write_all(&result.checksum_buf[..result.checksum_len])?;
                 bytes_sent += delta_total_bytes;
             } else {
                 // upstream: sender.c:354-369 - whole-file path; MSG_NO_SEND on open failure

--- a/docs/design/ffv-1-upstream-files-from-vanished-audit.md
+++ b/docs/design/ffv-1-upstream-files-from-vanished-audit.md
@@ -1,0 +1,275 @@
+# FFV-1: Upstream --files-from Vanished File Behavior Audit
+
+## Summary
+
+This document audits upstream rsync 3.4.1's behavior when a file listed in
+`--files-from` (or specified as a command-line source argument) cannot be
+found on disk. It covers the three modes controlled by `missing_args`, the
+warning/error messages emitted, and the resulting exit codes. It then
+compares oc-rsync's current implementation against upstream.
+
+## Upstream Behavior
+
+### Option Parsing (options.c)
+
+The `missing_args` global variable controls behavior (options.c:95):
+
+```c
+int missing_args = 0; /* 0 = FERROR_XFER, 1 = ignore, 2 = delete */
+```
+
+Both options use `POPT_BIT_SET`, so they OR their value into `missing_args`
+(options.c:718-719):
+
+```c
+{"delete-missing-args", 0, POPT_BIT_SET, &missing_args, 2, 0, 0},
+{"ignore-missing-args", 0, POPT_BIT_SET, &missing_args, 1, 0, 0},
+```
+
+If both options are specified, `missing_args` becomes 3 (1|2), which is
+simplified to 2 at options.c:2218-2219:
+
+```c
+if (missing_args == 3)
+    missing_args = 2;
+```
+
+`--delete-missing-args` requires delete cooperation from both sides -
+the sender sends the option to the server (options.c:2848-2853). The sender
+can handle `--ignore-missing-args` by itself, so it is only forwarded to
+the remote side when the remote is the sender (`!am_sender`).
+
+### send_file_list() Stat Failure Handling (flist.c:2390-2409)
+
+The same loop processes both `--files-from` entries and command-line argv
+entries. When `link_stat()` fails, the behavior is determined by
+`missing_args`:
+
+```c
+if (link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME) != 0
+ || (name_type != DOTDIR_NAME && is_excluded(...))
+ || (relative_paths && path_is_daemon_excluded(...))) {
+    if (errno != ENOENT || missing_args == 0) {
+        /* Non-ENOENT errors, or ENOENT with default mode */
+        if (errno != ENOENT)
+            io_error |= IOERR_GENERAL;
+        rsyserr(FERROR_XFER, errno, "link_stat %s failed",
+            full_fname(fbuf));
+        continue;
+    } else if (missing_args == 1) {
+        /* --ignore-missing-args: silently skip */
+        continue;
+    } else /* (missing_args == 2) */ {
+        /* --delete-missing-args: send as mode-0 "missing" entry */
+        memset(&st, 0, sizeof st);
+    }
+}
+```
+
+### Mode 0: Default (no flags)
+
+When a file from `--files-from` returns ENOENT on `link_stat()`:
+
+- **Warning**: `rsync: [sender] link_stat "<path>" failed: No such file or directory (2)`
+  - Emitted via `rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)`
+  - FERROR_XFER is logged as an error on both the local and remote side
+- **io_error**: `IOERR_GENERAL` is NOT set for ENOENT (only for non-ENOENT errors)
+  - However, the FERROR_XFER message itself sets `got_xfer_error` in the receiver
+- **Exit code**: 23 (RERR_PARTIAL) - "some files/attrs were not transferred"
+  - The FERROR_XFER message triggers the partial-transfer exit code
+
+For non-ENOENT errors (e.g., EACCES), `IOERR_GENERAL` is explicitly set,
+which also maps to exit code 23.
+
+### Mode 1: --ignore-missing-args
+
+- **Warning**: None. The entry is silently skipped.
+- **io_error**: Not modified.
+- **Exit code**: 0 (success), assuming no other errors occur.
+
+This only applies to initial source argument resolution. Files that vanish
+later during the transfer (after initial stat succeeded) still produce the
+normal "file has vanished" warning and exit code 24 (RERR_VANISHED).
+
+### Mode 2: --delete-missing-args
+
+- **Warning**: None during file list building.
+- **io_error**: Not modified during file list building.
+- **Wire format**: The missing file is sent as a file list entry with `mode = 0`
+  (all stat fields zeroed). This is identified by `IS_MISSING_FILE(st)` macro
+  (`rsync.h:917: #define IS_MISSING_FILE(statbuf) ((statbuf).st_mode == 0)`).
+- **Generator behavior** (generator.c:1348-1354): When the generator encounters
+  a mode-0 entry, it calls `delete_item()` on the corresponding destination
+  path, removing it if it exists.
+- **List-only output** (generator.c:1159-1162): Missing entries display as
+  `*missing` instead of the normal permissions/size/date line.
+- **Exit code**: 0 (success), assuming the deletion succeeds.
+
+### Server-Side Argument Forwarding (options.c:2848-2853)
+
+```c
+/* --delete-missing-args needs the cooperation of both sides, but
+ * the sender can handle --ignore-missing-args by itself. */
+if (missing_args == 2)
+    args[ac++] = "--delete-missing-args";
+else if (missing_args == 1 && !am_sender)
+    args[ac++] = "--ignore-missing-args";
+```
+
+`--delete-missing-args` always forwards to the server because the generator
+(receiver side) must know to delete matching destination entries.
+`--ignore-missing-args` only forwards when the remote is the sender, since
+the local sender can handle it autonomously.
+
+## oc-rsync Current State
+
+### Flag Parsing - IMPLEMENTED
+
+Both flags are fully parsed in the CLI layer:
+
+- `crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs:314-322` -
+  Clap argument definitions for both `--ignore-missing-args` and `--delete-missing-args`.
+- `crates/cli/src/frontend/arguments/parser/mod.rs:152-155` - Parser logic
+  correctly implements upstream's "delete implies ignore" semantics.
+- `crates/cli/src/frontend/arguments/parsed_args/mod.rs:183-227` - Fields on
+  `ParsedArgs`.
+
+### Config Propagation - IMPLEMENTED
+
+Both flags propagate through the config chain:
+
+- `ParsedArgs` -> `CoreConfigBuilder` (cli drive/config.rs:204,250)
+- `CoreConfigBuilder` -> `ClientConfig` (core builder/mod.rs:140,187,368,415)
+- `ClientConfig` -> `LocalCopyOptions` (core client/run/mod.rs:624-625)
+- `LocalCopyOptions` stores both flags (engine options/types.rs:99,184)
+
+### Local Copy Behavior - IMPLEMENTED
+
+The local-copy executor implements both modes for direct source arguments
+(`crates/engine/src/local_copy/executor/sources/metadata.rs:29-51`):
+
+- ENOENT + `delete_missing_args` -> calls `delete_missing_source_entry()` to
+  remove the destination entry.
+- ENOENT + `ignore_missing_args` -> returns `Handled` (silently skipped).
+- ENOENT + neither flag -> returns `NotFoundError`, which is reported as an
+  error and contributes to exit code 23.
+
+### Remote Transfer (Sender) - NOT IMPLEMENTED
+
+The transfer crate's `GeneratorContext` has zero references to
+`ignore_missing_args` or `delete_missing_args`. The flags are not wired
+into the generator's file list builder.
+
+When `build_file_list_with_base()` processes `--files-from` entries for
+remote transfers, it calls `walk_path()` for each entry. If `walk_path()`
+encounters ENOENT, it:
+
+1. Prints `file has vanished: "<path>"` (walk.rs:337)
+2. Sets `IOERR_VANISHED` via `record_io_error()` (walk.rs:43)
+3. Skips the entry and continues
+
+This means:
+
+- `--ignore-missing-args` has no effect during remote transfers. Missing
+  files still produce the "file has vanished" warning and set
+  `IOERR_VANISHED` (exit code 24).
+- `--delete-missing-args` has no effect during remote transfers. Missing
+  files are not sent as mode-0 entries, so the generator never deletes the
+  corresponding destination entries.
+
+### Server-Side Argument Forwarding - NOT AUDITED
+
+Whether oc-rsync forwards `--ignore-missing-args` / `--delete-missing-args`
+in server args for remote shell transfers has not been verified in this
+audit.
+
+## Gap Analysis
+
+| Capability | Upstream | oc-rsync | Status |
+|---|---|---|---|
+| Parse `--ignore-missing-args` | Yes | Yes | OK |
+| Parse `--delete-missing-args` | Yes | Yes | OK |
+| `delete` implies `ignore` | Yes | Yes | OK |
+| Both flags -> simplify to `delete` | Yes (3->2) | Yes (parser) | OK |
+| Local copy: ignore missing | Yes | Yes | OK |
+| Local copy: delete missing | Yes | Yes | OK |
+| Local copy: default ENOENT error | Yes (exit 23) | Yes (exit 23) | OK |
+| Remote sender: ignore missing | Silently skip, exit 0 | Warns + exit 24 | **GAP** |
+| Remote sender: delete missing | Send mode-0, generator deletes | Not implemented | **GAP** |
+| Remote sender: default ENOENT | FERROR_XFER, exit 23 | "vanished" + exit 24 | **GAP** |
+| Generator: mode-0 delete logic | Deletes dest entry | Not implemented | **GAP** |
+| `--list-only` `*missing` display | Shows `*missing` | Not implemented | **GAP** |
+| Server args forwarding | Conditional per mode | Not audited | **UNKNOWN** |
+
+### Default ENOENT Exit Code Divergence
+
+Even without `--ignore-missing-args` or `--delete-missing-args`, there is a
+behavioral difference in the remote sender path:
+
+- **Upstream**: ENOENT on an initial source arg emits `link_stat %s failed`
+  via `FERROR_XFER`, does NOT set `IOERR_GENERAL` (the `errno != ENOENT`
+  guard at flist.c:2396 skips it), but the `FERROR_XFER` message itself
+  triggers exit code 23 (RERR_PARTIAL) on the client side.
+- **oc-rsync**: ENOENT on an initial source arg calls `record_io_error()`
+  which sets `IOERR_VANISHED` (exit 24, RERR_VANISHED). The warning
+  message is "file has vanished" rather than upstream's
+  `link_stat "<path>" failed: No such file or directory (2)`.
+
+This is incorrect. Upstream distinguishes between:
+
+1. **Initial source arg missing** (flist.c:2398) - `link_stat %s failed` -
+   treated as a transfer error, exit 23.
+2. **File vanished during scan** (flist.c:1289) - `file has vanished: %s` -
+   treated as a vanished warning, exit 24.
+
+oc-rsync conflates both cases as "vanished" in the remote sender path.
+
+## Upstream Examples
+
+### Default mode (no flags)
+
+```
+$ rsync --files-from=list.txt /src/ /dst/
+rsync: [sender] link_stat "/src/nonexistent.txt" failed: No such file or directory (2)
+rsync error: some files/attrs were not transferred (code 23) at main.c(1337) [sender=3.4.1]
+```
+
+### --ignore-missing-args
+
+```
+$ rsync --ignore-missing-args --files-from=list.txt /src/ /dst/
+(no output, exit 0)
+```
+
+### --delete-missing-args
+
+```
+$ rsync --delete-missing-args --files-from=list.txt /src/ /dst/
+(no output, exit 0; destination entries for missing sources are deleted)
+```
+
+### --list-only with --delete-missing-args
+
+```
+$ rsync --list-only --delete-missing-args nonexistent.txt /dst/
+            *missing nonexistent.txt
+```
+
+## Recommended Follow-Up Tasks
+
+1. **FFV-2**: Wire `missing_args` config into `GeneratorContext` and
+   `build_file_list_with_base()`. Implement the three-mode branch in the
+   remote sender's stat failure path to match upstream flist.c:2393-2409.
+
+2. **FFV-3**: Implement mode-0 `FileEntry` (missing file sentinel) in the
+   protocol flist encoding. Add `IS_MISSING_FILE` predicate. Wire into
+   generator deletion logic.
+
+3. **FFV-4**: Fix the default ENOENT exit code divergence - initial source
+   arg ENOENT should produce `link_stat %s failed` and exit 23, not
+   "file has vanished" and exit 24.
+
+4. **FFV-5**: Implement `*missing` display for `--list-only` output.
+
+5. **FFV-6**: Audit and implement server-side argument forwarding for both
+   flags in the remote-shell argument builder.

--- a/docs/design/icv-2-iconv-feature-audit.md
+++ b/docs/design/icv-2-iconv-feature-audit.md
@@ -1,0 +1,113 @@
+# ICV-2: iconv Feature Flag Audit
+
+Date: 2026-06-03
+
+## Feature Flag Status
+
+The `iconv` feature propagates through the workspace dependency tree:
+
+| Crate | Feature definition | Backend |
+|-------|--------------------|---------|
+| `bin` (workspace root) | `iconv = ["cli/iconv", "core/iconv"]` | default-on |
+| `cli` | `iconv = ["core/iconv"]` | forwards to core |
+| `core` | `iconv = ["protocol/iconv", "transfer/iconv", "engine/iconv"]` | default-on |
+| `daemon` | `iconv = ["core/iconv", "protocol/iconv"]` | opt-in (not default) |
+| `engine` | `iconv = ["protocol/iconv"]` | forwards to protocol |
+| `transfer` | `iconv = ["protocol/iconv"]` | forwards to protocol |
+| `protocol` | `iconv = ["encoding_rs"]` | leaf - gates `encoding_rs` |
+
+When disabled, `protocol::iconv::FilenameConverter` compiles as a zero-field
+struct with identity-only stubs. Non-UTF-8 encoding names return
+`ConversionError` from `FilenameConverter::new()`.
+
+## CLI Parsing Status
+
+`--iconv=LOCAL,REMOTE` and `--no-iconv` are fully parsed:
+
+- `crates/cli/src/frontend/arguments/parser/mod.rs` - Clap argument definition.
+- `crates/cli/src/frontend/execution/options/iconv.rs` - `resolve_iconv_setting()`
+  maps the raw `OsStr` to `IconvSetting`.
+- When the `iconv` feature is compiled out, `accept_parsed_setting()` returns a
+  hard error: `"--iconv requires the iconv feature, which was disabled at build
+  time"` (exit code 1). This prevents silent no-op (#1915).
+- `--no-iconv` and absence of `--iconv` are accepted regardless of feature gate.
+
+## CI Coverage Status
+
+The `iconv` feature is exercised in CI through multiple paths:
+
+| CI Job | Feature coverage | Platform |
+|--------|-----------------|----------|
+| nextest (stable) | `--all-features` (includes iconv) | Linux |
+| clippy | `--all-features` | Linux |
+| Windows | `--all-features` on core/engine/cli | Windows |
+| macOS | `--all-features` on core/engine/cli/metadata/apple-fs | macOS |
+| Linux musl | `--no-default-features --features "zstd,lz4,xattr,iconv,..."` | Linux musl |
+| Interop | `test_iconv`, `test_iconv_upstream_interop`, `test_iconv_local_ssh_interop` | Linux |
+
+The interop harness (`tools/ci/run_interop.sh`) includes three dedicated iconv
+test functions:
+
+1. `test_iconv` - identity transfer (UTF-8,UTF-8) and cross-charset
+   (UTF-8,ISO-8859-1) local-mode.
+2. `test_iconv_upstream_interop` - daemon-mode round-trip vs upstream rsync
+   3.4.1+, both directions.
+3. `test_iconv_local_ssh_interop` - SSH/local-mode interop with fake-rsh,
+   upstream as receiver and sender.
+
+No CI job tests with the `iconv` feature *disabled*. The `#[cfg(not(feature =
+"iconv"))]` test paths (e.g., `test_stub_only_supports_utf8`,
+`resolve_iconv_setting_rejects_explicit_when_feature_off`) are never exercised
+in CI because all jobs enable iconv.
+
+## Test Coverage Status
+
+Test coverage is thorough across crates when the feature is enabled:
+
+| Location | Tests | Notes |
+|----------|-------|-------|
+| `protocol::iconv::mod` (inline) | 20 tests | Converter API, identity, round-trip, aliases, encoding errors. 12 gated on `#[cfg(feature = "iconv")]`, 1 on `#[cfg(not(feature = "iconv"))]`. |
+| `protocol/tests/iconv_golden_bytes.rs` | 16 tests | Wire-level golden byte tests: sender, receiver, round-trip, suffix_len. All `#[cfg(feature = "iconv")]`, receiver tests also `#[cfg(unix)]`. |
+| `cli::frontend::tests::iconv` | 4 tests | `resolve_iconv_setting` with explicit, disable, empty, feature-off rejection. |
+| `cli::frontend::tests::parse_args_recognises_iconv` | 2 tests | Argument parsing for `--iconv` and `--no-iconv`. |
+| `cli::frontend::execution::options::iconv` (inline) | 9 tests | Setting resolution, feature-off rejection, `--no-iconv` acceptance. |
+| `core::client::config::iconv` (inline) | 19 tests | `IconvSetting::parse`, `resolve_converter`, `resolve_local_copy_converter`, debug emissions. |
+| `engine/tests/iconv_local_copy.rs` | 4+ tests | Local-copy disk transcoding. Linux-only, iconv-gated. |
+| `transfer::receiver::tests::file_list::iconv_wire_order` | 3 tests | Receiver sort-order preservation under iconv. |
+| `protocol/tests/protocol_feature_gates.rs` | 1 test | `CF_SYMLINK_ICONV` compatibility flag. |
+
+## Gaps Found
+
+1. **No CI coverage for iconv-disabled builds.** All CI jobs enable
+   `--all-features` or explicitly include `iconv`. The `#[cfg(not(feature =
+   "iconv"))]` code paths - including the graceful rejection of `--iconv` when
+   the feature is off - are tested only by `cfg`-gated unit tests that are
+   compiled but never run in CI. A CI job with `--no-default-features --features
+   "zstd,lz4,xattr"` (omitting iconv) would close this gap.
+
+2. **Daemon crate does not default-enable iconv.** The `daemon` crate defines
+   `iconv = ["core/iconv", "protocol/iconv"]` but does not include it in its
+   default features. The `charset = ...` config directive in `oc-rsyncd.conf`
+   depends on the binary-level default features propagating iconv to daemon via
+   `core`. If someone builds daemon as a standalone crate without the workspace
+   default, `charset` silently has no effect. Low risk - standalone daemon builds
+   are not a supported workflow.
+
+3. **`converter_from_locale()` always returns identity.** Both the enabled and
+   disabled paths return `FilenameConverter::identity()` (UTF-8). On systems
+   where the locale is genuinely non-UTF-8 (e.g., `LC_CTYPE=ja_JP.EUC-JP`),
+   `--iconv=.` would not actually transcode. The code acknowledges this with a
+   comment. This matches upstream rsync on modern systems but diverges on legacy
+   locales.
+
+4. **No interop test for non-ASCII filenames over SSH with upstream.** The SSH
+   interop test (`test_iconv_local_ssh_interop`) uses `cafe\xcc\x81.txt` (a
+   combining accent) as its only non-ASCII fixture. There is no coverage for
+   multi-byte encodings (CJK via EUC-JP/Shift_JIS) or filenames with characters
+   unmappable in the target charset.
+
+5. **Engine integration tests are Linux-only.** The `iconv_local_copy.rs`
+   integration tests are gated on `#[cfg(all(target_os = "linux", feature =
+   "iconv"))]` because macOS APFS and Windows NTFS reject raw non-UTF-8 byte
+   sequences. This is a filesystem limitation, not a code gap, but it means the
+   local-copy iconv path has zero integration coverage on macOS and Windows.

--- a/docs/design/pg2-1-upstream-progress2-audit.md
+++ b/docs/design/pg2-1-upstream-progress2-audit.md
@@ -1,0 +1,428 @@
+# PG2-1: Upstream rsync progress2 Output Format Audit
+
+Audit of upstream rsync 3.4.1 `progress.c` and supporting files, documenting the
+exact behavior of `--info=progress2` (overall transfer progress) and the standard
+`--progress` (per-file progress) modes. Also catalogs oc-rsync's existing
+infrastructure and identifies gaps.
+
+## 1. Upstream progress levels
+
+Upstream uses a single `INFO_PROGRESS` integer level (options.c:279):
+
+| Level | Mode | Triggered by |
+|-------|------|-------------|
+| 0 | Disabled (default) | `--no-progress` or no flag |
+| 1 | Per-file progress | `--progress`, `-P`, or `--info=progress` |
+| 2 | Overall transfer progress | `--info=progress2` |
+
+`--progress` sets `do_progress = 1`. At options.c:2342-2345, if `do_progress &&
+!am_server`, upstream calls `parse_output_words` with `"FLIST2,PROGRESS"` -
+setting `info_levels[INFO_PROGRESS] = 1` (per-file) and `info_levels[INFO_FLIST]
+= 2`. The key distinction: `--info=progress2` sets the level to 2, switching to
+overall transfer progress (progress2 mode). There is no separate flag; it is the
+same `INFO_PROGRESS` variable at a higher level.
+
+`-P` is shorthand for `--progress --partial` (options.c:1600-1606).
+
+## 2. Exact output format string
+
+The format string at progress.c:129:
+
+```c
+rprintf(FCLIENT, "\r%15s %3d%% %7.2f%s %s%s",
+        human_num(ofs), pct, rate, units, rembuf, eol);
+```
+
+### Field breakdown
+
+| Field | Format | Width | Description |
+|-------|--------|-------|-------------|
+| `\r` | literal | 1 | Carriage return for in-place overwrite |
+| `ofs` | `%15s` | 15 | Bytes transferred, thousands-separated via `human_num()` |
+| ` ` | literal | 1 | Space separator |
+| `pct` | `%3d%%` | 4 | Percentage (0-100) followed by `%` sign |
+| ` ` | literal | 1 | Space separator |
+| `rate` | `%7.2f` | 7 | Transfer rate numeric value |
+| `units` | `%s` | 4 | Rate unit suffix: `kB/s`, `MB/s`, or `GB/s` |
+| ` ` | literal | 1 | Space separator |
+| `rembuf` | `%s` | 10 | Remaining time or elapsed time: `%4u:%02u:%02u` |
+| `eol` | `%s` | variable | Trailing info (see below) |
+
+### The `eol` field
+
+For mid-transfer ticks (`is_last == 0`), `eol` is `"  "` (two spaces) -
+progress.c:100.
+
+For final ticks (`is_last == 1`), `eol` is computed at progress.c:78-82:
+
+```c
+snprintf(eol, sizeof eol,
+    " (xfr#%d, %s-chk=%d/%d)\n",
+    stats.xferred_files, flist_eof ? "to" : "ir",
+    stats.num_files - current_file_index - 1,
+    stats.num_files);
+```
+
+Format: ` (xfr#N, to-chk=R/T)\n` or ` (xfr#N, ir-chk=R/T)\n`
+
+- `xfr#N`: 1-based count of files actually transferred (`stats.xferred_files`)
+- `to-chk` vs `ir-chk`: `to` when file list is complete (`flist_eof`), `ir`
+  during incremental recursion
+- `R`: remaining files to check (`stats.num_files - current_file_index - 1`)
+- `T`: total files (`stats.num_files`)
+
+### progress2 final-tick padding
+
+When `INFO_GTE(PROGRESS, 2)` (progress2 mode), the final-tick logic at
+progress.c:84-91 strips the trailing `\n` from `eol` and pads with spaces so the
+line never shrinks. This means progress2 never emits a newline mid-transfer - it
+continuously overwrites the same line with `\r`. The line only grows or stays the
+same width (never shortens), preventing visual artifacts.
+
+## 3. Rate calculation algorithm
+
+### Mid-transfer rate: sliding window
+
+Upstream uses a 5-slot circular buffer (`ph_list[5]`, progress.c:37-52) to
+compute the transfer rate from *recent* history, not the cumulative average:
+
+```c
+#define PROGRESS_HISTORY_SECS 5
+
+struct progress_history {
+    struct timeval time;
+    OFF_T ofs;
+};
+
+static struct progress_history ph_list[PROGRESS_HISTORY_SECS];
+static int newest_hpos, oldest_hpos;
+```
+
+Mid-transfer rate (progress.c:102-104):
+
+```c
+diff = msdiff(&ph_list[oldest_hpos].time, now);
+rate = (double)(ofs - ph_list[oldest_hpos].ofs) * 1000.0 / diff / 1024.0;
+```
+
+The rate is computed as bytes transferred between the oldest retained sample and
+the current time, divided by the elapsed milliseconds, converted to kB/s. This
+gives a rate that responds to recent throughput changes within the 5-second
+window.
+
+### Final-tick rate: cumulative from start
+
+For the final tick of a file (progress.c:94-96):
+
+```c
+diff = msdiff(&ph_start.time, now);
+rate = (double)(ofs - ph_start.ofs) * 1000.0 / diff / 1024.0;
+```
+
+Uses `ph_start` (the transfer start time/offset), giving the cumulative average
+rate for the entire file (or entire transfer in progress2 mode).
+
+### Rate unit scaling
+
+Rate is in kB/s (base-1024). Scaling at progress.c:108-116:
+
+```c
+if (rate > 1024*1024) {      // > 1 TB/s in kB/s units
+    rate /= 1024.0 * 1024.0;
+    units = "GB/s";
+} else if (rate > 1024) {    // > 1 GB/s in kB/s units
+    rate /= 1024.0;
+    units = "MB/s";
+} else {
+    units = "kB/s";
+}
+```
+
+Note: The thresholds are in kB/s space. `rate > 1024` means the raw rate exceeds
+1024 kB/s (= 1 MB/s), so it scales to MB/s. `rate > 1024*1024` means it exceeds
+1024 MB/s (= 1 GB/s), so it scales to GB/s. The unit never goes above GB/s -
+extreme rates stay in GB/s with a large numeric value.
+
+## 4. ETA algorithm
+
+### Mid-transfer ETA
+
+The ETA is computed from the sliding-window rate at progress.c:105:
+
+```c
+remain = rate ? (double)(size - ofs) / rate / 1000.0 : 0.0;
+```
+
+Where `rate` is in kB/s, so `(size - ofs)` bytes divided by `(rate * 1000)` gives
+seconds. When rate is zero (stalled transfer), remain collapses to `0.0`, rendering
+as `0:00:00` rather than an infinite/undefined ETA.
+
+### Final-tick ETA
+
+On the final tick, `remain` is replaced with the actual elapsed time
+(progress.c:98):
+
+```c
+remain = (double)diff / 1000.0;
+```
+
+This switches from "estimated time remaining" to "total time taken" for the final
+progress line.
+
+### ETA rendering
+
+Rendered at progress.c:118-125:
+
+```c
+if (remain < 0 || remain > 9999.0 * 3600.0)
+    strlcpy(rembuf, "  ??:??:??", sizeof rembuf);
+else {
+    snprintf(rembuf, sizeof rembuf, "%4u:%02u:%02u",
+             (unsigned int)(remain / 3600.0),
+             (unsigned int)(remain / 60.0) % 60,
+             (unsigned int)remain % 60);
+}
+```
+
+- Overflow guard: values exceeding 9999 hours (35,996,400 seconds) or negative
+  values render as `  ??:??:??` (10 chars including 2 leading spaces)
+- Normal format: `%4u:%02u:%02u` - hours right-justified in 4 chars, colon,
+  zero-padded minutes, colon, zero-padded seconds (10 chars total)
+
+## 5. Update frequency / triggering mechanism
+
+### Trigger: per `recv_token()` call in receiver
+
+`show_progress()` is called from three sites in receiver.c, all guarded by
+`INFO_GTE(PROGRESS, 1)`:
+
+1. **Append mode data copying** (receiver.c:294-295, 302-303): Called per
+   `CHUNK_SIZE` block while checksumming the existing portion of the file.
+
+2. **Delta token loop** (receiver.c:316-317): Called for every token received
+   from the sender - both literal data tokens (`i > 0`) and copy/match tokens
+   (`i < 0`). This is the primary update path.
+
+3. **File completion** (receiver.c:395-396): `end_progress(total_size)` called
+   after the delta token loop finishes.
+
+### Throttling: 1-second minimum between updates
+
+`show_progress()` (progress.c:224) enforces a 1-second minimum between ring
+rotations:
+
+```c
+if (msdiff(&ph_list[newest_hpos].time, &now) < 1000)
+    return;
+```
+
+When less than 1 second has passed since the last sample, `show_progress()`
+returns without calling `rprint_progress()`. This prevents excessive terminal
+output and keeps the sliding window's time resolution at 1 second.
+
+### First call initialization
+
+On the first call (progress.c:205-222), all 5 ring slots are initialized to the
+same `(time, ofs)` sample. If recent data from a previous file was received
+within 1500ms, the start time inherits from that sample (progress.c:211) -
+this avoids a rate spike when a new file begins immediately after the previous
+one.
+
+### progress2 mode: overall byte counters
+
+In progress2 mode (`INFO_GTE(PROGRESS, 2)`), `show_progress()` at
+progress.c:200-203 transforms the per-file offset into overall transfer counters:
+
+```c
+ofs = stats.total_transferred_size - size + ofs;
+size = stats.total_size;
+```
+
+The sliding window then tracks overall bytes/rate rather than per-file progress.
+Similarly, `end_progress()` at progress.c:172-174 uses `stats.total_transferred_size`
+and `stats.total_size` as the final values.
+
+### progress2 mode: per-file completion behavior
+
+In progress2 mode, `end_progress(0)` is called at phase boundaries
+(receiver.c:565-566) when `NDX_DONE` is received - not after each file. Per-file
+completions at receiver.c:395-396 still call `end_progress(total_size)`, but with
+`INFO_GTE(PROGRESS, 2)` the function uses overall stats, and the trailing `eol`
+is padded without a newline (progress.c:84-91). The visual effect: the single
+progress line continuously updates in place until the transfer completes.
+
+### SIGINFO instant progress
+
+On platforms with SIGINFO (macOS) or SIGVTALRM, a signal handler sets
+`want_progress_now = True` (main.c:1616-1617) when progress is not already
+enabled. The receiver checks this at receiver.c:895 after each file and calls
+`instant_progress()` for a one-shot status update.
+
+## 6. The `xfr#` / `to-chk` counter format
+
+### Counter semantics
+
+- `xfr#N`: The N-th file actually transferred in this session
+  (`stats.xferred_files`). Incremented only for files that involved data
+  transfer, not for skipped or up-to-date files.
+
+- `to-chk=R/T` or `ir-chk=R/T`: Files remaining to check out of total.
+  - `R = stats.num_files - current_file_index - 1`
+  - `T = stats.num_files`
+  - Prefix is `to` when `flist_eof` (file list complete), `ir` during
+    incremental recursion (INC_RECURSE)
+
+### `current_file_index` tracking
+
+`set_current_file_index()` (progress.c:147-156) is called from the receiver to
+track which file is currently being processed. It handles both sorted and
+unsorted file lists, adjusting for sub-list numbering in INC_RECURSE mode.
+
+## 7. oc-rsync current progress infrastructure
+
+### Option parsing
+
+- `crates/cli/src/frontend/execution/flags/info.rs`: `InfoFlagSpec` for
+  `progress` with `max_level: 2, strict_cap: true`. Both level 1 (PerFile) and
+  level 2 (Overall) are parsed.
+- `crates/cli/src/frontend/progress/mode.rs`: `ProgressSetting` enum with
+  `Unspecified`, `Disabled`, `PerFile`, `Overall`. Resolves to `ProgressMode`
+  (`PerFile` or `Overall`).
+- `crates/logging/src/levels/info.rs`: `InfoFlag::Progress` with `progress: u8`
+  level field. `config.apply_info_flag("progress2")` correctly sets level 2.
+
+### Format functions
+
+- `format_progress_bytes`: thousands-separated (non-human) or human-readable
+  suffixes. Maps to upstream `human_num()`.
+- `format_progress_percent`: `N%` or `??%` placeholder. Maps to upstream `pct`.
+- `format_progress_rate`: bytes/s -> kB/s/MB/s/GB/s with base-1024 scaling.
+  Matches upstream tier logic.
+- `format_progress_rate_decimal`: Base-1024 kB/s/MB/s/GB/s matching upstream
+  exactly.
+- `format_progress_elapsed`: `H:MM:SS` format. Matches upstream `%4u:%02u:%02u`
+  structure.
+
+### Sliding-window ETA estimator
+
+`RemainingTimeEstimator` in `crates/cli/src/frontend/progress/format/remaining.rs`:
+
+- 5-slot ring buffer (`HISTORY_SLOTS = 5`) matching upstream
+  `PROGRESS_HISTORY_SECS`
+- 1-second sample interval matching upstream's `msdiff < 1000` throttle
+- `9999 * 3600` second overflow guard matching upstream's `> 9999.0 * 3600.0`
+  clamp
+- Stall handling: returns `0.0` when bytes_delta is zero, matching upstream's
+  `rate ? ... : 0.0` behavior
+- Comprehensive tests verifying upstream parity
+
+### Live progress rendering
+
+`LiveProgress` in `crates/cli/src/frontend/progress/live.rs`:
+
+- Implements `ClientProgressObserver` for both `PerFile` and `Overall` modes
+- Uses `\r` carriage-return for in-place updates
+- Renders `xfr#N, to-chk=R/T` / `ir-chk=R/T` suffix
+- Per-file mode: prints filename on new line, then inline progress
+- Overall mode: single continuously-updated line
+- Uses `RemainingTimeEstimator` for mid-transfer ETA, switches to elapsed on
+  final tick
+
+### Batch/post-hoc progress rendering
+
+`emit_progress()` in `crates/cli/src/frontend/progress/render.rs`:
+
+- Renders progress lines from collected `ClientEvent` records (non-live)
+- Same field widths as upstream format string
+
+### Progress forwarding infrastructure
+
+`ClientProgressForwarder` in `crates/core/src/client/progress.rs`:
+
+- Wraps `LocalCopyRecordHandler` to convert per-file events into
+  `ClientProgressUpdate` objects
+- Tracks overall transferred bytes, total bytes, elapsed time
+- Handles both final updates (file complete) and intermediate progress
+- Local copies only - always sets `flist_eof: true` since file lists are
+  enumerated eagerly
+
+## 8. Infrastructure gap analysis
+
+### What exists and works
+
+1. **Option parsing**: `--progress`, `--no-progress`, `-P`, `--info=progress`,
+   `--info=progress2`, `--info=progress0` all parsed correctly
+2. **Format functions**: Bytes, percent, rate, elapsed/remaining all match
+   upstream field widths and scaling
+3. **Sliding-window estimator**: Faithful port of upstream's ring buffer algorithm
+4. **Live progress rendering**: Both per-file and overall modes implemented
+5. **`to-chk`/`ir-chk` prefix**: Correctly switches based on `flist_eof`
+
+### Gaps requiring implementation
+
+1. **progress2 final-tick padding** (progress.c:84-91): oc-rsync's `LiveProgress`
+   emits `writeln!` on final tick in both modes. Upstream progress2 strips the
+   newline and pads with spaces on the final per-file tick. Only the overall
+   transfer completion should emit a newline. The current implementation does
+   handle this for the overall mode (`final_tick` guard at live.rs:167), but the
+   per-file `end_progress` calls within progress2 mode still need the padding
+   behavior.
+
+2. **Rate unit base**: oc-rsync's `format_progress_rate` computes rate as
+   `bytes / seconds` (bytes/s), then scales with base-1024 thresholds. Upstream
+   computes rate as `bytes * 1000.0 / diff / 1024.0` (kB/s), then scales from
+   kB/s. The numeric output matches because both paths produce the same kB/s /
+   MB/s / GB/s values, but the oc-rsync code path is organized differently - the
+   rate starts in bytes/s and the `format_progress_rate_decimal` function applies
+   `/ 1024.0` for kB/s, `/ (1024^2)` for MB/s, `/ (1024^3)` for GB/s. This is
+   equivalent but should be verified for edge-case precision parity.
+
+3. **Remote/SSH transfer progress**: `ClientProgressForwarder` currently only
+   wraps local copy operations. SSH and daemon transfers need equivalent progress
+   forwarding from the receiver's delta token loop. The `from_transfer_event`
+   constructor exists but always sets `final_update: true` and
+   `overall_total_bytes: None` - intermediate progress ticks from remote
+   transfers are not yet wired.
+
+4. **ph_start time inheritance** (progress.c:209-213): When a new file begins
+   within 1500ms of the previous file's last data, upstream reuses the previous
+   timestamp to avoid rate spikes. oc-rsync's `RemainingTimeEstimator` creates a
+   fresh estimator per file (in per-file mode) or reuses a single estimator (in
+   overall mode). The per-file fresh-start behavior may cause rate spikes on the
+   first tick of small files.
+
+5. **SIGINFO handler**: Not implemented. Upstream exposes instant progress via
+   `want_progress_now` on SIGINFO (macOS Ctrl+T) or SIGVTALRM. oc-rsync does not
+   register these signal handlers.
+
+6. **Elapsed vs remaining on final tick**: In per-file mode, oc-rsync correctly
+   switches to elapsed time on `is_final()` (live.rs:119-120). In overall mode,
+   it only switches on `final_tick = remaining == 0 && is_final()` (live.rs:167).
+   Upstream switches to elapsed when `is_last` is true regardless of mode
+   (progress.c:94-98). This means the per-file end-of-file ticks in progress2
+   mode should show the cumulative elapsed time, not the ETA - but upstream uses
+   `ph_start` (overall start) for this, so the elapsed time is the overall
+   transfer duration so far.
+
+7. **`current_file_index` tracking**: The `to-chk=R/T` counter requires knowing
+   which file index is currently being processed. oc-rsync passes this through
+   `ClientProgressUpdate::remaining()` and `total()`, derived from the
+   `ClientProgressForwarder`'s count of progress events. For local copies this
+   works, but for remote transfers the counters need to track file-list indices
+   rather than transfer-event counts.
+
+## 9. Summary
+
+The upstream progress format is a single `rprintf` call with 6 fields:
+`\r` + 15-char bytes + 4-char percent + 11-char rate + 10-char time + variable
+trailer. Rate uses a 5-second sliding window with 1-second sample intervals;
+ETA divides remaining bytes by the windowed rate. Updates are triggered per
+`recv_token()` call but throttled to one per second by the ring rotation guard.
+progress2 mode transforms per-file offsets into overall transfer counters and
+suppresses per-file newlines.
+
+oc-rsync has substantial progress infrastructure already in place - format
+functions, sliding-window estimator, live rendering for both modes, and option
+parsing all match upstream semantics. The primary gaps are in wiring remote
+transfer progress updates, SIGINFO support, and minor behavioral details around
+final-tick padding in progress2 mode.

--- a/docs/design/pir-1-upstream-partial-interrupt-audit.md
+++ b/docs/design/pir-1-upstream-partial-interrupt-audit.md
@@ -1,0 +1,576 @@
+# PIR-1: Upstream rsync Partial-Interrupt Signal Handler Audit
+
+Reference: upstream rsync 3.4.1 source at `target/interop/upstream-src/rsync-3.4.1/`.
+
+This document traces the exact sequence of events when a signal interrupts a
+transfer while `--partial` is active. It is the reference spec for implementing
+partial-interrupt parity in oc-rsync.
+
+---
+
+## 1. Signal Installation
+
+Signals are registered in `main.c:1717-1790` after option parsing:
+
+| Signal   | Handler            | Registered at |
+|----------|--------------------|---------------|
+| SIGUSR1  | `sigusr1_handler`  | main.c:1725   |
+| SIGUSR2  | `sigusr2_handler`  | main.c:1726   |
+| SIGCHLD  | `remember_children`| main.c:1727   |
+| SIGINT   | `sig_int`          | main.c:1788   |
+| SIGHUP   | `sig_int`          | main.c:1789   |
+| SIGTERM  | `sig_int`          | main.c:1790   |
+| SIGPIPE  | SIG_IGN            | main.c:1797   |
+
+SIGINT, SIGHUP, and SIGTERM share the same handler: `sig_int()` in rsync.c:685.
+
+## 2. Signal-to-Cleanup Sequence
+
+### 2a. `sig_int()` (rsync.c:685-717)
+
+```c
+void sig_int(int sig_num)
+{
+    called_from_signal_handler = 1;
+    msleep(400);  // let ssh restore tty settings
+
+    // Daemon listener + SIGTERM => clean exit
+    if (am_daemon && !am_server && sig_num == SIGTERM)
+        exit_cleanup(0);
+
+    // Server or receiver: defer signal for controlled shutdown
+    if (!got_kill_signal && (am_server || am_receiver)) {
+        got_kill_signal = sig_num;
+        called_from_signal_handler = 0;  // reset - not immediate exit
+        return;                          // deferred handling
+    }
+
+    exit_cleanup(RERR_SIGNAL);  // immediate cleanup
+}
+```
+
+**Two paths diverge here:**
+
+- **Generator/client (sender side):** Calls `_exit_cleanup(RERR_SIGNAL)` immediately
+  from the signal handler. `called_from_signal_handler = 1` is set, so the
+  process terminates via `_exit()` (not `exit()`) at cleanup.c:273.
+
+- **Server or receiver:** Sets `got_kill_signal = sig_num` and returns. The
+  signal is handled later at the next I/O operation, when `perform_io()` checks
+  `got_kill_signal > 0` (io.c:750, 879, 901) and calls `handle_kill_signal(True)`.
+  This calls `exit_cleanup(RERR_SIGNAL)` with `flush_ok_after_signal = True`,
+  allowing the multiplexed output to be flushed so the remote side learns what
+  happened.
+
+### 2b. `sigusr1_handler()` (main.c:1597-1601)
+
+```c
+static void sigusr1_handler(UNUSED(int val))
+{
+    called_from_signal_handler = 1;
+    exit_cleanup(RERR_SIGNAL1);
+}
+```
+
+No deferral. Immediate cleanup. SIGUSR1 is the signal rsync uses to propagate
+shutdown to child processes (cleanup.c:203).
+
+### 2c. `handle_kill_signal()` (io.c:515-520)
+
+```c
+static void handle_kill_signal(BOOL flush_ok)
+{
+    got_kill_signal = -1;
+    flush_ok_after_signal = flush_ok;
+    exit_cleanup(RERR_SIGNAL);
+}
+```
+
+Bridges the deferred path into `_exit_cleanup`. The `flush_ok` flag controls
+whether step 4 of cleanup can flush I/O.
+
+## 3. `_exit_cleanup()` Step-by-Step (cleanup.c:103-275)
+
+The function uses `switch_step` and `case_N.h` includes to create a
+non-repeatable, re-entrant state machine. Each `#include "case_N.h"` generates
+the next `case N:` label. If cleanup triggers a recursive call (e.g., an I/O
+error during flush), the switch picks up at the next step.
+
+### Step 0: Entry (cleanup.c:127-141)
+- Masks SIGUSR1 and SIGUSR2 with SIG_IGN.
+- Preserves first error code.
+- Sets `am_server = 2` on clean exit (suppresses log_exit output).
+- Emits newline if `output_needs_newline`.
+- Debug logging if EXIT >= 2.
+
+### Step 1: Reap Child (cleanup.c:146-154)
+- If `cleanup_child_pid != -1`, calls `wait_process(WNOHANG)`.
+- Propagates child exit code upward if it is larger than current `exit_code`.
+
+### Step 2: Partial File Handling (cleanup.c:159-183)
+
+**This is the critical step for --partial.**
+
+```c
+if (cleanup_got_literal && (cleanup_fname || cleanup_fd_w != -1)) {
+    // close read fd
+    if (cleanup_fd_r != -1) {
+        close(cleanup_fd_r);
+        cleanup_fd_r = -1;
+    }
+    // flush and close write fd
+    if (cleanup_fd_w != -1) {
+        flush_write_file(cleanup_fd_w);
+        close(cleanup_fd_w);
+        cleanup_fd_w = -1;
+    }
+    // retain partial file if conditions met
+    if (cleanup_fname && cleanup_new_fname && keep_partial
+     && handle_partial_dir(cleanup_new_fname, PDIR_CREATE)) {
+        int tweak_modtime = 0;
+        const char *fname = cleanup_fname;
+        cleanup_fname = NULL;         // prevent step 5 from unlinking
+        if (!partial_dir) {
+            tweak_modtime = 1;
+            cleanup_file->modtime = 0;
+        }
+        finish_transfer(cleanup_new_fname, fname, NULL, NULL,
+                        cleanup_file, tweak_modtime, !partial_dir);
+    }
+}
+```
+
+### Step 3: Flush I/O (cleanup.c:189-195)
+- If `flush_ok_after_signal` and code is `RERR_SIGNAL`, flushes multiplexed I/O.
+- On clean exit (code 0), flushes all I/O.
+
+### Step 4: Unlink and Kill Children (cleanup.c:200-226)
+- If `cleanup_fname` is still set (i.e., step 2 did NOT retain the file),
+  `do_unlink(cleanup_fname)` removes the temp file.
+- If exiting with error, `kill_all(SIGUSR1)` sends SIGUSR1 to all child processes.
+- Removes daemon PID file if applicable.
+- Calculates final exit code from `io_error` flags and `got_xfer_error`.
+
+### Step 5: Log (cleanup.c:223-226)
+- `log_exit()` for error exits or daemon/logfile contexts.
+
+### Step 6: Debug (cleanup.c:231-237)
+- Debug logging if EXIT >= 1.
+
+### Step 7: MSG_ERROR_EXIT (cleanup.c:242-258)
+- For protocol >= 31 or receiver: sends `MSG_ERROR_EXIT` with exit code.
+- Calls `noop_io_until_death()` to drain remaining I/O.
+
+### Step 8: Final (cleanup.c:263-274)
+- `msleep(100)` for server side errors (lets client read buffered data).
+- `close_all()` closes all file descriptors.
+- If `called_from_signal_handler`, uses `_exit()`; otherwise `exit()`.
+
+## 4. `cleanup_got_literal`: Tracking Real Progress
+
+### Where Set to 0 (Start of File)
+
+**receiver.c:674** - Reset at the top of the recv_files() per-file loop, after
+stats are updated but before `receive_data()`:
+
+```c
+cleanup_got_literal = 0;
+```
+
+This happens for every file that enters the transfer path. It ensures that if
+the file is interrupted before any literal data arrives, the partial file is
+not retained (no real progress was made).
+
+### Where Set to 1 (Literal Data Received)
+
+**receiver.c:329** - Inside `receive_data()`, when a positive token (literal
+data) is received from the sender:
+
+```c
+if (i > 0) {
+    stats.literal_data += i;
+    cleanup_got_literal = 1;
+    sum_update(data, i);
+    // write to fd...
+}
+```
+
+This is set on the very first literal byte received. Copy tokens (negative `i`
+values, referencing matched blocks from the basis file) do NOT set this flag.
+
+### Where Reset (cleanup_disable)
+
+**cleanup.c:277-282** - `cleanup_disable()` resets `cleanup_got_literal = 0`
+along with all other cleanup state. Called at receiver.c:557 (top of main loop)
+and receiver.c:935 (after successful file completion).
+
+### Implication
+
+A file that is 100% matched (all copy tokens, no literal data) will have
+`cleanup_got_literal == 0`. If interrupted, such a file is always deleted -
+no real data was transmitted, so there is nothing to preserve.
+
+## 5. The Keep-Partial Decision Tree
+
+During signal cleanup (step 2 of `_exit_cleanup`), the partial file is retained
+only when ALL of these conditions are true:
+
+```
+cleanup_got_literal != 0           -- real data was written
+AND (cleanup_fname != NULL         -- temp file name is known
+     OR cleanup_fd_w != -1)        -- write fd is open
+AND cleanup_fname != NULL          -- temp file name is known
+AND cleanup_new_fname != NULL      -- destination name is known
+AND keep_partial != 0              -- --partial or --partial-dir is active
+AND handle_partial_dir() succeeds  -- partial dir is creatable
+```
+
+If any condition fails, the temp file is NOT retained by step 2, and step 4
+will `do_unlink(cleanup_fname)` to remove it.
+
+### Decision Flowchart
+
+```
+Signal arrives during file transfer
+  |
+  v
+cleanup_got_literal > 0?
+  |-- NO --> temp file deleted (step 4)
+  |
+  YES
+  |
+  v
+cleanup_fname set? (non-NULL)
+  |-- NO --> temp file deleted (step 4)
+  |
+  YES
+  |
+  v
+cleanup_new_fname set? (non-NULL)
+  |-- NO --> temp file deleted (step 4)
+  |
+  YES
+  |
+  v
+keep_partial enabled?
+  |-- NO --> temp file deleted (step 4)
+  |
+  YES
+  |
+  v
+handle_partial_dir(PDIR_CREATE) succeeds?
+  |-- NO --> temp file deleted (step 4)
+  |
+  YES
+  |
+  v
+partial_dir set?
+  |-- NO --> stamp modtime=0, finish_transfer (retained in-place)
+  |-- YES -> finish_transfer into partial-dir (retained in partial-dir)
+```
+
+## 6. `finish_transfer()` on Interrupt (cleanup.c:181-182)
+
+When the partial file is retained during cleanup, `finish_transfer` is called
+with these specific arguments:
+
+```c
+finish_transfer(cleanup_new_fname, fname, NULL, NULL,
+                cleanup_file, tweak_modtime, !partial_dir);
+```
+
+| Argument         | Value                  | Meaning |
+|------------------|------------------------|---------|
+| `fname`          | `cleanup_new_fname`    | Destination path (or partial-dir path) |
+| `fnametmp`       | `cleanup_fname` (temp) | Temp file to rename |
+| `fnamecmp`       | NULL                   | No basis comparison |
+| `partialptr`     | NULL                   | No cross-filesystem fallback |
+| `file`           | `cleanup_file`         | File metadata (possibly with modtime=0) |
+| `ok_to_set_time` | `tweak_modtime`        | 1 if no partial_dir (stamp epoch), 0 if partial_dir |
+| `overwriting_basis` | `!partial_dir`      | TRUE only when no partial_dir |
+
+Inside `finish_transfer()` (rsync.c:724-785):
+1. Since `inplace` is not the cleanup path, it proceeds to the rename branch.
+2. Calls `set_file_attrs()` on the temp file to set permissions.
+   - If `tweak_modtime == 1` (no partial_dir): uses `ATTRS_ACCURATE_TIME`,
+     which applies `cleanup_file->modtime` (already set to 0 = epoch).
+   - If `tweak_modtime == 0` (has partial_dir): uses
+     `ATTRS_SKIP_MTIME | ATTRS_SKIP_ATIME | ATTRS_SKIP_CRTIME` - mtime is
+     NOT modified; the file keeps whatever mtime it got from the write.
+3. Calls `robust_rename()` to move the temp file to the destination.
+   - `temp_copy_name` is NULL (partialptr was passed as NULL), so no
+     cross-filesystem copy fallback is attempted.
+
+## 7. The modtime=0 Stamp (cleanup.c:174-179)
+
+```c
+if (!partial_dir) {
+    tweak_modtime = 1;
+    cleanup_file->modtime = 0;
+}
+```
+
+**When:** Only when `--partial` is used WITHOUT `--partial-dir`. The partial
+file will be left at the destination path (overwriting any previous version).
+
+**Why:** Two reasons documented in the inline comment:
+1. **Prevent `--update` skipping.** If the partial file retained a modern mtime,
+   a subsequent `rsync --update` would see the partial file as newer than the
+   source and skip it, leaving a corrupt file permanently.
+2. **Visual identification.** A file with mtime of epoch (1970-01-01 00:00:00)
+   stands out in directory listings as clearly incomplete.
+
+**When NOT applied:** If `--partial-dir` is set, the partial file is moved into
+the partial directory, not the final destination. Since it will not be
+discovered by `--update` at the real destination path, the mtime is left as-is.
+The partial-dir file will be used as a basis file on the next transfer attempt.
+
+## 8. `cleanup_set()` / `cleanup_disable()` Bracket in `recv_files()`
+
+### `cleanup_disable()` (cleanup.c:277-282)
+
+```c
+void cleanup_disable(void)
+{
+    cleanup_fname = cleanup_new_fname = NULL;
+    cleanup_fd_r = cleanup_fd_w = -1;
+    cleanup_got_literal = 0;
+}
+```
+
+Called at two points in `recv_files()`:
+1. **receiver.c:557** - Top of the main `while(1)` loop, before `read_ndx_and_attrs()`.
+   Clears any state from the previous file.
+2. **receiver.c:935** - After all file completion logic (finish_transfer, delay-updates
+   bookkeeping, unlink). The file is done; cleanup state is disarmed.
+
+### `cleanup_set()` (cleanup.c:285-293)
+
+```c
+void cleanup_set(const char *fnametmp, const char *fname,
+                 struct file_struct *file, int fd_r, int fd_w)
+```
+
+Called at two points in `recv_files()`, depending on the transfer mode:
+
+1. **Inplace mode (receiver.c:868):**
+   ```c
+   cleanup_set(NULL, NULL, file, fd1, fd2);
+   ```
+   Both filename args are NULL. This means cleanup step 2 will see
+   `cleanup_fname == NULL` and skip partial retention entirely. The inplace
+   file is either complete or not - there is no temp file to retain.
+
+2. **Normal (temp file) mode (receiver.c:873):**
+   ```c
+   cleanup_set(fnametmp, partialptr, file, fd1, fd2);
+   ```
+   - `cleanup_fname = fnametmp` (the `.XXXXXX` temp file)
+   - `cleanup_new_fname = partialptr` (the partial-dir path, or `fname` if
+     no partial-dir)
+   - `cleanup_file = file` (the file_struct metadata)
+   - `cleanup_fd_r = fd1` (basis file read fd, or -1)
+   - `cleanup_fd_w = fd2` (temp file write fd)
+
+### The Bracket
+
+The lifecycle for each file is:
+
+```
+cleanup_disable()          -- receiver.c:557 (top of loop)
+  |
+  read_ndx_and_attrs()     -- receiver.c:560
+  |
+  ... open basis, open temp ...
+  |
+  cleanup_set(...)         -- receiver.c:868 or 873
+  |                          (signal can now trigger partial retention)
+  |
+  receive_data()           -- receiver.c:892
+  |                          (cleanup_got_literal set to 1 on first literal)
+  |
+  close(fd1), close(fd2)  -- receiver.c:898-904
+  |
+  finish_transfer()/unlink -- receiver.c:906-933
+  |
+  cleanup_disable()        -- receiver.c:935 (disarm)
+```
+
+If a signal arrives between the two `cleanup_disable()` calls (and after
+`cleanup_set()`), the partial file handling in step 2 of `_exit_cleanup` is
+armed. If it arrives outside this window, cleanup_fname is NULL and the temp
+file (if any) is simply unlinked.
+
+## 9. `delay_updates` Interaction
+
+### Overview
+
+`--delay-updates` defers renaming completed files until the end of the transfer
+phase. Files are written to the partial-dir during transfer, then renamed in
+bulk at phase transition.
+
+### Option Setup (options.c:2410-2444)
+
+- `--inplace` and `--delay-updates` are mutually exclusive (error at 2410).
+- `--append` and `--delay-updates` are mutually exclusive.
+- When `--delay-updates` is active, `partial_dir` and `keep_partial` are
+  always set (the delay-updates mechanism IS partial-dir).
+
+### Normal Completion with `delay_updates` (receiver.c:906-933)
+
+The post-transfer decision tree:
+
+```c
+if ((recv_ok && (!delay_updates || !partialptr)) || inplace) {
+    // Normal success: rename temp -> dest immediately
+    finish_transfer(fname, fnametmp, fnamecmp, partialptr, file, recv_ok, 1);
+}
+else if (keep_partial && partialptr && (!one_inplace || delay_updates)) {
+    // delay_updates path: move to partial-dir, mark in delayed_bits
+    handle_partial_dir(partialptr, PDIR_CREATE);
+    finish_transfer(partialptr, fnametmp, fnamecmp, NULL, file, recv_ok, !partial_dir);
+    if (delay_updates && recv_ok) {
+        bitbag_set_bit(delayed_bits, ndx);
+        recv_ok = 2;  // special return: delayed
+    }
+}
+else if (!one_inplace)
+    do_unlink(fnametmp);
+```
+
+When `delay_updates` is active and the transfer succeeds (`recv_ok` is true):
+1. The condition `!delay_updates || !partialptr` is false, so the first branch
+   is skipped.
+2. The second branch activates: temp file is renamed into the partial-dir.
+3. The file index is recorded in `delayed_bits` for the bulk rename later.
+4. `recv_ok` is set to 2, which bypasses the `send_msg_success` in the switch
+   below (only sent after the bulk rename in `handle_delayed_updates`).
+
+### Interrupt with Both `--delay-updates` and `--partial`
+
+On signal interrupt:
+- **Files already moved to partial-dir and recorded in `delayed_bits`** remain
+  in the partial-dir. They were successfully transferred and checksummed, but
+  never renamed to the final destination. On the next rsync invocation, they
+  serve as basis files (the generator detects them via `fnamecmp_type == FNAMECMP_PARTIAL_DIR`).
+- **The in-flight file** (if any) follows the normal cleanup_got_literal logic
+  in step 2 of `_exit_cleanup`. Since `keep_partial` is true (delay_updates
+  implies it), the partial file is retained if literal data was received.
+- **No bulk rename occurs.** The `handle_delayed_updates()` sweep never runs
+  because the receiver loop exits via signal before reaching the phase
+  transition.
+
+## 10. `handle_delayed_updates()` Sweep at Phase 2 (receiver.c:422-450, 584-585)
+
+```c
+if (phase == 2 && delay_updates)
+    handle_delayed_updates(local_name);
+```
+
+This is called when the receiver transitions from phase 1 to phase 2
+(receiver.c:584-585). Phase 2 is the redo phase for files that failed checksum
+verification in phase 1.
+
+### The Sweep (receiver.c:422-450)
+
+```c
+static void handle_delayed_updates(char *local_name)
+{
+    for (ndx = -1; (ndx = bitbag_next_bit(delayed_bits, ndx)) >= 0; ) {
+        file = cur_flist->files[ndx];
+        fname = local_name ? local_name : f_name(file, NULL);
+        partialptr = partial_dir_fname(fname);
+        if (partialptr != NULL) {
+            if (make_backups > 0 && !make_backup(fname, False))
+                continue;
+            do_rename(partialptr, fname);  // partial-dir -> final dest
+            if (success)
+                send_msg_success(fname, ndx);
+            handle_partial_dir(partialptr, PDIR_DELETE);
+        }
+    }
+}
+```
+
+For each file recorded in `delayed_bits`:
+1. Constructs the partial-dir path.
+2. Creates a backup of the existing destination if `--backup` is active.
+3. Renames from partial-dir to final destination.
+4. Sends `MSG_SUCCESS` to the generator (for `--remove-source-files` or
+   hard-link tracking).
+5. Removes the partial-dir subdirectory if it is now empty.
+
+**Note:** There is also a second call at receiver.c:988 for `protocol_version < 29`,
+which handles the case where max_phase is 1 (no redo phase):
+
+```c
+if (phase == 2 && delay_updates) /* for protocol_version < 29 */
+    handle_delayed_updates(local_name);
+```
+
+### Timing
+
+The sweep runs after all phase 1 files are transferred but before the phase 2
+redo loop begins. This is important because redo files need the destination to
+be in its final location, not still in the partial-dir.
+
+## 11. Inplace Mode Cleanup Behavior
+
+When `inplace` is true, `cleanup_set()` is called with NULL filenames
+(receiver.c:868):
+
+```c
+cleanup_set(NULL, NULL, file, fd1, fd2);
+```
+
+In `_exit_cleanup` step 2:
+- `cleanup_fname` is NULL, so `cleanup_fname` check fails.
+- `cleanup_fd_w != -1` is true, so the outer condition passes.
+- The `flush_write_file` and `close` calls execute on the write fd.
+- But the inner condition (`cleanup_fname && cleanup_new_fname && keep_partial`)
+  fails because `cleanup_fname` is NULL.
+- Step 4: `cleanup_fname` is NULL, so `do_unlink` is skipped.
+
+**Result:** The inplace file is flushed and closed but NOT deleted and NOT
+renamed. Whatever was written in-place remains. This is correct behavior -
+the file IS the destination, and any written data is already committed.
+
+## 12. Summary: Implementation Requirements for oc-rsync
+
+1. **Global mutable state:** `cleanup_got_literal`, `cleanup_fname`,
+   `cleanup_new_fname`, `cleanup_file`, `cleanup_fd_r`, `cleanup_fd_w` must
+   all be accessible from the signal handler path. In Rust, this requires
+   either atomic/static-mut or a signal-safe mechanism.
+
+2. **`cleanup_got_literal` must be set on the first literal token**, not on
+   copy tokens. Only literal data represents real progress.
+
+3. **The `cleanup_set`/`cleanup_disable` bracket** must precisely match the
+   upstream window: armed after temp file creation, disarmed after
+   finish_transfer completes.
+
+4. **modtime=0 stamp** must be applied when `--partial` is used without
+   `--partial-dir`, to prevent `--update` from skipping partial files.
+
+5. **`finish_transfer` from cleanup** passes `ok_to_set_time = tweak_modtime`
+   and `overwriting_basis = !partial_dir`. These differ from the normal
+   completion path.
+
+6. **Deferred signal handling** on server/receiver: set a flag, handle at next
+   I/O boundary. Do not call cleanup from within the signal handler on the
+   receiver side when multiplexed I/O is active.
+
+7. **`delay_updates` files in partial-dir survive interrupt.** They are valid,
+   fully checksummed files waiting for bulk rename. On re-run, the generator
+   uses them as basis files.
+
+8. **Inplace cleanup:** flush and close the fd, but do not delete or rename.
+   The file is the destination itself.
+
+9. **`called_from_signal_handler` determines exit method:** `_exit()` for
+   signal context (no atexit handlers, no stdio flush), `exit()` for normal
+   cleanup context.
+
+10. **Step ordering is non-repeatable.** If cleanup triggers a recursive error,
+    it resumes at the next step, never re-executes a completed step. The
+    `switch_step` / `case_N.h` mechanism implements this.

--- a/docs/design/pir-4b-5b-receiver-cleanup-audit.md
+++ b/docs/design/pir-4b-5b-receiver-cleanup-audit.md
@@ -1,0 +1,339 @@
+# PIR-4.b / PIR-5.b: Receiver Cleanup and Delay-Updates Audit
+
+Research audit for wiring `CleanupManager::register_temp_file` into the
+receiver pipeline and tracking committed-to-partial-dir files for the
+`--delay-updates` rename sweep.
+
+## PIR-4.b: All Temp File Creation Sites in `crates/transfer/src/`
+
+### Production Sites (non-test)
+
+There are **three distinct code paths** that create temp files. Each has
+both a Unix (sandboxed) and non-Unix (plain) variant.
+
+#### Site 1: `disk_commit/process.rs` - `open_output_file()` (line 267)
+
+The pipelined receiver's disk-commit thread calls this function for every
+file. Three branches:
+
+| Branch | Lines | Creates temp file? | Guard type |
+|--------|-------|--------------------|------------|
+| Device target | 272-273 | No (opens device directly) | `TempFileGuard::new(file_path)` with `keep_on_drop=false`, but `needs_rename=false` |
+| Inplace | 275-286 | No (opens dest directly) | `TempFileGuard::new(file_path)` with `needs_rename=false` |
+| Temp+rename | 294-303 | **Yes** | `open_tmpfile_sandboxed()` / `open_tmpfile()` returns `(File, TempFileGuard)` |
+
+The temp file path is `cleanup_guard.path()` after creation. The guard's
+`keep()` is called at line 418 inside `commit_file()` after the rename
+succeeds.
+
+**Integration point for CleanupManager**: Register the guard path at line
+303 (after `Ok((file, guard, true))`) and unregister at line 418 (after
+`cleanup_guard.keep()`).
+
+This site is called by both `process_file()` (chunked) and
+`process_whole_file()` (coalesced single-chunk) - both invoke
+`open_output_file()` at their top.
+
+#### Site 2: `transfer_ops/response.rs` - `process_file_response()` (line 64)
+
+The synchronous (non-pipelined) single-file response processor. Two
+branches:
+
+| Branch | Lines | Creates temp file? | Guard type |
+|--------|-------|--------------------|------------|
+| Inplace | 82-93 | No | `TempFileGuard::new(file_path)` |
+| Temp+rename | 98-103 | **Yes** | `open_tmpfile_sandboxed()` / `open_tmpfile()` |
+
+Guard `keep()` is called at line 356 after successful rename or inplace
+truncation.
+
+**Integration point for CleanupManager**: Register at line 103 (after
+guard creation), unregister at line 356 (after `cleanup_guard.keep()`).
+
+#### Site 3: `receiver/transfer/sync.rs` - `run_sync()` (line 204)
+
+The synchronous receiver transfer loop creates a temp file per file:
+
+| Lines | Creates temp file? | Guard type |
+|-------|--------------------|------------|
+| 204-211 | **Yes** | `open_tmpfile_sandboxed()` / `open_tmpfile()` |
+
+Guard `keep()` is called at line 374 after the rename.
+
+**Integration point for CleanupManager**: Register at line 211 (after
+guard creation), unregister at line 374 (after `temp_guard.keep()`).
+
+### Summary Table
+
+| # | File | Function | Line | Needs CleanupManager? |
+|---|------|----------|------|-----------------------|
+| 1 | `disk_commit/process.rs` | `open_output_file` | 295/302 | Yes (temp+rename path) |
+| 2 | `transfer_ops/response.rs` | `process_file_response` | 99/102 | Yes (temp+rename path) |
+| 3 | `receiver/transfer/sync.rs` | `run_sync` | 204/211 | Yes |
+
+Device-target and inplace branches create a `TempFileGuard` for API
+uniformity but never create a temp file on disk, so they do not need
+`CleanupManager` registration.
+
+### Existing Cleanup Infrastructure
+
+- **`TempFileGuard`** (`temp_guard.rs`): RAII guard that deletes the temp
+  file on drop unless `keep()` is called. Handles panics and early
+  returns. Does NOT register with `CleanupManager`.
+
+- **`CleanupManager`** (`core/src/signal/cleanup.rs`): Global singleton
+  using `OnceLock<Mutex<CleanupManagerState>>`. Stores a
+  `HashSet<PathBuf>` of registered paths. `cleanup()` and
+  `cleanup_temp_files()` delete all registered paths. Designed for signal
+  handlers (SIGINT/SIGTERM) where RAII cannot run.
+
+- **`cleanup_stale_temp_files()`** (`temp_cleanup.rs`): Startup-time
+  scan that removes `.filename.XXXXXX` files older than 24 hours. Catches
+  files orphaned by SIGKILL/OOM/power loss where neither RAII nor signal
+  handlers ran.
+
+### Gap Analysis
+
+`TempFileGuard` handles normal cleanup (RAII). `temp_cleanup` handles
+startup orphan removal. But between creation and `keep()`, a SIGINT could
+arrive and the signal handler's `CleanupManager::cleanup()` would not
+know about the temp file because nothing registers it. The PIR-4.b task
+closes this gap.
+
+---
+
+## PIR-5.b: Current `delay_updates` Handling
+
+### Configuration Flow
+
+1. **CLI**: `--delay-updates` flag parsed in `cli/src/frontend/`.
+2. **Core**: `ClientConfig.delay_updates` (bool) flows to
+   `LocalCopyOptions.delay_updates(true)` and
+   `ServerConfigBuilder.delay_updates(true)`.
+3. **Transfer crate**: `WriteConfig.delay_updates` (bool) in
+   `config/mod.rs:55`. Validated as mutually exclusive with `--inplace`
+   in `builder.rs:442`.
+4. **Engine crate**: `LocalCopyOptions.delay_updates` (bool) in
+   `local_copy/options/types.rs:190`.
+
+### How `delay_updates` Works in the Engine (Local Copy)
+
+The local-copy engine has a **complete `--delay-updates` implementation**:
+
+1. **Staging directory**: When `delay_updates=true` and no explicit
+   `--partial-dir`, the partial dir defaults to `.~tmp~`
+   (`DELAY_UPDATES_PARTIAL_DIR` constant in `staging.rs:15`). This
+   matches upstream `options.c`'s `static char tmp_partialdir[] =
+   ".~tmp~"`.
+
+2. **Deferred updates**: Each transferred file is staged into the partial
+   dir. Instead of committing (renaming) immediately,
+   `finalize_guard_and_metadata()` in `finalize.rs:48` creates a
+   `DeferredUpdate` and calls `context.register_deferred_update(update)`.
+
+3. **`DeferredUpdate` struct** (`context.rs:317`): Holds the
+   `DestinationWriteGuard` (temp file guard), `fs::Metadata`,
+   `MetadataOptions`, execution mode, path context, and final destination
+   path.
+
+4. **`DeferredOperationQueue`** (`context.rs:286`): Contains a
+   `Vec<DeferredUpdate>` for pending renames, plus a
+   `HashSet<PathBuf>` of staging directories (`.~tmp~`) for cleanup.
+
+5. **Flush at end**: `flush_deferred_updates()` in
+   `context_impl/state.rs:458` iterates all deferred updates, calling
+   `finalize_deferred_update()` which commits the guard (renames temp to
+   final) and applies metadata.
+
+6. **Delete timing**: `delay_updates` promotes `DeleteTiming::During` to
+   `DeleteTiming::After` (`deletion.rs:114`) so deletions happen after
+   the rename sweep.
+
+7. **Hard link handling**: When `delay_updates` is enabled and a hard
+   link target is being transferred, the code forces an early commit of
+   the deferred update for the target (`commit_deferred_update_for` in
+   `links.rs:126`) before creating the hard link.
+
+### How `delay_updates` Works in Upstream C (receiver.c)
+
+1. **Bitbag**: `delayed_bits = bitbag_create(cur_flist->used + 1)` at
+   line 547 - one bit per file index.
+
+2. **Per-file**: When transfer succeeds with `delay_updates` active, the
+   temp file is renamed into the partial-dir (`.~tmp~/<filename>`) and
+   `bitbag_set_bit(delayed_bits, ndx)` marks the index (line 927-929).
+   `recv_ok` is set to 2 (deferred).
+
+3. **Sweep**: `handle_delayed_updates()` at line 422 iterates all set
+   bits, computes `partial_dir_fname(fname)`, creates backups if needed,
+   and renames from partial-dir to final destination.
+
+4. **Timing**: Called at phase 2 transition (line 585) and again at the
+   end for protocol < 29 (line 988-989).
+
+### Current State in Transfer Crate (Remote Transfers)
+
+The transfer crate (used for remote/daemon transfers) **does NOT
+implement the delay_updates rename sweep**:
+
+- `WriteConfig.delay_updates` is stored but **never checked** in any of
+  the receiver transfer paths (`pipeline.rs`, `pipelined.rs`,
+  `pipelined_incremental.rs`, `sync.rs`).
+- `DiskCommitConfig` has no `delay_updates` field.
+- The disk commit thread (`process.rs`) always renames temp to final
+  immediately in `commit_file()`.
+- There is no `DeferredUpdate` equivalent in the transfer crate.
+- There is no bitbag or deferred-rename list.
+- There is no `handle_delayed_updates()` equivalent.
+
+The local-copy engine's `DeferredOperationQueue` and `DeferredUpdate`
+types are not available to the transfer crate (they are `pub(crate)` in
+the engine).
+
+---
+
+## PIR-5.b: Proposed Data Structure for Delayed File Tracking
+
+### Requirements
+
+For `--delay-updates` in the remote transfer path, we need to:
+
+1. Track which files were staged to the partial dir after successful
+   transfer.
+2. At phase 2 transition, iterate all tracked files and rename from
+   partial-dir path to final destination.
+3. Support backup creation before the rename (if `--backup` is active).
+
+### Upstream Model
+
+Upstream uses a bitbag (compact bitmap) keyed by file-list index, plus
+`partial_dir_fname()` to recompute the partial-dir path at rename time.
+This is memory-efficient (1 bit per file) but requires recomputing paths.
+
+### Proposed Design
+
+```rust
+/// Entry tracking a file staged to the partial-dir for deferred rename.
+///
+/// Stored in a flat Vec during phase 1. Iterated at the phase 2 boundary
+/// for the rename sweep.
+///
+/// upstream: receiver.c:927 - bitbag_set_bit(delayed_bits, ndx) + recv_ok=2
+pub struct DelayedFile {
+    /// File list index (used for metadata lookup during rename sweep).
+    pub file_index: usize,
+    /// Path inside the partial-dir where the file was staged.
+    /// e.g., `/dest/.~tmp~/filename`
+    pub partial_path: PathBuf,
+    /// Final destination path where the file should be renamed to.
+    /// e.g., `/dest/filename`
+    pub final_path: PathBuf,
+}
+
+/// Accumulator for files deferred by `--delay-updates`.
+///
+/// Mirrors upstream's `delayed_bits` bitbag but stores full paths to
+/// avoid recomputing `partial_dir_fname()` at sweep time.
+///
+/// The Vec is append-only during the transfer loop and consumed once
+/// during `handle_delayed_updates()` at the phase 2 boundary.
+pub struct DelayedUpdateQueue {
+    files: Vec<DelayedFile>,
+}
+
+impl DelayedUpdateQueue {
+    pub fn new() -> Self {
+        Self { files: Vec::new() }
+    }
+
+    /// Pre-allocates capacity matching the file list size.
+    pub fn with_capacity(n: usize) -> Self {
+        Self { files: Vec::with_capacity(n) }
+    }
+
+    /// Records a file as staged in the partial-dir.
+    pub fn push(&mut self, entry: DelayedFile) {
+        self.files.push(entry);
+    }
+
+    /// Returns the number of deferred files.
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Drains all entries for the rename sweep.
+    pub fn drain(&mut self) -> std::vec::Drain<'_, DelayedFile> {
+        self.files.drain(..)
+    }
+}
+```
+
+### Design Rationale
+
+- **Vec over bitbag**: The transfer crate does not have a bitbag
+  implementation, and the file list indices alone are insufficient - we
+  need both the partial-dir path and the final destination path. A Vec of
+  structs is simpler and avoids recomputing paths at sweep time. The
+  memory cost is small: ~100 bytes per deferred file (two PathBufs + one
+  usize).
+
+- **Append-only + drain**: Mirrors the upstream lifecycle: accumulate
+  during transfer (append), sweep at phase boundary (drain). No random
+  access or removal needed.
+
+- **Stored in `ReceiverContext`**: The queue lives alongside the
+  existing `file_list` and `config` in `ReceiverContext`. It is
+  `None` when `delay_updates` is false.
+
+- **Sweep location**: `handle_delayed_updates()` should be called from
+  `finalize_transfer()` in `phases.rs` at the phase 2 boundary, matching
+  upstream `receiver.c:585`.
+
+### Integration Points
+
+1. **Accumulation**: In `disk_commit/process.rs::commit_file()`, when
+   `delay_updates` is true and `needs_rename` is true, instead of
+   renaming temp to final, rename temp to partial-dir and push a
+   `DelayedFile` entry. The `DiskCommitConfig` needs a
+   `delay_updates: bool` field and a
+   `partial_dir: Option<PathBuf>` (already has `temp_dir`).
+
+2. **Sweep**: New `handle_delayed_updates()` method on `ReceiverContext`
+   called from `finalize_transfer()`. Iterates the queue, creates backups
+   if needed, and renames from partial to final.
+
+3. **Thread boundary**: The disk-commit thread populates the deferred
+   list. Since the thread communicates results back via
+   `CommitResult`, add an optional `DelayedFile` field to
+   `CommitResult` that the receiver drains into its queue.
+
+4. **For sync.rs**: The synchronous path can accumulate directly into
+   a local `DelayedUpdateQueue` since it runs single-threaded.
+
+---
+
+## Summary of Required Changes
+
+### PIR-4.b (CleanupManager wiring)
+
+Three sites need `register_temp_file` / `unregister_temp_file` calls:
+
+1. `disk_commit/process.rs:open_output_file()` - register after
+   `open_tmpfile*()` returns, unregister in `commit_file()` after
+   `cleanup_guard.keep()`.
+2. `transfer_ops/response.rs:process_file_response()` - register after
+   temp file creation (line 103), unregister after `cleanup_guard.keep()`
+   (line 356).
+3. `receiver/transfer/sync.rs:run_sync()` - register after temp file
+   creation (line 211), unregister after `temp_guard.keep()` (line 374).
+
+### PIR-5.b (Delayed rename tracking)
+
+1. New `DelayedFile` struct and `DelayedUpdateQueue` type.
+2. `DiskCommitConfig` gains `delay_updates: bool` and a partial-dir path.
+3. `CommitResult` gains an optional `DelayedFile` for the pipelined path.
+4. `ReceiverContext` gains an optional `DelayedUpdateQueue`.
+5. New `handle_delayed_updates()` method called from
+   `finalize_transfer()`.
+6. `commit_file()` in `disk_commit/process.rs` routes to partial-dir
+   instead of final destination when delay_updates is active.


### PR DESCRIPTION
## Summary

- **Inline checksum computation**: Merges whole-file checksum, wire-write, and zlib dictionary sync into a single pass over delta ops (`write_delta_with_inline_checksum`), eliminating a separate `compute_file_checksum` call that re-opened and re-read the source file. Mirrors upstream `match.c:matched()` where `sum_update()` and `send_token()` operate on the same `map_ptr()` data.
- **SyncWriter write coalescing**: Adds a 32KB staging buffer to the russh sync/async bridge writer, reducing per-write `Vec::to_vec()` heap allocations and channel sends by ~10x for typical transfer patterns (4-byte multiplex headers, varint NDX values). Sized to match upstream rsync's `IO_BUFFER_SIZE`.
- Together these address the primary sources of the 1.32x SSH push initial sync regression vs upstream rsync: triple file reads and per-write allocations in the SSH transport layer.

## Test plan

- [ ] CI passes (fmt, clippy, nextest, Windows, macOS, musl)
- [ ] Existing `sync_writer_to_closed_channel_is_broken_pipe` test updated to account for buffered writes (error surfaces on `flush()`)
- [ ] Existing `sync_writer_backpressure_blocks_until_drained` test updated to use large payload exceeding buffer size
- [ ] `compute_file_checksum` and `write_delta_with_compression` retained under `#[cfg(test)]` for independent verification