### PR TITLE
ci: add upstream rsync 3.4.4 to remaining workflow YAMLs (URS-15)

### DIFF
--- a/.github/workflows/_benchmark-macos.yml
+++ b/.github/workflows/_benchmark-macos.yml
@@ -1,7 +1,7 @@
 name: Benchmark (macOS throughput)
 
 # Reusable workflow: macOS throughput comparison between oc-rsync and
-# upstream rsync 3.4.2 built from source.
+# upstream rsync 3.4.4 built from source.
 #
 # Best-effort: macOS runners have more wall-clock variance than
 # bare-metal Linux. Numbers are a regression sniff, not a merge gate.
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   benchmark-macos:
-    name: throughput vs upstream rsync 3.4.2 (macOS, best-effort)
+    name: throughput vs upstream rsync 3.4.4 (macOS, best-effort)
     runs-on: macos-15
     timeout-minutes: ${{ inputs.timeout_minutes || 90 }}
     continue-on-error: true
@@ -62,21 +62,21 @@ jobs:
         id: cache-rsync
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: target/interop/upstream-src/rsync-3.4.2
-          key: upstream-rsync-3.4.2-${{ runner.os }}-full
+          path: target/interop/upstream-src/rsync-3.4.4
+          key: upstream-rsync-3.4.4-${{ runner.os }}-full
 
-      - name: Build upstream rsync 3.4.2
+      - name: Build upstream rsync 3.4.4
         if: steps.cache-rsync.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
           cd target/interop/upstream-src
 
