### PR TITLE
feat: add UTS-7.5 end-to-end test for daemon filter/exclude directives

### DIFF
--- a/docs/audits/uts-7-5-daemon-filter-directive.md
+++ b/docs/audits/uts-7-5-daemon-filter-directive.md
@@ -1,0 +1,94 @@
+# UTS-7.5 — daemon `filter` / `exclude` / `include` directive wire-up
+
+Status: covered end-to-end as of this PR. The runtime injection of daemon-side
+filter directives (`filter`, `exclude`, `include`, `exclude from`,
+`include from`) into the transfer's filter chain is in place; this note
+documents *where* the injection happens, *what order* the directives are
+applied, and *why* daemon rules take precedence over client-sent filters.
+
+## Injection point
+
+| Stage | Location | Responsibility |
+| --- | --- | --- |
+| Parser | `crates/daemon/src/daemon/sections/config_parsing/module_directives.rs` | Stores `filter` / `exclude` / `include` lines on `ModuleDefinitionBuilder` as `Vec<String>`; `exclude from` / `include from` as resolved `PathBuf`. |
+| Defaults | `crates/daemon/src/daemon/sections/module_definition/finish.rs` | Per-module directives override global defaults wholesale; an empty per-module list falls back to the global section's value. Mirrors upstream `loadparm.c` `P_LOCAL` semantics. |
+| Compilation | `crates/daemon/src/daemon/sections/module_access/helpers.rs::build_daemon_filter_rules` | Converts the stored strings into `Vec<FilterRuleWireFormat>`. Handles word-split, keyword forms (`include`/`exclude`/`hide`/`show`/`protect`/`risk`/`clear`), and `XFLG_DIR2WILD3` (`dir/` → `dir/***`) for directory-only excludes. Reads pattern files line-by-line, skipping `#`/`;` comments and blank lines. |
+| Wire-up | `crates/daemon/src/daemon/sections/module_access/transfer.rs:720` | Right after `build_server_config` succeeds and before any worker spawn, the compiled rules are written to `ServerConfig::daemon_filter_rules`. A pattern-file read failure aborts the session with `@ERROR: failed to load module filter rules: …`, matching upstream's `XFLG_FATAL_ERRORS` behaviour at `clientserver.c:881`. |
+| Receiver consumption | `crates/transfer/src/receiver/transfer/setup.rs:74-86` (deletion chain) and `crates/transfer/src/receiver/mod.rs:299` (`daemon_filter_set`, consulted at `build_files_to_transfer` and `create_directories`). | Daemon rules are prepended to client-sent wire rules before the `FilterSet`/`FilterChain` is built. A separate `daemon_filter_set` is held on `ReceiverContext` so receiver-side checks at file-list build and directory creation time consult the daemon rules even when no client filters arrived. |
+| Generator consumption | `crates/transfer/src/generator/filters.rs:64-86` | Same prepend-then-build pattern in server-mode `receive_filter_list_if_server`. |
+
+The directive ordering inside the compiled rule list matches upstream
+`clientserver.c:874-893` exactly:
+
+```
+1. filter        (parse_filter_str, FILTRULE_WORD_SPLIT)
+2. include_from  (parse_filter_file, FILTRULE_INCLUDE | FILTRULE_FATAL_ERRORS)
+3. include       (parse_filter_str, FILTRULE_INCLUDE | FILTRULE_WORD_SPLIT)
+4. exclude_from  (parse_filter_file, no flags + FILTRULE_FATAL_ERRORS)
+5. exclude       (parse_filter_str, FILTRULE_WORD_SPLIT)
+```
+
+Order is asserted by `build_daemon_filter_rules_ordering_filter_include_exclude_files`
+in `crates/daemon/src/daemon/sections/module_access/tests.rs`.
+
+## Precedence: daemon rules first
+
+Daemon-config rules are prepended to client-sent rules, not appended. Both
+sides of the transfer follow the same merge strategy:
+
+- **Receiver** — `crates/transfer/src/receiver/transfer/setup.rs:76-85`:
+
+  ```rust
+  let daemon_rules = &self.config.daemon_filter_rules;
+  let combined = if daemon_rules.is_empty() {
+      wire_rules
+  } else if wire_rules.is_empty() {
+      daemon_rules.clone()
+  } else {
+      let mut combined = daemon_rules.clone();
+      combined.extend(wire_rules);
+      combined
+  };
+  ```
+
+- **Generator** (server-mode) — `crates/transfer/src/generator/filters.rs:66-75`:
+  the same prepend pattern, behind a `client_mode` guard so client-side
+  filter construction is unaffected.
+
+Why prepend rather than append? In rsync's filter semantics the first
+matching rule wins. Upstream maintains a separate `daemon_filter_list`
+distinct from the client `filter_list` and consults it before any client
+filter via `check_filter()` calls in `receiver.c:711`, `generator.c:1273`,
+and the directory-listing path. Prepending into a single combined chain
+delivers the same observable behaviour: a daemon `- *.log` evaluated first
+will short-circuit a later client `+ *.log`, exactly as upstream's
+`check_filter(&daemon_filter_list)` short-circuits before the client list
+is consulted.
+
+The `XFLG_DIR2WILD3` transformation (`dir/` → `dir/***` for exclude rules
+only) is applied at compile time so the on-wire representation matches what
+upstream emits when it would have set the `FILTRULE_DIRECTORY` flag, and
+the include path keeps the trailing slash because upstream gates the
+transformation on `!FILTRULE_INCLUDE` (`exclude.c:212`).
+
+## Regression coverage
+
+| Layer | Test | Asserts |
+| --- | --- | --- |
+| Parser | `crates/daemon/src/daemon/sections/config_parsing/tests.rs` | Storage of `filter`/`exclude`/`include`/`exclude from`/`include from` on the builder. |
+| Builder finish | `crates/daemon/src/daemon/sections/module_definition/tests.rs` | Defaults fall through; per-module override replaces global. |
+| Compilation | `crates/daemon/src/daemon/sections/module_access/tests.rs` (`build_daemon_filter_rules_*`) | 15 cases covering empty/exclude/include/filter syntax, word-split, file load, missing-file failure, directive order, anchored, dir2wild3 transform, dir-only include preservation, and keyword forms (`exclude *.bak`). |
+| Receiver wire-up | `crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs` | `daemon_filter_rules` from `ServerConfig` compiles into the receiver's `daemon_filter_set` and rejects matching paths. |
+| End-to-end | `tests/integration_daemon_filter_directives.rs` (this PR) | Spawns a real in-process daemon, pushes mixed `.txt`/`.log` payload from `oc-rsync` subprocess, and asserts excluded files never land on disk under `filter = - *.log`, `exclude = *.log`, and `exclude from = <patterns-file>`. |
+
+## Upstream citations
+
+- `clientserver.c:rsync_module()` — daemon-filter list construction
+  (3.4.4 source: `target/interop/upstream-src/rsync-3.4.4/clientserver.c:876-895`).
+- `exclude.c::parse_filter_str` — `FILTRULE_WORD_SPLIT` semantics.
+- `exclude.c::parse_filter_file` — file-loaded patterns honour `#`/`;`
+  comments and blank lines.
+- `exclude.c:211-217` — `XFLG_DIR2WILD3` transformation gate
+  (`BITS_SETnUNSET(FILTRULE_DIRECTORY, FILTRULE_INCLUDE)`).
+- `receiver.c:711-714` and `generator.c:1273-1275` — `check_filter()` call
+  sites that consult `daemon_filter_list` before per-file actions.

