### PR TITLE
feat(transfer): add reorder-buffer telemetry (ROB-2, ROB-3)

### DIFF
--- a/.github/workflows/reorder-spill-regression.yml
+++ b/.github/workflows/reorder-spill-regression.yml
@@ -100,7 +100,7 @@ jobs:
             --locked \
             -p engine \
             --no-fail-fast \
-            -E 'test(=spill_activations_counter_increments_on_each_spill) + test(=spill_warning_fires_once_per_transfer) + test(/^reorder_spill_/)' \
+            -E 'test(spill_activations_counter_increments_on_each_spill) + test(spill_warning_fires_once_per_transfer) + test(/reorder_spill_/)' \
             2>&1 | tee "$OUT"
 
           # TODO(ROB-5/ROB-6): When the non-adversarial bench harness

--- a/crates/engine/src/concurrent_delta/consumer/loops.rs
+++ b/crates/engine/src/concurrent_delta/consumer/loops.rs
@@ -84,8 +84,10 @@ pub(super) fn run_spillable_loop(
     result_tx: &mpsc::Sender<DeltaResult>,
     mut reorder: SpillableReorderBuffer<DeltaResult>,
     spill_events: &Arc<AtomicU64>,
+    spill_activations: &Arc<AtomicU64>,
 ) {
     let mut prev_spill = reorder.spill_stats().spill_events;
+    let mut prev_activations = reorder.spill_stats().spill_activations;
 
     for result in stream_rx {
         let ndx = result.ndx();
@@ -124,6 +126,11 @@ pub(super) fn run_spillable_loop(
                             return;
                         }
                         publish_spill_events(&reorder, spill_events, &mut prev_spill);
+                        publish_spill_activations(
+                            &reorder,
+                            spill_activations,
+                            &mut prev_activations,
+                        );
                         break;
                     }
                 }
@@ -155,6 +162,7 @@ pub(super) fn run_spillable_loop(
             }
         }
         publish_spill_events(&reorder, spill_events, &mut prev_spill);
+        publish_spill_activations(&reorder, spill_activations, &mut prev_activations);
 
         match reorder.drain_ready() {
             Ok(items) => {
@@ -195,6 +203,7 @@ pub(super) fn run_spillable_loop(
         }
     }
     publish_spill_events(&reorder, spill_events, &mut prev_spill);
+    publish_spill_activations(&reorder, spill_activations, &mut prev_activations);
 }
 
 /// Republishes the cumulative spill-to-disk event counter so callers can
@@ -207,6 +216,25 @@ fn publish_spill_events(
     let current = reorder.spill_stats().spill_events;
     if current != *prev {
         spill_events.store(current, Ordering::Relaxed);
+        *prev = current;
+    }
+}
+
+/// Republishes the cumulative `spill_excess` activation counter so callers
+/// can observe normal-operation spill pressure via
+/// [`crate::concurrent_delta::consumer::DeltaConsumer::stats`] (ROB-2).
+///
+/// `spill_activations` is granularity-invariant: one increment per
+/// `spill_excess` call that wrote at least one record, regardless of
+/// whether the buffer is configured for `PerItem` or `WholeBatch`.
+fn publish_spill_activations(
+    reorder: &SpillableReorderBuffer<DeltaResult>,
+    spill_activations: &Arc<AtomicU64>,
+    prev: &mut u64,
+) {
+    let current = reorder.spill_stats().spill_activations;
+    if current != *prev {
+        spill_activations.store(current, Ordering::Relaxed);
         *prev = current;
     }
 }

