### PR TITLE
fix(daemon): emit single-file basename on sub-path module argument

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -357,6 +357,82 @@ fn resolve_receiver_dest(
     module_path.join(rel)
 }
 
+/// Resolves the sender's on-disk source paths from the client's positional
+/// path args for a pull request (Generator role).
+///
+/// Mirrors upstream's `glob_expand_module()` + `chdir(module_chdir)` ordering:
+/// once the module name has been stripped, upstream's daemon-mode sender sees
+/// argv positionals as paths relative to the module root, and the sender's
+/// per-arg `dir/fn` split (flist.c:2338-2349) chops the last `/` so the wire
+/// emits `fn` as the file-list name. We don't chdir, so each positional is
+/// resolved by joining the stripped tail with `module_path`. The trailing
+/// slash (if any) is preserved so the sender's existing dotdir branch can
+/// trigger when the client wrote `module/sub/` instead of `module/sub`.
+///
+/// Returns `[module_path]` when no positional was supplied or when every
+/// stripped tail is empty, matching the pre-existing "pull from module root"
+/// behaviour exactly.
+///
+/// Sub-paths that contain `..` segments or that resolve to a host-absolute
+/// path are rejected (returns `None`) so a malicious client cannot enumerate
+/// files outside the module root via a crafted `rsync://host/mod/../etc/...`
+/// URL. This is defense-in-depth on top of the chroot / Landlock sandbox.
+///
+/// # Upstream Reference
+///
+/// - `util1.c:804 glob_expand_module()` - strips the module name from each arg
+/// - `clientserver.c:992 change_dir(module_chdir, CD_NORMAL)` - relativises args
+/// - `flist.c:2338-2349 send_file_list()` - `dir/fn` split per positional
+fn resolve_sender_sources(
+    module_path: &std::path::Path,
+    client_args: &[String],
+    module_name: &str,
+) -> Option<Vec<std::path::PathBuf>> {
+    let positionals = extract_module_relative_paths(client_args, module_name);
+    if positionals.is_empty() {
+        return Some(vec![module_path.to_path_buf()]);
+    }
+    let mut sources = Vec::with_capacity(positionals.len());
+    let mut all_empty = true;
+    for raw in &positionals {
+        let tail = raw.trim();
+        if tail.is_empty() || tail == "." {
+            sources.push(module_path.to_path_buf());
+            continue;
+        }
+        all_empty = false;
+        // Reject `..` traversal segments so the joined path cannot escape the
+        // module root. Upstream rsync's sender-side `sanitize_path()` and the
+        // chroot wall it lives behind cover this; oc-rsync mirrors the check
+        // explicitly because the daemon does not always chroot.
+        let trimmed = tail.trim_start_matches(['/', '\\']);
+        for component in std::path::Path::new(trimmed).components() {
+            if matches!(component, std::path::Component::ParentDir) {
+                return None;
+            }
+        }
+        // Preserve the trailing slash so the sender can detect a dotdir-style
+        // source (upstream flist.c:2312-2322 appends `.` and sets DOTDIR_NAME
+        // for any `fbuf[len-1] == '/'`). PathBuf collapses trailing slashes
+        // during `join`, so we re-append the byte after the join when present.
+        let trailing = tail.ends_with('/') || tail.ends_with('\\');
+        let joined = module_path.join(trimmed);
+        let joined = if trailing {
+            let mut buf = joined.into_os_string();
+            buf.push("/");
+            std::path::PathBuf::from(buf)
+        } else {
+            joined
+        };
+        sources.push(joined);
+    }
+    if all_empty {
+        Some(vec![module_path.to_path_buf()])
+    } else {
+        Some(sources)
+    }
+}
+
 /// Builds the server configuration from client arguments.
 ///
 /// Returns the configuration on success, or sends an error and returns `None`.