-          if [ ! -d rsync-3.4.2 ]; then
-            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.2.tar.gz | tar xz
+          if [ ! -d rsync-3.4.4 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
           fi
 
-          cd rsync-3.4.2
+          cd rsync-3.4.4
           if [ ! -f rsync ]; then
             BREW_PREFIX="$(brew --prefix)"
             PKG_CONFIG_PATH="${BREW_PREFIX}/opt/openssl@3/lib/pkgconfig:${BREW_PREFIX}/opt/xxhash/lib/pkgconfig:${BREW_PREFIX}/opt/zstd/lib/pkgconfig:${BREW_PREFIX}/opt/lz4/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Verify upstream rsync binary
-        run: target/interop/upstream-src/rsync-3.4.2/rsync --version | head -3
+        run: target/interop/upstream-src/rsync-3.4.4/rsync --version | head -3
 
       - name: Set up SSH loopback
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,21 +73,21 @@ jobs:
         id: cache-rsync
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: target/interop/upstream-src/rsync-3.4.2
-          key: upstream-rsync-3.4.2-${{ runner.os }}-full
+          path: target/interop/upstream-src/rsync-3.4.4
+          key: upstream-rsync-3.4.4-${{ runner.os }}-full
 
-      - name: Build upstream rsync 3.4.2
+      - name: Build upstream rsync 3.4.4
         if: steps.cache-rsync.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
           cd target/interop/upstream-src
 
-          if [ ! -d rsync-3.4.2 ]; then
-            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.2.tar.gz | tar xz
+          if [ ! -d rsync-3.4.4 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
           fi
 
-          cd rsync-3.4.2
+          cd rsync-3.4.4
           if [ ! -f rsync ]; then
             ./configure
             make -j$(nproc)
@@ -103,7 +103,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no localhost true
 
       - name: Install upstream rsync to PATH
-        run: sudo cp target/interop/upstream-src/rsync-3.4.2/rsync /usr/local/bin/rsync
+        run: sudo cp target/interop/upstream-src/rsync-3.4.4/rsync /usr/local/bin/rsync
 
       - name: Run benchmark
         id: benchmark
@@ -224,8 +224,8 @@ jobs:
 
   # macOS throughput sniff: runs on tag, weekly schedule, and manual
   # dispatch. Best-effort (continue-on-error in the reusable workflow);
-  # not wired into branch protection. Builds upstream rsync 3.4.2 from
+  # not wired into branch protection. Builds upstream rsync 3.4.4 from
   # source and compares against oc-rsync release build.
   macos-throughput:
-    name: macOS throughput (vs upstream rsync 3.4.2)
+    name: macOS throughput (vs upstream rsync 3.4.4)
     uses: ./.github/workflows/_benchmark-macos.yml

--- a/.github/workflows/differential-fuzzer-overnight.yml
+++ b/.github/workflows/differential-fuzzer-overnight.yml
@@ -97,8 +97,10 @@ jobs:
           path: |
             target/interop/upstream-src
             target/interop/upstream-install
-          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          key: upstream-rsync-3.4.4-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
           restore-keys: |
+            upstream-rsync-3.4.4-${{ runner.os }}-
+            upstream-rsync-3.4.3-${{ runner.os }}-
             upstream-rsync-3.4.2-${{ runner.os }}-
 
       - name: Build upstream rsync
@@ -111,6 +113,8 @@ jobs:
         run: |
           set -euo pipefail
           for candidate in \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.4/bin/rsync" \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.3/bin/rsync" \
               "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.2/bin/rsync" \
               "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.1/bin/rsync"; do
               if [[ -x "${candidate}" ]]; then

--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -139,8 +139,10 @@ jobs:
           path: |
             target/interop/upstream-src
             target/interop/upstream-install
-          key: upstream-rsync-3.4.2-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
+          key: upstream-rsync-3.4.4-${{ runner.os }}-${{ hashFiles('tools/ci/run_interop.sh') }}
           restore-keys: |
+            upstream-rsync-3.4.4-${{ runner.os }}-
+            upstream-rsync-3.4.3-${{ runner.os }}-
             upstream-rsync-3.4.2-${{ runner.os }}-
 
       - name: Build upstream rsync
@@ -153,6 +155,8 @@ jobs:
         run: |
           set -euo pipefail
           for candidate in \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.4/bin/rsync" \
+              "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.3/bin/rsync" \
               "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.2/bin/rsync" \
               "${GITHUB_WORKSPACE}/target/interop/upstream-install/3.4.1/bin/rsync"; do
               if [[ -x "${candidate}" ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #5538 (Cargo.toml + `tools/ci/*` scripts) and #5539 (URS-14, which covered `interop-validation`, `upstream-testsuite`, `known-failures`, `filter-fuzzer-overnight`, `ssh-smoke-bench`, `_interop`, `ci`). This PR closes the gap on the four remaining workflow YAMLs surfaced by the URS audit.

## Files Touched

| File | Change |
|------|--------|
| `.github/workflows/benchmark.yml` | Pinned tarball/build bumped `3.4.2` -> `3.4.4` (path, cache key, build step name, source download, install-to-PATH copy, macOS sub-job comment + name) |
| `.github/workflows/_benchmark-macos.yml` | Same pattern: header comment, job name, cache path/key, build step name, tarball, verify step (`3.4.2` -> `3.4.4`) |
| `.github/workflows/differential-fuzzer-overnight.yml` | Cache key `3.4.2` -> `3.4.4`; add `3.4.4`/`3.4.3`/`3.4.2` restore-keys; expand `Locate upstream rsync` loop to try `3.4.4` -> `3.4.3` -> `3.4.2` -> `3.4.1` |
| `.github/workflows/fuzz-coverage-report.yml` | Cache key `3.4.2` -> `3.4.4`; restore-keys + candidate loop expansion (same as differential-fuzzer-overnight) |

Retains `3.4.1` / `3.4.2` / `3.4.3` as restore-key fallbacks and locate-loop candidates wherever multi-version slots existed, matching URS-14 conventions in #5539.

## Ordering Note

Depends on #5538 (and ideally #5539) being merged first so that `tools/ci/run_interop.sh build-only` knows how to build `3.4.4` from the upstream tarball list.

## Test plan

- [ ] CI green on this PR after #5538 / #5539 merge to master
- [ ] `benchmark` job builds and benches against `rsync-3.4.4`
- [ ] `_benchmark-macos` reusable workflow builds and benches against `rsync-3.4.4`
- [ ] `differential-fuzzer-overnight` locates `3.4.4` rsync via the new candidate loop
- [ ] `fuzz-coverage-report` locates `3.4.4` rsync via the new candidate loop