### PR TITLE
fix(daemon): drop redundant Read/Write imports + always-true cap test

### DIFF
--- a/crates/daemon/src/daemon/sections/capabilities.rs
+++ b/crates/daemon/src/daemon/sections/capabilities.rs
@@ -286,10 +286,10 @@ mod capabilities_tests {
         ModuleRuntime::new(def, None)
     }
 
-    #[test]
-    fn cap_feature_compiled_in_on_linux() {
-        assert!(CAP_FEATURE_AVAILABLE);
-    }
+    // CAP_FEATURE_AVAILABLE is a cfg-gated compile-time constant; the
+    // surrounding `cfg(all(test, target_os = "linux"))` already proves the
+    // feature is compiled in on Linux, so a runtime assertion against the
+    // constant adds no signal and clippy strips it as dead code.
 
     #[test]
     fn preflight_passes_when_no_module_requires_chown() {

--- a/crates/daemon/src/daemon/sections/hardening.rs
+++ b/crates/daemon/src/daemon/sections/hardening.rs
@@ -135,7 +135,7 @@ fn read_and_log_lsms_from(path: &Path, log_sink: Option<&SharedLogSink>) {
 #[cfg(all(test, target_os = "linux"))]
 mod hardening_tests {
     use super::*;
-    use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+    use std::io::{Seek as _, SeekFrom};
 
     /// Builds a [`SharedLogSink`] backed by a fresh tempfile and returns
     /// the sink alongside a clone of the underlying file. The clone is

--- a/crates/transfer/tests/uts_2_efg_ssh_alt_dest_verification.rs
+++ b/crates/transfer/tests/uts_2_efg_ssh_alt_dest_verification.rs
@@ -192,7 +192,7 @@ fn uts_2_g_wire_byte_parity_mkdir_is_receiver_local() {
     // duration of the call to make the absence of a writer argument
     // load-bearing - any refactor that adds a writer would fail to type-
     // check against this fixture.
-    let mut wire_capture: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+    let wire_capture: Cursor<Vec<u8>> = Cursor::new(Vec::new());
     let captured_len_before = wire_capture.get_ref().len();
 
     let created = ensure_dest_root_exists(&dest_root, 4, false, false)


### PR DESCRIPTION
## Summary

- `crates/daemon/src/daemon/sections/hardening.rs:138` — the test module imports `Read as _, Seek as _, SeekFrom, Write as _`, but the file is `include!()`-d into `daemon.rs` which already brings `Read` and `Write` into scope via `use std::io::{self, BufRead, BufReader, Read, Write};`. The redundant anonymous imports trip `-D unused-imports`. Drop them; keep `Seek as _` and `SeekFrom` which the outer module does not import.
- `crates/daemon/src/daemon/sections/capabilities.rs:291` — the cap_feature_compiled_in_on_linux test asserts a `cfg(target_os = "linux")` constant inside a `cfg(all(test, target_os = "linux"))` module. The constant is unconditionally `true` on Linux, so clippy's `assertions_on_constants` strips it. Remove the test (the cfg gate is already the contract) and document the rationale inline.

This unblocks master fmt+clippy and unsticks every open PR rebased onto master.

## Test plan
- [x] Master CI fmt+clippy turns green on this branch
- [ ] After merge: confirm at least one of #5674..#5682 turns green