### PR TITLE
fix: follow symlink at dest_root to match upstream main.c:745-754

### DIFF
--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -174,24 +174,45 @@ pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
 /// pre-flight was a no-op (already exists, single-file transfer without
 /// trailing slash, or `dry_run`).
 ///
-/// # Symlink refusal
+/// # Symlink resolution
 ///
-/// The existence check uses `symlink_metadata()` (lstat) rather than
-/// `metadata()` (stat) so a symlink at `dest_root` is detected directly
-/// instead of being silently resolved. When `dest_root` is itself a symlink -
-/// broken or otherwise - the helper refuses with `InvalidInput` instead of
-/// proceeding. A broken symlink would fall through the stat-based check
-/// (NotFound at the target) and let `create_dir_all` resolve through the
-/// symlink, materializing the directory outside the intended location; a
-/// dangling-link-class containment bypass analogous to the SEC-1 TOCTOU
-/// family. An existing-symlink dest is equally suspect because every
-/// per-entry write would land at the symlink target, sidestepping the
-/// daemon's `module.path` containment. Operators that genuinely need to
-/// receive into a symlinked location must materialize the real directory
-/// themselves; oc-rsync never auto-creates through a symlink.
+/// The existence check uses `metadata()` (stat) rather than
+/// `symlink_metadata()` (lstat) so a symlink at `dest_root` pointing at a
+/// real directory is accepted, matching upstream `main.c:745-754`
+/// `get_local_name()` which calls `do_stat()` (follows symlinks) and
+/// proceeds when `S_ISDIR(st.st_mode)` is true. A symlinked dest root is
+/// the upstream `symlink-dirlink-basis` interop scenario (issue #715).
+///
+/// A dangling symlink resolves to `ENOENT`, and the helper would then call
+/// `create_dir_all`, which would materialize the directory at the symlink
+/// target. To avoid that footgun we lstat first when the stat reports
+/// `NotFound`: if the path is actually a dangling symlink we propagate the
+/// stat-side `NotFound` instead of auto-creating through the link.
+///
+/// # Security model
+///
+/// Accepting a symlinked dest is safe because per-entry writes are sandboxed
+/// downstream of this helper:
+///
+/// - SEC-1.e/.f-.j: every per-entry open routes through a [`DirSandbox`]
+///   anchored at the resolved canonical path (see `transfer::setup`), and
+///   each path-component open uses `openat2(RESOLVE_BENEATH |
+///   RESOLVE_NO_SYMLINKS)` on Linux 5.6+ or `openat(O_NOFOLLOW |
+///   O_DIRECTORY)` elsewhere. A malicious symlink at `dest_root` resolves
+///   once here, then the sandbox locks every subsequent open below that
+///   resolved fd.
+/// - The daemon module-containment check is performed by the daemon module
+///   loader, not by this helper. A symlinked dest cannot escape the module
+///   root because the daemon already chroots / restricts `module.path` at
+///   the module-config layer.
+///
+/// [`DirSandbox`]: fast_io::DirSandbox
 ///
 /// # Upstream Reference
 ///
+/// - `main.c:745-754` - `get_local_name()` `S_ISDIR(st.st_mode)` branch:
+///   `do_stat()` follows symlinks, `change_dir()` resolves the link and
+///   enters the target.
 /// - `main.c:778-792` - `get_local_name()` pre-flight `do_mkdir(dest_path, ACCESSPERMS)`
 /// - `main.c:794-796` - sets `FLAG_DIR_CREATED` on the first flist entry when
 ///   its basename is `.` (deferred follow-up; oc-rsync's delete path does
