### PR TITLE
docs: fix broken rustdoc intra-doc links in fast_io crate

### DIFF
--- a/crates/fast_io/src/adaptive_dispatch.rs
+++ b/crates/fast_io/src/adaptive_dispatch.rs
@@ -16,20 +16,20 @@
 //! # Algorithm
 //!
 //! For each completed basis read the caller invokes
-//! [`record_sample`] with the chosen backend, the byte count, and the
+//! [`crate::adaptive_dispatch::record_sample`] with the chosen backend, the byte count, and the
 //! wall-clock duration. The module maintains an exponentially-weighted
 //! moving average of bytes-per-second per backend with `alpha = 0.2`
 //! per sample (the new sample contributes 20%, the running estimate
-//! contributes 80%). [`pick`] then compares the two EWMAs and returns
+//! contributes 80%). [`crate::adaptive_dispatch::pick`] then compares the two EWMAs and returns
 //! the faster backend, or falls back to the static size-threshold
-//! heuristic from Option 2 ([`size_threshold_pick`]) when one or both
+//! heuristic from Option 2 ([`crate::adaptive_dispatch::size_threshold_pick`]) when one or both
 //! backends has no recorded history.
 //!
 //! # Operator opt-out
 //!
 //! Setting `OC_RSYNC_ADAPTIVE_BASIS_DISPATCH=0` (or `off`, `false`,
 //! `no`) in the environment disables the adaptive path at runtime even
-//! when the feature is compiled in. [`pick`] then always falls back to
+//! when the feature is compiled in. [`crate::adaptive_dispatch::pick`] then always falls back to
 //! the size-threshold path so the operator can revert to the static
 //! Option 2 behaviour without rebuilding.
 
@@ -177,7 +177,7 @@ static GLOBAL_TRACKER: OnceLock<ThroughputTracker> = OnceLock::new();
 
 /// Return the process-wide [`ThroughputTracker`], constructing it on
 /// first call. Callers wiring the adaptive path through
-/// [`pick`] and [`record_sample`] use this implicitly; tests that
+/// [`crate::adaptive_dispatch::pick`] and [`crate::adaptive_dispatch::record_sample`] use this implicitly; tests that
 /// want isolation should construct their own [`ThroughputTracker`]
 /// instead.
 #[must_use]
@@ -198,19 +198,19 @@ pub fn record_sample(backend: BasisReadBackend, bytes: u64, elapsed: Duration) {
 ///
 /// 1. If the adaptive path is disabled at runtime
 ///    (`OC_RSYNC_ADAPTIVE_BASIS_DISPATCH=0`), fall straight back to
-///    [`size_threshold_pick`] (Option 2 behaviour).
+///    [`crate::adaptive_dispatch::size_threshold_pick`] (Option 2 behaviour).
 /// 2. Filter out backends the caller declared unavailable. If only
 ///    one is available, return it.
 /// 3. If both backends have recorded samples, return whichever has
 ///    the higher EWMA throughput. Ties resolve in favour of mmap
 ///    (the historically stable choice).
-/// 4. Otherwise fall back to [`size_threshold_pick`].
+/// 4. Otherwise fall back to [`crate::adaptive_dispatch::size_threshold_pick`].
 #[must_use]
 pub fn pick(size: u64, mmap_available: bool, iouring_available: bool) -> BasisReadBackend {
     pick_with_tracker(global_tracker(), size, mmap_available, iouring_available)
 }
 
-/// [`pick`] against a caller-supplied tracker. Lets tests exercise the
+/// [`crate::adaptive_dispatch::pick`] against a caller-supplied tracker. Lets tests exercise the
 /// decision logic without contending on the process-wide singleton.
 #[must_use]
 pub fn pick_with_tracker(

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -19,7 +19,7 @@
 //!    ([`secondary`](DirSandbox::secondary)) covers the four
 //!    cross-directory operands (`--backup-dir`, `--temp-dir`,
 //!    `--link-dest`, `--copy-dest`, `--compare-dest`). The cache is a
-//!    [`DashMap`] so the read-mostly lookup path stays lock-free; entries
+//!    `DashMap` so the read-mostly lookup path stays lock-free; entries
 //!    are inserted at receiver setup and never evicted.
 //!
 //! The module is `#[cfg(unix)]`. Windows uses NTFS handle-based ops per
@@ -36,7 +36,7 @@
 //! anchoring dirfd, and any magic-link resolution. Pairing
 //! `RESOLVE_BENEATH` with a real anchoring dirfd is the supported
 //! configuration (unlike the `AT_FDCWD` bootstrap in
-//! [`secure_open_dir`](crate::secure_open_dir), which intentionally drops
+//! [`secure_open_dir`](crate::secure_dir::secure_open_dir), which intentionally drops
 //! `RESOLVE_BENEATH` because the cwd anchor is the wrong scope for
 //! absolute paths).
 //!
@@ -51,14 +51,14 @@
 //! through [`current_dirfd`](DirSandbox::current_dirfd) hand out
 //! `BorrowedFd<'_>` values whose lifetime is bound to `&self`; rayon
 //! workers capturing the borrow do so by copy because `BorrowedFd<'_>`
-//! is `Copy + Send + Sync`. The side cache is a [`DashMap`] and supports
+//! is `Copy + Send + Sync`. The side cache is a `DashMap` and supports
 //! concurrent registration plus concurrent reads.
 //!
 //! # `unsafe` budget
 //!
 //! The only `unsafe` block in this module is the `openat2(2)` syscall
 //! invocation, which mirrors the safety argument in
-//! [`secure_open_dir`](crate::secure_open_dir::secure_open_dir). The
+//! [`secure_open_dir`](crate::secure_dir::secure_open_dir). The
 //! `openat(2)` fallback goes through `rustix`, which exposes a safe
 //! interface; no `unsafe` is needed there.
 
@@ -242,7 +242,7 @@ impl DirSandbox {
     ///
     /// On first call for a given `path` the helper opens the directory
     /// through [`secure_open_dir`] and stores the resulting `OwnedFd`
-    /// in the [`DashMap`] keyed by `path`. Subsequent calls return the
+    /// in the `DashMap` keyed by `path`. Subsequent calls return the
     /// cached [`Arc`] without issuing a syscall. The clone is cheap and
     /// hands the caller a shared owner whose [`BorrowedFd`] can be
     /// passed to two-dirfd syscalls (`renameat`, `linkat`) alongside

--- a/crates/fast_io/src/io_uring/bgid_lease.rs
+++ b/crates/fast_io/src/io_uring/bgid_lease.rs
@@ -35,7 +35,7 @@
 //!
 //! [`with_thread_lease`] keeps one `BgidLease` per OS thread, lazy-built
 //! on first use, alongside the per-thread io_uring ring established by
-//! [`super::per_thread_ring`]. Both live in `thread_local!` storage and
+//! `super::per_thread_ring`. Both live in `thread_local!` storage and
 //! reach their destructors on normal thread exit, so the lease's bgids
 //! flow back to the central pool without explicit teardown by callers.
 //!
@@ -109,7 +109,7 @@ impl BgidLease {
     /// - [`io::ErrorKind::OutOfMemory`] when the central pool has zero
     ///   ids available (free-list empty and counter at the namespace
     ///   limit). The error is the lossless conversion of
-    ///   [`BgidAllocError::Exhausted`] documented on
+    ///   [`super::buffer_ring::BgidAllocError::Exhausted`] documented on
     ///   [`super::buffer_ring::BgidAllocator::allocate_batch`].
     pub fn new(batch_size: usize) -> io::Result<Self> {
         if batch_size == 0 {

--- a/crates/fast_io/src/io_uring/buffer_ring/mod.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring/mod.rs
@@ -50,7 +50,7 @@
 //! 2. **Classic provide-buffers** (Linux 5.6+, `IORING_OP_PROVIDE_BUFFERS`
 //!    opcode 31, or `IORING_REGISTER_BUFFERS` opcode 0) - pre-registered
 //!    buffer pool with per-SQE selection. See
-//!    [`super::registered_buffers::RegisteredBufferGroup`].
+//!    [`crate::io_uring::registered_buffers::RegisteredBufferGroup`].
 //! 3. **Standard `read(2)` / `write(2)`** (any kernel) - the
 //!    `traits::StdFileReader` / `traits::StdFileWriter` fallback used when
 //!    io_uring is unavailable entirely.

--- a/crates/fast_io/src/io_uring/file_factory.rs
+++ b/crates/fast_io/src/io_uring/file_factory.rs
@@ -17,7 +17,7 @@ use crate::traits::{FileReader, FileReaderFactory, FileWriter, FileWriterFactory
 ///
 /// On each `open()` call, checks [`is_io_uring_available`] (cached atomic) and
 /// `force_fallback`. If io_uring is eligible, attempts to open an
-/// [`IoUringReader`]; on any failure, returns a [`StdFileReader`] instead.
+/// [`IoUringReader`]; on any failure, returns a [`crate::traits::StdFileReader`] instead.
 #[derive(Debug, Clone, Default)]
 pub struct IoUringReaderFactory {
     config: IoUringConfig,
@@ -138,7 +138,7 @@ impl FileReaderFactory for IoUringReaderFactory {
 ///
 /// On each `create()` call, checks [`is_io_uring_available`] (cached atomic) and
 /// `force_fallback`. If io_uring is eligible, attempts to create an
-/// [`IoUringWriter`]; on any failure, returns a [`StdFileWriter`] instead.
+/// [`IoUringWriter`]; on any failure, returns a [`crate::traits::StdFileWriter`] instead.
 #[derive(Debug, Clone, Default)]
 pub struct IoUringWriterFactory {
     config: IoUringConfig,

--- a/crates/fast_io/src/io_uring/linkat.rs
+++ b/crates/fast_io/src/io_uring/linkat.rs
@@ -10,7 +10,7 @@
 //!   `is_io_uring_available()` and then asks the kernel via
 //!   `IORING_REGISTER_PROBE` whether opcode 39 (`IORING_OP_LINKAT`) is
 //!   reported as supported.
-//! - [`build_linkat_sqe`] - constructs an [`squeue::Entry`] for a real LINKAT
+//! - [`build_linkat_sqe`] - constructs an `squeue::Entry` for a real LINKAT
 //!   submission; returns [`io::ErrorKind::Unsupported`] when the probe is
 //!   `false`. Callers must keep the [`LinkAtArgs`] paths alive until the
 //!   matching CQE has been reaped.
@@ -125,7 +125,7 @@ fn probe_linkat_support() -> bool {
 /// opcode.
 ///
 /// Returns [`io::ErrorKind::Unsupported`] when [`linkat_supported`] reports
-/// `false`. The returned [`squeue::Entry`] is unattached; callers are
+/// `false`. The returned `squeue::Entry` is unattached; callers are
 /// responsible for tagging it with `user_data` and pushing it onto a ring's
 /// submission queue under the `unsafe` contract documented by
 /// `io_uring::SubmissionQueue::push`.

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -80,7 +80,7 @@
 //! - **Provided-buffer rings (PBUF_RING)**: Linux 5.19+ ring-mapped supplied
 //!   buffers (`IORING_REGISTER_PBUF_RING`, opcode 22) -> classic provide-buffers
 //!   path on 5.6+ -> standard `read`/`write` -> non-Linux io_uring stub. The
-//!   probe is cached process-wide via [`buffer_ring::pbuf_ring_supported`] and
+//!   probe is cached process-wide via [`crate::io_uring::buffer_ring::pbuf_ring_supported`] and
 //!   surfaced on [`IoUringKernelInfo::pbuf_ring_supported`]. See
 //!   `docs/audits/iouring-pbuf-ring.md` for the full call-site survey.
 

--- a/crates/fast_io/src/io_uring/per_thread_ring.rs
+++ b/crates/fast_io/src/io_uring/per_thread_ring.rs
@@ -3,7 +3,7 @@
 //! Foundational lifecycle primitive for the hybrid per-thread topology chosen
 //! by IUR-2 (see `docs/design/iur-2-per-thread-rings.md`). Each calling thread
 //! gets its own `io_uring::IoUring` instance, lazily constructed on first
-//! [`with_ring`] call and dropped when the thread exits.
+//! `with_ring` call and dropped when the thread exits.
 //!
 //! # Why per-thread
 //!
@@ -32,7 +32,7 @@
 //!   and pinned to the disk-commit thread for the life of the session. No
 //!   second thread submits to it.
 //! - **Re-entrant submit/reap on the same thread.** This primitive enforces
-//!   single-borrow via `RefCell`; nested [`with_ring`] calls return
+//!   single-borrow via `RefCell`; nested `with_ring` calls return
 //!   `io::ErrorKind::WouldBlock` rather than deadlocking or aliasing the SQ
 //!   cursor.
 //!
@@ -58,7 +58,7 @@
 //!   prevent).
 //!
 //! This matches the storage shape used by the shipped
-//! [`super::session_pool::ThreadLocalRingPool`] and the rationale in IUR-2
+//! `super::session_pool::ThreadLocalRingPool` and the rationale in IUR-2
 //! design doc section 2.1.
 
 use std::cell::RefCell;

--- a/crates/fast_io/src/io_uring/registered_buffers/mod.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/mod.rs
@@ -36,7 +36,7 @@
 //! `Drop` only deallocates user memory and never touches the ring; the
 //! kernel would still hold the pinning until the ring fd later closes.
 //! However, the documented ordering matches the implementation in
-//! [`super::file_reader`] and [`super::file_writer`].
+//! `super::file_reader` and `super::file_writer`.
 //!
 //! # Why Drop does not call `unregister_buffers`
 //!

--- a/crates/fast_io/src/io_uring/renameat2.rs
+++ b/crates/fast_io/src/io_uring/renameat2.rs
@@ -5,7 +5,7 @@
 //! `RENAME_NOREPLACE`, `RENAME_EXCHANGE`, and `RENAME_WHITEOUT` flags. This
 //! module wraps `io_uring::opcode::RenameAt` with an availability probe that
 //! mirrors the patterns already used for `IORING_OP_POLL_ADD`
-//! (see [`super::shared_ring`]) and the splice syscall
+//! (see `super::shared_ring`) and the splice syscall
 //! (see [`crate::splice::is_splice_available`]).
 //!
 //! # Probe semantics
@@ -61,7 +61,7 @@ static RENAMEAT2_SUPPORTED: OnceLock<bool> = OnceLock::new();
 /// Returns `false` immediately when the base io_uring subsystem is
 /// unavailable, when probe registration fails, or when the probe explicitly
 /// reports the opcode as unsupported. On non-Linux platforms the stub in
-/// [`crate::io_uring_stub`] always returns `false`.
+/// `crate::io_uring_stub` always returns `false`.
 #[must_use]
 pub fn renameat2_supported() -> bool {
     *RENAMEAT2_SUPPORTED.get_or_init(probe_renameat2_support)

--- a/crates/fast_io/src/io_uring/session_pool.rs
+++ b/crates/fast_io/src/io_uring/session_pool.rs
@@ -18,7 +18,7 @@
 //!   [`IoUringConfig`].
 //! - [`acquire`](SessionRingPool::acquire) returns a [`RingLease`] that
 //!   dereferences to the underlying `IoUring`. Selection is round-robin via a
-//!   single relaxed [`AtomicUsize`] - the contention point at high concurrency
+//!   single relaxed `AtomicUsize` - the contention point at high concurrency
 //!   is the per-ring mutex, not the selector.
 //!
 //! Two pool primitives live in this module:

--- a/crates/fast_io/src/io_uring/shared_ring.rs
+++ b/crates/fast_io/src/io_uring/shared_ring.rs
@@ -1,7 +1,7 @@
 //! Single io_uring ring shared by a reader fd and a writer fd in one session.
 //!
-//! Background: the per-channel design in [`super::file_reader::IoUringReader`]
-//! and [`super::socket_writer::IoUringSocketWriter`] gives every endpoint its
+//! Background: the per-channel design in [`super::IoUringReader`]
+//! and [`super::IoUringSocketWriter`] gives every endpoint its
 //! own SQ/CQ. Co-locating them on one ring halves the per-op syscall cost
 //! (one `io_uring_enter` services both directions) and lets the kernel amortise
 //! SQE submission across read and write traffic. This module implements that

--- a/crates/fast_io/src/io_uring/statx.rs
+++ b/crates/fast_io/src/io_uring/statx.rs
@@ -11,7 +11,7 @@
 //!   `is_io_uring_available()` and then asks the kernel via
 //!   `IORING_REGISTER_PROBE` whether opcode 21 (`IORING_OP_STATX`) is
 //!   reported as supported.
-//! - [`build_statx_sqe`] - constructs an [`squeue::Entry`] for a STATX
+//! - [`build_statx_sqe`] - constructs an `squeue::Entry` for a STATX
 //!   submission; returns [`io::ErrorKind::Unsupported`] when the probe is
 //!   `false`. Callers must keep the [`StatxArgs`] path and buffer alive until
 //!   the matching CQE has been reaped.
@@ -150,7 +150,7 @@ fn probe_statx_support() -> bool {
 /// opcode.
 ///
 /// Returns [`io::ErrorKind::Unsupported`] when [`statx_supported`] reports
-/// `false`. The returned [`squeue::Entry`] is unattached; callers are
+/// `false`. The returned `squeue::Entry` is unattached; callers are
 /// responsible for tagging it with `user_data` and pushing it onto a ring's
 /// submission queue under the `unsafe` contract documented by
 /// `io_uring::SubmissionQueue::push`.

--- a/crates/fast_io/src/io_uring_common.rs
+++ b/crates/fast_io/src/io_uring_common.rs
@@ -197,7 +197,7 @@ pub struct SharedRingConfig {
 
 /// Structured kernel information for io_uring availability reporting.
 ///
-/// Returned by [`crate::io_uring::config::config_detail::io_uring_kernel_info`]
+/// Returned by [`crate::io_uring_kernel_info`]
 /// on Linux and by the equivalent stub on every other platform.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IoUringKernelInfo {

--- a/crates/fast_io/src/iocp_stub/socket.rs
+++ b/crates/fast_io/src/iocp_stub/socket.rs
@@ -3,7 +3,7 @@
 //! Mirrors the public surface of [`crate::iocp::socket`] on Windows so code
 //! that names `IocpSocketReader` / `IocpSocketWriter` behind a runtime check
 //! against [`super::is_iocp_available`] still compiles on Linux and macOS.
-//! All constructors and methods return [`io::ErrorKind::Unsupported`].
+//! All constructors and methods return [`std::io::ErrorKind::Unsupported`].
 
 use std::io;
 use std::sync::Arc;
@@ -15,7 +15,7 @@ use super::CompletionPump;
 pub type SharedPump = Arc<CompletionPump>;
 
 /// Stub IOCP socket reader. Construction always fails with
-/// [`io::ErrorKind::Unsupported`].
+/// [`std::io::ErrorKind::Unsupported`].
 pub struct IocpSocketReader {
     _private: (),
 }
@@ -59,7 +59,7 @@ impl IocpSocketReader {
 }
 
 /// Stub IOCP socket writer. Construction always fails with
-/// [`io::ErrorKind::Unsupported`].
+/// [`std::io::ErrorKind::Unsupported`].
 pub struct IocpSocketWriter {
     _private: (),
 }

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -7,7 +7,7 @@
 //! highest ABI the running kernel exposes.
 //!
 //! The helper is a one-shot per-thread restriction: once
-//! [`restrict_to_module_paths`] succeeds, the calling thread (and every
+//! [`crate::landlock::restrict_to_module_paths`] succeeds, the calling thread (and every
 //! process inherited from it - notably the daemon's name converter and
 //! pre/post-xfer-exec hooks) cannot reach paths outside the supplied roots
 //! through any filesystem syscall, regardless of how the path was resolved.
@@ -23,7 +23,7 @@ use landlock::{
     RulesetCreatedAttr, RulesetStatus,
 };
 
-/// Outcome of a [`restrict_to_module_paths`] call.
+/// Outcome of a [`crate::landlock::restrict_to_module_paths`] call.
 ///
 /// Carries enough detail for the daemon to log the actual enforcement level
 /// without leaking the `landlock` crate's types into the public API.
@@ -50,11 +50,11 @@ pub enum LandlockOutcome {
 /// Returns `true` on Linux 5.13+ with the LSM enabled at boot, `false`
 /// otherwise. The probe issues `landlock_create_ruleset(2)` via
 /// [`Ruleset::create`] and immediately drops the returned fd; **it must
-/// never call [`RulesetCreated::restrict_self`]** because Landlock
+/// never call `RulesetCreated::restrict_self`** because Landlock
 /// intersects every successive `restrict_self` on the calling thread.
 /// Probing with an empty allowlist would therefore deny every subsequent
 /// filesystem write for the rest of the thread's life and the real
-/// [`restrict_to_module_paths`] call could only narrow that intersection,
+/// [`crate::landlock::restrict_to_module_paths`] call could only narrow that intersection,
 /// never relax it. Cheap but not memoised - cache the result if you call
 /// repeatedly.
 #[must_use]

--- a/crates/fast_io/src/o_tmpfile/types.rs
+++ b/crates/fast_io/src/o_tmpfile/types.rs
@@ -81,7 +81,7 @@ impl AnonymousTempFile {
     /// Atomically materializes the anonymous file at `dest` using `linkat(2)`.
     ///
     /// The destination path must not already exist. To replace an existing
-    /// file, remove it first (see [`remove_existing_destination`] in the
+    /// file, remove it first (see `remove_existing_destination` in the
     /// engine crate).
     ///
     /// This method consumes `self` because the anonymous fd is no longer

--- a/crates/fast_io/src/page_aligned.rs
+++ b/crates/fast_io/src/page_aligned.rs
@@ -8,11 +8,11 @@
 //!
 //! [`PageAlignedBuffer`] owns a heap allocation guaranteed to start on a
 //! page boundary. On Windows the backing store comes from
-//! [`VirtualAlloc`](windows_sys::Win32::System::Memory::VirtualAlloc) so the
+//! `VirtualAlloc` so the
 //! buffer can be handed directly to overlapped `WriteFile` / `ReadFile` calls
 //! issued against a handle opened with `FILE_FLAG_NO_BUFFERING`. On every
 //! other platform the buffer is allocated through [`std::alloc::alloc`] with
-//! an explicit page-aligned [`Layout`], matching the helper used by the
+//! an explicit page-aligned `Layout`, matching the helper used by the
 //! io_uring registered-buffer registry.
 //!
 //! Using a page-aligned buffer in the IOCP write path avoids the bounce
@@ -99,11 +99,11 @@ pub fn round_up_to_page(size: usize) -> usize {
 /// fewer bytes.
 ///
 /// On Windows the allocation comes from
-/// [`VirtualAlloc`](windows_sys::Win32::System::Memory::VirtualAlloc) so the
+/// `VirtualAlloc` so the
 /// memory can be handed straight to overlapped `WriteFile`/`ReadFile` on a
 /// handle opened with `FILE_FLAG_NO_BUFFERING`. On all other platforms the
 /// allocation is performed via [`std::alloc::alloc`] using a page-aligned
-/// [`Layout`]. In both cases the buffer is freed with the matching API in
+/// `Layout`. In both cases the buffer is freed with the matching API in
 /// the [`Drop`] impl, so callers do not need to manage lifetime explicitly.
 pub struct PageAlignedBuffer {
     ptr: *mut u8,

--- a/crates/fast_io/src/syscall_batch.rs
+++ b/crates/fast_io/src/syscall_batch.rs
@@ -10,7 +10,7 @@
 //! - **Individual path**: Processes operations one at a time using standard library calls
 //! - **Batched path**: Groups operations by type and processes them together
 //!
-//! Runtime selection uses [`BATCH_THRESHOLD`]: below this, use individual path;
+//! Runtime selection uses [`crate::syscall_batch::BATCH_THRESHOLD`]: below this, use individual path;
 //! at or above, use batched path.
 //!
 //! # Platform Support

--- a/crates/fast_io/src/temp_file_strategy.rs
+++ b/crates/fast_io/src/temp_file_strategy.rs
@@ -6,7 +6,7 @@
 //!
 //! - **Linux**: [`AnonymousTempFileStrategy`] uses `O_TMPFILE` + `linkat(2)`
 //!   for zero-cleanup atomic writes. No directory entry exists until commit.
-//! - **Windows**: [`WindowsTempFileStrategy`] uses `FILE_FLAG_DELETE_ON_CLOSE`
+//! - **Windows**: `WindowsTempFileStrategy` uses `FILE_FLAG_DELETE_ON_CLOSE`
 //!   for auto-cleanup temp files. The kernel deletes the file when the last
 //!   handle closes, providing crash-safe cleanup analogous to `O_TMPFILE`.
 //! - **All platforms**: [`NamedTempFileStrategy`] uses a uniquely-named temp
@@ -329,7 +329,7 @@ impl TempFileStrategy for NamedTempFileStrategy {
 /// - **Linux**: probes `O_TMPFILE` on the destination filesystem. If available,
 ///   uses anonymous temp files via [`AnonymousTempFileStrategy`].
 /// - **Windows**: probes `FILE_FLAG_DELETE_ON_CLOSE`. If available, uses
-///   delete-on-close temp files via [`WindowsTempFileStrategy`].
+///   delete-on-close temp files via `WindowsTempFileStrategy`.
 /// - **All platforms**: falls back to named temp files via [`NamedTempFileStrategy`].
 pub struct DefaultTempFileStrategy {
     named: NamedTempFileStrategy,

--- a/crates/fast_io/src/vmsplice_writer.rs
+++ b/crates/fast_io/src/vmsplice_writer.rs
@@ -29,7 +29,7 @@
 //!   reference instead of falling back to an internal copy.
 //!
 //! On Linux with the `vmsplice` feature, [`VmspliceFileWriter::write_chunk`]
-//! enforces those gates and falls back to [`std::fs::File::write_all`]
+//! enforces those gates and falls back to `std::fs::File::write_all`
 //! otherwise. Any kernel-side rejection (`ErrorKind::Unsupported`,
 //! `InvalidInput` mapped from `EINVAL`) also drops to the fallback so
 //! unsupported filesystems (tmpfs/FUSE/NFS) keep working.
@@ -147,7 +147,7 @@ impl VmspliceFileWriter {
     ///
     /// Any other case, plus any kernel-side rejection
     /// (`ErrorKind::Unsupported`, `EINVAL` mapped to `InvalidInput`), routes
-    /// to [`File::write_all`].
+    /// to `File::write_all`.
     ///
     /// # Errors
     ///

--- a/crates/fast_io/src/zero_detect.rs
+++ b/crates/fast_io/src/zero_detect.rs
@@ -17,8 +17,8 @@
 //!
 //! # Public API
 //!
-//! - [`find_first_nonzero`] - Returns index of the first non-zero byte
-//! - [`is_all_zeros`] - Fast check whether an entire buffer is zero
+//! - [`crate::zero_detect::find_first_nonzero`] - Returns index of the first non-zero byte
+//! - [`crate::zero_detect::is_all_zeros`] - Fast check whether an entire buffer is zero
 //!
 //! # Safety
 //!


### PR DESCRIPTION
## Summary

- Resolves ~40 unresolved-link rustdoc errors in `crates/fast_io/` that broke the Pages workflow (5 consecutive failures on `master`).
- Root cause: `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links` plus crate-level `#![deny(rustdoc::broken_intra_doc_links)]` escalated every broken link into a hard build failure.
- Fixes applied per-pattern without any `#[allow(...)]` waivers:
  - External-crate refs (`DashMap`, `Layout`, `AtomicUsize`, `VirtualAlloc`, `RulesetCreated`, `squeue::Entry`) demoted to backtick-only.
  - cfg-gated cross-platform types (`WindowsTempFileStrategy`, `StdFileReader`, `StdFileWriter`) routed through fully-qualified `crate::traits::*` paths or demoted to backtick-only so the Linux rustdoc build resolves them.
  - `super::*` references inside `io_uring/` submodules either redirected through `crate::io_uring::*` (public path) or demoted to backtick-only (private siblings like `super::file_reader`).
  - Self-crate refs that were missing a path (`record_sample`, `pick`, `size_threshold_pick`, `find_first_nonzero`, `is_all_zeros`, `BATCH_THRESHOLD`, `restrict_to_module_paths`) rewritten as `crate::module::item` so they resolve from `//!` module-level docs.
  - Bad/non-existent stdlib paths (`File::write_all`, `io::ErrorKind::Unsupported`) corrected or demoted.
  - `crate::io_uring::config::config_detail::io_uring_kernel_info` redirected to the public re-export `crate::io_uring_kernel_info`.

Scope is strictly `crates/fast_io/`. No public API, no behaviour change.

## Test plan

- [ ] Pages workflow build succeeds (`cargo doc --workspace --all-features --no-deps --locked` under `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`).
- [ ] fmt + clippy stay green.
- [ ] Nextest stable / Windows / macOS / Linux musl unaffected (docs-only change).