### PR TITLE
style(fast_io): fmt win_path.rs UNC strip-prefix chain

### DIFF
--- a/crates/fast_io/src/win_path.rs
+++ b/crates/fast_io/src/win_path.rs
@@ -77,10 +77,7 @@ fn to_extended_path_windows(p: &Path) -> Cow<'_, Path> {
     // in unprefixed paths and our callers may receive paths in either form
     // from cross-platform sources. The `\\?\UNC\` prefix itself disables
     // kernel slash conversion, so the suffix must be normalised here.
-    if let Some(rest) = raw
-        .strip_prefix(r"\\")
-        .or_else(|| raw.strip_prefix("//"))
-    {
+    if let Some(rest) = raw.strip_prefix(r"\\").or_else(|| raw.strip_prefix("//")) {
         // UNC path: \\server\share\... -> \\?\UNC\server\share\...
         let normalised: String = rest
             .chars()


### PR DESCRIPTION
## Summary
- Collapse the `raw.strip_prefix(r"\\").or_else(|| raw.strip_prefix("//"))` chain in `to_extended_path_windows` onto a single line so it matches rustfmt output.
- Restores fmt+clippy CI cleanliness after the admin-merge of #5691 shipped an unformatted hunk on master.

## Test plan
- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes on Linux/macOS/Windows