### PR TITLE
feat: wire adaptive compression level strategy into transfer pipeline

### DIFF
--- a/crates/compress/src/strategy/adaptive_level.rs
+++ b/crates/compress/src/strategy/adaptive_level.rs
@@ -219,6 +219,129 @@ impl AdaptiveLevelStrategy for DefaultAdaptiveLevelStrategy {
     }
 }
 
+/// Per-file compression level controller that bridges the gap between
+/// [`AdaptiveLevelStrategy`] and the encoder pipeline.
+///
+/// The controller tracks input and output byte counts for each file. When
+/// a file finishes (`record_file_complete`), it computes the compression
+/// ratio and feeds it to the underlying strategy, which updates its
+/// recommendation for the next file. Since zlib/zstd encoders do not
+/// support changing the level mid-stream, level adaptation happens at file
+/// boundaries.
+///
+/// # Usage
+///
+/// ```
+/// use compress::strategy::adaptive_level::{AdaptiveLevelController, AdaptiveLevelConfig};
+///
+/// let mut ctrl = AdaptiveLevelController::for_zlib(6);
+///
+/// // File 1: highly compressible
+/// ctrl.record_input_bytes(1000);
+/// ctrl.record_output_bytes(200);
+/// ctrl.record_file_complete();
+/// assert!(ctrl.current_level() >= 6); // level should stay or increase
+///
+/// // File 2: incompressible
+/// ctrl.record_input_bytes(1000);
+/// ctrl.record_output_bytes(990);
+/// ctrl.record_file_complete();
+/// // After enough incompressible observations, level decreases
+/// ```
+#[derive(Clone, Debug)]
+pub struct AdaptiveLevelController {
+    strategy: DefaultAdaptiveLevelStrategy,
+    current_level: i32,
+    file_input_bytes: u64,
+    file_output_bytes: u64,
+}
+
+impl AdaptiveLevelController {
+    /// Creates a controller for zlib (level bounds 1..=9).
+    #[must_use]
+    pub fn for_zlib(initial_level: i32) -> Self {
+        let strategy = DefaultAdaptiveLevelStrategy::for_zlib();
+        let clamped = strategy.config().bounds.clamp(initial_level);
+        Self {
+            strategy,
+            current_level: clamped,
+            file_input_bytes: 0,
+            file_output_bytes: 0,
+        }
+    }
+
+    /// Creates a controller for zstd (level bounds 1..=19).
+    #[must_use]
+    pub fn for_zstd(initial_level: i32) -> Self {
+        let strategy = DefaultAdaptiveLevelStrategy::for_zstd();
+        let clamped = strategy.config().bounds.clamp(initial_level);
+        Self {
+            strategy,
+            current_level: clamped,
+            file_input_bytes: 0,
+            file_output_bytes: 0,
+        }
+    }
+
+    /// Creates a controller with custom configuration.
+    #[must_use]
+    pub fn with_config(config: AdaptiveLevelConfig, initial_level: i32) -> Self {
+        let strategy = DefaultAdaptiveLevelStrategy::new(config);
+        let clamped = config.bounds.clamp(initial_level);
+        Self {
+            strategy,
+            current_level: clamped,
+            file_input_bytes: 0,
+            file_output_bytes: 0,
+        }
+    }
+
+    /// Returns the current recommended compression level.
+    #[must_use]
+    pub const fn current_level(&self) -> i32 {
+        self.current_level
+    }
+
+    /// Accumulates input (uncompressed) bytes for the current file.
+    pub fn record_input_bytes(&mut self, bytes: u64) {
+        self.file_input_bytes = self.file_input_bytes.saturating_add(bytes);
+    }
+
+    /// Accumulates output (compressed) bytes for the current file.
+    pub fn record_output_bytes(&mut self, bytes: u64) {
+        self.file_output_bytes = self.file_output_bytes.saturating_add(bytes);
+    }
+
+    /// Signals that the current file has finished compressing.
+    ///
+    /// Computes the compression ratio from accumulated byte counts, feeds
+    /// the observation to the underlying strategy, and resets the per-file
+    /// counters. The updated level is available via [`current_level`](Self::current_level).
+    pub fn record_file_complete(&mut self) {
+        if self.file_input_bytes > 0 {
+            let ratio = self.file_output_bytes as f64 / self.file_input_bytes as f64;
+            self.current_level = self.strategy.recommend_level(ratio, self.current_level);
+        }
+        self.file_input_bytes = 0;
+        self.file_output_bytes = 0;
+    }
+
+    /// Resets the controller to its initial state, clearing both the
+    /// per-file counters and the strategy's EWMA history.
+    pub fn reset(&mut self) {
+        self.strategy.reset();
+        self.file_input_bytes = 0;
+        self.file_output_bytes = 0;
+    }
+
+    /// Returns the most recently smoothed compression ratio, if any files
+    /// have completed.
+    #[must_use]
+    pub const fn smoothed_ratio(&self) -> Option<f64> {
+        self.strategy.smoothed_ratio()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +462,135 @@ mod tests {
         let _ = s.recommend_level(0.3, 4);
         let _ = s.recommend_level(0.4, 4);
         assert!(s.smoothed_ratio().unwrap().is_finite());
+    }
+
+    // --- AdaptiveLevelController tests ---
+
+    #[test]
+    fn controller_initial_level_clamped_to_bounds() {
+        let ctrl = AdaptiveLevelController::for_zlib(100);
+        assert_eq!(ctrl.current_level(), 9);
+        let ctrl = AdaptiveLevelController::for_zlib(-5);
+        assert_eq!(ctrl.current_level(), 1);
+    }
+
+    #[test]
+    fn controller_compressible_files_increase_level() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(3);
+        // Simulate many highly compressible files (ratio ~0.2).
+        for _ in 0..20 {
+            ctrl.record_input_bytes(10_000);
+            ctrl.record_output_bytes(2_000);
+            ctrl.record_file_complete();
+        }
+        assert_eq!(ctrl.current_level(), 9, "level should reach max for highly compressible data");
+    }
+
+    #[test]
+    fn controller_incompressible_files_decrease_level() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(6);
+        // Simulate many incompressible files (ratio ~0.99).
+        for _ in 0..20 {
+            ctrl.record_input_bytes(10_000);
+            ctrl.record_output_bytes(9_900);
+            ctrl.record_file_complete();
+        }
+        assert_eq!(ctrl.current_level(), 1, "level should reach min for incompressible data");
+    }
+
+    #[test]
+    fn controller_neutral_ratio_holds_level() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(5);
+        // Ratio 0.7 sits between good (0.5) and poor (0.95) thresholds.
+        ctrl.record_input_bytes(1_000);
+        ctrl.record_output_bytes(700);
+        ctrl.record_file_complete();
+        assert_eq!(ctrl.current_level(), 5);
+    }
+
+    #[test]
+    fn controller_zero_input_bytes_does_not_update() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(5);
+        // Empty file should not affect the level.
+        ctrl.record_file_complete();
+        assert_eq!(ctrl.current_level(), 5);
+        assert!(ctrl.smoothed_ratio().is_none());
+    }
+
+    #[test]
+    fn controller_reset_clears_state() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(5);
+        ctrl.record_input_bytes(1_000);
+        ctrl.record_output_bytes(200);
+        ctrl.record_file_complete();
+        assert!(ctrl.smoothed_ratio().is_some());
+        ctrl.reset();
+        assert!(ctrl.smoothed_ratio().is_none());
+    }
+
+    #[test]
+    fn controller_zstd_uses_wider_bounds() {
+        let mut ctrl = AdaptiveLevelController::for_zstd(5);
+        for _ in 0..50 {
+            ctrl.record_input_bytes(10_000);
+            ctrl.record_output_bytes(500);
+            ctrl.record_file_complete();
+        }
+        assert_eq!(ctrl.current_level(), 19, "zstd controller should reach 19");
+    }
+
+    #[test]
+    fn controller_custom_config() {
+        let config = AdaptiveLevelConfig {
+            smoothing_alpha: 1.0, // Instant reaction
+            poor_ratio_threshold: 0.8,
+            good_ratio_threshold: 0.3,
+            bounds: LevelBounds::new(2, 7),
+        };
+        let mut ctrl = AdaptiveLevelController::with_config(config, 5);
+        // Poor ratio immediately drops with alpha=1.0
+        ctrl.record_input_bytes(1_000);
+        ctrl.record_output_bytes(900); // 0.9 > 0.8 threshold
+        ctrl.record_file_complete();
+        assert_eq!(ctrl.current_level(), 4);
+    }
+
+    #[test]
+    fn controller_adapts_across_mixed_workload() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(6);
+        // Start with compressible files - level should rise.
+        for _ in 0..10 {
+            ctrl.record_input_bytes(10_000);
+            ctrl.record_output_bytes(2_000);
+            ctrl.record_file_complete();
+        }
+        let after_compressible = ctrl.current_level();
+        assert!(after_compressible > 6);
+        // Switch to incompressible files - level should drop.
+        for _ in 0..30 {
+            ctrl.record_input_bytes(10_000);
+            ctrl.record_output_bytes(9_900);
+            ctrl.record_file_complete();
+        }
+        let after_incompressible = ctrl.current_level();
+        assert!(
+            after_incompressible < after_compressible,
+            "level should decrease after switching to incompressible data: {} vs {}",
+            after_incompressible,
+            after_compressible,
+        );
+    }
+
+    #[test]
+    fn controller_accumulates_bytes_across_chunks() {
+        let mut ctrl = AdaptiveLevelController::for_zlib(5);
+        // Multiple small chunks for one file.
+        ctrl.record_input_bytes(500);
+        ctrl.record_input_bytes(500);
+        ctrl.record_output_bytes(100);
+        ctrl.record_output_bytes(100);
+        ctrl.record_file_complete();
+        // Ratio = 200/1000 = 0.2, below good_ratio_threshold(0.5) - should increase
+        assert!(ctrl.current_level() > 5);
     }
 }

