### PR TITLE
feat(fast_io): URV-5.c.4 Landlock overhead bench harness

### DIFF
--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -337,3 +337,16 @@ required-features = ["io_uring"]
 [[bench]]
 name = "copy_basis_range_delta"
 harness = false
+
+# Linux-only bench: URV-5.c.4 - per-connection Landlock setup overhead
+# measured at the `is_supported` probe + `restrict_to_module_paths` setup
+# layer (1 / 2 / 4 allowlist roots). Compiles to a no-op stub on non-Linux
+# hosts and when the `landlock` feature is off, so the bench list stays
+# cross-platform. Gates the URV-5.c.5 default-on flip; pair with the
+# macro-bench in `scripts/landlock_overhead_macro.sh` for the 100K-file
+# daemon receive comparison. See
+# docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md for the
+# defense-in-depth rationale and PR #5601 for the allowlist widening.
+[[bench]]
+name = "landlock_overhead"
+harness = false

--- a/crates/fast_io/benches/landlock_overhead.rs
+++ b/crates/fast_io/benches/landlock_overhead.rs
@@ -1,0 +1,175 @@
+//! URV-5.c.4 - per-connection Landlock setup overhead bench.
+//!
+//! Measures the cost a daemon connection pays when SEC-1.p engages the
+//! Landlock LSM allowlist before transfer begins. Three cells:
+//!
+//! - `is_supported`: cost of the kernel probe that decides whether to
+//!   request a ruleset (runs on every connection regardless of feature).
+//! - `restrict_to_module_paths`: full setup of one ruleset over `N`
+//!   allowlist roots followed by `restrict_self()`. Each iteration runs
+//!   on a fresh worker thread because Landlock irreversibly intersects
+//!   the calling thread's policy; reusing the criterion measurement
+//!   thread would corrupt later cells.
+//! - `thread_spawn_baseline`: noise floor that callers subtract from
+//!   the `restrict` cells to isolate the Landlock-attributable cost.
+//!
+//! The companion shell harness `scripts/landlock_overhead_macro.sh`
+//! drives the full daemon-receive comparison (100K-file tree, landlock
+//! ON vs OFF) using hyperfine inside the `rsync-profile` container; the
+//! aggregated results land in
+//! `docs/benchmarks/landlock-overhead-100k.md`.
+//!
+//! Run with:
+//! ```sh
+//! cargo bench -p fast_io --bench landlock_overhead --features landlock
+//! ```
+//!
+//! On non-Linux hosts (or without the `landlock` feature) the bench
+//! compiles to a stub that prints a skip line, so the suite stays
+//! cross-platform clean. See
+//! `docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md` for the
+//! defense-in-depth rationale and PR #5601 for the allowlist widening
+//! that unblocks URV-5.c.5.
+
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use std::hint::black_box;
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use std::path::PathBuf;
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use std::thread;
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use std::time::{Duration, Instant};
+
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use tempfile::TempDir;
+
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+
+/// Allowlist sizes covered by the bench: 1 root models a typical
+/// single-module daemon, 4 roots models the worst case after
+/// PR #5601 widened the allowlist with `--temp-dir`, `--partial-dir`,
+/// and one `ref_dir` (e.g. `--compare-dest`).
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+const ROOT_COUNTS: &[usize] = &[1, 2, 4];
+
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+fn make_roots(count: usize) -> (TempDir, Vec<PathBuf>) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut roots = Vec::with_capacity(count);
+    for i in 0..count {
+        let p = tmp.path().join(format!("root_{i}"));
+        std::fs::create_dir_all(&p).expect("create root");
+        roots.push(p);
+    }
+    (tmp, roots)
+}
+
+/// Probe-only cell: every daemon connection pays this regardless of
+/// whether the feature is wired, so it gives a floor on the cost the
+/// URV-5.c.5 default-on flip cannot avoid.
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+fn bench_is_supported(c: &mut Criterion) {
+    let mut group = c.benchmark_group("landlock_overhead/is_supported");
+    group.bench_function("probe", |b| {
+        b.iter(|| black_box(is_supported()));
+    });
+    group.finish();
+}
+
+/// Full setup cell: each iteration spawns a fresh worker thread,
+/// calls `restrict_to_module_paths` exactly once, and joins. The
+/// fresh-thread requirement is structural: Landlock applies to the
+/// calling thread for the rest of its lifetime, so we cannot reuse
+/// the criterion harness thread without corrupting later cells.
+/// Criterion's measurement still captures the wall-clock cost of
+/// the syscalls + crate plumbing; the thread spawn overhead is the
+/// noise floor and is subtracted by comparing to the no-op
+/// `thread_spawn_baseline` cell below.
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+fn bench_restrict_to_module_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("landlock_overhead/restrict");
+    // Keep the sample count modest because each iteration costs a
+    // thread spawn + join in addition to the syscalls.
+    group.sample_size(50);
+    group.measurement_time(Duration::from_secs(10));
+
+    for &count in ROOT_COUNTS {
+        let (_tmp, roots) = make_roots(count);
+        group.bench_with_input(BenchmarkId::new("roots", count), &roots, |b, roots| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let roots = roots.clone();
+                    let handle = thread::Builder::new()
+                        .name("landlock-bench".into())
+                        .spawn(move || {
+                            let refs: Vec<&std::path::Path> =
+                                roots.iter().map(|p| p.as_path()).collect();
+                            let start = Instant::now();
+                            let outcome = restrict_to_module_paths(&refs);
+                            let elapsed = start.elapsed();
+                            // Touch the outcome so the optimiser cannot
+                            // eliminate the call.
+                            match outcome {
+                                LandlockOutcome::Enforced(_)
+                                | LandlockOutcome::Unavailable
+                                | LandlockOutcome::Error(_) => {}
+                            }
+                            elapsed
+                        })
+                        .expect("spawn landlock-bench worker");
+                    total += handle.join().expect("worker panicked");
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Baseline cell: thread spawn + join with no Landlock work, so the
+/// `restrict` cells can be normalised against the noise floor.
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+fn bench_thread_spawn_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("landlock_overhead/baseline");
+    group.sample_size(50);
+    group.bench_function("thread_spawn_join", |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                let handle = thread::Builder::new()
+                    .name("landlock-bench-baseline".into())
+                    .spawn(|| {
+                        let start = Instant::now();
+                        // No-op body so we measure only spawn + join.
+                        black_box(());
+                        start.elapsed()
+                    })
+                    .expect("spawn baseline worker");
+                total += handle.join().expect("baseline worker panicked");
+            }
+            total
+        });
+    });
+    group.finish();
+}
+
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+criterion_group!(
+    benches,
+    bench_is_supported,
+    bench_thread_spawn_baseline,
+    bench_restrict_to_module_paths,
+);
+#[cfg(all(target_os = "linux", feature = "landlock"))]
+criterion_main!(benches);
+
+#[cfg(not(all(target_os = "linux", feature = "landlock")))]
+fn main() {
+    eprintln!(
+        "landlock_overhead bench skipped: requires target_os=\"linux\" and the `landlock` Cargo feature."
+    );
+}

