### PR TITLE
ci(send_zc): forward iouring-send-zc feature through bin crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,13 @@ sender-inc-recurse = ["core/sender-inc-recurse", "transfer/sender-inc-recurse"]
 # Trade-offs: Linux-only, requires modern kernel, adds ~100KB to binary
 io_uring = ["transfer/io_uring", "fast_io/io_uring"]
 
+# SEND_ZC dispatch for io_uring sockets (Linux 6.0+) - IORING_OP_SEND_ZC
+# Requirements: Linux kernel 6.0+ (runtime probe with graceful fallback to
+# plain IORING_OP_SEND on older kernels). See SZP-3 / send-zc-5-15-lts.yml.
+# Forwards to fast_io's iouring-send-zc feature, which implicitly enables
+# io_uring as well.
+iouring-send-zc = ["fast_io/iouring-send-zc"]
+
 # IOCP (I/O Completion Ports) for Windows - async file I/O
 # Requirements: Windows Vista+ (runtime detection, automatic fallback)
 # Benefits: Overlapped async reads/writes via kernel completion ports


### PR DESCRIPTION
## Summary

The `SEND_ZC 5.15 LTS fallback` workflow (`send-zc-5-15-lts.yml`, SZP-3 #3303) has been failing on every PR that triggers it with:

```
error: the package 'bin' does not contain this feature: iouring-send-zc
##[error]iouring-send-zc feature not reported as 'on' in --version output
```

The workflow invokes both `cargo build --workspace --features iouring-send-zc` and `cargo run --features iouring-send-zc -- --version` from the repo root. Those resolve against the root `bin` crate, which only forwarded `io_uring`, `iocp`, and `copy_file_range` to `fast_io`. The `iouring-send-zc` feature was defined only on `fast_io`, so cargo rejected the flag at the root.

This adds a single passthrough on the root `bin` crate:

```toml
iouring-send-zc = ["fast_io/iouring-send-zc"]
```

mirroring the existing `io_uring`/`iocp`/`copy_file_range` forwarding pattern. `fast_io`'s `iouring-send-zc` already implicitly enables `io_uring`, so no other wiring changes are needed. Runtime behavior is unchanged for builds that do not pass `--features iouring-send-zc`.

## Context

- Failing CI run: https://github.com/oferchen/rsync/actions/runs/27342043297/job/80781065607
- Workflow source: `.github/workflows/send-zc-5-15-lts.yml`
- The workflow is non-required (`continue-on-error: true`) but the failure clutters every PR run's checks panel and obscures real SEND_ZC fallback regressions.

## Scope

Surgical: one feature declaration in the root `Cargo.toml`. No code changes, no behavior changes for default builds.

## Test plan

- [ ] `send-zc-5-15-lts` workflow runs to completion on this PR.
- [ ] The `iouring-send-zc feature compiled in` branch of the verify step is reachable (i.e. cargo no longer aborts before the version output is captured).
- [ ] Existing required checks (fmt+clippy, nextest, Windows, macOS, Linux musl) remain green - the new feature is opt-in and unused by default builds.