### PR TITLE
chore: pin upstream rsync 3.4.4 (closes #4965)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -441,7 +441,7 @@ strip = false
 
 [workspace.metadata.oc_rsync]
 brand = "oc"
-upstream_version = "3.4.2"
+upstream_version = "3.4.4"
 rust_version = "0.6.3"
 protocol = 32
 client_bin = "oc-rsync"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # oc-rsync
 
-`rsync` re-implemented in Rust. Wire-compatible with upstream rsync 3.4.3 (and back-compat with 3.4.2 / 3.4.1, protocol 32), works as a drop-in replacement.
+`rsync` re-implemented in Rust. Wire-compatible with upstream rsync 3.4.4 (and back-compat with 3.4.3 / 3.4.2 / 3.4.1, protocol 32), works as a drop-in replacement.
 
 Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict.
 
@@ -12,9 +12,9 @@ Binary name: **`oc-rsync`** - installs alongside system `rsync` without conflict
 
 ## Status
 
-**Release:** 0.6.3 - Wire-compatible drop-in replacement for rsync 3.4.3 (and 3.4.2 / 3.4.1, protocols 28-32).
+**Release:** 0.6.3 - Wire-compatible drop-in replacement for rsync 3.4.4 (and 3.4.3 / 3.4.2 / 3.4.1, protocols 28-32).
 
-All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop tested against upstream rsync 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2, and 3.4.3. Upstream rsync's own `testsuite/*.test` corpus runs in CI against `oc-rsync` as `$RSYNC` - all tests now pass (known-failures roster is empty).
+All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation, incremental recursion, and compression are complete. Interop tested against upstream rsync 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3, and 3.4.4. Upstream rsync's own `testsuite/*.test` corpus runs in CI against `oc-rsync` as `$RSYNC` - all tests now pass (known-failures roster is empty).
 
 | Component | Status |
 |-----------|--------|
@@ -145,7 +145,7 @@ Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 - SIMD vs scalar self-test added (cargo-fuzz target + unit test) cross-validating AVX2, SSE2, NEON, and scalar implementations at startup (3.4.2 parity)
 
 **Upstream interop**
-- Pinned upstream interop matrix bumped to rsync **3.4.3** (in addition to 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2)
+- Pinned upstream interop matrix bumped to rsync **3.4.4** (in addition to 2.6.9, 3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3)
 - All upstream `testsuite/*.test` tests now pass - known-failures roster is empty
 - Wire differential fuzzing validates protocol-level byte equivalence against upstream
 - Scheduled GitHub Actions watcher for new upstream releases
@@ -168,7 +168,7 @@ Legend: ✓ supported, ⚠ partial or not yet wired, ✗ not implemented.
 
 ### Interop Testing
 
-Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, **3.4.1**, **3.4.2**, and **3.4.3** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. Wire differential fuzzing against upstream rsync validates protocol-level byte equivalence. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
+Tested against upstream rsync **2.6.9**, **3.0.9**, **3.1.3**, **3.4.1**, **3.4.2**, **3.4.3**, and **3.4.4** in CI across protocols 28-32. Both push and pull directions verified for 30+ scenarios covering transfer modes, deletion, compression, metadata, reference dirs, file selection, batch roundtrip, path handling, device nodes, and daemon auth. Wire differential fuzzing against upstream rsync validates protocol-level byte equivalence. See the [full interop compatibility matrix](./docs/user/interop-compatibility-matrix.md) for per-version, per-feature, and per-platform detail.
 
 ### Supported rsync protocol versions
 
@@ -196,6 +196,7 @@ Per-version dispatch is implemented as `protocol_version` gates in the wire code
 | 3.4.1                  | 32       | push, pull, daemon, SSH  | gating |
 | 3.4.2                  | 32       | push, pull, daemon       | gating |
 | 3.4.3                  | 32       | push, pull, daemon, SSH  | gating |
+| 3.4.4                  | 32       | push, pull, daemon, SSH  | gating |
 
 Wire format is verified byte-identical to upstream rsync via CI golden-byte tests for the listed versions. Wire differential fuzzing validates protocol-level byte equivalence against upstream. Other versions may work but are not regression-tested.
 
@@ -284,7 +285,7 @@ Three one-shot warnings may appear on stderr (sync path) or via `tracing` target
 
 ### Known Limitations / Architectural Trade-offs
 
-oc-rsync is wire-compatible with upstream rsync 3.4.3, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
+oc-rsync is wire-compatible with upstream rsync 3.4.4, but a few architectural choices and unfinished surfaces are worth calling out for operators planning a deployment:
 
 - **io_uring kernel requirement.** Provided buffer rings (PBUF_RING) require Linux **5.19+**; older 5.6-5.18 kernels fall back to standard buffered I/O via runtime probing.
 - **Fixed io_uring buffer pool.** The registered buffer pool is sized at compile time (1024 × 4 KiB = 4 MiB) and does not adapt under sustained I/O pressure. Workloads with very high concurrent file fan-out may see throughput plateau before saturating the device.

--- a/tools/capture-handshakes.sh
+++ b/tools/capture-handshakes.sh
@@ -16,7 +16,7 @@ WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
 # Configuration
-UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.2}"
+UPSTREAM_VERSION="${UPSTREAM_VERSION:-3.4.4}"
 UPSTREAM_BIN="target/interop/upstream-install/${UPSTREAM_VERSION}/bin/rsync"
 TEST_PORT=18873
 CAPTURE_IFACE="${CAPTURE_IFACE:-lo}"

