### PR TITLE
perf: compact FileEntry from 88 to 80 bytes per entry

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -106,7 +106,7 @@ fn build_protocol_file_entry(
     // upstream: flist.c:send_file_entry() - FLAG_TOP_DIR marks root source
     // entries so --delete knows which directories are transfer roots.
     if is_top_dir && file_type.is_dir() {
-        entry.flags_mut().primary |= protocol::flist::XMIT_TOP_DIR;
+        entry.set_top_dir(true);
     }
 
     entry

--- a/crates/protocol/src/flist/accessor.rs
+++ b/crates/protocol/src/flist/accessor.rs
@@ -14,7 +14,6 @@
 use std::borrow::Cow;
 
 use super::entry::FileType;
-use super::flags::FileFlags;
 
 /// Read-only accessor for file-list entry metadata.
 ///
@@ -73,8 +72,16 @@ pub trait FileEntryAccessor {
     /// Returns the group ID if ownership is being preserved.
     fn gid(&self) -> Option<u32>;
 
-    /// Returns the wire format flags.
-    fn flags(&self) -> FileFlags;
+    // -- Persisted wire flags --
+
+    /// Returns true if this is a top-level directory in the transfer.
+    fn top_dir(&self) -> bool;
+
+    /// Returns true if this entry has hardlink information.
+    fn hlinked(&self) -> bool;
+
+    /// Returns true if this is the first (leader) entry in a hardlink group.
+    fn hlink_first(&self) -> bool;
 
     // -- Type queries --
 
@@ -218,8 +225,16 @@ impl FileEntryAccessor for FileEntry {
         self.gid()
     }
 
-    fn flags(&self) -> FileFlags {
-        self.flags()
+    fn top_dir(&self) -> bool {
+        self.top_dir()
+    }
+
+    fn hlinked(&self) -> bool {
+        self.hlinked()
+    }
+
+    fn hlink_first(&self) -> bool {
+        self.hlink_first()
     }
 
     fn content_dir(&self) -> bool {
@@ -307,7 +322,6 @@ mod flat_impl {
 
     use super::super::flat::{FlatFileEntry, PRESENT_CONTENT_DIR};
     use super::FileEntryAccessor;
-    use super::FileFlags;
 
     impl<'a> FileEntryAccessor for FlatFileEntry<'a> {
         fn name(&self) -> &str {
@@ -346,8 +360,19 @@ mod flat_impl {
             self.header.gid()
         }
 
-        fn flags(&self) -> FileFlags {
-            FileFlags::from_u32(u32::from(self.header.flags))
+        fn top_dir(&self) -> bool {
+            use crate::flist::flags::FileFlags;
+            FileFlags::from_u32(u32::from(self.header.flags)).top_dir()
+        }
+
+        fn hlinked(&self) -> bool {
+            use crate::flist::flags::FileFlags;
+            FileFlags::from_u32(u32::from(self.header.flags)).hlinked()
+        }
+
+        fn hlink_first(&self) -> bool {
+            use crate::flist::flags::FileFlags;
+            FileFlags::from_u32(u32::from(self.header.flags)).hlink_first()
         }
 
         fn content_dir(&self) -> bool {

--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -292,8 +292,13 @@ fn file_entry_to_flat(
 
     let flat_extras = build_flat_extras(entry);
 
-    let flags = entry.flags();
-    let flags_u16 = u16::from(flags.primary) | (u16::from(flags.extended) << 8);
+    // Reconstruct a u16 flags value from the persisted bits for the flat
+    // header's `flags` field. Only the 3 persisted wire flags survive
+    // past decoding (top_dir, hlinked, hlink_first); the remaining XMIT
+    // bits are transient wire-encoding state discarded at reception.
+    let flags_u16 = (entry.top_dir() as u16)
+        | ((entry.hlinked() as u16) << 9)
+        | ((entry.hlink_first() as u16) << 12);
 
     let header = FileEntryHeader {
         mtime: entry.mtime(),

--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use super::super::wire_path::path_bytes_to_wire;
 use super::FileEntry;
-use super::core::{
-    PRESENT_HLINKED, PRESENT_HLINK_FIRST, PRESENT_TOP_DIR, extract_dirname,
-};
+use super::core::{PRESENT_HLINK_FIRST, PRESENT_HLINKED, PRESENT_TOP_DIR, extract_dirname};
 use super::extras::FileEntryExtras;
 use super::file_type::FileType;
 

--- a/crates/protocol/src/flist/entry/accessors.rs
+++ b/crates/protocol/src/flist/entry/accessors.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use super::super::wire_path::path_bytes_to_wire;
 use super::FileEntry;
-use super::core::extract_dirname;
+use super::core::{
+    PRESENT_HLINKED, PRESENT_HLINK_FIRST, PRESENT_TOP_DIR, extract_dirname,
+};
 use super::extras::FileEntryExtras;
 use super::file_type::FileType;
 
@@ -147,14 +149,20 @@ impl FileEntry {
         self.size = size;
     }
 
-    /// Returns the Unix mode bits (type + permissions).
+    /// Returns the Unix mode bits (type + permissions) as `u32`.
+    ///
+    /// Internally stored as `u16` (matching upstream rsync's `uint16 mode`,
+    /// rsync.h:805). Widened to `u32` on return for API compatibility.
     #[inline]
     #[must_use]
     pub const fn mode(&self) -> u32 {
-        self.mode
+        self.mode as u32
     }
 
     /// Sets the Unix mode bits (type + permissions).
+    ///
+    /// Truncates to 16 bits - only the lower 16 bits carry meaning in POSIX
+    /// mode values (4-bit type mask + 12-bit permissions).
     ///
     /// Used to create mode-0 sentinel entries for `--delete-missing-args`,
     /// where the receiver interprets `mode == 0` as a deletion signal.
@@ -164,20 +172,20 @@ impl FileEntry {
     /// - `flist.c:2257` - `file->mode = 0` for delete-missing-args sentinel
     #[inline]
     pub fn set_mode(&mut self, mode: u32) {
-        self.mode = mode;
+        self.mode = mode as u16;
     }
 
     /// Returns the permission bits only (without type).
     #[inline]
     #[must_use]
     pub const fn permissions(&self) -> u32 {
-        self.mode & 0o7777
+        (self.mode as u32) & 0o7777
     }
 
     /// Returns the file type.
     #[must_use]
     pub fn file_type(&self) -> FileType {
-        FileType::from_mode(self.mode).unwrap_or(FileType::Regular)
+        FileType::from_mode(self.mode as u32).unwrap_or(FileType::Regular)
     }
 
     /// Returns the modification time as seconds since Unix epoch.
@@ -241,46 +249,93 @@ impl FileEntry {
         })
     }
 
-    /// Returns the wire format flags.
+    /// Returns true if this is a top-level directory in the transfer.
+    ///
+    /// Corresponds to upstream's `FLAG_TOP_DIR`. Used to scope `--delete`
+    /// to top-level directories. Stored in the `present` bitfield rather
+    /// than a separate `FileFlags` struct.
+    #[inline]
     #[must_use]
-    pub const fn flags(&self) -> super::super::flags::FileFlags {
-        self.flags
+    pub const fn top_dir(&self) -> bool {
+        self.present & PRESENT_TOP_DIR != 0
     }
 
-    /// Sets the wire format flags.
-    ///
-    /// Used by the generator to mark top-level directories with `XMIT_TOP_DIR`.
-    pub fn set_flags(&mut self, flags: super::super::flags::FileFlags) {
-        self.flags = flags;
+    /// Sets or clears the top-directory flag.
+    #[inline]
+    pub fn set_top_dir(&mut self, top: bool) {
+        if top {
+            self.present |= PRESENT_TOP_DIR;
+        } else {
+            self.present &= !PRESENT_TOP_DIR;
+        }
     }
 
-    /// Returns a mutable reference to the wire format flags.
+    /// Returns true if this entry has hardlink information.
     ///
-    /// Used by `match_hard_links()` to reassign leader/follower status in-place
-    /// after sorting without copying the entire flags struct.
-    pub fn flags_mut(&mut self) -> &mut super::super::flags::FileFlags {
-        &mut self.flags
+    /// Corresponds to upstream's `FLAG_HLINKED`. Indicates the entry belongs
+    /// to a hardlink group. Stored in the `present` bitfield.
+    #[inline]
+    #[must_use]
+    pub const fn hlinked(&self) -> bool {
+        self.present & PRESENT_HLINKED != 0
+    }
+
+    /// Sets or clears the hardlink flag.
+    ///
+    /// Called by `normalize_pre30_hardlinks()` and `match_hard_links()` to
+    /// mark entries that belong to a hardlink group.
+    #[inline]
+    pub fn set_hlinked(&mut self, linked: bool) {
+        if linked {
+            self.present |= PRESENT_HLINKED;
+        } else {
+            self.present &= !PRESENT_HLINKED;
+        }
+    }
+
+    /// Returns true if this is the first (leader) entry in a hardlink group.
+    ///
+    /// Corresponds to upstream's `FLAG_HLINK_FIRST`. Only meaningful when
+    /// `hlinked()` is also true.
+    #[inline]
+    #[must_use]
+    pub const fn hlink_first(&self) -> bool {
+        self.present & PRESENT_HLINK_FIRST != 0
+    }
+
+    /// Sets or clears the hardlink-first flag.
+    ///
+    /// Called by `match_hard_links()` after sorting to reassign
+    /// leader/follower status based on sorted order rather than wire order.
+    /// upstream: hlink.c:match_hard_links() reassigns FLAG_HLINK_FIRST.
+    #[inline]
+    pub fn set_hlink_first(&mut self, first: bool) {
+        if first {
+            self.present |= PRESENT_HLINK_FIRST;
+        } else {
+            self.present &= !PRESENT_HLINK_FIRST;
+        }
     }
 
     /// Returns true if this entry is a directory.
     #[inline]
     #[must_use]
     pub const fn is_dir(&self) -> bool {
-        self.mode & 0o170000 == 0o040000 // S_IFDIR
+        self.mode as u32 & 0o170000 == 0o040000 // S_IFDIR
     }
 
     /// Returns true if this entry is a regular file.
     #[inline]
     #[must_use]
     pub const fn is_file(&self) -> bool {
-        self.mode & 0o170000 == 0o100000 // S_IFREG
+        self.mode as u32 & 0o170000 == 0o100000 // S_IFREG
     }
 
     /// Returns true if this entry is a symbolic link.
     #[inline]
     #[must_use]
     pub const fn is_symlink(&self) -> bool {
-        self.mode & 0o170000 == 0o120000 // S_IFLNK
+        self.mode as u32 & 0o170000 == 0o120000 // S_IFLNK
     }
 
     /// Sets the modification time.
@@ -541,7 +596,7 @@ impl FileEntry {
     #[inline]
     #[must_use]
     pub const fn is_device(&self) -> bool {
-        let type_bits = self.mode & 0o170000;
+        let type_bits = self.mode as u32 & 0o170000;
         type_bits == 0o060000 || type_bits == 0o020000 // S_IFBLK or S_IFCHR
     }
 
@@ -549,21 +604,21 @@ impl FileEntry {
     #[inline]
     #[must_use]
     pub const fn is_block_device(&self) -> bool {
-        self.mode & 0o170000 == 0o060000 // S_IFBLK
+        self.mode as u32 & 0o170000 == 0o060000 // S_IFBLK
     }
 
     /// Returns true if this entry is a character device.
     #[inline]
     #[must_use]
     pub const fn is_char_device(&self) -> bool {
-        self.mode & 0o170000 == 0o020000 // S_IFCHR
+        self.mode as u32 & 0o170000 == 0o020000 // S_IFCHR
     }
 
     /// Returns true if this entry is a special file (socket or FIFO).
     #[inline]
     #[must_use]
     pub const fn is_special(&self) -> bool {
-        let type_bits = self.mode & 0o170000;
+        let type_bits = self.mode as u32 & 0o170000;
         type_bits == 0o140000 || type_bits == 0o010000 // S_IFSOCK or S_IFIFO
     }
 

--- a/crates/protocol/src/flist/entry/constructors.rs
+++ b/crates/protocol/src/flist/entry/constructors.rs
@@ -38,9 +38,8 @@ impl FileEntry {
             extras,
             uid: 0,
             gid: 0,
-            mode: file_type.to_mode_bits() | (permissions & 0o7777),
+            mode: (file_type.to_mode_bits() | (permissions & 0o7777)) as u16,
             mtime_nsec: 0,
-            flags: super::super::flags::FileFlags::default(),
             // Directories have content by default; uid/gid start absent.
             present: PRESENT_CONTENT_DIR,
         }
@@ -109,7 +108,7 @@ impl FileEntry {
         flags: super::super::flags::FileFlags,
     ) -> Self {
         let dirname = extract_dirname(&name);
-        Self {
+        let mut entry = Self {
             name,
             dirname,
             size,
@@ -117,11 +116,16 @@ impl FileEntry {
             extras: None,
             uid: 0,
             gid: 0,
-            mode,
+            mode: mode as u16,
             mtime_nsec,
-            flags,
             present: PRESENT_CONTENT_DIR,
-        }
+        };
+        // Persist the semantically-significant wire flags into the
+        // presence bitfield so tests round-trip correctly.
+        entry.set_top_dir(flags.top_dir());
+        entry.set_hlinked(flags.hlinked());
+        entry.set_hlink_first(flags.hlink_first());
+        entry
     }
 
     /// Creates a file entry from raw bytes (wire format, optimized).
@@ -133,6 +137,10 @@ impl FileEntry {
     /// The dirname is extracted from the path automatically. For interned
     /// dirname sharing, use [`Self::set_dirname`] after construction with a
     /// value from [`super::super::intern::PathInterner`].
+    ///
+    /// The `flags` parameter carries wire-encoding flags. Only the three
+    /// semantically persistent bits (`top_dir`, `hlinked`, `hlink_first`)
+    /// are stored; the remaining delta-encoding flags are discarded.
     ///
     /// This is the preferred constructor for wire protocol decoding.
     #[must_use]
@@ -158,7 +166,7 @@ impl FileEntry {
         };
 
         let dirname = extract_dirname(&path);
-        Self {
+        let mut entry = Self {
             name: path,
             dirname,
             size,
@@ -166,10 +174,16 @@ impl FileEntry {
             extras: None,
             uid: 0,
             gid: 0,
-            mode,
+            mode: mode as u16,
             mtime_nsec,
-            flags,
             present: PRESENT_CONTENT_DIR,
-        }
+        };
+        // Persist the 3 semantically-significant wire flags into the
+        // presence bitfield. The remaining XMIT flags are transient
+        // delta-encoding state recomputed during send.
+        entry.set_top_dir(flags.top_dir());
+        entry.set_hlinked(flags.hlinked());
+        entry.set_hlink_first(flags.hlink_first());
+        entry
     }
 }

--- a/crates/protocol/src/flist/entry/core.rs
+++ b/crates/protocol/src/flist/entry/core.rs
@@ -18,6 +18,23 @@ pub(super) const PRESENT_GID: u8 = 1 << 1;
 /// Set by default for directories; cleared for XMIT_NO_CONTENT_DIR (implied or
 /// content-less) directories. Non-directories report `true` via the accessor.
 pub(super) const PRESENT_CONTENT_DIR: u8 = 1 << 2;
+/// Presence bit: this is a top-level directory in the transfer.
+///
+/// Corresponds to upstream's `FLAG_TOP_DIR` (rsync.h). Used to scope
+/// `--delete` to top-level directories. Packed here instead of in a
+/// separate `FileFlags` struct to save 3 bytes per entry.
+pub(super) const PRESENT_TOP_DIR: u8 = 1 << 3;
+/// Presence bit: this entry has hardlink information.
+///
+/// Corresponds to upstream's `FLAG_HLINKED` (rsync.h). Indicates the entry
+/// belongs to a hardlink group. Packed here to avoid per-entry `FileFlags`.
+pub(super) const PRESENT_HLINKED: u8 = 1 << 4;
+/// Presence bit: this is the first (leader) entry in a hardlink group.
+///
+/// Corresponds to upstream's `FLAG_HLINK_FIRST` (rsync.h). Only meaningful
+/// when `PRESENT_HLINKED` is also set. Packed here to avoid per-entry
+/// `FileFlags`.
+pub(super) const PRESENT_HLINK_FIRST: u8 = 1 << 5;
 
 /// A single entry in the rsync file list.
 ///
@@ -31,14 +48,21 @@ pub(super) const PRESENT_CONTENT_DIR: u8 = 1 << 2;
 /// Rarely-used fields (symlink targets, device numbers, hardlink info,
 /// ACL/xattr indices, atime/crtime) are stored in a boxed `FileEntryExtras`
 /// that is only allocated when at least one such field is set. This reduces
-/// the common-case inline size from ~295 bytes to ~88 bytes - matching
+/// the common-case inline size from ~295 bytes to ~80 bytes - matching
 /// upstream rsync's conditional field allocation pattern.
 ///
-/// `uid`, `gid`, and the directory content flag are packed via a `present`
-/// bitfield rather than `Option`/`bool`, reclaiming the discriminant padding
-/// that `Option<u32>` and a trailing `bool` cost. This mirrors upstream's
-/// conditional `file_extras` layout where each extra is a plain 4-byte slot
-/// gated by a presence flag.
+/// `uid`, `gid`, the directory content flag, and the three persisted wire
+/// flags (`top_dir`, `hlinked`, `hlink_first`) are packed into a single
+/// `present: u8` bitfield. This eliminates the 3-byte `FileFlags` struct
+/// that previously stored 24 bits of wire-encoding state, of which only 3
+/// bits survived past decoding. The remaining XMIT flags (same_uid,
+/// same_gid, same_mode, same_time, etc.) are transient wire-encoding state
+/// recomputed by `FileListWriter::calculate_xflags()` during send.
+///
+/// The `mode` field uses `u16` to match upstream rsync's `uint16 mode`
+/// (rsync.h:805), saving 2 bytes vs the prior `u32`. POSIX mode values
+/// (4-bit type + 12-bit permissions) fit in 16 bits; the accessor returns
+/// `u32` for API compatibility.
 ///
 /// # Path Interning
 ///
@@ -77,19 +101,28 @@ pub struct FileEntry {
     pub(super) uid: u32,
     /// Group ID raw value. Meaningful only when `PRESENT_GID` is set in `present`.
     pub(super) gid: u32,
-    /// Unix mode bits (type + permissions).
-    pub(super) mode: u32,
     /// Modification time nanoseconds (protocol 31+).
     pub(super) mtime_nsec: u32,
 
     // 2-byte aligned fields
-    /// Entry flags from wire format.
-    pub(super) flags: super::super::flags::FileFlags,
+    /// Unix mode bits (type + permissions).
+    ///
+    /// Stored as `u16` matching upstream rsync's `uint16 mode` (rsync.h:805).
+    /// POSIX mode values fit in 16 bits (4-bit type mask `S_IFMT` = `0o170000`
+    /// + 12-bit permissions `0o7777`). The accessor returns `u32` for API
+    /// compatibility with callers that use `u32` mode constants.
+    pub(super) mode: u16,
 
     // 1-byte aligned fields
-    /// Presence bitfield for `uid`, `gid`, and the directory content flag.
+    /// Presence bitfield for metadata and persisted wire flags.
     ///
-    /// See `PRESENT_UID`, `PRESENT_GID`, and `PRESENT_CONTENT_DIR`.
+    /// Bits 0-2: metadata presence (`PRESENT_UID`, `PRESENT_GID`,
+    /// `PRESENT_CONTENT_DIR`).
+    /// Bits 3-5: persisted wire flags (`PRESENT_TOP_DIR`, `PRESENT_HLINKED`,
+    /// `PRESENT_HLINK_FIRST`). These are the only 3 of 24 XMIT wire flags
+    /// that survive past decoding - the rest are transient delta-encoding
+    /// state recomputed during send.
+    /// Bits 6-7: reserved.
     pub(super) present: u8,
 }
 
@@ -114,9 +147,8 @@ impl Clone for FileEntry {
             extras: self.extras.clone(),
             uid: self.uid,
             gid: self.gid,
-            mode: self.mode,
             mtime_nsec: self.mtime_nsec,
-            flags: self.flags,
+            mode: self.mode,
             present: self.present,
         }
     }
@@ -131,10 +163,13 @@ impl std::fmt::Debug for FileEntry {
             .field("mtime", &self.mtime)
             .field("uid", &self.uid())
             .field("gid", &self.gid())
-            .field("mode", &self.mode)
+            .field("mode", &self.mode())
             .field("mtime_nsec", &self.mtime_nsec)
-            .field("flags", &self.flags)
-            .field("content_dir", &self.content_dir());
+            .field("present", &self.present)
+            .field("content_dir", &self.content_dir())
+            .field("top_dir", &self.top_dir())
+            .field("hlinked", &self.hlinked())
+            .field("hlink_first", &self.hlink_first());
         if let Some(extras) = &self.extras {
             s.field("extras", extras);
         }
@@ -152,8 +187,7 @@ impl PartialEq for FileEntry {
             && self.gid() == other.gid()
             && self.mode == other.mode
             && self.mtime_nsec == other.mtime_nsec
-            && self.flags == other.flags
-            && self.content_dir() == other.content_dir()
+            && self.present == other.present
             && self.extras == other.extras
     }
 }

--- a/crates/protocol/src/flist/entry/core.rs
+++ b/crates/protocol/src/flist/entry/core.rs
@@ -110,7 +110,7 @@ pub struct FileEntry {
     /// Stored as `u16` matching upstream rsync's `uint16 mode` (rsync.h:805).
     /// POSIX mode values fit in 16 bits (4-bit type mask `S_IFMT` = `0o170000`
     /// + 12-bit permissions `0o7777`). The accessor returns `u32` for API
-    /// compatibility with callers that use `u32` mode constants.
+    ///   compatibility with callers that use `u32` mode constants.
     pub(super) mode: u16,
 
     // 1-byte aligned fields

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -246,7 +246,9 @@ fn directory_size_is_zero() {
 #[test]
 fn file_entry_flags_accessor() {
     let entry = FileEntry::new_file("test.txt".into(), 100, 0o644);
-    let _flags = entry.flags();
+    assert!(!entry.top_dir());
+    assert!(!entry.hlinked());
+    assert!(!entry.hlink_first());
 }
 
 #[test]
@@ -290,20 +292,21 @@ fn dirname_shared_across_entries() {
     assert!(Arc::ptr_eq(entry1.dirname(), entry2.dirname()));
 }
 
-/// Verifies the struct size optimization: FileEntry should be <= 88 bytes
-/// inline on Unix (down from 96 bytes before packing uid/gid/content_dir into
-/// a presence bitfield, and from ~295 bytes before the Box<FileEntryExtras>
-/// refactor). On Windows the cap is <= 96 because `PathBuf` is 8 bytes larger
-/// than on Unix (Windows `Wtf8Buf` carries an extra `is_known_utf8` bool, which
-/// pads the inner `OsString` from 24 to 32 bytes). This guards against
-/// accidental field additions that bloat the hot path.
+/// Verifies the struct size optimization: FileEntry should be <= 80 bytes
+/// inline on Unix (down from 88 bytes before packing FileFlags into the
+/// presence bitfield and narrowing mode to u16, from 96 bytes before
+/// packing uid/gid/content_dir, and from ~295 bytes before the
+/// Box<FileEntryExtras> refactor). On Windows the cap is <= 88 because
+/// `PathBuf` is 8 bytes larger (Windows `Wtf8Buf` carries an extra
+/// `is_known_utf8` bool, padding `OsString` from 24 to 32 bytes). This
+/// guards against accidental field additions that bloat the hot path.
 #[test]
 fn file_entry_size_optimized() {
     let size = std::mem::size_of::<FileEntry>();
     #[cfg(not(windows))]
-    const MAX: usize = 88;
+    const MAX: usize = 80;
     #[cfg(windows)]
-    const MAX: usize = 96;
+    const MAX: usize = 88;
     assert!(
         size <= MAX,
         "FileEntry is {size} bytes; expected <= {MAX}. \
@@ -315,13 +318,16 @@ fn file_entry_size_optimized() {
 /// bitfield must keep the struct at or below the prior 96-byte (Unix) /
 /// 104-byte (Windows) inline size, and must round-trip the absent/present
 /// distinction the old `Option<u32>` fields encoded.
+///
+/// RSS-2 further reduced the struct by packing FileFlags (3 bytes) into
+/// the presence bitfield and narrowing mode from u32 to u16.
 #[test]
 fn file_entry_presence_bitfield_roundtrip() {
     // (a) size did not regress against the pre-compaction layout.
     #[cfg(not(windows))]
-    const PREVIOUS: usize = 96;
+    const PREVIOUS: usize = 88;
     #[cfg(windows)]
-    const PREVIOUS: usize = 104;
+    const PREVIOUS: usize = 96;
     let size = std::mem::size_of::<FileEntry>();
     assert!(
         size <= PREVIOUS,
@@ -935,22 +941,31 @@ fn content_dir_default_and_set() {
     assert!(entry.content_dir());
 }
 
-/// flags_mut allows in-place mutation.
+/// Dedicated flag setters allow in-place mutation without a separate struct.
 #[test]
-fn flags_mut_accessor() {
+fn flags_set_roundtrip() {
     let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
-    let original = entry.flags();
-    let _flags_mut = entry.flags_mut();
-    assert_eq!(entry.flags(), original);
-}
+    assert!(!entry.top_dir());
+    assert!(!entry.hlinked());
+    assert!(!entry.hlink_first());
 
-/// set_flags replaces flags.
-#[test]
-fn set_flags_replaces() {
-    let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
-    let flags = crate::flist::flags::FileFlags::default();
-    entry.set_flags(flags);
-    assert_eq!(entry.flags(), flags);
+    entry.set_top_dir(true);
+    assert!(entry.top_dir());
+    assert!(!entry.hlinked());
+
+    entry.set_hlinked(true);
+    entry.set_hlink_first(true);
+    assert!(entry.hlinked());
+    assert!(entry.hlink_first());
+    assert!(entry.top_dir()); // other bits undisturbed
+
+    entry.set_hlink_first(false);
+    assert!(entry.hlinked());
+    assert!(!entry.hlink_first());
+
+    entry.set_top_dir(false);
+    assert!(!entry.top_dir());
+    assert!(entry.hlinked());
 }
 
 /// Getter roundtrip: set each extras field individually from a fresh entry,

--- a/crates/protocol/src/flist/trace.rs
+++ b/crates/protocol/src/flist/trace.rs
@@ -191,8 +191,9 @@ pub fn output_flist_entry(role: ProcessRole, ndx: i32, entry: &FileEntry) {
     let gid_str = entry
         .gid()
         .map_or(String::new(), |gid| format!(" gid={gid}"));
-    let flags = entry.flags();
-    let flags_value = flags.primary as u32 | ((flags.extended as u32) << 8);
+    let flags_value = (entry.top_dir() as u32)
+        | ((entry.hlinked() as u32) << 9)
+        | ((entry.hlink_first() as u32) << 12);
 
     debug_log!(
         Flist,

--- a/crates/protocol/src/flist/write/tests/extended_flags.rs
+++ b/crates/protocol/src/flist/write/tests/extended_flags.rs
@@ -88,7 +88,7 @@ fn extended_flags_all_basic_flags_combinations() {
         let mut cursor = Cursor::new(&buf[..]);
         let mut reader = FileListReader::new(protocol);
         let read = reader.read_entry(&mut cursor).unwrap().unwrap();
-        assert!(read.flags().top_dir(), "XMIT_TOP_DIR should round-trip");
+        assert!(read.top_dir(), "XMIT_TOP_DIR should round-trip");
     }
 
     // Test XMIT_LONG_NAME (paths > 255 bytes)

--- a/crates/protocol/src/flist/write/xflags.rs
+++ b/crates/protocol/src/flist/write/xflags.rs
@@ -90,7 +90,7 @@ impl FileListWriter {
     fn calculate_basic_flags(&self, entry: &FileEntry, same_len: usize, suffix_len: usize) -> u32 {
         let mut xflags: u32 = 0;
 
-        if entry.is_dir() && entry.flags().top_dir() {
+        if entry.is_dir() && entry.top_dir() {
             xflags |= XMIT_TOP_DIR as u32;
         }
 

--- a/crates/transfer/src/generator/entry_accessor.rs
+++ b/crates/transfer/src/generator/entry_accessor.rs
@@ -324,7 +324,7 @@ pub fn dest_mtime_newer_generic<T: FileEntryAccessor>(
 /// - `hlink.c:284` - `hard_link_check()` called for non-first entries
 #[must_use]
 pub fn is_hardlink_follower_generic<T: FileEntryAccessor>(entry: &T) -> bool {
-    entry.flags().hlinked() && !entry.flags().hlink_first()
+    entry.hlinked() && !entry.hlink_first()
 }
 
 /// Computes a file's checksum and compares it against an expected value.
@@ -725,8 +725,8 @@ mod tests {
     fn hardlink_follower_generic_leader() {
         let mut entry = make_file_entry("test.txt");
         // Leader has both HLINKED and HLINK_FIRST
-        entry.flags_mut().set_hlinked(true);
-        entry.flags_mut().set_hlink_first(true);
+        entry.set_hlinked(true);
+        entry.set_hlink_first(true);
         assert!(!is_hardlink_follower_generic(&entry));
     }
 
@@ -734,7 +734,7 @@ mod tests {
     fn hardlink_follower_generic_follower() {
         let mut entry = make_file_entry("test.txt");
         // Follower has HLINKED but NOT HLINK_FIRST
-        entry.flags_mut().set_hlinked(true);
+        entry.set_hlinked(true);
         assert!(is_hardlink_follower_generic(&entry));
     }
 
@@ -769,12 +769,12 @@ mod tests {
     #[test]
     fn hardlink_follower_and_leader_are_exclusive() {
         let mut follower = make_file_entry("f.txt");
-        follower.flags_mut().set_hlinked(true);
+        follower.set_hlinked(true);
         assert!(is_hardlink_follower_generic(&follower));
 
         let mut leader = make_file_entry("l.txt");
-        leader.flags_mut().set_hlinked(true);
-        leader.flags_mut().set_hlink_first(true);
+        leader.set_hlinked(true);
+        leader.set_hlink_first(true);
         assert!(!is_hardlink_follower_generic(&leader));
 
         let plain = make_file_entry("p.txt");

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -165,10 +165,7 @@ impl GeneratorContext {
         if let Ok(meta) = std::fs::symlink_metadata(base_dir) {
             if meta.is_dir() {
                 let mut dot_entry = self.create_entry(base_dir, PathBuf::from("."), &meta)?;
-                dot_entry.set_flags(protocol::flist::FileFlags::new(
-                    protocol::flist::XMIT_TOP_DIR,
-                    0,
-                ));
+                dot_entry.set_top_dir(true);
                 self.push_file_item(dot_entry, base_dir.to_path_buf());
             }
         }

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -130,10 +130,7 @@ impl GeneratorContext {
         // root transfer directory. Enables delete_in_dir() when --delete is active.
         if relative.as_os_str().is_empty() && metadata.is_dir() {
             let mut dot_entry = self.create_entry(&path, PathBuf::from("."), &metadata)?;
-            dot_entry.set_flags(protocol::flist::FileFlags::new(
-                protocol::flist::XMIT_TOP_DIR,
-                0,
-            ));
+            dot_entry.set_top_dir(true);
             self.push_file_item(dot_entry, path.clone());
 
             // upstream: exclude.c:push_local_filters() - read per-directory
@@ -208,10 +205,7 @@ impl GeneratorContext {
         // --relative the directory entry has a non-empty relative name (e.g.
         // "tmp/dbg/src/usr/bin") instead of ".", but it still needs the flag.
         if is_top_level && metadata.is_dir() {
-            entry.set_flags(protocol::flist::FileFlags::new(
-                protocol::flist::XMIT_TOP_DIR,
-                0,
-            ));
+            entry.set_top_dir(true);
         }
 
         // upstream: flist.c:send_file_list() - scan directory before recording entry

--- a/crates/transfer/src/generator/sender_accessor.rs
+++ b/crates/transfer/src/generator/sender_accessor.rs
@@ -347,8 +347,14 @@ mod tests {
         fn gid(&self) -> Option<u32> {
             None
         }
-        fn flags(&self) -> protocol::flist::FileFlags {
-            protocol::flist::FileFlags::from_u32(0)
+        fn top_dir(&self) -> bool {
+            false
+        }
+        fn hlinked(&self) -> bool {
+            false
+        }
+        fn hlink_first(&self) -> bool {
+            false
         }
         fn content_dir(&self) -> bool {
             self.is_dir()

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -209,7 +209,7 @@ impl ReceiverContext {
             // this covers leaders that matched quick-check (not transferred) or
             // were processed via the sync path.
             for entry in &self.file_list {
-                if entry.flags().hlink_first() {
+                if entry.hlink_first() {
                     let gnum = match entry.hardlink_idx() {
                         Some(idx) => idx,
                         None => continue,
@@ -232,7 +232,7 @@ impl ReceiverContext {
 
             // Second pass: link followers to their leaders.
             for (follower_ndx, entry) in self.file_list.iter().enumerate() {
-                if !entry.flags().hlinked() || entry.flags().hlink_first() {
+                if !entry.hlinked() || entry.hlink_first() {
                     continue;
                 }
                 let leader_idx = match entry.hardlink_idx() {

--- a/crates/transfer/src/receiver/entry_accessor.rs
+++ b/crates/transfer/src/receiver/entry_accessor.rs
@@ -115,7 +115,7 @@ pub fn dest_mtime_newer_generic<T: FileEntryAccessor + ?Sized>(
 /// - `generator.c:1539` - `F_HLINK_NOT_FIRST(file)` check
 /// - `hlink.c:284` - `hard_link_check()` called for non-first entries
 pub fn is_hardlink_follower_generic<T: FileEntryAccessor + ?Sized>(entry: &T) -> bool {
-    entry.flags().hlinked() && !entry.flags().hlink_first()
+    entry.hlinked() && !entry.hlink_first()
 }
 
 /// Applies ACLs from the receiver's ACL cache to a destination file.
@@ -210,8 +210,8 @@ mod tests {
     #[test]
     fn hardlink_leader_is_not_follower() {
         let mut entry = FileEntry::new_file("leader.txt".into(), 100, 0o644);
-        entry.flags_mut().set_hlinked(true);
-        entry.flags_mut().set_hlink_first(true);
+        entry.set_hlinked(true);
+        entry.set_hlink_first(true);
         assert!(!is_hardlink_follower_generic(&entry));
     }
 
@@ -219,8 +219,8 @@ mod tests {
     #[test]
     fn hardlink_follower_detected() {
         let mut entry = FileEntry::new_file("follower.txt".into(), 100, 0o644);
-        entry.flags_mut().set_hlinked(true);
-        entry.flags_mut().set_hlink_first(false);
+        entry.set_hlinked(true);
+        entry.set_hlink_first(false);
         assert!(is_hardlink_follower_generic(&entry));
     }
 
@@ -238,8 +238,8 @@ mod tests {
     #[test]
     fn follower_generic_matches_concrete_leader() {
         let mut entry = FileEntry::new_file("leader.txt".into(), 100, 0o644);
-        entry.flags_mut().set_hlinked(true);
-        entry.flags_mut().set_hlink_first(true);
+        entry.set_hlinked(true);
+        entry.set_hlink_first(true);
         assert_eq!(
             is_hardlink_follower_generic(&entry),
             super::super::quick_check::is_hardlink_follower(&entry),
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn follower_generic_matches_concrete_follower() {
         let mut entry = FileEntry::new_file("follower.txt".into(), 100, 0o644);
-        entry.flags_mut().set_hlinked(true);
+        entry.set_hlinked(true);
         assert_eq!(
             is_hardlink_follower_generic(&entry),
             super::super::quick_check::is_hardlink_follower(&entry),
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn hardlink_follower_via_trait_object() {
         let mut entry = FileEntry::new_file("f.txt".into(), 0, 0o644);
-        entry.flags_mut().set_hlinked(true);
+        entry.set_hlinked(true);
         let acc: &dyn FileEntryAccessor = &entry;
         assert!(is_hardlink_follower_generic(acc));
     }

--- a/crates/transfer/src/receiver/file_list/hardlinks.rs
+++ b/crates/transfer/src/receiver/file_list/hardlinks.rs
@@ -62,11 +62,11 @@ pub(in crate::receiver) fn match_hard_links(
 
             if is_first_in_segment && !seen_before {
                 // First occurrence of this gnum across all segments - this is the leader.
-                entry.flags_mut().set_hlink_first(true);
+                entry.set_hlink_first(true);
                 prior_hlinks.insert(gnum, true);
             } else {
                 // Either not first in segment, or gnum was seen in a prior segment.
-                entry.flags_mut().set_hlink_first(false);
+                entry.set_hlink_first(false);
                 // Record the gnum even if it was already present, so future
                 // segments know about it.
                 prior_hlinks.entry(gnum).or_insert(true);
@@ -123,8 +123,8 @@ pub(in crate::receiver) fn normalize_pre30_hardlinks(entries: &mut [FileEntry]) 
         let gnum = indices[0] as u32;
         for (pos, &idx) in indices.iter().enumerate() {
             entries[idx].set_hardlink_idx(gnum);
-            entries[idx].flags_mut().set_hlinked(true);
-            entries[idx].flags_mut().set_hlink_first(pos == 0);
+            entries[idx].set_hlinked(true);
+            entries[idx].set_hlink_first(pos == 0);
         }
     }
 }
@@ -163,13 +163,13 @@ mod tests {
         match_hard_links(&mut entries, &mut prior_hlinks);
 
         // Directory entries remain unaffected
-        assert!(!entries[0].flags().hlink_first());
-        assert!(!entries[2].flags().hlink_first());
+        assert!(!entries[0].hlink_first());
+        assert!(!entries[2].hlink_first());
 
         // First file in group 7 (sorted position 1) becomes leader
-        assert!(entries[1].flags().hlink_first());
+        assert!(entries[1].hlink_first());
         // Second file in group 7 (sorted position 3) becomes follower
-        assert!(!entries[3].flags().hlink_first());
+        assert!(!entries[3].hlink_first());
     }
 
     /// Verifies `match_hard_links` handles multiple hardlink groups interspersed
@@ -203,12 +203,12 @@ mod tests {
         match_hard_links(&mut entries, &mut prior_hlinks);
 
         // Group 1: position 1 is leader, position 2 is follower
-        assert!(entries[1].flags().hlink_first());
-        assert!(!entries[2].flags().hlink_first());
+        assert!(entries[1].hlink_first());
+        assert!(!entries[2].hlink_first());
 
         // Group 4: position 4 is leader, position 5 is follower
-        assert!(entries[4].flags().hlink_first());
-        assert!(!entries[5].flags().hlink_first());
+        assert!(entries[4].hlink_first());
+        assert!(!entries[5].hlink_first());
     }
 
     /// Verifies `normalize_pre30_hardlinks` assigns synthetic hardlink_idx and
@@ -229,11 +229,11 @@ mod tests {
         // Both entries get the same hardlink_idx
         assert_eq!(entries[0].hardlink_idx(), entries[1].hardlink_idx());
         // First entry is leader
-        assert!(entries[0].flags().hlinked());
-        assert!(entries[0].flags().hlink_first());
+        assert!(entries[0].hlinked());
+        assert!(entries[0].hlink_first());
         // Second entry is follower
-        assert!(entries[1].flags().hlinked());
-        assert!(!entries[1].flags().hlink_first());
+        assert!(entries[1].hlinked());
+        assert!(!entries[1].hlink_first());
     }
 
     /// Verifies `normalize_pre30_hardlinks` leaves single-entry (dev, ino) pairs
@@ -248,8 +248,8 @@ mod tests {
         normalize_pre30_hardlinks(&mut entries);
 
         assert!(entries[0].hardlink_idx().is_none());
-        assert!(!entries[0].flags().hlinked());
-        assert!(!entries[0].flags().hlink_first());
+        assert!(!entries[0].hlinked());
+        assert!(!entries[0].hlink_first());
     }
 
     /// Verifies `normalize_pre30_hardlinks` handles multiple independent groups.
@@ -277,14 +277,14 @@ mod tests {
         // Group A: entries 0, 1
         let idx_a = entries[0].hardlink_idx().unwrap();
         assert_eq!(entries[1].hardlink_idx().unwrap(), idx_a);
-        assert!(entries[0].flags().hlink_first());
-        assert!(!entries[1].flags().hlink_first());
+        assert!(entries[0].hlink_first());
+        assert!(!entries[1].hlink_first());
 
         // Group B: entries 2, 3
         let idx_b = entries[2].hardlink_idx().unwrap();
         assert_eq!(entries[3].hardlink_idx().unwrap(), idx_b);
-        assert!(entries[2].flags().hlink_first());
-        assert!(!entries[3].flags().hlink_first());
+        assert!(entries[2].hlink_first());
+        assert!(!entries[3].hlink_first());
 
         // Different groups have different indices
         assert_ne!(idx_a, idx_b);
@@ -310,8 +310,8 @@ mod tests {
         assert!(entries[0].hardlink_idx().is_none());
         // Files are grouped
         assert_eq!(entries[1].hardlink_idx(), entries[2].hardlink_idx());
-        assert!(entries[1].flags().hlink_first());
-        assert!(!entries[2].flags().hlink_first());
+        assert!(entries[1].hlink_first());
+        assert!(!entries[2].hlink_first());
     }
 
     /// Verifies `normalize_pre30_hardlinks` skips entries without dev/ino.
@@ -342,12 +342,12 @@ mod tests {
         let mut entry_a = FileEntry::new_file("a/file.txt".into(), 300, 0o644);
         entry_a.set_hardlink_idx(5);
         // Sender marked this as follower (not first in readdir order)
-        entry_a.flags_mut().set_hlink_first(false);
+        entry_a.set_hlink_first(false);
 
         let mut entry_z = FileEntry::new_file("z/file.txt".into(), 300, 0o644);
         entry_z.set_hardlink_idx(5);
         // Sender marked this as leader (first in readdir order)
-        entry_z.flags_mut().set_hlink_first(true);
+        entry_z.set_hlink_first(true);
 
         let mut entries = vec![entry_a, entry_z];
         let mut prior_hlinks = HashMap::new();
@@ -355,11 +355,11 @@ mod tests {
 
         // After match_hard_links, sorted position 0 becomes the new leader
         assert!(
-            entries[0].flags().hlink_first(),
+            entries[0].hlink_first(),
             "first in sorted order must be leader"
         );
         assert!(
-            !entries[1].flags().hlink_first(),
+            !entries[1].hlink_first(),
             "second in sorted order must be follower"
         );
     }
@@ -385,7 +385,7 @@ mod tests {
 
         // Leader in segment 1 should be marked as leader
         assert!(
-            seg1[0].flags().hlink_first(),
+            seg1[0].hlink_first(),
             "first occurrence of gnum 42 must be leader"
         );
         // prior_hlinks should now contain gnum 42
@@ -401,7 +401,7 @@ mod tests {
         // Follower in segment 2 must NOT be promoted to leader - its leader is
         // in segment 1.
         assert!(
-            !seg2[0].flags().hlink_first(),
+            !seg2[0].hlink_first(),
             "cross-segment follower must not be promoted to leader"
         );
     }
@@ -423,9 +423,9 @@ mod tests {
         let mut seg1 = vec![a, b, c];
         match_hard_links(&mut seg1, &mut prior_hlinks);
 
-        assert!(seg1[0].flags().hlink_first(), "gnum 10 leader in seg1");
-        assert!(!seg1[1].flags().hlink_first(), "gnum 10 follower in seg1");
-        assert!(seg1[2].flags().hlink_first(), "gnum 20 leader in seg1");
+        assert!(seg1[0].hlink_first(), "gnum 10 leader in seg1");
+        assert!(!seg1[1].hlink_first(), "gnum 10 follower in seg1");
+        assert!(seg1[2].hlink_first(), "gnum 20 leader in seg1");
 
         // Segment 2: follower for gnum 10, follower for gnum 20, leader for gnum 30
         let mut d = FileEntry::new_file("b/link1.txt".into(), 100, 0o644);
@@ -439,13 +439,13 @@ mod tests {
         match_hard_links(&mut seg2, &mut prior_hlinks);
 
         assert!(
-            !seg2[0].flags().hlink_first(),
+            !seg2[0].hlink_first(),
             "gnum 10 cross-segment follower"
         );
         assert!(
-            !seg2[1].flags().hlink_first(),
+            !seg2[1].hlink_first(),
             "gnum 20 cross-segment follower"
         );
-        assert!(seg2[2].flags().hlink_first(), "gnum 30 new leader in seg2");
+        assert!(seg2[2].hlink_first(), "gnum 30 new leader in seg2");
     }
 }

--- a/crates/transfer/src/receiver/file_list/hardlinks.rs
+++ b/crates/transfer/src/receiver/file_list/hardlinks.rs
@@ -438,14 +438,8 @@ mod tests {
         let mut seg2 = vec![d, e, f];
         match_hard_links(&mut seg2, &mut prior_hlinks);
 
-        assert!(
-            !seg2[0].hlink_first(),
-            "gnum 10 cross-segment follower"
-        );
-        assert!(
-            !seg2[1].hlink_first(),
-            "gnum 20 cross-segment follower"
-        );
+        assert!(!seg2[0].hlink_first(), "gnum 10 cross-segment follower");
+        assert!(!seg2[1].hlink_first(), "gnum 20 cross-segment follower");
         assert!(seg2[2].hlink_first(), "gnum 30 new leader in seg2");
     }
 }

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -80,7 +80,7 @@ impl ReceiverContext {
             let &(_flat_start, ndx_start) =
                 self.ndx_segments.last().expect("initial segment exists");
             for (i, entry) in self.file_list.iter_mut().enumerate() {
-                if entry.flags().hlink_first() {
+                if entry.hlink_first() {
                     entry.set_hardlink_idx((ndx_start + i as i32) as u32);
                 }
             }
@@ -201,7 +201,7 @@ impl ReceiverContext {
             // assigned before sorting.
             if self.config.flags.hard_links {
                 for (i, entry) in self.file_list[flat_start..].iter_mut().enumerate() {
-                    if entry.flags().hlink_first() {
+                    if entry.hlink_first() {
                         entry.set_hardlink_idx((seg_ndx_start + i as i32) as u32);
                     }
                 }

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -30,7 +30,7 @@ use super::apply_acls_from_receiver_cache;
 /// - `generator.c:1539` - `F_HLINK_NOT_FIRST(file)` check
 /// - `hlink.c:284` - `hard_link_check()` called for non-first entries
 pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
-    entry.flags().hlinked() && !entry.flags().hlink_first()
+    entry.hlinked() && !entry.hlink_first()
 }
 
 /// Pure-function quick-check: compares destination stat against source entry.

--- a/crates/transfer/src/receiver/tests/support.rs
+++ b/crates/transfer/src/receiver/tests/support.rs
@@ -8,7 +8,7 @@ use std::io::{self, Write};
 
 use engine::delta::{DeltaScript, DeltaToken};
 use protocol::ProtocolVersion;
-use protocol::flist::{FileEntry, XMIT_HLINK_FIRST, XMIT_HLINKED};
+use protocol::flist::FileEntry;
 use protocol::wire::DeltaOp;
 
 use crate::config::ServerConfig;
@@ -147,7 +147,8 @@ pub(super) fn receiver_with_hardlinks(entries: Vec<FileEntry>) -> ReceiverContex
 /// Helper to create a hardlink leader entry with appropriate flags.
 pub(super) fn make_hlink_leader(name: &str, size: u64, gnum: u32) -> FileEntry {
     let mut entry = FileEntry::new_file(name.into(), size, 0o644);
-    entry.flags_mut().extended |= XMIT_HLINKED | XMIT_HLINK_FIRST;
+    entry.set_hlinked(true);
+    entry.set_hlink_first(true);
     entry.set_hardlink_idx(gnum);
     entry
 }
@@ -155,7 +156,7 @@ pub(super) fn make_hlink_leader(name: &str, size: u64, gnum: u32) -> FileEntry {
 /// Helper to create a hardlink follower entry with appropriate flags.
 pub(super) fn make_hlink_follower(name: &str, size: u64, gnum: u32) -> FileEntry {
     let mut entry = FileEntry::new_file(name.into(), size, 0o644);
-    entry.flags_mut().extended |= XMIT_HLINKED;
+    entry.set_hlinked(true);
     entry.set_hardlink_idx(gnum);
     entry
 }


### PR DESCRIPTION
## Summary

- **Eliminate `FileFlags` from per-entry storage.** Only 3 of 24 wire flag bits (`top_dir`, `hlinked`, `hlink_first`) persist past decoding. These are now packed into the existing `present: u8` bitfield (which had 5 unused bits), removing the 3-byte `FileFlags` struct from `FileEntry`.
- **Narrow `mode` from `u32` to `u16`.** POSIX mode values use only 16 bits (4-bit type mask + 12-bit permissions), matching upstream rsync's `uint16 mode` in `file_struct`. Accessors widen/truncate at the boundary.
- **Net savings: 8 bytes per entry (88 -> 80 bytes on Unix).** At 1M files this saves ~7.6 MB of heap RSS.

## Motivation

RSS-2 analysis (tasks #2787-2789, #3164) identified `FileEntry` as the largest per-entry allocation. Upstream rsync's `file_struct` uses `uint16 mode` and pool-allocated compact entries. This PR closes the most actionable gaps without changing the public API semantics.

`FileFlags` remains as a wire-encoding type in the protocol read/write paths - only the per-entry storage is eliminated.

## Changes

| Area | Change |
|------|--------|
| `protocol::flist::entry::core` | Remove `flags: FileFlags` field, narrow `mode: u32` to `mode: u16`, add 3 presence-bit constants |
| `protocol::flist::entry::accessors` | Replace `flags()`/`set_flags()`/`flags_mut()` with 6 dedicated accessors operating on `present` bitfield |
| `protocol::flist::entry::constructors` | Extract persisted flags from `FileFlags` into presence bits during construction |
| `protocol::flist::accessor` | Update `FileEntryAccessor` trait: replace `fn flags()` with `top_dir()`/`hlinked()`/`hlink_first()` |
| `protocol::flist::dual` | Reconstruct bitfield for flat header flags from individual getters |
| `protocol::flist::trace` | Reconstruct flags for tracing from individual getters |
| `protocol::flist::write::xflags` | Use `entry.top_dir()` directly |
| `transfer::generator` | All `.flags().hlinked()` -> `.hlinked()`, `.set_flags(...)` -> `.set_top_dir(true)` |
| `transfer::receiver` | All `.flags_mut().set_hlinked(...)` -> `.set_hlinked(...)`, same for hlink_first |
| `engine::local_copy::batch` | Use `entry.set_top_dir(true)` instead of raw flag manipulation |
| Tests | Updated size assertions (88->80 Unix, 96->88 Windows), regression bounds, flag round-trip test |

## Test plan

- [ ] CI nextest passes (struct size assertions verify 80-byte layout)
- [ ] Interop tests pass (wire format unchanged - FileFlags still used in encode/decode)
- [ ] Windows CI passes (mode narrowing tested on both platforms)
- [ ] Flag round-trip test verifies all 3 persisted flags through presence bitfield