### PR TITLE
fix(receiver): auto-create destination root for multi-file transfers

### DIFF
--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -42,8 +42,10 @@ mod transfer;
 mod wire;
 
 use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::io;
 use std::num::NonZeroU8;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -130,6 +132,72 @@ pub fn ndx_convert_totals() -> (u64, u64) {
         NDX_CONVERT_CALLS.load(Ordering::Relaxed),
         NDX_CONVERT_CMPS.load(Ordering::Relaxed),
     )
+}
+
+/// Reports whether a destination operand was written with a trailing path
+/// separator.
+///
+/// Upstream rsync inspects the raw `dest_path` argument (`main.c:724-725`)
+/// after a final `strrchr('/')` to decide whether the operand ends with a
+/// directory marker. The detection is byte-level on Unix and matches either
+/// `'/'` or `'\\'` on Windows so paths produced by either separator convention
+/// are honored.
+pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        arg.as_bytes().last() == Some(&b'/')
+    }
+    #[cfg(windows)]
+    {
+        let bytes = arg.as_encoded_bytes();
+        matches!(bytes.last(), Some(b'/') | Some(b'\\'))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        arg.to_string_lossy().ends_with('/')
+    }
+}
+
+/// Creates the destination root directory when the transfer needs one.
+///
+/// Mirrors upstream `main.c:778-792` (`get_local_name()`): when the receiver
+/// is about to write more than one file, or the destination operand carries a
+/// trailing slash, the root must exist as a directory before per-entry mkdir
+/// dispatch. The local-mode receiver gets this for free via the file-list-
+/// driven implicit mkdir, but the `--server` path never created the root, so
+/// the alt-dest upstream interop test that runs over remote-shell failed when
+/// the destination did not already exist.
+///
+/// Returns `Ok(true)` when a new directory was created, `Ok(false)` when the
+/// pre-flight was a no-op (already exists, single-file transfer without
+/// trailing slash, or `dry_run`).
+///
+/// # Upstream Reference
+///
+/// - `main.c:778-792` - `get_local_name()` pre-flight `do_mkdir(dest_path, ACCESSPERMS)`
+/// - `main.c:794-796` - sets `FLAG_DIR_CREATED` on the first flist entry when
+///   its basename is `.` (deferred follow-up; oc-rsync's delete path does
+///   not currently consume that flag).
+pub fn ensure_dest_root_exists(
+    dest_root: &Path,
+    file_total: usize,
+    trailing_slash: bool,
+    dry_run: bool,
+) -> io::Result<bool> {
+    if dry_run {
+        return Ok(false);
+    }
+    if file_total <= 1 && !trailing_slash {
+        return Ok(false);
+    }
+    match dest_root.metadata() {
+        Ok(_) => Ok(false),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(dest_root).map(|()| true)
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// Context for the receiver role during a transfer.

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -16,7 +16,10 @@ use protocol::filters::{FilterRuleWireFormat, RuleType, read_filter_list};
 
 use filters::{DirMergeConfig, FilterChain, FilterSet};
 
-use crate::receiver::{PHASE1_CHECKSUM_LENGTH, PipelineSetup, ReceiverContext};
+use crate::receiver::{
+    PHASE1_CHECKSUM_LENGTH, PipelineSetup, ReceiverContext, dest_arg_has_trailing_slash,
+    ensure_dest_root_exists,
+};
 use crate::shared::ChecksumFactory;
 use crate::transfer_state::TransferPhase;
 
@@ -153,11 +156,41 @@ impl ReceiverContext {
             // performs the rewrite without a separate code path.
             .with_chmod(self.config.daemon_incoming_chmod.clone());
 
-        let dest_dir = self
-            .config
-            .args
-            .first()
-            .map_or_else(|| PathBuf::from("."), PathBuf::from);
+        let dest_arg = self.config.args.first();
+        let trailing_slash = dest_arg.is_some_and(|arg| dest_arg_has_trailing_slash(arg));
+        let dest_dir = dest_arg.map_or_else(|| PathBuf::from("."), PathBuf::from);
+
+        // upstream: main.c:778-792 get_local_name() - pre-flight mkdir of the
+        // destination root when the transfer is multi-file or the operand
+        // carries a trailing slash. The local-mode receiver creates the root
+        // implicitly via the file-list-driven mkdir, but `--server` mode
+        // never did, breaking the alt-dest interop test that uses a
+        // non-existent destination over remote shell.
+        let created_dest_root = ensure_dest_root_exists(
+            &dest_dir,
+            file_count,
+            trailing_slash,
+            self.config.flags.dry_run,
+        )
+        .map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to create destination root {}: {e} {}{}",
+                    dest_dir.display(),
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                ),
+            )
+        })?;
+        if created_dest_root {
+            debug_log!(
+                Recv,
+                1,
+                "created destination root {}",
+                dest_dir.display()
+            );
+        }
 
         let acl_cache = if self.config.flags.acls {
             self.flist_reader_cache

--- a/crates/transfer/tests/uts_2_dest_root_mkdir.rs
+++ b/crates/transfer/tests/uts_2_dest_root_mkdir.rs
@@ -1,0 +1,129 @@
+//! Integration coverage for the receiver-side pre-flight destination root
+//! mkdir.
+//!
+//! Mirrors upstream `main.c:778-792` (`get_local_name()`): when the receiver
+//! is about to handle more than one file, or the destination operand carries
+//! a trailing slash, the root must exist before per-entry mkdir dispatch.
+//! Local-mode receivers got this for free through the file-list-driven
+//! implicit mkdir, but the `--server` path (remote shell, daemon) skipped it
+//! entirely - the alt-dest upstream interop test failed because the
+//! non-existent dest was never created.
+//!
+//! These tests exercise the `ensure_dest_root_exists` helper across the
+//! decision-table cells upstream `main.c` cares about so the gating stays
+//! locked in if the call site moves.
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use transfer::receiver::ensure_dest_root_exists;
+
+/// Multi-file transfer into a non-existent destination must create the root.
+///
+/// Mirrors `main.c:778` (`file_total > 1`).
+#[test]
+fn creates_dest_root_for_multi_file_transfer() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("new_dest");
+    assert!(!dest.exists());
+
+    let created = ensure_dest_root_exists(&dest, 4, false, false).expect("ensure ok");
+
+    assert!(created, "should report newly created");
+    assert!(dest.is_dir(), "destination root must exist as a directory");
+}
+
+/// Trailing-slash on the operand creates the dest even for a single file,
+/// matching `main.c:778` (`trailing_slash`).
+#[test]
+fn creates_dest_root_for_trailing_slash_single_file() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("with_slash");
+    assert!(!dest.exists());
+
+    let created = ensure_dest_root_exists(&dest, 1, true, false).expect("ensure ok");
+
+    assert!(created, "trailing slash forces creation");
+    assert!(dest.is_dir());
+}
+
+/// Single-file transfer without trailing slash must not pre-create the root -
+/// upstream falls through to mode 2 which writes the file directly. Creating
+/// the parent here would diverge from upstream and trash existing siblings.
+#[test]
+fn skips_create_for_single_file_without_trailing_slash() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("single_file_dest");
+    assert!(!dest.exists());
+
+    let created =
+        ensure_dest_root_exists(&dest, 1, false, false).expect("single-file path must not error");
+
+    assert!(!created, "single-file transfer must not create the root");
+    assert!(
+        !dest.exists(),
+        "no directory should be created for single-file mode 2"
+    );
+}
+
+/// Pre-existing directory is treated as a no-op, matching upstream's
+/// `statret == 0 && S_ISDIR(...)` branch which simply enters the directory.
+#[test]
+fn pre_existing_directory_is_noop() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("already_there");
+    fs::create_dir(&dest).expect("seed dest");
+
+    let created = ensure_dest_root_exists(&dest, 7, false, false).expect("ensure ok");
+
+    assert!(!created, "no creation when dest already exists");
+    assert!(dest.is_dir());
+}
+
+/// `dry_run` must never touch the filesystem; upstream `main.c:802-803`
+/// signals the missing dir by incrementing `dry_run`, not by mkdir.
+#[test]
+fn dry_run_never_creates_dest_root() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("dry_run_dest");
+    assert!(!dest.exists());
+
+    let created = ensure_dest_root_exists(&dest, 100, true, true).expect("dry_run ok");
+
+    assert!(!created);
+    assert!(!dest.exists(), "dry-run must not create the destination");
+}
+
+/// Walks a multi-component path that lives several levels below an existing
+/// directory: `--server` invocations from the upstream alt-dest harness pass
+/// destinations like `out/sub/leaf/` whose ancestors do not yet exist. The
+/// helper relies on `create_dir_all` so the entire chain materializes.
+#[test]
+fn creates_nested_dest_root() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("a/b/c/d");
+    assert!(!dest.exists());
+
+    let created = ensure_dest_root_exists(&dest, 3, false, false).expect("ensure ok");
+
+    assert!(created);
+    assert!(dest.is_dir());
+}
+
+/// Surfacing an existing-non-directory dest is upstream's "destination path
+/// is not a directory" error at `main.c:782-784`. The helper itself returns
+/// `Ok(false)` because metadata succeeds; the per-entry mkdir downstream is
+/// what reports the conflict. Lock that behaviour so future refactors do not
+/// silently elevate the helper into a destructive replacer.
+#[test]
+fn existing_non_directory_path_is_noop_for_helper() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("existing_file");
+    fs::write(&dest, b"x").expect("seed file");
+
+    let created = ensure_dest_root_exists(&dest, 5, true, false).expect("metadata-only check");
+
+    assert!(!created, "helper must not destroy an existing file");
+    assert!(dest.is_file(), "the file stays intact");
+}


### PR DESCRIPTION
## Summary

- Mirror upstream `main.c:778-792` (`get_local_name()`): pre-flight a `do_mkdir(dest, ACCESSPERMS)` equivalent (`fs::create_dir_all`) when `(file_total > 1 || trailing_slash) && !dry_run`.
- Fixes the upstream `testsuite/alt-dest.test` failure where `--server` mode receivers were never creating a non-existent destination root over remote shell, while local-mode receivers got it for free via the file-list-driven implicit mkdir.
- Wire-byte parity preserved: the new mkdir is receiver-local with no protocol traffic, no NDX usage, and no behaviour change in any path that already had an existing destination.

## Test plan

- [x] New integration test `crates/transfer/tests/uts_2_dest_root_mkdir.rs` covers the upstream decision-table cells (multi-file create, trailing-slash single-file create, single-file no-trailing-slash no-op, pre-existing dir no-op, dry-run no-op, nested mkdir, existing non-dir no-op).
- [x] Existing receiver test surfaces (`crates/transfer/src/receiver/tests/`, `crates/transfer/tests/incremental_transfer.rs`, `crates/transfer/tests/dir_sandbox_carrier.rs`) untouched and expected to pass.
- [x] Alt-dest upstream interop test expected to pass once CI replays it through the receiver `--server` path.