--- a/tools/ci/check_known_failures.sh
+++ b/tools/ci/check_known_failures.sh
@@ -119,7 +119,7 @@ stop_daemon() {
 run_daemon_test() {
   local direction=$1 scenario_name=$2
 
-  local version="3.4.2"
+  local version="3.4.4"
   # For protocol-31 with upstream 3.0.9, use that version
   if [[ "$scenario_name" == "protocol-31" && "$direction" == "up" ]]; then
     version="3.0.9"
@@ -127,8 +127,11 @@ run_daemon_test() {
 
   local upstream_binary
   upstream_binary=$(find_upstream_binary "$version") || upstream_binary=""
-  if [[ -z "$upstream_binary" && "$version" == "3.4.2" ]]; then
-    upstream_binary=$(find_upstream_binary "3.4.1") || upstream_binary=""
+  if [[ -z "$upstream_binary" && "$version" == "3.4.4" ]]; then
+    upstream_binary=$(find_upstream_binary "3.4.3") \
+      || upstream_binary=$(find_upstream_binary "3.4.2") \
+      || upstream_binary=$(find_upstream_binary "3.4.1") \
+      || upstream_binary=""
   fi
   if [[ -z "$upstream_binary" ]]; then
     echo "SKIP:no-binary"
@@ -197,7 +200,11 @@ run_daemon_test() {
 run_standalone_test_by_name() {
   local name=$1
   local upstream_binary
-  upstream_binary=$(find_upstream_binary "3.4.2") || upstream_binary=$(find_upstream_binary "3.4.1") || {
+  upstream_binary=$(find_upstream_binary "3.4.4") \
+    || upstream_binary=$(find_upstream_binary "3.4.3") \
+    || upstream_binary=$(find_upstream_binary "3.4.2") \
+    || upstream_binary=$(find_upstream_binary "3.4.1") \
+    || {
     echo "SKIP:no-binary"
     return 2
   }

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -8,6 +8,7 @@
 #     3.4.1  -> deb.debian.org (3.4.1+ds1-6)
 #     3.4.2  -> deb.debian.org (3.4.2+ds1-1, fallback to source if missing)
 #     3.4.3  -> source-built (security release, no .deb yet)
+#     3.4.4  -> source-built (latest release, no .deb yet)
 # - Falls back to source build if the exact .deb for this arch is missing
 # - Starts oc-rsync --daemon on a non-privileged port by passing --port on the CLI
 set -euo pipefail
@@ -53,7 +54,7 @@ upstream_install_root="${workspace_root}/target/interop/upstream-install"
 interop_log_dir="${workspace_root}/target/interop/logs"
 
 # Versions we run interop scenarios against.
-versions=(3.0.9 3.1.3 3.4.1 3.4.2 3.4.3)
+versions=(3.0.9 3.1.3 3.4.1 3.4.2 3.4.3 3.4.4)
 # Versions we only build and cache (no scenarios wired up yet). 2.6.9 is the
 # protocol-28 cutoff peer (advertises protocol 29, accepts down to 28); the
 # binary is needed so follow-up tasks can wire push/pull cells against it.
@@ -133,6 +134,10 @@ build_version_url() {
       ;;
     3.4.3)
       # 3.4.3 is a recent security release; no .deb available yet, force source build.
+      echo ""
+      ;;
+    3.4.4)
+      # 3.4.4 is the latest upstream release; no .deb available yet, force source build.
       echo ""
       ;;
     *)
@@ -230,6 +235,11 @@ try_fetch_deb_generic() {
       ;;
     3.4.3)
       # Recent security release; no .deb available yet, skip straight to source build.
+      rm -f "$tmp_deb"
+      return 1
+      ;;
+    3.4.4)
+      # Latest upstream release; no .deb available yet, skip straight to source build.
       rm -f "$tmp_deb"
       return 1
       ;;
@@ -11041,9 +11051,9 @@ run_comprehensive_interop_case() {
 
   # Extended scenarios only for the newest upstream versions (3.4.1+).
   # xattrs requires protocol >= 30 (upstream compat.c), so it only works
-  # against 3.4.1/3.4.2/3.4.3 (protocol 32), not 3.0.9 (protocol 28) or 3.1.3
-  # (protocol 31 but may lack --enable-xattr-support).
-  if [[ "${version}" == "3.4.1" || "${version}" == "3.4.2" || "${version}" == "3.4.3" ]]; then
+  # against 3.4.1/3.4.2/3.4.3/3.4.4 (protocol 32), not 3.0.9 (protocol 28) or
+  # 3.1.3 (protocol 31 but may lack --enable-xattr-support).
+  if [[ "${version}" == "3.4.1" || "${version}" == "3.4.2" || "${version}" == "3.4.3" || "${version}" == "3.4.4" ]]; then
     scenarios+=(
       "xattrs|-avX|xattrs"
       "one-file-system|-avx|basic"
@@ -11351,12 +11361,12 @@ echo "=== Parallel version tests complete ==="
 
 # =====================================================================
 # Protocol version forcing tests: all 5 protocols via the newest
-# available upstream binary (3.4.3, falling back to 3.4.2/3.4.1).
+# available upstream binary (3.4.4, falling back to 3.4.3/3.4.2/3.4.1).
 # Run sequentially to avoid port contention under CI load.
 # =====================================================================
 newest_label=""
 newest_binary=""
-for nv in 3.4.3 3.4.2 3.4.1; do
+for nv in 3.4.4 3.4.3 3.4.2 3.4.1; do
   if [[ -x "${upstream_install_root}/${nv}/bin/rsync" ]]; then
     newest_label="$nv"
     newest_binary="${upstream_install_root}/${nv}/bin/rsync"
@@ -11401,7 +11411,7 @@ echo "=== Standalone Interop Tests ==="
 
 # Use the newest available upstream binary for standalone tests
 standalone_binary=""
-for nv in 3.4.3 3.4.2 3.4.1; do
+for nv in 3.4.4 3.4.3 3.4.2 3.4.1; do
   if [[ -x "${upstream_install_root}/${nv}/bin/rsync" ]]; then
     standalone_binary="${upstream_install_root}/${nv}/bin/rsync"
     break

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -16,13 +16,13 @@
 # Usage:
 #   tools/ci/run_upstream_testsuite.sh                # run all *.test
 #   WHICHTESTS=00-hello.test tools/ci/...sh           # run a single test
-#   UPSTREAM_VERSION=3.4.2 tools/ci/...sh             # pin upstream version
+#   UPSTREAM_VERSION=3.4.4 tools/ci/...sh             # pin upstream version
 #   PRESERVE_SCRATCH=yes tools/ci/...sh               # keep per-test scratch dirs
 
 set -euo pipefail
 
 workspace_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-upstream_version="${UPSTREAM_VERSION:-3.4.3}"
+upstream_version="${UPSTREAM_VERSION:-3.4.4}"
 upstream_src_root="${workspace_root}/target/interop/upstream-src"
 upstream_src_dir="${upstream_src_root}/rsync-${upstream_version}"
 oc_rsync_bin="${OC_RSYNC_BIN:-${workspace_root}/target/release/oc-rsync}"

--- a/tools/ci/test_check_upstream_release.sh
+++ b/tools/ci/test_check_upstream_release.sh
@@ -48,13 +48,13 @@ run_case() {
     fi
 }
 
-write_news "3.4.2"; write_cargo "3.4.2"
+write_news "3.4.4"; write_cargo "3.4.4"
 run_case "equal versions returns 0" 0 "${tmp}/NEWS"
 
-write_news "3.5.0"; write_cargo "3.4.2"
+write_news "3.5.0"; write_cargo "3.4.4"
 run_case "upstream ahead returns 1" 1 "${tmp}/NEWS"
 
-write_cargo "3.4.2"
+write_cargo "3.4.4"
 run_case "missing NEWS returns 2" 2 "${tmp}/missing-NEWS"
 
 if [[ "${failures}" -ne 0 ]]; then

--- a/tools/run_upstream_client_interop_tests.sh
+++ b/tools/run_upstream_client_interop_tests.sh
@@ -2,7 +2,7 @@
 # Run upstream rsync client to oc-rsync daemon interoperability tests.
 #
 # This script runs the comprehensive test suite that verifies upstream rsync
-# clients (3.0.9, 3.1.3, 3.4.1, 3.4.2) can successfully connect to and transfer files
+# clients (3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3, 3.4.4) can successfully connect to and transfer files
 # with the oc-rsync daemon implementation.
 #
 # Prerequisites:
@@ -11,6 +11,8 @@
 #    - target/interop/upstream-install/3.1.3/bin/rsync
 #    - target/interop/upstream-install/3.4.1/bin/rsync
 #    - target/interop/upstream-install/3.4.2/bin/rsync
+#    - target/interop/upstream-install/3.4.3/bin/rsync
+#    - target/interop/upstream-install/3.4.4/bin/rsync
 #
 # 2. oc-rsync binary must be built at:
 #    - target/release/oc-rsync (preferred)
@@ -119,6 +121,8 @@ check_prerequisites() {
     check_binary "target/interop/upstream-install/3.1.3/bin/rsync" "upstream rsync 3.1.3" || all_found=false
     check_binary "target/interop/upstream-install/3.4.1/bin/rsync" "upstream rsync 3.4.1" || all_found=false
     check_binary "target/interop/upstream-install/3.4.2/bin/rsync" "upstream rsync 3.4.2" || all_found=false
+    check_binary "target/interop/upstream-install/3.4.3/bin/rsync" "upstream rsync 3.4.3" || all_found=false
+    check_binary "target/interop/upstream-install/3.4.4/bin/rsync" "upstream rsync 3.4.4" || all_found=false
 
     echo ""
 

--- a/tools/simple-capture.sh
+++ b/tools/simple-capture.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
-UPSTREAM_BIN="target/interop/upstream-install/3.4.2/bin/rsync"
-if [[ ! -x "${UPSTREAM_BIN}" ]]; then
-    UPSTREAM_BIN="target/interop/upstream-install/3.4.1/bin/rsync"
-fi
+UPSTREAM_BIN="target/interop/upstream-install/3.4.4/bin/rsync"
+for fallback in 3.4.3 3.4.2 3.4.1; do
+    [[ -x "${UPSTREAM_BIN}" ]] && break
+    UPSTREAM_BIN="target/interop/upstream-install/${fallback}/bin/rsync"
+done
 TEST_PORT=18873
 OUTPUT_DIR="tests/protocol_handshakes"
 

--- a/tools/strace-capture.sh
+++ b/tools/strace-capture.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WORKSPACE_ROOT"
 
-UPSTREAM_BIN="target/interop/upstream-install/3.4.2/bin/rsync"
-if [[ ! -x "${UPSTREAM_BIN}" ]]; then
-    UPSTREAM_BIN="target/interop/upstream-install/3.4.1/bin/rsync"
-fi
+UPSTREAM_BIN="target/interop/upstream-install/3.4.4/bin/rsync"
+for fallback in 3.4.3 3.4.2 3.4.1; do
+    [[ -x "${UPSTREAM_BIN}" ]] && break
+    UPSTREAM_BIN="target/interop/upstream-install/${fallback}/bin/rsync"
+done
 TEST_PORT=18873
 OUTPUT_DIR="tests/protocol_handshakes"
 


### PR DESCRIPTION
## Summary

Upstream rsync 3.4.4 was released 2026-06-08. This PR migrates the workspace upstream pin from 3.4.2 to 3.4.4 and adds 3.4.4 to the interop CI matrix. The existing versions (3.0.9, 3.1.3, 3.4.1, 3.4.2, 3.4.3) remain validation targets.

NEWS: https://download.samba.org/pub/rsync/NEWS
Tarball: https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz

## Changes

- `Cargo.toml`: `workspace.metadata.oc_rsync.upstream_version` 3.4.2 -> 3.4.4
- `tools/ci/run_interop.sh`: append 3.4.4 to `versions=(...)`, add 3.4.4 cells in `build_version_url`/`try_fetch_deb_generic` (source-built; no .deb yet), extend the protocol-32 extended-scenarios gate, and prepend 3.4.4 in newest-binary preference loops for protocol forcing + standalone tests
- `tools/ci/run_upstream_testsuite.sh`: default `UPSTREAM_VERSION` 3.4.3 -> 3.4.4
- `tools/ci/test_check_upstream_release.sh`: refresh mocked Cargo/NEWS fixtures to 3.4.4 (no semantic change; still covers equal/ahead/error)
- `tools/ci/check_known_failures.sh`: prefer 3.4.4 with 3.4.3/3.4.2/3.4.1 fallback chain for both daemon and standalone scenarios
- `tools/run_upstream_client_interop_tests.sh`: add 3.4.3/3.4.4 binary checks, refresh documented client-version list
- `tools/strace-capture.sh`, `tools/simple-capture.sh`: prefer 3.4.4 with 3.4.3/3.4.2/3.4.1 fallback chain
- `tools/capture-handshakes.sh`: default `UPSTREAM_VERSION` 3.4.2 -> 3.4.4

## Notes

`tools/ci/check_upstream_release.sh` reads `upstream_version` from `Cargo.toml` dynamically; the workspace bump propagates automatically.

No tarball SHA256 is hardcoded in the listed scripts - upstream tarballs are fetched directly. 3.4.4 has no Debian/Ubuntu .deb yet, so the interop harness falls back to source build (same handling as 3.4.3).

## Follow-up

Several `.github/workflows/*.yml` files contain version-keyed cache keys and standalone steps still referencing 3.4.2/3.4.3 (e.g., `interop-validation.yml`, `upstream-testsuite.yml`, `known-failures.yml`, `filter-fuzzer-overnight.yml`, `ssh-smoke-bench.yml`, `_interop.yml`). These are out of scope for this PR (per the targets list) but should be aligned in a follow-up.

## Test plan

- [ ] CI nextest stable / Windows / macOS / Linux musl pass
- [ ] interop validation workflow exercises 3.4.4 via `run_interop.sh` matrix
- [ ] `tools/ci/test_check_upstream_release.sh` passes with new fixtures

Closes #4965.