@@ -208,26 +229,34 @@ pub fn ensure_dest_root_exists(
     if file_total <= 1 && !trailing_slash {
         return Ok(false);
     }
-    // lstat instead of stat so a symlink at `dest_root` is observed directly.
-    // Upstream `main.c:778-792` does not pre-flight a symlinked dest_path
-    // (`do_stat` follows the link and either reports the target dir or
-    // returns ENOENT, after which `do_mkdir` resolves through the symlink).
-    // We refuse instead: auto-creating through an attacker-planted symlink
-    // would resolve to whatever the link points at, defeating the
-    // module-root containment that the SEC-1 `*at` chain enforces for every
-    // subsequent per-entry write.
-    match dest_root.symlink_metadata() {
-        Ok(meta) if meta.file_type().is_symlink() => Err(io::Error::new(
+    // stat (follows symlinks) so a symlinked dest pointing at a real
+    // directory is accepted, matching upstream main.c:745-754 do_stat() +
+    // S_ISDIR + change_dir() flow. A non-directory target (regular file,
+    // broken symlink, etc.) is still rejected at the call site below.
+    match dest_root.metadata() {
+        Ok(meta) if meta.is_dir() => Ok(false),
+        Ok(_) => Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
-                "refusing to create destination root '{}' through a symlink: \
-                 auto-creating at the symlink target would bypass module \
-                 containment (UTS-2 follow-up to PR #5567)",
+                "destination root '{}' exists but is not a directory",
                 dest_root.display(),
             ),
         )),
-        Ok(_) => Ok(false),
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            // Distinguish "path absent" from "dangling symlink": if lstat
+            // shows a symlink while stat says NotFound, the link target is
+            // missing and create_dir_all would resolve the link and
+            // materialize a directory at the target. Refuse that footgun
+            // by surfacing the original stat error.
+            if dest_root.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "destination root '{}' is a dangling symlink",
+                        dest_root.display(),
+                    ),
+                ));
+            }
             std::fs::create_dir_all(dest_root).map(|()| true)
         }
         Err(err) => Err(err),

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -248,7 +248,10 @@ pub fn ensure_dest_root_exists(
             // missing and create_dir_all would resolve the link and
             // materialize a directory at the target. Refuse that footgun
             // by surfacing the original stat error.
-            if dest_root.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink()) {
+            if dest_root
+                .symlink_metadata()
+                .is_ok_and(|m| m.file_type().is_symlink())
+            {
                 return Err(io::Error::new(
                     io::ErrorKind::NotFound,
                     format!(

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -196,6 +196,54 @@ impl ReceiverContext {
             debug_log!(Recv, 1, "created destination root {}", dest_dir.display());
         }
 
+        // UTS-SLDB: when the dest root is a symlink that resolved to a real
+        // directory via the stat path in ensure_dest_root_exists, lock the
+        // canonical target in here so every downstream open (DirSandbox,
+        // per-entry `*at` syscalls) operates on the resolved directory.
+        // Upstream `main.c:748` reaches the same state by calling
+        // `change_dir(dest_path, CD_NORMAL)` after `S_ISDIR` succeeds: the
+        // kernel resolves the link once and every subsequent syscall is
+        // relative to the resolved cwd. We mirror that by canonicalizing
+        // here instead of relying on chdir.
+        //
+        // Skipped under daemon connections: the daemon strict path in
+        // `open_sandbox_for_dest_strict` refuses a symlinked dest outright
+        // (chdir-symlink-race defense), and the module loader has already
+        // restricted `module.path`. Canonicalizing here would mask the
+        // symlink and let strict mode silently succeed against the resolved
+        // target. Local-mode and non-daemon SSH transfers are the
+        // upstream-parity case (issue #715 `symlink-dirlink-basis`).
+        let dest_dir = if !self.config.flags.dry_run
+            && !self.config.connection.is_daemon_connection
+            && dest_dir
+                .symlink_metadata()
+                .is_ok_and(|m| m.file_type().is_symlink())
+        {
+            match std::fs::canonicalize(&dest_dir) {
+                Ok(resolved) => {
+                    debug_log!(
+                        Recv,
+                        2,
+                        "resolved symlinked destination root {} -> {}",
+                        dest_dir.display(),
+                        resolved.display()
+                    );
+                    resolved
+                }
+                Err(err) => {
+                    debug_log!(
+                        Recv,
+                        1,
+                        "canonicalize({}) failed: {err}; keeping link path",
+                        dest_dir.display()
+                    );
+                    dest_dir
+                }
+            }
+        } else {
+            dest_dir
+        };
+
         let acl_cache = if self.config.flags.acls {
             self.flist_reader_cache
                 .as_ref()

--- a/crates/transfer/tests/uts_2_dest_root_mkdir.rs
+++ b/crates/transfer/tests/uts_2_dest_root_mkdir.rs
@@ -135,7 +135,10 @@ fn rejects_broken_symlink_dest_root() {
     let dest = tmp.path().join("dest_root");
     symlink(&outside_target, &dest).expect("create broken symlink");
     assert!(
-        dest.symlink_metadata().expect("lstat dest").file_type().is_symlink(),
+        dest.symlink_metadata()
+            .expect("lstat dest")
+            .file_type()
+            .is_symlink(),
         "fixture must place a symlink at dest"
     );
     assert!(!outside_target.exists(), "target must remain dangling");
@@ -172,8 +175,8 @@ fn accepts_symlink_to_existing_directory() {
     let dest = tmp.path().join("dest_root");
     symlink(&real_dir, &dest).expect("symlink dest -> real_dir");
 
-    let created =
-        ensure_dest_root_exists(&dest, 5, false, false).expect("symlink-to-dir dest must be accepted");
+    let created = ensure_dest_root_exists(&dest, 5, false, false)
+        .expect("symlink-to-dir dest must be accepted");
 
     assert!(
         !created,
@@ -254,5 +257,8 @@ fn rejects_chained_dangling_symlink_dest_root() {
     let err = ensure_dest_root_exists(&dangling_link, 3, false, false)
         .expect_err("dangling-chain symlink dest must error");
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
-    assert!(!intermediate.exists(), "no auto-create through the dangling chain");
+    assert!(
+        !intermediate.exists(),
+        "no auto-create through the dangling chain"
+    );
 }

--- a/crates/transfer/tests/uts_2_dest_root_mkdir.rs
+++ b/crates/transfer/tests/uts_2_dest_root_mkdir.rs
@@ -111,34 +111,22 @@ fn creates_nested_dest_root() {
     assert!(dest.is_dir());
 }
 
-/// Surfacing an existing-non-directory dest is upstream's "destination path
-/// is not a directory" error at `main.c:782-784`. The helper itself returns
-/// `Ok(false)` because metadata succeeds; the per-entry mkdir downstream is
-/// what reports the conflict. Lock that behaviour so future refactors do not
-/// silently elevate the helper into a destructive replacer.
-#[test]
-fn existing_non_directory_path_is_noop_for_helper() {
-    let tmp = tempdir().expect("tempdir");
-    let dest = tmp.path().join("existing_file");
-    fs::write(&dest, b"x").expect("seed file");
-
-    let created = ensure_dest_root_exists(&dest, 5, true, false).expect("metadata-only check");
-
-    assert!(!created, "helper must not destroy an existing file");
-    assert!(dest.is_file(), "the file stays intact");
-}
-
-/// Broken symlink pointing OUTSIDE the would-be containment must be refused.
+/// Broken (dangling) symlink at the dest root must error rather than
+/// auto-create a directory at the missing link target.
 ///
-/// The pre-PR-5567 helper called `dest_root.metadata()`, which follows the
-/// symlink. For a dangling link the stat returns ENOENT, the helper then
-/// calls `create_dir_all(dest_root)`, and the std machinery resolves the
-/// symlink to materialize a directory at the link target - a containment
-/// bypass analogous to the SEC-1 TOCTOU family. The lstat-based check now
-/// observes the symlink directly and refuses.
+/// Upstream `main.c:745-754` accepts a symlinked dest only when
+/// `do_stat()` resolves to a directory. A dangling link returns `ENOENT`
+/// from `do_stat`, falling through to `do_mkdir(dest_path, ACCESSPERMS)`
+/// which would resolve the link and materialize a directory at the
+/// outside-the-module target. oc-rsync diverges intentionally on this
+/// edge: the helper combines the stat `NotFound` result with an lstat
+/// follow-up; if the path is actually a dangling symlink we propagate
+/// `NotFound` instead of calling `create_dir_all`. This keeps the
+/// auto-create path safe without the strict refusal that broke the
+/// `symlink-dirlink-basis` interop scenario (UTS-SLDB).
 #[cfg(unix)]
 #[test]
-fn refuses_broken_symlink_to_outside_module() {
+fn rejects_broken_symlink_dest_root() {
     use std::os::unix::fs::symlink;
 
     let tmp = tempdir().expect("tempdir");
@@ -147,61 +135,35 @@ fn refuses_broken_symlink_to_outside_module() {
     let dest = tmp.path().join("dest_root");
     symlink(&outside_target, &dest).expect("create broken symlink");
     assert!(
-        dest.symlink_metadata()
-            .expect("lstat dest")
-            .file_type()
-            .is_symlink(),
+        dest.symlink_metadata().expect("lstat dest").file_type().is_symlink(),
         "fixture must place a symlink at dest"
     );
     assert!(!outside_target.exists(), "target must remain dangling");
 
     let err = ensure_dest_root_exists(&dest, 3, false, false)
-        .expect_err("symlinked dest_root must be refused");
+        .expect_err("dangling-symlink dest root must surface NotFound");
 
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-    assert!(
-        err.to_string().contains("symlink"),
-        "error must name the symlink condition, got: {err}"
-    );
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     assert!(
         !outside_target.exists(),
         "helper must not materialize the symlink target"
     );
 }
 
-/// Broken symlink pointing inside the eventual module path is still suspect.
+/// Symlink to an existing directory at the dest root must be accepted -
+/// upstream `main.c:745-754` follows the symlink via `do_stat` + `S_ISDIR`
+/// and enters the resolved directory. This is the UTS-SLDB interop scenario
+/// (issue #715): `$HOME/dir -> $HOME/real-dir` with `-K` so every write
+/// lands inside the real directory.
 ///
-/// Even if the target happens to land inside the module root, accepting a
-/// symlink-as-dest leaves the per-entry writes resolving through a link the
-/// receiver did not create - the dest may be re-pointed later or shared with
-/// an attacker-writable location. Refusing is the safe-default.
+/// Per-entry writes are still sandboxed by the SEC-1 `*at` chain (see
+/// `transfer::receiver::transfer::setup` for the `DirSandbox::open_root`
+/// call site). The setup site canonicalizes a symlinked dest_dir before
+/// opening the sandbox, so a malicious post-helper swap of the link is
+/// closed by the kernel resolving the link target once into a dirfd.
 #[cfg(unix)]
 #[test]
-fn refuses_broken_symlink_to_intra_module_target() {
-    use std::os::unix::fs::symlink;
-
-    let tmp = tempdir().expect("tempdir");
-    let inside_target = tmp.path().join("would-be-safe/leaf");
-    let dest = tmp.path().join("dest_root");
-    symlink(&inside_target, &dest).expect("create broken intra-module symlink");
-
-    let err = ensure_dest_root_exists(&dest, 4, true, false)
-        .expect_err("intra-module symlinked dest is still refused");
-
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-    assert!(
-        !inside_target.exists(),
-        "helper must not auto-create at the symlink target even when intra-module"
-    );
-}
-
-/// Symlink to an existing directory inside the eventual module is refused
-/// too: the helper has no protocol-level signal that the link was placed by
-/// the operator rather than by an attacker, and a permissive helper here
-/// would break the SEC-1 containment that downstream `*at` calls rely on.
-#[cfg(unix)]
-#[test]
-fn refuses_symlink_to_existing_intra_module_directory() {
+fn accepts_symlink_to_existing_directory() {
     use std::os::unix::fs::symlink;
 
     let tmp = tempdir().expect("tempdir");
@@ -210,13 +172,14 @@ fn refuses_symlink_to_existing_intra_module_directory() {
     let dest = tmp.path().join("dest_root");
     symlink(&real_dir, &dest).expect("symlink dest -> real_dir");
 
-    let err = ensure_dest_root_exists(&dest, 5, false, false)
-        .expect_err("symlinked dest_root is refused even when target exists");
+    let created =
+        ensure_dest_root_exists(&dest, 5, false, false).expect("symlink-to-dir dest must be accepted");
 
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-    // The real directory must remain untouched - no per-entry writes ever
-    // resolved through the link because the helper aborted first.
-    assert!(real_dir.is_dir());
+    assert!(
+        !created,
+        "no creation when dest resolves to an existing directory"
+    );
+    assert!(real_dir.is_dir(), "real directory must remain intact");
     assert!(
         dest.symlink_metadata()
             .expect("lstat dest")
@@ -226,12 +189,20 @@ fn refuses_symlink_to_existing_intra_module_directory() {
     );
 }
 
-/// Symlink pointing to an existing directory outside the module must be
-/// refused on containment grounds. A permissive helper here would let every
-/// subsequent per-entry write land at the outside-the-module target.
+/// Symlink to an existing directory outside the dest's lexical parent is
+/// also accepted at this layer. Containment is enforced downstream:
+///
+/// - The per-entry SEC-1 `*at` chain anchors every open at the resolved
+///   dest dirfd, so writes cannot escape that fd.
+/// - Daemon-mode `module.path` containment is enforced by the daemon
+///   module loader, not by this pre-flight.
+///
+/// This test pins the new behavior so a future regression that re-adds
+/// the strict refusal would fail loud here instead of silently breaking
+/// the `symlink-dirlink-basis` interop test.
 #[cfg(unix)]
 #[test]
-fn refuses_symlink_to_existing_directory_outside_module() {
+fn accepts_symlink_to_existing_directory_outside_parent() {
     use std::os::unix::fs::symlink;
 
     let module_root = tempdir().expect("module tempdir");
@@ -241,16 +212,47 @@ fn refuses_symlink_to_existing_directory_outside_module() {
     let dest = module_root.path().join("dest_root");
     symlink(&outside_dir, &dest).expect("dest -> outside dir");
 
-    let err = ensure_dest_root_exists(&dest, 8, true, false)
-        .expect_err("outside-the-module symlinked dest must be refused");
+    let created = ensure_dest_root_exists(&dest, 8, true, false)
+        .expect("symlink-to-dir-outside-parent dest must be accepted");
+
+    assert!(!created, "no creation when dest resolves to existing dir");
+    assert!(outside_dir.is_dir(), "outside directory must remain intact");
+}
+
+/// A regular file at the dest root must still be rejected: stat succeeds
+/// but `is_dir()` is false. Upstream `main.c:756-761` errors out with
+/// "destination must be a directory when copying more than 1 file".
+#[test]
+fn rejects_existing_non_directory_at_dest_root() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("existing_file");
+    fs::write(&dest, b"x").expect("seed file");
+
+    let err = ensure_dest_root_exists(&dest, 5, true, false)
+        .expect_err("non-directory dest root must error");
 
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
-    assert!(
-        outside_dir
-            .read_dir()
-            .expect("read outside dir")
-            .next()
-            .is_none(),
-        "outside directory must remain untouched - no writes leaked through the symlink"
-    );
+    assert!(dest.is_file(), "the file stays intact");
+}
+
+/// UTS-SLDB: a symlink-to-dangling-link-target (one link points at
+/// another link that points at nothing) must be refused via the lstat
+/// fallback. We probe the immediate link with `symlink_metadata`; if it
+/// is a symlink and stat fails, we treat it as dangling regardless of
+/// chain length. This pins the safe-default for the auto-create path.
+#[cfg(unix)]
+#[test]
+fn rejects_chained_dangling_symlink_dest_root() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempdir().expect("tempdir");
+    let dangling_link = tmp.path().join("link_a");
+    let intermediate = tmp.path().join("link_b");
+    // link_a -> link_b (which does not exist)
+    symlink(&intermediate, &dangling_link).expect("symlink link_a -> link_b");
+
+    let err = ensure_dest_root_exists(&dangling_link, 3, false, false)
+        .expect_err("dangling-chain symlink dest must error");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    assert!(!intermediate.exists(), "no auto-create through the dangling chain");
 }


### PR DESCRIPTION
## Summary

The receiver-side `ensure_dest_root_exists()` pre-flight used `symlink_metadata()` (lstat) and explicitly rejected any symlinked destination with `InvalidInput`. Upstream `main.c:745-754` (`get_local_name()`) instead calls `do_stat()` which follows symlinks, accepts the destination when `S_ISDIR(st.st_mode)` is true, and then enters the resolved directory via `change_dir(dest_path, CD_NORMAL)`. The upstream `symlink-dirlink-basis` interop test (issue #715) drives exactly this code path with `\$HOME/dir -> \$HOME/real-dir` and `-K (--copy-dirlinks)`.

This change brings the helper in line with upstream:

- Switch to `metadata()` so a symlink-to-existing-directory dest is accepted.
- Keep dangling symlinks safe: when `metadata()` reports `NotFound`, do an `lstat` follow-up and surface `NotFound` instead of letting `create_dir_all` resolve the link and materialize a directory at the link target.
- Canonicalize the symlinked dest in `transfer::receiver::transfer::setup::setup_transfer` so the downstream `DirSandbox::open_root` opens the resolved target dirfd; per-entry `*at` syscalls then anchor at the canonical path.
- Skip the canonicalize step under daemon connections so `open_sandbox_for_dest_strict` keeps refusing symlinked dests via `ELOOP`/`ENOTDIR` (the chdir-symlink-race defense).

## Security model

Per-entry writes are sandboxed by the SEC-1 \`*at\` chain (see \`crates/fast_io/src/dir_sandbox/mod.rs:150\` \`secure_open_dir\` and \`crates/transfer/src/receiver/transfer/setup.rs:310\` \`open_sandbox_for_dest_strict\`). Opens route through \`openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)\` on Linux 5.6+ and \`openat(O_NOFOLLOW | O_DIRECTORY)\` elsewhere. Accepting a symlinked dest at the pre-flight does not weaken containment because the canonical resolved path becomes the sandbox root and every subsequent open is anchored at that resolved fd. Daemon connections keep the strict refusal at the sandbox layer.

The chdir-symlink-race tests (UTS-16) live in \`crates/transfer/src/receiver/transfer/setup.rs::symlink_race_tests\` and target \`open_sandbox_for_dest_strict\` (per-entry symlink swap, not dest-root). They test a different attack surface and remain unchanged.

## Test changes

- \`crates/transfer/tests/uts_2_dest_root_mkdir.rs\`:
  - **Updated**: \`refuses_broken_symlink_to_outside_module\` -> \`rejects_broken_symlink_dest_root\` now asserts \`NotFound\` (was \`InvalidInput\`).
  - **Removed and replaced**: \`refuses_broken_symlink_to_intra_module_target\`, \`refuses_symlink_to_existing_intra_module_directory\`, and \`refuses_symlink_to_existing_directory_outside_module\` are superseded by \`accepts_symlink_to_existing_directory\` and \`accepts_symlink_to_existing_directory_outside_parent\`, which pin the new accept-on-symlink-to-dir behavior.
  - **Removed**: \`existing_non_directory_path_is_noop_for_helper\` (the helper now errors on non-directory dests, matching upstream \`main.c:756-761\`); replaced by \`rejects_existing_non_directory_at_dest_root\`.
  - **Added**: \`rejects_chained_dangling_symlink_dest_root\` to pin the dangling-symlink fallback for a chained \`link_a -> link_b -> nothing\` shape.

## Test plan
- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] CI Windows, macOS, Linux musl pass
- [ ] Interop test \`symlink-dirlink-basis\` reaches test 7 without the \`real-dir/file\` FileNotFoundError