### PR TITLE
docs(packaging): add AppArmor profile + SELinux policy templates for oc-rsyncd

### DIFF
--- a/contrib/security/README.md
+++ b/contrib/security/README.md
@@ -1,0 +1,113 @@
+# LSM profile templates for oc-rsyncd
+
+This directory ships AppArmor and SELinux templates for the `oc-rsyncd` daemon. They are starting points for distribution packagers and site operators, not strict requirements. Operators are expected to extend the module-root and tmpdir stanzas to match their deployment.
+
+These templates compose with the `--features landlock` defense-in-depth layer documented in [docs/packaging/landlock-feature-guidance.md](../../docs/packaging/landlock-feature-guidance.md). Landlock is purely additive and stacks with both AppArmor and SELinux.
+
+## AppArmor (Ubuntu LTS, openSUSE, Debian)
+
+File: `usr.sbin.oc-rsyncd.apparmor`
+
+### Install
+
+```sh
+sudo cp usr.sbin.oc-rsyncd.apparmor /etc/apparmor.d/usr.sbin.oc-rsyncd
+sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.oc-rsyncd
+```
+
+### Verify
+
+```sh
+sudo aa-status | grep oc-rsyncd
+```
+
+The profile should appear in the "profiles are in enforce mode" list.
+
+### Customize
+
+Before reloading, edit the profile and add the module roots your `oc-rsyncd.conf` exposes. The shipped template includes commented examples:
+
+```
+# /srv/backups/** rw,
+# /var/lib/oc-rsync-modules/** rw,
+# /tmp/oc-rsync-stage/** rw,
+```
+
+Uncomment and adjust to match your `path =` lines.
+
+### Troubleshooting
+
+If the daemon hits a permission denied that does not appear in `oc-rsyncd.log`, check the kernel audit log:
+
+```sh
+sudo journalctl -k --grep="apparmor.*DENIED.*oc-rsyncd"
+```
+
+Add the missing path to the profile and reload with `apparmor_parser -r`.
+
+## SELinux (RHEL, Fedora, CentOS Stream)
+
+Files: `oc_rsyncd.te`, `oc_rsyncd.fc`, `oc_rsyncd.if`
+
+### Build
+
+Install the SELinux policy development tooling first:
+
+```sh
+sudo dnf install selinux-policy-devel
+```
+
+Then build the policy module:
+
+```sh
+make -f /usr/share/selinux/devel/Makefile oc_rsyncd.pp
+```
+
+### Install
+
+```sh
+sudo semodule -i oc_rsyncd.pp
+sudo chcon -t oc_rsyncd_exec_t /usr/sbin/oc-rsyncd
+```
+
+If the binary lives elsewhere (for example `/usr/local/sbin/oc-rsyncd` from a source build), edit `oc_rsyncd.fc` to match before building.
+
+### Verify
+
+```sh
+ls -Z /usr/sbin/oc-rsyncd
+sudo semodule -l | grep oc_rsyncd
+```
+
+The first command should show `oc_rsyncd_exec_t`; the second should list `oc_rsyncd` as an installed module.
+
+### Customize
+
+The template grants read/write on `rsync_data_t`, which is the existing label used by upstream rsync. Run
+
+```sh
+sudo semanage fcontext -a -t rsync_data_t '/srv/backups(/.*)?'
+sudo restorecon -Rv /srv/backups
+```
+
+to apply the label to your module roots. Repeat for each `path =` directory in `oc-rsyncd.conf`.
+
+### Troubleshooting
+
+If the daemon hits an AVC denial, capture it:
+
+```sh
+sudo ausearch -m AVC -c oc-rsyncd --start recent
+```
+
+Generate a supplemental policy stanza with `audit2allow` and review it before installing:
+
+```sh
+sudo ausearch -m AVC -c oc-rsyncd --start recent | audit2allow -M oc_rsyncd_local
+sudo semodule -i oc_rsyncd_local.pp
+```
+
+## Cross-references
+
+- [docs/packaging/landlock-feature-guidance.md](../../docs/packaging/landlock-feature-guidance.md) - Landlock build/runtime guidance for the same distro audience.
+- Upstream rsync ships no AppArmor or SELinux templates of its own, so these files do not have a one-to-one counterpart in `target/interop/upstream-src/rsync-3.4.4/packaging/`. The `rsync_data_t` SELinux label referenced in `oc_rsyncd.te` is provided by the base `selinux-policy` package and is the same label upstream `rsync` uses.

