### PR TITLE
fix: increase default daemon listen backlog from 5 to 128

### DIFF
--- a/crates/daemon/src/daemon/runtime_options/accessors.rs
+++ b/crates/daemon/src/daemon/runtime_options/accessors.rs
@@ -9,7 +9,8 @@ impl RuntimeOptions {
 
     /// Returns the configured TCP listen backlog.
     ///
-    /// Upstream: `daemon-parm.txt` - `listen_backlog` INTEGER, default 5.
+    /// Upstream: `daemon-parm.txt` - `listen_backlog` INTEGER (upstream default 5,
+    /// oc-rsync default 128 for better connection scaling).
     pub(crate) fn listen_backlog(&self) -> Option<u32> {
         self.listen_backlog
     }

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -134,10 +134,6 @@ fn serve_connections(
         bound_addresses = vec![local_addr];
         listeners = vec![listener];
     } else {
-        // upstream: daemon-parm.txt - listen_backlog INTEGER, default 5.
-        // Using socket2 to create the listener allows explicit control over the
-        // backlog argument passed to listen(2).
-        const DEFAULT_LISTEN_BACKLOG: i32 = 5;
         let backlog = listen_backlog.map_or(DEFAULT_LISTEN_BACKLOG, |v| v as i32);
 
         listeners = Vec::with_capacity(bind_addresses.len());

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -37,6 +37,16 @@ const fn normalize_peer_address(addr: SocketAddr) -> SocketAddr {
     }
 }
 
+/// Default TCP listen backlog when not overridden by `listen backlog` in the
+/// daemon configuration file.
+///
+/// Upstream rsync defaults to 5 (`daemon-parm.txt`), which is too low for
+/// production workloads - the kernel drops SYN packets once the backlog queue
+/// is full, creating a hard ceiling around 250 concurrent connections.
+/// A backlog of 128 matches `SOMAXCONN` on most Linux systems and is the
+/// standard default for production TCP servers.
+const DEFAULT_LISTEN_BACKLOG: i32 = 128;
+
 /// Interval between signal flag checks in the accept loop.
 ///
 /// The listener uses a non-blocking timeout so the loop can periodically

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -958,3 +958,12 @@ fn accept_loop_recovers_after_disconnect() {
     // must not write a refusal line to the socket.
     assert!(!refuse_if_at_capacity(&mut server_stream, peer, &state));
 }
+
+#[test]
+fn default_listen_backlog_is_128() {
+    // The default backlog must be high enough for production workloads.
+    // A value of 5 (upstream's historical default) causes connection drops
+    // under moderate concurrency. 128 matches SOMAXCONN on most Linux
+    // systems and is the standard default for production TCP servers.
+    assert_eq!(DEFAULT_LISTEN_BACKLOG, 128);
+}

--- a/crates/daemon/src/rsyncd_config/sections.rs
+++ b/crates/daemon/src/rsyncd_config/sections.rs
@@ -127,8 +127,9 @@ impl GlobalConfig {
 
     /// Returns the TCP listen backlog, if configured.
     ///
-    /// Upstream: `daemon-parm.txt` - `listen_backlog` INTEGER, default 5.
-    /// Controls the backlog argument passed to `listen(2)` on the daemon socket.
+    /// Upstream: `daemon-parm.txt` - `listen_backlog` INTEGER (upstream default 5,
+    /// oc-rsync default 128). Controls the backlog argument passed to `listen(2)`
+    /// on the daemon socket.
     pub fn listen_backlog(&self) -> Option<u32> {
         self.listen_backlog
     }


### PR DESCRIPTION
## Summary

- Increase `DEFAULT_LISTEN_BACKLOG` from 5 to 128 to prevent connection drops under moderate concurrency
- Move the constant to module scope for testability and add a regression test
- Update doc comments to reflect the new default while noting the upstream value

## Context

The daemon TCP listener backlog was set to 5 (matching upstream rsync's historical default). When the kernel's SYN backlog queue fills, new connections are silently dropped, creating a hard ceiling around 250 concurrent connections. A backlog of 128 matches `SOMAXCONN` on most Linux systems and is the standard default for production TCP servers.

The `listen backlog` config directive is unchanged - operators can still override the default in `rsyncd.conf`.

## Test plan

- [ ] New `default_listen_backlog_is_128` test verifies the constant value
- [ ] CI passes (fmt, clippy, nextest, all platform matrices)