### PR TITLE
fix: apply daemon incoming/outgoing chmod specs at transfer time

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -395,6 +395,30 @@ fn build_server_config(
             // is demoted to --super on the wire and never reaches us.
             cfg.fake_super = module.fake_super;
 
+            // upstream: clientserver.c:rsync_module() - the `incoming chmod`
+            // and `outgoing chmod` directives feed `parse_chmod(...)` and the
+            // parsed clauses arm `daemon_chmod_modes`, applied at flist build
+            // time (sender) and at file finalize time (receiver). We delay
+            // parsing to module-use rather than module-load so the operator
+            // sees the @ERROR live; an invalid spec aborts the session with
+            // the same exit semantics as a bad client option.
+            match parse_daemon_chmod_specs(module) {
+                Ok((incoming, outgoing)) => {
+                    cfg.daemon_incoming_chmod = incoming;
+                    cfg.daemon_outgoing_chmod = outgoing;
+                }
+                Err(err) => {
+                    let payload = format!("@ERROR: {err}");
+                    send_error_and_exit(
+                        ctx.reader.get_mut(),
+                        ctx.limiter,
+                        ctx.messages,
+                        &payload,
+                    )?;
+                    return Ok(None);
+                }
+            }
+
             Ok(Some(cfg))
         }
         Err(err) => {
@@ -713,6 +737,77 @@ fn resolve_module_charset_converter(charset: Option<&str>) -> Option<FilenameCon
             );
             None
         }
