### PR TITLE
fix: forward --trust-sender and --checksum-seed to remote server

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -353,6 +353,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--numeric-ids"));
         }
 
+        // upstream: options.c:2889-2890 - --trust-sender forwarded as long-form.
+        if self.config.trust_sender() {
+            args.push(OsString::from("--trust-sender"));
+        }
+
+        // upstream: options.c:2892-2894 - --checksum-seed=N forwarded so the
+        // server uses the same seed for rolling and strong checksum generation.
+        if let Some(seed) = self.config.checksum_seed() {
+            args.push(OsString::from(format!("--checksum-seed={seed}")));
+        }
+
         if self.config.size_only() {
             args.push(OsString::from("--size-only"));
         }

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -450,6 +450,8 @@ const UPSTREAM_SERVER_LONG_ARGS: &[&str] = &[
     "--safe-links",
     "--munge-links",
     "--numeric-ids",
+    "--trust-sender",
+    "--checksum-seed",
     "--size-only",
     "--ignore-times",
     "--ignore-existing",
@@ -1160,6 +1162,46 @@ fn numeric_ids_is_long_form_not_in_flag_string() {
     assert!(
         args.iter().any(|a| a == "--numeric-ids"),
         "expected --numeric-ids in long-form args: {args:?}"
+    );
+}
+
+#[test]
+fn includes_trust_sender_long_arg() {
+    let config = ClientConfig::builder().trust_sender(true).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--trust-sender"),
+        "expected --trust-sender in args: {args:?}"
+    );
+}
+
+#[test]
+fn omits_trust_sender_when_not_set() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a == "--trust-sender"),
+        "unexpected --trust-sender in args: {args:?}"
+    );
+}
+
+#[test]
+fn includes_checksum_seed_long_arg() {
+    let config = ClientConfig::builder().checksum_seed(Some(12345)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--checksum-seed=12345"),
+        "expected --checksum-seed=12345 in args: {args:?}"
+    );
+}
+
+#[test]
+fn omits_checksum_seed_when_none() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--checksum-seed=")),
+        "unexpected --checksum-seed in args: {args:?}"
     );
 }
 
@@ -2059,6 +2101,8 @@ fn all_flags_enabled_produces_valid_invocation() {
         .acls(true)
         .xattrs(true)
         .numeric_ids(true)
+        .trust_sender(true)
+        .checksum_seed(Some(42))
         .dry_run(true)
         .delete_before(true)
         .whole_file(true)
@@ -2173,6 +2217,8 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--delete-excluded",
         "--force",
         "--numeric-ids",
+        "--trust-sender",
+        "--checksum-seed=42",
         "--max-delete=50",
         "--max-size=1000000",
         "--min-size=100",


### PR DESCRIPTION
## Summary

- Forward `--trust-sender` and `--checksum-seed=N` in the remote invocation builder's `append_long_form_args()`, matching upstream rsync's `server_options()` behavior
- Both flags were already parsed by the server-side argument parser and had full `ClientConfig` support, but were silently dropped during SSH client-to-server argument construction
- Add both flags to the upstream-compatibility allowlist and the comprehensive all-flags-enabled integration test

## Test plan

- [ ] `includes_trust_sender_long_arg` verifies the flag is emitted when enabled
- [ ] `omits_trust_sender_when_not_set` verifies the flag is absent by default
- [ ] `includes_checksum_seed_long_arg` verifies `--checksum-seed=12345` is emitted
- [ ] `omits_checksum_seed_when_none` verifies no seed arg is emitted by default
- [ ] `all_flags_enabled_produces_valid_invocation` now covers both new flags
- [ ] `remote_invocation_only_sends_upstream_compatible_args` validates both flags against the upstream allowlist