### PR TITLE
docs(protocol): repair broken rustdoc intra-doc links

### DIFF
--- a/crates/protocol/src/bind/trace.rs
+++ b/crates/protocol/src/bind/trace.rs
@@ -34,7 +34,7 @@ use logging::debug_log;
 /// `"bind() failed: %s (address-family %d)\n"`. `address_family` carries
 /// the raw integer from `resp->ai_family` (typically `AF_INET = 2` or
 /// `AF_INET6 = 10` on Linux). The error string mirrors what upstream
-/// produces via `strerror(errno)`; we use [`io::Error::to_string`] which
+/// produces via `strerror(errno)`; we use `io::Error::to_string` which
 /// resolves to the same OS message text on Unix targets.
 ///
 /// The helper is gated internally on `DebugFlag::Bind` level 1, so

--- a/crates/protocol/src/flist/flat/flist.rs
+++ b/crates/protocol/src/flist/flat/flist.rs
@@ -157,7 +157,7 @@ impl FlatFileList {
     /// Appends a header to the list.
     ///
     /// The caller must have already interned the entry's name and dirname
-    /// strings into this list's [`PathArena`] (via [`paths_mut`]) and set
+    /// strings into this list's [`PathArena`] (via `paths_mut`) and set
     /// the resulting handles on the header before calling `push`. The
     /// header's [`ExtrasRef`](super::header::ExtrasRef) should already
     /// reference a tail in this list's [`ExtrasArena`] (via
@@ -234,8 +234,8 @@ impl FlatFileList {
     /// Records a [`Segment`] boundary at the current end of the header
     /// array, then pushes all `headers` in order. Path handles and extras
     /// refs carried by the headers must already reference this list's
-    /// [`PathArena`] and [`ExtrasArena`] (interned via [`paths_mut`] and
-    /// [`extras_mut`] or [`push_with_extras`] before calling this method).
+    /// [`PathArena`] and [`ExtrasArena`] (interned via `paths_mut` and
+    /// `extras_mut` or `push_with_extras` before calling this method).
     ///
     /// Existing `PathHandle` and `ExtrasRef` values from prior segments
     /// remain valid because all three backing stores are append-only and

--- a/crates/protocol/src/nstr/mod.rs
+++ b/crates/protocol/src/nstr/mod.rs
@@ -4,7 +4,7 @@
 //! emission sites in a single helper module so callers across the
 //! workspace share one byte-for-byte definition of each emission shape.
 //!
-//! See [`trace`] for the producer helpers and upstream-reference notes.
+//! See `trace` for the producer helpers and upstream-reference notes.
 
 pub mod trace;
 

--- a/crates/protocol/src/state/mod.rs
+++ b/crates/protocol/src/state/mod.rs
@@ -26,11 +26,11 @@
 //! - `Negotiation -> FileList` requires both `protocol_version` and `checksum_seed`.
 //! - `FileList -> Transfer` requires `file_count`.
 //! - `Transfer -> Finalize` is always valid and consumes the transfer state.
-//! - `Finalize` is terminal: [`DynamicProtocolState::advance`] is a no-op once
+//! - `Finalize` is terminal: `DynamicProtocolState::advance` is a no-op once
 //!   reached, so callers may invoke it unconditionally.
-//! - [`ProtocolState`] enforces the above at compile time via the typestate
-//!   pattern; [`DynamicProtocolState`] enforces it at runtime via
-//!   [`TransitionError`].
+//! - `ProtocolState` enforces the above at compile time via the typestate
+//!   pattern; `DynamicProtocolState` enforces it at runtime via
+//!   `TransitionError`.
 //!
 //! # Submodules
 //!

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -94,14 +94,14 @@ impl DeleteStats {
 
     /// Reads delete stats from a stream in wire format.
     ///
-    /// Each field is capped at [`MAX_WIRE_DEL_STAT`] to reject unreasonably
+    /// Each field is capped at `MAX_WIRE_DEL_STAT` to reject unreasonably
     /// large values from the wire before they can cause overflow during
     /// accumulation.
     ///
     /// # Errors
     ///
     /// Returns an error if reading from the stream fails or if any field
-    /// exceeds [`MAX_WIRE_DEL_STAT`].
+    /// exceeds `MAX_WIRE_DEL_STAT`.
     pub fn read_from<R: Read>(reader: &mut R) -> io::Result<Self> {
         use crate::varint::read_varint;
 


### PR DESCRIPTION
## Summary

The Pages workflow on master has failed five consecutive times because rustdoc cannot resolve intra-doc links under `-D rustdoc::broken_intra_doc_links`. The protocol crate accounted for nine link errors and two private-link warnings across five files. This PR converts each broken link to backtick-only code formatting so the rendered output is unchanged while rustdoc no longer attempts to resolve the symbol.

## Files fixed

- `crates/protocol/src/bind/trace.rs` — 1 link (`io::Error::to_string`).
- `crates/protocol/src/flist/flat/flist.rs` — 4 links (`paths_mut` x2, `extras_mut`, `push_with_extras`).
- `crates/protocol/src/state/mod.rs` — 4 links (`DynamicProtocolState::advance`, `ProtocolState`, `DynamicProtocolState`, `TransitionError`).
- `crates/protocol/src/nstr/mod.rs` — 1 link (`trace` submodule).
- `crates/protocol/src/stats/delete.rs` — 2 links (`MAX_WIRE_DEL_STAT` private-const refs from `read_from` public docs).

12 links total.

## Approach

- Per the codebase convention "Module doc `[`TypeName`]` links don't resolve when the type is re-exported through `lib.rs`. Use backtick-only `` `TypeName` `` instead of doc links" - applied to module-level re-exports in `state/mod.rs` and the submodule reference in `nstr/mod.rs`.
- Bare `[name]` doc links inside method docs (`flist.rs` lines 160, 237-238) replaced with backtick-only since the surrounding context already uses `[name](Self::name)` form elsewhere in the same file where resolution does work.
- Cross-crate `[io::Error::to_string]` is flaky in intra-doc-links, so backtick-only.
- Private `MAX_WIRE_DEL_STAT` referenced from public `read_from` docs would surface as a dangling link on the rustdoc page; backtick-only avoids that.

No `#[allow(rustdoc::broken_intra_doc_links)]` waivers, no `pub use` added for link resolution, no module-structure changes, no other crates touched.

## Test plan

- [ ] Pages workflow build-rustdoc step turns green (the 9 protocol-crate errors in the master log are gone).
- [ ] No new clippy lints fire (`rustdoc::bare_urls`, `rustdoc::invalid_codeblock_attributes`, etc.).
- [ ] Rendered docs for `DeleteStats::read_from`, `FlatFileList::push`, `protocol::state` module page, `protocol::nstr` module page, and `bind::trace::trace_bind_failure` look identical to before (backticks render as code, just without an active link).