### PR TITLE
feat: embed filter rules in batch replay scripts

### DIFF
--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -169,7 +169,8 @@ pub mod reader;
 /// Shell script generation for batch replay.
 ///
 /// This module provides functions to generate executable shell scripts
-/// that can replay batch files. See [`script::generate_script`] and
+/// that can replay batch files. See [`script::generate_script`],
+/// [`script::generate_script_with_filters`], and
 /// [`script::generate_script_with_args`].
 pub mod script;
 

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -23,6 +23,25 @@ use std::os::unix::fs::PermissionsExt;
 ///   without a shebang line. The `.sh` file is opened with mode `S_IRUSR |
 ///   S_IWUSR | S_IXUSR` (0o700).
 pub fn generate_script(config: &BatchConfig) -> BatchResult<()> {
+    generate_script_with_filters(config, None)
+}
+
+/// Generate a shell script for replaying a batch file with optional filter rules.
+///
+/// When `filter_rules` is `Some`, the script includes `--filter=._-` (protocol
+/// >= 29) or `--exclude-from=-` (protocol < 29) and appends the rules as a
+/// heredoc so that the replay applies the same filters used during batch
+/// creation.
+///
+/// # Upstream Reference
+///
+/// - `batch.c:205-222`: `write_filter_rules()` embeds filter rules in the
+///   shell script using a `<<'#E#'` heredoc.
+/// - `batch.c:262-267`: filter option selection based on protocol version.
+pub fn generate_script_with_filters(
+    config: &BatchConfig,
+    filter_rules: Option<&str>,
+) -> BatchResult<()> {
     let script_path = config.script_file_path();
     let batch_name = config.batch_file_path().to_string_lossy();
     let mut file = File::create(&script_path).map_err(|e| {
@@ -33,11 +52,43 @@ pub fn generate_script(config: &BatchConfig) -> BatchResult<()> {
     })?;
 
     // upstream: write_batch_shell_file() writes the command without a shebang
-    writeln!(
+    write!(file, "oc-rsync")?;
+
+    // upstream: batch.c:262-267 - embed filter option before --read-batch
+    // so the heredoc at the end of the script feeds rules into stdin
+    if filter_rules.is_some() {
+        if config.protocol_version >= 29 {
+            // upstream: batch.c:263-264 write_opt("--filter", "._-")
+            write!(file, " --filter=._-")?;
+        } else {
+            // upstream: batch.c:265-266 write_opt("--exclude-from", "-")
+            write!(file, " --exclude-from=-")?;
+        }
+    }
+
+    // upstream: batch.c:292-294 - write --read-batch with the batch file path
+    write!(
         file,
-        "oc-rsync --read-batch={} ${{1:-.}}",
+        " --read-batch={}",
         shell_quote(&batch_name)
     )?;
+
+    // upstream: batch.c:300-304 - destination placeholder
+    write!(file, " ${{1:-.}}")?;
+
+    // upstream: batch.c:305-306 - append filter rules as heredoc
+    if let Some(rules) = filter_rules {
+        // upstream: batch.c:209 write_sbuf(fd, " <<'#E#'\n")
+        writeln!(file, " <<'#E#'")?;
+        write!(file, "{rules}")?;
+        if !rules.ends_with('\n') {
+            writeln!(file)?;
+        }
+        // upstream: batch.c:221 write_sbuf(fd, "#E#")
+        write!(file, "#E#")?;
+    }
+
+    writeln!(file)?;
 
     file.flush()?;
 
@@ -465,6 +516,108 @@ mod tests {
             !content.contains("--include=*.txt"),
             "Include args should be stripped: {content}"
         );
+    }
+
+    /// Verify that `generate_script_with_filters` embeds filter rules via heredoc
+    /// and adds --filter=._- for protocol >= 29.
+    ///
+    /// upstream: batch.c:205-222 write_filter_rules() + batch.c:262-267 option.
+    #[test]
+    fn test_generate_script_with_filters_embeds_heredoc() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+
+        let filter_rules = "- *.tmp\n+ */\n+ *.txt\n- *\n";
+
+        let result = generate_script_with_filters(&config, Some(filter_rules));
+        assert!(result.is_ok());
+
+        let script_path = config.script_file_path();
+        let content = fs::read_to_string(&script_path).unwrap();
+
+        assert!(
+            content.contains("--filter=._-"),
+            "Script must include --filter=._- for protocol >= 29: {content}"
+        );
+        assert!(content.contains("--read-batch="));
+        assert!(content.contains("<<'#E#'"));
+        assert!(content.contains(filter_rules));
+        assert!(content.contains("#E#"));
+        assert!(
+            !content.starts_with("#!/bin/sh"),
+            "Upstream rsync batch scripts have no shebang"
+        );
+    }
+
+    /// Verify that `generate_script_with_filters` without rules produces a
+    /// clean script with no heredoc or filter options.
+    #[test]
+    fn test_generate_script_with_filters_none_produces_clean_script() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+
+        let result = generate_script_with_filters(&config, None);
+        assert!(result.is_ok());
+
+        let script_path = config.script_file_path();
+        let content = fs::read_to_string(&script_path).unwrap();
+
+        assert!(
+            !content.contains("--filter"),
+            "No --filter option without filter rules: {content}"
+        );
+        assert!(
+            !content.contains("#E#"),
+            "No heredoc without filter rules: {content}"
+        );
+        assert!(content.contains("--read-batch="));
+        assert!(content.contains("oc-rsync"));
+    }
+
+    /// Verify that protocol < 29 uses --exclude-from=- instead of --filter=._-.
+    ///
+    /// upstream: batch.c:265-266 write_opt("--exclude-from", "-")
+    #[test]
+    fn test_generate_script_with_filters_protocol_28_exclude_from() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            28,
+        );
+
+        let filter_rules = "- *.log\n";
+
+        let result = generate_script_with_filters(&config, Some(filter_rules));
+        assert!(result.is_ok());
+
+        let script_path = config.script_file_path();
+        let content = fs::read_to_string(&script_path).unwrap();
+
+        assert!(
+            content.contains("--exclude-from=-"),
+            "Script must include --exclude-from=- for protocol < 29: {content}"
+        );
+        assert!(
+            !content.contains("--filter=._-"),
+            "Should not use --filter for protocol < 29: {content}"
+        );
+        assert!(content.contains("<<'#E#'"));
+        assert!(content.contains("- *.log"));
     }
 
     #[test]

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -67,11 +67,7 @@ pub fn generate_script_with_filters(
     }
 
     // upstream: batch.c:292-294 - write --read-batch with the batch file path
