### PR TITLE
fix(fast_io): cfg-gate Path import in iouring bench

### DIFF
--- a/crates/fast_io/benches/iouring_high_file_count.rs
+++ b/crates/fast_io/benches/iouring_high_file_count.rs
@@ -86,7 +86,9 @@
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+#[cfg(all(target_os = "linux", feature = "io_uring"))]
+use std::path::Path;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use tempfile::TempDir;


### PR DESCRIPTION
## Summary

`crates/fast_io/benches/iouring_high_file_count.rs:89` imports `Path` unconditionally, but it is only referenced inside `#[cfg(all(target_os = "linux", feature = "io_uring"))]` blocks (lines 224, 391). On macOS, Windows, or with `io_uring` disabled, `Path` becomes unused and `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` fails with `unused_imports`.

This was a pre-existing master baseline regression that landed between commit \`a933345\` (last verified-green fmt+clippy at 2026-06-10T15:18:28Z) and the current tip. It blocks fmt+clippy CI on all open PRs that compile this bench, even though they did not introduce the issue.

## Fix

Move the \`Path\` import behind the same cfg gate that guards its usage:

```rust
use std::path::PathBuf;
#[cfg(all(target_os = "linux", feature = "io_uring"))]
use std::path::Path;
```

Surgical, behaviour-neutral, no test changes.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean (local)
- [x] \`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings\` clean (local, macOS 1.88.0)
- [ ] CI fmt+clippy gate confirms restored
- [ ] No regression to oc-rsync features (parallel-receive-delta, io_uring, IOCP, flat-flist, daemon-tls)