### PR TITLE
docs(audits): URV-1 scope correction for UTS-18 zlib basis-window panic chain

### DIFF
--- a/docs/audits/upstream-3.4.4-conformance.md
+++ b/docs/audits/upstream-3.4.4-conformance.md
@@ -8,7 +8,7 @@ Sources: `target/interop/upstream-src/rsync-3.4.4/` + GitHub issues #951, #829, 
 
 | URV | UTS PR | Upstream issue | Verdict | Follow-ups |
 |---|---|---|---|---|
-| URV-1 | #5535 (UTS-18) | #951 zlib obuf overflow | DIVERGENT-SAFE | - |
+| URV-1 | #5535 (UTS-18) | #951 zlib obuf overflow | DIVERGENT-SAFE (scope corrected, UTS-18.j) | #5566, #5569, #5588, #5590, #5627 |
 | URV-2 | #5531 (UTS-8) | #829 daemon arg backslash | DIVERGENT-SAFE | #3615 |
 | URV-3 | #5523 (UTS-19) | #910 mode-0 sentinel | PARITY | - |
 | URV-4 | #5522 + #5532 (UTS-12) | #897 path=/ sender | DIVERGENT-SAFE | #3620 |
@@ -20,6 +20,65 @@ Two PARITY/SAFE, three DIVERGENT-SAFE, two DIVERGENT-RISK. The two -RISK verdict
 ## URV-1: zlib obuf drain (PR #5535 vs #951)
 
 `avail_out_size` formula matches upstream `n*1001/1000+16` exactly (`token.c:344` <-> `zlib_codec.rs:~55`). oc-rsync allocates `SEE_TOKEN_OBUF_SIZE + 16` slack vs upstream `AVAIL_OUT_SIZE(CHUNK_SIZE)` - strictly larger reserve. Drain semantics equivalent through `flate2` state carryover (oc-rsync's input-driven loop vs upstream's `avail_in != 0 || avail_out == 0`). `Z_SYNC_FLUSH` carryover handled identically; `Z_INSERT_ONLY` defaults to `Z_SYNC_FLUSH` in both. No wire impact.
