### PR TITLE
perf: eliminate redundant stat calls in metadata no-change path

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -257,12 +257,44 @@ pub fn metadata_unchanged(
         }
     }
 
-    // chmod modifiers need the full apply path regardless of stat match
+    // upstream: generator.c:495-502 - chmod modifiers applied on top of the
+    // entry's mode. Evaluate the modifier against the current stat and only
+    // fall through to the full apply path when the result would differ.
+    #[cfg(unix)]
+    if let Some(chmod) = options.chmod() {
+        use std::os::unix::fs::MetadataExt;
+        // Start with the entry's mode when -p is active, else the current mode
+        let base_mode = if options.permissions() {
+            entry.permissions()
+        } else {
+            cached_meta.mode()
+        };
+        let new_mode = chmod.apply(base_mode, cached_meta.file_type());
+        if (cached_meta.mode() & 0o7777) != (new_mode & 0o7777) {
+            return false;
+        }
+    }
+    #[cfg(not(unix))]
     if options.chmod().is_some() {
         return false;
     }
 
-    // Owner/group overrides need the full apply path
+    // Owner/group overrides: compare override values against cached stat.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Some(uid) = options.owner_override() {
+            if cached_meta.uid() != uid {
+                return false;
+            }
+        }
+        if let Some(gid) = options.group_override() {
+            if cached_meta.gid() != gid {
+                return false;
+            }
+        }
+    }
+    #[cfg(not(unix))]
     if options.owner_override().is_some() || options.group_override().is_some() {
         return false;
     }

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -402,6 +402,10 @@ pub(super) fn apply_permissions_from_entry(
             return Ok(());
         }
 
+        // Track whether the -p path actually changed permissions so the
+        // --chmod branch below knows if cached_meta is still valid.
+        let mut perms_changed = false;
+
         if options.permissions() {
             let mode = entry.permissions();
             // upstream: rsync.c:set_file_attrs() - skips chmod when mode already matches
@@ -415,13 +419,17 @@ pub(super) fn apply_permissions_from_entry(
                 fs::set_permissions(destination, permissions).map_err(|error| {
                     MetadataError::new("preserve permissions", destination, error)
                 })?;
+                perms_changed = true;
             }
         }
 
         if let Some(chmod) = options.chmod() {
-            // upstream: rsync.c:set_file_attrs() - read current mode before applying chmod modifiers
+            // upstream: rsync.c:set_file_attrs() - read current mode before
+            // applying chmod modifiers. When -p changed permissions above we
+            // must re-stat; when -p matched (no change) we reuse cached_meta
+            // to avoid a redundant stat syscall on the no-change path.
             let fresh_meta;
-            let current_meta = if options.permissions() {
+            let current_meta = if options.permissions() && perms_changed {
                 fresh_meta = fs::metadata(destination)
                     .map_err(|error| MetadataError::new("read permissions", destination, error))?;
                 &fresh_meta

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1256,23 +1256,146 @@ fn metadata_unchanged_ignores_perms_when_not_preserved() {
     );
 }
 
+#[cfg(unix)]
 #[test]
-fn metadata_unchanged_returns_false_when_chmod_active() {
+fn metadata_unchanged_returns_false_when_chmod_would_change_mode() {
     use protocol::flist::FileEntry;
 
     let temp = tempdir().expect("tempdir");
-    let dest = temp.path().join("chmod-active.txt");
+    let dest = temp.path().join("chmod-changes.txt");
     fs::write(&dest, b"data").expect("write dest");
 
     let meta = fs::metadata(&dest).expect("metadata");
 
-    let entry = FileEntry::new_file("chmod-active.txt".into(), 4, 0o644);
+    let entry = FileEntry::new_file("chmod-changes.txt".into(), 4, 0o644);
 
+    // u+x would change 0o644 to 0o744
     let chmod = crate::ChmodModifiers::parse("u+x").expect("parse chmod");
     let opts = MetadataOptions::new().with_chmod(Some(chmod));
 
     assert!(
         !metadata_unchanged(&entry, &opts, &meta),
-        "should return false when chmod modifiers are active"
+        "should return false when chmod would change mode"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_true_when_chmod_is_noop() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("chmod-noop.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o755)).expect("set perms");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let mut entry = FileEntry::new_file("chmod-noop.txt".into(), 4, meta.mode() & 0o7777);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    // u+x on a file that already has u+x is a no-op
+    let chmod = crate::ChmodModifiers::parse("u+x").expect("parse chmod");
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .preserve_owner(true)
+        .preserve_group(true)
+        .with_chmod(Some(chmod));
+
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta),
+        "should return true when chmod modifier does not change mode"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_true_when_owner_override_matches() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("owner-match.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let mut entry = FileEntry::new_file("owner-match.txt".into(), 4, meta.mode() & 0o7777);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    // Set owner override to current UID - no actual change needed
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .with_owner_override(Some(meta.uid()));
+
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta),
+        "should return true when owner override matches current uid"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_false_when_owner_override_differs() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("owner-differ.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let mut entry = FileEntry::new_file("owner-differ.txt".into(), 4, meta.mode() & 0o7777);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    // Set owner override to a different UID
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .with_owner_override(Some(meta.uid() + 1));
+
+    assert!(
+        !metadata_unchanged(&entry, &opts, &meta),
+        "should return false when owner override differs from current uid"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_returns_true_when_group_override_matches() {
+    use protocol::flist::FileEntry;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("group-match.txt");
+    fs::write(&dest, b"data").expect("write dest");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+    let mtime = FileTime::from_last_modification_time(&meta);
+
+    let mut entry = FileEntry::new_file("group-match.txt".into(), 4, meta.mode() & 0o7777);
+    entry.set_mtime(mtime.unix_seconds(), mtime.nanoseconds());
+    entry.set_uid(meta.uid());
+    entry.set_gid(meta.gid());
+
+    // Set group override to current GID - no actual change needed
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .with_group_override(Some(meta.gid()));
+
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta),
+        "should return true when group override matches current gid"
     );
 }


### PR DESCRIPTION
## Summary

- Evaluate `--chmod` modifiers against the cached stat in `metadata_unchanged()` instead of unconditionally returning `false` and falling through to the full `apply_metadata_with_cached_stat()` path. On a no-change scan with `--chmod u+x` where files already have the execute bit, this eliminates one stat + three syscalls (chown/chmod/utimensat) per file.
- Evaluate `--chown`/`--chgrp` overrides against the cached stat in `metadata_unchanged()` instead of unconditionally returning `false`. Same syscall savings when the override already matches.
- Skip the redundant `fs::metadata()` re-stat in `apply_permissions_from_entry()` when `-p` is active with `--chmod` but the `-p` step did not actually change permissions (the common no-change case).

### Upstream reference

Mirrors `generator.c:461-502 unchanged_attrs()` which evaluates all attribute comparisons in-memory before deciding whether to call `set_file_attrs()`.

## Test plan

- [x] New test: `metadata_unchanged_returns_false_when_chmod_would_change_mode` - chmod that would alter mode returns false
- [x] New test: `metadata_unchanged_returns_true_when_chmod_is_noop` - chmod no-op returns true
- [x] New test: `metadata_unchanged_returns_true_when_owner_override_matches` - uid match returns true
- [x] New test: `metadata_unchanged_returns_false_when_owner_override_differs` - uid mismatch returns false
- [x] New test: `metadata_unchanged_returns_true_when_group_override_matches` - gid match returns true
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl