### PR TITLE
fix: pass upstream link-dest-relative-basis/pathroot/module-escape tests

### DIFF
--- a/crates/daemon/src/daemon/sections/capabilities.rs
+++ b/crates/daemon/src/daemon/sections/capabilities.rs
@@ -120,6 +120,18 @@ fn module_requires_chown(module: &ModuleRuntime) -> bool {
     matches!(module.uid, Some(0))
 }
 
+/// Returns whether the calling process currently has an effective uid of 0.
+///
+/// Used to detect "module has no explicit `uid` directive and the daemon
+/// process is running as root" - the case where the per-module privilege
+/// drop leaves the worker inheriting root from the daemon. Calling
+/// `nix::unistd::geteuid` here avoids racing with any partial setuid the
+/// privilege-drop path may have just performed.
+#[cfg(target_os = "linux")]
+fn current_euid_is_zero() -> bool {
+    nix::unistd::geteuid().is_root()
+}
+
 /// Drops `CAP_NET_BIND_SERVICE` from the daemon's effective and permitted
 /// capability sets.
 ///
@@ -195,6 +207,37 @@ fn drop_worker_capabilities(
 ) {
     use caps::{CapSet, Capability};
 
+    // Skip the per-worker drop whenever the worker is still running as
+    // root - either because the module is configured with `uid = 0`, or
+    // because no per-module `uid` was set and the daemon-wide identity
+    // (which the worker inherits when the per-module drop is skipped) is
+    // root. The kernel grants root all capabilities implicitly; dropping
+    // them here would strip CAP_DAC_OVERRIDE / CAP_DAC_READ_SEARCH /
+    // CAP_FOWNER / CAP_FSETID and leave a root worker EACCES-ing module
+    // trees that live under unprivileged user homedirs (the runtests.py
+    // scratch under `/home/<user>/...` with mode 750 was the smoke gun).
+    // Upstream rsync does not drop capabilities from a root daemon, so
+    // skipping the drop here preserves behavioural parity. LSM-CAP is a
+    // defense-in-depth layer for the unprivileged-uid case; for uid=0
+    // the operator has explicitly chosen the root identity and the
+    // capability surface that comes with it.
+    let worker_is_root = match module.uid {
+        Some(0) => true,
+        None => current_euid_is_zero(),
+        Some(_) => false,
+    };
+    if worker_is_root {
+        if let Some(log) = log_sink {
+            let text = format!(
+                "module '{}': skipping worker capability drop (root worker keeps the kernel's implicit capability set)",
+                module.name,
+            );
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return;
+    }
+
     let required = required_capabilities_for_module(module);
 
     // Iterate all known capabilities and drop the ones not in the required
@@ -255,9 +298,22 @@ fn drop_worker_capabilities(
 ///
 /// The inventory is intentionally minimal: workers run inside the post-chroot
 /// post-setuid environment where most operations need no capability at all.
-/// The only case requiring a non-empty set is a module configured with
-/// `uid = 0` that must honour client-supplied `--owner`/`--group`/`--chown`,
-/// which traps to `fchown(2)` and requires `CAP_CHOWN`.
+/// When the module is configured with `uid = 0` the worker continues as root,
+/// so the file-system bypass set the kernel grants root implicitly must be
+/// retained here too: dropping CAP_DAC_OVERRIDE / CAP_DAC_READ_SEARCH would
+/// leave a root worker unable to read or write into directories owned by
+/// unprivileged users (the common runtests.py scratch under
+/// `/home/<user>/...` was the smoke gun: every push into a 750-mode user
+/// homedir returned EACCES even though the worker UID was 0). Upstream rsync
+/// does not drop these capabilities for a root daemon, so retaining them
+/// keeps LSM-CAP a defense-in-depth layer rather than a behavioural break.
+///
+/// `CAP_FOWNER` covers `chmod` / `utime` against files the worker did not
+/// create (mirroring upstream's metadata-restore path), and `CAP_FSETID` is
+/// needed to preserve setuid/setgid bits across the chmod that follows a
+/// fresh open. Together with `CAP_CHOWN` for `--owner`/`--group`/`--chown`,
+/// this matches the implicit capability set a root daemon would have if no
+/// drop happened at all.
 #[cfg(target_os = "linux")]
 fn required_capabilities_for_module(
     module: &ModuleRuntime,
@@ -268,6 +324,10 @@ fn required_capabilities_for_module(
     let mut required = HashSet::new();
     if module_requires_chown(module) {
         required.insert(Capability::CAP_CHOWN);
+        required.insert(Capability::CAP_DAC_OVERRIDE);
+        required.insert(Capability::CAP_DAC_READ_SEARCH);
+        required.insert(Capability::CAP_FOWNER);
+        required.insert(Capability::CAP_FSETID);
     }
     required
 }
@@ -322,6 +382,23 @@ mod capabilities_tests {
         let module = module_with("uploads", Some(0));
         let required = required_capabilities_for_module(&module);
         assert!(required.contains(&Capability::CAP_CHOWN));
+    }
+
+    /// A root-mode module must retain the kernel's implicit DAC bypass set so
+    /// the worker can read and write into module trees that live under
+    /// directories owned by unprivileged users. Without DAC_OVERRIDE the
+    /// runtests.py scratch under `/home/<user>/...` (homedir mode 750) returns
+    /// EACCES on the first `openat(O_PATH)`; the same scenario hits any
+    /// daemon module configured with `path = /var/.../user/...`.
+    #[test]
+    fn required_capabilities_include_dac_bypass_for_root_module() {
+        use caps::Capability;
+        let module = module_with("uploads", Some(0));
+        let required = required_capabilities_for_module(&module);
+        assert!(required.contains(&Capability::CAP_DAC_OVERRIDE));
+        assert!(required.contains(&Capability::CAP_DAC_READ_SEARCH));
+        assert!(required.contains(&Capability::CAP_FOWNER));
+        assert!(required.contains(&Capability::CAP_FSETID));
     }
 
     /// The `drop_cap_net_bind_service` helper must be safe to call even when

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -445,6 +445,43 @@ fn resolve_sender_sources(
     }
 }
 
+/// Collapses `.` and `..` segments lexically without touching the filesystem.
+///
+/// Used to fold a relative basis path like `mod/00/../01` into `mod/01` before
+/// the module-root containment check runs. Pure path arithmetic: no syscalls,
+/// no canonicalisation, so the result is well-defined even when the resolved
+/// directory does not exist yet (a `--link-dest` basis is allowed to be
+/// missing without aborting the transfer).
+///
+/// `..` at the head of an otherwise relative path is preserved verbatim so a
+/// climb that escapes the join base survives into the caller's `starts_with`
+/// check, which then rejects the basis as out-of-module.
+fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
+    use std::path::{Component, PathBuf};
+
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                out.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let popped = out.pop();
+                if !popped {
+                    // Nothing to pop; preserve the `..` so the caller's
+                    // `starts_with(module_root)` check rejects the escape.
+                    out.push("..");
+                }
+            }
+        }
+    }
+    if out.as_os_str().is_empty() {
+        out.push(".");
+    }
+    out
+}
+
 /// Builds the server configuration from client arguments.
 ///
 /// Returns the configuration on success, or sends an error and returns `None`.
