### PR TITLE
docs(design): document zlib codec invariants and basis-window contract

### DIFF
--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -75,6 +75,8 @@ jobs:
           - workspace: fuzz
             target: decompressor_zlib
           - workspace: fuzz
+            target: zlib_token_decode
+          - workspace: fuzz
             target: acl_xattr_wire
           - workspace: fuzz
             target: differential_multiplex

--- a/crates/compress/src/zlib/tests.rs
+++ b/crates/compress/src/zlib/tests.rs
@@ -1152,3 +1152,91 @@ fn counting_encoder_flush_produces_sync_flush() {
         b"token-one data payloadtoken-two different data",
     );
 }
+
+/// UTS-18.k invariant: a malformed insert token whose deflate frame is
+/// truncated past the literal-payload edge must surface a typed
+/// `io::Error` from the streaming decoder, never a panic.
+///
+/// Mirrors the "INSERT token past the basis-window edge" failure mode
+/// documented in `docs/design/zlib-codec-invariants.md` section 1.1:
+/// the wire promises N bytes of decompressed literal but the deflate
+/// stream ends before N bytes have been produced. The receiver pipeline
+/// hands the partial frame to `CountingZlibDecoder` via the
+/// `compressed_token` layer; this test pins the panic-freedom guarantee
+/// at the lowest level.
+#[test]
+fn malformed_deflate_header_returns_err() {
+    // Start a valid deflate frame (`0x78` = BFINAL=0, BTYPE=00, stored
+    // block) but follow it with an inconsistent length/NLEN pair so the
+    // stored-block header fails its ones-complement check. The raw
+    // deflate decoder MUST reject this without aborting.
+    //
+    // Wire layout: byte 0 = block header, bytes 1..3 = LEN, bytes 3..5
+    // = NLEN. LEN = 0x0A and NLEN = 0x0A produce `~LEN != NLEN`, the
+    // canonical malformed stored-block trigger.
+    let malformed: Vec<u8> = vec![0x78, 0x0A, 0x00, 0x0A, 0x00, 0xDE, 0xAD, 0xBE, 0xEF];
+
+    let mut decoder = CountingZlibDecoder::new(Cursor::new(malformed));
+    let mut sink = Vec::new();
+    let result = decoder.read_to_end(&mut sink);
+
+    // The reject path must surface as `Err`, not as a clean Ok with
+    // empty output. A clean Ok would mask a class of malformed-frame
+    // failures the receiver pipeline relies on for fail-loud
+    // semantics.
+    assert!(
+        result.is_err(),
+        "malformed stored-block header must surface as Err, got Ok({})",
+        sink.len(),
+    );
+    // Counter must honour the saturating-add invariant from section
+    // 2.4 of the design doc: bytes_read tracks output produced before
+    // the error, so it cannot exceed what landed in the sink.
+    assert!(
+        decoder.bytes_read() as usize == sink.len(),
+        "bytes_read counter ({}) must match sink length ({})",
+        decoder.bytes_read(),
+        sink.len(),
+    );
+}
+
+/// UTS-18.k invariant: a COPY token that would address bytes past the
+/// decoded-stream edge - the streaming analog of `offset + len >
+/// window_start + window_len` - must surface a typed `io::Error` from
+/// the streaming decoder, never a panic.
+///
+/// Mirrors the "COPY token with offset beyond `window_start +
+/// window_len`" failure mode documented in section 1.2 of the design
+/// doc: a valid deflate frame produces M decompressed bytes, but the
+/// caller continues to pull from the decoder after EOF. The decoder
+/// must signal end-of-stream cleanly (`Ok(0)`) without ever indexing
+/// past the inflate engine's internal output window.
+#[test]
+fn read_beyond_decoded_payload_returns_eof_not_panic() {
+    let payload = b"basis-window literal payload".repeat(4);
+    let compressed =
+        compress_to_vec(&payload, CompressionLevel::Default).expect("compress payload");
+
+    let mut decoder = CountingZlibDecoder::new(Cursor::new(compressed));
+    let mut sink = Vec::new();
+    decoder.read_to_end(&mut sink).expect("decode valid stream");
+    assert_eq!(sink, payload);
+    let bytes_after_valid_decode = decoder.bytes_read();
+
+    // Continuing to read past the end of the decompressed payload must
+    // return `Ok(0)` (clean EOF) on every subsequent call. The decoder
+    // must not panic, and `bytes_read` must not advance past the actual
+    // decoded length.
+    let mut tail_buf = [0u8; 64];
+    for _ in 0..4 {
+        let n = decoder
+            .read(&mut tail_buf)
+            .expect("post-EOF read must not error");
+        assert_eq!(n, 0, "expected Ok(0) past stream end, got {n}");
+    }
+    assert_eq!(
+        decoder.bytes_read(),
+        bytes_after_valid_decode,
+        "bytes_read must not advance past clean EOF",
+    );
+}

