### PR TITLE
fix: close remaining &include parser gap for daemon-config upstream test

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
@@ -9,7 +9,7 @@
 /// upstream: loadparm.c - when a P_LOCAL parameter appears in the global
 /// section, it sets the default value (`def_ptr`) that all subsequently
 /// parsed modules inherit via `init_section()` / `copy_section()`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct GlobalModuleDefaults {
     exclude: Vec<String>,
     include: Vec<String>,
@@ -77,6 +77,16 @@ struct GlobalParseState {
     /// upstream: loadparm.c - P_LOCAL parameters in the global section set
     /// defaults inherited by all modules that don't override them.
     module_defaults: GlobalModuleDefaults,
+    /// Snapshot of the parent file's globals when this state is the body
+    /// of an `&include`/`&merge` target. Modules declared in the included
+    /// file use these as fallbacks when no value is set in this file, so
+    /// they inherit the parent's defaults the same way upstream's shared
+    /// `Vars` block carries the parent state across the `]push`/`]pop`
+    /// boundary in `params.c::Parse`.
+    inherited_use_chroot: Option<bool>,
+    inherited_secrets_file: Option<PathBuf>,
+    inherited_incoming_chmod: Option<String>,
+    inherited_outgoing_chmod: Option<String>,
 }
 
 impl GlobalParseState {
@@ -105,7 +115,52 @@ impl GlobalParseState {
             daemon_chroot: None,
             modules: Vec::new(),
             module_defaults: GlobalModuleDefaults::default(),
+            inherited_use_chroot: None,
+            inherited_secrets_file: None,
+            inherited_incoming_chmod: None,
+            inherited_outgoing_chmod: None,
         }
+    }
+
+    /// Builds a fresh parse state seeded with the parent file's global
+    /// defaults so modules declared inside an `&include`/`&merge` target
+    /// inherit the same P_LOCAL defaults the parent file already
+    /// established.
+    ///
+    /// upstream: params.c:Parse / loadparm.c::do_section - `&include`
+    /// wraps the recursive parse in `]push`/`]pop` calls that snapshot
+    /// the shared `Vars` block; modules added by the included file
+    /// finalize against the live `Vars` state, which still carries the
+    /// parent file's defaults until the matching `]pop` restores the
+    /// snapshot. Mirror that by stashing the inheritable defaults into
+    /// dedicated fallback slots, leaving the duplicate-detection state
+    /// for explicit per-file directives untouched so the include can
+    /// still redeclare a global without colliding with the parent's
+    /// origin.
+    fn inherited_from(parent: &Self) -> Self {
+        let mut state = Self::new();
+        state.inherited_use_chroot = parent
+            .global_use_chroot
+            .as_ref()
+            .map(|(value, _)| *value)
+            .or(parent.inherited_use_chroot);
+        state.inherited_secrets_file = parent
+            .global_secrets_file
+            .as_ref()
+            .map(|(value, _)| value.clone())
+            .or_else(|| parent.inherited_secrets_file.clone());
+        state.inherited_incoming_chmod = parent
+            .global_incoming_chmod
+            .as_ref()
+            .map(|(value, _)| value.clone())
+            .or_else(|| parent.inherited_incoming_chmod.clone());
+        state.inherited_outgoing_chmod = parent
+            .global_outgoing_chmod
+            .as_ref()
+            .map(|(value, _)| value.clone())
+            .or_else(|| parent.inherited_outgoing_chmod.clone());
+        state.module_defaults = parent.module_defaults.clone();
+        state
     }
 
     /// Converts the accumulated global state into the final parsed result.

--- a/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
@@ -28,18 +28,24 @@ fn apply_include_directive(
     }
 
     let include_path = resolve_config_relative_path(canonical, trimmed);
-    let included = parse_config_modules_inner(&include_path, stack).map_err(|error| {
-        // Wrap inner failures so the user sees both the directive site that
-        // triggered the include and the underlying parse error from the
-        // included file. Missing-file and recursive-include errors already
-        // name the offending path; this wrap adds the parent line context.
-        let display = include_path.display();
-        config_parse_error(
-            path,
-            line_number,
-            format!("failed to process '{directive} {display}': {error}"),
-        )
-    })?;
+    // upstream: loadparm.c::lp_load() &include handling - pass the parent
+    // state's globals into the recursive parse so modules declared in the
+    // included file inherit the parent's P_LOCAL defaults (use chroot,
+    // hosts allow, secrets file, etc.), matching upstream's shared `Vars`
+    // semantics across the `]push`/`]pop` boundary.
+    let included =
+        parse_config_modules_inner(&include_path, stack, Some(state)).map_err(|error| {
+            // Wrap inner failures so the user sees both the directive site that
+            // triggered the include and the underlying parse error from the
+            // included file. Missing-file and recursive-include errors already
+            // name the offending path; this wrap adds the parent line context.
+            let display = include_path.display();
+            config_parse_error(
+                path,
+                line_number,
+                format!("failed to process '{directive} {display}': {error}"),
+            )
+        })?;
 
     if !included.modules.is_empty() {
         state.modules.extend(included.modules);

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -7,12 +7,13 @@
 /// Parses the `rsyncd.conf` at `path` into module definitions and global settings.
 pub(crate) fn parse_config_modules(path: &Path) -> Result<ParsedConfigModules, DaemonError> {
     let mut stack = Vec::new();
-    parse_config_modules_inner(path, &mut stack)
+    parse_config_modules_inner(path, &mut stack, None)
 }
 
 fn parse_config_modules_inner(
     path: &Path,
     stack: &mut Vec<PathBuf>,
+    inherited: Option<&GlobalParseState>,
 ) -> Result<ParsedConfigModules, DaemonError> {
     let canonical = path
         .canonicalize()
@@ -30,7 +31,15 @@ fn parse_config_modules_inner(
         .map_err(|error| config_io_error("read", &canonical, error))?;
     stack.push(canonical.clone());
 
-    let mut state = GlobalParseState::new();
+    // upstream: loadparm.c::lp_load() &include handling - the included file
+    // continues parsing against the shared `Vars` block, so modules declared
+    // there inherit the parent's P_LOCAL defaults (use chroot, hosts allow,
+    // secrets file, ...). Seed the child state from the parent so
+    // `finish_module_builder` resolves defaults the same way as upstream.
+    let mut state = match inherited {
+        Some(parent) => GlobalParseState::inherited_from(parent),
+        None => GlobalParseState::new(),
+    };
     let mut current: Option<ModuleDefinitionBuilder> = None;
 
     let result = (|| -> Result<ParsedConfigModules, DaemonError> {
@@ -144,21 +153,37 @@ fn parse_config_modules_inner(
 }
 
 /// Finalizes a module builder using the current global defaults.
+///
+/// Explicit globals declared in the same file win over inherited values
+/// from a parent file (set when this state is the body of an
+/// `&include`/`&merge` target), matching upstream's shared-`Vars`
+/// semantics where the includer's defaults serve as fallbacks until the
+/// included file overrides them.
 fn finish_module_builder(
     builder: ModuleDefinitionBuilder,
     path: &Path,
     state: &GlobalParseState,
 ) -> Result<ModuleDefinition, DaemonError> {
-    let default_secrets = state.global_secrets_file.as_ref().map(|(p, _)| p.as_path());
+    let default_secrets = state
+        .global_secrets_file
+        .as_ref()
+        .map(|(p, _)| p.as_path())
+        .or_else(|| state.inherited_secrets_file.as_deref());
     let default_incoming = state
         .global_incoming_chmod
         .as_ref()
-        .map(|(value, _)| value.as_str());
+        .map(|(value, _)| value.as_str())
+        .or_else(|| state.inherited_incoming_chmod.as_deref());
     let default_outgoing = state
         .global_outgoing_chmod
         .as_ref()
-        .map(|(value, _)| value.as_str());
-    let default_use_chroot = state.global_use_chroot.as_ref().map(|(v, _)| *v);
+        .map(|(value, _)| value.as_str())
+        .or_else(|| state.inherited_outgoing_chmod.as_deref());
+    let default_use_chroot = state
+        .global_use_chroot
+        .as_ref()
+        .map(|(v, _)| *v)
+        .or(state.inherited_use_chroot);
     builder.finish(
         path,
         default_secrets,

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -168,17 +168,17 @@ fn finish_module_builder(
         .global_secrets_file
         .as_ref()
         .map(|(p, _)| p.as_path())
-        .or_else(|| state.inherited_secrets_file.as_deref());
+        .or(state.inherited_secrets_file.as_deref());
     let default_incoming = state
         .global_incoming_chmod
         .as_ref()
         .map(|(value, _)| value.as_str())
-        .or_else(|| state.inherited_incoming_chmod.as_deref());
+        .or(state.inherited_incoming_chmod.as_deref());
     let default_outgoing = state
         .global_outgoing_chmod
         .as_ref()
         .map(|(value, _)| value.as_str())
-        .or_else(|| state.inherited_outgoing_chmod.as_deref());
+        .or(state.inherited_outgoing_chmod.as_deref());
     let default_use_chroot = state
         .global_use_chroot
         .as_ref()

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -399,6 +399,87 @@ mod config_parsing_tests {
     }
 
     #[test]
+    fn parse_amp_include_inherits_parent_globals_for_included_module() {
+        // Regression: modules declared inside an `&include` target must
+        // inherit the parent file's P_LOCAL defaults (use chroot, hosts
+        // allow, read only, ...). Upstream's `loadparm.c::do_section`
+        // shares the `Vars` block across the `]push`/`]pop` boundary so
+        // the included file's sections finalize against the parent's
+        // current globals. Without this inheritance the upstream
+        // `daemon-config` testsuite case fails: `inc-mod` lands with
+        // `use_chroot=true` (the rsync default) even though the parent
+        // declared `use chroot = no`, which makes the daemon attempt
+        // `chroot()` and corrupt the wire stream for non-root listens.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let included = format!(
+            "[inc-mod]\npath = {}\nread only = yes\ncomment = via-include\n",
+            path.display(),
+        );
+        let include_file = write_config(&included);
+
+        let main_config = format!(
+            "use chroot = no\nhosts allow = localhost 127.0.0.0/8\n&include {}\n",
+            include_file.path().display(),
+        );
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        let included_mod = result
+            .modules
+            .iter()
+            .find(|m| m.name == "inc-mod")
+            .expect("inc-mod present");
+        assert!(
+            !included_mod.use_chroot,
+            "use chroot from parent must be inherited by included module",
+        );
+        assert_eq!(
+            included_mod.hosts_allow.len(),
+            2,
+            "global hosts allow must propagate into included module",
+        );
+        assert!(included_mod.read_only, "module's own read only must be honoured");
+    }
+
+    #[test]
+    fn parse_amp_include_module_overrides_inherited_default() {
+        // Regression: per-module directives inside an `&include` target
+        // must still win over the parent's inherited defaults so the
+        // include is purely additive, never coercive. Mirrors upstream's
+        // shared-Vars semantics where per-section settings shadow the
+        // active defaults until the next `]pop` restores the snapshot.
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let included = format!(
+            "[override-mod]\npath = {}\nuse chroot = yes\n",
+            path.display(),
+        );
+        let include_file = write_config(&included);
+
+        let main_config = format!(
+            "use chroot = no\n&include {}\n",
+            include_file.path().display(),
+        );
+        let main_file = write_config(&main_config);
+
+        let result = parse_config_modules(main_file.path()).expect("parse succeeds");
+        let module = result
+            .modules
+            .iter()
+            .find(|m| m.name == "override-mod")
+            .expect("override-mod present");
+        assert!(
+            module.use_chroot,
+            "per-module use chroot must override inherited parent default",
+        );
+    }
+
+    #[test]
     fn parse_amp_merge_directive_with_equals() {
         // upstream: params.c - `&merge` is the bare-include variant; the
         // optional '=' separator must also be accepted.

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -290,10 +290,14 @@ fn handle_legacy_session(
 
     let request = request.unwrap_or_default();
 
-    if request == "#list" {
-        // upstream: clientserver.c - the #list handler does NOT send
-        // @RSYNCD: CAP before the module listing. Capabilities are only
-        // sent after module selection during the transfer handshake.
+    if request.is_empty() || request == "#list" {
+        // upstream: clientserver.c:1420 - `if (!*line || strcmp(line,
+        // "#list") == 0) { send_listing(); }` - both an empty module
+        // name (the client connected with `rsync rsync://host/`) and an
+        // explicit `#list` request fall through to the module listing.
+        // The #list handler does NOT send @RSYNCD: CAP before the
+        // listing; capabilities are only sent after module selection
+        // during the transfer handshake.
         if let Some(log) = log_sink.as_ref() {
             log_list_request(log, peer_host.as_deref(), peer_addr);
         }
@@ -307,19 +311,6 @@ fn handle_legacy_session(
             messages,
         )?;
         // FSM: -> Closing after sending the module list and EXIT.
-        _ = conn_state
-            .transition(ConnectionState::Closing)
-            .map_err(transition_error)?;
-    } else if request.is_empty() {
-        write_limited(
-            reader.get_mut(),
-            &mut limiter,
-            HANDSHAKE_ERROR_PAYLOAD.as_bytes(),
-        )?;
-        write_limited(reader.get_mut(), &mut limiter, b"\n")?;
-        messages.write_exit(reader.get_mut(), &mut limiter)?;
-        reader.get_mut().flush()?;
-        // FSM: -> Closing after sending error and EXIT for empty request.
         _ = conn_state
             .transition(ConnectionState::Closing)
             .map_err(transition_error)?;


### PR DESCRIPTION
## Summary

- Restore parent-globals inheritance for modules declared inside an `&include`/`&merge` target so each section finalizes against the includer's `use chroot`, `hosts allow`, secrets file, and incoming/outgoing chmod defaults. Mirrors upstream `loadparm.c::do_section` semantics where the shared `Vars` block carries the parent state across the `]push`/`]pop` boundary in `params.c::Parse`.
- The inheritable defaults flow through dedicated fallback slots on `GlobalParseState` rather than `state.global_*`, leaving the duplicate-detection origin state intact so an include can still redeclare a global without colliding with the parent's directive.
- Treat an empty module request in the legacy `@RSYNCD:` greeting as the module-listing trigger, matching `clientserver.c:1420` (`if (!*line || strcmp(line, "#list") == 0) { send_listing(); }`). The upstream `daemon-config` test runs `rsync rsync://host/` for its second probe and previously got back `@ERROR: daemon functionality is unavailable in this build`.

## Root cause

The upstream test config sets `use chroot = no` in the parent file and then declares `[inc-mod]` via `&include`. Each included file was being parsed against a freshly-zeroed `GlobalParseState`, so the included module finalized with `use_chroot = true` (the rsync default). The daemon then attempted `chroot()` on the module path during the transfer, failed under a non-root listen, and corrupted the multiplex stream - the receiver reported `unexpected tag 92 [Receiver]`.

## Test plan

- Added `parse_amp_include_inherits_parent_globals_for_included_module` and `parse_amp_include_module_overrides_inherited_default` to `crates/daemon/src/daemon/sections/config_parsing/tests.rs`. The first asserts the parent's `use chroot = no` and `hosts allow` propagate into a module declared via `&include` while the module's own `read only = yes` still wins. The second asserts that a per-module `use chroot = yes` inside the include still overrides the inherited parent default.
- Verified the upstream `daemon-config` testsuite (`runtests.py --use-tcp daemon-config`) now passes against the patched binary; the same test still fails on master with `unexpected tag 92 [Receiver]`.
- Re-ran the adjacent daemon upstream tests (`daemon-access`, `daemon-access-ip`, `daemon-path-root-read`, `daemon-filter`) and confirmed they still pass. The pre-existing `daemon` and `daemon-refuse` failures reproduce on master too and are unrelated to this change.