### PR TITLE
ci: add upstream rsync 3.4.4 to CI workflow matrices (URS-14)

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -10,7 +10,7 @@ on:
       upstream_rsync_version:
         description: 'Upstream rsync version for cache key'
         type: string
-        default: '3.4.3'
+        default: '3.4.4'
       rust_toolchain:
         description: 'Rust toolchain version'
         type: string
@@ -65,6 +65,9 @@ jobs:
           key: upstream-rsync-${{ inputs.upstream_rsync_version }}-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
           restore-keys: |
             upstream-rsync-${{ inputs.upstream_rsync_version }}-${{ runner.os }}-
+            upstream-rsync-3.4.4-${{ runner.os }}-
+            upstream-rsync-3.4.3-${{ runner.os }}-
+            upstream-rsync-3.4.2-${{ runner.os }}-
 
       - name: Build upstream rsync
         if: steps.cache-rsync.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,7 +566,7 @@ jobs:
     uses: ./.github/workflows/_interop.yml
     with:
       cache_version: ${{ vars.CACHE_VERSION || 'v1' }}
-      upstream_rsync_version: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.2' }}
+      upstream_rsync_version: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.4' }}
       timeout_minutes: 30
 
   # ===========================================================================

--- a/.github/workflows/filter-fuzzer-overnight.yml
+++ b/.github/workflows/filter-fuzzer-overnight.yml
@@ -94,8 +94,10 @@ jobs:
           path: |
             target/interop/upstream-src
             target/interop/upstream-install
-          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          key: upstream-rsync-3.4.4-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
           restore-keys: |
+            upstream-rsync-3.4.4-${{ runner.os }}-
+            upstream-rsync-3.4.3-${{ runner.os }}-
             upstream-rsync-3.4.2-${{ runner.os }}-
 
       - name: Build upstream rsync
@@ -107,6 +109,8 @@ jobs:
         run: |
           set -euo pipefail
           for candidate in \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.4/bin/rsync" \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.3/bin/rsync" \
               "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.2/bin/rsync" \
               "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.1/bin/rsync"; do
               if [[ -x "${candidate}" ]]; then

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -36,7 +36,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
   CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
-  UPSTREAM_RSYNC_VERSION: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.3' }}
+  UPSTREAM_RSYNC_VERSION: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.4' }}
 
 jobs:
   build:

--- a/.github/workflows/known-failures.yml
+++ b/.github/workflows/known-failures.yml
@@ -52,8 +52,10 @@ jobs:
           path: |
             target/interop/upstream-src
             target/interop/upstream-install
-          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          key: upstream-rsync-3.4.4-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
           restore-keys: |
+            upstream-rsync-3.4.4-${{ runner.os }}-
+            upstream-rsync-3.4.3-${{ runner.os }}-
             upstream-rsync-3.4.2-${{ runner.os }}-
 
       - name: Build upstream rsync

--- a/.github/workflows/ssh-smoke-bench.yml
+++ b/.github/workflows/ssh-smoke-bench.yml
@@ -75,28 +75,28 @@ jobs:
         id: cache-rsync
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: target/interop/upstream-src/rsync-3.4.2
-          key: upstream-rsync-3.4.2-${{ runner.os }}-full
+          path: target/interop/upstream-src/rsync-3.4.4
+          key: upstream-rsync-3.4.4-${{ runner.os }}-full
 
-      - name: Build upstream rsync 3.4.2
+      - name: Build upstream rsync 3.4.4
         if: steps.cache-rsync.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
           cd target/interop/upstream-src
 
-          if [ ! -d rsync-3.4.2 ]; then
-            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.2.tar.gz | tar xz
+          if [ ! -d rsync-3.4.4 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
           fi
 
-          cd rsync-3.4.2
+          cd rsync-3.4.4
           if [ ! -f rsync ]; then
             ./configure
             make -j"$(nproc)"
           fi
 
       - name: Install upstream rsync to PATH
-        run: sudo cp target/interop/upstream-src/rsync-3.4.2/rsync /usr/local/bin/rsync
+        run: sudo cp target/interop/upstream-src/rsync-3.4.4/rsync /usr/local/bin/rsync
 
       - name: Build oc-rsync (release)
         run: cargo build --locked --release --workspace

--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -35,7 +35,7 @@ env:
   RUSTFLAGS: "-D warnings"
   RUST_BACKTRACE: "full"
   CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
-  UPSTREAM_RSYNC_VERSION: "3.4.3"
+  UPSTREAM_RSYNC_VERSION: "3.4.4"
 
 jobs:
   upstream-testsuite:


### PR DESCRIPTION
## Summary

Follow-up to #5538 (URS upstream rsync 3.4.4 pin). That PR bumped `tools/ci/*` scripts and the `Cargo.toml` workspace pin but explicitly skipped the workflow YAML files. This PR closes the gap.

- Bumps single-version pins (env vars, workflow_call defaults, pinned source tarball downloads) from 3.4.2 / 3.4.3 to **3.4.4** across the six workflow files surfaced by the URS-14 audit.
- Retains 3.4.1 / 3.4.2 / 3.4.3 as restore-key fallbacks and `Locate upstream rsync` candidates where multi-version slots existed.
- Caller side: also bumps `ci.yml` `interop-upstream` default (`vars.UPSTREAM_RSYNC_VERSION || '3.4.2'` -> `'3.4.4'`) so the `_interop.yml` consumer side receives the right input when the org-level `vars.UPSTREAM_RSYNC_VERSION` is not set.

## Files Touched

| File | Change |
|------|--------|
| `.github/workflows/interop-validation.yml` | `UPSTREAM_RSYNC_VERSION` default `3.4.3` -> `3.4.4` |
| `.github/workflows/upstream-testsuite.yml` | `UPSTREAM_RSYNC_VERSION` `3.4.3` -> `3.4.4` |
| `.github/workflows/known-failures.yml` | Cache key `3.4.2` -> `3.4.4`; add `3.4.3` / `3.4.2` restore fallbacks |
| `.github/workflows/filter-fuzzer-overnight.yml` | Cache key `3.4.2` -> `3.4.4`; restore-keys fallback; `Locate upstream rsync` loop now tries `3.4.4` -> `3.4.3` -> `3.4.2` -> `3.4.1` |
| `.github/workflows/ssh-smoke-bench.yml` | Pinned tarball download `3.4.2` -> `3.4.4` (path, cache key, build step, PATH install) |
| `.github/workflows/_interop.yml` | `workflow_call` default `upstream_rsync_version` `3.4.3` -> `3.4.4`; add `3.4.4`/`3.4.3`/`3.4.2` restore-keys |
| `.github/workflows/ci.yml` | `interop-upstream` caller default `3.4.2` -> `3.4.4` |

## Ordering Note

This PR depends on #5538 being merged first because `tools/ci/run_interop.sh build-only` only knows how to build 3.4.4 after that PR's `versions=(3.0.9 3.1.3 3.4.1 3.4.2 3.4.3 3.4.4)` array bump. Once #5538 lands, this PR is mechanical.

## Test plan

- [ ] CI green on this PR after #5538 merges to master
- [ ] `interop-upstream` cell builds and uses `3.4.4` binary
- [ ] `upstream-testsuite` runs against 3.4.4
- [ ] `filter-fuzzer-overnight` locates `3.4.4` rsync via the new candidate