### PR TITLE
fix: confine daemon alt-basis paths to module root (URV-5.a)

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -250,11 +250,31 @@ fn build_server_config(
 
             // upstream: after chroot + chdir, reference directory paths resolve
             // relative to the module root. We don't chdir, so resolve relative
-            // paths explicitly against the module path.
+            // paths explicitly against the module path. The relative path is
+            // wire-influenced via --copy-dest / --link-dest / --compare-dest
+            // (options.c:2915-2923), so we must confine the join beneath the
+            // module root - matching `secure_relative_open()` in upstream
+            // 3.4.4 syscall.c:1791-1896. Without this an attacker can submit
+            // `--copy-dest=../../etc` on a chroot-disabled module and escape
+            // to arbitrary filesystem locations.
             let module_path = std::path::Path::new(&module.path);
             for ref_dir in &mut cfg.reference_directories {
                 if ref_dir.path.is_relative() {
-                    ref_dir.path = module_path.join(&ref_dir.path);
+                    match confine_alt_basis_to_module_root(module_path, &ref_dir.path) {
+                        Ok(resolved) => ref_dir.path = resolved,
+                        Err(err) => {
+                            let payload = format!(
+                                "@ERROR: refusing alt-basis path that escapes module root: {err}"
+                            );
+                            send_error_and_exit(
+                                ctx.reader.get_mut(),
+                                ctx.limiter,
+                                ctx.messages,
+                                &payload,
+                            )?;
+                            return Ok(None);
+                        }
+                    }
                 }
             }
 
@@ -297,6 +317,70 @@ fn build_server_config(
             Ok(None)
         }
     }
+}
+
+/// Returns `true` if any normal component of `path` is exactly `..`.
+///
+/// Mirrors upstream rsync 3.4.4 `syscall.c:1679 path_has_dotdot_component()`,
+/// which scans `/`-separated segments for a bare `..`. Used by
+/// [`confine_alt_basis_to_module_root`] as the front-door rejection that
+/// upstream's `secure_relative_open()` applies before any kernel-side
+/// `RESOLVE_BENEATH` open (`syscall.c:1858-1866`, `syscall.c:1889-1896`).
+/// On Windows, `Component::ParentDir` covers both `..` and the rare back-
+/// slash form because `PathBuf` parses with platform-native separators.
+fn path_has_dotdot_component(path: &std::path::Path) -> bool {
+    path.components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+/// Confines a daemon alt-basis relative path (`--copy-dest=REL`,
+/// `--link-dest=REL`, `--compare-dest=REL`) beneath `module_root`.
+///
+/// Mirrors `secure_relative_open()` in upstream rsync 3.4.4
+/// `syscall.c:1791-1896`. The relative path is wire-influenced by the
+/// client, so without this check `--copy-dest=../../etc` is accepted on a
+/// chroot-disabled module and lets the attacker target arbitrary inodes
+/// outside the module root. Confinement runs unconditionally because
+/// oc-rsync does not actually `chroot()` into the module path (see the
+/// comment in `build_server_config` above the call site).
+///
+/// Confinement strategy mirrors upstream's portable fallback
+/// (`syscall.c:1883-1896`):
+///
+/// 1. Front-door reject any `..` component in the relative path with
+///    `EINVAL`. This is the only safe behaviour without a kernel-enforced
+///    `RESOLVE_BENEATH`; per-component walking cannot adjudicate `..`
+///    against bind-mounts and symlinks racing in between checks.
+/// 2. Join the validated relative path onto `module_root` and return the
+///    resulting `PathBuf` to the caller. Because step 1 rejected every
+///    `..`, the join can only descend into the module root, matching
+///    `RESOLVE_BENEATH`'s confinement semantics.
+///
+/// Upstream's re-anchoring branch (`syscall.c:1817-1844`) handles the
+/// case where rsync has chdir'd into a transfer subdirectory of the
+/// module and wants to allow `--link-dest=../sibling` to reach a peer
+/// directory inside the module. oc-rsync never chdir's the daemon
+/// process into the module, so the relative path is always interpreted
+/// against the module root directly and the re-anchoring branch does
+/// not apply.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidInput`] when the relative path
+/// contains any `..` component. The caller maps this to an
+/// `@ERROR: refusing alt-basis path that escapes module root: ...`
+/// payload and tears down the session.
+fn confine_alt_basis_to_module_root(
+    module_root: &std::path::Path,
+    relative: &std::path::Path,
+) -> io::Result<std::path::PathBuf> {
+    if path_has_dotdot_component(relative) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("relative path {relative:?} contains a `..` component"),
+        ));
+    }
+    Ok(module_root.join(relative))
 }
 
 /// Applies long-form arguments from the client to the server configuration.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -800,6 +800,101 @@ mod module_access_tests {
         assert!(config.reference_directories.is_empty());
     }
 
