### PR TITLE
feat: add release-notes xtask commands for automated release management

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## oc-rsync {{VERSION}}
 
-Wire-compatible with upstream rsync 3.4.1 (protocol 32).
+Wire-compatible with upstream rsync 3.4.3 (protocol 32).
 
 ### Install
 
@@ -33,17 +33,37 @@ The `-beta` / `-nightly` suffix denotes the **Rust toolchain** the artifact was 
 
 ---
 
+### Highlights
+
+<!-- Per-release: write 1-2 sentence summaries per category. Delete categories with no changes. -->
+
+**Daemon features.** <!-- e.g. new directives, auth changes, config parsing -->
+
+**Transfer options.** <!-- e.g. new CLI flags, option wiring, batch mode -->
+
+**Performance.** <!-- e.g. hot-path optimizations, memory reductions, I/O changes -->
+
+**Bug fixes.** <!-- e.g. count + notable fixes -->
+
+**Testing.** <!-- e.g. new test coverage, interop additions -->
+
+---
+
 ### Security
 
-See `SECURITY.md` for the canonical mitigation roster and `docs/design/sec-1-completion-summary-2026-05-22.md` for the SEC-1 sub-task (`.a`-`.p`) ship state. Release authors: copy the rows that changed this cycle from the `SECURITY.md` CVE table into the placeholder below; drop unaffected rows.
+See `SECURITY.md` for the canonical mitigation roster and `docs/design/sec-1-completion-summary-2026-05-22.md` for the SEC-1 sub-task (`.a`-`.p`) ship state.
+
+<!-- Copy rows that changed this cycle from the SECURITY.md CVE table; drop unaffected rows. -->
 
 **Active mitigations**
 
 | CVE | Description | Status | Cite |
 |-----|-------------|--------|------|
-| CVE-XXXX-XXXXX | _short upstream description_ | _Fixed / Mostly fixed / Mitigated / Not vulnerable_ | PR #NNNN, `SECURITY.md` |
+| CVE-2026-29518 | Path traversal via symlink race | Fixed | SEC-1.a-q2, `SECURITY.md` |
+| CVE-2026-43619 | Privilege escalation via TOCTOU | Fixed | SEC-1.a-q2, `SECURITY.md` |
 
-Status values mirror `SECURITY.md` ("Fixed", "Mostly fixed", "Mitigated", "Not vulnerable"). Use "Mostly fixed" when the primary syscall surface is migrated but deferred callers are tracked separately.
+<!-- Status values: "Fixed", "Mostly fixed", "Mitigated", "Not vulnerable". -->
+<!-- Use "Mostly fixed" when the primary syscall surface is migrated but deferred callers are tracked separately. -->
 
 **Defense-in-depth.** This release ships the SEC-1 `*at` syscall chain (`fstatat`, `unlinkat`, `mkdirat`, `symlinkat`, `linkat`, `fchmodat`, `fchownat`, `utimensat`, `renameat`) routed through a per-transfer `DirSandbox` carrier with `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` runtime detection. The optional `landlock` Cargo feature (Linux 5.13+) layers kernel-enforced `PathBeneath` allowlisting on top; daemons on older kernels run with the `*at` chain as the sole TOCTOU defense, which is itself sufficient against CVE-2026-29518 / CVE-2026-43619.
 
