### PR TITLE
feat: typed SqpollUnavailable error on CAP_SYS_NICE missing (SQP-LAND.5)

### DIFF
--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -6,6 +6,7 @@
 
 use std::ffi::CStr;
 use std::io;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use io_uring::IoUring as RawIoUring;
@@ -67,6 +68,59 @@ static SQPOLL_FALLBACK: AtomicBool = AtomicBool::new(false);
 #[must_use]
 pub fn sqpoll_fell_back() -> bool {
     SQPOLL_FALLBACK.load(Ordering::Relaxed)
+}
+
+/// Latched human-readable hint explaining the SQPOLL fallback cause.
+///
+/// Populated the first time [`IoUringConfig::build_ring`] attempts SQPOLL and
+/// the kernel rejects it. The hint differentiates the common errnos:
+///
+/// - `EPERM` (1): rootless container or missing `CAP_SYS_NICE`
+/// - `ENOSYS` (38): kernel predates `IORING_SETUP_SQPOLL`
+/// - other: generic kernel rejection
+///
+/// Surface this via [`sqpoll_unavailability_hint`] so callers (CLI
+/// `--io-uring-status`, daemon log, structured error reporting) can show the
+/// operator how to either grant the capability or disable SQPOLL.
+static SQPOLL_UNAVAILABLE_HINT: OnceLock<String> = OnceLock::new();
+
+/// Returns the latched SQPOLL unavailability hint, if any.
+///
+/// Returns `Some(hint)` after the first failed SQPOLL setup attempt and
+/// `None` otherwise (SQPOLL not requested, or it succeeded). The hint is a
+/// human-readable sentence ending with the recommended remediation, e.g.
+/// "add `CAP_SYS_NICE` or run as root, or set `OC_RSYNC_DISABLE_IOURING=1`
+/// to bypass io_uring entirely".
+#[must_use]
+pub fn sqpoll_unavailability_hint() -> Option<String> {
+    SQPOLL_UNAVAILABLE_HINT.get().cloned()
+}
+
+/// Composes the SQPOLL fallback hint from the captured errno.
+///
+/// Public for [`crate::status`] so the same wording is reused in
+/// `IoUringRestriction::SqpollUnavailable` rendering. Callers outside this
+/// crate should prefer [`sqpoll_unavailability_hint`] which returns the
+/// latched value from the actual fallback event.
+#[must_use]
+pub fn sqpoll_fallback_hint(errno: Option<i32>) -> String {
+    match errno {
+        Some(libc::EPERM) => "io_uring SQPOLL setup failed with EPERM (missing CAP_SYS_NICE); \
+             add the capability, run as root, or set OC_RSYNC_DISABLE_IOURING=1 \
+             to bypass io_uring entirely"
+            .to_string(),
+        Some(libc::ENOSYS) => "io_uring SQPOLL setup failed with ENOSYS (kernel predates \
+             IORING_SETUP_SQPOLL); upgrade to Linux 5.13+ or set \
+             OC_RSYNC_DISABLE_IOURING=1 to bypass io_uring entirely"
+            .to_string(),
+        Some(e) => format!(
+            "io_uring SQPOLL setup failed with errno {e}; falling back to a \
+             regular ring (set OC_RSYNC_DISABLE_IOURING=1 to bypass io_uring entirely)"
+        ),
+        None => "io_uring SQPOLL setup failed (errno unavailable); falling back to a \
+             regular ring (set OC_RSYNC_DISABLE_IOURING=1 to bypass io_uring entirely)"
+            .to_string(),
+    }
 }
 
 /// Parses kernel version from uname release string (e.g., "5.15.0-generic").
