### PR TITLE
fix(transfer): use modern NDX_DONE encoding in proto31 goodbye flush test

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2303,8 +2303,7 @@ mod legacy_goodbye_tests {
         // Receiver wire: NDX_DONE + final NDX_DONE in modern (proto >= 30)
         // single-byte encoding. The legacy 4-byte LE form is only valid for
         // protocol < 30; using it here would decode as -256 instead of -1.
-        let receiver_input =
-            [NDX_DONE_MODERN.as_slice(), NDX_DONE_MODERN.as_slice()].concat();
+        let receiver_input = [NDX_DONE_MODERN.as_slice(), NDX_DONE_MODERN.as_slice()].concat();
         let mut reader = Cursor::new(receiver_input);
 
         let mut output = FlushTrackingWriter::default();

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2159,8 +2159,14 @@ mod legacy_goodbye_tests {
     use super::*;
     use protocol::codec::{MonotonicNdxWriter, create_ndx_codec};
 
-    /// NDX_DONE as 4-byte little-endian (-1 = 0xFFFFFFFF).
+    /// NDX_DONE as 4-byte little-endian (-1 = 0xFFFFFFFF), used by the legacy
+    /// codec for protocol < 30.
     const NDX_DONE_LE: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
+
+    /// NDX_DONE as encoded by the modern (protocol >= 30) codec.
+    ///
+    /// upstream io.c:2259-2262 - single 0x00 byte with no side effects.
+    const NDX_DONE_MODERN: [u8; 1] = [0x00];
 
     /// Creates a `GeneratorContext` for a specific protocol version.
     fn generator_for(protocol_version: u8) -> GeneratorContext {
@@ -2294,8 +2300,11 @@ mod legacy_goodbye_tests {
         config.do_stats = false;
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
-        // Receiver wire: NDX_DONE + final NDX_DONE.
-        let receiver_input = [NDX_DONE_LE.as_slice(), NDX_DONE_LE.as_slice()].concat();
+        // Receiver wire: NDX_DONE + final NDX_DONE in modern (proto >= 30)
+        // single-byte encoding. The legacy 4-byte LE form is only valid for
+        // protocol < 30; using it here would decode as -256 instead of -1.
+        let receiver_input =
+            [NDX_DONE_MODERN.as_slice(), NDX_DONE_MODERN.as_slice()].concat();
         let mut reader = Cursor::new(receiver_input);
 
         let mut output = FlushTrackingWriter::default();
@@ -2305,9 +2314,9 @@ mod legacy_goodbye_tests {
         ctx.handle_goodbye(&mut reader, &mut output, &mut ndx_read, &mut ndx_write)
             .expect("goodbye completes");
 
-        // The wire payload must end with the NDX_DONE marker bytes.
+        // The wire payload must end with the NDX_DONE marker byte.
         assert!(
-            output.buffer.ends_with(&NDX_DONE_LE),
+            output.buffer.ends_with(&NDX_DONE_MODERN),
             "wire output must end with NDX_DONE: {:?}",
             output.buffer
         );


### PR DESCRIPTION
## Summary

`generator::tests::legacy_goodbye_tests::handle_goodbye_proto31_flushes_ndx_done_before_close` was added in commit a3bc2cbd2 (UTS-15.c) but uses the **legacy** 4-byte LE `NDX_DONE` wire form (`0xFFFFFFFF`) while exercising a protocol-31 codec. The modern codec (protocol >= 30) encodes `NDX_DONE` as a single `0x00` byte (upstream `io.c:2259-2262`), so the first `0xFF` is parsed as a negative-value sentinel and the following `0xFF` as a delta byte, yielding `-256` instead of `-1`.

`handle_goodbye` fails before any production flush is reached:

```
expected goodbye NDX_DONE (-1) from receiver, got -256 at goodbye.rs(73) [sender=0.6.3]
```

This patch teaches the test fixture about the modern wire form. The production flush is already correct:

- `crates/transfer/src/generator/transfer/goodbye.rs:101-102` - `writer.flush()` immediately after `write_ndx_done` inside the extended-goodbye branch.
- `crates/transfer/src/generator/transfer/orchestrator.rs:142-146` - post-goodbye tail `writer.flush()` mirroring upstream `main.c:912` / `main.c:968` `io_flush(FULL_FLUSH)`, with `is_early_close_error` tolerance shared with the symmetric receiver-side flush.

This is the same `is_early_close_error` re-exported at the `transfer` crate root and reused by the receiver-side tail flush in #5674.

## Why this matters

Master HEAD `6b8aa7fba` was failing this test on every Linux nextest cell. Cited evidence:

- `nextest (stable)` master job 80769150507 - https://github.com/oferchen/rsync/actions/runs/27337833728/job/80769150507
- `Feature flag combinations / io_uring (linux)` master job 80769151021 - same failure mode (`expected goodbye NDX_DONE (-1), got -256`).
- `Feature flag combinations / compression (linux)` master job 80769151039 - same failure mode.

Every open PR inherited the red signal through the Feature flag combinations / Linux cells until this is fixed.

## Test plan

- [x] `NDX_DONE_MODERN = [0x00]` introduced alongside the existing `NDX_DONE_LE` constant; both are now documented with the protocol-version range they apply to.
- [x] The proto-31 fixture (`receiver_input`) and the `ends_with` assertion both switch to `NDX_DONE_MODERN` so the test reaches the flush assertions it was authored to verify (`flushes >= 1`, `last_op_was_flush == true`).
- [x] Existing proto-28 / proto-29 legacy goodbye tests (`handle_goodbye_proto28_reads_single_ndx_done`, `handle_goodbye_proto29_reads_single_ndx_done`, `handle_goodbye_proto28_rejects_non_ndx_done`, `handle_goodbye_proto28_no_del_stats_sent`) continue to use `NDX_DONE_LE`, which is the correct wire form for protocol < 30.
- [x] No production change. The flush contract guarded by the test was already in place from a3bc2cbd2 (generator orchestrator tail flush) and #5674 (receiver tail flush) - this only repairs the test fixture so it actually exercises that code path.

## References

- Upstream `io.c:2259-2262` - modern codec encodes `NDX_DONE` as single `0x00`.
- Upstream `main.c:875-906` - `read_final_goodbye()` extended-goodbye round-trip for protocol >= 31.
- Upstream `main.c:912` / `main.c:968` - `io_flush(FULL_FLUSH)` before return from `client_run()` and `do_server_sender()`.
- Prior art: a3bc2cbd2 (UTS-15.c) added the production tail flush this test was meant to guard; #5674 added the symmetric receiver-side tail flush sharing the same `is_early_close_error` predicate.