### PR TITLE
perf: tune mimalloc arena reservation and purge delay for lower RSS

### DIFF
--- a/src/bin/oc-rsync.rs
+++ b/src/bin/oc-rsync.rs
@@ -12,7 +12,34 @@ mod support;
 
 use std::{env, io, process::ExitCode};
 
+/// Set mimalloc environment variable defaults before the allocator reads them.
+///
+/// Mimalloc's default 1 GiB virtual arena reservation and deferred purge cause
+/// ~16 MiB RSS overhead from committed-but-purged pages (RSS-2 profiling root
+/// cause #5). Reducing the arena to 128 MiB and setting immediate purge closes
+/// most of that gap while preserving allocation throughput.
+///
+/// Only sets defaults - user-supplied `MIMALLOC_*` env vars take precedence.
+///
+/// # Safety
+///
+/// Called at the start of `main()` before any threads are spawned, so the
+/// single-threaded precondition for `env::set_var` is satisfied.
+#[allow(unsafe_code)]
+fn configure_mimalloc_defaults() {
+    if env::var_os("MIMALLOC_ARENA_RESERVE").is_none() {
+        // Reduce from default 1 GiB to 128 MiB to cut virtual arena overhead.
+        unsafe { env::set_var("MIMALLOC_ARENA_RESERVE", "128m") };
+    }
+    if env::var_os("MIMALLOC_PURGE_DELAY").is_none() {
+        // Decommit freed pages immediately instead of deferring (default 10ms).
+        unsafe { env::set_var("MIMALLOC_PURGE_DELAY", "0") };
+    }
+}
+
 fn main() -> ExitCode {
+    configure_mimalloc_defaults();
+
     #[cfg(all(target_os = "windows", target_env = "gnu"))]
     windows_gnu_eh::force_link();
 


### PR DESCRIPTION
## Summary

- Reduce mimalloc's default virtual arena reservation from 1 GiB to 128 MiB via `MIMALLOC_ARENA_RESERVE` environment variable default
- Set purge delay to 0 (immediate decommit) via `MIMALLOC_PURGE_DELAY` to release committed-but-purged pages promptly
- RSS-2 profiling identified this as root cause #5 of the 9.8x RSS gap vs upstream, contributing ~16 MiB overhead from mimalloc's committed-but-purged pages (committed=75.8 MiB, purged=70 MiB)
- Defaults are set early in `main()` before any threads spawn; user-supplied `MIMALLOC_*` env vars take precedence

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] Verify with `MIMALLOC_VERBOSE=1` that arena reservation reflects 128 MiB
- [ ] Measure RSS on 1M-file corpus to confirm ~16 MiB reduction vs baseline
- [ ] Verify user override: `MIMALLOC_ARENA_RESERVE=1g oc-rsync ...` restores original behavior