### PR TITLE
test: add comprehensive IP/CIDR host ACL enforcement tests for daemon

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -131,6 +131,7 @@ include!("tests/chunks/module_bwlimit_unlimited_with_burst_override_clears_daemo
 include!("tests/chunks/module_bwlimit_unlimited_with_explicit_burst_preserves_daemon_cap.rs");
 include!("tests/chunks/module_bwlimit_updates_burst_without_lowering_limit.rs");
 include!("tests/chunks/module_bwlimit_zero_burst_clears_existing_burst.rs");
+include!("tests/chunks/module_definition_empty_acls_allow_all.rs");
 include!("tests/chunks/module_definition_hostname_allow_matches_exact.rs");
 include!("tests/chunks/module_definition_hostname_deny_takes_precedence.rs");
 include!("tests/chunks/module_definition_hostname_suffix_matches.rs");
@@ -138,6 +139,18 @@ include!("tests/chunks/module_definition_hostname_wildcard_collapses_consecutive
 include!("tests/chunks/module_definition_hostname_wildcard_handles_multiple_asterisks.rs");
 include!("tests/chunks/module_definition_hostname_wildcard_matches.rs");
 include!("tests/chunks/module_definition_hostname_wildcard_treats_question_as_single_character.rs");
+include!("tests/chunks/module_definition_ipv4_allow_deny_precedence.rs");
+include!("tests/chunks/module_definition_ipv4_allow_matches_exact.rs");
+include!("tests/chunks/module_definition_ipv4_cidr_24_boundary.rs");
+include!("tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs");
+include!("tests/chunks/module_definition_ipv4_deny_blocks_matching_ip.rs");
+include!("tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs");
+include!("tests/chunks/module_definition_ipv6_allow_matches_exact.rs");
+include!("tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs");
+include!("tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs");
+include!("tests/chunks/module_definition_only_allow_denies_non_matching.rs");
+include!("tests/chunks/module_definition_only_deny_allows_non_matching.rs");
+include!("tests/chunks/module_definition_wildcard_any_allows_all.rs");
 include!("tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs");
 include!("tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs");
 include!("tests/chunks/module_peer_hostname_uses_override.rs");
@@ -223,6 +236,7 @@ include!("tests/chunks/daemon_negotiation_module_listing.rs");
 include!("tests/chunks/daemon_negotiation_authentication.rs");
 include!("tests/chunks/daemon_negotiation_version.rs");
 include!("tests/chunks/daemon_negotiation_error_handling.rs");
+include!("tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs");
 // Protocol 28 forced-mode daemon negotiation
 include!("tests/chunks/daemon_protocol_28_forced_negotiation.rs");
 include!("tests/chunks/runtime_options_allows_relative_path_when_use_chroot_disabled.rs");

--- a/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
+++ b/crates/daemon/src/tests/chunks/daemon_negotiation_error_host_allow_blocks_unlisted.rs
@@ -1,0 +1,69 @@
+#[test]
+fn daemon_negotiation_error_host_allow_blocks_unlisted() {
+    // When hosts_allow is set to an address that does NOT match the loopback
+    // test connection, the daemon must deny access with "@ERROR: access denied".
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+
+    let config_path = dir.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        format!(
+            "[restricted]\npath = {}\nhosts allow = 203.0.113.0/24\n",
+            module_dir.display()
+        ),
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--once"),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+
+    // Read greeting
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+
+    // Send version
+    stream
+        .write_all(b"@RSYNCD: 32.0\n")
+        .expect("send version");
+    stream.flush().expect("flush");
+
+    // Request module (our loopback IP is not in 203.0.113.0/24)
+    stream.write_all(b"restricted\n").expect("send module");
+    stream.flush().expect("flush");
+
+    // Should receive access denied
+    line.clear();
+    reader.read_line(&mut line).expect("response");
+    assert!(
+        line.contains("@ERROR:") && line.contains("access denied"),
+        "Expected access denied when hosts allow does not include loopback, got: {line}"
+    );
+
+    // Should receive EXIT
+    line.clear();
+    reader.read_line(&mut line).expect("exit");
+    assert_eq!(line, "@RSYNCD: EXIT\n");
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}

--- a/crates/daemon/src/tests/chunks/module_definition_empty_acls_allow_all.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_empty_acls_allow_all.rs
@@ -1,0 +1,8 @@
+#[test]
+fn module_definition_empty_acls_allow_all() {
+    // upstream: access.c - when neither hosts_allow nor hosts_deny is set,
+    // all connections are permitted.
+    let module = module_with_host_patterns(&[], &[]);
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
@@ -1,0 +1,12 @@
+#[test]
+fn module_definition_ipv4_allow_deny_precedence() {
+    // upstream: access.c - hosts_allow is checked first (must match), then
+    // hosts_deny (must not match). A peer in both lists is denied.
+    let module = module_with_host_patterns(&["192.168.0.0/16"], &["192.168.1.0/24"]);
+    // In the allowed subnet but not in the denied subnet - permitted.
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
+    // In both the allowed and denied subnets - denied.
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
+    // Outside the allowed subnet entirely - denied by allow check.
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_matches_exact.rs
@@ -1,0 +1,8 @@
+#[test]
+fn module_definition_ipv4_allow_matches_exact() {
+    let module = module_with_host_patterns(&["192.168.1.1"], &[]);
+    let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+    let denied = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2));
+    assert!(module.permits(allowed, None));
+    assert!(!module.permits(denied, None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_24_boundary.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_24_boundary.rs
@@ -1,0 +1,10 @@
+#[test]
+fn module_definition_ipv4_cidr_24_boundary() {
+    let module = module_with_host_patterns(&["192.168.1.0/24"], &[]);
+    // First and last address in /24.
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255)), None));
+    // One address outside the /24 boundary on each side.
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 255)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0)), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_cidr_allow_matches_subnet.rs
@@ -1,0 +1,8 @@
+#[test]
+fn module_definition_ipv4_cidr_allow_matches_subnet() {
+    let module = module_with_host_patterns(&["10.0.0.0/8"], &[]);
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_blocks_matching_ip.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_blocks_matching_ip.rs
@@ -1,0 +1,8 @@
+#[test]
+fn module_definition_ipv4_deny_blocks_matching_ip() {
+    let module = module_with_host_patterns(&[], &["192.168.1.100"]);
+    let blocked = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
+    let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101));
+    assert!(!module.permits(blocked, None));
+    assert!(module.permits(allowed, None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_deny_cidr_blocks_subnet.rs
@@ -1,0 +1,8 @@
+#[test]
+fn module_definition_ipv4_deny_cidr_blocks_subnet() {
+    let module = module_with_host_patterns(&[], &["172.16.0.0/12"]);
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(172, 31, 255, 254)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(172, 32, 0, 1)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv6_allow_matches_exact.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv6_allow_matches_exact.rs
@@ -1,0 +1,8 @@
+#[test]
+fn module_definition_ipv6_allow_matches_exact() {
+    let module = module_with_host_patterns(&["::1"], &[]);
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
+    assert!(!module.permits(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)), None));
+    // IPv4 peer does not match an IPv6 allow rule.
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv6_cidr_allow_matches_prefix.rs
@@ -1,0 +1,16 @@
+#[test]
+fn module_definition_ipv6_cidr_allow_matches_prefix() {
+    let module = module_with_host_patterns(&["fd00::/8"], &[]);
+    assert!(module.permits(
+        IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)),
+        None,
+    ));
+    assert!(module.permits(
+        IpAddr::V6(Ipv6Addr::new(0xfdff, 0xffff, 0, 0, 0, 0, 0, 1)),
+        None,
+    ));
+    assert!(!module.permits(
+        IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)),
+        None,
+    ));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
@@ -1,0 +1,22 @@
+#[test]
+fn module_definition_mixed_ip_and_hostname_acl() {
+    // Allow a CIDR range and a hostname pattern; deny a specific IP.
+    let module = module_with_host_patterns(
+        &["192.168.0.0/16", "*.trusted.org"],
+        &["192.168.1.99"],
+    );
+    // IP in allowed range, not in deny list.
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
+    // IP in allowed range but also in deny list.
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), None));
+    // IP outside allowed range but hostname matches allow pattern.
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
+        Some("build.trusted.org"),
+    ));
+    // IP outside allowed range and hostname does not match.
+    assert!(!module.permits(
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
+        Some("build.untrusted.org"),
+    ));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_only_allow_denies_non_matching.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_only_allow_denies_non_matching.rs
@@ -1,0 +1,9 @@
+#[test]
+fn module_definition_only_allow_denies_non_matching() {
+    // upstream: access.c - when only hosts_allow is set, anything not allowed
+    // is denied.
+    let module = module_with_host_patterns(&["192.168.1.0/24"], &[]);
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_only_deny_allows_non_matching.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_only_deny_allows_non_matching.rs
@@ -1,0 +1,9 @@
+#[test]
+fn module_definition_only_deny_allows_non_matching() {
+    // upstream: access.c - when only hosts_deny is set, anything not denied
+    // is allowed.
+    let module = module_with_host_patterns(&[], &["10.0.0.0/8"]);
+    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), None));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
+}

