### PR TITLE
fix(transfer): never shrink BufferedMap buffer to avoid overlap data loss

### DIFF
--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -130,7 +130,17 @@ impl BufferedMap {
         // overlaps the beginning of the new window AND the new window extends
         // past the old window's end, shift the overlap via copy_within and
         // only read the new portion from disk.
+        //
+        // upstream: fileio.c:236 `realloc_array` only grows the backing buffer;
+        // it never shrinks. Mirror that invariant: when a smaller window is
+        // requested (e.g., the new window is near EOF after a full-size load),
+        // `Vec::resize` would otherwise truncate the bytes the overlap branch
+        // is about to relocate via `copy_within`, panicking on out-of-bounds
+        // source or dropping bytes intended for reuse. Using `.max(buffer.len())`
+        // keeps the buffer monotonically non-decreasing; `window_len` continues
+        // to bound the valid region so callers never observe stale tail bytes.
         let old_end = self.window_start + self.window_len as u64;
+        let target_len = window_size.max(self.buffer.len());
         let (read_start, read_offset) = if self.window_len > 0
             && aligned_start >= self.window_start
             && aligned_start < old_end
@@ -139,13 +149,13 @@ impl BufferedMap {
             let reuse_len = (old_end - aligned_start) as usize;
             let src_offset = (aligned_start - self.window_start) as usize;
 
-            self.buffer.resize(window_size, 0);
+            self.buffer.resize(target_len, 0);
             self.buffer
                 .copy_within(src_offset..src_offset + reuse_len, 0);
 
             (old_end, reuse_len)
         } else {
-            self.buffer.resize(window_size, 0);
+            self.buffer.resize(target_len, 0);
             (aligned_start, 0)
         };
 

--- a/crates/transfer/src/map_file/tests.rs
+++ b/crates/transfer/src/map_file/tests.rs
@@ -488,6 +488,47 @@ fn window_slide_forward_reuses_overlap() {
     assert_eq!(data, &expected[..]);
 }
 
+/// Reload that requests a smaller window than the buffer's current length
+/// must not drop bytes the overlap branch is about to relocate.
+///
+/// Reproduces the data-loss path flagged during PR #5569 review: upstream
+/// `fileio.c:236` `realloc_array` only grows; mirroring that, `Vec::resize`
+/// must never shrink the buffer while `copy_within` is about to shift a
+/// suffix of the old window to the head of the new window.
+#[test]
+fn load_window_overlap_shrink_preserves_data() {
+    // File size > window cap forces a real overlap-shrink near EOF.
+    let size = 5000;
+    let temp = create_test_file(size);
+    let mut map = BufferedMap::open_with_window(temp.path(), 4096).unwrap();
+
+    // Load 1: aligned_start=0, window_size=min(4096, 5000)=4096.
+    // buffer.len() and window_len both end at 4096.
+    let _ = map.map_ptr(0, 100).unwrap();
+    assert_eq!(map.window_start, 0);
+    assert_eq!(map.window_len, 4096);
+
+    // Load 2: aligned_start=2048 (align_down(3000)), remaining=2952,
+    // window_size=min(4096, 2952)=2952. The overlap branch fires because
+    // [2048, 5000) overlaps [0, 4096) and extends past old_end. With the
+    // never-shrink invariant in place, copy_within(2048..4096, 0) shifts
+    // the tail of the old window in place; the trailing bytes are read
+    // from disk into buffer[2048..2952]; window_len clamps to 2952.
+    let data = map.map_ptr(3000, 1000).unwrap();
+    let expected: Vec<u8> = (3000..4000).map(|i| (i % 256) as u8).collect();
+    assert_eq!(data, &expected[..]);
+    assert_eq!(map.window_start, 2048);
+    assert_eq!(map.window_len, 2952);
+
+    // Every byte of the new window must reflect the file, including the
+    // bytes that landed at offsets near the buffer's old upper bound -
+    // exactly the region that would be silently truncated if the buffer
+    // had been shrunk before copy_within ran.
+    let full = map.map_ptr(2048, 2952).unwrap();
+    let expected_full: Vec<u8> = (2048..5000).map(|i| (i % 256) as u8).collect();
+    assert_eq!(full, &expected_full[..]);
+}
+
 #[test]
 fn window_can_slide_backward() {
     let size = MAX_MAP_SIZE * 2;


### PR DESCRIPTION
## Summary

- Closes the data-loss path flagged during PR #5569 review: `BufferedMap::load_window` calls `Vec::resize(window_size, 0)` which truncates the buffer when a smaller window is requested, dropping bytes the overlap branch is about to relocate via `copy_within` and either panicking on the now-out-of-bounds source range or (after PR #5566's guard) surfacing the corruption as `InvalidData`.
- Matches upstream `fileio.c:236` where `realloc_array` only grows the backing buffer and never shrinks; the new window's valid extent is bounded by `window_len`, so retaining extra trailing capacity is harmless.
- Surgical 1-line behavior change: `buffer.resize(window_size.max(buffer.len()), 0)` plus an upstream-citing comment and a positive regression test.

## Test plan

- [x] New positive regression test `load_window_overlap_shrink_preserves_data` (mirrors PR #5569's positive-test style):
  - Opens a 5000-byte file with a 4096-byte window cap.
  - Calls `map_ptr(0, 100)` to fill the buffer to `window_len = 4096`.
  - Calls `map_ptr(3000, 1000)` which triggers the overlap-shrink branch (aligned_start=2048, window_size=2952 < buffer.len()=4096) and would panic on the old code's `copy_within(2048..4096, 0)` against a 2952-byte buffer.
  - Asserts the returned slice matches file bytes `3000..4000`.
  - Asserts `window_start == 2048` and `window_len == 2952` (clamp to remaining file bytes).
  - Asserts the full new window via `map_ptr(2048, 2952)` matches file bytes `2048..5000` end-to-end, catching any silent truncation of the relocated suffix.
- [x] Existing `window_slide_forward_reuses_overlap` test continues to pass (overlap reuse without shrink is unchanged - `target_len` equals the existing buffer length).
- [x] `cargo fmt --all -- --check` (verified by CI fmt+clippy gate).
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (verified by CI).
- [x] `cargo nextest run -p transfer --all-features` covers `map_file::tests::load_window_overlap_shrink_preserves_data` (verified by CI nextest matrix).