### PR TITLE
fix(daemon): echo daemon @ERROR line verbatim before structured error

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/mod.rs
@@ -159,6 +159,30 @@ fn extract_digest_list_from_greeting(greeting: &str) -> Option<&str> {
     }
 }
 
+/// Echoes a daemon `@ERROR` line to stderr and constructs the matching
+/// client error.
+///
+/// Mirrors upstream `clientserver.c:382` - `rprintf(FERROR, "%s\n", line)` -
+/// which prints the raw `@ERROR` line verbatim to stderr before returning
+/// the fatal error to the caller. External tools (and the upstream
+/// testsuite/daemon-chroot-acl_test.py GHSA-rjfm-3w2m-jf4f regression
+/// among them) match on the `@ERROR` prefix in the client's stderr to
+/// confirm the daemon's deny path fired; suppressing the verbatim echo
+/// makes those checks fail-OPEN even though the daemon correctly denied
+/// the connection.
+///
+/// The payload is also threaded into a structured `ClientError` so the
+/// existing diagnostic envelope (exit code, role, source location) is
+/// preserved.
+#[cold]
+fn handle_daemon_at_error(line: &str) -> ClientError {
+    eprintln!("{line}");
+    daemon_error(
+        line.strip_prefix("@ERROR: ").unwrap_or(line),
+        CLIENT_SERVER_PROTOCOL_EXIT_CODE,
+    )
+}
+
 /// Performs the rsync daemon handshake protocol.
 ///
 /// Follows upstream `clientserver.c:start_inband_exchange()`:
@@ -328,10 +352,7 @@ pub(crate) fn perform_daemon_handshake<R: std::io::Read, W: Write>(
         }
 
         if trimmed.starts_with("@ERROR") {
-            return Err(daemon_error(
-                trimmed.strip_prefix("@ERROR: ").unwrap_or(trimmed),
-                CLIENT_SERVER_PROTOCOL_EXIT_CODE,
-            ));
+            return Err(handle_daemon_at_error(trimmed));
         }
 
         // upstream: rprintf(FINFO, "%s\n", line) - MOTD output.

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -440,3 +440,78 @@ mod early_input_roundtrip_tests {
         assert_eq!(received, content);
     }
 }
+
+/// Pins the daemon `@ERROR` -> client mapping.
+///
+/// Regression coverage for the UTS-22.b port of upstream's
+/// `testsuite/daemon-chroot-acl_test.py`. The python test greps the
+/// client's combined output for `@ERROR` to confirm the GHSA-rjfm-3w2m-jf4f
+/// hostname-deny path fired; if the client renders only its envelope
+/// (`oc-rsync error: access denied ... (code 5)`) without echoing the
+/// raw `@ERROR:` line, the regression check silently fails-OPEN even
+/// though the daemon correctly denied the connection.
+///
+/// The daemon-side GHSA hardening lives in
+/// `crates/daemon/src/daemon/module_state/definition.rs::permits` and is
+/// covered by `tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs`;
+/// this test pins the matching client-side rendering so the two halves
+/// can never drift out of sync.
+#[cfg(test)]
+mod handle_at_error_tests {
+    use super::*;
+    use crate::client::error::CLIENT_SERVER_PROTOCOL_EXIT_CODE;
+
+    #[test]
+    fn payload_strips_at_error_prefix() {
+        let err = handle_daemon_at_error(
+            "@ERROR: access denied to chrootmod from 127.0.0.1 (127.0.0.1)",
+        );
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("access denied to chrootmod"),
+            "expected payload in rendered error, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("@ERROR: "),
+            "structured envelope should not duplicate the @ERROR prefix, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn payload_falls_through_when_prefix_format_differs() {
+        // upstream sometimes emits "@ERROR foo" (no colon) when the C
+        // path uses io_printf with concatenated tokens; the strip must
+        // not return None, the whole line is kept verbatim.
+        let err = handle_daemon_at_error("@ERROR no colon variant");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("@ERROR no colon variant"),
+            "fall-through path must preserve the whole line, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn maps_to_client_server_protocol_exit_code() {
+        // upstream: main.c:1879 - @ERROR client-server handshake failures
+        // exit with RERR_PROTOCOL (code 5).
+        let err = handle_daemon_at_error("@ERROR: auth failed on module foo");
+        assert_eq!(err.exit_code(), CLIENT_SERVER_PROTOCOL_EXIT_CODE);
+    }
+
+    #[test]
+    fn ghsa_rjfm_3w2m_jf4f_payload_renders_intact() {
+        // The exact wire string the daemon emits for the GHSA-rjfm-3w2m-jf4f
+        // hostname-deny ACL path. upstream: clientserver.c:733 -
+        // `@ERROR: access denied to %s from %s (%s)\n`.
+        let wire = "@ERROR: access denied to chrootmod from 127.0.0.1 (127.0.0.1)";
+        let err = handle_daemon_at_error(wire);
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("access denied to chrootmod from 127.0.0.1 (127.0.0.1)"),
+            "GHSA hostname-deny payload must round-trip into client error, got: {rendered}"
+        );
+        assert_eq!(err.exit_code(), CLIENT_SERVER_PROTOCOL_EXIT_CODE);
+    }
+}