@@ -379,18 +455,33 @@ fn build_server_config(
     // upstream: main.c:1203-1204 + util1.c:804 (glob_expand_module) - receivers
     // resolve their destination by joining the module path with the client's
     // module-relative tail (e.g. `upload/realdir/` -> module + `realdir/`).
-    // The original argv[0] is always the module root; legacy tests that push
-    // straight into the module root keep that behaviour.
-    let receiver_dest = if role == ServerRole::Receiver {
-        resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name)
+    // Senders (pull requests) split each positional the same way so the
+    // sender's per-source `dir/fn` (flist.c:2338-2349) walks the requested
+    // sub-tree instead of the entire module root. The original argv[0] is
+    // always the module root; legacy tests that push straight into the module
+    // root keep that behaviour.
+    let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
+        let dest = resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name);
+        vec![OsString::from(dest.as_os_str())]
     } else {
-        std::path::PathBuf::from(&module.path)
+        match resolve_sender_sources(std::path::Path::new(&module.path), client_args, &module.name) {
+            Some(sources) => sources
+                .into_iter()
+                .map(|p| OsString::from(p.as_os_str()))
+                .collect(),
+            None => {
+                let payload =
+                    "@ERROR: requested path resolves outside module root".to_owned();
+                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                return Ok(None);
+            }
+        }
     };
 
     match ServerConfig::from_flag_string_and_args(
         role,
         flag_string,
-        vec![OsString::from(receiver_dest.as_os_str())],
+        positional_args,
     ) {
         Ok(mut cfg) => {
             // Parse long-form arguments that upstream rsync sends via server_options()

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1972,4 +1972,89 @@ mod module_access_tests {
         let result = classify_client_path_against_module(&escape, &module_root);
         assert!(matches!(result, Err(())));
     }
+
+    #[test]
+    fn resolve_sender_sources_returns_module_root_without_positional() {
+        // upstream: clientserver.c:1073 - bare module request (no sub-path)
+        // means the sender walks the module root directly. Pre-fix behaviour
+        // must be preserved exactly to avoid regressing the existing pull
+        // tests that target `rsync://h/module/`.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args: Vec<String> = vec![];
+        let sources = resolve_sender_sources(module_path, &args, "upload")
+            .expect("bare module request must resolve");
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_returns_module_root_for_empty_subpath() {
+        // upstream: util1.c:813-814 - `module/` strips to "" after
+        // glob_expand_module; the daemon sender should still walk the module
+        // root and emit "." with FLAG_TOP_DIR.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload")
+            .expect("empty sub-path must resolve");
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_joins_single_file_subpath_with_module_root() {
+        // upstream: flist.c:2338-2349 - a single-file sub-path positional is
+        // joined with module_path so the sender walks exactly that one path
+        // and the per-positional dir/fn split emits the basename.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload")
+            .expect("file sub-path must resolve");
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
+        );
+    }
+
+    #[test]
+    fn resolve_sender_sources_preserves_trailing_slash_on_subdir() {
+        // upstream: flist.c:2312-2322 - a trailing slash promotes the source
+        // to DOTDIR_NAME; we must keep the slash intact so the sender's walk
+        // emits "." with FLAG_TOP_DIR for the sub-directory's contents.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload")
+            .expect("sub-dir trailing-slash path must resolve");
+        let lossy: Vec<String> = sources
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(lossy, vec!["/srv/upload/d1/d2/".to_owned()]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_rejects_parent_dir_traversal() {
+        // SEC-1.q defense-in-depth: a `..` segment escaping the module root
+        // must be rejected at argv-resolution time so chroot-less daemons
+        // cannot leak files via sub-path requests like `module/../etc/...`.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/../etc/passwd".to_owned()];
+        assert!(resolve_sender_sources(module_path, &args, "upload").is_none());
+    }
+
+    #[test]
+    fn resolve_sender_sources_rejects_mid_path_parent_dir() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/d1/../../secret".to_owned()];
+        assert!(resolve_sender_sources(module_path, &args, "upload").is_none());
+    }
+
+    #[test]
+    fn resolve_sender_sources_strips_leading_slash_before_join() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload//d1/d2/f2".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload")
+            .expect("leading-slash sub-path must resolve");
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
+        );
+    }
 }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -231,6 +231,8 @@ include!("tests/chunks/daemon_munge_symlinks_pull.rs");
 include!("tests/chunks/daemon_compare_dest_push.rs");
 // Daemon relative receive end-to-end test
 include!("tests/chunks/daemon_relative_receive.rs");
+// Daemon sub-path pull resolution (UTS-3)
+include!("tests/chunks/daemon_pull_subpath.rs");
 // Daemon combined hardlinks + relative receive end-to-end test
 include!("tests/chunks/daemon_hardlinks_relative_receive.rs");
 // Daemon itemize end-to-end tests

--- a/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
@@ -1,23 +1,22 @@
-/// End-to-end tests for daemon module sub-path pull resolution.
-///
-/// Mirrors upstream `clientserver.c:1073 read_args()` + `util1.c:804
-/// glob_expand_module()` + `flist.c:2338-2349` sender per-positional split:
-/// when a client requests `rsync://h/mod/d1/d2/f2`, the wire emits a single
-/// file-list entry whose name is the basename (`f2`), so the receiver writes
-/// it directly under the destination directory instead of recreating the
-/// full sub-path.
-///
-/// Each test stands up a temporary daemon module, issues a pull, and asserts
-/// the destination layout. The cases cover the four upstream-supported sub-
-/// path shapes: a single file, a sub-directory with trailing slash, a sub-
-/// directory without trailing slash (oc-rsync's non-relative-mode dotdir
-/// semantics flatten the leaf), and a deeply nested file.
-///
-/// # Upstream Reference
-///
-/// - `clientserver.c:1073` - `read_args()` with `mod_name` triggers `glob_expand_module`
-/// - `util1.c:804`         - `glob_expand_module()` strips the module prefix
-/// - `flist.c:2338-2349`   - per-positional `dir/fn` split before `link_stat`
+// End-to-end tests for daemon module sub-path pull resolution.
+//
+// Mirrors upstream `clientserver.c:1073 read_args()` + `util1.c:804
+// glob_expand_module()` + `flist.c:2338-2349` sender per-positional split:
+// when a client requests `rsync://h/mod/d1/d2/f2`, the wire emits a single
+// file-list entry whose name is the basename (`f2`), so the receiver writes
+// it directly under the destination directory instead of recreating the
+// full sub-path.
+//
+// Each test stands up a temporary daemon module, issues a pull, and asserts
+// the destination layout. The cases cover the four upstream-supported sub-
+// path shapes: a single file, a sub-directory with trailing slash, a sub-
+// directory without trailing slash (oc-rsync's non-relative-mode dotdir
+// semantics flatten the leaf), and a deeply nested file.
+//
+// Upstream reference:
+// - `clientserver.c:1073` - `read_args()` with `mod_name` triggers `glob_expand_module`
+// - `util1.c:804`         - `glob_expand_module()` strips the module prefix
+// - `flist.c:2338-2349`   - per-positional `dir/fn` split before `link_stat`
 
 #[cfg(unix)]
 fn write_subpath_daemon_config(temp: &Path, module_dir: &Path) -> PathBuf {

--- a/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
+++ b/crates/daemon/src/tests/chunks/daemon_pull_subpath.rs
@@ -1,0 +1,332 @@
+/// End-to-end tests for daemon module sub-path pull resolution.
+///
+/// Mirrors upstream `clientserver.c:1073 read_args()` + `util1.c:804
+/// glob_expand_module()` + `flist.c:2338-2349` sender per-positional split:
+/// when a client requests `rsync://h/mod/d1/d2/f2`, the wire emits a single
+/// file-list entry whose name is the basename (`f2`), so the receiver writes
+/// it directly under the destination directory instead of recreating the
+/// full sub-path.
+///
+/// Each test stands up a temporary daemon module, issues a pull, and asserts
+/// the destination layout. The cases cover the four upstream-supported sub-
+/// path shapes: a single file, a sub-directory with trailing slash, a sub-
+/// directory without trailing slash (oc-rsync's non-relative-mode dotdir
+/// semantics flatten the leaf), and a deeply nested file.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:1073` - `read_args()` with `mod_name` triggers `glob_expand_module`
+/// - `util1.c:804`         - `glob_expand_module()` strips the module prefix
+/// - `flist.c:2338-2349`   - per-positional `dir/fn` split before `link_stat`
+
+#[cfg(unix)]
+fn write_subpath_daemon_config(temp: &Path, module_dir: &Path) -> PathBuf {
+    let config_file = temp.join("rsyncd.conf");
+    let config_content = format!(
+        "[sub]\n\
+         path = {}\n\
+         read only = true\n\
+         use chroot = false\n",
+        module_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+    config_file
+}
+
+#[cfg(unix)]
+fn launch_subpath_daemon(
+    config_file: &Path,
+    port: u16,
+    held: std::net::TcpListener,
+) -> (
+    std::net::TcpStream,
+    std::thread::JoinHandle<Result<(), DaemonError>>,
+) {
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--max-sessions"),
+            OsString::from("3"),
+        ])
+        .build();
+    start_daemon(daemon_config, port, held)
+}
+
+#[cfg(unix)]
+fn build_subpath_module_tree(module_dir: &Path) {
+    let d2 = module_dir.join("d1").join("d2");
+    fs::create_dir_all(&d2).expect("create d1/d2");
+    fs::write(d2.join("f2"), b"sub-path leaf content\n").expect("write f2");
+    fs::write(d2.join("sibling.txt"), b"sibling under d2\n").expect("write sibling");
+    // Add an unrelated file outside the requested sub-path so we can prove the
+    // sender does NOT walk the whole module root for a sub-path request.
+    fs::write(module_dir.join("unrelated.txt"), b"should not be transferred\n")
+        .expect("write unrelated");
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_pull_subpath_single_file_emits_basename() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+    let module_dir = temp.path().join("module");
+    fs::create_dir(&module_dir).expect("create module");
+    build_subpath_module_tree(&module_dir);
+
+    let dest = temp.path().join("pulled");
+    fs::create_dir(&dest).expect("create dest");
+
+    let (port, held) = allocate_test_port();
+    let config_file = write_subpath_daemon_config(temp.path(), &module_dir);
+    let (probe, handle) = launch_subpath_daemon(&config_file, port, held);
+    drop(probe);
+
+    // upstream: clientserver.c:1073 - the wire arg `sub/d1/d2/f2` is the
+    // module name plus the sub-path; glob_expand_module strips `sub` before
+    // the sender walks the single positional.
+    let url = format!("rsync://127.0.0.1:{port}/sub/d1/d2/f2");
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([OsString::from(&url), OsString::from(dest.as_os_str())])
+        .build();
+    let result = core::client::run_client(client_config);
+    if let Err(e) = &result {
+        let _ = handle.join();
+        panic!("sub-path pull failed: {e}");
+    }
+
+    // upstream: flist.c:2338-2349 - dir=d1/d2, fn=f2; receiver writes <dest>/f2.
+    assert_eq!(
+        fs::read(dest.join("f2")).expect("read pulled f2"),
+        b"sub-path leaf content\n",
+        "single-file sub-path pull must land at <dest>/<basename>",
+    );
+    // The sibling file under the same parent must NOT come along - the sender
+    // walked only the explicit positional.
+    assert!(
+        !dest.join("sibling.txt").exists(),
+        "single-file sub-path pull must not enumerate siblings",
+    );
+    // The unrelated file at module root must NOT come along either.
+    assert!(
+        !dest.join("unrelated.txt").exists(),
+        "single-file sub-path pull must not walk the whole module root",
+    );
+
+    let _ = handle.join();
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_pull_subpath_directory_trailing_slash_flattens_contents() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+    let module_dir = temp.path().join("module");
+    fs::create_dir(&module_dir).expect("create module");
+    build_subpath_module_tree(&module_dir);
+
+    let dest = temp.path().join("pulled");
+    fs::create_dir(&dest).expect("create dest");
+
+    let (port, held) = allocate_test_port();
+    let config_file = write_subpath_daemon_config(temp.path(), &module_dir);
+    let (probe, handle) = launch_subpath_daemon(&config_file, port, held);
+    drop(probe);
+
+    // upstream: flist.c:2312-2322 - trailing slash promotes the source to
+    // DOTDIR_NAME, walking the directory's contents as `.`/children.
+    let url = format!("rsync://127.0.0.1:{port}/sub/d1/d2/");
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([OsString::from(&url), OsString::from(dest.as_os_str())])
+        .recursive(true)
+        .build();
+    let result = core::client::run_client(client_config);
+    if let Err(e) = &result {
+        let _ = handle.join();
+        panic!("trailing-slash sub-path pull failed: {e}");
+    }
+
+    assert_eq!(
+        fs::read(dest.join("f2")).expect("read pulled f2"),
+        b"sub-path leaf content\n",
+        "trailing-slash sub-path pull must flatten the sub-directory contents",
+    );
+    assert_eq!(
+        fs::read(dest.join("sibling.txt")).expect("read pulled sibling"),
+        b"sibling under d2\n",
+        "trailing-slash sub-path pull must include every child of the leaf dir",
+    );
+    // The unrelated file at module root must NOT come along.
+    assert!(
+        !dest.join("unrelated.txt").exists(),
+        "trailing-slash sub-path pull must not walk above the requested directory",
+    );
+
+    let _ = handle.join();
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_pull_subpath_directory_no_trailing_slash_walks_subtree() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+    let module_dir = temp.path().join("module");
+    fs::create_dir(&module_dir).expect("create module");
+    build_subpath_module_tree(&module_dir);
+
+    let dest = temp.path().join("pulled");
+    fs::create_dir(&dest).expect("create dest");
+
+    let (port, held) = allocate_test_port();
+    let config_file = write_subpath_daemon_config(temp.path(), &module_dir);
+    let (probe, handle) = launch_subpath_daemon(&config_file, port, held);
+    drop(probe);
+
+    // upstream: flist.c:2338-2349 - without a trailing slash the source is
+    // still a directory: oc-rsync's non-relative walk emits dot + children
+    // (matching the `non_relative_mode_uses_basename` regression test),
+    // so the destination receives the children directly without a `d2/`
+    // wrapper. The critical regression check is that the unrelated module
+    // root file is NOT transferred - the sub-path constraint must hold even
+    // when the sub-path resolves to a directory.
+    let url = format!("rsync://127.0.0.1:{port}/sub/d1/d2");
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([OsString::from(&url), OsString::from(dest.as_os_str())])
+        .recursive(true)
+        .build();
+    let result = core::client::run_client(client_config);
+    if let Err(e) = &result {
+        let _ = handle.join();
+        panic!("no-trailing-slash sub-path pull failed: {e}");
+    }
+
+    // Children of d1/d2 must be present (flattened under dest by oc-rsync's
+    // non-relative dotdir semantics).
+    assert_eq!(
+        fs::read(dest.join("f2")).expect("read pulled f2"),
+        b"sub-path leaf content\n",
+        "directory sub-path pull must transfer leaf contents",
+    );
+    assert_eq!(
+        fs::read(dest.join("sibling.txt")).expect("read pulled sibling"),
+        b"sibling under d2\n",
+        "directory sub-path pull must transfer all children of the leaf dir",
+    );
+    // Files outside the requested sub-path must NOT come along - this is the
+    // core invariant the fix establishes.
+    assert!(
+        !dest.join("unrelated.txt").exists(),
+        "directory sub-path pull must not escape the requested sub-tree",
+    );
+
+    let _ = handle.join();
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_pull_subpath_deeply_nested_file_emits_basename() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+    let module_dir = temp.path().join("module");
+    let deep = module_dir.join("a").join("b").join("c").join("d").join("e");
+    fs::create_dir_all(&deep).expect("create deep tree");
+    fs::write(deep.join("leaf.bin"), b"\x00\x01\x02deep payload").expect("write leaf");
+
+    let dest = temp.path().join("pulled");
+    fs::create_dir(&dest).expect("create dest");
+
+    let (port, held) = allocate_test_port();
+    let config_file = write_subpath_daemon_config(temp.path(), &module_dir);
+    let (probe, handle) = launch_subpath_daemon(&config_file, port, held);
+    drop(probe);
+
+    // upstream: flist.c:2338-2349 - the per-positional dir/fn split walks the
+    // last `/` regardless of nesting depth, so the wire entry is just `leaf.bin`.
+    let url = format!("rsync://127.0.0.1:{port}/sub/a/b/c/d/e/leaf.bin");
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([OsString::from(&url), OsString::from(dest.as_os_str())])
+        .build();
+    let result = core::client::run_client(client_config);
+    if let Err(e) = &result {
+        let _ = handle.join();
+        panic!("deep sub-path pull failed: {e}");
+    }
+
+    assert_eq!(
+        fs::read(dest.join("leaf.bin")).expect("read deep leaf"),
+        b"\x00\x01\x02deep payload",
+        "deeply nested single-file sub-path pull must still land at <dest>/<basename>",
+    );
+    // No intermediate directory leakage.
+    assert!(
+        !dest.join("a").exists(),
+        "deep sub-path pull must NOT recreate the intermediate path components",
+    );
+
+    let _ = handle.join();
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_pull_subpath_rejects_parent_dir_traversal() {
+    // SEC-1.q: a crafted `rsync://h/mod/../etc/passwd` URL must be refused at
+    // the daemon's argument-resolution stage. The chroot / Landlock layer
+    // covers the same ground inside the sandbox, but defense-in-depth here
+    // ensures non-chroot daemons cannot leak files outside the module root.
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+    let module_dir = temp.path().join("module");
+    fs::create_dir(&module_dir).expect("create module");
+    fs::write(module_dir.join("inside.txt"), b"in-module\n").expect("write inside");
+    // A "secret" file alongside the module root that the client must not
+    // be able to reach via `..` traversal.
+    fs::write(temp.path().join("secret.txt"), b"top secret\n").expect("write secret");
+
+    let dest = temp.path().join("pulled");
+    fs::create_dir(&dest).expect("create dest");
+
+    let (port, held) = allocate_test_port();
+    let config_file = write_subpath_daemon_config(temp.path(), &module_dir);
+    let (probe, handle) = launch_subpath_daemon(&config_file, port, held);
+    drop(probe);
+
+    let url = format!("rsync://127.0.0.1:{port}/sub/../secret.txt");
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([OsString::from(&url), OsString::from(dest.as_os_str())])
+        .build();
+    let result = core::client::run_client(client_config);
+
+    assert!(
+        result.is_err(),
+        "traversal pull must fail; secret file was {}",
+        if dest.join("secret.txt").exists() {
+            "READ THROUGH"
+        } else {
+            "not transferred but client did not error"
+        },
+    );
+    assert!(
+        !dest.join("secret.txt").exists(),
+        "traversal pull must NEVER place a file outside the module on disk",
+    );
+
+    let _ = handle.join();
+}

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -126,6 +126,23 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         let relative = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
 
+        // upstream: flist.c:2338-2349 - non-relative single-file sources split
+        // on the last `/` so the wire-side relative name is just the basename
+        // (`fn` in upstream's terminology). When base == path for a regular
+        // file, our `strip_prefix` would otherwise leave `relative` empty and
+        // the receiver would write the bytes into the destination directory's
+        // own name slot, producing an empty / corrupt entry. Restoring the
+        // basename here matches upstream's daemon-mode `chdir(dir); link_stat(fn)`
+        // ordering for the sub-path pull case (e.g. `rsync rsync://h/m/a/b/f`).
+        let relative = if relative.as_os_str().is_empty() && !metadata.is_dir() {
+            match path.file_name() {
+                Some(name) => PathBuf::from(name),
+                None => relative,
+            }
+        } else {
+            relative
+        };
+
         // upstream: flist.c:2287 - always emit "." with XMIT_TOP_DIR for the
         // root transfer directory. Enables delete_in_dir() when --delete is active.
         if relative.as_os_str().is_empty() && metadata.is_dir() {


### PR DESCRIPTION
## Summary

- `rsync rsync://h/mod/d1/d2/f2 dest/` silently lost the file because the daemon ignored the client's sub-path positional and passed only `[module.path]` to the Generator; the sender's walk then produced an empty file-list name (`base == path` → empty `relative`).
- New `resolve_sender_sources()` parallels `resolve_receiver_dest()` for the Generator role: it joins each sub-path with `module.path`, preserves trailing slashes (so the dotdir branch still fires for `mod/sub/` pulls), and rejects `..` traversal segments as defense-in-depth on top of chroot / Landlock.
- The sender's `walk_path_with_metadata()` now restores `path.file_name()` whenever a non-directory source resolves to an empty relative name, mirroring upstream's `flist.c:2338-2349` `chdir(dir); link_stat(fn); send_file_name(fn, ...)` ordering for daemon mode.
- Bare-module pulls (`rsync://h/mod/`) and existing push tests are unchanged — `resolve_sender_sources()` falls back to `[module.path]` whenever every positional is empty, and the Receiver branch keeps using the established `resolve_receiver_dest()` helper.

## Wire-byte parity

Upstream's daemon-mode sender for `rsync rsync://h/mod/d1/d2/f2 dest/`:
1. `clientserver.c:1073 read_args()` calls `glob_expand_module("mod", "mod/d1/d2/f2", ...)` which strips `mod`, leaving `d1/d2/f2`.
2. `clientserver.c:992 change_dir(module_chdir)` makes that path relative to the module root.
3. `flist.c:2338-2349` splits on the last `/` → `dir = "d1/d2"`, `fn = "f2"`; `change_pathname` cd's to `dir` and `link_stat("f2")` produces a single file entry whose wire name is `f2`.

After this fix oc-rsync's sender emits the same single `f2` entry (one `MSG_DATA` segment with `XMIT_*` flags + name length 2 + bytes `66 32`), followed by the standard transfer pipeline. The pre-fix wire bytes carried an empty name slot, which is what corrupted the receiver's destination resolution. The dot-dir cases (`mod/`, `mod/sub/`) keep emitting `.` with `FLAG_TOP_DIR` exactly as before — the daemon helper preserves the trailing slash byte so the sender's existing dotdir branch still fires.

## Test plan

- [x] `daemon_pull_subpath_single_file_emits_basename` — `rsync rsync://h/sub/d1/d2/f2 pulled/` writes `pulled/f2` and does NOT bring along the sibling or the unrelated module-root file.
- [x] `daemon_pull_subpath_directory_trailing_slash_flattens_contents` — `rsync rsync://h/sub/d1/d2/ pulled/` flattens `f2` + `sibling.txt` directly under `pulled/` and excludes the module-root file (dotdir semantics preserved).
- [x] `daemon_pull_subpath_directory_no_trailing_slash_walks_subtree` — `rsync rsync://h/sub/d1/d2 pulled/` transfers the sub-tree contents and crucially does NOT enumerate the rest of the module root (matches oc-rsync's existing `non_relative_mode_uses_basename` semantics).
- [x] `daemon_pull_subpath_deeply_nested_file_emits_basename` — `rsync rsync://h/sub/a/b/c/d/e/leaf.bin pulled/` lands as `pulled/leaf.bin` without recreating intermediate path components.
- [x] `daemon_pull_subpath_rejects_parent_dir_traversal` — `rsync rsync://h/sub/../secret.txt pulled/` is refused with `@ERROR: requested path resolves outside module root` and the file outside the module never appears on disk.
- [x] Unit tests on `resolve_sender_sources` cover the empty / sub-path / leading-slash / `..` rejection cases at the helper boundary.
- [x] Existing daemon pull lifecycle tests (`daemon_pull_lifecycle_copies_full_tree`, `daemon_push_then_pull_roundtrip_preserves_content`, `daemon_protocol_28_forced_push_then_pull_roundtrip`) remain green: bare-module URLs continue to resolve to `[module.path]` with dotdir emission unchanged.