### PR TITLE
fix: apply munge symlinks prefix/strip in transfer paths

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -479,6 +479,13 @@ fn build_server_config(
                 }
             }
 
+            // upstream: clientserver.c:992-993 - `munge_symlinks = lp_munge_symlinks(i)`
+            // with `!use_chroot || module_dirlen` as the auto default. The bit is
+            // purely daemon-config-driven (no client-side override) and travels
+            // through the transfer layer so the sender strips `/rsyncd-munged/`
+            // on `readlink()` and the receiver prepends it on `symlink()` writes.
+            cfg.munge_symlinks = module.effective_munge_symlinks();
+
             Ok(Some(cfg))
         }
         Err(err) => {

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -89,6 +89,7 @@ pub struct ServerConfigBuilder {
     fake_super: bool,
     daemon_incoming_chmod: Option<ChmodModifiers>,
     daemon_outgoing_chmod: Option<ChmodModifiers>,
+    munge_symlinks: bool,
 }
 
 impl Default for ServerConfigBuilder {
@@ -128,6 +129,7 @@ impl ServerConfigBuilder {
             fake_super: false,
             daemon_incoming_chmod: None,
             daemon_outgoing_chmod: None,
+            munge_symlinks: false,
         }
     }
 
@@ -507,6 +509,24 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Enables or disables symlink munging.
+    ///
+    /// When enabled, the daemon prepends `/rsyncd-munged/` to incoming
+    /// symlink targets (receiver) and strips the prefix from outgoing
+    /// symlink targets (sender) so symlinks cannot resolve outside the
+    /// module root when followed.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:992-1004` - daemon resolves `munge_symlinks` from
+    ///   `lp_munge_symlinks()` and the `use_chroot` auto default.
+    /// - `flist.c:222-226` - sender-side strip.
+    /// - `flist.c:1122-1126` - receiver-side prepend.
+    pub fn munge_symlinks(&mut self, enabled: bool) -> &mut Self {
+        self.munge_symlinks = enabled;
+        self
+    }
+
     /// Validates the builder configuration.
     fn validate(&self) -> Result<(), BuilderError> {
         // upstream: options.c:2934 - --inplace and --delay-updates are mutually exclusive
@@ -585,6 +605,7 @@ impl ServerConfigBuilder {
             fake_super: self.fake_super,
             daemon_incoming_chmod: self.daemon_incoming_chmod.clone(),
             daemon_outgoing_chmod: self.daemon_outgoing_chmod.clone(),
+            munge_symlinks: self.munge_symlinks,
         }
     }
 }

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -453,6 +453,22 @@ pub struct ServerConfig {
     /// - `loadparm.c` - `outgoing chmod` module parameter
     /// - `flist.c:make_file()` - `daemon_chmod_modes` applied during flist build
     pub daemon_outgoing_chmod: Option<ChmodModifiers>,
+    /// When true, munge symlink targets with the `/rsyncd-munged/` prefix.
+    ///
+    /// Sourced from the daemon module's `munge symlinks` directive (or its
+    /// `!use_chroot` auto default). Mirrors upstream's `munge_symlinks`
+    /// global. Propagated into [`ParsedServerFlags::munge_symlinks`] when the
+    /// server config is consumed so the sender (strip on `readlink()`) and
+    /// receiver (prepend on `symlink()` write) apply the bidirectional
+    /// transform.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:992-1004` - daemon sets `munge_symlinks` from
+    ///   `lp_munge_symlinks()`.
+    /// - `flist.c:222-226` - sender strips the prefix.
+    /// - `flist.c:1122-1126` - receiver prepends the prefix.
+    pub munge_symlinks: bool,
 }
 
 impl Default for ServerConfig {
@@ -484,6 +500,7 @@ impl Default for ServerConfig {
             fake_super: false,
             daemon_incoming_chmod: None,
             daemon_outgoing_chmod: None,
+            munge_symlinks: false,
         }
     }
 }

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -80,7 +80,14 @@ impl GeneratorContext {
 
             FileEntry::new_directory(relative_path, mode)
         } else if file_type.is_symlink() {
-            let target = std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from(""));
+            let raw_target = std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from(""));
+
+            // upstream: flist.c:222-226 - sender strips the `/rsyncd-munged/`
+            // prefix from the readlink result when the daemon module has
+            // `munge symlinks = yes`, restoring the original target before it
+            // is sent on the wire. The matching prepend on the receive side
+            // re-applies the prefix when the link is materialized on disk.
+            let target = strip_symlink_munge_prefix(self.config.munge_symlinks, raw_target);
 
             FileEntry::new_symlink(relative_path, target)
         } else {
@@ -375,6 +382,88 @@ pub(in crate::generator) fn rdev_to_major_minor(rdev: u64) -> (u32, u32) {
     let major = (rdev >> 24) as u32;
     let minor = (rdev & 0xffffff) as u32;
     (major, minor)
+}
+
+/// Strips the `/rsyncd-munged/` prefix from a symlink target when munging is active.
+///
+/// Mirrors upstream `flist.c:222-226`: when the daemon module has
+/// `munge symlinks = yes`, the sender restores the original target before it
+/// is encoded onto the wire so the receiver can reapply the prefix on its
+/// side. The receiver-side write path uses the matching
+/// [`crate::receiver::directory::apply_symlink_munge_prefix`] helper.
+///
+/// Targets that lack the prefix pass through unchanged; this is the
+/// `llen > SYMLINK_PREFIX_LEN && strncmp(...) == 0` branch in upstream's
+/// `readlink_stat()`.
+fn strip_symlink_munge_prefix(munge_symlinks: bool, target: PathBuf) -> PathBuf {
+    if !munge_symlinks {
+        return target;
+    }
+    let prefix_len = ::metadata::SYMLINK_MUNGE_PREFIX.len();
+    // upstream: flist.c:222 - the strncmp guard requires `llen > SYMLINK_PREFIX_LEN`,
+    // so a target consisting of exactly the prefix is left untouched.
+    #[cfg(unix)]
+    {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = target.as_os_str().as_bytes();
+        let prefix = ::metadata::SYMLINK_MUNGE_PREFIX.as_bytes();
+        if bytes.len() > prefix_len && bytes.starts_with(prefix) {
+            let tail = OsStr::from_bytes(&bytes[prefix_len..]);
+            return PathBuf::from(tail);
+        }
+        target
+    }
+    #[cfg(not(unix))]
+    {
+        match target.to_str() {
+            Some(text)
+                if text.len() > prefix_len
+                    && text.starts_with(::metadata::SYMLINK_MUNGE_PREFIX) =>
+            {
+                PathBuf::from(&text[prefix_len..])
+            }
+            _ => target,
+        }
+    }
+}
+
+#[cfg(test)]
+mod munge_strip_tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_when_disabled() {
+        let original = PathBuf::from("/rsyncd-munged/etc/passwd");
+        let returned = strip_symlink_munge_prefix(false, original.clone());
+        assert_eq!(returned, original);
+    }
+
+    #[test]
+    fn strips_prefix_when_enabled() {
+        let original = PathBuf::from("/rsyncd-munged/etc/passwd");
+        let returned = strip_symlink_munge_prefix(true, original);
+        assert_eq!(returned, PathBuf::from("etc/passwd"));
+    }
+
+    #[test]
+    fn passes_through_unprefixed_target_when_enabled() {
+        let original = PathBuf::from("../sibling");
+        let returned = strip_symlink_munge_prefix(true, original.clone());
+        assert_eq!(returned, original);
+    }
+
+    #[test]
+    fn does_not_strip_exact_prefix_match() {
+        // upstream: flist.c:222 - `llen > SYMLINK_PREFIX_LEN` is strict, so a
+        // target whose entire content is the prefix is left untouched. Without
+        // the strict check we would emit an empty target onto the wire and
+        // diverge from upstream byte-for-byte.
+        let original = PathBuf::from("/rsyncd-munged/");
+        let returned = strip_symlink_munge_prefix(true, original.clone());
+        assert_eq!(returned, original);
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -733,5 +822,94 @@ mod daemon_outgoing_chmod_tests {
             .expect("create_entry");
 
         assert_eq!(entry.permissions() & 0o7777, 0o664);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod munge_symlinks_tests {
+    //! Sender-side `munge symlinks` regression tests.
+    //!
+    //! upstream: flist.c:222-226 - when the daemon enabled `munge symlinks`,
+    //! the sender strips the `/rsyncd-munged/` prefix after `readlink()` so
+    //! the wire format carries the original target. The matching prepend on
+    //! the receive side lives in `crate::receiver::directory::links`.
+
+    use super::super::super::GeneratorContext;
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use protocol::ProtocolVersion;
+    use std::ffi::OsString;
+    use std::os::unix::fs::symlink;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    fn generator_with_munge(munge_symlinks: bool) -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            munge_symlinks,
+            ..Default::default()
+        };
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    #[test]
+    fn sender_strips_munge_prefix_before_emitting_wire_target() {
+        // upstream: flist.c:222-226 - when the daemon enabled `munge symlinks`,
+        // the sender restores the original target before encoding the flist
+        // entry. Verify the in-memory `FileEntry` carries the stripped path so
+        // the wire format never leaks `/rsyncd-munged/`.
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("escape");
+        symlink(Path::new("/rsyncd-munged//etc/passwd"), &link).unwrap();
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+
+        let ctx = generator_with_munge(true);
+        let entry = ctx
+            .create_entry(&link, PathBuf::from("escape"), &meta)
+            .unwrap();
+
+        assert_eq!(
+            entry.link_target().map(PathBuf::as_path),
+            Some(Path::new("/etc/passwd")),
+            "sender must strip `/rsyncd-munged/` before transmission \
+             (upstream flist.c:222-226)",
+        );
+    }
+
+    #[test]
+    fn sender_preserves_prefix_when_munge_disabled() {
+        // Negative control: with `munge_symlinks=false` the prefix on the
+        // source link is part of the user's intentional target and must
+        // travel verbatim on the wire.
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("escape");
+        symlink(Path::new("/rsyncd-munged//etc/passwd"), &link).unwrap();
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+
+        let ctx = generator_with_munge(false);
+        let entry = ctx
+            .create_entry(&link, PathBuf::from("escape"), &meta)
+            .unwrap();
+
+        assert_eq!(
+            entry.link_target().map(PathBuf::as_path),
+            Some(Path::new("/rsyncd-munged//etc/passwd")),
+            "without `munge symlinks`, the prefix is part of the target and \
+             must round-trip verbatim",
+        );
     }
 }

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -45,7 +45,7 @@ impl ReceiverContext {
                 continue;
             }
 
-            let target = match entry.link_target() {
+            let wire_target = match entry.link_target() {
                 Some(t) => t,
                 None => continue,
             };
@@ -54,9 +54,12 @@ impl ReceiverContext {
 
             // upstream: generator.c:1547 - skip unsafe symlinks when --safe-links
             // is set. Check stays here (not in sanitize_file_list) to preserve
-            // protocol index alignment with the sender.
+            // protocol index alignment with the sender. Safe-link evaluation
+            // runs against the wire target (pre-munge) so the policy decision
+            // matches upstream's `flist.c` ordering where the munge prefix is
+            // applied only after safety checks complete.
             if self.config.flags.safe_links
-                && crate::symlink_safety::is_unsafe_symlink(target.as_os_str(), relative_path)
+                && crate::symlink_safety::is_unsafe_symlink(wire_target.as_os_str(), relative_path)
             {
                 // upstream: generator.c:1554 - log skipped unsafe symlinks
                 info_log!(
@@ -64,10 +67,23 @@ impl ReceiverContext {
                     1,
                     "skipping unsafe symlink \"{}\" -> \"{}\"",
                     relative_path.display(),
-                    target.display()
+                    wire_target.display()
                 );
                 continue;
             }
+
+            // upstream: flist.c:1122-1126 - receiver prepends `/rsyncd-munged/`
+            // to the symlink target when the daemon enabled `munge symlinks`,
+            // so the on-disk link cannot resolve outside the module root when
+            // followed. Apply once here so both the quick-check comparison and
+            // the create syscall see the prefixed form.
+            let munged: std::path::PathBuf;
+            let target: &std::path::Path = if self.config.munge_symlinks {
+                munged = apply_symlink_munge_prefix(wire_target);
+                munged.as_path()
+            } else {
+                wire_target.as_path()
+            };
 
             let link_path = dest_dir.join(relative_path);
 
@@ -415,6 +431,27 @@ impl ReceiverContext {
         // during file list reception (normalize_pre30_hardlinks), so the
         // protocol 30+ path above handles both versions uniformly.
     }
+}
+
+/// Prepends the `/rsyncd-munged/` prefix to a symlink target.
+///
+/// Mirrors upstream `flist.c:1122-1126` where the receiver prepends
+/// `SYMLINK_PREFIX` to the wire target so the on-disk symlink cannot resolve
+/// outside the module root when followed. Only invoked when the daemon module
+/// has `munge symlinks = yes` (or the `!use_chroot` auto default).
+///
+/// The transform is a pure byte-level prepend so a non-UTF-8 target still
+/// receives the ASCII prefix without any lossy decode. The matching strip
+/// happens on the sender via `strip_symlink_munge_prefix` in
+/// `crate::generator::file_list::entry`.
+#[cfg(unix)]
+pub(in crate::receiver) fn apply_symlink_munge_prefix(target: &Path) -> std::path::PathBuf {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let mut bytes = ::metadata::SYMLINK_MUNGE_PREFIX.as_bytes().to_vec();
+    bytes.extend_from_slice(target.as_os_str().as_bytes());
+    std::path::PathBuf::from(OsString::from_vec(bytes))
 }
 
 #[cfg(test)]

--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -19,6 +19,8 @@ mod delta_apply;
 mod errors_and_timeouts;
 mod file_list;
 mod hard_links;
+#[cfg(unix)]
+mod munge_symlinks;
 mod parallel_delta_notice;
 mod partial_resume;
 mod support;

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -1,0 +1,130 @@
+//! Receiver-side `munge symlinks` regression tests.
+//!
+//! Mirrors the on-disk transform upstream applies in `flist.c:1122-1126`:
+//! when the daemon module has `munge symlinks = yes`, every symlink that the
+//! receiver materializes carries the `/rsyncd-munged/` prefix so that
+//! following the link cannot escape the module root. The complementary
+//! sender-side strip lives in `super::munge_symlinks` (file-list entry).
+//!
+//! # Upstream Reference
+//!
+//! - `clientserver.c:992-1004` - daemon resolves `munge_symlinks` from
+//!   `lp_munge_symlinks()` and aborts if `rsyncd-munged` already exists at
+//!   the module root.
+//! - `flist.c:1122-1126` - receiver prepends `SYMLINK_PREFIX` to the wire
+//!   target before the link is written to disk.
+
+use std::ffi::OsString;
+use std::io::{self, Write};
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileEntry;
+
+use super::super::ReceiverContext;
+use super::support::test_handshake;
+use crate::config::ServerConfig;
+use crate::flags::ParsedServerFlags;
+use crate::role::ServerRole;
+use crate::writer::MsgInfoSender;
+
+/// Sink that captures emitted MSG_INFO frames so the test can assert
+/// itemize output without touching the daemon multiplex layer.
+struct CapturingMsgInfoWriter;
+
+impl Write for CapturingMsgInfoWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl MsgInfoSender for CapturingMsgInfoWriter {
+    fn send_msg_info(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn munge_receiver_config() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            links: true,
+            ..Default::default()
+        },
+        args: vec![OsString::from(".")],
+        munge_symlinks: true,
+        ..Default::default()
+    }
+}
+
+fn plain_receiver_config() -> ServerConfig {
+    ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        flags: ParsedServerFlags {
+            links: true,
+            ..Default::default()
+        },
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
+    // upstream: flist.c:1122-1126 - the receiver-side prepend is the only
+    // signal that the daemon enabled `munge symlinks`. Verify the on-disk
+    // link carries the `/rsyncd-munged/` prefix so following it lands inside
+    // the module root.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, munge_receiver_config());
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "escape".into(),
+        "/etc/passwd".into(),
+    )];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, None, &mut writer);
+
+    let on_disk = std::fs::read_link(dest.join("escape")).expect("read_link");
+    assert_eq!(
+        on_disk,
+        std::path::Path::new("/rsyncd-munged//etc/passwd"),
+        "receiver must prepend `/rsyncd-munged/` so following the link \
+         cannot escape the module root (upstream flist.c:1122-1126)",
+    );
+}
+
+#[test]
+fn receiver_writes_unmunged_target_when_disabled() {
+    // Negative control: the same flist with `munge_symlinks=false` must
+    // produce a byte-identical target on disk. The munge transform is
+    // strictly opt-in via daemon configuration.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "escape".into(),
+        "/etc/passwd".into(),
+    )];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, None, &mut writer);
+
+    let on_disk = std::fs::read_link(dest.join("escape")).expect("read_link");
+    assert_eq!(
+        on_disk,
+        std::path::Path::new("/etc/passwd"),
+        "without `munge symlinks`, the receiver writes the wire target verbatim",
+    );
+}

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -486,6 +486,7 @@ write_rust_daemon_conf() {
 pid file = ${pid_file}
 port = ${port}
 use chroot = false
+munge symlinks = false
 
 [interop]
 path = ${dest}

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -8595,6 +8595,7 @@ test_symlinks_upstream() {
 pid file = ${sl_pid}
 port = ${oc_port}
 use chroot = false
+munge symlinks = false
 
 [interop]
 path = ${sl_dest}


### PR DESCRIPTION
## Summary

Task UTS-11 (#3574). The daemon's `munge symlinks` directive was parsed and
stored on `ModuleDefinition::munge_symlinks: Option<bool>`, but the actual
prefix/strip transform was missing from the transfer path. Push and pull
through a module configured with `munge symlinks = yes` silently bypassed
upstream's anti-escape guard - the on-disk symlink written by the receiver
never carried the `/rsyncd-munged/` prefix, and the sender never stripped
it when reading source symlinks.

- Wire `ModuleRuntime::effective_munge_symlinks()` into
  `ServerConfig.munge_symlinks` alongside the existing `fake_super` wiring
  (`crates/daemon/src/daemon/sections/module_access/client_args.rs:292-297`).
- Sender: strip the prefix in `GeneratorContext::create_entry` after
  `read_link()` so the wire target matches the unmunged source path
  (`crates/transfer/src/generator/file_list/entry.rs:82-94, 375-407`).
- Receiver: prepend the prefix in `ReceiverContext::create_symlinks` before
  the `symlinkat` write so the quick-check comparison and the create syscall
  both see the munged form
  (`crates/transfer/src/receiver/directory/links.rs:75-86, 444-465`).

## Upstream reference

- `clientserver.c:992-1004` - daemon resolves `munge_symlinks` from
  `lp_munge_symlinks()` and the `!use_chroot || module_dirlen` auto default.
- `flist.c:222-226` - sender strips `SYMLINK_PREFIX` after `readlink()`,
  guarded by `llen > SYMLINK_PREFIX_LEN`.
- `flist.c:1122-1126` - receiver prepends `SYMLINK_PREFIX` to the wire
  target when storing the symlink in the file list.
- `rsync.h:36` - `#define SYMLINK_PREFIX "/rsyncd-munged/"` (15 bytes).

The strip helper mirrors the strict `llen > SYMLINK_PREFIX_LEN` guard so a
target whose entire content is the 15-byte prefix passes through
unchanged - matching upstream's `strncmp` branch byte-for-byte. The
receiver-side prepend uses `OsStrExt::as_bytes` on Unix so non-UTF-8
targets keep their raw bytes; the safe-link check continues to evaluate
the pre-munge wire target so the policy decision matches upstream
ordering.

## Wiring audit findings

- `ModuleDefinition::munge_symlinks: Option<bool>` and
  `effective_munge_symlinks()` (auto = `!use_chroot`) were already in
  place at `crates/daemon/src/daemon/module_state/definition.rs:54-56,
  273-275`.
- `metadata::munge_symlink` / `unmunge_symlink` /
  `SYMLINK_MUNGE_PREFIX` were already exported and exercised by the
  local-copy executor at
  `crates/engine/src/local_copy/executor/special/symlink.rs:120-150,
  402-409`.
- The missing wiring was the bridge between the parsed daemon directive
  and the transfer layer (`ServerConfig.munge_symlinks` + sender/receiver
  call sites).

## Cross-platform

- The receiver prefix helper is gated `#[cfg(unix)]`; the matching
  `create_symlinks` is already Unix-only with a no-op fallback for
  Windows.
- The sender strip is portable: on Unix it operates on the raw OsStr
  bytes; on non-Unix it falls back to UTF-8 since `read_link` already
  rejects non-UTF-8 paths on those platforms.

## Test plan

- [x] `crates/transfer/src/generator/file_list/entry.rs::munge_strip_tests`
  - prefix passes through when disabled
  - prefix stripped when enabled
  - unprefixed target untouched when enabled
  - exact-prefix target untouched (matches upstream's strict `>` guard)
- [x] `crates/transfer/src/generator/file_list/entry.rs::munge_symlinks_tests`
  - sender strips `/rsyncd-munged/` before encoding the file list entry
  - sender preserves the prefix verbatim when munging is disabled
- [x] `crates/transfer/src/receiver/tests/munge_symlinks.rs`
  - receiver writes a prefixed symlink to disk when munging is enabled
  - receiver writes the wire target verbatim when munging is disabled
- [ ] CI: fmt + clippy + nextest stable across Linux/macOS/Windows/musl.
- [ ] CI: interop suite confirms no regression on existing
  `daemon_safe_links_receive` test (uses `munge symlinks = false`).