### PR TITLE
fix: emit NDX_DEL_STATS without --stats gate (URV-6.a)

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1986,23 +1986,13 @@ fn write_delta_with_compression_plain_fallback() {
 }
 
 #[test]
-fn del_stats_not_sent_without_do_stats() {
-    // upstream: INFO_GTE(STATS, 2) is false => never send del_stats
+fn del_stats_sent_without_do_stats_when_deleting() {
+    // URV-6.a: upstream 3.4.4 removed the INFO_GTE(STATS, 2) gate. del_stats
+    // must be emitted whenever delete_mode is active, regardless of --stats.
+    // upstream: generator.c:2394 in 3.4.4 - early path no longer references STATS
     let handshake = test_handshake();
     let mut config = test_config();
     config.do_stats = false;
-    config.flags.delete = true;
-    config.deletion.late_delete = false;
-    let ctx = GeneratorContext::new_for_test(&handshake, config);
-    assert!(!ctx.should_send_del_stats());
-}
-
-#[test]
-fn del_stats_early_sent_with_do_stats_and_delete() {
-    // upstream: generator.c:2377 - early path: INFO_GTE(STATS, 2) && delete_mode
-    let handshake = test_handshake();
-    let mut config = test_config();
-    config.do_stats = true;
     config.flags.delete = true;
     config.deletion.late_delete = false;
     let ctx = GeneratorContext::new_for_test(&handshake, config);
@@ -2010,8 +2000,9 @@ fn del_stats_early_sent_with_do_stats_and_delete() {
 }
 
 #[test]
-fn del_stats_early_not_sent_without_delete() {
-    // upstream: generator.c:2377 - early path requires delete_mode || force_delete
+fn del_stats_not_sent_when_no_delete() {
+    // upstream: generator.c:2394 in 3.4.4 - !(delete_mode||force_delete||read_batch)
+    // skips write_del_stats regardless of --stats.
     let handshake = test_handshake();
     let mut config = test_config();
     config.do_stats = true;
@@ -2022,39 +2013,52 @@ fn del_stats_early_not_sent_without_delete() {
 }
 
 #[test]
-fn del_stats_late_sent_with_do_stats_only() {
-    // upstream: generator.c:2422 - late path: INFO_GTE(STATS, 2) is sufficient
+fn del_stats_early_sent_with_delete() {
+    // upstream: generator.c:2394 in 3.4.4 - early path: delete_mode (no STATS gate)
     let handshake = test_handshake();
     let mut config = test_config();
     config.do_stats = true;
-    config.flags.delete = false;
+    config.flags.delete = true;
+    config.deletion.late_delete = false;
+    let ctx = GeneratorContext::new_for_test(&handshake, config);
+    assert!(ctx.should_send_del_stats());
+}
+
+#[test]
+fn del_stats_late_sent_with_delete() {
+    // upstream: generator.c:2439 in 3.4.4 - late path: delete_mode (no STATS gate)
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.do_stats = true;
+    config.flags.delete = true;
     config.deletion.late_delete = true;
     let ctx = GeneratorContext::new_for_test(&handshake, config);
     assert!(ctx.should_send_del_stats());
 }
 
 #[test]
-fn del_stats_late_not_sent_without_do_stats() {
-    // upstream: INFO_GTE(STATS, 2) is false => even late path skips del_stats
+fn del_stats_late_sent_without_do_stats() {
+    // URV-6.a: late path must also emit del_stats without --stats in 3.4.4.
+    // upstream: generator.c:2439 in 3.4.4 - no INFO_GTE(STATS, 2) requirement
     let handshake = test_handshake();
     let mut config = test_config();
     config.do_stats = false;
     config.flags.delete = true;
     config.deletion.late_delete = true;
     let ctx = GeneratorContext::new_for_test(&handshake, config);
-    assert!(!ctx.should_send_del_stats());
+    assert!(ctx.should_send_del_stats());
 }
 
 #[test]
-fn del_stats_late_with_delete_and_stats() {
-    // upstream: late path with both delete_mode and stats - should send
+fn del_stats_late_not_sent_without_delete() {
+    // upstream: generator.c:2439 in 3.4.4 - late path skipped when delete inactive
     let handshake = test_handshake();
     let mut config = test_config();
     config.do_stats = true;
-    config.flags.delete = true;
+    config.flags.delete = false;
     config.deletion.late_delete = true;
     let ctx = GeneratorContext::new_for_test(&handshake, config);
-    assert!(ctx.should_send_del_stats());
+    assert!(!ctx.should_send_del_stats());
 }
 
 #[test]

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -29,10 +29,14 @@ impl GeneratorContext {
     /// `read_ndx_and_attrs()` which loops over NDX_DEL_STATS, reading 5 varints of
     /// deletion counts before continuing to expect NDX_DONE.
     ///
-    /// Deletion statistics are only sent when `--stats` is active (INFO_GTE(STATS, 2))
-    /// and follow upstream's early/late timing:
-    /// - **Early** (delete_during or delete_before): sent when `do_stats && delete_mode`.
-    /// - **Late** (delete_delay or delete_after): sent when `do_stats`.
+    /// Deletion statistics are sent whenever deletion is active, following
+    /// upstream 3.4.4's early/late timing (the `--stats`/`INFO_GTE(STATS, 2)`
+    /// requirement was removed in 3.4.4). Both paths share the predicate
+    /// `delete_mode || force_delete || read_batch`:
+    /// - **Early** (delete_during or delete_before): sent at the early-delete
+    ///   checkpoint just after the first phase NDX_DONE pair.
+    /// - **Late** (delete_delay or delete_after): sent at the late-delete
+    ///   checkpoint after delayed deletions complete.
     ///
     /// # Upstream Reference
     ///
@@ -41,8 +45,8 @@ impl GeneratorContext {
     /// - `main.c:885-886` - protocol >= 29 uses `read_ndx_and_attrs()`
     /// - `rsync.c:337-342` - NDX_DEL_STATS handling in `read_ndx_and_attrs()`
     /// - `main.c:225-238` - `write_del_stats()` format
-    /// - `generator.c:2376-2381` - early del_stats path
-    /// - `generator.c:2420-2425` - late del_stats path
+    /// - `generator.c:2393-2398` (3.4.4) - early del_stats path (no STATS gate)
+    /// - `generator.c:2437-2442` (3.4.4) - late del_stats path (no STATS gate)
     pub(in crate::generator) fn handle_goodbye<R: Read, W: Write>(
         &mut self,
         reader: &mut R,
@@ -78,12 +82,12 @@ impl GeneratorContext {
 
         // For protocol 31+: conditionally send del_stats, echo NDX_DONE, read final NDX_DONE.
         //
-        // Upstream gates del_stats sending on INFO_GTE(STATS, 2) (i.e. --stats was passed)
-        // and splits it into early vs late paths depending on deletion timing:
-        // - Early (generator.c:2376-2381): !(delete_during==2 || delete_after) =>
-        //   send del_stats only when (do_stats && (delete_mode || force_delete))
-        // - Late (generator.c:2420-2425): (delete_during==2 || delete_after) =>
-        //   send del_stats when do_stats
+        // Upstream 3.4.4 removed the INFO_GTE(STATS, 2) (--stats) gate. del_stats are now
+        // sent whenever deletion is active, split into early vs late paths by timing:
+        // - Early (generator.c:2393-2398 in 3.4.4): !(delete_during==2 || delete_after) =>
+        //   send del_stats when (delete_mode || force_delete || read_batch)
+        // - Late  (generator.c:2437-2442 in 3.4.4): (delete_during==2 || delete_after) =>
+        //   send del_stats when (delete_mode || force_delete || read_batch)
         if self.protocol.supports_extended_goodbye() {
             // Writes during goodbye may fail when the daemon has already closed
             // the connection (common in dry-run mode).
@@ -137,25 +141,26 @@ impl GeneratorContext {
 
     /// Determines whether del_stats should be sent during the goodbye phase.
     ///
-    /// Mirrors upstream's conditional logic for `write_del_stats()` in the
-    /// generator goodbye sequence. The conditions differ for early vs late
-    /// deletion timing:
+    /// Mirrors upstream 3.4.4's conditional logic for `write_del_stats()` in
+    /// the generator goodbye sequence. Upstream 3.4.4 removed the
+    /// `INFO_GTE(STATS, 2)` (`--stats`) gate; del_stats are now emitted
+    /// whenever deletion is active, with timing split by early vs late:
     ///
-    /// - **Early** (`!late_delete`): `do_stats && flags.delete`
-    ///   (upstream: generator.c:2377 - `INFO_GTE(STATS, 2) && (delete_mode || force_delete)`)
-    /// - **Late** (`late_delete`): `do_stats`
-    ///   (upstream: generator.c:2422 - `INFO_GTE(STATS, 2)`)
+    /// - **Early** (`!late_delete`): `delete_mode || force_delete || read_batch`
+    ///   (upstream: generator.c:2394 in 3.4.4)
+    /// - **Late** (`late_delete`): same condition
+    ///   (upstream: generator.c:2439 in 3.4.4)
+    ///
+    /// Note: oc-rsync does not currently track `force_delete` or `read_batch`
+    /// as distinct flags in the transfer config. `flags.delete` covers the
+    /// `delete_mode` case; the other two are out of scope for URV-6.a and
+    /// will be wired in once the corresponding config plumbing exists.
     pub(in crate::generator) fn should_send_del_stats(&self) -> bool {
-        if !self.config.do_stats {
-            return false;
-        }
-        if self.config.deletion.late_delete {
-            // upstream: generator.c:2422 - INFO_GTE(STATS, 2) (already checked above)
-            true
-        } else {
-            // upstream: generator.c:2377 - INFO_GTE(STATS, 2) && (delete_mode || force_delete)
-            self.config.flags.delete
-        }
+        // upstream: generator.c:2394 / 2439 in 3.4.4 -
+        // delete_mode || force_delete || read_batch (no INFO_GTE(STATS, 2) gate).
+        // Early and late paths share the same predicate; `late_delete` governs
+        // *which* checkpoint emits the message, not whether to emit.
+        self.config.flags.delete
     }
 
     /// Reads the next NDX value, consuming any NDX_DEL_STATS messages.


### PR DESCRIPTION
## Summary

- Align `should_send_del_stats()` with upstream rsync 3.4.4 by removing the `INFO_GTE(STATS, 2)` (`--stats` / `do_stats`) gate on NDX_DEL_STATS emission during the goodbye phase.
- Match upstream `generator.c:2393-2398` (early del_stats path) and `generator.c:2437-2442` (late del_stats path), both of which dropped the `INFO_GTE(STATS, 2)` requirement in 3.4.4 and now gate solely on `delete_mode || force_delete || read_batch`.
- Verified `supports_extended_goodbye()` already returns `>= 31`, matching upstream's `protocol_version >= 31` guard - no change required to the protocol gate.

## Background

Pre-3.4.4 upstream gated NDX_DEL_STATS on `INFO_GTE(STATS, 2)`. In 3.4.4 that gate was deliberately removed: deletion statistics are now emitted whenever deletion is active, independent of whether the user passed `--stats`. oc-rsync's previous gate (`do_stats && flags.delete` early / `do_stats` late) silently dropped NDX_DEL_STATS in the common case, breaking wire-level conformance with 3.4.4 and leaving the sender-side accumulator at zero.

## Scope notes

- oc-rsync's transfer config does not track `force_delete` or `read_batch` as distinct fields. The new gate uses `flags.delete` to cover the `delete_mode` case; wiring up the other two branches is left as follow-up once the corresponding config plumbing exists.
- Receiver-side NDX_DEL_STATS handling in `crates/transfer/src/receiver/transfer/phases.rs` was already permissive (loops past NDX_DEL_STATS), so no receiver changes are required.
- Reference: URV-6 upstream 3.4.4 conformance audit at `docs/audits/upstream-3.4.4-conformance.md`.

## Test plan

- [x] Existing `should_send_del_stats` tests restructured to drop the `do_stats=true` precondition.
- [x] New regression `del_stats_sent_without_do_stats_when_deleting` asserts emission proceeds with `--stats` off (early path).
- [x] New regression `del_stats_late_sent_without_do_stats` asserts the same on the late path.
- [x] Retained `del_stats_not_sent_when_no_delete` and `del_stats_late_not_sent_without_delete` to confirm the predicate still skips emission when deletion is inactive.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.