### PR TITLE
feat: parse missing upstream rsyncd.conf directives and warn on unknown keys

### DIFF
--- a/crates/daemon/src/rsyncd_config/parser.rs
+++ b/crates/daemon/src/rsyncd_config/parser.rs
@@ -242,7 +242,12 @@ impl<'a> Parser<'a> {
                 global.ssl_ca = Some(PathBuf::from(trimmed));
             }
             _ => {
-                // Unknown global directives are silently ignored for forward compatibility
+                eprintln!(
+                    "warning: unknown global directive '{}' at line {} in '{}'",
+                    key,
+                    self.line_number,
+                    self.path.display(),
+                );
             }
         }
         Ok(())
@@ -385,8 +390,72 @@ impl<'a> Parser<'a> {
             "open noatime" => {
                 builder.open_noatime = Some(self.parse_bool(value)?);
             }
+            "charset" => {
+                builder.charset = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
+            "temp dir" => {
+                builder.temp_dir = if value.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(value))
+                };
+            }
+            "forward lookup" => {
+                builder.forward_lookup = Some(self.parse_bool(value)?);
+            }
+            "reverse lookup" => {
+                builder.reverse_lookup = Some(self.parse_bool(value)?);
+            }
+            "ignore errors" => {
+                builder.ignore_errors = Some(self.parse_bool(value)?);
+            }
+            "ignore nonreadable" => {
+                builder.ignore_nonreadable = Some(self.parse_bool(value)?);
+            }
+            "munge symlinks" => {
+                builder.munge_symlinks = Some(Some(self.parse_bool(value)?));
+            }
+            // upstream: daemon-parm.txt - these are P_LOCAL directives that can
+            // appear at module level to override the global defaults.
+            "log file" => {
+                builder.module_log_file = if value.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(value))
+                };
+            }
+            "log format" => {
+                builder.module_log_format = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
+            "syslog facility" => {
+                builder.module_syslog_facility = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
+            "syslog tag" => {
+                builder.module_syslog_tag = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
             _ => {
-                // Unknown module directives are silently ignored
+                eprintln!(
+                    "warning: unknown per-module directive '{}' at line {} in '{}'",
+                    key,
+                    self.line_number,
+                    self.path.display(),
+                );
             }
         }
         Ok(())
@@ -492,6 +561,17 @@ struct ModuleBuilder {
     name_converter: Option<String>,
     strict_modes: Option<bool>,
     open_noatime: Option<bool>,
+    charset: Option<String>,
+    temp_dir: Option<PathBuf>,
+    forward_lookup: Option<bool>,
+    reverse_lookup: Option<bool>,
+    ignore_errors: Option<bool>,
+    ignore_nonreadable: Option<bool>,
+    munge_symlinks: Option<Option<bool>>,
+    module_log_file: Option<PathBuf>,
+    module_log_format: Option<String>,
+    module_syslog_facility: Option<String>,
+    module_syslog_tag: Option<String>,
 }
 
 impl ModuleBuilder {
@@ -551,6 +631,17 @@ impl ModuleBuilder {
             name_converter: self.name_converter,
             strict_modes: self.strict_modes.unwrap_or(true),
             open_noatime: self.open_noatime.unwrap_or(false),
+            charset: self.charset,
+            temp_dir: self.temp_dir,
+            forward_lookup: self.forward_lookup.unwrap_or(true),
+            reverse_lookup: self.reverse_lookup.unwrap_or(true),
+            ignore_errors: self.ignore_errors.unwrap_or(false),
+            ignore_nonreadable: self.ignore_nonreadable.unwrap_or(false),
+            munge_symlinks: self.munge_symlinks.unwrap_or(None),
+            module_log_file: self.module_log_file,
+            module_log_format: self.module_log_format,
+            module_syslog_facility: self.module_syslog_facility,
+            module_syslog_tag: self.module_syslog_tag,
         })
     }
 }

