### PR TITLE
feat(metadata): classify NTFS reparse points (symlink/junction/mount-point/cloud)

### DIFF
--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -44,6 +44,8 @@ windows = { workspace = true, features = [
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
     "Win32_System_SystemServices",
     "Win32_System_Threading",
 ] }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -161,6 +161,11 @@ pub use nfsv4_acl_stub as nfsv4_acl;
 /// Fake super-user mode for preserving privileged metadata without root.
 pub mod fake_super;
 
+/// Windows-specific NTFS metadata helpers (reparse-point classification,
+/// future native primitives). Empty on non-Windows targets.
+#[cfg(target_os = "windows")]
+pub mod windows;
+
 #[cfg(all(
     feature = "acl",
     any(target_os = "linux", target_os = "macos", target_os = "freebsd")

--- a/crates/metadata/src/windows/mod.rs
+++ b/crates/metadata/src/windows/mod.rs
@@ -1,0 +1,22 @@
+#![cfg(target_os = "windows")]
+
+//! Windows-specific metadata helpers.
+//!
+//! Houses native NTFS metadata facilities that have no upstream rsync
+//! analogue. Upstream rsync delegates Windows-specific behaviour to Cygwin,
+//! which emulates a POSIX surface on top of Win32 (for example by treating
+//! every reparse point as a symbolic link). Native `oc-rsync` interacts with
+//! the NTFS layer directly, so this module provides primitives that bridge
+//! Win32 semantics to the cross-platform metadata layer.
+//!
+//! Submodules:
+//! - [`reparse`] classifies NTFS reparse points into their concrete kinds
+//!   (symlink, junction, mount-point, OneDrive/cloud placeholder, AF_UNIX
+//!   socket, or an opaque tag value) so higher layers can decide how to
+//!   transfer each kind without losing information.
+
+/// NTFS reparse-point classifier (symlink, junction, mount-point,
+/// cloud placeholder, WSL `AF_UNIX` socket, opaque tag).
+pub mod reparse;
+
+pub use reparse::{ReparseKind, classify_reparse_point};

--- a/crates/metadata/src/windows/mod.rs
+++ b/crates/metadata/src/windows/mod.rs
@@ -13,10 +13,13 @@
 //! - [`reparse`] classifies NTFS reparse points into their concrete kinds
 //!   (symlink, junction, mount-point, OneDrive/cloud placeholder, AF_UNIX
 //!   socket, or an opaque tag value) so higher layers can decide how to
-//!   transfer each kind without losing information.
+//!   transfer each kind without losing information. Re-exports
+//!   [`reparse::classify_path`] for callers (transfer-side flist
+//!   generation, audit tools) that hold a `Path` rather than a raw
+//!   `FILE_FLAG_OPEN_REPARSE_POINT` handle.
 
 /// NTFS reparse-point classifier (symlink, junction, mount-point,
 /// cloud placeholder, WSL `AF_UNIX` socket, opaque tag).
 pub mod reparse;
 
-pub use reparse::{ReparseKind, classify_reparse_point};
+pub use reparse::{ReparseKind, classify_path, classify_reparse_point};

--- a/crates/metadata/src/windows/reparse.rs
+++ b/crates/metadata/src/windows/reparse.rs
@@ -34,12 +34,22 @@
 
 use std::ffi::OsString;
 use std::io;
-use std::os::windows::ffi::OsStringExt;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::os::windows::io::AsRawHandle;
+use std::path::Path;
 
-use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING,
+};
 use windows::Win32::System::IO::DeviceIoControl;
 use windows::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
+
+/// `FILE_READ_ATTRIBUTES` access right (`winnt.h`). The `windows` crate
+/// exposes this only via `FILE_ACCESS_RIGHTS`; pinning the value locally
+/// avoids the version-dependent re-export and keeps the call site small.
+const FILE_READ_ATTRIBUTES: u32 = 0x0080;
 
 /// Maximum size of a reparse data buffer, per `winnt.h`.
 ///
@@ -209,6 +219,93 @@ pub fn classify_reparse_point(handle: &impl AsRawHandle) -> io::Result<ReparseKi
     }
 
     Ok(classify_from_buffer(&buffer[..returned]))
+}
+
+/// Classify the reparse-point at `path` by opening it with
+/// `FILE_FLAG_OPEN_REPARSE_POINT` and delegating to
+/// [`classify_reparse_point`].
+///
+/// Intended for transfer-side flist generation on Windows, where the caller
+/// already knows from `FILE_ATTRIBUTE_REPARSE_POINT` (or a previous
+/// `std::fs::FileType::is_symlink()` probe) that the entry is some flavour
+/// of reparse point. Centralises the `CreateFileW` call so consumers do not
+/// duplicate the FFI surface or the safety reasoning.
+///
+/// # Errors
+///
+/// Surfaces the underlying `CreateFileW` or `DeviceIoControl` failure as
+/// [`io::Error`] via [`io::Error::last_os_error`]. Callers that want to
+/// treat classification failures as non-fatal (for example, falling back
+/// to a plain symlink emission) should match on the error and continue.
+///
+/// # Cygwin parity
+///
+/// Upstream rsync runs through Cygwin on Windows and never opens a reparse
+/// point directly; this helper exists so the native `oc-rsync` build can
+/// distinguish junctions, mount-points, and cloud placeholders that Cygwin
+/// folds into POSIX symbolic links.
+pub fn classify_path(path: &Path) -> io::Result<ReparseKind> {
+    let handle = open_reparse_handle(path)?;
+    classify_reparse_point(&handle)
+}
+
+/// RAII wrapper that calls [`CloseHandle`] on drop.
+///
+/// The handle is opened with [`open_reparse_handle`] and exposed through
+/// [`AsRawHandle`] so [`classify_reparse_point`] can borrow it without an
+/// allocation.
+struct ReparseHandle(HANDLE);
+
+impl AsRawHandle for ReparseHandle {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        self.0.0 as std::os::windows::io::RawHandle
+    }
+}
+
+impl Drop for ReparseHandle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was returned by `CreateFileW` in
+        // [`open_reparse_handle`] and has not been closed elsewhere; the
+        // guard owns the handle uniquely for its lifetime.
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+/// Open `path` with `FILE_FLAG_OPEN_REPARSE_POINT` so the reparse data is
+/// returned by `DeviceIoControl` instead of being followed.
+///
+/// `FILE_FLAG_BACKUP_SEMANTICS` is set so directory reparse points (the
+/// common `mklink /d` and `mklink /j` shapes) can be opened with the same
+/// call. Read access is limited to `FILE_READ_ATTRIBUTES`; sharing is left
+/// permissive (`FILE_SHARE_READ | FILE_SHARE_WRITE`) so we never block a
+/// concurrent enumerator.
+fn open_reparse_handle(path: &Path) -> io::Result<ReparseHandle> {
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // SAFETY: `wide` is a null-terminated UTF-16 slice owned for the
+    // duration of the call. The combination of `FILE_FLAG_OPEN_REPARSE_POINT`
+    // and `FILE_FLAG_BACKUP_SEMANTICS` is the documented recipe for opening
+    // an arbitrary reparse-point entry without following it; no input or
+    // output buffers are passed besides the path.
+    let handle = unsafe {
+        CreateFileW(
+            windows::core::PCWSTR(wide.as_ptr()),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            None,
+        )
+    };
+    let handle = handle.map_err(|_| io::Error::last_os_error())?;
+    Ok(ReparseHandle(handle))
 }
 
 /// Classify a reparse-point from an in-memory `REPARSE_DATA_BUFFER` byte
@@ -959,9 +1056,9 @@ mod integration_tests {
     //! runtime when the test environment lacks the privilege rather than
     //! failing the build.
 
-    use super::*;
+    use super::{FILE_READ_ATTRIBUTES, *};
     use std::fs;
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStrExt as _;
     use std::path::Path;
     use std::process::Command;
 
@@ -970,8 +1067,6 @@ mod integration_tests {
         CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
         FILE_SHARE_WRITE, OPEN_EXISTING,
     };
-
-    const FILE_READ_ATTRIBUTES: u32 = 0x0080;
 
     struct OwnedHandle(HANDLE);
 

--- a/crates/metadata/src/windows/reparse.rs
+++ b/crates/metadata/src/windows/reparse.rs
@@ -21,10 +21,20 @@
 //!
 //! Tag constants follow `winnt.h`. Unknown tags surface as
 //! [`ReparseKind::Other`] so callers can choose to skip, error, or fall
-//! through. Deeper payload parsing (substitute names, print names, symlink
-//! flags) is intentionally deferred to follow-up tasks.
+//! through.
+//!
+//! In addition to classification, the module exposes the per-kind payload
+//! parsers [`parse_symlink_reparse`], [`parse_junction_reparse`], and
+//! [`parse_mount_point_reparse`]. Each parser validates the buffer against
+//! the documented `SYMBOLIC_LINK_REPARSE_BUFFER` / `MOUNT_POINT_REPARSE_BUFFER`
+//! layout from `winnt.h` and returns the substitute and print names as
+//! [`OsString`] values plus, for symlinks, the `SYMLINK_FLAG_RELATIVE`
+//! bit. Cloud and `AF_UNIX` payloads are not parsed because they carry
+//! opaque per-provider blobs.
 
+use std::ffi::OsString;
 use std::io;
+use std::os::windows::ffi::OsStringExt;
 use std::os::windows::io::AsRawHandle;
 
 use windows::Win32::Foundation::HANDLE;
@@ -77,6 +87,34 @@ const MOUNT_POINT_SUBSTITUTE_NAME_LENGTH: usize = REPARSE_HEADER_SIZE + 2;
 /// Offset of the variable-length `PathBuffer` inside
 /// `MountPointReparseBuffer` (after the four `u16` offset/length fields).
 const MOUNT_POINT_PATH_BUFFER_OFFSET: usize = REPARSE_HEADER_SIZE + 8;
+
+/// `PrintNameOffset` field offset inside `MountPointReparseBuffer`.
+const MOUNT_POINT_PRINT_NAME_OFFSET: usize = REPARSE_HEADER_SIZE + 4;
+/// `PrintNameLength` field offset inside `MountPointReparseBuffer`.
+const MOUNT_POINT_PRINT_NAME_LENGTH: usize = REPARSE_HEADER_SIZE + 6;
+
+/// `SubstituteNameOffset` field offset inside the `SymbolicLinkReparseBuffer`
+/// payload (immediately following the common header).
+const SYMLINK_SUBSTITUTE_NAME_OFFSET: usize = REPARSE_HEADER_SIZE;
+/// `SubstituteNameLength` field offset inside `SymbolicLinkReparseBuffer`.
+const SYMLINK_SUBSTITUTE_NAME_LENGTH: usize = REPARSE_HEADER_SIZE + 2;
+/// `PrintNameOffset` field offset inside `SymbolicLinkReparseBuffer`.
+const SYMLINK_PRINT_NAME_OFFSET: usize = REPARSE_HEADER_SIZE + 4;
+/// `PrintNameLength` field offset inside `SymbolicLinkReparseBuffer`.
+const SYMLINK_PRINT_NAME_LENGTH: usize = REPARSE_HEADER_SIZE + 6;
+/// `Flags` field offset (u32) inside `SymbolicLinkReparseBuffer`.
+const SYMLINK_FLAGS_OFFSET: usize = REPARSE_HEADER_SIZE + 8;
+/// Offset of the variable-length `PathBuffer` inside
+/// `SymbolicLinkReparseBuffer` (after the four `u16` offset/length fields
+/// and the `u32` flags word).
+const SYMLINK_PATH_BUFFER_OFFSET: usize = REPARSE_HEADER_SIZE + 12;
+
+/// `SYMLINK_FLAG_RELATIVE` from `winnt.h`. Set when the substitute-name is
+/// a relative path; cleared when it is an absolute NT-namespace path.
+///
+/// `windows::Win32::System::Ioctl` does not expose this constant directly,
+/// so it is pinned here against the documented value.
+const SYMLINK_FLAG_RELATIVE: u32 = 0x0000_0001;
 
 /// Classification of an NTFS reparse-point entry.
 ///
@@ -296,6 +334,307 @@ fn read_u32_le(buf: &[u8], offset: usize) -> u32 {
     ])
 }
 
