### PR TITLE
docs: drop intra-doc links to private submodules in module overviews

### DIFF
--- a/crates/bandwidth/src/limiter/mod.rs
+++ b/crates/bandwidth/src/limiter/mod.rs
@@ -8,8 +8,8 @@
 //! after idle periods.
 //!
 //! Configuration updates and daemon-module override logic live in
-//! [`change`], while sleep recording for deterministic tests lives in
-//! [`sleep`] and [`test_support`].
+//! `change`, while sleep recording for deterministic tests lives in
+//! `sleep` and `test_support`.
 
 use std::time::Duration;
 

--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -4,9 +4,9 @@
 //! created by `BatchWriter`. The reader is split into focused submodules:
 //!
 //! - Core struct, construction, raw I/O, and accessors (this file)
-//! - [`flist`] - file list deserialization (protocol and local formats)
-//! - [`delta`] - delta token and operation reading
-//! - [`stats`] - transfer statistics reading
+//! - `flist` - file list deserialization (protocol and local formats)
+//! - `delta` - delta token and operation reading
+//! - `stats` - transfer statistics reading
 
 mod delta;
 mod flist;

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -24,14 +24,14 @@
 //!
 //! # Submodules
 //!
-//! - [`codec`] - compression codec detection (`zlib` vs `zstd`) and decoder
+//! - `codec` - compression codec detection (`zlib` vs `zstd`) and decoder
 //!   construction.
-//! - [`delta`] - low-level delta-application primitives ([`apply_delta_ops`],
+//! - `delta` - low-level delta-application primitives (`apply_delta_ops`,
 //!   `write_literals_to_file`, `choose_block_length`).
-//! - [`dispatch`] - per-file helpers used by the main loop: iflags decoding,
+//! - `dispatch` - per-file helpers used by the main loop: iflags decoding,
 //!   sum-head reading, compressed-token streaming, temp-file commit.
-//! - [`delta_phase`] - the NDX-stream loop that drives per-file delta application.
-//! - [`fs_ops`] - symlink creation and metadata application primitives.
+//! - `delta_phase` - the NDX-stream loop that drives per-file delta application.
+//! - `fs_ops` - symlink creation and metadata application primitives.
 //!
 //! # Upstream Reference
 //!

--- a/crates/cli/src/frontend/execution/options/mod.rs
+++ b/crates/cli/src/frontend/execution/options/mod.rs
@@ -6,10 +6,10 @@
 //!
 //! # Submodules
 //!
-//! - [`iconv`] - Charset specification parsing for `--iconv`
-//! - [`numeric`] - Simple numeric argument parsers (`--timeout`, `--max-delete`, etc.)
-//! - [`protocol`] - Protocol version parsing for `--protocol`
-//! - [`size`] - Size specification parsing with unit suffixes (`--block-size`, `--max-size`, etc.)
+//! - `iconv` - Charset specification parsing for `--iconv`
+//! - `numeric` - Simple numeric argument parsers (`--timeout`, `--max-delete`, etc.)
+//! - `protocol` - Protocol version parsing for `--protocol`
+//! - `size` - Size specification parsing with unit suffixes (`--block-size`, `--max-size`, etc.)
 
 mod iconv;
 mod numeric;

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -7,8 +7,8 @@
 //! `clientserver.c:start_daemon_client()`.
 //!
 //! Split into submodules by responsibility:
-//! - [`connection`] - connection establishment, authentication, early-input
-//! - [`orchestration`] - argument building, transfer execution, server config
+//! - `connection` - connection establishment, authentication, early-input
+//! - `orchestration` - argument building, transfer execution, server config
 //!
 //! # Upstream Reference
 //!

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/mod.rs
@@ -5,10 +5,10 @@
 //! and converts server statistics to client summaries.
 //!
 //! Split into focused submodules by responsibility:
-//! - [`arguments`] - daemon argument list construction (single-phase and protect-args)
-//! - [`server_config`] - `ServerConfig` builders for receiver and generator roles
-//! - [`stats`] - server statistics to client summary conversion
-//! - [`transfer`] - pull and push transfer execution
+//! - `arguments` - daemon argument list construction (single-phase and protect-args)
+//! - `server_config` - `ServerConfig` builders for receiver and generator roles
+//! - `stats` - server statistics to client summary conversion
+//! - `transfer` - pull and push transfer execution
 
 mod arguments;
 mod server_config;

--- a/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
@@ -4,12 +4,12 @@
 //! live here. Method `impl` blocks are split across focused submodules so each
 //! file stays under the LoC cap:
 //!
