### PR TITLE
fix: dedupe implied parents against explicit files-from dirs

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -170,12 +170,41 @@ impl GeneratorContext {
             }
         }
 
+        // Pre-populate the explicit-directory set with every --files-from
+        // entry that is itself a directory. The implied-parent loop below
+        // skips emission for entries already in this set so the explicit
+        // top-level walk owns their emission, and the set is later used to
+        // distinguish "explicit dir, walk normally" from
+        // "implied-only dir, already emitted, skip the duplicate top-level
+        // walk that upstream's `implied_filter_list` check rejects".
+        let mut explicit_dirs: HashSet<PathBuf> = HashSet::new();
+        for path in file_paths {
+            if let Ok(rel) = path.strip_prefix(base_dir) {
+                if rel.as_os_str().is_empty() {
+                    continue;
+                }
+                if let Ok(meta) = std::fs::symlink_metadata(path) {
+                    if meta.is_dir() {
+                        explicit_dirs.insert(rel.to_path_buf());
+                    }
+                }
+            }
+        }
+
         // Emit implied parent directory entries for files-from paths that
         // contain subdirectories. Without these entries the receiver cannot
         // create the parent directories needed for nested files.
         // upstream: flist.c:send_implied_dirs() - creates directory entries
         // for every intermediate path component of a --files-from entry.
