### PR TITLE
fix: add force_delete + read_batch fields to ParsedServerFlags for NDX_DEL_STATS gate parity (URV-6.c)

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -245,6 +245,14 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // upstream: options.c:2881-2885 - copy_unsafe_links and safe_links are long-form only
     server_config.flags.copy_unsafe_links = config.copy_unsafe_links();
     server_config.flags.safe_links = config.safe_links();
+    // upstream: options.c:722-723 - --force / --no-force toggles force_delete.
+    // Gates NDX_DEL_STATS emission alongside delete_mode (generator.c:2394/2439).
+    server_config.flags.force_delete = config.force_replacements();
+    // upstream: options.c:1663 - --read-batch sets read_batch=1.
+    // Gates NDX_DEL_STATS emission alongside delete_mode (generator.c:2394/2439).
+    server_config.flags.read_batch = config
+        .batch_config()
+        .is_some_and(engine::batch::BatchConfig::is_read_mode);
     // upstream: syscall.c do_open / do_open_nofollow propagate O_NOATIME when set.
     server_config.write.open_noatime = config.open_noatime();
     // upstream: options.c:2750-2762 - itemize_changes is forwarded to the remote
@@ -392,6 +400,62 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
         assert_eq!(server_config.connection.compression_threads, None);
+    }
+
+    /// URV-6.c: --force must propagate into `flags.force_delete` so the
+    /// generator goodbye gate `delete_mode || force_delete || read_batch`
+    /// matches upstream 3.4.4 (generator.c:2394, 2439).
+    #[test]
+    fn apply_common_server_flags_propagates_force_delete() {
+        let config = ClientConfig::builder().force_replacements(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.flags.force_delete);
+    }
+
+    #[test]
+    fn apply_common_server_flags_force_delete_default_false() {
+        let config = ClientConfig::default();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.flags.force_delete);
+    }
+
+    /// URV-6.c: --read-batch must propagate into `flags.read_batch` so the
+    /// generator goodbye gate matches upstream 3.4.4.
+    #[test]
+    fn apply_common_server_flags_propagates_read_batch() {
+        let batch = engine::batch::BatchConfig::new(
+            engine::batch::BatchMode::Read,
+            "testbatch".to_owned(),
+            32,
+        );
+        let config = ClientConfig::builder().batch_config(Some(batch)).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.flags.read_batch);
+    }
+
+    /// Write-batch modes are not read_batch and must not set the flag.
+    #[test]
+    fn apply_common_server_flags_read_batch_false_for_write_mode() {
+        let batch = engine::batch::BatchConfig::new(
+            engine::batch::BatchMode::Write,
+            "testbatch".to_owned(),
+            32,
+        );
+        let config = ClientConfig::builder().batch_config(Some(batch)).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.flags.read_batch);
+    }
+
+    #[test]
+    fn apply_common_server_flags_read_batch_default_false() {
+        let config = ClientConfig::default();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.flags.read_batch);
     }
 
     #[test]

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -54,6 +54,18 @@ pub struct ParsedServerFlags {
     /// Not part of the compact flag string; set via long-form args or explicit
     /// propagation. In upstream, `'d'` means `--dirs`, not delete.
     pub delete: bool,
+    /// Force deletion of non-empty directories during update (long-form `--force`).
+    ///
+    /// Not part of the compact flag string; set via long-form args or explicit
+    /// propagation. Upstream tracks this as the global `force_delete` flag
+    /// (options.c:100, options.c:722-723).
+    pub force_delete: bool,
+    /// Replay a previously recorded batch file (long-form `--read-batch=FILE`).
+    ///
+    /// Not part of the compact flag string; set via long-form args or explicit
+    /// propagation. Upstream tracks this as the global `read_batch` flag
+    /// (options.c:167, options.c:1663).
+    pub read_batch: bool,
     /// Dry-run / no-transfer mode (`n` flag, upstream: `!do_xfers`).
     pub dry_run: bool,
     /// Transfer directories without recursion (`d` flag, `--dirs`).
@@ -435,6 +447,26 @@ mod tests {
     fn backup_not_set_by_default() {
         let flags = ParsedServerFlags::parse("-r").unwrap();
         assert!(!flags.backup);
+    }
+
+    /// URV-6.c: force_delete and read_batch are long-form-only flags (not part of
+    /// the compact flag string), so parsing any compact string leaves them at
+    /// their default `false` value. Callers populate them from `--force` and
+    /// `--read-batch` long-form args.
+    #[test]
+    fn force_delete_and_read_batch_default_to_false() {
+        let flags = ParsedServerFlags::parse("-r").unwrap();
+        assert!(!flags.force_delete);
+        assert!(!flags.read_batch);
+    }
+
+    /// URV-6.c: the compact flag-string parser does not interpret 'f' or any
+    /// other character as force_delete or read_batch - they are set externally.
+    #[test]
+    fn force_delete_and_read_batch_not_set_from_compact_string() {
+        let flags = ParsedServerFlags::parse("-logDtpre.iLsfxC").unwrap();
+        assert!(!flags.force_delete);
+        assert!(!flags.read_batch);
     }
 
     /// When neither ACLs nor xattrs are requested, clearing unsupported features

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2062,6 +2062,79 @@ fn del_stats_late_not_sent_without_delete() {
 }
 
 #[test]
+fn del_stats_sent_with_force_delete_only() {
+    // URV-6.c: --force alone (without --delete) must emit NDX_DEL_STATS in 3.4.4.
+    // upstream: generator.c:2394 - gate is delete_mode || force_delete || read_batch.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = false;
+    config.flags.force_delete = true;
+    config.flags.read_batch = false;
+    config.deletion.late_delete = false;
+    let ctx = GeneratorContext::new_for_test(&handshake, config);
+    assert!(ctx.should_send_del_stats());
+}
+
+#[test]
+fn del_stats_sent_with_read_batch_only() {
+    // URV-6.c: --read-batch alone must emit NDX_DEL_STATS in 3.4.4.
+    // upstream: generator.c:2394 - read_batch satisfies the gate independently.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = false;
+    config.flags.force_delete = false;
+    config.flags.read_batch = true;
+    config.deletion.late_delete = false;
+    let ctx = GeneratorContext::new_for_test(&handshake, config);
+    assert!(ctx.should_send_del_stats());
+}
+
+#[test]
+fn del_stats_late_sent_with_force_delete_only() {
+    // URV-6.c: late path also gates on force_delete in 3.4.4.
+    // upstream: generator.c:2439 - same predicate as the early path.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = false;
+    config.flags.force_delete = true;
+    config.flags.read_batch = false;
+    config.deletion.late_delete = true;
+    let ctx = GeneratorContext::new_for_test(&handshake, config);
+    assert!(ctx.should_send_del_stats());
+}
+
+#[test]
+fn del_stats_late_sent_with_read_batch_only() {
+    // URV-6.c: late path also gates on read_batch in 3.4.4.
+    // upstream: generator.c:2439 - same predicate as the early path.
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = false;
+    config.flags.force_delete = false;
+    config.flags.read_batch = true;
+    config.deletion.late_delete = true;
+    let ctx = GeneratorContext::new_for_test(&handshake, config);
+    assert!(ctx.should_send_del_stats());
+}
+
+#[test]
+fn del_stats_not_sent_when_no_delete_force_or_batch() {
+    // URV-6.c: with all three flags off, neither path emits NDX_DEL_STATS.
+    // upstream: generator.c:2394 / 2439 - !(delete_mode||force_delete||read_batch).
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = false;
+    config.flags.force_delete = false;
+    config.flags.read_batch = false;
+    config.deletion.late_delete = false;
+    let early_ctx = GeneratorContext::new_for_test(&handshake, config.clone());
+    assert!(!early_ctx.should_send_del_stats());
+    config.deletion.late_delete = true;
+    let late_ctx = GeneratorContext::new_for_test(&handshake, config);
+    assert!(!late_ctx.should_send_del_stats());
+}
+
+#[test]
 fn record_io_error_not_found_sets_vanished() {
     let handshake = test_handshake();
     let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -150,17 +150,14 @@ impl GeneratorContext {
     ///   (upstream: generator.c:2394 in 3.4.4)
     /// - **Late** (`late_delete`): same condition
     ///   (upstream: generator.c:2439 in 3.4.4)
-    ///
-    /// Note: oc-rsync does not currently track `force_delete` or `read_batch`
-    /// as distinct flags in the transfer config. `flags.delete` covers the
-    /// `delete_mode` case; the other two are out of scope for URV-6.a and
-    /// will be wired in once the corresponding config plumbing exists.
     pub(in crate::generator) fn should_send_del_stats(&self) -> bool {
         // upstream: generator.c:2394 / 2439 in 3.4.4 -
         // delete_mode || force_delete || read_batch (no INFO_GTE(STATS, 2) gate).
         // Early and late paths share the same predicate; `late_delete` governs
         // *which* checkpoint emits the message, not whether to emit.
         self.config.flags.delete
+            || self.config.flags.force_delete
+            || self.config.flags.read_batch
     }
 
     /// Reads the next NDX value, consuming any NDX_DEL_STATS messages.

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -155,9 +155,7 @@ impl GeneratorContext {
         // delete_mode || force_delete || read_batch (no INFO_GTE(STATS, 2) gate).
         // Early and late paths share the same predicate; `late_delete` governs
         // *which* checkpoint emits the message, not whether to emit.
-        self.config.flags.delete
-            || self.config.flags.force_delete
-            || self.config.flags.read_batch
+        self.config.flags.delete || self.config.flags.force_delete || self.config.flags.read_batch
     }
 
     /// Reads the next NDX value, consuming any NDX_DEL_STATS messages.


### PR DESCRIPTION
## Summary

Adds `force_delete` and `read_batch` fields to `ParsedServerFlags` and wires them into the NDX_DEL_STATS gate so the generator goodbye predicate matches upstream rsync 3.4.4 (`generator.c:2394`, `generator.c:2439`) **exactly**:

```
delete_mode || force_delete || read_batch
```

URV-6.a (PR #5543) removed the obsolete `INFO_GTE(STATS, 2)` requirement but scoped the new predicate to `flags.delete` only because oc-rsync's transfer config did not yet track `force_delete` or `read_batch` as distinct fields. This PR closes that gap.

## Base branch

This PR targets `fix/urv-6a-ndx-del-stats-gate` (PR #5543) because both PRs touch `should_send_del_stats()` in `crates/transfer/src/generator/transfer/goodbye.rs`. Merge after #5543 lands; the chain then auto-rebases onto master.

## Changes

**`crates/transfer/src/flags.rs`**
- Add `pub force_delete: bool` and `pub read_batch: bool` to `ParsedServerFlags`, documented as long-form-only (not part of the compact `-logDtpre...` flag string).

**`crates/core/src/client/remote/flags.rs`**
- `apply_common_server_flags()` now propagates both fields from `ClientConfig`:
  - `flags.force_delete = config.force_replacements()` (covers all four client-side builders: SSH push/pull, daemon push/pull, embedded SSH push/pull, since they all call `apply_common_server_flags`).
  - `flags.read_batch = config.batch_config().is_some_and(BatchConfig::is_read_mode)`.

**`crates/transfer/src/generator/transfer/goodbye.rs`**
- `should_send_del_stats()` now returns `flags.delete || flags.force_delete || flags.read_batch`, dropping the "out of scope" note from URV-6.a.

## Upstream references

- `options.c:100`, `options.c:722-723` — `force_delete` declaration + `--force`/`--no-force` parsing.
- `options.c:167`, `options.c:1663` — `read_batch` declaration + `--read-batch=FILE` parsing.
- `generator.c:2394` (3.4.4 early path) and `generator.c:2439` (3.4.4 late path) — the new gate.

## Test plan

- [x] `ParsedServerFlags` defaults for the two new fields verified at `false`.
- [x] Compact flag-string parser leaves both fields unchanged.
- [x] `apply_common_server_flags_propagates_force_delete` / `_read_batch` cover CLI -> ServerConfig propagation.
- [x] `apply_common_server_flags_read_batch_false_for_write_mode` confirms `--write-batch` / `--only-write-batch` do **not** set `read_batch`.
- [x] `del_stats_sent_with_force_delete_only` and `del_stats_sent_with_read_batch_only` (early path).
- [x] `del_stats_late_sent_with_force_delete_only` and `del_stats_late_sent_with_read_batch_only` (late path).
- [x] `del_stats_not_sent_when_no_delete_force_or_batch` confirms the negative case for both paths.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.