### PR TITLE
test(protocol): assert recv_secluded_args stops exactly at terminator

### DIFF
--- a/crates/protocol/src/secluded_args.rs
+++ b/crates/protocol/src/secluded_args.rs
@@ -405,4 +405,39 @@ mod tests {
             .expect_err("recv should fail when terminator is missing");
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
+
+    #[test]
+    fn recv_secluded_args_stops_exactly_after_terminator_byte() {
+        // Wire format: args, terminator NUL, then a trailing greeting byte
+        // that belongs to the next protocol phase. recv_secluded_args must
+        // consume exactly through the terminator NUL and leave the trailing
+        // byte intact for the next reader.
+        //
+        // This locks the boundary more strictly than the buffer-end check:
+        // a function that read one byte too few would leave the cursor
+        // before the terminator; a function that read one byte too many
+        // would swallow the greeting byte. Only consuming exactly through
+        // the terminator NUL passes.
+        let wire: &[u8] = b"--server\0--sender\0.\0/path\0\0@";
+        let terminator_end = wire.len() - 1;
+        let mut cursor = io::Cursor::new(wire);
+
+        let args = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+
+        assert_eq!(args, vec!["--server", "--sender", ".", "/path"]);
+        assert_eq!(
+            cursor.position(),
+            terminator_end as u64,
+            "cursor must rest on the trailing byte after the terminator NUL"
+        );
+
+        // The trailing byte must still be readable verbatim from the cursor;
+        // otherwise the subsequent protocol greeting reader sees corrupted
+        // input and the handshake fails with a confusing error.
+        let mut leftover = [0u8; 1];
+        cursor
+            .read_exact(&mut leftover)
+            .expect("trailing byte must remain in the stream");
+        assert_eq!(leftover, [b'@']);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a regression test that locks the strict drain invariant for `recv_secluded_args`.

Existing tests in this module verify the cursor reaches the buffer end after a clean payload. That check passes even if the implementation reads one byte too many or too few, as long as nothing follows the terminator. The new test feeds an extra trailing byte after the empty-arg terminator NUL and asserts:

- the parsed args match the expected vector,
- the cursor rests on the trailing byte (terminator NUL was consumed exactly once),
- the trailing byte remains readable verbatim for the next reader.

The invariant matters because any residual byte leaks into the next protocol phase (the `@RSYNCD:` greeting handshake) and surfaces as a confusing handshake failure rather than a clear argument-protocol error.

## Test plan

- [ ] CI nextest stable green on Linux, macOS, Windows, Linux musl
- [ ] fmt + clippy clean