### PR TITLE
fix: expand refuse-options compress alias to all -z variants

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -36,6 +36,24 @@ const VITAL_OPTIONS: &[&str] = &[
     "write-devices",
 ];
 
+/// Sibling options grouped with `--compress` for refuse-list matching.
+///
+/// upstream: options.c - when `set_refuse_options()` marks `'z'` as refused it
+/// captures the popt val into `refused_compress`. `parse_arguments()` then
+/// rejects any client that activates compression via `-z`, `--compress`,
+/// `--compress-level`, `--compress-choice`, `--old-compress`, or
+/// `--new-compress` (and their `--zl` / `--zc` short aliases). `--no-compress`
+/// is the inverse and remains allowed because it clears `do_compression`.
+const COMPRESS_ALIAS_GROUP: &[&str] = &[
+    "compress",
+    "compress-level",
+    "compress-choice",
+    "old-compress",
+    "new-compress",
+    "zl",
+    "zc",
+];
+
 /// Checks whether a client-requested option is refused by the module's refuse list.
 ///
 /// The refuse list supports:
@@ -214,7 +232,7 @@ fn is_option_refused(refuse_list: &[String], canonical: &str) -> bool {
         let matches = if is_glob {
             wildcard_match(&pattern, canonical)
         } else {
-            pattern == canonical
+            pattern == canonical || rule_alias_matches(&pattern, canonical)
         };
 
         if matches {
@@ -222,6 +240,20 @@ fn is_option_refused(refuse_list: &[String], canonical: &str) -> bool {
         }
     }
     refused
+}
+
+/// Resolves popt-style refuse aliases that share a single `val` field.
+///
+/// upstream: options.c `parse_arguments()` consults `refused_compress` (set by
+/// `set_refuse_options()` when `'z'` is refused) to reject any option that
+/// activates compression. We mirror that by treating `compress` as a group:
+/// the rule matches `--compress`, `--compress-level`, `--compress-choice`,
+/// `--old-compress`, `--new-compress`, and the `--zl` / `--zc` short aliases.
+fn rule_alias_matches(pattern: &str, canonical: &str) -> bool {
+    if pattern == "compress" || pattern == "z" {
+        return COMPRESS_ALIAS_GROUP.contains(&canonical);
+    }
+    false
 }
 
 /// Returns whether an option is in the vital set that is immune to wildcards.

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -362,6 +362,64 @@ fn refused_client_arg_short_n_dry_run_spared_by_wildcard() {
     assert_eq!(refused_client_arg(&module, &args), None);
 }
 
