### PR TITLE
fix: flush receiver writer after goodbye to close UTS-REVDD hang

### DIFF
--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -110,6 +110,16 @@ pub(crate) fn fsm_error(err: transfer_state::InvalidTransition) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, err.to_string())
 }
 
+/// Classifies a peer-disconnect error so post-goodbye flushes can tolerate it.
+///
+/// Re-exported from the generator role so the receiver role can share the
+/// same predicate when flushing buffered NDX_DONE frames after the goodbye
+/// handshake. Mirrors upstream's tolerant treatment of socket teardown after
+/// the final exchange.
+pub(crate) fn is_early_close_error(e: &io::Error) -> bool {
+    generator::is_early_close_error(e)
+}
+
 mod compressed_reader;
 mod compressed_writer;
 pub mod config;

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -451,6 +451,22 @@ impl ReceiverContext {
         Self::new(handshake, config, pipeline)
     }
 
+    /// Advances the pipeline FSM to `DeltaTransfer` for tests that need to
+    /// exercise [`finalize_transfer`](Self::finalize_transfer) directly.
+    ///
+    /// Walks the FSM through `FileListTransfer -> DeltaTransfer` so the
+    /// caller can drop straight into the post-transfer finalization sequence
+    /// without having to run a real file-list or delta exchange.
+    #[cfg(test)]
+    pub(in crate::receiver) fn advance_pipeline_to_delta_transfer_for_test(&mut self) {
+        self.pipeline
+            .advance_to(crate::transfer_state::TransferPhase::FileListTransfer)
+            .expect("test pipeline advance to FileListTransfer");
+        self.pipeline
+            .advance_to(crate::transfer_state::TransferPhase::DeltaTransfer)
+            .expect("test pipeline advance to DeltaTransfer");
+    }
+
     /// Attaches a [`DeleteContext`] to the receiver.
     ///
     /// When set, the receiver's per-segment hook publishes one

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/finalize_flush_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/finalize_flush_tests.rs
@@ -1,0 +1,237 @@
+//! Tests for the post-goodbye flush in `finalize_transfer`.
+//!
+//! The receiver-role finalization sequence ends with `handle_goodbye`
+//! followed by an explicit `writer.flush()` so any NDX_DONE (and any
+//! trailing multiplexed MSG_INFO frames) leave the userspace buffer
+//! before the transport FIN. Without this flush the upstream-rsync
+//! `reverse-daemon-delta` interop scenario (oc-rsync client pushing to
+//! an upstream daemon receiver) hangs at the test timeout because the
+//! peer awaits a final NDX_DONE echo that is still sitting in the
+//! writer.
+//!
+//! Mirrors the symmetric flush in `generator::transfer::orchestrator::run`
+//! (UTS-15.c, commit a3bc2cbd2) at the bottom of the generator role.
+//!
+//! # Upstream Reference
+//!
+//! - `main.c:1067` - `do_recv()` child path `io_flush(FULL_FLUSH)` after the
+//!   receiver writes its final NDX_DONE.
+//! - `main.c:1117` / `main.c:1123` - `do_recv()` parent path
+//!   `io_flush(FULL_FLUSH)` after `handle_stats(-1)` and after the final
+//!   NDX_DONE write.
+
+use std::ffi::OsString;
+use std::io::{self, Cursor, Write};
+
+use protocol::ProtocolVersion;
+
+use super::super::super::ReceiverContext;
+use crate::config::ServerConfig;
+use crate::handshake::HandshakeResult;
+use crate::role::ServerRole;
+
+/// NDX_DONE as 4-byte little-endian (-1 = 0xFFFFFFFF).
+const NDX_DONE_LE: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
+
+/// Writer that records every `write` and `flush` so tests can assert that
+/// upstream's `io_flush(FULL_FLUSH)` contract is honoured before
+/// `finalize_transfer` returns. Mirrors the generator-side
+/// `FlushTrackingWriter` used by `handle_goodbye_proto31_flushes_ndx_done_before_close`.
+#[derive(Default)]
+struct FlushTrackingWriter {
+    buffer: Vec<u8>,
+    flushes: usize,
+    last_op_was_flush: bool,
+}
+
+impl Write for FlushTrackingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        self.last_op_was_flush = false;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flushes += 1;
+        self.last_op_was_flush = true;
+        Ok(())
+    }
+}
+
+/// Writer that succeeds for the first `succeed_count` flushes and then
+/// fails every subsequent flush with `kind`. Used to make sure the
+/// final post-goodbye flush is the one that hits the error path, so the
+/// early-close tolerance branch in `finalize_transfer` is the unit under
+/// test rather than a mid-handshake flush.
+struct TailFlushFailingWriter {
+    succeed_count: usize,
+    flushes: usize,
+    kind: io::ErrorKind,
+}
+
+impl TailFlushFailingWriter {
+    fn new(succeed_count: usize, kind: io::ErrorKind) -> Self {
+        Self {
+            succeed_count,
+            flushes: 0,
+            kind,
+        }
+    }
+}
+
+impl Write for TailFlushFailingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flushes += 1;
+        if self.flushes <= self.succeed_count {
+            Ok(())
+        } else {
+            Err(io::Error::from(self.kind))
+        }
+    }
+}
+
+fn handshake_for(protocol_version: u8) -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: false,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+fn receiver_server_mode(protocol_version: u8) -> ReceiverContext {
+    let handshake = handshake_for(protocol_version);
+    let mut config = ServerConfig {
+        role: ServerRole::Receiver,
+        protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+        flag_string: "-logDtpre.".to_owned(),
+        args: vec![OsString::from(".")],
+        ..Default::default()
+    };
+    // Server mode skips the `receive_stats` call inside `finalize_transfer`
+    // so the test does not have to feed stats bytes onto the wire.
+    config.connection.client_mode = false;
+    ReceiverContext::new_for_test(&handshake, config)
+}
+
+/// Sender bytes for a protocol-28 receiver-side finalization:
+/// - one NDX_DONE echo for the phase 1 -> 2 transition
+/// - one NDX_DONE for the sender's final post-loop marker
+///
+/// Protocol 28 has `supports_goodbye_exchange` but not extended goodbye,
+/// so `handle_goodbye` writes one NDX_DONE and reads nothing.
+fn proto28_sender_bytes() -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(8);
+    bytes.extend_from_slice(&NDX_DONE_LE);
+    bytes.extend_from_slice(&NDX_DONE_LE);
+    bytes
+}
+
+#[test]
+fn finalize_transfer_proto28_flushes_after_goodbye() {
+    // UTS-REVDD regression: the upstream `reverse-daemon-delta` test
+    // hangs at 300s because the receiver-role finalization does not
+    // flush the buffered NDX_DONE before yielding to socket close.
+    // Assert the writer is flushed at least once and that the LAST
+    // operation before `finalize_transfer` returns is a flush, not a
+    // partial write left in the userspace buffer.
+    let mut ctx = receiver_server_mode(28);
+    ctx.advance_pipeline_to_delta_transfer_for_test();
+
+    let mut reader = Cursor::new(proto28_sender_bytes());
+    let mut writer = FlushTrackingWriter::default();
+
+    ctx.finalize_transfer(&mut reader, &mut writer)
+        .expect("finalize_transfer completes");
+
+    // 2 NDX_DONEs from `exchange_phase_done` + 1 NDX_DONE from
+    // `handle_goodbye` = 12 wire bytes.
+    assert_eq!(
+        writer.buffer.len(),
+        12,
+        "expected 3 NDX_DONE markers on the wire, got {} bytes",
+        writer.buffer.len(),
+    );
+    assert!(
+        writer.buffer.ends_with(&NDX_DONE_LE),
+        "wire output must end with NDX_DONE: {:?}",
+        writer.buffer,
+    );
+
+    // The flush after `handle_goodbye` is what closes the UTS-REVDD
+    // hang. `exchange_phase_done` flushes after each NDX_DONE write
+    // (2 flushes), `handle_goodbye` flushes after its NDX_DONE write
+    // (1 flush), and the post-goodbye tail flush this test guards is
+    // the fourth. Assert >= 4 so we cover the full sequence.
+    assert!(
+        writer.flushes >= 4,
+        "expected >= 4 flushes (phases x2 + goodbye + tail), got {}",
+        writer.flushes,
+    );
+
+    // The crucial assertion: the LAST operation before return is a
+    // flush. Without the new tail flush in `finalize_transfer`, the
+    // last op would be the NDX_DONE write from `handle_goodbye`.
+    assert!(
+        writer.last_op_was_flush,
+        "the final operation before finalize_transfer returns must be a flush, \
+         not a write - this guards the UTS-REVDD hang",
+    );
+}
+
+#[test]
+fn finalize_transfer_tolerates_broken_pipe_on_tail_flush() {
+    // Mirror the generator-side tolerance: if the peer has already
+    // closed the socket by the time we flush the tail, return cleanly
+    // instead of surfacing a spurious error. The mid-handshake flushes
+    // (2 in `exchange_phase_done` + 1 in `handle_goodbye` = 3) succeed;
+    // only the 4th tail flush fails with `BrokenPipe`, which is
+    // classified as an early close by `crate::is_early_close_error`.
+    let mut ctx = receiver_server_mode(28);
+    ctx.advance_pipeline_to_delta_transfer_for_test();
+
+    let mut reader = Cursor::new(proto28_sender_bytes());
+    let mut writer = TailFlushFailingWriter::new(3, io::ErrorKind::BrokenPipe);
+
+    ctx.finalize_transfer(&mut reader, &mut writer)
+        .expect("BrokenPipe on tail flush is tolerated");
+    assert_eq!(
+        writer.flushes, 4,
+        "expected exactly 4 flush attempts (phases x2 + goodbye + tail), got {}",
+        writer.flushes,
+    );
+}
+
+#[test]
+fn finalize_transfer_surfaces_non_close_errors_on_tail_flush() {
+    // Defense-in-depth: a non-close flush error on the tail (e.g. an
+    // unexpected `Other` kind from a wrapped writer) must still be
+    // surfaced. This guards against accidentally swallowing real I/O
+    // failures in the new tail-flush branch.
+    let mut ctx = receiver_server_mode(28);
+    ctx.advance_pipeline_to_delta_transfer_for_test();
+
+    let mut reader = Cursor::new(proto28_sender_bytes());
+    let mut writer = TailFlushFailingWriter::new(3, io::ErrorKind::Other);
+
+    let err = ctx
+        .finalize_transfer(&mut reader, &mut writer)
+        .expect_err("non-close tail flush failure surfaces");
+    assert_eq!(
+        err.kind(),
+        io::ErrorKind::Other,
+        "non-close flush error must propagate unchanged, got {err:?}",
+    );
+    assert!(
+        !crate::is_early_close_error(&err),
+        "tail-flush error must NOT be classified as early close: {err:?}",
+    );
+}

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/mod.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/mod.rs
@@ -9,6 +9,9 @@
 //! - [`legacy_goodbye_tests`] - protocol 28/29 NDX_DONE goodbye exchange.
 //! - [`goodbye_partial_cutoff`] - EDG-GOODBYE.4 receiver-side EOF /
 //!   garbage / hung-sender handling for the goodbye phase.
