### PR TITLE
fix(cli): enable --xattrs on Windows with feature flag

### DIFF
--- a/crates/cli/src/frontend/execution/drive/messages.rs
+++ b/crates/cli/src/frontend/execution/drive/messages.rs
@@ -31,7 +31,7 @@ where
 
 #[cfg(any(
     not(all(any(unix, windows), feature = "acl")),
-    not(all(unix, feature = "xattr"))
+    not(all(any(unix, windows), feature = "xattr"))
 ))]
 /// Emits an error message with a caller-supplied fallback string and returns the exit code.
 pub(super) fn fail_with_custom_fallback<Err>(

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -18,7 +18,7 @@ use super::super::super::{
 };
 #[cfg(any(
     not(all(any(unix, windows), feature = "acl")),
-    not(all(unix, feature = "xattr"))
+    not(all(any(unix, windows), feature = "xattr"))
 ))]
 use super::super::messages::fail_with_custom_fallback;
 use super::super::messages::fail_with_message;
@@ -173,7 +173,7 @@ where
     #[cfg(all(any(unix, windows), feature = "acl"))]
     let _ = preserve_acls;
 
-    #[cfg(not(all(unix, feature = "xattr")))]
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
     if xattrs.unwrap_or(false) {
         let message = rsync_error!(1, "extended attributes are not supported on this client")
             .with_role(Role::Client);
@@ -181,10 +181,10 @@ where
         return Err(fail_with_custom_fallback(message, fallback, stderr));
     }
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     let _ = xattrs;
 
-    #[cfg(all(unix, feature = "acl", feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "acl", feature = "xattr"))]
     let _ = stderr;
 
     Ok(())

--- a/crates/cli/src/frontend/tests/xattrs.rs
+++ b/crates/cli/src/frontend/tests/xattrs.rs
@@ -26,6 +26,34 @@ fn xattrs_option_reports_unsupported_when_feature_disabled() {
     assert_contains_client_trailer(&rendered);
 }
 
+/// Windows builds with the `xattr` feature must accept `--xattrs` and not
+/// emit the "extended attributes are not supported on this client" preflight
+/// rejection. The CLI gate must mirror Unix so `metadata::xattr_windows`
+/// (FindFirstStreamW ADS impl) can run.
+#[cfg(all(windows, feature = "xattr"))]
+#[test]
+fn xattrs_preflight_accepts_on_windows_with_feature() {
+    use tempfile::tempdir;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    std::fs::write(&source, b"data").expect("write source");
+
+    let (_code, _stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--xattrs"),
+        source.into_os_string(),
+        destination.into_os_string(),
+    ]);
+
+    let rendered = String::from_utf8(stderr).expect("UTF-8 error");
+    assert!(
+        !rendered.contains("extended attributes are not supported on this client"),
+        "preflight must not reject --xattrs on Windows with feature = xattr: {rendered}"
+    );
+}
+
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn xattrs_option_preserves_attributes() {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -78,8 +78,8 @@ zlib-ng = ["compress/zlib-ng", "engine/zlib-ng", "transfer/zlib-ng", "protocol/z
 # ============================================================================
 # Metadata Features
 # ============================================================================
-# xattr in core is a no-op on Windows; on Unix the target deps above add the real bits
-xattr = ["transfer/xattr"]
+# xattr on Windows uses metadata/xattr_windows (FindFirstStreamW ADS); on Unix the target deps above add the real bits
+xattr = ["metadata/xattr", "transfer/xattr"]
 acl = ["metadata/acl", "engine/acl", "transfer/acl"]
 
 # Character encoding conversion for filenames (iconv)


### PR DESCRIPTION
## Summary

- Widen the CLI preflight cfg gate so `--xattrs` is accepted on Windows when built with `feature = "xattr"`, instead of being silently rejected before `metadata::xattr_windows` (FindFirstStreamW ADS impl) can run. Mirrors the ACL gate.
- Update the matching cfg gate on the `fail_with_custom_fallback` definition in `messages.rs` so it does not become dead code on Windows + `--features acl,xattr` (the missing half that broke #5564's Windows CI cells with `function 'fail_with_custom_fallback' is never used`).
- Propagate `metadata/xattr` through the `core` crate's `xattr` feature so the metadata implementation actually compiles in, mirroring the `acl` wiring at the adjacent line.
- Add a Windows-only regression test (`cfg(all(windows, feature = "xattr"))`) that runs `--xattrs` end-to-end through the CLI and asserts no `extended attributes are not supported on this client` preflight rejection.

Supersedes #5564 (closed by this PR). #5564 fixed the preflight site only; the matching gate on the `fail_with_custom_fallback` definition was missed, which surfaced as `Windows (stable/beta/nightly)`, `Windows IOCP`, `Windows ACL/xattr`, and `Windows GNU cross-check` failing with `function 'fail_with_custom_fallback' is never used`.

Follow-ups (out of scope; tracked separately):

- The `cfg(unix)` target-specific `metadata` and `engine` dependencies in `crates/core/Cargo.toml` still pin the `xattr` feature only for Unix targets. The propagation added here (`xattr = ["metadata/xattr", "transfer/xattr"]`) is sufficient because `metadata` is a base (non-target-gated) dependency in `core`, but the target-gated blocks and the matching wiring in `crates/cli/Cargo.toml` / `crates/metadata/Cargo.toml` could be audited for consistency in a follow-up.

## Test plan

- [ ] Windows nextest cell: new `xattrs_preflight_accepts_on_windows_with_feature` test passes and the previous `function 'fail_with_custom_fallback' is never used` build failure is gone.
- [ ] Linux/macOS nextest cells: existing `xattrs_option_reports_unsupported_when_feature_disabled` and `xattrs_option_preserves_attributes` paths unchanged.
- [ ] Required CI cells green: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable).