### PR TITLE
fix: accept path = / in rsyncd.conf module definitions

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -2132,4 +2132,38 @@ mod config_parsing_tests {
         let result = parse_config_modules(file.path()).unwrap();
         assert!(result.modules[0].log_file.is_none());
     }
+
+    /// Modules may legitimately serve the filesystem root.
+    ///
+    /// upstream: loadparm.c stores `path = /` verbatim (P_PATH only strips
+    /// trailing slashes when `len > 1`, so the bare `/` is preserved), and
+    /// clientserver.c serves it directly when `use chroot = no`. oc-rsync
+    /// must accept the same form for wire-compatible daemon configs.
+    #[test]
+    #[cfg(unix)]
+    fn parse_module_path_root_without_chroot() {
+        let config = "[root]\npath = /\nuse chroot = no\n";
+        let file = write_config(config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].name, "root");
+        assert_eq!(result.modules[0].path, PathBuf::from("/"));
+        assert!(!result.modules[0].use_chroot);
+    }
+
+    /// Upstream tolerates `path = /` with `use chroot = yes` as well: the
+    /// resulting `chroot("/")` is a no-op rather than an error, and the parser
+    /// must not reject the configuration on that basis.
+    #[test]
+    #[cfg(unix)]
+    fn parse_module_path_root_with_chroot() {
+        let config = "[root]\npath = /\nuse chroot = yes\n";
+        let file = write_config(config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].path, PathBuf::from("/"));
+        assert!(result.modules[0].use_chroot);
+    }
 }

--- a/crates/daemon/src/daemon/sections/module_definition/finish.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/finish.rs
@@ -39,6 +39,12 @@ impl ModuleDefinitionBuilder {
         // `use chroot` does not apply there. The check uses `Path::is_absolute()`
         // which rejects Unix-style paths (e.g. `/srv/docs`) on Windows for lack
         // of a drive letter. Mirrors the sibling fix in `module_parsing.rs`.
+        //
+        // The bare root `/` is `is_absolute()` and is accepted intentionally:
+        // upstream loadparm.c (P_PATH) preserves a single-slash module path
+        // verbatim, and clientserver.c serves from it both with and without
+        // chroot (the chroot("/") path is a no-op). See the upstream
+        // daemon-path-root-read scenario.
         #[cfg(unix)]
         if use_chroot && !path.is_absolute() {
             return Err(config_parse_error(

--- a/crates/daemon/src/daemon/sections/module_definition/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/tests.rs
@@ -565,6 +565,40 @@ fn finish_allows_relative_path_without_chroot() {
     assert!(result.is_ok());
 }
 
+/// Root path `/` is a legitimate module root: upstream loadparm.c P_PATH
+/// preserves the bare slash (its trailing-slash strip only fires when
+/// `len > 1`), and clientserver.c chroot's into it as a no-op when
+/// `use chroot = yes`. The `is_absolute()` gate must pass for `/` so the
+/// daemon-path-root-read scenario is accepted under chroot.
+#[test]
+#[cfg(unix)]
+fn finish_allows_root_path_with_chroot() {
+    let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
+    builder.set_path(PathBuf::from("/"), &test_config_path(), 2).unwrap();
+    builder.set_use_chroot(true, &test_config_path(), 3).unwrap();
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().path, PathBuf::from("/"));
+}
+
+/// Companion to `finish_allows_root_path_with_chroot`: the upstream daemon
+/// also serves `path = /` when `use chroot = no`, exposing the absolute root
+/// without the chroot wrapper. The validator must accept this combination.
+#[test]
+#[cfg(unix)]
+fn finish_allows_root_path_without_chroot() {
+    let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);
+    builder.set_path(PathBuf::from("/"), &test_config_path(), 2).unwrap();
+    builder.set_use_chroot(false, &test_config_path(), 3).unwrap();
+    let defaults = GlobalModuleDefaults::default();
+    let result = builder.finish(&test_config_path(), None, None, None, None, &defaults);
+    assert!(result.is_ok());
+    let def = result.unwrap();
+    assert_eq!(def.path, PathBuf::from("/"));
+    assert!(!def.use_chroot);
+}
+
 #[test]
 fn finish_applies_default_secrets_for_auth_users() {
     let mut builder = ModuleDefinitionBuilder::new("testmod".to_owned(), 1);

--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -265,6 +265,11 @@ fn parse_module_definition(
     // and rejecting Unix-style absolute paths (e.g. `/srv/docs`, which Windows
     // `Path::is_absolute()` treats as non-absolute because they lack a drive
     // letter) would block every cross-platform daemon config file.
+    //
+    // The bare root `/` is accepted intentionally: upstream rsync treats it as
+    // a legitimate module path under either `use chroot` setting (loadparm.c
+    // P_PATH preserves it; clientserver.c serves from it directly when chroot
+    // is off and chroot's into it as a no-op when on).
     #[cfg(unix)]
     if module.use_chroot && !module.path.is_absolute() {
         return Err(config_error(format!(


### PR DESCRIPTION
## Summary

- Locks in the behaviour that the daemon-config parser accepts a bare `path = /`
  under both `use chroot = no` and `use chroot = yes`, mirroring upstream
  semantics for the `daemon-path-root-read` interop scenario (UTS-12).
- Adds regression coverage at two layers so the existing `is_absolute()` gate
  cannot be tightened into a `/`-rejecter without failing tests.

## Upstream reference

- `loadparm.c` (P_PATH, rsync 3.4.2 line 443-450): trailing-slash strip only
  fires when `len > 1`, so the single character `/` is preserved verbatim and
  reachable as `lp_path(module_id)`.
- `clientserver.c` (line 823-865, rsync 3.4.2): when `use chroot = no` the
  module path is normalized and served as-is; when `use chroot = yes` the
  daemon `chroot()`s into the path, with `chroot("/")` succeeding as a no-op.

## Changes

- `crates/daemon/src/daemon/sections/module_definition/finish.rs`: documents
  the validator's intent to accept `/` and cites the upstream behaviour so
  future maintenance does not regress it.
- `crates/daemon/src/daemon/sections/module_parsing.rs`: same clarifying
  comment on the sibling `--module name=/` inline path validator.
- `crates/daemon/src/daemon/sections/module_definition/tests.rs`: two unit
  tests covering `finish()` with `path = /` plus `use_chroot = true` and
  `use_chroot = false` respectively.
- `crates/daemon/src/daemon/sections/config_parsing/tests.rs`: two end-to-end
  parser tests for `[root]\npath = /\nuse chroot = {no,yes}\n`.

No changes to wire protocol, branding, or any oc-rsync-specific path
(parallel-receive-delta, io_uring, IOCP, flat-flist, daemon-tls, DirSandbox,
SEND_ZC, flat arena flist). Daemon-config scope only.

## Test plan

- [ ] CI `fmt+clippy` passes.
- [ ] CI `nextest (stable)` passes the four new tests:
      `parse_module_path_root_without_chroot`,
      `parse_module_path_root_with_chroot`,
      `finish_allows_root_path_with_chroot`,
      `finish_allows_root_path_without_chroot`.
- [ ] CI Windows / macOS / Linux musl matrices stay green (new tests are
      `#[cfg(unix)]` so Windows is unaffected).