@@ -374,10 +428,15 @@ impl IoUringConfig {
             builder.setup_sqpoll(self.sqpoll_idle_ms);
             match builder.build(self.sq_entries) {
                 Ok(ring) => return Ok(ring),
-                Err(_) => {
+                Err(err) => {
                     // SQPOLL requires CAP_SYS_NICE on most kernels. Record
-                    // the fallback so callers can surface it in diagnostics.
+                    // the fallback and latch a typed hint so callers can
+                    // surface why SQPOLL was downgraded (rootless container
+                    // vs older kernel vs generic kernel rejection).
                     SQPOLL_FALLBACK.store(true, Ordering::Relaxed);
+                    let hint = sqpoll_fallback_hint(err.raw_os_error());
+                    logging::debug_log!(Io, 1, "{hint}");
+                    let _ = SQPOLL_UNAVAILABLE_HINT.set(hint);
                 }
             }
         }
@@ -823,6 +882,72 @@ mod tests {
                  sqpoll-mlock-basis is off"
             );
         }
+    }
+
+    #[test]
+    fn sqpoll_fallback_hint_eperm_mentions_cap_sys_nice() {
+        let hint = sqpoll_fallback_hint(Some(libc::EPERM));
+        assert!(
+            hint.contains("EPERM"),
+            "EPERM hint must surface the errno name, got: {hint}"
+        );
+        assert!(
+            hint.contains("CAP_SYS_NICE"),
+            "EPERM hint must mention CAP_SYS_NICE remediation, got: {hint}"
+        );
+        assert!(
+            hint.contains("OC_RSYNC_DISABLE_IOURING"),
+            "EPERM hint must mention the bypass env var, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn sqpoll_fallback_hint_enosys_mentions_kernel_upgrade() {
+        let hint = sqpoll_fallback_hint(Some(libc::ENOSYS));
+        assert!(
+            hint.contains("ENOSYS"),
+            "ENOSYS hint must surface the errno name, got: {hint}"
+        );
+        assert!(
+            hint.contains("5.13") || hint.contains("kernel"),
+            "ENOSYS hint must mention the kernel upgrade path, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn sqpoll_fallback_hint_generic_errno_includes_number() {
+        // EINVAL is neither EPERM nor ENOSYS; the generic branch must
+        // include the numeric errno so unknown failures remain debuggable.
+        let hint = sqpoll_fallback_hint(Some(libc::EINVAL));
+        assert!(
+            hint.contains(&libc::EINVAL.to_string()),
+            "generic hint must include the numeric errno, got: {hint}"
+        );
+        assert!(
+            hint.contains("OC_RSYNC_DISABLE_IOURING"),
+            "generic hint must mention the bypass env var, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn sqpoll_fallback_hint_missing_errno_is_still_actionable() {
+        let hint = sqpoll_fallback_hint(None);
+        assert!(
+            !hint.is_empty(),
+            "absent-errno hint must not be empty: {hint}"
+        );
+        assert!(
+            hint.contains("OC_RSYNC_DISABLE_IOURING"),
+            "absent-errno hint must still mention the bypass env var, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn sqpoll_unavailability_hint_starts_unset() {
+        // The hint is latched the first time build_ring() observes an SQPOLL
+        // failure. Before any build_ring() call (or when SQPOLL succeeds on
+        // privileged hosts), the accessor must return None without panic.
+        let _ = sqpoll_unavailability_hint();
     }
 
     #[test]

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -145,7 +145,8 @@ pub use cancel::{
     cancel_all_by_fd, cancel_by_user_data,
 };
 pub use config::{
-    IoUringConfig, IoUringKernelInfo, config_detail, is_io_uring_available, sqpoll_fell_back,
+    IoUringConfig, IoUringKernelInfo, config_detail, is_io_uring_available,
+    sqpoll_fallback_hint, sqpoll_fell_back, sqpoll_unavailability_hint,
 };
 #[cfg(feature = "iouring-data-reads")]
 pub use data_reader::IoUringFileReader;

--- a/crates/fast_io/src/io_uring_stub/config.rs
+++ b/crates/fast_io/src/io_uring_stub/config.rs
@@ -34,6 +34,25 @@ pub fn sqpoll_fell_back() -> bool {
     false
 }
 
+/// Returns the latched SQPOLL unavailability hint (always `None` on this platform).
+///
+/// io_uring SQPOLL is a Linux kernel feature; on stub platforms there is no
+/// ring to build, so the fallback path is never exercised.
+#[must_use]
+pub fn sqpoll_unavailability_hint() -> Option<String> {
+    None
+}
+
+/// Composes a SQPOLL fallback hint from the captured errno.
+///
+/// Mirrors the Linux implementation so cross-platform callers can format
+/// the same wording without conditional compilation. On stub platforms the
+/// hint is informational only because the fallback path is unreachable.
+#[must_use]
+pub fn sqpoll_fallback_hint(_errno: Option<i32>) -> String {
+    "io_uring SQPOLL is unavailable on this platform (io_uring is Linux-only)".to_string()
+}
+
 /// Public accessors for kernel version detection used by `--version` output.
 ///
 /// Mirrors the real Linux module so cross-platform callers can use the same

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -71,7 +71,10 @@ pub use buffer_ring::{
     bgid_peak_used, bgid_snapshot, pbuf_ring_supported,
 };
 pub use cancel::{CancelOutcome, cancel_all_by_fd, cancel_by_user_data};
-pub use config::{StubIoUringBackend, config_detail, is_io_uring_available, sqpoll_fell_back};
+pub use config::{
+    StubIoUringBackend, config_detail, is_io_uring_available, sqpoll_fallback_hint,
+    sqpoll_fell_back, sqpoll_unavailability_hint,
+};
 pub use disk_batch::IoUringDiskBatch;
 pub use file_factory::{
     IoUringOrStdReader, IoUringOrStdWriter, IoUringReaderFactory, IoUringWriterFactory, read_file,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -320,9 +320,9 @@ pub use io_uring::{
     build_linkat_sqe, build_linkat_sqe_unchecked, build_renameat2_sqe,
     build_renameat2_sqe_unchecked, build_statx_sqe, build_statx_sqe_unchecked,
     is_io_uring_available, linkat_supported, pbuf_ring_supported, reader_from_path,
-    reader_from_path_with_depth, renameat2_blocking, renameat2_supported, sqpoll_fell_back,
-    statx_supported, submit_linkat_blocking, submit_statx_batch, submit_statx_blocking,
-    writer_from_file, writer_from_file_with_depth,
+    reader_from_path_with_depth, renameat2_blocking, renameat2_supported, sqpoll_fallback_hint,
+    sqpoll_fell_back, sqpoll_unavailability_hint, statx_supported, submit_linkat_blocking,
+    submit_statx_batch, submit_statx_blocking, writer_from_file, writer_from_file_with_depth,
 };
 
 #[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]

--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -53,6 +53,23 @@ pub enum IoUringRestriction {
         /// Detected kernel minor version.
         minor: u32,
     },
+    /// `io_uring` itself is available, but `IORING_SETUP_SQPOLL` was rejected
+    /// by the kernel and the ring was rebuilt without the SQPOLL kthread.
+    ///
+    /// The `hint` is a human-readable sentence that distinguishes the common
+    /// causes (rootless container / missing `CAP_SYS_NICE` on `EPERM`, older
+    /// kernel on `ENOSYS`, otherwise a generic kernel rejection) and points
+    /// the operator at the remediation. It mirrors the message logged by
+    /// [`crate::io_uring::config::build_ring`] at the time of the fallback so
+    /// `--io-uring-status` and structured callers see the same wording.
+    ///
+    /// This variant does not block io_uring itself - all non-SQPOLL paths
+    /// remain functional. It exists so callers debugging "why is my daemon
+    /// slow?" can see the SQPOLL downgrade without parsing log output.
+    SqpollUnavailable {
+        /// Human-readable cause + remediation, suitable for log output.
+        hint: String,
+    },
     /// Could not determine the kernel version.
     KernelVersionUnknown,
 }
@@ -73,6 +90,7 @@ impl std::fmt::Display for IoUringRestriction {
                      (seccomp, container runtime, or cgroup restriction)"
                 )
             }
+            Self::SqpollUnavailable { hint } => write!(f, "{hint}"),
             Self::KernelVersionUnknown => write!(f, "could not detect kernel version"),
         }
     }
@@ -767,6 +785,33 @@ mod tests {
                 "restriction must not be None when io_uring is unavailable"
             );
         }