--- a/tests/integration_daemon_filter_directives.rs
+++ b/tests/integration_daemon_filter_directives.rs
@@ -1,0 +1,337 @@
+//! UTS-7.5: end-to-end regression for daemon `filter`/`exclude`/`include from`/
+//! `exclude from` directives in rsyncd.conf.
+//!
+//! The wire-up funnels module config -> `build_daemon_filter_rules()` ->
+//! `ServerConfig::daemon_filter_rules` -> the receiver's `daemon_filter_set`
+//! plus a prepend into the deletion filter chain. This file pushes through a
+//! real in-process daemon and asserts that patterns excluded by a module
+//! directive never land on disk - regardless of whether the client supplied
+//! any filter on its own.
+//!
+//! upstream: clientserver.c:874-893 - `rsync_module()` builds
+//! `daemon_filter_list` from `filter` / `include_from` / `include` /
+//! `exclude_from` / `exclude` in that order, then `check_filter()` at
+//! `receiver.c:711-714` and `generator.c:1273-1275` consults it before any
+//! per-file action.
+//!
+//! Gated `#[cfg(unix)]` because the in-process client + daemon split uses
+//! POSIX TCP and the helper walks the destination with `read_dir`; the test
+//! also skips silently when ephemeral port allocation fails (sandboxed CI),
+//! mirroring the pattern from `integration_daemon_max_connections_cap.rs`
+//! and the daemon crate's `daemon_itemize_push` chunk.
+
+#![cfg(unix)]
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fs;
+use std::net::{Ipv4Addr, TcpListener};
+use std::path::Path;
+use std::sync::Mutex;
+use std::thread;
+
+use core::client::ClientConfig;
+use daemon::{DaemonConfig, run_daemon};
+use tempfile::tempdir;
+
+/// Serialise daemon-spawning tests in this binary. Port allocation is
+/// ephemeral but the lock keeps the source/destination tempdirs from
+/// stepping on each other when nextest schedules multiple binaries
+/// concurrently on a constrained CI runner.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Allocates a free TCP port for the test daemon. Returns both the port and
+/// the bound `TcpListener` so the listener can be handed to the daemon via
+/// `pre_bound_listener` - this closes the TOCTOU window between port
+/// allocation and the daemon's own bind.
+fn allocate_test_port() -> Option<(u16, TcpListener)> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    Some((port, listener))
+}
+
+/// Walks `root` recursively and returns the set of relative file paths. Used
+/// to assert the destination contains exactly the files we expect.
+fn collect_files(root: &Path) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                stack.push(path);
+            } else if meta.is_file() {
+                if let Ok(rel) = path.strip_prefix(root) {
+                    out.insert(rel.to_string_lossy().into_owned());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Result of running one push-to-daemon scenario.
+struct ScenarioOutcome {
+    files: HashSet<String>,
+}
+
+/// Configures a daemon with a single `[uploads]` module carrying the
+/// supplied per-module directive block, populates a `src/` tree with two
+/// `.txt` files (expected to land) and two `.log` files (expected to be
+/// excluded), and pushes via the in-process client. Returns `None` if the
+/// daemon could not bind (treated as a soft skip in CI sandboxes).
+fn run_filter_scenario(
+    test_name: &'static str,
+    extra_directive_lines: &str,
+) -> Option<ScenarioOutcome> {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    let Some((port, held_listener)) = allocate_test_port() else {
+        eprintln!("{test_name}: skipped, no free port");
+        return None;
+    };
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::create_dir(&src).expect("create src");
+    fs::create_dir(&dst).expect("create dst");
+
+    // Two of each: a single accidentally-dropped file cannot pass.
+    fs::write(src.join("keep1.txt"), b"keep me 1").expect("write keep1");
+    fs::write(src.join("keep2.txt"), b"keep me 2").expect("write keep2");
+    fs::write(src.join("drop1.log"), b"drop me 1").expect("write drop1");
+    fs::write(src.join("drop2.log"), b"drop me 2").expect("write drop2");
+
+    let config_path = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[uploads]\n\
+         path = {dst}\n\
+         use chroot = false\n\
+         read only = false\n\
+         {directives}\n",
+        dst = dst.display(),
+        directives = extra_directive_lines,
+    );
+    fs::write(&config_path, &config_content).expect("write rsyncd.conf");
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+            OsString::from("--max-sessions"),
+            OsString::from("1"),
+        ])
+        .pre_bound_listener(held_listener)
+        .build();
+
+    let daemon_handle = thread::spawn(move || run_daemon(daemon_config));
+
+    // Build the client-side push directly through `core::client::run_client`
+    // so the test exercises the same in-process orchestration as production
+    // CLI invocations, without spawning a separate subprocess.
+    let mut src_arg = src.clone().into_os_string();
+    src_arg.push("/");
+    let url = format!("rsync://127.0.0.1:{port}/uploads/");
+
+    let client_config = ClientConfig::builder()
+        .transfer_args([src_arg, OsString::from(&url)])
+        .recursive(true)
+        .build();
+
+    let client_result = core::client::run_client(client_config);
+
+    // The daemon was launched with `--max-sessions 1` so it returns to
+    // `run_daemon`'s return point after the single transfer drains.
+    let daemon_result = daemon_handle.join().expect("daemon thread panicked");
+
+    if let Err(err) = client_result {
+        panic!("{test_name}: client push failed: {err}");
+    }
+    if let Err(err) = daemon_result {
+        panic!("{test_name}: daemon exited with error: {err:?}");
+    }
+
+    Some(ScenarioOutcome {
+        files: collect_files(&dst),
+    })
+}
+
+/// `filter = - *.log` strips `.log` files server-side, regardless of any
+/// client-supplied filter. This proves the daemon-config injection site at
+/// `module_access::transfer::serve_module` (`build_daemon_filter_rules` ->
+/// `ServerConfig::daemon_filter_rules`) actually reaches the receiver's
+/// `daemon_filter_set` and the per-file filter check in
+/// `receiver/transfer/candidates.rs`.
+#[test]
+fn daemon_filter_directive_excludes_match_pattern() {
+    let Some(outcome) = run_filter_scenario(
+        "daemon_filter_directive_excludes_match_pattern",
+        "filter = - *.log",
+    ) else {
+        return;
+    };
+
+    assert!(
+        outcome.files.contains("keep1.txt"),
+        "keep1.txt must be transferred, got {:?}",
+        outcome.files
+    );
+    assert!(
+        outcome.files.contains("keep2.txt"),
+        "keep2.txt must be transferred, got {:?}",
+        outcome.files
+    );
+    assert!(
+        !outcome.files.contains("drop1.log"),
+        "drop1.log must be excluded by `filter = - *.log`, got {:?}",
+        outcome.files
+    );
+    assert!(
+        !outcome.files.contains("drop2.log"),
+        "drop2.log must be excluded by `filter = - *.log`, got {:?}",
+        outcome.files
+    );
+}
+
+/// `exclude = *.log` is the simple-exclude form upstream parses with
+/// `FILTRULE_WORD_SPLIT` and no `FILTRULE_INCLUDE` flag. The destination must
+/// be identical to the `filter = - *.log` form: both compile to the same
+/// exclude rule.
+#[test]
+fn daemon_exclude_directive_excludes_match_pattern() {
+    let Some(outcome) = run_filter_scenario(
+        "daemon_exclude_directive_excludes_match_pattern",
+        "exclude = *.log",
+    ) else {
+        return;
+    };
+
+    assert!(
+        outcome.files.contains("keep1.txt"),
+        "keep1.txt missing: {:?}",
+        outcome.files
+    );
+    assert!(
+        outcome.files.contains("keep2.txt"),
+        "keep2.txt missing: {:?}",
+        outcome.files
+    );
+    assert!(
+        !outcome.files.contains("drop1.log"),
+        "drop1.log must be excluded by `exclude = *.log`, got {:?}",
+        outcome.files
+    );
+    assert!(
+        !outcome.files.contains("drop2.log"),
+        "drop2.log must be excluded by `exclude = *.log`, got {:?}",
+        outcome.files
+    );
+}
+
+/// `exclude from = <file>` loads patterns one-per-line. Upstream parses each
+/// non-blank, non-`#`/`;` line via `parse_filter_file()` at
+/// `clientserver.c:889-891`. The same end-state must hold: `.txt` lands,
+/// `.log` is filtered before the receiver opens the temp file. The pattern
+/// file deliberately mixes blank lines, `#` comments, and `;` comments to
+/// guard against a future regression in `read_patterns_from_file()` skipping
+/// the wrong sentinel.
+#[test]
+fn daemon_exclude_from_directive_loads_pattern_file() {
+    let _guard = TEST_LOCK.lock().expect("test lock poisoned");
+
+    let Some((port, held_listener)) = allocate_test_port() else {
+        eprintln!("daemon_exclude_from_directive_loads_pattern_file: skipped, no free port");
+        return;
+    };
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    let patterns = temp.path().join("excludes.lst");
+    fs::create_dir(&src).expect("create src");
+    fs::create_dir(&dst).expect("create dst");
+
+    fs::write(src.join("keep1.txt"), b"keep1").expect("write keep1");
+    fs::write(src.join("keep2.txt"), b"keep2").expect("write keep2");
+    fs::write(src.join("drop1.log"), b"drop1").expect("write drop1");
+    fs::write(src.join("drop2.log"), b"drop2").expect("write drop2");
+
+    // upstream: parse_filter_file() honours `#` / `;` comments and ignores
+    // blank lines. Include all three flavours so any future regression in
+    // `read_patterns_from_file()` would surface here, not in a downstream
+    // interop run.
+    fs::write(
+        &patterns,
+        b"# block-style comment\n\
+          ; semicolon comment\n\
+          \n\
+          *.log\n",
+    )
+    .expect("write patterns");
+
+    let config_path = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[uploads]\n\
+         path = {dst}\n\
+         use chroot = false\n\
+         read only = false\n\
+         exclude from = {patterns}\n",
+        dst = dst.display(),
+        patterns = patterns.display(),
+    );
+    fs::write(&config_path, &config_content).expect("write rsyncd.conf");
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+            OsString::from("--max-sessions"),
+            OsString::from("1"),
+        ])
+        .pre_bound_listener(held_listener)
+        .build();
+
+    let daemon_handle = thread::spawn(move || run_daemon(daemon_config));
+
+    let mut src_arg = src.clone().into_os_string();
+    src_arg.push("/");
+    let url = format!("rsync://127.0.0.1:{port}/uploads/");
+
+    let client_config = ClientConfig::builder()
+        .transfer_args([src_arg, OsString::from(&url)])
+        .recursive(true)
+        .build();
+
+    let client_result = core::client::run_client(client_config);
+    let daemon_result = daemon_handle.join().expect("daemon thread panicked");
+
+    if let Err(err) = client_result {
+        panic!("client push failed: {err}");
+    }
+    if let Err(err) = daemon_result {
+        panic!("daemon exited with error: {err:?}");
+    }
+
+    let files = collect_files(&dst);
+    assert!(files.contains("keep1.txt"), "keep1.txt missing: {files:?}");
+    assert!(files.contains("keep2.txt"), "keep2.txt missing: {files:?}");
+    assert!(
+        !files.contains("drop1.log"),
+        "drop1.log must be excluded by exclude-from file, got {files:?}"
+    );
+    assert!(
+        !files.contains("drop2.log"),
+        "drop2.log must be excluded by exclude-from file, got {files:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- UTS-7.5 (#3957) closure: the runtime wire-up that turns rsyncd.conf `filter`, `exclude`, `include`, `exclude from`, and `include from` directives into receiver-side filter rules is already in place at `module_access::transfer::serve_module` -> `build_daemon_filter_rules` -> `ServerConfig::daemon_filter_rules` -> `daemon_filter_set` on the receiver, with module rules prepended to client-sent wire rules in `receiver/transfer/setup.rs` and `generator/filters.rs`.
- What was missing was a regression test that pushes through a real in-process daemon and asserts the directive actually drops matching files on disk. This PR adds `tests/integration_daemon_filter_directives.rs` which spawns `run_daemon` against a pre-bound listener, runs an in-process `core::client::run_client` push, and asserts `.txt` survives while `.log` is filtered, under three directive forms: `filter = - *.log`, `exclude = *.log`, and `exclude from = <file>` (with the file mixing blank lines plus `#`/`;` comments to guard the `read_patterns_from_file` parser).
- Adds `docs/audits/uts-7-5-daemon-filter-directive.md` documenting the injection point (`crates/daemon/src/daemon/sections/module_access/transfer.rs:720`) and the daemon-rules-first precedence decision, with upstream `clientserver.c:874-893` citations.

## Test plan

- [x] `daemon_filter_directive_excludes_match_pattern` - `filter = - *.log` drops `drop1.log`/`drop2.log`; `keep1.txt`/`keep2.txt` land.
- [x] `daemon_exclude_directive_excludes_match_pattern` - `exclude = *.log` (the bare-pattern form) reaches the same end-state as the `filter = - *.log` form.
- [x] `daemon_exclude_from_directive_loads_pattern_file` - `exclude from = <patterns>` with a file that mixes blank lines, `#`, and `;` comments still loads the `*.log` rule and filters on disk.
- [x] Soft-skips when ephemeral-port allocation fails (mirrors the sandboxed-CI path used by `integration_daemon_max_connections_cap.rs`).
- [x] `cfg(unix)`-gated; daemon parity on Windows is not yet certified, matching the gating decision in the sibling daemon tests.