### PR TITLE
docs: document rust-landlock as preferred daemon-sandboxing primitive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,58 @@ singleton with a per-test factory.
 
 ---
 
+## Sandboxing primitives
+
+When adding or modifying daemon-side code that admits a filesystem path
+(`module.path`, `ref_dir`, `--temp-dir`, `--partial-dir`, `--backup-dir`,
+`--link-dest` / `--copy-dest` / `--compare-dest`), prefer kernel-enforced
+confinement over hand-rolled checks. The defense layers, in decreasing
+strength:
+
+1. **rust-landlock** (preferred). The `landlock` Cargo feature wires
+   [rust-landlock 0.4](https://github.com/landlock-lsm/rust-landlock) through
+   `fast_io::landlock::restrict_to_module_paths(&[...])`. Once engaged on the
+   per-connection receiver thread, every path-based syscall outside the
+   supplied roots returns `EACCES` from the kernel, regardless of which
+   syscall userspace chose or how the path was resolved. This is the only
+   layer that survives a future commit accidentally calling `std::fs::*` or a
+   raw `libc::*` path syscall outside `DirSandbox`. Linux 5.13+ only;
+   best-effort ABI downgrade picks the highest level the running kernel
+   exposes (v3 on 6.2+, v2 on 5.19+, v1 on 5.13+). The stub returns
+   `LandlockOutcome::Unavailable` on non-Linux targets and on pre-5.13 Linux
+   per the IKV-F runtime-fallback contract, so callers never need to gate
+   their code on kernel version.
+2. **`openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)`** via the `DirSandbox`
+   carrier in `crates/fast_io/src/dir_sandbox/`. Closes the per-call TOCTOU
+   window on every `*at` helper and is the first line of defense whenever
+   Landlock is unavailable.
+3. **Lexical `..` rejection.** Last-resort string-level check; necessary but
+   never sufficient. Never rely on it as the sole barrier.
+
+### Checklist when admitting a new root
+
+Any change that introduces a new admission path - a new `ref_dir`, a new
+`--temp-dir` / `--partial-dir` operand wiring, a new `--*-dest` cache, a new
+out-of-tree backup target - must:
+
+- Confirm the SEC-1.p ruleset built at
+  `crates/daemon/src/daemon/sections/module_access/transfer.rs::engage_landlock_sandbox`
+  includes the new root (or document why the new root must remain client-side
+  only and is rejected at the wire-protocol layer, matching the existing
+  `--temp-dir` / `--partial-dir` / `--backup-dir` posture).
+- Route every mutation through `DirSandbox` so the `*at` helper layer also
+  covers the root.
+- Reference: SEC-1.p design at
+  [`docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md`](./docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md);
+  packager guidance at
+  [`docs/packaging/landlock-feature-guidance.md`](./docs/packaging/landlock-feature-guidance.md).
+
+Do not invent a new confinement primitive. If the existing layers do not
+cover a case, extend `fast_io::landlock` or `fast_io::dir_sandbox` rather
+than adding a parallel check.
+
+---
+
 ## Parallel work pattern
 
 - **Worktrees recommended.** Use `git worktree add` so each in-flight branch


### PR DESCRIPTION
## Summary

- Adds a "Sandboxing primitives" section to `CONTRIBUTING.md` documenting the project's defense-in-depth ordering for daemon path confinement: rust-landlock > `openat2(RESOLVE_BENEATH)` > lexical `..` rejection.
- Points contributors at the existing public API (`fast_io::landlock::restrict_to_module_paths`), records the Linux 5.13+ kernel floor with best-effort ABI downgrade, and the runtime-fallback contract that means callers never need to gate on kernel version.
- Adds a checklist for changes that introduce a new admission path (`ref_dir`, `--temp-dir`, `--partial-dir`, `--*-dest`, `--backup-dir`): verify the SEC-1.p ruleset built at `engage_landlock_sandbox` covers the new root, route every mutation through `DirSandbox`, and reference the SEC-1.p design doc and the packager guidance.

Closes URV-LDL-1 (#3625).

## Test plan

- [x] Markdown renders correctly (single new top-level section, hyphens not em-dashes per writing-style rule).
- [x] No code changes; no CI gates affected beyond fmt+clippy already required.