### PR TITLE
feat(cli): add --io-uring=sqpoll-off flag + K8s deployment guide

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -448,7 +448,10 @@ pub struct ParsedArgs {
     /// `--fsync` - sync files to disk after writing.
     pub fsync: Option<bool>,
 
-    /// `--io-uring` / `--no-io-uring` - io_uring policy for file I/O.
+    /// `--io-uring` / `--no-io-uring` / `--no-io-uring-sqpoll` - io_uring
+    /// policy for file I/O. `--no-io-uring-sqpoll` keeps io_uring on but
+    /// suppresses `IORING_SETUP_SQPOLL` for rootless-container deployments
+    /// that cannot grant `CAP_SYS_NICE`.
     pub io_uring_policy: fast_io::IoUringPolicy,
 
     /// `--io-uring-depth=N` - override io_uring submission queue depth.

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -457,6 +457,13 @@ where
         fast_io::IoUringPolicy::Enabled
     } else if matches.get_flag("no-io-uring") {
         fast_io::IoUringPolicy::Disabled
+    } else if matches.get_flag("no-io-uring-sqpoll") {
+        // Set the process-wide SQPOLL gate eagerly so that any io_uring
+        // ring built later in this process - including ones created from
+        // configs with `sqpoll: true` and the session pool's shared rings
+        // - honours the opt-out without re-reading the policy.
+        fast_io::set_sqpoll_disabled_by_policy();
+        fast_io::IoUringPolicy::SqpollOff
     } else {
         fast_io::IoUringPolicy::Auto
     };

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1237,6 +1237,54 @@ mod option_values {
         assert!(err.to_string().contains("--io-uring-depth"));
     }
 
+    /// The `--no-io-uring-sqpoll` flag must parse to the dedicated
+    /// `IoUringPolicy::SqpollOff` variant and leave io_uring active. This
+    /// is the explicit opt-out for rootless containers and Kubernetes pods
+    /// that cannot grant `CAP_SYS_NICE`; the test pins the parse mapping
+    /// so future refactors cannot silently fold it into `Auto` or
+    /// `Disabled`.
+    #[test]
+    fn no_io_uring_sqpoll_parses_to_sqpoll_off_variant() {
+        let parsed =
+            parse_test_args(["--no-io-uring-sqpoll", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.io_uring_policy, fast_io::IoUringPolicy::SqpollOff);
+        assert!(
+            parsed.io_uring_policy.is_io_uring_active(),
+            "SqpollOff must keep io_uring active for file and socket I/O"
+        );
+        assert!(
+            parsed.io_uring_policy.forbids_sqpoll(),
+            "SqpollOff must mark SQPOLL as forbidden so ring builders honour the gate"
+        );
+    }
+
+    /// `--no-io-uring-sqpoll` must take precedence over a preceding
+    /// `--no-io-uring` (the last io_uring policy flag wins, mirroring how
+    /// `--io-uring`/`--no-io-uring` already override each other). This
+    /// matters for operators who set `--no-io-uring` in shared wrapper
+    /// scripts and want to selectively re-enable io_uring (minus SQPOLL)
+    /// on a single invocation without rewriting the wrapper.
+    #[test]
+    fn no_io_uring_sqpoll_overrides_no_io_uring() {
+        let parsed = parse_test_args([
+            "--no-io-uring",
+            "--no-io-uring-sqpoll",
+            "src/",
+            "dst/",
+        ])
+        .expect("parse");
+        assert_eq!(parsed.io_uring_policy, fast_io::IoUringPolicy::SqpollOff);
+    }
+
+    /// The default policy is `Auto`. Pin it so removing the new variant or
+    /// reordering the parser branches cannot accidentally make `SqpollOff`
+    /// the default.
+    #[test]
+    fn io_uring_policy_defaults_to_auto() {
+        let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.io_uring_policy, fast_io::IoUringPolicy::Auto);
+    }
+
     #[test]
     fn modify_window_with_equals() {
         let parsed = parse_test_args(["--modify-window=2", "src/", "dst/"]).expect("parse");

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -167,7 +167,23 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                          supports io_uring.",
                     )
                     .action(ArgAction::SetTrue)
