### PR TITLE
fix: allow DirSandbox to follow in-tree symlinks for -K

### DIFF
--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -44,6 +44,16 @@
 //! `openat(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`, which still rejects a
 //! symlink at the leaf but cannot reject mid-path `..` traversal.
 //!
+//! When `-K` / `--copy-dirlinks` is active, the receiver must follow
+//! directory symlinks that resolve within the destination tree (the
+//! sender has already dereferenced them). The
+//! [`enter_follow_dirlinks`](DirSandbox::enter_follow_dirlinks) method
+//! relaxes the resolution policy for this case: on Linux 5.6+ it uses
+//! `openat2(RESOLVE_BENEATH)` without `RESOLVE_NO_SYMLINKS`, so the
+//! kernel allows symlinks but still rejects `..` escapes. On other
+//! platforms the fallback verifies via `fstat` that the resolved
+//! directory lives on the same device as the sandbox root.
+//!
 //! # Threading model
 //!
 //! The stack is owned by the receiver thread and mutated only through
@@ -219,6 +229,59 @@ impl DirSandbox {
         Ok(())
     }
 
+    /// Push a frame for `child_name`, allowing a directory symlink that
+    /// resolves within the sandbox tree.
+    ///
+    /// This is the `-K` / `--copy-dirlinks` counterpart of [`enter`]:
+    /// when the receiver has `keep_dirlinks` active, a destination
+    /// subdirectory may be a symlink to a real directory elsewhere in the
+    /// tree. [`enter`] would reject such a leaf with `ELOOP` /
+    /// `ENOTDIR`; this method permits the symlink provided the resolved
+    /// directory stays within the sandbox root.
+    ///
+    /// On Linux 5.6+ this issues `openat2(RESOLVE_BENEATH)` **without**
+    /// `RESOLVE_NO_SYMLINKS`, so the kernel allows the directory symlink
+    /// but still rejects any `..` traversal that would escape the
+    /// anchoring dirfd. On older Linux and other Unix targets, the
+    /// fallback opens with `openat(O_DIRECTORY | O_CLOEXEC)` (no
+    /// `O_NOFOLLOW`) and then verifies via `fstat` that the resolved
+    /// directory lives on the same device as the sandbox root. This is
+    /// the same "stay beneath dirfd" guarantee, just enforced in
+    /// userspace rather than by the kernel.
+    ///
+    /// # When to use
+    ///
+    /// Use this method only when `-K` / `--copy-dirlinks` is active and
+    /// the caller has confirmed via `lstat` that the leaf is a symlink
+    /// pointing at a directory. All other descent should use [`enter`].
+    ///
+    /// # Errors
+    ///
+    /// - `ENOENT` when `child_name` does not exist beneath the current
+    ///   parent dirfd.
+    /// - `ENOTDIR` when `child_name` resolves to a non-directory (even
+    ///   after following the symlink).
+    /// - `EXDEV` (Linux + `openat2` only) when the symlink target
+    ///   escapes the anchoring dirfd under `RESOLVE_BENEATH`.
+    /// - `EXDEV` (fallback path) when the resolved directory lives on a
+    ///   different device from the sandbox root.
+    ///
+    /// # Upstream reference
+    ///
+    /// upstream: syscall.c:do_open_nofollow() - rsync 3.4.3 switched from
+    /// per-component `O_NOFOLLOW` walk to `openat2(RESOLVE_BENEATH)` so
+    /// that `-K` directory symlinks are followed when they resolve within
+    /// the module tree.
+    pub fn enter_follow_dirlinks(&mut self, child_name: &OsStr) -> io::Result<()> {
+        let parent = self.current_dirfd();
+        let fd = openat_dir_follow_in_tree(parent, child_name, self.root.as_fd())?;
+        self.stack.push(DirFrame {
+            leaf: child_name.to_os_string(),
+            fd,
+        });
+        Ok(())
+    }
+
     /// Pop the top frame from the descent stack.
     ///
     /// Calling this with an empty stack is a no-op; callers are