+    }
+}
+
+/// Parses the module's `incoming chmod` / `outgoing chmod` directives into the
+/// typed [`metadata::ChmodModifiers`] used by the receiver and sender code
+/// paths. Returns a human-readable error message when a spec is malformed so
+/// the caller can wrap it in an `@ERROR` reply.
+///
+/// # Upstream Reference
+///
+/// - `options.c:parse_chmod()` - canonical chmod-spec grammar
+/// - `clientserver.c:rsync_module()` - daemon-side arming of `daemon_chmod_modes`
+fn parse_daemon_chmod_specs(
+    module: &ModuleRuntime,
+) -> Result<
+    (
+        Option<metadata::ChmodModifiers>,
+        Option<metadata::ChmodModifiers>,
+    ),
+    String,
+> {
+    let incoming = parse_one_chmod_spec("incoming chmod", module.incoming_chmod())?;
+    let outgoing = parse_one_chmod_spec("outgoing chmod", module.outgoing_chmod())?;
+    Ok((incoming, outgoing))
+}
+
+fn parse_one_chmod_spec(
+    directive: &'static str,
+    spec: Option<&str>,
+) -> Result<Option<metadata::ChmodModifiers>, String> {
+    match spec {
+        Some(text) => metadata::ChmodModifiers::parse(text)
+            .map(Some)
+            .map_err(|err| format!("invalid '{directive}' directive '{text}': {err}")),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod daemon_chmod_spec_tests {
+    use super::parse_one_chmod_spec;
+
+    #[test]
+    fn parse_one_chmod_spec_returns_none_for_unset_directive() {
+        let result = parse_one_chmod_spec("incoming chmod", None).expect("ok");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_one_chmod_spec_accepts_numeric_class_action_form() {
+        // upstream parse_chmod() accepts bare octal (`644`), prefix-letter
+        // (`F600`), class-action-perms (`u+x`), and combined forms.
+        for spec in ["644", "F600", "u+x", "Du+x,Fg-r,Fo-r"] {
+            let parsed = parse_one_chmod_spec("incoming chmod", Some(spec))
+                .unwrap_or_else(|err| panic!("spec '{spec}' must parse: {err}"));
+            assert!(parsed.is_some(), "spec '{spec}' produced no clauses");
+        }
+    }
+
+    #[test]
+    fn parse_one_chmod_spec_surfaces_directive_name_on_error() {
+        let err = parse_one_chmod_spec("outgoing chmod", Some("bogus"))
+            .expect_err("malformed spec must error");
+        assert!(
+            err.contains("outgoing chmod"),
+            "error '{err}' must name the offending directive",
+        );
+        assert!(
+            err.contains("bogus"),
+            "error '{err}' must include the offending spec text",
+        );
     }
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -758,8 +758,8 @@ fn parse_daemon_chmod_specs(
     ),
     String,
 > {
-    let incoming = parse_one_chmod_spec("incoming chmod", module.incoming_chmod())?;
-    let outgoing = parse_one_chmod_spec("outgoing chmod", module.outgoing_chmod())?;
+    let incoming = parse_one_chmod_spec("incoming chmod", module.incoming_chmod.as_deref())?;
+    let outgoing = parse_one_chmod_spec("outgoing chmod", module.outgoing_chmod.as_deref())?;
     Ok((incoming, outgoing))
 }
 

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -23,6 +23,7 @@ use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
+use metadata::ChmodModifiers;
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
 use protocol::filters::FilterRuleWireFormat;
@@ -86,6 +87,8 @@ pub struct ServerConfigBuilder {
     temp_dir: Option<PathBuf>,
     skip_compress: Option<SkipCompressList>,
     fake_super: bool,
+    daemon_incoming_chmod: Option<ChmodModifiers>,
+    daemon_outgoing_chmod: Option<ChmodModifiers>,
 }
 
 impl Default for ServerConfigBuilder {
@@ -123,6 +126,8 @@ impl ServerConfigBuilder {
             temp_dir: None,
             skip_compress: None,
             fake_super: false,
+            daemon_incoming_chmod: None,
+            daemon_outgoing_chmod: None,
         }
     }
 
@@ -470,6 +475,38 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Sets the parsed `incoming chmod = SPEC` modifiers from the daemon
+    /// module definition.
+    ///
+    /// Push transfers (client to daemon) consult this value during file
+    /// finalization to rewrite the destination mode according to the
+    /// chmod-spec clauses. Pull transfers ignore it.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:rsync_module()` - `parse_chmod(lp_incoming_chmod(i), ...)`
+    /// - `loadparm.c` - `incoming chmod` module parameter
+    pub fn daemon_incoming_chmod(&mut self, modifiers: Option<ChmodModifiers>) -> &mut Self {
+        self.daemon_incoming_chmod = modifiers;
+        self
+    }
+
+    /// Sets the parsed `outgoing chmod = SPEC` modifiers from the daemon
+    /// module definition.
+    ///
+    /// Pull transfers (daemon to client) consult this value when building
+    /// the file list to rewrite the mode emitted on the wire. Push transfers
+    /// ignore it.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:rsync_module()` - `parse_chmod(lp_outgoing_chmod(i), ...)`
+    /// - `loadparm.c` - `outgoing chmod` module parameter
+    pub fn daemon_outgoing_chmod(&mut self, modifiers: Option<ChmodModifiers>) -> &mut Self {
+        self.daemon_outgoing_chmod = modifiers;
+        self
+    }
+
     /// Validates the builder configuration.
     fn validate(&self) -> Result<(), BuilderError> {
         // upstream: options.c:2934 - --inplace and --delay-updates are mutually exclusive
@@ -546,6 +583,8 @@ impl ServerConfigBuilder {
             temp_dir: self.temp_dir.clone(),
             skip_compress: self.skip_compress.clone(),
             fake_super: self.fake_super,
+            daemon_incoming_chmod: self.daemon_incoming_chmod.clone(),
+            daemon_outgoing_chmod: self.daemon_outgoing_chmod.clone(),
         }
     }
 }

--- a/crates/transfer/src/config/builder_tests.rs
+++ b/crates/transfer/src/config/builder_tests.rs
@@ -224,6 +224,48 @@ mod defaults {
             .expect("valid");
         assert!(!disabled.fake_super);
     }
+
+    /// Daemon-side `incoming chmod = SPEC` flows through the builder into
+    /// `ServerConfig.daemon_incoming_chmod` so the receiver-side setup can
+    /// install the chmod modifiers on the per-transfer `MetadataOptions`
+    /// before any on-disk mode is finalized (upstream: `clientserver.c:rsync_module()`
+    /// calls `parse_chmod(lp_incoming_chmod(i), &daemon_chmod_modes)`).
+    #[test]
+    fn daemon_incoming_chmod_round_trips_through_builder() {
+        let modifiers = metadata::ChmodModifiers::parse("F600").expect("parse");
+        let config = ServerConfigBuilder::new()
+            .daemon_incoming_chmod(Some(modifiers.clone()))
+            .build()
+            .expect("valid");
+        assert_eq!(config.daemon_incoming_chmod.as_ref(), Some(&modifiers));
+        assert!(config.daemon_outgoing_chmod.is_none());
+
+        let cleared = ServerConfigBuilder::new()
+            .daemon_incoming_chmod(None)
+            .build()
+            .expect("valid");
+        assert!(cleared.daemon_incoming_chmod.is_none());
+    }
+
+    /// Symmetric test for `outgoing chmod = SPEC`: the sender consults this
+    /// value when populating each `FileEntry` mode in `create_entry`, mirroring
+    /// upstream's `daemon_chmod_modes` application in `flist.c:make_file()`.
+    #[test]
+    fn daemon_outgoing_chmod_round_trips_through_builder() {
+        let modifiers = metadata::ChmodModifiers::parse("Fg-r,Fo-r").expect("parse");
+        let config = ServerConfigBuilder::new()
+            .daemon_outgoing_chmod(Some(modifiers.clone()))
+            .build()
+            .expect("valid");
+        assert_eq!(config.daemon_outgoing_chmod.as_ref(), Some(&modifiers));
+        assert!(config.daemon_incoming_chmod.is_none());
+
+        let cleared = ServerConfigBuilder::new()
+            .daemon_outgoing_chmod(None)
+            .build()
+            .expect("valid");
+        assert!(cleared.daemon_outgoing_chmod.is_none());
+    }
 }
 
 mod validation {

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -11,6 +11,7 @@ use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
+use metadata::ChmodModifiers;
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
 use protocol::filters::FilterRuleWireFormat;
@@ -420,6 +421,38 @@ pub struct ServerConfig {
     /// - `loadparm.c` - `fake super` module parameter
     /// - `rsync.c:set_file_attrs()` - fake-super stores ownership in xattrs
     pub fake_super: bool,
+    /// Daemon module `incoming chmod` modifiers applied to received files.
+    ///
+    /// Parsed from the module's `incoming chmod = SPEC` directive in
+    /// `rsyncd.conf`. When set, the receiver rewrites the destination mode
+    /// according to the chmod-spec clauses before finalising on-disk
+    /// permissions. Push transfers (client to daemon) consult this value;
+    /// pull transfers ignore it.
+    ///
+    /// Daemon-config-driven; never populated from a client `--chmod` flag.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:rsync_module()` - `parse_chmod(lp_xxx_chmod(i), &daemon_chmod_modes)`
+    /// - `loadparm.c` - `incoming chmod` module parameter
+    /// - `generator.c` / `receiver.c` - `daemon_chmod_modes` applied to incoming entries
+    pub daemon_incoming_chmod: Option<ChmodModifiers>,
+    /// Daemon module `outgoing chmod` modifiers applied to sent files.
+    ///
+    /// Parsed from the module's `outgoing chmod = SPEC` directive in
+    /// `rsyncd.conf`. When set, the sender rewrites the mode emitted on the
+    /// wire for each file list entry according to the chmod-spec clauses.
+    /// Pull transfers (daemon to client) consult this value; push transfers
+    /// ignore it.
+    ///
+    /// Daemon-config-driven; never populated from a client `--chmod` flag.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `clientserver.c:rsync_module()` - `parse_chmod(lp_xxx_chmod(i), &daemon_chmod_modes)`
+    /// - `loadparm.c` - `outgoing chmod` module parameter
+    /// - `flist.c:make_file()` - `daemon_chmod_modes` applied during flist build
+    pub daemon_outgoing_chmod: Option<ChmodModifiers>,
 }
 
 impl Default for ServerConfig {
@@ -449,6 +482,8 @@ impl Default for ServerConfig {
             temp_dir: None,
             skip_compress: None,
             fake_super: false,
+            daemon_incoming_chmod: None,
+            daemon_outgoing_chmod: None,
         }
     }
 }

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -244,6 +244,18 @@ impl GeneratorContext {
             }
         }
 
+        // upstream: clientserver.c:rsync_module() arms `daemon_chmod_modes`
+        // and flist.c:make_file() applies it as the file_struct is built so
+        // the wire-emitted mode reflects the daemon's `outgoing chmod = SPEC`
+        // directive. We mirror that ordering: rewrite the entry's mode after
+        // every other flist field has been populated but before the caller
+        // serialises it. The chmod parser preserves the file-type bits, so
+        // the entry's S_IFREG/S_IFDIR/etc. classification is untouched.
+        if let Some(modifiers) = self.config.daemon_outgoing_chmod.as_ref() {
+            let rewritten = modifiers.apply(entry.mode(), file_type);
+            entry.set_mode(rewritten);
+        }
+
         Ok(entry)
     }
 
