### PR TITLE
feat: forward --stop-at deadline to remote server in SSH transfers

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -365,6 +365,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--numeric-ids"));
         }
 
+        // upstream: options.c:2889-2890 - --trust-sender forwarded as long-form.
+        if self.config.trust_sender() {
+            args.push(OsString::from("--trust-sender"));
+        }
+
+        // upstream: options.c:2892-2894 - --checksum-seed=N forwarded so the
+        // server uses the same seed for rolling and strong checksum generation.
+        if let Some(seed) = self.config.checksum_seed() {
+            args.push(OsString::from(format!("--checksum-seed={seed}")));
+        }
+
         if self.config.size_only() {
             args.push(OsString::from("--size-only"));
         }
@@ -491,6 +502,12 @@ impl<'a> RemoteInvocationBuilder<'a> {
                 let forwarded = remote.as_deref().unwrap_or(local);
                 args.push(OsString::from(format!("--iconv={forwarded}")));
             }
+        }
+
+        // upstream: options.c:2986-2993 - remote_options[] are appended after
+        // all other server arguments. Each -M value is forwarded verbatim.
+        for opt in self.config.remote_options() {
+            args.push(opt.clone());
         }
     }
 

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -10,6 +10,7 @@
 //! - `options.c:parse_arguments()` - Server-side argument parsing
 
 use std::ffi::OsString;
+use std::time::SystemTime;
 
 use super::super::super::config::{
     ClientConfig, DeleteMode, FilesFromSource, IconvSetting, ReferenceDirectoryKind,
@@ -307,6 +308,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
 
         if let TransferTimeout::Seconds(secs) = self.config.timeout() {
             args.push(OsString::from(format!("--timeout={}", secs.get())));
+        }
+
+        // upstream: options.c:server_options() - stop_at_utime is forwarded
+        // as --stop-at=YYYY/MM/DDTHH:MM so the remote side enforces the
+        // same deadline. Both --stop-after (duration) and --stop-at (absolute)
+        // are converted to an absolute SystemTime at parse time, so only the
+        // absolute form is forwarded.
+        if let Some(deadline) = self.config.stop_at() {
+            if let Some(formatted) = format_system_time_for_stop_at(deadline) {
+                args.push(OsString::from(format!("--stop-at={formatted}")));
+            }
         }
 
         // upstream: options.c - bwlimit forwarded as bytes-per-second.
@@ -677,4 +689,54 @@ pub(super) fn compression_level_to_numeric(level: compress::zlib::CompressionLev
         CompressionLevel::Best => 9,
         CompressionLevel::Precise(n) => u32::from(n.get()),
     }
+}
+
+/// Formats a `SystemTime` deadline as `YYYY/MM/DDTHH:MM` for the `--stop-at`
+/// server argument.
+///
+/// Uses UTC to avoid timezone ambiguity between local and remote hosts.
+/// Returns `None` if the timestamp predates the UNIX epoch (cannot be
+/// represented).
+///
+/// The format matches upstream rsync's `stopat_format()` in `options.c`, which
+/// produces `YYYY/MM/DDTHH:MM:SS`. We drop seconds (always `:00`) because the
+/// server-side `parse_time()` only parses `HH:MM`.
+///
+/// # Algorithm
+///
+/// Calendar conversion uses Howard Hinnant's `civil_from_days` algorithm for
+/// correct Gregorian date computation without external crate dependencies.
+pub(super) fn format_system_time_for_stop_at(time: SystemTime) -> Option<String> {
+    let secs = time.duration_since(SystemTime::UNIX_EPOCH).ok()?.as_secs();
+    let (year, month, day, hour, minute) = unix_secs_to_utc_components(secs);
+    Some(format!(
+        "{year:04}/{month:02}/{day:02}T{hour:02}:{minute:02}"
+    ))
+}
+
+/// Converts UNIX seconds to UTC calendar components (year, month, day, hour, minute).
+///
+/// Uses Howard Hinnant's `civil_from_days` algorithm (public domain) which
+/// converts a day count since the epoch into Gregorian year/month/day
+/// components in O(1) with no branching on month lengths or leap years.
+pub(super) fn unix_secs_to_utc_components(secs: u64) -> (i32, u8, u8, u8, u8) {
+    let day_secs = secs % 86_400;
+    let hour = (day_secs / 3_600) as u8;
+    let minute = ((day_secs % 3_600) / 60) as u8;
+
+    // civil_from_days: convert days since 1970-01-01 to (year, month, day).
+    // Shift epoch to 0000-03-01 so Feb is the last month of a "year",
+    // simplifying leap-year handling.
+    let z = (secs / 86_400) as i64 + 719_468; // days since 0000-03-01
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u32; // day of era [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
+    let mp = (5 * doy + 2) / 153; // month prime [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // day [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // month [1, 12]
+    let y = if m <= 2 { y + 1 } else { y }; // adjust year for Jan/Feb
+
+    (y as i32, m as u8, d as u8, hour, minute)
 }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for remote invocation builder and transfer role detection.
 
 use std::ffi::{OsStr, OsString};
