### PR TITLE
fix: align daemon module listing with upstream format

### DIFF
--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -18,6 +18,11 @@ pub(crate) fn render_module_list<W: Write, E: Write>(
         }
     }
 
+    // upstream: clientserver.c:1254 emits `%-15s\t%s\n` for every listable
+    // module, even when the comment is empty. The client echoes the line
+    // verbatim, so we must emit the tab whenever the daemon supplied a
+    // comment field (i.e. the entry was parsed from a tab-separated line),
+    // including when that field is the empty string.
     for entry in list.entries() {
         let name = entry.name();
         if let Some(comment) = entry.comment() {

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -97,14 +97,13 @@ pub struct ModuleListEntry {
 
 impl ModuleListEntry {
     fn from_line(line: &str) -> Self {
+        // upstream: clientserver.c:1254 emits `%-15s\t%s\n`, so any line with a
+        // tab carries a comment field (possibly empty). Preserve the empty
+        // string so the renderer reproduces the tab byte-for-byte.
         match line.split_once('\t') {
             Some((name, comment)) => Self {
                 name: name.to_owned(),
-                comment: if comment.is_empty() {
-                    None
-                } else {
-                    Some(comment.to_owned())
-                },
+                comment: Some(comment.to_owned()),
             },
             None => Self {
                 name: line.to_owned(),
@@ -463,9 +462,12 @@ mod tests {
 
     #[test]
     fn module_list_entry_from_line_empty_comment() {
+        // upstream sends `%-15s\t%s\n` so a tab with no following comment must
+        // be preserved (Some("")) to round-trip the wire bytes through the
+        // client renderer.
         let entry = ModuleListEntry::from_line("data\t");
         assert_eq!(entry.name(), "data");
-        assert!(entry.comment().is_none());
+        assert_eq!(entry.comment(), Some(""));
     }
 
     #[test]

--- a/crates/core/src/client/tests/module_list_listing.rs
+++ b/crates/core/src/client/tests/module_list_listing.rs
@@ -28,6 +28,42 @@ fn run_module_list_accepts_plaintext_motd_before_acknowledgment() {
 }
 
 #[test]
+fn run_module_list_preserves_empty_comment_marker_for_upstream_format() {
+    // upstream emits `%-15s\t%s\n` for every module, including those without a
+    // configured comment. The client must preserve the trailing tab so the
+    // rendered output matches upstream byte-for-byte. This regression covers
+    // the upstream `daemon.test` expectation for the `test-scratch` module.
+    let _guard = env_lock().lock().expect("env mutex poisoned");
+
+    let responses = vec![
+        "@RSYNCD: OK\n",
+        "test-from      \tr/o\n",
+        "test-to        \tr/w\n",
+        "test-scratch   \t\n",
+        "@RSYNCD: EXIT\n",
+    ];
+    let (addr, handle) = spawn_stub_daemon(responses);
+
+    let request = ModuleListRequest::from_components(
+        DaemonAddress::new(addr.ip().to_string(), addr.port()).expect("address"),
+        None,
+        ProtocolVersion::NEWEST,
+    );
+
+    let list = run_module_list(request).expect("module list succeeds");
+
+    assert_eq!(list.entries().len(), 3);
+    assert_eq!(list.entries()[0].name(), "test-from      ");
+    assert_eq!(list.entries()[0].comment(), Some("r/o"));
+    assert_eq!(list.entries()[1].name(), "test-to        ");
+    assert_eq!(list.entries()[1].comment(), Some("r/w"));
+    assert_eq!(list.entries()[2].name(), "test-scratch   ");
+    assert_eq!(list.entries()[2].comment(), Some(""));
+
+    handle.join().expect("daemon thread completes");
+}
+
+#[test]
 fn run_module_list_suppresses_plaintext_motd_when_requested() {
     let _guard = env_lock().lock().expect("env mutex poisoned");
 


### PR DESCRIPTION
## Summary

- Preserve the trailing tab on module listing lines whose comment is empty so the client renders the upstream `%-15s\t%s\n` format byte-for-byte
- Adds a stub-daemon regression that pins the `daemon.test` expectation for `test-from`, `test-to`, and `test-scratch`
- Updates the existing `from_line` unit test to reflect the new `Some("")` contract

## Why

The upstream testsuite `daemon.test` checks the output of `rsync -v localhost::` against a fixed expected file. Upstream emits one `%-15s\t%s\n` line per listable module including modules with no `comment =` directive (the comment is the empty string). The oc-rsync client was collapsing an empty comment to `None` in `ModuleListEntry::from_line`, then suppressing the tab during render, which produced `test-scratch   \n` instead of `test-scratch   \t\n`. The diff broke the upstream daemon test.

Reference: `clientserver.c:1247-1259` (`send_listing()`).

## Test plan

- [x] New core regression `run_module_list_preserves_empty_comment_marker_for_upstream_format` reproduces the daemon.test wire format
- [x] Updated `module_list_entry_from_line_empty_comment` asserts `Some("")`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) workspace
- [ ] CI: Windows, macOS, Linux musl
- [ ] CI: interop daemon push/pull