### PR TITLE
fix: remove orphan process_missing_args_sentinels call breaking master

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -89,14 +89,6 @@ impl ReceiverContext {
         #[cfg(not(unix))]
         self.create_symlinks(&setup.dest_dir, writer);
 
-        // upstream: generator.c:1348-1354 - missing_args == 2 && file->mode == 0
-        // deletes the destination path and skips any creation for the sentinel.
-        self.process_missing_args_sentinels(
-            &setup.dest_dir,
-            #[cfg(unix)]
-            setup.sandbox.as_deref(),
-        )?;
-
         // Mirror `run_pipelined`: when `--delete` is in effect, sweep the
         // destination for extraneous entries and capture per-type counters.
         // Upstream accumulates these globally across all delete paths so they


### PR DESCRIPTION
## Summary

- Master is failing to compile across all 5 CI workflows (MSRV, CI, Interop, Parallel Determinism, Async Wire Parity) with `E0599: no method named process_missing_args_sentinels found for &mut ReceiverContext` at `crates/transfer/src/receiver/transfer/pipelined_incremental.rs:94`.
- Root cause: PR #5541 (`d69254ab1`) deleted `crates/transfer/src/receiver/directory/missing_args.rs` (which defined the method) and removed call sites in `pipelined.rs` and `sync.rs`, but left the call site in `pipelined_incremental.rs` orphan.
- Fix: drop the 8-line orphan call to restore master compilation, matching the intent of the original cleanup.

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] MSRV Check passes
- [ ] Interop Validation passes
- [ ] Parallel Determinism passes
- [ ] Async Wire Parity passes
