### PR TITLE
perf: reduce per-file overhead in SSH push no-change scan path

### DIFF
--- a/crates/metadata/src/options/accessors.rs
+++ b/crates/metadata/src/options/accessors.rs
@@ -96,4 +96,33 @@ impl MetadataOptions {
     pub const fn destination_is_new(&self) -> bool {
         self.destination_is_new
     }
+
+    /// Returns `true` when at least one metadata preservation flag is active.
+    ///
+    /// Used by the receiver's quick-check skip path to avoid entering the
+    /// `apply_metadata_with_cached_stat` call chain when no attributes would
+    /// be inspected. Each inner function (`apply_ownership_from_entry`,
+    /// `apply_permissions_from_entry`, `apply_timestamps_from_entry`) already
+    /// has its own early-exit guard, but skipping the entire chain saves the
+    /// function-call overhead per file.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:574-625` - `set_file_attrs()` is unconditionally called for
+    ///   quick-check matched files. oc-rsync mirrors this by always calling the
+    ///   apply chain when `requires_apply()` returns true.
+    #[must_use]
+    pub const fn requires_apply(&self) -> bool {
+        self.preserve_owner
+            || self.preserve_group
+            || self.preserve_executability
+            || self.preserve_permissions
+            || self.preserve_times
+            || self.preserve_atimes
+            || self.preserve_crtimes
+            || self.fake_super
+            || self.owner_override.is_some()
+            || self.group_override.is_some()
+            || self.chmod.is_some()
+    }
 }

--- a/crates/metadata/src/options/tests.rs
+++ b/crates/metadata/src/options/tests.rs
@@ -285,16 +285,8 @@ fn requires_apply_true_for_each_flag_independently() {
     assert!(base.clone().preserve_atimes(true).requires_apply());
     assert!(base.clone().preserve_crtimes(true).requires_apply());
     assert!(base.clone().fake_super(true).requires_apply());
-    assert!(
-        base.clone()
-            .with_owner_override(Some(0))
-            .requires_apply()
-    );
-    assert!(
-        base.clone()
-            .with_group_override(Some(0))
-            .requires_apply()
-    );
+    assert!(base.clone().with_owner_override(Some(0)).requires_apply());
+    assert!(base.clone().with_group_override(Some(0)).requires_apply());
     assert!(
         base.clone()
             .with_chmod(Some(ChmodModifiers::parse("u+x").unwrap()))

--- a/crates/metadata/src/options/tests.rs
+++ b/crates/metadata/src/options/tests.rs
@@ -252,3 +252,52 @@ fn overrides_and_chmod_can_be_cleared() {
     assert!(cleared.group_override().is_none());
     assert!(cleared.chmod().is_none());
 }
+
+#[test]
+fn requires_apply_true_for_default_options() {
+    // Default MetadataOptions has preserve_permissions=true and
+    // preserve_times=true, so requires_apply must be true.
+    let opts = MetadataOptions::new();
+    assert!(opts.requires_apply());
+}
+
+#[test]
+fn requires_apply_false_when_all_flags_cleared() {
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false)
+        .preserve_owner(false)
+        .preserve_group(false);
+    assert!(!opts.requires_apply());
+}
+
+#[test]
+fn requires_apply_true_for_each_flag_independently() {
+    let base = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false);
+
+    assert!(base.clone().preserve_owner(true).requires_apply());
+    assert!(base.clone().preserve_group(true).requires_apply());
+    assert!(base.clone().preserve_executability(true).requires_apply());
+    assert!(base.clone().preserve_permissions(true).requires_apply());
+    assert!(base.clone().preserve_times(true).requires_apply());
+    assert!(base.clone().preserve_atimes(true).requires_apply());
+    assert!(base.clone().preserve_crtimes(true).requires_apply());
+    assert!(base.clone().fake_super(true).requires_apply());
+    assert!(
+        base.clone()
+            .with_owner_override(Some(0))
+            .requires_apply()
+    );
+    assert!(
+        base.clone()
+            .with_group_override(Some(0))
+            .requires_apply()
+    );
+    assert!(
+        base.clone()
+            .with_chmod(Some(ChmodModifiers::parse("u+x").unwrap()))
+            .requires_apply()
+    );
+}

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -150,6 +150,20 @@ impl ReceiverContext {
             );
 
         // Phase C: Sequential post-processing with stat results.
