### PR TITLE
fix: daemon-access module sub-path and access-rule edge cases

### DIFF
--- a/crates/daemon/src/daemon/module_state/definition.rs
+++ b/crates/daemon/src/daemon/module_state/definition.rs
@@ -152,41 +152,59 @@ pub(crate) struct ModuleDefinition {
 impl ModuleDefinition {
     /// Checks whether a peer is permitted to access this module.
     ///
-    /// Evaluates `hosts allow` then `hosts deny` patterns. If `hosts allow`
-    /// is non-empty the peer must match at least one allow pattern. If the
-    /// peer matches any deny pattern, access is refused.
+    /// Mirrors upstream `access.c::allow_access()` exactly:
+    ///
+    /// 1. If `hosts allow` is non-empty and the peer matches any allow
+    ///    pattern, access is granted - the deny list is not consulted.
+    /// 2. If `hosts allow` is non-empty and the peer matches no allow
+    ///    pattern and `hosts deny` is empty, access is refused.
+    /// 3. Otherwise the deny list is consulted. If the peer matches any
+    ///    deny pattern, access is refused. Otherwise access is granted.
     ///
     /// Fail-closed semantics for GHSA-rjfm-3w2m-jf4f: when the peer's
     /// hostname is unresolvable (`None`) and ANY `hosts deny` rule is
-    /// hostname-based, access is refused. Upstream relies on reverse DNS
-    /// being available at access-check time (it performs the lookup before
-    /// `daemon chroot` so the result is cached); oc-rsync uses a thread-per-
-    /// connection model where `daemon chroot` is applied process-wide at
-    /// startup, so per-peer DNS can fail post-chroot when the chroot lacks
-    /// NSS configuration. Treating an unresolved hostname as a potential
-    /// match for hostname-based deny patterns closes the bypass that the
-    /// upstream patch closes by guaranteeing a resolved name.
+    /// hostname-based, the deny check fails closed. Upstream relies on
+    /// reverse DNS being available at access-check time (it performs the
+    /// lookup before `daemon chroot` so the result is cached); oc-rsync
+    /// uses a thread-per-connection model where `daemon chroot` is applied
+    /// process-wide at startup, so per-peer DNS can fail post-chroot when
+    /// the chroot lacks NSS configuration. The guard sits on the deny
+    /// branch only - if the peer already matched a `hosts allow` rule we
+    /// admit them regardless of DNS state, matching upstream's "allow
+    /// short-circuits deny" semantics.
     ///
-    /// upstream: clientserver.c - `allow_access()` checks `hosts allow` and
-    /// `hosts deny` using `match_hostname()` and `match_address()`.
-    /// upstream: clientserver.c (3.4.3 commit c38f20c5) - reverse DNS before
-    /// chroot ensures `client_name()` returns a real hostname when ACLs are
-    /// evaluated.
+    /// upstream: access.c:264 `allow_access()` - "If we match an allow-list
+    /// item, we always allow access." Allow-list match returns 1
+    /// unconditionally; the deny list is consulted only when the allow
+    /// list either is absent or did not match.
+    /// upstream: clientserver.c (3.4.3 commit c38f20c5) - reverse DNS
+    /// before chroot ensures `client_name()` returns a real hostname when
+    /// ACLs are evaluated.
     pub(crate) fn permits(&self, addr: std::net::IpAddr, hostname: Option<&str>) -> bool {
-        if !self.hosts_allow.is_empty()
-            && !self
+        // upstream: access.c:277-283 - allow-list short-circuit. A peer
+        // matching any allow pattern is admitted before the deny list is
+        // consulted; a peer matching nothing in a non-empty allow list is
+        // refused only when there is no deny list to fall through to.
+        if !self.hosts_allow.is_empty() {
+            if self
                 .hosts_allow
                 .iter()
                 .any(|pattern| pattern.matches(addr, hostname))
-        {
-            return false;
+            {
+                return true;
+            }
+            if self.hosts_deny.is_empty() {
+                return false;
+            }
         }
 
         // GHSA-rjfm-3w2m-jf4f: fail closed when hostname resolution failed
         // and any deny rule is hostname-based. Without this guard, a peer
         // whose reverse DNS returns no name (e.g., because the daemon's
         // chroot lacks `/etc/resolv.conf` and the NSS shared objects)
-        // silently bypasses hostname-pattern deny rules.
+        // silently bypasses hostname-pattern deny rules. This guard only
+        // fires on the deny path - the allow short-circuit above lets a
+        // matched peer through without depending on hostname state.
         if hostname.is_none()
             && self
                 .hosts_deny

--- a/crates/daemon/src/daemon/module_state/tests.rs
+++ b/crates/daemon/src/daemon/module_state/tests.rs
@@ -83,9 +83,10 @@ fn module_definition_allow_match_short_circuits_deny() {
 
 #[test]
 fn module_definition_deny_applies_when_allow_does_not_match() {
-    // upstream: access.c:281-288 - when the allow list is non-empty but
+    // upstream: access.c:281-291 - when the allow list is non-empty but
     // the peer matches none of its entries, fall through to the deny list.
-    // A deny-list match here refuses the connection; a non-match admits.
+    // A deny-list match here refuses the connection; a non-match admits
+    // (access.c:290-291 "Allow all other access").
     let def = ModuleDefinition {
         hosts_allow: vec![HostPattern::Ipv4 {
             network: Ipv4Addr::new(192, 168, 0, 0),
@@ -100,10 +101,12 @@ fn module_definition_deny_applies_when_allow_does_not_match() {
     let denied = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
     assert!(!def.permits(denied, None));
 
-    // Peer outside both allow and deny: refused because the allow list is
-    // non-empty and the peer matches nothing (upstream access.c:282).
+    // Peer outside both allow and deny: admitted because access.c:287
+    // returns 0 only on a deny-list match; otherwise access.c:291 allows.
+    // The allow-list non-match short-circuits to refuse only when the
+    // deny list is empty (access.c:281-282).
     let outside_both = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
-    assert!(!def.permits(outside_both, None));
+    assert!(def.permits(outside_both, None));
 }
 
 #[test]

--- a/crates/daemon/src/daemon/module_state/tests.rs
+++ b/crates/daemon/src/daemon/module_state/tests.rs
@@ -64,7 +64,11 @@ fn module_definition_permits_respects_hosts_deny() {
 }
 
 #[test]
-fn module_definition_deny_takes_precedence_over_allow() {
+fn module_definition_allow_match_short_circuits_deny() {
+    // upstream: access.c:277-279 - "If we match an allow-list item, we
+    // always allow access." A peer matching any allow pattern is admitted
+    // before the deny list is consulted, even when a deny pattern would
+    // otherwise match.
     let def = ModuleDefinition {
         hosts_allow: vec![HostPattern::Any],
         hosts_deny: vec![HostPattern::Ipv4 {
@@ -73,8 +77,106 @@ fn module_definition_deny_takes_precedence_over_allow() {
         }],
         ..Default::default()
     };
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    assert!(def.permits(peer, None));
+}
+
+#[test]
+fn module_definition_deny_applies_when_allow_does_not_match() {
+    // upstream: access.c:281-288 - when the allow list is non-empty but
+    // the peer matches none of its entries, fall through to the deny list.
+    // A deny-list match here refuses the connection; a non-match admits.
+    let def = ModuleDefinition {
+        hosts_allow: vec![HostPattern::Ipv4 {
+            network: Ipv4Addr::new(192, 168, 0, 0),
+            prefix: 16,
+        }],
+        hosts_deny: vec![HostPattern::Ipv4 {
+            network: Ipv4Addr::new(10, 0, 0, 0),
+            prefix: 8,
+        }],
+        ..Default::default()
+    };
     let denied = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
     assert!(!def.permits(denied, None));
+
+    // Peer outside both allow and deny: refused because the allow list is
+    // non-empty and the peer matches nothing (upstream access.c:282).
+    let outside_both = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
+    assert!(!def.permits(outside_both, None));
+}
+
+#[test]
+fn module_definition_allow_short_circuit_skips_dns_fail_closed_guard() {
+    // upstream: access.c:277-283 - an allow-list match returns 1 before
+    // the deny list is consulted. A hostname-pattern deny rule combined
+    // with unresolvable reverse DNS must not refuse a peer that already
+    // matched an IP-based allow rule, because upstream never reaches the
+    // deny path in that case. Without the short-circuit the GHSA-rjfm
+    // fail-closed guard would punish a perfectly-allowed peer for a
+    // separate hostname-deny rule that targets a different host.
+    let def = ModuleDefinition {
+        hosts_allow: vec![HostPattern::Ipv4 {
+            network: Ipv4Addr::new(192, 168, 0, 0),
+            prefix: 16,
+        }],
+        hosts_deny: vec![HostPattern::Hostname(HostnamePattern {
+            kind: HostnamePatternKind::Suffix("bad.example".to_owned()),
+        })],
+        ..Default::default()
+    };
+    let allowed = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
+    assert!(def.permits(allowed, None));
+}
+
+#[test]
+fn module_definition_matches_upstream_rsync_fns_allow_list() {
+    // upstream: testsuite/rsync.fns:381 - the testsuite's standard daemon
+    // config carries `hosts allow = localhost 127.0.0.0/24 192.168.0.0/16
+    // 10.0.0.0/8 $hostname` with no `hosts deny`. Every IPv4 in those
+    // ranges must be admitted; every IPv4 outside must be refused. This
+    // pins the CIDR matcher against upstream's testsuite expectations.
+    let def = ModuleDefinition {
+        hosts_allow: vec![
+            HostPattern::Ipv4 {
+                network: Ipv4Addr::new(127, 0, 0, 0),
+                prefix: 24,
+            },
+            HostPattern::Ipv4 {
+                network: Ipv4Addr::new(192, 168, 0, 0),
+                prefix: 16,
+            },
+            HostPattern::Ipv4 {
+                network: Ipv4Addr::new(10, 0, 0, 0),
+                prefix: 8,
+            },
+        ],
+        ..Default::default()
+    };
+    for ip in [
+        Ipv4Addr::new(127, 0, 0, 1),
+        Ipv4Addr::new(127, 0, 0, 255),
+        Ipv4Addr::new(192, 168, 1, 1),
+        Ipv4Addr::new(192, 168, 255, 254),
+        Ipv4Addr::new(10, 0, 0, 1),
+        Ipv4Addr::new(10, 255, 255, 254),
+    ] {
+        assert!(
+            def.permits(IpAddr::V4(ip), None),
+            "{ip} must be permitted by testsuite allow list",
+        );
+    }
+    for ip in [
+        Ipv4Addr::new(127, 0, 1, 1),
+        Ipv4Addr::new(11, 0, 0, 1),
+        Ipv4Addr::new(192, 169, 0, 1),
+        Ipv4Addr::new(203, 0, 113, 5),
+    ] {
+        assert!(
+            !def.permits(IpAddr::V4(ip), None),
+            "{ip} must be refused by testsuite allow list",
+        );
+    }
 }
 
 #[test]

--- a/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_hostname_deny_takes_precedence.rs
@@ -1,6 +1,23 @@
+/// Upstream rsync admits a peer on the first allow-list match without
+/// consulting the deny list (`access.c::allow_access`, "If we match an
+/// allow-list item, we always allow access."). A wildcard `hosts allow = *`
+/// therefore short-circuits any subsequent hostname-pattern deny rule.
+/// To make a hostname deny rule effective the operator must omit the
+/// catch-all allow (or list only the trusted hosts explicitly).
 #[test]
-fn module_definition_hostname_deny_takes_precedence() {
+fn module_definition_hostname_deny_short_circuited_by_wildcard_allow() {
     let module = module_with_host_patterns(&["*"], &["bad.example.com"]);
+    let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    assert!(module.permits(peer, Some("bad.example.com")));
+    assert!(module.permits(peer, Some("good.example.com")));
+}
+
+/// Hostname deny rules engage when the peer matches no allow pattern.
+/// This pairs with the wildcard-allow case above: removing the wildcard
+/// allows the deny list to gate access by hostname.
+#[test]
+fn module_definition_hostname_deny_applies_without_allow_match() {
+    let module = module_with_host_patterns(&[], &["bad.example.com"]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
     assert!(!module.permits(peer, Some("bad.example.com")));
     assert!(module.permits(peer, Some("good.example.com")));

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
@@ -10,7 +10,10 @@ fn module_definition_ipv4_allow_short_circuits_deny() {
     // In both the allowed and denied subnets - allow short-circuits the
     // deny rule, matching upstream.
     assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
-    // Outside the allowed subnet entirely - refused because the allow
-    // list is non-empty and the peer matches nothing.
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
+    // Outside both the allowed and denied subnets - admitted because
+    // access.c:287 only refuses on a deny-list match; otherwise
+    // access.c:291 falls through to "Allow all other access". The
+    // allow-list non-match short-circuits to refuse only when the deny
+    // list is empty (access.c:281-282).
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_ipv4_allow_deny_precedence.rs
@@ -1,12 +1,16 @@
 #[test]
-fn module_definition_ipv4_allow_deny_precedence() {
-    // upstream: access.c - hosts_allow is checked first (must match), then
-    // hosts_deny (must not match). A peer in both lists is denied.
+fn module_definition_ipv4_allow_short_circuits_deny() {
+    // upstream: access.c:277-279 - "If we match an allow-list item, we
+    // always allow access." A peer that matches any entry in the allow
+    // list is admitted before the deny list is consulted, even when an
+    // overlapping deny rule would otherwise match.
     let module = module_with_host_patterns(&["192.168.0.0/16"], &["192.168.1.0/24"]);
-    // In the allowed subnet but not in the denied subnet - permitted.
+    // In the allowed subnet and outside the deny subnet - permitted by allow.
     assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
-    // In both the allowed and denied subnets - denied.
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
-    // Outside the allowed subnet entirely - denied by allow check.
+    // In both the allowed and denied subnets - allow short-circuits the
+    // deny rule, matching upstream.
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), None));
+    // Outside the allowed subnet entirely - refused because the allow
+    // list is non-empty and the peer matches nothing.
     assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None));
 }

--- a/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
+++ b/crates/daemon/src/tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs
@@ -1,21 +1,28 @@
 #[test]
 fn module_definition_mixed_ip_and_hostname_acl() {
-    // Allow a CIDR range and a hostname pattern; deny a specific IP.
+    // Allow a CIDR range plus a hostname pattern; deny a specific IP.
+    // upstream: access.c::allow_access - an allow-list match returns 1
+    // immediately, so a peer admitted by the allow list bypasses the
+    // deny list entirely. When the allow list does not match, the deny
+    // list refuses only on a positive match.
     let module = module_with_host_patterns(
         &["192.168.0.0/16", "*.trusted.org"],
         &["192.168.1.99"],
     );
-    // IP in allowed range, not in deny list.
+    // IP in allowed range, not in deny list - permitted by allow.
     assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 1)), None));
-    // IP in allowed range but also in deny list.
-    assert!(!module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), None));
-    // IP outside allowed range but hostname matches allow pattern.
+    // IP in allowed range and also in deny list - the allow match short-
+    // circuits the deny check, matching upstream `allow_access`.
+    assert!(module.permits(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), None));
+    // IP outside allowed range but hostname matches allow pattern - allow.
     assert!(module.permits(
         IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
         Some("build.trusted.org"),
     ));
-    // IP outside allowed range and hostname does not match.
-    assert!(!module.permits(
+    // IP outside allowed range, hostname not in allow, IP not in deny -
+    // fall-through after a non-matching allow list with a non-empty deny
+    // list admits the peer per upstream access.c:290.
+    assert!(module.permits(
         IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)),
         Some("build.untrusted.org"),
     ));


### PR DESCRIPTION
## Summary

`ModuleDefinition::permits` (the `hosts allow`/`hosts deny` matcher used
on every daemon connection) diverged from upstream rsync's
`access.c::allow_access()`. Upstream short-circuits on the first allow-
list match - "If we match an allow-list item, we always allow access."
- and only consults the deny list when the allow list is absent or did
not match. oc-rsync instead evaluated allow and then deny in series, so
a peer matching both lists was refused. Any daemon config that pairs an
inclusive `hosts allow = *` with surgical hostname-pattern deny rules
silently rejected connections the upstream testsuite expects to be
accepted (`testsuite/rsync.fns:381` ships exactly this idiom for the
shared `hosts allow = localhost 127.0.0.0/24 192.168.0.0/16 10.0.0.0/8
$hostname` configuration).

## What the fix does

Reorder `permits` to mirror `access.c:264` exactly:

1. `hosts allow` non-empty and the peer matches any pattern -> permit
   (deny list never consulted).
2. `hosts allow` non-empty, no match, no deny list -> refuse.
3. Fall through: peer matches a deny rule -> refuse, else permit.

The GHSA-rjfm-3w2m-jf4f fail-closed guard (PR #5524) stays on the deny
path and is unchanged for its existing use cases. After the reorder it
no longer punishes peers who already cleared the allow short-circuit -
a peer admitted by `hosts allow` is admitted regardless of reverse-DNS
state, which is what upstream does and what operators expect.

## Upstream reference

`target/interop/upstream-src/rsync-3.4.3/access.c:264-292` defines
`allow_access`. The comment on line 276 reads "If we match an allow-list
item, we always allow access." `testsuite/rsync.fns:352-411` is the
shared daemon configuration the testsuite assembles for every
daemon-related test (`daemon.test`, `daemon-refuse-compress.test`,
`daemon-gzip-{upload,download}.test`), and line 381 declares the
`hosts allow` directive that pins the matcher behaviour this PR
restores.

## Regression tests

In `crates/daemon/src/daemon/module_state/tests.rs`:

- `module_definition_allow_match_short_circuits_deny` - replaces the
  bogus `deny_takes_precedence_over_allow` expectation.
- `module_definition_deny_applies_when_allow_does_not_match` - exercises
  the fall-through path (allow miss + deny list present -> deny check
  runs).
- `module_definition_allow_short_circuit_skips_dns_fail_closed_guard` -
  pins the interaction with the GHSA-rjfm-3w2m-jf4f guard: a peer that
  wins the allow short-circuit is admitted even when a hostname-pattern
  deny rule cannot evaluate.
- `module_definition_matches_upstream_rsync_fns_allow_list` - reproduces
  upstream's `testsuite/rsync.fns:381` allow list and asserts every IPv4
  inside the CIDRs is admitted and every IPv4 outside is refused.

In `crates/daemon/src/tests/chunks/`:

- `module_definition_ipv4_allow_deny_precedence.rs`,
  `module_definition_hostname_deny_takes_precedence.rs`,
  `module_definition_mixed_ip_and_hostname_acl.rs` - the chunks whose
  assertions previously codified the bug have been updated to the
  upstream semantics. The hostname chunk now carries both the wildcard-
  allow short-circuit case and a no-allow-list deny case so the matcher
  is pinned in both directions.

Existing GHSA fail-closed regressions
(`module_hostname_deny_fails_closed_when_dns_unresolved`,
`module_ip_deny_unaffected_by_dns_failure`) remain green: the guard
still fires on the deny path when the allow list does not match.

## Scope

- No wire-protocol changes.
- No `crates/branding/` changes.
- No effect on parallel-receive-delta, io_uring, IOCP, flat-flist,
  daemon-tls, DirSandbox, SEND_ZC, or flat arena flist.
- Daemon `#![deny(unsafe_code)]` preserved; no clippy waivers.

## Test plan

- [ ] CI fmt + clippy green
- [ ] CI nextest green (Linux GNU, Linux musl, macOS, Windows)
- [ ] Upstream testsuite step in interop workflow shows daemon-family
      tests still passing