### PR TITLE
test: cover daemon runtime serving path = / without chroot

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -201,6 +201,7 @@ include!("tests/chunks/run_daemon_rejects_invalid_port.rs");
 include!("tests/chunks/run_daemon_rejects_unknown_argument.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_read_only_module.rs");
 include!("tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs");
+include!("tests/chunks/run_daemon_serves_module_with_root_path_no_chroot.rs");
 include!("tests/chunks/daemon_pre_xfer_exec_rejects_on_nonzero_exit.rs");
 include!("tests/chunks/run_daemon_requests_authentication_for_protected_module.rs");
 include!("tests/chunks/run_daemon_auth_failure_rejects_wrong_credentials.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_serves_module_with_root_path_no_chroot.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_serves_module_with_root_path_no_chroot.rs
@@ -1,0 +1,60 @@
+/// Daemon must accept and serve a module configured with `path = /` and
+/// `use chroot = no` end-to-end (UTS-12 daemon-path-root-read scenario).
+///
+/// Upstream `loadparm.c` (P_PATH) preserves the bare slash and
+/// `clientserver.c` serves it directly when `use chroot = no`. The unit
+/// tests in `module_definition` and `config_parsing` cover the validator
+/// gate; this exercise wires the runtime path: the daemon must start with
+/// the config, advertise the module on `#list`, and emit `@RSYNCD: EXIT`
+/// without falling over inside the connection handler.
+#[test]
+#[cfg(unix)]
+fn run_daemon_serves_module_with_root_path_no_chroot() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let dir = tempdir().expect("temp dir");
+    let config_path = dir.path().join("root.conf");
+    fs::write(
+        &config_path,
+        "[root]\npath = /\nuse chroot = no\nread only = yes\n",
+    )
+    .expect("write config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let inline_config = format!("--config={}", config_path.display());
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from(inline_config),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let expected_greeting = legacy_daemon_greeting();
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, expected_greeting);
+
+    stream.write_all(b"#list\n").expect("send list request");
+    stream.flush().expect("flush list request");
+
+    line.clear();
+    reader.read_line(&mut line).expect("module listing");
+    assert_eq!(line, "root           \t\n");
+
+    line.clear();
+    reader.read_line(&mut line).expect("exit line");
+    assert_eq!(line, "@RSYNCD: EXIT\n");
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

- Adds an end-to-end daemon integration test for the UTS-12
  `daemon-path-root-read` scenario: a module configured with
  `path = /`, `use chroot = no`, `read only = yes` must accept a
  `#list` request and advertise the module without the connection
  handler tripping over the bare-slash path.
- Complements the validator-layer coverage merged in #5522 so a
  future regression that passes parsing but breaks inside the
  runtime path (e.g. a chdir/chroot mishap or a stray
  `is_absolute()`-style guard sneaking in) fails fast.

## Upstream reference

- `loadparm.c` (P_PATH, rsync 3.4.2): single `/` survives the
  trailing-slash strip (`len > 1` guard) and is reachable via
  `lp_path(module_id)`.
- `clientserver.c` (rsync 3.4.2, line ~823-865): when
  `use chroot = no` the daemon serves the module path as-is; when
  `use chroot = yes` `chroot("/")` succeeds as a no-op.

## Changes

- `crates/daemon/src/tests/chunks/run_daemon_serves_module_with_root_path_no_chroot.rs`:
  new `#[cfg(unix)]` integration test that starts the daemon with
  an inline rsyncd.conf containing `[root] path = / use chroot = no
  read only = yes`, connects, issues `#list`, and asserts the
  module is advertised followed by `@RSYNCD: EXIT`.
- `crates/daemon/src/tests.rs`: wires the new chunk into the
  daemon test module.

No changes to wire protocol, branding, or any oc-rsync-specific
path (parallel-receive-delta, io_uring, IOCP, flat-flist,
daemon-tls, DirSandbox, SEND_ZC, flat arena flist). Test-only.

## Test plan

- [ ] CI `fmt+clippy` passes.
- [ ] CI `nextest (stable)` passes the new
      `run_daemon_serves_module_with_root_path_no_chroot` test.
- [ ] Windows CI stays green (new test is `#[cfg(unix)]`).