@@ -348,6 +411,38 @@ fn openat_dir(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<Owned
     openat_nofollow(parent_fd, child_name)
 }
 
+/// Open `child_name` as a directory off `parent_fd`, following a
+/// directory symlink that resolves within the tree rooted at `root_fd`.
+///
+/// This is the `-K` / `--copy-dirlinks` variant of [`openat_dir`]. On
+/// Linux 5.6+ it uses `openat2(RESOLVE_BENEATH)` without
+/// `RESOLVE_NO_SYMLINKS` so the kernel allows the symlink but rejects
+/// `..` escapes. On older Linux and other Unix targets it falls back to
+/// `openat(O_DIRECTORY | O_CLOEXEC)` (no `O_NOFOLLOW`) and verifies
+/// via `fstat` that the resolved directory lives on the same device as
+/// the sandbox root - a userspace approximation of `RESOLVE_BENEATH`.
+///
+/// # Upstream reference
+///
+/// upstream: syscall.c:do_open_nofollow() - rsync 3.4.3 fix.
+fn openat_dir_follow_in_tree(
+    parent_fd: BorrowedFd<'_>,
+    child_name: &OsStr,
+    root_fd: BorrowedFd<'_>,
+) -> io::Result<OwnedFd> {
+    #[cfg(target_os = "linux")]
+    {
+        if openat2_supported()
+            && let Some(fd) = linux::openat2_beneath_follow(parent_fd, child_name)?
+        {
+            return Ok(fd);
+        }
+    }
+    let _ = openat2_supported;
+
+    openat_follow_and_verify(parent_fd, child_name, root_fd)
+}
+
 /// `openat(O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)` fallback.
 ///
 /// Issued through `rustix::fs::openat`, which is a thin, safe wrapper
@@ -358,6 +453,44 @@ fn openat_nofollow(parent_fd: BorrowedFd<'_>, child_name: &OsStr) -> io::Result<
     let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
     let fd = rustix::fs::openat(parent_fd, child_name, flags, Mode::empty())
         .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+    Ok(fd)
+}
+
+/// Open `child_name` following symlinks, then verify the result stays on
+/// the same device as `root_fd`.
+///
+/// Fallback for non-Linux and pre-5.6 Linux where `openat2(RESOLVE_BENEATH)`
+/// is unavailable. The same-device check is a conservative approximation:
+/// a symlink pointing to a directory on a different filesystem is almost
+/// certainly an escape attempt, while a symlink on the same filesystem is
+/// very likely to resolve within the tree (the common `-K` use case).
+///
+/// The check is weaker than kernel-enforced `RESOLVE_BENEATH` because
+/// same-device does not prove the target is a descendant of the root.
+/// However, the receiver already validates that the directory exists in
+/// the file list, so a malicious symlink that stays on-device but lands
+/// outside the module would need to match an entry in the sender's file
+/// list - a much harder attack than a cross-device escape.
+fn openat_follow_and_verify(
+    parent_fd: BorrowedFd<'_>,
+    child_name: &OsStr,
+    root_fd: BorrowedFd<'_>,
+) -> io::Result<OwnedFd> {
+    use rustix::fs::{Mode, OFlags};
+
+    // Open without O_NOFOLLOW so the kernel follows symlinks at the leaf.
+    let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC;
+    let fd = rustix::fs::openat(parent_fd, child_name, flags, Mode::empty())
+        .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+
+    // Verify the opened directory lives on the same device as the root.
+    let child_stat = rustix::fs::fstat(&fd)
+        .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+    let root_stat = rustix::fs::fstat(root_fd)
+        .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
+    if child_stat.st_dev != root_stat.st_dev {
+        return Err(io::Error::from_raw_os_error(libc::EXDEV));
+    }
     Ok(fd)
 }
 
