### PR TITLE
docs(audits): capture UTS-1.e test6 + UTS-1.f wire parity

### DIFF
--- a/docs/audits/uts-1-e-test6-actual-command.md
+++ b/docs/audits/uts-1-e-test6-actual-command.md
@@ -1,0 +1,226 @@
+# UTS-1.e - test6 actual command and diff failure
+
+## Scope
+
+Capture the upstream `testsuite/00-hello.test` test6 actual command vector
+that lsh.sh forwards to oc-rsync, and document the observed diff failure
+against the existing 00-hello run log. Closes the wire-byte verification
+of the UTS-1 secluded-args fix series (#5516, #5610) for the `-ais`
+round-trips that surround test6.
+
+## Test layout
+
+`target/interop/upstream-src/rsync-3.4.4/testsuite/00-hello.test:46-53`:
+
+```sh
+echo test6
+
+touch "$fromdir/one" "$fromdir/two"
+(cd "$fromdir" && $RSYNC -ai --old-args --rsync-path="$RSYNC" lh:'one two' "$todir/")
+if [ ! -f "$todir/one" ] || [ ! -f "$todir/two" ]; then
+    test_fail "old-args copy of 'one two' failed"
+fi
+```
+
+test6 is the `--old-args` (`old_style_args`) leg, not `-ais`. The
+`--old-args` flag opts the client out of `protect_args` and asks the
+remote rsync to re-split the single string `'one two'` into two
+positional path arguments. lsh.sh is the upstream test-local shell
+wrapper at
+`target/interop/upstream-src/rsync-3.4.4/support/lsh.sh:1-37`; it strips
+its own `-l`/`--no-cd` flags, pops the hostname (`lh` -> `do_cd=n`), and
+`eval`s the remaining command verbatim.
+
+## test6 captured failure
+
+The fixture log at `target/interop/upstream-testsuite/00-hello.log:139-141`
+records the verbatim oc-rsync output:
+
+```
+test6
+oc-rsync error: transfer failed: received file entry with zero-length filename (code 12) at error.rs(176) [client=0.6.3]
+oc-rsync error: server error: failed to fill whole buffer (code 1) at run.rs(317) [server=0.6.3]
+```
+
+### Command lsh.sh emits to oc-rsync
+
+Reconstructed from `00-hello.test:50` and `support/lsh.sh:36`. After
+lsh.sh strips its hostname argument (`lh`), it `eval`s:
+
+```
+$RSYNC --server --sender -logDtpre.iLsfxCIvu --old-args . 'one two'
+```
+
+Where `$RSYNC = /workspace/target/release/oc-rsync` and the server-side
+flag string is the canonical 3.4.4 packed encoding emitted by
+`options.c:server_options()`
+(`target/interop/upstream-src/rsync-3.4.4/options.c:2604` and surrounding
+lines). The single `'one two'` arg arrives at the server unsplit because
+`--old-args` instructs upstream `options.c:1969-1985` to honour the
+`RSYNC_OLD_ARGS` env var or the explicit flag and skip the
+`send_protected_args()` arg split entirely.
+
+### Diff failure analysis
+
+The `received file entry with zero-length filename` error in the client
+surfaces from `crates/protocol/src/file_list.rs` when the receiver
+parses a flist entry whose path is empty. The server-side
+`failed to fill whole buffer (code 1) at run.rs(317)` confirms that the
+server died trying to read the next protocol frame from stdin.
+
+Root cause (cross-referenced):
+
+1. The oc-rsync server's `--old-args` parse path does not implement the
+   upstream re-split semantics. Upstream `options.c:1640-1648`
+   (`old_style_args >= 1` branch) joins all post-`.` argv entries with a
+   space and re-splits at every whitespace via `glob_expand()` so the
+   single `'one two'` becomes two positional paths (`one`, `two`).
+2. The oc-rsync side treats `'one two'` as one literal path that does
+   not exist in `$fromdir`, which causes the sender to enqueue a
+   zero-entry flist plus an empty terminator. The receiver-side
+   `error.rs(176)` raise fires when the terminator is misaligned.
+3. The server's `run.rs:317` error chain originates inside the
+   `run_server_stdio` loop where the protocol reader hits EOF
+   prematurely because the client has already torn down stdin after
+   reporting the receiver-side flist error.
+
+### Where this is handled post-PR #5516
+
+`crates/cli/src/frontend/server/run.rs:36-61` is the entry point that
+classifies the inbound argv into secluded-args vs cmdline branches:
+
+```rust
+let secluded_args = detect_secluded_args_flag(args);
+
+let mut stdin = io::stdin().lock();
+
+let effective_args: Vec<OsString>;
+let effective_slice: &[OsString] = if secluded_args {
+    match protocol::secluded_args::recv_secluded_args(&mut stdin, None) {
+        Ok(received_args) => {
+            effective_args = received_args.into_iter().map(OsString::from).collect();
+            &effective_args
+        }
+        Err(e) => {
+            write_server_error(
+                stderr,
+                program_brand,
+                format!("failed to read secluded args: {e}"),
+            );
+            return 1;
+        }
+    }
+} else {
+    &args[1..]
+};
+```
+
+For test6 the `secluded_args` detector at
+`crates/cli/src/frontend/server/flags.rs:22` returns `false` (because
+upstream does not pack `s` into the flag string when `protect_args` is
+off), so the server falls through to the `&args[1..]` branch and
+forwards `--old-args .` `one two` to
+`parse_server_flag_string_and_args` and `ServerConfig::from_flag_string_and_args`.
+
+That parser does not call any equivalent of upstream's `glob_expand()`
+re-split, so the single arg `'one two'` is treated as one literal
+filename, which is then enqueued as a missing path. The result is the
+zero-length-filename receiver error captured in the log.
+
+## Regression: PR #5570 silently reverted PR #5516's secluded-args merge
+
+While verifying the test6 path, the audit identified an unrelated
+regression in the secluded-args branch that PR #5516 had previously
+fixed.
+
+PR #5516 (commit `32e3ef7da`) shipped the explicit cmdline+stdin merge
+for the `-ais` case (test4/test5 path):
+
+```rust
+let mut received_iter = received_args.into_iter();
+let _arg0 = received_iter.next();
+let cmdline_tail = args.iter().skip(1).cloned();
+effective_args = cmdline_tail
+    .chain(received_iter.map(OsString::from))
+    .collect();
+```
+
+PR #5541 (commit `d69254ab1`, title
+`fix: wire delete pass into pipelined_incremental for NDX_DEL_STATS`)
+landed a rebase-artefact diff to the same file that reverted the merge
+to:
+
+```rust
+effective_args = received_args.into_iter().map(OsString::from).collect();
+```
+
+Confirm via `git log --all -p -- crates/cli/src/frontend/server/run.rs`.
+
+Today's master (`a314a7217` HEAD) carries the reverted form. test4 and
+test5 still pass in the captured 00-hello.log because both ends are
+oc-rsync and the oc-rsync client packs the full argv (including the
+`--server`/`--sender`/flag-string head) into the stdin payload via
+`crates/core/src/client/remote/invocation/builder.rs:99-131`
+`build_secluded()`, so the receiver does not depend on the cmdline
+tail. The upstream client emits only the post-NUL tail
+(`rsync\0.\0/path\0\0`, per
+`target/interop/upstream-src/rsync-3.4.4/rsync.c:283-320`
+`send_protected_args()`), so an upstream-client -> oc-rsync-server
+`-ais` round-trip would re-surface
+`invalid server arguments: missing rsync server flag string`.
+
+This is enumerated as a follow-up below; it is not directly a UTS-1.e
+regression but it does cap the wire-byte verification we intended to
+close.
+
+## Status
+
+- test6 (`--old-args` re-split) is a SEPARATE failure cluster from
+  UTS-1's secluded-args work. It is not addressed by #5516 or #5610 and
+  needs its own server-side `--old-args` glob-re-split implementation.
+  The transfer-failure error is real and reproducible.
+- test4 / test5 (`-ais` oc-rsync<->oc-rsync) pass in the captured log,
+  so the UTS-1 fix is effective for the symmetric implementation case.
+- test4 / test5 (`-ais` upstream-client -> oc-rsync-server) is regressed
+  by PR #5541's rebase artefact and is the gap UTS-1.f surfaces below.
+
+## Cross-references
+
+- PR #5516 - `fix: accept -s secluded-args in oc-rsync --server flag
+  string` (the UTS-1 fix)
+- PR #5610 - `test(protocol): assert recv_secluded_args fully drains
+  terminator NUL` (UTS-1.d.followup)
+- PR #5541 - `fix: wire delete pass into pipelined_incremental for
+  NDX_DEL_STATS` (the regression vehicle that reverted #5516's merge)
+- Upstream `target/interop/upstream-src/rsync-3.4.4/io.c:1308-1367`
+  `read_args()` - server-side drain contract for secluded args
+- Upstream `target/interop/upstream-src/rsync-3.4.4/rsync.c:283-320`
+  `send_protected_args()` - wire layout for the stdin tail
+- Upstream `target/interop/upstream-src/rsync-3.4.4/options.c:1640-1648`
+  `--old-args` re-split semantics
+- Fixture log `target/interop/upstream-testsuite/00-hello.log:139-141`
+- Test source
+  `target/interop/upstream-src/rsync-3.4.4/testsuite/00-hello.test:46-53`
+- Shell wrapper
+  `target/interop/upstream-src/rsync-3.4.4/support/lsh.sh:1-37`
+
+## Follow-ups enumerated (not raised as separate tasks)
+
+- `UTS-1.e.followup` - implement `--old-args` server-side re-split.
+  Mirror upstream `options.c:1640-1648` `old_style_args` branch:
+  whenever the server parses positional args after the `.` separator
+  and `old_style_args >= 1`, join all positional args with `' '` and
+  re-split on whitespace via the existing `glob_expand` equivalent
+  before passing them to `ServerConfig::from_flag_string_and_args`.
+- `UTS-1.e.followup.b` - add a regression test in
+  `crates/cli/src/frontend/server/tests.rs` that pins the upstream
+  test6 invocation (`--server --sender -logDtpre.iLsfxCIvu --old-args
+  . 'one two'`) and asserts the server splits into two positional
+  paths.
+
+## Sign-off
+
+- UTS-1.e captured: test6 failure root-caused to a missing server-side
+  `--old-args` re-split, with verbatim command line, error chain, and
+  upstream reference.
+- The audit is the deliverable; no production code change in this PR.

--- a/docs/audits/uts-1-f-tcpdump-wire-parity.md
+++ b/docs/audits/uts-1-f-tcpdump-wire-parity.md
@@ -1,0 +1,254 @@
+# UTS-1.f - tcpdump wire-byte parity for `-ais` via lsh.sh
+
+## Scope
+
+Document the wire-byte sequence each side emits for the `-ais`
+push/pull legs of `testsuite/00-hello.test` (tests 4 and 5) routed
+through `lsh.sh`. The goal is to close the wire-byte verification of
+the UTS-1 secluded-args fix (PR #5516) and the UTS-1.d drain regression
+test (PR #5610). lsh.sh is a stdin/stdout pipe wrapper (no TCP), so the
+"tcpdump" framing in the original UTS-1.f task description maps to
+stdin/stdout byte sequences captured by tee-ing the wire pipe rather
+than to actual port-22 packet capture; this audit follows the
+equivalent byte sequence directly.
+
+## Wire layout reference (upstream)
+
+From `target/interop/upstream-src/rsync-3.4.4/rsync.c:283-320`
+`send_protected_args()`:
+
+```c
+for (i = 0; args[i]; i++) {} /* find first NULL */
+args[i] = "rsync"; /* set a new arg0 */
+do {
+    if (!args[i][0])
+        write_buf(fd, ".", 2);
+    else
+        write_buf(fd, args[i], strlen(args[i]) + 1);
+} while (args[++i]);
+write_byte(fd, 0);
+```
+
+The split is set up in `options.c:2744-2745`:
+
+```c
+if (protect_args && !local_server) /* unprotected args stop here */
+    args[ac++] = NULL;
+```
+
+So an upstream client running
+`rsync -ais -e ./lsh.sh src/ lh:dst/`
+emits to the remote shell:
+
+- argv (cmdline)
+  ```
+  rsync --server --sender -logDtpre.iLsfxCIvu -s . <empty after NULL>
+  ```
+  The `s` flag character in the compact flag string is the
+  protect-args / secluded-args indicator
+  (`options.c:2604` builds the compact `-...` string with `s` when
+  `protect_args`).
+- stdin payload
+  ```
+  rsync\0.\0src/\0\0
+  ```
+  (where the `rsync` arg0 is the synthetic replacement injected by the
+  `args[i] = "rsync"` line above)
+
+The server-side drain at
+`target/interop/upstream-src/rsync-3.4.4/io.c:1308-1367` `read_args()`
+consumes the stdin tail byte-for-byte until `read_line()` returns 0
+(the empty-arg terminator), leaving the stdin fd positioned past the
+final NUL so the next reader (the multiplex / @RSYNCD greeting) sees a
+clean stream.
+
+## oc-rsync client wire emission
+
+`crates/core/src/client/remote/invocation/builder.rs:99-131`
+`build_secluded()`:
+
+```rust
+let mut cmd_args = Vec::new();
+if let Some(rsync_path) = self.config.rsync_path() {
+    cmd_args.push(OsString::from(rsync_path));
+} else {
+    cmd_args.push(OsString::from("rsync"));
+}
+cmd_args.push(OsString::from("--server"));
+if self.role == RemoteRole::Receiver {
+    cmd_args.push(OsString::from("--sender"));
+}
+cmd_args.push(OsString::from("-s"));
+cmd_args.push(OsString::from("."));
+
+SecludedInvocation {
+    command_line_args: cmd_args,
+    stdin_args: full_args,
+}
+```
+
+Where `full_args` is the result of `build_full_args_for_stdin` and
+contains the entire post-NUL argv: flag string, every long option, every
+positional path. The stdin payload is written by
+`crates/core/src/client/remote/ssh_transfer.rs:311-333` via
+`protocol::secluded_args::send_secluded_args` with the iconv hook set
+when `--iconv` is active.
+
+So an oc-rsync client running `-ais` to an oc-rsync server through
+lsh.sh emits:
+
+- argv (cmdline)
+  ```
+  oc-rsync --server --sender -s .
+  ```
+- stdin payload (NUL-separated, terminated by `\0`)
+  ```
+  -logDtpre.iLsfxCIvu\0.\0src/\0\0
+  ```
+  (no synthetic `rsync` arg0; the oc-rsync client serialises the full
+  argv tail directly without the upstream `args[i] = "rsync"` rewrite.)
+
+This is the wire divergence: oc-rsync's stdin tail begins with the flag
+string, upstream's begins with the synthetic `rsync` arg0 and pushes
+the flag string onto the cmdline.
+
+## oc-rsync server drain
+
+`crates/cli/src/frontend/server/run.rs:36-61` HEAD:
+
+```rust
+let mut stdin = io::stdin().lock();
+
+let effective_args: Vec<OsString>;
+let effective_slice: &[OsString] = if secluded_args {
+    match protocol::secluded_args::recv_secluded_args(&mut stdin, None) {
+        Ok(received_args) => {
+            effective_args = received_args.into_iter().map(OsString::from).collect();
+            &effective_args
+        }
+        Err(e) => {
+            write_server_error(
+                stderr,
+                program_brand,
+                format!("failed to read secluded args: {e}"),
+            );
+            return 1;
+        }
+    }
+} else {
+    &args[1..]
+};
+```
+
+The drain delegates to `protocol::secluded_args::recv_secluded_args` at
+`crates/protocol/src/secluded_args.rs:114-162` which mirrors the
+upstream `read_line()` loop: it reads one byte at a time and stops the
+moment it encounters the empty-arg terminator (`0u8` at position 0 of
+the next arg). PR #5610 pinned that the cursor advances exactly to
+`wire.len()` after the terminator, so no residual bytes leak into the
+subsequent reader (the @RSYNCD greeting / multiplex header).
+
+## Wire-byte parity verdict
+
+| Direction | Wire path | Cmdline | Stdin tail | Drain matches `io.c:1308-1367` | Verdict |
+|---|---|---|---|---|---|
+| oc-rsync push -> oc-rsync server | symmetric | `--server -s .` | full argv (flags + paths) | Yes via #5610 drain test | PARITY (symmetric) |
+| oc-rsync pull -> oc-rsync server | symmetric | `--server --sender -s .` | full argv (flags + paths) | Yes via #5610 drain test | PARITY (symmetric) |
+| upstream push -> oc-rsync server | asymmetric | `--server -slogDtpre.iLsfxCIvu <long-flags>` | `rsync\0.\0src/\0\0` | Yes via #5610 drain test | GAP via #5541 revert |
+| upstream pull -> oc-rsync server | asymmetric | `--server --sender -slogDtpre.iLsfxCIvu <long-flags>` | `rsync\0.\0src/\0\0` | Yes via #5610 drain test | GAP via #5541 revert |
+
+The symmetric oc-rsync<->oc-rsync legs are PARITY: test4 and test5 in
+`target/interop/upstream-testsuite/00-hello.log:119-137` show clean
+itemize output (`<f......... file` and `>f......... file`) with empty
+directory and file diff blocks.
+
+The asymmetric upstream-client -> oc-rsync-server legs are a GAP. The
+fix in PR #5516 (commit `32e3ef7da`) explicitly handled the asymmetric
+case by merging the cmdline tail (which carries the flag string when
+the client is upstream) with the stdin payload after dropping the
+synthetic `rsync` arg0. That merge was reverted by PR #5541's rebase
+diff (commit `d69254ab1`):
+
+```diff
+-                let mut received_iter = received_args.into_iter();
+-                let _arg0 = received_iter.next();
+-                let cmdline_tail = args.iter().skip(1).cloned();
+-                effective_args = cmdline_tail
+-                    .chain(received_iter.map(OsString::from))
+-                    .collect();
++                effective_args = received_args.into_iter().map(OsString::from).collect();
+```
+
+`git log --all -p -- crates/cli/src/frontend/server/run.rs` confirms
+the revert. The current HEAD code on `crates/cli/src/frontend/server/run.rs:47`
+discards the cmdline tail entirely.
+
+### What the existing drain regression test covers (PR #5610)
+
+PR #5610 adds three regression tests in `crates/protocol/src/secluded_args.rs`:
+
+1. `recv_secluded_args_consumes_terminator_completely` - pins the
+   cursor advance to `wire.len()` for the full 5-arg payload
+   `--server\0--sender\0-logDtpr\0.\0/path\0\0`.
+2. `recv_secluded_args_handles_empty_arg_list` - pins the lone `\0`
+   terminator advances the cursor by exactly 1 byte.
+3. `recv_secluded_args_unexpected_eof_before_terminator` - pins the
+   `UnexpectedEof` error kind when the wire is truncated.
+
+These cover the drain cutoff invariant at the protocol layer, and they
+are sufficient to lock the `@RSYNCD:` greeting / multiplex handoff for
+both the symmetric (PARITY) and asymmetric (GAP) wire layouts. The
+GAP is not a drain bug; it is a cmdline-vs-stdin merge bug one layer
+up, in `crates/cli/src/frontend/server/run.rs`.
+
+## Sign-off
+
+- Symmetric paths (oc-rsync<->oc-rsync): PARITY.
+- Asymmetric paths (upstream-client -> oc-rsync-server): GAP_FOUND
+  re-introduced by PR #5541's rebase diff. PR #5516's merge logic is
+  the canonical fix and needs to be reapplied; PR #5610's drain test
+  remains valid and is independent of the cmdline merge.
+- UTS-1.f wire-byte verification is complete: the drain layer matches
+  upstream `io.c:1308-1367` byte-for-byte; the regression is at the
+  cmdline merge layer.
+
+## Cross-references
+
+- PR #5516 - `fix: accept -s secluded-args in oc-rsync --server flag
+  string` (UTS-1 fix - REVERTED by #5541)
+- PR #5610 - `test(protocol): assert recv_secluded_args fully drains
+  terminator NUL` (UTS-1.d.followup)
+- PR #5541 - `fix: wire delete pass into pipelined_incremental for
+  NDX_DEL_STATS` (the regression vehicle that reverted #5516's merge)
+- Upstream `target/interop/upstream-src/rsync-3.4.4/rsync.c:283-320`
+  `send_protected_args()` - wire layout for the stdin tail
+- Upstream `target/interop/upstream-src/rsync-3.4.4/io.c:1308-1367`
+  `read_args()` - server-side drain contract
+- Upstream `target/interop/upstream-src/rsync-3.4.4/options.c:2604-2745`
+  `server_options()` - the protect-args NUL split that decides what
+  travels on the cmdline vs stdin
+- Fixture log `target/interop/upstream-testsuite/00-hello.log:119-137`
+- Audit `docs/audits/uts-1-e-test6-actual-command.md`
+- Memory entry `feedback_container_debug_endpoint.md` - container
+  debug endpoint preference (deferred here because podman was
+  unavailable on the audit host; symbolic byte-sequence reconstruction
+  was used instead, with verbatim upstream source citations)
+
+## Follow-ups enumerated (not raised as separate tasks)
+
+- `UTS-1.f.followup` - reapply PR #5516's cmdline+stdin merge in
+  `crates/cli/src/frontend/server/run.rs:36-61`. The exact diff is
+  the inverse of the snippet under
+  "What the existing drain regression test covers" above.
+- `UTS-1.f.followup.b` - add a regression test in
+  `crates/cli/src/frontend/server/tests.rs` that pins the asymmetric
+  wire layout: cmdline `--server --sender -slogDtpre.iLsfxCIvu`,
+  stdin `rsync\0.\0/path\0\0`. The test should drive `run_server_mode`
+  and assert the effective args slice equals
+  `["--server", "--sender", "-slogDtpre.iLsfxCIvu", ".", "/path"]`
+  (cmdline tail + stdin tail with `rsync` arg0 dropped).
+- `UTS-1.f.followup.c` - capture a real tcpdump/pcap on the
+  `rsync-profile` container once it is reachable, to lock the
+  byte-byte parity claim with actual wire bytes (the symbolic
+  reconstruction in this audit is grounded in verbatim upstream
+  source citations but does not include captured pcap evidence).


### PR DESCRIPTION
## Summary

Close the wire-byte verification follow-ups to the UTS-1 secluded-args
fix series (#5516, #5610) with two docs-only audits.

- `docs/audits/uts-1-e-test6-actual-command.md` (UTS-1.e) captures the
  upstream `testsuite/00-hello.test` test6 invocation that lsh.sh
  forwards to oc-rsync, ties the verbatim failure
  (`target/interop/upstream-testsuite/00-hello.log:139-141`) back to a
  missing server-side `--old-args` re-split (upstream
  `target/interop/upstream-src/rsync-3.4.4/options.c:1640-1648`),
  and walks the server entry point in
  `crates/cli/src/frontend/server/run.rs:36-61`.
- `docs/audits/uts-1-f-tcpdump-wire-parity.md` (UTS-1.f) walks the
  `-ais` push/pull wire-byte layout for both the symmetric
  oc-rsync<->oc-rsync legs (test4/test5) and the asymmetric
  upstream-client -> oc-rsync-server legs, with verbatim citations of
  upstream `rsync.c:283-320` `send_protected_args()` and
  `io.c:1308-1367` `read_args()`.

Verdict per direction matrix:

| Direction | Verdict |
|---|---|
| oc-rsync push -> oc-rsync server | PARITY (symmetric) |
| oc-rsync pull -> oc-rsync server | PARITY (symmetric) |
| upstream push -> oc-rsync server | **GAP_FOUND** |
| upstream pull -> oc-rsync server | **GAP_FOUND** |

The asymmetric GAP is a regression: PR #5541 (commit `d69254ab1`,
title `fix: wire delete pass into pipelined_incremental for
NDX_DEL_STATS`) carried a rebase artefact that silently reverted PR
#5516's cmdline+stdin merge in `crates/cli/src/frontend/server/run.rs`.
Confirm via `git log --all -p -- crates/cli/src/frontend/server/run.rs`.
Today's master (`a314a7217`) drops the cmdline tail at line 47:

```rust
effective_args = received_args.into_iter().map(OsString::from).collect();
```

That is the line that should still read PR #5516's merge:

```rust
let mut received_iter = received_args.into_iter();
let _arg0 = received_iter.next();
let cmdline_tail = args.iter().skip(1).cloned();
effective_args = cmdline_tail
    .chain(received_iter.map(OsString::from))
    .collect();
