### PR TITLE
fix(fast_io): accept forward-slash UNC paths in to_extended_path

### DIFF
--- a/crates/fast_io/src/win_path.rs
+++ b/crates/fast_io/src/win_path.rs
@@ -72,7 +72,15 @@ fn to_extended_path_windows(p: &Path) -> Cow<'_, Path> {
         return Cow::Borrowed(p);
     }
 
-    if let Some(rest) = raw.strip_prefix(r"\\") {
+    // UNC paths can arrive with either backslash (`\\server\share`) or
+    // forward-slash (`//server/share`) separators because Win32 accepts both
+    // in unprefixed paths and our callers may receive paths in either form
+    // from cross-platform sources. The `\\?\UNC\` prefix itself disables
+    // kernel slash conversion, so the suffix must be normalised here.
+    if let Some(rest) = raw
+        .strip_prefix(r"\\")
+        .or_else(|| raw.strip_prefix("//"))
+    {
         // UNC path: \\server\share\... -> \\?\UNC\server\share\...
         let normalised: String = rest
             .chars()


### PR DESCRIPTION
## Summary

- `to_extended_path` only stripped `\\` as the UNC prefix, so forward-slash UNC inputs like `//server/share/file` fell through to the identity branch instead of becoming `\\?\UNC\server\share\file`.
- That regressed `win_path::tests::forward_slashes_converted_for_unc_paths` on the Windows nextest cell (the test was added in PR #5639 alongside the production code and never exercised the branch it covers).
- Strip either `\\` or `//` as the UNC anchor so both separator styles produce the documented extended-prefix output. Backslash-style UNC paths, drive-letter paths, already-prefixed paths, and identity branches are unchanged.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) on Linux
- [ ] CI: Windows nextest cell - confirms `forward_slashes_converted_for_unc_paths` now passes
- [ ] CI: macOS nextest cell
- [ ] CI: Linux musl