### PR TITLE
feat: forward --remote-option (-M) args to remote rsync process

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -154,6 +154,8 @@ pub(crate) struct ConfigInputs {
     pub(crate) jump_hosts: Option<OsString>,
     pub(crate) batch_config: Option<BatchConfig>,
     pub(crate) no_motd: bool,
+    /// Extra options forwarded to the remote rsync process via `-M`.
+    pub(crate) remote_options: Vec<OsString>,
     pub(crate) daemon_params: Vec<String>,
     pub(crate) files_from: FilesFromSource,
     pub(crate) from0: bool,
@@ -385,5 +387,6 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
     builder
         .force_event_collection(force_event_collection)
         .no_motd(inputs.no_motd)
+        .remote_options(inputs.remote_options)
         .daemon_params(inputs.daemon_params)
 }

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -828,6 +828,7 @@ where
         jump_hosts: jump_host,
         batch_config,
         no_motd,
+        remote_options,
         daemon_params: dparam
             .into_iter()
             .map(|s| s.to_string_lossy().into_owned())

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -262,6 +262,7 @@ pub struct ClientConfigBuilder {
     spill_threshold_bytes: Option<u64>,
     no_spill: bool,
     no_motd: bool,
+    remote_options: Vec<OsString>,
     daemon_params: Vec<String>,
     protocol_version: Option<protocol::ProtocolVersion>,
     #[cfg(feature = "embedded-ssh")]
@@ -494,6 +495,7 @@ impl ClientConfigBuilder {
             spill_threshold_bytes: self.spill_threshold_bytes,
             no_spill: self.no_spill,
             no_motd: self.no_motd,
+            remote_options: self.remote_options,
             daemon_params: self.daemon_params,
             protocol_version: self.protocol_version,
             #[cfg(feature = "embedded-ssh")]

--- a/crates/core/src/client/config/builder/network.rs
+++ b/crates/core/src/client/config/builder/network.rs
@@ -109,6 +109,32 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Sets extra options to forward to the remote rsync process.
+    ///
+    /// Each entry in the iterator is a complete option string (e.g. `--bwlimit=100`)
+    /// that will be appended verbatim to the server command line after all
+    /// locally-derived arguments. Mirrors upstream `options.c:server_options()`
+    /// which appends `remote_options[]` at the end of the server args.
+    ///
+    /// # Example
+    /// ```
+    /// # use core::client::ClientConfig;
+    /// let config = ClientConfig::builder()
+    ///     .remote_options(vec!["--bwlimit=100", "--compress-level=1"])
+    ///     .build();
+    /// ```
+    #[must_use]
+    #[doc(alias = "--remote-option")]
+    #[doc(alias = "-M")]
+    pub fn remote_options<I, S>(mut self, opts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.remote_options = opts.into_iter().map(Into::into).collect();
+        self
+    }
+
     /// Configures a custom remote shell command for SSH transfers.
     ///
     /// This method accepts an iterable of command arguments where the first element

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -696,6 +696,31 @@ fn set_rsync_path_sets_value() {
 }
 
 #[test]
+fn remote_options_default_is_empty() {
+    let config = builder().build();
+    assert!(config.remote_options().is_empty());
+}
+
+#[test]
+fn remote_options_sets_values() {
+    let config = builder()
+        .remote_options(vec!["--bwlimit=100", "--compress-level=1"])
+        .build();
+    assert_eq!(config.remote_options().len(), 2);
+    assert_eq!(config.remote_options()[0], "--bwlimit=100");
+    assert_eq!(config.remote_options()[1], "--compress-level=1");
+}
+
+#[test]
+fn remote_options_empty_clears_values() {
+    let config = builder()
+        .remote_options(vec!["--bwlimit=100"])
+        .remote_options(Vec::<&str>::new())
+        .build();
+    assert!(config.remote_options().is_empty());
+}
+
+#[test]
 fn early_input_sets_path() {
     let config = builder()
         .early_input(Some(PathBuf::from("/tmp/early-input")))

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -397,6 +397,7 @@ impl Default for ClientConfig {
             spill_threshold_bytes: None,
             no_spill: false,
             no_motd: false,
+            remote_options: Vec::new(),
             daemon_params: Vec::new(),
             protocol_version: None,
             #[cfg(feature = "embedded-ssh")]

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -222,6 +222,13 @@ pub struct ClientConfig {
     /// `in_memory_only` to `true`. Precedence: **CLI > env > defaults**.
     pub(super) no_spill: bool,
     pub(super) no_motd: bool,
+    /// Extra options forwarded to the remote rsync process via `-M` / `--remote-option`.
+    ///
+    /// Each entry is a complete option string (e.g. `--bwlimit=100`) appended
+    /// verbatim to the server command line after all locally-derived arguments.
+    /// upstream: `options.c:server_options()` appends `remote_options[]` at the
+    /// end of the server argument vector.
+    pub(super) remote_options: Vec<OsString>,
     pub(super) daemon_params: Vec<String>,
     pub(super) protocol_version: Option<protocol::ProtocolVersion>,
     #[cfg(feature = "embedded-ssh")]

--- a/crates/core/src/client/config/client/network.rs
+++ b/crates/core/src/client/config/client/network.rs
@@ -60,6 +60,17 @@ impl ClientConfig {
         self.stop_at
     }
 
+    /// Returns the extra options forwarded to the remote rsync process.
+    ///
+    /// Empty when no `-M` / `--remote-option` flags were specified.
+    /// upstream: `options.c:server_options()` appends these after all other
+    /// server arguments.
+    #[doc(alias = "--remote-option")]
+    #[doc(alias = "-M")]
+    pub fn remote_options(&self) -> &[OsString] {
+        &self.remote_options
+    }
+
     /// Returns the custom remote shell command arguments, if specified.
     #[doc(alias = "--rsh")]
     #[doc(alias = "-e")]
@@ -229,6 +240,12 @@ mod tests {
     fn stop_at_default_is_none() {
         let config = default_config();
         assert!(config.stop_at().is_none());
+    }
+
+    #[test]
+    fn remote_options_default_is_empty() {
+        let config = default_config();
+        assert!(config.remote_options().is_empty());
     }
 
     #[test]

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -480,6 +480,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
                 args.push(OsString::from(format!("--iconv={forwarded}")));
             }
         }
+
+        // upstream: options.c:2986-2993 - remote_options[] are appended after
+        // all other server arguments. Each -M value is forwarded verbatim.
+        for opt in self.config.remote_options() {
+            args.push(opt.clone());
+        }
     }
 
     /// Builds the compact flag string from client configuration.

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2666,3 +2666,146 @@ fn shell_safe_escaping_in_normal_mode() {
         secluded.command_line_args
     );
 }
+
+// -----------------------------------------------------------------------
+// Remote option (-M / --remote-option) forwarding
+// -----------------------------------------------------------------------
+
+#[test]
+fn remote_options_appended_to_sender_invocation() {
+    // upstream: options.c:2986-2993 - remote_options[] appended after all
+    // other server args, before "." and remote paths.
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--bwlimit=100", "--compress-level=1"])
+        .build();
+    let args = build_sender_args(&config);
+
+    assert!(
+        args.iter().any(|a| a == "--bwlimit=100"),
+        "expected --bwlimit=100 from -M in args: {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--compress-level=1"),
+        "expected --compress-level=1 from -M in args: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_appended_to_receiver_invocation() {
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--timeout=60"])
+        .build();
+    let args = build_receiver_args(&config);
+
+    assert!(
+        args.iter().any(|a| a == "--timeout=60"),
+        "expected --timeout=60 from -M in args: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_appear_before_dot_placeholder() {
+    // upstream: server_options() appends remote_options before returning,
+    // then do_cmd() appends "." and paths. So remote options must precede ".".
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--bwlimit=200"])
+        .build();
+    let args = build_sender_args(&config);
+
+    let dot_idx = args.iter().position(|a| a == ".").unwrap();
+    let opt_idx = args.iter().position(|a| a == "--bwlimit=200").unwrap();
+    assert!(
+        opt_idx < dot_idx,
+        "remote option should appear before '.' placeholder: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_appear_after_locally_derived_args() {
+    // Remote options should come after all locally-derived long-form args
+    // but before "." and paths.
+    let config = ClientConfig::builder()
+        .numeric_ids(true)
+        .remote_options(vec!["--max-delete=50"])
+        .build();
+    let args = build_sender_args(&config);
+
+    let numeric_idx = args.iter().position(|a| a == "--numeric-ids").unwrap();
+    let remote_idx = args.iter().position(|a| a == "--max-delete=50").unwrap();
+    assert!(
+        remote_idx > numeric_idx,
+        "remote option should appear after locally-derived args: {args:?}"
+    );
+}
+
+#[test]
+fn empty_remote_options_adds_nothing() {
+    let config_with = ClientConfig::builder()
+        .remote_options(Vec::<&str>::new())
+        .build();
+    let config_without = ClientConfig::builder().build();
+    let args_with = build_sender_args(&config_with);
+    let args_without = build_sender_args(&config_without);
+
+    assert_eq!(
+        args_with, args_without,
+        "empty remote_options should produce identical invocation"
+    );
+}
+
+#[test]
+fn multiple_remote_options_preserve_order() {
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--first", "--second", "--third"])
+        .build();
+    let args = build_sender_args(&config);
+
+    let first_idx = args.iter().position(|a| a == "--first").unwrap();
+    let second_idx = args.iter().position(|a| a == "--second").unwrap();
+    let third_idx = args.iter().position(|a| a == "--third").unwrap();
+    assert!(
+        first_idx < second_idx && second_idx < third_idx,
+        "remote options must preserve insertion order: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_included_in_secluded_stdin_args() {
+    // When protect_args is active, remote options must appear in the
+    // stdin_args (the full argument list), not on the SSH command line.
+    let config = ClientConfig::builder()
+        .protect_args(Some(true))
+        .remote_options(vec!["--bwlimit=500"])
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let secluded = builder.build_secluded(&["/data"]);
+
+    assert!(
+        secluded.stdin_args.iter().any(|a| a == "--bwlimit=500"),
+        "secluded stdin_args should contain remote option: {:?}",
+        secluded.stdin_args
+    );
+    // The minimal SSH command line should NOT contain the remote option.
+    assert!(
+        !secluded
+            .command_line_args
+            .iter()
+            .any(|a| a.to_string_lossy() == "--bwlimit=500"),
+        "secluded command_line_args should NOT contain remote option: {:?}",
+        secluded.command_line_args
+    );
+}
+
+#[test]
+fn remote_option_short_flag_forwarded_verbatim() {
+    // -M can forward short flags like -v or compound options.
+    let config = ClientConfig::builder()
+        .remote_options(vec!["-v"])
+        .build();
+    let args = build_sender_args(&config);
+
+    assert!(
+        args.iter().any(|a| a == "-v"),
+        "expected short flag -v from -M in args: {args:?}"
+    );
+}

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2799,9 +2799,7 @@ fn remote_options_included_in_secluded_stdin_args() {
 #[test]
 fn remote_option_short_flag_forwarded_verbatim() {
     // -M can forward short flags like -v or compound options.
-    let config = ClientConfig::builder()
-        .remote_options(vec!["-v"])
-        .build();
+    let config = ClientConfig::builder().remote_options(vec!["-v"]).build();
     let args = build_sender_args(&config);
 
     assert!(


### PR DESCRIPTION
## Summary

- Wire `--remote-option` / `-M` values through the full config chain (CLI `ConfigInputs` -> `ClientConfigBuilder` -> `ClientConfig`) and append them to the server command line in `RemoteInvocationBuilder`
- Previously, `-M` options were parsed and validated (rejected for local transfers) but never forwarded to the remote side
- Matches upstream rsync `options.c:2986-2993` where `remote_options[]` are appended after all other `server_options()` arguments, before the `.` placeholder and remote paths

## Changes

- **`ClientConfigBuilder`**: Added `remote_options: Vec<OsString>` field and `remote_options()` builder method
- **`ClientConfig`**: Added `remote_options` field and accessor
- **`RemoteInvocationBuilder`**: Appends remote options at the end of `append_long_form_args()`, matching upstream ordering
- **CLI**: Wired `remote_options` through `ConfigInputs` and `build_base_config()`

## Test plan

- [x] Builder tests: default empty, setter stores values, re-set clears
- [x] Config accessor tests: default is empty
- [x] Invocation tests: options appear in sender and receiver args
- [x] Invocation tests: options appear before `.` placeholder
- [x] Invocation tests: options appear after locally-derived args
- [x] Invocation tests: empty options produce identical invocation
- [x] Invocation tests: multiple options preserve insertion order
- [x] Invocation tests: options appear in secluded-args stdin (not SSH command line)
- [x] Invocation tests: short flags forwarded verbatim
- [x] Existing validation test for local-only rejection still passes