### PR TITLE
docs(transfer): correct spawn_blocking rustdoc that actually uses rayon

### DIFF
--- a/crates/transfer/src/parallel_io.rs
+++ b/crates/transfer/src/parallel_io.rs
@@ -162,10 +162,10 @@ impl ParallelThresholds {
 /// than `min_parallel`, falls back to sequential `Iterator::map` to
 /// avoid dispatch overhead.
 ///
-/// Unlike the previous tokio `spawn_blocking` implementation, rayon's
-/// approach avoids per-item task creation, semaphore management, and
-/// runtime construction overhead. For 10K stat() calls, this eliminates
-/// ~10K task spawns and semaphore acquire/release cycles.
+/// Rayon's work-stealing scheduler avoids per-item task creation, semaphore
+/// management, and runtime construction overhead. For 10K stat() calls, this
+/// keeps dispatch bounded to the rayon pool size rather than spawning one
+/// task per item.
 pub(crate) fn map_blocking<T, R, F>(items: Vec<T>, min_parallel: usize, f: F) -> Vec<R>
 where
     T: Send + 'static,

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -24,8 +24,10 @@ impl ReceiverContext {
     ///
     /// Two-phase approach: directory creation is sequential (cheap, respects
     /// parent-child ordering), metadata application (`chown`/`chmod`/`utimes`)
-    /// runs in parallel via tokio `spawn_blocking` + semaphore when above
-    /// threshold.
+    /// is dispatched through `crate::parallel_io::map_blocking`, which runs on
+    /// rayon's work-stealing pool when the directory count exceeds the
+    /// `ParallelOp::Metadata` threshold and falls back to sequential iteration
+    /// below it.
     ///
     /// Returns a list of metadata errors encountered (path, error message).
     ///

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -29,8 +29,9 @@ impl ReceiverContext {
     /// scans for entries not present in the source list and removes them. Directories
     /// are removed recursively (depth-first).
     ///
-    /// Uses tokio `spawn_blocking` + semaphore for parallel directory scanning when
-    /// directory count exceeds threshold. When `max_delete` is set, an atomic counter
+    /// Uses `crate::parallel_io::map_blocking` (rayon's work-stealing pool) for
+    /// parallel directory scanning when the directory count exceeds the
+    /// `ParallelOp::Deletion` threshold. When `max_delete` is set, an atomic counter
     /// enforces the deletion limit across all parallel workers. Protect/risk filter
     /// rules are evaluated via `FilterChain::allows_deletion()` before each deletion.
     ///


### PR DESCRIPTION
## Summary

- Fix misleading rustdoc on `create_directories`, `delete_extraneous_files`, and `parallel_io::map_blocking` that claimed work was dispatched via tokio `spawn_blocking` + semaphore - the current implementation runs on rayon's work-stealing pool through `parallel_io::map_blocking`.
- Replace stale "previous tokio `spawn_blocking` implementation" historical reference on `map_blocking` with a direct description of what rayon's scheduler does today.
- Preserve every existing `// upstream: <file.c>:<line>` reference verbatim per the CCL series convention.

## Test plan

- [ ] CI build green (docs-only diff; no production code touched).
- [ ] `git diff --stat` shows only `///` rustdoc lines changed in three files.