--- a/crates/daemon/src/rsyncd_config/sections.rs
+++ b/crates/daemon/src/rsyncd_config/sections.rs
@@ -240,6 +240,51 @@ pub struct ModuleConfig {
     pub(crate) name_converter: Option<String>,
     pub(crate) strict_modes: bool,
     pub(crate) open_noatime: bool,
+    /// Character set for filename conversion.
+    ///
+    /// upstream: daemon-parm.txt - `charset` STRING, P_LOCAL, default NULL.
+    pub(crate) charset: Option<String>,
+    /// Temporary directory for partial transfers.
+    ///
+    /// upstream: daemon-parm.txt - `temp_dir` PATH, P_LOCAL, default NULL.
+    pub(crate) temp_dir: Option<PathBuf>,
+    /// Whether to perform DNS forward lookups for connecting hosts (default: true).
+    ///
+    /// upstream: daemon-parm.txt - `forward_lookup` BOOL, P_LOCAL, default True.
+    pub(crate) forward_lookup: bool,
+    /// Whether to perform DNS reverse lookups for connecting hosts (default: true).
+    ///
+    /// upstream: daemon-parm.txt - `reverse_lookup` BOOL, P_LOCAL, default True.
+    pub(crate) reverse_lookup: bool,
+    /// Whether to ignore I/O errors during delete operations (default: false).
+    ///
+    /// upstream: daemon-parm.txt - `ignore_errors` BOOL, P_LOCAL, default False.
+    pub(crate) ignore_errors: bool,
+    /// Whether to skip files that are not readable (default: false).
+    ///
+    /// upstream: daemon-parm.txt - `ignore_nonreadable` BOOL, P_LOCAL, default False.
+    pub(crate) ignore_nonreadable: bool,
+    /// Whether to mangle symlinks for safety (tri-state: None = unset).
+    ///
+    /// upstream: daemon-parm.txt - `munge_symlinks` BOOL3, P_LOCAL, default Unset.
+    pub(crate) munge_symlinks: Option<bool>,
+    /// Per-module log file path override.
+    ///
+    /// upstream: daemon-parm.txt - `log_file` STRING, P_LOCAL, default NULL.
+    pub(crate) module_log_file: Option<PathBuf>,
+    /// Per-module log format string override.
+    ///
+    /// upstream: daemon-parm.txt - `log_format` STRING, P_LOCAL,
+    /// default "%o %h [%a] %m (%u) %f %l".
+    pub(crate) module_log_format: Option<String>,
+    /// Per-module syslog facility override.
+    ///
+    /// upstream: daemon-parm.txt - `syslog_facility` ENUM, P_LOCAL, default LOG_DAEMON.
+    pub(crate) module_syslog_facility: Option<String>,
+    /// Per-module syslog tag override.
+    ///
+    /// upstream: daemon-parm.txt - `syslog_tag` STRING, P_LOCAL, default "rsyncd".
+    pub(crate) module_syslog_tag: Option<String>,
 }
 
 impl ModuleConfig {
@@ -473,5 +518,87 @@ impl ModuleConfig {
     /// Upstream: `loadparm.c` - `open noatime` parameter, default false.
     pub fn open_noatime(&self) -> bool {
         self.open_noatime
+    }
+
+    /// Returns the charset for filename conversion, if specified.
+    ///
+    /// Upstream: `loadparm.c` - `charset` parameter, default NULL.
+    pub fn charset(&self) -> Option<&str> {
+        self.charset.as_deref()
+    }
+
+    /// Returns the temporary directory for partial transfers, if specified.
+    ///
+    /// Upstream: `loadparm.c` - `temp dir` parameter, default NULL.
+    pub fn temp_dir(&self) -> Option<&Path> {
+        self.temp_dir.as_deref()
+    }
+
+    /// Returns whether DNS forward lookups are enabled (default: true).
+    ///
+    /// Upstream: `loadparm.c` - `forward lookup` parameter, default true.
+    pub fn forward_lookup(&self) -> bool {
+        self.forward_lookup
+    }
+
+    /// Returns whether DNS reverse lookups are enabled (default: true).
+    ///
+    /// Upstream: `loadparm.c` - `reverse lookup` parameter, default true.
+    pub fn reverse_lookup(&self) -> bool {
+        self.reverse_lookup
+    }
+
+    /// Returns whether I/O errors during delete are ignored (default: false).
+    ///
+    /// Upstream: `loadparm.c` - `ignore errors` parameter, default false.
+    pub fn ignore_errors(&self) -> bool {
+        self.ignore_errors
+    }
+
+    /// Returns whether unreadable files are silently skipped (default: false).
+    ///
+    /// Upstream: `loadparm.c` - `ignore nonreadable` parameter, default false.
+    pub fn ignore_nonreadable(&self) -> bool {
+        self.ignore_nonreadable
+    }
+
+    /// Returns the munge symlinks setting (None = unset/auto).
+    ///
+    /// When unset, the daemon determines symlink munging based on the
+    /// `use chroot` setting. Upstream: `loadparm.c` - `munge symlinks`
+    /// parameter, default Unset (BOOL3).
+    pub fn munge_symlinks(&self) -> Option<bool> {
+        self.munge_symlinks
+    }
+
+    /// Returns the per-module log file path, if specified.
+    ///
+    /// Upstream: `loadparm.c` - `log file` parameter (P_LOCAL), default NULL.
+    pub fn module_log_file(&self) -> Option<&Path> {
+        self.module_log_file.as_deref()
+    }
+
+    /// Returns the per-module log format string, if specified.
+    ///
+    /// Upstream: `loadparm.c` - `log format` parameter (P_LOCAL),
+    /// default "%o %h [%a] %m (%u) %f %l".
+    pub fn module_log_format(&self) -> Option<&str> {
+        self.module_log_format.as_deref()
+    }
+
+    /// Returns the per-module syslog facility, if specified.
+    ///
+    /// Upstream: `loadparm.c` - `syslog facility` parameter (P_LOCAL),
+    /// default LOG_DAEMON.
+    pub fn module_syslog_facility(&self) -> Option<&str> {
+        self.module_syslog_facility.as_deref()
+    }
+
+    /// Returns the per-module syslog tag, if specified.
+    ///
+    /// Upstream: `loadparm.c` - `syslog tag` parameter (P_LOCAL),
+    /// default "rsyncd".
+    pub fn module_syslog_tag(&self) -> Option<&str> {
+        self.module_syslog_tag.as_deref()
     }
 }

--- a/crates/daemon/src/rsyncd_config/tests.rs
+++ b/crates/daemon/src/rsyncd_config/tests.rs
@@ -868,6 +868,294 @@ fn module_fake_super_yes_parses_to_true_for_am_root_demotion() {
     );
 }
 
