### PR TITLE
feat: wire --info subcategory dispatch to thread-local verbosity config

### DIFF
--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -148,16 +148,16 @@ where
                 name_overridden = true;
             }
 
-            for info_arg in info_args {
-                if let Some(s) = info_arg.to_str() {
-                    for token in s.split(',') {
-                        let token = token.trim();
-                        if !token.is_empty() && token != "help" {
-                            let _ = logging::apply_info_flag(token);
-                        }
-                    }
-                }
-            }
+            // Apply all resolved info flag levels to the thread-local
+            // VerbosityConfig. This replaces the prior token-by-token loop
+            // which could not handle composite tokens like "all", "none",
+            // or bare numeric levels (those tokens silently failed in
+            // logging::apply_info_flag). The resolved InfoFlagSettings
+            // already handles all token forms correctly, so applying the
+            // fully-resolved per-flag levels ensures the thread-local
+            // config matches what the user requested.
+            // upstream: options.c set_output_verbosity / parse_output_words
+            settings.apply_to_thread_local();
 
             Ok(InfoFlagsResult {
                 progress_setting,

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -130,6 +130,59 @@ impl InfoFlagSettings {
         }
     }
 
+    /// Apply resolved settings to the thread-local verbosity config.
+    ///
+    /// For each subcategory that was explicitly set (non-None), this calls
+    /// `logging::apply_info_flag()` with the resolved level. This correctly
+    /// handles composite tokens like "all", "none", and bare numeric levels
+    /// that `apply_info_flag()` alone cannot parse, because
+    /// `InfoFlagSettings` has already resolved them into per-flag levels.
+    ///
+    /// upstream: options.c set_output_verbosity - cumulative flag application
+    pub(crate) fn apply_to_thread_local(&self) {
+        let apply = |name: &str, level: Option<u8>| {
+            if let Some(lvl) = level {
+                let _ = logging::apply_info_flag(&format!("{name}{lvl}"));
+            }
+        };
+
+        // progress level comes from the ProgressSetting enum
+        match self.progress {
+            ProgressSetting::Unspecified => {}
+            ProgressSetting::Disabled => {
+                let _ = logging::apply_info_flag("progress0");
+            }
+            ProgressSetting::PerFile => {
+                let _ = logging::apply_info_flag("progress1");
+            }
+            ProgressSetting::Overall => {
+                let _ = logging::apply_info_flag("progress2");
+            }
+        }
+
+        // name level comes from the NameOutputLevel enum
+        if let Some(ref level) = self.name {
+            let lvl = match level {
+                NameOutputLevel::Disabled => 0,
+                NameOutputLevel::UpdatedOnly => 1,
+                NameOutputLevel::UpdatedAndUnchanged => 2,
+            };
+            let _ = logging::apply_info_flag(&format!("name{lvl}"));
+        }
+
+        apply("stats", self.stats);
+        apply("backup", self.backup);
+        apply("copy", self.copy);
+        apply("del", self.del);
+        apply("flist", self.flist);
+        apply("misc", self.misc);
+        apply("mount", self.mount);
+        apply("nonreg", self.nonreg);
+        apply("remove", self.remove);
+        apply("skip", self.skip);
+        apply("symsafe", self.symsafe);
+    }
+
     fn spec_for(name: &str) -> Option<&'static InfoFlagSpec> {
         INFO_FLAG_SPECS.iter().find(|spec| spec.name == name)
     }

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -1099,3 +1099,157 @@ fn info_flag_numeric_n_caps_each_priority_group_at_per_flag_max() {
         );
     }
 }
