### PR TITLE
test(transfer): trigger load_window in overlap-shrink regression

### DIFF
--- a/crates/transfer/src/map_file/tests.rs
+++ b/crates/transfer/src/map_file/tests.rs
@@ -509,13 +509,15 @@ fn load_window_overlap_shrink_preserves_data() {
     assert_eq!(map.window_len, 4096);
 
     // Load 2: aligned_start=2048 (align_down(3000)), remaining=2952,
-    // window_size=min(4096, 2952)=2952. The overlap branch fires because
+    // window_size=min(4096, 2952)=2952. The requested range [3000, 4500)
+    // crosses the old window's end (4096), so `is_in_window` returns false
+    // and `load_window` is entered. The overlap branch fires because
     // [2048, 5000) overlaps [0, 4096) and extends past old_end. With the
     // never-shrink invariant in place, copy_within(2048..4096, 0) shifts
     // the tail of the old window in place; the trailing bytes are read
     // from disk into buffer[2048..2952]; window_len clamps to 2952.
-    let data = map.map_ptr(3000, 1000).unwrap();
-    let expected: Vec<u8> = (3000..4000).map(|i| (i % 256) as u8).collect();
+    let data = map.map_ptr(3000, 1500).unwrap();
+    let expected: Vec<u8> = (3000..4500).map(|i| (i % 256) as u8).collect();
     assert_eq!(data, &expected[..]);
     assert_eq!(map.window_start, 2048);
     assert_eq!(map.window_len, 2952);


### PR DESCRIPTION
## Summary

- `map_file::tests::load_window_overlap_shrink_preserves_data` was failing on every Linux nextest cell (stable/beta/nightly) and Linux musl (stable/beta/nightly).
- The test asserted post-conditions about `window_start` / `window_len` that only hold if `load_window` runs, but its `map_ptr(3000, 1000)` request fit entirely inside the existing `[0, 4096)` window, so `is_in_window` short-circuited and the window never slid.
- Extend the request to `map_ptr(3000, 1500)` so `[3000, 4500)` crosses the prior window's upper bound, forcing `load_window` into the overlap-shrink branch the test was written to cover. Update the expected slice accordingly.

## Root cause

The test was introduced alongside the never-shrink invariant fix in `BufferedMap::load_window` (`buffer.resize(window_size.max(buffer.len()), 0)`). The production change is correct and already shipped on master; only the test harness was miswired - the chosen request length never triggered a window reload, so the `assert_eq!(map.window_start, 2048)` always failed. No production code change is needed.

## Test plan

- [x] Local trace of `map_ptr(3000, 1500)` confirms `load_window` enters the overlap-shrink branch: `aligned_start=2048`, `window_size=2952`, `reuse_len=2048`, `copy_within(2048..4096, 0)`, buffer remains at length 4096 (never-shrink invariant), trailing 904 bytes read into `buffer[2048..2952]`, `window_len` clamps to 2952.
- [x] Returned slice `buffer[952..2452]` equals file bytes `[3000, 4500)`.
- [x] Follow-up `map_ptr(2048, 2952)` returns file bytes `[2048, 5000)` end-to-end, exercising both the relocated head and the freshly-read tail.
- [ ] Linux nextest (stable / beta / nightly) green on this PR.
- [ ] Linux musl (stable / beta / nightly) green on this PR.