### PR TITLE
fix: accept -s secluded-args in oc-rsync --server flag string

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -36,15 +36,35 @@ where
 
     let mut stdin = io::stdin().lock();
 
-    // When secluded-args is active, read the full argument list from stdin
-    // before parsing server flags. The client sends arguments as
-    // null-separated strings terminated by an empty string.
-    // upstream: main.c - read_args() reads protected args from stdin.
+    // When secluded-args is active, the client splits its argv: the
+    // server-options flag string and long flags travel on the command
+    // line, while the trailing positional args (the `.` separator and
+    // path arguments) are streamed over stdin as NUL-delimited bytes
+    // terminated by an empty string. Mirroring upstream, we keep the
+    // command-line args and substitute the stdin-supplied positional
+    // tail.
+    //
+    // upstream: rsync.c:283 send_protected_args() - sender writes a
+    // replacement arg0 ("rsync") followed by the args after the NULL
+    // split inserted by options.c:2745.
+    // upstream: io.c:1295 read_args() - server reads the NUL-delimited
+    // payload into a fresh argv before re-running parse_arguments(),
+    // which is what supplies the positional path tail.
     let effective_args: Vec<OsString>;
     let effective_slice: &[OsString] = if secluded_args {
         match protocol::secluded_args::recv_secluded_args(&mut stdin, None) {
             Ok(received_args) => {
-                effective_args = received_args.into_iter().map(OsString::from).collect();
+                // The wire payload starts with a synthetic arg0 ("rsync")
+                // that mirrors how upstream rebuilds argv. We discard it
+                // because the command-line argv already carries the real
+                // server-options head (--server / --sender / flag string
+                // / long flags).
+                let mut received_iter = received_args.into_iter();
+                let _arg0 = received_iter.next();
+                let cmdline_tail = args.iter().skip(1).cloned();
+                effective_args = cmdline_tail
+                    .chain(received_iter.map(OsString::from))
+                    .collect();
                 &effective_args
             }
             Err(e) => {

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1136,10 +1136,7 @@ fn secluded_args_round_trip_merges_cmdline_and_stdin() {
 
     let (flag_string, positional) = parse_server_flag_string_and_args(&effective_args);
     assert_eq!(flag_string, "-slogDtpre.iLsfxCIvu");
-    assert_eq!(
-        positional,
-        vec![OsString::from("/home/ofer/reproA/from/")],
-    );
+    assert_eq!(positional, vec![OsString::from("/home/ofer/reproA/from/")],);
 }
 
 /// When `-s` is sent as a standalone short flag (rather than embedded in

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1087,3 +1087,89 @@ fn server_daemon_arguments_sets_daemon_program_name() {
     // First element should be the daemon program name
     assert!(!result.is_empty());
 }
+
+/// Reproduces the wire layout upstream produces for `rsync -ais lh:src/ dest/`:
+/// the command-line argv carries the server-options head (`--server`,
+/// `--sender`, packed `-slogDtpre.iLsfxCIvu`) and stdin carries a synthetic
+/// "rsync" arg0 followed by `.` and the path tail.
+///
+/// upstream: rsync.c:283 send_protected_args() and io.c:1295 read_args()
+#[test]
+fn secluded_args_round_trip_merges_cmdline_and_stdin() {
+    use std::io::Cursor;
+
+    // Command-line argv as oc-rsync --server receives it under lsh.sh -s.
+    let argv: Vec<OsString> = vec![
+        OsString::from("oc-rsync"),
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-slogDtpre.iLsfxCIvu"),
+    ];
+
+    // Wire bytes captured from upstream 3.4.3's send_protected_args for
+    // `rsync -ais lh:reproA/from/ /tmp/dest/`:
+    //   rsync\0.\0/home/ofer/reproA/from/\0\0
+    let wire: &[u8] = b"rsync\0.\0/home/ofer/reproA/from/\0\0";
+    let mut reader = Cursor::new(wire);
+    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+        .expect("recv should succeed");
+    assert_eq!(
+        received,
+        vec![
+            "rsync".to_owned(),
+            ".".to_owned(),
+            "/home/ofer/reproA/from/".to_owned(),
+        ],
+    );
+
+    // The fix discards the synthetic arg0 and merges the rest with the
+    // command-line tail. The flag string must come from argv, and the
+    // positional path from stdin.
+    let mut received_iter = received.into_iter();
+    let _arg0 = received_iter.next();
+    let effective_args: Vec<OsString> = argv
+        .iter()
+        .skip(1)
+        .cloned()
+        .chain(received_iter.map(OsString::from))
+        .collect();
+
+    let (flag_string, positional) = parse_server_flag_string_and_args(&effective_args);
+    assert_eq!(flag_string, "-slogDtpre.iLsfxCIvu");
+    assert_eq!(
+        positional,
+        vec![OsString::from("/home/ofer/reproA/from/")],
+    );
+}
+
+/// When `-s` is sent as a standalone short flag (rather than embedded in
+/// the packed flag string), the same merge produces the right split.
+#[test]
+fn secluded_args_round_trip_standalone_s_flag() {
+    use std::io::Cursor;
+
+    let argv: Vec<OsString> = vec![
+        OsString::from("oc-rsync"),
+        OsString::from("--server"),
+        OsString::from("-s"),
+        OsString::from("-logDtpr"),
+    ];
+
+    let wire: &[u8] = b"rsync\0.\0/srv/data/\0\0";
+    let mut reader = Cursor::new(wire);
+    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+        .expect("recv should succeed");
+
+    let mut received_iter = received.into_iter();
+    let _arg0 = received_iter.next();
+    let effective_args: Vec<OsString> = argv
+        .iter()
+        .skip(1)
+        .cloned()
+        .chain(received_iter.map(OsString::from))
+        .collect();
+
+    let (flag_string, positional) = parse_server_flag_string_and_args(&effective_args);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("/srv/data/")]);
+}


### PR DESCRIPTION
## Summary

When upstream rsync invokes `--server` with `--secluded-args` / `-s`, the
client splits its argv: the server-options head (`--server`, `--sender`,
the packed transfer-flag string such as `-slogDtpre.iLsfxCIvu`, and the
value-bearing long flags) travels on the command line, while the trailing
positional args (the `.` separator and path arguments) stream over stdin
as NUL-delimited bytes terminated by an empty string.

The server-mode handler previously replaced its effective argument slice
with the stdin payload alone, discarding the flag string entirely. That
triggered `invalid server arguments: missing rsync server flag string` on
every upstream invocation with `-s` -- including the `-ais` round-trips in
`testsuite/00-hello_test.py` (test4, test5) under `lsh.sh`.

This change matches upstream's `read_args()` contract (`io.c:1295`) and
the `send_protected_args()` wire layout (`rsync.c:283`): we keep the
command-line argv tail, skip the synthetic `rsync` arg0 that the wire
prepends, and append the rest of the stdin payload as positional args.

## Wire evidence (captured under lsh.sh -ais)

Captured via a tee wrapper around `oc-rsync --server` while running
`rsync -ais --rsync-path=oc-rsync lh:reproA/from/ /tmp/reproA/`:

- Command-line argv: `--server --sender -slogDtpre.iLsfxCIvu`
- Stdin payload: `rsync\0.\0/home/ofer/reproA/from/\0\0`

The flag string travels on the command line. Before this fix the server
discarded it; after this fix it is preserved and merged with the
stdin-provided positional path tail.

## Test results on the Linux interop host

Before this PR:

```
test4
oc-rsync error: invalid server arguments: missing rsync server flag string (code 1)
rsync error: error in rsync protocol data stream (code 12)
Failed: status=12 dir-diff file-diff
FAIL    00-hello
```

After this PR (00-hello, tests 1-5):

```
test1 ... test5 -- transfer completes, ls-from and ls-to match
test6  -- still fails (--old-args, a different feature, not covered here)
```

Other suites that previously reported the same `missing rsync server flag
string` error no longer surface that error:

- `exclude-lsh`, `files-from`, `alt-dest`, `batch-mode`, `hardlinks`

Those suites still fail on independent issues (filter semantics,
symlink-mtime drift, `--old-args` re-splitting) that are tracked as
separate follow-ups.

## Test plan

- [x] `testsuite/00-hello_test.py` tests 4 & 5 pass under `lsh.sh -ais`
      with `oc-rsync --server` (previously hard-failed with arg parser
      error)
- [x] Non-secluded `--server` path is unchanged (verified by running
      `rsync -ai --rsync-path=oc-rsync lh:src/ dest/` end-to-end)
- [x] Added two round-trip regression tests in
      `crates/cli/src/frontend/server/tests.rs` using captured upstream
      wire bytes -- one for the packed `-slogDtpre.iLsfxCIvu` form and
      one for the standalone `-s` form
- [x] CI must pass: fmt+clippy, nextest (stable), Windows, macOS, Linux
      musl

upstream: `rsync.c:283` `send_protected_args()`, `io.c:1295` `read_args()`,
`options.c:2604` `server_options()` (sets the `s` flag-string char and the
NULL split between command-line and stdin tails)