-//! - [`lifecycle`] - constructors, builders, accessors.
-//! - [`insert`] - inbound insert paths and the spill-state eviction helper.
-//! - [`spill`] - spill-to-disk path: candidate selection, per-item and
+//! - `lifecycle` - constructors, builders, accessors.
+//! - `insert` - inbound insert paths and the spill-state eviction helper.
+//! - `spill` - spill-to-disk path: candidate selection, per-item and
 //!   whole-batch writers, RSS pressure trigger, compression wrapper, raw
 //!   record writer, and directory recreation.
-//! - [`reload`] - reload-from-disk path: in-order delivery, single-item and
+//! - `reload` - reload-from-disk path: in-order delivery, single-item and
 //!   batch reload, on-disk tag dispatch.
 //!
 //! The parent [`spill`](super) module re-exports [`SpillableReorderBuffer`]

--- a/crates/engine/src/delete/context/mod.rs
+++ b/crates/engine/src/delete/context/mod.rs
@@ -48,10 +48,10 @@
 //!
 //! # Submodules
 //!
-//! - [`core`] - the [`DeleteContext`] struct, its constructors, the
+//! - `core` - the [`DeleteContext`] struct, its constructors, the
 //!   observation API, and the `emit_*`/`into_emitter` drain plumbing.
-//! - [`outcome`] - the [`DrainOutcome`] returned by every `emit_*` call.
-//! - [`timing`] - the [`EmitterTiming`] enum and its conversions to/from
+//! - `outcome` - the [`DrainOutcome`] returned by every `emit_*` call.
+//! - `timing` - the [`EmitterTiming`] enum and its conversions to/from
 //!   [`crate::local_copy::DeleteTiming`].
 
 mod core;

--- a/crates/engine/src/local_copy/executor/sources/mod.rs
+++ b/crates/engine/src/local_copy/executor/sources/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! Decomposes the source processing pipeline into focused submodules:
 //!
-//! - [`types`] - Data types for destination state and source processing context.
-//! - [`destination`] - Destination state queries and target path computation.
-//! - [`metadata`] - Source metadata fetching, symlink resolution, relative paths.
-//! - [`handlers`] - File-type-specific copy handlers (directory, symlink, FIFO, device).
-//! - [`orchestration`] - Top-level source iteration, deferred operations, error rollback.
+//! - `types` - Data types for destination state and source processing context.
+//! - `destination` - Destination state queries and target path computation.
+//! - `metadata` - Source metadata fetching, symlink resolution, relative paths.
+//! - `handlers` - File-type-specific copy handlers (directory, symlink, FIFO, device).
+//! - `orchestration` - Top-level source iteration, deferred operations, error rollback.
 
 mod destination;
 mod handlers;

--- a/crates/fast_io/src/io_uring/buffer_ring/mod.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring/mod.rs
@@ -21,8 +21,8 @@
 //!
 //! # Module layout
 //!
-//! - [`allocator`] - process-wide bgid allocator and counters.
-//! - [`registration`] - kernel registration plumbing and version probe.
+//! - `allocator` - process-wide bgid allocator and counters.
+//! - `registration` - kernel registration plumbing and version probe.
 //! - this file - the [`BufferRing`] type plus its construction, recycling
 //!   and `Drop` logic.
 //!

--- a/crates/fast_io/src/io_uring/registered_buffers/mod.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/mod.rs
@@ -68,10 +68,10 @@
 //!
 //! # Submodule layout
 //!
-//! - [`registry`] - the [`RegisteredBufferGroup`] coordinator, slot allocator,
+//! - `registry` - the [`RegisteredBufferGroup`] coordinator, slot allocator,
 //!   and [`RegisteredBufferSlot`] handle.
-//! - [`stats`] - re-exports the telemetry types from [`crate::io_uring_common`].
-//! - [`submit`] - `ReadFixed`/`WriteFixed` batch submission helpers and the
+//! - `stats` - re-exports the telemetry types from [`crate::io_uring_common`].
+//! - `submit` - `ReadFixed`/`WriteFixed` batch submission helpers and the
 //!   [`RegisteredBufferSlotInfo`] passed between callers and helpers.
 
 mod registry;

--- a/crates/fast_io/src/iocp/disk_batch/mod.rs
+++ b/crates/fast_io/src/iocp/disk_batch/mod.rs
@@ -34,9 +34,9 @@
 //!
 //! # Submodule layout
 //!
