### PR TITLE
fix(transfer): receiver MUST NOT advertise INC_RECURSE

### DIFF
--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -269,11 +269,7 @@ fn requires_multiplex_output(
 /// upstream: compat.c:161-179 set_allow_inc_recurse,
 /// sender.c:228-232 (send_extra_file_list throttle),
 /// io.c:1740-1760 (receiver's inline sub-list dispatch oc-rsync does not implement).
-pub(crate) fn compute_allow_inc_recurse(
-    recursive: bool,
-    qsort: bool,
-    role: ServerRole,
-) -> bool {
+pub(crate) fn compute_allow_inc_recurse(recursive: bool, qsort: bool, role: ServerRole) -> bool {
     recursive && !qsort && role == ServerRole::Generator
 }
 

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -258,6 +258,25 @@ fn requires_multiplex_output(
     }
 }
 
+/// Decides whether the local side may advertise INC_RECURSE in its compat
+/// flags response. Mirrors upstream `compat.c:161-179 set_allow_inc_recurse`
+/// with one local restriction: the receiver role never advertises INC_RECURSE
+/// because `receive_extra_file_lists` drains the entire sub-list stream
+/// upfront, which deadlocks against upstream's
+/// `MIN_FILECNT_LOOKAHEAD`-throttled `send_extra_file_list` (sender.c:228-232)
+/// on source trees larger than the lookahead window.
+///
+/// upstream: compat.c:161-179 set_allow_inc_recurse,
+/// sender.c:228-232 (send_extra_file_list throttle),
+/// io.c:1740-1760 (receiver's inline sub-list dispatch oc-rsync does not implement).
+pub(crate) fn compute_allow_inc_recurse(
+    recursive: bool,
+    qsort: bool,
+    role: ServerRole,
+) -> bool {
+    recursive && !qsort && role == ServerRole::Generator
+}
+
 /// Executes the native server entry point over standard I/O.
 ///
 /// The implementation performs the protocol handshake before dispatching to the
@@ -404,13 +423,10 @@ pub fn run_server_with_handshake<W: Write>(
             )
         })?;
 
-    // Compute allow_inc_recurse matching upstream compat.c:161-179.
-    // Requires recursive mode and not qsort. For receivers, also disallows
-    // delete and prune_empty_dirs (which need the complete file list upfront).
-    let allow_inc_recurse = config.flags.recursive
-        && !config.qsort
-        && (config.role == ServerRole::Generator
-            || (!config.flags.delete && !config.flags.prune_empty_dirs));
+    // Compute allow_inc_recurse matching upstream compat.c:161-179 with the
+    // receiver-side restriction documented on `compute_allow_inc_recurse`.
+    let allow_inc_recurse =
+        compute_allow_inc_recurse(config.flags.recursive, config.qsort, config.role);
 
     // In SSH server mode (client_args is None), pass the compact flag string
     // so setup_protocol can extract the `-e.xxx` capability string from it.

--- a/crates/transfer/src/tests/allow_inc_recurse.rs
+++ b/crates/transfer/src/tests/allow_inc_recurse.rs
@@ -1,0 +1,62 @@
+//! Regression coverage for `compute_allow_inc_recurse`.
+//!
+//! Pins the receiver-side restriction that gates INC_RECURSE so the upstream
+//! testsuite `hardlinks` test no longer deadlocks against a source tree that
+//! exceeds upstream's `MIN_FILECNT_LOOKAHEAD` window.
+//!
+//! upstream: compat.c:161-179 set_allow_inc_recurse,
+//! sender.c:228-232 send_extra_file_list throttle,
+//! io.c:1740-1760 receiver inline sub-list dispatch.
+
+use crate::{ServerRole, compute_allow_inc_recurse};
+
+#[test]
+fn generator_with_recursion_advertises_inc_recurse() {
+    assert!(compute_allow_inc_recurse(
+        true,
+        false,
+        ServerRole::Generator
+    ));
+}
+
+#[test]
+fn generator_without_recursion_does_not_advertise() {
+    assert!(!compute_allow_inc_recurse(
+        false,
+        false,
+        ServerRole::Generator
+    ));
+}
+
+#[test]
+fn generator_with_qsort_does_not_advertise() {
+    assert!(!compute_allow_inc_recurse(
+        true,
+        true,
+        ServerRole::Generator
+    ));
+}
+
+/// Receiver MUST never advertise INC_RECURSE - drives the upstream
+/// testsuite `hardlinks` test deadlock fix. Without this restriction,
+/// upstream's sender throttles extra sub-lists at MIN_FILECNT_LOOKAHEAD
+/// (1000 entries) while oc-rsync's `receive_extra_file_lists` keeps
+/// reading sub-lists upfront, deadlocking on any tree > 1000 entries.
+#[test]
+fn receiver_never_advertises_inc_recurse() {
+    assert!(!compute_allow_inc_recurse(
+        true,
+        false,
+        ServerRole::Receiver
+    ));
+    assert!(!compute_allow_inc_recurse(
+        true,
+        true,
+        ServerRole::Receiver
+    ));
+    assert!(!compute_allow_inc_recurse(
+        false,
+        false,
+        ServerRole::Receiver
+    ));
+}

