### PR TITLE
feat: add --password-command option for daemon authentication

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -124,6 +124,9 @@ pub struct ParsedArgs {
     /// `--password-file` - file containing daemon authentication password.
     pub password_file: Option<OsString>,
 
+    /// `--password-command` - shell command whose stdout provides the daemon password.
+    pub password_command: Option<OsString>,
+
     /// `--archive`, `-a` - shorthand for `-rlptgoD`.
     pub archive: bool,
 

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -686,6 +686,7 @@ where
     let existing = matches.get_flag("existing");
     let update = matches.get_flag("update");
     let password_file = matches.remove_one::<OsString>("password-file");
+    let password_command = matches.remove_one::<OsString>("password-command");
     // upstream: options.c does not range-check --protocol at parse time.
     // Incompatible versions fail during negotiation with RERR_PROTOCOL (exit 2).
     let protocol = matches.remove_one::<OsString>("protocol");
@@ -860,6 +861,7 @@ where
         xattrs,
         no_motd,
         password_file,
+        password_command,
         protocol,
         timeout,
         contimeout,

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -595,6 +595,14 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .action(ArgAction::Set),
             )
             .arg(
+                Arg::new("password-command")
+                    .long("password-command")
+                    .value_name("COMMAND")
+                    .help("Run COMMAND via the system shell and read daemon password from its stdout.")
+                    .value_parser(OsStringValueParser::new())
+                    .action(ArgAction::Set),
+            )
+            .arg(
                 Arg::new("motd")
                     .long("motd")
                     .help("Display daemon MOTD lines when listing rsync:// modules.")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -12,7 +12,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--suffix, --checksum/-c, --checksum-choice, --checksum-seed, --size-only, --ignore-times, --ignore-existing, --existing, ",
     "--ignore-missing-args, --delete-missing-args, --update/-u, --modify-window, --exclude, --exclude-from, ",
     "--include, --include-from, --compare-dest, --copy-dest, --link-dest, --hard-links/-H, --no-hard-links, ",
-    "--cvs-exclude/-C, --apple-double-skip, --filter/-F (including exclude-if-present=FILE), --files-from, --password-file, --no-motd, ",
+    "--cvs-exclude/-C, --apple-double-skip, --filter/-F (including exclude-if-present=FILE), --files-from, --password-file, --password-command, --no-motd, ",
     "--from0, --no-from0, --bwlimit, --no-bwlimit, --timeout, --contimeout, --stop-after/--time-limit, --stop-at, --sockopts, ",
     "--blocking-io, --no-blocking-io, --protocol, --compress/-z, --no-compress, --compress-level, --compress-choice, --compress-threads, ",
     "--skip-compress, --open-noatime, --no-open-noatime, --iconv, --no-iconv, --info, --debug, --verbose/-v, --no-verbose, ",

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -154,6 +154,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) jump_hosts: Option<OsString>,
     pub(crate) batch_config: Option<BatchConfig>,
     pub(crate) no_motd: bool,
+    pub(crate) password_override: Option<Vec<u8>>,
     pub(crate) daemon_params: Vec<String>,
     pub(crate) files_from: FilesFromSource,
     pub(crate) from0: bool,
@@ -385,5 +386,6 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
     builder
         .force_event_collection(force_event_collection)
         .no_motd(inputs.no_motd)
+        .password_override(inputs.password_override)
         .daemon_params(inputs.daemon_params)
 }

--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsString;
 use std::io::Write;
