### PR TITLE
test(core): UTS-9 daemon-pull -zz goodbye flush regression coverage

### DIFF
--- a/crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs
+++ b/crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs
@@ -1,0 +1,171 @@
+//! Regression test for UTS-9.REOPEN: daemon-gzip download goodbye flush.
+//!
+//! Symptom: when an oc-rsync client pulls a file from an oc-rsync daemon with
+//! `-zz` (new-style compression), the receiver could observe a connection
+//! close at protocol byte ~612425 mid-stream, before the goodbye exchange
+//! completed. The wire ended without an `@ERROR` frame, so the receiver
+//! reported `connection unexpectedly closed`.
+//!
+//! Root cause: `GeneratorContext::run()` did not call `writer.flush()` after
+//! `handle_goodbye()` returned. Any diagnostic frame queued after the
+//! goodbye exchange (`MSG_INFO`, stats summary, etc.) could race the
+//! transport FIN and end up in a torn capture. The fix in
+//! `crates/transfer/src/generator/transfer/orchestrator.rs` mirrors upstream
+//! `main.c:983` `do_server_sender()` which calls `io_flush(FULL_FLUSH)`
+//! immediately before returning.
+//!
+//! This test reproduces the daemon-pull `-zz` codepath that the UTS-9
+//! audit identified: an oc-rsync client (receiver) pulling a deterministic
+//! ~700 KB file from an oc-rsync daemon (sender) with `-zz` compression.
+//! 700 KB is sized to clear the 612425-byte cutoff observed in the original
+//! capture. The transfer must complete with exit 0, the destination must
+//! match the source byte-for-byte, and stderr must not contain the
+//! `connection unexpectedly closed` signature.
+//!
+//! Companion fix and analysis live in PR #5609 (UTS-15.c) which added the
+//! same flush to handle the upstream batch-mode interop suite. This test
+//! locks the contract for the UTS-9 daemon-pull `-zz` lineage so a future
+//! refactor cannot regress either codepath without tripping a regression.
+//!
+//! Upstream references:
+//! - `main.c:983` `do_server_sender()` - `io_flush(FULL_FLUSH)` before return
+//! - `main.c:1344` `client_run()` - `io_flush(FULL_FLUSH)` before return
+//! - `main.c:875-906` `read_final_goodbye()` - goodbye exchange contract
+
+#[cfg(unix)]
+mod common;
+
+#[cfg(unix)]
+use common::{DaemonBinary, TestDaemon, create_test_file};
+
+#[cfg(unix)]
+use std::env;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::path::PathBuf;
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(unix)]
+use tempfile::tempdir;
+
+/// Deterministic ~700 KB payload - large enough to cross the 612425-byte
+/// cutoff observed in the original UTS-9 capture, small enough to keep the
+/// test fast on CI runners.
+#[cfg(unix)]
+const TEST_FILE_SIZE: usize = 700 * 1024;
+
+/// Locate the oc-rsync binary for subprocess spawning. Mirrors the helper in
+/// `partial_mid_transfer_kill.rs`; kept inline to avoid touching shared
+/// `common::mod` from a regression test added late in the cycle.
+#[cfg(unix)]
+fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    let binary_name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
+    let current_exe = env::current_exe().ok()?;
+    let mut dir = current_exe.parent()?;
+
+    while !dir.ends_with("target") {
+        let candidate = dir.join(&binary_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+
+    for subdir in ["debug", "release"] {
+        let candidate = dir.join(subdir).join(&binary_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+/// Deterministic byte pattern so the destination can be compared
+/// byte-for-byte without storing the full payload in the test binary.
+#[cfg(unix)]
+fn generate_test_data(size: usize) -> Vec<u8> {
+    let pattern: Vec<u8> = (0..=255u8).collect();
+    pattern.iter().copied().cycle().take(size).collect()
+}
+
+/// UTS-9.REOPEN.5 regression: oc-rsync client pulling a ~700 KB file from
+/// an oc-rsync daemon with `-zz` (new-style compression) must complete
+/// without a mid-stream connection drop.
+///
+/// The test is `#[ignore]` because it requires both the oc-rsync binary
+/// and a free TCP port. Run with `cargo nextest run --run-ignored` or
+/// `cargo test -- --ignored` during interop validation.
+#[cfg(unix)]
+#[test]
+#[ignore = "requires oc-rsync binary"]
+fn daemon_download_with_zz_completes_without_connection_drop() {
+    let oc_rsync = match locate_oc_rsync() {
+        Some(path) => path,
+        None => {
+            eprintln!("Skipping: oc-rsync binary not found");
+            return;
+        }
+    };
+
+    let daemon = TestDaemon::start(DaemonBinary::OcRsync).expect("start oc-rsync daemon");
+
+    let test_data = generate_test_data(TEST_FILE_SIZE);
+    create_test_file(&daemon.module_path().join("uts9.bin"), &test_data);
+
+    let dest_dir = tempdir().expect("create dest dir");
+    let dest_file = dest_dir.path().join("uts9.bin");
+
+    // `-azz` archives + new-style compression (zlibx in upstream's
+    // options.c:2012 mapping). The doubled `-z` is the trigger that
+    // reproduces the original UTS-9 wire pattern; archive mode (`-a`)
+    // is included so the codepath exercises the standard pull flow
+    // rather than a degenerate single-file mode.
+    let output = Command::new(&oc_rsync)
+        .arg("-azz")
+        .arg("--timeout=30")
+        .arg(format!("{}/uts9.bin", daemon.url()))
+        .arg(dest_dir.path().as_os_str())
+        .output()
+        .expect("spawn oc-rsync client");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    assert!(
+        output.status.success(),
+        "daemon-pull -zz must complete with exit 0; status={:?}\nstdout: {stdout}\nstderr: {stderr}\ndaemon log: {}",
+        output.status.code(),
+        daemon
+            .log_contents()
+            .unwrap_or_else(|_| "(unavailable)".into())
+    );
+
+    // Wire-level fail-loud: the original UTS-9 capture surfaced as
+    // `connection unexpectedly closed`. If the goodbye flush regresses,
+    // this signature reappears even when the exit code is masked.
+    assert!(
+        !stderr.contains("connection unexpectedly closed"),
+        "stderr must not contain 'connection unexpectedly closed' (UTS-9 signature); stderr: {stderr}"
+    );
+
+    let received = fs::read(&dest_file).expect("read transferred file");
+    assert_eq!(
+        received.len(),
+        test_data.len(),
+        "transferred file size must match source"
+    );
+    assert_eq!(
+        received, test_data,
+        "transferred file must match source byte-for-byte"
+    );
+}

--- a/docs/audits/uts-9-daemon-gzip-download-goodbye.md
+++ b/docs/audits/uts-9-daemon-gzip-download-goodbye.md
@@ -1,0 +1,112 @@
+# UTS-9: daemon-gzip download goodbye flush
+
+Status: verification gap closed
+Tracks: UTS-9.REOPEN (#3890), sub-tasks #3958-#3962
+Companion fix: PR #5609 (UTS-15.c)
+
+## Symptom
+
+An oc-rsync client pulling a file from an oc-rsync daemon with `-zz`
+(new-style compression) observed an early connection close at protocol
+byte ~612425, mid-stream. The receiver reported
+`connection unexpectedly closed (... bytes received so far)` and exited
+with a non-zero status. No `@ERROR` frame reached the wire, so the
+diagnostic surface was empty: the symptom was a torn capture between the
+final NDX_DONE and the transport FIN.
+
+The cutoff at ~612425 bytes is the size of the multiplexed window in
+which the trailing NDX_DONE + any post-goodbye MSG_INFO frame became
+visible to the client kernel. The exact byte depends on negotiated
+buffer sizes; the symptom is the absence of an orderly goodbye, not a
+specific byte offset.
+
+## Codepath analysis
+
+The daemon-pull `-zz` codepath exercises the server-sender role:
+
+1. Client invokes `oc-rsync -azz rsync://daemon/module/file dst/`.
+2. Daemon spawns a worker that runs `run_server_with_handshake`
+   (`crates/transfer/src/lib.rs:308`).
+3. `config.role == ServerRole::Generator` dispatches to
+   `GeneratorContext::run()`
+   (`crates/transfer/src/generator/transfer/orchestrator.rs:36`).
+4. `run()` drives the transfer loop, sends server stats, then calls
+   `handle_goodbye()`
+   (`crates/transfer/src/generator/transfer/goodbye.rs:46`).
+5. For protocol >= 29 (which all `-zz` transfers use since zstd/zlibx
+   require a modern protocol), `handle_goodbye` performs its own
+   `writer.flush()` after writing the final NDX_DONE
+   (`goodbye.rs:102`).
+6. Control returns to `run()`.
+
+Before the fix, step 6 returned without an additional flush. Any
+diagnostic frame queued after `handle_goodbye` (cumulative INC_RECURSE
+totals, debug-log MSG_INFO frames, etc.) could remain in the buffered
+writer when the underlying transport closed. The kernel then sent the
+FIN before the trailing frames, producing the silent close symptom.
+
+## Cross-check vs UTS-15.c batch-mode
+
+PR #5609 (UTS-15.c) added the explicit post-`handle_goodbye` flush to
+fix the upstream batch-mode interop suite, which surfaced the same
+class of defect at a different protocol offset
+(~2241725 bytes, inside the file-list framing region). The two
+symptoms share a root cause: `GeneratorContext::run()` did not enforce
+upstream's `io_flush(FULL_FLUSH)` contract before returning.
+
+The fix location is the **same** for both lineages:
+
+```
+crates/transfer/src/generator/transfer/orchestrator.rs
+  GeneratorContext::run()
+    handle_goodbye(...)?;
+    if let Err(e) = writer.flush() {
+        if !is_early_close_error(&e) {
+            return Err(e);
+        }
+    }
+```
+
+This mirrors upstream `main.c:983` (`do_server_sender()`) and
+`main.c:1344` (`client_run()`), both of which call
+`io_flush(FULL_FLUSH)` immediately before returning. Because every
+daemon-sender path - batch-mode (UTS-15.c) and `-zz` daemon-pull
+(UTS-9) - flows through the same `run()` exit point, a single flush
+closes both gaps.
+
+## Verification
+
+The UTS-9 regression test lives in
+`crates/core/tests/uts_9_daemon_gzip_download_goodbye.rs`:
+
+- Spawns an oc-rsync daemon serving a deterministic ~700 KB file
+  (sized to clear the 612425-byte cutoff).
+- Pulls the file with `oc-rsync -azz --timeout=30
+  rsync://localhost:N/testmodule/uts9.bin`.
+- Asserts exit code 0.
+- Asserts stderr does not contain the
+  `connection unexpectedly closed` signature.
+- Asserts the destination matches the source byte-for-byte.
+
+The test is `#[ignore]` because it requires the oc-rsync binary and an
+OS-assigned TCP port; it runs during interop validation rather than
+default CI.
+
+## Invariants
+
+- **Flush invariant** (shared with UTS-15.c): every successful
+  `GeneratorContext::run()` ends with a `writer.flush()` call.
+  NDX_DONE is the last byte on the wire before the transport FIN.
+- **Wire signature invariant**: `connection unexpectedly closed`
+  appearing in client stderr during a daemon-pull `-zz` transfer is a
+  defect, not a transient. The regression test guards the signature so
+  a future regression cannot mask the symptom behind a successful exit
+  code.
+
+## Upstream references
+
+- `main.c:983` `do_server_sender()` - `io_flush(FULL_FLUSH)` before
+  return
+- `main.c:1344` `client_run()` - `io_flush(FULL_FLUSH)` before return
+- `main.c:875-906` `read_final_goodbye()` - goodbye exchange contract
+- `options.c:2011-2012` `-zz` -> `compress_choice = "zlibx"` mapping


### PR DESCRIPTION
## Summary

- Adds a regression test for UTS-9.REOPEN: an oc-rsync client pulling a deterministic ~700 KB file from an oc-rsync daemon with `-zz` (new-style compression) must complete with exit 0, no `connection unexpectedly closed` stderr signature, and a byte-for-byte match. The 612425-byte cutoff that the original capture surfaced sat inside the buffered window between the final NDX_DONE and the transport FIN.
- Cites PR #5609 (UTS-15.c) as the originating fix: that PR added an explicit `writer.flush()` at the end of `GeneratorContext::run()` to mirror upstream `main.c:983 do_server_sender()` / `main.c:1344 client_run()`. Every daemon-sender role flows through the same `run()` return point, so the same flush closes both the UTS-15 batch-mode lineage and this UTS-9 daemon-pull `-zz` lineage. This change closes the verification gap for UTS-9 without duplicating the fix.
- Documents the codepath analysis, the UTS-15.c cross-check, and the upstream `io_flush(FULL_FLUSH)` references in `docs/audits/uts-9-daemon-gzip-download-goodbye.md`.

Classification: test-only (verification gap closer).

## Test plan

- [ ] Manual: with PR #5609 merged on master, `cargo nextest run -p core --all-features -E 'test(daemon_download_with_zz_completes_without_connection_drop)' --run-ignored=all` succeeds.
- [ ] Manual: stderr from a `-zz` daemon pull never contains `connection unexpectedly closed`.
- [ ] CI: the test is `#[ignore]`-gated so default CI does not regress on PRs that have not yet picked up PR #5609.