@@ -635,5 +647,91 @@ mod fake_super_round_trip_tests {
             rdev: None,
         };
         assert_eq!(stat.encode(), "100644 0,0 1234:5678");
+    }
+}
+
+#[cfg(all(test, unix))]
+mod daemon_outgoing_chmod_tests {
+    //! Daemon `outgoing chmod = SPEC` regression: the sender must rewrite the
+    //! wire-emitted mode for each file list entry when the daemon module has
+    //! an `outgoing chmod` directive configured. Mirrors upstream
+    //! `clientserver.c:rsync_module()` arming `daemon_chmod_modes` and
+    //! `flist.c:make_file()` applying them as file_struct values are built.
+
+    use super::super::super::GeneratorContext;
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use ::metadata::ChmodModifiers;
+    use protocol::ProtocolVersion;
+    use std::ffi::OsString;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_generator(outgoing_chmod: Option<ChmodModifiers>) -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let mut config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            daemon_outgoing_chmod: outgoing_chmod,
+            ..Default::default()
+        };
+        config.flags.numeric_ids = true;
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// `outgoing chmod = Fg-r` must clear the group-read bit on the wire-emitted
+    /// mode for every file entry the sender constructs. The on-disk source
+    /// retains its original permissions; only the file list entry is rewritten.
+    #[test]
+    fn outgoing_chmod_clears_group_read_bit_on_wire() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("source.txt");
+        std::fs::write(&path, b"payload").expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o664))
+            .expect("set source perms");
+
+        let modifiers = ChmodModifiers::parse("Fg-r").expect("parse chmod spec");
+        let ctx = make_generator(Some(modifiers));
+        let meta = std::fs::symlink_metadata(&path).expect("metadata");
+        let entry = ctx
+            .create_entry(&path, PathBuf::from("source.txt"), &meta)
+            .expect("create_entry");
+
+        // Group-read (0o040) must be cleared; other bits left intact.
+        let perms = entry.permissions() & 0o7777;
+        assert_eq!(perms & 0o040, 0, "group-read must be cleared on wire");
+        assert_eq!(perms, 0o624, "Fg-r rewrites 0o664 to 0o624");
+    }
+
+    /// When no `outgoing chmod` is configured, `create_entry` must emit the
+    /// on-disk mode verbatim - no rewrite, no silent default.
+    #[test]
+    fn no_outgoing_chmod_leaves_mode_untouched() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("source.txt");
+        std::fs::write(&path, b"payload").expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o664))
+            .expect("set source perms");
+
+        let ctx = make_generator(None);
+        let meta = std::fs::symlink_metadata(&path).expect("metadata");
+        let entry = ctx
+            .create_entry(&path, PathBuf::from("source.txt"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.permissions() & 0o7777, 0o664);
     }
 }

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -505,11 +505,9 @@ mod daemon_incoming_chmod_tests {
         fs::write(&source, b"payload").expect("write source");
         fs::write(&dest, b"payload").expect("write dest");
         // Source-side mode the sender would have advertised on the wire.
-        fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
-            .expect("set source perms");
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("set source perms");
         // Existing dest mode the receiver overwrites.
-        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600))
-            .expect("set dest perms");
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600)).expect("set dest perms");
 
         let source_meta = fs::metadata(&source).expect("source metadata");
         let modifiers = ChmodModifiers::parse("F600").expect("parse chmod spec");
@@ -518,7 +516,10 @@ mod daemon_incoming_chmod_tests {
         apply_file_metadata_with_options(&dest, &source_meta, &opts)
             .expect("apply daemon incoming chmod");
 
-        let mode = fs::metadata(&dest).expect("dest metadata").permissions().mode();
+        let mode = fs::metadata(&dest)
+            .expect("dest metadata")
+            .permissions()
+            .mode();
         assert_eq!(
             mode & 0o7777,
             0o600,
@@ -535,10 +536,8 @@ mod daemon_incoming_chmod_tests {
         let dest = tmp.path().join("dest.bin");
         fs::write(&source, b"payload").expect("write source");
         fs::write(&dest, b"payload").expect("write dest");
-        fs::set_permissions(&source, fs::Permissions::from_mode(0o640))
-            .expect("set source perms");
-        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600))
-            .expect("set dest perms");
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o640)).expect("set source perms");
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600)).expect("set dest perms");
 
         let source_meta = fs::metadata(&source).expect("source metadata");
         let opts = receiver_metadata_opts(None);
@@ -546,7 +545,10 @@ mod daemon_incoming_chmod_tests {
         apply_file_metadata_with_options(&dest, &source_meta, &opts)
             .expect("apply metadata without chmod");
 
-        let mode = fs::metadata(&dest).expect("dest metadata").permissions().mode();
+        let mode = fs::metadata(&dest)
+            .expect("dest metadata")
+            .permissions()
+            .mode();
         assert_eq!(mode & 0o7777, 0o640);
     }
 }

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -144,7 +144,14 @@ impl ReceiverContext {
             // daemon module forces fake-super metadata storage on the receiver
             // (ownership and special-file metadata go to user.rsync.%stat
             // xattrs instead of being applied to inodes).
-            .fake_super(self.config.fake_super);
+            .fake_super(self.config.fake_super)
+            // upstream: clientserver.c:rsync_module() + generator.c -
+            // `daemon_chmod_modes` rewrites the destination mode at finalize
+            // time. The parser ran at module-load and stored a parsed
+            // `ChmodModifiers`; we hand it to MetadataOptions so the existing
+            // chmod-application site in `apply_permissions_with_chmod`
+            // performs the rewrite without a separate code path.
+            .with_chmod(self.config.daemon_incoming_chmod.clone());
 
         let dest_dir = self
             .config
@@ -458,5 +465,88 @@ mod symlink_race_tests {
         let result = open_sandbox_for_dest_strict(&missing, true)
             .expect("ENOENT must be a soft failure - first-run push will mkdir later");
         assert!(result.is_none());
+    }
+}
+
+#[cfg(all(test, unix))]
+mod daemon_incoming_chmod_tests {
+    //! Daemon `incoming chmod = SPEC` regression: the receiver must apply the
+    //! daemon module's chmod modifiers on top of the destination mode before
+    //! the on-disk permissions are finalized. Mirrors upstream
+    //! `clientserver.c:rsync_module()` arming `daemon_chmod_modes` and
+    //! `receiver.c` invoking it via `set_file_attrs()` at finalize time.
+
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use ::metadata::{ChmodModifiers, MetadataOptions, apply_file_metadata_with_options};
+
+    /// Builds the same `MetadataOptions` chain the receiver-side
+    /// `setup_transfer` produces (perms + chmod modifiers + fake_super) for a
+    /// daemon-config-driven `incoming chmod`. This is the receiver's runtime
+    /// contract: the chmod modifiers must be installed via
+    /// `MetadataOptions::with_chmod` so the existing apply path rewrites the
+    /// destination mode at finalize time.
+    fn receiver_metadata_opts(chmod: Option<ChmodModifiers>) -> MetadataOptions {
+        MetadataOptions::new()
+            .preserve_permissions(true)
+            .preserve_times(false)
+            .with_chmod(chmod)
+    }
+
+    /// `incoming chmod = F600` forces every received regular file to land on
+    /// disk with mode 0o600 regardless of the source's mode bits, matching
+    /// upstream's `daemon_chmod_modes` semantics for push transfers.
+    #[test]
+    fn incoming_chmod_f600_rewrites_dest_to_0600() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let source = tmp.path().join("source.bin");
+        let dest = tmp.path().join("dest.bin");
+        fs::write(&source, b"payload").expect("write source");
+        fs::write(&dest, b"payload").expect("write dest");
+        // Source-side mode the sender would have advertised on the wire.
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o644))
+            .expect("set source perms");
+        // Existing dest mode the receiver overwrites.
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600))
+            .expect("set dest perms");
+
+        let source_meta = fs::metadata(&source).expect("source metadata");
+        let modifiers = ChmodModifiers::parse("F600").expect("parse chmod spec");
+        let opts = receiver_metadata_opts(Some(modifiers));
+
+        apply_file_metadata_with_options(&dest, &source_meta, &opts)
+            .expect("apply daemon incoming chmod");
+
+        let mode = fs::metadata(&dest).expect("dest metadata").permissions().mode();
+        assert_eq!(
+            mode & 0o7777,
+            0o600,
+            "incoming chmod = F600 must force destination mode to 0o600",
+        );
+    }
+
+    /// Without an `incoming chmod` directive the receiver preserves the
+    /// source mode exactly - no silent rewrite, no default fall-through.
+    #[test]
+    fn no_incoming_chmod_preserves_source_mode() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let source = tmp.path().join("source.bin");
+        let dest = tmp.path().join("dest.bin");
+        fs::write(&source, b"payload").expect("write source");
+        fs::write(&dest, b"payload").expect("write dest");
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o640))
+            .expect("set source perms");
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o600))
+            .expect("set dest perms");
+
+        let source_meta = fs::metadata(&source).expect("source metadata");
+        let opts = receiver_metadata_opts(None);
+
+        apply_file_metadata_with_options(&dest, &source_meta, &opts)
+            .expect("apply metadata without chmod");
+
+        let mode = fs::metadata(&dest).expect("dest metadata").permissions().mode();
+        assert_eq!(mode & 0o7777, 0o640);
     }
 }