+#[test]
+fn refused_client_arg_compress_alias_group_long_variants() {
+    // upstream: options.c `refused_compress` extends `refuse options = compress`
+    // to every long-form that activates compression. `--no-compress` is the
+    // inverse and remains permitted.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    for variant in &[
+        "--compress",
+        "--compress-level=6",
+        "--compress-choice=zstd",
+        "--new-compress",
+        "--old-compress",
+        "--zl=4",
+        "--zc=zstd",
+    ] {
+        let args = vec!["--server".to_owned(), (*variant).to_owned()];
+        assert!(
+            refused_client_arg(&module, &args).is_some(),
+            "expected '{variant}' to be refused by 'refuse options = compress'",
+        );
+    }
+    let allowed = vec!["--server".to_owned(), "--no-compress".to_owned()];
+    assert_eq!(refused_client_arg(&module, &allowed), None);
+}
+
+#[test]
+fn refused_client_arg_compress_alias_negated() {
+    // upstream: a trailing `!compress-level` negation in the refuse list
+    // re-allows the specific alias member while still refusing siblings.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned(), "!compress-level".to_owned()],
+        ..Default::default()
+    };
+    let level_allowed = vec!["--compress-level=6".to_owned()];
+    assert_eq!(refused_client_arg(&module, &level_allowed), None);
+    let still_refused = vec!["--compress".to_owned()];
+    assert_eq!(
+        refused_client_arg(&module, &still_refused),
+        Some("--compress".to_owned()),
+    );
+}
+
+#[test]
+fn refused_client_arg_zc_short_letter_unaffected_by_alias_group() {
+    // The alias group must not over-trigger from unrelated short letters.
+    // Bundled `-vlogDtpre` (no `z`) must remain allowed when only `compress`
+    // is refused.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["-vlogDtpre.LsfxCIvu".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
 
 #[test]
 fn program_name_rsyncd_as_str() {

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -195,6 +195,7 @@ include!("tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs");
 include!("tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs");
 include!("tests/chunks/run_daemon_records_log_file_entries.rs");
 include!("tests/chunks/run_daemon_refuses_disallowed_module_options.rs");
+include!("tests/chunks/run_daemon_refuse_compress_rejects_bundled_short_z.rs");
 include!("tests/chunks/run_daemon_rejects_duplicate_session_limits.rs");
 include!("tests/chunks/run_daemon_rejects_invalid_max_sessions.rs");
 include!("tests/chunks/run_daemon_rejects_invalid_port.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_refuse_compress_rejects_bundled_short_z.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refuse_compress_rejects_bundled_short_z.rs
@@ -1,0 +1,75 @@
+#[test]
+fn run_daemon_refuse_compress_rejects_bundled_short_z() {
+    // upstream: testsuite/daemon-refuse-compress_test.py exercises the post-OK
+    // client-args round-trip. A module with `refuse options = compress` must
+    // reject `rsync -avz`, which is delivered to the daemon as a bundled
+    // server argstr (e.g. `-vlogDtprez.iLsfxCIvu`) where the `z` letter sits
+    // inside the packed short-option run.
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[docs]\npath = {module_path}\nrefuse options = compress\n",
+    )
+    .expect("write config");
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            file.path().as_os_str().to_os_string(),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let expected_greeting = legacy_daemon_greeting();
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, expected_greeting);
+
+    stream
+        .write_all(b"@RSYNCD: 32.0\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream.write_all(b"docs\n").expect("send module request");
+    stream.flush().expect("flush module request");
+
+    line.clear();
+    reader.read_line(&mut line).expect("ok line");
+    assert_eq!(line, "@RSYNCD: OK\n", "Expected OK before client args");
+
+    // Post-OK client argv mirrors upstream's `read_args()` payload for
+    // `rsync -avz src/ user@host::docs/`: protocol 32 uses NUL-terminated
+    // arguments and an empty arg (`\0`) marks end-of-list.
+    // upstream: io.c:1292 - read_args() with use_nulls=1 for protocol >= 30.
+    let args = b"--server\0-vlogDtprez.iLsfxCIvu\0.\0docs/\0\0";
+    stream.write_all(args).expect("send client args");
+    stream.flush().expect("flush client args");
+
+    line.clear();
+    reader.read_line(&mut line).expect("refusal message");
+    assert_eq!(
+        line.trim_end(),
+        "@ERROR: The server is configured to refuse --compress",
+    );
+
+    line.clear();
+    reader.read_line(&mut line).expect("exit message");
+    assert_eq!(line, "@RSYNCD: EXIT\n");
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

- Mirror upstream rsync's `refused_compress` semantics from `options.c`: when a daemon module is configured with `refuse options = compress`, the daemon now also rejects the sibling options that activate compression (`--compress-level`, `--compress-choice`, `--old-compress`, `--new-compress`, and the `--zl` / `--zc` short aliases). `--no-compress` remains permitted because it clears `do_compression`.
- Resolve the alias group inside `is_option_refused` via a small `rule_alias_matches` helper, keeping wildcard, negation, and vital-option handling untouched.
- Extend `refused_client_arg` coverage with unit tests for every alias variant plus a regression chunk test that drives the post-OK `read_args()` round-trip with the bundled `-vlogDtprez.iLsfxCIvu` server argstr that upstream's `daemon-refuse-compress_test.py` exercises.

## Test plan

- [x] `cargo nextest run -p daemon --all-features -E 'test(refused)'` covers exact, alias, negation, wildcard, and bundled-short cases (verified via CI).
- [x] Existing `run_daemon_refuses_disallowed_module_options` continues to assert the `@ERROR: The server is configured to refuse --compress` wire payload.
- [x] New `run_daemon_refuse_compress_rejects_bundled_short_z` integration test drives the full handshake through the post-OK args path with a packed `-z` letter.