### PR TITLE
fix: emit NDX_DEL_STATS in daemon-receive goodbye for --delete pushes

### DIFF
--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -80,7 +80,7 @@ impl DeleteStats {
     /// # Errors
     ///
     /// Returns an error if writing to the stream fails.
-    pub fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+    pub fn write_to<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
         use crate::varint::write_varint;
 
         write_varint(writer, self.files as i32)?;

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -52,6 +52,7 @@ use protocol::acl::AclCache;
 use protocol::filters::FilterRuleWireFormat;
 use protocol::flist::{FileEntry, FileListReader};
 use protocol::idlist::IdList;
+use protocol::stats::DeleteStats;
 use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion};
 
 use engine::HardlinkApplyTracker;
@@ -256,6 +257,18 @@ pub struct ReceiverContext {
     /// This is wired by task DDP-B3 (#2257) and consumed by the emitter
     /// wiring in tasks DDP-E1-E5.
     delete_ctx: Option<Arc<DeleteContext>>,
+    /// Deletion statistics accumulated during the receiver's delete pass.
+    ///
+    /// Set by the receiver after `delete_extraneous_files()` completes and
+    /// emitted by `handle_goodbye()` as an `NDX_DEL_STATS` wire message when
+    /// upstream's conditions are met (`do_stats` plus delete-mode timing).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2376-2381` - early `write_del_stats()` path
+    /// - `generator.c:2420-2425` - late `write_del_stats()` path
+    /// - `main.c:225-238` - `write_del_stats()` wire format
+    pending_del_stats: DeleteStats,
     /// Transfer pipeline FSM tracking the current protocol phase.
     ///
     /// Enforces the linear phase progression through the transfer lifecycle.
@@ -317,6 +330,7 @@ impl ReceiverContext {
             flist_io_error: 0,
             parallel_thresholds: ParallelThresholds::default(),
             delete_ctx: None,
+            pending_del_stats: DeleteStats::new(),
             pipeline,
         }
     }