-        let mut emitted_dirs: HashSet<PathBuf> = HashSet::new();
+        //
+        // `emitted_dirs` starts with the explicit-dir pre-population so a
+        // parent that is ALSO an explicit --files-from entry is not emitted
+        // here (the top-level walk below owns its emission). The loop adds
+        // every purely implied ancestor it pushes; the difference set
+        // `implied_only_dirs` is later consulted by
+        // `try_walk_source_entry_dedup` to suppress the duplicate top-level
+        // walk that would re-emit an implied parent.
+        let mut emitted_dirs: HashSet<PathBuf> = explicit_dirs.clone();
         for path in file_paths {
             if let Ok(rel) = path.strip_prefix(base_dir) {
                 // Walk each ancestor of the relative path and emit a
@@ -199,6 +228,15 @@ impl GeneratorContext {
             }
         }
 
+        // Directories emitted purely as implied parents of some other entry
+        // (i.e. not also listed explicitly in --files-from). The top-level
+        // walk skips these so we do not produce a duplicate file-list entry
+        // that upstream's `implied_filter_list` check (flist.c:998) would
+        // reject as "unrequested". Explicit --files-from dirs remain walkable
+        // so their recursive contents continue to flow normally.
+        let implied_only_dirs: HashSet<PathBuf> =
+            emitted_dirs.difference(&explicit_dirs).cloned().collect();
+
         // Walk each listed file using the shared base directory so that
         // relative paths are computed correctly (e.g., "hello.txt" instead
         // of an empty string).
@@ -207,7 +245,7 @@ impl GeneratorContext {
             // and apply missing_args handling before walk_path. This separates
             // "source never existed" (ENOENT at flist time) from "source vanished
             // during recursive walk" (ENOENT during child traversal).
-            if !self.try_walk_source_entry(base_dir, path)? {
+            if !self.try_walk_source_entry_dedup(base_dir, path, Some(&implied_only_dirs))? {
                 continue;
             }
         }

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -10,6 +10,7 @@
 //! - `flist.c:send_file_list()` - recursive directory scanning
 //! - `flist.c:readlink_stat()` - symlink resolution modes
 
+use std::collections::HashSet;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -42,11 +43,58 @@ impl GeneratorContext {
         base: &Path,
         path: &Path,
     ) -> io::Result<bool> {
+        self.try_walk_source_entry_dedup(base, path, None)
+    }
+
+    /// Like [`try_walk_source_entry`], but consults `emitted_dirs` to skip
+    /// re-emitting a directory entry that was already pushed by an earlier
+    /// pass (e.g. the implied-parent loop in `build_file_list_with_base`).
+    ///
+    /// When the source path is a directory whose relative name is already in
+    /// `emitted_dirs`, the function returns `Ok(true)` without re-emitting or
+    /// recursing. Subsequent `--files-from` entries that explicitly name
+    /// children of the same directory still reach the receiver via their own
+    /// top-level walks, and re-walking here would produce a duplicate parent
+    /// entry that upstream's `implied_filter_list` check rejects with
+    /// "rejecting unrequested file-list name" (flist.c:998).
+    ///
+    /// `emitted_dirs` is `Some` only from `build_file_list_with_base`, which
+    /// passes the set of directories already emitted by its implied-parent
+    /// loop. All other callers (single-source `build_file_list`) pass `None`
+    /// and retain the original walk-everything behaviour.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:998` - `check_filter(&implied_filter_list, ...)` rejects
+    ///   second occurrences as "unrequested file-list name".
+    /// - `flist.c:1901` - `send_implied_dirs()` is upstream's equivalent
+    ///   single emission point for the same logical directory.
+    pub(in crate::generator) fn try_walk_source_entry_dedup(
+        &mut self,
+        base: &Path,
+        path: &Path,
+        emitted_dirs: Option<&HashSet<PathBuf>>,
+    ) -> io::Result<bool> {
         // upstream: flist.c:2390 - link_stat() once, then pass &st to
         // send_file_name(). Reuse the metadata to avoid a redundant stat
         // inside walk_path_with_metadata.
         match self.resolve_symlink_metadata(path, base) {
             Ok(metadata) => {
+                // If a prior pass already emitted this directory (e.g. the
+                // implied-parent loop in build_file_list_with_base), skip the
+                // top-level walk so we do not produce a duplicate file-list
+                // entry. The directory's contents will be reached by the
+                // explicit child entries from --files-from. Files are never
+                // deduped through this path; only directories at the top
+                // level can collide with the implied-parent loop's output.
+                if metadata.is_dir() {
+                    if let Some(seen) = emitted_dirs {
+                        let relative = path.strip_prefix(base).unwrap_or(path);
+                        if !relative.as_os_str().is_empty() && seen.contains(relative) {
+                            return Ok(true);
+                        }
+                    }
+                }
                 // Path exists - pass pre-resolved metadata directly.
                 self.walk_path_with_metadata(base, path.to_path_buf(), metadata, true)?;
                 Ok(true)

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2557,8 +2557,7 @@ mod files_from {
         // Count occurrences of every distinct relative name. The subdir
         // must appear exactly once; duplicates would re-trigger the
         // upstream rejection.
-        let mut counts: std::collections::HashMap<String, usize> =
-            std::collections::HashMap::new();
+        let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
         for entry in ctx.file_list().iter() {
             *counts.entry(entry.name().to_string()).or_insert(0) += 1;
         }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2524,6 +2524,66 @@ mod files_from {
         assert!(names.contains(&"."), "expected dot entry in {names:?}");
     }
 
+    #[test]
+    fn build_file_list_with_base_deduplicates_explicit_dir_and_child_file() {
+        // UTS-21 regression: when --files-from contains both an explicit
+        // directory (e.g. `dir/subdir`) and a file inside it (e.g.
+        // `dir/subdir/child.txt`), the directory must appear in the wire
+        // file list exactly ONCE. Upstream's `implied_filter_list` check
+        // (flist.c:998) rejects the second occurrence as
+        // "rejecting unrequested file-list name: dir/subdir", which broke
+        // upstream's `files-from.test` interop suite in the pull direction.
+        //
+        // The implied-parent loop previously emitted `dir/subdir` because it
+        // is the parent of `child.txt`, and the top-level walk emitted it
+        // again because it is also an explicit --files-from entry. The fix
+        // pre-populates the explicit-dir set so the implied-parent loop
+        // skips it, leaving the top-level walk as the single emission site.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let nested = src.join("dir").join("subdir");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("child.txt"), b"payload").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        config.flags.recursive = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let file_paths = vec![nested.clone(), nested.join("child.txt")];
+        ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+
+        // Count occurrences of every distinct relative name. The subdir
+        // must appear exactly once; duplicates would re-trigger the
+        // upstream rejection.
+        let mut counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for entry in ctx.file_list().iter() {
+            *counts.entry(entry.name().to_string()).or_insert(0) += 1;
+        }
+
+        let subdir_name = nested.strip_prefix(&src).unwrap().to_string_lossy();
+        let subdir_count = counts.get(subdir_name.as_ref()).copied().unwrap_or(0);
+        assert_eq!(
+            subdir_count, 1,
+            "explicit dir + child must emit subdir exactly once, got {subdir_count} \
+             across entries {counts:?}"
+        );
+
+        // The child file must still be present so the receiver can transfer it.
+        let child_name = nested
+            .join("child.txt")
+            .strip_prefix(&src)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            counts.contains_key(&child_name),
+            "child.txt must remain in the file list, got {counts:?}"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn relative_absolute_source_preserves_full_prefix() {


### PR DESCRIPTION
## Summary

- Fix duplicate directory emission in `build_file_list_with_base` when a `--files-from` list contains both an explicit directory and one of its children.
- Add a regression test that asserts the explicit directory appears in the wire file list exactly once.

## Why

Upstream rsync's testsuite `files-from` test fails when oc-rsync acts as the sender (pull direction) and upstream rsync is the receiver:

```
ERROR: rejecting unrequested file-list name: from/dir/subdir
rsync error: requested action not supported (code 4) at flist.c(1028) [Receiver=3.4.3-...]
```

In `crates/transfer/src/generator/file_list/mod.rs`, two passes emit directory entries:

1. The implied-parent loop walks each `--files-from` entry's ancestors and pushes a directory entry for every component that has not been seen.
2. The top-level walk (`try_walk_source_entry`) then walks each entry as a source argument and pushes another directory entry for it.

When a `--files-from` list contains both an explicit directory (e.g. `from/dir/subdir`) and a file inside it (e.g. `from/dir/subdir/foobar.baz`), pass 1 emits `from/dir/subdir` as an implied parent of the child, and pass 2 emits it a second time as a top-level source. Upstream's `implied_filter_list` check at `flist.c:998` rejects the second occurrence as "unrequested".

## How

- **Pre-populate** an `explicit_dirs` set with every `--files-from` entry that stats as a directory, before entering the implied-parent loop.
- Seed `emitted_dirs` with `explicit_dirs` so the implied-parent loop skips any explicit dir while it walks an ancestor chain - the top-level walk owns those emissions.
- Compute `implied_only_dirs = emitted_dirs - explicit_dirs` and pass it to a new `try_walk_source_entry_dedup` helper. The helper early-returns at the top level only when a directory is in the implied-only set, leaving explicit dirs walkable so their recursive contents continue to flow.

The wire encoding is unchanged: the directory's single emission carries the existing `FLAG_TOP_DIR | FLAG_CONTENT_DIR` semantics from the top-level walk. Upstream's `FLAG_IMPLIED_DIR` is an internal flag that the receiver reconstructs from `XMIT_TOP_DIR | XMIT_NO_CONTENT_DIR`, but the rejection at `flist.c:998` fires before that reconstruction is consulted, so suppressing the duplicate is sufficient.

## Test plan

- [ ] CI: nextest stable on Linux, macOS, Windows, Linux musl.
- [ ] CI: fmt + clippy.
- [ ] CI: interop validation suite (covers upstream `files-from.test` in pull direction).
- [ ] New unit test `build_file_list_with_base_deduplicates_explicit_dir_and_child_file` asserts the directory appears exactly once when both parent and child are in the files-from list.