### PR TITLE
ci: drop --cfg docsrs from Pages RUSTDOCFLAGS to compile on stable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
-  RUSTDOCFLAGS: "--cfg docsrs -D rustdoc::broken_intra_doc_links"
+  RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

The Pages workflow (added in PR #5560) uses \`dtolnay/rust-toolchain@stable\` but passes \`--cfg docsrs\` in \`RUSTDOCFLAGS\`. That cfg activates a nightly feature attribute in \`crates/branding/src/lib.rs\`:

\`\`\`rust
#![cfg_attr(docsrs, feature(doc_cfg))]
\`\`\`

Stable rustc rejects \`#![feature]\` with \`error[E0554]\`, breaking the rustdoc build (run 27276554812). Drop \`--cfg docsrs\` from \`RUSTDOCFLAGS\` so the workspace compiles under stable. The \`broken_intra_doc_links\` lint is stable and stays.

## Test plan

- [ ] CI: \`fmt + clippy\` and standard checks pass (workflow-YAML-only change)
- [ ] After merge, Pages workflow run completes \`Build rustdoc\` successfully and deploys
- [ ] \`https://oferchen.github.io/rsync/\` redirects to \`cli/index.html\`