### PR TITLE
fix(daemon): join module-relative sender sources with `/` on Windows

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -413,28 +413,30 @@ fn resolve_sender_sources(
         }
         // Preserve the trailing slash so the sender can detect a dotdir-style
         // source (upstream flist.c:2312-2322 appends `.` and sets DOTDIR_NAME
-        // for any `fbuf[len-1] == '/'`). PathBuf collapses trailing slashes
-        // during `join`, so we re-append the byte after the join when present.
+        // for any `fbuf[len-1] == '/'`). Upstream rsync joins module-relative
+        // paths with a literal `/` regardless of host OS (util1.c pathjoin()),
+        // so build the result the same way instead of going through
+        // PathBuf::join, which on Windows inserts `\` and on macOS leaves
+        // a trailing `/` that doubles when we re-append.
         let trailing = tail.ends_with('/') || tail.ends_with('\\');
-        let joined = module_path.join(trimmed);
-        // Path::join collapses a trailing slash on Linux but preserves one
-        // on macOS, so re-append only when the joined path doesn't already
-        // end with the separator. Otherwise the macOS path emits a double
-        // slash that diverges from upstream's DOTDIR_NAME match in
-        // flist.c:2312-2322.
-        let joined = if trailing {
-            let bytes = joined.as_os_str().as_encoded_bytes();
-            if bytes.last().is_some_and(|b| *b == b'/' || *b == b'\\') {
-                joined
-            } else {
-                let mut buf = joined.into_os_string();
-                buf.push("/");
-                std::path::PathBuf::from(buf)
-            }
-        } else {
-            joined
-        };
-        sources.push(joined);
+        let mut buf = module_path.as_os_str().to_owned();
+        let needs_leading_sep = !buf
+            .as_encoded_bytes()
+            .last()
+            .is_some_and(|b| *b == b'/' || *b == b'\\');
+        if needs_leading_sep {
+            buf.push("/");
+        }
+        buf.push(trimmed);
+        if trailing
+            && !buf
+                .as_encoded_bytes()
+                .last()
+                .is_some_and(|b| *b == b'/' || *b == b'\\')
+        {
+            buf.push("/");
+        }
+        sources.push(std::path::PathBuf::from(buf));
     }
     if all_empty {
         Some(vec![module_path.to_path_buf()])


### PR DESCRIPTION
## Summary

`resolve_sender_sources` went through `PathBuf::join` to attach the client's positional tail to the daemon module root. On Windows that inserts a `\` separator, so input `upload/d1/d2/` produces `/srv/upload\d1/d2/`, which diverges from upstream's `util1.c::pathjoin()` and trips `resolve_sender_sources_preserves_trailing_slash_on_subdir` on every Windows nextest cell.

This blocks every in-flight PR on Windows IOCP, Windows ACL/xattr, daemon-tls, tracing, async, and concurrent-sessions feature cells.

The fix builds the joined path directly from the module-root `OsStr` with a literal `/` separator, matching how upstream rsync names module-relative paths regardless of host OS. The trailing-slash preservation (so the sender's existing DOTDIR_NAME branch triggers correctly per `flist.c:2312-2322`) and the `..` traversal rejection are left intact.

## Test plan

- [x] `resolve_sender_sources_preserves_trailing_slash_on_subdir` produces `/srv/upload/d1/d2/` byte-identical on Linux/macOS/Windows (manual trace).
- [x] `resolve_sender_sources_joins_single_file_subpath_with_module_root` continues to produce `/srv/upload/d1/d2/f2`.
- [x] `resolve_sender_sources_strips_leading_slash_before_join` continues to produce `/srv/upload/d1/d2/f2`.
- [x] `resolve_sender_sources_returns_module_root_*` and the `..` traversal rejection paths are untouched.
- [ ] CI green on the Windows IOCP / ACL+xattr / daemon-tls / tracing / async / concurrent-sessions cells.
- [ ] Linux + macOS nextest still green.

Unblocks Windows cells across the open PR queue.