--- a/crates/transfer/src/tests/allow_inc_recurse.rs
+++ b/crates/transfer/src/tests/allow_inc_recurse.rs
@@ -49,11 +49,7 @@ fn receiver_never_advertises_inc_recurse() {
         false,
         ServerRole::Receiver
     ));
-    assert!(!compute_allow_inc_recurse(
-        true,
-        true,
-        ServerRole::Receiver
-    ));
+    assert!(!compute_allow_inc_recurse(true, true, ServerRole::Receiver));
     assert!(!compute_allow_inc_recurse(
         false,
         false,

--- a/crates/transfer/src/tests/mod.rs
+++ b/crates/transfer/src/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Tests for server module.
 
+mod allow_inc_recurse;
 mod config;
 mod multiplex_protocol_version;
 mod negotiated_algorithms;


### PR DESCRIPTION
## Summary

- Disable INC_RECURSE advertisement on the receiver-role side so the upstream peer (sender) clears `CF_INC_RECURSE` and sends the file list upfront instead of throttling sub-list dispatch at `MIN_FILECNT_LOOKAHEAD`.
- Sender-role INC_RECURSE behavior is preserved verbatim per PR #5085; only the `Receiver` role path changes.

## Why this hangs

Upstream testsuite `hardlinks` deterministically hangs `oc-rsync --server` under `lsh.sh` for source trees larger than ~1000 entries. Stack and strace evidence:

- oc-rsync `--server` blocked in `read(0, _, 65536)` on the lsh stdin socket; `unix_stream_data_wait` per `/proc/<pid>/wchan`. 4 writes total: protocol, compat flags varint (`0x81 0xFF` = 0x1FF), checksum vstring (35 chars), checksum seed.
- Upstream rsync sender blocked in `send_files() -> read_ndx_and_attrs() -> read_a_msg() -> select()` after writing exactly 2 file-list MUX `MSG_DATA` frames (124 + 18148 bytes). Frame 2 carries the wire NDX `0xFF 0x65` decoding to `NDX_FLIST_OFFSET - dir_ndx = -102` -> `dir_ndx = 1`. Both socket buffers (`ss -xp`) are empty.
- Sender stops because `file_total - file_old_total >= MIN_FILECNT_LOOKAHEAD` after the first extra sub-list (subdir contributes ~1297 entries). The next sub-lists for `subdir/down` and `subdir/down/deep` are gated on the receiver consuming files.
- oc-rsync receiver calls `receive_extra_file_lists` in `setup_transfer` (`crates/transfer/src/receiver/transfer/setup.rs:123`) once after the initial file list. That loop reads NDX until `NDX_FLIST_EOF`, but the sender will not emit `NDX_FLIST_EOF` (or any further sub-list) until the receiver starts requesting files. Classic deadlock.

upstream references:
- `compat.c:161-179` - `set_allow_inc_recurse()` clears `allow_inc_recurse` server-side when the capability char `'i'` is missing.
- `sender.c:228-232` - `send_extra_file_list(f_out, MIN_FILECNT_LOOKAHEAD)` is the throttle that strands the next sub-list.
- `io.c:1740-1760` - upstream's receiver dispatches additional `recv_file_list(dir_ndx)` calls inline from `wait_for_receiver` when it sees `NDX_FLIST_OFFSET` interleaved with file NDXes. oc-rsync does not implement this inline dispatch.

## Why this fix is conservative

The complete fix is to mirror upstream's inline dispatch: when the transfer loop reads `NDX_FLIST_OFFSET - dir_ndx` from the sender, recurse into `recv_file_list(dir_ndx)` before processing more file NDXes. That touches the receiver transfer driver, the pipelined drivers, the parallel-receive-delta path, and the FSM. Pulling INC_RECURSE off the receiver wire negotiation is the minimal, surgical change that keeps interop correct, preserves sender-side INC_RECURSE (PR #5085), and unblocks the upstream testsuite without touching any of the at-risk subsystems (parallel-receive-delta, io_uring, IOCP, flat-flist, daemon-tls, INC_RECURSE sender, branding).

The full inline-dispatch port is the long-term direction; tracked in the receiver INC_RECURSE backlog. See also `feedback_no_wire_protocol_features.md`.

## Diagnostics captured

- Live `gdb -batch -p <pid>` showing receiver blocked on read syscall and sender blocked in `send_files -> read_ndx_and_attrs -> select`.
- `strace -ff` from the `lsh.sh` invocation showing both peers' I/O up to the deadlock.
- `ss -xp` showing both Unix-stream socket buffers empty in both directions at deadlock.
- Wire payload hex-decoded to confirm `0x81 0xFF` = `write_varint(0x1FF)` (full compat flags inc. CF_INC_RECURSE) and `0xFF 0x65` = NDX for the second sub-list's `NDX_FLIST_OFFSET - 1`.

## Test plan

- [x] Unit test pinning the receiver-role restriction (`crates/transfer/src/tests/allow_inc_recurse.rs`).
- [ ] CI: fmt + clippy, nextest stable on all platform cells.
- [ ] CI: full interop matrix (UTS hardlinks no longer hangs; existing daemon INC_RECURSE push test still passes because its 5-file fixture stays under the lookahead window even on the non-INC_RECURSE wire path).
- [ ] Bake against upstream testsuite hardlinks fixture (1300+ entries) after CI green.