+/// Parsed payload of an `IO_REPARSE_TAG_SYMLINK` reparse buffer.
+///
+/// Mirrors the documented `SymbolicLinkReparseBuffer` shape from `winnt.h`:
+///
+/// ```text
+/// USHORT SubstituteNameOffset;
+/// USHORT SubstituteNameLength;
+/// USHORT PrintNameOffset;
+/// USHORT PrintNameLength;
+/// ULONG  Flags;
+/// WCHAR  PathBuffer[1];
+/// ```
+///
+/// The substitute and print names are stored as UTF-16LE without a
+/// trailing null. `is_relative` reflects the `SYMLINK_FLAG_RELATIVE`
+/// (`0x00000001`) bit in `Flags`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SymlinkReparseData {
+    /// NT-namespace target as stored on disk, decoded from the
+    /// substitute-name UTF-16LE slice. For absolute links this carries the
+    /// `\??\` prefix; for relative links it carries the bare relative
+    /// path.
+    pub substitute_name: OsString,
+    /// User-facing target as stored on disk, decoded from the print-name
+    /// UTF-16LE slice. May be empty when the kernel omitted a print name.
+    pub print_name: OsString,
+    /// `true` when the link is relative (`SYMLINK_FLAG_RELATIVE` set in
+    /// `Flags`); `false` for absolute NT-namespace targets.
+    pub is_relative: bool,
+}
+
+/// Parsed payload of a directory junction (non-volume
+/// `IO_REPARSE_TAG_MOUNT_POINT`) reparse buffer.
+///
+/// Junctions and volume mount-points share the on-disk
+/// `MountPointReparseBuffer` layout; the substitute-name prefix
+/// distinguishes them. See [`classify_mount_point`] for the split.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JunctionReparseData {
+    /// NT-namespace target as stored on disk, typically `\??\C:\target`.
+    pub substitute_name: OsString,
+    /// User-facing target as stored on disk, typically `C:\target`. May
+    /// be empty when the kernel omitted a print name.
+    pub print_name: OsString,
+}
+
+/// Parsed payload of a volume mount-point (volume-prefixed
+/// `IO_REPARSE_TAG_MOUNT_POINT`) reparse buffer.
+///
+/// Same on-disk shape as [`JunctionReparseData`]; the substitute-name
+/// carries the `\??\Volume{GUID}\` NT-namespace prefix when the entry
+/// is a volume mount-point.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MountPointReparseData {
+    /// NT-namespace volume path. Expected to start with the
+    /// `\??\Volume{GUID}\` prefix; callers may treat this as the source
+    /// of truth for the mounted volume identity.
+    pub volume_guid_path: OsString,
+    /// User-facing mount-point target as stored on disk. May be empty.
+    pub print_name: OsString,
+}
+
+/// Parse the payload of an `IO_REPARSE_TAG_SYMLINK` reparse buffer.
+///
+/// `buf` must hold the full `REPARSE_DATA_BUFFER` (header + payload) as
+/// returned by `FSCTL_GET_REPARSE_POINT`. Validates the `ReparseTag`,
+/// `ReparseDataLength`, the four `u16` offset/length fields, the `u32`
+/// flags word, and the substitute/print-name slices before decoding the
+/// UTF-16LE bytes into [`OsString`] via [`OsStringExt::from_wide`].
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidData`] when:
+/// - the buffer is shorter than the documented minimum header/payload size,
+/// - the tag is not `IO_REPARSE_TAG_SYMLINK`,
+/// - `ReparseDataLength` declares more bytes than `buf` carries,
+/// - any substitute/print-name offset/length pair runs past the payload,
+/// - any substitute/print-name length is not a multiple of two bytes.
+pub(crate) fn parse_symlink_reparse(buf: &[u8]) -> io::Result<SymlinkReparseData> {
+    validate_tag(buf, IO_REPARSE_TAG_SYMLINK)?;
+
+    let payload_end = validate_payload_bounds(buf, SYMLINK_PATH_BUFFER_OFFSET)?;
+
+    let substitute_offset = read_u16_le(buf, SYMLINK_SUBSTITUTE_NAME_OFFSET) as usize;
+    let substitute_length = read_u16_le(buf, SYMLINK_SUBSTITUTE_NAME_LENGTH) as usize;
+    let print_offset = read_u16_le(buf, SYMLINK_PRINT_NAME_OFFSET) as usize;
+    let print_length = read_u16_le(buf, SYMLINK_PRINT_NAME_LENGTH) as usize;
+    let flags = read_u32_le(buf, SYMLINK_FLAGS_OFFSET);
+
+    let substitute_name = decode_utf16_name(
+        buf,
+        SYMLINK_PATH_BUFFER_OFFSET,
+        substitute_offset,
+        substitute_length,
+        payload_end,
+        "symlink substitute name",
+    )?;
+    let print_name = decode_utf16_name(
+        buf,
+        SYMLINK_PATH_BUFFER_OFFSET,
+        print_offset,
+        print_length,
+        payload_end,
+        "symlink print name",
+    )?;
+
+    Ok(SymlinkReparseData {
+        substitute_name,
+        print_name,
+        is_relative: (flags & SYMLINK_FLAG_RELATIVE) != 0,
+    })
+}
+
+/// Parse the payload of a directory junction reparse buffer.
+///
+/// Junctions use `IO_REPARSE_TAG_MOUNT_POINT` with a non-volume
+/// substitute-name prefix. This parser only validates the tag and
+/// layout; the caller is expected to call [`classify_reparse_point`] or
+/// [`classify_from_buffer`] first to distinguish a junction from a
+/// volume mount-point.
+///
+/// # Errors
+///
+/// Same conditions as [`parse_symlink_reparse`], but for the
+/// `MountPointReparseBuffer` shape (no flags word).
+pub(crate) fn parse_junction_reparse(buf: &[u8]) -> io::Result<JunctionReparseData> {
+    let (substitute_name, print_name) = parse_mount_point_layout(buf)?;
+    Ok(JunctionReparseData {
+        substitute_name,
+        print_name,
+    })
+}
+
+/// Parse the payload of a volume mount-point reparse buffer.
+///
+/// Volume mount-points share the on-disk layout of directory junctions
+/// (`IO_REPARSE_TAG_MOUNT_POINT`) but carry a `\??\Volume{GUID}\`
+/// substitute-name prefix. The parser returns the substitute-name in
+/// `volume_guid_path` for callers that want to extract the volume GUID.
+///
+/// # Errors
+///
+/// Same conditions as [`parse_junction_reparse`].
+pub(crate) fn parse_mount_point_reparse(buf: &[u8]) -> io::Result<MountPointReparseData> {
+    let (volume_guid_path, print_name) = parse_mount_point_layout(buf)?;
+    Ok(MountPointReparseData {
+        volume_guid_path,
+        print_name,
+    })
+}
+
+/// Shared validator+decoder for the `MountPointReparseBuffer` shape used
+/// by both junctions and volume mount-points.
+///
+/// Returns `(substitute_name, print_name)` as decoded [`OsString`]s.
+fn parse_mount_point_layout(buf: &[u8]) -> io::Result<(OsString, OsString)> {
+    validate_tag(buf, IO_REPARSE_TAG_MOUNT_POINT)?;
+
+    let payload_end = validate_payload_bounds(buf, MOUNT_POINT_PATH_BUFFER_OFFSET)?;
+
+    let substitute_offset = read_u16_le(buf, MOUNT_POINT_SUBSTITUTE_NAME_OFFSET) as usize;
+    let substitute_length = read_u16_le(buf, MOUNT_POINT_SUBSTITUTE_NAME_LENGTH) as usize;
+    let print_offset = read_u16_le(buf, MOUNT_POINT_PRINT_NAME_OFFSET) as usize;
+    let print_length = read_u16_le(buf, MOUNT_POINT_PRINT_NAME_LENGTH) as usize;
+
+    let substitute_name = decode_utf16_name(
+        buf,
+        MOUNT_POINT_PATH_BUFFER_OFFSET,
+        substitute_offset,
+        substitute_length,
+        payload_end,
+        "mount-point substitute name",
+    )?;
+    let print_name = decode_utf16_name(
+        buf,
+        MOUNT_POINT_PATH_BUFFER_OFFSET,
+        print_offset,
+        print_length,
+        payload_end,
+        "mount-point print name",
+    )?;
+    Ok((substitute_name, print_name))
+}
+
+/// Validate that `buf` carries the documented `REPARSE_DATA_BUFFER`
+/// header and that `ReparseTag` matches `expected`.
+fn validate_tag(buf: &[u8], expected: u32) -> io::Result<()> {
+    if buf.len() < REPARSE_HEADER_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "reparse buffer too short: {} bytes, expected at least {}",
+                buf.len(),
+                REPARSE_HEADER_SIZE
+            ),
+        ));
+    }
+    let tag = read_u32_le(buf, REPARSE_TAG_OFFSET);
+    if tag != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unexpected reparse tag {tag:#010x}, expected {expected:#010x}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate that `ReparseDataLength` fits inside `buf` and that the
+/// payload covers at least up to `path_buffer_offset` (the start of the
+/// variable-length name area).
+///
+/// Returns the absolute end offset of the payload inside `buf` so the
+/// name decoders can clamp their slices.
+fn validate_payload_bounds(buf: &[u8], path_buffer_offset: usize) -> io::Result<usize> {
+    let data_length = read_u16_le(buf, REPARSE_DATA_LENGTH_OFFSET) as usize;
+    let payload_end = REPARSE_HEADER_SIZE
+        .checked_add(data_length)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("ReparseDataLength {data_length} overflows usize"),
+            )
+        })?;
+    if payload_end > buf.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "ReparseDataLength {data_length} runs past buffer (buf {}, payload_end {})",
+                buf.len(),
+                payload_end
+            ),
+        ));
+    }
+    if payload_end < path_buffer_offset {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "reparse payload {data_length} bytes shorter than minimum header {}",
+                path_buffer_offset - REPARSE_HEADER_SIZE
+            ),
+        ));
+    }
+    Ok(payload_end)
+}
+
+/// Decode a UTF-16LE name slice out of a `REPARSE_DATA_BUFFER` payload.
+///
+/// `path_buffer_offset` is the absolute offset of `PathBuffer` inside
+/// `buf`. `name_offset` and `name_length` are the per-name offset and
+/// length values read out of the payload's `u16` fields, both in bytes.
+/// `payload_end` is the absolute end of the declared payload inside
+/// `buf` and is used to clamp the name slice.
+///
+/// Zero-length names decode to an empty [`OsString`]; non-zero lengths
+/// that are not a multiple of two bytes or that run past the payload
+/// surface as [`io::ErrorKind::InvalidData`] with the supplied `label`
+/// in the message.
+fn decode_utf16_name(
+    buf: &[u8],
+    path_buffer_offset: usize,
+    name_offset: usize,
+    name_length: usize,
+    payload_end: usize,
+    label: &str,
+) -> io::Result<OsString> {
+    if name_length == 0 {
+        return Ok(OsString::new());
+    }
+    if name_length % size_of::<u16>() != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{label} length {name_length} not a multiple of 2"),
+        ));
+    }
+    let name_start = path_buffer_offset.checked_add(name_offset).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{label} offset {name_offset} overflows usize"),
+        )
+    })?;
+    let name_end = name_start.checked_add(name_length).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{label} length {name_length} overflows usize"),
+        )
+    })?;
+    if name_end > payload_end {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{label} runs past payload (name_end {name_end}, payload_end {payload_end})"
+            ),
+        ));
+    }
+    let wide: Vec<u16> = buf[name_start..name_end]
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    Ok(OsString::from_wide(&wide))
+}
+
 /// Read a little-endian `u16` from `buf` at `offset`. Caller must ensure
 /// `offset + 2 <= buf.len()`.
 fn read_u16_le(buf: &[u8], offset: usize) -> u16 {
@@ -429,6 +768,181 @@ mod tests {
         buf.extend_from_slice(&[0u8; 4]);
         assert_eq!(classify_from_buffer(&buf), ReparseKind::Junction);
     }
+
+    /// Build a synthetic `SymbolicLinkReparseBuffer` with the supplied
+    /// substitute and print names laid out back-to-back inside
+    /// `PathBuffer` with `u16` null-terminators between them.
+    fn build_symlink_buffer(substitute: &str, print: &str, flags: u32) -> Vec<u8> {
+        let sub_utf16 = utf16_le(substitute);
+        let print_utf16 = utf16_le(print);
+        let sub_len = sub_utf16.len();
+        let print_len = print_utf16.len();
+        let path_buffer_len = sub_len + 2 + print_len + 2;
+        // 4 u16 offset/length fields + 1 u32 flags + variable PathBuffer.
+        let data_length = 8 + 4 + path_buffer_len;
+
+        let mut buf = Vec::with_capacity(REPARSE_HEADER_SIZE + data_length);
+        buf.extend_from_slice(&IO_REPARSE_TAG_SYMLINK.to_le_bytes());
+        buf.extend_from_slice(&(data_length as u16).to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // Reserved
+        buf.extend_from_slice(&0u16.to_le_bytes()); // SubstituteNameOffset = 0
+        buf.extend_from_slice(&(sub_len as u16).to_le_bytes()); // SubstituteNameLength
+        buf.extend_from_slice(&((sub_len + 2) as u16).to_le_bytes()); // PrintNameOffset
+        buf.extend_from_slice(&(print_len as u16).to_le_bytes()); // PrintNameLength
+        buf.extend_from_slice(&flags.to_le_bytes()); // Flags
+        buf.extend_from_slice(&sub_utf16);
+        buf.extend_from_slice(&[0, 0]); // sub-name null-term
+        buf.extend_from_slice(&print_utf16);
+        buf.extend_from_slice(&[0, 0]); // print-name null-term
+        buf
+    }
+
+    /// Build a synthetic `MountPointReparseBuffer` with both substitute
+    /// and print names populated.
+    fn build_mount_point_buffer_with_print(substitute: &str, print: &str) -> Vec<u8> {
+        let sub_utf16 = utf16_le(substitute);
+        let print_utf16 = utf16_le(print);
+        let sub_len = sub_utf16.len();
+        let print_len = print_utf16.len();
+        let path_buffer_len = sub_len + 2 + print_len + 2;
+        let data_length = 8 + path_buffer_len;
+
+        let mut buf = Vec::with_capacity(REPARSE_HEADER_SIZE + data_length);
+        buf.extend_from_slice(&IO_REPARSE_TAG_MOUNT_POINT.to_le_bytes());
+        buf.extend_from_slice(&(data_length as u16).to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // Reserved
+        buf.extend_from_slice(&0u16.to_le_bytes()); // SubstituteNameOffset = 0
+        buf.extend_from_slice(&(sub_len as u16).to_le_bytes());
+        buf.extend_from_slice(&((sub_len + 2) as u16).to_le_bytes());
+        buf.extend_from_slice(&(print_len as u16).to_le_bytes());
+        buf.extend_from_slice(&sub_utf16);
+        buf.extend_from_slice(&[0, 0]);
+        buf.extend_from_slice(&print_utf16);
+        buf.extend_from_slice(&[0, 0]);
+        buf
+    }
+
+    #[test]
+    fn parses_relative_symlink() {
+        let buf = build_symlink_buffer("..\\target", "..\\target", SYMLINK_FLAG_RELATIVE);
+        let parsed = parse_symlink_reparse(&buf).expect("parse relative symlink");
+        assert_eq!(parsed.substitute_name, OsString::from("..\\target"));
+        assert_eq!(parsed.print_name, OsString::from("..\\target"));
+        assert!(parsed.is_relative);
+    }
+
+    #[test]
+    fn parses_absolute_symlink() {
+        let buf = build_symlink_buffer("\\??\\C:\\target", "C:\\target", 0);
+        let parsed = parse_symlink_reparse(&buf).expect("parse absolute symlink");
+        assert_eq!(parsed.substitute_name, OsString::from("\\??\\C:\\target"));
+        assert_eq!(parsed.print_name, OsString::from("C:\\target"));
+        assert!(!parsed.is_relative);
+    }
+
+    #[test]
+    fn parses_symlink_with_empty_print_name() {
+        let buf = build_symlink_buffer("\\??\\C:\\target", "", SYMLINK_FLAG_RELATIVE);
+        let parsed = parse_symlink_reparse(&buf).expect("parse symlink with empty print");
+        assert_eq!(parsed.substitute_name, OsString::from("\\??\\C:\\target"));
+        assert_eq!(parsed.print_name, OsString::new());
+        assert!(parsed.is_relative);
+    }
+
+    #[test]
+    fn rejects_symlink_with_wrong_tag() {
+        let mut buf = build_symlink_buffer("..\\x", "..\\x", SYMLINK_FLAG_RELATIVE);
+        // Overwrite the tag with IO_REPARSE_TAG_MOUNT_POINT.
+        buf[..4].copy_from_slice(&IO_REPARSE_TAG_MOUNT_POINT.to_le_bytes());
+        let err = parse_symlink_reparse(&buf).expect_err("wrong tag must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rejects_truncated_symlink_buffer() {
+        let buf = build_symlink_buffer("..\\target", "..\\target", SYMLINK_FLAG_RELATIVE);
+        // Truncate inside the header to force a length check.
+        let err = parse_symlink_reparse(&buf[..REPARSE_HEADER_SIZE - 1])
+            .expect_err("truncated header must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rejects_symlink_with_oversized_data_length() {
+        let mut buf = build_symlink_buffer("..\\x", "..\\x", SYMLINK_FLAG_RELATIVE);
+        // Bump ReparseDataLength past the actual buffer length.
+        let oversized = (buf.len() as u16).saturating_add(64);
+        buf[REPARSE_DATA_LENGTH_OFFSET..REPARSE_DATA_LENGTH_OFFSET + 2]
+            .copy_from_slice(&oversized.to_le_bytes());
+        let err = parse_symlink_reparse(&buf).expect_err("oversized data length must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parses_junction() {
+        let buf = build_mount_point_buffer_with_print("\\??\\C:\\target", "C:\\target");
+        let parsed = parse_junction_reparse(&buf).expect("parse junction");
+        assert_eq!(parsed.substitute_name, OsString::from("\\??\\C:\\target"));
+        assert_eq!(parsed.print_name, OsString::from("C:\\target"));
+    }
+
+    #[test]
+    fn rejects_junction_with_wrong_tag() {
+        let mut buf = build_mount_point_buffer_with_print("\\??\\C:\\target", "C:\\target");
+        buf[..4].copy_from_slice(&IO_REPARSE_TAG_SYMLINK.to_le_bytes());
+        let err = parse_junction_reparse(&buf).expect_err("wrong tag must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parses_mount_point() {
+        let buf = build_mount_point_buffer_with_print(
+            "\\??\\Volume{12345678-1234-1234-1234-123456789012}\\",
+            "",
+        );
+        let parsed = parse_mount_point_reparse(&buf).expect("parse mount-point");
+        assert_eq!(
+            parsed.volume_guid_path,
+            OsString::from("\\??\\Volume{12345678-1234-1234-1234-123456789012}\\")
+        );
+        assert_eq!(parsed.print_name, OsString::new());
+    }
+
+    #[test]
+    fn rejects_truncated_mount_point_buffer() {
+        let buf = build_mount_point_buffer_with_print("\\??\\C:\\x", "C:\\x");
+        let err = parse_junction_reparse(&buf[..REPARSE_HEADER_SIZE])
+            .expect_err("truncated payload must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn parses_mount_point_with_zero_length_names() {
+        // Build a minimal valid layout where both name lengths are zero;
+        // both substitute_name and print_name should decode to empty.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&IO_REPARSE_TAG_MOUNT_POINT.to_le_bytes());
+        // ReparseDataLength = 8 (four u16 fields) + 4 (PathBuffer terminators)
+        buf.extend_from_slice(&12u16.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // Reserved
+        buf.extend_from_slice(&[0u8; 8]); // four u16 fields all zero
+        buf.extend_from_slice(&[0u8; 4]); // empty PathBuffer terminators
+
+        let parsed = parse_junction_reparse(&buf).expect("zero-length names parse");
+        assert!(parsed.substitute_name.is_empty());
+        assert!(parsed.print_name.is_empty());
+    }
+
+    #[test]
+    fn rejects_symlink_with_odd_name_length() {
+        let mut buf = build_symlink_buffer("..\\x", "..\\x", SYMLINK_FLAG_RELATIVE);
+        // SubstituteNameLength sits at REPARSE_HEADER_SIZE + 2 = offset 10.
+        let bad = 3u16; // odd, not a multiple of 2
+        buf[SYMLINK_SUBSTITUTE_NAME_LENGTH..SYMLINK_SUBSTITUTE_NAME_LENGTH + 2]
+            .copy_from_slice(&bad.to_le_bytes());
+        let err = parse_symlink_reparse(&buf).expect_err("odd UTF-16 length must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
 }
 
 #[cfg(all(test, target_os = "windows"))]
@@ -533,5 +1047,89 @@ mod integration_tests {
         let handle = open_reparse(&junction).expect("open junction reparse");
         let kind = classify_reparse_point(&handle).expect("classify junction");
         assert_eq!(kind, ReparseKind::Junction);
+    }
+
+    #[test]
+    fn junction_parse_extracts_target_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("target");
+        let junction = tmp.path().join("link");
+        fs::create_dir(&target).expect("create target dir");
+
+        let status = Command::new("cmd")
+            .args([
+                "/c",
+                "mklink",
+                "/j",
+                junction.to_str().expect("utf8 junction path"),
+                target.to_str().expect("utf8 target path"),
+            ])
+            .status();
+
+        let status = match status {
+            Ok(s) => s,
+            Err(_) => return, // cmd.exe unavailable; skip
+        };
+        if !status.success() {
+            return; // junction creation refused; skip rather than fail
+        }
+
+        let handle = open_reparse(&junction).expect("open junction reparse");
+        let buf = fetch_reparse_buffer(&handle).expect("read reparse buffer");
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::Junction);
+        let parsed = parse_junction_reparse(&buf).expect("parse junction reparse");
+
+        // The kernel stores the NT-namespace form (\??\<path>) in the
+        // substitute-name; the user-facing form lives in the print-name.
+        // We only assert that the target path is preserved in one of the
+        // two name fields to keep the test resilient to the canonical-form
+        // normalisation Windows applies (e.g. trailing slashes, \\?\ vs
+        // \??\). The target string is compared as wide chars so that
+        // case-insensitive volume letters do not flip the result.
+        let target_str = target.to_str().expect("utf8 target path");
+        let substitute = parsed.substitute_name.to_string_lossy().into_owned();
+        let print = parsed.print_name.to_string_lossy().into_owned();
+        let found = substitute.eq_ignore_ascii_case(target_str)
+            || substitute
+                .trim_start_matches("\\??\\")
+                .eq_ignore_ascii_case(target_str)
+            || print.eq_ignore_ascii_case(target_str)
+            || print
+                .trim_start_matches("\\??\\")
+                .eq_ignore_ascii_case(target_str);
+        assert!(
+            found,
+            "junction target not preserved (substitute={substitute:?}, print={print:?}, target={target_str:?})"
+        );
+    }
+
+    /// Fetch the raw `REPARSE_DATA_BUFFER` bytes for an open reparse-point
+    /// handle so the parser can be exercised in isolation from the
+    /// classifier wrapper.
+    fn fetch_reparse_buffer(handle: &OwnedHandle) -> io::Result<Vec<u8>> {
+        let mut buffer = vec![0u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+        let mut bytes_returned: u32 = 0;
+        let raw = handle.as_raw_handle();
+        let h = HANDLE(raw.cast());
+
+        // SAFETY: `h` is a valid Win32 file handle borrowed for the call;
+        // `buffer` is heap-owned at the documented maximum payload size;
+        // `bytes_returned` is a valid stack pointer; no input buffer is
+        // required for `FSCTL_GET_REPARSE_POINT`.
+        let result = unsafe {
+            DeviceIoControl(
+                h,
+                FSCTL_GET_REPARSE_POINT,
+                None,
+                0,
+                Some(buffer.as_mut_ptr().cast()),
+                buffer.len() as u32,
+                Some(&mut bytes_returned),
+                None,
+            )
+        };
+        result.map_err(|_| io::Error::last_os_error())?;
+        buffer.truncate(bytes_returned as usize);
+        Ok(buffer)
     }
 }

--- a/crates/metadata/src/windows/reparse.rs
+++ b/crates/metadata/src/windows/reparse.rs
@@ -217,7 +217,9 @@ pub(crate) fn classify_from_buffer(buf: &[u8]) -> ReparseKind {
 fn classify_mount_point(buf: &[u8]) -> ReparseKind {
     let data_length = read_u16_le(buf, REPARSE_DATA_LENGTH_OFFSET) as usize;
     let payload_end = REPARSE_HEADER_SIZE + data_length;
-    if buf.len() < payload_end || data_length < (MOUNT_POINT_PATH_BUFFER_OFFSET - REPARSE_HEADER_SIZE) {
+    if buf.len() < payload_end
+        || data_length < (MOUNT_POINT_PATH_BUFFER_OFFSET - REPARSE_HEADER_SIZE)
+    {
         return ReparseKind::Junction;
     }
 
@@ -306,9 +308,7 @@ mod tests {
 
     /// Encode a UTF-16 little-endian byte sequence for a `&str`.
     fn utf16_le(s: &str) -> Vec<u8> {
-        s.encode_utf16()
-            .flat_map(|u| u.to_le_bytes())
-            .collect()
+        s.encode_utf16().flat_map(|u| u.to_le_bytes()).collect()
     }
 
     /// Build a synthetic `MOUNT_POINT_REPARSE_BUFFER` with the supplied
@@ -357,8 +357,7 @@ mod tests {
 
     #[test]
     fn classifies_mount_point_volume_prefix_as_mount_point() {
-        let buf =
-            build_mount_point_buffer("\\??\\Volume{12345678-1234-1234-1234-1234567890ab}\\");
+        let buf = build_mount_point_buffer("\\??\\Volume{12345678-1234-1234-1234-1234567890ab}\\");
         assert_eq!(classify_from_buffer(&buf), ReparseKind::MountPoint);
     }
 

--- a/crates/metadata/src/windows/reparse.rs
+++ b/crates/metadata/src/windows/reparse.rs
@@ -1,0 +1,538 @@
+#![cfg(target_os = "windows")]
+#![allow(unsafe_code)]
+
+//! Windows NTFS reparse-point classification.
+//!
+//! Uses the `windows` crate FFI surface to read the leading
+//! `REPARSE_DATA_BUFFER` header via `DeviceIoControl(FSCTL_GET_REPARSE_POINT)`
+//! and classifies the entry by its `ReparseTag`.
+//!
+//! Upstream rsync has no native reparse-point handling; on Windows it runs
+//! under Cygwin, which treats every reparse point as a POSIX symbolic link.
+//! Native `oc-rsync` distinguishes the four common NTFS shapes:
+//!
+//! - `mklink` symlinks (`IO_REPARSE_TAG_SYMLINK`)
+//! - `mklink /j` directory junctions and volume mount-points
+//!   (`IO_REPARSE_TAG_MOUNT_POINT`, disambiguated by the substitute-name
+//!   prefix - mount-points use `\??\Volume{GUID}\`)
+//! - OneDrive / cloud placeholders (`IO_REPARSE_TAG_CLOUD*`,
+//!   `IO_REPARSE_TAG_ONEDRIVE`)
+//! - WSL `AF_UNIX` sockets (`IO_REPARSE_TAG_AF_UNIX`)
+//!
+//! Tag constants follow `winnt.h`. Unknown tags surface as
+//! [`ReparseKind::Other`] so callers can choose to skip, error, or fall
+//! through. Deeper payload parsing (substitute names, print names, symlink
+//! flags) is intentionally deferred to follow-up tasks.
+
+use std::io;
+use std::os::windows::io::AsRawHandle;
+
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::IO::DeviceIoControl;
+use windows::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
+
+/// Maximum size of a reparse data buffer, per `winnt.h`.
+///
+/// Microsoft fixes this at 16 KiB. The `windows` crate exposes the constant
+/// under several modules across versions; we pin the value locally to avoid
+/// churn and to keep the type explicit.
+const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: usize = 16 * 1024;
+
+/// `IO_REPARSE_TAG_SYMLINK` from `winnt.h`.
+const IO_REPARSE_TAG_SYMLINK: u32 = 0xA000_000C;
+/// `IO_REPARSE_TAG_MOUNT_POINT` from `winnt.h` (covers junctions and
+/// volume mount-points; the kind is disambiguated by the substitute-name
+/// prefix).
+const IO_REPARSE_TAG_MOUNT_POINT: u32 = 0xA000_0003;
+/// `IO_REPARSE_TAG_AF_UNIX` (WSL `AF_UNIX` socket file).
+const IO_REPARSE_TAG_AF_UNIX: u32 = 0x8000_0023;
+/// `IO_REPARSE_TAG_CLOUD` legacy cloud-files placeholder tag.
+const IO_REPARSE_TAG_CLOUD: u32 = 0x9000_001A;
+/// `IO_REPARSE_TAG_ONEDRIVE` legacy OneDrive placeholder tag.
+const IO_REPARSE_TAG_ONEDRIVE: u32 = 0x9000_001B;
+
+/// Mask used to detect modern cloud-files reparse tags
+/// (`IO_REPARSE_TAG_CLOUD_*`, range `0x9000_0010..=0x9000_001F`).
+///
+/// Modern Windows builds allocate a contiguous block of tag values for the
+/// cloud-files API, and the `windows` crate exposes them individually; we
+/// match the range rather than enumerating every constant.
+const CLOUD_TAG_RANGE_START: u32 = 0x9000_0010;
+/// Upper bound (inclusive) of the cloud-files tag range.
+const CLOUD_TAG_RANGE_END: u32 = 0x9000_001F;
+
+/// Byte offset of `ReparseTag` inside `REPARSE_DATA_BUFFER`.
+const REPARSE_TAG_OFFSET: usize = 0;
+/// Byte offset of `ReparseDataLength` inside `REPARSE_DATA_BUFFER`.
+const REPARSE_DATA_LENGTH_OFFSET: usize = 4;
+/// Byte offset of the payload (after `ReparseTag` + `ReparseDataLength` +
+/// `Reserved`).
+const REPARSE_HEADER_SIZE: usize = 8;
+
+/// `SubstituteNameOffset` field offset inside the `MountPointReparseBuffer`
+/// payload (immediately following the common header).
+const MOUNT_POINT_SUBSTITUTE_NAME_OFFSET: usize = REPARSE_HEADER_SIZE;
+/// `SubstituteNameLength` field offset inside `MountPointReparseBuffer`.
+const MOUNT_POINT_SUBSTITUTE_NAME_LENGTH: usize = REPARSE_HEADER_SIZE + 2;
+/// Offset of the variable-length `PathBuffer` inside
+/// `MountPointReparseBuffer` (after the four `u16` offset/length fields).
+const MOUNT_POINT_PATH_BUFFER_OFFSET: usize = REPARSE_HEADER_SIZE + 8;
+
+/// Classification of an NTFS reparse-point entry.
+///
+/// Variants correspond to the well-known `IO_REPARSE_TAG_*` values from
+/// `winnt.h`. The `MountPoint` and `Junction` variants share the same
+/// `IO_REPARSE_TAG_MOUNT_POINT` tag and are distinguished by the substitute-
+/// name prefix: volume mount-points use `\??\Volume{GUID}\`, while
+/// `mklink /j` junctions point at directory paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReparseKind {
+    /// Symbolic link created by `mklink` (file or directory).
+    /// Tag: `IO_REPARSE_TAG_SYMLINK` (`0xA000000C`).
+    Symlink,
+    /// Directory junction created by `mklink /j`.
+    /// Tag: `IO_REPARSE_TAG_MOUNT_POINT` (`0xA0000003`) with a non-volume
+    /// substitute-name prefix.
+    Junction,
+    /// Volume mount-point exposing a separate volume at a directory path.
+    /// Tag: `IO_REPARSE_TAG_MOUNT_POINT` (`0xA0000003`) with a
+    /// `\??\Volume{GUID}\` substitute-name prefix.
+    MountPoint,
+    /// OneDrive or generic cloud-files placeholder.
+    /// Tag: `IO_REPARSE_TAG_ONEDRIVE` (`0x9000001B`),
+    /// `IO_REPARSE_TAG_CLOUD` (`0x9000001A`), or any tag in the
+    /// `IO_REPARSE_TAG_CLOUD_*` range (`0x90000010..=0x9000001F`).
+    OneDrive,
+    /// WSL `AF_UNIX` socket file. Tag: `IO_REPARSE_TAG_AF_UNIX`
+    /// (`0x80000023`).
+    AfUnix,
+    /// Unknown or unsupported reparse tag. Carries the raw `ReparseTag`
+    /// value so callers can log it, skip the entry, or decide to error.
+    Other(u32),
+}
+
+/// Classify a reparse-point by reading `FSCTL_GET_REPARSE_POINT` from a
+/// handle opened with `FILE_FLAG_OPEN_REPARSE_POINT`.
+///
+/// # Preconditions
+///
+/// `handle` must refer to an open Win32 file handle obtained with
+/// `CreateFileW`/`File::open` using `FILE_FLAG_OPEN_REPARSE_POINT` so the
+/// reparse data is returned rather than followed. The handle must remain
+/// valid for the duration of this call.
+///
+/// # Errors
+///
+/// Returns the last OS error if `DeviceIoControl` fails (for example, if
+/// the file is not a reparse point or the handle was opened without
+/// reparse-point access). The error preserves the raw Win32 error code so
+/// callers can surface it through [`crate::MetadataError`].
+///
+/// # Behaviour
+///
+/// On success the leading `REPARSE_DATA_BUFFER` header is inspected and
+/// the entry is classified via [`classify_from_buffer`]. Unknown tags
+/// surface as [`ReparseKind::Other`].
+pub fn classify_reparse_point(handle: &impl AsRawHandle) -> io::Result<ReparseKind> {
+    let mut buffer = vec![0u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+    let mut bytes_returned: u32 = 0;
+    let raw = handle.as_raw_handle();
+    let h = HANDLE(raw.cast());
+
+    // SAFETY: `h` is a valid Win32 file handle borrowed for the duration of
+    // the call (the caller's `&impl AsRawHandle` lifetime outlives this
+    // function). `buffer` is heap-owned and exactly
+    // `MAXIMUM_REPARSE_DATA_BUFFER_SIZE` bytes long, matching the maximum
+    // payload the kernel can return. `bytes_returned` is a valid stack
+    // pointer. No input buffer is required for `FSCTL_GET_REPARSE_POINT`.
+    let result = unsafe {
+        DeviceIoControl(
+            h,
+            FSCTL_GET_REPARSE_POINT,
+            None,
+            0,
+            Some(buffer.as_mut_ptr().cast()),
+            buffer.len() as u32,
+            Some(&mut bytes_returned),
+            None,
+        )
+    };
+
+    result.map_err(|_| io::Error::last_os_error())?;
+
+    let returned = bytes_returned as usize;
+    if returned < REPARSE_HEADER_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "FSCTL_GET_REPARSE_POINT returned {returned} bytes, expected at least {REPARSE_HEADER_SIZE}"
+            ),
+        ));
+    }
+
+    Ok(classify_from_buffer(&buffer[..returned]))
+}
+
+/// Classify a reparse-point from an in-memory `REPARSE_DATA_BUFFER` byte
+/// slice without touching the OS.
+///
+/// Exposed at `pub(crate)` for unit tests and any future caller that
+/// already holds the raw buffer (for example a cached metadata blob from
+/// `FindFirstFileExW` follow-ups). Reads only the four-byte `ReparseTag`
+/// at offset zero, then peeks at the `MountPointReparseBuffer`
+/// substitute-name prefix when needed to split
+/// [`ReparseKind::MountPoint`] from [`ReparseKind::Junction`].
+///
+/// Buffers shorter than the 8-byte `REPARSE_DATA_BUFFER` header classify
+/// as [`ReparseKind::Other`] with a tag of zero to avoid panics on
+/// malformed input; callers that require strict validation should check
+/// the length before calling.
+pub(crate) fn classify_from_buffer(buf: &[u8]) -> ReparseKind {
+    if buf.len() < REPARSE_HEADER_SIZE {
+        return ReparseKind::Other(0);
+    }
+
+    let tag = read_u32_le(buf, REPARSE_TAG_OFFSET);
+
+    match tag {
+        IO_REPARSE_TAG_SYMLINK => ReparseKind::Symlink,
+        IO_REPARSE_TAG_MOUNT_POINT => classify_mount_point(buf),
+        IO_REPARSE_TAG_AF_UNIX => ReparseKind::AfUnix,
+        IO_REPARSE_TAG_ONEDRIVE | IO_REPARSE_TAG_CLOUD => ReparseKind::OneDrive,
+        t if (CLOUD_TAG_RANGE_START..=CLOUD_TAG_RANGE_END).contains(&t) => ReparseKind::OneDrive,
+        t => ReparseKind::Other(t),
+    }
+}
+
+/// Distinguish a volume mount-point from a directory junction by peeking
+/// at the substitute-name prefix inside the `MountPointReparseBuffer`
+/// payload.
+///
+/// Both shapes share `IO_REPARSE_TAG_MOUNT_POINT`. Volume mount-points
+/// use the `\??\Volume{GUID}\` NT-namespace prefix; directory junctions
+/// point at filesystem paths (typically `\??\C:\...`). When the payload
+/// is too short to contain a substitute name we conservatively classify
+/// as [`ReparseKind::Junction`] since that is the more common shape and
+/// the one with the broader use-case in transfer pipelines.
+fn classify_mount_point(buf: &[u8]) -> ReparseKind {
+    let data_length = read_u16_le(buf, REPARSE_DATA_LENGTH_OFFSET) as usize;
+    let payload_end = REPARSE_HEADER_SIZE + data_length;
+    if buf.len() < payload_end || data_length < (MOUNT_POINT_PATH_BUFFER_OFFSET - REPARSE_HEADER_SIZE) {
+        return ReparseKind::Junction;
+    }
+
+    let substitute_offset = read_u16_le(buf, MOUNT_POINT_SUBSTITUTE_NAME_OFFSET) as usize;
+    let substitute_length = read_u16_le(buf, MOUNT_POINT_SUBSTITUTE_NAME_LENGTH) as usize;
+    if substitute_length == 0 {
+        return ReparseKind::Junction;
+    }
+
+    let path_buffer_start = MOUNT_POINT_PATH_BUFFER_OFFSET;
+    let name_start = path_buffer_start + substitute_offset;
+    let name_end = name_start + substitute_length;
+    if name_end > buf.len() || (name_end - name_start) % size_of::<u16>() != 0 {
+        return ReparseKind::Junction;
+    }
+
+    let wide: Vec<u16> = buf[name_start..name_end]
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+
+    if substitute_name_is_volume(&wide) {
+        ReparseKind::MountPoint
+    } else {
+        ReparseKind::Junction
+    }
+}
+
+/// Returns `true` when a substitute-name UTF-16 slice starts with the
+/// `\??\Volume{` NT-namespace prefix that volume mount-points use.
+///
+/// Case-insensitive on the literal `Volume` segment, matching Windows
+/// path semantics. Directory junctions never produce this prefix.
+fn substitute_name_is_volume(wide: &[u16]) -> bool {
+    const PREFIX: &[u16] = &[
+        b'\\' as u16,
+        b'?' as u16,
+        b'?' as u16,
+        b'\\' as u16,
+        b'V' as u16,
+        b'o' as u16,
+        b'l' as u16,
+        b'u' as u16,
+        b'm' as u16,
+        b'e' as u16,
+        b'{' as u16,
+    ];
+    if wide.len() < PREFIX.len() {
+        return false;
+    }
+    wide.iter()
+        .zip(PREFIX.iter())
+        .all(|(a, b)| ascii_eq_ignore_case(*a, *b))
+}
+
+/// ASCII-case-insensitive equality for UTF-16 code units in the BMP
+/// ASCII range. Non-ASCII code units compare strictly.
+fn ascii_eq_ignore_case(a: u16, b: u16) -> bool {
+    if a < 0x80 && b < 0x80 {
+        (a as u8).eq_ignore_ascii_case(&(b as u8))
+    } else {
+        a == b
+    }
+}
+
+/// Read a little-endian `u32` from `buf` at `offset`. Caller must ensure
+/// `offset + 4 <= buf.len()`.
+fn read_u32_le(buf: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        buf[offset],
+        buf[offset + 1],
+        buf[offset + 2],
+        buf[offset + 3],
+    ])
+}
+
+/// Read a little-endian `u16` from `buf` at `offset`. Caller must ensure
+/// `offset + 2 <= buf.len()`.
+fn read_u16_le(buf: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([buf[offset], buf[offset + 1]])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a UTF-16 little-endian byte sequence for a `&str`.
+    fn utf16_le(s: &str) -> Vec<u8> {
+        s.encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect()
+    }
+
+    /// Build a synthetic `MOUNT_POINT_REPARSE_BUFFER` with the supplied
+    /// substitute-name. The print-name is left empty for brevity since
+    /// the classifier does not consult it.
+    fn build_mount_point_buffer(substitute_name: &str) -> Vec<u8> {
+        let sub_utf16 = utf16_le(substitute_name);
+        let sub_len = sub_utf16.len();
+        // PathBuffer layout: [substitute_name][null-term][print_name (empty)][null-term]
+        let path_buffer_len = sub_len + 2 + 2;
+        let data_length = 8 + path_buffer_len; // 4 u16 fields + variable PathBuffer
+
+        let mut buf = Vec::with_capacity(REPARSE_HEADER_SIZE + data_length);
+        buf.extend_from_slice(&IO_REPARSE_TAG_MOUNT_POINT.to_le_bytes());
+        buf.extend_from_slice(&(data_length as u16).to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // Reserved
+        // SubstituteNameOffset = 0 (start of PathBuffer)
+        buf.extend_from_slice(&0u16.to_le_bytes());
+        // SubstituteNameLength = sub_len
+        buf.extend_from_slice(&(sub_len as u16).to_le_bytes());
+        // PrintNameOffset = sub_len + 2 (after sub-name null-term)
+        buf.extend_from_slice(&((sub_len + 2) as u16).to_le_bytes());
+        // PrintNameLength = 0
+        buf.extend_from_slice(&0u16.to_le_bytes());
+        // PathBuffer
+        buf.extend_from_slice(&sub_utf16);
+        buf.extend_from_slice(&[0, 0]); // sub-name null-term
+        buf.extend_from_slice(&[0, 0]); // print-name null-term
+
+        buf
+    }
+
+    fn build_simple_tag(tag: u32) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(REPARSE_HEADER_SIZE);
+        buf.extend_from_slice(&tag.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // ReparseDataLength = 0
+        buf.extend_from_slice(&0u16.to_le_bytes()); // Reserved
+        buf
+    }
+
+    #[test]
+    fn classifies_symlink_tag() {
+        let buf = build_simple_tag(IO_REPARSE_TAG_SYMLINK);
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::Symlink);
+    }
+
+    #[test]
+    fn classifies_mount_point_volume_prefix_as_mount_point() {
+        let buf =
+            build_mount_point_buffer("\\??\\Volume{12345678-1234-1234-1234-1234567890ab}\\");
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::MountPoint);
+    }
+
+    #[test]
+    fn classifies_mount_point_directory_prefix_as_junction() {
+        let buf = build_mount_point_buffer("\\??\\C:\\Users\\target");
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::Junction);
+    }
+
+    #[test]
+    fn classifies_mount_point_volume_prefix_case_insensitive() {
+        let buf = build_mount_point_buffer("\\??\\VOLUME{ABCDEF12-3456-7890-ABCD-EF1234567890}\\");
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::MountPoint);
+    }
+
+    #[test]
+    fn classifies_af_unix_tag() {
+        let buf = build_simple_tag(IO_REPARSE_TAG_AF_UNIX);
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::AfUnix);
+    }
+
+    #[test]
+    fn classifies_onedrive_legacy_tag() {
+        let buf = build_simple_tag(IO_REPARSE_TAG_ONEDRIVE);
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::OneDrive);
+    }
+
+    #[test]
+    fn classifies_cloud_legacy_tag() {
+        let buf = build_simple_tag(IO_REPARSE_TAG_CLOUD);
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::OneDrive);
+    }
+
+    #[test]
+    fn classifies_cloud_range_tags() {
+        for tag in CLOUD_TAG_RANGE_START..=CLOUD_TAG_RANGE_END {
+            let buf = build_simple_tag(tag);
+            assert_eq!(
+                classify_from_buffer(&buf),
+                ReparseKind::OneDrive,
+                "tag {tag:#010x} should map to OneDrive"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_unknown_tag_as_other() {
+        let tag = 0xDEAD_BEEF_u32;
+        let buf = build_simple_tag(tag);
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::Other(tag));
+    }
+
+    #[test]
+    fn rejects_truncated_buffer() {
+        let buf = vec![0u8; REPARSE_HEADER_SIZE - 1];
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::Other(0));
+    }
+
+    #[test]
+    fn mount_point_with_zero_substitute_length_is_junction() {
+        // Build a mount-point buffer with the substitute-name fields zeroed out.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&IO_REPARSE_TAG_MOUNT_POINT.to_le_bytes());
+        buf.extend_from_slice(&12u16.to_le_bytes()); // ReparseDataLength
+        buf.extend_from_slice(&0u16.to_le_bytes()); // Reserved
+        // SubstituteNameOffset, SubstituteNameLength, PrintNameOffset, PrintNameLength = 0
+        buf.extend_from_slice(&[0u8; 8]);
+        // Empty PathBuffer terminators
+        buf.extend_from_slice(&[0u8; 4]);
+        assert_eq!(classify_from_buffer(&buf), ReparseKind::Junction);
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod integration_tests {
+    //! Integration tests that materialise real NTFS reparse points and
+    //! invoke [`classify_reparse_point`] against an open `CreateFileW`
+    //! handle.
+    //!
+    //! `mklink /j` (directory junction) does not require administrator
+    //! privileges on Windows 10+, so the junction test runs unconditionally
+    //! and provides end-to-end coverage of the
+    //! `DeviceIoControl`/`FSCTL_GET_REPARSE_POINT` code path. Symlink
+    //! creation requires either developer mode or admin and is skipped at
+    //! runtime when the test environment lacks the privilege rather than
+    //! failing the build.
+
+    use super::*;
+    use std::fs;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+    use std::process::Command;
+
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    const FILE_READ_ATTRIBUTES: u32 = 0x0080;
+
+    struct OwnedHandle(HANDLE);
+
+    impl std::os::windows::io::AsRawHandle for OwnedHandle {
+        fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+            self.0.0 as std::os::windows::io::RawHandle
+        }
+    }
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` was returned by `CreateFileW` above and has
+            // not been closed elsewhere. Ownership is unique because the
+            // handle lives only inside this guard.
+            unsafe {
+                let _ = windows::Win32::Foundation::CloseHandle(self.0);
+            }
+        }
+    }
+
+    fn open_reparse(path: &Path) -> io::Result<OwnedHandle> {
+        let wide: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        // SAFETY: `wide` is a null-terminated UTF-16 path slice owned for
+        // the duration of the call. `FILE_FLAG_OPEN_REPARSE_POINT` ensures
+        // the reparse data is returned instead of followed;
+        // `FILE_FLAG_BACKUP_SEMANTICS` is required to open directories.
+        let handle = unsafe {
+            CreateFileW(
+                windows::core::PCWSTR(wide.as_ptr()),
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                None,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                None,
+            )
+        };
+
+        let handle = handle.map_err(|_| io::Error::last_os_error())?;
+        Ok(OwnedHandle(handle))
+    }
+
+    #[test]
+    fn junction_is_classified_as_junction() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("target");
+        let junction = tmp.path().join("link");
+        fs::create_dir(&target).expect("create target dir");
+
+        let status = Command::new("cmd")
+            .args([
+                "/c",
+                "mklink",
+                "/j",
+                junction.to_str().expect("utf8 junction path"),
+                target.to_str().expect("utf8 target path"),
+            ])
+            .status();
+
+        let status = match status {
+            Ok(s) => s,
+            Err(_) => return, // cmd.exe unavailable; skip
+        };
+        if !status.success() {
+            return; // junction creation refused; skip rather than fail
+        }
+
+        let handle = open_reparse(&junction).expect("open junction reparse");
+        let kind = classify_reparse_point(&handle).expect("classify junction");
+        assert_eq!(kind, ReparseKind::Junction);
+    }
+}