### PR DESCRIPTION
## Summary

The daemon parser stored `incoming chmod = SPEC` and `outgoing chmod = SPEC` as raw strings on `ModuleDefinition` but never converted them into mode-bit rewrites at transfer time. Push transfers silently ignored `incoming chmod`, and pull transfers silently ignored `outgoing chmod`, so the upstream `daemon-filter_test.py` regression for these directives was a no-op.

This change parses both directives into `metadata::ChmodModifiers` via the existing client-side `--chmod` parser at module-use time, then plumbs the parsed clauses through `ServerConfig` to the canonical mode-finalize sites in each direction:

- **Receiver (push direction).** `setup_transfer` now installs `daemon_incoming_chmod` on the per-file `MetadataOptions` via `with_chmod`, so the existing `apply_permissions_with_chmod` site rewrites the destination mode at file-finalize time. Mirrors upstream `rsync.c:set_file_attrs()` consulting `daemon_chmod_modes`.
- **Sender (pull direction).** `GeneratorContext::create_entry` rewrites the entry's mode via `ChmodModifiers::apply` after every other flist field is populated but before the caller serializes the entry. Mirrors upstream `flist.c:make_file()` applying `daemon_chmod_modes` to the wire-emitted `file_struct`.

Invalid specs surface as `@ERROR: invalid 'incoming chmod' directive ...` during module setup, matching the upstream semantics of aborting a session on a malformed chmod argument.