@@ -355,6 +369,20 @@ impl ReceiverContext {
     #[must_use]
     pub fn delete_context(&self) -> Option<Arc<DeleteContext>> {
         self.delete_ctx.as_ref().map(Arc::clone)
+    }
+
+    /// Records the deletion statistics that should be emitted as `NDX_DEL_STATS`
+    /// during the goodbye handshake.
+    ///
+    /// Called by the receiver after `delete_extraneous_files()` completes so the
+    /// stats are available when `handle_goodbye()` writes the final NDX frames.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2376-2381` - early del-stats path
+    /// - `generator.c:2420-2425` - late del-stats path
+    pub(in crate::receiver) fn set_pending_del_stats(&mut self, stats: DeleteStats) {
+        self.pending_del_stats = stats;
     }
 
     /// Converts a wire NDX value to a flat file list array index.

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_del_stats_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_del_stats_tests.rs
@@ -1,0 +1,293 @@
+//! Tests for `NDX_DEL_STATS` emission from the receiver's goodbye handshake.
+//!
+//! The daemon-receive (push) direction does not run a separate generator
+//! process. The receiver itself must emit `NDX_DEL_STATS` during goodbye so
+//! the sender's `read_final_goodbye()` can decode the per-type deletion
+//! counters when the upstream conditions are met.
+//!
+//! upstream:
+//! - `generator.c:2376-2381` early `write_del_stats()` path
+//! - `generator.c:2420-2425` late `write_del_stats()` path
+//! - `main.c:225-238` `write_del_stats()` wire format
+//! - `rsync.c:337-342` `read_ndx_and_attrs()` consumes NDX_DEL_STATS
+
+use std::ffi::OsString;
+use std::io::Cursor;
+
+use protocol::codec::{NDX_DEL_STATS, NdxCodec, create_ndx_codec};
+use protocol::stats::DeleteStats;
+use protocol::{ProtocolVersion, read_varint};
+
+use super::super::super::ReceiverContext;
+use crate::config::{DeletionConfig, ServerConfig};
+use crate::flags::ParsedServerFlags;
+use crate::handshake::HandshakeResult;
+use crate::role::ServerRole;
+
+const NDX_DONE_LE: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
+
+fn handshake_for(protocol_version: u8) -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: false,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+/// Builds a receiver configured to mirror a daemon-receive push:
+/// `--delete --stats`, default early-delete timing, and the requested
+/// protocol version.
+fn receiver_with_delete_and_stats(protocol_version: u8) -> ReceiverContext {
+    let handshake = handshake_for(protocol_version);
+    let flags = ParsedServerFlags {
+        delete: true,
+        ..ParsedServerFlags::default()
+    };
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        flags,
+        deletion: DeletionConfig {
+            max_delete: None,
+            ignore_errors: false,
+            late_delete: false,
+        },
+        do_stats: true,
+        ..Default::default()
+    };
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+/// Verifies that a protocol 31 daemon-receiver with `--delete --stats` emits
+/// `NDX_DEL_STATS` followed by 5 varints carrying the per-type counters,
+/// then closes goodbye with `NDX_DONE`. Mirrors what upstream's
+/// `read_final_goodbye()` expects to decode on the sender side.
+#[test]
+fn handle_goodbye_proto31_emits_ndx_del_stats_then_done() {
+    let mut ctx = receiver_with_delete_and_stats(31);
+    let stats = DeleteStats {
+        files: 7,
+        dirs: 3,
+        symlinks: 2,
+        devices: 1,
+        specials: 4,
+    };
+    ctx.set_pending_del_stats(stats);
+
+    // Sender's echo + final NDX_DONE
+    let mut sender_input = Vec::new();
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+
+    let mut reader = Cursor::new(sender_input);
+    let mut output = Vec::new();
+    let mut ndx_write = create_ndx_codec(31);
+    let mut ndx_read = create_ndx_codec(31);
+
+    ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
+        .unwrap();
+
+    let mut cursor = Cursor::new(&output);
+    let mut codec = create_ndx_codec(31);
+    let first = codec.read_ndx(&mut cursor).unwrap();
+    assert_eq!(
+        first, NDX_DEL_STATS,
+        "first frame must be NDX_DEL_STATS, got {first}"
+    );
+
+    let decoded = DeleteStats::read_from(&mut cursor).unwrap();
+    assert_eq!(decoded, stats, "del stats round-trip mismatch");
+
+    let second = codec.read_ndx(&mut cursor).unwrap();
+    assert_eq!(second, -1, "second frame must be NDX_DONE");
+
+    let third = codec.read_ndx(&mut cursor).unwrap();
+    assert_eq!(
+        third, -1,
+        "third frame must be the extended-goodbye NDX_DONE"
+    );
+
+    assert_eq!(
+        cursor.position() as usize,
+        output.len(),
+        "trailing bytes after extended goodbye"
+    );
+}
+
+/// Verifies that the receiver does not emit `NDX_DEL_STATS` when `--stats`
+/// is absent, mirroring upstream's `INFO_GTE(STATS, 2)` gate.
+#[test]
+fn handle_goodbye_proto31_skips_ndx_del_stats_without_do_stats() {
+    let handshake = handshake_for(31);
+    let flags = ParsedServerFlags {
+        delete: true,
+        ..ParsedServerFlags::default()
+    };
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(31).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        flags,
+        do_stats: false,
+        ..Default::default()
+    };
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.set_pending_del_stats(DeleteStats {
+        files: 9,
+        ..DeleteStats::new()
+    });
+
+    let mut sender_input = Vec::new();
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+
+    let mut reader = Cursor::new(sender_input);
+    let mut output = Vec::new();
+    let mut ndx_write = create_ndx_codec(31);
+    let mut ndx_read = create_ndx_codec(31);
+
+    ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
+        .unwrap();
+
+    // Two NDX_DONEs only - no NDX_DEL_STATS.
+    assert_eq!(output.len(), 8);
+    assert_eq!(&output[..4], &NDX_DONE_LE);
+    assert_eq!(&output[4..], &NDX_DONE_LE);
+}
+
+/// Late-delete timing (`--delete-delay` / `--delete-after`) must emit
+/// `NDX_DEL_STATS` whenever `do_stats` is set, even without the `delete`
+/// flag (upstream gates on `INFO_GTE(STATS, 2)` alone in the late path).
+#[test]
+fn handle_goodbye_proto31_late_delete_emits_on_do_stats_only() {
+    let handshake = handshake_for(31);
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(31).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        deletion: DeletionConfig {
+            max_delete: None,
+            ignore_errors: false,
+            late_delete: true,
+        },
+        do_stats: true,
+        ..Default::default()
+    };
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.set_pending_del_stats(DeleteStats {
+        files: 1,
+        dirs: 2,
+        symlinks: 3,
+        devices: 4,
+        specials: 5,
+    });
+
+    let mut sender_input = Vec::new();
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+
+    let mut reader = Cursor::new(sender_input);
+    let mut output = Vec::new();
+    let mut ndx_write = create_ndx_codec(31);
+    let mut ndx_read = create_ndx_codec(31);
+
+    ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
+        .unwrap();
+
+    let mut cursor = Cursor::new(&output);
+    let mut codec = create_ndx_codec(31);
+    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), NDX_DEL_STATS);
+    let decoded = DeleteStats::read_from(&mut cursor).unwrap();
+    assert_eq!(decoded.files, 1);
+    assert_eq!(decoded.dirs, 2);
+    assert_eq!(decoded.symlinks, 3);
+    assert_eq!(decoded.devices, 4);
+    assert_eq!(decoded.specials, 5);
+    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), -1);
+    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), -1);
+}
+
+/// Pre-protocol-31 transports must never emit `NDX_DEL_STATS` even with
+/// `--delete --stats` set, since the message did not exist before
+/// protocol 31. Mirrors upstream's `protocol_version >= 31` guard.
+#[test]
+fn handle_goodbye_proto30_never_emits_ndx_del_stats() {
+    let handshake = handshake_for(30);
+    let flags = ParsedServerFlags {
+        delete: true,
+        ..ParsedServerFlags::default()
+    };
+    let config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(30).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        flags,
+        do_stats: true,
+        ..Default::default()
+    };
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.set_pending_del_stats(DeleteStats {
+        files: 9,
+        ..DeleteStats::new()
+    });
+
+    let mut reader = Cursor::new(Vec::<u8>::new());
+    let mut output = Vec::new();
+    let mut ndx_write = create_ndx_codec(30);
+    let mut ndx_read = create_ndx_codec(30);
+
+    ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
+        .unwrap();
+
+    assert_eq!(output.len(), 4);
+    assert_eq!(&output[..], &NDX_DONE_LE);
+}
+
+/// Wire-format spot check: the five fields after `NDX_DEL_STATS` are
+/// independent varints in (files, dirs, symlinks, devices, specials)
+/// order. Asserts the order matches upstream `main.c:225-238`.
+#[test]
+fn handle_goodbye_proto31_varint_field_order_matches_upstream() {
+    let mut ctx = receiver_with_delete_and_stats(31);
+    let stats = DeleteStats {
+        files: 11,
+        dirs: 22,
+        symlinks: 33,
+        devices: 44,
+        specials: 55,
+    };
+    ctx.set_pending_del_stats(stats);
+
+    let mut sender_input = Vec::new();
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+    sender_input.extend_from_slice(&NDX_DONE_LE);
+
+    let mut reader = Cursor::new(sender_input);
+    let mut output = Vec::new();
+    let mut ndx_write = create_ndx_codec(31);
+    let mut ndx_read = create_ndx_codec(31);
+
+    ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
+        .unwrap();
+
+    let mut cursor = Cursor::new(&output);
+    let mut codec = create_ndx_codec(31);
+    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), NDX_DEL_STATS);
+
+    // Verify each varint independently in upstream order.
+    assert_eq!(read_varint(&mut cursor).unwrap(), 11);
+    assert_eq!(read_varint(&mut cursor).unwrap(), 22);
+    assert_eq!(read_varint(&mut cursor).unwrap(), 33);
+    assert_eq!(read_varint(&mut cursor).unwrap(), 44);
+    assert_eq!(read_varint(&mut cursor).unwrap(), 55);
+}

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_del_stats_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_del_stats_tests.rs
@@ -14,7 +14,7 @@
 use std::ffi::OsString;
 use std::io::Cursor;
 
-use protocol::codec::{NDX_DEL_STATS, NdxCodec, create_ndx_codec};
+use protocol::codec::{NDX_DEL_STATS, NDX_DONE, NdxCodec, create_ndx_codec};
 use protocol::stats::DeleteStats;
 use protocol::{ProtocolVersion, read_varint};
 
@@ -24,7 +24,17 @@ use crate::flags::ParsedServerFlags;
 use crate::handshake::HandshakeResult;
 use crate::role::ServerRole;
 
-const NDX_DONE_LE: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
+/// Encodes a single NDX_DONE via the protocol-version-appropriate codec.
+///
+/// Legacy (proto < 30) emits 4 little-endian bytes; modern (proto >= 30)
+/// emits a single `0x00`. Tests must drive both sides through the codec
+/// so they remain wire-accurate across protocol versions.
+fn encode_ndx_done(protocol_version: u8) -> Vec<u8> {
+    let mut codec = create_ndx_codec(protocol_version);
+    let mut buf = Vec::new();
+    codec.write_ndx_done(&mut buf).unwrap();
+    buf
+}
 
 fn handshake_for(protocol_version: u8) -> HandshakeResult {
     HandshakeResult {
@@ -81,10 +91,9 @@ fn handle_goodbye_proto31_emits_ndx_del_stats_then_done() {
     };
     ctx.set_pending_del_stats(stats);
 
-    // Sender's echo + final NDX_DONE
-    let mut sender_input = Vec::new();
-    sender_input.extend_from_slice(&NDX_DONE_LE);
-    sender_input.extend_from_slice(&NDX_DONE_LE);
+    // Sender's echo + final NDX_DONE, encoded via the modern codec.
+    let mut sender_input = encode_ndx_done(31);
+    sender_input.extend_from_slice(&encode_ndx_done(31));
 
     let mut reader = Cursor::new(sender_input);
     let mut output = Vec::new();
@@ -106,11 +115,11 @@ fn handle_goodbye_proto31_emits_ndx_del_stats_then_done() {
     assert_eq!(decoded, stats, "del stats round-trip mismatch");
 
     let second = codec.read_ndx(&mut cursor).unwrap();
-    assert_eq!(second, -1, "second frame must be NDX_DONE");
+    assert_eq!(second, NDX_DONE, "second frame must be NDX_DONE");
 
     let third = codec.read_ndx(&mut cursor).unwrap();
     assert_eq!(
-        third, -1,
+        third, NDX_DONE,
         "third frame must be the extended-goodbye NDX_DONE"
     );
 
@@ -145,9 +154,8 @@ fn handle_goodbye_proto31_skips_ndx_del_stats_without_do_stats() {
         ..DeleteStats::new()
     });
 
-    let mut sender_input = Vec::new();
-    sender_input.extend_from_slice(&NDX_DONE_LE);
-    sender_input.extend_from_slice(&NDX_DONE_LE);
+    let mut sender_input = encode_ndx_done(31);
+    sender_input.extend_from_slice(&encode_ndx_done(31));
 
     let mut reader = Cursor::new(sender_input);
     let mut output = Vec::new();
@@ -157,10 +165,13 @@ fn handle_goodbye_proto31_skips_ndx_del_stats_without_do_stats() {
     ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
         .unwrap();
 
-    // Two NDX_DONEs only - no NDX_DEL_STATS.
-    assert_eq!(output.len(), 8);
-    assert_eq!(&output[..4], &NDX_DONE_LE);
-    assert_eq!(&output[4..], &NDX_DONE_LE);
+    // Output must contain exactly two modern NDX_DONE frames (one byte each).
+    let expected = {
+        let mut v = encode_ndx_done(31);
+        v.extend_from_slice(&encode_ndx_done(31));
+        v
+    };
+    assert_eq!(output, expected, "no NDX_DEL_STATS frame, two NDX_DONEs");
 }
 
 /// Late-delete timing (`--delete-delay` / `--delete-after`) must emit
@@ -191,9 +202,8 @@ fn handle_goodbye_proto31_late_delete_emits_on_do_stats_only() {
         specials: 5,
     });
 
-    let mut sender_input = Vec::new();
-    sender_input.extend_from_slice(&NDX_DONE_LE);
-    sender_input.extend_from_slice(&NDX_DONE_LE);
+    let mut sender_input = encode_ndx_done(31);
+    sender_input.extend_from_slice(&encode_ndx_done(31));
 
     let mut reader = Cursor::new(sender_input);
     let mut output = Vec::new();
@@ -212,8 +222,8 @@ fn handle_goodbye_proto31_late_delete_emits_on_do_stats_only() {
     assert_eq!(decoded.symlinks, 3);
     assert_eq!(decoded.devices, 4);
     assert_eq!(decoded.specials, 5);
-    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), -1);
-    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), -1);
+    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), NDX_DONE);
+    assert_eq!(codec.read_ndx(&mut cursor).unwrap(), NDX_DONE);
 }
 
 /// Pre-protocol-31 transports must never emit `NDX_DEL_STATS` even with