--- a/crates/compress/src/strategy/adaptive_level.rs
+++ b/crates/compress/src/strategy/adaptive_level.rs
@@ -583,9 +583,7 @@ mod tests {
         let after_incompressible = ctrl.current_level();
         assert!(
             after_incompressible < after_compressible,
-            "level should decrease after switching to incompressible data: {} vs {}",
-            after_incompressible,
-            after_compressible,
+            "level should decrease after switching to incompressible data: {after_incompressible} vs {after_compressible}",
         );
     }
 

--- a/crates/compress/src/strategy/adaptive_level.rs
+++ b/crates/compress/src/strategy/adaptive_level.rs
@@ -483,7 +483,11 @@ mod tests {
             ctrl.record_output_bytes(2_000);
             ctrl.record_file_complete();
         }
-        assert_eq!(ctrl.current_level(), 9, "level should reach max for highly compressible data");
+        assert_eq!(
+            ctrl.current_level(),
+            9,
+            "level should reach max for highly compressible data"
+        );
     }
 
     #[test]
@@ -495,7 +499,11 @@ mod tests {
             ctrl.record_output_bytes(9_900);
             ctrl.record_file_complete();
         }
-        assert_eq!(ctrl.current_level(), 1, "level should reach min for incompressible data");
+        assert_eq!(
+            ctrl.current_level(),
+            1,
+            "level should reach min for incompressible data"
+        );
     }
 
     #[test]