--- a/contrib/security/oc_rsyncd.fc
+++ b/contrib/security/oc_rsyncd.fc
@@ -1,0 +1,1 @@
+/usr/sbin/oc-rsyncd  --  gen_context(system_u:object_r:oc_rsyncd_exec_t,s0)

--- a/contrib/security/oc_rsyncd.if
+++ b/contrib/security/oc_rsyncd.if
@@ -1,0 +1,15 @@
+## <summary>oc-rsyncd daemon - file synchronization service.</summary>
+##
+## <desc>
+##   <p>
+##     This interface file is intentionally minimal. The oc_rsyncd
+##     policy module defines its own domain (oc_rsyncd_t) and does not
+##     currently export interfaces for other domains to call.
+##   </p>
+##   <p>
+##     Distributions or site operators that need to grant other domains
+##     access to oc-rsyncd resources should add interface stanzas here
+##     (e.g. oc_rsyncd_read_config, oc_rsyncd_admin) following the
+##     conventions in /usr/share/selinux/devel/include/.
+##   </p>
+## </desc>

--- a/contrib/security/oc_rsyncd.te
+++ b/contrib/security/oc_rsyncd.te
@@ -1,0 +1,35 @@
+# SELinux type-enforcement policy for oc-rsyncd daemon.
+# Compatible with upstream rsync's selinux policy.
+# Build: make -f /usr/share/selinux/devel/Makefile oc_rsyncd.pp
+# Install: semodule -i oc_rsyncd.pp
+# Activate: chcon -t oc_rsyncd_exec_t /usr/sbin/oc-rsyncd
+
+policy_module(oc_rsyncd, 1.0.0)
+
+require {
+    type rsync_data_t;
+    attribute file_type;
+    class capability { net_bind_service chown };
+}
+
+# Define oc-rsyncd domain
+type oc_rsyncd_t;
+type oc_rsyncd_exec_t;
+init_daemon_domain(oc_rsyncd_t, oc_rsyncd_exec_t)
+
+# Allow oc-rsyncd to bind to rsync_port_t (873)
+corenet_tcp_bind_generic_node(oc_rsyncd_t)
+corenet_tcp_bind_rsync_port(oc_rsyncd_t)
+
+# Allow read of config files
+files_read_etc_files(oc_rsyncd_t)
+
+# Allow read/write of module data (uses upstream rsync's data type)
+allow oc_rsyncd_t rsync_data_t:file rw_file_perms;
+allow oc_rsyncd_t rsync_data_t:dir rw_dir_perms;
+
+# Allow chown for --chown module configs
+allow oc_rsyncd_t self:capability { net_bind_service chown };
+
+# Logging
+logging_send_syslog_msg(oc_rsyncd_t)

--- a/contrib/security/usr.sbin.oc-rsyncd.apparmor
+++ b/contrib/security/usr.sbin.oc-rsyncd.apparmor
@@ -1,0 +1,44 @@
+# AppArmor profile for oc-rsyncd daemon
+# Install: cp this file to /etc/apparmor.d/usr.sbin.oc-rsyncd
+#         then run: sudo apparmor_parser -r /etc/apparmor.d/usr.sbin.oc-rsyncd
+# Verify: sudo aa-status | grep oc-rsyncd
+
+#include <tunables/global>
+
+/usr/sbin/oc-rsyncd {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+
+  # Bind to the configured rsync port (default 873)
+  capability net_bind_service,
+
+  # Read configuration
+  /etc/rsyncd.conf r,
+  /etc/oc-rsyncd.conf r,
+  /etc/oc-rsyncd.secrets r,
+  /etc/oc-rsyncd.d/** r,
+
+  # PID file
+  /run/oc-rsyncd.pid rwk,
+  /var/run/oc-rsyncd.pid rwk,
+
+  # Log files
+  /var/log/oc-rsyncd.log w,
+  /var/log/rsyncd.log w,
+
+  # Network socket
+  network inet stream,
+  network inet6 stream,
+
+  # Module roots - operators add their own here, e.g.:
+  # /srv/backups/** rw,
+  # /var/lib/oc-rsync-modules/** rw,
+  # /tmp/oc-rsync-stage/** rw,
+
+  # Standard tmpdir for partial files
+  /tmp/** rw,
+
+  # Self-introspection (for --lsm-status if shipped)
+  /sys/kernel/security/lsm r,
+  /proc/self/status r,
+}

--- a/docs/packaging/landlock-feature-guidance.md
+++ b/docs/packaging/landlock-feature-guidance.md
@@ -91,6 +91,22 @@ cargo build --release --bin oc-rsync --no-default-features \
 
 Adjust the explicit feature list to whatever else the distro normally enables. The SEC-1 `*at` syscall chain remains the sole defense in that case; the daemon is still hardened against the CVE-2026-29518 / CVE-2026-43619 TOCTOU symlink race class, just without the kernel-enforced second layer.
 
+## AppArmor + SELinux templates
+
+Landlock is stackable with classic LSMs. For distros where AppArmor (Ubuntu LTS, openSUSE, Debian) or SELinux (RHEL, Fedora, CentOS Stream) is the primary mandatory access control layer, ship the templates from `contrib/security/` alongside the binary:
+
+| Template | Path | Audience |
+|----------|------|----------|
+| AppArmor profile | [`contrib/security/usr.sbin.oc-rsyncd.apparmor`](../../contrib/security/usr.sbin.oc-rsyncd.apparmor) | AppArmor-first distros |
+| SELinux type enforcement | [`contrib/security/oc_rsyncd.te`](../../contrib/security/oc_rsyncd.te) | SELinux-enforcing distros |
+| SELinux file contexts | [`contrib/security/oc_rsyncd.fc`](../../contrib/security/oc_rsyncd.fc) | SELinux-enforcing distros |
+| SELinux interfaces | [`contrib/security/oc_rsyncd.if`](../../contrib/security/oc_rsyncd.if) | SELinux-enforcing distros |
+| Install + verify guide | [`contrib/security/README.md`](../../contrib/security/README.md) | Packagers + ops |
+
+These are templates, not strict requirements. Operators MUST customize the module-root stanzas to match the `path =` entries in their `oc-rsyncd.conf`. The templates leave the module roots commented out by default so a fresh install enforces only the configuration, log, and PID-file paths.
+
+The SELinux template reuses the `rsync_data_t` label shipped by the base `selinux-policy` package, so it composes with any pre-labelled module trees the host already exposes to upstream `rsync`.
+
 ## Verifying the engaged ABI on a built binary
 
 Run the daemon at info-level logging against a throwaway module and grep for the Landlock startup line:


### PR DESCRIPTION
## Summary

- Adds `contrib/security/usr.sbin.oc-rsyncd.apparmor`: AppArmor profile template for the `oc-rsyncd` daemon targeted at AppArmor-first distros (Ubuntu LTS, openSUSE, Debian). Grants config/log/PID-file/port-873/inet+inet6 access; leaves module-root stanzas as commented placeholders the operator extends.
- Adds `contrib/security/oc_rsyncd.te` + `oc_rsyncd.fc` + `oc_rsyncd.if`: SELinux policy module for RHEL, Fedora, CentOS Stream. Defines `oc_rsyncd_t` / `oc_rsyncd_exec_t`, binds the standard `rsync_port_t`, reuses the existing `rsync_data_t` label so pre-labelled module trees keep working without relabelling.
- Adds `contrib/security/README.md`: install/verify procedures for both profiles (`apparmor_parser -r`, `aa-status`, `semodule -i`, `chcon`, `audit2allow` troubleshooting) plus customization guidance for module roots.
- Cross-links the new templates from `docs/packaging/landlock-feature-guidance.md` so packagers reading the existing companion doc discover them; notes Landlock stacks cleanly with both AppArmor and SELinux.

## Test plan

- [ ] CI build green (config templates + docs only; no code changes, no behavior changes).
- [ ] AppArmor profile parses on Ubuntu 24.04 / openSUSE Tumbleweed with `apparmor_parser -r` (operator-side, post-merge).
- [ ] SELinux module builds via `make -f /usr/share/selinux/devel/Makefile oc_rsyncd.pp` on Fedora / CentOS Stream (operator-side, post-merge).