--- a/crates/metadata/tests/windows_reparse_classify_path.rs
+++ b/crates/metadata/tests/windows_reparse_classify_path.rs
@@ -1,0 +1,114 @@
+//! End-to-end coverage for the `metadata::windows::classify_path` helper
+//! (WPC-8'.9): the public path-based wrapper that opens a reparse-point
+//! handle internally and runs the classifier without forcing callers to
+//! handle the `CreateFileW` FFI surface themselves.
+//!
+//! The helper is the boundary the transfer crate uses when populating
+//! `FileEntry` values on Windows; this integration test materialises real
+//! NTFS reparse points so a regression in the open/classify glue surfaces
+//! without depending on the transfer crate's test bring-up.
+//!
+//! `mklink /j` runs without elevation on Windows 10+, so the junction case
+//! is unconditional. `mklink /d` (directory symlink) and `mountvol`
+//! (volume mount-point) require admin or Windows 10 developer mode and
+//! are downgraded to runtime skips when the privilege is missing,
+//! mirroring the in-tree integration tests shipped with the classifier
+//! itself.
+
+#![cfg(target_os = "windows")]
+
+use std::fs;
+use std::process::Command;
+
+use metadata::windows::{ReparseKind, classify_path};
+
+/// Returns `true` when `mklink` succeeded; `false` when the test should
+/// be skipped because `cmd.exe` is unavailable or the privilege to create
+/// the reparse point is missing. Mirrors the pattern in
+/// `crates/metadata/src/windows/reparse.rs` integration tests so a
+/// non-admin CI runner stays green without flaking the suite.
+fn try_mklink(args: &[&str]) -> bool {
+    match Command::new("cmd").args(args).status() {
+        Ok(s) => s.success(),
+        Err(_) => false,
+    }
+}
+
+/// Plain (non-reparse) entries must surface as `io::Error` rather than
+/// being silently classified, so the caller can short-circuit on the
+/// expected `ERROR_NOT_A_REPARSE_POINT` (4390) from `DeviceIoControl` and
+/// skip the symlink emission branch entirely.
+#[test]
+fn regular_file_returns_not_a_reparse_point_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("plain.txt");
+    fs::write(&path, b"data").expect("write");
+
+    let err = classify_path(&path).expect_err("regular file must error");
+    let raw = err.raw_os_error().unwrap_or(0);
+    assert!(
+        raw == 4390 || raw == 0,
+        "expected ERROR_NOT_A_REPARSE_POINT (4390) for plain file, got {raw} ({err})"
+    );
+}
+
+/// `mklink /j` produces an `IO_REPARSE_TAG_MOUNT_POINT` reparse point
+/// whose substitute-name points at a directory; the classifier must
+/// disambiguate that as a directory junction rather than a volume
+/// mount-point.
+#[test]
+fn junction_classifies_as_junction() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join("target");
+    let junction = tmp.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+
+    let (Some(j), Some(t)) = (junction.to_str(), target.to_str()) else {
+        return; // non-UTF8 tempdir; skip rather than fail
+    };
+    if !try_mklink(&["/c", "mklink", "/j", j, t]) {
+        return; // privilege missing or cmd.exe unavailable; skip
+    }
+
+    let kind = classify_path(&junction).expect("classify junction");
+    assert_eq!(kind, ReparseKind::Junction);
+}
+
+/// `mklink /d` produces an `IO_REPARSE_TAG_SYMLINK` reparse point on a
+/// directory; the classifier must surface it as `Symlink` (the most
+/// common shape that round-trips through every receiver).
+#[test]
+fn directory_symlink_classifies_as_symlink() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join("target");
+    let link = tmp.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+
+    let (Some(l), Some(t)) = (link.to_str(), target.to_str()) else {
+        return;
+    };
+    if !try_mklink(&["/c", "mklink", "/d", l, t]) {
+        // `mklink /d` requires admin / developer mode; downgrade to skip
+        // rather than failing the suite on a non-admin CI runner.
+        return;
+    }
+
+    let kind = classify_path(&link).expect("classify symlink");
+    assert_eq!(kind, ReparseKind::Symlink);
+}
+
+/// `classify_path` must reject a missing path with `NotFound`; we surface
+/// the underlying `CreateFileW` failure so callers can decide whether to
+/// retry or drop the entry from the transfer.
+#[test]
+fn missing_path_returns_not_found_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("does-not-exist");
+
+    let err = classify_path(&missing).expect_err("missing path must error");
+    assert!(
+        err.kind() == std::io::ErrorKind::NotFound
+            || err.raw_os_error().map_or(false, |n| n == 2 || n == 3),
+        "expected NotFound for missing path, got {err}"
+    );
+}

--- a/crates/metadata/tests/windows_reparse_fixtures.rs
+++ b/crates/metadata/tests/windows_reparse_fixtures.rs
@@ -215,10 +215,7 @@ impl Drop for MountPointFixture {
         // touching the volume contents. Ignore failures: the test may
         // already have removed the directory, or `mountvol` may be
         // unavailable in the cleanup environment.
-        let _ = Command::new("mountvol")
-            .arg(&self.link)
-            .arg("/d")
-            .status();
+        let _ = Command::new("mountvol").arg(&self.link).arg("/d").status();
         let _ = std::fs::remove_dir(&self.link);
     }
 }

--- a/crates/metadata/tests/windows_reparse_fixtures.rs
+++ b/crates/metadata/tests/windows_reparse_fixtures.rs
@@ -1,0 +1,373 @@
+//! Windows reparse-point fixture helpers and classifier integration tests.
+//!
+//! Feeds the WPC-8 reparse classifier
+//! (`metadata::windows::reparse::classify_reparse_point`) with realistic
+//! `mklink`- and `mountvol`-created reparse points. Provides three RAII-style
+//! fixtures so individual test cases can request a specific NTFS reparse
+//! shape and have it cleaned up automatically on drop:
+//!
+//! - [`DirSymlinkFixture`]    -> `mklink /d <link> <target>`
+//!                               (`IO_REPARSE_TAG_SYMLINK`)
+//! - [`JunctionFixture`]      -> `mklink /j <link> <target>`
+//!                               (`IO_REPARSE_TAG_MOUNT_POINT`, non-volume
+//!                               substitute-name)
+//! - [`MountPointFixture`]    -> `mountvol <link> <volume_guid>`
+//!                               (`IO_REPARSE_TAG_MOUNT_POINT`, volume
+//!                               substitute-name)
+//!
+//! `mklink /d` and `mountvol` require either administrator privileges or
+//! Windows 10 developer mode; the fixtures surface the privilege failure as
+//! an `io::Error` and individual tests downgrade to a runtime skip rather
+//! than failing the suite. `mklink /j` works without elevation on Windows
+//! 10+ and runs unconditionally, mirroring the in-tree integration test
+//! shipped with the classifier itself.
+//!
+//! # Standard-library-first policy
+//!
+//! All three fixtures shell out to OS-provided utilities (`cmd.exe` for
+//! `mklink`, `mountvol.exe` for the volume mount-point) via
+//! `std::process::Command`. The metadata crate already pulls in the
+//! `windows` crate for the classifier's FFI surface, but the test fixtures
+//! deliberately avoid touching FFI so they can act as a pure-`std`
+//! reference for callers who want to create reparse points outside the
+//! metadata crate.
+
+#![cfg(target_os = "windows")]
+
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use metadata::windows::reparse::{ReparseKind, classify_reparse_point};
+
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+
+/// `FILE_READ_ATTRIBUTES` access mask (`winnt.h`). Sufficient for
+/// `FSCTL_GET_REPARSE_POINT` and avoids the broader rights `GENERIC_READ`
+/// would request, keeping the open path side-effect free.
+const FILE_READ_ATTRIBUTES: u32 = 0x0080;
+
+/// RAII fixture creating a directory symbolic link via
+/// `cmd.exe /c mklink /d <link> <target>`.
+///
+/// `mklink /d` produces a reparse point with `IO_REPARSE_TAG_SYMLINK`
+/// (`0xA000000C`) so the classifier returns [`ReparseKind::Symlink`].
+/// Requires the `SeCreateSymbolicLinkPrivilege` privilege, which on
+/// Windows 10+ ships with administrator accounts or with developer mode
+/// enabled (Settings -> Update & Security -> For developers). When the
+/// privilege is missing `mklink` exits non-zero; the constructor maps the
+/// failure to [`io::ErrorKind::PermissionDenied`] and callers should
+/// downgrade to a runtime skip rather than panicking.
+///
+/// On drop, the symlink is removed with [`std::fs::remove_dir`], which is
+/// the correct primitive for both directory junctions and `mklink /d`
+/// symlinks on Windows (the reparse point is the directory itself, not a
+/// file).
+pub struct DirSymlinkFixture {
+    link: PathBuf,
+}
+
+impl DirSymlinkFixture {
+    /// Create a directory symlink at `link` that points at `target`.
+    ///
+    /// Returns [`io::ErrorKind::PermissionDenied`] when `mklink /d`
+    /// refuses the operation (most often because the caller lacks
+    /// `SeCreateSymbolicLinkPrivilege`), so tests can skip cleanly
+    /// without failing the suite.
+    pub fn new(link: &Path, target: &Path) -> io::Result<Self> {
+        let status = Command::new("cmd")
+            .args(["/c", "mklink", "/d"])
+            .arg(link)
+            .arg(target)
+            .status()?;
+        if !status.success() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "mklink /d requires administrator or developer mode",
+            ));
+        }
+        Ok(Self {
+            link: link.to_path_buf(),
+        })
+    }
+
+    /// Path to the created symlink.
+    pub fn path(&self) -> &Path {
+        &self.link
+    }
+}
+
+impl Drop for DirSymlinkFixture {
+    fn drop(&mut self) {
+        // Windows treats directory symlinks as directories at the
+        // filesystem layer; `remove_dir` deletes the reparse point
+        // itself without touching the target.
+        let _ = std::fs::remove_dir(&self.link);
+    }
+}
+
+/// RAII fixture creating a directory junction via
+/// `cmd.exe /c mklink /j <link> <target>`.
+///
+/// Junctions use `IO_REPARSE_TAG_MOUNT_POINT` (`0xA0000003`) with a
+/// non-volume substitute-name (typically `\??\C:\path\to\target`), so
+/// the classifier returns [`ReparseKind::Junction`]. Junction creation
+/// does not require elevation on Windows 10+, so the constructor only
+/// returns an error when `cmd.exe` is unavailable or the underlying
+/// `mklink` invocation fails for filesystem reasons.
+pub struct JunctionFixture {
+    link: PathBuf,
+}
+
+impl JunctionFixture {
+    /// Create a junction at `link` that points at `target`.
+    ///
+    /// Returns [`io::ErrorKind::Other`] when `mklink /j` exits non-zero
+    /// (rare on Windows 10+ since junctions do not require privilege
+    /// elevation).
+    pub fn new(link: &Path, target: &Path) -> io::Result<Self> {
+        let status = Command::new("cmd")
+            .args(["/c", "mklink", "/j"])
+            .arg(link)
+            .arg(target)
+            .status()?;
+        if !status.success() {
+            return Err(io::Error::other(format!(
+                "mklink /j {} {} exited with {status:?}",
+                link.display(),
+                target.display()
+            )));
+        }
+        Ok(Self {
+            link: link.to_path_buf(),
+        })
+    }
+
+    /// Path to the created junction.
+    pub fn path(&self) -> &Path {
+        &self.link
+    }
+}
+
+impl Drop for JunctionFixture {
+    fn drop(&mut self) {
+        // Junctions are directory reparse points; `remove_dir` removes
+        // the reparse without recursing into the target.
+        let _ = std::fs::remove_dir(&self.link);
+    }
+}
+
+/// RAII fixture creating a volume mount-point via
+/// `mountvol.exe <mount_point_dir> <volume_guid>`.
+///
+/// Mount-points share `IO_REPARSE_TAG_MOUNT_POINT` with junctions but
+/// use a `\??\Volume{GUID}\` substitute-name, so the classifier returns
+/// [`ReparseKind::MountPoint`]. `mountvol` requires administrator
+/// privileges; without elevation the constructor returns
+/// [`io::ErrorKind::PermissionDenied`] and tests skip rather than fail.
+///
+/// On drop the mount-point is dismounted with `mountvol /d`, which
+/// detaches the volume without affecting its data.
+pub struct MountPointFixture {
+    link: PathBuf,
+}
+
+impl MountPointFixture {
+    /// Mount the volume identified by `volume_guid_path` (for example
+    /// `\\?\Volume{12345678-1234-1234-1234-123456789abc}\`) at
+    /// `mount_point_dir`. The mount-point directory must already exist
+    /// and be empty, matching `mountvol`'s preconditions.
+    ///
+    /// Returns [`io::ErrorKind::PermissionDenied`] when `mountvol`
+    /// exits non-zero, which most often indicates the caller is not
+    /// running as administrator. Callers should downgrade to a runtime
+    /// skip rather than panicking.
+    pub fn new(mount_point_dir: &Path, volume_guid_path: &str) -> io::Result<Self> {
+        let status = Command::new("mountvol")
+            .arg(mount_point_dir)
+            .arg(volume_guid_path)
+            .status()?;
+        if !status.success() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "mountvol requires administrator privileges",
+            ));
+        }
+        Ok(Self {
+            link: mount_point_dir.to_path_buf(),
+        })
+    }
+
+    /// Path to the created mount-point directory.
+    pub fn path(&self) -> &Path {
+        &self.link
+    }
+}
+
+impl Drop for MountPointFixture {
+    fn drop(&mut self) {
+        // `mountvol /d` detaches the volume from the directory without
+        // touching the volume contents. Ignore failures: the test may
+        // already have removed the directory, or `mountvol` may be
+        // unavailable in the cleanup environment.
+        let _ = Command::new("mountvol")
+            .arg(&self.link)
+            .arg("/d")
+            .status();
+        let _ = std::fs::remove_dir(&self.link);
+    }
+}
+
+/// Owns a Win32 file handle obtained from `CreateFileW` and closes it on
+/// drop. Mirrors the helper used inside the classifier's in-tree
+/// integration test so this file can call [`classify_reparse_point`]
+/// against the same handle shape the production caller would supply.
+struct OwnedHandle(HANDLE);
+
+impl std::os::windows::io::AsRawHandle for OwnedHandle {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        self.0.0 as std::os::windows::io::RawHandle
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was returned by `CreateFileW` in `open_reparse`
+        // and is owned uniquely by this guard. The handle has not been
+        // closed elsewhere.
+        unsafe {
+            let _ = windows::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+/// Open `path` with `FILE_FLAG_OPEN_REPARSE_POINT |
+/// FILE_FLAG_BACKUP_SEMANTICS` so the reparse data is returned by
+/// `FSCTL_GET_REPARSE_POINT` instead of being followed. Backup-semantics
+/// is required to open directory reparse points (junctions, mount-points,
+/// `mklink /d` symlinks).
+fn open_reparse(path: &Path) -> io::Result<OwnedHandle> {
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // SAFETY: `wide` is a null-terminated UTF-16 path slice owned for the
+    // duration of the call. `FILE_FLAG_OPEN_REPARSE_POINT` ensures the
+    // reparse data is returned instead of followed; `FILE_FLAG_BACKUP_SEMANTICS`
+    // is required to open directories. The returned `HANDLE` is wrapped
+    // in [`OwnedHandle`] for guaranteed close-on-drop.
+    let handle = unsafe {
+        CreateFileW(
+            windows::core::PCWSTR(wide.as_ptr()),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            None,
+        )
+    };
+
+    let handle = handle.map_err(|_| io::Error::last_os_error())?;
+    Ok(OwnedHandle(handle))
+}
+
+/// Query `mountvol` for a volume GUID path that can be remounted at a
+/// fresh directory. Returns the first `\\?\Volume{...}\` line emitted by
+/// `mountvol` with no arguments; on failure (`mountvol` unavailable, no
+/// volumes listed, output unparseable) returns `None` so the calling
+/// test can downgrade to a runtime skip.
+fn first_volume_guid_path() -> Option<String> {
+    let output = Command::new("mountvol").output().ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("\\\\?\\Volume{") && trimmed.ends_with('\\') {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+#[test]
+fn classify_returns_symlink_for_dir_symlink() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("real_dir");
+    std::fs::create_dir(&target).expect("create target dir");
+    let link = dir.path().join("a_symlink");
+
+    let fixture = match DirSymlinkFixture::new(&link, &target) {
+        Ok(f) => f,
+        Err(err) => {
+            eprintln!("skipping: mklink /d unavailable ({err})");
+            return;
+        }
+    };
+
+    let handle = open_reparse(fixture.path()).expect("open dir symlink reparse");
+    let kind = classify_reparse_point(&handle).expect("classify dir symlink");
+    assert_eq!(
+        kind,
+        ReparseKind::Symlink,
+        "mklink /d should produce IO_REPARSE_TAG_SYMLINK"
+    );
+}
+
+#[test]
+fn classify_returns_junction_for_mklink_j() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("real_dir");
+    std::fs::create_dir(&target).expect("create target dir");
+    let link = dir.path().join("a_junction");
+
+    let fixture = match JunctionFixture::new(&link, &target) {
+        Ok(f) => f,
+        Err(err) => {
+            eprintln!("skipping: mklink /j unavailable ({err})");
+            return;
+        }
+    };
+
+    let handle = open_reparse(fixture.path()).expect("open junction reparse");
+    let kind = classify_reparse_point(&handle).expect("classify junction");
+    assert_eq!(
+        kind,
+        ReparseKind::Junction,
+        "mklink /j should produce IO_REPARSE_TAG_MOUNT_POINT with a directory substitute-name"
+    );
+}
+
+#[test]
+fn classify_returns_mount_point_for_setvolumemountpoint() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mount_dir = dir.path().join("a_mount");
+    std::fs::create_dir(&mount_dir).expect("create mount target dir");
+
+    let Some(volume_guid) = first_volume_guid_path() else {
+        eprintln!("skipping: no volume GUID available from mountvol");
+        return;
+    };
+
+    let fixture = match MountPointFixture::new(&mount_dir, &volume_guid) {
+        Ok(f) => f,
+        Err(err) => {
+            eprintln!("skipping: mountvol unavailable or non-admin ({err})");
+            return;
+        }
+    };
+
+    let handle = open_reparse(fixture.path()).expect("open mount-point reparse");
+    let kind = classify_reparse_point(&handle).expect("classify mount-point");
+    assert_eq!(
+        kind,
+        ReparseKind::MountPoint,
+        "mountvol mount should produce IO_REPARSE_TAG_MOUNT_POINT with a \\??\\Volume{{...}}\\ substitute-name"
+    );
+}

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -39,6 +39,26 @@ impl GeneratorContext {
 
         let file_type = metadata.file_type();
 
+        // Native Windows reparse-point detection. `std::fs::FileType::is_symlink`
+        // only returns `true` for `IO_REPARSE_TAG_SYMLINK` and
+        // `IO_REPARSE_TAG_MOUNT_POINT`; tags like `IO_REPARSE_TAG_AF_UNIX`,
+        // `IO_REPARSE_TAG_ONEDRIVE`, and the cloud-files range therefore slip
+        // through and would otherwise serialise as plain regular files. The
+        // `FILE_ATTRIBUTE_REPARSE_POINT` attribute catches every reparse
+        // shape; we route the entry through the symlink branch so the WPC-8
+        // classifier (`metadata::windows::reparse::classify_path`) governs the
+        // wire emission rather than the surface `FileType` probe.
+        //
+        // Upstream rsync runs through Cygwin on Windows and treats every
+        // reparse point as a POSIX symbolic link; this mirror keeps the wire
+        // output compatible without losing the classifier's distinction.
+        #[cfg(windows)]
+        let is_reparse_point = {
+            use std::os::windows::fs::MetadataExt;
+            const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+            metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        };
+
         // upstream: xattrs.c:get_stat_xattr() - when `--fake-super` is in
         // effect, a previous fake-super receiver may have recorded the real
         // ownership, permissions, and device numbers in the source file's
@@ -50,7 +70,29 @@ impl GeneratorContext {
         #[cfg(unix)]
         let fake_super_override = self.fake_super_override(full_path, metadata);
 
-        let mut entry = if file_type.is_file() {
+        // Windows reparse-point branch. Run before the regular-file probe so
+        // non-symlink reparse points (cloud placeholders, AF_UNIX sockets,
+        // opaque vendor tags) do not slip into the regular-file emission.
+        // Junctions and mount-points already pass through
+        // `file_type.is_symlink()`, but routing them here too lets the
+        // classifier choose the wire shape for every flavour in one place.
+        #[cfg(windows)]
+        let reparse_kind = if is_reparse_point {
+            metadata::windows::classify_path(full_path).ok()
+        } else {
+            None
+        };
+
+        let mut entry = if file_type.is_file() && {
+            #[cfg(windows)]
+            {
+                !is_reparse_point
+            }
+            #[cfg(not(windows))]
+            {
+                true
+            }
+        } {
             #[cfg(unix)]
             let mode = metadata.mode() & 0o7777;
             #[cfg(not(unix))]
@@ -79,7 +121,36 @@ impl GeneratorContext {
             let mode = 0o755;
 
             FileEntry::new_directory(relative_path, mode)
-        } else if file_type.is_symlink() {
+        } else if file_type.is_symlink() || {
+            #[cfg(windows)]
+            {
+                is_reparse_point
+            }
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        } {
+            // upstream: flist.c:readlink_stat() returns the link target as
+            // recorded on disk. On Windows the kernel exposes junctions and
+            // symlinks through `read_link`; cloud placeholders and AF_UNIX
+            // sockets do not have a portable target and we fall back to an
+            // empty path so the receiver materialises a stub link rather than
+            // dropping the entry. The WPC-8 classification is consulted only
+            // to decide whether we trust `read_link` (Symlink/Junction) or
+            // emit an empty target (OneDrive/AfUnix/Other); the on-wire
+            // type is always SYMLINK for Cygwin parity.
+            #[cfg(windows)]
+            let raw_target = match reparse_kind {
+                Some(metadata::windows::ReparseKind::Symlink)
+                | Some(metadata::windows::ReparseKind::Junction)
+                | Some(metadata::windows::ReparseKind::MountPoint)
+                | None => std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from("")),
+                Some(metadata::windows::ReparseKind::OneDrive)
+                | Some(metadata::windows::ReparseKind::AfUnix)
+                | Some(metadata::windows::ReparseKind::Other(_)) => PathBuf::from(""),
+            };
+            #[cfg(not(windows))]
             let raw_target = std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from(""));
 
             // upstream: flist.c:222-226 - sender strips the `/rsyncd-munged/`
@@ -910,6 +981,172 @@ mod munge_symlinks_tests {
             Some(Path::new("/rsyncd-munged//etc/passwd")),
             "without `munge symlinks`, the prefix is part of the target and \
              must round-trip verbatim",
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_reparse_tests {
+    //! Windows reparse-point classification regression tests (WPC-8'.9).
+    //!
+    //! Verifies that `create_entry` routes NTFS reparse points through the
+    //! WPC-8 classifier so junctions, symbolic links, and non-symlink
+    //! reparse points serialise as SYMLINK-class `FileEntry` values
+    //! (matching upstream's Cygwin behaviour) rather than as regular files.
+    //!
+    //! `mklink /j` runs without elevation on Windows 10+; `mklink /d`
+    //! (directory symlink) requires admin or developer mode and is
+    //! downgraded to a runtime skip when the privilege is missing, matching
+    //! the in-tree integration tests that ship with the classifier itself.
+    //!
+    //! Mount-point coverage is left to the classifier-level integration
+    //! tests because `mountvol` requires admin elevation and a free volume
+    //! GUID; the wiring contract under test here is "every reparse-point
+    //! attribute routes through `metadata::windows::classify_path` and lands
+    //! in the symlink branch", which the junction case already verifies
+    //! end-to-end.
+
+    use super::super::super::GeneratorContext;
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use protocol::ProtocolVersion;
+    use protocol::flist::FileType;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn windows_generator() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// Returns `Some(status)` when `mklink` succeeded, `None` when the test
+    /// should be skipped because `cmd.exe` is unavailable or the privilege
+    /// to create the reparse point is missing.
+    fn try_mklink(args: &[&str]) -> Option<()> {
+        let status = Command::new("cmd").args(args).status().ok()?;
+        if status.success() { Some(()) } else { None }
+    }
+
+    /// Regular file: stays Regular, does not flip to Symlink.
+    ///
+    /// Negative control: ensures the reparse-attribute probe does not
+    /// false-positive on non-reparse entries.
+    #[test]
+    fn regular_file_is_classified_as_regular() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("plain.txt");
+        std::fs::write(&path, b"data").expect("write file");
+        let meta = std::fs::symlink_metadata(&path).expect("symlink_metadata");
+
+        let ctx = windows_generator();
+        let entry = ctx
+            .create_entry(&path, PathBuf::from("plain.txt"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.file_type(), FileType::Regular);
+        assert_eq!(entry.size(), 4);
+    }
+
+    /// Directory junction (`mklink /j`): WPC-8 classifies as `Junction`,
+    /// `create_entry` emits a `Symlink` FileEntry whose target is preserved.
+    ///
+    /// Mirrors upstream rsync Cygwin behaviour (every reparse point becomes
+    /// a POSIX symbolic link on the wire) while exercising the wiring that
+    /// PR #5579 + PR #5592 deferred behind the classifier API.
+    #[test]
+    fn junction_is_emitted_as_symlink_entry() {
+        let tmp = TempDir::new().expect("tempdir");
+        let target = tmp.path().join("target");
+        let junction = tmp.path().join("link");
+        std::fs::create_dir(&target).expect("create target dir");
+
+        let junction_str = match junction.to_str() {
+            Some(s) => s,
+            None => return, // non-UTF8 tempdir, skip
+        };
+        let target_str = match target.to_str() {
+            Some(s) => s,
+            None => return,
+        };
+        if try_mklink(&["/c", "mklink", "/j", junction_str, target_str]).is_none() {
+            // junction creation refused (no cmd.exe, or filesystem rejects);
+            // skip rather than fail so non-admin CI runners stay green.
+            return;
+        }
+
+        let meta = std::fs::symlink_metadata(&junction).expect("symlink_metadata");
+        let ctx = windows_generator();
+        let entry = ctx
+            .create_entry(&junction, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(
+            entry.file_type(),
+            FileType::Symlink,
+            "junction must serialise as SYMLINK for Cygwin parity"
+        );
+        let link_target = entry.link_target().cloned().unwrap_or_default();
+        assert!(
+            !link_target.as_os_str().is_empty(),
+            "junction target must be preserved (got empty), \
+             entry={entry:?}"
+        );
+    }
+
+    /// Directory symlink (`mklink /d`): WPC-8 classifies as `Symlink`,
+    /// `create_entry` emits a `Symlink` FileEntry with a non-empty target.
+    ///
+    /// Skipped at runtime when `mklink /d` is refused (requires admin or
+    /// Windows 10 developer mode).
+    #[test]
+    fn directory_symlink_is_emitted_as_symlink_entry() {
+        let tmp = TempDir::new().expect("tempdir");
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("link");
+        std::fs::create_dir(&target).expect("create target dir");
+
+        let link_str = match link.to_str() {
+            Some(s) => s,
+            None => return,
+        };
+        let target_str = match target.to_str() {
+            Some(s) => s,
+            None => return,
+        };
+        if try_mklink(&["/c", "mklink", "/d", link_str, target_str]).is_none() {
+            return; // privilege missing, skip
+        }
+
+        let meta = std::fs::symlink_metadata(&link).expect("symlink_metadata");
+        let ctx = windows_generator();
+        let entry = ctx
+            .create_entry(&link, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.file_type(), FileType::Symlink);
+        let link_target = entry.link_target().cloned().unwrap_or_default();
+        assert!(
+            !link_target.as_os_str().is_empty(),
+            "directory symlink target must be preserved, entry={entry:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `metadata::windows::reparse` (Windows-only) that issues `DeviceIoControl(FSCTL_GET_REPARSE_POINT)` against a handle opened with `FILE_FLAG_OPEN_REPARSE_POINT` and classifies the entry by its `ReparseTag`.
- `ReparseKind` distinguishes `Symlink`, `Junction`, `MountPoint`, `OneDrive` (legacy + `0x90000010..=0x9000001F` cloud range), `AfUnix`, and `Other(tag)`; mount-points are split from junctions by detecting the `\??\Volume{GUID}\` substitute-name prefix.
- Closes the WPC-8 gap: upstream rsync runs on Windows under Cygwin which treats every reparse point as a POSIX symlink, so native oc-rsync needs its own classifier to decide how to transfer each shape without losing information.
- Pulls in `Win32_System_IO` and `Win32_System_Ioctl` feature flags on the existing `windows` dependency; module-level `#![allow(unsafe_code)]` keeps the FFI block inside the metadata crate, which the unsafe-code policy permits.

## Test plan

- [ ] Unit (`classifies_symlink_tag`) - synthetic `IO_REPARSE_TAG_SYMLINK` buffer maps to `ReparseKind::Symlink`.
- [ ] Unit (`classifies_mount_point_volume_prefix_as_mount_point`) - `IO_REPARSE_TAG_MOUNT_POINT` + `\??\Volume{...}\` prefix maps to `ReparseKind::MountPoint`.
- [ ] Unit (`classifies_mount_point_directory_prefix_as_junction`) - `IO_REPARSE_TAG_MOUNT_POINT` + `\??\C:\Users\target` maps to `ReparseKind::Junction`.
- [ ] Unit (`classifies_mount_point_volume_prefix_case_insensitive`) - `\??\VOLUME{...}` upper-case still classifies as `MountPoint`.
- [ ] Unit (`classifies_af_unix_tag`) - WSL `IO_REPARSE_TAG_AF_UNIX` maps to `ReparseKind::AfUnix`.
- [ ] Unit (`classifies_onedrive_legacy_tag`, `classifies_cloud_legacy_tag`, `classifies_cloud_range_tags`) - legacy + range cloud tags all map to `ReparseKind::OneDrive`.
- [ ] Unit (`classifies_unknown_tag_as_other`) - `0xDEADBEEF` round-trips through `ReparseKind::Other(tag)`.
- [ ] Unit (`rejects_truncated_buffer`, `mount_point_with_zero_substitute_length_is_junction`) - malformed buffers degrade to safe defaults instead of panicking.
- [ ] Integration (`junction_is_classified_as_junction`, Windows-only) - creates a real `mklink /j` junction in a `tempfile::tempdir`, opens it with `CreateFileW(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)`, asserts `classify_reparse_point` returns `ReparseKind::Junction`. Skips when `cmd.exe` is unavailable or junction creation is refused, never fails the suite.
- [ ] CI matrix - fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable) must pass.