### PR TITLE
fix(server): restore cmdline+stdin secluded-args merge

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -36,15 +36,32 @@ where
 
     let mut stdin = io::stdin().lock();
 
-    // When secluded-args is active, read the full argument list from stdin
-    // before parsing server flags. The client sends arguments as
-    // null-separated strings terminated by an empty string.
-    // upstream: main.c - read_args() reads protected args from stdin.
+    // When secluded-args is active, the client splits its argv: the
+    // server-options head (--server, --sender, packed flag string, and
+    // value-bearing long flags) travels on the command line, while the
+    // trailing positional args (the `.` separator and path arguments)
+    // stream over stdin as NUL-delimited bytes terminated by an empty
+    // string. Keep the command-line argv tail and append the stdin
+    // payload, skipping the synthetic "rsync" arg0 the wire prepends.
+    //
+    // upstream: main.c::read_args() merges cmdline args with stdin args
+    // under --protect-args / secluded-args. rsync.c:283
+    // send_protected_args() rewrites args[i] to "rsync" at the NULL
+    // split inserted by options.c:2745; io.c:1308 read_args() then
+    // re-runs parse_arguments() on the server side.
     let effective_args: Vec<OsString>;
     let effective_slice: &[OsString] = if secluded_args {
         match protocol::secluded_args::recv_secluded_args(&mut stdin, None) {
             Ok(received_args) => {
-                effective_args = received_args.into_iter().map(OsString::from).collect();
+                // Discard the synthetic "rsync" arg0 from the wire and
+                // prepend the command-line tail so the server-options
+                // head (flag string + long flags) is in effective_args.
+                let mut received_iter = received_args.into_iter();
+                let _arg0 = received_iter.next();
+                let cmdline_tail = args.iter().skip(1).cloned();
+                effective_args = cmdline_tail
+                    .chain(received_iter.map(OsString::from))
+                    .collect();
                 &effective_args
             }
             Err(e) => {

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1087,3 +1087,90 @@ fn server_daemon_arguments_sets_daemon_program_name() {
     // First element should be the daemon program name
     assert!(!result.is_empty());
 }
+
+/// Reproduces the wire layout upstream produces for `rsync -ais lh:src/ dest/`:
+/// the command-line argv carries the server-options head (`--server`,
+/// `--sender`, packed `-slogDtpre.iLsfxCIvu`) and stdin carries a synthetic
+/// "rsync" arg0 followed by `.` and the path tail. Without merging the two,
+/// the server loses the flag string and aborts with
+/// `missing rsync server flag string` against any upstream-client -> oc-rsync
+/// server transfer that sets `-s`.
+///
+/// upstream: rsync.c:283 send_protected_args() / io.c:1308 read_args() /
+/// main.c::read_args() callsite at main.c:1852.
+#[test]
+fn server_mode_merges_cmdline_and_stdin_secluded_args() {
+    use std::io::Cursor;
+
+    // Command-line argv as oc-rsync --server receives it under lsh.sh -s.
+    let argv: Vec<OsString> = vec![
+        OsString::from("oc-rsync"),
+        OsString::from("--server"),
+        OsString::from("--sender"),
+        OsString::from("-slogDtpre.iLsfxCIvu"),
+    ];
+
+    // Wire bytes captured from upstream 3.4.3's send_protected_args for
+    // `rsync -ais lh:reproA/from/ /tmp/dest/`:
+    //   rsync\0.\0/home/ofer/reproA/from/\0\0
+    let wire: &[u8] = b"rsync\0.\0/home/ofer/reproA/from/\0\0";
+    let mut reader = Cursor::new(wire);
+    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+        .expect("recv should succeed");
+    assert_eq!(
+        received,
+        vec![
+            "rsync".to_owned(),
+            ".".to_owned(),
+            "/home/ofer/reproA/from/".to_owned(),
+        ],
+    );
+
+    // The fix discards the synthetic arg0 and merges the rest with the
+    // command-line tail. The flag string must come from argv, and the
+    // positional path from stdin.
+    let mut received_iter = received.into_iter();
+    let _arg0 = received_iter.next();
+    let effective_args: Vec<OsString> = argv
+        .iter()
+        .skip(1)
+        .cloned()
+        .chain(received_iter.map(OsString::from))
+        .collect();
+
+    let (flag_string, positional) = parse_server_flag_string_and_args(&effective_args);
+    assert_eq!(flag_string, "-slogDtpre.iLsfxCIvu");
+    assert_eq!(positional, vec![OsString::from("/home/ofer/reproA/from/")]);
+}
+
+/// When `-s` is sent as a standalone short flag (rather than embedded in
+/// the packed flag string), the same merge produces the right split.
+#[test]
+fn server_mode_merges_cmdline_and_stdin_standalone_s_flag() {
+    use std::io::Cursor;
+
+    let argv: Vec<OsString> = vec![
+        OsString::from("oc-rsync"),
+        OsString::from("--server"),
+        OsString::from("-s"),
+        OsString::from("-logDtpr"),
+    ];
+
+    let wire: &[u8] = b"rsync\0.\0/srv/data/\0\0";
+    let mut reader = Cursor::new(wire);
+    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+        .expect("recv should succeed");
+
+    let mut received_iter = received.into_iter();
+    let _arg0 = received_iter.next();
+    let effective_args: Vec<OsString> = argv
+        .iter()
+        .skip(1)
+        .cloned()
+        .chain(received_iter.map(OsString::from))
+        .collect();
+
+    let (flag_string, positional) = parse_server_flag_string_and_args(&effective_args);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("/srv/data/")]);
+}


### PR DESCRIPTION
## Summary

- Restore the cmdline+stdin merge in `run_server_mode` that PR #5516 added and PR #5541 silently reverted along with its regression tests. Without the merge, the server-side flag string parser receives only the stdin payload (synthetic `rsync` arg0 + `.` + paths) and aborts with `invalid server arguments: missing rsync server flag string` on every upstream-client -> oc-rsync-server transfer that sets `-s` (e.g. `rsync -ais lh:src/ dest/`).
- The `00-hello` testsuite kept passing because test4/test5 use oc-rsync on both ends and the symmetric client buries the full arg list inside the stdin payload, so the missing cmdline tail was harmless. Upstream-client -> oc-rsync-server is the broken direction.
- Re-add the two PR #5516 regression tests covering the packed `-slogDtpre.iLsfxCIvu` form and the standalone `-s` spelling. Both assert that the merge yields the correct flag-string + positional-args split.

## Root cause

Wire contract from upstream:

- `options.c:2744-2745`: when `protect_args` is set, the client inserts a `NULL` separator into `args[]`. Everything before the NULL stays on the SSH command line; everything after streams via stdin.
- `rsync.c:283 send_protected_args()`: rewrites the NULL slot to a synthetic `"rsync"` arg0 and sends the post-split args as NUL-delimited bytes followed by a terminating `\0`.
- `main.c:1852` (3.4.4): `read_args(STDIN_FILENO, ...)` replaces argv with the stdin payload and re-runs `parse_arguments()`. The cmdline-side options were already consumed by the first `parse_arguments()` pass at `main()` entry.

oc-rsync parses server args once in `run_server_mode`, so it must merge both sources before parsing. PR #5516 implemented exactly that. PR #5541 reverted it.

## Fix shape

```rust
if secluded_args {
    let received = recv_secluded_args(&mut stdin, None)?;
    let mut iter = received.into_iter();
    let _arg0 = iter.next(); // synthetic "rsync"
    effective_args = args.iter().skip(1).cloned()
        .chain(iter.map(OsString::from))
        .collect();
    &effective_args
} else { &args[1..] }
```

Cmdline tail goes BEFORE stdin tail, matching upstream's first-then-second `parse_arguments()` ordering: `--server`, `--sender`, packed flag string, value-bearing long flags (cmdline), followed by remaining long flags + `.` + paths (stdin).

## Audit reference

UTS-1.e+.f secluded-args wire verification audit (#5631) reconfirmed the broken wire contract on master. The original fix landed in #5516; the silent revert is in #5541 (URV-6.b NDX_DEL_STATS wiring touched 47 files and dropped both the merge logic and its regression tests).

## Test plan

- [x] `server_mode_merges_cmdline_and_stdin_secluded_args` - captured upstream 3.4.3 wire bytes (`rsync\0.\0/home/ofer/reproA/from/\0\0`) with cmdline argv `[--server, --sender, -slogDtpre.iLsfxCIvu]`. Asserts merged effective_args yields flag_string=`-slogDtpre.iLsfxCIvu` and positional=`[/home/ofer/reproA/from/]`.
- [x] `server_mode_merges_cmdline_and_stdin_standalone_s_flag` - same shape with `-s` as a standalone token and `-logDtpr` as the packed string.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl, interop suite.