-use std::path::Path;
 
 use core::client::{
     AddressMode, BindAddress, ModuleListOptions, ModuleListRequest, TransferTimeout,
@@ -9,9 +8,7 @@ use core::client::{
 use logging_sink::MessageSink;
 use protocol::ProtocolVersion;
 
-use crate::frontend::{
-    execution::render_module_list, password::load_optional_password, write_message,
-};
+use crate::frontend::{execution::render_module_list, write_message};
 
 /// Inputs for attempting a daemon module listing request.
 pub(super) struct ModuleListingInputs<'a> {
@@ -19,7 +16,7 @@ pub(super) struct ModuleListingInputs<'a> {
     pub remainder: &'a [OsString],
     pub daemon_port: Option<u16>,
     pub desired_protocol: Option<ProtocolVersion>,
-    pub password_file: Option<&'a Path>,
+    pub password_override: Option<Vec<u8>>,
     pub no_motd: bool,
     pub address_mode: AddressMode,
     pub bind_address: Option<&'a BindAddress>,
@@ -47,7 +44,7 @@ where
         remainder,
         daemon_port,
         desired_protocol,
-        password_file,
+        password_override,
         no_motd,
         address_mode,
         bind_address,
@@ -78,17 +75,6 @@ where
         request.with_protocol(protocol)
     } else {
         request
-    };
-
-    let password_override = match load_optional_password(password_file) {
-        Ok(secret) => secret,
-        Err(message) => {
-            if write_message(&message, stderr).is_err() {
-                let fallback = message.to_string();
-                let _ = writeln!(stderr.writer_mut(), "{fallback}");
-            }
-            return Some(1);
-        }
     };
 
     let list_options = ModuleListOptions::default()

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -14,8 +14,7 @@ pub(crate) const REMOTE_OPTION_REMOTE_ONLY_MESSAGE: &str =
 pub(crate) const PROTOCOL_DAEMON_ONLY_MESSAGE: &str =
     "the --protocol option may only be used when accessing an rsync daemon";
 /// Error message when a password option is used without a daemon connection.
-pub(crate) const PASSWORD_DAEMON_ONLY_MESSAGE: &str =
-    "the --password-file and --password-command options may only be used when accessing an rsync daemon";
+pub(crate) const PASSWORD_DAEMON_ONLY_MESSAGE: &str = "the --password-file and --password-command options may only be used when accessing an rsync daemon";
 /// Error message when `--connect-program` is used without a daemon connection.
 pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
     "the --connect-program option may only be used when accessing an rsync daemon";

--- a/crates/cli/src/frontend/execution/drive/validation.rs
+++ b/crates/cli/src/frontend/execution/drive/validation.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsString;
 use std::io::Write;
-use std::path::PathBuf;
 
 use core::{message::Role, rsync_error};
 use logging_sink::MessageSink;
@@ -14,9 +13,9 @@ pub(crate) const REMOTE_OPTION_REMOTE_ONLY_MESSAGE: &str =
 /// Error message when `--protocol` is used without a daemon connection.
 pub(crate) const PROTOCOL_DAEMON_ONLY_MESSAGE: &str =
     "the --protocol option may only be used when accessing an rsync daemon";
-/// Error message when `--password-file` is used without a daemon connection.
-pub(crate) const PASSWORD_FILE_DAEMON_ONLY_MESSAGE: &str =
-    "the --password-file option may only be used when accessing an rsync daemon";
+/// Error message when a password option is used without a daemon connection.
+pub(crate) const PASSWORD_DAEMON_ONLY_MESSAGE: &str =
+    "the --password-file and --password-command options may only be used when accessing an rsync daemon";
 /// Error message when `--connect-program` is used without a daemon connection.
 pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
     "the --connect-program option may only be used when accessing an rsync daemon";
@@ -31,7 +30,8 @@ pub(crate) const CONNECT_PROGRAM_DAEMON_ONLY_MESSAGE: &str =
 /// this behavior (e.g., the exclude test passes `--rsync-path` on local runs).
 pub(super) fn validate_local_only_options<Err>(
     desired_protocol: Option<ProtocolVersion>,
-    password_file: Option<&PathBuf>,
+    has_password_override: bool,
+    has_password_option: bool,
     connect_program: Option<&OsString>,
     _rsync_path: Option<&OsString>,
     remote_options: &[OsString],
@@ -54,10 +54,10 @@ where
         ));
     }
 