--- a/crates/daemon/src/tests/chunks/module_definition_wildcard_any_allows_all.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_wildcard_any_allows_all.rs
@@ -1,0 +1,7 @@
+#[test]
+fn module_definition_wildcard_any_allows_all() {
+    let module = module_with_host_patterns(&["*"], &[]);
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), None));
+    assert!(module.permits(IpAddr::V6(Ipv6Addr::LOCALHOST), None));
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::LOCALHOST), Some("anything.example.com")));
+}


### PR DESCRIPTION
## Summary

- Add 13 unit tests covering `ModuleDefinition::permits()` for IPv4/IPv6 address matching, CIDR subnet matching, allow/deny precedence, boundary conditions, and mixed IP + hostname ACLs
- Add 1 integration test verifying the daemon returns `@ERROR: access denied` when `hosts allow` is set to a CIDR that excludes the connecting client
- Validate upstream `access.c` semantics: allow-first-then-deny, empty ACLs permit all, only-deny permits non-matching, only-allow blocks non-matching

## Test plan

- [ ] All new tests pass in CI (nextest stable)
- [ ] No regressions in existing daemon tests
- [ ] Tests cover: exact IPv4, CIDR /8 /12 /16 /24, boundary addresses, exact IPv6, IPv6 CIDR /8, wildcard `*`, empty ACLs, only-allow, only-deny, allow+deny precedence, mixed IP+hostname, integration deny path