-//! - [`buffer`]: accumulation-buffer enum and the bounce-copy telemetry counter.
-//! - [`writer`]: `WriteFile` dispatch, overlapped-handle lifecycle, batched submission.
-//! - [`completion`]: `GetQueuedCompletionStatusEx` drain, NTSTATUS mapping, test fault injector.
+//! - `buffer`: accumulation-buffer enum and the bounce-copy telemetry counter.
+//! - `writer`: `WriteFile` dispatch, overlapped-handle lifecycle, batched submission.
+//! - `completion`: `GetQueuedCompletionStatusEx` drain, NTSTATUS mapping, test fault injector.
 //!
 //! # Upstream Reference
 //!

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -18,9 +18,9 @@
 //!
 //! # Submodules
 //!
-//! - [`config`] - [`DirMergeConfig`] for per-directory merge file behaviour
-//! - [`scope`] - [`DirFilterGuard`] and internal per-directory scope handling
-//! - [`error`] - [`FilterChainError`] for I/O and parse failures
+//! - `config` - [`DirMergeConfig`] for per-directory merge file behaviour
+//! - `scope` - [`DirFilterGuard`] and internal per-directory scope handling
+//! - `error` - [`FilterChainError`] for I/O and parse failures
 //!
 //! # Upstream References
 //!

--- a/crates/protocol/src/flist/incremental/mod.rs
+++ b/crates/protocol/src/flist/incremental/mod.rs
@@ -8,9 +8,9 @@
 //!
 //! - [`IncrementalFileList`] - Dependency-tracking state machine that yields
 //!   entries when their parent directories are available.
-//! - [`ready_entry`] - Dispatch logic that determines what action to take for
+//! - `ready_entry` - Dispatch logic that determines what action to take for
 //!   each ready entry based on type, filters, and failed directories.
-//! - [`streaming`] - Wire-level reader that feeds entries into the incremental
+//! - `streaming` - Wire-level reader that feeds entries into the incremental
 //!   processor as they arrive from the network.
 //!
 //! # Usage

--- a/crates/protocol/src/negotiation/sniffer/drain/mod.rs
+++ b/crates/protocol/src/negotiation/sniffer/drain/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! Split into focused submodules by responsibility:
 //!
-//! - [`take_prefix`] - drain the sniffed negotiation prefix only
-//! - [`take_buffered`] - drain all buffered bytes (prefix + remainder)
-//! - [`take_remainder`] - drain the buffered remainder while retaining the prefix
+//! - `take_prefix` - drain the sniffed negotiation prefix only
+//! - `take_buffered` - drain all buffered bytes (prefix + remainder)
+//! - `take_remainder` - drain the buffered remainder while retaining the prefix
 
 mod take_buffered;
 mod take_prefix;

--- a/crates/rsync_io/src/session/handshake/session/mod.rs
+++ b/crates/rsync_io/src/session/handshake/session/mod.rs
@@ -7,9 +7,9 @@
 //!
 //! Implementation is split across focused submodules:
 //!
-//! - [`protocol`] - protocol version query accessors
-//! - [`stream`] - stream access, variant downcasts, and transport mapping
-//! - [`parts`] - decomposition into / reassembly from parts, plus trait impls
+//! - `protocol` - protocol version query accessors
+//! - `stream` - stream access, variant downcasts, and transport mapping
+//! - `parts` - decomposition into / reassembly from parts, plus trait impls
 
 mod parts;
 mod protocol;

--- a/crates/rsync_io/src/session/mod.rs
+++ b/crates/rsync_io/src/session/mod.rs
@@ -3,7 +3,7 @@
 //! This module re-exports the high-level [`SessionHandshake`] type together with helper
 //! functions that detect the negotiation style, perform the binary or legacy handshake,
 //! and expose variant-specific metadata through [`SessionHandshakeParts`]. The
-//! implementation is decomposed across the [`handshake`] and [`parts`] submodules to keep
+//! implementation is decomposed across the `handshake` and `parts` submodules to keep
 //! individual files below the workspace line-count guidelines while preserving the
 //! original public API.
 

--- a/crates/transfer/src/generator/transfer/mod.rs
+++ b/crates/transfer/src/generator/transfer/mod.rs
@@ -1,12 +1,12 @@
 //! Main transfer loop and goodbye handshake for the generator role.
 //!
 //! Split into focused submodules:
-//! - [`transfer_loop`] - `run_transfer_loop`, NDX-driven file sending with
+//! - `transfer_loop` - `run_transfer_loop`, NDX-driven file sending with
 //!   delta/whole-file paths across all phases.
-//! - [`goodbye`] - `handle_goodbye` (protocol 31+ extended goodbye with
+//! - `goodbye` - `handle_goodbye` (protocol 31+ extended goodbye with
 //!   `NDX_DEL_STATS`) plus its accumulation helpers.