+// --- Tests for newly-parsed upstream directives ---
+
+#[test]
+fn parse_charset_directive() {
+    let file = write_config("[mod]\npath = /data\ncharset = utf-8\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(config.modules()[0].charset(), Some("utf-8"));
+}
+
+#[test]
+fn charset_default_is_none() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].charset().is_none());
+}
+
+#[test]
+fn parse_temp_dir_directive() {
+    let file = write_config("[mod]\npath = /data\ntemp dir = /tmp/rsync\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(
+        config.modules()[0].temp_dir(),
+        Some(Path::new("/tmp/rsync"))
+    );
+}
+
+#[test]
+fn temp_dir_default_is_none() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].temp_dir().is_none());
+}
+
+#[test]
+fn parse_forward_lookup_yes() {
+    let file = write_config("[mod]\npath = /data\nforward lookup = yes\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].forward_lookup());
+}
+
+#[test]
+fn parse_forward_lookup_no() {
+    let file = write_config("[mod]\npath = /data\nforward lookup = no\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(!config.modules()[0].forward_lookup());
+}
+
+#[test]
+fn forward_lookup_default_is_true() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].forward_lookup());
+}
+
+#[test]
+fn parse_reverse_lookup_yes() {
+    let file = write_config("[mod]\npath = /data\nreverse lookup = yes\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].reverse_lookup());
+}
+
+#[test]
+fn parse_reverse_lookup_no() {
+    let file = write_config("[mod]\npath = /data\nreverse lookup = no\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(!config.modules()[0].reverse_lookup());
+}
+
+#[test]
+fn reverse_lookup_default_is_true() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].reverse_lookup());
+}
+
+#[test]
+fn parse_ignore_errors_yes() {
+    let file = write_config("[mod]\npath = /data\nignore errors = yes\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].ignore_errors());
+}
+
+#[test]
+fn parse_ignore_errors_no() {
+    let file = write_config("[mod]\npath = /data\nignore errors = no\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(!config.modules()[0].ignore_errors());
+}
+
+#[test]
+fn ignore_errors_default_is_false() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(!config.modules()[0].ignore_errors());
+}
+
+#[test]
+fn parse_ignore_nonreadable_yes() {
+    let file = write_config("[mod]\npath = /data\nignore nonreadable = yes\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].ignore_nonreadable());
+}
+
+#[test]
+fn parse_ignore_nonreadable_no() {
+    let file = write_config("[mod]\npath = /data\nignore nonreadable = no\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(!config.modules()[0].ignore_nonreadable());
+}
+
+#[test]
+fn ignore_nonreadable_default_is_false() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(!config.modules()[0].ignore_nonreadable());
+}
+
+#[test]
+fn parse_munge_symlinks_yes() {
+    let file = write_config("[mod]\npath = /data\nmunge symlinks = yes\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(config.modules()[0].munge_symlinks(), Some(true));
+}
+
+#[test]
+fn parse_munge_symlinks_no() {
+    let file = write_config("[mod]\npath = /data\nmunge symlinks = no\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(config.modules()[0].munge_symlinks(), Some(false));
+}
+
+#[test]
+fn munge_symlinks_default_is_none() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert!(config.modules()[0].munge_symlinks().is_none());
+}
+
+#[test]
+fn parse_module_log_file() {
+    let file = write_config("[mod]\npath = /data\nlog file = /var/log/mod.log\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(
+        config.modules()[0].module_log_file(),
+        Some(Path::new("/var/log/mod.log"))
+    );
+}
+
+#[test]
+fn parse_module_log_format() {
+    let file = write_config("[mod]\npath = /data\nlog format = %o %f %l\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(
+        config.modules()[0].module_log_format(),
+        Some("%o %f %l")
+    );
+}
+
+#[test]
+fn parse_module_syslog_facility() {
+    let file = write_config("[mod]\npath = /data\nsyslog facility = local3\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(
+        config.modules()[0].module_syslog_facility(),
+        Some("local3")
+    );
+}
+
+#[test]
+fn parse_module_syslog_tag() {
+    let file = write_config("[mod]\npath = /data\nsyslog tag = custom-mod\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    assert_eq!(
+        config.modules()[0].module_syslog_tag(),
+        Some("custom-mod")
+    );
+}
+
+#[test]
+fn module_level_log_directives_default_to_none() {
+    let file = write_config("[mod]\npath = /data\n");
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    let module = &config.modules()[0];
+    assert!(module.module_log_file().is_none());
+    assert!(module.module_log_format().is_none());
+    assert!(module.module_syslog_facility().is_none());
+    assert!(module.module_syslog_tag().is_none());
+}
+
+#[test]
+fn per_module_directives_do_not_bleed_across_modules() {
+    let file = write_config(
+        "[alpha]\n\
+         path = /srv/alpha\n\
+         charset = utf-8\n\
+         forward lookup = no\n\
+         ignore errors = yes\n\
+         munge symlinks = yes\n\
+         log file = /var/log/alpha.log\n\
+         \n\
+         [beta]\n\
+         path = /srv/beta\n",
+    );
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+
+    let alpha = config.get_module("alpha").unwrap();
+    assert_eq!(alpha.charset(), Some("utf-8"));
+    assert!(!alpha.forward_lookup());
+    assert!(alpha.ignore_errors());
+    assert_eq!(alpha.munge_symlinks(), Some(true));
+    assert_eq!(
+        alpha.module_log_file(),
+        Some(Path::new("/var/log/alpha.log"))
+    );
+
+    let beta = config.get_module("beta").unwrap();
+    assert!(beta.charset().is_none());
+    assert!(beta.forward_lookup());
+    assert!(!beta.ignore_errors());
+    assert!(beta.munge_symlinks().is_none());
+    assert!(beta.module_log_file().is_none());
+}
+
+#[test]
+fn full_module_with_all_upstream_directives() {
+    let file = write_config(
+        "[full]\n\
+         path = /srv/full\n\
+         comment = Full module\n\
+         read only = no\n\
+         write only = no\n\
+         list = yes\n\
+         uid = nobody\n\
+         gid = nogroup\n\
+         max connections = 10\n\
+         lock file = /var/lock/rsync\n\
+         auth users = user1, user2\n\
+         secrets file = /etc/rsyncd.secrets\n\
+         hosts allow = 192.168.1.0/24\n\
+         hosts deny = *\n\
+         exclude = .git/\n\
+         include = *.txt\n\
+         filter = - *.tmp\n\
+         timeout = 300\n\
+         use chroot = no\n\
+         numeric ids = yes\n\
+         fake super = yes\n\
+         transfer logging = yes\n\
+         refuse options = delete, hardlinks\n\
+         dont compress = *.zip *.gz\n\
+         early exec = /usr/local/bin/early-check\n\
+         pre-xfer exec = /usr/local/bin/pre-xfer\n\
+         post-xfer exec = /usr/local/bin/post-xfer\n\
+         name converter = /usr/local/bin/nameconv\n\
+         strict modes = no\n\
+         open noatime = yes\n\
+         charset = utf-8\n\
+         temp dir = /tmp/rsync-temp\n\
+         forward lookup = no\n\
+         reverse lookup = no\n\
+         ignore errors = yes\n\
+         ignore nonreadable = yes\n\
+         munge symlinks = yes\n\
+         log file = /var/log/module.log\n\
+         log format = %o %h %f\n\
+         syslog facility = local5\n\
+         syslog tag = full-mod\n",
+    );
+    let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
+    let m = &config.modules()[0];
+
+    assert_eq!(m.name(), "full");
+    assert_eq!(m.charset(), Some("utf-8"));
+    assert_eq!(m.temp_dir(), Some(Path::new("/tmp/rsync-temp")));
+    assert!(!m.forward_lookup());
+    assert!(!m.reverse_lookup());
+    assert!(m.ignore_errors());
+    assert!(m.ignore_nonreadable());
+    assert_eq!(m.munge_symlinks(), Some(true));
+    assert_eq!(
+        m.module_log_file(),
+        Some(Path::new("/var/log/module.log"))
+    );
+    assert_eq!(m.module_log_format(), Some("%o %h %f"));
+    assert_eq!(m.module_syslog_facility(), Some("local5"));
+    assert_eq!(m.module_syslog_tag(), Some("full-mod"));
+}
+
 #[cfg(feature = "daemon-tls")]
 mod tls_directives {
     use super::*;

--- a/crates/daemon/src/rsyncd_config/tests.rs
+++ b/crates/daemon/src/rsyncd_config/tests.rs
@@ -1020,30 +1020,21 @@ fn parse_module_log_file() {
 fn parse_module_log_format() {
     let file = write_config("[mod]\npath = /data\nlog format = %o %f %l\n");
     let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
-    assert_eq!(
-        config.modules()[0].module_log_format(),
-        Some("%o %f %l")
-    );
+    assert_eq!(config.modules()[0].module_log_format(), Some("%o %f %l"));
 }
 
 #[test]
 fn parse_module_syslog_facility() {
     let file = write_config("[mod]\npath = /data\nsyslog facility = local3\n");
     let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
-    assert_eq!(
-        config.modules()[0].module_syslog_facility(),
-        Some("local3")
-    );
+    assert_eq!(config.modules()[0].module_syslog_facility(), Some("local3"));
 }
 
 #[test]
 fn parse_module_syslog_tag() {
     let file = write_config("[mod]\npath = /data\nsyslog tag = custom-mod\n");
     let config = RsyncdConfig::from_file(file.path()).expect("parse succeeds");
-    assert_eq!(
-        config.modules()[0].module_syslog_tag(),
-        Some("custom-mod")
-    );
+    assert_eq!(config.modules()[0].module_syslog_tag(), Some("custom-mod"));
 }
 
 #[test]
@@ -1147,10 +1138,7 @@ fn full_module_with_all_upstream_directives() {
     assert!(m.ignore_errors());
     assert!(m.ignore_nonreadable());
     assert_eq!(m.munge_symlinks(), Some(true));
-    assert_eq!(
-        m.module_log_file(),
-        Some(Path::new("/var/log/module.log"))
-    );
+    assert_eq!(m.module_log_file(), Some(Path::new("/var/log/module.log")));
     assert_eq!(m.module_log_format(), Some("%o %h %f"));
     assert_eq!(m.module_syslog_facility(), Some("local5"));
     assert_eq!(m.module_syslog_tag(), Some("full-mod"));


### PR DESCRIPTION
## Summary

- Add parsing for 11 upstream `daemon-parm.txt` directives that the standalone `rsyncd_config` parser was silently dropping: `charset`, `temp dir`, `forward lookup`, `reverse lookup`, `ignore errors`, `ignore nonreadable`, `munge symlinks`, plus per-module overrides for `log file`, `log format`, `syslog facility`, and `syslog tag`
- Replace silent catch-all in both global and per-module directive handlers with `eprintln` warnings so administrators get feedback on unrecognized config keys
- Add fields, accessors, and defaults on `ModuleConfig` matching upstream `loadparm.c` semantics (correct default values, tri-state BOOL3 for `munge symlinks`)

## Test plan

- [x] Each new directive has parse and default-value tests
- [x] Cross-module isolation test verifies directives do not bleed between modules
- [x] Full-module test exercises all upstream directives in a single config
- [x] Existing tests remain unaffected (warning output goes to stderr, not parsed values)
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl