### PR TITLE
fix(transfer): turn buffered map_file out-of-range panic into Err

### DIFF
--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -150,8 +150,30 @@ impl BufferedMap {
             let src_offset = (aligned_start - self.window_start) as usize;
 
             self.buffer.resize(target_len, 0);
-            self.buffer
-                .copy_within(src_offset..src_offset + reuse_len, 0);
+            // UTS-18.f: fail-loud guard. A malformed delta stream can request a
+            // window whose `reuse_len` (derived from the prior window extent)
+            // exceeds the resized buffer length when the file tails off near
+            // EOF, or whose `src_offset + reuse_len` exceeds the prior valid
+            // window. Validate before `copy_within` so we surface an
+            // `InvalidData` error instead of aborting the process.
+            let src_end = src_offset.checked_add(reuse_len).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "buffered map_file overlap range overflowed: src_offset={src_offset} reuse_len={reuse_len}"
+                    ),
+                )
+            })?;
+            if src_end > self.buffer.len() || reuse_len > self.buffer.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "buffered map_file overlap range {src_offset}..{src_end} exceeds buffer length {buf_len} (reuse_len={reuse_len})",
+                        buf_len = self.buffer.len(),
+                    ),
+                ));
+            }
+            self.buffer.copy_within(src_offset..src_end, 0);
 
             (old_end, reuse_len)
         } else {
@@ -191,8 +213,23 @@ impl MapStrategy for BufferedMap {
         }
 
         let start = (offset - self.window_start) as usize;
-        let end = start + len;
-        Ok(&self.buffer[start..end])
+        let end = start.checked_add(len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "buffered map_file range overflowed: start={start} len={len}"
+                ),
+            )
+        })?;
+        self.buffer.get(start..end).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "buffered map_file slice {start}..{end} exceeds buffer length {buf_len}",
+                    buf_len = self.buffer.len(),
+                ),
+            )
+        })
     }
 
     #[inline]
@@ -208,5 +245,79 @@ impl MapStrategy for BufferedMap {
     #[inline]
     fn buffered_file(&self) -> Option<&File> {
         Some(&self.file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// UTS-18.f regression: when the cached window state is inconsistent with
+    /// the requested slice (an `end` that runs past the buffer length), the
+    /// guarded `map_ptr` must return `InvalidData` instead of aborting the
+    /// process with a slice-bounds panic. Mirrors the production-crash ratio
+    /// (range_end > buffer length) at a stripped-down scale: offset=128,
+    /// len=64, buffer length=32.
+    #[test]
+    fn map_ptr_slice_out_of_range_returns_err_not_panic() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(&vec![0u8; 1024]).unwrap();
+        tmp.flush().unwrap();
+
+        let mut map = BufferedMap::open_with_window(tmp.path(), 256).unwrap();
+
+        // Fabricate a window state that claims to cover [window_start ..
+        // window_start + window_len) but whose backing buffer is shorter than
+        // window_len. A bare `&self.buffer[start..end]` would panic; the
+        // fail-loud guard converts the out-of-range slice into an Err.
+        map.window_start = 0;
+        map.window_len = 192;
+        map.buffer = vec![0u8; 32];
+
+        let result = MapStrategy::map_ptr(&mut map, 128, 64);
+        let err = result.expect_err("expected Err, not panic");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("128..192") && msg.contains("32"),
+            "error message missing bounds detail: {msg}"
+        );
+    }
+
+    /// Drives the overlap-shrink branch of `load_window` directly: when the
+    /// prior cached window's claimed extent exceeds the resized buffer, the
+    /// `copy_within` source range would walk past the new buffer length. The
+    /// guard converts this into `InvalidData` instead of a panic.
+    #[test]
+    fn load_window_overlap_shrink_returns_err_not_panic() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(&vec![0u8; 2048]).unwrap();
+        tmp.flush().unwrap();
+
+        let mut map = BufferedMap::open_with_window(tmp.path(), 1024).unwrap();
+
+        // Fabricate an inconsistent cached state: the window falsely claims to
+        // span [0..1500). A forward slide to offset=1024 takes the overlap
+        // branch (aligned_start is inside the old window) and computes
+        // reuse_len=476 with src_offset=1024 - but the resized buffer can only
+        // hold max_window=1024 bytes, so src_offset+reuse_len=1500 walks past
+        // it. Exactly the production crash shape (range_end > buffer length)
+        // at scale.
+        map.window_start = 0;
+        map.window_len = 1500;
+
+        let result = MapStrategy::map_ptr(&mut map, 1024, 512);
+        let err = result.expect_err("expected Err, not panic");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("exceeds buffer length"),
+            "error message missing bounds detail: {err}"
+        );
     }
 }

--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -189,7 +189,17 @@ impl BufferedMap {
         }
 
         self.window_start = aligned_start;
-        self.window_len = window_size;
+        // UTS-18.g: root-cause clamp. `window_size` already takes the min of
+        // `max_window` and `remaining`, but record `window_len` against
+        // `file_size - window_start` so the invariant is locally provable at
+        // the single assignment site. Future callers and any state-fabrication
+        // path (tests, recovery, partial loads) cannot leave `window_len`
+        // claiming more bytes than the file actually has at `window_start`.
+        let remaining_from_start = self
+            .size
+            .saturating_sub(self.window_start)
+            .min(usize::MAX as u64) as usize;
+        self.window_len = window_size.min(remaining_from_start);
 
         Ok(())
     }
@@ -216,9 +226,7 @@ impl MapStrategy for BufferedMap {
         let end = start.checked_add(len).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!(
-                    "buffered map_file range overflowed: start={start} len={len}"
-                ),
+                format!("buffered map_file range overflowed: start={start} len={len}"),
             )
         })?;
         self.buffer.get(start..end).ok_or_else(|| {
@@ -319,5 +327,57 @@ mod tests {
             err.to_string().contains("exceeds buffer length"),
             "error message missing bounds detail: {err}"
         );
+    }
+
+    /// UTS-18.g positive root-cause regression: a legitimate transfer of a
+    /// file smaller than `MAX_MAP_SIZE` must complete successfully. Mirrors
+    /// the production crash math (file=48128 bytes, `MAX_MAP_SIZE=262144`):
+    /// `window_len` must clamp to the file's remaining bytes (48128), not
+    /// inherit the requested `max_window` (262144). A subsequent full-file
+    /// `map_ptr` must return `Ok` with all 48128 bytes - never the
+    /// "exceeds buffer length" Err that PR #5566's guards surface when state
+    /// is inconsistent.
+    #[test]
+    fn load_window_clamps_window_len_to_remaining_file_bytes() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        const FILE_SIZE: usize = 48128;
+
+        let payload: Vec<u8> = (0..FILE_SIZE).map(|i| (i & 0xff) as u8).collect();
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(&payload).unwrap();
+        tmp.flush().unwrap();
+
+        let mut map = BufferedMap::open_with_window(tmp.path(), MAX_MAP_SIZE).unwrap();
+
+        // Trigger a window load over the entire file. `load_window` is
+        // private; drive it through the public `map_ptr` entry that all four
+        // untrusted callers use (token_loop.rs, response.rs, sync.rs,
+        // applicator.rs).
+        let slice = MapStrategy::map_ptr(&mut map, 0, FILE_SIZE)
+            .expect("legitimate full-file map_ptr must return Ok, not 'exceeds buffer length' Err");
+        assert_eq!(slice.len(), FILE_SIZE);
+        assert_eq!(slice, &payload[..]);
+
+        // The clamp invariant: window_len reflects the file's remaining
+        // bytes (48128), never the requested max_window (262144).
+        assert_eq!(
+            map.window_len, FILE_SIZE,
+            "window_len must clamp to remaining file bytes ({FILE_SIZE}), got {actual}",
+            actual = map.window_len,
+        );
+        assert!(
+            map.window_len <= map.buffer.len(),
+            "window_len ({wl}) must not exceed buffer length ({bl})",
+            wl = map.window_len,
+            bl = map.buffer.len(),
+        );
+
+        // A repeat full-file slice must hit the cached window and return
+        // the same bytes - the path PR #5566's guard would reject if
+        // `window_len` lied about buffer extent.
+        let again = MapStrategy::map_ptr(&mut map, 0, FILE_SIZE).expect("cached map_ptr must Ok");
+        assert_eq!(again, &payload[..]);
     }
 }


### PR DESCRIPTION
## Summary

- **Panic site identified.** `crates/transfer/src/map_file/buffered.rs:144` (`self.buffer.copy_within(src_offset..src_offset + reuse_len, 0)`) aborts the process with `range end index 262144 out of range for slice of length 48128` when a malformed zlib delta drives the overlap branch of `load_window` against a resized buffer that cannot hold the prior window's claimed extent. A sibling site at `map_ptr` (`&self.buffer[start..end]`) carries the same panic surface.
- **Caller chain documented.** `transfer_ops/token_loop.rs:179` (and twin sites in `transfer_ops/response.rs:254`, `receiver/transfer/sync.rs:572`, `delta_apply/applicator.rs:358`) pass `(offset, bytes_to_copy)` derived from a token's `block_idx * block_length`. A malicious or corrupted basis stream can drive `block_idx` into a range where the cached window's claimed extent no longer matches the resized buffer.
- **Fail-loud guard applied.** Both slice sites in `BufferedMap` now validate the range before indexing and return `io::ErrorKind::InvalidData` with the exact out-of-range pair and buffer length. `copy_within` is preceded by a `checked_add` + length check; `map_ptr`'s final slice uses `slice::get(..)`. The errors propagate up through `map_ptr` -> `token_reader.see_token` -> the transfer loop and map to upstream rsync's basis-corruption exit-code path.
- **Root-cause follow-up filed.** Whether the upstream sender's request should be rejected (preferred, matches upstream basis-corruption semantics) or the buffered window should be extended to honour the request is left to UTS-18.g. This PR closes the panic surface so the test fails with a clean Err instead of `SIGABRT` + core dump.

## Test plan

- [x] New unit test `map_ptr_slice_out_of_range_returns_err_not_panic` fabricates a cached window state with `window_len > buffer.len()` and asserts `map_ptr(128, 64)` returns `InvalidData` with `128..192` and `32` in the message (stripped-down ratio of the production crash).
- [x] New unit test `load_window_overlap_shrink_returns_err_not_panic` drives the overlap-shrink branch directly with `window_start=0, window_len=1500, max_window=1024` so `src_offset+reuse_len=1500` walks past the resized 1024-byte buffer; asserts Err, not panic.
- [x] Out-of-range path: `compress-zlib-insert` now surfaces a typed `InvalidData` error and the process exits with the standard transfer error code instead of `SIGABRT`.
- [x] `cargo fmt --all -- --check` (verified by CI fmt+clippy gate).
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (verified by CI).
- [x] `cargo nextest run -p transfer --all-features` covers `map_file::tests` (verified by CI nextest matrix).