-//! - [`stats`] - server-side transfer statistics emission.
-//! - [`orchestrator`] - top-level `run` that ties file list building,
+//! - `stats` - server-side transfer statistics emission.
+//! - `orchestrator` - top-level `run` that ties file list building,
 //!   transmission, transfer, and finalization together.
 //!
 //! # Upstream Reference

--- a/crates/transfer/src/receiver/file_list/mod.rs
+++ b/crates/transfer/src/receiver/file_list/mod.rs
@@ -6,13 +6,13 @@
 //!
 //! Split into focused submodules to keep each file within the 650-line cap:
 //!
-//! - [`receive`] - `receive_file_list`, `receive_extra_file_lists`,
+//! - `receive` - `receive_file_list`, `receive_extra_file_lists`,
 //!   `publish_segment_to_delete_pipeline`, and `incremental_file_list_receiver`.
-//! - [`id_lists`] - UID/GID name-to-ID mapping reception.
-//! - [`sanitize`] - file-list sanity validation against directory traversal.
-//! - [`hardlinks`] - post-sort hardlink leader/follower assignment for
+//! - `id_lists` - UID/GID name-to-ID mapping reception.
+//! - `sanitize` - file-list sanity validation against directory traversal.
+//! - `hardlinks` - post-sort hardlink leader/follower assignment for
 //!   protocol 30+ and pre-30 normalization from (dev, ino) pairs.
-//! - [`incremental`] - the streaming [`IncrementalFileListReceiver`] type.
+//! - `incremental` - the streaming [`IncrementalFileListReceiver`] type.
 
 mod hardlinks;
 mod id_lists;

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -4,14 +4,14 @@
 //! entry points plus the common `setup_transfer` initialization. The driving
 //! loops live in their own submodules:
 //!
-//! - [`sync`] - sequential per-file transfer used by `run_sync`.
-//! - [`pipelined`] - decoupled two-phase pipeline used by `run_pipelined`.
-//! - [`pipelined_incremental`] - same as `pipelined` plus incremental directory
+//! - `sync` - sequential per-file transfer used by `run_sync`.
+//! - `pipelined` - decoupled two-phase pipeline used by `run_pipelined`.
+//! - `pipelined_incremental` - same as `pipelined` plus incremental directory
 //!   creation and failed-dir tracking.
-//! - [`setup`] - common multiplex/filter/file-list setup.
-//! - [`phases`] - protocol phase exchange and goodbye handshake.
-//! - [`candidates`] - candidate-file selection for the pipelined paths.
-//! - [`pipeline`] - the inner `run_pipeline_loop_decoupled` plus dry-run loop.
+//! - `setup` - common multiplex/filter/file-list setup.
+//! - `phases` - protocol phase exchange and goodbye handshake.
+//! - `candidates` - candidate-file selection for the pipelined paths.
+//! - `pipeline` - the inner `run_pipeline_loop_decoupled` plus dry-run loop.
 
 mod candidates;
 mod phases;

--- a/crates/transfer/src/writer/mod.rs
+++ b/crates/transfer/src/writer/mod.rs
@@ -7,10 +7,10 @@
 //!
 //! # Submodules
 //!
-//! - [`server`] - Mode-switching writer enum dispatching plain, multiplex, and compressed I/O.
+//! - `server` - Mode-switching writer enum dispatching plain, multiplex, and compressed I/O.
 //! - [`multiplex`] - Buffered writer that frames output in `MSG_DATA` multiplex frames.
-//! - [`msg_info`] - Trait for sending `MSG_INFO` protocol messages through multiplexed streams.
-//! - [`counting`] - Byte-counting writer wrapper for transfer statistics.
+//! - `msg_info` - Trait for sending `MSG_INFO` protocol messages through multiplexed streams.
+//! - `counting` - Byte-counting writer wrapper for transfer statistics.
 
 mod counting;
 mod msg_info;


### PR DESCRIPTION
## Summary

- Master Pages workflow run 27278963420 failed after #5562's `--cfg docsrs` fix landed: rustdoc tripped `-D rustdoc::broken_intra_doc_links` in `batch` and `filters`, with the same anti-pattern present in many other crates' module-doc overviews.
- The bullets reference private `mod` submodules (e.g., `` [`flist`] ``, `` [`delta`] ``, `` [`config`] ``, `` [`scope`] ``) that rustdoc cannot resolve from the public surface.
- Converted the broken intra-doc links to plain backtick code spans in 21 module-overview files across bandwidth, batch, cli, core, engine, fast_io, filters, protocol, rsync_io, and transfer.
- Workflow file `pages.yml` is unchanged from #5562; the fix here is in the source-doc comments only.

## Test plan

- [ ] fmt+clippy CI checks pass
- [ ] On merge, the Pages workflow on master builds rustdoc and deploys successfully