+
+### URV-1 update: scope correction and UTS-18 panic chain (UTS-18.j)
+
+The original URV-1 verdict (DIVERGENT-SAFE) reflected only the codec-layer
+obuf overflow that upstream #951 closed in `token.c::send_deflated_token`.
+It did not cover the basis-window layer that feeds the decoder, and the
+upstream-testsuite `compress-zlib-insert` run subsequently surfaced a
+chain of receiver-side panics that URV-1's scope had silently excluded:
+
+1. **`window_len` overstatement.** `BufferedMap::load_window` computed
+   `window_len = MAX_MAP_SIZE` (262144) without clamping against
+   `file_size - window_start`. A 48128-byte basis paired with the default
+   `MAX_MAP_SIZE` produced a window descriptor that overran the file. The
+   subsequent `copy_within` and `&buffer[start..end]` operations relied on
+   that descriptor for bounds. Fixed in PR #5569 by clamping
+   `window_len = min(MAX_MAP_SIZE, file_size - aligned_start)` at the
+   single derivation site.
+
+2. **`buffer.resize` overlap-shrink data loss.** `load_window` shrank
+   `self.buffer` to the new `window_size` before relocating overlap bytes
+   with `copy_within`. When the new `window_size` was smaller than the
+   prior allocation but the overlap source offset sat inside the
+   to-be-truncated tail, `resize` dropped the very bytes the relocation
+   was about to read. Fixed in PR #5588 by switching to
+   `target_len = window_size.max(buffer.len())` so the backing buffer
+   only grows, mirroring upstream `fileio.c:236::realloc_array`.
+
+3. **Bare slice index on misaligned chunk requests.** `BufferedMap::map_ptr`
+   bare-indexed `&buffer[start..start + len]` when a COPY token requested
+   bytes past EOF or past the clamped window. Even with the clamp in (1)
+   in place, a sender that asks for `offset + len > file_size` could
+   trigger the panic. Fixed in PR #5566 by returning
+   `io::ErrorKind::UnexpectedEof` from `map_ptr` before any slice
+   indexing, using saturating arithmetic to keep the bounds check itself
+   wrap-safe. Regression coverage added in PR #5590 (libfuzzer corpus +
+   adversarial seeds) and locked in `docs/design/zlib-codec-invariants.md`
+   (PR #5627).
+
+**Why the original URV-1 audit missed these.** URV-1 was scoped to the
+encoder-side `send_deflated_token` formula against upstream #951 and
+verified codec-layer obuf safety in `zlib_codec.rs`. The audit did not
+inspect the basis-window mapper in `crates/transfer/src/map_file/buffered.rs`,
+which is where the panics actually surfaced. Upstream #951's fix path
+(`token.c::send_deflated_token` flush loop) and oc-rsync's affected path
+(`BufferedMap::load_window` window-clamp + buffer-resize + slice-index)
+sit on opposite sides of the receiver's COPY-token dispatch boundary,
+which is why a codec-only re-validation cleared the file while a
+basis-window-driven workload still tripped panics.
+
+**Revised verdict.** URV-1 remains DIVERGENT-SAFE at the codec layer.
+The basis-window layer is now also covered: fail-loud bounds (#5566),
+window clamp at the source (#5569), monotonic buffer (#5588), regression
+fuzz corpus (#5590), and load-bearing invariant doc (#5627). The
+`compress-zlib-insert` upstream-testsuite entry stays out of
+`tools/ci/upstream_testsuite_known_failures.conf` and the
+`.github/workflows/upstream-testsuite.yml` cell exercises it on every
+push/PR matching the workflow's path filter, providing continuous
+regression coverage against the original URV-1 surface and the UTS-18
+panic chain together.
 
 ## URV-2: daemon arg backslash (PR #5531 vs #829)
 

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -18,6 +18,19 @@ KNOWN_FAILURES=(
   # -----------------------------------------------------------------------
   # Removed entries:
   #
+  # "compress-zlib-insert" - intentionally NOT listed (UTS-18.i).
+  #   Exercises the basis-window mapper at BufferedMap::load_window /
+  #   BufferedMap::map_ptr via zlib delta upload with insert tokens past
+  #   the basis-window edge. After PRs #5566 (fail-loud bounds),
+  #   #5569 (clamp window_len), #5588 (never-shrink), and #5590 (fuzz
+  #   coverage), this test is expected to PASS. Keeping it out of the
+  #   known-failures list ensures any regression in the zlib codec or
+  #   basis-window invariants documented in docs/design/zlib-codec-
+  #   invariants.md (PR #5627) surfaces as an UNEXPECTED FAIL in the
+  #   Upstream Testsuite workflow rather than silently slipping under an
+  #   XFAIL. See docs/audits/upstream-3.4.4-conformance.md URV-1 update
+  #   for the UTS-18.j scope-correction rationale.
+  #
   # "ssh-basic" - now passes after build_capability_string_suffix()
   #   provides the embeddable capability string for remote shell
   #   invocation, matching upstream's -e.LsfxCIvu format.


### PR DESCRIPTION
## Summary

Closes UTS-18.i (#3887) and UTS-18.j (#3888) as a paired doc + CI
configuration update.

- **UTS-18.j**: Append a URV-1 scope-correction subsection to
  `docs/audits/upstream-3.4.4-conformance.md` that documents the
  basis-window panic chain the original codec-layer audit missed,
  names the remediation PRs, and explains why a codec-only review
  cleared the surface while a basis-window-driven workload still
  tripped panics. Update the summary table's URV-1 row to reflect
  the scope correction and cross-link the remediation PRs (#5566,
  #5569, #5588, #5590, #5627).
- **UTS-18.i**: Add an explanatory comment block to
  `tools/ci/upstream_testsuite_known_failures.conf` documenting why
  `compress-zlib-insert` is intentionally NOT listed - the workflow's
  wildcard test loop already runs it, and the test is expected to
  PASS after the UTS-18.f/.g/.h fixes, so any regression should
  surface as an UNEXPECTED FAIL rather than slipping under an XFAIL.

## Known-failures delta

No add/remove. `compress-zlib-insert` was never in the list and is
expected to PASS; this PR documents that policy in-place.

## Attestation update

Adds a fourth subsection under URV-1 (after the existing PARITY/SAFE
paragraph) titled "URV-1 update: scope correction and UTS-18 panic
chain (UTS-18.j)". Cross-references `docs/design/zlib-codec-invariants.md`
(PR #5627) for the load-bearing invariants the chain locked in.

## Verified PR-number remediation chain

- #5566 - `fix(transfer): turn buffered map_file out-of-range panic into Err` (UTS-18.f, MERGED)
- #5569 - `fix(transfer): clamp window_len to remaining file bytes in load_window` (UTS-18.g.2, MERGED)
- #5588 - `fix(transfer): never shrink BufferedMap buffer to avoid overlap data loss` (UTS-18.h, MERGED)
- #5590 - `test(fuzz): add buffered_map fuzz target + UTS-18 regression corpus` (MERGED)
- #5627 - `docs(design): document zlib codec invariants and basis-window contract` (UTS-18.k, MERGED)
- #5535 - `fix: guard zlib obuf overflow on matched-block inserts (upstream #951)` (URV-1, CLOSED - codec-layer attestation reference only)

## Test plan

- [ ] CI `Upstream Testsuite` cell runs `compress-zlib-insert` via the
      existing `$suitedir/*.test` wildcard and reports PASS.
- [ ] Required CI checks (fmt+clippy, nextest, Windows, macOS, Linux musl)
      remain green - this PR is doc-and-config only.