### PR TITLE
perf: pre-size Vec<LocalCopyRecord> to eliminate growth copies

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -124,6 +124,14 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    /// Reserves additional capacity in the events buffer to avoid
+    /// growth-copy reallocations when the entry count is known ahead of time.
+    pub(super) fn reserve_event_capacity(&mut self, additional: usize) {
+        if let Some(events) = &mut self.events {
+            events.reserve(additional);
+        }
+    }
+
     /// Records that forward progress was made, resetting the timeout clock.
     pub(in crate::local_copy) fn register_progress(&mut self) {
         self.last_progress = Instant::now();

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -87,6 +87,7 @@ pub(crate) fn copy_directory_recursive(
     let list_start = Instant::now();
     let entries = read_directory_entries_sorted(source)?;
     context.record_file_list_generation(list_start.elapsed());
+    context.reserve_event_capacity(entries.len());
     context.register_progress();
 
     let dir_merge_guard = context.enter_directory(source)?;


### PR DESCRIPTION
## Summary

- Heap profiling identified `Vec<LocalCopyRecord>::push` as 23.6% of all allocations (46 MB at 100K files) due to amortized doubling without pre-sizing
- Added `CopyContext::reserve_event_capacity()` method that reserves capacity on the events buffer when the entry count is known
- Called from `copy_directory_recursive()` after `read_directory_entries_sorted()` returns, so each directory level pre-sizes for its entries before processing

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] Verify no behavioral change - the events Vec contents are identical, only allocation pattern changes
- [ ] Confirm with heap profiler that `Vec<LocalCopyRecord>::push` reallocation count drops proportionally to directory fan-out