--- a/crates/engine/src/concurrent_delta/consumer/mod.rs
+++ b/crates/engine/src/concurrent_delta/consumer/mod.rs
@@ -84,6 +84,15 @@ pub struct DeltaConsumerStats {
     ///
     /// Always zero when the consumer was spawned without a spill threshold.
     pub spill_events: u64,
+    /// Cumulative count of `spill_excess` calls that wrote at least one
+    /// record. Granularity-invariant: a single call increments this counter
+    /// by exactly one even when [`SpillGranularity::PerItem`](super::spill::SpillGranularity::PerItem)
+    /// produces many on-disk records. Always zero when the consumer was
+    /// spawned without a spill threshold. ROB-2 (#3667) surfaces this
+    /// through the consumer-side stats so operators can observe normal-
+    /// operation spill rate without instrumenting the spillable buffer
+    /// directly.
+    pub spill_activations: u64,
     /// Cumulative count of ordering-fallback inserts performed by the
     /// underlying [`ReorderBuffer`](super::reorder::ReorderBuffer) when the
     /// ring saturated while `next_expected` was still missing.
@@ -151,6 +160,13 @@ pub struct DeltaConsumer {
     /// Shared counter incremented by the reorder thread on each spill-to-disk
     /// event. Exposed via [`DeltaConsumer::stats`].
     pub(super) spill_events: Arc<AtomicU64>,
+    /// Shared counter incremented by the reorder thread on each
+    /// `spill_excess` call that wrote at least one record. ROB-2 (#3667)
+    /// surfaces this granularity-invariant counter through
+    /// [`DeltaConsumer::stats`] so operators see normal-operation spill
+    /// pressure without compensating for `PerItem` vs `WholeBatch`
+    /// record fan-out.
+    pub(super) spill_activations: Arc<AtomicU64>,
     /// Shared handle aliasing the underlying [`ReorderBuffer`](super::reorder::ReorderBuffer)
     /// `force_insert` counter. The reorder buffer updates this atomic
     /// directly, so [`DeltaConsumer::stats`] reflects the latest value
@@ -242,6 +258,7 @@ impl DeltaConsumer {
     pub fn stats(&self) -> DeltaConsumerStats {
         DeltaConsumerStats {
             spill_events: self.spill_events.load(Ordering::Relaxed),
+            spill_activations: self.spill_activations.load(Ordering::Relaxed),
             force_inserts: self.force_inserts.load(Ordering::Relaxed),
         }
     }

--- a/crates/engine/src/concurrent_delta/consumer/spawn.rs
+++ b/crates/engine/src/concurrent_delta/consumer/spawn.rs
@@ -71,6 +71,7 @@ impl ReorderMode {
 pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaConsumer {
     let (result_tx, result_rx) = mpsc::channel();
     let spill_events = Arc::new(AtomicU64::new(0));
+    let spill_activations = Arc::new(AtomicU64::new(0));
 
     // Bounded channel between drain and reorder threads. Capacity matches
     // reorder buffer so workers can stay ahead without unbounded buffering.
@@ -107,6 +108,7 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
     // Thread 2: receives streamed results, reorders (or passes through),
     // and forwards to the consumer channel.
     let spill_events_thread = Arc::clone(&spill_events);
+    let spill_activations_thread = Arc::clone(&spill_activations);
     let handle = thread::Builder::new()
         .name("delta-reorder".to_string())
         .spawn(move || {
@@ -115,7 +117,13 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
                     run_bare_loop(stream_rx, &result_tx, *buf, &metrics_thread);
                 }
                 ReorderBackend::Spillable(buf) => {
-                    run_spillable_loop(stream_rx, &result_tx, *buf, &spill_events_thread);
+                    run_spillable_loop(
+                        stream_rx,
+                        &result_tx,
+                        *buf,
+                        &spill_events_thread,
+                        &spill_activations_thread,
+                    );
                 }
                 ReorderBackend::Failed(err) => {
                     let _ = result_tx.send(DeltaResult::failed(
@@ -135,6 +143,7 @@ pub(super) fn spawn_inner(rx: WorkQueueReceiver, mode: ReorderMode) -> DeltaCons
         handle: Some(handle),
         metrics,
         spill_events,
+        spill_activations,
         force_inserts,
     }
 }

--- a/crates/engine/src/concurrent_delta/parallel_apply/batch.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/batch.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use rayon::prelude::*;
 
-use super::{DeltaChunk, ParallelApplyError, ParallelDeltaApplier, VerifiedChunk};
+use super::{DeltaChunk, IngestError, ParallelApplyError, ParallelDeltaApplier, VerifiedChunk};
 
 impl ParallelDeltaApplier {
     /// Applies a batch of chunks, fanning the verify step across the rayon
@@ -102,7 +102,12 @@ impl ParallelDeltaApplier {
             // the guard was not dropped prematurely by a future refactor.
             #[cfg(debug_assertions)]
             let bytes_before = slot.bytes_written();
-            slot.ingest(v.chunk)?;
+            if let Err(err) = slot.ingest(v.chunk) {
+                if let IngestError::ReorderSaturated { chunk_sequence, .. } = &err {
+                    self.note_reorder_saturation(ndx, *chunk_sequence);
+                }
+                return Err(err.into());
+            }
             #[cfg(debug_assertions)]
             debug_assert!(
                 slot.bytes_written() >= bytes_before,

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -33,6 +33,7 @@
 //! `DeltaConsumer` pattern already covers that case).
 
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, MutexGuard};
 
 use checksums::strong::strategy::{
@@ -227,6 +228,41 @@ impl DeltaChunk {
     }
 }
 
+/// Error outcomes for [`FileSlot::ingest`].
+///
+/// Distinguishes the per-file reorder-ring saturation case from generic
+/// writer I/O failures so [`ParallelDeltaApplier`] can update its ROB-3
+/// telemetry without parsing error strings. Both variants convert into a
+/// plain [`io::Error`] for the existing `io::Result`-shaped public API.
+#[derive(Debug)]
+pub(in crate::concurrent_delta::parallel_apply) enum IngestError {
+    /// The per-file reorder buffer rejected the chunk because its offset
+    /// from `next_expected` exceeded the configured ring capacity. The
+    /// chunk is not committed and the writer remains untouched.
+    ReorderSaturated {
+        /// Per-file chunk sequence that overflowed the ring.
+        chunk_sequence: u64,
+        /// Underlying [`ReorderBuffer`] capacity bound that was hit.
+        capacity: usize,
+    },
+    /// Writer-side I/O failure while draining ready chunks.
+    Io(io::Error),
+}
+
+impl From<IngestError> for io::Error {
+    fn from(value: IngestError) -> Self {
+        match value {
+            IngestError::ReorderSaturated {
+                chunk_sequence,
+                capacity,
+            } => io::Error::other(format!(
+                "parallel apply reorder full: chunk_sequence={chunk_sequence} exceeds per-file ring capacity={capacity}"
+            )),
+            IngestError::Io(e) => e,
+        }
+    }
+}
+
 /// Per-file destination writer plus the reorder buffer that re-establishes
 /// submission order after the rayon verify step completes out of order.
 struct FileSlot {
@@ -250,14 +286,23 @@ impl FileSlot {
     /// The reorder buffer is the single source of truth for per-file
     /// sequencing; the writer only sees chunks once they have arrived in
     /// strict `chunk_sequence` order.
-    fn ingest(&mut self, chunk: DeltaChunk) -> io::Result<()> {
+    ///
+    /// Returns [`IngestError::ReorderSaturated`] when the per-file ring is
+    /// full; the applier's [`ParallelDeltaApplier::note_reorder_saturation`]
+    /// reads this to update the ROB-3 telemetry counter and emit the
+    /// one-shot warning before mapping back to [`io::Error`] for the caller.
+    fn ingest(&mut self, chunk: DeltaChunk) -> Result<(), IngestError> {
         let seq = chunk.chunk_sequence;
+        let capacity = self.reorder.capacity();
         self.reorder
             .insert(seq, chunk)
-            .map_err(|e| io::Error::other(format!("parallel apply reorder full: {e}")))?;
+            .map_err(|_| IngestError::ReorderSaturated {
+                chunk_sequence: seq,
+                capacity,
+            })?;
         let ready: Vec<DeltaChunk> = self.reorder.drain_ready().collect();
         for chunk in ready {
-            self.write_chunk(chunk)?;
+            self.write_chunk(chunk).map_err(IngestError::Io)?;
         }
         Ok(())
     }
@@ -404,6 +449,30 @@ pub struct ParallelDeltaApplier {
     /// (#2498) plumbs the field; BR-3i.c (#2499) replaces the
     /// length-only verify stub with `strategy.compute(&chunk.data)`.
     strategy: Arc<dyn ChecksumStrategy>,
+    /// Cumulative count of per-file reorder-ring saturation events
+    /// observed since the applier was constructed (ROB-2, #3667).
+    ///
+    /// Incremented exactly once per [`IngestError::ReorderSaturated`]
+    /// returned by [`FileSlot::ingest`]. The per-file applier has no
+    /// spill backend today, so saturation events surface as
+    /// [`io::Error::other`] back to the caller; this counter lets
+    /// operators observe the rate without parsing error strings.
+    ///
+    /// Exposed via [`Self::reorder_saturations`]. Pairs with
+    /// [`reorder_saturated_warned`](Self::reorder_saturated_warned) so the
+    /// first event also emits the ROB-3 one-shot warning.
+    reorder_saturations: AtomicU64,
+    /// One-shot guard ensuring the per-file ring-saturation warning fires
+    /// at most once for the lifetime of this applier (ROB-3, #3667).
+    ///
+    /// The first [`IngestError::ReorderSaturated`] swaps this from `false`
+    /// to `true` and emits a `tracing::warn!` (mirrored to stderr) that
+    /// names the saturated file, the in-effect ring capacity, the
+    /// `OC_RSYNC_REORDER_RING_CAP` env knob, and the registered file
+    /// count. Subsequent saturations only bump
+    /// [`reorder_saturations`](Self::reorder_saturations); the operator
+    /// sees one warning per transfer rather than one per file.
+    reorder_saturated_warned: AtomicBool,
 }
 
 impl std::fmt::Debug for ParallelDeltaApplier {
@@ -485,6 +554,8 @@ impl ParallelDeltaApplier {
             per_file_reorder_capacity,
             concurrency,
             strategy,
+            reorder_saturations: AtomicU64::new(0),
+            reorder_saturated_warned: AtomicBool::new(false),
         }
     }
 
@@ -526,6 +597,64 @@ impl ParallelDeltaApplier {
     #[must_use]
     pub fn per_file_reorder_capacity(&self) -> usize {
         self.per_file_reorder_capacity
+    }
+
+    /// Returns the cumulative number of per-file reorder-ring saturation
+    /// events observed since the applier was constructed (ROB-2, #3667).
+    ///
+    /// Granularity-invariant: one increment per
+    /// [`IngestError::ReorderSaturated`] regardless of which file
+    /// produced it. Pairs with the ROB-3 one-shot warning emitted by
+    /// [`Self::note_reorder_saturation`].
+    #[must_use]
+    pub fn reorder_saturations(&self) -> u64 {
+        self.reorder_saturations.load(Ordering::Relaxed)
+    }
+
+    /// Records a per-file reorder-ring saturation event and, on the first
+    /// observation per applier instance, emits the ROB-3 one-shot warning.
+    ///
+    /// Increments [`Self::reorder_saturations`] unconditionally and uses an
+    /// [`AtomicBool::compare_exchange`] guard so the warning fires exactly
+    /// once even when several files saturate concurrently from rayon
+    /// workers. The warning text includes the file index, the in-effect
+    /// per-file ring capacity, the offending `chunk_sequence`, the
+    /// registered file count at the time of saturation, and a pointer to
+    /// the `OC_RSYNC_REORDER_RING_CAP` env knob (ROB-11) so operators
+    /// have an actionable next step.
+    ///
+    /// The warning goes through `tracing::warn!` (visible at `--info=ALL`
+    /// minimum) and is mirrored to stderr via [`eprintln!`] so default
+    /// builds without the `tracing` feature still surface it. Mirrors the
+    /// SRO-6 pattern used by [`SpillableReorderBuffer`].
+    pub(crate) fn note_reorder_saturation(&self, ndx: FileNdx, chunk_sequence: u64) {
+        self.reorder_saturations.fetch_add(1, Ordering::Relaxed);
+        if self
+            .reorder_saturated_warned
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+        {
+            let capacity = self.per_file_reorder_capacity;
+            let file_count = self.files.len();
+            eprintln!(
+                "warning: per-file reorder ring saturated during transfer \
+                 (ndx={ndx}, chunk_sequence={chunk_sequence}, ring_capacity={capacity}, \
+                 registered_files={file_count}); this indicates either an adversarial \
+                 chunk ordering or undersized ring capacity. \
+                 Set OC_RSYNC_REORDER_RING_CAP to a larger positive integer to widen the \
+                 per-file ring. (one-time warning per applier)"
+            );
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                ndx = %ndx,
+                chunk_sequence,
+                ring_capacity = capacity,
+                registered_files = file_count,
+                "per-file reorder ring saturated during transfer; \
+                 set OC_RSYNC_REORDER_RING_CAP to widen the per-file ring \
+                 (one-time warning per applier)"
+            );
+        }
     }
 
     /// Registers a destination writer for `ndx`.
@@ -608,7 +737,15 @@ impl ParallelDeltaApplier {
 
         let mut slot = handle.lock_slot(ndx, "apply_one_chunk")?;
         let _ = verified.digest; // reserved for future stats wiring
-        slot.ingest(verified.chunk)
+        match slot.ingest(verified.chunk) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if let IngestError::ReorderSaturated { chunk_sequence, .. } = &err {
+                    self.note_reorder_saturation(ndx, *chunk_sequence);
+                }
+                Err(err.into())
+            }
+        }
     }
 
     /// Returns the total bytes written to `ndx` so far.

--- a/crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs
+++ b/crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs
@@ -143,8 +143,8 @@ fn delta_consumer_stats_exposes_spill_activations() {
     // long enough to overflow the byte budget and force repeated spills.
     let producer = std::thread::spawn(move || {
         for seq in 1..COUNT {
-            let work = DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64)
-                .with_sequence(u64::from(seq));
+            let work =
+                DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64).with_sequence(u64::from(seq));
             tx.send(work).expect("send out-of-order item");
         }
         std::thread::sleep(std::time::Duration::from_millis(50));

--- a/crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs
+++ b/crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs
@@ -1,0 +1,189 @@
+//! Regression coverage for the ROB-2 / ROB-3 reorder-buffer telemetry
+//! additions (#3667).
+//!
+//! Two surfaces are exercised:
+//!
+//! * **ROB-2 / ROB-3 (per-file applier)** -
+//!   [`ParallelDeltaApplier::reorder_saturations`] advances on every
+//!   per-file ring saturation; the one-shot warn guard inside
+//!   [`ParallelDeltaApplier::note_reorder_saturation`] fires at most once
+//!   per applier instance. A tiny per-file ring capacity is constructed,
+//!   then chunks are submitted with sequence numbers that overflow the
+//!   ring; the saturation counter must advance even though the applier
+//!   funnels the underlying
+//!   [`engine::concurrent_delta::reorder::CapacityExceeded`] into
+//!   [`std::io::Error`] for the caller.
+//!
+//! * **ROB-2 (pipeline spill activations)** -
+//!   [`engine::concurrent_delta::DeltaConsumerStats::spill_activations`]
+//!   is plumbed from the underlying
+//!   [`engine::concurrent_delta::spill::SpillableReorderBuffer`]'s
+//!   granularity-invariant counter. A tight byte threshold drives spill
+//!   events; the consumer-side stats snapshot must reflect a non-zero
+//!   activation total by the time the pipeline drains.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use engine::concurrent_delta::{
+    ConcurrentDeltaConfig, DeltaChunk, DeltaConsumer, DeltaWork, ParallelDeltaApplier, work_queue,
+};
+
+/// Sink that swallows every write; the test only cares about the reorder
+/// buffer's saturation outcome, not the bytes themselves.
+struct NullSink;
+
+impl Write for NullSink {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Submits an out-of-window chunk against a deliberately tiny per-file
+/// reorder ring. The first saturation must increment
+/// [`ParallelDeltaApplier::reorder_saturations`] and the second event
+/// must also advance the counter monotonically; the warn guard's
+/// one-shot semantics are validated by the constant counter delta of
+/// exactly one per saturation event.
+#[test]
+fn per_file_ring_saturation_advances_counter_monotonically() {
+    // Capacity 2 means only sequence offsets [0, 2) fit in the ring. Submitting
+    // chunk_sequence=5 with the head still missing forces a CapacityExceeded.
+    let applier = ParallelDeltaApplier::new(1).with_per_file_reorder_capacity(2);
+    applier
+        .register_file(0u32, Box::new(NullSink))
+        .expect("register_file");
+
+    assert_eq!(
+        applier.reorder_saturations(),
+        0,
+        "fresh applier must report zero saturations"
+    );
+
+    // chunk_sequence 5 with capacity 2 sits outside the [0, 2) window so the
+    // ring rejects it. The applier maps the error back into an io::Error and
+    // updates the ROB-2 counter en route.
+    let chunk = DeltaChunk::literal(0u32, 5, vec![0u8; 8]);
+    let err = applier
+        .apply_one_chunk(chunk)
+        .expect_err("oversized sequence must saturate the per-file ring");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("parallel apply reorder full"),
+        "saturation error must keep the historical message marker; got: {msg}"
+    );
+
+    assert_eq!(
+        applier.reorder_saturations(),
+        1,
+        "first ReorderSaturated must advance the counter exactly once"
+    );
+
+    // Second saturation: same applier, different file. Counter must still
+    // advance by exactly one - the ROB-3 warn guard is one-shot per applier
+    // but the ROB-2 counter is per-event.
+    applier
+        .register_file(1u32, Box::new(NullSink))
+        .expect("register_file second slot");
+    let chunk2 = DeltaChunk::literal(1u32, 9, vec![0u8; 8]);
+    let _ = applier
+        .apply_one_chunk(chunk2)
+        .expect_err("second saturation event still reports an error");
+
+    assert_eq!(
+        applier.reorder_saturations(),
+        2,
+        "subsequent saturations must keep advancing reorder_saturations"
+    );
+}
+
+/// Sanity check that a healthy in-order stream against a tight ring does
+/// not advance the saturation counter. A regression that wired the counter
+/// to a hot path (e.g. ordinary `insert` calls) would trip this test.
+#[test]
+fn in_order_submission_never_increments_saturation_counter() {
+    let applier = ParallelDeltaApplier::new(1).with_per_file_reorder_capacity(2);
+    applier
+        .register_file(0u32, Box::new(NullSink))
+        .expect("register_file");
+
+    for seq in 0..4u64 {
+        let chunk = DeltaChunk::literal(0u32, seq, vec![0u8; 4]);
+        applier
+            .apply_one_chunk(chunk)
+            .expect("in-order submission must succeed");
+    }
+
+    assert_eq!(
+        applier.reorder_saturations(),
+        0,
+        "in-order submission must not touch the saturation counter"
+    );
+}
+
+/// Drives a [`DeltaConsumer`] backed by a spillable reorder buffer with a
+/// deliberately delayed head-of-line item and a tight 1 KiB byte
+/// threshold, mirroring the pattern in the consumer-side spill regression
+/// (`spillable_consumer_preserves_order_under_pressure`). The new
+/// [`engine::concurrent_delta::DeltaConsumerStats::spill_activations`]
+/// counter must be non-zero by the time the consumer drains, proving that
+/// ROB-2's granularity-invariant activation counter is observable through
+/// the public consumer-side API.
+#[test]
+fn delta_consumer_stats_exposes_spill_activations() {
+    const COUNT: u32 = 1000;
+    const THRESHOLD: u64 = 1024;
+
+    let (tx, rx) = work_queue::bounded_with_capacity(COUNT as usize);
+
+    // Sequences 1..COUNT first, then seq 0 last - the head stays missing
+    // long enough to overflow the byte budget and force repeated spills.
+    let producer = std::thread::spawn(move || {
+        for seq in 1..COUNT {
+            let work = DeltaWork::whole_file(seq, PathBuf::from("/dst"), 64)
+                .with_sequence(u64::from(seq));
+            tx.send(work).expect("send out-of-order item");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        tx.send(DeltaWork::whole_file(0u32, PathBuf::from("/dst"), 64).with_sequence(0))
+            .expect("send head-of-line item");
+    });
+
+    let cfg = ConcurrentDeltaConfig::with_spill_threshold(THRESHOLD);
+    let consumer = DeltaConsumer::spawn_with_config(rx, COUNT as usize, cfg);
+    let delivered: usize = consumer.iter().count();
+    let stats = consumer.stats();
+    producer.join().expect("producer join");
+    consumer.join().expect("consumer join");
+
+    assert_eq!(
+        delivered, COUNT as usize,
+        "every produced item must be delivered"
+    );
+    assert!(
+        stats.spill_events > 0,
+        "ROB-2 prerequisite: tight threshold must produce spill events; \
+         got spill_events={}",
+        stats.spill_events
+    );
+    assert!(
+        stats.spill_activations > 0,
+        "ROB-2 plumbing must surface at least one spill activation through \
+         DeltaConsumerStats; got spill_activations={} (spill_events={})",
+        stats.spill_activations,
+        stats.spill_events
+    );
+    // Activations are granularity-invariant: one per `spill_excess` call
+    // that wrote at least one record. The PerItem-equivalent `spill_events`
+    // counter is necessarily >= `spill_activations` because each call can
+    // emit multiple records.
+    assert!(
+        stats.spill_events >= stats.spill_activations,
+        "spill_events ({}) must be >= spill_activations ({}) by definition",
+        stats.spill_events,
+        stats.spill_activations
+    );
+}


### PR DESCRIPTION
## Summary

Adds observability for normal-operation reorder-buffer pressure on both
the spillable pipeline ring and the per-file applier ring. No behavior
change; counters and one-shot warnings only.

- **ROB-1** - audit: the ring-cap formula and call sites are documented
  in `docs/audits/rob-1-ring-cap-formula.md` (already in tree). Findings
  summarised below.
- **ROB-2** - `spill_activations` was already tracked inside
  `SpillableReorderBuffer` as a granularity-invariant counter, but
  unreachable through `DeltaConsumer::stats()`. This PR plumbs it through
  `DeltaConsumerStats` alongside `spill_events` and adds the same
  per-file applier accessor `ParallelDeltaApplier::reorder_saturations()`.
- **ROB-3** - `SpillableReorderBuffer` already emits a one-shot warning
  on first spill (SRO-6). This PR adds the analogous one-shot warning on
  the per-file applier surface, which has no spill backend at all and
  previously failed silently into `io::Error`. The warning names the
  saturating file, the in-effect ring capacity, the registered file
  count, and the `OC_RSYNC_REORDER_RING_CAP` env knob (ROB-11) so the
  operator has an actionable next step.

## ROB-1 audit findings

Source of truth: `docs/audits/rob-1-ring-cap-formula.md` (full report).
The relevant in-scope ring is
`engine::concurrent_delta::reorder::ReorderBuffer<T>` plus the
`SpillableReorderBuffer` wrapper. The pre-allocated ring takes
`capacity` verbatim - the 2x multiplier the parent issue flagged is
caller-side, not inside the ring.

**Formula A (pipeline ring)** -
`crates/transfer/src/delta_pipeline/parallel.rs:77-100, 146-159`:

```
capacity = worker_count.saturating_mul(2).max(2);
// adaptive variant: (2..=8) * worker_count by avg_target_size band
```

**Formula B (per-file applier ring)** -
`crates/engine/src/concurrent_delta/parallel_apply/mod.rs:429, 478-489`:

```
const DEFAULT_PER_FILE_REORDER_CAPACITY: usize = 64;
per_file_reorder_capacity =
    ring_cap_env::resolve_ring_capacity(DEFAULT_PER_FILE_REORDER_CAPACITY);
```

Call sites (production):

| Site | Cap | Spill? | Env override? |
| --- | --- | --- | --- |
| `ParallelDeltaPipeline::new(...)` -> `DeltaConsumer::spawn` | `2*workers` (or 2..8 adaptive) | Opt-in via `spawn_with_config` + `SpillPolicy.threshold_bytes` | No |
| `ParallelDeltaPipeline::new_bypass(...)` | passthrough | None | N/A |
| `DeltaConsumer::spawn_with_config(rx, cap, cfg)` | caller-set | `SpillableReorderBuffer` | Via `OC_RSYNC_SPILL_*` env (STN-8/9/10) |
| `ParallelDeltaApplier::{new, with_strategy}` | 64 default | None | `OC_RSYNC_REORDER_RING_CAP` (ROB-11) |

Upstream comparison: `target/interop/upstream-src/rsync-3.4.1/io.c::send_msg()`
and the `flist.c` flow-control sites use blocking writes and a single
sequential delta loop; upstream has no equivalent ring or spill backend
because results are not produced out of order. The oc-rsync formulas
are wire-compatible add-ons, not protocol changes.

## Code changes

- `DeltaConsumerStats` gains `spill_activations: u64`.
- `DeltaConsumer` plumbs a new `Arc<AtomicU64>` through `spawn_inner`
  and `run_spillable_loop` next to the existing `spill_events`
  publish hop; bypass and bare backends keep zero values.
- `ParallelDeltaApplier` gains `reorder_saturations: AtomicU64`,
  `reorder_saturated_warned: AtomicBool`, the
  `reorder_saturations()` accessor, and the
  `note_reorder_saturation(ndx, chunk_sequence)` helper (counter +
  one-shot `tracing::warn!` mirrored to `eprintln!`).
- `FileSlot::ingest` returns a private `IngestError` enum so
  `apply_one_chunk` and `apply_batch_parallel` can call
  `note_reorder_saturation` without string-matching. The public
  `io::Result<()>` API and the historical
  "parallel apply reorder full" message marker are preserved.

## Test plan

- [ ] `crates/engine/tests/rob_2_3_reorder_buffer_telemetry.rs` -
  three new tests:
  - `per_file_ring_saturation_advances_counter_monotonically` - drives
    two saturations against a capacity-2 ring on different files;
    verifies `reorder_saturations()` advances by exactly one per event
    and that the historical error message marker stays intact.
  - `in_order_submission_never_increments_saturation_counter` - sanity
    check that the counter stays zero on the hot path.
  - `delta_consumer_stats_exposes_spill_activations` - mirrors the
    existing `spillable_consumer_preserves_order_under_pressure` pattern
    and asserts the new `DeltaConsumerStats.spill_activations` field
    becomes non-zero by drain.
- [ ] CI fmt+clippy on master.
- [ ] CI nextest (stable) full workspace.
- [ ] CI Windows/macOS/Linux musl matrix.

## Constraints honoured

- No wire-protocol or behavior change; observability only.
- No regressions to parallel-receive-delta (PIP-10), io_uring, IOCP,
  flat-flist, daemon-tls (no code in those crates touched).
- No clippy `allow` waivers.
- Per-file applier warning gated through the same `tracing` feature
  used elsewhere in the engine; default builds still see the
  `eprintln!` fallback.