--- a/crates/compress/src/strategy/mod.rs
+++ b/crates/compress/src/strategy/mod.rs
@@ -77,7 +77,8 @@ mod traits;
 mod tests;
 
 pub use adaptive_level::{
-    AdaptiveLevelConfig, AdaptiveLevelStrategy, DefaultAdaptiveLevelStrategy, LevelBounds,
+    AdaptiveLevelConfig, AdaptiveLevelController, AdaptiveLevelStrategy,
+    DefaultAdaptiveLevelStrategy, LevelBounds,
 };
 #[cfg(feature = "lz4")]
 pub use impls::Lz4Strategy;

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -43,6 +43,7 @@ use ::metadata::{MetadataOptions, apply_file_metadata_with_options};
 use bandwidth::{BandwidthLimitComponents, BandwidthLimiter};
 use checksums::RollingChecksum;
 use compress::algorithm::CompressionAlgorithm;
+use compress::strategy::adaptive_level::AdaptiveLevelController;
 use compress::zlib::CompressionLevel;
 use filters::FilterRule;
 use logging::info_log;
@@ -159,6 +160,9 @@ pub(crate) struct CopyContext<'a> {
     /// allocation for the intermediate `(OsString, PathBuf)` collection per
     /// directory during recursive traversal.
     readdir_buf: Vec<(OsString, PathBuf)>,