-    if password_file.is_some() {
+    if has_password_override || has_password_option {
         return Some(reject_local_only_option(
             stderr,
-            PASSWORD_FILE_DAEMON_ONLY_MESSAGE,
+            PASSWORD_DAEMON_ONLY_MESSAGE,
         ));
     }
 

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -204,6 +204,7 @@ where
         xattrs,
         no_motd,
         password_file,
+        password_command,
         protocol,
         timeout,
         contimeout,
@@ -272,6 +273,16 @@ where
     if let Err(code) = validate_stdin_sources_conflict(&password_file, &files_from, stderr) {
         return code;
     }
+
+    // Resolve daemon password from the available sources in precedence order:
+    // --password-command > --password-file > RSYNC_PASSWORD (handled later in core)
+    let password_override = match crate::frontend::password::resolve_password(
+        password_command.as_deref(),
+        password_file.as_deref(),
+    ) {
+        Ok(password) => password,
+        Err(message) => return fail_with_message(message, stderr),
+    };
 
     let desired_protocol = match resolve_desired_protocol(protocol.as_ref(), stderr) {
         Ok(protocol) => protocol,
@@ -447,7 +458,7 @@ where
             remainder: &remainder,
             daemon_port,
             desired_protocol,
-            password_file: password_file.as_deref(),
+            password_override: password_override.clone(),
             no_motd,
             address_mode,
             bind_address: bind_address.as_ref(),
@@ -609,7 +620,8 @@ where
     if !is_daemon_transfer {
         if let Some(exit_code) = validation::validate_local_only_options(
             desired_protocol,
-            password_file.as_ref(),
+            password_override.is_some(),
+            password_file.is_some() || password_command.is_some(),
             connect_program.as_ref(),
             parsed.rsync_path.as_ref(),
             &remote_options,
@@ -828,6 +840,7 @@ where
         jump_hosts: jump_host,
         batch_config,
         no_motd,
+        password_override,
         daemon_params: dparam
             .into_iter()
             .map(|s| s.to_string_lossy().into_owned())

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -79,6 +79,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "  -F            Alias for per-directory .rsync-filter handling (repeat to also load receiver-side files).\n",
             "      --files-from=FILE  Read additional source operands from FILE.\n",
             "      --password-file=FILE  Read daemon passwords from FILE when contacting rsync:// daemons.\n",
+            "      --password-command=COMMAND  Run COMMAND via system shell and read daemon password from stdout.\n",
             "      --no-motd    Suppress daemon MOTD lines when listing rsync:// modules.\n",
             "      --from0      Treat file list entries as NUL-terminated records.\n",
             "      --no-from0  Disable NUL-terminated file list handling.\n",

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -368,11 +368,7 @@ mod tests {
 
     #[test]
     fn load_password_command_reads_echo_output() {
-        let cmd = if cfg!(windows) {
-            OsString::from("echo cmd-secret")
-        } else {
-            OsString::from("echo cmd-secret")
-        };
+        let cmd = OsString::from("echo cmd-secret");
 
         let password = load_password_command(&cmd).expect("echo command");
         assert_eq!(password, b"cmd-secret");

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -2,8 +2,9 @@
 //!
 //! This module centralises password loading logic so the sprawling argument
 //! parser in `lib.rs` can delegate to cohesive helpers. The functions here keep
-//! responsibility focused on reading passwords from standard input or from
-//! filesystem paths while enforcing upstream rsync's permission checks.
+//! responsibility focused on reading passwords from standard input, from
+//! filesystem paths, or from external commands while enforcing upstream rsync's
+//! permission checks.
 //! Tests operate through the exported helpers rather than touching the
 //! implementation details directly, which keeps the core file smaller and easier
 //! to audit.
@@ -12,9 +13,11 @@ use core::{
     message::{Message, Role},
     rsync_error,
 };
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;
+use std::process::Command;
 
 #[cfg(test)]
 use std::cell::RefCell;
@@ -37,6 +40,119 @@ pub(crate) fn load_optional_password(path: Option<&Path>) -> Result<Option<Vec<u
     match path {
         Some(path) => load_password_file(path).map(Some),
         None => Ok(None),
+    }
+}
+
+/// Resolves the daemon password from the available sources in precedence order.
+///
+/// The resolution chain mirrors upstream rsync's auth_client() with the addition
+/// of `--password-command`:
+///
+/// 1. `--password-command=COMMAND` - run COMMAND via the system shell, read stdout
+/// 2. `--password-file=FILE` - read password from a file (or `-` for stdin)
+///
+/// Returns `Ok(None)` when neither source is specified (the caller falls through
+/// to `RSYNC_PASSWORD` env var at the core layer).
+pub(crate) fn resolve_password(
+    password_command: Option<&OsStr>,
+    password_file: Option<&Path>,
+) -> Result<Option<Vec<u8>>, Message> {
+    if let Some(command) = password_command {
+        return load_password_command(command).map(Some);
+    }
+    load_optional_password(password_file)
+}
+
+/// Runs an external command via the system shell and reads the password from
+/// its standard output.
+///
+/// The command string is passed to the platform's shell interpreter:
+/// - Unix: `/bin/sh -c <command>`
+/// - Windows: `cmd.exe /C <command>`
+///
+/// Only the first line of output is used. Trailing newlines and carriage returns
+/// are stripped, matching `--password-file` semantics. The command must produce
+/// at least one byte of output and must exit with status 0.
+///
+/// # Security model
+///
+/// The command string is user-provided and intentionally executed as-is. This
+/// enables integration with secret managers (e.g., `pass show rsync/server`,
+/// `vault read -field=password secret/rsync`). The caller is responsible for
+/// the safety of the command they provide.
+pub(crate) fn load_password_command(command: &OsStr) -> Result<Vec<u8>, Message> {
+    let command_str = command.to_string_lossy();
+
+    if command_str.is_empty() {
+        return Err(
+            rsync_error!(1, "--password-command requires a non-empty command string")
+                .with_role(Role::Client),
+        );
+    }
+
+    let output = build_shell_command(command)
+        .output()
+        .map_err(|error| {
+            rsync_error!(
+                1,
+                format!("failed to execute password command '{}': {}", command_str, error)
+            )
+            .with_role(Role::Client)
+        })?;
+
+    if !output.status.success() {
+        let code = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".to_owned());
+        return Err(rsync_error!(
+            1,
+            format!(
+                "password command '{}' failed with exit code {}",
+                command_str, code
+            )
+        )
+        .with_role(Role::Client));
+    }
+
+    let mut bytes = first_line(&output.stdout);
+    trim_trailing_newlines(&mut bytes);
+
+    if bytes.is_empty() {
+        return Err(
+            rsync_error!(
+                1,
+                format!(
+                    "password command '{}' produced no output",
+                    command_str
+                )
+            )
+            .with_role(Role::Client),
+        );
+    }
+
+    Ok(bytes)
+}
+
+/// Builds a [`Command`] that invokes the given string through the platform shell.
+fn build_shell_command(command: &OsStr) -> Command {
+    #[cfg(not(windows))]
+    let (shell, flag) = ("/bin/sh", "-c");
+    #[cfg(windows)]
+    let (shell, flag) = ("cmd.exe", "/C");
+
+    let mut cmd = Command::new(shell);
+    cmd.arg(flag).arg(command);
+    cmd
+}
+
+/// Extracts the first line from raw byte output.
+fn first_line(bytes: &[u8]) -> Vec<u8> {
+    if let Some(pos) = bytes.iter().position(|&b| b == b'\n') {
+        bytes[..pos].to_vec()
+    } else {
+        bytes.to_vec()
     }
 }
 
@@ -158,6 +274,7 @@ pub(crate) fn set_password_stdin_input(data: Vec<u8>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::io::Write;
 
     use tempfile::NamedTempFile;
@@ -242,5 +359,117 @@ mod tests {
             "unexpected diagnostic: {}",
             error.text()
         );
+    }
+
+    #[test]
+    fn first_line_extracts_before_newline() {
+        assert_eq!(first_line(b"hello\nworld"), b"hello");
+        assert_eq!(first_line(b"only-line"), b"only-line");
+        assert_eq!(first_line(b""), b"");
+        assert_eq!(first_line(b"\n"), b"");
+        assert_eq!(first_line(b"line1\nline2\nline3"), b"line1");
+    }
+
+    #[test]
+    fn load_password_command_reads_echo_output() {
+        let cmd = if cfg!(windows) {
+            OsString::from("echo cmd-secret")
+        } else {
+            OsString::from("echo cmd-secret")
+        };
+
+        let password = load_password_command(&cmd).expect("echo command");
+        assert_eq!(password, b"cmd-secret");
+    }
+
+    #[test]
+    fn load_password_command_strips_trailing_newlines() {
+        let cmd = if cfg!(windows) {
+            OsString::from("echo cmd-stripped")
+        } else {
+            OsString::from("printf 'cmd-stripped\\n\\r\\n'")
+        };
+
+        let password = load_password_command(&cmd).expect("newline stripping");
+        assert_eq!(password, b"cmd-stripped");
+    }
+
+    #[test]
+    fn load_password_command_takes_only_first_line() {
+        #[cfg(unix)]
+        {
+            let cmd = OsString::from("printf 'first-line\\nsecond-line\\n'");
+            let password = load_password_command(&cmd).expect("first line only");
+            assert_eq!(password, b"first-line");
+        }
+    }
+
+    #[test]
+    fn load_password_command_rejects_empty_command() {
+        let error = load_password_command(OsStr::new("")).expect_err("empty command");
+
+        assert_eq!(error.code(), Some(1));
+        assert_eq!(error.role(), Some(Role::Client));
+        assert!(
+            error.text().contains("non-empty command string"),
+            "unexpected diagnostic: {}",
+            error.text()
+        );
+    }
+
+    #[test]
+    fn load_password_command_rejects_failing_command() {
+        let cmd = OsString::from("exit 42");
+        let error = load_password_command(&cmd).expect_err("non-zero exit");
+
+        assert_eq!(error.code(), Some(1));
+        assert_eq!(error.role(), Some(Role::Client));
+        assert!(
+            error.text().contains("failed with exit code 42"),
+            "unexpected diagnostic: {}",
+            error.text()
+        );
+    }
+
+    #[test]
+    fn load_password_command_rejects_empty_output() {
+        let cmd = OsString::from("true");
+        let error = load_password_command(&cmd).expect_err("empty output");
+
+        assert_eq!(error.code(), Some(1));
+        assert_eq!(error.role(), Some(Role::Client));
+        assert!(
+            error.text().contains("produced no output"),
+            "unexpected diagnostic: {}",
+            error.text()
+        );
+    }
+
+    #[test]
+    fn resolve_password_prefers_command_over_file() {
+        let mut file = NamedTempFile::new().expect("create temp file");
+        file.write_all(b"file-secret\n").expect("write secret");
+        let path = file.into_temp_path();
+
+        let cmd = OsString::from("echo cmd-secret");
+        let password = resolve_password(Some(&cmd), Some(path.as_ref())).expect("resolve");
+
+        assert_eq!(password, Some(b"cmd-secret".to_vec()));
+    }
+
+    #[test]
+    fn resolve_password_falls_back_to_file() {
+        let mut file = NamedTempFile::new().expect("create temp file");
+        file.write_all(b"file-secret\n").expect("write secret");
+        let path = file.into_temp_path();
+
+        let password = resolve_password(None, Some(path.as_ref())).expect("resolve");
+        assert_eq!(password, Some(b"file-secret".to_vec()));
+    }
+
+    #[test]
+    fn resolve_password_returns_none_when_no_source() {
+        let password = resolve_password(None, None).expect("resolve");
+        assert_eq!(password, None);
     }
 }

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -90,15 +90,16 @@ pub(crate) fn load_password_command(command: &OsStr) -> Result<Vec<u8>, Message>
         );
     }
 
-    let output = build_shell_command(command)
-        .output()
-        .map_err(|error| {
-            rsync_error!(
-                1,
-                format!("failed to execute password command '{}': {}", command_str, error)
+    let output = build_shell_command(command).output().map_err(|error| {
+        rsync_error!(
+            1,
+            format!(
+                "failed to execute password command '{}': {}",
+                command_str, error
             )
-            .with_role(Role::Client)
-        })?;
+        )
+        .with_role(Role::Client)
+    })?;
 
     if !output.status.success() {
         let code = output
@@ -120,16 +121,11 @@ pub(crate) fn load_password_command(command: &OsStr) -> Result<Vec<u8>, Message>
     trim_trailing_newlines(&mut bytes);
 
     if bytes.is_empty() {
-        return Err(
-            rsync_error!(
-                1,
-                format!(
-                    "password command '{}' produced no output",
-                    command_str
-                )
-            )
-            .with_role(Role::Client),
-        );
+        return Err(rsync_error!(
+            1,
+            format!("password command '{}' produced no output", command_str)
+        )
+        .with_role(Role::Client));
     }
 
     Ok(bytes)

--- a/crates/cli/src/frontend/tests/module.rs
+++ b/crates/cli/src/frontend/tests/module.rs
@@ -120,6 +120,44 @@ fn module_list_uses_password_file_for_authentication() {
 }
 
 #[test]
+fn module_list_uses_password_command_for_authentication() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
+    use checksums::strong::Sha512;
+
+    let challenge = "cmd-test";
+    let secret = b"cmd-secret";
+    let expected_digest = {
+        let mut hasher = Sha512::new();
+        hasher.update(secret);
+        hasher.update(challenge.as_bytes());
+        let digest = hasher.finalize();
+        STANDARD_NO_PAD.encode(digest)
+    };
+
+    let expected_credentials = format!("user {expected_digest}");
+    let (addr, handle) = spawn_auth_stub_daemon(
+        challenge,
+        expected_credentials,
+        vec!["@RSYNCD: OK\n", "protected\n", "@RSYNCD: EXIT\n"],
+    );
+
+    let url = format!("rsync://user@{}:{}/", addr.ip(), addr.port());
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--password-command=echo cmd-secret"),
+        OsString::from(url),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(stderr.is_empty());
+    let rendered = String::from_utf8(stdout).expect("module listing is UTF-8");
+    assert!(rendered.contains("protected"));
+
+    handle.join().expect("server thread");
+}
+
+#[test]
 fn module_list_reads_password_from_stdin() {
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD_NO_PAD;

--- a/crates/cli/src/frontend/tests/parse_args_recognises_password.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_password.rs
@@ -49,8 +49,5 @@ fn parse_args_recognises_password_command() {
     ])
     .expect("parse");
 
-    assert_eq!(
-        parsed.password_command,
-        Some(OsString::from("echo secret"))
-    );
+    assert_eq!(parsed.password_command, Some(OsString::from("echo secret")));
 }

--- a/crates/cli/src/frontend/tests/parse_args_recognises_password.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_password.rs
@@ -24,3 +24,33 @@ fn parse_args_recognises_password_file() {
 
     assert_eq!(parsed.password_file, Some(OsString::from("secrets.d")));
 }
+
+#[test]
+fn parse_args_recognises_password_command() {
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--password-command"),
+        OsString::from("pass show rsync/server"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(
+        parsed.password_command,
+        Some(OsString::from("pass show rsync/server"))
+    );
+
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("--password-command=echo secret"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert_eq!(
+        parsed.password_command,
+        Some(OsString::from("echo secret"))
+    );
+}

--- a/crates/cli/src/frontend/tests/password.rs
+++ b/crates/cli/src/frontend/tests/password.rs
@@ -52,3 +52,31 @@ fn password_file_dash_conflicts_with_files_from_dash() {
     let rendered = String::from_utf8(stderr).expect("diagnostic is UTF-8");
     assert!(rendered.contains("--password-file=- cannot be combined with --files-from=-"));
 }
+
+#[test]
+fn password_command_requires_daemon_operands() {
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    std::fs::write(&source, b"data").expect("write source");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--password-command=echo secret"),
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 1);
+    assert!(stdout.is_empty());
+    let rendered = String::from_utf8(stderr).expect("diagnostic is UTF-8");
+    assert!(
+        rendered.contains("--password-command") || rendered.contains("--password-file"),
+        "expected password daemon-only diagnostic, got: {}",
+        rendered
+    );
+    assert!(rendered.contains("rsync daemon"));
+    assert!(!destination.exists());
+}

--- a/crates/cli/src/frontend/tests/password.rs
+++ b/crates/cli/src/frontend/tests/password.rs
@@ -74,8 +74,7 @@ fn password_command_requires_daemon_operands() {
     let rendered = String::from_utf8(stderr).expect("diagnostic is UTF-8");
     assert!(
         rendered.contains("--password-command") || rendered.contains("--password-file"),
-        "expected password daemon-only diagnostic, got: {}",
-        rendered
+        "expected password daemon-only diagnostic, got: {rendered}"
     );
     assert!(rendered.contains("rsync daemon"));
     assert!(!destination.exists());

--- a/crates/cli/tests/argument_defaults_values.rs
+++ b/crates/cli/tests/argument_defaults_values.rs
@@ -227,6 +227,15 @@ fn test_password_file_defaults_to_none() {
 }
 
 #[test]
+fn test_password_command_defaults_to_none() {
+    let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
+    assert_eq!(
+        args.password_command, None,
+        "password_command should default to None"
+    );
+}
+
+#[test]
 fn test_chown_defaults_to_none() {
     let args = parse_args(["oc-rsync", "src", "dest"]).unwrap();
     assert_eq!(args.chown, None, "chown should default to None");

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -262,6 +262,7 @@ pub struct ClientConfigBuilder {
     spill_threshold_bytes: Option<u64>,
     no_spill: bool,
     no_motd: bool,
+    password_override: Option<Vec<u8>>,
     daemon_params: Vec<String>,
     protocol_version: Option<protocol::ProtocolVersion>,
     #[cfg(feature = "embedded-ssh")]
@@ -494,6 +495,7 @@ impl ClientConfigBuilder {
             spill_threshold_bytes: self.spill_threshold_bytes,
             no_spill: self.no_spill,
             no_motd: self.no_motd,
+            password_override: self.password_override,
             daemon_params: self.daemon_params,
             protocol_version: self.protocol_version,
             #[cfg(feature = "embedded-ssh")]

--- a/crates/core/src/client/config/builder/output.rs
+++ b/crates/core/src/client/config/builder/output.rs
@@ -55,6 +55,17 @@ impl ClientConfigBuilder {
         self
     }
 
+    /// Sets a pre-loaded password override for daemon authentication.
+    ///
+    /// When `Some`, this password takes precedence over the `RSYNC_PASSWORD`
+    /// environment variable during the daemon handshake. Typically populated
+    /// from `--password-command` or `--password-file`.
+    #[must_use]
+    pub fn password_override(mut self, password: Option<Vec<u8>>) -> Self {
+        self.password_override = password;
+        self
+    }
+
     /// Configures daemon parameter overrides sent during the daemon handshake.
     ///
     /// Each entry should be a `key=value` string that overrides a module-level

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -222,6 +222,12 @@ pub struct ClientConfig {
     /// `in_memory_only` to `true`. Precedence: **CLI > env > defaults**.
     pub(super) no_spill: bool,
     pub(super) no_motd: bool,
+    /// Pre-loaded password override for daemon authentication.
+    ///
+    /// When `Some`, this password takes precedence over the `RSYNC_PASSWORD`
+    /// environment variable during daemon handshake. Populated from
+    /// `--password-command` or `--password-file` at the CLI layer.
+    pub(super) password_override: Option<Vec<u8>>,
     pub(super) daemon_params: Vec<String>,
     pub(super) protocol_version: Option<protocol::ProtocolVersion>,
     #[cfg(feature = "embedded-ssh")]
@@ -390,6 +396,7 @@ impl Default for ClientConfig {
             spill_threshold_bytes: None,
             no_spill: false,
             no_motd: false,
+            password_override: None,
             daemon_params: Vec::new(),
             protocol_version: None,
             #[cfg(feature = "embedded-ssh")]

--- a/crates/core/src/client/config/client/output.rs
+++ b/crates/core/src/client/config/client/output.rs
@@ -63,6 +63,16 @@ impl ClientConfig {
         self.no_motd
     }
 
+    /// Returns the pre-loaded password override for daemon authentication.
+    ///
+    /// When `Some`, this password takes precedence over the `RSYNC_PASSWORD`
+    /// environment variable during the daemon handshake. Populated from
+    /// `--password-command` or `--password-file` at the CLI layer.
+    #[must_use]
+    pub fn password_override(&self) -> Option<&[u8]> {
+        self.password_override.as_deref()
+    }
+
     /// Returns the daemon parameter overrides to send during the daemon handshake.
     ///
     /// Each entry is a `key=value` string that overrides a module-level

--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -179,6 +179,7 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
     daemon_params: &[String],
     early_input: Option<&Path>,
     protocol_override: Option<ProtocolVersion>,
+    password_override: Option<&[u8]>,
 ) -> Result<ProtocolVersion, ClientError> {
     let mut greeting = String::new();
     reader.read_line(&mut greeting).map_err(|e| {
@@ -273,12 +274,16 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
         let trimmed = line.trim();
 
         if let Some(challenge) = trimmed.strip_prefix("@RSYNCD: AUTHREQD ") {
-            let secret = load_daemon_password().ok_or_else(|| {
-                daemon_error(
-                    "daemon requires authentication but RSYNC_PASSWORD not set",
-                    CLIENT_SERVER_PROTOCOL_EXIT_CODE,
-                )
-            })?;
+            let secret = password_override
+                .map(|s| s.to_vec())
+                .or_else(load_daemon_password)
+                .ok_or_else(|| {
+                    daemon_error(
+                        "daemon requires authentication but no password source available \
+                         (use --password-command, --password-file, or RSYNC_PASSWORD)",
+                        CLIENT_SERVER_PROTOCOL_EXIT_CODE,
+                    )
+                })?;
 
             let username = request.username.clone().unwrap_or_else(|| {
                 std::env::var("USER")

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -175,6 +175,7 @@ pub fn run_daemon_transfer(
         config.daemon_params(),
         config.early_input(),
         config.protocol_version(),
+        config.password_override(),
     )?;
 
     // For pull (we receive), the daemon is the sender, so is_sender=true.
@@ -363,6 +364,7 @@ pub fn run_daemon_over_remote_shell(
         config.daemon_params(),
         config.early_input(),
         config.protocol_version(),
+        config.password_override(),
     )?;
 
     let daemon_is_sender = matches!(role, RemoteRole::Receiver);


### PR DESCRIPTION
## Summary

- Add `--password-command=COMMAND` CLI option that runs a shell command and reads the daemon authentication password from its stdout
- Wire the resolved password through both the module listing and daemon transfer authentication paths via a `password_override` field on `ClientConfig`
- Password source precedence: `--password-command` > `--password-file` > `RSYNC_PASSWORD` environment variable

## Details

The command is executed via the platform shell (`/bin/sh -c` on Unix, `cmd.exe /C` on Windows). Only the first line of output is used, with trailing newlines/carriage returns stripped, matching `--password-file` semantics.

Error handling covers: empty command strings, non-zero exit codes, and empty output. The command string is user-provided and intentionally executed as-is, enabling integration with secret managers (e.g., `pass show rsync/server`, `vault read -field=password secret/rsync`).

### Files changed

- **CLI layer**: clap argument definition, parsed args struct, parser extraction
- **Password resolution**: new `load_password_command()` and `resolve_password()` in `password.rs`
- **Config pipeline**: `password_override` field added to `ConfigInputs`, `ClientConfigBuilder`, and `ClientConfig`
- **Daemon handshake**: `perform_daemon_handshake()` accepts optional password override, falling back to `RSYNC_PASSWORD`
- **Module listing**: accepts pre-resolved password override instead of raw file path
- **Validation**: updated to reject both `--password-file` and `--password-command` on non-daemon transfers

## Test plan

- [ ] `load_password_command` unit tests: echo output, newline stripping, first-line extraction, empty command rejection, failing command, empty output
- [ ] `resolve_password` precedence tests: command over file, file fallback, none returns None
- [ ] `first_line` extraction tests
- [ ] CLI parsing tests: `--password-command` and `--password-command=...` forms
- [ ] Integration test: `--password-command` with daemon module listing authentication
- [ ] Integration test: `--password-command` rejected for non-daemon transfers
- [ ] Default value test: `password_command` defaults to None
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl