### PR TITLE
fix: accept &include/&merge directives and refuse client args in daemon

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
@@ -183,7 +183,14 @@ fn apply_global_directive(
                 },
             ));
         }
-        "include" => {
+        "include" | "&include" | "&merge" => {
+            // upstream: params.c:parse_directives - `&include` and `&merge` both
+            // pull configuration from another file. The historical `include =`
+            // form is retained as a synonym so existing oc-rsync configs keep
+            // working. `&merge` differs from `&include` in upstream only in
+            // global-defaults handling for directory inclusion; we apply file
+            // contents uniformly because oc-rsync does not yet track Vars push/
+            // pop semantics for directory globbing.
             apply_include_directive(state, value, path, line_number, canonical, stack)?;
         }
         "motd file" => {

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -77,13 +77,45 @@ fn parse_config_modules_inner(
                 continue;
             }
 
-            let (key, value) = line.split_once('=').ok_or_else(|| {
-                config_parse_error(path, line_number, "expected 'key = value' directive")
-            })?;
-            let key = key.trim().to_ascii_lowercase();
-            let value = value.trim();
+            // upstream: params.c:Parameter() - directives that start with '&'
+            // (e.g. `&include /path/to/file.conf`, `&merge /path/to/snippet.inc`)
+            // use whitespace as the name/value separator and treat a following
+            // '=' as optional. Detect them before the regular `key = value`
+            // dispatch so the file inclusion syntax is accepted as-written.
+            let (key, value) = if let Some(rest) = line.strip_prefix('&') {
+                let (name, raw_value) = rest
+                    .split_once(|c: char| c.is_whitespace() || c == '=')
+                    .ok_or_else(|| {
+                        config_parse_error(
+                            path,
+                            line_number,
+                            "expected '&directive value' or '&directive = value'",
+                        )
+                    })?;
+                let trimmed_value = raw_value
+                    .trim_start()
+                    .strip_prefix('=')
+                    .unwrap_or(raw_value);
+                (
+                    format!("&{}", name.trim().to_ascii_lowercase()),
+                    trimmed_value.trim(),
+                )
+            } else {
+                let (raw_key, raw_value) = line.split_once('=').ok_or_else(|| {
+                    config_parse_error(path, line_number, "expected 'key = value' directive")
+                })?;
+                (raw_key.trim().to_ascii_lowercase(), raw_value.trim())
+            };
 
-            if let Some(builder) = current.as_mut() {
+            // upstream: params.c:Parse() - the `&include`/`&merge` directives
+            // are dispatched from the top-level switch and apply to the global
+            // configuration regardless of any open module section. Forward
+            // them to the global-directive handler rather than the per-module
+            // setter so the recursive include works after a `[name]` line.
+            let is_amp_directive = key.starts_with('&');
+            if !is_amp_directive
+                && let Some(builder) = current.as_mut()
+            {
                 apply_module_directive(builder, &key, value, path, line_number, &canonical)?;
                 continue;
             }

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -380,6 +380,44 @@ mod config_parsing_tests {
     }
 
     #[test]
+    fn parse_amp_include_directive() {
+        // upstream: params.c:parse_directives - `&include /path` (whitespace
+        // separator, no '=') is the canonical syntax in rsync 3.4.3.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let included = format!("[amp_included]\npath = {}\n", path.display());
+        let include_file = write_config(&included);
+
+        let main_config = format!("&include {}\n", include_file.path().display());
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "amp_included");
+    }
+
+    #[test]
+    fn parse_amp_merge_directive_with_equals() {
+        // upstream: params.c - `&merge` is the bare-include variant; the
+        // optional '=' separator must also be accepted.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let included = format!("[merge_included]\npath = {}\n", path.display());
+        let include_file = write_config(&included);
+
+        let main_config = format!("&merge = {}\n", include_file.path().display());
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "merge_included");
+    }
+
+    #[test]
     fn parse_recursive_include_detected() {
         let dir = TempDir::new().expect("create temp dir");
         let config_path = dir.path().join("config.conf");

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -613,6 +613,15 @@ fn process_approved_module(
         None => return Ok(()),
     };
 
+    // upstream: clientserver.c:rsync_module() -> parse_arguments() applies the
+    // module's `refuse options` list against the actual client argv after the
+    // post-OK `read_args()` round-trip. The earlier check at the OPTION-line
+    // pre-handshake stage only sees client-supplied dparam overrides, never
+    // the real transfer flags (e.g. `-z` packed into `-vlogDtprez.iLsfxCIvu`).
+    if let Some(refused) = refused_client_arg(module, &client_args) {
+        return handle_refused_option(ctx, &refused);
+    }
+
     // Enforce read-only / write-only access restrictions.
     // upstream: clientserver.c:rsync_module() - after reading args, check
     // am_sender against lp_read_only(i) and lp_write_only(i).

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -63,6 +63,126 @@ fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Optio
     })
 }
 
+/// Maps a single short-option letter to its canonical long-name (lowercase).
+///
+/// Mirrors the `shortName` -> `longName` columns of upstream's `long_options[]`
+/// table for the subset of options that ship as bundled short letters in the
+/// daemon-mode argument string (e.g. `-vlogDtprez.iLsfxCIvu`). When no mapping
+/// exists the literal letter is returned so wildcard-only refuse rules still
+/// catch it.
+///
+/// upstream: options.c long_options[] - the canonical short/long pairing the
+/// daemon's popt-based refuse check uses to compare against `refuse options`.
+fn short_option_long_name(letter: char) -> &'static str {
+    match letter {
+        'v' => "verbose",
+        'q' => "quiet",
+        'h' => "human-readable",
+        'n' => "dry-run",
+        'a' => "archive",
+        'r' => "recursive",
+        'd' => "dirs",
+        'p' => "perms",
+        'E' => "executability",
+        'A' => "acls",
+        'X' => "xattrs",
+        't' => "times",
+        'U' => "atimes",
+        'N' => "crtimes",
+        'O' => "omit-dir-times",
+        'J' => "omit-link-times",
+        'o' => "owner",
+        'g' => "group",
+        'D' => "devices",
+        'l' => "links",
+        'L' => "copy-links",
+        'k' => "copy-dirlinks",
+        'K' => "keep-dirlinks",
+        'H' => "hard-links",
+        'R' => "relative",
+        'I' => "ignore-times",
+        'x' => "one-file-system",
+        'u' => "update",
+        'S' => "sparse",
+        'F' => "filter",
+        'C' => "cvs-exclude",
+        'W' => "whole-file",
+        'c' => "checksum",
+        'y' => "fuzzy",
+        'z' => "compress",
+        'P' => "partial",
+        'm' => "prune-empty-dirs",
+        'i' => "itemize-changes",
+        'b' => "backup",
+        's' => "secluded-args",
+        'V' => "version",
+        'B' => "block-size",
+        'T' => "temp-dir",
+        'M' => "remote-option",
+        'f' => "filter",
+        'e' => "e",
+        _ => "",
+    }
+}
+
+/// Checks whether any client argument is refused by the module's refuse list.
+///
+/// Expands bundled short options (e.g. `-vlogDtprez.iLsfxCIvu`) into their
+/// long-name equivalents so a `refuse options = compress` rule rejects `-z`
+/// inside a packed letter string the same way upstream rsync's popt-based
+/// refuse check does.
+///
+/// Returns the long-name of the first refused option (formatted with the
+/// `--` prefix to match the upstream `--<longname>` diagnostic) so callers
+/// can include it verbatim in the error message.
+///
+/// upstream: clientserver.c - the daemon runs `parse_arguments()` on the
+/// post-OK arg list; popt treats each bundled short letter as a separate
+/// option and rejects any that the module's refuse list disabled.
+fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Option<String> {
+    if module.refuse_options.is_empty() {
+        return None;
+    }
+
+    for arg in client_args {
+        let trimmed = arg.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("--") {
+            let canonical = canonical_option(rest);
+            if canonical.is_empty() {
+                continue;
+            }
+            if is_option_refused(&module.refuse_options, &canonical) {
+                return Some(format!("--{canonical}"));
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix('-') {
+            // Skip the dot-suffix capability string (e.g. `.LsfxCIvu`) and any
+            // option-argument that follows a letter (e.g. `e.LsfxCIvu`).
+            let letters = rest.split('.').next().unwrap_or("");
+            for letter in letters.chars() {
+                if !letter.is_ascii_alphabetic() {
+                    break;
+                }
+                let long = short_option_long_name(letter);
+                let candidate = if long.is_empty() {
+                    letter.to_ascii_lowercase().to_string()
+                } else {
+                    long.to_owned()
+                };
+                if is_option_refused(&module.refuse_options, &candidate) {
+                    return Some(if long.is_empty() {
+                        format!("-{letter}")
+                    } else {
+                        format!("--{long}")
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Evaluates a canonical option name against an ordered refuse list.
 ///
 /// Processes rules left-to-right. A rule starting with `!` negates a previous

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -280,6 +280,88 @@ fn is_vital_option_rejects_non_vitals() {
     assert!(!is_vital_option("archive"));
 }
 
+#[test]
+fn refused_client_arg_matches_long_form() {
+    // upstream: clientserver.c rejects `--compress` when the module's
+    // `refuse options = compress` rule is active.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["--server".to_owned(), "--compress".to_owned()];
+    assert_eq!(
+        refused_client_arg(&module, &args),
+        Some("--compress".to_owned())
+    );
+}
+
+#[test]
+fn refused_client_arg_expands_bundled_short() {
+    // upstream: the daemon expands `-z` inside a packed short-letter
+    // server argstr (e.g. `-vlogDtprez.iLsfxCIvu`) into `--compress` via
+    // popt's longName mapping, then matches against the refuse list.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    let args = vec![
+        "--server".to_owned(),
+        "-vlogDtprez.iLsfxCIvu".to_owned(),
+        ".".to_owned(),
+        "no-compress/".to_owned(),
+    ];
+    assert_eq!(
+        refused_client_arg(&module, &args),
+        Some("--compress".to_owned())
+    );
+}
+
+#[test]
+fn refused_client_arg_skips_capability_suffix() {
+    // The capability dot-suffix (`.LsfxCIvu`) is not a list of options and
+    // must not be expanded - otherwise wildcard rules would erroneously
+    // refuse them.
+    let module = ModuleDefinition {
+        refuse_options: vec!["fuzzy".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["-e.LsfxCIvu".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_allows_when_refuse_list_empty() {
+    let module = ModuleDefinition {
+        refuse_options: Vec::new(),
+        ..Default::default()
+    };
+    let args = vec!["-avz".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_wildcard_spares_vital_e() {
+    // upstream: the `e` short letter (carries the compatibility-flags
+    // string) is exempt from wildcard refuse rules.
+    let module = ModuleDefinition {
+        refuse_options: vec!["*".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["-e.LsfxCIvu".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_short_n_dry_run_spared_by_wildcard() {
+    // upstream: `--dry-run` / `-n` is vital and must survive `*`.
+    let module = ModuleDefinition {
+        refuse_options: vec!["*".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["-n".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
 
 #[test]
 fn program_name_rsyncd_as_str() {


### PR DESCRIPTION
## Summary

Two upstream-compat gaps in the rsyncd.conf parser/daemon surface as testsuite failures against rsync 3.4.3:

- **`&include` / `&merge` syntax** — the config parser only accepted the historical `include = <path>` form. Upstream's `params.c:parse_directives` treats `&include /path/to/snippet.conf` (whitespace separator, no `=`) as the canonical inclusion directive. The parser now recognises `&` directives with the same whitespace-or-`=` separator upstream's `Parameter()` applies when the name starts with `&`, and `&include` / `&merge` route to the existing file-inclusion logic regardless of any open module section.
- **`refuse options` matched against the real client argv** — the module's `refuse options = compress` rule was matched only against the dparam `OPTION` lines exchanged before `@RSYNCD: OK`, never against the post-OK argv. A client invoking `-avz` slipped through because `-z` lives inside the packed `-vlogDtprez.iLsfxCIvu` server flag string. The refuse check now expands each bundled short letter to its long name (via the same shortName→longName mapping popt uses) and runs against the actual client args. The diagnostic still matches upstream's `--<longname>` shape so the testsuite grep on `--compress` succeeds.

Both changes ship with regression coverage in `crates/daemon/src/daemon/sections/config_parsing/tests.rs` and `crates/daemon/src/daemon/sections/tests.rs`.

## Test plan
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable)
- [ ] Re-run `daemon-config`, `daemon-refuse-compress`, and other daemon upstream-testsuite cases on the interop host once CI is green