+    /// Adaptive compression level controller that adjusts compression level
+    /// between files based on observed compression ratios.
+    adaptive_level: Option<AdaptiveLevelController>,
 }
 
 /// Path and type context for metadata finalization.

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -230,6 +230,7 @@ impl<'a> CopyContext<'a> {
             })?;
             let delta = compressed_total.saturating_sub(compressed_progress);
             self.register_limiter_bytes(delta);
+            self.record_adaptive_compression(literal_bytes, compressed_total);
             FileCopyOutcome::new(literal_bytes, Some(compressed_total))
         } else {
             FileCopyOutcome::new(literal_bytes, None)

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -88,10 +88,6 @@ impl<'a> CopyContext<'a> {
         self.compress_enabled() && !self.options.should_skip_compress(relative)
     }
 
-    pub(super) const fn adaptive_compress_enabled(&self) -> bool {
-        self.options.adaptive_compress_enabled()
-    }
-
     pub(super) const fn compression_level(&self) -> CompressionLevel {
         self.options.compression_level()
     }

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -88,6 +88,10 @@ impl<'a> CopyContext<'a> {
         self.compress_enabled() && !self.options.should_skip_compress(relative)
     }
 
+    pub(super) const fn adaptive_compress_enabled(&self) -> bool {
+        self.options.adaptive_compress_enabled()
+    }
+
     pub(super) const fn compression_level(&self) -> CompressionLevel {
         self.options.compression_level()
     }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -84,6 +84,33 @@ impl<'a> CopyContext<'a> {
                 .with_preserve_crtimes(options.preserve_crtimes())
         });
 
