### PR TITLE
fix(daemon): emit deletions + NDX_DEL_STATS on daemon-receive uploads

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -22,6 +22,8 @@ pub(super) fn convert_server_stats_to_summary(
 
     let (local_summary, io_error, error_count) = match stats {
         ServerStats::Receiver(ref transfer_stats) => {
+            // Daemon-pull: local side ran the receiver and its `--delete`
+            // sweep. The per-type counters live on `delete_stats`.
             let s = LocalCopySummary::from_receiver_stats(
                 transfer_stats.files_listed,
                 transfer_stats.files_transferred,
@@ -31,15 +33,21 @@ pub(super) fn convert_server_stats_to_summary(
                 elapsed,
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
+                u64::from(transfer_stats.delete_stats.total()),
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }
         ServerStats::Generator(ref generator_stats) => {
+            // Daemon-upload: local side ran the sender/generator. The remote
+            // receiver ran the `--delete` sweep and reported the per-type
+            // counters via `NDX_DEL_STATS` during the goodbye phase
+            // (see `GeneratorContext::handle_goodbye`).
             let s = LocalCopySummary::from_generator_stats(
                 generator_stats.files_listed,
                 generator_stats.files_transferred,
                 generator_stats.bytes_sent,
                 elapsed,
+                u64::from(generator_stats.delete_stats.total()),
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -443,6 +443,7 @@ pub(super) fn convert_server_stats_to_summary(
 
     let (local_summary, io_error, error_count) = match stats {
         ServerStats::Receiver(ref transfer_stats) => {
+            // SSH-pull: local side ran the receiver and its `--delete` sweep.
             let s = LocalCopySummary::from_receiver_stats(
                 transfer_stats.files_listed,
                 transfer_stats.files_transferred,
@@ -452,15 +453,19 @@ pub(super) fn convert_server_stats_to_summary(
                 elapsed,
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
+                u64::from(transfer_stats.delete_stats.total()),
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }
         ServerStats::Generator(ref generator_stats) => {
+            // SSH-push: local side ran the sender/generator; the remote
+            // receiver reported its delete counters via `NDX_DEL_STATS`.
             let s = LocalCopySummary::from_generator_stats(
                 generator_stats.files_listed,
                 generator_stats.files_transferred,
                 generator_stats.bytes_sent,
                 elapsed,
+                u64::from(generator_stats.delete_stats.total()),
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -380,6 +380,10 @@ include!("tests/chunks/daemon_checksum_push.rs");
 include!("tests/chunks/daemon_compress_push.rs");
 // Daemon delete push end-to-end test
 include!("tests/chunks/daemon_delete_push.rs");
+// Daemon delete push NDX_DEL_STATS regression (URV-6 upload-direction gap)
+include!("tests/chunks/daemon_delete_push_emits_stats.rs");
+// Daemon delete pull NDX_DEL_STATS regression (URV-6 pull-direction)
+include!("tests/chunks/daemon_delete_pull_emits_stats.rs");
 // Daemon inplace push end-to-end test
 include!("tests/chunks/daemon_inplace_push.rs");
 // Daemon push/pull lifecycle end-to-end tests

--- a/crates/daemon/src/tests/chunks/daemon_delete_pull_emits_stats.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_pull_emits_stats.rs
@@ -1,0 +1,100 @@
+/// End-to-end test for `--delete` stats emission during a daemon pull.
+///
+/// Pull-direction regression for URV-6: ensure that wiring the upload-direction
+/// delete pass does not break the previously-working pull case. On a pull the
+/// local client runs the receiver and performs the sweep itself; the per-type
+/// counters must surface via `ClientSummary::items_deleted()` from the
+/// receiver's `TransferStats.delete_stats` field.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:do_delete_pass()` - full tree walk deletion sweep
+/// - `receiver.c:delete_in_dir()` - local sweep on the pull-side receiver
+#[cfg(unix)]
+#[test]
+fn daemon_delete_pull_reports_delete_stats() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+
+    let source_dir = temp.path().join("source");
+    fs::create_dir(&source_dir).expect("create source");
+    fs::write(source_dir.join("file_a.txt"), "contents of A\n").expect("write a");
+    fs::write(source_dir.join("file_b.txt"), "contents of B\n").expect("write b");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir(&dest_dir).expect("create dest");
+    fs::write(dest_dir.join("file_a.txt"), "contents of A\n").expect("seed a");
+    fs::write(dest_dir.join("file_b.txt"), "contents of B\n").expect("seed b");
+    fs::write(dest_dir.join("extra.txt"), "should be deleted\n").expect("seed extra");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[pullmod]\n\
+         path = {}\n\
+         read only = true\n\
+         use chroot = false\n",
+        source_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--max-sessions"),
+            OsString::from("4"),
+        ])
+        .build();
+
+    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    drop(probe_stream);
+
+    let rsync_url = format!("rsync://127.0.0.1:{port}/pullmod/");
+    let mut dest_arg = dest_dir.clone().into_os_string();
+    dest_arg.push("/");
+
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([OsString::from(&rsync_url), dest_arg])
+        .delete(true)
+        .stats(true)
+        .build();
+
+    let result = core::client::run_client(client_config);
+
+    let summary = match result {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = daemon_handle.join();
+            panic!("delete-stats pull failed: {e}");
+        }
+    };
+
+    assert!(
+        dest_dir.join("file_a.txt").exists(),
+        "file_a.txt must survive the pull"
+    );
+    assert!(
+        dest_dir.join("file_b.txt").exists(),
+        "file_b.txt must survive the pull"
+    );
+    assert!(
+        !dest_dir.join("extra.txt").exists(),
+        "extra.txt must be removed by --delete on the pull-side receiver"
+    );
+
+    assert_eq!(
+        summary.items_deleted(),
+        1,
+        "client summary must report one deleted file from the local receiver sweep"
+    );
+
+    let _ = daemon_handle.join();
+}

--- a/crates/daemon/src/tests/chunks/daemon_delete_push_emits_stats.rs
+++ b/crates/daemon/src/tests/chunks/daemon_delete_push_emits_stats.rs
@@ -1,0 +1,114 @@
+/// End-to-end test for `--delete` stats emission during a daemon upload.
+///
+/// Reproduces the URV-6 upload-direction gap: with the default-features build
+/// the receiver runs `run_pipelined_incremental`, which previously skipped
+/// `delete_extraneous_files` entirely. Even with the URV-6.a `--stats` gate
+/// fix, the receiver never carried a non-zero `DeleteStats` and never wrote
+/// `NDX_DEL_STATS` during the goodbye handshake. The client sender therefore
+/// surfaced "Number of deleted files: 0" no matter how many extraneous
+/// entries existed.
+///
+/// The test performs an upload with `--delete --stats`. The destination is
+/// pre-seeded with an extra file absent from the source. After the upload
+/// the destination must be in sync and the client summary must report
+/// exactly one deleted entry.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:do_delete_pass()` - full tree walk deletion sweep
+/// - `generator.c:2393-2398` - `delete_mode || force_delete || read_batch`
+///   gate for early `write_del_stats()`
+/// - `main.c:225-238` - `write_del_stats()` wire format
+#[cfg(unix)]
+#[test]
+fn daemon_delete_push_reports_delete_stats() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+
+    let source_dir = temp.path().join("source");
+    fs::create_dir(&source_dir).expect("create source");
+    fs::write(source_dir.join("file_a.txt"), "contents of A\n").expect("write a");
+    fs::write(source_dir.join("file_b.txt"), "contents of B\n").expect("write b");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir(&dest_dir).expect("create dest");
+    // Seed the destination with the same two files plus an extra entry that
+    // is absent from the source set - this is the one `--delete` must remove.
+    fs::write(dest_dir.join("file_a.txt"), "contents of A\n").expect("seed a");
+    fs::write(dest_dir.join("file_b.txt"), "contents of B\n").expect("seed b");
+    fs::write(dest_dir.join("extra.txt"), "should be deleted\n").expect("seed extra");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[pushmod]\n\
+         path = {}\n\
+         read only = false\n\
+         use chroot = false\n",
+        dest_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--max-sessions"),
+            OsString::from("4"),
+        ])
+        .build();
+
+    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    drop(probe_stream);
+
+    let mut source_arg = source_dir.clone().into_os_string();
+    source_arg.push("/");
+    let rsync_url = format!("rsync://127.0.0.1:{port}/pushmod/");
+
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([source_arg, OsString::from(&rsync_url)])
+        .delete(true)
+        .stats(true)
+        .build();
+
+    let result = core::client::run_client(client_config);
+
+    let summary = match result {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = daemon_handle.join();
+            panic!("delete-stats push failed: {e}");
+        }
+    };
+
+    assert!(
+        dest_dir.join("file_a.txt").exists(),
+        "file_a.txt must survive the upload"
+    );
+    assert!(
+        dest_dir.join("file_b.txt").exists(),
+        "file_b.txt must survive the upload"
+    );
+    assert!(
+        !dest_dir.join("extra.txt").exists(),
+        "extra.txt must be removed by --delete on the daemon-receive side"
+    );
+
+    // The receiver must propagate NDX_DEL_STATS so the sender's --stats output
+    // reflects the count. Before URV-6.b + this PR the counter stayed at zero
+    // even though the deletion happened on disk.
+    assert_eq!(
+        summary.items_deleted(),
+        1,
+        "client summary must report one deleted file (NDX_DEL_STATS not propagated)"
+    );
+
+    let _ = daemon_handle.join();
+}

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -233,6 +233,7 @@ impl LocalCopySummary {
     /// It maps the available receiver statistics (files listed, files transferred, bytes received,
     /// bytes sent, total source bytes) to the corresponding LocalCopySummary fields.
     #[must_use]
+    #[allow(clippy::too_many_arguments)] // REASON: maps a wire-stats struct field-by-field
     pub fn from_receiver_stats(
         files_listed: usize,
         files_transferred: usize,
@@ -242,6 +243,7 @@ impl LocalCopySummary {
         elapsed: Duration,
         literal_data: u64,
         matched_data: u64,
+        items_deleted: u64,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
@@ -251,6 +253,7 @@ impl LocalCopySummary {
             bytes_copied: literal_data,
             matched_bytes: matched_data,
             total_source_bytes,
+            items_deleted,
             total_elapsed: elapsed,
             ..Default::default()
         }
@@ -267,11 +270,13 @@ impl LocalCopySummary {
         files_transferred: usize,
         bytes_sent: u64,
         elapsed: Duration,
+        items_deleted: u64,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
             bytes_sent,
+            items_deleted,
             total_elapsed: elapsed,
             ..Default::default()
         }
@@ -449,6 +454,7 @@ mod tests {
             Duration::from_secs(5),
             0,
             0,
+            0,
         );
         assert_eq!(summary.regular_files_total(), 100);
         assert_eq!(summary.files_copied(), 50);
@@ -469,6 +475,7 @@ mod tests {
             Duration::from_secs(2),
             800,
             1200,
+            0,
         );
         assert_eq!(summary.bytes_copied(), 800);
         assert_eq!(summary.matched_bytes(), 1200);
@@ -476,9 +483,40 @@ mod tests {
         assert_eq!(summary.bytes_received(), 2048);
     }
 
+    /// Mirrors the daemon-upload + `--delete` path: the daemon receiver
+    /// sweeps the destination and sends `NDX_DEL_STATS` back to the client
+    /// sender. The client's `LocalCopySummary` must surface the count so
+    /// `--stats` renders "Number of deleted files: N" instead of zero.
+    #[test]
+    fn from_generator_stats_records_items_deleted() {
+        let summary =
+            LocalCopySummary::from_generator_stats(10, 5, 2048, Duration::from_secs(1), 7);
+        assert_eq!(summary.items_deleted(), 7);
+    }
+
+    /// Mirrors the daemon-pull + `--delete` path: the local receiver
+    /// performs the delete sweep and records the count locally; the
+    /// summary must surface the same counter.
+    #[test]
+    fn from_receiver_stats_records_items_deleted() {
+        let summary = LocalCopySummary::from_receiver_stats(
+            10,
+            5,
+            2048,
+            512,
+            4096,
+            Duration::from_secs(2),
+            0,
+            0,
+            3,
+        );
+        assert_eq!(summary.items_deleted(), 3);
+    }
+
     #[test]
     fn from_generator_stats_sets_fields() {
-        let summary = LocalCopySummary::from_generator_stats(200, 75, 2048, Duration::from_secs(3));
+        let summary =
+            LocalCopySummary::from_generator_stats(200, 75, 2048, Duration::from_secs(3), 0);
         assert_eq!(summary.regular_files_total(), 200);
         assert_eq!(summary.files_copied(), 75);
         assert_eq!(summary.bytes_sent(), 2048);

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -80,7 +80,7 @@ impl DeleteStats {
     /// # Errors
     ///
     /// Returns an error if writing to the stream fails.
-    pub fn write_to<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+    pub fn write_to<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
         use crate::varint::write_varint;
 
         write_varint(writer, self.files as i32)?;
@@ -101,8 +101,8 @@ impl DeleteStats {
     /// # Errors
     ///
     /// Returns an error if reading from the stream fails or if any field
-    /// exceeds `MAX_WIRE_DEL_STAT`.
-    pub fn read_from<R: Read>(reader: &mut R) -> io::Result<Self> {
+    /// exceeds [`MAX_WIRE_DEL_STAT`].
+    pub fn read_from<R: Read + ?Sized>(reader: &mut R) -> io::Result<Self> {
         use crate::varint::read_varint;
 
         let files = read_capped_del_stat(read_varint(reader)?, "files")?;

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -54,6 +54,7 @@ use protocol::acl::AclCache;
 use protocol::filters::FilterRuleWireFormat;
 use protocol::flist::{FileEntry, FileListReader};
 use protocol::idlist::IdList;
+use protocol::stats::DeleteStats;
 use protocol::{CompatibilityFlags, NegotiationResult, ProtocolVersion};
 
 use engine::HardlinkApplyTracker;
@@ -324,6 +325,19 @@ pub struct ReceiverContext {
     /// This is wired by task DDP-B3 (#2257) and consumed by the emitter
     /// wiring in tasks DDP-E1-E5.
     delete_ctx: Option<Arc<DeleteContext>>,
+    /// Deletion stats produced by the receiver's pre-transfer `--delete` sweep.
+    ///
+    /// Populated by `delete_extraneous_files` from both `run_pipelined` and
+    /// `run_pipelined_incremental`, then consumed by `handle_goodbye` to
+    /// emit `NDX_DEL_STATS` during the goodbye phase. Mirrors upstream's
+    /// daemon-recv fork where the generator (which performs the delete pass)
+    /// is also the side that emits `write_del_stats(f_out)`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2393-2398` - early `write_del_stats` when `delete_mode || force_delete || read_batch`
+    /// - `main.c:225-238` - `write_del_stats()` wire format
+    pending_del_stats: DeleteStats,
     /// Transfer pipeline FSM tracking the current protocol phase.
     ///
     /// Enforces the linear phase progression through the transfer lifecycle.
@@ -385,6 +399,7 @@ impl ReceiverContext {
             flist_io_error: 0,
             parallel_thresholds: ParallelThresholds::default(),
             delete_ctx: None,
+            pending_del_stats: DeleteStats::new(),
             pipeline,
         }
     }

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -127,8 +127,21 @@ impl ReceiverContext {
 
     /// Handles the goodbye handshake at end of transfer.
     ///
-    /// For protocol >= 31, sends NDX_DONE. For extended goodbye (protocol >= 32),
-    /// additionally reads the echo and sends a final NDX_DONE.
+    /// For protocol >= 31, sends `NDX_DEL_STATS` (when `--delete` ran) followed
+    /// by `NDX_DONE`. For extended goodbye (protocol >= 32), additionally reads
+    /// the echo and sends a final `NDX_DONE`.
+    ///
+    /// `NDX_DEL_STATS` emission mirrors upstream's daemon-recv parent process
+    /// (the generator running alongside the receiver child). Our receiver
+    /// performs the delete pass inline rather than forking, so it carries the
+    /// counters in `self.pending_del_stats` and emits them here to keep wire
+    /// parity with upstream.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:1107-1132` - daemon-recv parent process runs `generate_files`
+    /// - `generator.c:2393-2398` - early `write_del_stats(f_out)` emission
+    /// - `main.c:225-238` - `write_del_stats()` wire format
     pub(in crate::receiver) fn handle_goodbye<R: Read, W: Write + ?Sized>(
         &self,
         reader: &mut R,
@@ -138,6 +151,21 @@ impl ReceiverContext {
     ) -> io::Result<()> {
         if !self.protocol.supports_goodbye_exchange() {
             return Ok(());
+        }
+
+        // upstream: generator.c:2393-2394 -
+        //   `if (protocol_version >= 31 && EARLY_DELETE_DONE_MSG()) {
+        //       if (delete_mode || force_delete || read_batch)
+        //           write_del_stats(f_out);
+        //   }`
+        // Runs in the daemon-recv parent's `generate_files()`. We always
+        // sweep before the transfer (EARLY case), so the early-emission gate
+        // applies whenever deletion was requested. `force_delete` and
+        // `read_batch` are not yet wired into `ParsedServerFlags`; `flags.delete`
+        // is the only term we evaluate today.
+        if self.protocol.supports_extended_goodbye() && self.config.flags.delete {
+            ndx_write_codec.write_ndx(&mut *writer, NDX_DEL_STATS)?;
+            self.pending_del_stats.write_to(&mut *writer)?;
         }
 
         ndx_write_codec.write_ndx_done(&mut *writer)?;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -70,6 +70,10 @@ impl ReceiverContext {
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
             delete_io_error = io_bits;
+            // Carry the per-type counters into the receiver context so the
+            // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
+            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
+            self.pending_del_stats = delete_stats;
         }
 
         let mut stats = TransferStats {

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -109,6 +109,13 @@ impl ReceiverContext {
             // chdir-symlink-race refusal becomes a non-zero exit instead of a
             // silent skip.
             stats.io_error |= io_bits;
+            // Carry the counters into the receiver context so the goodbye
+            // handshake can emit NDX_DEL_STATS to the peer sender. URV-6.b
+            // landed the on-disk deletion but the counters were never
+            // propagated to the wire, so client `--stats` reported
+            // "Number of deleted files: 0" on every daemon upload.
+            // upstream: generator.c:2393-2398 - early write_del_stats() emission.
+            self.pending_del_stats = delete_stats;
         }
 
         let files_to_transfer = self.build_files_to_transfer(

--- a/docs/audits/upstream-3.4.4-conformance.md
+++ b/docs/audits/upstream-3.4.4-conformance.md
@@ -8,9 +8,9 @@ Sources: `target/interop/upstream-src/rsync-3.4.4/` + GitHub issues #951, #829, 
 
 | URV | UTS PR | Upstream issue | Verdict | Follow-ups |
 |---|---|---|---|---|
-| URV-1 | #5535 (UTS-18) | #951 zlib obuf overflow | DIVERGENT-SAFE | — |
+| URV-1 | #5535 (UTS-18) | #951 zlib obuf overflow | DIVERGENT-SAFE | - |
 | URV-2 | #5531 (UTS-8) | #829 daemon arg backslash | DIVERGENT-SAFE | #3615 |
-| URV-3 | #5523 (UTS-19) | #910 mode-0 sentinel | PARITY | — |
+| URV-3 | #5523 (UTS-19) | #910 mode-0 sentinel | PARITY | - |
 | URV-4 | #5522 + #5532 (UTS-12) | #897 path=/ sender | DIVERGENT-SAFE | #3620 |
 | URV-5 | #5525 (UTS-2) | #915 alt-basis daemon | DIVERGENT-RISK | #3617 |
 | URV-6 | #5536 (UTS-6) | daemon-upload delete-stats | DIVERGENT-RISK | #3618, #3619 |
@@ -19,7 +19,7 @@ Two PARITY/SAFE, three DIVERGENT-SAFE, two DIVERGENT-RISK. The two -RISK verdict
 
 ## URV-1: zlib obuf drain (PR #5535 vs #951)
 
-`avail_out_size` formula matches upstream `n*1001/1000+16` exactly (`token.c:344` ↔ `zlib_codec.rs:~55`). oc-rsync allocates `SEE_TOKEN_OBUF_SIZE + 16` slack vs upstream `AVAIL_OUT_SIZE(CHUNK_SIZE)` — strictly larger reserve. Drain semantics equivalent through `flate2` state carryover (oc-rsync's input-driven loop vs upstream's `avail_in != 0 || avail_out == 0`). `Z_SYNC_FLUSH` carryover handled identically; `Z_INSERT_ONLY` defaults to `Z_SYNC_FLUSH` in both. No wire impact.
+`avail_out_size` formula matches upstream `n*1001/1000+16` exactly (`token.c:344` <-> `zlib_codec.rs:~55`). oc-rsync allocates `SEE_TOKEN_OBUF_SIZE + 16` slack vs upstream `AVAIL_OUT_SIZE(CHUNK_SIZE)` - strictly larger reserve. Drain semantics equivalent through `flate2` state carryover (oc-rsync's input-driven loop vs upstream's `avail_in != 0 || avail_out == 0`). `Z_SYNC_FLUSH` carryover handled identically; `Z_INSERT_ONLY` defaults to `Z_SYNC_FLUSH` in both. No wire impact.
 
 ## URV-2: daemon arg backslash (PR #5531 vs #829)
 
@@ -27,13 +27,13 @@ Different root bugs at different layers. Upstream #829: client escapes wildcards
 
 ## URV-3: mode-0 sentinel (PR #5523 vs #910)
 
-Identical wire format (regular `FileEntry` with mode=0). Upstream's fix was a carve-out for `mode==0 && missing_args==2` in `flist.c:recv_file_entry` (a rejection upstream introduced in 3.4.3). oc-rsync never had that rejection — the read path stores mode as-is — so the wire-acceptance side was never broken. PR #5523 adds the deletion consumer mirroring upstream's `generator.c:1360-1364`. Behaviorally equivalent.
+Identical wire format (regular `FileEntry` with mode=0). Upstream's fix was a carve-out for `mode==0 && missing_args==2` in `flist.c:recv_file_entry` (a rejection upstream introduced in 3.4.3). oc-rsync never had that rejection - the read path stores mode as-is - so the wire-acceptance side was never broken. PR #5523 adds the deletion consumer mirroring upstream's `generator.c:1360-1364`. Behaviorally equivalent.
 
 ## URV-4: path = / sender (PRs #5522 + #5532 vs #897)
 
 Architecture differs. Upstream #897 fix in `sender.c:362-381` strips leading slashes from joined `secure_path` before `secure_relative_open(module_dir, relp, ...)`. oc-rsync doesn't use per-file `secure_relative_open`; the daemon passes `module.path` to `ServerConfig` and the engine reads via canonical paths from the flist. The upstream bug class doesn't reproduce. Parser/validator parity is complete (#5522). Follow-up #3620 closes the test-coverage gap.
 
-## URV-5: relative alt-basis daemon (PR #5525 vs #915) — RISK
+## URV-5: relative alt-basis daemon (PR #5525 vs #915) - RISK
 
 PR #5525 achieves the SYMLINK-handling parity (oc-rsync's `try_reference_dest` now dispatches on `copy_links` matching upstream `link_stat(..., 0)`). But the RELATIVE alt-basis re-anchor diverges: oc-rsync does `module_path.join(rel)` in `client_args.rs:254-259` with NO kernel-level confinement and NO `..`-rejection fallback. Upstream's `secure_relative_open()` (`syscall.c:1791-1896`) uses `openat2(RESOLVE_BENEATH)` on Linux / `O_RESOLVE_BENEATH` on FreeBSD13+/macOS15+, with a portable fallback rejecting `..` outright.
 
@@ -54,9 +54,9 @@ Regression coverage: `classify_client_path_*` and `allows_writes_under_every_roo
 
 This closes URV-5.b.REOPEN and unblocks URV-5.c.5 (Landlock default-on flip).
 
-## URV-6: NDX_DEL_STATS daemon-upload (PR #5536 vs upstream change) — RISK
+## URV-6: NDX_DEL_STATS daemon-upload (PR #5536 vs upstream change) - RISK
 
-Wire format, varint order, and direction all parity. **Verbosity gate diverges**: upstream 3.4.4's whole point in `generator.c:2393, 2437` was REMOVING the `INFO_GTE(STATS, 2)` (`--stats`) requirement — gate is now `delete_mode || force_delete || read_batch`. oc-rsync's `should_send_del_stats()` still requires `do_stats`, so a daemon-upload without `--stats` won't emit, contradicting the 3.4.4 intent.
+Wire format, varint order, and direction all parity. **Verbosity gate diverges**: upstream 3.4.4's whole point in `generator.c:2393, 2437` was REMOVING the `INFO_GTE(STATS, 2)` (`--stats`) requirement - gate is now `delete_mode || force_delete || read_batch`. oc-rsync's `should_send_del_stats()` still requires `do_stats`, so a daemon-upload without `--stats` won't emit, contradicting the 3.4.4 intent.
 
 Minor: protocol gate uses `supports_extended_goodbye()` which is proto 32; upstream uses `protocol_version >= 31`.
 


### PR DESCRIPTION
## Summary

- URV-6.b wired `delete_extraneous_files` into the incremental receiver driver but left the wire-stats half unfinished: the receiver's `handle_goodbye` only emitted `NDX_DONE`, so a daemon upload with `--delete --stats` always reported "Number of deleted files: 0" even when the sweep removed entries on disk.
- Fix the gate: receiver now carries per-type counters in `ReceiverContext::pending_del_stats` (populated by both `run_pipelined` and `run_pipelined_incremental`) and emits `NDX_DEL_STATS` from `handle_goodbye` whenever protocol >= 31 and `flags.delete` is set, matching upstream `generator.c:2393-2398` (`delete_mode || force_delete || read_batch`).
- Surface the counter into `ClientSummary::items_deleted()` for both `ServerStats::Receiver` (pull) and `ServerStats::Generator` (upload) so `--stats` renders the right value regardless of direction.
- Update `docs/audits/upstream-3.4.4-conformance.md` with a URV-6.b note that the upload-direction wire-stats gap was discovered via `runtests.py` and fixed by this PR, so a future audit pass does not retread it.

## Test plan

- [ ] `daemon_delete_push_reports_delete_stats`: client uploads to a daemon module with `--delete --stats`; asserts the extra destination entry is removed AND `ClientSummary::items_deleted() == 1` (would fail before this PR with the counter stuck at 0).
- [ ] `daemon_delete_pull_reports_delete_stats`: client pulls from a daemon module with `--delete --stats`; regression guard that wiring the upload-direction emission does not break the previously-working pull-direction sweep (still reports `items_deleted() == 1`).
- [ ] Existing `daemon_delete_push_removes_extraneous_destination_files` continues to pass (on-disk deletion semantics unchanged).
- [ ] Existing receiver `handle_goodbye_proto28_sends_single_ndx_done` / `_proto29_` continue to pass (gate is `supports_extended_goodbye() && flags.delete`, so legacy protocols with `flags.delete = false` are byte-identical).
