### PR TITLE
feat(metadata): wire to_extended_path into Windows ACL/xattr handle acquisition (WPC-5'.7)

### DIFF
--- a/crates/metadata/src/windows/reparse.rs
+++ b/crates/metadata/src/windows/reparse.rs
@@ -49,6 +49,7 @@ use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::os::windows::io::AsRawHandle;
 use std::path::Path;
 
+use fast_io::to_extended_path;
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ,
@@ -292,8 +293,14 @@ impl Drop for ReparseHandle {
 /// call. Read access is limited to `FILE_READ_ATTRIBUTES`; sharing is left
 /// permissive (`FILE_SHARE_READ | FILE_SHARE_WRITE`) so we never block a
 /// concurrent enumerator.
+///
+/// The path is first routed through [`fast_io::to_extended_path`] so absolute
+/// drive and UNC inputs gain the `\\?\` extended-length prefix. Without the
+/// prefix, `CreateFileW` rejects paths exceeding the 260-character `MAX_PATH`
+/// cap with `ERROR_PATH_NOT_FOUND`, which would silently break reparse-point
+/// classification on deeply nested trees.
 fn open_reparse_handle(path: &Path) -> io::Result<ReparseHandle> {
-    let wide: Vec<u16> = path
+    let wide: Vec<u16> = to_extended_path(path)
         .as_os_str()
         .encode_wide()
         .chain(std::iter::once(0))

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -4,8 +4,8 @@
 //! The Win32 file APIs reject plain paths above `MAX_PATH` (260 characters)
 //! with `ERROR_PATH_NOT_FOUND` unless the caller opts in to the
 //! extended-length syntax (`\\?\C:\...`). The metadata crate routes every
-//! ACL / xattr boundary through `fast_io::to_extended_path` so deeply
-//! nested trees keep working.
+//! ACL / xattr / reparse-point boundary through `fast_io::to_extended_path`
+//! so deeply nested trees keep working.
 //!
 //! These tests build a 30-segment / 25-char-per-segment directory tree
 //! (~750 absolute characters) and exercise:
@@ -19,6 +19,9 @@
 //!   `metadata::apply_xattrs_from_list`) which fans into the
 //!   `xattr_windows::path_to_wide` / `stream_path_wide` boundaries feeding
 //!   `FindFirstStreamW` and `CreateFileW`.
+//! - The Windows reparse-point classifier (`metadata::windows::classify_path`)
+//!   which routes through `open_reparse_handle` feeding `CreateFileW` with
+//!   `FILE_FLAG_OPEN_REPARSE_POINT`.
 //!
 //! Long-path support is filesystem-dependent: NTFS supports it, FAT32
 //! does not, and SMB / network mounts may reject creation regardless of
@@ -31,6 +34,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use metadata::windows::classify_path;
 use metadata::{apply_xattrs_from_list, read_dacl_sddl, read_xattrs_for_wire, write_dacl_sddl};
 use protocol::xattr::{XattrEntry, XattrList};
 use tempfile::tempdir;
@@ -199,4 +203,31 @@ fn long_path_ads_round_trip() {
         stream_value.as_slice(),
         "ADS payload must round-trip byte-for-byte",
     );
+}
+
+#[test]
+fn long_path_reparse_classifier_acquires_handle() {
+    // The reparse-point classifier opens its target via `CreateFileW` with
+    // `FILE_FLAG_OPEN_REPARSE_POINT`; the path is routed through
+    // `to_extended_path` so deeply nested files do not trip `MAX_PATH`.
+    const TARGET_CHARS: usize = 600;
+
+    let dir = tempdir().expect("create temp dir");
+    let Some(leaf) = try_create_long_tree(dir.path(), TARGET_CHARS) else {
+        return;
+    };
+
+    let file = leaf.join("plain.txt");
+    fs::write(&file, b"payload").expect("seed file in long path");
+    assert!(
+        file.as_os_str().len() >= TARGET_CHARS,
+        "absolute file path must exceed MAX_PATH: got {} chars",
+        file.as_os_str().len(),
+    );
+
+    // Plain regular files have no reparse data; the classifier must
+    // succeed in acquiring the underlying handle through
+    // `to_extended_path` and return without an io::Error. A short-path
+    // `CreateFileW` would surface `ERROR_PATH_NOT_FOUND` at >260 chars.
+    classify_path(&file).expect("classify reparse on long path must succeed");
 }


### PR DESCRIPTION
## Summary

- Wires `fast_io::to_extended_path` into the metadata::windows reparse-point classifier's `open_reparse_handle` so deeply nested paths (>260 chars) no longer fail with `ERROR_PATH_NOT_FOUND` at the `CreateFileW` boundary.
- Audits the rest of the metadata::windows handle-acquisition surface and confirms the existing ACL boundary (`acl_windows::common::to_wide`) and xattr boundary (`xattr_windows::path_to_wide` + `xattr_windows::stream_path_wide`) already route through `to_extended_path`. This commit closes the remaining gap at the reparse classifier site.
- Adds a Windows-only integration test (`long_path_reparse_classifier_acquires_handle`) that builds a >600-character path tree and exercises `metadata::windows::classify_path` on the deepest leaf. The pre-existing `long_path_acl_round_trip` and `long_path_ads_round_trip` tests in the same file already cover the ACL and ADS acquisition sites at the same depth.

## Sites wrapped

- `crates/metadata/src/windows/reparse.rs::open_reparse_handle` (production path). The non-Windows builds keep using the existing `Cow::Borrowed` identity stub, so the call site is zero-cost off Windows.

The existing sites listed here were already wired before this PR and verified by audit:

- `crates/metadata/src/acl_windows/common.rs::to_wide` (feeds `GetNamedSecurityInfoW` / `SetNamedSecurityInfoW`)
- `crates/metadata/src/xattr_windows.rs::path_to_wide` (feeds `FindFirstStreamW`)
- `crates/metadata/src/xattr_windows.rs::stream_path_wide` (feeds `CreateFileW` / `DeleteFileW` on ADS streams)

## Test plan

- [ ] `long_path_acl_round_trip` exercises the ACL read+write path on a >600-char path
- [ ] `long_path_ads_round_trip` exercises the FindFirstStreamW + CreateFileW ADS path on a >600-char path
- [ ] `long_path_reparse_classifier_acquires_handle` exercises the reparse-classifier CreateFileW path on a >600-char path
- [ ] Non-Windows builds remain zero-cost: the stub returns `Cow::Borrowed(path)` and the import compiles away to a no-op identity transform