+        //
+        // Pre-compute feature flags to avoid per-file method dispatch on the
+        // quick-check skip path. For a no-change scan (SSH push where all
+        // files are up-to-date), this loop processes every file without
+        // producing any transfer work, so minimising per-iteration overhead
+        // is critical.
+        //
+        // upstream: generator.c generate_files() loop uses global variables
+        // for the same purpose (preserve_perms, preserve_mtimes, etc.).
+        let needs_metadata_apply = metadata_opts.requires_apply();
+        let has_acl_cache = acl_cache.is_some();
+        let has_xattrs = self.config.flags.xattrs;
+        let emit_itemize = self.should_emit_itemize();
+
         let mut files_to_transfer = Vec::with_capacity(stat_results.len());
         for (idx, file_path, dest_meta) in stat_results {
             let entry = &self.file_list[idx];
@@ -168,13 +182,15 @@ impl ReceiverContext {
                     size_only,
                     always_checksum,
                 ) {
+                    // upstream: generator.c:1814-1816 - quick-check matched:
+                    // apply metadata (set_file_attrs) then itemize. Skip the
+                    // chain entirely when no preservation flags are active.
                     // upstream: generator.c:461 unchanged_attrs() - fast-path
-                    // check avoids the per-function-call overhead of the full
-                    // apply_metadata chain when all attributes already match.
-                    // On a no-change scan this eliminates ownership mapping,
-                    // permission comparison, and timestamp construction for
-                    // every file that passes quick-check.
-                    if !metadata_unchanged(entry, metadata_opts, meta) {
+                    // check avoids apply_metadata overhead when all attributes
+                    // already match.
+                    if needs_metadata_apply
+                        && !metadata_unchanged(entry, metadata_opts, meta)
+                    {
                         if let Err(e) = apply_metadata_with_cached_stat(
                             &file_path,
                             entry,
@@ -184,22 +200,33 @@ impl ReceiverContext {
                             metadata_errors.push((file_path.clone(), e.to_string()));
                         }
                     }
-                    // upstream: generator.c:2260 - itemize() for up-to-date files
-                    let iflags = crate::generator::ItemFlags::from_raw(0);
-                    let _ = self.emit_itemize(writer, &iflags, entry);
-                    if let Err(e) = apply_acls_from_receiver_cache(
-                        &file_path,
-                        entry,
-                        acl_cache,
-                        !entry.is_symlink(),
-                    ) {
-                        metadata_errors.push((file_path, e.to_string()));
-                    } else if let Some(ref xattr_list) = self.resolve_xattr_list(entry) {
-                        // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
-                        if let Err(e) =
-                            metadata::apply_xattrs_from_list(&file_path, xattr_list, true)
-                        {
-                            metadata_errors.push((file_path, e.to_string()));
+
+                    // upstream: generator.c:574-576 - itemize() for up-to-date
+                    // files. Only emitted when significant iflags are set; zero
+                    // iflags (completely unchanged) produces no output.
+                    if emit_itemize {
+                        let iflags = crate::generator::ItemFlags::from_raw(0);
+                        let _ = self.emit_itemize(writer, &iflags, entry);
+                    }
+
+                    if has_acl_cache {
+                        if let Err(e) = apply_acls_from_receiver_cache(
+                            &file_path,
+                            entry,
+                            acl_cache,
+                            !entry.is_symlink(),
+                        ) {
+                            metadata_errors.push((file_path.clone(), e.to_string()));
+                        }
+                    }
+                    if has_xattrs {
+                        if let Some(ref xattr_list) = self.resolve_xattr_list(entry) {
+                            // upstream: xattrs.c:set_xattr() - apply xattrs after metadata
+                            if let Err(e) =
+                                metadata::apply_xattrs_from_list(&file_path, xattr_list, true)
+                            {
+                                metadata_errors.push((file_path, e.to_string()));
+                            }
                         }
                     }
                     continue;

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -188,9 +188,7 @@ impl ReceiverContext {
                     // upstream: generator.c:461 unchanged_attrs() - fast-path
                     // check avoids apply_metadata overhead when all attributes
                     // already match.
-                    if needs_metadata_apply
-                        && !metadata_unchanged(entry, metadata_opts, meta)
-                    {
+                    if needs_metadata_apply && !metadata_unchanged(entry, metadata_opts, meta) {
                         if let Err(e) = apply_metadata_with_cached_stat(
                             &file_path,
                             entry,


### PR DESCRIPTION
## Summary

- Add `MetadataOptions::requires_apply()` const method that returns `true` when at least one metadata preservation flag is active, enabling the receiver to skip the entire `apply_metadata_with_cached_stat` call chain when no attributes would be inspected
- Pre-compute feature flags (`needs_metadata_apply`, `has_acl_cache`, `has_xattrs`, `emit_itemize`) before the Phase C sequential loop to avoid per-file method dispatch on the quick-check skip path
- Guard ACL and xattr application with pre-computed boolean flags to avoid entering those code paths when the features are not configured
- Fix a latent bug where ACL application failure would skip xattr application due to an `else if` chain between independent operations

## Context

Closes BPR-6.a (audit) and BPR-6.c (implement). The SSH push no-change scan path processes every file in the file list without producing any transfer work. Minimizing per-iteration overhead in this loop is critical for closing the 1.58x regression vs upstream rsync on no-change scans.

Upstream `generator.c:generate_files()` pre-computes global flags (`preserve_perms`, `preserve_mtimes`, etc.) before its loop. This PR mirrors that pattern by hoisting flag checks out of the hot loop and gating the metadata/ACL/xattr application chains behind pre-computed booleans.

## Test plan

- [ ] CI passes (fmt, clippy, nextest on all platforms)
- [ ] New tests for `requires_apply()` verify correct flag detection:
  - Default options (perms+times enabled) returns `true`
  - All flags cleared returns `false`
  - Each flag independently triggers `true`
- [ ] Existing quick-check and metadata tests continue to pass