The chmod-spec parser (`metadata::ChmodModifiers::parse`) was already vetted for the client-side `--chmod` flag and accepts every form upstream's `parse_chmod()` accepts: bare octal (`644`), prefix-letter (`F600`), class-action-perms (`u+x`), and combined (`Du+x,Fg-r,Fo-r`).

### Audit findings

- Parser at `crates/daemon/src/daemon/sections/config_parsing/module_directives.rs:195-220` stored `incoming chmod` / `outgoing chmod` as `Option<String>` on `ModuleDefinition` and never converted them to mode bits.
- Existing client-side chmod-spec parser at `crates/metadata/src/chmod/{mod,parse,apply,spec}.rs` was the natural reuse target; no new grammar code needed.
- Receiver mode-finalize site: `crates/transfer/src/receiver/transfer/setup.rs:135-154` (the `MetadataOptions` builder) routes into `crates/metadata/src/apply/permissions.rs:142-192` (`apply_permissions_with_chmod`).
- Sender mode-emission site: `crates/transfer/src/generator/file_list/entry.rs:53-110` (the `FileEntry` construction switch); a single `set_mode` rewrite after every other field is populated covers all file types uniformly.

### Wire-up

- `ServerConfig` (`crates/transfer/src/config/mod.rs:421-451`): two new optional `ChmodModifiers` fields.
- `ServerConfigBuilder` (`crates/transfer/src/config/builder.rs:468-505`): matching `daemon_incoming_chmod` / `daemon_outgoing_chmod` setters.
- Daemon module setup (`crates/daemon/src/daemon/sections/module_access/client_args.rs:292-314`): parse strings on session entry, abort with `@ERROR` on invalid spec.
- Receiver wire-up (`crates/transfer/src/receiver/transfer/setup.rs:148-154`): `MetadataOptions::with_chmod`.
- Sender wire-up (`crates/transfer/src/generator/file_list/entry.rs:247-258`): `set_mode` rewrite at the end of `create_entry`.

### Regression coverage

- `crates/transfer/src/receiver/transfer/setup.rs` daemon_incoming_chmod_tests: end-to-end filesystem test - `incoming chmod = F600` rewrites a `0o644` source into a `0o600` destination on disk; absence of the directive preserves the source mode verbatim.
- `crates/transfer/src/generator/file_list/entry.rs` daemon_outgoing_chmod_tests: end-to-end wire-emission test - `outgoing chmod = Fg-r` clears the group-read bit on the `FileEntry` mode (`0o664` -> `0o624`); absence of the directive emits the on-disk mode untouched.
- `crates/transfer/src/config/builder_tests.rs`: builder round-trip tests for both new fields.
- `crates/daemon/src/daemon/sections/module_access/client_args.rs` daemon_chmod_spec_tests: parser tests for None passthrough, all four upstream spec forms, and error-message provenance.

### Cross-platform

`ChmodModifiers::apply` and `apply_permissions_with_chmod` already short-circuit to no-op on non-Unix. No additional `#[cfg]` gates needed; the `incoming chmod` path naturally becomes a no-op on Windows, matching upstream's behavior where `daemon_chmod_modes` is filtered through POSIX-only mode bits.

## Test plan

- [ ] `cargo nextest run -p transfer --all-features -E 'test(daemon_incoming_chmod)'` passes
- [ ] `cargo nextest run -p transfer --all-features -E 'test(daemon_outgoing_chmod)'` passes
- [ ] `cargo nextest run -p transfer --all-features -E 'test(builder)'` passes (new builder round-trip tests)
- [ ] `cargo nextest run -p daemon --all-features -E 'test(daemon_chmod_spec)'` passes
- [ ] Full CI matrix (fmt+clippy, nextest stable Linux, Windows, macOS, Linux musl) green
- [ ] Upstream `daemon-filter_test.py` `incoming chmod` / `outgoing chmod` cases pass against the new daemon binary

## Upstream references

- `options.c::parse_chmod()` - canonical chmod-spec parser
- `clientserver.c::rsync_module()` - daemon-side arming of `daemon_chmod_modes` via `parse_chmod(lp_xxx_chmod(i), ...)`
- `flist.c::make_file()` - sender applies `daemon_chmod_modes` while building wire `file_struct`
- `rsync.c::set_file_attrs()` - receiver consults `daemon_chmod_modes` at file finalize time