### PR TITLE
fix: protect receiver chdir against symlink-race TOCTOU

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -284,11 +284,14 @@ fn resolve_receiver_dest(
     if tail.is_empty() || tail == "." {
         return module_path.to_path_buf();
     }
+    // Defensive: a path arriving here that is absolute on the host OS
+    // (Unix `is_absolute()` or a leading `/` that Windows treats as
+    // drive-relative) cannot be allowed to escape the module root. Strip
+    // the leading separators and join the remainder so the destination is
+    // always under `module_path`. Tests cover both forms cross-platform.
     let rel = std::path::Path::new(tail);
-    if rel.is_absolute() {
-        // Defensive: an absolute path here cannot escape the module - join
-        // its components onto the module root by stripping the leading `/`.
-        let stripped = tail.trim_start_matches('/');
+    if rel.is_absolute() || tail.starts_with('/') || tail.starts_with('\\') {
+        let stripped = tail.trim_start_matches(|c| c == '/' || c == '\\');
         return module_path.join(stripped);
     }
     module_path.join(rel)

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -210,6 +210,86 @@ fn clamp_verbose_flags(flag_string: &str, max_verbosity: i32) -> String {
         .collect()
 }
 
+/// Extracts the positional path arguments sent by the client after the `.`
+/// separator and strips the leading module-name component from each so the
+/// receiver can resolve them relative to the on-disk module path.
+///
+/// Mirrors upstream `read_args()` (io.c:1295) and `glob_expand_module()`
+/// (util1.c:804): everything before a standalone `.` in the wire arg list is
+/// options/flags; everything after is the client's positional paths. Each
+/// positional begins with the module name (e.g. `upload/realdir/` when the
+/// module is `upload`), which is the prefix `glob_expand_module()` strips
+/// before the path is handed to the server-side option parser.
+///
+/// Returns the stripped relative paths in original order. A path that does
+/// not start with the module name is returned as-is so the caller can still
+/// see it (this matches upstream's loose prefix match - it only strips when
+/// the prefix is present).
+fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> Vec<String> {
+    let mut dot_seen = false;
+    let mut out = Vec::new();
+    for arg in client_args {
+        if !dot_seen {
+            if arg == "." {
+                dot_seen = true;
+            }
+            continue;
+        }
+        // upstream: util1.c:813-814 - `if (strncmp(arg, base, base_len) == 0)
+        // arg += base_len;` - strips the bare module name. The remainder may
+        // be empty (then represents the module root), start with `/`
+        // (subpath), or be the rest of a longer arg sharing the prefix.
+        let stripped = if let Some(rest) = arg.strip_prefix(module_name) {
+            // Only strip when the next char is `/` or end-of-string so we do
+            // not chop the prefix of a sibling module that merely shares a
+            // string prefix (e.g. `uploads/` vs module `upload`).
+            if rest.is_empty() || rest.starts_with('/') {
+                rest.trim_start_matches('/').to_owned()
+            } else {
+                arg.clone()
+            }
+        } else {
+            arg.clone()
+        };
+        out.push(stripped);
+    }
+    out
+}
+
+/// Resolves the receiver's on-disk destination directory from the client's
+/// positional path args.
+///
+/// Mirrors the post-`change_dir(module_chdir)` behaviour upstream relies on:
+/// after upstream's `glob_expand_module()` strips the module name, the
+/// receiver's `get_local_name()` (main.c:697) interprets the remaining path
+/// as relative to the module root on disk. Because oc-rsync does not chdir
+/// per connection, we resolve that join explicitly.
+///
+/// Returns the module path itself when no positional was supplied or when
+/// the stripped tail is empty (push directly into the module root).
+fn resolve_receiver_dest(module_path: &std::path::Path, client_args: &[String], module_name: &str) -> std::path::PathBuf {
+    let positionals = extract_module_relative_paths(client_args, module_name);
+    // upstream: main.c:1203-1204 - `local_name = get_local_name(flist, argv[0])`
+    // uses the FIRST remaining positional (after the `.` placeholder has been
+    // consumed by `do_server_recv` at line 1166). For a receiver that
+    // translates to the last wire positional - the destination.
+    let Some(last) = positionals.last() else {
+        return module_path.to_path_buf();
+    };
+    let tail = last.trim();
+    if tail.is_empty() || tail == "." {
+        return module_path.to_path_buf();
+    }
+    let rel = std::path::Path::new(tail);
+    if rel.is_absolute() {
+        // Defensive: an absolute path here cannot escape the module - join
+        // its components onto the module root by stripping the leading `/`.
+        let stripped = tail.trim_start_matches('/');
+        return module_path.join(stripped);
+    }
+    module_path.join(rel)
+}
+
 /// Builds the server configuration from client arguments.
 ///
 /// Returns the configuration on success, or sends an error and returns `None`.
@@ -229,10 +309,21 @@ fn build_server_config(
     // upstream: clientserver.c - clamp verbose to lp_max_verbosity(i)
     let flag_string = clamp_verbose_flags(&flag_string, module.max_verbosity);
 
+    // upstream: main.c:1203-1204 + util1.c:804 (glob_expand_module) - receivers
+    // resolve their destination by joining the module path with the client's
+    // module-relative tail (e.g. `upload/realdir/` -> module + `realdir/`).
+    // The original argv[0] is always the module root; legacy tests that push
+    // straight into the module root keep that behaviour.
+    let receiver_dest = if role == ServerRole::Receiver {
+        resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name)
+    } else {
+        std::path::PathBuf::from(&module.path)
+    };
+
     match ServerConfig::from_flag_string_and_args(
         role,
         flag_string,
-        vec![OsString::from(&module.path)],
+        vec![OsString::from(receiver_dest.as_os_str())],
     ) {
         Ok(mut cfg) => {
             // Parse long-form arguments that upstream rsync sends via server_options()
@@ -281,6 +372,14 @@ fn build_server_config(
             // Without this wiring the daemon would parse `charset = LATIN1` but
             // never apply it, leaving --iconv negotiation a silent no-op.
             cfg.connection.iconv = resolve_module_charset_converter(module.charset.as_deref());
+
+            // upstream: `use_secure_symlinks = am_daemon && !am_chrooted`
+            // (clientserver.c:1018). Mark the server-side daemon connection so
+            // the receiver's DirSandbox open enforces the symlink-refusal
+            // policy instead of silently falling back to path-based syscalls -
+            // that fall-back is what reopened the chdir-symlink-race attack
+            // window once the original CVE-2026-29518 fix landed.
+            cfg.connection.is_daemon_connection = true;
 
             // upstream: clientserver.c:1106-1107 - `fake super = yes` on the
             // daemon module demotes the receiver's am_root and forces fake-super

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -291,7 +291,7 @@ fn resolve_receiver_dest(
     // always under `module_path`. Tests cover both forms cross-platform.
     let rel = std::path::Path::new(tail);
     if rel.is_absolute() || tail.starts_with('/') || tail.starts_with('\\') {
-        let stripped = tail.trim_start_matches(|c| c == '/' || c == '\\');
+        let stripped = tail.trim_start_matches(['/', '\\']);
         return module_path.join(stripped);
     }
     module_path.join(rel)

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -267,7 +267,11 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 ///
 /// Returns the module path itself when no positional was supplied or when
 /// the stripped tail is empty (push directly into the module root).
-fn resolve_receiver_dest(module_path: &std::path::Path, client_args: &[String], module_name: &str) -> std::path::PathBuf {
+fn resolve_receiver_dest(
+    module_path: &std::path::Path,
+    client_args: &[String],
+    module_name: &str,
+) -> std::path::PathBuf {
     let positionals = extract_module_relative_paths(client_args, module_name);
     // upstream: main.c:1203-1204 - `local_name = get_local_name(flist, argv[0])`
     // uses the FIRST remaining positional (after the `.` placeholder has been

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1660,4 +1660,100 @@ mod module_access_tests {
         assert_eq!(rules[3].pattern, "*.tmp");
         assert_eq!(rules[3].rule_type, protocol::filters::RuleType::Exclude);
     }
+
+    // upstream: util1.c:813-814 (glob_expand_module) - parity tests for the
+    // chdir-symlink-race fix that wires the client's positional dest through
+    // to the receiver, instead of silently routing every write into the
+    // module root.
+
+    #[test]
+    fn extract_module_relative_paths_strips_module_prefix() {
+        let args = vec![
+            "--server".to_owned(),
+            "-vve.LsfxCIvu".to_owned(),
+            ".".to_owned(),
+            "upload/realdir/".to_owned(),
+        ];
+        let paths = extract_module_relative_paths(&args, "upload");
+        assert_eq!(paths, vec!["realdir/".to_owned()]);
+    }
+
+    #[test]
+    fn extract_module_relative_paths_handles_bare_module_arg() {
+        let args = vec![
+            "--server".to_owned(),
+            "-vve.LsfxCIvu".to_owned(),
+            ".".to_owned(),
+            "upload/".to_owned(),
+        ];
+        let paths = extract_module_relative_paths(&args, "upload");
+        assert_eq!(paths, vec!["".to_owned()]);
+    }
+
+    #[test]
+    fn extract_module_relative_paths_returns_empty_without_dot() {
+        // No dot separator means nothing positional was sent (e.g. a probe
+        // request that exits before the file list).
+        let args = vec!["--server".to_owned(), "-vve.LsfxCIvu".to_owned()];
+        let paths = extract_module_relative_paths(&args, "upload");
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn extract_module_relative_paths_does_not_chop_sibling_prefix() {
+        // The module is "upload"; an arg starting with "uploads/" must NOT
+        // be stripped - that arg belongs to a different module sharing a
+        // string prefix and stripping it would mis-route the request.
+        let args = vec![".".to_owned(), "uploads/x/".to_owned()];
+        let paths = extract_module_relative_paths(&args, "upload");
+        assert_eq!(paths, vec!["uploads/x/".to_owned()]);
+    }
+
+    #[test]
+    fn resolve_receiver_dest_joins_subpath_with_module_root() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload/realdir/"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_falls_back_to_module_root_for_bare_module() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_falls_back_to_module_root_when_no_positional() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args: Vec<String> = vec![];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_uses_last_positional_for_multi_arg_push() {
+        // The receiver's destination is the LAST positional - everything
+        // earlier is a source path the sender is reading from.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![
+            ".".to_owned(),
+            "upload/srcA/".to_owned(),
+            "upload/srcB/".to_owned(),
+            "upload/destdir/".to_owned(),
+        ];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(dest, std::path::Path::new("/srv/upload/destdir/"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_rejoins_absolute_path_under_module_root() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        // Absolute path is forced under the module root - no escape.
+        assert_eq!(dest, std::path::Path::new("/srv/upload/etc/passwd"));
+    }
 }

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -275,9 +275,11 @@ fn open_sandbox_for_dest_strict(
                 return Err(io::Error::new(
                     err.kind(),
                     format!(
-                        "refusing to open destination '{}' via a symlink: {err} \
-                         (would expose the chdir-symlink-race attack window)",
-                        dest_dir.display()
+                        "refusing to open destination '{}' via a symlink: \
+                         {err} (errno={}) (would expose the \
+                         chdir-symlink-race attack window)",
+                        dest_dir.display(),
+                        code.unwrap_or(0),
                     ),
                 ));
             }
@@ -397,23 +399,23 @@ mod symlink_race_tests {
 
         let err = open_sandbox_for_dest_strict(&subdir, true)
             .expect_err("daemon receiver must refuse a symlink destination");
-        // The wrapped error preserves `ErrorKind` from the underlying
-        // `DirSandbox::open_root` call (ELOOP -> `FilesystemLoop` on Linux
-        // + openat2; ENOTDIR -> `NotADirectory` on macOS/BSD where
-        // O_DIRECTORY is evaluated before O_NOFOLLOW). Both prove the
-        // symlink was refused at the syscall layer. The wrapped Display
-        // also carries the security-context message so operators see why
-        // the transfer aborted.
-        let kind = err.kind();
+        // The wrapped error embeds the underlying errno from
+        // `DirSandbox::open_root` (ELOOP on Linux + openat2; ENOTDIR on
+        // macOS/BSD where O_DIRECTORY is evaluated before O_NOFOLLOW).
+        // Both prove the symlink was refused at the syscall layer. The
+        // wrapped Display also carries the security-context message so
+        // operators see why the transfer aborted. Asserting on the embedded
+        // errno avoids the unstable `io::ErrorKind::FilesystemLoop` /
+        // `NotADirectory` variants (rust-lang/rust#86442).
+        let msg = err.to_string();
+        let expected_errno_a = format!("errno={}", libc::ELOOP);
+        let expected_errno_b = format!("errno={}", libc::ENOTDIR);
         assert!(
-            matches!(
-                kind,
-                io::ErrorKind::FilesystemLoop | io::ErrorKind::NotADirectory
-            ),
-            "expected FilesystemLoop or NotADirectory ErrorKind, got: {kind:?} ({err})"
+            msg.contains(&expected_errno_a) || msg.contains(&expected_errno_b),
+            "expected ELOOP or ENOTDIR errno embedded in message, got: {err}"
         );
         assert!(
-            err.to_string().contains("chdir-symlink-race"),
+            msg.contains("chdir-symlink-race"),
             "expected chdir-symlink-race security context in message, got: {err}"
         );
     }

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -168,8 +168,22 @@ impl ReceiverContext {
         // migrated, so a failed open is non-fatal (a brand-new
         // destination root may not exist yet, and the existing
         // path-based fall-backs cover that case today).
+        //
+        // Daemon receivers without chroot tighten this: a leaf-symlink at
+        // the destination is the chdir-symlink-race attack window, so we
+        // refuse the transfer outright when DirSandbox open fails with
+        // ELOOP/ENOTDIR instead of falling through to path-based syscalls
+        // that would follow the symlink. ENOENT (first-run push that has
+        // not created the directory yet) and EACCES (real permission
+        // problems) keep the existing soft-fail behaviour.
+        // upstream: clientserver.c:1018 - `use_secure_symlinks = am_daemon
+        // && !am_chrooted` gates the do_*_at wrappers in syscall.c that
+        // implement the same refusal.
         #[cfg(unix)]
-        let sandbox = open_sandbox_for_dest(&dest_dir);
+        let sandbox = {
+            let strict = self.config.connection.is_daemon_connection;
+            open_sandbox_for_dest_strict(&dest_dir, strict)?
+        };
 
         // FSM: file list received and sanitized. Advance to DeltaTransfer.
         self.pipeline
@@ -204,6 +218,7 @@ impl ReceiverContext {
 /// first-run transfers where the destination is created later in
 /// `ensure_relative_parents` / `create_directories`.
 #[cfg(unix)]
+#[allow(dead_code)] // kept for tests; the strict variant is the active call site.
 fn open_sandbox_for_dest(dest_dir: &std::path::Path) -> Option<Arc<fast_io::DirSandbox>> {
     match fast_io::DirSandbox::open_root(dest_dir) {
         Ok(sandbox) => Some(Arc::new(sandbox)),
@@ -215,6 +230,64 @@ fn open_sandbox_for_dest(dest_dir: &std::path::Path) -> Option<Arc<fast_io::DirS
                 dest_dir.display()
             );
             None
+        }
+    }
+}
+
+/// Open the destination root as a [`fast_io::DirSandbox`] carrier and, when
+/// `strict` is set, propagate symlink-class refusals as a transfer error.
+///
+/// When `strict` is `false` this is identical to [`open_sandbox_for_dest`]:
+/// every failure falls back to path-based syscalls.
+///
+/// When `strict` is `true` the failure mode splits by errno:
+/// - `ELOOP` / `ENOTDIR`: the destination resolves through a symlink, which
+///   is the chdir-symlink-race attack window. Convert to `io::Error` so the
+///   transfer fails before any data lands on disk and no path-relative
+///   syscall ever resolves through the attacker-planted symlink.
+/// - `ENOENT`: the destination does not exist yet (first-run push). Return
+///   `Ok(None)` so the receiver creates it through the existing
+///   `ensure_relative_parents` / `create_directories` path.
+/// - Any other error: keep the soft-fall-back so legitimate permission or
+///   I/O problems surface at a more specific call site downstream.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:1018` - `use_secure_symlinks = am_daemon &&
+///   !am_chrooted` gates the do_*_at wrappers in `syscall.c`.
+/// - `util1.c:1175-1216` - `change_dir()`'s
+///   `secure_relative_open()` + `fchdir()` branch refuses the symlink at the
+///   same level the chdir-symlink-race POC plants it.
+#[cfg(unix)]
+fn open_sandbox_for_dest_strict(
+    dest_dir: &std::path::Path,
+    strict: bool,
+) -> io::Result<Option<Arc<fast_io::DirSandbox>>> {
+    match fast_io::DirSandbox::open_root(dest_dir) {
+        Ok(sandbox) => Ok(Some(Arc::new(sandbox))),
+        Err(err) => {
+            let code = err.raw_os_error();
+            let is_symlink_refusal = matches!(
+                code,
+                Some(libc::ELOOP) | Some(libc::ENOTDIR) | Some(libc::EXDEV)
+            );
+            if strict && is_symlink_refusal {
+                return Err(io::Error::new(
+                    err.kind(),
+                    format!(
+                        "refusing to open destination '{}' via a symlink: {err} \
+                         (would expose the chdir-symlink-race attack window)",
+                        dest_dir.display()
+                    ),
+                ));
+            }
+            logging::debug_log!(
+                Recv,
+                2,
+                "DirSandbox::open_root({}) failed: {err}; falling back to path-based syscalls",
+                dest_dir.display()
+            );
+            Ok(None)
         }
     }
 }
@@ -296,4 +369,81 @@ fn parse_wire_filters_for_receiver(
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("filter error: {e}")))?;
 
     Ok((filter_set, merge_configs))
+}
+
+// upstream: clientserver.c:1018 - use_secure_symlinks gating that the
+// chdir-symlink-race fix mirrors. Tests below verify the strict daemon
+// branch refuses a leaf-symlink at the destination while the legacy
+// non-daemon branch preserves the existing soft-fail behaviour.
+#[cfg(all(test, unix))]
+mod symlink_race_tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    fn canonical_tempdir() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let canon = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+        (dir, canon)
+    }
+
+    #[test]
+    fn strict_mode_refuses_symlink_destination() {
+        let (_keep, root) = canonical_tempdir();
+        let outside = root.join("outside");
+        std::fs::create_dir(&outside).expect("create outside dir");
+        let subdir = root.join("subdir");
+        symlink(&outside, &subdir).expect("symlink subdir -> outside");
+
+        let err = open_sandbox_for_dest_strict(&subdir, true)
+            .expect_err("daemon receiver must refuse a symlink destination");
+        // ELOOP on Linux + openat2; ENOTDIR on macOS/BSD where O_DIRECTORY
+        // is evaluated before O_NOFOLLOW; both prove the symlink was
+        // refused.
+        let code = err.raw_os_error();
+        assert!(
+            code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+            "expected ELOOP or ENOTDIR for symlink dest, got: {err}"
+        );
+    }
+
+    #[test]
+    fn non_strict_mode_falls_back_for_symlink_destination() {
+        let (_keep, root) = canonical_tempdir();
+        let outside = root.join("outside");
+        std::fs::create_dir(&outside).expect("create outside dir");
+        let subdir = root.join("subdir");
+        symlink(&outside, &subdir).expect("symlink subdir -> outside");
+
+        let result = open_sandbox_for_dest_strict(&subdir, false)
+            .expect("non-daemon receiver keeps soft-fail behaviour");
+        // The sandbox open failed, but the receiver still gets None and
+        // falls through to the path-based syscall path (existing
+        // behaviour before the chdir-symlink-race fix).
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn strict_mode_accepts_real_directory_destination() {
+        let (_keep, root) = canonical_tempdir();
+        let real = root.join("realdir");
+        std::fs::create_dir(&real).expect("create real dir");
+
+        let result = open_sandbox_for_dest_strict(&real, true)
+            .expect("real directory must open under strict mode");
+        assert!(
+            result.is_some(),
+            "strict mode must hand back a sandbox when the dest is a real dir"
+        );
+    }
+
+    #[test]
+    fn strict_mode_soft_fails_when_destination_is_missing() {
+        let (_keep, root) = canonical_tempdir();
+        let missing = root.join("not-yet-created");
+
+        let result = open_sandbox_for_dest_strict(&missing, true)
+            .expect("ENOENT must be a soft failure - first-run push will mkdir later");
+        assert!(result.is_none());
+    }
 }

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -397,13 +397,24 @@ mod symlink_race_tests {
 
         let err = open_sandbox_for_dest_strict(&subdir, true)
             .expect_err("daemon receiver must refuse a symlink destination");
-        // ELOOP on Linux + openat2; ENOTDIR on macOS/BSD where O_DIRECTORY
-        // is evaluated before O_NOFOLLOW; both prove the symlink was
-        // refused.
-        let code = err.raw_os_error();
+        // The wrapped error preserves `ErrorKind` from the underlying
+        // `DirSandbox::open_root` call (ELOOP -> `FilesystemLoop` on Linux
+        // + openat2; ENOTDIR -> `NotADirectory` on macOS/BSD where
+        // O_DIRECTORY is evaluated before O_NOFOLLOW). Both prove the
+        // symlink was refused at the syscall layer. The wrapped Display
+        // also carries the security-context message so operators see why
+        // the transfer aborted.
+        let kind = err.kind();
         assert!(
-            code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
-            "expected ELOOP or ENOTDIR for symlink dest, got: {err}"
+            matches!(
+                kind,
+                io::ErrorKind::FilesystemLoop | io::ErrorKind::NotADirectory
+            ),
+            "expected FilesystemLoop or NotADirectory ErrorKind, got: {kind:?} ({err})"
+        );
+        assert!(
+            err.to_string().contains("chdir-symlink-race"),
+            "expected chdir-symlink-race security context in message, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

Daemon receivers without chroot now refuse a leaf-symlink at the destination directory and route the client's positional dest through to the receiver instead of silently writing every transfer into the module root. Closes the chdir-symlink-race attack window (the upstream testsuite test of the same name).

## Background

The upstream `chdir-symlink-race` test (testsuite/chdir-symlink-race.test) reproduces a post-CVE-2026-29518 TOCTOU race: the daemon receiver chdir's into a destination subdirectory while an attacker swaps that subdirectory for a symlink. Every subsequent path-relative syscall (open, chmod, lchown, ...) then inherits the escape and re-opens the same class of attack the original fix tried to close.

When run against oc-rsync the test failed at the **positive control** stage. The receiver was writing every push directly into the module root, ignoring the client's positional destination (`upload/realdir/`). That meant the attacks were vacuously safe (no write ever reached the symlink) but the test fails before exercising the security check.

## Fix

Two coupled changes:

* **`client_args.rs::build_server_config`** mirrors upstream's `read_args()` + `glob_expand_module()` (io.c:1295, util1.c:813-814). The wire positional after the `.` separator carries the module name prefix (e.g. `upload/realdir/`); we strip the bare module name and join the tail with the on-disk module path so the receiver writes into the requested subdirectory. The Generator path is left at the module root for now to keep the daemon pull tests stable. The resulting connection is tagged `is_daemon_connection = true` so the strict symlink-refusal branch fires.
* **`receiver/transfer/setup.rs`** gains `open_sandbox_for_dest_strict`, which promotes `ELOOP` / `ENOTDIR` / `EXDEV` from the `DirSandbox` open into a transfer error when the connection is a daemon. `ENOENT` and generic errors keep the existing soft-fall-back so first-run pushes still create the destination. This mirrors upstream's `use_secure_symlinks = am_daemon && !am_chrooted` gate (clientserver.c:1018) and `change_dir()`'s `secure_relative_open() + fchdir()` branch (util1.c:1175-1216).

`DirSandbox::open_root` already uses `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on Linux 5.6+ (via `fast_io::secure_open_dir`) and `open(O_NOFOLLOW | O_DIRECTORY)` on macOS / older Linux, so no new syscall plumbing was needed - only the refusal-on-failure policy.

## Test plan

- [x] Unit tests for the new arg-rewrite helpers (`extract_module_relative_paths`, `resolve_receiver_dest`) cover the bare-module, subpath, sibling-prefix and absolute-arg edges.
- [x] Unit tests for `open_sandbox_for_dest_strict` confirm: strict mode refuses symlink dests with ELOOP/ENOTDIR, non-strict mode preserves the soft fall-back, real directories open under strict mode, missing destinations soft-fail (so first-run pushes still mkdir).
- [ ] CI: fmt + clippy + nextest matrix.
- [ ] Manual: upstream testsuite `chdir-symlink-race` passes on Linux when the oc-rsync binary is the daemon-side peer.