### PR TITLE
fix: propagate ELOOP from sandboxed delete scan as IOERR_GENERAL

### DIFF
--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -39,7 +39,7 @@ fn receiver_filter_chain_protects_from_deletion() {
     ctx.set_filter_chain(::filters::FilterChain::new(global));
 
     let mut writer = TestDeletionWriter;
-    let (stats, _) = ctx
+    let (stats, _, _) = ctx
         .delete_extraneous_files(
             dest,
             #[cfg(unix)]
@@ -91,7 +91,7 @@ fn receiver_filter_chain_empty_allows_all_deletions() {
 
     // Empty filter chain - all deletions should proceed
     let mut writer = TestDeletionWriter;
-    let (stats, _) = ctx
+    let (stats, _, _) = ctx
         .delete_extraneous_files(
             dest,
             #[cfg(unix)]
@@ -147,7 +147,7 @@ fn single_char_wildcard_exclude_does_not_block_top_level_deletion() {
     ctx.set_filter_chain(::filters::FilterChain::new(global));
 
     let mut writer = TestDeletionWriter;
-    let (stats, _) = ctx
+    let (stats, _, _) = ctx
         .delete_extraneous_files(
             dest,
             #[cfg(unix)]
@@ -180,4 +180,187 @@ fn receiver_set_and_get_filter_chain() {
     ctx.set_filter_chain(chain);
 
     assert!(!ctx.filter_chain().is_empty());
+}
+
+/// UTS-16.b.7 regression: an ordinary in-module subdir deletion must succeed
+/// with no io_error bits set, even when the sandbox is plumbed. Pins the
+/// "no over-correction" invariant: the chdir-symlink-race fix in
+/// `delete_extraneous_files` must not poison legitimate sweeps with
+/// `IOERR_GENERAL`.
+///
+/// upstream: generator.c:delete_in_dir() - the legitimate path issues a
+/// successful `secure_relative_open` and never touches io_error.
+#[cfg(unix)]
+#[test]
+fn delete_ordinary_subdir_succeeds_with_no_io_error() {
+    use std::os::unix::ffi::OsStrExt;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    // Canonicalize so the sandbox open does not trip on macOS
+    // `/tmp -> /private/tmp` under RESOLVE_NO_SYMLINKS.
+    let dest = std::fs::canonicalize(temp_dir.path()).unwrap();
+
+    // Build an in-module subdir with an extraneous file that should be deleted.
+    let subdir = dest.join("subdir");
+    std::fs::create_dir(&subdir).unwrap();
+    std::fs::write(subdir.join("keep.txt"), b"keep").unwrap();
+    std::fs::write(subdir.join("extraneous.txt"), b"extraneous").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(
+        std::str::from_utf8(dest.as_os_str().as_bytes()).unwrap(),
+    )];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Sender's flist: "." + subdir + subdir/keep.txt. extraneous.txt is missing.
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("subdir".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("subdir/keep.txt".into(), 4, 0o644));
+
+    let sandbox = Arc::new(::fast_io::DirSandbox::open_root(&dest).expect("open sandbox"));
+
+    let mut writer = TestDeletionWriter;
+    let (stats, _exceeded, io_error_bits) = ctx
+        .delete_extraneous_files(&dest, Some(&sandbox), &mut writer)
+        .expect("delete pass must not surface io::Error on legitimate trees");
+
+    assert_eq!(
+        io_error_bits, 0,
+        "ordinary subdir deletion must not set IOERR_GENERAL"
+    );
+    assert_eq!(stats.files, 1, "extraneous.txt should be deleted");
+    assert!(
+        !subdir.join("extraneous.txt").exists(),
+        "extraneous.txt must be removed"
+    );
+    assert!(
+        subdir.join("keep.txt").exists(),
+        "keep.txt must survive a clean sweep"
+    );
+}
+
+/// UTS-16.b.6 regression: the chdir-symlink-race attack window. An
+/// attacker plants a symlink at `dest/symlinkattack` pointing outside
+/// the destination root before the receiver's `--delete` scan runs.
+/// The sandbox-anchored scan must refuse to descend through the
+/// symlink and surface `IOERR_GENERAL` so the receiver returns
+/// exit code 23 (`RERR_PARTIAL`) instead of completing silently
+/// while leaving the attacker's symlink in place.
+///
+/// Additionally asserts the outside tree is untouched - the
+/// symlink-refusal must close the syscall before any unlink can
+/// land on the attacker-chosen inode.
+///
+/// upstream: clientserver.c:1018 `use_secure_symlinks` gates the
+/// `do_*_at` wrappers in `syscall.c`; `secure_relative_open` returns
+/// `errno=ELOOP` and the caller sets `io_error |= IOERR_GENERAL`.
+#[cfg(unix)]
+#[test]
+fn delete_symlinked_subdir_surfaces_ioerr_general() {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::symlink;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use crate::generator::io_error_flags::{IOERR_GENERAL, to_exit_code};
+
+    let temp_dir = TempDir::new().unwrap();
+    let parent = std::fs::canonicalize(temp_dir.path()).unwrap();
+
+    // The "sensitive" tree the attacker wants the receiver's scan
+    // (and any follow-up unlink) to land on - sits outside the
+    // destination root.
+    let outside = parent.join("outside");
+    std::fs::create_dir(&outside).unwrap();
+    let outside_sentinel = outside.join("sentinel");
+    std::fs::write(&outside_sentinel, b"must-survive").unwrap();
+
+    let dest = parent.join("dest");
+    std::fs::create_dir(&dest).unwrap();
+
+    // Attacker swaps the destination subdir for a symlink to the
+    // sensitive tree above. The receiver's flist names `symlinkattack/`
+    // as a real subdir, so the scan path matches a single-component
+    // leaf under the sandbox root - the sandbox helper takes the
+    // anchored fast path with O_NOFOLLOW and refuses the leaf.
+    let attack_link = dest.join("symlinkattack");
+    symlink(&outside, &attack_link).unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(
+        std::str::from_utf8(dest.as_os_str().as_bytes()).unwrap(),
+    )];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Sender's flist advertises `symlinkattack/` as a directory with a
+    // child, so the deletion scan tries to enumerate the destination
+    // subdir `dest/symlinkattack` to find extraneous entries. The
+    // attacker-controlled destination is a symlink, so the
+    // sandbox-anchored `read_dir` must refuse the leaf with ELOOP /
+    // ENOTDIR rather than enumerating the outside tree.
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("symlinkattack".into(), 0o755));
+    ctx.file_list.push(FileEntry::new_file(
+        "symlinkattack/keep.txt".into(),
+        4,
+        0o644,
+    ));
+
+    let sandbox = Arc::new(::fast_io::DirSandbox::open_root(&dest).expect("open sandbox"));
+
+    let mut writer = TestDeletionWriter;
+    let (_stats, _exceeded, io_error_bits) = ctx
+        .delete_extraneous_files(&dest, Some(&sandbox), &mut writer)
+        .expect("delete pass returns Ok with IOERR_GENERAL surfaced via bits");
+
+    assert!(
+        io_error_bits & IOERR_GENERAL != 0,
+        "sandbox-rejected scan of a symlinked subdir must surface IOERR_GENERAL \
+         (got 0x{io_error_bits:x})"
+    );
+    assert_eq!(
+        to_exit_code(io_error_bits),
+        23,
+        "IOERR_GENERAL must map to exit code 23 (RERR_PARTIAL)"
+    );
+
+    // Defense-in-depth assertion: the outside tree must be untouched.
+    // The sandbox helper closes the syscall at the O_NOFOLLOW probe
+    // before any unlink dispatch, so the attacker-chosen inode never
+    // sees a write.
+    assert!(
+        outside.is_dir(),
+        "the outside tree must survive the refused scan"
+    );
+    assert!(
+        outside_sentinel.is_file(),
+        "the outside sentinel file must survive untouched"
+    );
+    assert_eq!(
+        std::fs::read(&outside_sentinel).unwrap(),
+        b"must-survive",
+        "the outside sentinel contents must be untouched"
+    );
+
+    // The symlink itself stays in place - the scan refusal must not
+    // implicitly unlink the attacker's symlink either; that decision
+    // belongs to the explicit per-entry deletion path, which the
+    // refusal short-circuited.
+    assert!(
+        attack_link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "the planted symlink must remain in place (scan refusal closes the window without unlinking)"
+    );
 }

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -557,7 +557,7 @@ mod incremental_mode_tests {
 
         // Call the delete pass the same way `run_pipelined_incremental` does.
         let mut writer = TestDeletionWriter;
-        let (delete_stats, delete_limit_exceeded) = ctx
+        let (delete_stats, delete_limit_exceeded, _io_error_bits) = ctx
             .delete_extraneous_files(
                 dest,
                 #[cfg(unix)]

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -56,8 +56,12 @@ impl ReceiverContext {
 
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
+        // UTS-16.b: sandbox-rejected scans surface IOERR_GENERAL here so the
+        // chdir-symlink-race refusal becomes a non-zero exit instead of a
+        // silent skip.
+        let mut delete_io_error: i32 = 0;
         if self.config.flags.delete {
-            let (ds, exceeded) = self.delete_extraneous_files(
+            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -65,13 +69,15 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
+            delete_io_error = io_bits;
         }
 
         let mut stats = TransferStats {
             files_listed: file_count,
             entries_received: file_count as u64,
             io_error: self.flist_reader_cache.as_ref().map_or(0, |r| r.io_error())
-                | self.flist_io_error,
+                | self.flist_io_error
+                | delete_io_error,
             ..Default::default()
         };
         let files_to_transfer = self.build_files_to_transfer(

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -97,7 +97,7 @@ impl ReceiverContext {
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
         if self.config.flags.delete {
-            let (ds, exceeded) = self.delete_extraneous_files(
+            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -105,6 +105,10 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
+            // UTS-16.b: sandbox-rejected delete scan surfaces here so the
+            // chdir-symlink-race refusal becomes a non-zero exit instead of a
+            // silent skip.
+            stats.io_error |= io_bits;
         }
 
         let files_to_transfer = self.build_files_to_transfer(


### PR DESCRIPTION
## Summary

UTS-16.b chdir-symlink-race fix: the receiver-side `--delete` scan
previously swallowed the sandbox's symlink-class refusal (ELOOP /
ENOTDIR / EXDEV) and returned empty stats, so a transfer that hit a
swapped-symlink subdir at the destination completed with exit code 0 as
if everything was fine. Phase 1 audits (UTS-16.b.1-.3) shipped earlier
identified the silent-skip site; this PR applies the fix.

- The per-directory worker in `delete_extraneous_files` now distinguishes
  symlink-class refusals (the chdir-symlink-race attack signature) from
  legitimate soft-skip cases (ENOENT, EACCES).
- Symlink refusals accumulate `IOERR_GENERAL` in a new third tuple slot
  and emit a `Del` info log naming the refused path. The mapping mirrors
  upstream `generator.c:delete_in_dir()` +
  `syscall.c:secure_relative_open()`: ELOOP -> `rsyserr(FERROR_XFER,
  ...)` -> `io_error |= IOERR_GENERAL` -> exit 23 (`RERR_PARTIAL`).
- The pipelined and pipelined-incremental drivers OR the bits into
  `TransferStats.io_error` so the receiver returns a non-zero exit code
  instead of silently completing.

## Test plan

- [x] Positive regression (UTS-16.b.7): ordinary in-module subdir
      deletion with the sandbox plumbed must surface `io_error_bits == 0`
      and complete the sweep (extraneous removed, kept survives).
- [x] Negative regression (UTS-16.b.6): planted symlink at
      `dest/symlinkattack -> /tmp/.../outside` must surface
      `IOERR_GENERAL`, leave the outside tree untouched, and leave the
      planted symlink in place (scan refusal closes the syscall before
      any unlink dispatch).
- [x] Existing `delete_extraneous_files` tests destructure the new
      3-tuple shape (one in `incremental_directories.rs`, three in
      `filter_chain.rs`).
- [x] `to_exit_code(IOERR_GENERAL)` asserted as 23 (`RERR_PARTIAL`) so
      the wire-equivalent exit-code mapping is pinned.