+    }
+
+    #[test]
+    fn sqpoll_unavailable_variant_constructs_and_displays() {
+        // The SqpollUnavailable variant is the typed entry point for
+        // SQP-LAND.4 wire-up. It must be constructible with an arbitrary
+        // hint string and render that hint verbatim through Display so
+        // callers can pass through messages composed by build_ring().
+        let hint = "io_uring SQPOLL setup failed with EPERM (missing CAP_SYS_NICE); \
+                    add the capability, run as root, or set OC_RSYNC_DISABLE_IOURING=1 \
+                    to bypass io_uring entirely";
+        let restriction = IoUringRestriction::SqpollUnavailable {
+            hint: hint.to_string(),
+        };
+        let display = format!("{restriction}");
+        assert_eq!(display, hint);
+        assert!(display.contains("EPERM"));
+        assert!(display.contains("CAP_SYS_NICE"));
+        assert!(display.contains("OC_RSYNC_DISABLE_IOURING"));
+    }
+
+    #[test]
+    fn sqpoll_unavailable_variant_is_distinct_from_none() {
+        let restriction = IoUringRestriction::SqpollUnavailable {
+            hint: "anything".to_string(),
+        };
+        assert_ne!(restriction, IoUringRestriction::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Per SQP-LAND.1 audit (PR #5548), `IoUringConfig::build_ring()` previously discarded the SQPOLL setup errno and set `SQPOLL_FALLBACK` without a log. Users debugging "why is my daemon slow?" could not tell that SQPOLL was disabled or why.
- Add a typed `IoUringRestriction::SqpollUnavailable { hint }` variant plus a `OnceLock`-latched hint accessor so the cause survives the build path and is readable by `--io-uring-status`, daemon log, and structured callers.
- Capture `err.raw_os_error()` when `IORING_SETUP_SQPOLL` is rejected and compose a hint distinguishing `EPERM` (rootless container / missing `CAP_SYS_NICE`), `ENOSYS` (kernel predates SQPOLL), and generic kernel rejection. The hint is emitted via `debug_log!(Io, 1, ...)`.

This PR is independent of SQP-LAND.4 - it introduces the typed variant and log only. SQP-LAND.4 will wire `detect_io_uring_restriction()` to consume the latched hint.

## Variant definition

```rust
/// `io_uring` itself is available, but `IORING_SETUP_SQPOLL` was rejected
/// by the kernel and the ring was rebuilt without the SQPOLL kthread.
SqpollUnavailable {
    /// Human-readable cause + remediation, suitable for log output.
    hint: String,
},
```

## Log message (EPERM case)

```
io_uring SQPOLL setup failed with EPERM (missing CAP_SYS_NICE); add the capability, run as root, or set OC_RSYNC_DISABLE_IOURING=1 to bypass io_uring entirely
```

## Test plan

- [x] Unit tests cover all four hint branches (EPERM / ENOSYS / generic errno / missing errno)
- [x] Unit test asserts `SqpollUnavailable` variant constructs and renders verbatim through `Display`
- [x] Unit test asserts the variant is distinct from `IoUringRestriction::None`
- [x] Unit test asserts `sqpoll_unavailability_hint()` is queryable without panic before any failure is observed
- [x] Non-Linux stub mirrors the API surface (`sqpoll_fallback_hint`, `sqpoll_unavailability_hint`) so cross-platform callers do not need conditional compilation
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl