### PR TITLE
fix: implement receiver-side mode-0 sentinel for --delete-missing-args

### DIFF
--- a/crates/transfer/src/receiver/directory/missing_args.rs
+++ b/crates/transfer/src/receiver/directory/missing_args.rs
@@ -1,0 +1,159 @@
+//! Receiver-side handler for `--delete-missing-args` mode-0 sentinel entries.
+//!
+//! When the sender emits a mode-0 sentinel entry for a vanished top-level
+//! source (`flist.c:2254-2258`), the receiver must delete the corresponding
+//! destination path if it exists and skip any further processing for that
+//! entry. Without this handler the sentinel survives in the file list but
+//! triggers no filesystem action, leaving stale destination state behind
+//! and producing the observable "missing-arg file was not deleted"
+//! divergence against upstream rsync.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:1348-1354` - `if (missing_args == 2 && file->mode == 0)`:
+//!   apply the filter list, then `delete_item()` when `statret == 0`.
+//! - `flist.c:2254-2258` - `missing_args == 2` sender branch that emits
+//!   the mode-0 sentinel this handler consumes.
+
+use std::io;
+use std::path::Path;
+
+use logging::{debug_log, info_log};
+
+use crate::receiver::ReceiverContext;
+
+impl ReceiverContext {
+    /// Processes mode-0 sentinel entries injected by the sender's
+    /// `--delete-missing-args` (`missing_args == 2`) branch.
+    ///
+    /// For every entry whose `mode == 0` we look up the corresponding
+    /// destination path relative to `dest_dir` and remove it if it exists.
+    /// Mode-0 entries carry no usable file type bits (the sender writes a
+    /// raw zero), so we dispatch on the destination filesystem's symlink
+    /// metadata: directories are removed recursively, everything else
+    /// is unlinked. Missing destinations are a no-op, matching upstream's
+    /// `statret == 0` guard.
+    ///
+    /// All filesystem mutations route through the sandbox helpers
+    /// ([`fast_io::unlink_via_sandbox_or_fallback`],
+    /// [`fast_io::recursive_unlinkat_via_sandbox_or_fallback`]) so a TOCTOU
+    /// swap on a single-component leaf under the destination root cannot
+    /// redirect the deletion to an attacker-chosen path. Multi-component
+    /// relative paths take the documented path-based fallback inside the
+    /// helper (see `crates/fast_io/src/dir_sandbox/at_syscalls.rs`).
+    ///
+    /// # No-op conditions
+    ///
+    /// - `delete_missing_args` is not in effect on the receiver config.
+    /// - `dry_run` is in effect (no filesystem mutations).
+    /// - The destination path does not exist (`ENOENT` is silently
+    ///   swallowed, mirroring upstream's `statret == 0` guard).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1348-1354` - `missing_args == 2 && file->mode == 0`
+    ///   branch that calls `delete_item()` for an existing destination
+    ///   and falls through (no creation) for a missing destination.
+    pub(in crate::receiver) fn process_missing_args_sentinels(
+        &self,
+        dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
+    ) -> io::Result<()> {
+        if !self.config.file_selection.delete_missing_args {
+            return Ok(());
+        }
+        if self.config.flags.dry_run {
+            return Ok(());
+        }
+
+        for entry in &self.file_list {
+            // upstream: generator.c:1348 - sentinel is identified by mode == 0.
+            if entry.mode() != 0 {
+                continue;
+            }
+
+            let relative = entry.path();
+            // Defensive: never act on the implicit root entry.
+            if relative.as_os_str().is_empty() || relative.as_os_str() == "." {
+                continue;
+            }
+
+            let target = dest_dir.join(relative);
+
+            // upstream: generator.c:1351 - `statret == 0`: only delete an
+            // existing destination. `symlink_metadata` here mirrors
+            // `link_stat()` so a symlink is removed rather than followed.
+            let metadata = match std::fs::symlink_metadata(&target) {
+                Ok(meta) => meta,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => {
+                    debug_log!(
+                        Del,
+                        1,
+                        "delete-missing-args: stat {} failed: {}",
+                        target.display(),
+                        err,
+                    );
+                    continue;
+                }
+            };
+
+            #[cfg(unix)]
+            let sandbox_ref = sandbox;
+
+            let is_dir = metadata.is_dir();
+            let result = if is_dir {
+                #[cfg(unix)]
+                {
+                    fast_io::recursive_unlinkat_via_sandbox_or_fallback(
+                        sandbox_ref,
+                        dest_dir,
+                        relative,
+                        &target,
+                    )
+                }
+                #[cfg(not(unix))]
+                {
+                    std::fs::remove_dir_all(&target)
+                }
+            } else {
+                #[cfg(unix)]
+                {
+                    fast_io::unlink_via_sandbox_or_fallback(
+                        sandbox_ref,
+                        dest_dir,
+                        relative,
+                        &target,
+                        fast_io::UnlinkFlags::File,
+                    )
+                }
+                #[cfg(not(unix))]
+                {
+                    std::fs::remove_file(&target)
+                }
+            };
+
+            match result {
+                Ok(()) => {
+                    if is_dir {
+                        info_log!(Del, 1, "deleting directory {}", target.display());
+                    } else {
+                        info_log!(Del, 1, "deleting {}", target.display());
+                    }
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    debug_log!(
+                        Del,
+                        1,
+                        "delete-missing-args: failed to delete {}: {}",
+                        target.display(),
+                        err,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -7,6 +7,7 @@
 mod creation;
 mod deletion;
 mod links;
+mod missing_args;
 
 /// Normalizes a filename for cross-platform comparison.
 ///

--- a/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
+++ b/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
@@ -1,0 +1,217 @@
+//! UTS-19.f: receiver-side mode-0 sentinel handler for
+//! `--delete-missing-args`.
+//!
+//! Exercises [`crate::receiver::ReceiverContext::process_missing_args_sentinels`]
+//! end-to-end against a real on-disk destination. The sender writes a mode-0
+//! sentinel entry into the wire flist for a vanished top-level source; the
+//! receiver must consume the entry, delete the named destination path, and
+//! perform no further filesystem creation for that entry.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:1348-1354` - `missing_args == 2 && file->mode == 0`
+//!   branch that calls `delete_item()` when the destination exists and
+//!   falls through (no creation) otherwise.
+
+use std::ffi::OsString;
+use std::io::Cursor;
+
+use protocol::flist::{FileEntry, FileListWriter};
+use tempfile::TempDir;
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake};
+
+/// Builds a wire-encoded file list containing the supplied entries.
+fn encode_flist(entries: &[FileEntry]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let handshake = test_handshake();
+    let mut writer = FileListWriter::new(handshake.protocol);
+    for entry in entries {
+        writer.write_entry(&mut bytes, entry).unwrap();
+    }
+    writer.write_end(&mut bytes, None).unwrap();
+    bytes
+}
+
+/// Constructs a mode-0 sentinel entry whose name matches a top-level
+/// destination path (`flist.c:2254-2258`, `make_file()` + `file->mode = 0`).
+fn sentinel_entry(name: &str) -> FileEntry {
+    let mut entry = FileEntry::new_file(name.into(), 0, 0);
+    entry.set_mode(0);
+    entry
+}
+
+/// Receiver consumes a mode-0 sentinel entry and deletes the named
+/// destination file when `--delete-missing-args` is in effect.
+///
+/// Why this matters: without the receiver-side branch, the sentinel is
+/// silently dropped (mode 0 is neither file/dir/symlink/special), so the
+/// transfer exits cleanly but the destination retains the stale file -
+/// observable as "missing-arg file was not deleted" in upstream interop.
+#[test]
+fn receiver_consumes_mode_zero_sentinel_and_deletes_destination() {
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // Pre-existing destination file that the sentinel must remove.
+    std::fs::write(dest.join("ghost.txt"), b"stale").unwrap();
+    // Sibling file that is NOT a sentinel target - must survive.
+    std::fs::write(dest.join("keep.txt"), b"keep me").unwrap();
+
+    // Receive the wire flist: a root directory plus the mode-0 sentinel.
+    let mut data = Vec::new();
+    data.extend_from_slice(&encode_flist(&[
+        FileEntry::new_directory(".".into(), 0o755),
+        sentinel_entry("ghost.txt"),
+    ]));
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.file_selection.delete_missing_args = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    let mut cursor = Cursor::new(&data[..]);
+    let count = ctx.receive_file_list(&mut cursor).unwrap();
+    assert_eq!(count, 2);
+
+    // Drive the sentinel handler against the real destination.
+    ctx.process_missing_args_sentinels(
+        dest,
+        #[cfg(unix)]
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !dest.join("ghost.txt").exists(),
+        "sentinel must delete the named destination file",
+    );
+    assert!(
+        dest.join("keep.txt").exists(),
+        "non-sentinel sibling must be preserved",
+    );
+}
+
+/// When `--delete-missing-args` is off, sentinel entries (if any) must NOT
+/// trigger deletion. Upstream guards the `delete_item()` call on
+/// `missing_args == 2`; the receiver mirrors that guard via the config flag.
+#[test]
+fn receiver_ignores_sentinel_when_delete_missing_args_off() {
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    std::fs::write(dest.join("ghost.txt"), b"stale").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    // delete_missing_args left default (false).
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list.push(sentinel_entry("ghost.txt"));
+
+    ctx.process_missing_args_sentinels(
+        dest,
+        #[cfg(unix)]
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        dest.join("ghost.txt").exists(),
+        "sentinel must not trigger deletion without --delete-missing-args",
+    );
+}
+
+/// Missing destination path is a no-op (mirrors upstream's `statret == 0`
+/// guard at `generator.c:1351`).
+#[test]
+fn receiver_sentinel_for_missing_destination_is_noop() {
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.file_selection.delete_missing_args = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list.push(sentinel_entry("never-existed.txt"));
+
+    // Should not error even though the destination path does not exist.
+    ctx.process_missing_args_sentinels(
+        dest,
+        #[cfg(unix)]
+        None,
+    )
+    .unwrap();
+}
+
+/// `--dry-run` short-circuits all filesystem mutations (mirrors upstream's
+/// receiver.c:693).
+#[test]
+fn receiver_sentinel_dry_run_skips_deletion() {
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    std::fs::write(dest.join("ghost.txt"), b"stale").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.file_selection.delete_missing_args = true;
+    config.flags.dry_run = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list.push(sentinel_entry("ghost.txt"));
+
+    ctx.process_missing_args_sentinels(
+        dest,
+        #[cfg(unix)]
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        dest.join("ghost.txt").exists(),
+        "dry_run must not perform any deletion",
+    );
+}
+
+/// Mode-0 sentinel naming a directory removes it recursively, mirroring
+/// upstream's `delete_item()` dispatch on the destination's `sx.st.st_mode`.
+#[test]
+fn receiver_sentinel_removes_directory_recursively() {
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    let dir = dest.join("ghost-dir");
+    std::fs::create_dir(&dir).unwrap();
+    std::fs::write(dir.join("inner.txt"), b"inner").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.file_selection.delete_missing_args = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list.push(sentinel_entry("ghost-dir"));
+
+    ctx.process_missing_args_sentinels(
+        dest,
+        #[cfg(unix)]
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !dir.exists(),
+        "sentinel must remove the named directory and its contents",
+    );
+}

--- a/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
+++ b/crates/transfer/src/receiver/tests/file_list/missing_args_sentinel.rs
@@ -110,7 +110,8 @@ fn receiver_ignores_sentinel_when_delete_missing_args_off() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
     ctx.file_list.push(sentinel_entry("ghost.txt"));
 
     ctx.process_missing_args_sentinels(
@@ -139,7 +140,8 @@ fn receiver_sentinel_for_missing_destination_is_noop() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
     ctx.file_list.push(sentinel_entry("never-existed.txt"));
 
     // Should not error even though the destination path does not exist.
@@ -167,7 +169,8 @@ fn receiver_sentinel_dry_run_skips_deletion() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
     ctx.file_list.push(sentinel_entry("ghost.txt"));
 
     ctx.process_missing_args_sentinels(
@@ -200,7 +203,8 @@ fn receiver_sentinel_removes_directory_recursively() {
     config.args = vec![OsString::from(dest.to_str().unwrap())];
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    ctx.file_list.push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
     ctx.file_list.push(sentinel_entry("ghost-dir"));
 
     ctx.process_missing_args_sentinels(

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -24,6 +24,8 @@
 //! - [`iconv_wire_order`] - regression coverage for the receiver-side
 //!   `--iconv` ordering invariant (file_list stays in sender wire-emit
 //!   order, never re-sorted on local-charset bytes).
+//! - [`missing_args_sentinel`] - UTS-19.f receiver-side handler for the
+//!   mode-0 sentinel emitted by `--delete-missing-args`.
 
 mod delete_pipeline_hook;
 mod filter_chain;
@@ -32,6 +34,7 @@ mod iconv_wire_order;
 mod id_lists;
 mod incremental_directories;
 mod incremental_receiver;
+mod missing_args_sentinel;
 mod ndx_convert;
 mod proto_io_error;
 mod wire_attrs;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -54,6 +54,14 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer);
 
+        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // deletes the destination path and skips any creation for the sentinel.
+        self.process_missing_args_sentinels(
+            &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        )?;
+
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
         if self.config.flags.delete {

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -88,6 +88,14 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer);
 
+        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // deletes the destination path and skips any creation for the sentinel.
+        self.process_missing_args_sentinels(
+            &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
+        )?;
+
         let files_to_transfer = self.build_files_to_transfer(
             writer,
             &setup.dest_dir,

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -78,6 +78,14 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_symlinks(&dest_dir, writer);
 
+        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
+        // deletes the destination path and skips any creation for the sentinel.
+        self.process_missing_args_sentinels(
+            &dest_dir,
+            #[cfg(unix)]
+            sandbox.as_deref(),
+        )?;
+
         let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
 


### PR DESCRIPTION
## Summary

- Sender already emits a mode-0 sentinel entry for `--delete-missing-args` (mirrors upstream `flist.c:2254-2258`), but the receiver had no matching consumer. The sentinel is neither file, directory, symlink, nor special, so all existing receiver passes silently skipped it - the named destination path survived against an upstream 3.4.3 sender (clean exit, undeleted file).
- Add `process_missing_args_sentinels()` in `crates/transfer/src/receiver/directory/missing_args.rs` mirroring upstream `generator.c:1348-1354` (`missing_args == 2 && file->mode == 0`): iterate the file list once, delete the named destination when it exists, skip any creation for the sentinel entry.
- Wire the new pass into all three receiver transfer loops (`sync.rs`, `pipelined.rs`, `pipelined_incremental.rs`) between symlink creation and the extraneous-delete sweep.
- Deletions route through `fast_io::unlink_via_sandbox_or_fallback` / `recursive_unlinkat_via_sandbox_or_fallback`, preserving SEC-1.q TOCTOU guarantees and matching the existing sandbox-anchored deletion contract.
- Guarded on `delete_missing_args` and `dry_run` (matches upstream `missing_args == 2` and `do_xfers` checks).

## Upstream reference

- `generator.c:1348-1354` - `if (missing_args == 2 && file->mode == 0)`: apply filter list, then `delete_item()` when `statret == 0`.
- `flist.c:2254-2258` - sender branch that emits the mode-0 sentinel this handler consumes.

## Test plan

- [x] Receiver consumes a wire-flist mode-0 sentinel and deletes the named destination file; sibling files survive.
- [x] Mode-0 sentinel is a no-op when `--delete-missing-args` is off.
- [x] Mode-0 sentinel naming a missing destination is a clean no-op (mirrors upstream's `statret == 0` guard).
- [x] `--dry-run` short-circuits the deletion pass.
- [x] Mode-0 sentinel naming a directory removes it recursively (mirrors `delete_item()` dispatch on the destination's `st_mode`).
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.