+use std::time::SystemTime;
 
 use compress::algorithm::CompressionAlgorithm;
 use transfer::setup::build_capability_string_suffix;
@@ -472,6 +473,7 @@ const UPSTREAM_SERVER_LONG_ARGS: &[&str] = &[
     "--write-devices",
     "--open-noatime",
     "--preallocate",
+    "--stop-at",
 ];
 
 /// Returns whether a long-form argument matches one of the upstream allowlist
@@ -2114,6 +2116,9 @@ fn all_flags_enabled_produces_valid_invocation() {
         .write_devices(true)
         .open_noatime(true)
         .preallocate(true)
+        .stop_at(Some(
+            SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_893_456_000),
+        ))
         .set_rsync_path("/custom/rsync")
         .inc_recursive_send(true)
         .build();
@@ -2224,6 +2229,7 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--link-dest=",
         "--compare-dest=",
         "--copy-dest=",
+        "--stop-at=",
     ];
     for prefix in expected_prefixed {
         assert!(
@@ -2665,4 +2671,164 @@ fn shell_safe_escaping_in_normal_mode() {
         "normal command_line_args should contain escaped path: {:?}",
         secluded.command_line_args
     );
+}
+
+// --stop-at forwarding tests
+
+#[test]
+fn includes_stop_at_long_arg_when_set() {
+    use std::time::{Duration, SystemTime};
+
+    let deadline = SystemTime::UNIX_EPOCH + Duration::from_secs(1_893_456_000);
+    let config = ClientConfig::builder().stop_at(Some(deadline)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a.starts_with("--stop-at=")),
+        "expected --stop-at=... in args: {args:?}"
+    );
+}
+
+#[test]
+fn omits_stop_at_when_none() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--stop-at=")),
+        "should not emit --stop-at= when none: {args:?}"
+    );
+}
+
+#[test]
+fn stop_at_forwarded_as_utc_datetime_format() {
+    use std::time::{Duration, SystemTime};
+
+    // 2030-01-15T12:30:00 UTC = 1_894_796_200 unix seconds
+    // (2030-01-15 12:30:00 UTC)
+    let deadline = SystemTime::UNIX_EPOCH + Duration::from_secs(1_894_796_200);
+    let config = ClientConfig::builder().stop_at(Some(deadline)).build();
+    let args = build_sender_args(&config);
+    let stop_arg = args
+        .iter()
+        .find(|a| a.starts_with("--stop-at="))
+        .expect("--stop-at arg");
+    // The formatted value should be a valid datetime like YYYY/MM/DDTHH:MM
+    let value = stop_arg.strip_prefix("--stop-at=").unwrap();
+    assert!(
+        value.contains('T'),
+        "stop-at value should contain 'T' separator: {value}"
+    );
+    assert!(
+        value.contains('/') || value.contains('-'),
+        "stop-at value should contain date separators: {value}"
+    );
+}
+
+#[test]
+fn stop_at_forwarded_in_secluded_mode() {
+    use std::time::{Duration, SystemTime};
+
+    let deadline = SystemTime::UNIX_EPOCH + Duration::from_secs(1_893_456_000);
+    let config = ClientConfig::builder()
+        .stop_at(Some(deadline))
+        .protect_args(Some(true))
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let secluded = builder.build_secluded(&["/path"]);
+
+    assert!(
+        secluded
+            .stdin_args
+            .iter()
+            .any(|a| a.starts_with("--stop-at=")),
+        "secluded stdin_args should contain --stop-at=: {:?}",
+        secluded.stdin_args
+    );
+}
+
+// format_system_time_for_stop_at and unix_secs_to_utc_components tests
+
+#[test]
+fn format_stop_at_unix_epoch() {
+    use super::builder::format_system_time_for_stop_at;
+
+    let formatted = format_system_time_for_stop_at(SystemTime::UNIX_EPOCH).unwrap();
+    assert_eq!(formatted, "1970/01/01T00:00");
+}
+
+#[test]
+fn format_stop_at_y2k() {
+    use super::builder::format_system_time_for_stop_at;
+    use std::time::Duration;
+
+    // 2000-01-01T00:00:00 UTC = 946_684_800 (well-known Y2K timestamp)
+    let time = SystemTime::UNIX_EPOCH + Duration::from_secs(946_684_800);
+    let formatted = format_system_time_for_stop_at(time).unwrap();
+    assert_eq!(formatted, "2000/01/01T00:00");
+}
+
+#[test]
+fn format_stop_at_round_trip_with_parser() {
+    use super::builder::format_system_time_for_stop_at;
+    use std::time::Duration;
+
+    // Verify the formatter output is parseable by checking the format structure.
+    // Use a future timestamp to ensure it's always valid.
+    let time = SystemTime::UNIX_EPOCH + Duration::from_secs(4_102_444_800);
+    let formatted = format_system_time_for_stop_at(time).unwrap();
+    // Must be YYYY/MM/DDTHH:MM
+    let parts: Vec<&str> = formatted.split('T').collect();
+    assert_eq!(parts.len(), 2, "must have date and time parts: {formatted}");
+    let date_parts: Vec<&str> = parts[0].split('/').collect();
+    assert_eq!(
+        date_parts.len(),
+        3,
+        "date must have 3 parts: {}",
+        parts[0]
+    );
+    let time_parts: Vec<&str> = parts[1].split(':').collect();
+    assert_eq!(
+        time_parts.len(),
+        2,
+        "time must have 2 parts: {}",
+        parts[1]
+    );
+}
+
+#[test]
+fn unix_secs_to_utc_epoch() {
+    use super::builder::unix_secs_to_utc_components;
+    let (y, m, d, h, min) = unix_secs_to_utc_components(0);
+    assert_eq!((y, m, d, h, min), (1970, 1, 1, 0, 0));
+}
+
+#[test]
+fn unix_secs_to_utc_known_date() {
+    use super::builder::unix_secs_to_utc_components;
+    // 2000-01-01T00:00:00 UTC = 946_684_800
+    let (y, m, d, h, min) = unix_secs_to_utc_components(946_684_800);
+    assert_eq!((y, m, d, h, min), (2000, 1, 1, 0, 0));
+}
+
+#[test]
+fn unix_secs_to_utc_one_day() {
+    use super::builder::unix_secs_to_utc_components;
+    // 1970-01-02T00:00:00 UTC = 86400
+    let (y, m, d, h, min) = unix_secs_to_utc_components(86_400);
+    assert_eq!((y, m, d, h, min), (1970, 1, 2, 0, 0));
+}
+
+#[test]
+fn unix_secs_to_utc_time_components() {
+    use super::builder::unix_secs_to_utc_components;
+    // 1970-01-01T23:59:00 UTC = 86340
+    let (y, m, d, h, min) = unix_secs_to_utc_components(86_340);
+    assert_eq!((y, m, d, h, min), (1970, 1, 1, 23, 59));
+}
+
+#[test]
+fn unix_secs_to_utc_y2k() {
+    use super::builder::unix_secs_to_utc_components;
+    // 2000-01-01T00:00:00 UTC = 946_684_800 (well-known Y2K timestamp)
+    let (y, m, d, h, min) = unix_secs_to_utc_components(946_684_800);
+    assert_eq!((y, m, d, h, min), (2000, 1, 1, 0, 0));
 }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -473,6 +473,8 @@ const UPSTREAM_SERVER_LONG_ARGS: &[&str] = &[
     "--write-devices",
     "--open-noatime",
     "--preallocate",
+    "--trust-sender",
+    "--checksum-seed",
     "--stop-at",
 ];
 
@@ -1162,6 +1164,46 @@ fn numeric_ids_is_long_form_not_in_flag_string() {
     assert!(
         args.iter().any(|a| a == "--numeric-ids"),
         "expected --numeric-ids in long-form args: {args:?}"
+    );
+}
+
+#[test]
+fn includes_trust_sender_long_arg() {
+    let config = ClientConfig::builder().trust_sender(true).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--trust-sender"),
+        "expected --trust-sender in args: {args:?}"
+    );
+}
+
+#[test]
+fn omits_trust_sender_when_not_set() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--trust-sender"),
+        "unexpected --trust-sender in args: {args:?}"
+    );
+}
+
+#[test]
+fn includes_checksum_seed_long_arg() {
+    let config = ClientConfig::builder().checksum_seed(Some(12345)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--checksum-seed=12345"),
+        "expected --checksum-seed=12345 in args: {args:?}"
+    );
+}
+
+#[test]
+fn omits_checksum_seed_when_none() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--checksum-seed=")),
+        "unexpected --checksum-seed in args: {args:?}"
     );
 }
 
@@ -2074,6 +2116,8 @@ fn all_flags_enabled_produces_valid_invocation() {
         .prune_empty_dirs(true)
         .verbosity(2)
         // Long-form args
+        .trust_sender(true)
+        .checksum_seed(Some(42))
         .ignore_errors(true)
         .fsync(true)
         .delete_excluded(true)
@@ -2178,6 +2222,8 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--delete-excluded",
         "--force",
         "--numeric-ids",
+        "--trust-sender",
+        "--checksum-seed=42",
         "--max-delete=50",
         "--max-size=1000000",
         "--min-size=100",
@@ -2821,4 +2867,138 @@ fn unix_secs_to_utc_y2k() {
     // 2000-01-01T00:00:00 UTC = 946_684_800 (well-known Y2K timestamp)
     let (y, m, d, h, min) = unix_secs_to_utc_components(946_684_800);
     assert_eq!((y, m, d, h, min), (2000, 1, 1, 0, 0));
+}
+
+// -----------------------------------------------------------------------
+// Remote option (-M / --remote-option) forwarding
+// -----------------------------------------------------------------------
+
+#[test]
+fn remote_options_appended_to_sender_invocation() {
+    // upstream: options.c:2986-2993 - remote_options[] appended after all
+    // other server args, before "." and remote paths.
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--bwlimit=100", "--compress-level=1"])
+        .build();
+    let args = build_sender_args(&config);
+
+    assert!(
+        args.iter().any(|a| a == "--bwlimit=100"),
+        "expected --bwlimit=100 from -M in args: {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--compress-level=1"),
+        "expected --compress-level=1 from -M in args: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_appended_to_receiver_invocation() {
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--timeout=60"])
+        .build();
+    let args = build_receiver_args(&config);
+
+    assert!(
+        args.iter().any(|a| a == "--timeout=60"),
+        "expected --timeout=60 from -M in args: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_appear_before_dot_placeholder() {
+    // upstream: server_options() appends remote_options before returning,
+    // then do_cmd() appends "." and paths. So remote options must precede ".".
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--bwlimit=200"])
+        .build();
+    let args = build_sender_args(&config);
+
+    let dot_idx = args.iter().position(|a| a == ".").unwrap();
+    let opt_idx = args.iter().position(|a| a == "--bwlimit=200").unwrap();
+    assert!(
+        opt_idx < dot_idx,
+        "remote option should appear before '.' placeholder: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_appear_after_locally_derived_args() {
+    // Remote options should come after all locally-derived long-form args
+    // but before "." and paths.
+    let config = ClientConfig::builder()
+        .numeric_ids(true)
+        .remote_options(vec!["--max-delete=50"])
+        .build();
+    let args = build_sender_args(&config);
+
+    let numeric_idx = args.iter().position(|a| a == "--numeric-ids").unwrap();
+    let remote_idx = args.iter().position(|a| a == "--max-delete=50").unwrap();
+    assert!(
+        remote_idx > numeric_idx,
+        "remote option should appear after locally-derived args: {args:?}"
+    );
+}
+
+#[test]
+fn empty_remote_options_adds_nothing() {
+    let config_with = ClientConfig::builder()
+        .remote_options(Vec::<&str>::new())
+        .build();
+    let config_without = ClientConfig::builder().build();
+    let args_with = build_sender_args(&config_with);
+    let args_without = build_sender_args(&config_without);
+
+    assert_eq!(
+        args_with, args_without,
+        "empty remote_options should produce identical invocation"
+    );
+}
+
+#[test]
+fn multiple_remote_options_preserve_order() {
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--first", "--second", "--third"])
+        .build();
+    let args = build_sender_args(&config);
+
+    let first_idx = args.iter().position(|a| a == "--first").unwrap();
+    let second_idx = args.iter().position(|a| a == "--second").unwrap();
+    let third_idx = args.iter().position(|a| a == "--third").unwrap();
+    assert!(
+        first_idx < second_idx && second_idx < third_idx,
+        "remote options must preserve insertion order: {args:?}"
+    );
+}
+
+#[test]
+fn remote_options_forwarded_in_secluded_mode() {
+    let config = ClientConfig::builder()
+        .protect_args(Some(true))
+        .remote_options(vec!["--bwlimit=500"])
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let secluded = builder.build_secluded(&["/path"]);
+
+    assert!(
+        secluded.stdin_args.iter().any(|a| a == "--bwlimit=500"),
+        "secluded stdin_args should contain remote option: {:?}",
+        secluded.stdin_args
+    );
+}
+
+#[test]
+fn remote_options_not_on_upstream_allowlist_still_forwarded() {
+    // Remote options (-M) are user-provided overrides forwarded verbatim.
+    // They deliberately bypass the upstream long-arg allowlist because they
+    // are explicitly requested by the user.
+    let config = ClientConfig::builder()
+        .remote_options(vec!["--custom-extension=value"])
+        .build();
+    let args = build_sender_args(&config);
+
+    assert!(
+        args.iter().any(|a| a == "--custom-extension=value"),
+        "remote options should be forwarded verbatim: {args:?}"
+    );
 }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2779,19 +2779,9 @@ fn format_stop_at_round_trip_with_parser() {
     let parts: Vec<&str> = formatted.split('T').collect();
     assert_eq!(parts.len(), 2, "must have date and time parts: {formatted}");
     let date_parts: Vec<&str> = parts[0].split('/').collect();
-    assert_eq!(
-        date_parts.len(),
-        3,
-        "date must have 3 parts: {}",
-        parts[0]
-    );
+    assert_eq!(date_parts.len(), 3, "date must have 3 parts: {}", parts[0]);
     let time_parts: Vec<&str> = parts[1].split(':').collect();
-    assert_eq!(
-        time_parts.len(),
-        2,
-        "time must have 2 parts: {}",
-        parts[1]
-    );
+    assert_eq!(time_parts.len(), 2, "time must have 2 parts: {}", parts[1]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Wire the `--stop-at` deadline through `RemoteInvocationBuilder::append_long_form_args()` so that remote rsync processes in SSH transfers enforce the same deadline as the local side.
- Both `--stop-after` (duration) and `--stop-at` (absolute) are converted to an absolute `SystemTime` at parse time, so only the absolute form is forwarded as `--stop-at=YYYY/MM/DDTHH:MM` in UTC.
- Calendar conversion uses Howard Hinnant's `civil_from_days` algorithm (public domain, O(1)) to format UTC datetime without adding external crate dependencies to the `core` crate.

## Details

The `--stop-at` and `--time-limit`/`--stop-after` options were already fully implemented on the local side:
- CLI parsing in `crates/cli/src/frontend/execution/stop.rs` and clap definitions in `crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs`
- `TransferDeadline` monotonic deadline in `crates/transfer/src/shared/deadline.rs`
- Deadline checks at file boundaries in generator (`transfer_loop.rs`), receiver (`sync.rs`, `pipeline.rs`)
- `ExitCode::Timeout = 30` mapping

The gap was that `RemoteInvocationBuilder` did not forward the deadline to the remote server, so in SSH transfers the remote process would not stop at the configured time.

## Test plan

- [x] `includes_stop_at_long_arg_when_set` - verifies `--stop-at=` present when deadline set
- [x] `omits_stop_at_when_none` - verifies no `--stop-at=` when no deadline
- [x] `stop_at_forwarded_as_utc_datetime_format` - validates format structure
- [x] `stop_at_forwarded_in_secluded_mode` - verifies forwarding in `--protect-args` mode
- [x] `format_stop_at_unix_epoch` - epoch formats as `1970/01/01T00:00`
- [x] `format_stop_at_y2k` - Y2K timestamp formats correctly
- [x] `format_stop_at_round_trip_with_parser` - structural format validation
- [x] `unix_secs_to_utc_epoch` - epoch components
- [x] `unix_secs_to_utc_known_date` - well-known Y2K timestamp
- [x] `unix_secs_to_utc_one_day` - 86400 seconds = 1970-01-02
- [x] `unix_secs_to_utc_time_components` - hour/minute extraction
- [x] `unix_secs_to_utc_y2k` - Y2K boundary components
- [x] `all_flags_enabled_produces_valid_invocation` - updated with `--stop-at=` in expected_prefixed
- [x] CI: nextest, fmt+clippy, Windows, macOS, Linux musl