@@ -249,8 +259,8 @@ fn handle_goodbye_proto30_never_emits_ndx_del_stats() {
     ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_write, &mut ndx_read)
         .unwrap();
 
-    assert_eq!(output.len(), 4);
-    assert_eq!(&output[..], &NDX_DONE_LE);
+    // Protocol 30 closes with a single NDX_DONE and no extended exchange.
+    assert_eq!(output, encode_ndx_done(30));
 }
 
 /// Wire-format spot check: the five fields after `NDX_DEL_STATS` are
@@ -268,9 +278,8 @@ fn handle_goodbye_proto31_varint_field_order_matches_upstream() {
     };
     ctx.set_pending_del_stats(stats);
 
-    let mut sender_input = Vec::new();
-    sender_input.extend_from_slice(&NDX_DONE_LE);
-    sender_input.extend_from_slice(&NDX_DONE_LE);
+    let mut sender_input = encode_ndx_done(31);
+    sender_input.extend_from_slice(&encode_ndx_done(31));
 
     let mut reader = Cursor::new(sender_input);
     let mut output = Vec::new();

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/mod.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/mod.rs
@@ -7,6 +7,8 @@
 //! the 650-line cap:
 //!
 //! - [`legacy_goodbye_tests`] - protocol 28/29 NDX_DONE goodbye exchange.