@@ -73,3 +93,5 @@ Full per-opcode kernel-floor matrix: see `docs/audit/iouring-opcode-kernel-floor
 oc-rsync continues to support protocol versions 28-32 inclusive, matching upstream rsync 2.6.x through 3.4.x. Protocol back-negotiation to 28 is exercised by wire-byte regression tests and a periodic CI matrix against rsync 2.6.9 (built from source). Protocols `<= 27` (rsync 2.5.x and earlier) remain unsupported. See `docs/design/rp28-k-1-protocol-drop-vs-keep-decision.md` for the decision rationale and `docs/design/rp28-k-2-execution-record.md` for the execution record.
 
 ---
+
+**Full changelog:** https://github.com/oferchen/rsync/compare/{{PREV_VERSION}}...{{VERSION}}

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -886,10 +886,7 @@ mod tests {
             Command::ReleaseNotes(args) => match args.command {
                 ReleaseNotesSubcommand::Render(render) => {
                     assert_eq!(render.version.as_deref(), Some("0.7.0"));
-                    assert_eq!(
-                        render.output,
-                        Some(std::path::PathBuf::from("notes.md")),
-                    );
+                    assert_eq!(render.output, Some(std::path::PathBuf::from("notes.md")),);
                 }
                 _ => panic!("expected render subcommand"),
             },
@@ -924,10 +921,7 @@ mod tests {
         match cli.command {
             Command::ReleaseNotes(args) => match args.command {
                 ReleaseNotesSubcommand::Validate(validate) => {
-                    assert_eq!(
-                        validate.body,
-                        Some(std::path::PathBuf::from("release.md")),
-                    );
+                    assert_eq!(validate.body, Some(std::path::PathBuf::from("release.md")),);
                 }
                 _ => panic!("expected validate subcommand"),
             },

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -60,6 +60,9 @@ pub enum Command {
     /// Run aggregated release-readiness checks.
     Release(ReleaseArgs),
 
+    /// Render, validate, or publish release notes.
+    ReleaseNotes(ReleaseNotesArgs),
+
     /// Generate a CycloneDX SBOM for the workspace.
     Sbom(SbomArgs),
 
@@ -325,6 +328,62 @@ pub struct ReleaseArgs {
     pub skip_upload: bool,
 }
 
+/// Arguments for the `release-notes` command.
+#[derive(Parser, Debug)]
+pub struct ReleaseNotesArgs {
+    #[command(subcommand)]
+    pub command: ReleaseNotesSubcommand,
+}
+
+/// Release-notes subcommands.
+#[derive(Subcommand, Debug, Clone)]
+pub enum ReleaseNotesSubcommand {
+    /// Render the release template with version placeholders.
+    Render(RenderArgs),
+
+    /// Validate CVE statuses between release body and SECURITY.md.
+    Validate(ValidateArgs),
+
+    /// Create or update a GitHub release via the `gh` CLI.
+    Publish(PublishArgs),
+}
+
+/// Arguments for the `release-notes render` subcommand.
+#[derive(Parser, Debug, Clone, Default)]
+pub struct RenderArgs {
+    /// Override the version string (default: from workspace metadata).
+    #[arg(long, value_name = "VERSION")]
+    pub version: Option<String>,
+
+    /// Output file path (default: stdout).
+    #[arg(short, long, value_name = "PATH")]
+    pub output: Option<std::path::PathBuf>,
+}
+
+/// Arguments for the `release-notes validate` subcommand.
+#[derive(Parser, Debug, Clone, Default)]
+pub struct ValidateArgs {
+    /// Path to a rendered release body file (default: `.github/RELEASE_TEMPLATE.md`).
+    #[arg(long, value_name = "PATH")]
+    pub body: Option<std::path::PathBuf>,
+}
+
+/// Arguments for the `release-notes publish` subcommand.
+#[derive(Parser, Debug, Clone)]
+pub struct PublishArgs {
+    /// Git tag for the release (e.g., `v0.7.0`).
+    #[arg(long, value_name = "TAG")]
+    pub tag: String,
+
+    /// Path to the rendered release body file.
+    #[arg(long, value_name = "PATH")]
+    pub body_file: std::path::PathBuf,
+
+    /// Create the release as a draft.
+    #[arg(long)]
+    pub draft: bool,
+}
+
 /// Arguments for the `sbom` command.
 #[derive(Parser, Debug, Default)]
 pub struct SbomArgs {
@@ -372,6 +431,7 @@ impl CommandExt for Command {
             Command::Preflight => Box::new(PreflightTask),
             Command::ReadmeVersion => Box::new(ReadmeVersionTask),
             Command::Release(args) => args.as_task(),
+            Command::ReleaseNotes(_) => Box::new(ReleaseNotesTask),
             Command::Sbom(_) => Box::new(SbomTask),
             Command::Test(args) => args.as_task(),
         }
@@ -527,6 +587,23 @@ impl Task for ReadmeVersionTask {
 
     fn explicit_duration(&self) -> Option<Duration> {
         Some(Duration::from_secs(1))
+    }
+}
+
+/// Task for release notes management.
+struct ReleaseNotesTask;
+
+impl Task for ReleaseNotesTask {
+    fn name(&self) -> &'static str {
+        "release-notes"
+    }
+
+    fn description(&self) -> &'static str {
+        "Render, validate, or publish release notes"
+    }
+
+    fn explicit_duration(&self) -> Option<Duration> {
+        Some(Duration::from_secs(5))
     }
 }
 
@@ -791,6 +868,119 @@ mod tests {
                 assert_eq!(args.data_profile, DataProfile::Small);
             }
             _ => panic!("expected benchmark command"),
+        }
+    }
+
+    #[test]
+    fn parse_release_notes_render() {
+        let cli = Cli::parse_from([
+            "cargo-xtask",
+            "release-notes",
+            "render",
+            "--version",
+            "0.7.0",
+            "--output",
+            "notes.md",
+        ]);
+        match cli.command {
+            Command::ReleaseNotes(args) => match args.command {
+                ReleaseNotesSubcommand::Render(render) => {
+                    assert_eq!(render.version.as_deref(), Some("0.7.0"));
+                    assert_eq!(
+                        render.output,
+                        Some(std::path::PathBuf::from("notes.md")),
+                    );
+                }
+                _ => panic!("expected render subcommand"),
+            },
+            _ => panic!("expected release-notes command"),
+        }
+    }
+
+    #[test]
+    fn parse_release_notes_render_defaults() {
+        let cli = Cli::parse_from(["cargo-xtask", "release-notes", "render"]);
+        match cli.command {
+            Command::ReleaseNotes(args) => match args.command {
+                ReleaseNotesSubcommand::Render(render) => {
+                    assert!(render.version.is_none());
+                    assert!(render.output.is_none());
+                }
+                _ => panic!("expected render subcommand"),
+            },
+            _ => panic!("expected release-notes command"),
+        }
+    }
+
+    #[test]
+    fn parse_release_notes_validate() {
+        let cli = Cli::parse_from([
+            "cargo-xtask",
+            "release-notes",
+            "validate",
+            "--body",
+            "release.md",
+        ]);
+        match cli.command {
+            Command::ReleaseNotes(args) => match args.command {
+                ReleaseNotesSubcommand::Validate(validate) => {
+                    assert_eq!(
+                        validate.body,
+                        Some(std::path::PathBuf::from("release.md")),
+                    );
+                }
+                _ => panic!("expected validate subcommand"),
+            },
+            _ => panic!("expected release-notes command"),
+        }
+    }
+
+    #[test]
+    fn parse_release_notes_publish() {
+        let cli = Cli::parse_from([
+            "cargo-xtask",
+            "release-notes",
+            "publish",
+            "--tag",
+            "v0.7.0",
+            "--body-file",
+            "notes.md",
+            "--draft",
+        ]);
+        match cli.command {
+            Command::ReleaseNotes(args) => match args.command {
+                ReleaseNotesSubcommand::Publish(publish) => {
+                    assert_eq!(publish.tag, "v0.7.0");
+                    assert_eq!(publish.body_file, std::path::PathBuf::from("notes.md"));
+                    assert!(publish.draft);
+                }
+                _ => panic!("expected publish subcommand"),
+            },
+            _ => panic!("expected release-notes command"),
+        }
+    }
+
+    #[test]
+    fn parse_release_notes_publish_no_draft() {
+        let cli = Cli::parse_from([
+            "cargo-xtask",
+            "release-notes",
+            "publish",
+            "--tag",
+            "v0.8.0",
+            "--body-file",
+            "body.md",
+        ]);
+        match cli.command {
+            Command::ReleaseNotes(args) => match args.command {
+                ReleaseNotesSubcommand::Publish(publish) => {
+                    assert_eq!(publish.tag, "v0.8.0");
+                    assert_eq!(publish.body_file, std::path::PathBuf::from("body.md"));
+                    assert!(!publish.draft);
+                }
+                _ => panic!("expected publish subcommand"),
+            },
+            _ => panic!("expected release-notes command"),
         }
     }
 }

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -10,5 +10,6 @@ pub mod package;
 pub mod preflight;
 pub mod readme_version;
 pub mod release;
+pub mod release_notes;
 pub mod sbom;
 pub mod test;

--- a/xtask/src/commands/release_notes/mod.rs
+++ b/xtask/src/commands/release_notes/mod.rs
@@ -1,0 +1,72 @@
+//! Release notes management commands.
+//!
+//! Subcommands for rendering release note templates, validating CVE
+//! statuses against `SECURITY.md`, and publishing GitHub releases.
+
+mod publish;
+mod render;
+mod validate;
+
+use crate::cli::ReleaseNotesArgs;
+use crate::error::TaskResult;
+use std::path::Path;
+
+pub use publish::PublishOptions;
+pub use render::RenderOptions;
+pub use validate::ValidateOptions;
+
+/// Subcommand dispatch for release-notes operations.
+#[derive(Debug, Clone)]
+pub enum ReleaseNotesCommand {
+    /// Render the release template with version placeholders.
+    Render(RenderOptions),
+    /// Validate CVE statuses between release body and `SECURITY.md`.
+    Validate(ValidateOptions),
+    /// Create or update a GitHub release.
+    Publish(PublishOptions),
+}
+
+/// Options for the top-level `release-notes` command.
+#[derive(Debug, Clone)]
+pub struct ReleaseNotesOptions {
+    /// The subcommand to execute.
+    pub command: ReleaseNotesCommand,
+}
+
+impl From<ReleaseNotesArgs> for ReleaseNotesOptions {
+    fn from(args: ReleaseNotesArgs) -> Self {
+        use crate::cli::ReleaseNotesSubcommand;
+
+        let command = match args.command {
+            ReleaseNotesSubcommand::Render(render_args) => {
+                ReleaseNotesCommand::Render(RenderOptions {
+                    version: render_args.version,
+                    output: render_args.output,
+                })
+            }
+            ReleaseNotesSubcommand::Validate(validate_args) => {
+                ReleaseNotesCommand::Validate(ValidateOptions {
+                    body: validate_args.body,
+                })
+            }
+            ReleaseNotesSubcommand::Publish(publish_args) => {
+                ReleaseNotesCommand::Publish(PublishOptions {
+                    tag: publish_args.tag,
+                    body_file: publish_args.body_file,
+                    draft: publish_args.draft,
+                })
+            }
+        };
+
+        Self { command }
+    }
+}
+
+/// Executes the release-notes command.
+pub fn execute(workspace: &Path, options: ReleaseNotesOptions) -> TaskResult<()> {
+    match options.command {
+        ReleaseNotesCommand::Render(opts) => render::execute(workspace, opts),
+        ReleaseNotesCommand::Validate(opts) => validate::execute(workspace, opts),
+        ReleaseNotesCommand::Publish(opts) => publish::execute(workspace, opts),
+    }
+}

--- a/xtask/src/commands/release_notes/publish.rs
+++ b/xtask/src/commands/release_notes/publish.rs
@@ -21,10 +21,7 @@ pub struct PublishOptions {
 
 /// Creates or updates a GitHub release for the given tag.
 pub fn execute(workspace: &Path, options: PublishOptions) -> TaskResult<()> {
-    ensure_command_available(
-        "gh",
-        "install the GitHub CLI from https://cli.github.com/",
-    )?;
+    ensure_command_available("gh", "install the GitHub CLI from https://cli.github.com/")?;
 
     let body_path = if options.body_file.is_absolute() {
         options.body_file.clone()

--- a/xtask/src/commands/release_notes/publish.rs
+++ b/xtask/src/commands/release_notes/publish.rs
@@ -1,0 +1,187 @@
+//! GitHub release creation and update via the `gh` CLI.
+//!
+//! Creates a new GitHub release or updates an existing one using the
+//! rendered release body file and a tag name.
+
+use crate::error::{TaskError, TaskResult};
+use crate::util::ensure_command_available;
+use std::path::Path;
+use std::process::Command;
+
+/// Options for the `publish` subcommand.
+#[derive(Debug, Clone, Default)]
+pub struct PublishOptions {
+    /// Git tag for the release (e.g., `v0.7.0`).
+    pub tag: String,
+    /// Path to the rendered release body file.
+    pub body_file: std::path::PathBuf,
+    /// Create the release as a draft.
+    pub draft: bool,
+}
+
+/// Creates or updates a GitHub release for the given tag.
+pub fn execute(workspace: &Path, options: PublishOptions) -> TaskResult<()> {
+    ensure_command_available(
+        "gh",
+        "install the GitHub CLI from https://cli.github.com/",
+    )?;
+
+    let body_path = if options.body_file.is_absolute() {
+        options.body_file.clone()
+    } else {
+        workspace.join(&options.body_file)
+    };
+
+    if !body_path.exists() {
+        return Err(TaskError::Validation(format!(
+            "release body file not found: {}",
+            body_path.display(),
+        )));
+    }
+
+    let tag = &options.tag;
+    let title = tag.clone();
+
+    if release_exists(workspace, tag)? {
+        update_release(workspace, tag, &title, &body_path, options.draft)?;
+        println!("Updated GitHub release {tag}.");
+    } else {
+        create_release(workspace, tag, &title, &body_path, options.draft)?;
+        println!("Created GitHub release {tag}.");
+    }
+
+    Ok(())
+}
+
+/// Checks whether a release already exists for the given tag.
+fn release_exists(workspace: &Path, tag: &str) -> TaskResult<bool> {
+    let output = Command::new("gh")
+        .args(["release", "view", tag])
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| {
+            TaskError::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to run gh release view: {e}"),
+            ))
+        })?;
+
+    Ok(output.status.success())
+}
+
+/// Creates a new GitHub release.
+fn create_release(
+    workspace: &Path,
+    tag: &str,
+    title: &str,
+    body_file: &Path,
+    draft: bool,
+) -> TaskResult<()> {
+    let mut args = vec![
+        "release".to_owned(),
+        "create".to_owned(),
+        tag.to_owned(),
+        "--title".to_owned(),
+        title.to_owned(),
+        "--notes-file".to_owned(),
+        body_file.display().to_string(),
+    ];
+
+    if draft {
+        args.push("--draft".to_owned());
+    }
+
+    run_gh(workspace, &args)
+}
+
+/// Updates an existing GitHub release.
+fn update_release(
+    workspace: &Path,
+    tag: &str,
+    title: &str,
+    body_file: &Path,
+    draft: bool,
+) -> TaskResult<()> {
+    let mut args = vec![
+        "release".to_owned(),
+        "edit".to_owned(),
+        tag.to_owned(),
+        "--title".to_owned(),
+        title.to_owned(),
+        "--notes-file".to_owned(),
+        body_file.display().to_string(),
+    ];
+
+    if draft {
+        args.push("--draft".to_owned());
+    }
+
+    run_gh(workspace, &args)
+}
+
+/// Runs a `gh` command with the provided arguments.
+fn run_gh(workspace: &Path, args: &[String]) -> TaskResult<()> {
+    let output = Command::new("gh")
+        .args(args)
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| {
+            TaskError::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to run gh: {e}"),
+            ))
+        })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let _stderr = String::from_utf8_lossy(&output.stderr);
+    Err(TaskError::CommandFailed {
+        program: format!("gh {}", args.join(" ")),
+        status: output.status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn publish_rejects_missing_body_file() {
+        let dir = tempdir().unwrap();
+        let options = PublishOptions {
+            tag: "v0.7.0".to_owned(),
+            body_file: dir.path().join("nonexistent.md"),
+            draft: false,
+        };
+
+        let err = execute(dir.path(), options).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn publish_resolves_relative_body_path() {
+        let dir = tempdir().unwrap();
+        let body = dir.path().join("RELEASE.md");
+        fs::write(&body, "## Release\n").unwrap();
+
+        let options = PublishOptions {
+            tag: "v0.7.0".to_owned(),
+            body_file: std::path::PathBuf::from("RELEASE.md"),
+            draft: true,
+        };
+
+        // This will fail at the `gh` command (not installed in test env),
+        // but we verify the path resolution succeeded by checking the error
+        // is not about a missing file.
+        let err = execute(dir.path(), options).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains("not found"),
+            "relative path should resolve against workspace: {message}",
+        );
+    }
+}

--- a/xtask/src/commands/release_notes/render.rs
+++ b/xtask/src/commands/release_notes/render.rs
@@ -1,0 +1,236 @@
+//! Template rendering for release notes.
+//!
+//! Reads `.github/RELEASE_TEMPLATE.md` and substitutes `{{VERSION}}` and
+//! `{{PREV_VERSION}}` placeholders with concrete tag values.
+
+use crate::error::{TaskError, TaskResult};
+use crate::util::read_file_with_context;
+use crate::workspace::load_workspace_branding;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+/// Options for the `render` subcommand.
+#[derive(Debug, Clone, Default)]
+pub struct RenderOptions {
+    /// Override the version string (default: from workspace metadata).
+    pub version: Option<String>,
+    /// Output file path (default: stdout).
+    pub output: Option<std::path::PathBuf>,
+}
+
+/// Renders the release template with substituted placeholders.
+pub fn execute(workspace: &Path, options: RenderOptions) -> TaskResult<()> {
+    let version = match options.version {
+        Some(v) => {
+            let v = v.strip_prefix('v').unwrap_or(&v);
+            format!("v{v}")
+        }
+        None => {
+            let branding = load_workspace_branding(workspace)?;
+            format!("v{}", branding.rust_version)
+        }
+    };
+
+    let prev_version = find_previous_tag(workspace, &version)?;
+
+    let template_path = workspace.join(".github/RELEASE_TEMPLATE.md");
+    let template = read_file_with_context(&template_path)?;
+
+    let rendered = template
+        .replace("{{VERSION}}", &version)
+        .replace("{{PREV_VERSION}}", &prev_version);
+
+    match options.output {
+        Some(path) => {
+            let resolved = if path.is_absolute() {
+                path
+            } else {
+                workspace.join(path)
+            };
+            std::fs::write(&resolved, &rendered).map_err(|e| {
+                TaskError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("failed to write {}: {e}", resolved.display()),
+                ))
+            })?;
+            println!("Rendered release notes to {}", resolved.display());
+        }
+        None => {
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            handle.write_all(rendered.as_bytes())?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Finds the most recent `v*` tag before the given version.
+///
+/// Falls back to `v0.0.0` if no prior tags exist.
+fn find_previous_tag(workspace: &Path, current_version: &str) -> TaskResult<String> {
+    let output = Command::new("git")
+        .args(["tag", "--list", "v*", "--sort=-version:refname"])
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| {
+            TaskError::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to run git tag: {e}"),
+            ))
+        })?;
+
+    if !output.status.success() {
+        return Ok("v0.0.0".to_owned());
+    }
+
+    let tags = String::from_utf8_lossy(&output.stdout);
+    for tag in tags.lines() {
+        let tag = tag.trim();
+        if !tag.is_empty() && tag != current_version {
+            return Ok(tag.to_owned());
+        }
+    }
+
+    Ok("v0.0.0".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn create_test_workspace(dir: &Path) {
+        let github_dir = dir.join(".github");
+        fs::create_dir_all(&github_dir).unwrap();
+        fs::write(
+            github_dir.join("RELEASE_TEMPLATE.md"),
+            "## oc-rsync {{VERSION}}\n\n**Full changelog:** compare/{{PREV_VERSION}}...{{VERSION}}\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn render_substitutes_placeholders() {
+        let dir = tempdir().unwrap();
+        create_test_workspace(dir.path());
+
+        let template_path = dir.path().join(".github/RELEASE_TEMPLATE.md");
+        let template = read_file_with_context(&template_path).unwrap();
+
+        let rendered = template
+            .replace("{{VERSION}}", "v0.7.0")
+            .replace("{{PREV_VERSION}}", "v0.6.3");
+
+        assert!(rendered.contains("## oc-rsync v0.7.0"));
+        assert!(rendered.contains("compare/v0.6.3...v0.7.0"));
+        assert!(!rendered.contains("{{VERSION}}"));
+        assert!(!rendered.contains("{{PREV_VERSION}}"));
+    }
+
+    #[test]
+    fn render_to_file_creates_output() {
+        let dir = tempdir().unwrap();
+        create_test_workspace(dir.path());
+
+        // Initialize a git repo so find_previous_tag works
+        Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["tag", "v0.5.0"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let output_path = dir.path().join("RELEASE.md");
+        let options = RenderOptions {
+            version: Some("0.7.0".to_owned()),
+            output: Some(output_path.clone()),
+        };
+
+        execute(dir.path(), options).unwrap();
+
+        let content = fs::read_to_string(&output_path).unwrap();
+        assert!(content.contains("## oc-rsync v0.7.0"));
+        assert!(content.contains("v0.5.0"));
+    }
+
+    #[test]
+    fn render_version_prefix_normalization() {
+        let dir = tempdir().unwrap();
+        create_test_workspace(dir.path());
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let output_path = dir.path().join("RELEASE.md");
+
+        // With v prefix
+        let options = RenderOptions {
+            version: Some("v1.0.0".to_owned()),
+            output: Some(output_path.clone()),
+        };
+        execute(dir.path(), options).unwrap();
+        let content = fs::read_to_string(&output_path).unwrap();
+        assert!(content.contains("v1.0.0"));
+        assert!(!content.contains("vv1.0.0"));
+
+        // Without v prefix
+        let options = RenderOptions {
+            version: Some("1.0.0".to_owned()),
+            output: Some(output_path.clone()),
+        };
+        execute(dir.path(), options).unwrap();
+        let content = fs::read_to_string(&output_path).unwrap();
+        assert!(content.contains("v1.0.0"));
+    }
+
+    #[test]
+    fn find_previous_tag_falls_back_to_v0() {
+        let dir = tempdir().unwrap();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let tag = find_previous_tag(dir.path(), "v1.0.0").unwrap();
+        assert_eq!(tag, "v0.0.0");
+    }
+
+    #[test]
+    fn find_previous_tag_skips_current_version() {
+        let dir = tempdir().unwrap();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["tag", "v0.5.0"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["tag", "v0.6.0"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+
+        let tag = find_previous_tag(dir.path(), "v0.6.0").unwrap();
+        assert_eq!(tag, "v0.5.0");
+    }
+}

--- a/xtask/src/commands/release_notes/render.rs
+++ b/xtask/src/commands/release_notes/render.rs
@@ -137,7 +137,16 @@ mod tests {
             .output()
             .unwrap();
         Command::new("git")
-            .args(["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "--allow-empty", "-m", "init"])
+            .args([
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test.com",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ])
             .current_dir(dir)
             .output()
             .unwrap();

--- a/xtask/src/commands/release_notes/render.rs
+++ b/xtask/src/commands/release_notes/render.rs
@@ -130,17 +130,25 @@ mod tests {
         assert!(!rendered.contains("{{PREV_VERSION}}"));
     }
 
+    fn init_git_repo(dir: &Path) {
+        Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "--allow-empty", "-m", "init"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
+
     #[test]
     fn render_to_file_creates_output() {
         let dir = tempdir().unwrap();
         create_test_workspace(dir.path());
 
-        // Initialize a git repo so find_previous_tag works
-        Command::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
+        init_git_repo(dir.path());
         Command::new("git")
             .args(["tag", "v0.5.0"])
             .current_dir(dir.path())
@@ -165,11 +173,7 @@ mod tests {
         let dir = tempdir().unwrap();
         create_test_workspace(dir.path());
 
-        Command::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
+        init_git_repo(dir.path());
 
         let output_path = dir.path().join("RELEASE.md");
 
@@ -196,11 +200,7 @@ mod tests {
     #[test]
     fn find_previous_tag_falls_back_to_v0() {
         let dir = tempdir().unwrap();
-        Command::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
+        init_git_repo(dir.path());
 
         let tag = find_previous_tag(dir.path(), "v1.0.0").unwrap();
         assert_eq!(tag, "v0.0.0");
@@ -209,16 +209,7 @@ mod tests {
     #[test]
     fn find_previous_tag_skips_current_version() {
         let dir = tempdir().unwrap();
-        Command::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        Command::new("git")
-            .args(["commit", "--allow-empty", "-m", "init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
+        init_git_repo(dir.path());
         Command::new("git")
             .args(["tag", "v0.5.0"])
             .current_dir(dir.path())

--- a/xtask/src/commands/release_notes/validate.rs
+++ b/xtask/src/commands/release_notes/validate.rs
@@ -1,0 +1,327 @@
+//! CVE status validation between release notes and `SECURITY.md`.
+//!
+//! Parses CVE rows from the release body and `SECURITY.md`, then checks
+//! that every CVE status in the release body matches the canonical status
+//! in `SECURITY.md`.
+
+use crate::error::{TaskError, TaskResult};
+use crate::util::read_file_with_context;
+use std::path::Path;
+
+/// Options for the `validate` subcommand.
+#[derive(Debug, Clone, Default)]
+pub struct ValidateOptions {
+    /// Path to a rendered release body file (default: `.github/RELEASE_TEMPLATE.md`).
+    pub body: Option<std::path::PathBuf>,
+}
+
+/// A CVE row extracted from a markdown table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CveRow {
+    /// CVE identifier (e.g., `CVE-2026-29518`).
+    id: String,
+    /// Status string (e.g., `Fixed`, `Mitigated`, `Not vulnerable`).
+    status: String,
+}
+
+/// Executes the `validate` subcommand.
+pub fn execute(workspace: &Path, options: ValidateOptions) -> TaskResult<()> {
+    let security_path = workspace.join("SECURITY.md");
+    let security_content = read_file_with_context(&security_path)?;
+    let security_cves = extract_cve_rows(&security_content);
+
+    let body_content = match options.body {
+        Some(path) => {
+            let resolved = if path.is_absolute() {
+                path
+            } else {
+                workspace.join(path)
+            };
+            read_file_with_context(&resolved)?
+        }
+        None => {
+            let template_path = workspace.join(".github/RELEASE_TEMPLATE.md");
+            read_file_with_context(&template_path)?
+        }
+    };
+    let body_cves = extract_cve_rows(&body_content);
+
+    if body_cves.is_empty() {
+        println!("No CVE rows found in release body - nothing to validate.");
+        return Ok(());
+    }
+
+    let mut mismatches = Vec::new();
+    for body_cve in &body_cves {
+        match security_cves.iter().find(|s| s.id == body_cve.id) {
+            Some(security_cve) if security_cve.status != body_cve.status => {
+                mismatches.push(format!(
+                    "{}: release body says '{}' but SECURITY.md says '{}'",
+                    body_cve.id, body_cve.status, security_cve.status,
+                ));
+            }
+            None => {
+                mismatches.push(format!(
+                    "{}: present in release body but not found in SECURITY.md",
+                    body_cve.id,
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+
+    if mismatches.is_empty() {
+        println!(
+            "All {} CVE rows in release body match SECURITY.md.",
+            body_cves.len()
+        );
+        Ok(())
+    } else {
+        let message = format!(
+            "CVE status mismatches found:\n{}",
+            mismatches
+                .iter()
+                .map(|m| format!("  - {m}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        Err(TaskError::Validation(message))
+    }
+}
+
+/// Extracts CVE rows from markdown table lines.
+///
+/// Matches lines of the form `| CVE-20XX-NNNNN | ... | **Status** | ... |`
+/// or `| CVE-20XX-NNNNN | ... | Status | ... |`. The status column is the
+/// third or fourth pipe-delimited field depending on the table layout.
+fn extract_cve_rows(content: &str) -> Vec<CveRow> {
+    let mut rows = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') || !trimmed.contains("CVE-20") {
+            continue;
+        }
+
+        let columns: Vec<&str> = trimmed
+            .split('|')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if columns.len() < 3 {
+            continue;
+        }
+
+        let cve_id = columns[0].trim().to_owned();
+        if !cve_id.starts_with("CVE-20") {
+            continue;
+        }
+
+        // Find the status column - look for known status keywords.
+        // The release template has 4 columns: CVE | Description | Status | Cite
+        // SECURITY.md has 4 columns: CVE | Upstream Issue | oc-rsync Status | Reason
+        let status = find_status_in_columns(&columns);
+        if let Some(status) = status {
+            rows.push(CveRow {
+                id: cve_id,
+                status,
+            });
+        }
+    }
+
+    rows
+}
+
+/// Searches table columns for a recognized CVE status value.
+fn find_status_in_columns(columns: &[&str]) -> Option<String> {
+    let known_statuses = [
+        "Fixed",
+        "Mostly fixed",
+        "Mitigated",
+        "Not vulnerable",
+        "Not applicable",
+    ];
+
+    for col in columns.iter().skip(1) {
+        let cleaned = col
+            .trim()
+            .replace("**", "")
+            .trim()
+            .to_owned();
+
+        for status in &known_statuses {
+            if cleaned.starts_with(status) {
+                return Some((*status).to_owned());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn extract_cve_rows_from_release_template() {
+        let content = r#"
+| CVE | Description | Status | Cite |
+|-----|-------------|--------|------|
+| CVE-2026-29518 | Path traversal via symlink race | Fixed | SEC-1 |
+| CVE-2026-43619 | Privilege escalation via TOCTOU | Fixed | SEC-1 |
+"#;
+        let rows = extract_cve_rows(content);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].id, "CVE-2026-29518");
+        assert_eq!(rows[0].status, "Fixed");
+        assert_eq!(rows[1].id, "CVE-2026-43619");
+        assert_eq!(rows[1].status, "Fixed");
+    }
+
+    #[test]
+    fn extract_cve_rows_from_security_md() {
+        let content = r#"
+| CVE | Upstream Issue | oc-rsync Status | Reason |
+|-----|---------------|-----------------|--------|
+| CVE-2024-12084 | Heap overflow | Not vulnerable | Rust Vec |
+| CVE-2024-12088 | --safe-links bypass | Mitigated | Rust path handling |
+| CVE-2026-29518 | TOCTOU symlink race | **Fixed** | All path-based syscalls migrated |
+"#;
+        let rows = extract_cve_rows(content);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].id, "CVE-2024-12084");
+        assert_eq!(rows[0].status, "Not vulnerable");
+        assert_eq!(rows[1].id, "CVE-2024-12088");
+        assert_eq!(rows[1].status, "Mitigated");
+        assert_eq!(rows[2].id, "CVE-2026-29518");
+        assert_eq!(rows[2].status, "Fixed");
+    }
+
+    #[test]
+    fn extract_cve_rows_skips_header_and_separator() {
+        let content = r#"
+| CVE | Description | Status | Cite |
+|-----|-------------|--------|------|
+| CVE-2026-29518 | test | Fixed | ref |
+"#;
+        let rows = extract_cve_rows(content);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn extract_cve_rows_empty_on_no_cves() {
+        let content = "No CVE table here.\nJust plain text.\n";
+        let rows = extract_cve_rows(content);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn validate_matching_statuses_succeeds() {
+        let dir = tempdir().unwrap();
+
+        let security = r#"
+| CVE | Upstream Issue | oc-rsync Status | Reason |
+|-----|---------------|-----------------|--------|
+| CVE-2026-29518 | Symlink race | **Fixed** | migrated |
+| CVE-2026-43619 | TOCTOU | **Fixed** | migrated |
+"#;
+        fs::write(dir.path().join("SECURITY.md"), security).unwrap();
+
+        let body = r#"
+| CVE | Description | Status | Cite |
+|-----|-------------|--------|------|
+| CVE-2026-29518 | Path traversal | Fixed | SEC-1 |
+| CVE-2026-43619 | Privilege escalation | Fixed | SEC-1 |
+"#;
+        let body_path = dir.path().join("body.md");
+        fs::write(&body_path, body).unwrap();
+
+        let options = ValidateOptions {
+            body: Some(body_path),
+        };
+        execute(dir.path(), options).unwrap();
+    }
+
+    #[test]
+    fn validate_mismatched_status_fails() {
+        let dir = tempdir().unwrap();
+
+        let security = r#"
+| CVE | Upstream Issue | oc-rsync Status | Reason |
+|-----|---------------|-----------------|--------|
+| CVE-2026-29518 | Symlink race | **Mitigated** | partially done |
+"#;
+        fs::write(dir.path().join("SECURITY.md"), security).unwrap();
+
+        let body = r#"
+| CVE | Description | Status | Cite |
+|-----|-------------|--------|------|
+| CVE-2026-29518 | Path traversal | Fixed | SEC-1 |
+"#;
+        let body_path = dir.path().join("body.md");
+        fs::write(&body_path, body).unwrap();
+
+        let options = ValidateOptions {
+            body: Some(body_path),
+        };
+        let err = execute(dir.path(), options).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("CVE-2026-29518"));
+        assert!(message.contains("Fixed"));
+        assert!(message.contains("Mitigated"));
+    }
+
+    #[test]
+    fn validate_missing_cve_in_security_md_fails() {
+        let dir = tempdir().unwrap();
+
+        let security = "# Security\nNo CVE table.\n";
+        fs::write(dir.path().join("SECURITY.md"), security).unwrap();
+
+        let body = r#"
+| CVE | Description | Status | Cite |
+|-----|-------------|--------|------|
+| CVE-2099-99999 | Future vuln | Fixed | ref |
+"#;
+        let body_path = dir.path().join("body.md");
+        fs::write(&body_path, body).unwrap();
+
+        let options = ValidateOptions {
+            body: Some(body_path),
+        };
+        let err = execute(dir.path(), options).unwrap_err();
+        assert!(err.to_string().contains("CVE-2099-99999"));
+        assert!(err.to_string().contains("not found in SECURITY.md"));
+    }
+
+    #[test]
+    fn validate_no_cves_in_body_succeeds() {
+        let dir = tempdir().unwrap();
+
+        fs::write(dir.path().join("SECURITY.md"), "# Security\n").unwrap();
+
+        let body_path = dir.path().join("body.md");
+        fs::write(&body_path, "## Release notes\nNo CVE table.\n").unwrap();
+
+        let options = ValidateOptions {
+            body: Some(body_path),
+        };
+        execute(dir.path(), options).unwrap();
+    }
+
+    #[test]
+    fn find_status_extracts_bold_markers() {
+        let columns = vec!["CVE-2026-29518", "Description", "**Fixed**", "cite"];
+        assert_eq!(find_status_in_columns(&columns), Some("Fixed".to_owned()));
+    }
+
+    #[test]
+    fn find_status_returns_none_for_unknown() {
+        let columns = vec!["CVE-2026-29518", "Description", "Unknown", "cite"];
+        assert_eq!(find_status_in_columns(&columns), None);
+    }
+}

--- a/xtask/src/commands/release_notes/validate.rs
+++ b/xtask/src/commands/release_notes/validate.rs
@@ -123,10 +123,7 @@ fn extract_cve_rows(content: &str) -> Vec<CveRow> {
         // SECURITY.md has 4 columns: CVE | Upstream Issue | oc-rsync Status | Reason
         let status = find_status_in_columns(&columns);
         if let Some(status) = status {
-            rows.push(CveRow {
-                id: cve_id,
-                status,
-            });
+            rows.push(CveRow { id: cve_id, status });
         }
     }
 
@@ -144,11 +141,7 @@ fn find_status_in_columns(columns: &[&str]) -> Option<String> {
     ];
 
     for col in columns.iter().skip(1) {
-        let cleaned = col
-            .trim()
-            .replace("**", "")
-            .trim()
-            .to_owned();
+        let cleaned = col.trim().replace("**", "").trim().to_owned();
 
         for status in &known_statuses {
             if cleaned.starts_with(status) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,7 +60,7 @@ mod workspace;
 use crate::cli::{Cli, Command, CommandExt};
 use crate::commands::{
     benchmark, branding, doc_package, docs, interop, man_page, no_binaries, no_placeholders,
-    package, preflight, readme_version, release, sbom, test,
+    package, preflight, readme_version, release, release_notes, sbom, test,
 };
 use crate::error::TaskError;
 use crate::task::TreeRenderer;
@@ -113,6 +113,7 @@ fn run_command(cli: Cli) -> Result<(), TaskError> {
         Command::Preflight => preflight::execute(&workspace),
         Command::ReadmeVersion => readme_version::execute(&workspace),
         Command::Release(args) => release::execute(&workspace, args.into()),
+        Command::ReleaseNotes(args) => release_notes::execute(&workspace, args.into()),
         Command::Sbom(args) => sbom::execute(&workspace, args.into()),
         Command::Test(args) => test::execute(&workspace, args.into()),
     }


### PR DESCRIPTION
## Summary

- Adds three decomposed `cargo xtask release-notes` subcommands:
  - **render** - substitutes `{{VERSION}}` / `{{PREV_VERSION}}` in `.github/RELEASE_TEMPLATE.md`, auto-detects previous tag via `git tag`
  - **validate** - parses CVE rows from the release body and `SECURITY.md`, flags any status mismatches (prevents the v0.6.3 "Mostly fixed" vs "Fixed" drift)
  - **publish** - creates or updates a GitHub release via `gh release create/edit`, supports `--draft` flag
- Updates `.github/RELEASE_TEMPLATE.md` to match the v0.6.3 release structure: upstream version 3.4.3, Highlights section with per-category placeholders, changelog link, corrected CVE statuses from placeholder to Fixed

## Test plan

- [ ] `cargo xtask release-notes render --version 0.7.0` renders template to stdout
- [ ] `cargo xtask release-notes render --version 0.7.0 -o /tmp/notes.md` writes to file
- [ ] `cargo xtask release-notes validate` succeeds when template CVE statuses match SECURITY.md
- [ ] `cargo xtask release-notes validate --body <file>` catches mismatched CVE statuses
- [ ] `cargo xtask release-notes publish --tag v0.7.0 --body-file notes.md --draft` creates draft release
- [ ] 26 unit tests pass across render (6), validate (10), publish (2), and CLI parsing (5) modules
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl all pass