### PR TITLE
feat(engine): add spill_activations counter + one-shot spill warning telemetry

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -38,6 +38,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             spill_write_pos: 0,
             granularity: SpillGranularity::default(),
             spill_count: 0,
+            spill_activations: 0,
             reload_count: 0,
             dir_recreate_count: 0,
             compression: SpillCompression::None,
@@ -80,6 +81,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             spill_write_pos: 0,
             granularity: SpillGranularity::default(),
             spill_count: 0,
+            spill_activations: 0,
             reload_count: 0,
             dir_recreate_count: 0,
             compression: SpillCompression::None,
@@ -233,6 +235,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
         SpillStats {
             spilled_items: self.spill_index.len(),
             spill_events: self.spill_count,
+            spill_activations: self.spill_activations,
             reload_events: self.reload_count,
             memory_used: self.memory_used,
             threshold: self.threshold,

--- a/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/mod.rs
@@ -117,7 +117,18 @@ pub struct SpillableReorderBuffer<T: SpillCodec> {
     /// one-record-per-item layout.
     granularity: SpillGranularity,
     /// Running count of spill-to-disk events (for diagnostics).
+    ///
+    /// One event is one on-disk record written; granularity-dependent.
     spill_count: u64,
+    /// Running count of `spill_excess` calls that produced at least one
+    /// on-disk record (for diagnostics).
+    ///
+    /// Granularity-invariant: a single call always increments this counter by
+    /// at most one, even when [`SpillGranularity::PerItem`] writes many
+    /// records. Surfaced through
+    /// [`SpillStats::spill_activations`](super::SpillStats::spill_activations)
+    /// to feed adaptive ring sizing (ROB-7) and bench rate audits (ROB-6).
+    spill_activations: u64,
     /// Running count of reload-from-disk events (for diagnostics).
     reload_count: u64,
     /// Running count of `create_dir_all` retries after the spill directory
@@ -154,6 +165,7 @@ impl<T: SpillCodec> std::fmt::Debug for SpillableReorderBuffer<T> {
             .field("buffered_count", &self.inner.buffered_count())
             .field("spilled_count", &self.spill_index.len())
             .field("spill_events", &self.spill_count)
+            .field("spill_activations", &self.spill_activations)
             .field("reload_events", &self.reload_count)
             .field("dir_recreate_count", &self.dir_recreate_count)
             .field("granularity", &self.granularity)

--- a/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/spill.rs
@@ -100,7 +100,12 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
         // Emit the one-shot warning after a successful spill that actually
         // wrote at least one record. Checking spill_count > prev_spill_count
         // avoids false positives when all candidates were in the hot zone.
+        // The per-call `spill_activations` counter is granularity-invariant
+        // (one increment per successful call) so adaptive ring sizing can
+        // measure pressure without compensating for PerItem vs WholeBatch
+        // record fan-out.
         if result.is_ok() && self.spill_count > prev_spill_count {
+            self.spill_activations += 1;
             self.spill_warned =
                 emit_spill_warning(self.spill_dir.as_deref(), self.threshold, self.spill_warned);
         }

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs
@@ -300,3 +300,88 @@ fn spill_warned_false_when_no_spill() {
     );
     assert_eq!(buf.spill_stats().spill_events, 0);
 }
+
+#[test]
+fn spill_activations_counter_increments_on_each_spill() {
+    // ROB-2: spill_activations is the per-call counter that adaptive ring
+    // sizing (ROB-7) reads. It must rise once per successful spill_excess
+    // call regardless of the on-disk record count produced by that call.
+
+    // PerItem granularity so the test does not need to reason about the
+    // whole-batch record-fan-out path. Threshold = 16 bytes = 2 items.
+    use super::super::super::SpillGranularity;
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::new(64, 16).with_granularity(SpillGranularity::PerItem);
+
+    // First insert past threshold: one activation.
+    for i in (0..4).rev() {
+        buf.insert(i, i * 10).unwrap();
+    }
+    let after_first = buf.spill_stats().spill_activations;
+    assert!(
+        after_first >= 1,
+        "expected >= 1 activation after first spill, got {after_first}"
+    );
+
+    // Drain to free memory, then refill past threshold again - another
+    // activation must register on the second pressure event.
+    let drained = drain_all(&mut buf);
+    assert_eq!(drained.len(), 4);
+    for i in (4..8).rev() {
+        buf.insert(i, i * 10).unwrap();
+    }
+    let after_second = buf.spill_stats().spill_activations;
+    assert!(
+        after_second > after_first,
+        "second pressure event must increment activations: {after_first} -> {after_second}"
+    );
+
+    // Third pressure event.
+    let _ = drain_all(&mut buf);
+    for i in (8..12).rev() {
+        buf.insert(i, i * 10).unwrap();
+    }
+    let after_third = buf.spill_stats().spill_activations;
+    assert!(
+        after_third > after_second,
+        "third pressure event must increment activations: {after_second} -> {after_third}"
+    );
+}
+
+#[test]
+fn spill_warning_fires_once_per_transfer() {
+    // ROB-3: the one-shot warning must fire exactly once per buffer lifetime
+    // even when many activations occur. We exercise the `spill_warned()`
+    // accessor because it is the established convention in this module for
+    // verifying warning behaviour (no `tracing-subscriber` dev-dep is wired).
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(64, 16);
+
+    // Before any spill: warning has not fired.
+    assert!(!buf.spill_warned(), "warning must not fire pre-threshold");
+
+    // Force at least 5 activations by alternating fill / drain cycles. Each
+    // cycle climbs past the threshold, triggering one or more on-disk records.
+    let mut base: u64 = 0;
+    for _ in 0..5 {
+        for i in (0..6).rev() {
+            buf.insert(base + i, (base + i) * 10).unwrap();
+        }
+        let drained = drain_all(&mut buf);
+        assert_eq!(drained.len(), 6);
+        base += 6;
+    }
+
+    let stats = buf.spill_stats();
+    assert!(
+        stats.spill_activations >= 5,
+        "expected >= 5 activations across 5 pressure cycles, got {}",
+        stats.spill_activations
+    );
+
+    // Despite many activations the one-shot flag is still set (it never
+    // un-sets) and the warning is documented to have fired exactly once.
+    assert!(
+        buf.spill_warned(),
+        "warning flag must be set after the first activation"
+    );
+}

--- a/crates/engine/src/concurrent_delta/spill/stats.rs
+++ b/crates/engine/src/concurrent_delta/spill/stats.rs
@@ -12,7 +12,22 @@ pub struct SpillStats {
     /// Number of items currently spilled to disk.
     pub spilled_items: usize,
     /// Total spill-to-disk events since creation.
+    ///
+    /// One event is one on-disk record written. Under
+    /// [`SpillGranularity::PerItem`](super::SpillGranularity::PerItem) this
+    /// rises once per spilled item; under
+    /// [`SpillGranularity::WholeBatch`](super::SpillGranularity::WholeBatch)
+    /// it rises once per batch. See [`spill_activations`](Self::spill_activations)
+    /// for a per-call counter that is invariant to granularity.
     pub spill_events: u64,
+    /// Total spill-activation events since creation.
+    ///
+    /// Counts each `spill_excess` call that successfully wrote at least one
+    /// record, regardless of how many records that call produced. Adaptive
+    /// ring sizing (ROB-7) and bench normal-operation spill-rate audits
+    /// (ROB-6) use this counter because it is invariant to
+    /// [`SpillGranularity`](super::SpillGranularity).
+    pub spill_activations: u64,
     /// Total reload-from-disk events since creation.
     pub reload_events: u64,
     /// Current estimated in-memory bytes.

--- a/docs/audits/rob-spill-prevention.md
+++ b/docs/audits/rob-spill-prevention.md
@@ -1,0 +1,53 @@
+# ROB - Reorder Buffer Spill Prevention
+
+Parent task: ROB-1 (spill-prevention initiative for the parallel-delta
+`SpillableReorderBuffer`). This audit tracks the observability and adaptive
+sizing work that lets us see and then reduce disk-spill events on
+normal-operation transfers.
+
+## Status
+
+| Task | Topic | Status |
+|------|-------|--------|
+| ROB-2 | `spill_activations` counter on `SpillStats` | shipped |
+| ROB-3 | One-shot `warn!` on first spill activation per transfer | shipped |
+| ROB-4 | Which-paths-spill audit (consumer / WholeBatch vs PerItem) | open |
+| ROB-5 | Heuristics for adaptive ring sizing | open |
+| ROB-6 | Bench normal-operation spill rate against upstream | open |
+| ROB-7 | Adaptive ring sizing wired into `SpillPolicy` | open |
+
+## Telemetry surface (ROB-2 / ROB-3)
+
+`SpillStats` now exposes `spill_activations: u64` alongside the historical
+`spill_events` counter:
+
+- `spill_events` rises once per on-disk record written. With
+  `SpillGranularity::PerItem` a single `spill_excess` call can produce many
+  events; with `SpillGranularity::WholeBatch` it produces one event per call.
+- `spill_activations` rises exactly once per `spill_excess` call that
+  succeeded in writing at least one record. The counter is
+  granularity-invariant, so ROB-6's bench harness and ROB-7's adaptive sizer
+  can compare normal-operation spill pressure across granularities without
+  compensating for record fan-out.
+
+The one-shot `warn!` (emitted via `tracing::warn!` when the `tracing` feature
+is enabled) carries the spill directory path so operators can locate the
+temp files for diagnosis even before ROB-7's adaptive sizing ships. The
+warning fires at most once per buffer lifetime; subsequent activations
+increment `spill_activations` silently so log volume stays bounded under
+sustained pressure.
+
+## Why this is the prerequisite
+
+ROB-4 (which-paths-spill audit) needs a per-call counter to attribute spill
+pressure to specific dispatch paths. ROB-6 (bench rate) needs a counter
+that does not change shape when the granularity policy is tuned. Both depend
+on this PR landing first so the downstream tasks measure something stable.
+
+## Verification convention
+
+The buffer module does not wire `tracing-subscriber` as a dev-dependency, so
+warning behaviour is verified through the existing `spill_warned()` accessor
+rather than log capture. New tests for `spill_activations` exercise the
+counter directly through `spill_stats()` and confirm the one-shot semantics
+via the same flag the earlier `spill_warned_*` tests use.


### PR DESCRIPTION
## Summary

- Add a granularity-invariant `spill_activations` counter to `SpillStats` (and the live counter on `SpillableReorderBuffer`) so adaptive ring sizing and bench rate audits can measure spill pressure without compensating for `SpillGranularity::PerItem` vs `WholeBatch` record fan-out.
- Document the existing one-shot `tracing::warn!` that fires on the first activation per buffer lifetime and includes the spill-directory path; the warning is the operator-visible signal that the threshold has been crossed.
- Add a brief audit at `docs/audits/rob-spill-prevention.md` recording how downstream ROB tasks (which-paths-spill audit, bench normal-operation spill rate, adaptive ring sizing) consume the new telemetry.

This is the observability prerequisite for the ROB series. Telemetry-only change - no spill semantics modified.

## Test plan

- [x] Two new unit tests in `crates/engine/src/concurrent_delta/spill/buffer/tests/basic.rs`:
  - `spill_activations_counter_increments_on_each_spill` - forces three pressure events under `PerItem` granularity and asserts the counter rises monotonically.
  - `spill_warning_fires_once_per_transfer` - drives 5 activation cycles and confirms `spill_warned()` stays set after the first event (matches the existing module convention for warning-behaviour verification).
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.