--- a/docs/design/fuzz-coverage-matrix.md
+++ b/docs/design/fuzz-coverage-matrix.md
@@ -49,6 +49,7 @@ The matrix below tracks per-target coverage metrics. Columns:
 | `decompressor_zlib`       | codec    | -     | -        | -      | 0      | -        |
 | `decompressor_zstd`       | codec    | -     | -        | -      | 0      | -        |
 | `simd_checksum_parity`    | codec    | -     | -        | -      | 0      | -        |
+| `zlib_token_decode`       | codec    | -     | -        | -      | 0      | -        |
 
 ### 1.4 Differential targets (threshold: >80% edge coverage)
 

--- a/docs/design/zlib-codec-invariants.md
+++ b/docs/design/zlib-codec-invariants.md
@@ -1,0 +1,204 @@
+# UTS-18.k - Zlib codec and basis-window invariants
+
+This document records the wire-byte and runtime invariants that govern the
+delta-transfer codec stack: the upstream-compatible zlib token decoder
+(`crates/protocol/src/wire/compressed_token/zlib_codec.rs`), the basis-window
+mapper that backs every COPY token (`crates/transfer/src/map_file/buffered.rs`),
+and the streaming raw-deflate encoder/decoder primitives in
+`crates/compress/src/zlib/`. The invariants below are load-bearing for the
+panic-freedom guarantees the receiver pipeline depends on; any change to the
+codec, mapper, or compress crate that relaxes one of these invariants must be
+accompanied by a new regression test in the same module.
+
+Tracked under the UTS-18 series. Closes the documentation gap left open by
+PRs #5566 / #5569 / #5588 (BufferedMap fail-loud, window clamp, never-shrink)
+and PR #5535 / URV-1 (zlib obuf overflow on matched-block inserts).
+
+## 1. Wire-byte invariants
+
+The delta wire stream is a sequence of token frames. Each token references
+either literal bytes (the sender's INSERT) or a position in the receiver's
+basis file (the sender's COPY). The codec carries the literal payload; the
+basis mapper materialises COPY ranges out of the receiver's local file. Both
+sides share a single contract: the offsets the wire commits to must be
+addressable, and any out-of-range request must surface as a typed
+`io::Error`, never an abort.
+
+### 1.1 INSERT tokens
+
+- INSERT tokens carry literal bytes inline. For zlib mode, the literal is
+  delivered as one or more `DEFLATED_DATA` frames whose 14-bit length field
+  is bounded by `MAX_DATA_COUNT = 16383` per upstream `token.c:338`.
+- A receiver must accept consecutive `DEFLATED_DATA` frames until a
+  non-DEFLATED flag byte appears. The accumulator that joins them MUST cap
+  the aggregate length so an unbounded chain cannot drive the decoder to
+  OOM. The cap lives at
+  `crates/protocol/src/wire/compressed_token/zlib_codec.rs::MAX_ACCUMULATED_COMPRESSED_BYTES`
+  (64 MiB). Upstream's defence-in-depth equivalent was added in 3.4.3.
+- The literal length the receiver writes out of `recv_token` is bounded by
+  `CHUNK_SIZE`. Any larger decompressed run must be returned across
+  multiple `CompressedToken::Literal` calls so a single allocation never
+  exceeds `CHUNK_SIZE`.
+
+### 1.2 COPY tokens and the basis window
+
+- COPY tokens carry a 32-bit block index that the receiver translates into
+  a `(offset, len)` request against the basis-file mapper. The mapper is
+  `BufferedMap` in `crates/transfer/src/map_file/buffered.rs`.
+- The basis window covers `[window_start, window_start + window_len)`. A
+  COPY request `(offset, len)` is in-window iff
+  `offset >= window_start && offset + len <= window_start + window_len`.
+  Out-of-window requests trigger `load_window`.
+- `window_len` is clamped at the single assignment site in `load_window`
+  to `min(MAX_MAP_SIZE, file_size - window_start)`. The clamp is the only
+  legitimate path that produces a window smaller than the configured
+  maximum. This is the UTS-18.g.2 / PR #5569 invariant.
+- `MAX_MAP_SIZE = 256 KiB` (mirrors upstream `MAX_MAP_SIZE` in
+  `crates/transfer/src/constants.rs`). The window is aligned down to
+  `MIN_MAP_SIZE = 1024` byte boundaries via `align_down()` so partial
+  blocks at the head of the buffer remain addressable.
+- Any COPY request that would address `offset + len > file_size` returns
+  `io::ErrorKind::UnexpectedEof` from `map_ptr` without ever indexing into
+  the buffer slice. This is the UTS-18.f / PR #5566 invariant.
+
+### 1.3 END marker
+
+- The encoder writes the `END_FLAG` byte (`0x00`) after the final token
+  run. The decoder treats `END_FLAG` as a clean stream terminator and
+  returns `CompressedToken::End`.
+- A stream that ends mid-frame (no `END_FLAG`, or `END_FLAG` arriving while
+  the run counter is non-zero) MUST surface an `io::Error` from
+  `read_exact`. The decoder never silently terminates with pending state.
+
+## 2. Runtime invariants
+
+### 2.1 BufferedMap: fail-loud bounds (UTS-18.f / PR #5566)
+
+- `map_ptr(offset, len)` returns `io::ErrorKind::UnexpectedEof` when
+  `offset + len > file_size`. Saturation arithmetic on `offset + len`
+  prevents the bounds-check itself from wrapping.
+- `len == 0` is short-circuited to `Ok(&[])` before any range arithmetic
+  so a zero-length call cannot underflow the slice index.
+- Inside `load_window`, if the clamped `window_size` is still smaller than
+  `offset_in_window + min_len`, the function returns
+  `io::ErrorKind::UnexpectedEof` BEFORE the subsequent `copy_within` /
+  `read_exact` calls. The two slice indexing operations that previously
+  panicked (`copy_within` at the resize site and `&buffer[start..end]` in
+  `map_ptr`) are now reachable only when the bounds check has succeeded.
+
+### 2.2 BufferedMap: window clamp at the source (UTS-18.g.2 / PR #5569)
+
+- `window_size` is computed once at the top of `load_window` as
+  `(self.max_window as u64).min(remaining) as usize` where `remaining =
+  size - aligned_start`. This is the only place `window_len` is derived.
+  No downstream code in the receiver should re-clamp `window_len`; doing
+  so would mask future regressions in the source clamp.
+- The clamp keeps a small file (e.g., 48128 bytes) paired with the default
+  `MAX_MAP_SIZE = 262144` window from generating a `window_len` larger
+  than the file, which previously triggered the `copy_within` panic the
+  guards in 2.1 now catch.
+
+### 2.3 BufferedMap: monotonic buffer length (UTS-18.h / PR #5588)
+
+- `self.buffer` grows but never shrinks during a session. The
+  reload paths in `load_window` use `target_len = window_size.max(buffer.len())`
+  so a reload that requests a smaller window than the prior allocation
+  cannot truncate the bytes the overlap branch is about to relocate via
+  `copy_within`. This mirrors upstream `fileio.c:236` `realloc_array`,
+  which only grows the backing buffer.
+- `window_len` continues to bound the valid region. Callers only read
+  `&buffer[start..start + len]` after the `is_in_window` / `load_window`
+  bounds checks, so a buffer that is allocated larger than `window_len`
+  cannot leak stale tail bytes to a caller.
+
+### 2.4 Zlib token decoder: counter and accumulator bounds (URV-1 / PR #5535 + 3.4.3 defence-in-depth)
+
+- `rx_token` increments use `checked_add` for both the `TOKEN_REL` /
+  `TOKEN_LONG` literal-flag path and the run-tail emission loop. A
+  malicious sender that drives `rx_token` past `i32::MAX` receives
+  `io::ErrorKind::InvalidData`; the decoder never wraps into the valid
+  block-index range.
+- Absolute `TOKEN_LONG` values that decode to negative `i32` (high bit
+  set) are rejected with `io::ErrorKind::InvalidData`. This prevents a
+  block index that wraps from `u32::MAX` back into the receiver's basis
+  range, mirroring upstream's 3.4.2 hardening.
+- Accumulated `DEFLATED_DATA` runs are capped at
+  `MAX_ACCUMULATED_COMPRESSED_BYTES = 64 MiB` per token call. Hostile
+  peers cannot drive the decoder to allocate without bound.
+
+### 2.5 Zlib token encoder: matched-block insert obuf safety (URV-1 / PR #5535)
+
+- `see_token` (the dictionary-sync path for CPRES_ZLIB) loops the
+  underlying `compress()` call until the input chunk is fully consumed.
+  Single-shot calls could leave a worst-case 0xFFFF-byte incompressible
+  insert with unconsumed tail bytes, silently corrupting the receiver's
+  dictionary on the next literal pass. The fix mirrors upstream's
+  `send_deflated_token` flush handling at `token.c:367`.
+- The encoder's `compress_buf` is sized for the worst-case stored-block
+  expansion (`AVAIL_OUT_SIZE(0xFFFF) + 16`) so a single matched insert
+  never trips `Z_BUF_ERROR` mid-stream.
+
+## 3. Failure modes locked by regression tests
+
+| Failure mode                                        | Regression site                                                                                                | PR    |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----- |
+| `copy_within` panic on shrink-truncated buffer      | `crates/transfer/src/map_file/tests.rs::load_window_overlap_shrink_preserves_data`                              | #5588 |
+| Slice index past EOF in `map_ptr`                   | `crates/transfer/src/map_file/tests.rs` (map_ptr out-of-range tests)                                            | #5566 |
+| `window_len > file_size` from unclamped reload      | `crates/transfer/src/map_file/tests.rs` (window-clamp test)                                                     | #5569 |
+| BufferedMap panic-freedom under arbitrary input     | `fuzz/fuzz_targets/buffered_map.rs` with `fuzz/corpus/buffered_map/`                                            | #5590 |
+| Matched-block insert >= obuf size corrupts stream   | `crates/protocol/src/wire/compressed_token/tests.rs::see_token_large_incompressible_insert_no_overflow`         | #5535 |
+| Decoder token-index overflow on hostile run         | `crates/protocol/src/wire/compressed_token/tests.rs` (`rx_token` overflow tests, 3.4.3 cap)                     | -     |
+| Accumulated DEFLATED_DATA exceeds 64 MiB cap        | `crates/protocol/src/wire/compressed_token/tests.rs` (accumulator cap test, 3.4.3 cap)                          | -     |
+| Streaming zlib decoder panic on arbitrary bytes     | `fuzz/fuzz_targets/decompressor_zlib.rs` + (new) `fuzz/fuzz_targets/zlib_token_decode.rs`                       | -     |
+| Streaming zlib decoder panic on truncated header    | `crates/compress/src/zlib/tests.rs::malformed_deflate_header_returns_err`                                       | UTS-18.k |
+| Streaming zlib decoder panic on truncated payload   | `crates/compress/src/zlib/tests.rs::truncated_payload_returns_err`                                              | UTS-18.k |
+
+Every row in the table represents a concrete invariant covered by a single
+named test. Future regressions surface as a named test failure rather than a
+crash report from production.
+
+## 4. Fuzz target rationale
+
+The wire codec stack has two complementary fuzz targets:
+
+1. `fuzz/fuzz_targets/buffered_map.rs` (PR #5590): drives `BufferedMap`
+   through `MapStrategy::map_ptr` with arbitrary `(file_size, window_size,
+   request_start, request_len)` parameter combinations. Locks the UTS-18.f /
+   UTS-18.g / UTS-18.h panic class. Corpus seeds live under
+   `fuzz/corpus/buffered_map/` and are documented in
+   `docs/audits/edg-panic-4-buffered-fuzz.md`.
+
+2. `fuzz/fuzz_targets/zlib_token_decode.rs` (new in this PR): drives the
+   per-token zlib codec layer one level above `CountingZlibDecoder`. The
+   target feeds arbitrary byte sequences to the streaming raw-deflate
+   decoder and asserts panic-freedom across malformed `DEFLATED_DATA`
+   headers, truncated payloads, and arbitrary flag-byte combinations.
+   Complements `fuzz/fuzz_targets/decompressor_zlib.rs`, which covers the
+   one-shot `decompress_to_vec` path and the streaming decoder's
+   expansion-ratio guard, by exercising the same decoder under streaming
+   read semantics.
+
+Adversarial inputs from the upstream `compress-zlib-insert` testsuite
+(matched-block inserts up to 64 KiB of incompressible bytes) must not panic
+either fuzz target. The encoder-side counterpart is locked by the
+`see_token_large_incompressible_insert_no_overflow` regression test
+referenced in the table above.
+
+## 5. Cross-references
+
+- `crates/transfer/src/map_file/buffered.rs` - basis-window mapper.
+- `crates/transfer/src/constants.rs` - `MAX_MAP_SIZE`, `MIN_MAP_SIZE`,
+  `align_down()`.
+- `crates/protocol/src/wire/compressed_token/zlib_codec.rs` - zlib token
+  encoder/decoder, `MAX_ACCUMULATED_COMPRESSED_BYTES`.
+- `crates/compress/src/zlib/` - streaming raw-deflate primitives
+  (`CountingZlibEncoder`, `CountingZlibDecoder`, `compress_to_vec`,
+  `decompress_to_vec`).
+- `target/interop/upstream-src/rsync-3.4.4/token.c` - upstream
+  `simple_recv_token`, `recv_deflated_token`, `send_deflated_token`.
+- `target/interop/upstream-src/rsync-3.4.4/fileio.c` - upstream `map_ptr`
+  / `realloc_array`.
+- `docs/audits/edg-panic-4-buffered-fuzz.md` - EDG-PANIC.4 BufferedMap
+  fuzz target and corpus rationale.
+- `docs/audits/edg-panic-5-unwrap-on-slice.md` - sibling audit covering
+  the broader `.unwrap()` / `.expect()` slice-driven panic class.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -108,6 +108,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "zlib_token_decode"
+path = "fuzz_targets/zlib_token_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "filter_list_wire"
 path = "fuzz_targets/filter_list_wire.rs"
 test = false

--- a/fuzz/fuzz_targets/zlib_token_decode.rs
+++ b/fuzz/fuzz_targets/zlib_token_decode.rs
@@ -1,0 +1,118 @@
+#![no_main]
+
+//! Fuzz target for the per-token streaming raw-deflate decoder.
+//!
+//! Complements `fuzz/fuzz_targets/decompressor_zlib.rs`: that target drives
+//! the one-shot `decompress_to_vec` helper, while this target exercises the
+//! `CountingZlibDecoder` streaming path under adversarial read sizes and
+//! malformed frame boundaries (truncated DEFLATED_DATA blocks, half-written
+//! sync markers, arbitrary flag-byte combinations).
+//!
+//! Invariants enforced per input:
+//!
+//! 1. The decoder may return any `io::Result` value but MUST NOT panic
+//!    across COPY/INSERT/MAP_END token combinations expressed in the
+//!    fuzzed byte stream.
+//! 2. The bytes-read counter never wraps. `bytes_read` is `u64` and the
+//!    decoder uses `saturating_add`, so a malformed stream that exhausts
+//!    the underlying reader must not produce a counter value greater than
+//!    the actual output written into the caller-supplied buffer.
+//! 3. Output never exceeds the 100x expansion ceiling enforced by the
+//!    sibling `decompressor_zlib` target. Mirrors the same zip-bomb cap.
+//!
+//! No new public APIs are introduced by this target - it only consumes
+//! existing entry points (`CountingZlibDecoder::new`, `Read::read`,
+//! `Read::read_to_end`, `bytes_read`).
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo +nightly fuzz run zlib_token_decode
+//! ```
+
+use std::io::Read;
+
+use libfuzzer_sys::fuzz_target;
+
+use compress::zlib::CountingZlibDecoder;
+
+/// Hard cap on the expansion ratio. See `decompressor_zlib` for rationale.
+const MAX_RATIO: u64 = 100;
+
+/// Absolute cap on bytes pulled out of the streaming decoder so the fuzzer
+/// cannot stall when an input expands without bound before the ratio check
+/// fires.
+const READ_BUDGET: u64 = 8 * 1024 * 1024;
+
+/// Minimum number of bytes to allocate as a streaming read chunk. Drives
+/// the streaming decoder through a per-call read loop so partial frames
+/// surface as `Err` rather than as a panic from the underlying inflate
+/// engine.
+const CHUNK_SIZE: usize = 4096;
+
+fuzz_target!(|data: &[u8]| {
+    // Path A: streaming reads through fixed-size chunks.
+    //
+    // The streaming decoder must accept arbitrary `read()` granularity.
+    // Mirrors the receiver pipeline that pulls per-token literals out of
+    // a wire stream where DEFLATED_DATA frames can split mid-block.
+    let mut decoder = CountingZlibDecoder::new(data);
+    let mut chunk = [0u8; CHUNK_SIZE];
+    let mut total_written: u64 = 0;
+    let mut last_counter: u64 = decoder.bytes_read();
+    loop {
+        let cap = std::cmp::min(
+            READ_BUDGET.saturating_sub(total_written),
+            chunk.len() as u64,
+        );
+        if cap == 0 {
+            break;
+        }
+        match decoder.read(&mut chunk[..cap as usize]) {
+            Ok(0) => break,
+            Ok(n) => {
+                total_written = total_written.saturating_add(n as u64);
+                let counter = decoder.bytes_read();
+                // Counter must move forward with each successful read.
+                assert!(
+                    counter >= last_counter,
+                    "bytes_read regressed: {counter} < {last_counter}",
+                );
+                assert!(
+                    counter <= total_written,
+                    "bytes_read {counter} exceeds bytes written {total_written}",
+                );
+                last_counter = counter;
+            }
+            Err(_) => break,
+        }
+    }
+    assert_expansion_bounded(data.len(), total_written as usize);
+
+    // Path B: one-shot read_to_end through the streaming decoder, capped
+    // by `take(READ_BUDGET)`. Exercises the inflate engine's
+    // chunked-state path under maximum-size buffer growth pressure.
+    let mut decoder = CountingZlibDecoder::new(data);
+    let mut sink = Vec::new();
+    let limit = std::cmp::min(
+        READ_BUDGET,
+        (data.len() as u64)
+            .saturating_mul(MAX_RATIO)
+            .saturating_add(1),
+    );
+    let _ = (&mut decoder).take(limit).read_to_end(&mut sink);
+    assert_expansion_bounded(data.len(), sink.len());
+});
+
+/// Enforce the 100x expansion ceiling. Zero-length input is allowed to
+/// produce up to a single byte of output before the ratio check kicks in,
+/// matching the sibling `decompressor_zlib` target.
+fn assert_expansion_bounded(input_len: usize, output_len: usize) {
+    let allowed = (input_len as u64)
+        .saturating_mul(MAX_RATIO)
+        .saturating_add(1);
+    assert!(
+        (output_len as u64) <= allowed,
+        "deflate expansion exceeded {MAX_RATIO}x ceiling: input={input_len} output={output_len}",
+    );
+}


### PR DESCRIPTION
## Summary

- Records the wire-byte and runtime invariants that govern the delta-transfer codec stack: the upstream-compatible zlib token decoder (\`crates/protocol/src/wire/compressed_token/zlib_codec.rs\`), the \`BufferedMap\` basis-window mapper (\`crates/transfer/src/map_file/buffered.rs\`), and the streaming raw-deflate primitives in \`crates/compress/src/zlib/\`.
- Closes the documentation gap left open by the UTS-18 series: BufferedMap fail-loud bounds (#5566), \`window_len\` clamp at the source (#5569), monotonic buffer length (#5588), libfuzzer coverage + EDG-PANIC.4 corpus (#5590), and the URV-1 zlib obuf overflow fix on matched-block inserts (PR #5535).
- Adds a complementary fuzz target (\`zlib_token_decode\`) that drives \`CountingZlibDecoder\` through arbitrary byte sequences under streaming read semantics, and two regression tests in \`crates/compress/src/zlib/tests.rs\` that pin the malformed-INSERT and COPY-past-EOF panic-freedom guarantees at the streaming decoder layer.

## Changes

- \`docs/design/zlib-codec-invariants.md\` (new) - wire-byte invariants (INSERT / COPY / END token contracts), runtime invariants per code path, failure-mode -> regression-test table, and fuzz target rationale.
- \`fuzz/fuzz_targets/zlib_token_decode.rs\` (new) - libfuzzer harness using only existing crate APIs (\`CountingZlibDecoder::new\`, \`Read::read\`, \`Read::read_to_end\`, \`bytes_read\`). Asserts panic-freedom across COPY/INSERT/MAP_END token combinations, monotonic byte-counter, and the same 100x expansion ceiling as \`decompressor_zlib\`.
- \`fuzz/Cargo.toml\` - registers the new \`[[bin]]\` entry.
- \`.github/workflows/fuzz-coverage-report.yml\` - adds the new target to the nightly coverage matrix.
- \`docs/design/fuzz-coverage-matrix.md\` - lists the new target under codec category.
- \`crates/compress/src/zlib/tests.rs\` - two regression tests:
  - \`malformed_deflate_header_returns_err\` - malformed stored-block header (LEN / NLEN ones-complement mismatch) must surface as typed \`Err\`, never a panic. Mirrors the \"INSERT past basis-window edge\" failure mode.
  - \`read_beyond_decoded_payload_returns_eof_not_panic\` - reading past the end of a valid decompressed payload must return \`Ok(0)\` cleanly without advancing the byte counter. Mirrors the \"COPY token offset beyond \`window_start + window_len\`\" failure mode.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - new tests \`malformed_deflate_header_returns_err\` and \`read_beyond_decoded_payload_returns_eof_not_panic\` execute under \`compress\` crate
- [ ] CI: Windows / macOS / Linux musl matrices stay green
- [ ] Nightly fuzz-coverage workflow auto-discovers and runs \`zlib_token_decode\` for 5 minutes (\`max_total_time=300\`); coverage lcov uploads as a new matrix artifact.