--- a/docs/benchmarks/landlock-overhead-100k.md
+++ b/docs/benchmarks/landlock-overhead-100k.md
@@ -1,0 +1,132 @@
+# Landlock overhead bench (URV-5.c.4)
+
+Per-connection cost of the SEC-1.p Landlock LSM allowlist on a 100K-file
+daemon receive. Gates the URV-5.c.5 default-on flip in
+`crates/daemon/Cargo.toml`.
+
+## Bench plan
+
+Two harnesses, each with a defined scope:
+
+- **Micro-bench (criterion)** -- `crates/fast_io/benches/landlock_overhead.rs`.
+  Measures the per-connection setup the daemon pays before any transfer
+  byte moves: kernel probe (`is_supported`) plus
+  `restrict_to_module_paths` over 1 / 2 / 4 allowlist roots. Cross-platform
+  stub on non-Linux hosts.
+- **Macro-bench (hyperfine + strace)** -- `scripts/landlock_overhead_macro.sh`.
+  Drives a 100K-file push transfer (upstream rsync client -> oc-rsync
+  daemon) on localhost TCP. Captures wall-clock (median of 5 runs), peak
+  RSS, and `strace -c -f` syscall counts for landlock ON vs OFF.
+
+The macro-bench requires two pre-built `oc-rsync` release binaries: one
+with `landlock` wired in (current Linux default) and one with
+`features = ["landlock"]` stripped from the daemon's Linux dep on
+`fast_io`. URV-5.c.5 replaces the manual edit with a Cargo-level toggle.
+
+## Workload
+
+- 100,000 files across 1,000 directories, 1 KB each (10^5 inode pressure,
+  ~100 MB payload). Modelled on `scripts/benchmark_100k.sh` so the cell
+  sits in the same regime as DIS-7 / RSS-1.
+- Push transfer: `rsync -a TREE/ rsync://localhost:PORT/bench/`.
+- hyperfine `--runs 5 --warmup 1`, fresh destination directory per run.
+- strace cell attaches `strace -c -f` to the daemon PID for one full
+  transfer per cell (no measurement-time amortisation because the
+  attached strace dominates the wall-clock).
+
+## Environment
+
+- Container: `rsync-profile` (Debian, `rust:latest` base), aarch64
+  Linux 6.x. Required because Landlock is Linux-only and the host
+  development machine cannot exercise the LSM. See
+  `feedback_use_container_for_linux_bench`.
+
+## Results
+
+Pending: container run on `rsync-profile`. Numbers below populate once
+the macro-bench has been driven; the micro-bench cells are included so
+the per-connection floor is on record independently of the data-path
+run.
+
+### Macro-bench: full 100K-file daemon receive
+
+| Configuration | Wall-clock median (ms) | Peak RSS (MB) | Total syscalls | Setup overhead (us) |
+|---------------|------------------------|---------------|----------------|---------------------|
+| landlock OFF  | TBD pending container run | TBD | TBD | 0 |
+| landlock ON   | TBD pending container run | TBD | TBD | TBD |
+| Delta         | TBD                    | TBD           | TBD            | TBD                 |
+
+### Micro-bench: per-connection setup cost
+
+`cargo bench -p fast_io --bench landlock_overhead --features landlock`
+
+| Cell                              | Median (us) | p99 (us) | Notes                                                                     |
+|-----------------------------------|-------------|----------|---------------------------------------------------------------------------|
+| `is_supported/probe`              | TBD         | TBD      | Pre-feature floor; runs on every daemon connection regardless of feature. |
+| `baseline/thread_spawn_join`      | TBD         | TBD      | Noise floor; subtract from `restrict/*` to isolate Landlock-attributable. |
+| `restrict/roots=1`                | TBD         | TBD      | Typical single-module daemon path.                                        |
+| `restrict/roots=2`                | TBD         | TBD      | Module + `--temp-dir` after PR #5601.                                     |
+| `restrict/roots=4`                | TBD         | TBD      | Worst case after PR #5601 (module + temp/partial + 1 ref_dir).            |
+
+### strace -c -f syscall breakdown
+
+Pending container run. Expected delta: a handful of
+`landlock_create_ruleset` / `landlock_add_rule` / `landlock_restrict_self`
+calls plus the inherited overhead on later `openat` / `linkat` /
+`renameat2` calls.
+
+```
+# landlock OFF strace summary -- TBD
+# landlock ON strace summary  -- TBD
+```
+
+## Decision criteria for URV-5.c.5
+
+The default-on flip lands when the macro-bench numbers fall into one of
+the first two rows:
+
+| Wall-clock overhead | Action                                                                                   |
+|---------------------|------------------------------------------------------------------------------------------|
+| < 1%                | Flip default-on with no release-note callout beyond the security note.                   |
+| 1% to 5%            | Flip default-on; release notes call out the trade and the per-module opt-out path.       |
+| > 5%                | Keep opt-in; document the gap in `docs/packaging/landlock-feature-guidance.md` and re-task. |
+
+The micro-bench gates a complementary axis: if the per-connection setup
+floor exceeds 1 ms median on a clean kernel, the flip is deferred even
+when the macro-bench wall-clock is under 1%, because the setup latency
+hits every short-lived daemon connection rather than amortising over the
+transfer.
+
+## Cross-references
+
+- Design: [`docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md`](../design/sec-1-p-landlock-defense-in-depth-2026-05-22.md)
+- Packaging guidance: [`docs/packaging/landlock-feature-guidance.md`](../packaging/landlock-feature-guidance.md)
+- Allowlist widening (URV-5.b.REOPEN): PR #5601
+- Preferred sandboxing primitive: `feedback_rust_landlock_preferred`
+- Linux bench container policy: `feedback_use_container_for_linux_bench`
+
+## Reproduction
+
+Inside `rsync-profile`:
+
+```sh
+# Stage the landlock-OFF binary by stripping `features = ["landlock"]`
+# from `crates/daemon/Cargo.toml`'s Linux fast_io dep, then:
+cargo build --release --bin oc-rsync
+cp target/release/oc-rsync /tmp/oc-rsync-landlock-off
+
+# Revert the Cargo.toml edit and rebuild for the ON binary:
+git checkout -- crates/daemon/Cargo.toml
+cargo build --release --bin oc-rsync
+cp target/release/oc-rsync /tmp/oc-rsync-landlock-on
+
+# Drive the macro-bench (creates the 100K tree, runs hyperfine + strace,
+# appends results to docs/benchmarks/landlock-overhead-100k.md):
+OC_ON=/tmp/oc-rsync-landlock-on \
+OC_OFF=/tmp/oc-rsync-landlock-off \
+KEEP_BUILDS=1 \
+bash scripts/landlock_overhead_macro.sh
+
+# Micro-bench (no manual binary staging required):
+cargo bench -p fast_io --bench landlock_overhead --features landlock
+```