+
+// Tests for apply_to_thread_local - verifying that resolved InfoFlagSettings
+// are correctly propagated to the thread-local VerbosityConfig used by
+// info_log! callsites throughout the codebase.
+
+#[test]
+fn apply_to_thread_local_individual_flags() {
+    logging::init(logging::VerbosityConfig::default());
+
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("copy", "copy").unwrap();
+    settings.apply("del", "del").unwrap();
+    settings.apply("flist2", "flist2").unwrap();
+    settings.apply_to_thread_local();
+
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Del, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Flist, 2));
+    assert!(!logging::info_gte(logging::InfoFlag::Flist, 3));
+    // Unset flags should remain at their default (0)
+    assert!(!logging::info_gte(logging::InfoFlag::Mount, 1));
+}
+
+#[test]
+fn apply_to_thread_local_all_token() {
+    logging::init(logging::VerbosityConfig::default());
+
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("all", "all").unwrap();
+    settings.apply_to_thread_local();
+
+    // All flags should be at level 1 (capped by max_level)
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Del, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Flist, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Misc, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Name, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Stats, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Backup, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Mount, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Remove, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Skip, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Symsafe, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Nonreg, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Progress, 1));
+}
+
+#[test]
+fn apply_to_thread_local_none_token() {
+    // First enable everything via verbose level
+    logging::init(logging::VerbosityConfig::from_verbose_level(2));
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+
+    // Then apply none - should zero all flags
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("none", "none").unwrap();
+    settings.apply_to_thread_local();
+
+    assert!(!logging::info_gte(logging::InfoFlag::Copy, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Del, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Flist, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Name, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Stats, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Progress, 1));
+}
+
+#[test]
+fn apply_to_thread_local_numeric_level() {
+    logging::init(logging::VerbosityConfig::default());
+
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("2", "2").unwrap();
+    settings.apply_to_thread_local();
+
+    // Level 2 enables all flags, capped by per-flag max_level
+    assert!(logging::info_gte(logging::InfoFlag::Stats, 2));
+    assert!(!logging::info_gte(logging::InfoFlag::Stats, 3));
+    assert!(logging::info_gte(logging::InfoFlag::Flist, 2));
+    assert!(logging::info_gte(logging::InfoFlag::Name, 2));
+    // Flags with max_level=1 are capped at 1
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Copy, 2));
+}
+
+#[test]
+fn apply_to_thread_local_all_then_override() {
+    logging::init(logging::VerbosityConfig::default());
+
+    let flags = vec![OsString::from("all,name0")];
+    let settings = parse_info_flags(&flags).unwrap();
+    settings.apply_to_thread_local();
+
+    // all sets name=1, then name0 overrides to 0
+    assert!(!logging::info_gte(logging::InfoFlag::Name, 1));
+    // Other flags should still be enabled
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Stats, 1));
+}
+
+#[test]
+fn apply_to_thread_local_verbose_then_info_override() {
+    // Start with -v (verbose level 1) which sets NAME=1
+    logging::init(logging::VerbosityConfig::from_verbose_level(1));
+    assert!(logging::info_gte(logging::InfoFlag::Name, 1));
+    assert!(!logging::info_gte(logging::InfoFlag::Backup, 1));
+
+    // Apply --info=backup to enable backup without touching name
+    let flags = vec![OsString::from("backup")];
+    let settings = parse_info_flags(&flags).unwrap();
+    settings.apply_to_thread_local();
+
+    // Name should still be enabled from -v (not touched by --info=backup)
+    assert!(logging::info_gte(logging::InfoFlag::Name, 1));
+    // Backup should now be enabled
+    assert!(logging::info_gte(logging::InfoFlag::Backup, 1));
+}
+
+#[test]
+fn apply_to_thread_local_progress_levels() {
+    logging::init(logging::VerbosityConfig::default());
+
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("progress2", "progress2").unwrap();
+    settings.apply_to_thread_local();
+
+    assert!(logging::info_gte(logging::InfoFlag::Progress, 2));
+
+    // Reset and test progress disabled
+    logging::init(logging::VerbosityConfig::from_verbose_level(1));
+    let mut settings = InfoFlagSettings::default();
+    settings.apply("progress0", "progress0").unwrap();
+    settings.apply_to_thread_local();
+
+    assert!(!logging::info_gte(logging::InfoFlag::Progress, 1));
+}
+
+#[test]
+fn apply_to_thread_local_unset_flags_not_touched() {
+    // Start with verbose level 2 which sets many flags
+    logging::init(logging::VerbosityConfig::from_verbose_level(2));
+    assert!(logging::info_gte(logging::InfoFlag::Mount, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+
+    // Apply only stats2 - should not touch other flags
+    let flags = vec![OsString::from("stats2")];
+    let settings = parse_info_flags(&flags).unwrap();
+    settings.apply_to_thread_local();
+
+    // Stats should be updated
+    assert!(logging::info_gte(logging::InfoFlag::Stats, 2));
+    // Other flags from verbose level 2 should remain untouched
+    assert!(logging::info_gte(logging::InfoFlag::Mount, 1));
+    assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
+}

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -95,11 +95,19 @@ where
     // silently ignores unknown tokens so a newer client can forward names
     // this build has not learned yet. The well-formed empty/level errors
     // still surface so malformed input is not swallowed entirely.
-    if !long_flags.info.is_empty()
-        && let Err(message) = super::super::execution::parse_info_flags_server(&long_flags.info)
-    {
-        write_server_error(stderr, program_brand, message.text().to_owned());
-        return 1;
+    if !long_flags.info.is_empty() {
+        match super::super::execution::parse_info_flags_server(&long_flags.info) {
+            Ok(settings) => {
+                // Apply resolved info levels to the thread-local config so
+                // info_log! callsites on the server side respect the client's
+                // --info settings.
+                settings.apply_to_thread_local();
+            }
+            Err(message) => {
+                write_server_error(stderr, program_brand, message.text().to_owned());
+                return 1;
+            }
+        }
     }
 
     // Boolean and move-only flags applied after value parsing releases its borrow.


### PR DESCRIPTION
## Summary

- Add `InfoFlagSettings::apply_to_thread_local()` to propagate fully resolved `--info` flag levels to the thread-local `VerbosityConfig` that gates `info_log!` callsites
- Replace the broken token-by-token re-parsing loop in `parse_info_settings()` (client-side) that silently failed on composite tokens like `all`, `none`, and bare numeric levels
- Wire resolved info levels into the server-side path so `info_log!` callsites on the server respect the client's `--info` settings
- Add 8 tests covering individual flags, `all`, `none`, numeric levels, override composition, verbose-then-info layering, progress levels, and selective flag application

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] New unit tests verify `apply_to_thread_local` for all token forms: individual flags, `all`, `none`, bare numeric, composite `all,name0`, verbose-then-info override, progress levels, unset-flags-not-touched
- [ ] Existing `--info` integration tests (`info_all_enables_comprehensive_output`, `info_none_suppresses_verbose_name_output`, `info_name_emits_filenames_without_verbose`) continue to pass