+//! - [`goodbye_del_stats_tests`] - protocol 31+ NDX_DEL_STATS emission
+//!   during the receiver goodbye for daemon-receive (push) transfers.
 //! - [`input_multiplex_tests`] - client/server input multiplex activation
 //!   per protocol version.
 //! - [`sanitize_file_list`] - trust gating that strips absolute / `..`
@@ -15,6 +17,7 @@
 //!   from `daemon_filter_rules`.
 
 mod daemon_filter_tests;
+mod goodbye_del_stats_tests;
 mod input_multiplex_tests;
 mod legacy_goodbye_tests;
 mod sanitize_file_list;

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -129,6 +129,12 @@ impl ReceiverContext {
     ///
     /// For protocol >= 31, sends NDX_DONE. For extended goodbye (protocol >= 32),
     /// additionally reads the echo and sends a final NDX_DONE.
+    ///
+    /// When the upstream conditions for emitting deletion statistics are met,
+    /// an `NDX_DEL_STATS` frame plus 5 varints is written immediately before
+    /// the final NDX_DONE. This mirrors `generator.c:2376-2381` (early path)
+    /// and `generator.c:2420-2425` (late path). The sender consumes both via
+    /// `read_ndx_and_attrs()` (`rsync.c:337-342`).
     pub(in crate::receiver) fn handle_goodbye<R: Read, W: Write + ?Sized>(
         &self,
         reader: &mut R,
@@ -138,6 +144,17 @@ impl ReceiverContext {
     ) -> io::Result<()> {
         if !self.protocol.supports_goodbye_exchange() {
             return Ok(());
+        }
+
+        if self.protocol.supports_extended_goodbye() && self.should_send_del_stats() {
+            ndx_write_codec.write_ndx(&mut *writer, NDX_DEL_STATS)?;
+            self.pending_del_stats.write_to(&mut *writer)?;
+            debug_log!(
+                Flist,
+                2,
+                "sent NDX_DEL_STATS during receiver goodbye: {} deletions",
+                self.pending_del_stats.total()
+            );
         }
 
         ndx_write_codec.write_ndx_done(&mut *writer)?;
@@ -171,6 +188,25 @@ impl ReceiverContext {
         }
 
         Ok(())
+    }
+
+    /// Determines whether `NDX_DEL_STATS` should be sent during the goodbye
+    /// phase. Mirrors the conditions used by the generator's identically
+    /// named helper.
+    ///
+    /// Upstream gates emission on `INFO_GTE(STATS, 2)` (i.e. `--stats`) and
+    /// splits early vs late delete:
+    /// - Early (`generator.c:2377`): `do_stats && (delete_mode || force_delete)`
+    /// - Late (`generator.c:2422`): `do_stats`
+    pub(in crate::receiver) fn should_send_del_stats(&self) -> bool {
+        if !self.config.do_stats {
+            return false;
+        }
+        if self.config.deletion.late_delete {
+            true
+        } else {
+            self.config.flags.delete
+        }
     }
 
     /// Receives transfer statistics from the sender.

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -66,6 +66,9 @@ impl ReceiverContext {
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
         }
+        // Stash for goodbye-phase NDX_DEL_STATS emission. Mirrors upstream's
+        // generator.c:2376-2381 (early) and 2420-2425 (late) write_del_stats().
+        self.set_pending_del_stats(delete_stats);
 
         let mut stats = TransferStats {
             files_listed: file_count,


### PR DESCRIPTION
## Summary

- Adds `NDX_DEL_STATS` emission to the receiver's goodbye handshake so daemon-receive (push with `--delete --stats`) transfers correctly deliver per-type deletion counters back to the sender.
- Mirrors upstream's generator path: protocol 31+ gates plus the existing early/late `do_stats && delete_mode` conditions used by `crate::generator`'s `should_send_del_stats`.
- Stashes the receiver's delete stats from `run_pipelined` so they are available when `handle_goodbye` writes the final NDX frames.

## Upstream Reference

- `generator.c:2376-2381` early `write_del_stats()` path
- `generator.c:2420-2425` late `write_del_stats()` path
- `main.c:225-238` `write_del_stats()` wire format
- `rsync.c:337-342` `read_ndx_and_attrs()` consumes `NDX_DEL_STATS`

## Test plan

- [x] Added `goodbye_del_stats_tests.rs` covering:
  - Protocol 31 emits `NDX_DEL_STATS` + 5 varints + `NDX_DONE`, then echo `NDX_DONE`.
  - Protocol 31 suppresses emission when `do_stats=false`.
  - Late delete (`--delete-delay` / `--delete-after`) emits on `do_stats` alone.
  - Protocol 30 never emits the message (upstream protocol guard).
  - Varint field order matches upstream `main.c:225-238`.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl, interop.