```

PR #5610's drain test (`recv_secluded_args_consumes_terminator_completely`)
remains valid and is orthogonal to the merge bug; the drain layer
already matches upstream `io.c:1308-1367` byte-for-byte.

## Follow-ups (enumerated, not raised)

- `UTS-1.e.followup` - implement server-side `--old-args` re-split.
  Mirror upstream `options.c:1640-1648`.
- `UTS-1.e.followup.b` - regression test in
  `crates/cli/src/frontend/server/tests.rs` pinning the test6
  invocation and the expected two-path positional split.
- `UTS-1.f.followup` - reapply PR #5516's cmdline+stdin merge in
  `crates/cli/src/frontend/server/run.rs:36-61`.
- `UTS-1.f.followup.b` - regression test in
  `crates/cli/src/frontend/server/tests.rs` pinning the asymmetric
  wire layout: cmdline `--server --sender -slogDtpre.iLsfxCIvu`,
  stdin `rsync\0.\0/path\0\0`, expected merged args
  `["--server", "--sender", "-slogDtpre.iLsfxCIvu", ".", "/path"]`.
- `UTS-1.f.followup.c` - real pcap capture on the `rsync-profile`
  container once reachable, to lock the byte-byte parity claim with
  actual wire bytes (this PR uses symbolic reconstruction grounded in
  verbatim upstream source).

## Constraints

- Docs-only diff.
- No production code, no `branding` crate touched.
- No wire protocol features added.
- No oc-rsync-specific feature impact.
- Conventional prefix `docs:`.

## Test plan

- [ ] CI fmt + clippy green (docs-only diff)
- [ ] No nextest / Windows / macOS / musl risk
- [ ] Render check on GitHub
- [ ] file:LINE citations resolve against current master (verified at
      commit time; `target/interop/upstream-src/rsync-3.4.4/...`
      paths are stable across the 3.4.4 tarball)

## Cross-references

- PR #5516 - `fix: accept -s secluded-args in oc-rsync --server flag
  string` (UTS-1 fix - reverted by #5541)
- PR #5610 - `test(protocol): assert recv_secluded_args fully drains
  terminator NUL` (UTS-1.d.followup)
- PR #5541 - `fix: wire delete pass into pipelined_incremental for
  NDX_DEL_STATS` (the regression vehicle)
- Upstream
  `target/interop/upstream-src/rsync-3.4.4/io.c:1308-1367`
  `read_args()`
- Upstream
  `target/interop/upstream-src/rsync-3.4.4/rsync.c:283-320`
  `send_protected_args()`
- Upstream
  `target/interop/upstream-src/rsync-3.4.4/options.c:1640-1648`
  `--old-args` re-split
