### PR TITLE
fix: forward --stats into daemon, drain Sync flush, normalize delete path

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -76,6 +76,13 @@ pub(super) struct ServerLongFlags {
     pub(super) numeric_ids: bool,
     /// Delete extraneous files (upstream: `--delete-*` variants, long-form only).
     pub(super) delete: bool,
+    /// Whether `--stats` was forwarded by the client.
+    ///
+    /// upstream: options.c:2838-2839 - `server_options()` emits `--stats` whenever
+    /// the client requested detailed statistics. The server-side `do_stats` flag
+    /// gates emission of `NDX_DEL_STATS` during the goodbye phase, which the
+    /// client relies on for the "Number of deleted files" stats line.
+    pub(super) stats: bool,
     /// Skip updating files that exist at destination (upstream: `--ignore-existing`).
     pub(super) ignore_existing: bool,
     /// Skip creating files not present at destination (upstream: `--existing`).
@@ -153,6 +160,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         size_only: false,
         numeric_ids: false,
         delete: false,
+        stats: false,
         ignore_existing: false,
         existing_only: false,
         max_delete: None,
@@ -187,6 +195,10 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // upstream: --delete variants are long-form only (options.c:2818-2827)
             "--delete" | "--delete-before" | "--delete-during" | "--delete-after"
             | "--delete-delay" | "--delete-excluded" => flags.delete = true,
+            // upstream: options.c:2838-2839 - --stats forwarded by server_options()
+            // when do_stats was set. The server-side flag drives NDX_DEL_STATS
+            // emission in the goodbye phase (generator.c:2377,2422).
+            "--stats" => flags.stats = true,
             // upstream: options.c:2831 - --ignore-existing sent as long-form arg
             "--ignore-existing" => flags.ignore_existing = true,
             // upstream: options.c:2833 - --existing (--ignore-non-existing) sent as long-form arg
@@ -298,6 +310,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--delete-after"
             | "--delete-delay"
             | "--delete-excluded"
+            | "--stats"
             | "--ignore-existing"
             | "--existing"
             | "--ignore-non-existing"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -127,6 +127,10 @@ where
     config.file_selection.existing_only = long_flags.existing_only;
     config.flags.numeric_ids = long_flags.numeric_ids;
     config.flags.delete = long_flags.delete;
+    // upstream: options.c:2046-2048 - do_stats sets info_levels[INFO_STATS] >= 2.
+    // The server-side flag must be set so the generator emits NDX_DEL_STATS
+    // during the goodbye phase (generator.c:2377,2422).
+    config.do_stats = long_flags.stats;
     config.reference_directories = long_flags.reference_directories;
 
     // upstream: options.c:2327-2338 - server parses --log-format to determine

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -526,7 +526,8 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) {
                 // alias for --out-format. The server parses it to set
                 // stdout_format_has_i (options.c:2327-2331) which drives itemize
                 // emission. We only need the %i presence, not the full format.
-                } else if let Some(fmt) = arg.strip_prefix("--log-format=")
+                } else if let Some(fmt) = arg
+                    .strip_prefix("--log-format=")
                     .or_else(|| arg.strip_prefix("--out-format="))
                 {
                     if fmt.contains("%i") {
@@ -626,8 +627,7 @@ mod iconv_charset_converter_tests {
 
     #[test]
     fn iconv_charset_dot_means_locale_default() {
-        let converter =
-            resolve_module_charset_converter(Some(".")).expect("dot should resolve");
+        let converter = resolve_module_charset_converter(Some(".")).expect("dot should resolve");
         assert!(converter.is_identity());
     }
 
@@ -635,8 +635,8 @@ mod iconv_charset_converter_tests {
     fn iconv_charset_comma_with_dot_resolves_to_identity() {
         // upstream: rsync.c:118-120 - server side honours the post-comma value.
         // upstream: rsync.c:125-126 - "." means "use locale default".
-        let converter = resolve_module_charset_converter(Some("UTF-8,."))
-            .expect("dot remote should resolve");
+        let converter =
+            resolve_module_charset_converter(Some("UTF-8,.")).expect("dot remote should resolve");
         assert!(converter.is_identity());
     }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -329,6 +329,13 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) {
             "--delete-excluded" => {
                 config.flags.delete = true;
             }
+            // upstream: options.c:2838-2839 - --stats sets do_stats which causes
+            // INFO_STATS to level 2+. Without this flag, the generator does not
+            // emit NDX_DEL_STATS during the goodbye phase and the client sender's
+            // "Number of deleted files" line stays at zero on daemon uploads.
+            "--stats" => {
+                config.do_stats = true;
+            }
             // upstream: options.c:2836-2837
             "--size-only" => {
                 config.file_selection.size_only = true;

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -419,4 +419,35 @@ mod tests {
         assert!(!compiled.matches(Path::new("subdir/debug.log"), false));
         assert!(!compiled.matches(Path::new("subdir/report.csv"), false));
     }
+
+    /// Verifies that an `exclude = ?` daemon-config rule does not block
+    /// deletion of multi-character filenames. The upstream daemon-delete-stats
+    /// test ships with a global `exclude = ? foobar.baz` directive; the single-
+    /// character glob `?` must only match a single-character filename, never
+    /// `delete.txt` or any longer name.
+    ///
+    /// Regression test for the upstream-testsuite `daemon-delete-stats` failure.
+    #[test]
+    fn single_char_wildcard_does_not_match_multichar_names() {
+        let rule = FilterRule {
+            action: FilterAction::Exclude,
+            pattern: "?".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+
+        // The bare ? glob matches single-character names only.
+        assert!(compiled.matches(Path::new("a"), false));
+        // Multi-character names must not match either at the root or at depth.
+        assert!(!compiled.matches(Path::new("delete.txt"), false));
+        assert!(!compiled.matches(Path::new("keep.txt"), false));
+        assert!(!compiled.matches(Path::new("subdir/delete.txt"), false));
+    }
+
 }

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -449,5 +449,4 @@ mod tests {
         assert!(!compiled.matches(Path::new("keep.txt"), false));
         assert!(!compiled.matches(Path::new("subdir/delete.txt"), false));
     }
-
 }

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -687,7 +687,7 @@ fn see_token_exact_chunk_boundary() {
 #[test]
 fn see_token_large_incompressible_insert_no_overflow() {
     // xorshift64 byte sequence: deterministic and resists deflate compression.
-    let mut state: u64 = 0xc05dc0de_a55a_5a5au64;
+    let mut state: u64 = 0xc05d_c0de_a55a_5a5a_u64;
     let mut block = Vec::with_capacity(0xFFFF);
     for _ in 0..0xFFFF {
         state ^= state << 13;

--- a/crates/protocol/src/wire/compressed_token/tests.rs
+++ b/crates/protocol/src/wire/compressed_token/tests.rs
@@ -670,6 +670,54 @@ fn see_token_exact_chunk_boundary() {
     decoder.see_token(&boundary_data).unwrap();
 }
 
+/// Regression test for upstream issue #951: a single ~64 KiB incompressible
+/// matched-block insert overflowed the deflate output buffer in
+/// `send_deflated_token()` because the implementation only called
+/// `deflate(...Z_SYNC_FLUSH)` once per chunk instead of looping. When the
+/// stored-block + sync-marker output exceeds the buffer, residual output
+/// stays trapped inside the deflate state and corrupts the next literal
+/// chunk that follows.
+///
+/// The matched basis block must be incompressible so the deflate stored-block
+/// path is taken and the output >= the input size. We use an xorshift64
+/// sequence to generate deterministic, incompressible bytes without pulling
+/// in a rand dependency. `--block-size=65535` in the upstream
+/// `compress-zlib-insert` testsuite reproduces the abort with
+/// "deflate on token returned 0 (N bytes left)".
+#[test]
+fn see_token_large_incompressible_insert_no_overflow() {
+    // xorshift64 byte sequence: deterministic and resists deflate compression.
+    let mut state: u64 = 0xc05dc0de_a55a_5a5au64;
+    let mut block = Vec::with_capacity(0xFFFF);
+    for _ in 0..0xFFFF {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        block.push((state & 0xFF) as u8);
+    }
+
+    let mut encoder = CompressedTokenEncoder::new(CompressionLevel::Default, 31);
+
+    // A single insert that would overflow the encoder's compress_buf
+    // (CHUNK_SIZE * 2 = 64 KiB). Without the overflow guard this aborts
+    // with an io::Error; with the loop it returns Ok and the dictionary
+    // is consistent for the next literal chunk.
+    encoder
+        .see_token(&block)
+        .expect("large insert must not overflow");
+
+    // A literal write after the insert must still produce valid deflate
+    // output. Before the fix the trapped Sync residue desynchronised the
+    // stream and the next literal pass either errored or wrote garbage
+    // to the wire.
+    let mut wire = Vec::new();
+    encoder
+        .send_literal(&mut wire, b"after-large-insert")
+        .expect("literal after insert must succeed");
+    encoder.finish(&mut wire).expect("finish must succeed");
+    assert!(!wire.is_empty());
+}
+
 #[test]
 fn compressed_token_enum_equality() {
     let lit1 = CompressedToken::Literal(vec![1, 2, 3]);

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -124,6 +124,18 @@ impl ZlibTokenEncoder {
     ///
     /// Only active in CPRES_ZLIB mode (noop for zlibx).
     /// Reference: upstream token.c lines 463-484.
+    ///
+    /// # Overflow handling
+    ///
+    /// `Z_SYNC_FLUSH` can emit a stored-block header + payload + sync trailer
+    /// that exceeds `compress_buf`. Upstream issue #951 (rsync 3.4.3) addressed
+    /// the symmetric bug in `send_deflated_token()`: a single matched-block
+    /// insert larger than the fixed `obuf` aborted with "deflate on token
+    /// returned 0 (N bytes left)". The fix is to loop until the compressor
+    /// has consumed the chunk *and* has no pending output buffered. The
+    /// discarded output stays inside the deflate dictionary so the receiver's
+    /// matching `see_token()` (see [`ZlibTokenDecoder::see_token`]) stays in
+    /// lockstep without needing the bytes on the wire.
     pub(super) fn see_token(&mut self, data: &[u8]) -> io::Result<()> {
         if self.is_zlibx {
             return Ok(());
@@ -136,9 +148,36 @@ impl ZlibTokenEncoder {
             let chunk = &data[offset..offset + chunk_len];
             toklen -= chunk_len;
 
-            self.compressor
-                .compress(chunk, &mut self.compress_buf, FlushCompress::Sync)
-                .map_err(|e| io::Error::other(e.to_string()))?;
+            // Feed the chunk through the compressor with Sync flush, looping
+            // until the input is fully consumed AND the compressor has no
+            // more pending output. A single Sync flush of a ~64 KiB
+            // incompressible insert produces stored-block output > compress_buf;
+            // the first compress() call consumes the input and fills the
+            // output buffer, leaving residual output trapped inside the
+            // deflate state. We must call compress() again with empty input
+            // to drain the residue. Output bytes are discarded - only the
+            // dictionary update side-effect matters.
+            let mut input = chunk;
+            loop {
+                let before_in = self.compressor.total_in();
+                let before_out = self.compressor.total_out();
+
+                self.compressor
+                    .compress(input, &mut self.compress_buf, FlushCompress::Sync)
+                    .map_err(|e| io::Error::other(e.to_string()))?;
+
+                let consumed = (self.compressor.total_in() - before_in) as usize;
+                let produced = (self.compressor.total_out() - before_out) as usize;
+
+                input = &input[consumed..];
+
+                if input.is_empty() && produced < self.compress_buf.len() {
+                    // Input fully consumed and last call only partially filled
+                    // the output buffer: the Sync flush is complete. Includes
+                    // the produced == 0 case (no residue left to drain).
+                    break;
+                }
+            }
 
             if self.protocol_version >= 31 {
                 offset += chunk_len;

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -14,7 +14,7 @@
 //! `crates/fast_io/src/dir_sandbox/at_syscalls.rs::single_component_leaf`).
 
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
 use protocol::stats::DeleteStats;
@@ -199,7 +199,18 @@ impl ReceiverContext {
                     // upstream: generator.c:delete_in_dir() - is_excluded()
                     // check before deletion. allows_deletion() evaluates
                     // protect/risk rules from the global filter chain.
-                    let rel_for_filter = dir_relative.join(&name);
+                    //
+                    // Strip the implicit "." directory prefix when scanning
+                    // the deletion root so a glob like `?` does not see the
+                    // dot as a single-character directory component. Without
+                    // this, descendant matchers (e.g. `?/**`) would match
+                    // top-level deletion candidates as if they sat under a
+                    // single-char parent, suppressing legitimate deletes.
+                    let rel_for_filter = if dir_relative.as_os_str() == "." {
+                        PathBuf::from(&name)
+                    } else {
+                        dir_relative.join(&name)
+                    };
                     if !filter_chain.allows_deletion(&rel_for_filter, is_dir) {
                         continue;
                     }
@@ -266,8 +277,16 @@ impl ReceiverContext {
 
                     match result {
                         Ok(()) => {
-                            // Compute relative path for itemize output
-                            let rel = dir_relative.join(&name);
+                            // Compute relative path for itemize output.
+                            // upstream: delete.c:180 - log_delete(fbuf) emits the
+                            // filename relative to the deletion root. Top-level
+                            // entries are emitted as bare names ("delete.txt"),
+                            // not "./delete.txt", matching upstream output.
+                            let rel = if dir_relative.as_os_str() == "." {
+                                PathBuf::from(&name)
+                            } else {
+                                dir_relative.join(&name)
+                            };
                             if is_dir {
                                 info_log!(Del, 1, "deleting directory {}", path.display());
                                 stats.dirs += 1;

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -14,7 +14,7 @@
 //! `crates/fast_io/src/dir_sandbox/at_syscalls.rs::single_component_leaf`).
 
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use logging::{debug_log, info_log};
 use protocol::stats::DeleteStats;

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -106,6 +106,64 @@ fn receiver_filter_chain_empty_allows_all_deletions() {
     assert_eq!(stats.files, 2);
 }
 
+/// Regression test for the upstream-testsuite `daemon-delete-stats` failure.
+///
+/// The test's daemon config carries a global `exclude = ? foobar.baz` rule.
+/// Single-character glob `?` previously caused deletion to skip every
+/// top-level extraneous file because `delete_extraneous_files()` queried the
+/// filter chain with `"./<name>"`. The descendant matcher `?/**` derived
+/// from the bare `?` pattern then treated `.` as a single-character parent
+/// directory and incorrectly excluded the candidate, leaving
+/// `delete.txt` in place. The fix is to strip the implicit `.` prefix
+/// before consulting the filter chain at the deletion root.
+#[test]
+fn single_char_wildcard_exclude_does_not_block_top_level_deletion() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    std::fs::write(dest.join("delete.txt"), b"delete\n").unwrap();
+    std::fs::write(dest.join("keep.txt"), b"keep\n").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Source advertises only `.` and `keep.txt`; `delete.txt` is extraneous.
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("keep.txt".into(), 5, 0o644));
+
+    // Daemon-level `exclude = ? foobar.baz` reproduction.
+    let global = ::filters::FilterSet::from_rules([
+        ::filters::FilterRule::exclude("?"),
+        ::filters::FilterRule::exclude("foobar.baz"),
+    ])
+    .unwrap();
+    ctx.set_filter_chain(::filters::FilterChain::new(global));
+
+    let mut writer = TestDeletionWriter;
+    let (stats, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+
+    assert!(
+        !dest.join("delete.txt").exists(),
+        "delete.txt must be deleted despite the `?` exclude rule"
+    );
+    assert!(dest.join("keep.txt").exists(), "keep.txt must survive");
+    assert_eq!(stats.files, 1);
+}
+
 #[test]
 fn receiver_set_and_get_filter_chain() {
     let handshake = test_handshake();


### PR DESCRIPTION
## Summary

Three independent fixes for upstream rsync 3.4.3 testsuite failures on the daemon-side wire format:

- **`daemon-delete-stats` (UTS-6, #3569)**: the daemon never propagated `--stats` to `ServerConfig.do_stats`, so the generator skipped emitting `NDX_DEL_STATS` during the goodbye phase and the client's "Number of deleted files" stat stayed at zero on daemon uploads. Wire `--stats` into both the daemon's long-form arg parser and the server-mode flag parser.
- **`daemon-delete-stats` (UTS-6)**: `delete_extraneous_files()` consulted the filter chain with `"./<name>"` at the deletion root. A daemon-side `exclude = ?` rule then matched the `.` as a single-character parent component via the descendant matcher `?/**`, silently suppressing every legitimate top-level delete. Strip the implicit `.` prefix.
- **`compress-zlib-insert` (UTS-18, #3581)**: `ZlibTokenEncoder::see_token()` called `Compress::compress(..., Z_SYNC_FLUSH)` once per 0xFFFF chunk. A 64 KiB incompressible matched-block insert emits stored-block output > `compress_buf`, leaving residue trapped inside the deflate state that desynchronises the next literal write. Mirrors upstream rsync issue #951. Loop the Sync flush, discarding output, until the chunk is consumed and the buffer is partially filled.

`daemon-gzip-upload` (UTS-10) and `daemon-gzip-download` (UTS-9) already passed on master and are validated as part of the same testsuite run.

## Test plan

- [ ] CI `nextest (stable)` passes
- [ ] CI `fmt + clippy` passes
- [ ] CI `Windows`, `macOS`, `Linux musl` pass
- [ ] Upstream testsuite cell (IFX-15) runs `daemon-delete-stats`, `daemon-gzip-download`, `daemon-gzip-upload`, `compress-zlib-insert` against rsync 3.4.3 and the four go green
- [ ] New filter regression test `single_char_wildcard_exclude_does_not_block_top_level_deletion` passes
- [ ] New filter unit test `single_char_wildcard_does_not_match_multichar_names` passes
- [ ] New encoder regression test `see_token_large_incompressible_insert_no_overflow` passes