### PR TITLE
feat(daemon): apply PR_SET_NO_NEW_PRIVS + log active LSMs at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "libc",
  "logging-sink",
  "metadata",
+ "nix",
  "platform",
  "protocol",
  "rcgen",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -89,6 +89,8 @@ seccompiler = { version = "0.5", optional = true }
 # Audit-clean per the unsafe-code policy: the crate's public API contains no
 # unsafe blocks the daemon needs to opt into.
 caps = "0.5"
+# `process` enables nix::sys::prctl for PR_SET_NO_NEW_PRIVS startup hardening.
+nix = { workspace = true, features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]
 checksums = { path = "../checksums", default-features = false }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -288,6 +288,12 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
         None
     };
 
+    // Apply Linux-only defense-in-depth startup hardenings before serving
+    // the remote-shell daemon session. Mirrors the standalone and inetd
+    // paths so PR_SET_NO_NEW_PRIVS and the LSM audit line apply uniformly
+    // regardless of which entry point launched the daemon.
+    apply_startup_hardening(log_sink.as_ref());
+
     let connection_limiter: Option<Arc<ConnectionLimiter>> = None;
     let modules: Vec<ModuleRuntime> = modules
         .into_iter()
@@ -477,6 +483,8 @@ include!("daemon/sections/privilege.rs");
 include!("daemon/sections/seccomp.rs");
 
 include!("daemon/sections/capabilities.rs");
+
+include!("daemon/sections/hardening.rs");
 
 include!("daemon/sections/log_format.rs");
 

--- a/crates/daemon/src/daemon/sections/hardening.rs
+++ b/crates/daemon/src/daemon/sections/hardening.rs
@@ -1,0 +1,205 @@
+/// Path to the kernel's active-LSM list pseudofile.
+///
+/// On a Linux system with securityfs mounted, `/sys/kernel/security/lsm`
+/// contains a comma-separated list of the LSMs active in the kernel (for
+/// example, `lockdown,capability,landlock,yama,apparmor,bpf`). The file is
+/// absent when securityfs is not mounted - typical for stripped-down
+/// containers without `/sys` exposed.
+#[cfg(target_os = "linux")]
+const LSM_LIST_PATH: &str = "/sys/kernel/security/lsm";
+
+/// Applies the Linux-only startup defense-in-depth hardenings.
+///
+/// Runs two surgical changes once at daemon main-entry, before the listener
+/// is bound or any privileged hook is exec'd:
+///
+/// 1. Sets `PR_SET_NO_NEW_PRIVS` so any later `execve()` (notably the
+///    pre/post-xfer-exec hook helpers) cannot acquire elevated privileges
+///    via setuid binaries. This is also required for proper Landlock
+///    engagement on kernels that gate the LSM behind the no-new-privs bit.
+/// 2. Reads `/sys/kernel/security/lsm` and emits the active LSM list to
+///    the daemon log so operators can confirm at a glance which kernel
+///    security modules cover the process - in particular whether Landlock
+///    is loaded alongside SEC-1 *at* helpers.
+///
+/// Both steps are best-effort observability and short-circuit to a no-op
+/// on non-Linux targets. Failures inside either step never propagate: the
+/// daemon still serves connections, but the operator sees a diagnostic in
+/// the log explaining the degraded posture.
+fn apply_startup_hardening(log_sink: Option<&SharedLogSink>) {
+    apply_no_new_privs(log_sink);
+    log_active_lsms(log_sink);
+}
+
+/// Sets `PR_SET_NO_NEW_PRIVS` for the daemon process.
+///
+/// On Linux, calls `prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)` via the safe
+/// `nix::sys::prctl::set_no_new_privs` wrapper. The flag is a one-way bit:
+/// once set it cannot be cleared, and it propagates to every child of the
+/// process. After this call any `execve()` of a setuid or setgid binary
+/// (or one with capabilities or a Linux Security Module that grants extra
+/// privileges via the exec) is silently downgraded to the calling user's
+/// privileges.
+///
+/// On non-Linux targets this is a no-op.
+#[cfg(target_os = "linux")]
+fn apply_no_new_privs(log_sink: Option<&SharedLogSink>) {
+    match nix::sys::prctl::set_no_new_privs() {
+        Ok(()) => {
+            if let Some(log) = log_sink {
+                let message = rsync_info!("PR_SET_NO_NEW_PRIVS active for daemon process")
+                    .with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+        }
+        Err(err) => {
+            if let Some(log) = log_sink {
+                let text = format!(
+                    "PR_SET_NO_NEW_PRIVS prctl failed: {err}; continuing without it"
+                );
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+        }
+    }
+}
+
+/// Stub for platforms without `prctl(2)`.
+#[cfg(not(target_os = "linux"))]
+fn apply_no_new_privs(_log_sink: Option<&SharedLogSink>) {}
+
+/// Reads `/sys/kernel/security/lsm` and logs the active LSM list.
+///
+/// The pseudofile is exposed by securityfs and lists the comma-separated
+/// names of the Linux Security Modules currently loaded in the kernel.
+/// Logging this once at startup gives operators a single audit line that
+/// confirms which kernel-side defenses (Landlock, AppArmor, SELinux, Yama,
+/// lockdown) cover the daemon process.
+///
+/// A missing file or read error is logged at debug level - LSM detection
+/// is purely observability, so the absence of securityfs (common in
+/// minimal containers) must not block daemon startup.
+///
+/// On non-Linux targets this is a no-op.
+#[cfg(target_os = "linux")]
+fn log_active_lsms(log_sink: Option<&SharedLogSink>) {
+    read_and_log_lsms_from(Path::new(LSM_LIST_PATH), log_sink);
+}
+
+/// Stub for platforms without securityfs.
+#[cfg(not(target_os = "linux"))]
+fn log_active_lsms(_log_sink: Option<&SharedLogSink>) {}
+
+/// Reads the LSM list from `path` and logs it, factored for testing.
+///
+/// Trims whitespace and emits an info diagnostic on success. On error
+/// (file missing, unreadable, or empty after trim) emits a debug
+/// diagnostic so the operator can confirm the read was attempted without
+/// promoting expected absences (rootless containers) to warning noise.
+#[cfg(target_os = "linux")]
+fn read_and_log_lsms_from(path: &Path, log_sink: Option<&SharedLogSink>) {
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            let lsms = contents.trim();
+            if lsms.is_empty() {
+                if let Some(log) = log_sink {
+                    let text = format!(
+                        "active Linux Security Modules: <empty> (read from {})",
+                        path.display(),
+                    );
+                    let message = rsync_info!(text).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+                return;
+            }
+
+            if let Some(log) = log_sink {
+                let text = format!("active Linux Security Modules: {lsms}");
+                let message = rsync_info!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+        }
+        Err(err) => {
+            if let Some(log) = log_sink {
+                let text = format!(
+                    "active Linux Security Modules: detection skipped ({} unavailable: {err})",
+                    path.display(),
+                );
+                let message = rsync_info!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod hardening_tests {
+    use super::*;
+    use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+
+    /// Builds a [`SharedLogSink`] backed by a fresh tempfile and returns
+    /// the sink alongside a clone of the underlying file. The clone is
+    /// used to read back the rendered log output without taking the sink
+    /// lock from the test thread.
+    fn capturing_sink() -> (SharedLogSink, std::fs::File) {
+        let file = tempfile::tempfile().expect("create capturing tempfile");
+        let reader = file.try_clone().expect("clone capturing tempfile");
+        let sink = Arc::new(Mutex::new(MessageSink::with_brand(file, Brand::Oc)));
+        (sink, reader)
+    }
+
+    /// Reads the captured log file end-to-end and returns the rendered text.
+    fn drain_capture(mut reader: std::fs::File) -> String {
+        reader
+            .seek(SeekFrom::Start(0))
+            .expect("rewind capturing tempfile");
+        let mut buf = String::new();
+        reader
+            .read_to_string(&mut buf)
+            .expect("read capturing tempfile");
+        buf
+    }
+
+    /// A valid LSM list parses, trims, and is forwarded to the log sink
+    /// verbatim. The mocked file uses the kernel's documented format -
+    /// comma-separated names with a trailing newline - so the test
+    /// exercises the exact trim contract operators see in production.
+    #[test]
+    fn read_and_log_lsms_emits_trimmed_list() {
+        let dir = tempfile::tempdir().expect("create tempdir for LSM mock");
+        let path = dir.path().join("lsm");
+        let mut file = std::fs::File::create(&path).expect("create LSM mock file");
+        file.write_all(b"lockdown,capability,landlock,yama,bpf\n")
+            .expect("write LSM mock contents");
+        file.flush().expect("flush LSM mock contents");
+
+        let (sink, reader) = capturing_sink();
+        read_and_log_lsms_from(&path, Some(&sink));
+        let captured = drain_capture(reader);
+
+        assert!(
+            captured.contains(
+                "active Linux Security Modules: lockdown,capability,landlock,yama,bpf"
+            ),
+            "expected trimmed LSM list in log output, got: {captured:?}",
+        );
+    }
+
+    /// A missing securityfs pseudofile must not panic and must not
+    /// promote the read failure to an error. The graceful-skip path
+    /// keeps daemon startup quiet on minimal containers.
+    #[test]
+    fn read_and_log_lsms_skips_when_file_missing() {
+        let dir = tempfile::tempdir().expect("create tempdir for missing-path probe");
+        let path = dir.path().join("does-not-exist");
+
+        let (sink, reader) = capturing_sink();
+        read_and_log_lsms_from(&path, Some(&sink));
+        let captured = drain_capture(reader);
+
+        assert!(
+            captured.contains("detection skipped") && captured.contains("unavailable"),
+            "expected skip diagnostic, got: {captured:?}",
+        );
+    }
+}

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -65,6 +65,14 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
         None
     };
 
+    // Inetd path serves one session in this process and exits, but the
+    // hardening is still cheap insurance: PR_SET_NO_NEW_PRIVS prevents
+    // any later setuid exec (e.g. a pre-xfer-exec hook configured on the
+    // requested module) from regaining privileges, and the LSM audit line
+    // makes the active kernel defenses visible to operators inspecting
+    // inetd-style logs.
+    apply_startup_hardening(log_sink.as_ref());
+
     let connection_limiter: Option<Arc<ConnectionLimiter>> = None;
     let modules: Vec<ModuleRuntime> = modules
         .into_iter()

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -67,6 +67,13 @@ fn serve_connections(
         None
     };
 
+    // Apply Linux-only defense-in-depth startup hardenings before the
+    // listener binds or any pre-xfer-exec hook is spawned. PR_SET_NO_NEW_PRIVS
+    // is a one-way bit and must run before bind/fork so it propagates to
+    // every per-connection worker; the LSM-detection log is a one-shot
+    // audit line tied to the same startup transition.
+    apply_startup_hardening(log_sink.as_ref());
+
     // Open syslog connection when no log file is configured (matching upstream
     // rsync's behaviour: log.c routes to syslog when logfile_name is NULL).
     // The guard is held for the daemon's lifetime; dropping it calls closelog(3).

--- a/docs/packaging/landlock-feature-guidance.md
+++ b/docs/packaging/landlock-feature-guidance.md
@@ -118,6 +118,20 @@ oc-rsync --daemon --no-detach --log-file=- --log-file-format=info 2>&1 | \
 
 The line reports either the achieved ABI level (1, 2, or 3) or `landlock unavailable on this kernel`. Use this to confirm the package was built with the feature enabled and the host kernel exposes the LSM.
 
+## Companion startup hardenings (always on, no operator action required)
+
+Two Linux-only defense-in-depth measures run automatically at daemon startup, regardless of whether the `landlock` feature is compiled in:
+
+1. **`PR_SET_NO_NEW_PRIVS`** is applied to the daemon process before the listener binds. The flag is a one-way bit that prevents any subsequent `execve()` from acquiring elevated privileges via setuid/setgid binaries, file capabilities, or LSM-mediated privilege grants. It also satisfies the precondition some kernels apply to Landlock engagement. The flag inherits across `fork()`, so every per-connection worker and every `pre-xfer-exec` / `post-xfer-exec` hook spawned by the daemon runs with it set.
+2. **Active LSM detection** reads `/sys/kernel/security/lsm` and emits a single info-level line listing the kernel-side defenses (for example `lockdown,capability,landlock,yama,bpf`). Operators can grep this line to confirm which LSMs cover the daemon process - in particular whether Landlock is loaded alongside the SEC-1 `*at` chain. When `/sys/kernel/security/lsm` is absent (minimal containers without securityfs mounted) the daemon logs the skip and continues; LSM detection is observability, not enforcement.
+
+Neither hardening requires configuration. Both short-circuit to a no-op on non-Linux targets. Verifying both at runtime:
+
+```sh
+oc-rsync --daemon --no-detach --log-file=- 2>&1 | \
+    grep -E "PR_SET_NO_NEW_PRIVS|Linux Security Modules"
+```
+
 ## Layered defense: seccomp BPF (`daemon-seccomp`)
 
 `daemon-seccomp` adds a kernel-enforced syscall allowlist on top of Landlock. Where Landlock denies a path-based syscall with `EACCES`, seccomp denies an unlisted syscall with `SIGSYS` before the kernel ever consults the LSM stack. The two layers compose: a regression that bypasses `*at` helpers still hits Landlock; one that skips Landlock still hits seccomp.


### PR DESCRIPTION
## Summary

- Sets `PR_SET_NO_NEW_PRIVS` once at daemon main-entry via `nix::sys::prctl::set_no_new_privs`, so any later `execve()` (including pre/post-xfer-exec hooks) cannot regain privileges and Landlock can engage on kernels that gate it behind the no-new-privs bit.
- Reads `/sys/kernel/security/lsm` and emits the active LSM list at info level so operators see a single audit line confirming which kernel-side defenses (Landlock, lockdown, Yama, AppArmor, etc.) cover the daemon. Missing securityfs degrades to a graceful skip.
- Applies uniformly across all three daemon entry points (standalone TCP accept loop, inetd stdio, `--server --daemon` stdio); no-op on non-Linux targets.

## Test plan

- [ ] `cargo nextest run -p daemon --all-features -E 'test(hardening)'` covers the two new unit tests: a mocked-file LSM read that asserts the trimmed list reaches the log sink, and a missing-path probe that asserts graceful skip without panic.
- [ ] Full CI matrix (fmt+clippy, nextest stable, Windows, macOS, Linux musl) exercises the cross-platform no-op stub on non-Linux and confirms the Linux-only `nix` `process` feature compiles.
- [ ] Existing daemon integration tests (`tests::support::run_daemon`) confirm the daemon still starts successfully on Linux with the prctl call wired in.