-    write!(
-        file,
-        " --read-batch={}",
-        shell_quote(&batch_name)
-    )?;
+    write!(file, " --read-batch={}", shell_quote(&batch_name))?;
 
     // upstream: batch.c:300-304 - destination placeholder
     write!(file, " ${{1:-.}}")?;

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -29,7 +29,7 @@ pub fn generate_script(config: &BatchConfig) -> BatchResult<()> {
 /// Generate a shell script for replaying a batch file with optional filter rules.
 ///
 /// When `filter_rules` is `Some`, the script includes `--filter=._-` (protocol
-/// >= 29) or `--exclude-from=-` (protocol < 29) and appends the rules as a
+/// 29+) or `--exclude-from=-` (older protocols) and appends the rules as a
 /// heredoc so that the replay applies the same filters used during batch
 /// creation.
 ///

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -504,10 +504,8 @@ mod tests {
         ];
         let filter_text = serialize_filter_rules(&rules);
 
-        let result = engine::batch::script::generate_script_with_filters(
-            &batch_cfg,
-            Some(&filter_text),
-        );
+        let result =
+            engine::batch::script::generate_script_with_filters(&batch_cfg, Some(&filter_text));
         assert!(result.is_ok());
 
         let script_path = batch_cfg.script_file_path();

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -12,7 +12,7 @@ use engine::batch::{BatchConfig, BatchStats, BatchWriter};
 use crate::message::Role;
 use crate::rsync_error;
 
-use super::super::config::ClientConfig;
+use super::super::config::{ClientConfig, FilterRuleKind, FilterRuleSpec};
 use super::super::error::ClientError;
 use super::super::remote;
 use super::super::summary::ClientSummary;
@@ -132,11 +132,16 @@ pub(crate) fn write_batch_header(
 
 /// Writes trailing stats, flushes the batch file, and generates the replay script.
 ///
+/// When filter rules are active in `config`, the replay script embeds them
+/// using the same heredoc format as upstream `batch.c:write_filter_rules()`,
+/// ensuring the replay applies identical filters.
+///
 /// Called after a successful transfer to finalize the batch recording.
 /// Mirrors upstream `main.c:374-383` for stats writing.
 pub(crate) fn finalize_batch(
     writer_arc: &Arc<Mutex<BatchWriter>>,
     batch_cfg: &BatchConfig,
+    config: &ClientConfig,
     summary: &ClientSummary,
 ) -> Result<(), ClientError> {
     {
@@ -198,7 +203,15 @@ pub(crate) fn finalize_batch(
         }
     }
 
-    if let Err(e) = engine::batch::script::generate_script(batch_cfg) {
+    // upstream: batch.c:305-306 - embed filter rules in the replay script
+    let filter_text = serialize_filter_rules(config.filter_rules());
+    let filter_opt = if filter_text.is_empty() {
+        None
+    } else {
+        Some(filter_text.as_str())
+    };
+
+    if let Err(e) = engine::batch::script::generate_script_with_filters(batch_cfg, filter_opt) {
         let msg = format!("failed to generate batch script: {e}");
         return Err(ClientError::new(
             1,
@@ -207,6 +220,82 @@ pub(crate) fn finalize_batch(
     }
 
     Ok(())
+}
+
+/// Serializes filter rules into the text format used by batch script heredocs.
+///
+/// Each rule is formatted as a single line matching upstream rsync's
+/// `batch.c:write_filter_rules()` / `exclude.c:get_rule_prefix()` output:
+///
+/// ```text
+/// {prefix} {pattern}[/]\n
+/// ```
+///
+/// The prefix encodes the rule action (`+`/`-`/`P`/`R`/`:`) and modifier
+/// flags (`s`/`r`/`p`/`x`/`!`). A trailing `/` is appended for
+/// directory-only patterns. Returns an empty string when no rules are present.
+///
+/// # Upstream Reference
+///
+/// - `batch.c:205-222`: `write_filter_rules()` iterates filter_list
+/// - `exclude.c:1525-1587`: `get_rule_prefix()` builds the prefix string
+fn serialize_filter_rules(rules: &[FilterRuleSpec]) -> String {
+    if rules.is_empty() {
+        return String::new();
+    }
+
+    let mut output = String::new();
+    for rule in rules {
+        // upstream: exclude.c:1532-1541 - action prefix
+        let action_char = match rule.kind() {
+            FilterRuleKind::Include => '+',
+            FilterRuleKind::Exclude | FilterRuleKind::ExcludeIfPresent => '-',
+            FilterRuleKind::Protect => 'P',
+            FilterRuleKind::Risk => 'R',
+            FilterRuleKind::DirMerge => ':',
+            FilterRuleKind::Clear => '!',
+        };
+        output.push(action_char);
+
+        // upstream: exclude.c:1546-1547 - negate modifier
+        if rule.is_negated() {
+            output.push('!');
+        }
+
+        // upstream: exclude.c:1564-1565 - xattr modifier
+        if rule.is_xattr_only() {
+            output.push('x');
+        }
+
+        // upstream: exclude.c:1566-1572 - sender/receiver side modifiers
+        if rule.applies_to_sender() && !rule.applies_to_receiver() {
+            output.push('s');
+        }
+        if rule.applies_to_receiver() && !rule.applies_to_sender() {
+            output.push('r');
+        }
+
+        // upstream: exclude.c:1573-1578 - perishable modifier
+        if rule.is_perishable() {
+            output.push('p');
+        }
+
+        // upstream: exclude.c:1581-1582 - space separator before pattern
+        output.push(' ');
+
+        // upstream: batch.c:213-214 - pattern text
+        let pattern = rule.pattern();
+        output.push_str(pattern);
+
+        // upstream: batch.c:215-216 - trailing '/' for directory-only rules.
+        // FilterRuleSpec stores the trailing '/' as part of the pattern text,
+        // so we do not append an extra one.
+
+        // upstream: batch.c:217 - newline terminator (non-null-terminated mode)
+        output.push('\n');
+    }
+
+    output
 }
 
 /// Replay a batch file to reconstruct the transfer at the destination.
@@ -303,6 +392,202 @@ mod tests {
         assert!(
             !flags.do_compression,
             "do_compression must be false - oc-rsync captures uncompressed data"
+        );
+    }
+
+    // --- serialize_filter_rules tests ---
+
+    #[test]
+    fn serialize_empty_rules_returns_empty_string() {
+        assert_eq!(serialize_filter_rules(&[]), "");
+    }
+
+    #[test]
+    fn serialize_exclude_rule() {
+        let rules = [FilterRuleSpec::exclude("*.tmp")];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "- *.tmp\n");
+    }
+
+    #[test]
+    fn serialize_include_rule() {
+        let rules = [FilterRuleSpec::include("*.rs")];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "+ *.rs\n");
+    }
+
+    #[test]
+    fn serialize_protect_rule() {
+        let rules = [FilterRuleSpec::protect("/data")];
+        let output = serialize_filter_rules(&rules);
+        // upstream: protect is 'P', receiver-only gets 'r' modifier
+        assert_eq!(output, "Pr /data\n");
+    }
+
+    #[test]
+    fn serialize_risk_rule() {
+        let rules = [FilterRuleSpec::risk("/temp")];
+        let output = serialize_filter_rules(&rules);
+        // upstream: risk is 'R', receiver-only gets 'r' modifier
+        assert_eq!(output, "Rr /temp\n");
+    }
+
+    #[test]
+    fn serialize_clear_rule() {
+        let rules = [FilterRuleSpec::clear()];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "! \n");
+    }
+
+    #[test]
+    fn serialize_multiple_rules() {
+        let rules = [
+            FilterRuleSpec::exclude("*.tmp"),
+            FilterRuleSpec::include("*/"),
+            FilterRuleSpec::include("*.txt"),
+            FilterRuleSpec::exclude("*"),
+        ];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "- *.tmp\n+ */\n+ *.txt\n- *\n");
+    }
+
+    #[test]
+    fn serialize_sender_only_rule() {
+        let rules = [FilterRuleSpec::hide("*.bak")];
+        let output = serialize_filter_rules(&rules);
+        // upstream: sender-only gets 's' modifier
+        assert_eq!(output, "-s *.bak\n");
+    }
+
+    #[test]
+    fn serialize_perishable_rule() {
+        let rules = [FilterRuleSpec::exclude("*.tmp").with_perishable(true)];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "-p *.tmp\n");
+    }
+
+    #[test]
+    fn serialize_xattr_only_rule() {
+        let rules = [FilterRuleSpec::exclude("user.*").with_xattr_only(true)];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "-x user.*\n");
+    }
+
+    #[test]
+    fn serialize_negated_rule() {
+        let rules = [FilterRuleSpec::exclude("*.txt").with_negate(true)];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "-! *.txt\n");
+    }
+
+    #[test]
+    fn serialize_directory_only_pattern() {
+        // FilterRuleSpec stores the trailing '/' as part of the pattern
+        let rules = [FilterRuleSpec::exclude("build/")];
+        let output = serialize_filter_rules(&rules);
+        assert_eq!(output, "- build/\n");
+    }
+
+    /// Full round-trip: serialize rules, embed in batch script, verify output.
+    #[test]
+    fn serialize_and_embed_in_batch_script() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("roundtrip.batch");
+        let batch_cfg = BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), 31)
+            .with_checksum_seed(1);
+
+        let rules = [
+            FilterRuleSpec::exclude("*.tmp"),
+            FilterRuleSpec::include("*/"),
+            FilterRuleSpec::include("*.txt"),
+            FilterRuleSpec::exclude("*"),
+        ];
+        let filter_text = serialize_filter_rules(&rules);
+
+        let result = engine::batch::script::generate_script_with_filters(
+            &batch_cfg,
+            Some(&filter_text),
+        );
+        assert!(result.is_ok());
+
+        let script_path = batch_cfg.script_file_path();
+        let content = std::fs::read_to_string(&script_path).unwrap();
+        assert!(
+            content.contains("--filter=._-"),
+            "Script must include --filter=._- for protocol >= 29: {content}"
+        );
+        assert!(content.contains("<<'#E#'"));
+        assert!(content.contains("- *.tmp\n+ */\n+ *.txt\n- *\n"));
+        assert!(content.contains("#E#"));
+        assert!(content.contains("--read-batch="));
+    }
+
+    /// Verify finalize_batch embeds filter rules from config.
+    #[test]
+    fn finalize_batch_embeds_filter_rules_in_script() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("finalize.batch");
+        let batch_cfg = BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), 31)
+            .with_checksum_seed(1);
+
+        let writer_arc = create_batch_writer(&batch_cfg).unwrap();
+
+        let config = ClientConfig::builder()
+            .compress(false)
+            .add_filter_rule(FilterRuleSpec::exclude("*.log"))
+            .add_filter_rule(FilterRuleSpec::include("*.txt"))
+            .batch_config(Some(batch_cfg.clone()))
+            .build();
+
+        write_batch_header(&writer_arc, &config).unwrap();
+
+        let summary = ClientSummary::from_summary(engine::local_copy::LocalCopySummary::default());
+        let result = finalize_batch(&writer_arc, &batch_cfg, &config, &summary);
+        assert!(result.is_ok());
+
+        let script_path = batch_cfg.script_file_path();
+        let content = std::fs::read_to_string(&script_path).unwrap();
+        assert!(
+            content.contains("--filter=._-"),
+            "Script should embed filter option: {content}"
+        );
+        assert!(
+            content.contains("- *.log"),
+            "Script should contain exclude rule: {content}"
+        );
+        assert!(
+            content.contains("+ *.txt"),
+            "Script should contain include rule: {content}"
+        );
+        assert!(content.contains("<<'#E#'"), "Script should contain heredoc");
+    }
+
+    /// Verify finalize_batch produces clean script when no filter rules.
+    #[test]
+    fn finalize_batch_no_filters_produces_clean_script() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("nofilt.batch");
+        let batch_cfg = BatchConfig::new(BatchMode::Write, path.to_string_lossy().to_string(), 31)
+            .with_checksum_seed(1);
+
+        let writer_arc = create_batch_writer(&batch_cfg).unwrap();
+
+        let config = config_with_compress(false);
+        write_batch_header(&writer_arc, &config).unwrap();
+
+        let summary = ClientSummary::from_summary(engine::local_copy::LocalCopySummary::default());
+        let result = finalize_batch(&writer_arc, &batch_cfg, &config, &summary);
+        assert!(result.is_ok());
+
+        let script_path = batch_cfg.script_file_path();
+        let content = std::fs::read_to_string(&script_path).unwrap();
+        assert!(
+            !content.contains("--filter"),
+            "No --filter without rules: {content}"
+        );
+        assert!(
+            !content.contains("#E#"),
+            "No heredoc without rules: {content}"
         );
     }
 }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -232,7 +232,7 @@ fn run_client_internal(
                 if let Some(ref writer_arc) = batch_writer
                     && let Some(batch_cfg) = config.batch_config()
                 {
-                    batch::finalize_batch(writer_arc, batch_cfg, &summary)?;
+                    batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
                 }
 
                 return Ok(summary);
@@ -256,7 +256,7 @@ fn run_client_internal(
         if let Some(ref writer_arc) = batch_writer
             && let Some(batch_cfg) = config.batch_config()
         {
-            batch::finalize_batch(writer_arc, batch_cfg, &summary)?;
+            batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
         }
 
         return Ok(summary);
@@ -347,7 +347,7 @@ fn run_client_internal(
     if let Some(ref writer_arc) = batch_writer
         && let Some(batch_cfg) = config.batch_config()
     {
-        batch::finalize_batch(writer_arc, batch_cfg, &summary)?;
+        batch::finalize_batch(writer_arc, batch_cfg, &config, &summary)?;
     }
 
     Ok(summary)

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -153,7 +153,9 @@ pub mod batch {
 
     /// Script generation for batch replay.
     pub mod script {
-        pub use batch::script::{generate_script, generate_script_with_args};
+        pub use batch::script::{
+            generate_script, generate_script_with_args, generate_script_with_filters,
+        };
     }
 }
 


### PR DESCRIPTION
## Summary

- Serialize active filter rules into batch replay `.sh` scripts using upstream rsync's heredoc format (`<<'#E#'`), matching `batch.c:write_filter_rules()` behavior
- Add `generate_script_with_filters()` to the batch crate for filter-aware script generation with protocol-version-gated option selection (`--filter=._-` for protocol >= 29, `--exclude-from=-` for protocol < 29)
- Add `serialize_filter_rules()` in the core crate to convert `FilterRuleSpec` rules to upstream-compatible text format with action prefixes (`+`/`-`/`P`/`R`/`:`/`!`) and modifier flags (`s`/`r`/`p`/`x`/`!`)
- Update `finalize_batch()` to accept `ClientConfig` and embed active filter rules when present

## Test plan

- [ ] Unit tests for `serialize_filter_rules()` covering all rule kinds (include, exclude, protect, risk, clear, dir-merge), modifier flags (sender-only, receiver-only, perishable, xattr-only, negated), directory-only patterns, and multi-rule serialization
- [ ] Unit tests for `generate_script_with_filters()` covering heredoc embedding (protocol >= 29 and < 29), clean output without filters, and correct script structure
- [ ] Integration test: full round-trip from `FilterRuleSpec` through serialization to embedded script content verification
- [ ] Integration test: `finalize_batch()` with filter rules produces script containing `--filter=._-` and heredoc with serialized rules
- [ ] Integration test: `finalize_batch()` without filter rules produces clean script with no heredoc
- [ ] CI validation across all platforms (Linux, macOS, Windows)