### PR TITLE
test: pin hostname ACL resolution before chroot per GHSA-rjfm-3w2m-jf4f

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -151,6 +151,7 @@ include!("tests/chunks/module_definition_mixed_ip_and_hostname_acl.rs");
 include!("tests/chunks/module_definition_only_allow_denies_non_matching.rs");
 include!("tests/chunks/module_definition_only_deny_allows_non_matching.rs");
 include!("tests/chunks/module_definition_wildcard_any_allows_all.rs");
+include!("tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs");
 include!("tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs");
 include!("tests/chunks/module_ip_deny_unaffected_by_dns_failure.rs");
 include!("tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs");

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
@@ -68,7 +68,7 @@ fn module_hostname_allow_fails_closed_under_chroot() {
     let mut cache = None;
     let resolved = module_peer_hostname(&module, &mut cache, peer, true);
     assert_eq!(
-        resolved.as_deref(),
+        resolved,
         Some("test-host.example"),
         "override must surface the configured hostname for the positive case"
     );

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
@@ -1,0 +1,82 @@
+/// Regression test for GHSA-rjfm-3w2m-jf4f (CVE-2026-43617), Scenario B
+/// from upstream's `testsuite/daemon-chroot-acl.test`: a hostname-based
+/// `hosts allow` rule combined with `use chroot = yes` must refuse a
+/// connection when reverse DNS fails post-chroot.
+///
+/// The fail-closed property here is structural rather than a guard added
+/// by the GHSA patch: with `hosts allow` non-empty, `permits()` requires
+/// at least one allow pattern to match the peer. A `Hostname(_)` pattern
+/// returns `false` whenever the peer hostname is `None`, so an
+/// unresolvable peer cannot satisfy a hostname-only allow list and is
+/// refused. This test pins that property so future refactors of
+/// `permits()` cannot accidentally introduce an allowed-by-default path
+/// for the allow-side of the GHSA scenario.
+///
+/// Pairs with `module_hostname_deny_fails_closed_when_dns_unresolved`
+/// (Scenario A, deny direction, closed by the explicit guard in
+/// `permits()`).
+///
+/// upstream: clientserver.c - `allow_access()` evaluates `hosts allow`
+/// before `hosts deny`; an empty allow match refuses the connection.
+/// upstream: clientserver.c (3.4.3 commit c38f20c5) "clientserver: fix
+/// hostname ACL bypass when using daemon chroot" - reverse DNS is
+/// performed before chroot so `client_name()` returns a real hostname at
+/// ACL evaluation time.
+#[test]
+fn module_hostname_allow_fails_closed_under_chroot() {
+    clear_test_hostname_overrides();
+
+    // Module mirrors upstream's `testsuite/daemon-chroot-acl.test`
+    // Scenario B fixture: `use chroot = yes`, single hostname-pattern
+    // `hosts allow` entry, no `hosts deny`.
+    let module = ModuleDefinition {
+        use_chroot: true,
+        ..module_with_host_patterns(&["test-host.example"], &[])
+    };
+
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+
+    // Simulate the post-chroot DNS failure: the chroot lacks
+    // `/etc/resolv.conf` / NSS shared objects, so reverse DNS returns
+    // `None`. Upstream rsync 3.4.3 sidesteps this by caching the lookup
+    // before entering chroot; oc-rsync's module-level path resolves the
+    // hostname in `module_access::request.rs::process_module_request()`
+    // before `apply_module_privilege_restrictions()` enters the chroot,
+    // and the matcher fails closed when resolution is impossible.
+    set_test_hostname_override(peer, None);
+
+    let mut cache = None;
+    let resolved = module_peer_hostname(&module, &mut cache, peer, true);
+    assert!(
+        resolved.is_none(),
+        "simulated post-chroot DNS failure must produce None hostname"
+    );
+
+    // The security property: an unresolved hostname must not satisfy a
+    // hostname-only `hosts allow` list. The peer is refused even though
+    // its IP is not explicitly denied.
+    assert!(
+        !module.permits(peer, resolved),
+        "hostname-pattern `hosts allow` rule must refuse peers whose \
+         reverse DNS fails under chroot (GHSA-rjfm-3w2m-jf4f Scenario B)"
+    );
+
+    // Sanity check: a resolvable peer matching the pattern is admitted,
+    // so the refusal above is attributable to the DNS failure and not a
+    // broken matcher.
+    set_test_hostname_override(peer, Some("test-host.example"));
+    let mut cache = None;
+    let resolved = module_peer_hostname(&module, &mut cache, peer, true);
+    assert_eq!(
+        resolved.as_deref(),
+        Some("test-host.example"),
+        "override must surface the configured hostname for the positive case"
+    );
+    assert!(
+        module.permits(peer, resolved),
+        "matching hostname must be admitted; the prior refusal is from \
+         the DNS failure, not a pattern mismatch"
+    );
+
+    clear_test_hostname_overrides();
+}


### PR DESCRIPTION
## Summary

Adds a single regression test pinning **Scenario B** of upstream's
`testsuite/daemon-chroot-acl.test` for [GHSA-rjfm-3w2m-jf4f] /
CVE-2026-43617: a daemon module with `use chroot = yes` and a
hostname-based `hosts allow` rule must refuse a connection whose
reverse DNS fails post-chroot, instead of falling through to an
allowed-by-default state.

[GHSA-rjfm-3w2m-jf4f]: https://github.com/RsyncProject/rsync/security/advisories/GHSA-rjfm-3w2m-jf4f

## Why this is just a test

The GHSA fix landed in #5524 (commit `50f389f50`), which targets the
`hosts deny` direction with an explicit fail-closed guard in
`ModuleDefinition::permits()`. The `hosts allow` direction is already
structurally fail-closed because `HostPattern::Hostname(_)::matches`
returns `false` when the peer hostname is `None`, so a hostname-only
allow list cannot be satisfied by an unresolvable peer and `permits()`
returns `false` on the empty-allow-match branch.

The existing chunk `module_peer_hostname_resolution_before_chroot_denies_unknown`
covers the same property, but it is named for the CVE rather than for
the upstream-testsuite scenario, and pairs poorly with
`module_hostname_deny_fails_closed_when_dns_unresolved`, which is
explicitly named after Scenario A. This PR adds a Scenario B mirror so
the two upstream-test scenarios are pinned with matching names and
matching docblock structure; future refactors of `permits()` cannot
accidentally introduce an allowed-by-default path for the allow-side
without flipping a clearly-labeled regression test.

## Upstream reference

- `clientserver.c` (upstream rsync 3.4.3, commit
  [`c38f20c5`](https://github.com/RsyncProject/rsync/commit/c38f20c5ffabacd0c0c483786ab224a36e14bf43))
  moves reverse DNS before chroot/setuid so `client_name()` returns a
  real hostname at ACL evaluation time. oc-rsync's module-access path
  (`module_access::request.rs::process_module_request()`) resolves the
  hostname before `apply_module_privilege_restrictions()` enters
  the per-module chroot; the matcher returns `false` whenever the
  hostname is `None`, so a hostname-only `hosts allow` rule refuses
  the connection.
- `testsuite/daemon-chroot-acl.test` Scenario B: `use chroot = yes` +
  `hosts allow = <hostname>` + DNS fail -> refuse.

## Scope

- Test-only addition. No production code changes.
- No wire-protocol changes.
- No `crates/branding/` changes.
- No effect on parallel-receive-delta, io_uring, IOCP, flat-flist,
  daemon-tls, DirSandbox, SEND_ZC, or flat arena flist.
- Daemon `#![deny(unsafe_code)]` preserved; no clippy waivers.

## Test plan

- [ ] CI fmt + clippy green
- [ ] CI nextest green (Linux GNU, Linux musl, macOS, Windows)