+        let adaptive_level = if options.compress_enabled() && options.adaptive_compress_enabled() {
+            let initial = options.compression_level();
+            let level_i32 = match initial {
+                CompressionLevel::None => 0,
+                CompressionLevel::Fast => 1,
+                CompressionLevel::Default => 6,
+                CompressionLevel::Best => 9,
+                CompressionLevel::Precise(v) => i32::from(v.get()),
+            };
+            match options.compression_algorithm() {
+                CompressionAlgorithm::Zlib => {
+                    Some(compress::strategy::adaptive_level::AdaptiveLevelController::for_zlib(
+                        level_i32,
+                    ))
+                }
+                #[cfg(feature = "zstd")]
+                CompressionAlgorithm::Zstd => {
+                    Some(compress::strategy::adaptive_level::AdaptiveLevelController::for_zstd(
+                        level_i32,
+                    ))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         Self {
             mode,
             options,
@@ -122,6 +149,7 @@ impl<'a> CopyContext<'a> {
             batch_flist_index: 0,
             batch_ndx_codec,
             readdir_buf: Vec::new(),
+            adaptive_level,
         }
     }
 

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -8,13 +8,38 @@ impl<'a> CopyContext<'a> {
             return Ok(None);
         }
 
+        let level = if let Some(ctrl) = &self.adaptive_level {
+            // Convert the adaptive strategy's recommended i32 level to a
+            // CompressionLevel. The controller clamps to codec-valid bounds.
+            let recommended = ctrl.current_level();
+            if recommended == 0 {
+                CompressionLevel::None
+            } else if let Some(nz) = std::num::NonZeroU8::new(recommended as u8) {
+                CompressionLevel::Precise(nz)
+            } else {
+                self.compression_level()
+            }
+        } else {
+            self.compression_level()
+        };
+
         ActiveCompressor::new_with_workers(
             self.compression_algorithm(),
-            self.compression_level(),
+            level,
             self.compression_threads(),
         )
         .map(Some)
         .map_err(|error| LocalCopyError::io("initialise compression", source, error))
+    }
+
+    /// Feeds compression ratio feedback to the adaptive level controller
+    /// after a file finishes compressing.
+    fn record_adaptive_compression(&mut self, input_bytes: u64, compressed_bytes: u64) {
+        if let Some(ctrl) = &mut self.adaptive_level {
+            ctrl.record_input_bytes(input_bytes);
+            ctrl.record_output_bytes(compressed_bytes);
+            ctrl.record_file_complete();
+        }
     }
 
     fn register_limiter_bytes(&mut self, bytes: u64) {
@@ -379,6 +404,7 @@ impl<'a> CopyContext<'a> {
             self.register_progress();
             let delta = compressed_total.saturating_sub(compressed_progress);
             self.register_limiter_bytes(delta);
+            self.record_adaptive_compression(literal_bytes, compressed_total);
             FileCopyOutcome::new(literal_bytes, Some(compressed_total))
         } else {
             FileCopyOutcome::new(literal_bytes, None)
@@ -489,6 +515,7 @@ impl<'a> CopyContext<'a> {
             self.register_progress();
             let delta = compressed_total.saturating_sub(compressed_progress);
             self.register_limiter_bytes(delta);
+            self.record_adaptive_compression(literal_bytes, compressed_total);
             FileCopyOutcome::new(literal_bytes, Some(compressed_total))
         } else {
             FileCopyOutcome::new(literal_bytes, None)

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -62,6 +62,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) compression_level_override: Option<CompressionLevel>,
     pub(super) compression_level: CompressionLevel,
     pub(super) compression_threads: Option<std::num::NonZeroU8>,
+    pub(super) adaptive_compress: bool,
     pub(super) skip_compress: SkipCompressList,
 
     pub(super) open_noatime: bool,
@@ -195,6 +196,7 @@ impl LocalCopyOptionsBuilder {
             compression_level_override: None,
             compression_level: CompressionLevel::Default,
             compression_threads: None,
+            adaptive_compress: false,
             skip_compress: SkipCompressList::default(),
             open_noatime: false,
             whole_file: None,

--- a/crates/engine/src/local_copy/options/builder/setters_transfer.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_transfer.rs
@@ -96,6 +96,13 @@ impl LocalCopyOptionsBuilder {
         self
     }
 
+    /// Enables adaptive compression level tuning across files.
+    #[must_use]
+    pub fn adaptive_compress(mut self, enabled: bool) -> Self {
+        self.adaptive_compress = enabled;
+        self
+    }
+
     /// Sets the skip-compress list for file suffixes.
     #[must_use]
     pub fn skip_compress(mut self, list: SkipCompressList) -> Self {

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -123,6 +123,7 @@ impl LocalCopyOptionsBuilder {
             compression_level_override: self.compression_level_override,
             compression_level: self.compression_level,
             compression_threads: self.compression_threads,
+            adaptive_compress: self.adaptive_compress,
             skip_compress: self.skip_compress,
             open_noatime: self.open_noatime,
             whole_file: self.whole_file,

--- a/crates/engine/src/local_copy/options/compression.rs
+++ b/crates/engine/src/local_copy/options/compression.rs
@@ -57,6 +57,24 @@ impl LocalCopyOptions {
         self
     }
 
+    /// Enables or disables adaptive compression level tuning.
+    ///
+    /// When enabled, the compression level is adjusted between files based on
+    /// observed compression ratios. Incompressible data ratchets the level down
+    /// to save CPU; highly compressible data ratchets it up for better ratio.
+    /// The adaptation is sender-side only and does not affect the wire format.
+    #[must_use]
+    pub const fn adaptive_compress(mut self, enabled: bool) -> Self {
+        self.adaptive_compress = enabled;
+        self
+    }
+
+    /// Returns whether adaptive compression level tuning is enabled.
+    #[must_use]
+    pub const fn adaptive_compress_enabled(&self) -> bool {
+        self.adaptive_compress
+    }
+
     /// Overrides the suffix list used to disable compression for specific files.
     #[must_use]
     pub fn with_skip_compress(mut self, list: SkipCompressList) -> Self {
@@ -290,5 +308,25 @@ mod tests {
             opts.compression_algorithm(),
             CompressionAlgorithm::default_algorithm()
         );
+    }
+
+    #[test]
+    fn adaptive_compress_default_disabled() {
+        let opts = LocalCopyOptions::new();
+        assert!(!opts.adaptive_compress_enabled());
+    }
+
+    #[test]
+    fn adaptive_compress_enables() {
+        let opts = LocalCopyOptions::new().adaptive_compress(true);
+        assert!(opts.adaptive_compress_enabled());
+    }
+
+    #[test]
+    fn adaptive_compress_disables() {
+        let opts = LocalCopyOptions::new()
+            .adaptive_compress(true)
+            .adaptive_compress(false);
+        assert!(!opts.adaptive_compress_enabled());
     }
 }

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -113,6 +113,7 @@ pub struct LocalCopyOptions {
     /// Worker count for `ZSTD_c_nbWorkers`, only meaningful for zstd.
     /// upstream: `token.c:701`, `options.c:89`.
     pub(super) compression_threads: Option<NonZeroU8>,
+    pub(super) adaptive_compress: bool,
     pub(super) skip_compress: SkipCompressList,
     pub(super) open_noatime: bool,
     pub(super) whole_file: Option<bool>,
@@ -269,6 +270,7 @@ impl LocalCopyOptions {
             compression_level_override: None,
             compression_level: CompressionLevel::Default,
             compression_threads: None,
+            adaptive_compress: false,
             skip_compress: SkipCompressList::default(),
             open_noatime: false,
             whole_file: None,


### PR DESCRIPTION
## Summary

- Adds `AdaptiveLevelController` to the compress crate that bridges the existing `AdaptiveLevelStrategy` trait with the per-file compression pipeline, tracking input/output byte counts per file and computing compression ratios at file boundaries
- Wires the controller into the engine's `CopyContext` so that `start_compressor()` uses the adaptively recommended level instead of the fixed configured level, with ratio feedback after each file completes (normal, sparse, and delta copy paths)
- Adds `adaptive_compress` option to `LocalCopyOptions` and its builder (disabled by default) to opt in to adaptive level tuning

## Design

Compression level adaptation happens at file boundaries because zlib/zstd encoders do not support changing the level mid-stream. The `AdaptiveLevelController` uses an EWMA-smoothed compression ratio to ratchet the level down when data is incompressible (saving CPU) and up when data is highly compressible (improving ratio). This is a sender-side optimization that does not affect the wire format or protocol capabilities.

## Test plan

- [x] `AdaptiveLevelController` unit tests verify level increases for compressible data, decreases for incompressible data, neutral ratio holds, zero-byte files are skipped, reset clears state, custom configs work, mixed workloads adapt correctly, and multi-chunk accumulation works
- [x] `LocalCopyOptions` tests verify adaptive_compress toggle defaults to disabled and round-trips correctly
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl