### PR TITLE
fix(xtask): validate body file before checking gh availability

### DIFF
--- a/xtask/src/commands/release_notes/publish.rs
+++ b/xtask/src/commands/release_notes/publish.rs
@@ -21,8 +21,6 @@ pub struct PublishOptions {
 
 /// Creates or updates a GitHub release for the given tag.
 pub fn execute(workspace: &Path, options: PublishOptions) -> TaskResult<()> {
-    ensure_command_available("gh", "install the GitHub CLI from https://cli.github.com/")?;
-
     let body_path = if options.body_file.is_absolute() {
         options.body_file.clone()
     } else {
@@ -35,6 +33,8 @@ pub fn execute(workspace: &Path, options: PublishOptions) -> TaskResult<()> {
             body_path.display(),
         )));
     }
+
+    ensure_command_available("gh", "install the GitHub CLI from https://cli.github.com/")?;
 
     let tag = &options.tag;
     let title = tag.clone();


### PR DESCRIPTION
## Summary

- Reorders checks in `xtask release-notes publish` so the body-file existence check runs before the `gh` availability check.
- Fixes `publish_rejects_missing_body_file` test failure in environments where `gh` is not on `PATH` (the test asserted the error contains "not found", but the prior code returned `ToolMissing("gh is unavailable; ...")` first).
- Semantic improvement: report the user's bad input (missing body file) before suggesting they install a CLI tool they might not need yet.

## Test plan

- [ ] `cargo nextest run -p xtask -E 'test(publish_)'` passes both `publish_rejects_missing_body_file` and `publish_resolves_relative_body_path` regardless of whether `gh` is installed.
- [ ] No behavioural change when both checks pass.
- [ ] CI fmt+clippy/nextest matrix green.