--- a/scripts/landlock_overhead_macro.sh
+++ b/scripts/landlock_overhead_macro.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+# URV-5.c.4 - Landlock overhead macro-bench.
+#
+# Compares a 100K-file daemon receive with the `landlock` Cargo feature
+# ON vs OFF, capturing wall-clock time (median of 5 runs), peak RSS, and
+# strace syscall counts. The micro-bench in
+# `crates/fast_io/benches/landlock_overhead.rs` covers the per-connection
+# setup cost; this script covers the full transfer path so URV-5.c.5 has
+# end-to-end evidence for the default-on flip decision.
+#
+# Designed to run inside the `rsync-profile` container per
+# feedback_use_container_for_linux_bench; the host environment has no
+# Landlock LSM and the macro-bench would be meaningless there.
+#
+# Usage:
+#   scripts/landlock_overhead_macro.sh                # auto, results to docs/benchmarks/landlock-overhead-100k.md
+#   OUT=/tmp/landlock.md scripts/landlock_overhead_macro.sh
+#
+# Environment variables:
+#   NUM_DIRS         Directories in the 100K tree (default: 1000)
+#   FILES_PER_DIR    Files per directory (default: 100)
+#   RUNS             hyperfine measurement runs per cell (default: 5)
+#   OUT              Output markdown path (default: docs/benchmarks/landlock-overhead-100k.md)
+#   KEEP_BUILDS      Set to 1 to skip rebuilding (debug iteration)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+NUM_DIRS="${NUM_DIRS:-1000}"
+FILES_PER_DIR="${FILES_PER_DIR:-100}"
+TOTAL_FILES=$((NUM_DIRS * FILES_PER_DIR))
+RUNS="${RUNS:-5}"
+OUT="${OUT:-${PROJECT_ROOT}/docs/benchmarks/landlock-overhead-100k.md}"
+KEEP_BUILDS="${KEEP_BUILDS:-0}"
+
+WORKDIR="$(mktemp -d -t landlock-bench-XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+OC_ON="${OC_ON:-${WORKDIR}/oc-rsync-landlock-on}"
+OC_OFF="${OC_OFF:-${WORKDIR}/oc-rsync-landlock-off}"
+TREE_SRC="${WORKDIR}/tree-src"
+DEST_BASE="${WORKDIR}/dest"
+DAEMON_CONF="${WORKDIR}/oc-rsyncd.conf"
+DAEMON_LOG="${WORKDIR}/daemon.log"
+DAEMON_PID="${WORKDIR}/daemon.pid"
+DAEMON_PORT=18738
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "ERROR: $1 not found in PATH; install before running this bench" >&2
+        exit 1
+    }
+}
+
+require cargo
+require hyperfine
+require strace
+require rsync
+
+is_linux() {
+    [[ "$(uname -s)" == "Linux" ]]
+}
+
+if ! is_linux; then
+    echo "ERROR: Landlock is Linux-only; run this script inside the rsync-profile container." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Build the two binaries.
+#
+# Until URV-5.c.5 introduces a Cargo-level toggle for the daemon Landlock
+# wiring (currently forced on at the daemon -> fast_io edge for Linux),
+# the OFF baseline is produced by editing
+# `crates/daemon/Cargo.toml` to drop the `landlock` feature from the
+# Linux target dep, building, then reverting. The operator does this
+# manually before invoking the script with `KEEP_BUILDS=1` and the two
+# binaries pre-placed at $OC_ON / $OC_OFF. The script refuses to run
+# otherwise so the OFF cell cannot silently exercise the sandbox.
+# ---------------------------------------------------------------------------
+build_binaries() {
+    if [[ "$KEEP_BUILDS" == "1" && -x "$OC_ON" && -x "$OC_OFF" ]]; then
+        echo "[build] reusing pre-staged binaries (KEEP_BUILDS=1)"
+        return
+    fi
+    cat >&2 <<'EOM'
+ERROR: this bench requires two pre-built oc-rsync binaries:
+  $OC_ON  - release build with the `landlock` feature wired in
+  $OC_OFF - release build with `landlock` stripped from
+            crates/daemon/Cargo.toml (drop `features = ["landlock"]`
+            from the `target.'cfg(target_os = "linux")'.dependencies`
+            entry for fast_io before building)
+
+After staging both binaries set KEEP_BUILDS=1 and rerun. URV-5.c.5
+will replace this manual step with a Cargo-level feature toggle.
+EOM
+    exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Build the 100K-file tree once and reuse it across cells.
+# ---------------------------------------------------------------------------
+build_tree() {
+    if [[ -d "$TREE_SRC" ]] && [[ "$(find "$TREE_SRC" -type f | wc -l)" -ge "$TOTAL_FILES" ]]; then
+        echo "[tree] reusing existing 100K tree at $TREE_SRC"
+        return
+    fi
+    rm -rf "$TREE_SRC"
+    mkdir -p "$TREE_SRC"
+    echo "[tree] creating $TOTAL_FILES files across $NUM_DIRS directories"
+    for d in $(seq 0 $((NUM_DIRS - 1))); do
+        dir="${TREE_SRC}/d${d}"
+        mkdir -p "$dir"
+        for f in $(seq 0 $((FILES_PER_DIR - 1))); do
+            # Deterministic 1 KB payload so checksum cost is uniform across runs.
+            printf 'oc-rsync-landlock-bench %d %d %s\n' "$d" "$f" \
+                "$(head -c 1000 /dev/urandom | base64 | head -c 1000)" \
+                > "${dir}/f${f}.dat"
+        done
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Daemon lifecycle (one daemon per cell so the per-connection setup runs).
+# ---------------------------------------------------------------------------
+write_conf() {
+    local module_root="$1"
+    cat > "$DAEMON_CONF" <<EOF
+uid = $(id -u)
+gid = $(id -g)
+use chroot = no
+pid file = $DAEMON_PID
+log file = $DAEMON_LOG
+port = $DAEMON_PORT
+
+[bench]
+    path = $module_root
+    read only = no
+    write only = no
+    list = yes
+EOF
+}
+
+start_daemon() {
+    local bin="$1"
+    local module_root="$2"
+    mkdir -p "$module_root"
+    rm -f "$DAEMON_LOG"
+    write_conf "$module_root"
+    "$bin" --daemon --no-detach --config "$DAEMON_CONF" \
+        > "$DAEMON_LOG" 2>&1 &
+    echo $! > "${DAEMON_PID}.shell"
+    # Wait up to 3 s for the daemon to bind.
+    for _ in $(seq 1 30); do
+        if ss -tln 2>/dev/null | grep -q ":${DAEMON_PORT}\b"; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    echo "ERROR: daemon failed to bind on port $DAEMON_PORT" >&2
+    cat "$DAEMON_LOG" >&2
+    return 1
+}
+
+stop_daemon() {
+    if [[ -f "${DAEMON_PID}.shell" ]]; then
+        kill "$(cat "${DAEMON_PID}.shell")" 2>/dev/null || true
+        wait 2>/dev/null || true
+        rm -f "${DAEMON_PID}.shell"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Cell runners.
+# ---------------------------------------------------------------------------
+run_hyperfine_cell() {
+    local label="$1"
+    local bin="$2"
+    local dest="${DEST_BASE}-${label}"
+    local export_md="${WORKDIR}/${label}.md"
+
+    rm -rf "$dest"
+    start_daemon "$bin" "$dest"
+
+    echo "[bench] $label - hyperfine $RUNS runs"
+    hyperfine --warmup 1 --runs "$RUNS" --export-markdown "$export_md" \
+        --prepare "rm -rf '$dest' && mkdir -p '$dest'" \
+        "rsync -a '${TREE_SRC}/' 'rsync://localhost:${DAEMON_PORT}/bench/'"
+
+    stop_daemon
+    cat "$export_md"
+}
+
+run_strace_cell() {
+    local label="$1"
+    local bin="$2"
+    local dest="${DEST_BASE}-${label}-strace"
+    local strace_log="${WORKDIR}/${label}.strace"
+
+    rm -rf "$dest"
+    start_daemon "$bin" "$dest"
+
+    echo "[bench] $label - strace -c -f"
+    strace -c -f -o "$strace_log" -p "$(cat "${DAEMON_PID}.shell")" &
+    local strace_pid=$!
+    rsync -a "${TREE_SRC}/" "rsync://localhost:${DAEMON_PORT}/bench/" >/dev/null
+    kill "$strace_pid" 2>/dev/null || true
+    wait "$strace_pid" 2>/dev/null || true
+
+    stop_daemon
+    echo "--- $label strace summary ---"
+    cat "$strace_log"
+}
+
+run_setup_cell() {
+    # Per-connection Landlock setup latency, isolated from the data path.
+    # Pulls the `landlock_overhead/restrict` row out of the criterion bench
+    # so the macro-doc table can quote a single number.
+    echo "[bench] per-connection setup (criterion micro-bench)"
+    (cd "$PROJECT_ROOT" && cargo bench -p fast_io --bench landlock_overhead \
+        --features landlock -- landlock_overhead/restrict 2>&1 | tail -40)
+}
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+main() {
+    build_binaries
+    build_tree
+
+    mkdir -p "$(dirname "$OUT")"
+
+    {
+        echo "# Landlock overhead macro-bench (URV-5.c.4)"
+        echo
+        echo "Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) on $(uname -srm)."
+        echo
+        echo "## Workload"
+        echo
+        echo "- $TOTAL_FILES files across $NUM_DIRS directories, 1 KB each."
+        echo "- Push transfer: upstream rsync client -> oc-rsync daemon over localhost TCP."
+        echo "- hyperfine $RUNS runs per cell, 1 warmup."
+        echo
+    } > "$OUT"
+
+    echo
+    echo "=========================================="
+    echo "  Cell 1 / 3 - hyperfine landlock OFF"
+    echo "=========================================="
+    run_hyperfine_cell "landlock_off" "$OC_OFF" | tee -a "$OUT"
+
+    echo
+    echo "=========================================="
+    echo "  Cell 2 / 3 - hyperfine landlock ON"
+    echo "=========================================="
+    run_hyperfine_cell "landlock_on" "$OC_ON" | tee -a "$OUT"
+
+    echo
+    echo "=========================================="
+    echo "  Cell 3 / 3 - strace syscall counts"
+    echo "=========================================="
+    {
+        echo
+        echo "## strace -c -f summary"
+        echo
+        echo '```'
+        run_strace_cell "landlock_off" "$OC_OFF"
+        echo
+        run_strace_cell "landlock_on" "$OC_ON"
+        echo '```'
+        echo
+        echo "## Per-connection setup (criterion micro-bench)"
+        echo
+        echo '```'
+        run_setup_cell
+        echo '```'
+    } | tee -a "$OUT"
+
+    echo
+    echo "[done] results captured to $OUT"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds the URV-5.c.4 bench harness that gates the URV-5.c.5 default-on flip for the daemon's SEC-1.p Landlock LSM allowlist.
- Micro-bench at `crates/fast_io/benches/landlock_overhead.rs` measures per-connection cost: `is_supported` probe and `restrict_to_module_paths` over 1 / 2 / 4 allowlist roots, with a thread-spawn-join baseline so callers can isolate the Landlock-attributable fraction. Stubbed on non-Linux hosts and when the `landlock` feature is off, so the bench list stays cross-platform.
- Macro-bench at `scripts/landlock_overhead_macro.sh` drives the full 100K-file daemon receive comparison (upstream rsync client -> oc-rsync daemon over localhost TCP) with hyperfine (5 runs + 1 warmup) and `strace -c -f` syscall counts. Designed for the `rsync-profile` container per the Linux-bench feedback rule.
- Results doc at `docs/benchmarks/landlock-overhead-100k.md` captures the decision criteria (< 1% / 1-5% / > 5% wall-clock overhead) and TBD rows pending the container run.

## Why the macro-bench rows are TBD

The host development environment has no Linux kernel and no Landlock LSM, and `podman` was not reachable from the agent. Per the task constraints, the bench harness + design doc land first and the macro-bench numbers populate once the harness has been driven inside `rsync-profile`. The micro-bench rows populate at the same time.

## Why two pre-staged binaries

The current `crates/daemon/Cargo.toml` Linux wiring unconditionally enables `fast_io`'s `landlock` feature at the daemon dep edge. Until URV-5.c.5 introduces a Cargo-level toggle, the OFF baseline is produced by stripping `features = ["landlock"]` from the daemon's Linux fast_io dep, building, then reverting. The macro-bench script refuses to run unless both binaries are pre-staged at `$OC_ON` / `$OC_OFF` and `KEEP_BUILDS=1` is set, so the OFF cell cannot silently exercise the sandbox.

## Decision criteria for URV-5.c.5

| Wall-clock overhead | Action |
|---------------------|--------|
| < 1%                | Flip default-on with the security-note callout only. |
| 1% to 5%            | Flip default-on; release notes call out the trade and per-module opt-out. |
| > 5%                | Keep opt-in; document the gap in `docs/packaging/landlock-feature-guidance.md`. |

The per-connection floor from the micro-bench is a complementary axis: > 1 ms median setup defers the flip even when the macro-bench wall-clock is under 1%, because short-lived connections don't amortise the cost.

## Cross-references

- PR #5601 - URV-5.b.REOPEN Landlock allowlist widening (`temp-dir` / `partial-dir` / `ref_dirs`).
- `docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md` - defense-in-depth design and kernel-ABI matrix.
- `docs/packaging/landlock-feature-guidance.md` - distro packaging guidance.
- Linux-bench container policy per `feedback_use_container_for_linux_bench`.
- Sandboxing primitive choice per `feedback_rust_landlock_preferred`.

## Test plan

- [x] CI fmt + clippy across the workspace (no new lints; bench is `#[cfg]`-stubbed on non-Linux).
- [x] CI nextest across stable / Windows / macOS / Linux musl (bench targets are not part of the test cell; cross-platform stub prevents bench-name discovery from failing).
- [ ] Manual: bring up `rsync-profile`, stage both binaries per the script's pre-run error message, run `bash scripts/landlock_overhead_macro.sh`, and verify `docs/benchmarks/landlock-overhead-100k.md` populates without `TBD pending container run` rows.
- [ ] Manual: `cargo bench -p fast_io --bench landlock_overhead --features landlock` inside the container; capture the `is_supported` / `restrict/roots=*` medians into the same doc.