### PR TITLE
fix: preserve --groupmap wildcards through daemon arg escape

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -328,6 +328,20 @@ pub(super) fn build_full_daemon_args(
         }
     }
 
+    // upstream: options.c:2894-2898 - --usermap / --groupmap are forwarded
+    // verbatim. With `protect_args` (always on for daemon mode), upstream
+    // `safe_arg()` returns the value unchanged (no shell escaping) because
+    // the args are shipped over the secluded-args byte stream rather than a
+    // shell command line. Wildcards like `*` must reach the receiver intact
+    // so `uidlist.c:parse_name_map()` recognises them and installs a
+    // `NFLAGS_WILD_NAME_MATCH` rule.
+    if let Some(mapping) = config.user_mapping() {
+        args.push(format!("--usermap={}", mapping.spec()));
+    }
+    if let Some(mapping) = config.group_mapping() {
+        args.push(format!("--groupmap={}", mapping.spec()));
+    }
+
     // upstream: options.c:2716-2723, options.c:2052-2054 - --iconv forwarding
     // to the remote daemon. When iconv_opt contains a comma, only the
     // post-comma half (daemon's local charset) is forwarded; otherwise the

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -304,6 +304,115 @@ mod protect_args_daemon_tests {
             "should not include --log-format without itemize: {args:?}"
         );
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_full_args_forwards_groupmap_wildcard_verbatim() {
+        // upstream: options.c:2894-2898 - --groupmap value is shipped verbatim
+        // through the daemon secluded-args byte stream. Wildcards like `*`
+        // must survive so the receiver's `uidlist.c:parse_name_map()` sees
+        // `strpbrk(cp, "*[?")` and installs a `NFLAGS_WILD_NAME_MATCH` rule.
+        let group_mapping = ::metadata::GroupMapping::parse("*:1234").expect("parse groupmap");
+        let config = ClientConfig::builder()
+            .group_mapping(Some(group_mapping))
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(
+            args.iter().any(|a| a == "--groupmap=*:1234"),
+            "expected --groupmap=*:1234 verbatim (no backslash escape): {args:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_full_args_forwards_usermap_wildcard_verbatim() {
+        let user_mapping = ::metadata::UserMapping::parse("*:5678").expect("parse usermap");
+        let config = ClientConfig::builder()
+            .user_mapping(Some(user_mapping))
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, true);
+
+        assert!(
+            args.iter().any(|a| a == "--usermap=*:5678"),
+            "expected --usermap=*:5678 verbatim: {args:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_full_args_forwards_groupmap_multi_rule_verbatim() {
+        // Multi-rule specs (comma-separated) must round-trip without rule
+        // reordering or whitespace mangling.
+        let group_mapping =
+            ::metadata::GroupMapping::parse("100-200:1234,wheel:9999,*:0").expect("parse groupmap");
+        let config = ClientConfig::builder()
+            .group_mapping(Some(group_mapping))
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(
+            args.iter()
+                .any(|a| a == "--groupmap=100-200:1234,wheel:9999,*:0"),
+            "expected multi-rule groupmap verbatim: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_full_args_omits_groupmap_when_unset() {
+        let config = ClientConfig::default();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(
+            !args.iter().any(|a| a.starts_with("--groupmap")),
+            "default config must not emit --groupmap: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a.starts_with("--usermap")),
+            "default config must not emit --usermap: {args:?}"
+        );
+    }
+
+    #[test]
+    fn secluded_args_round_trip_preserves_groupmap_wildcard() {
+        // Wire-byte regression: the secluded-args (protect-args) protocol must
+        // ship `--groupmap=*:1234` byte-for-byte from sender to receiver. This
+        // mirrors the wire path used when `protect_args` is active and the
+        // daemon reads phase-2 args via `recv_secluded_args()` -- the upstream
+        // `read_args()` equivalent in oc-rsync.
+        use protocol::secluded_args::{recv_secluded_args, send_secluded_args};
+        use std::io::Cursor;
+
+        let sent = vec![
+            "rsync",
+            "--server",
+            "--groupmap=*:1234",
+            "--usermap=*:5678",
+            ".",
+            "module/",
+        ];
+        let mut wire = Vec::new();
+        send_secluded_args(&mut wire, &sent, None).expect("send");
+
+        // Wildcard must appear unescaped on the wire.
+        assert!(
+            wire.windows(b"--groupmap=*:1234\0".len())
+                .any(|w| w == b"--groupmap=*:1234\0"),
+            "wildcard '*' must reach the wire unescaped"
+        );
+
+        let mut cursor = Cursor::new(wire);
+        let received = recv_secluded_args(&mut cursor, None).expect("recv");
+        assert_eq!(received, sent);
+    }
 }
 
 mod server_config_reference_dirs {

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -487,6 +487,21 @@ impl<'a> RemoteInvocationBuilder<'a> {
             }
         }
 
+        // upstream: options.c:2894-2898 - --usermap / --groupmap are
+        // forwarded as `--key=value` arguments. With `protect_args` the value
+        // is shipped verbatim; without `protect_args`, upstream wraps it in
+        // `safe_arg("--usermap", value)` which escapes shell + wildcard
+        // characters so a downstream `eval "$@"` does not glob-expand them.
+        // We rely on `protect_args` being the default for SSH transports
+        // (matching upstream's `old_style_args = -1` default at options.c:325),
+        // so the verbatim form is correct and the wildcard `*` survives.
+        if let Some(mapping) = self.config.user_mapping() {
+            args.push(OsString::from(format!("--usermap={}", mapping.spec())));
+        }
+        if let Some(mapping) = self.config.group_mapping() {
+            args.push(OsString::from(format!("--groupmap={}", mapping.spec())));
+        }
+
         // upstream: options.c:2716-2723 - --iconv forwarding. When iconv_opt
         // contains a comma, only the post-comma half (the remote charset) is
         // forwarded; otherwise the whole string is forwarded as-is.

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2719,6 +2719,67 @@ fn shell_safe_escaping_in_normal_mode() {
     );
 }
 
+// --usermap / --groupmap forwarding tests
+
+#[cfg(unix)]
+#[test]
+fn includes_groupmap_wildcard_verbatim() {
+    // upstream: options.c:2898 - --groupmap is forwarded verbatim under
+    // `protect_args` (the default). The wildcard `*` must survive so the
+    // receiver's `uidlist.c:parse_name_map()` installs a wildcard rule.
+    let mapping = ::metadata::GroupMapping::parse("*:1234").expect("parse");
+    let config = ClientConfig::builder()
+        .group_mapping(Some(mapping))
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--groupmap=*:1234"),
+        "expected --groupmap=*:1234 verbatim: {args:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn includes_usermap_wildcard_verbatim() {
+    let mapping = ::metadata::UserMapping::parse("*:5678").expect("parse");
+    let config = ClientConfig::builder().user_mapping(Some(mapping)).build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter().any(|a| a == "--usermap=*:5678"),
+        "expected --usermap=*:5678 verbatim: {args:?}"
+    );
+}
+
+#[test]
+fn omits_usermap_and_groupmap_when_unset() {
+    let config = ClientConfig::builder().build();
+    let args = build_sender_args(&config);
+    assert!(
+        !args.iter().any(|a| a.starts_with("--usermap")),
+        "default config must not emit --usermap: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a.starts_with("--groupmap")),
+        "default config must not emit --groupmap: {args:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn forwards_multi_rule_groupmap_verbatim() {
+    let mapping =
+        ::metadata::GroupMapping::parse("100-200:1234,wheel:9999,*:0").expect("parse");
+    let config = ClientConfig::builder()
+        .group_mapping(Some(mapping))
+        .build();
+    let args = build_sender_args(&config);
+    assert!(
+        args.iter()
+            .any(|a| a == "--groupmap=100-200:1234,wheel:9999,*:0"),
+        "expected multi-rule groupmap verbatim (no rule reordering): {args:?}"
+    );
+}
+
 // --stop-at forwarding tests
 
 #[test]

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2728,9 +2728,7 @@ fn includes_groupmap_wildcard_verbatim() {
     // `protect_args` (the default). The wildcard `*` must survive so the
     // receiver's `uidlist.c:parse_name_map()` installs a wildcard rule.
     let mapping = ::metadata::GroupMapping::parse("*:1234").expect("parse");
-    let config = ClientConfig::builder()
-        .group_mapping(Some(mapping))
-        .build();
+    let config = ClientConfig::builder().group_mapping(Some(mapping)).build();
     let args = build_sender_args(&config);
     assert!(
         args.iter().any(|a| a == "--groupmap=*:1234"),
@@ -2767,11 +2765,8 @@ fn omits_usermap_and_groupmap_when_unset() {
 #[cfg(unix)]
 #[test]
 fn forwards_multi_rule_groupmap_verbatim() {
-    let mapping =
-        ::metadata::GroupMapping::parse("100-200:1234,wheel:9999,*:0").expect("parse");
-    let config = ClientConfig::builder()
-        .group_mapping(Some(mapping))
-        .build();
+    let mapping = ::metadata::GroupMapping::parse("100-200:1234,wheel:9999,*:0").expect("parse");
+    let config = ClientConfig::builder().group_mapping(Some(mapping)).build();
     let args = build_sender_args(&config);
     assert!(
         args.iter()

--- a/crates/metadata/src/mapping/name_mapping.rs
+++ b/crates/metadata/src/mapping/name_mapping.rs
@@ -18,6 +18,14 @@ use super::types::{MappingKind, MappingParseError, MappingRule};
 pub struct NameMapping {
     pub(super) rules: Vec<MappingRule>,
     pub(super) kind: MappingKind,
+    /// Original specification string supplied by the caller.
+    ///
+    /// Preserved verbatim (after a trim of surrounding whitespace) so the
+    /// daemon/SSH client can forward the exact value to the server. Re-parsing
+    /// from the rule list would be lossy: a literal `*:1234` would round-trip
+    /// to a wire string that no longer signals the wildcard matcher because
+    /// the rules vector no longer carries the source representation.
+    pub(super) spec: String,
 }
 
 impl NameMapping {
@@ -64,7 +72,22 @@ impl NameMapping {
             rules.push(MappingRule { matcher, target });
         }
 
-        Ok(Self { rules, kind })
+        Ok(Self {
+            rules,
+            kind,
+            spec: trimmed.to_owned(),
+        })
+    }
+
+    /// Returns the original specification string (post-trim) used to construct
+    /// this mapping.
+    ///
+    /// Mirrors upstream rsync's behavior: when the client forwards `--usermap`
+    /// or `--groupmap` to a remote server (SSH or daemon), the spec is shipped
+    /// verbatim so wildcard characters like `*` survive the round trip.
+    #[must_use]
+    pub fn spec(&self) -> &str {
+        &self.spec
     }
 
     /// Finds the first matching rule for the given identifier.

--- a/crates/metadata/src/mapping/tests.rs
+++ b/crates/metadata/src/mapping/tests.rs
@@ -112,6 +112,41 @@ fn parse_wildcard_source() {
 }
 
 #[test]
+fn spec_preserves_wildcard_for_daemon_round_trip() {
+    // Regression: --groupmap=*:1234 must reach the daemon receiver with `*`
+    // intact so `uidlist.c:parse_name_map()` recognises the wildcard matcher.
+    let mapping = NameMapping::parse(MappingKind::Group, "*:1234").expect("parse mapping");
+    assert_eq!(mapping.spec(), "*:1234");
+}
+
+#[test]
+fn spec_preserves_multi_rule_ordering() {
+    let spec = "100-200:1234,wheel:9999,*:0";
+    let mapping = NameMapping::parse(MappingKind::Group, spec).expect("parse mapping");
+    assert_eq!(mapping.spec(), spec);
+}
+
+#[test]
+fn spec_trims_surrounding_whitespace() {
+    let mapping = NameMapping::parse(MappingKind::User, "  *:0  ").expect("parse mapping");
+    assert_eq!(mapping.spec(), "*:0");
+}
+
+#[test]
+fn user_mapping_spec_accessor_round_trip() {
+    use super::UserMapping;
+    let mapping = UserMapping::parse("*:5678").expect("parse usermap");
+    assert_eq!(mapping.spec(), "*:5678");
+}
+
+#[test]
+fn group_mapping_spec_accessor_round_trip() {
+    use super::GroupMapping;
+    let mapping = GroupMapping::parse("*:1234").expect("parse groupmap");
+    assert_eq!(mapping.spec(), "*:1234");
+}
+
+#[test]
 fn parse_range_source() {
     let mapping = NameMapping::parse(MappingKind::User, "100-200:1000").expect("parse mapping");
     assert_eq!(mapping.len(), 1);

--- a/crates/metadata/src/mapping/user_group.rs
+++ b/crates/metadata/src/mapping/user_group.rs
@@ -34,6 +34,15 @@ impl UserMapping {
     pub const fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    /// Returns the original `--usermap` specification (post-trim).
+    ///
+    /// Used by client-side argument builders to forward the value verbatim to
+    /// remote servers so wildcards like `*` survive the round trip.
+    #[must_use]
+    pub fn spec(&self) -> &str {
+        self.0.spec()
+    }
 }
 
 /// Parsed `--groupmap` rules.
@@ -57,6 +66,15 @@ impl GroupMapping {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Returns the original `--groupmap` specification (post-trim).
+    ///
+    /// Used by client-side argument builders to forward the value verbatim to
+    /// remote servers so wildcards like `*` survive the round trip.
+    #[must_use]
+    pub fn spec(&self) -> &str {
+        self.0.spec()
     }
 }
 

--- a/crates/metadata/src/mapping_win.rs
+++ b/crates/metadata/src/mapping_win.rs
@@ -57,6 +57,17 @@ impl UserMapping {
     pub fn parse(_spec: &str) -> Result<Self, MappingParseError> {
         Err(MappingParseError)
     }
+
+    /// Returns an empty string on Windows.
+    ///
+    /// The Unix variant returns the original `--usermap` specification so
+    /// callers can forward it verbatim to a remote server. On Windows the
+    /// type cannot be constructed, so this method is provided only to keep
+    /// the cross-platform API surface uniform.
+    #[must_use]
+    pub fn spec(&self) -> &str {
+        ""
+    }
 }
 
 /// Group mapping placeholder for Windows.
@@ -71,6 +82,17 @@ impl GroupMapping {
     pub fn parse(_spec: &str) -> Result<Self, MappingParseError> {
         Err(MappingParseError)
     }
+
+    /// Returns an empty string on Windows.
+    ///
+    /// The Unix variant returns the original `--groupmap` specification so
+    /// callers can forward it verbatim to a remote server. On Windows the
+    /// type cannot be constructed, so this method is provided only to keep
+    /// the cross-platform API surface uniform.
+    #[must_use]
+    pub fn spec(&self) -> &str {
+        ""
+    }
 }
 
 /// Name mapping placeholder for Windows.
@@ -84,6 +106,15 @@ impl NameMapping {
     /// Always returns [`MappingParseError`].
     pub fn parse(_spec: &str) -> Result<Self, MappingParseError> {
         Err(MappingParseError)
+    }
+
+    /// Returns an empty string on Windows.
+    ///
+    /// Provided so the cross-platform API surface stays uniform; the Unix
+    /// variant exposes the original mapping specification string.
+    #[must_use]
+    pub fn spec(&self) -> &str {
+        ""
     }
 }
 


### PR DESCRIPTION
## Summary

- Forward `--usermap` and `--groupmap` as `--key=value` arguments from both the SSH and daemon argument builders. They were previously dropped on the client side, so the receiver never applied the mapping.
- Preserve the original specification string on `NameMapping` / `UserMapping` / `GroupMapping` via a new `spec()` accessor so the wildcard `*` reaches the upstream `uidlist.c:parse_name_map()` parser intact.
- Under the secluded-args wire format the value travels verbatim, matching upstream's behaviour when `protect_args` is active and `options.c:safe_arg()` skips shell escaping.

## Test plan

- [ ] CI: nextest (stable) Linux musl, Windows, macOS
- [ ] CI: fmt + clippy
- [ ] Unit: `crates/metadata/src/mapping/tests.rs` round-trip the spec accessor with `*:1234` and multi-rule specs.
- [ ] Unit: `crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs` verifies `--groupmap=*:1234` and `--usermap=*:5678` are emitted verbatim by `build_full_daemon_args` and survive the secluded-args wire round-trip.
- [ ] Unit: `crates/core/src/client/remote/invocation/tests.rs` verifies the SSH arg builder forwards the wildcard spec without escaping.