### PR TITLE
docs: fix master broken intra-doc links + private-item warnings

### DIFF
--- a/crates/fast_io/src/io_uring/buffer_ring/allocator.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring/allocator.rs
@@ -293,14 +293,14 @@ impl BgidAllocator {
     /// Allocates up to `count` bgids in a single free-list lock acquisition.
     ///
     /// The hot per-thread bgid-lease path (IUR-3.e) batches allocation so the
-    /// process-wide [`bgid_free_list`] mutex is acquired once per slice
+    /// process-wide `bgid_free_list` mutex is acquired once per slice
     /// instead of once per id. The returned vector contains as many ids as
     /// were available: it is shorter than `count` only when the namespace
     /// drains mid-batch, in which case the caller can either fall back to
     /// the plain `recv`/`read` path or retry once leased ids are returned.
     ///
-    /// Each returned id participates in [`PEAK_USED`] and
-    /// [`maybe_warn_namespace_pressure`] exactly as if it had been issued
+    /// Each returned id participates in `PEAK_USED` and
+    /// `maybe_warn_namespace_pressure` exactly as if it had been issued
     /// through [`allocate`](Self::allocate), so operator-facing metrics
     /// remain consistent.
     ///
@@ -373,7 +373,7 @@ impl BgidAllocator {
     ///
     /// Mirror image of [`allocate_batch`](Self::allocate_batch): used by
     /// [`super::super::bgid_lease::BgidLease`]'s `Drop` to return every id
-    /// it owned without paying the [`bgid_free_list`] mutex per id. Each
+    /// it owned without paying the `bgid_free_list` mutex per id. Each
     /// duplicate id present in the input or already in the free-list is
     /// dropped silently to preserve the no-duplicates invariant documented
     /// on [`deallocate`](Self::deallocate).

--- a/crates/fast_io/src/io_uring/buffer_ring/mod.rs
+++ b/crates/fast_io/src/io_uring/buffer_ring/mod.rs
@@ -100,7 +100,7 @@ struct IoUringBuf {
 
 /// Validates a [`BufferRingConfig`] for use with the Linux backend.
 ///
-/// The plain-data [`BufferRingConfig`] lives in [`crate::io_uring_common`]
+/// The plain-data [`BufferRingConfig`] lives in `io_uring_common`
 /// so the non-Linux stub can expose the identical field layout; this
 /// validator is the only Linux-only behaviour and stays here next to the
 /// rest of the ring construction code.

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -56,7 +56,7 @@ static SQPOLL_FALLBACK: AtomicBool = AtomicBool::new(false);
 ///
 /// Set by [`set_sqpoll_disabled_by_policy`] when the CLI parser sees
 /// `--no-io-uring-sqpoll`. Every ring construction site
-/// ([`IoUringConfig::build_ring`] and the session-pool ring builder in
+/// (`IoUringConfig::build_ring` and the session-pool ring builder in
 /// `session_pool.rs`) consults this flag before calling
 /// `io_uring::IoUring::builder().setup_sqpoll(...)`. When set, the SQPOLL
 /// kthread is never requested, even if a particular `IoUringConfig` has
@@ -213,7 +213,7 @@ pub mod config_detail {
 /// 1. Running on Linux
 /// 2. Kernel version is 5.6 or later (parsed from `uname().release`)
 /// 3. `io_uring_setup(2)` succeeds - not blocked by seccomp or container runtime
-/// 4. The [`DISABLE_ENV`] environment variable is unset (or not truthy)
+/// 4. The `DISABLE_ENV` (`OC_RSYNC_DISABLE_IOURING`) environment variable is unset (or not truthy)
 ///
 /// The kernel probe result is cached after the first call. The environment
 /// variable is consulted on every call so tests and operators can force the
@@ -357,7 +357,7 @@ pub use crate::io_uring_common::IoUringConfig;
 
 /// Linux-only ring-construction methods for the shared [`IoUringConfig`].
 ///
-/// The plain-data struct lives in [`crate::io_uring_common`] so the
+/// The plain-data struct lives in `io_uring_common` so the
 /// non-Linux stub can expose the identical field layout without duplicating
 /// the definition. The `build_ring` method below is the only platform-gated
 /// behaviour: it requires the `io_uring` crate which is Linux-only.

--- a/crates/fast_io/src/io_uring/registered_buffers/mod.rs
+++ b/crates/fast_io/src/io_uring/registered_buffers/mod.rs
@@ -70,7 +70,7 @@
 //!
 //! - `registry` - the [`RegisteredBufferGroup`] coordinator, slot allocator,
 //!   and [`RegisteredBufferSlot`] handle.
-//! - `stats` - re-exports the telemetry types from [`crate::io_uring_common`].
+//! - `stats` - re-exports the telemetry types from `io_uring_common`.
 //! - `submit` - `ReadFixed`/`WriteFixed` batch submission helpers and the
 //!   [`RegisteredBufferSlotInfo`] passed between callers and helpers.
 

--- a/crates/fast_io/src/io_uring/send_zc.rs
+++ b/crates/fast_io/src/io_uring/send_zc.rs
@@ -68,7 +68,7 @@ static SEND_ZC_SUPPORTED: AtomicI8 = AtomicI8::new(0);
 /// Returns `true` when the running kernel advertises `IORING_OP_SEND_ZC`.
 ///
 /// Uses `IORING_REGISTER_PROBE` on a throwaway 4-entry ring, mirroring the
-/// `count_supported_ops` cache in [`super::config`]. Distros backport features
+/// `count_supported_ops` cache in `super::config`. Distros backport features
 /// and container runtimes lie about kernel versions, so the opcode probe is
 /// preferred over a `uname()` floor check.
 ///

--- a/crates/fast_io/src/io_uring/session_pool.rs
+++ b/crates/fast_io/src/io_uring/session_pool.rs
@@ -3,7 +3,7 @@
 //! # Why
 //!
 //! Today each disk-batch, file-writer, and file-reader builds its own ring via
-//! [`IoUringConfig::build_ring`]. Per-construction the cost is small, but at
+//! `IoUringConfig::build_ring`. Per-construction the cost is small, but at
 //! the daemon-session level it stacks: bursty connections pay
 //! `io_uring_setup(2)` plus optional `IORING_REGISTER_*` calls on every
 //! short-lived consumer. The session ring pool amortises that cost by holding
@@ -81,7 +81,7 @@ pub struct SessionPoolConfig {
     /// `IORING_SETUP_SQPOLL` enables [`setup_sqpoll`] with
     /// [`SessionPoolConfig::sqpoll_idle_ms`]. Unrecognised bits are ignored;
     /// callers that need exotic flags should construct the ring directly via
-    /// [`IoUringConfig::build_ring`](crate::io_uring::IoUringConfig::build_ring).
+    /// `IoUringConfig::build_ring`.
     ///
     /// [`setup_iopoll`]: io_uring::Builder::setup_iopoll
     /// [`setup_sqpoll`]: io_uring::Builder::setup_sqpoll

--- a/crates/fast_io/src/io_uring/socket_writer.rs
+++ b/crates/fast_io/src/io_uring/socket_writer.rs
@@ -105,7 +105,7 @@ impl IoUringSocketWriter {
     }
 
     /// Returns `true` when this writer will attempt `IORING_OP_SEND_ZC` for
-    /// payloads at or above [`SEND_ZC_MIN_BYTES`]. Exposed for diagnostics
+    /// payloads at or above `SEND_ZC_MIN_BYTES`. Exposed for diagnostics
     /// and tests; the production hot path consults the field directly.
     #[must_use]
     pub fn send_zc_active(&self) -> bool {

--- a/crates/fast_io/src/io_uring_common.rs
+++ b/crates/fast_io/src/io_uring_common.rs
@@ -2,7 +2,7 @@
 //!
 //! This module compiles on every target and hosts the plain-data definitions
 //! shared by both the Linux io_uring backend (`crate::io_uring`) and the
-//! portable fallback ([`crate::io_uring_stub`]). Centralising these
+//! portable fallback (`io_uring_stub`). Centralising these
 //! definitions removes the mechanical duplication that previously forced the
 //! stub to redeclare every config struct, every UAPI constant, and every
 //! enum variant just so cross-platform callers compiled without `cfg`-gating.
@@ -529,8 +529,8 @@ impl RegisteredBufferStatus {
 
 /// Cross-platform contract for an io_uring-style I/O backend.
 ///
-/// Implemented by the real Linux backend ([`crate::io_uring`]) and the no-op
-/// stub ([`crate::io_uring_stub`]). The trait captures the small set of
+/// Implemented by the real Linux backend (`io_uring`) and the no-op
+/// stub (`io_uring_stub`). The trait captures the small set of
 /// runtime queries that callers need without binding them to a specific
 /// platform's concrete reader/writer types - those types still live in their
 /// respective modules and are surfaced through the existing crate-level

--- a/crates/fast_io/src/io_uring_stub/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/buffer_ring.rs
@@ -1,7 +1,7 @@
-//! Stub provided-buffer ring mirroring [`crate::io_uring::buffer_ring`].
+//! Stub provided-buffer ring mirroring `io_uring::buffer_ring`.
 //!
 //! Re-exports the shared [`BufferRingConfig`] and [`BufferRingError`] from
-//! [`crate::io_uring_common`] and supplies the opaque [`BufferRing`] /
+//! `io_uring_common` and supplies the opaque [`BufferRing`] /
 //! [`BgidAllocator`] handles that only exist as compile-time placeholders
 //! here.
 

--- a/crates/fast_io/src/io_uring_stub/config.rs
+++ b/crates/fast_io/src/io_uring_stub/config.rs
@@ -1,4 +1,4 @@
-//! Stub config / availability detection mirroring [`crate::io_uring::config`].
+//! Stub config / availability detection mirroring `io_uring::config`.
 //!
 //! Every entry point reports the backend as unavailable on this platform.
 

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -8,13 +8,13 @@
 //! - The `io_uring` cargo feature is not enabled
 //!
 //! All cross-platform plain-data types (configs, kernel UAPI constants, error
-//! enums, telemetry structs) live in [`crate::io_uring_common`] so they
+//! enums, telemetry structs) live in `io_uring_common` so they
 //! compile identically on every target. This module hosts only the
 //! opaque-handle types and "always Unsupported" entry points that are unique
 //! to the stub backend - which is the only thing the Linux backend cannot
 //! share with us.
 //!
-//! Submodule layout mirrors [`crate::io_uring`] so cross-platform call sites
+//! Submodule layout mirrors `io_uring` so cross-platform call sites
 //! can import the same paths regardless of which backend is compiled.
 
 #![allow(dead_code)]

--- a/crates/fast_io/src/io_uring_stub/registered_buffers.rs
+++ b/crates/fast_io/src/io_uring_stub/registered_buffers.rs
@@ -1,5 +1,5 @@
 //! Stub registered-buffer module mirroring
-//! [`crate::io_uring::registered_buffers`]. Not available on this platform.
+//! `io_uring::registered_buffers`. Not available on this platform.
 
 pub use crate::io_uring_common::{RegisteredBufferStats, RegisteredBufferStatus};
 use std::io;

--- a/crates/fast_io/src/lsm.rs
+++ b/crates/fast_io/src/lsm.rs
@@ -107,7 +107,7 @@ pub fn has_mandatory_lsm() -> bool {
 }
 
 /// Returns `true` iff `lsms` contains at least one name in
-/// [`MANDATORY_LSM_NAMES`]. Pure function exposed for testing.
+/// `MANDATORY_LSM_NAMES`. Pure function exposed for testing.
 #[must_use]
 pub fn classify_mandatory(lsms: Option<&[String]>) -> bool {
     let Some(lsms) = lsms else {

--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -11,7 +11,7 @@
 //! Container runtimes (Docker pre-20.10.2, gVisor), seccomp profiles, and
 //! cgroup v2 device controllers can silently block `io_uring_setup(2)`.
 //! This module detects these restrictions once at startup via the cached
-//! probe in [`crate::io_uring::config`] and provides user-visible messages.
+//! probe in `io_uring::config` and provides user-visible messages.
 
 use crate::io_uring;
 #[cfg(target_os = "linux")]
@@ -26,7 +26,7 @@ use crate::splice::is_splice_available;
 /// Reason io_uring is restricted or unavailable on this system.
 ///
 /// Returned by [`detect_io_uring_restriction`]. The variants map onto the
-/// five outcomes of the startup probe in [`crate::io_uring::config`] but
+/// five outcomes of the startup probe in `io_uring::config` but
 /// are exposed as a public enum so callers (CLI `--io-uring-status`,
 /// daemon log) can act on them without parsing strings.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,7 +80,7 @@ impl std::fmt::Display for IoUringRestriction {
 
 /// Detects whether io_uring is restricted and why.
 ///
-/// Uses the cached probe result from [`crate::io_uring::config`] (which
+/// Uses the cached probe result from `io_uring::config` (which
 /// runs once per process), so this function is cheap to call repeatedly.
 /// On non-Linux platforms or without the `io_uring` feature, returns a
 /// compile-time-known restriction without any runtime cost.

--- a/crates/fast_io/src/win_path.rs
+++ b/crates/fast_io/src/win_path.rs
@@ -25,7 +25,7 @@
 //! where a short path that happens to grow at runtime (e.g. via appending a
 //! filename) silently loses long-path support. The owned-path cost is paid
 //! only on paths that actually need conversion; already-prefixed paths and
-//! all non-Windows inputs return a [`Cow::Borrowed`].
+//! all non-Windows inputs return a [`std::borrow::Cow::Borrowed`].
 
 use std::borrow::Cow;
 use std::path::Path;

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -101,7 +101,7 @@ impl DeleteStats {
     /// # Errors
     ///
     /// Returns an error if reading from the stream fails or if any field
-    /// exceeds [`MAX_WIRE_DEL_STAT`].
+    /// exceeds `MAX_WIRE_DEL_STAT`.
     pub fn read_from<R: Read + ?Sized>(reader: &mut R) -> io::Result<Self> {
         use crate::varint::read_varint;
 


### PR DESCRIPTION
## Summary

Resolves the Pages workflow's `Build rustdoc` failure on master HEAD
(run [27337833707](https://github.com/oferchen/rsync/actions/runs/27337833707/job/80766967200))
under `#![deny(rustdoc::broken_intra_doc_links)]`.

### Hard errors fixed (4)

- `unresolved link to \`Cow::Borrowed\`` in `fast_io::win_path` — switched
  to fully-qualified `std::borrow::Cow::Borrowed`.
- `unresolved link to \`crate::io_uring_stub\`` — dropped doc link; the
  module is mounted as `io_uring` via `#[path]` so the `io_uring_stub`
  name does not exist as a public path.
- `unresolved link to \`crate::io_uring::config\`` (×2) — dropped doc
  link; `mod config` inside `io_uring` is private and cannot be reached
  from public docs.

### `private_intra_doc_links` warnings fixed (11)

Each public-doc reference to a private item was switched to
backtick-only code form. No `#[allow(rustdoc::...)]` waivers were added
(per the project's no-waivers rule):

- `allocate_batch` / `deallocate_batch` → `bgid_free_list`, `PEAK_USED`,
  `maybe_warn_namespace_pressure`
- `is_io_uring_available` → `DISABLE_ENV`
- `registered_buffers` → `crate::io_uring_common`
- `is_supported` → `super::config`
- `session_pool` / `flags` → `IoUringConfig::build_ring`
- `send_zc_active` → `SEND_ZC_MIN_BYTES`
- `classify_mandatory` → `MANDATORY_LSM_NAMES`
- `protocol::DeleteStats::read_from` → `MAX_WIRE_DEL_STAT`

## Test plan

- [ ] `Pages / Build rustdoc` step passes on CI (the only check this PR
      targets).
- [ ] All other required checks (fmt+clippy, nextest stable, Windows,
      macOS, Linux musl) remain green — no code or behaviour changes,
      only rustdoc surface.