### PR TITLE
feat(metadata): wire ReparseKind classification into Windows FileEntry generation

### DIFF
--- a/crates/metadata/src/windows/mod.rs
+++ b/crates/metadata/src/windows/mod.rs
@@ -13,10 +13,13 @@
 //! - [`reparse`] classifies NTFS reparse points into their concrete kinds
 //!   (symlink, junction, mount-point, OneDrive/cloud placeholder, AF_UNIX
 //!   socket, or an opaque tag value) so higher layers can decide how to
-//!   transfer each kind without losing information.
+//!   transfer each kind without losing information. Re-exports
+//!   [`reparse::classify_path`] for callers (transfer-side flist
+//!   generation, audit tools) that hold a `Path` rather than a raw
+//!   `FILE_FLAG_OPEN_REPARSE_POINT` handle.
 
 /// NTFS reparse-point classifier (symlink, junction, mount-point,
 /// cloud placeholder, WSL `AF_UNIX` socket, opaque tag).
 pub mod reparse;
 
-pub use reparse::{ReparseKind, classify_reparse_point};
+pub use reparse::{ReparseKind, classify_path, classify_reparse_point};

--- a/crates/metadata/src/windows/reparse.rs
+++ b/crates/metadata/src/windows/reparse.rs
@@ -34,12 +34,22 @@
 
 use std::ffi::OsString;
 use std::io;
-use std::os::windows::ffi::OsStringExt;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::os::windows::io::AsRawHandle;
+use std::path::Path;
 
-use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING,
+};
 use windows::Win32::System::IO::DeviceIoControl;
 use windows::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
+
+/// `FILE_READ_ATTRIBUTES` access right (`winnt.h`). The `windows` crate
+/// exposes this only via `FILE_ACCESS_RIGHTS`; pinning the value locally
+/// avoids the version-dependent re-export and keeps the call site small.
+const FILE_READ_ATTRIBUTES: u32 = 0x0080;
 
 /// Maximum size of a reparse data buffer, per `winnt.h`.
 ///
@@ -209,6 +219,93 @@ pub fn classify_reparse_point(handle: &impl AsRawHandle) -> io::Result<ReparseKi
     }
 
     Ok(classify_from_buffer(&buffer[..returned]))
+}
+
+/// Classify the reparse-point at `path` by opening it with
+/// `FILE_FLAG_OPEN_REPARSE_POINT` and delegating to
+/// [`classify_reparse_point`].
+///
+/// Intended for transfer-side flist generation on Windows, where the caller
+/// already knows from `FILE_ATTRIBUTE_REPARSE_POINT` (or a previous
+/// `std::fs::FileType::is_symlink()` probe) that the entry is some flavour
+/// of reparse point. Centralises the `CreateFileW` call so consumers do not
+/// duplicate the FFI surface or the safety reasoning.
+///
+/// # Errors
+///
+/// Surfaces the underlying `CreateFileW` or `DeviceIoControl` failure as
+/// [`io::Error`] via [`io::Error::last_os_error`]. Callers that want to
+/// treat classification failures as non-fatal (for example, falling back
+/// to a plain symlink emission) should match on the error and continue.
+///
+/// # Cygwin parity
+///
+/// Upstream rsync runs through Cygwin on Windows and never opens a reparse
+/// point directly; this helper exists so the native `oc-rsync` build can
+/// distinguish junctions, mount-points, and cloud placeholders that Cygwin
+/// folds into POSIX symbolic links.
+pub fn classify_path(path: &Path) -> io::Result<ReparseKind> {
+    let handle = open_reparse_handle(path)?;
+    classify_reparse_point(&handle)
+}
+
+/// RAII wrapper that calls [`CloseHandle`] on drop.
+///
+/// The handle is opened with [`open_reparse_handle`] and exposed through
+/// [`AsRawHandle`] so [`classify_reparse_point`] can borrow it without an
+/// allocation.
+struct ReparseHandle(HANDLE);
+
+impl AsRawHandle for ReparseHandle {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        self.0.0 as std::os::windows::io::RawHandle
+    }
+}
+
+impl Drop for ReparseHandle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was returned by `CreateFileW` in
+        // [`open_reparse_handle`] and has not been closed elsewhere; the
+        // guard owns the handle uniquely for its lifetime.
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+/// Open `path` with `FILE_FLAG_OPEN_REPARSE_POINT` so the reparse data is
+/// returned by `DeviceIoControl` instead of being followed.
+///
+/// `FILE_FLAG_BACKUP_SEMANTICS` is set so directory reparse points (the
+/// common `mklink /d` and `mklink /j` shapes) can be opened with the same
+/// call. Read access is limited to `FILE_READ_ATTRIBUTES`; sharing is left
+/// permissive (`FILE_SHARE_READ | FILE_SHARE_WRITE`) so we never block a
+/// concurrent enumerator.
+fn open_reparse_handle(path: &Path) -> io::Result<ReparseHandle> {
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // SAFETY: `wide` is a null-terminated UTF-16 slice owned for the
+    // duration of the call. The combination of `FILE_FLAG_OPEN_REPARSE_POINT`
+    // and `FILE_FLAG_BACKUP_SEMANTICS` is the documented recipe for opening
+    // an arbitrary reparse-point entry without following it; no input or
+    // output buffers are passed besides the path.
+    let handle = unsafe {
+        CreateFileW(
+            windows::core::PCWSTR(wide.as_ptr()),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            None,
+        )
+    };
+    let handle = handle.map_err(|_| io::Error::last_os_error())?;
+    Ok(ReparseHandle(handle))
 }
 
 /// Classify a reparse-point from an in-memory `REPARSE_DATA_BUFFER` byte
@@ -960,9 +1057,9 @@ mod integration_tests {
     //! runtime when the test environment lacks the privilege rather than
     //! failing the build.
 
-    use super::*;
+    use super::{FILE_READ_ATTRIBUTES, *};
     use std::fs;
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::OsStrExt as _;
     use std::path::Path;
     use std::process::Command;
 
@@ -971,8 +1068,6 @@ mod integration_tests {
         CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
         FILE_SHARE_WRITE, OPEN_EXISTING,
     };
-
-    const FILE_READ_ATTRIBUTES: u32 = 0x0080;
 
     struct OwnedHandle(HANDLE);
 

--- a/crates/metadata/tests/windows_reparse_classify_path.rs
+++ b/crates/metadata/tests/windows_reparse_classify_path.rs
@@ -1,0 +1,114 @@
+//! End-to-end coverage for the `metadata::windows::classify_path` helper
+//! (WPC-8'.9): the public path-based wrapper that opens a reparse-point
+//! handle internally and runs the classifier without forcing callers to
+//! handle the `CreateFileW` FFI surface themselves.
+//!
+//! The helper is the boundary the transfer crate uses when populating
+//! `FileEntry` values on Windows; this integration test materialises real
+//! NTFS reparse points so a regression in the open/classify glue surfaces
+//! without depending on the transfer crate's test bring-up.
+//!
+//! `mklink /j` runs without elevation on Windows 10+, so the junction case
+//! is unconditional. `mklink /d` (directory symlink) and `mountvol`
+//! (volume mount-point) require admin or Windows 10 developer mode and
+//! are downgraded to runtime skips when the privilege is missing,
+//! mirroring the in-tree integration tests shipped with the classifier
+//! itself.
+
+#![cfg(target_os = "windows")]
+
+use std::fs;
+use std::process::Command;
+
+use metadata::windows::{ReparseKind, classify_path};
+
+/// Returns `true` when `mklink` succeeded; `false` when the test should
+/// be skipped because `cmd.exe` is unavailable or the privilege to create
+/// the reparse point is missing. Mirrors the pattern in
+/// `crates/metadata/src/windows/reparse.rs` integration tests so a
+/// non-admin CI runner stays green without flaking the suite.
+fn try_mklink(args: &[&str]) -> bool {
+    match Command::new("cmd").args(args).status() {
+        Ok(s) => s.success(),
+        Err(_) => false,
+    }
+}
+
+/// Plain (non-reparse) entries must surface as `io::Error` rather than
+/// being silently classified, so the caller can short-circuit on the
+/// expected `ERROR_NOT_A_REPARSE_POINT` (4390) from `DeviceIoControl` and
+/// skip the symlink emission branch entirely.
+#[test]
+fn regular_file_returns_not_a_reparse_point_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("plain.txt");
+    fs::write(&path, b"data").expect("write");
+
+    let err = classify_path(&path).expect_err("regular file must error");
+    let raw = err.raw_os_error().unwrap_or(0);
+    assert!(
+        raw == 4390 || raw == 0,
+        "expected ERROR_NOT_A_REPARSE_POINT (4390) for plain file, got {raw} ({err})"
+    );
+}
+
+/// `mklink /j` produces an `IO_REPARSE_TAG_MOUNT_POINT` reparse point
+/// whose substitute-name points at a directory; the classifier must
+/// disambiguate that as a directory junction rather than a volume
+/// mount-point.
+#[test]
+fn junction_classifies_as_junction() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join("target");
+    let junction = tmp.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+
+    let (Some(j), Some(t)) = (junction.to_str(), target.to_str()) else {
+        return; // non-UTF8 tempdir; skip rather than fail
+    };
+    if !try_mklink(&["/c", "mklink", "/j", j, t]) {
+        return; // privilege missing or cmd.exe unavailable; skip
+    }
+
+    let kind = classify_path(&junction).expect("classify junction");
+    assert_eq!(kind, ReparseKind::Junction);
+}
+
+/// `mklink /d` produces an `IO_REPARSE_TAG_SYMLINK` reparse point on a
+/// directory; the classifier must surface it as `Symlink` (the most
+/// common shape that round-trips through every receiver).
+#[test]
+fn directory_symlink_classifies_as_symlink() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join("target");
+    let link = tmp.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+
+    let (Some(l), Some(t)) = (link.to_str(), target.to_str()) else {
+        return;
+    };
+    if !try_mklink(&["/c", "mklink", "/d", l, t]) {
+        // `mklink /d` requires admin / developer mode; downgrade to skip
+        // rather than failing the suite on a non-admin CI runner.
+        return;
+    }
+
+    let kind = classify_path(&link).expect("classify symlink");
+    assert_eq!(kind, ReparseKind::Symlink);
+}
+
+/// `classify_path` must reject a missing path with `NotFound`; we surface
+/// the underlying `CreateFileW` failure so callers can decide whether to
+/// retry or drop the entry from the transfer.
+#[test]
+fn missing_path_returns_not_found_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("does-not-exist");
+
+    let err = classify_path(&missing).expect_err("missing path must error");
+    assert!(
+        err.kind() == std::io::ErrorKind::NotFound
+            || err.raw_os_error().map_or(false, |n| n == 2 || n == 3),
+        "expected NotFound for missing path, got {err}"
+    );
+}

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -39,6 +39,26 @@ impl GeneratorContext {
 
         let file_type = metadata.file_type();
 
+        // Native Windows reparse-point detection. `std::fs::FileType::is_symlink`
+        // only returns `true` for `IO_REPARSE_TAG_SYMLINK` and
+        // `IO_REPARSE_TAG_MOUNT_POINT`; tags like `IO_REPARSE_TAG_AF_UNIX`,
+        // `IO_REPARSE_TAG_ONEDRIVE`, and the cloud-files range therefore slip
+        // through and would otherwise serialise as plain regular files. The
+        // `FILE_ATTRIBUTE_REPARSE_POINT` attribute catches every reparse
+        // shape; we route the entry through the symlink branch so the WPC-8
+        // classifier (`metadata::windows::reparse::classify_path`) governs the
+        // wire emission rather than the surface `FileType` probe.
+        //
+        // Upstream rsync runs through Cygwin on Windows and treats every
+        // reparse point as a POSIX symbolic link; this mirror keeps the wire
+        // output compatible without losing the classifier's distinction.
+        #[cfg(windows)]
+        let is_reparse_point = {
+            use std::os::windows::fs::MetadataExt;
+            const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+            metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        };
+
         // upstream: xattrs.c:get_stat_xattr() - when `--fake-super` is in
         // effect, a previous fake-super receiver may have recorded the real
         // ownership, permissions, and device numbers in the source file's
@@ -50,7 +70,29 @@ impl GeneratorContext {
         #[cfg(unix)]
         let fake_super_override = self.fake_super_override(full_path, metadata);
 
-        let mut entry = if file_type.is_file() {
+        // Windows reparse-point branch. Run before the regular-file probe so
+        // non-symlink reparse points (cloud placeholders, AF_UNIX sockets,
+        // opaque vendor tags) do not slip into the regular-file emission.
+        // Junctions and mount-points already pass through
+        // `file_type.is_symlink()`, but routing them here too lets the
+        // classifier choose the wire shape for every flavour in one place.
+        #[cfg(windows)]
+        let reparse_kind = if is_reparse_point {
+            metadata::windows::classify_path(full_path).ok()
+        } else {
+            None
+        };
+
+        let mut entry = if file_type.is_file() && {
+            #[cfg(windows)]
+            {
+                !is_reparse_point
+            }
+            #[cfg(not(windows))]
+            {
+                true
+            }
+        } {
             #[cfg(unix)]
             let mode = metadata.mode() & 0o7777;
             #[cfg(not(unix))]
@@ -79,7 +121,36 @@ impl GeneratorContext {
             let mode = 0o755;
 
             FileEntry::new_directory(relative_path, mode)
-        } else if file_type.is_symlink() {
+        } else if file_type.is_symlink() || {
+            #[cfg(windows)]
+            {
+                is_reparse_point
+            }
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        } {
+            // upstream: flist.c:readlink_stat() returns the link target as
+            // recorded on disk. On Windows the kernel exposes junctions and
+            // symlinks through `read_link`; cloud placeholders and AF_UNIX
+            // sockets do not have a portable target and we fall back to an
+            // empty path so the receiver materialises a stub link rather than
+            // dropping the entry. The WPC-8 classification is consulted only
+            // to decide whether we trust `read_link` (Symlink/Junction) or
+            // emit an empty target (OneDrive/AfUnix/Other); the on-wire
+            // type is always SYMLINK for Cygwin parity.
+            #[cfg(windows)]
+            let raw_target = match reparse_kind {
+                Some(metadata::windows::ReparseKind::Symlink)
+                | Some(metadata::windows::ReparseKind::Junction)
+                | Some(metadata::windows::ReparseKind::MountPoint)
+                | None => std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from("")),
+                Some(metadata::windows::ReparseKind::OneDrive)
+                | Some(metadata::windows::ReparseKind::AfUnix)
+                | Some(metadata::windows::ReparseKind::Other(_)) => PathBuf::from(""),
+            };
+            #[cfg(not(windows))]
             let raw_target = std::fs::read_link(full_path).unwrap_or_else(|_| PathBuf::from(""));
 
             // upstream: flist.c:222-226 - sender strips the `/rsyncd-munged/`
@@ -910,6 +981,172 @@ mod munge_symlinks_tests {
             Some(Path::new("/rsyncd-munged//etc/passwd")),
             "without `munge symlinks`, the prefix is part of the target and \
              must round-trip verbatim",
+        );
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_reparse_tests {
+    //! Windows reparse-point classification regression tests (WPC-8'.9).
+    //!
+    //! Verifies that `create_entry` routes NTFS reparse points through the
+    //! WPC-8 classifier so junctions, symbolic links, and non-symlink
+    //! reparse points serialise as SYMLINK-class `FileEntry` values
+    //! (matching upstream's Cygwin behaviour) rather than as regular files.
+    //!
+    //! `mklink /j` runs without elevation on Windows 10+; `mklink /d`
+    //! (directory symlink) requires admin or developer mode and is
+    //! downgraded to a runtime skip when the privilege is missing, matching
+    //! the in-tree integration tests that ship with the classifier itself.
+    //!
+    //! Mount-point coverage is left to the classifier-level integration
+    //! tests because `mountvol` requires admin elevation and a free volume
+    //! GUID; the wiring contract under test here is "every reparse-point
+    //! attribute routes through `metadata::windows::classify_path` and lands
+    //! in the symlink branch", which the junction case already verifies
+    //! end-to-end.
+
+    use super::super::super::GeneratorContext;
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use protocol::ProtocolVersion;
+    use protocol::flist::FileType;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn windows_generator() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// Returns `Some(status)` when `mklink` succeeded, `None` when the test
+    /// should be skipped because `cmd.exe` is unavailable or the privilege
+    /// to create the reparse point is missing.
+    fn try_mklink(args: &[&str]) -> Option<()> {
+        let status = Command::new("cmd").args(args).status().ok()?;
+        if status.success() { Some(()) } else { None }
+    }
+
+    /// Regular file: stays Regular, does not flip to Symlink.
+    ///
+    /// Negative control: ensures the reparse-attribute probe does not
+    /// false-positive on non-reparse entries.
+    #[test]
+    fn regular_file_is_classified_as_regular() {
+        let tmp = TempDir::new().expect("tempdir");
+        let path = tmp.path().join("plain.txt");
+        std::fs::write(&path, b"data").expect("write file");
+        let meta = std::fs::symlink_metadata(&path).expect("symlink_metadata");
+
+        let ctx = windows_generator();
+        let entry = ctx
+            .create_entry(&path, PathBuf::from("plain.txt"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.file_type(), FileType::Regular);
+        assert_eq!(entry.size(), 4);
+    }
+
+    /// Directory junction (`mklink /j`): WPC-8 classifies as `Junction`,
+    /// `create_entry` emits a `Symlink` FileEntry whose target is preserved.
+    ///
+    /// Mirrors upstream rsync Cygwin behaviour (every reparse point becomes
+    /// a POSIX symbolic link on the wire) while exercising the wiring that
+    /// PR #5579 + PR #5592 deferred behind the classifier API.
+    #[test]
+    fn junction_is_emitted_as_symlink_entry() {
+        let tmp = TempDir::new().expect("tempdir");
+        let target = tmp.path().join("target");
+        let junction = tmp.path().join("link");
+        std::fs::create_dir(&target).expect("create target dir");
+
+        let junction_str = match junction.to_str() {
+            Some(s) => s,
+            None => return, // non-UTF8 tempdir, skip
+        };
+        let target_str = match target.to_str() {
+            Some(s) => s,
+            None => return,
+        };
+        if try_mklink(&["/c", "mklink", "/j", junction_str, target_str]).is_none() {
+            // junction creation refused (no cmd.exe, or filesystem rejects);
+            // skip rather than fail so non-admin CI runners stay green.
+            return;
+        }
+
+        let meta = std::fs::symlink_metadata(&junction).expect("symlink_metadata");
+        let ctx = windows_generator();
+        let entry = ctx
+            .create_entry(&junction, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(
+            entry.file_type(),
+            FileType::Symlink,
+            "junction must serialise as SYMLINK for Cygwin parity"
+        );
+        let link_target = entry.link_target().cloned().unwrap_or_default();
+        assert!(
+            !link_target.as_os_str().is_empty(),
+            "junction target must be preserved (got empty), \
+             entry={entry:?}"
+        );
+    }
+
+    /// Directory symlink (`mklink /d`): WPC-8 classifies as `Symlink`,
+    /// `create_entry` emits a `Symlink` FileEntry with a non-empty target.
+    ///
+    /// Skipped at runtime when `mklink /d` is refused (requires admin or
+    /// Windows 10 developer mode).
+    #[test]
+    fn directory_symlink_is_emitted_as_symlink_entry() {
+        let tmp = TempDir::new().expect("tempdir");
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("link");
+        std::fs::create_dir(&target).expect("create target dir");
+
+        let link_str = match link.to_str() {
+            Some(s) => s,
+            None => return,
+        };
+        let target_str = match target.to_str() {
+            Some(s) => s,
+            None => return,
+        };
+        if try_mklink(&["/c", "mklink", "/d", link_str, target_str]).is_none() {
+            return; // privilege missing, skip
+        }
+
+        let meta = std::fs::symlink_metadata(&link).expect("symlink_metadata");
+        let ctx = windows_generator();
+        let entry = ctx
+            .create_entry(&link, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.file_type(), FileType::Symlink);
+        let link_target = entry.link_target().cloned().unwrap_or_default();
+        assert!(
+            !link_target.as_os_str().is_empty(),
+            "directory symlink target must be preserved, entry={entry:?}"
         );
     }
 }

--- a/docs/user/windows-support-matrix.md
+++ b/docs/user/windows-support-matrix.md
@@ -88,7 +88,7 @@ Maturity legend:
 | Signal handling (Ctrl+C, Ctrl+Break, console close) | Full | Production | `SetConsoleCtrlHandler` maps CTRL_C / CTRL_CLOSE to shutdown and CTRL_BREAK to graceful exit. SIGHUP-equivalent config reload via named events is not wired. |
 | EH ABI (`windows-gnu-eh`) | Full | Resolved | Zero-cost no-op on MSVC release binaries. Exists only for `x86_64-pc-windows-gnu` cross-compilation via `cargo-zigbuild`. See `docs/audit/win-gc-gnu-eh-abi-status.md` and `docs/audit/win-gd-gnu-eh-release-implications.md`. |
 | Long paths (`\\?\` prefix) | Full | Audited | `\\?\` prefix applied by the path builder for paths exceeding `MAX_PATH`. Audited under WPC-5/WPC-6; see `docs/audit/windows-long-path-support.md`. |
-| Reparse points (junctions, mount points) | Partial | Audited | Non-symlink reparse points classified by tag. Junctions followed like directory symlinks. OneDrive/Cloud Files API placeholders detected but not transparently hydrated. See `docs/audit/windows-reparse-point-classification.md` (WPC-8/WPC-9). |
+| Reparse points (junctions, mount points) | Partial | Shipped, end-to-end wired | Reparse-point classification (WPC-8/WPC-9) is consumed by the transfer-side flist generator: every `FILE_ATTRIBUTE_REPARSE_POINT` entry routes through `metadata::windows::classify_path` and serialises as a SYMLINK-class `FileEntry` for Cygwin parity. Junctions and symbolic links carry their on-disk target; OneDrive / Cloud Files placeholders, WSL `AF_UNIX` sockets, and opaque vendor tags emit an empty target stub. Transparent OneDrive hydration is still out of scope. See `docs/audit/windows-reparse-point-classification.md` (WPC-8/WPC-9). |
 | Case-insensitive FS conflict detection | Full | Audited | Receiver detects source-side name collisions (e.g., `a.txt` vs `A.txt`) before applying the second write. Regression test per WPC-11; see `docs/audit/windows-case-insensitive-conflict-detection.md`. |
 
 ## 3. Known limitations
@@ -218,9 +218,13 @@ into `.github/RELEASE_TEMPLATE.md` under the appropriate heading.
   warning emitted when ADS detected without `-X`.
 - **Long paths (`\\?\`)**: implemented per WPC-5/WPC-6. Paths
   exceeding `MAX_PATH` are prefixed automatically.
-- **Reparse points**: classified by tag per WPC-8/WPC-9. Junctions
-  followed like directory symlinks. Cloud Files placeholders
-  detected but not hydrated.
+- **Reparse points**: classified by tag per WPC-8/WPC-9 and wired
+  end-to-end into transfer-side flist generation. Junctions and
+  symbolic links serialise as SYMLINK-class entries carrying their
+  on-disk target; OneDrive/Cloud Files placeholders, WSL `AF_UNIX`
+  sockets, and opaque vendor tags emit empty-target SYMLINK stubs
+  rather than slipping through as regular files. Transparent
+  on-demand hydration is still out of scope.
 - **EH ABI**: resolved per WIN-G.c/WIN-G.d. The `windows-gnu-eh`
   crate is a zero-cost no-op on MSVC release binaries.
 - **Case-insensitive FS**: collision detection implemented per


### PR DESCRIPTION
## Summary

- Wires the WPC-8 `ReparseKind` classifier (PR #5579) and the WPC-8.b payload parsers (PR #5592) into the transfer-side flist generator on Windows so every `FILE_ATTRIBUTE_REPARSE_POINT` entry serialises as a SYMLINK-class `FileEntry` (matching upstream rsync's Cygwin behaviour) instead of slipping through as a regular file when `std::fs::FileType::is_symlink` reports false (cloud placeholders, WSL `AF_UNIX` sockets, opaque vendor tags).
- Adds a public `metadata::windows::classify_path(path: &Path)` wrapper that owns the `CreateFileW` / `FILE_FLAG_OPEN_REPARSE_POINT` FFI plumbing so the transfer crate does not duplicate the unsafe surface.
- Routes per-kind target handling through the classifier: `Symlink` / `Junction` / `MountPoint` carry the on-disk target via `read_link`; `OneDrive` / `AfUnix` / `Other` emit an empty-target SYMLINK stub so the receiver materialises a placeholder link rather than dropping the entry. Transparent OneDrive hydration is still out of scope and noted as future work.
- Updates `docs/user/windows-support-matrix.md` to mark reparse-point classification as shipped end-to-end rather than at the classifier layer only. Tracks WPC-8'.9 (#3785).

## Test plan

- [ ] CI: `fmt+clippy`
- [ ] CI: `nextest (stable)` across Linux, macOS, Windows, Linux musl
- [ ] Windows runner exercises the new `windows_reparse_tests` integration tests in `crates/transfer/src/generator/file_list/entry.rs` and the new `crates/metadata/tests/windows_reparse_classify_path.rs` end-to-end suite (junction case unconditional, symlink case skipped gracefully without admin / developer mode).
- [ ] Non-Windows runners verify the `#[cfg(target_os = "windows")]`-gated additions compile cleanly and do not regress the existing `fake_super_tests`, `daemon_outgoing_chmod_tests`, and `munge_symlinks_tests` suites.

## Stacking

Based on `feat/wpc-8-reparse-parsers` (PR #5592). Merge order: #5579 -> #5592 -> this PR. The stack is independent of PR #5583 (test fixtures); the integration tests added here use the same inline `mklink` pattern as the classifier's in-tree integration tests so the wiring is exercised without depending on the fixture helpers.