+    // URV-5.a regression tests: the daemon's alt-basis relative path
+    // resolution (--copy-dest / --link-dest / --compare-dest) must
+    // confine the join beneath the module root, matching upstream
+    // 3.4.4 secure_relative_open() in syscall.c:1791-1896. Without
+    // confinement, --copy-dest=../../etc on a chroot-disabled module
+    // is accepted and points at arbitrary filesystem locations.
+
+    #[test]
+    fn confine_alt_basis_admits_clean_relative_sibling() {
+        let module_root = std::path::Path::new("/tmp/module");
+        let resolved =
+            confine_alt_basis_to_module_root(module_root, std::path::Path::new("sibling"))
+                .expect("clean sibling should resolve beneath module root");
+        assert_eq!(resolved, std::path::PathBuf::from("/tmp/module/sibling"));
+    }
+
+    #[test]
+    fn confine_alt_basis_admits_nested_relative_path() {
+        let module_root = std::path::Path::new("/tmp/module");
+        let resolved = confine_alt_basis_to_module_root(
+            module_root,
+            std::path::Path::new("snapshots/daily/01"),
+        )
+        .expect("nested path with no `..` should resolve beneath module root");
+        assert_eq!(
+            resolved,
+            std::path::PathBuf::from("/tmp/module/snapshots/daily/01")
+        );
+    }
+
+    #[test]
+    fn confine_alt_basis_rejects_bare_dotdot() {
+        let module_root = std::path::Path::new("/tmp/module");
+        let err = confine_alt_basis_to_module_root(module_root, std::path::Path::new(".."))
+            .expect_err("bare `..` must be rejected to match upstream secure_relative_open");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn confine_alt_basis_rejects_leading_dotdot() {
+        let module_root = std::path::Path::new("/tmp/module");
+        let err =
+            confine_alt_basis_to_module_root(module_root, std::path::Path::new("../sibling"))
+                .expect_err("`../sibling` must be rejected to prevent module-root escape");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn confine_alt_basis_rejects_path_traversal_to_etc() {
+        // The headline URV-5.a exploit: --copy-dest=../../etc on a
+        // chroot-disabled module must be refused.
+        let module_root = std::path::Path::new("/tmp/module");
+        let err = confine_alt_basis_to_module_root(module_root, std::path::Path::new("../../etc"))
+            .expect_err("`../../etc` must be rejected as a module-root escape");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn confine_alt_basis_rejects_embedded_dotdot() {
+        let module_root = std::path::Path::new("/tmp/module");
+        let err = confine_alt_basis_to_module_root(
+            module_root,
+            std::path::Path::new("subdir/../../escape"),
+        )
+        .expect_err("`subdir/../../escape` must be rejected even after partial descent");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn confine_alt_basis_rejects_trailing_dotdot() {
+        let module_root = std::path::Path::new("/tmp/module");
+        let err =
+            confine_alt_basis_to_module_root(module_root, std::path::Path::new("subdir/.."))
+                .expect_err("`subdir/..` must be rejected (matches upstream's portable fallback)");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn path_has_dotdot_component_detects_all_forms() {
+        // Mirrors upstream syscall.c:1679 path_has_dotdot_component()
+        // coverage: bare "..", leading, trailing, embedded.
+        assert!(path_has_dotdot_component(std::path::Path::new("..")));
+        assert!(path_has_dotdot_component(std::path::Path::new("../foo")));
+        assert!(path_has_dotdot_component(std::path::Path::new("foo/..")));
+        assert!(path_has_dotdot_component(std::path::Path::new("foo/../bar")));
+        assert!(!path_has_dotdot_component(std::path::Path::new("foo")));
+        assert!(!path_has_dotdot_component(std::path::Path::new("foo/bar")));
+        // A single dot is `Component::CurDir`, not `ParentDir`, and
+        // poses no escape risk.
+        assert!(!path_has_dotdot_component(std::path::Path::new("./foo")));
+        // Strings that merely contain "..", such as "foo..bar", are not
+        // path components and must be admitted.
+        assert!(!path_has_dotdot_component(std::path::Path::new("foo..bar")));
+    }
+
     // upstream: options.c:2750-2761 - server_options() sends --log-format=%i
     // when the client uses -i/--itemize-changes. The daemon must parse this
     // to set info_flags.itemize so the receiver emits MSG_INFO itemize frames.


### PR DESCRIPTION
## Summary

- Wire upstream rsync 3.4.4 `secure_relative_open()` confinement (`syscall.c:1791-1896`) into the daemon's relative alt-basis admission path in `crates/daemon/src/daemon/sections/module_access/client_args.rs`.
- The previous code called `module_path.join(rel)` with no `..` rejection and no `RESOLVE_BENEATH` confinement, so a client could submit `--copy-dest=../../etc` on a chroot-disabled module and the receiver would target inodes outside the module root.
- Front-door reject any `..` component in `--copy-dest=REL` / `--link-dest=REL` / `--compare-dest=REL` relative paths, then join the validated path onto the module root. The session is torn down with `@ERROR: refusing alt-basis path that escapes module root: ...` on rejection.

## Why upstream's portable fallback, not RESOLVE_BENEATH

Upstream's RESOLVE_BENEATH branch handles a case oc-rsync does not hit: rsync chdir's into a transfer subdirectory of the module and then needs to allow `--link-dest=../sibling-within-module` to climb back to a peer directory still inside the module (`syscall.c:1817-1844`). oc-rsync never chdir's the daemon process into a subdirectory of the module path (see the existing comment at `build_server_config` above the call site), so the relative ref-dir path is always interpreted against the module root directly. Upstream's portable fallback (`syscall.c:1883-1896`) is the matching semantics in that regime: reject `..` outright. This is also the safest behaviour on platforms without kernel-side `RESOLVE_BENEATH` (NetBSD, OpenBSD, Solaris, Cygwin, pre-5.6 Linux), where per-component walking cannot adjudicate `..` against bind-mounts and racing symlinks.

## SECURITY.md classification

Bug class falls under the SEC-1 family in SECURITY.md (TOCTOU and filesystem confinement on chroot-disabled modules). The closely related CVE-2026-29518 / CVE-2026-43619 entries cover symlink races on receiver syscalls; this fix closes a narrower but related admission-time path-traversal hole on the same `use chroot = no` configurations that the SEC-1 work targets.

## Test plan

- [x] Unit test: `confine_alt_basis_admits_clean_relative_sibling`
- [x] Unit test: `confine_alt_basis_admits_nested_relative_path`
- [x] Unit test: `confine_alt_basis_rejects_bare_dotdot`
- [x] Unit test: `confine_alt_basis_rejects_leading_dotdot`
- [x] Unit test: `confine_alt_basis_rejects_path_traversal_to_etc` (the headline `../../etc` exploit)
- [x] Unit test: `confine_alt_basis_rejects_embedded_dotdot`
- [x] Unit test: `confine_alt_basis_rejects_trailing_dotdot`
- [x] Unit test: `path_has_dotdot_component_detects_all_forms`
- [ ] CI: fmt + clippy
- [ ] CI: nextest (Linux gnu/musl, macOS, Windows)