-                    .overrides_with("io-uring"),
+                    .overrides_with("io-uring")
+                    .overrides_with("no-io-uring-sqpoll"),
+            )
+            .arg(
+                Arg::new("no-io-uring-sqpoll")
+                    .long("no-io-uring-sqpoll")
+                    .help(
+                        "Keep io_uring on but suppress IORING_SETUP_SQPOLL \
+                         (policy=sqpoll-off). All other io_uring features \
+                         remain active. Use in rootless containers and \
+                         Kubernetes pods that cannot grant CAP_SYS_NICE: \
+                         guarantees the SQPOLL kthread is never requested \
+                         instead of relying on the EPERM fallback.",
+                    )
+                    .action(ArgAction::SetTrue)
+                    .overrides_with("io-uring")
+                    .overrides_with("no-io-uring"),
             )
             .arg(
                 Arg::new("io-uring-depth")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -21,7 +21,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--force, --no-force, --fuzzy/-y, --no-fuzzy, --msgs2stderr, --no-msgs2stderr, --8-bit-output, --outbuf, ",
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --xxh64-dedup, --remove-source-files, ",
-    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --io-uring-depth, --io-uring-status, --simd, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
+    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --no-io-uring-sqpoll, --io-uring-depth, --io-uring-status, --simd, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
     "--human-readable/-h, --no-human-readable, -P, --sparse/-S, --no-sparse/--no-S, --sparse-detect, --links/-l, --no-links/--no-l, ",
     "--copy-links/-L, ",
     "--copy-unsafe-links, --safe-links, --copy-dirlinks/-k, --keep-dirlinks/-K, ",

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -145,6 +145,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --fsync    Fsync updated files after writing completes.\n",
             "      --io-uring   Force io_uring for file I/O (policy=enabled); error if unavailable. Default policy is auto: probe kernel and fall back to standard I/O.\n",
             "      --no-io-uring  Disable io_uring (policy=disabled); always use standard buffered I/O even when the kernel supports io_uring.\n",
+            "      --no-io-uring-sqpoll  Keep io_uring on but suppress IORING_SETUP_SQPOLL (policy=sqpoll-off). For rootless containers and K8s pods that cannot grant CAP_SYS_NICE.\n",
             "      --io-uring-depth=N  Override io_uring submission queue depth (default 64); must be a power of two between 1 and 32768.\n",
             "      --io-uring-status  Print the io_uring capability matrix and exit.\n",
             "      --simd=LEVEL Force the SIMD level used by checksum dispatch (auto, avx512, avx2, sse4, neon, none).\n",

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -52,6 +52,45 @@ fn disable_via_env() -> bool {
 /// can query this via [`sqpoll_fell_back`] for diagnostics or `--version` output.
 static SQPOLL_FALLBACK: AtomicBool = AtomicBool::new(false);
 
+/// Process-wide gate that suppresses every `IORING_SETUP_SQPOLL` request.
+///
+/// Set by [`set_sqpoll_disabled_by_policy`] when the CLI parser sees
+/// `--no-io-uring-sqpoll`. Every ring construction site
+/// ([`IoUringConfig::build_ring`] and the session-pool ring builder in
+/// `session_pool.rs`) consults this flag before calling
+/// `io_uring::IoUring::builder().setup_sqpoll(...)`. When set, the SQPOLL
+/// kthread is never requested, even if a particular `IoUringConfig` has
+/// `sqpoll: true`. The opt-out is one-way per process - there is no
+/// matching unset, since toggling SQPOLL on for an in-flight transfer
+/// would race the ring builder.
+static SQPOLL_DISABLED_BY_POLICY: AtomicBool = AtomicBool::new(false);
+
+/// Returns `true` when [`set_sqpoll_disabled_by_policy`] has been called for
+/// this process.
+///
+/// Ring-construction sites use this to short-circuit SQPOLL requests
+/// regardless of any per-config `sqpoll: true` setting. Kept `pub` so
+/// callers outside the `io_uring::config` module (the session pool builder
+/// in `session_pool.rs` and the `--io-uring-status` reporter in
+/// `status.rs`) can read the gate without re-exporting the atomic.
+#[must_use]
+pub fn is_sqpoll_disabled_by_policy() -> bool {
+    SQPOLL_DISABLED_BY_POLICY.load(Ordering::Relaxed)
+}
+
+/// Records the process-wide opt-out from SQPOLL.
+///
+/// Once called, every subsequent `build_ring()` call (and every
+/// session-pool ring builder) honours
+/// [`is_sqpoll_disabled_by_policy`] and skips the
+/// `IORING_SETUP_SQPOLL` flag. The CLI parser invokes this when the user
+/// passes `--no-io-uring-sqpoll`. The function is idempotent and one-way
+/// per process to keep the gate race-free against ring construction on
+/// other threads.
+pub fn set_sqpoll_disabled_by_policy() {
+    SQPOLL_DISABLED_BY_POLICY.store(true, Ordering::Relaxed);
+}
+
 /// Returns `true` if SQPOLL was requested but setup failed.
 ///
 /// When `IoUringConfig::sqpoll` is `true` but the kernel rejects the request
@@ -355,7 +394,15 @@ impl IoUringConfig {
     /// refusal here remains the safety net: the ring is built without
     /// SQPOLL and `SQPOLL_FALLBACK` is set so callers see the degrade.
     pub(crate) fn build_ring(&self) -> io::Result<RawIoUring> {
-        let sqpoll_requested = self.sqpoll;
+        let sqpoll_requested = self.sqpoll && !is_sqpoll_disabled_by_policy();
+        if self.sqpoll && !sqpoll_requested {
+            logging::debug_log!(
+                Io,
+                1,
+                "io_uring: SQPOLL suppressed by --no-io-uring-sqpoll; \
+                 building a regular ring (BGID and other features remain active)"
+            );
+        }
         let mlock_basis_enabled = cfg!(feature = "sqpoll-mlock-basis");
         let sqpoll_safe = sqpoll_requested && (!self.mmap_basis_active || mlock_basis_enabled);
         if sqpoll_requested && !sqpoll_safe {

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -145,7 +145,8 @@ pub use cancel::{
     cancel_all_by_fd, cancel_by_user_data,
 };
 pub use config::{
-    IoUringConfig, IoUringKernelInfo, config_detail, is_io_uring_available, sqpoll_fell_back,
+    IoUringConfig, IoUringKernelInfo, config_detail, is_io_uring_available,
+    is_sqpoll_disabled_by_policy, set_sqpoll_disabled_by_policy, sqpoll_fell_back,
 };
 #[cfg(feature = "iouring-data-reads")]
 pub use data_reader::IoUringFileReader;
@@ -270,7 +271,7 @@ pub fn writer_from_file_with_depth(
     }
 
     match policy {
-        crate::IoUringPolicy::Auto => {
+        crate::IoUringPolicy::Auto | crate::IoUringPolicy::SqpollOff => {
             if is_io_uring_available() {
                 // Probe the per-thread ring; on setup failure `file` is still
                 // ours and we fall back to standard I/O.
@@ -356,7 +357,7 @@ pub fn reader_from_path_with_depth<P: AsRef<std::path::Path>>(
     }
 
     match policy {
-        crate::IoUringPolicy::Auto => {
+        crate::IoUringPolicy::Auto | crate::IoUringPolicy::SqpollOff => {
             if is_io_uring_available() {
                 match IoUringReader::open(path.as_ref(), &config) {
                     Ok(r) => return Ok(IoUringOrStdReader::IoUring(r)),

--- a/crates/fast_io/src/io_uring/session_pool.rs
+++ b/crates/fast_io/src/io_uring/session_pool.rs
@@ -274,7 +274,16 @@ fn build_ring(config: &SessionPoolConfig) -> std::io::Result<RawIoUring> {
     if config.flags & IORING_SETUP_IOPOLL != 0 {
         builder.setup_iopoll();
     }
-    if config.flags & IORING_SETUP_SQPOLL != 0 {
+    let sqpoll_gated_off =
+        config.flags & IORING_SETUP_SQPOLL != 0 && super::config::is_sqpoll_disabled_by_policy();
+    if sqpoll_gated_off {
+        logging::debug_log!(
+            Io,
+            1,
+            "io_uring session pool: SQPOLL suppressed by --no-io-uring-sqpoll; \
+             building a regular ring"
+        );
+    } else if config.flags & IORING_SETUP_SQPOLL != 0 {
         builder.setup_sqpoll(config.sqpoll_idle_ms);
     }
     builder

--- a/crates/fast_io/src/io_uring/socket_factory.rs
+++ b/crates/fast_io/src/io_uring/socket_factory.rs
@@ -69,7 +69,7 @@ pub fn socket_reader_from_fd(
     };
 
     match policy {
-        crate::IoUringPolicy::Auto => {
+        crate::IoUringPolicy::Auto | crate::IoUringPolicy::SqpollOff => {
             if is_io_uring_available() {
                 if let Ok(reader) = IoUringSocketReader::from_raw_fd(fd, &config) {
                     return Ok(IoUringOrStdSocketReader::IoUring(reader));
@@ -120,7 +120,7 @@ pub fn socket_writer_from_fd(
     };
 
     match policy {
-        crate::IoUringPolicy::Auto => {
+        crate::IoUringPolicy::Auto | crate::IoUringPolicy::SqpollOff => {
             if is_io_uring_available() {
                 if let Ok(writer) = IoUringSocketWriter::from_raw_fd(fd, &config) {
                     return Ok(IoUringOrStdSocketWriter::IoUring(writer));

--- a/crates/fast_io/src/io_uring_stub/config.rs
+++ b/crates/fast_io/src/io_uring_stub/config.rs
@@ -34,6 +34,24 @@ pub fn sqpoll_fell_back() -> bool {
     false
 }
 
+/// Records the process-wide SQPOLL opt-out (no-op on this platform).
+///
+/// Linux exposes a real atomic gate via
+/// [`crate::io_uring::set_sqpoll_disabled_by_policy`]. On non-Linux
+/// targets there is no SQPOLL kthread to suppress, so the stub keeps the
+/// symbol available for cross-platform CLI wiring but does nothing.
+pub fn set_sqpoll_disabled_by_policy() {}
+
+/// Returns whether the SQPOLL opt-out has been set (always `false` on this platform).
+///
+/// Mirrors the Linux query so cross-platform callers can use the same
+/// import path. The stub always reports `false` because there is no
+/// SQPOLL kthread to begin with.
+#[must_use]
+pub fn is_sqpoll_disabled_by_policy() -> bool {
+    false
+}
+
 /// Public accessors for kernel version detection used by `--version` output.
 ///
 /// Mirrors the real Linux module so cross-platform callers can use the same

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -71,7 +71,10 @@ pub use buffer_ring::{
     bgid_peak_used, bgid_snapshot, pbuf_ring_supported,
 };
 pub use cancel::{CancelOutcome, cancel_all_by_fd, cancel_by_user_data};
-pub use config::{StubIoUringBackend, config_detail, is_io_uring_available, sqpoll_fell_back};
+pub use config::{
+    StubIoUringBackend, config_detail, is_io_uring_available, is_sqpoll_disabled_by_policy,
+    set_sqpoll_disabled_by_policy, sqpoll_fell_back,
+};
 pub use disk_batch::IoUringDiskBatch;
 pub use file_factory::{
     IoUringOrStdReader, IoUringOrStdWriter, IoUringReaderFactory, IoUringWriterFactory, read_file,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -322,10 +322,10 @@ pub use io_uring::{
     bgid_exhausted_count, bgid_inflight, bgid_peak_used, bgid_snapshot, buffer_id_from_cqe_flags,
     build_linkat_sqe, build_linkat_sqe_unchecked, build_renameat2_sqe,
     build_renameat2_sqe_unchecked, build_statx_sqe, build_statx_sqe_unchecked,
-    is_io_uring_available, linkat_supported, pbuf_ring_supported, reader_from_path,
-    reader_from_path_with_depth, renameat2_blocking, renameat2_supported, sqpoll_fell_back,
-    statx_supported, submit_linkat_blocking, submit_statx_batch, submit_statx_blocking,
-    writer_from_file, writer_from_file_with_depth,
+    is_io_uring_available, is_sqpoll_disabled_by_policy, linkat_supported, pbuf_ring_supported,
+    reader_from_path, reader_from_path_with_depth, renameat2_blocking, renameat2_supported,
+    set_sqpoll_disabled_by_policy, sqpoll_fell_back, statx_supported, submit_linkat_blocking,
+    submit_statx_batch, submit_statx_blocking, writer_from_file, writer_from_file_with_depth,
 };
 
 #[cfg(all(target_os = "linux", feature = "iouring-data-reads"))]

--- a/crates/fast_io/src/policy.rs
+++ b/crates/fast_io/src/policy.rs
@@ -4,13 +4,14 @@
 //! mechanisms (io_uring, IOCP, kernel zero-copy, copy-on-write reflink)
 //! and map onto the corresponding CLI flags.
 //!
-//! Three subsystem opt-in/opt-out enums share the same `Auto / Enabled /
-//! Disabled` shape: [`IoUringPolicy`], [`IocpPolicy`], and [`ZeroCopyPolicy`].
-//! They are type aliases of the canonical [`BackendPolicy`] enum to avoid
-//! duplicated rustdoc, `Default`, and pattern-matching boilerplate while
-//! preserving each name at the API surface. [`CowPolicy`] keeps a separate
-//! two-variant definition because reflink is best-effort and has no
-//! `Enabled` semantics.
+//! [`IocpPolicy`] and [`ZeroCopyPolicy`] share the `Auto / Enabled /
+//! Disabled` shape and are type aliases of the canonical [`BackendPolicy`]
+//! enum, avoiding duplicated rustdoc, `Default`, and pattern-matching
+//! boilerplate while preserving each name at the API surface.
+//! [`IoUringPolicy`] is structurally similar but adds a fourth `SqpollOff`
+//! arm for the rootless-container opt-out path, so it is defined as its own
+//! enum rather than an alias. [`CowPolicy`] keeps a separate two-variant
+//! definition because reflink is best-effort and has no `Enabled` semantics.
 
 #[allow(unused_imports)]
 use crate::platform_copy;
@@ -21,9 +22,10 @@ use crate::platform_copy;
 /// `Enabled` forces the subsystem and errors out if it is unavailable;
 /// `Disabled` always routes through the portable buffered fallback.
 ///
-/// This is the canonical type used by [`IoUringPolicy`], [`IocpPolicy`], and
-/// [`ZeroCopyPolicy`]. Each alias preserves the original name for source
-/// compatibility and CLI-flag wiring.
+/// This is the canonical type used by [`IocpPolicy`] and [`ZeroCopyPolicy`].
+/// Each alias preserves the original name for source compatibility and
+/// CLI-flag wiring. [`IoUringPolicy`] is a distinct enum so it can expose a
+/// fourth `SqpollOff` variant without polluting the shared shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BackendPolicy {
     /// Auto-detect availability at runtime (default).
@@ -47,13 +49,21 @@ pub enum BackendPolicy {
 
 /// Policy controlling io_uring usage for file and socket I/O.
 ///
-/// Alias of [`BackendPolicy`]. Steered by the CLI flags `--io-uring` and
-/// `--no-io-uring`.
+/// Steered by the CLI flags `--io-uring`, `--no-io-uring`, and
+/// `--no-io-uring-sqpoll`. Mirrors [`BackendPolicy`] but adds a fourth
+/// [`SqpollOff`](IoUringPolicy::SqpollOff) variant which keeps io_uring
+/// active for file and socket I/O while suppressing the
+/// `IORING_SETUP_SQPOLL` kernel-thread request. This is the explicit
+/// opt-out for environments where SQPOLL cannot be granted
+/// `CAP_SYS_NICE` (most notably rootless Kubernetes pods); operators
+/// pick it to match production behaviour in non-K8s test environments
+/// without disabling io_uring entirely.
 ///
 /// # Runtime detection
 ///
-/// When set to `Auto`, the runtime check ([`crate::io_uring::is_io_uring_available`])
-/// performs three validations, caching the result in a process-wide atomic for
+/// When set to `Auto` or `SqpollOff`, the runtime check
+/// ([`crate::io_uring::is_io_uring_available`]) performs three
+/// validations, caching the result in a process-wide atomic for
 /// subsequent fast-path lookups:
 ///
 /// 1. **Kernel version** - Parses `uname().release` and requires >= 5.6.
@@ -62,7 +72,8 @@ pub enum BackendPolicy {
 ///    `io_uring_setup(2)`.
 /// 3. **Ring construction** - On first actual I/O, `IoUringConfig::build_ring`
 ///    creates the real ring. If SQPOLL is requested but the process lacks
-///    `CAP_SYS_NICE`, it falls back to a normal ring silently.
+///    `CAP_SYS_NICE`, it falls back to a normal ring silently. With
+///    `SqpollOff`, the SQPOLL request is skipped entirely.
 ///
 /// If any step fails, the factory transparently returns a standard buffered
 /// I/O reader or writer with no error.
@@ -75,7 +86,70 @@ pub enum BackendPolicy {
 /// | `IORING_REGISTER_FILES` | 5.6 | Fixed-file descriptors, ~50ns/SQE savings |
 /// | `IORING_SETUP_SQPOLL` | 5.6 | Kernel-side SQ polling, needs `CAP_SYS_NICE` |
 /// | `IORING_OP_SEND` (socket I/O) | 5.6 | Used for socket writer batching |
-pub type IoUringPolicy = BackendPolicy;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IoUringPolicy {
+    /// Auto-detect availability at runtime (default).
+    ///
+    /// Equivalent to [`BackendPolicy::Auto`]: probe the kernel, use
+    /// io_uring when available, fall back to standard buffered I/O
+    /// otherwise. SQPOLL is attempted when configured and transparently
+    /// downgraded if `CAP_SYS_NICE` is missing.
+    #[default]
+    Auto,
+    /// Force io_uring on. Returns an error if the kernel does not support it.
+    ///
+    /// Equivalent to [`BackendPolicy::Enabled`].
+    Enabled,
+    /// Disable io_uring entirely; always use standard buffered I/O.
+    ///
+    /// Equivalent to [`BackendPolicy::Disabled`].
+    Disabled,
+    /// Keep io_uring on but forbid `IORING_SETUP_SQPOLL`.
+    ///
+    /// io_uring still initialises and BGID, registered buffers, file
+    /// registration, and every other feature remain active. Only the
+    /// SQPOLL kernel-thread request is suppressed. Selected via
+    /// `--no-io-uring-sqpoll`. The CLI parser also calls
+    /// [`crate::io_uring::set_sqpoll_disabled_by_policy`] so that ring
+    /// construction sites that internally request SQPOLL (e.g.
+    /// dedicated session pools) honour the opt-out without each call
+    /// site re-reading the policy.
+    ///
+    /// Use this in rootless containers and Kubernetes pods that
+    /// cannot grant `CAP_SYS_NICE`: it gives operators an explicit
+    /// guarantee that the SQPOLL kthread is never requested, instead
+    /// of relying on the transparent `EPERM` fallback path. The
+    /// difference is observable in `--io-uring-status` (no
+    /// `sqpoll fell back: yes` line) and matters when audit policy
+    /// disallows even unsuccessful SQPOLL setup attempts.
+    SqpollOff,
+}
+
+impl IoUringPolicy {
+    /// Returns `true` when io_uring should be active for file and socket I/O.
+    ///
+    /// This is `true` for [`Auto`](Self::Auto), [`Enabled`](Self::Enabled),
+    /// and [`SqpollOff`](Self::SqpollOff); only [`Disabled`](Self::Disabled)
+    /// routes through the portable buffered fallback. Used by dispatch sites
+    /// that previously distinguished `Auto`/`Enabled` from `Disabled` and now
+    /// also need to treat `SqpollOff` as an io_uring-active mode.
+    #[must_use]
+    pub fn is_io_uring_active(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    /// Returns `true` when SQPOLL must be suppressed regardless of any other
+    /// configuration that would otherwise request it.
+    ///
+    /// Only [`SqpollOff`](Self::SqpollOff) returns `true`. Wired into the CLI
+    /// path so that ring construction sites can short-circuit SQPOLL via the
+    /// process-global gate set by
+    /// [`crate::io_uring::set_sqpoll_disabled_by_policy`].
+    #[must_use]
+    pub fn forbids_sqpoll(self) -> bool {
+        matches!(self, Self::SqpollOff)
+    }
+}
 
 /// Policy controlling copy-on-write reflink usage for whole-file copies.
 ///
@@ -309,12 +383,46 @@ mod tests {
 
     #[test]
     fn aliases_resolve_to_backend_policy() {
-        let a: IoUringPolicy = IoUringPolicy::Auto;
         let b: IocpPolicy = IocpPolicy::Auto;
         let c: ZeroCopyPolicy = ZeroCopyPolicy::Auto;
-        assert_eq!(a, b);
         assert_eq!(b, c);
         assert_eq!(c, BackendPolicy::Auto);
+    }
+
+    #[test]
+    fn io_uring_policy_default_is_auto() {
+        assert_eq!(IoUringPolicy::default(), IoUringPolicy::Auto);
+    }
+
+    #[test]
+    fn io_uring_policy_four_variants_are_distinct() {
+        let variants = [
+            IoUringPolicy::Auto,
+            IoUringPolicy::Enabled,
+            IoUringPolicy::Disabled,
+            IoUringPolicy::SqpollOff,
+        ];
+        for (i, a) in variants.iter().enumerate() {
+            for b in &variants[i + 1..] {
+                assert_ne!(a, b, "{a:?} must differ from {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn io_uring_policy_sqpoll_off_keeps_io_uring_active() {
+        assert!(IoUringPolicy::SqpollOff.is_io_uring_active());
+        assert!(IoUringPolicy::Auto.is_io_uring_active());
+        assert!(IoUringPolicy::Enabled.is_io_uring_active());
+        assert!(!IoUringPolicy::Disabled.is_io_uring_active());
+    }
+
+    #[test]
+    fn io_uring_policy_only_sqpoll_off_forbids_sqpoll() {
+        assert!(IoUringPolicy::SqpollOff.forbids_sqpoll());
+        assert!(!IoUringPolicy::Auto.forbids_sqpoll());
+        assert!(!IoUringPolicy::Enabled.forbids_sqpoll());
+        assert!(!IoUringPolicy::Disabled.forbids_sqpoll());
     }
 
     #[test]

--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -192,6 +192,14 @@ pub fn io_uring_capability_matrix() -> String {
                 "no"
             }
         ));
+        lines.push(format!(
+            "  sqpoll opt-out:     {}",
+            if crate::is_sqpoll_disabled_by_policy() {
+                "yes (--no-io-uring-sqpoll)"
+            } else {
+                "no"
+            }
+        ));
     }
 
     // Feature gates

--- a/crates/fast_io/tests/sqpoll_policy_gate.rs
+++ b/crates/fast_io/tests/sqpoll_policy_gate.rs
@@ -1,0 +1,96 @@
+//! Integration tests for the `--no-io-uring-sqpoll` opt-out gate.
+//!
+//! Verifies that calling [`fast_io::set_sqpoll_disabled_by_policy`] flips
+//! the process-wide [`fast_io::is_sqpoll_disabled_by_policy`] query, and
+//! that on Linux the ring builder honours the gate by never requesting
+//! `IORING_SETUP_SQPOLL` even when the per-config `sqpoll: true` flag is
+//! set. The gate exists so rootless Kubernetes pods and other
+//! `CAP_SYS_NICE`-less environments get a deterministic opt-out instead
+//! of relying on the transparent `EPERM` fallback.
+
+use fast_io::{is_sqpoll_disabled_by_policy, set_sqpoll_disabled_by_policy};
+
+/// The gate must read as `false` before any explicit opt-out and must
+/// flip to `true` exactly when [`set_sqpoll_disabled_by_policy`] is
+/// called. Once set, it must stay set: there is no public unset path,
+/// since toggling SQPOLL back on while rings are being built on other
+/// threads would race the builder.
+///
+/// This test runs in its own integration binary so the
+/// `AtomicBool` state cannot leak across unrelated unit tests sharing
+/// the same process. Cargo gives every `tests/*.rs` file its own
+/// binary, isolating the state.
+#[test]
+fn sqpoll_gate_is_off_until_explicitly_set_and_then_stays_on() {
+    // Initial state: gate is off so production builds keep their existing
+    // SQPOLL behaviour (the per-config `sqpoll: false` default already
+    // makes this a no-op for default callers, but the gate must not
+    // misreport itself).
+    assert!(
+        !is_sqpoll_disabled_by_policy(),
+        "process must start with the SQPOLL opt-out gate off"
+    );
+
+    set_sqpoll_disabled_by_policy();
+
+    assert!(
+        is_sqpoll_disabled_by_policy(),
+        "set_sqpoll_disabled_by_policy must flip the gate to true"
+    );
+
+    // Idempotent: calling the setter again must not toggle the state
+    // back. There is no API to clear it; verify by calling twice.
+    set_sqpoll_disabled_by_policy();
+    assert!(
+        is_sqpoll_disabled_by_policy(),
+        "the SQPOLL opt-out must be one-way once set"
+    );
+}
+
+/// On Linux with the `io_uring` feature, building a ring from a config
+/// that requests SQPOLL must still succeed after the gate is set: the
+/// builder silently downgrades to a regular ring. This is the safety net
+/// for environments where SQPOLL would fail with `EPERM`; the gate makes
+/// the downgrade deterministic instead of relying on the kernel reject.
+///
+/// The behaviour we assert is "ring builds", not "no SQPOLL kthread is
+/// observable" - the latter would require sampling `/proc` from a test,
+/// which is brittle. The deterministic check is that the gate causes
+/// [`fast_io::IoUringConfig::build_ring`] to take its
+/// suppress-SQPOLL branch, which we verify indirectly: the existing
+/// `build_ring_with_sqpoll_falls_back_gracefully` unit test in
+/// `config.rs` already proves the fallback succeeds; this test confirms
+/// the gate-driven path stays compatible with that contract.
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+#[test]
+fn sqpoll_gate_keeps_ring_construction_compatible_with_sqpoll_off_policy() {
+    if !fast_io::is_io_uring_available() {
+        // The CI runner kernel may be below 5.6 or block io_uring via
+        // seccomp; skip rather than fail. The fallback path that
+        // applies when io_uring is unavailable already routes through
+        // standard I/O, so the gate has nothing to gate.
+        return;
+    }
+
+    set_sqpoll_disabled_by_policy();
+    assert!(is_sqpoll_disabled_by_policy());
+
+    // The visible contract: the policy-driven factory dispatches
+    // through the same ring-construction code path that `build_ring`
+    // uses internally, and must return a valid writer under
+    // `IoUringPolicy::SqpollOff` without panicking or returning
+    // `Unsupported`. `build_ring` itself is `pub(crate)`; the factory
+    // call is the public surface that proves the gate-driven path
+    // stays compatible.
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let path = tmpdir.path().join("sqpoll-gate.bin");
+    let file = std::fs::File::create(&path).expect("create");
+    let writer = fast_io::writer_from_file(file, 4096, fast_io::IoUringPolicy::SqpollOff)
+        .expect("writer_from_file must succeed under the SQPOLL opt-out");
+    drop(writer);
+
+    assert!(
+        is_sqpoll_disabled_by_policy(),
+        "the gate must remain set after factory dispatch"
+    );
+}

--- a/crates/transfer/src/disk_commit/thread.rs
+++ b/crates/transfer/src/disk_commit/thread.rs
@@ -66,8 +66,10 @@ pub fn spawn_disk_thread(config: DiskCommitConfig) -> DiskThreadHandle {
 /// Attempts to create an io_uring batch writer based on the configured policy.
 ///
 /// Returns `Some` on Linux 5.6+ when the `io_uring` feature is enabled and
-/// the policy is `Auto` or `Enabled`. Returns `None` when io_uring is
-/// unavailable or the policy is `Disabled`.
+/// the policy is `Auto`, `Enabled`, or `SqpollOff`. Returns `None` when
+/// io_uring is unavailable or the policy is `Disabled`. `SqpollOff` keeps
+/// io_uring active but suppresses `IORING_SETUP_SQPOLL` via the process-wide
+/// gate set by the CLI parser.
 ///
 /// The optional `depth` overrides [`fast_io::IoUringConfig::sq_entries`] when
 /// provided, mirroring the `--io-uring-depth=N` CLI tunable.
@@ -81,7 +83,9 @@ fn try_create_disk_batch(
     }
     match policy {
         fast_io::IoUringPolicy::Disabled => None,
-        fast_io::IoUringPolicy::Auto => fast_io::IoUringDiskBatch::try_new(&config),
+        fast_io::IoUringPolicy::Auto | fast_io::IoUringPolicy::SqpollOff => {
+            fast_io::IoUringDiskBatch::try_new(&config)
+        }
         fast_io::IoUringPolicy::Enabled => {
             // Enabled policy: try to create, but log and proceed if it fails.
             // The caller explicitly requested io_uring, so we attempt it but
@@ -119,6 +123,24 @@ fn log_io_uring_status(policy: fast_io::IoUringPolicy, batch_created: bool) {
                 1,
                 "io_uring disabled by --no-io-uring, using standard I/O"
             );
+        }
+        fast_io::IoUringPolicy::SqpollOff => {
+            if batch_created {
+                debug_log!(
+                    Io,
+                    1,
+                    "disk I/O: {} (SQPOLL suppressed by --no-io-uring-sqpoll)",
+                    fast_io::io_uring_availability_reason()
+                );
+            } else {
+                debug_log!(
+                    Io,
+                    1,
+                    "disk I/O: {} (SQPOLL suppressed by --no-io-uring-sqpoll), \
+                     using standard I/O fallback",
+                    fast_io::io_uring_availability_reason()
+                );
+            }
         }
         fast_io::IoUringPolicy::Auto | fast_io::IoUringPolicy::Enabled => {
             if batch_created {

--- a/docs/deployment/container-io-uring.md
+++ b/docs/deployment/container-io-uring.md
@@ -100,6 +100,13 @@ the `io_uring_*` syscall family.
 
 ## Kubernetes Configuration
 
+For the full Kubernetes deployment guide - Job manifests, daemon-as-Pod
+deployment, Pod Security Admission profile interactions, and the
+quantitative tradeoff table for `--no-io-uring-sqpoll` - see
+[kubernetes.md](kubernetes.md). The brief recipes below cover the most
+common Pod spec snippets; refer to the dedicated guide for the full
+context.
+
 ### Pod securityContext for SQPOLL
 
 ```yaml
@@ -134,12 +141,47 @@ spec:
       # and standard I/O fallback engages if io_uring is blocked.
 ```
 
+### Explicit SQPOLL opt-out for rootless Pods
+
+Rootless Kubernetes Pods (most production clusters) cannot grant
+`CAP_SYS_NICE` because Pod Security Admission rejects
+`capabilities.add: ["SYS_NICE"]` under `restricted` and stricter
+profiles. The default `Auto` policy still works - SQPOLL is attempted
+and falls back transparently on `EPERM` - but operators who want a
+deterministic guarantee that the SQPOLL kthread is never requested can
+pass `--no-io-uring-sqpoll`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oc-rsync-rootless
+spec:
+  containers:
+    - name: rsync
+      image: myregistry/oc-rsync:latest
+      command:
+        - "oc-rsync"
+        - "--no-io-uring-sqpoll"
+        - "src/"
+        - "dst/"
+      # io_uring stays active for file and socket I/O; only
+      # IORING_SETUP_SQPOLL is suppressed. BGID, registered buffers,
+      # file registration and SEND_ZC remain available where supported.
+```
+
+The flag is also useful in non-K8s test environments that want to
+reproduce production rootless behaviour exactly: the kernel never sees
+a SQPOLL setup request, so the codepath under test matches the
+audit-restricted production deployment.
+
 ### Kubernetes Security Policies
 
 If your cluster uses PodSecurityStandards or PodSecurityPolicies:
 
 - **Restricted profile**: Blocks `SYS_NICE`. SQPOLL is unavailable; basic
-  io_uring may still work depending on the seccomp profile.
+  io_uring may still work depending on the seccomp profile. Use
+  `--no-io-uring-sqpoll` to suppress the SQPOLL request at the source.
 - **Baseline profile**: Does not add `SYS_NICE` by default but does not block
   it if explicitly requested in the pod spec.
 - **Privileged profile**: All capabilities available.
@@ -207,6 +249,16 @@ measurable only at high submission rates (thousands of SQEs per second). For
 typical rsync workloads transferring moderate numbers of files, non-SQPOLL
 io_uring already provides most of the benefit over standard I/O.
 
+## CLI Flags
+
+| Flag | Effect |
+|------|--------|
+| `--io-uring` | Force io_uring on; error if the kernel does not support it. Policy = `Enabled`. |
+| `--no-io-uring` | Disable io_uring entirely; always use standard buffered I/O. Policy = `Disabled`. |
+| `--no-io-uring-sqpoll` | Keep io_uring on but suppress `IORING_SETUP_SQPOLL`. Policy = `SqpollOff`. Recommended for rootless containers and Kubernetes Pods without `CAP_SYS_NICE`. |
+| `--io-uring-depth=N` | Override submission queue depth (default 64). |
+| `--io-uring-status` | Print the capability matrix and exit. |
+
 ## Environment Variables
 
 | Variable | Effect |
@@ -224,6 +276,10 @@ io_uring already provides most of the benefit over standard I/O.
 
 3. **Rootless containers**: SQPOLL is unavailable. Basic io_uring still works
    unless blocked by seccomp. No action required - the fallback is automatic.
+   Operators who want a deterministic opt-out (no SQPOLL request at all)
+   should pass `--no-io-uring-sqpoll`; this matches the production behaviour
+   under Pod Security Admission `restricted` profiles exactly. See
+   [kubernetes.md](kubernetes.md) for the full Kubernetes deployment guide.
 
 4. **Troubleshooting**: Run `oc-rsync --io-uring-status` inside the container
    to see the full capability matrix and identify which tier is active.

--- a/docs/deployment/io-uring-feature-matrix.md
+++ b/docs/deployment/io-uring-feature-matrix.md
@@ -179,7 +179,12 @@ Key constraints:
 3. **SQPOLL**: Only beneficial for sustained high-IOPS workloads (many small
    files). Requires `CAP_SYS_NICE` which is often unavailable in containers.
    The syscall savings from SQPOLL are marginal compared to the batch
-   submission model that regular io_uring already provides.
+   submission model that regular io_uring already provides. Operators in
+   rootless containers and Kubernetes Pods that cannot grant `CAP_SYS_NICE`
+   should pass `--no-io-uring-sqpoll` for a deterministic opt-out (keeps
+   io_uring on, suppresses only `IORING_SETUP_SQPOLL`). See
+   [container-io-uring.md](container-io-uring.md) and
+   [kubernetes.md](kubernetes.md) for the deployment recipes.
 
 4. **Verify before deploying**: Always run `oc-rsync --io-uring-status` on the
    target system to confirm which features are actually available after

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,309 @@
+# Kubernetes Deployment
+
+This guide covers running oc-rsync as a workload inside Kubernetes Pods.
+The focus is the interaction between Pod `securityContext`, the
+`CAP_SYS_NICE` capability that `IORING_SETUP_SQPOLL` requires, and the
+`--no-io-uring-sqpoll` CLI flag that lets operators opt out of SQPOLL
+without disabling io_uring entirely.
+
+For the broader container guide (Podman, Docker, kernel matrix), see
+[container-io-uring.md](container-io-uring.md). For the per-feature
+kernel requirement matrix, see
+[io-uring-feature-matrix.md](io-uring-feature-matrix.md).
+
+## Contents
+
+- [1. Quickstart: rsync transfer as a one-shot Job](#1-quickstart-rsync-transfer-as-a-one-shot-job)
+- [2. SQPOLL and CAP_SYS_NICE inside Pods](#2-sqpoll-and-cap_sys_nice-inside-pods)
+- [3. Rootless Pods and the `--no-io-uring-sqpoll` opt-out](#3-rootless-pods-and-the---no-io-uring-sqpoll-opt-out)
+- [4. Daemon-as-Pod deployment](#4-daemon-as-pod-deployment)
+- [5. Pod Security Standards / Pod Security Admission](#5-pod-security-standards--pod-security-admission)
+- [6. Verifying the active io_uring tier](#6-verifying-the-active-io_uring-tier)
+- [7. Troubleshooting](#7-troubleshooting)
+
+## 1. Quickstart: rsync transfer as a one-shot Job
+
+The simplest deployment is a `Job` that copies between two PVCs and
+exits. No extra capabilities are required; oc-rsync falls back to
+standard buffered I/O if io_uring is unavailable.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rsync-copy
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: rsync
+          image: ghcr.io/example/oc-rsync:latest
+          args:
+            - "-aHAX"
+            - "--no-io-uring-sqpoll"
+            - "/source/"
+            - "/dest/"
+          volumeMounts:
+            - name: source
+              mountPath: /source
+            - name: dest
+              mountPath: /dest
+      volumes:
+        - name: source
+          persistentVolumeClaim:
+            claimName: source-pvc
+        - name: dest
+          persistentVolumeClaim:
+            claimName: dest-pvc
+```
+
+`--no-io-uring-sqpoll` is the right default for rootless / restricted
+Pods; see [section 3](#3-rootless-pods-and-the---no-io-uring-sqpoll-opt-out)
+for the rationale.
+
+## 2. SQPOLL and CAP_SYS_NICE inside Pods
+
+`IORING_SETUP_SQPOLL` spawns a kernel thread that polls the submission
+queue, removing one `io_uring_enter(2)` syscall per batch. The kernel
+requires `CAP_SYS_NICE` (or root) to grant the elevated scheduling
+priority that thread runs at. Inside a Pod that means:
+
+- The container must run with `SYS_NICE` in
+  `securityContext.capabilities.add`.
+- The container must NOT be confined by a seccomp profile that drops
+  `io_uring_setup(2)`.
+- The cluster's admission controller (Pod Security Admission, OPA
+  Gatekeeper, Kyverno) must allow `SYS_NICE` to be added.
+
+Manifest snippet for a Pod that explicitly grants `CAP_SYS_NICE`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oc-rsync-sqpoll
+spec:
+  containers:
+    - name: rsync
+      image: ghcr.io/example/oc-rsync:latest
+      args: ["--io-uring", "src/", "dst/"]
+      securityContext:
+        capabilities:
+          add:
+            - SYS_NICE
+```
+
+The graceful fallback path still applies: if the kernel rejects SQPOLL
+despite the capability (for example because the seccomp profile blocks
+`io_uring_setup`), oc-rsync silently builds a regular io_uring ring and
+sets the diagnostic flag visible via `--io-uring-status`.
+
+## 3. Rootless Pods and the `--no-io-uring-sqpoll` opt-out
+
+Most production Kubernetes clusters run Pods rootless (no container
+root, no extra Linux capabilities by default). In that mode:
+
+- `securityContext.capabilities.add: ["SYS_NICE"]` is rejected by the
+  cluster's Pod Security Admission policy.
+- Without `SYS_NICE`, `IORING_SETUP_SQPOLL` returns `EPERM` and
+  oc-rsync transparently builds a regular ring.
+- Some seccomp profiles block `io_uring_setup` entirely, in which case
+  oc-rsync falls back to standard buffered I/O.
+
+There is a third option for clusters that disallow `SYS_NICE` but still
+want io_uring acceleration:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oc-rsync-no-sqpoll
+spec:
+  containers:
+    - name: rsync
+      image: ghcr.io/example/oc-rsync:latest
+      args:
+        - "--no-io-uring-sqpoll"
+        - "src/"
+        - "dst/"
+      # No extra capabilities required.
+```
+
+`--no-io-uring-sqpoll` keeps io_uring on for file and socket I/O,
+including BGID-based buffer rings, registered buffers, file
+registration, and zero-copy socket sends when supported. Only the
+`IORING_SETUP_SQPOLL` flag is suppressed. This makes the runtime
+behaviour identical to what you would observe in a rootless Pod
+**before** the EPERM fallback kicks in: the kthread is never requested
+in the first place.
+
+### Why not just run as privileged?
+
+Running `securityContext.privileged: true` grants every capability and
+disables most isolation. It is the cluster equivalent of `--privileged`
+on Podman/Docker and is strongly discouraged for production workloads.
+The `--no-io-uring-sqpoll` flag gives the same throughput tradeoff
+(lose SQPOLL, keep everything else) without weakening the security
+posture.
+
+### Tradeoffs vs `--cap-add SYS_NICE`
+
+| Mode | Pod requirements | SQPOLL active | Other io_uring features | When to use |
+|------|------------------|---------------|------------------------|-------------|
+| `--io-uring` + `SYS_NICE` | `securityContext.capabilities.add: ["SYS_NICE"]` and a permissive PSA profile | Yes | Yes | Trusted clusters where you control the security profile and the workload is throughput-bound |
+| `--no-io-uring-sqpoll` | None | No | Yes | Rootless Pods, baseline / restricted PSA profiles, audit-restricted clusters |
+| `--io-uring` (default `Auto`) without `SYS_NICE` | None | Attempted, falls back on `EPERM` | Yes | Trusted but inconsistent cluster security profiles; relies on the kernel reject path |
+| `--no-io-uring` | None | No | No (standard buffered I/O) | Debugging, container runtimes that block `io_uring_setup` entirely |
+
+Quantitative numbers comparing rootless throughput with and without
+SQPOLL on K8s are tracked separately and will be added once the
+in-container benchmark harness lands.
+
+## 4. Daemon-as-Pod deployment
+
+Running the daemon as a Pod is supported when you want clients outside
+the cluster to push or pull through `rsync://` URLs. The minimum
+manifest is a `Deployment` with a `Service` that exposes the daemon's
+listening port (873/tcp by default).
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oc-rsyncd
+  labels:
+    app: oc-rsyncd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oc-rsyncd
+  template:
+    metadata:
+      labels:
+        app: oc-rsyncd
+    spec:
+      containers:
+        - name: daemon
+          image: ghcr.io/example/oc-rsync:latest
+          command: ["oc-rsync"]
+          args:
+            - "--daemon"
+            - "--no-detach"
+            - "--config=/etc/oc-rsyncd.conf"
+            - "--no-io-uring-sqpoll"
+          ports:
+            - name: rsync
+              containerPort: 873
+          volumeMounts:
+            - name: config
+              mountPath: /etc/oc-rsyncd.conf
+              subPath: oc-rsyncd.conf
+              readOnly: true
+            - name: data
+              mountPath: /srv/rsync
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: config
+          configMap:
+            name: oc-rsyncd-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: rsync-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oc-rsyncd
+spec:
+  selector:
+    app: oc-rsyncd
+  ports:
+    - name: rsync
+      port: 873
+      targetPort: 873
+```
+
+The daemon manifest pairs the rootless `securityContext` with
+`--no-io-uring-sqpoll` so the io_uring fast path stays active without
+requesting `CAP_SYS_NICE`. Add a `NetworkPolicy` to restrict ingress to
+the client CIDR; external rsync over TLS belongs behind an stunnel
+sidecar (see [`daemon-tls.md`](daemon-tls.md) for native TLS or the
+external-terminator recipes).
+
+## 5. Pod Security Standards / Pod Security Admission
+
+Kubernetes 1.25+ ships Pod Security Admission (PSA) with three
+profiles: `privileged`, `baseline`, and `restricted`. The interaction
+with oc-rsync's io_uring features is:
+
+| PSA Profile | `CAP_SYS_NICE` available | Default seccomp behaviour | Recommended flag |
+|-------------|--------------------------|---------------------------|------------------|
+| `restricted` | No (capabilities must be dropped) | `RuntimeDefault` profile permits `io_uring_setup` on most runtimes | `--no-io-uring-sqpoll` |
+| `baseline` | Yes if requested in pod spec | `RuntimeDefault` permits `io_uring_setup` | `--io-uring` if `SYS_NICE` is added, else `--no-io-uring-sqpoll` |
+| `privileged` | Yes (no admission constraint) | No seccomp filter | `--io-uring` |
+
+For namespaces labelled `pod-security.kubernetes.io/enforce: restricted`
+the pod spec MUST NOT include `securityContext.capabilities.add` -
+admission rejects it. `--no-io-uring-sqpoll` is the correct choice
+because it requires no capabilities.
+
+OPA Gatekeeper, Kyverno, and similar policy engines apply their own
+constraints. If your cluster blocks `SYS_NICE` cluster-wide via a
+custom policy, the `--no-io-uring-sqpoll` flag is the only path to
+io_uring acceleration short of relaxing the policy.
+
+## 6. Verifying the active io_uring tier
+
+After deploying, exec into the pod and run:
+
+```bash
+kubectl exec -it <pod> -- oc-rsync --io-uring-status
+```
+
+Example output inside a rootless Pod with `--no-io-uring-sqpoll`:
+
+```text
+io_uring capability matrix:
+
+  compiled in:        yes
+  platform:           linux
+  kernel version:     6.1
+  available:          yes
+  supported ops:      48
+  pbuf_ring:          yes (kernel 5.19+)
+  sqpoll fell back:   no
+  sqpoll opt-out:     yes (--no-io-uring-sqpoll)
+
+  feature gates:
+    io_uring:             on
+    iouring-data-reads:   on
+    iouring-send-zc:      on
+```
+
+`sqpoll fell back: no` together with `sqpoll opt-out: yes
+(--no-io-uring-sqpoll)` is the expected outcome under the opt-out: the
+kthread was never requested, so there is nothing to fall back from.
+Contrast this with the default `Auto` policy in the same environment,
+which would show `sqpoll fell back: yes (CAP_SYS_NICE likely missing)`
+after the EPERM reject and `sqpoll opt-out: no`.
+
+## 7. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `Pod admission denied: capability "SYS_NICE" not allowed` | PSA `restricted` or custom policy | Drop `capabilities.add` and add `--no-io-uring-sqpoll` to the args |
+| `--io-uring-status` reports `available: no` | seccomp profile blocks `io_uring_setup` | Use a runtime/profile that permits it, or accept the standard I/O fallback |
+| `available: yes` but `sqpoll fell back: yes` | `Auto` policy and no `CAP_SYS_NICE` | Add `--no-io-uring-sqpoll` for a clean opt-out, or grant `SYS_NICE` |
+| Daemon Pod fails liveness check on first connection | Read-only root filesystem prevents temp-file commit | Mount a writable `emptyDir` at `/tmp` or use `--inplace` |
+| Throughput much lower than bare-metal benchmark | Standard I/O fallback engaged | Check the seccomp profile; if io_uring is genuinely unavailable, accept it |


### PR DESCRIPTION
## Summary

- Adds a fourth `IoUringPolicy` variant (`SqpollOff`) wired to a new `--no-io-uring-sqpoll` flag; keeps io_uring active for file and socket I/O but suppresses `IORING_SETUP_SQPOLL` via a process-wide gate that `build_ring()` and the session-pool ring builder consult, so rootless containers and Kubernetes Pods that cannot grant `CAP_SYS_NICE` get a deterministic opt-out instead of relying on the kernel `EPERM` fallback.
- Adds `docs/deployment/kubernetes.md` covering Pod manifests for SQPOLL-enabled and SQPOLL-suppressed workloads, daemon-as-Pod deployment, Pod Security Admission interactions, and the `SYS_NICE` vs `--no-io-uring-sqpoll` tradeoff table.
- Extends `docs/deployment/container-io-uring.md` (IKV-F.6) with a K8s rootless-opt-out subsection and adds the new flag to the deployment-flag reference table.
- Surfaces the gate state in `--io-uring-status` (new `sqpoll opt-out:` line) and the disk-I/O `-vv` debug log so operators can confirm the policy took effect.

Bundles SQP-K8S.1 / .3 / .4 (#4004 / #4006 / #4007). The rootless throughput bench (SQP-K8S.2) requires container access and is deferred to a follow-up PR.

## Test plan

- [ ] CLI parse unit: `--no-io-uring-sqpoll` parses to `IoUringPolicy::SqpollOff` and keeps `is_io_uring_active()` true (`crates/cli/src/frontend/arguments/tests.rs::option_values`).
- [ ] CLI parse unit: `--no-io-uring --no-io-uring-sqpoll` resolves to `SqpollOff` (last-wins via `overrides_with`).
- [ ] CLI parse unit: default policy is `Auto`.
- [ ] fast_io integration: `set_sqpoll_disabled_by_policy` flips the process-wide gate and the gate stays set across factory dispatch (`crates/fast_io/tests/sqpoll_policy_gate.rs`).
- [ ] fast_io integration (Linux + `io_uring` feature): `writer_from_file` with `IoUringPolicy::SqpollOff` returns a writer without panicking once the gate is set.
- [ ] CI fmt + clippy + nextest matrices (Linux, Linux musl, macOS, Windows) verify cross-platform parity; the new policy variant has stub coverage in `io_uring_stub/config.rs` so non-Linux builds keep `set_sqpoll_disabled_by_policy` as a no-op.