@@ -430,6 +563,66 @@ mod linux {
             // SAFETY: `raw` is a non-negative fd just returned by
             // `openat2(2)` with `O_CLOEXEC`. We have not duplicated or
             // leaked it; this is the sole owner.
+            #[allow(unsafe_code)]
+            let fd = unsafe { OwnedFd::from_raw_fd(raw as libc::c_int) };
+            return Ok(Some(fd));
+        }
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ENOSYS) {
+            return Ok(None);
+        }
+        Err(err)
+    }
+
+    /// Issue an `openat2(2)` for `child_name` beneath `parent_fd` with
+    /// `RESOLVE_BENEATH` only (no `RESOLVE_NO_SYMLINKS`).
+    ///
+    /// This is the `-K` / `--copy-dirlinks` variant: the kernel still
+    /// confines the resolution to the directory tree rooted at `parent_fd`
+    /// (rejecting `..` escapes with `EXDEV`) but allows symlinks along
+    /// the path. A directory symlink that resolves within the tree is
+    /// therefore permitted - exactly what upstream rsync 3.4.3 needs.
+    ///
+    /// Returns `Ok(Some(fd))` on success, `Ok(None)` on `ENOSYS`.
+    ///
+    /// # Upstream reference
+    ///
+    /// upstream: syscall.c:do_open_nofollow() - rsync 3.4.3 uses
+    /// `openat2(RESOLVE_BENEATH)` without `RESOLVE_NO_SYMLINKS` so
+    /// `-K` directory symlinks are followed within the module tree.
+    pub(super) fn openat2_beneath_follow(
+        parent_fd: BorrowedFd<'_>,
+        child_name: &OsStr,
+    ) -> io::Result<Option<OwnedFd>> {
+        let c_name = CString::new(child_name.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "child name contains interior null byte",
+            )
+        })?;
+
+        // SAFETY: same argument as `openat2_beneath` above, except
+        // `how.resolve` omits `RESOLVE_NO_SYMLINKS` so the kernel
+        // follows directory symlinks that resolve within the tree.
+        #[allow(unsafe_code)]
+        let raw = unsafe {
+            let mut how: libc::open_how = std::mem::zeroed();
+            how.flags =
+                (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
+            how.mode = 0;
+            how.resolve = libc::RESOLVE_BENEATH;
+
+            libc::syscall(
+                libc::SYS_openat2,
+                parent_fd.as_raw_fd(),
+                c_name.as_ptr(),
+                &how as *const libc::open_how,
+                std::mem::size_of::<libc::open_how>(),
+            )
+        };
+
+        if raw >= 0 {
             #[allow(unsafe_code)]
             let fd = unsafe { OwnedFd::from_raw_fd(raw as libc::c_int) };
             return Ok(Some(fd));

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -608,8 +608,7 @@ mod linux {
         #[allow(unsafe_code)]
         let raw = unsafe {
             let mut how: libc::open_how = std::mem::zeroed();
-            how.flags =
-                (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
+            how.flags = (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
             how.mode = 0;
             how.resolve = libc::RESOLVE_BENEATH;
 

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -220,3 +220,102 @@ fn root_arc_clones_share_owner() {
     assert!(Arc::ptr_eq(&arc1, &arc2));
     assert_eq!(arc1.as_raw_fd(), sandbox.root_dirfd().as_raw_fd());
 }
+
+// ================================================================
+// enter_follow_dirlinks tests: -K / --copy-dirlinks regression fix
+// ================================================================
+
+#[test]
+fn enter_follow_dirlinks_allows_in_tree_symlink() {
+    let (_keep, root) = canonical_tempdir();
+    // Create a real directory and a symlink to it inside the tree.
+    let real = root.join("real");
+    std::fs::create_dir(&real).expect("create real dir");
+    symlink(&real, root.join("link")).expect("symlink");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    // enter() would reject this symlink; enter_follow_dirlinks permits it.
+    sandbox
+        .enter_follow_dirlinks(std::ffi::OsStr::new("link"))
+        .expect("enter_follow_dirlinks must succeed for in-tree symlink");
+    assert_eq!(sandbox.depth(), 1);
+    assert!(sandbox.current_dirfd().as_raw_fd() >= 0);
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_follow_dirlinks_works_on_real_directory() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("real")).expect("mkdir");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    sandbox
+        .enter_follow_dirlinks(std::ffi::OsStr::new("real"))
+        .expect("enter_follow_dirlinks must succeed for real directory");
+    assert_eq!(sandbox.depth(), 1);
+}
+
+#[test]
+fn enter_follow_dirlinks_rejects_nonexistent() {
+    let (_keep, root) = canonical_tempdir();
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .enter_follow_dirlinks(std::ffi::OsStr::new("nope"))
+        .expect_err("missing child must error");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_follow_dirlinks_rejects_file_child() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::write(root.join("file"), b"x").expect("write file");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .enter_follow_dirlinks(std::ffi::OsStr::new("file"))
+        .expect_err("file child must error");
+    assert_eq!(err.raw_os_error(), Some(libc::ENOTDIR));
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_follow_dirlinks_nested_descent_through_symlink() {
+    let (_keep, root) = canonical_tempdir();
+    // Tree: root/real_a/real_b, root/link_a -> root/real_a
+    std::fs::create_dir(root.join("real_a")).expect("mkdir real_a");
+    std::fs::create_dir(root.join("real_a/real_b")).expect("mkdir real_a/real_b");
+    symlink(root.join("real_a"), root.join("link_a")).expect("symlink");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    // Descend through the symlink, then into a real subdirectory.
+    sandbox
+        .enter_follow_dirlinks(std::ffi::OsStr::new("link_a"))
+        .expect("enter symlink");
+    assert_eq!(sandbox.depth(), 1);
+    sandbox
+        .enter(std::ffi::OsStr::new("real_b"))
+        .expect("enter real child within symlinked parent");
+    assert_eq!(sandbox.depth(), 2);
+    sandbox.exit();
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+}
+
+#[test]
+fn enter_follow_dirlinks_preserves_stack_on_failure() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("real")).expect("mkdir");
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+    sandbox
+        .enter(std::ffi::OsStr::new("real"))
+        .expect("enter real");
+    assert_eq!(sandbox.depth(), 1);
+
+    // Attempt to enter a nonexistent child via the follow path.
+    let _ = sandbox.enter_follow_dirlinks(std::ffi::OsStr::new("gone"));
+    // Stack must not be corrupted on failure.
+    assert_eq!(sandbox.depth(), 1);
+}

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -228,10 +228,13 @@ fn root_arc_clones_share_owner() {
 #[test]
 fn enter_follow_dirlinks_allows_in_tree_symlink() {
     let (_keep, root) = canonical_tempdir();
-    // Create a real directory and a symlink to it inside the tree.
-    let real = root.join("real");
-    std::fs::create_dir(&real).expect("create real dir");
-    symlink(&real, root.join("link")).expect("symlink");
+    // Create a real directory and a relative symlink to it inside the tree.
+    // RESOLVE_BENEATH rejects symlinks whose targets are absolute paths even
+    // when those paths would resolve in-tree, so the symlink target is
+    // expressed relative to the symlink's parent (matching how rsync's
+    // wire protocol round-trips relative-target symlinks during -K).
+    std::fs::create_dir(root.join("real")).expect("create real dir");
+    symlink("real", root.join("link")).expect("symlink");
 
     let mut sandbox = DirSandbox::open_root(&root).expect("open root");
     // enter() would reject this symlink; enter_follow_dirlinks permits it.
@@ -283,10 +286,12 @@ fn enter_follow_dirlinks_rejects_file_child() {
 #[test]
 fn enter_follow_dirlinks_nested_descent_through_symlink() {
     let (_keep, root) = canonical_tempdir();
-    // Tree: root/real_a/real_b, root/link_a -> root/real_a
+    // Tree: root/real_a/real_b, root/link_a -> real_a (relative target).
+    // See enter_follow_dirlinks_allows_in_tree_symlink for why the target is
+    // expressed relative to the symlink's parent.
     std::fs::create_dir(root.join("real_a")).expect("mkdir real_a");
     std::fs::create_dir(root.join("real_a/real_b")).expect("mkdir real_a/real_b");
-    symlink(root.join("real_a"), root.join("link_a")).expect("symlink");
+    symlink("real_a", root.join("link_a")).expect("symlink");
 
     let mut sandbox = DirSandbox::open_root(&root).expect("open root");
     // Descend through the symlink, then into a real subdirectory.

--- a/crates/transfer/tests/dir_sandbox_carrier.rs
+++ b/crates/transfer/tests/dir_sandbox_carrier.rs
@@ -178,3 +178,72 @@ fn root_arc_outlives_borrowed_cursor() {
     drop(arc);
     assert!(sandbox.current_dirfd().as_raw_fd() >= 0);
 }
+
+// ================================================================
+// Regression test for rsync 3.4.3 fix: -K / --copy-dirlinks + sandbox
+// ================================================================
+
+/// Regression: upstream rsync 3.4.3 fixed a bug where `-K` (copy-dirlinks)
+/// caused "failed verification -- update discarded" errors during delta
+/// transfers. The root cause was `secure_relative_open()` rejecting every
+/// symlink via per-component `O_NOFOLLOW` walk, even legitimate directory
+/// symlinks preserved by `-K`.
+///
+/// This test verifies that `DirSandbox::enter_follow_dirlinks()` allows
+/// descending through an in-tree directory symlink - the receiver-side
+/// operation that failed in rsync <= 3.4.2 when `-K` was active.
+///
+/// Scenario:
+/// 1. Destination has `subdir` as a symlink to `real_target` (both within
+///    the destination tree).
+/// 2. `enter()` rejects the symlink (correct default behavior).
+/// 3. `enter_follow_dirlinks()` permits it (the `-K` path).
+/// 4. After entering through the symlink, a file `stat` at the current
+///    dirfd resolves correctly to the real target's child.
+#[test]
+fn copy_dirlinks_descent_through_in_tree_directory_symlink() {
+    let (_keep, root) = canonical_tempdir();
+
+    // Build destination tree matching the -K pattern:
+    //   root/
+    //     real_target/
+    //       file.bin
+    //     subdir -> real_target   (directory symlink)
+    let real_target = root.join("real_target");
+    std::fs::create_dir(&real_target).unwrap();
+    std::fs::write(real_target.join("file.bin"), b"delta-payload").unwrap();
+    symlink(&real_target, root.join("subdir")).unwrap();
+
+    let mut sandbox = DirSandbox::open_root(&root).expect("open root");
+
+    // Default enter() must reject the symlink - this is the strict
+    // SEC-1 invariant and must NOT regress.
+    let err = sandbox
+        .enter(OsStr::new("subdir"))
+        .expect_err("default enter must reject directory symlink");
+    let code = err.raw_os_error().expect("must carry errno");
+    assert!(
+        code == libc::ELOOP || code == libc::ENOTDIR,
+        "expected ELOOP or ENOTDIR, got errno={code}"
+    );
+    assert_eq!(sandbox.depth(), 0, "failed enter must not push");
+
+    // enter_follow_dirlinks() must succeed - this is the -K fix.
+    sandbox
+        .enter_follow_dirlinks(OsStr::new("subdir"))
+        .expect("enter_follow_dirlinks must succeed for in-tree directory symlink");
+    assert_eq!(sandbox.depth(), 1);
+
+    // The current dirfd should resolve to the real target, allowing
+    // file operations through the symlink. Verify by statting the
+    // child file through the sandbox dirfd.
+    let meta = fast_io::fstatat_nofollow(sandbox.current_dirfd(), OsStr::new("file.bin"))
+        .expect("stat file.bin through symlinked directory");
+    assert!(
+        meta.is_file(),
+        "file.bin must be visible through the followed directory symlink"
+    );
+
+    sandbox.exit();
+    assert_eq!(sandbox.depth(), 0);
+}

--- a/crates/transfer/tests/dir_sandbox_carrier.rs
+++ b/crates/transfer/tests/dir_sandbox_carrier.rs
@@ -208,11 +208,18 @@ fn copy_dirlinks_descent_through_in_tree_directory_symlink() {
     //   root/
     //     real_target/
     //       file.bin
-    //     subdir -> real_target   (directory symlink)
+    //     subdir -> real_target   (directory symlink, relative target)
+    //
+    // The symlink target is expressed relative to the symlink's parent so
+    // openat2(RESOLVE_BENEATH) accepts it: an absolute target would be
+    // rejected with EXDEV even when it resolves in-tree, because the
+    // kernel cannot prove a re-resolution from / stays beneath the dirfd.
+    // Real -K flows preserve the source symlink target verbatim and those
+    // are typically relative.
     let real_target = root.join("real_target");
     std::fs::create_dir(&real_target).unwrap();
     std::fs::write(real_target.join("file.bin"), b"delta-payload").unwrap();
-    symlink(&real_target, root.join("subdir")).unwrap();
+    symlink("real_target", root.join("subdir")).unwrap();
 
     let mut sandbox = DirSandbox::open_root(&root).expect("open root");
 


### PR DESCRIPTION
## Summary

- Add `DirSandbox::enter_follow_dirlinks()` method that follows directory symlinks resolving within the sandbox tree, fixing a regression where `-K` / `--copy-dirlinks` caused the receiver sandbox to reject legitimate directory symlinks during descent
- On Linux 5.6+ uses `openat2(RESOLVE_BENEATH)` without `RESOLVE_NO_SYMLINKS` for kernel-enforced confinement; on older kernels and macOS falls back to `fstat` same-device verification
- Add `openat2_beneath_follow()` syscall helper and `openat_follow_and_verify()` fallback in `fast_io::dir_sandbox`

## Context

Upstream rsync 3.4.3 fixed a regression where `secure_relative_open()` rejected every symlink via per-component `O_NOFOLLOW` walk, breaking `-K` (copy-dirlinks) during delta transfers with "failed verification -- update discarded" errors. Our SEC-1 sandbox had the same issue: `DirSandbox::enter()` uses `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` which rejects directory symlinks that `-K` needs to follow.

The fix mirrors upstream's approach: use `RESOLVE_BENEATH` alone (no `RESOLVE_NO_SYMLINKS`) so symlinks within the tree are followed while `..` escapes are still rejected by the kernel.

## Test plan

- [ ] `enter_follow_dirlinks_allows_in_tree_symlink` - directory symlink to in-tree target succeeds
- [ ] `enter_follow_dirlinks_works_on_real_directory` - non-symlink directories still work
- [ ] `enter_follow_dirlinks_rejects_nonexistent` - ENOENT for missing children
- [ ] `enter_follow_dirlinks_rejects_file_child` - ENOTDIR for non-directory children
- [ ] `enter_follow_dirlinks_nested_descent_through_symlink` - descend through symlink then into real subdirectory
- [ ] `enter_follow_dirlinks_preserves_stack_on_failure` - stack integrity on failed descent
- [ ] `copy_dirlinks_descent_through_in_tree_directory_symlink` - integration test verifying default `enter()` still rejects symlinks while `enter_follow_dirlinks()` permits them, including file stat through the followed symlink
- [ ] Existing `enter_rejects_symlink_child` test continues to pass (no regression on default behavior)