--- a/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/connection/tests.rs
@@ -463,9 +463,8 @@ mod handle_at_error_tests {
 
     #[test]
     fn payload_strips_at_error_prefix() {
-        let err = handle_daemon_at_error(
-            "@ERROR: access denied to chrootmod from 127.0.0.1 (127.0.0.1)",
-        );
+        let err =
+            handle_daemon_at_error("@ERROR: access denied to chrootmod from 127.0.0.1 (127.0.0.1)");
 
         let rendered = err.to_string();
         assert!(


### PR DESCRIPTION
## Summary

Mirror upstream rsync's `rprintf(FERROR, "%s\n", line)` from `clientserver.c:382` on the daemon-handshake `@ERROR` path. When the daemon sends an `@ERROR: ...` response (access denied, auth failed, unknown module, ...), the raw line must be written to the client's stderr verbatim before the structured error envelope is returned. The upstream `testsuite/daemon-chroot-acl_test.py` GHSA-rjfm-3w2m-jf4f regression test (UTS-22.b) greps the client output for `@ERROR` to confirm the deny path fired; without the verbatim echo the check silently fails-OPEN even when the daemon correctly denied the connection.

## Scope

- **Client-side only.** The daemon-side GHSA-rjfm-3w2m-jf4f hardening shipped earlier in `crates/daemon/src/daemon/module_state/definition.rs::permits` (PR #5524, commit `50f389f50`) is untouched. This PR does not alter ACL evaluation, the chroot path, or DirSandbox semantics.
- One call site changed in `crates/core/src/client/remote/daemon_transfer/connection/mod.rs`. The `@ERROR` branch is extracted into a small `handle_daemon_at_error` helper so the format is unit-testable. Behavior is otherwise byte-identical to the previous code: same `strip_prefix("@ERROR: ")` strategy, same `CLIENT_SERVER_PROTOCOL_EXIT_CODE` (RERR_PROTOCOL = 5) exit code, same `daemon_error` constructor.

## GHSA-rjfm-3w2m-jf4f preservation

The hostname-ACL fail-closed guard from PR #5524 is in a different crate (`daemon`) and a different code path (`ModuleDefinition::permits` evaluating `hosts deny` rules). The regression chunk test `module_hostname_deny_fails_closed_when_dns_unresolved` at `crates/daemon/src/tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs` is unchanged and still exercised by CI.

## DirSandbox preservation

DirSandbox / SEC-1.q is wired through the receiver's transfer pipeline, not the client handshake. See `crates/transfer/src/receiver/transfer/pipelined.rs:50-51` (sandbox plumbed via `setup.sandbox.as_deref()` into `create_symlinks` and the delete-extraneous scan) - unchanged by this PR. The handshake path this PR touches runs strictly before any file-system access.

## Verification

Reproduced and verified on a Linux container with the upstream `testsuite/daemon-chroot-acl_test.py` harness (`./runtests.py --rsync-bin <oc-rsync> --use-tcp daemon-chroot-acl`, run under sudo):

- Baseline (master HEAD): `Scenario A: hostname deny rule was bypassed` -> FAIL. Client emits only the structured envelope; no `@ERROR` line.
- With this PR: PASS for both scenarios.
 - Scenario A (`reverse lookup = yes` globally + per-module):
   ```
   @ERROR: access denied to chrootmod from 127.0.0.1 (127.0.0.1)
   oc-rsync error: access denied to chrootmod from 127.0.0.1 (127.0.0.1) (code 5) at error.rs(309) [client=0.6.3]
   ```
 - Scenario B (global `no`, per-module `yes`): same two-line output, same exit code 5.

Matches upstream rsync 3.4.3 client behavior byte-for-byte on the two lines that matter to the test.

## Test plan

- [ ] CI fmt + clippy clean on the new helper and tests
- [ ] CI nextest stable - new unit tests under `connection::handle_at_error_tests` pass
- [ ] CI nextest Windows / macOS / Linux musl green
- [ ] Existing `module_hostname_deny_fails_closed_when_dns_unresolved` GHSA regression still passes (no change)
- [ ] No regression to `module_ip_deny_unaffected_by_dns_failure` (no change)