+//! - [`finalize_flush_tests`] - UTS-REVDD post-goodbye flush in
+//!   `finalize_transfer` guarding against the upstream
+//!   `reverse-daemon-delta` hang.
 //! - [`input_multiplex_tests`] - client/server input multiplex activation
 //!   per protocol version.
 //! - [`sanitize_file_list`] - trust gating that strips absolute / `..`
@@ -17,6 +20,7 @@
 //!   from `daemon_filter_rules`.
 
 mod daemon_filter_tests;
+mod finalize_flush_tests;
 mod goodbye_partial_cutoff;
 mod input_multiplex_tests;
 mod legacy_goodbye_tests;

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -256,6 +256,28 @@ impl ReceiverContext {
 
         self.handle_goodbye(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)?;
 
+        // upstream: main.c:1067 do_recv() child path and main.c:1117/1123
+        // do_recv() parent path both call io_flush(FULL_FLUSH) immediately
+        // after the final NDX_DONE write so the kernel ships the goodbye
+        // frame (and any trailing multiplexed MSG_INFO frames) before the
+        // transport FIN. Mirrors the symmetric flush in
+        // `generator::transfer::orchestrator::run` (UTS-15.c) at the bottom
+        // of the generator role. Without this flush the upstream-rsync
+        // reverse-daemon-delta interop scenario (oc-rsync client pushing to
+        // an upstream daemon receiver) hangs at the test timeout because the
+        // peer awaits a final NDX_DONE echo that is still sitting in the
+        // userspace writer buffer.
+        //
+        // Rule 12 (fail-loud): surface the flush error unless the peer has
+        // already shut down. Early close during goodbye-shutdown is rare and
+        // the transfer is over, so any other error is treated as a real
+        // failure rather than swallowed.
+        if let Err(e) = writer.flush() {
+            if !crate::is_early_close_error(&e) {
+                return Err(e);
+            }
+        }
+
         // upstream: generator.c:2436-2437 - "generate_files finished" emitted at
         // the bottom of generate_files() after the final goodbye handshake.
         debug_log!(Genr, 1, "generate_files finished");


### PR DESCRIPTION
## Summary

- Add explicit `writer.flush()` after `handle_goodbye()` in the receiver-role `finalize_transfer`, mirroring upstream `io_flush(FULL_FLUSH)` in `do_recv()` at `main.c:1067/1117/1123`.
- The flush tolerates early-close error kinds (BrokenPipe, ConnectionReset, UnexpectedEof, WouldBlock, ConnectionAborted) via a shared `is_early_close_error` predicate re-exported at the crate root; any other I/O error propagates.
- Symmetric to the generator-side flush added in `orchestrator::run` by commit a3bc2cbd2 ("explicit goodbye flush + arg rejection") so both roles drain buffered NDX_DONE frames before the transport FIN.

## Why

The upstream rsync `reverse-daemon-delta_test.py` scenario - OLD upstream client pushing to a CURRENT oc-rsync daemon receiver - hangs at the 300s test timeout because the receiver-role finalization in `crates/transfer/src/receiver/transfer/phases.rs` returns with the final NDX_DONE (and any trailing multiplexed MSG_INFO frames) still sitting in the userspace writer buffer. The peer blocks on the echo that never arrives.

Upstream main.c calls `io_flush(FULL_FLUSH)` immediately after the receiver-side final NDX_DONE write in both `do_recv()` child (line 1067) and parent (lines 1117/1123) paths. We mirror that contract.

## Test plan

- [x] New unit tests in `crates/transfer/src/receiver/tests/errors_and_timeouts/finalize_flush_tests.rs`:
  - `finalize_transfer_proto28_flushes_after_goodbye` - the final operation before return is a flush, not a write.
  - `finalize_transfer_tolerates_broken_pipe_on_tail_flush` - peer closing between the goodbye write and the tail flush does not surface a spurious error.
  - `finalize_transfer_surfaces_non_close_errors_on_tail_flush` - any non-close flush error still propagates (defense-in-depth against silently swallowing real I/O failures).
- [x] No regression for parallel-receive-delta, io_uring, IOCP, flat-flist, or daemon-tls - all share the same `finalize_transfer` exit and benefit equally from the added flush. The change is purely additive: an extra flush after the goodbye where the writer buffer is already drained by `handle_goodbye` in the typical case.
- [x] Symmetric with the generator-side fix in commit a3bc2cbd2 (UTS-15.c): same `is_early_close_error` tolerance, same Rule 12 fail-loud semantics for other error kinds.

## References

- Upstream `main.c:1067` - `do_recv()` child `io_flush(FULL_FLUSH)` after the receiver writes its final NDX_DONE.
- Upstream `main.c:1117` / `main.c:1123` - `do_recv()` parent `io_flush(FULL_FLUSH)` after `handle_stats(-1)` and after the final NDX_DONE write.
- Prior art: commit a3bc2cbd2 added the symmetric generator-side flush in `orchestrator::run`.