@@ -531,15 +568,49 @@ fn build_server_config(
                 cfg.connection.compression_level = Some(compress::zlib::CompressionLevel::Default);
             }
 
-            // upstream: after chroot + chdir, reference directory paths resolve
-            // relative to the module root. We don't chdir, so resolve relative
-            // paths explicitly against the module path.
-            let module_path = std::path::Path::new(&module.path);
-            for ref_dir in &mut cfg.reference_directories {
+            // upstream: main.c:1199-1206 calls `check_alt_basis_dirs()` after
+            // `get_local_name(flist, argv[0])` chdir's into the dest directory,
+            // so relative basis paths like `--link-dest=../01` resolve against
+            // the receiver's destination (a sibling of `dest/00/`), not against
+            // the module root. We do not chdir, so resolve relative ref_dirs
+            // explicitly against the receiver's dest directory (the positional
+            // arg). For sender role positionals are source paths, not a dest;
+            // keep the module-root fallback so the legacy compare-dest lookup
+            // path stays unchanged.
+            //
+            // The resolved path is then confined inside the module root: if
+            // the lexical climb (`..`) escapes the module tree the ref_dir is
+            // silently dropped so the basis lookup falls through to a normal
+            // transfer instead of leaking files from outside the module
+            // (link-dest-module-escape security pin).
+            let module_root_canonical = std::path::Path::new(&module.path)
+                .canonicalize()
+                .unwrap_or_else(|_| std::path::PathBuf::from(&module.path));
+            let resolve_base: std::path::PathBuf = if role == ServerRole::Receiver {
+                cfg.args
+                    .first()
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|| std::path::PathBuf::from(&module.path))
+            } else {
+                std::path::PathBuf::from(&module.path)
+            };
+            cfg.reference_directories.retain_mut(|ref_dir| {
                 if ref_dir.path.is_relative() {
-                    ref_dir.path = module_path.join(&ref_dir.path);
+                    let joined = resolve_base.join(&ref_dir.path);
+                    let resolved = lexically_normalize(&joined);
+                    let resolved_canonical = resolved
+                        .canonicalize()
+                        .unwrap_or_else(|_| resolved.clone());
+                    if !resolved_canonical.starts_with(&module_root_canonical) {
+                        // Lexical or canonical climb escapes the module root;
+                        // drop the basis so the receiver re-transfers instead
+                        // of hard-linking to an out-of-module target.
+                        return false;
+                    }
+                    ref_dir.path = resolved;
                 }
-            }
+                true
+            });
 
             // upstream: loadparm.c - `temp dir` module parameter provides a
             // default temp directory. The client's --temp-dir takes precedence

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -56,9 +56,9 @@ impl ReceiverContext {
 
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
-        let delete_io_error: i32 = 0;
+        let mut delete_io_error: i32 = 0;
         if self.config.flags.delete {
-            let (ds, exceeded) = self.delete_extraneous_files(
+            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -66,6 +66,7 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
+            delete_io_error = io_bits;
             // Carry the per-type counters into the receiver context so the
             // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
             // upstream: generator.c:2393-2398 - early write_del_stats() emission.

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -56,12 +56,9 @@ impl ReceiverContext {
 
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
-        // UTS-16.b: sandbox-rejected scans surface IOERR_GENERAL here so the
-        // chdir-symlink-race refusal becomes a non-zero exit instead of a
-        // silent skip.
-        let mut delete_io_error: i32 = 0;
+        let delete_io_error: i32 = 0;
         if self.config.flags.delete {
-            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
+            let (ds, exceeded) = self.delete_extraneous_files(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -69,7 +66,6 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
-            delete_io_error = io_bits;
             // Carry the per-type counters into the receiver context so the
             // goodbye handshake can emit NDX_DEL_STATS to the peer sender.
             // upstream: generator.c:2393-2398 - early write_del_stats() emission.

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -97,7 +97,7 @@ impl ReceiverContext {
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
         if self.config.flags.delete {
-            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
+            let (ds, exceeded) = self.delete_extraneous_files(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -105,10 +105,6 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
-            // UTS-16.b: sandbox-rejected delete scan surfaces here so the
-            // chdir-symlink-race refusal becomes a non-zero exit instead of a
-            // silent skip.
-            stats.io_error |= io_bits;
             // Carry the counters into the receiver context so the goodbye
             // handshake can emit NDX_DEL_STATS to the peer sender. URV-6.b
             // landed the on-disk deletion but the counters were never

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -96,7 +96,6 @@ impl ReceiverContext {
         // upstream: generator.c:do_delete_pass()
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
-        let mut delete_io_error: i32 = 0;
         if self.config.flags.delete {
             let (ds, exceeded, io_bits) = self.delete_extraneous_files(
                 &setup.dest_dir,
@@ -106,8 +105,7 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
-            delete_io_error = io_bits;
-            stats.io_error |= delete_io_error;
+            stats.io_error |= io_bits;
             // Carry the counters into the receiver context so the goodbye
             // handshake can emit NDX_DEL_STATS to the peer sender. URV-6.b
             // landed the on-disk deletion but the counters were never

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -96,8 +96,9 @@ impl ReceiverContext {
         // upstream: generator.c:do_delete_pass()
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;
+        let mut delete_io_error: i32 = 0;
         if self.config.flags.delete {
-            let (ds, exceeded) = self.delete_extraneous_files(
+            let (ds, exceeded, io_bits) = self.delete_extraneous_files(
                 &setup.dest_dir,
                 #[cfg(unix)]
                 setup.sandbox.as_ref(),
@@ -105,6 +106,8 @@ impl ReceiverContext {
             )?;
             delete_stats = ds;
             delete_limit_exceeded = exceeded;
+            delete_io_error = io_bits;
+            stats.io_error |= delete_io_error;
             // Carry the counters into the receiver context so the goodbye
             // handshake can emit NDX_DEL_STATS to the peer sender. URV-6.b
             // landed the on-disk deletion but the counters were never


### PR DESCRIPTION
## Summary
Three commits, two distinct root causes, one PR because both regressions had to clear for the failing upstream tests to pass:

- **fix(transfer)**: master is currently broken — PR #5620 merged the caller-side 3-tuple change but not the `deletion.rs` body that produces it. Revert the caller-side change to restore the build. The IOERR_GENERAL surface on sandbox-rejected delete scans (UTS-16.b) is temporarily disabled and tracked by the original PR.
- **fix(daemon) link-dest resolution**: daemon receiver was joining relative `--link-dest=../01` against the module root instead of the dest subdirectory, producing `mod/../01` (parent of module) instead of `mod/00/../01 = mod/01` (the in-module sibling). Every basis lookup missed and the file was re-transferred. Pre-resolve relative ref_dirs against the receiver's positional dest arg, lexically collapse `..` segments, and confine the result inside the module root (URV-5.a.1.c absolute-path validation unchanged).
- **fix(daemon) LSM-CAP root worker**: LSM-CAP at PR #5581 dropped CAP_DAC_OVERRIDE / CAP_DAC_READ_SEARCH / CAP_FOWNER / CAP_FSETID even when the worker was still running as root, leaving it EACCES on any module tree under a 750-mode user homedir. Short-circuit `drop_worker_capabilities` whenever the worker is root — by explicit `uid = 0` or by inheriting root from the daemon process (no per-module `uid` directive plus a daemon-wide root identity). Matches upstream rsync's behaviour.

## Reproduced first
Linux host: `runtests.py --use-tcp` against `oc-rsync` daemon. Three tests reproduce on master:

```
$ for t in link-dest-module-escape link-dest-pathroot link-dest-relative-basis; do \
    sudo python3 ./runtests.py --rsync-bin /home/ofer/rsync/rsync \
      --rsync-bin2 /home/ofer/oc-rsync/target/release/oc-rsync \
      --use-tcp $t; \
  done
FAIL    link-dest-module-escape    (destination file missing)
FAIL    link-dest-pathroot         (connection unexpectedly closed, rc=12)
FAIL    link-dest-relative-basis   (connection unexpectedly closed, rc=12)
```

Strace evidence on the failing path:
- `mkdirat(AT_FDCWD, "mod/00/", 0777) = -1 EACCES` (LSM-CAP stripping DAC bypass from root worker)
- `openat(AT_FDCWD, "mod/../01/f.dat") = -1 ENOENT` (relative basis resolved against module root, not dest dir)

Both signals collected by re-running with `strace -ff -e capset,openat,landlock_*` on the daemon child.

## Post-fix verification
Re-ran the same harness with the patched binary:

```
PASS    link-dest-module-escape
PASS    link-dest-pathroot
PASS    link-dest-relative-basis
```

## Security guarantees preserved
- **URV-5.a.1.c** (`validate_client_paths_in_module`): absolute `--copy-dest` / `--link-dest` / `--compare-dest` paths that escape the module root still get an `@ERROR` reply before this code path runs.
- **URV-5.a containment for relative ref_dirs**: my pre-resolve step lexically collapses `..` segments and runs `starts_with(canonicalised module root)`; the `link-dest-module-escape` test exercises the `../../OUTSIDE` climb and confirms the basis is silently dropped (file re-transferred, not hard-linked to the OUTSIDE secret).
- **No regression to parallel-receive-delta / io_uring / IOCP / flat-flist / daemon-tls / DirSandbox / SEC-1 \*at syscalls**: the diff is scoped to `crates/daemon/sections/module_access/client_args.rs` and `crates/daemon/sections/capabilities.rs`. The transfer crate revert is a temporary master-build unblock that gives back the 3-tuple IOERR_GENERAL propagation — UTS-16.b coverage is restored when the dropped `deletion.rs` half of #5620 relands.

## Test plan
- [x] Build with `cargo build --release` on Linux aarch64 (the test host) and on macOS aarch64 (local) clean
- [x] `runtests.py --use-tcp link-dest-module-escape link-dest-pathroot link-dest-relative-basis` — all PASS
- [ ] CI fmt+clippy / nextest / Windows / macOS / Linux musl green