### PR TITLE
feat(fast_io): log SQPOLL rootless-fallback reason (SQP-LAND.7)

### DIFF
--- a/crates/fast_io/src/container.rs
+++ b/crates/fast_io/src/container.rs
@@ -26,9 +26,10 @@
 //! SQPOLL (and the entire io_uring SQPOLL safety story) is Linux-only.
 //!
 //! See `docs/audits/sqpoll-rootless-detection-status.md` (SQP-LAND.1) for
-//! the gap analysis that motivates this helper. The future SQP-LAND.4
-//! task wires the helper into [`crate::io_uring`] configuration; this
-//! module ships the pure helper only - no call-site changes here.
+//! the gap analysis that motivates this helper. SQP-LAND.4 wired the
+//! helper into [`crate::io_uring`] configuration; SQP-LAND.7 added the
+//! [`rootless_signal`] accessor so the SQPOLL fall-back site can log
+//! which marker triggered the decision.
 
 /// Returns `true` when the current process is running inside a rootless
 /// container or any user namespace where SQPOLL is structurally unable
@@ -40,7 +41,62 @@
 /// On non-Linux targets always returns `false`.
 #[must_use]
 pub fn detect_rootless_container() -> bool {
-    imp::detect_rootless_container()
+    rootless_signal().is_rootless()
+}
+
+/// Which detection signal triggered the rootless verdict.
+///
+/// Returned by [`rootless_signal`] so call sites (notably the SQPOLL
+/// fall-back logger introduced in SQP-LAND.7) can surface the precise
+/// reason a rootless container was detected. Operators in rootless
+/// Podman / Kubernetes can then map the signal back to their environment
+/// (a non-identity `/proc/self/uid_map`, a Podman `.containerenv`
+/// marker, or a Docker `.dockerenv` marker) without having to grep
+/// `/proc` by hand.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RootlessSignal {
+    /// Not in a rootless container. SQPOLL should be attempted normally.
+    NotRootless,
+    /// `/proc/self/uid_map` showed a non-identity mapping - the most
+    /// reliable signal that the process is inside a user namespace.
+    NonIdentityUidMap,
+    /// `/run/.containerenv` is present (Podman convention).
+    PodmanContainerEnv,
+    /// `/.dockerenv` is present (Docker convention).
+    DockerEnv,
+}
+
+impl RootlessSignal {
+    /// Returns a short human-readable label suitable for log output.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NotRootless => "not-rootless",
+            Self::NonIdentityUidMap => "non-identity-uid-map",
+            Self::PodmanContainerEnv => "podman-containerenv",
+            Self::DockerEnv => "docker-env",
+        }
+    }
+
+    /// Returns `true` when the signal indicates a rootless container.
+    #[must_use]
+    pub fn is_rootless(self) -> bool {
+        !matches!(self, Self::NotRootless)
+    }
+}
+
+/// Returns the specific detection signal that triggered (or did not
+/// trigger) the rootless verdict for this process.
+///
+/// Used by SQP-LAND.7 logging at the SQPOLL fall-back site so deployers
+/// can see exactly which marker fired. On non-Linux targets always
+/// returns [`RootlessSignal::NotRootless`].
+///
+/// Like [`detect_rootless_container`], this is cached after the first
+/// invocation.
+#[must_use]
+pub fn rootless_signal() -> RootlessSignal {
+    imp::rootless_signal()
 }
 
 #[cfg(target_os = "linux")]
@@ -48,9 +104,11 @@ mod imp {
     use std::path::Path;
     use std::sync::OnceLock;
 
-    static CACHED: OnceLock<bool> = OnceLock::new();
+    use super::RootlessSignal;
 
-    pub(super) fn detect_rootless_container() -> bool {
+    static CACHED: OnceLock<RootlessSignal> = OnceLock::new();
+
+    pub(super) fn rootless_signal() -> RootlessSignal {
         if let Some(cached) = CACHED.get().copied() {
             return cached;
         }
@@ -71,8 +129,10 @@ mod imp {
     ///
     /// `read_uid_map` returns `Some(contents)` if `/proc/self/uid_map` is
     /// readable, `None` otherwise. `path_exists` checks the well-known
-    /// container marker paths.
-    fn probe_with_reader<F, G>(read_uid_map: F, path_exists: G) -> bool
+    /// container marker paths. The returned [`RootlessSignal`] names the
+    /// first matching marker (or [`RootlessSignal::NotRootless`] when
+    /// nothing triggered) so callers can log a precise reason.
+    fn probe_with_reader<F, G>(read_uid_map: F, path_exists: G) -> RootlessSignal
     where
         F: FnOnce() -> Option<String>,
         G: Fn(&str) -> bool,
@@ -80,15 +140,15 @@ mod imp {
         if let Some(contents) = read_uid_map()
             && !is_identity_uid_map(&contents)
         {
-            return true;
+            return RootlessSignal::NonIdentityUidMap;
         }
         if path_exists("/run/.containerenv") {
-            return true;
+            return RootlessSignal::PodmanContainerEnv;
         }
         if path_exists("/.dockerenv") {
-            return true;
+            return RootlessSignal::DockerEnv;
         }
-        false
+        RootlessSignal::NotRootless
     }
 
     /// Returns `true` when `/proc/self/uid_map` contains exactly the
@@ -119,20 +179,24 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::container::detect_rootless_container;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         #[test]
         fn host_identity_uid_map_is_not_container() {
             let read = || Some(String::from("         0          0 4294967295\n"));
             let exists = |_p: &str| false;
-            assert!(!probe_with_reader(read, exists));
+            assert_eq!(probe_with_reader(read, exists), RootlessSignal::NotRootless);
         }
 
         #[test]
         fn rootless_uid_map_detected() {
             let read = || Some(String::from("         0       1000          1\n"));
             let exists = |_p: &str| false;
-            assert!(probe_with_reader(read, exists));
+            assert_eq!(
+                probe_with_reader(read, exists),
+                RootlessSignal::NonIdentityUidMap
+            );
         }
 
         #[test]
@@ -143,49 +207,61 @@ mod imp {
                 ))
             };
             let exists = |_p: &str| false;
-            assert!(probe_with_reader(read, exists));
+            assert_eq!(
+                probe_with_reader(read, exists),
+                RootlessSignal::NonIdentityUidMap
+            );
         }
 
         #[test]
         fn truncated_range_detected() {
             let read = || Some(String::from("0 0 65536\n"));
             let exists = |_p: &str| false;
-            assert!(probe_with_reader(read, exists));
+            assert_eq!(
+                probe_with_reader(read, exists),
+                RootlessSignal::NonIdentityUidMap
+            );
         }
 
         #[test]
         fn missing_uid_map_falls_through_to_dockerenv() {
             let read = || None;
             let exists = |p: &str| p == "/.dockerenv";
-            assert!(probe_with_reader(read, exists));
+            assert_eq!(probe_with_reader(read, exists), RootlessSignal::DockerEnv);
         }
 
         #[test]
         fn missing_uid_map_falls_through_to_containerenv() {
             let read = || None;
             let exists = |p: &str| p == "/run/.containerenv";
-            assert!(probe_with_reader(read, exists));
+            assert_eq!(
+                probe_with_reader(read, exists),
+                RootlessSignal::PodmanContainerEnv
+            );
         }
 
         #[test]
         fn no_signals_returns_false() {
             let read = || Some(String::from("         0          0 4294967295\n"));
             let exists = |_p: &str| false;
-            assert!(!probe_with_reader(read, exists));
+            assert_eq!(probe_with_reader(read, exists), RootlessSignal::NotRootless);
         }
 
         #[test]
         fn empty_uid_map_falls_through() {
             let read = || Some(String::new());
             let exists = |_p: &str| false;
-            assert!(!probe_with_reader(read, exists));
+            assert_eq!(probe_with_reader(read, exists), RootlessSignal::NotRootless);
         }
 
         #[test]
         fn uid_map_takes_priority_over_markers() {
             let read = || Some(String::from("0 1000 1\n"));
             let exists = |_p: &str| panic!("path probes must not run when uid_map signals");
-            assert!(probe_with_reader(read, exists));
+            assert_eq!(
+                probe_with_reader(read, exists),
+                RootlessSignal::NonIdentityUidMap
+            );
         }
 
         #[test]
@@ -198,6 +274,16 @@ mod imp {
             let exists = |_p: &str| false;
             let _ = probe_with_reader(read, exists);
             assert_eq!(count.load(Ordering::SeqCst), 1);
+        }
+
+        #[test]
+        fn containerenv_marker_takes_priority_over_dockerenv() {
+            let read = || None;
+            let exists = |_p: &str| true;
+            assert_eq!(
+                probe_with_reader(read, exists),
+                RootlessSignal::PodmanContainerEnv
+            );
         }
 
         #[test]
@@ -227,17 +313,46 @@ mod imp {
 
 #[cfg(not(target_os = "linux"))]
 mod imp {
-    pub(super) fn detect_rootless_container() -> bool {
-        false
+    use super::RootlessSignal;
+
+    pub(super) fn rootless_signal() -> RootlessSignal {
+        RootlessSignal::NotRootless
     }
 
     #[cfg(test)]
     mod tests {
-        use super::*;
+        use crate::container::detect_rootless_container;
 
         #[test]
         fn non_linux_always_returns_false() {
             assert!(!detect_rootless_container());
         }
+    }
+}
+
+#[cfg(test)]
+mod signal_tests {
+    use super::*;
+
+    #[test]
+    fn label_is_short_and_human_readable() {
+        assert_eq!(RootlessSignal::NotRootless.label(), "not-rootless");
+        assert_eq!(
+            RootlessSignal::NonIdentityUidMap.label(),
+            "non-identity-uid-map"
+        );
+        assert_eq!(
+            RootlessSignal::PodmanContainerEnv.label(),
+            "podman-containerenv"
+        );
+        assert_eq!(RootlessSignal::DockerEnv.label(), "docker-env");
+    }
+
+    #[test]
+    fn is_rootless_classifies_signals_correctly() {
+        assert!(!RootlessSignal::NotRootless.is_rootless());
+        assert!(RootlessSignal::NonIdentityUidMap.is_rootless());
+        assert!(RootlessSignal::PodmanContainerEnv.is_rootless());
+        assert!(RootlessSignal::DockerEnv.is_rootless());
     }
 }

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -6,9 +6,12 @@
 
 use std::ffi::CStr;
 use std::io;
+use std::sync::Once;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use io_uring::IoUring as RawIoUring;
+
+use crate::container::rootless_signal;
 
 /// Minimum kernel version required for io_uring.
 ///
@@ -89,6 +92,74 @@ pub fn is_sqpoll_disabled_by_policy() -> bool {
 /// other threads.
 pub fn set_sqpoll_disabled_by_policy() {
     SQPOLL_DISABLED_BY_POLICY.store(true, Ordering::Relaxed);
+}
+
+/// One-shot guard so the rootless-fallback log emits once per process.
+///
+/// SQP-LAND.7 wires [`rootless_signal`] into ring construction so we can
+/// skip a doomed SQPOLL setup syscall in rootless containers. The log
+/// itself is informational (configuration decision, not an error), but
+/// daemon workloads build many rings per process and we do not want to
+/// flood operator logs - hence the [`Once`] gate.
+static ROOTLESS_SQPOLL_LOG_ONCE: Once = Once::new();
+
+/// Skip SQPOLL when the process is inside a rootless container.
+///
+/// `CAP_SYS_NICE` is structurally unavailable inside a user namespace
+/// (rootless Podman, Docker with `--userns=...`, Kubernetes with a
+/// `runAsNonRoot` securityContext), so requesting
+/// `IORING_SETUP_SQPOLL` is guaranteed to fail with `EPERM` and leaves
+/// the operator wondering why io_uring performance is degraded. We
+/// short-circuit here and emit one structured info-level log per
+/// process so deployers can map the verdict back to their environment.
+///
+/// Returns `true` when SQPOLL must be suppressed for this build. The
+/// caller stays on the plain-ring path.
+///
+/// See SQP-LAND series (SQP-LAND.3 helper, SQP-LAND.4 wiring,
+/// SQP-LAND.7 observability) and [`crate::container`] for the
+/// detection logic.
+fn should_skip_sqpoll_due_to_rootless() -> bool {
+    rootless_skip_decision(
+        rootless_signal(),
+        &ROOTLESS_SQPOLL_LOG_ONCE,
+        log_rootless_skip,
+    )
+}
+
+/// Pure decision helper for SQP-LAND.7: takes a signal + a one-shot
+/// guard + a log-emitter and returns whether SQPOLL must be skipped.
+///
+/// Split out from [`should_skip_sqpoll_due_to_rootless`] so unit tests
+/// can drive every code path (not-rootless / once-fires /
+/// already-fired) without depending on the process-cached
+/// [`rootless_signal`].
+fn rootless_skip_decision<L>(signal: crate::container::RootlessSignal, once: &Once, log: L) -> bool
+where
+    L: FnOnce(crate::container::RootlessSignal),
+{
+    if !signal.is_rootless() {
+        return false;
+    }
+    once.call_once(|| log(signal));
+    true
+}
+
+/// Default log emitter for the rootless-fallback decision.
+///
+/// Mirrors the IKV-F.1 fallback-log convention (Io target, level 1) so
+/// operators see this alongside the other io_uring decisions under
+/// `--debug=io1`. Kept as a free function so [`rootless_skip_decision`]
+/// can drive it from unit tests via a substitute closure.
+fn log_rootless_skip(signal: crate::container::RootlessSignal) {
+    // SQP-LAND.7: deployer-facing rationale for the SQPOLL skip.
+    logging::debug_log!(
+        Io,
+        1,
+        "io_uring SQPOLL disabled: rootless container detected (signal={}, no CAP_SYS_NICE \
+         available in this user namespace); falling back to standard polling",
+        signal.label()
+    );
 }
 
 /// Returns `true` if SQPOLL was requested but setup failed.
@@ -394,14 +465,22 @@ impl IoUringConfig {
     /// refusal here remains the safety net: the ring is built without
     /// SQPOLL and `SQPOLL_FALLBACK` is set so callers see the degrade.
     pub(crate) fn build_ring(&self) -> io::Result<RawIoUring> {
-        let sqpoll_requested = self.sqpoll && !is_sqpoll_disabled_by_policy();
-        if self.sqpoll && !sqpoll_requested {
+        let policy_disabled = is_sqpoll_disabled_by_policy();
+        let rootless_skip = self.sqpoll && !policy_disabled && should_skip_sqpoll_due_to_rootless();
+        let sqpoll_requested = self.sqpoll && !policy_disabled && !rootless_skip;
+        if self.sqpoll && policy_disabled {
             logging::debug_log!(
                 Io,
                 1,
                 "io_uring: SQPOLL suppressed by --no-io-uring-sqpoll; \
                  building a regular ring (BGID and other features remain active)"
             );
+        }
+        if rootless_skip {
+            // SQP-LAND.7: record the structural skip so callers querying
+            // sqpoll_fell_back() see the same "ran without SQPOLL" verdict
+            // they would observe after a kernel EPERM.
+            SQPOLL_FALLBACK.store(true, Ordering::Relaxed);
         }
         let mlock_basis_enabled = cfg!(feature = "sqpoll-mlock-basis");
         let sqpoll_safe = sqpoll_requested && (!self.mmap_basis_active || mlock_basis_enabled);
@@ -870,6 +949,72 @@ mod tests {
                  sqpoll-mlock-basis is off"
             );
         }
+    }
+
+    #[test]
+    fn sqpoll_fallback_logs_rootless_reason() {
+        // SQP-LAND.7: when the rootless detector trips, the decision
+        // helper must short-circuit SQPOLL, invoke the log emitter
+        // exactly once, and report the precise signal that fired.
+        use crate::container::RootlessSignal;
+        use std::sync::atomic::{AtomicU32, AtomicUsize};
+
+        let once = Once::new();
+        let invocations = AtomicUsize::new(0);
+        let captured = AtomicU32::new(0);
+        let log = |signal: RootlessSignal| {
+            invocations.fetch_add(1, Ordering::SeqCst);
+            captured.store(signal as u32, Ordering::SeqCst);
+        };
+
+        let skipped = rootless_skip_decision(RootlessSignal::NonIdentityUidMap, &once, log);
+
+        assert!(skipped, "rootless verdict must skip SQPOLL");
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            1,
+            "log emitter must fire exactly once on the first rootless decision"
+        );
+        assert_eq!(
+            captured.load(Ordering::SeqCst),
+            RootlessSignal::NonIdentityUidMap as u32,
+            "captured signal must match the precise marker that triggered the verdict"
+        );
+
+        // A second invocation through the same Once must not re-fire the
+        // log emitter - this guards against daemon-log flooding.
+        let log_again = |_signal: RootlessSignal| {
+            panic!("log emitter must fire at most once per process");
+        };
+        let skipped_again =
+            rootless_skip_decision(RootlessSignal::PodmanContainerEnv, &once, log_again);
+        assert!(
+            skipped_again,
+            "every rootless verdict must still skip SQPOLL"
+        );
+    }
+
+    #[test]
+    fn sqpoll_fallback_skips_log_when_not_rootless() {
+        // The non-rootless path is the hot path on bare-metal hosts: it
+        // must not emit any log or even consume the Once guard, so a
+        // later rootless verdict on the same process can still log.
+        use crate::container::RootlessSignal;
+
+        let once = Once::new();
+        let log = |_signal: RootlessSignal| {
+            panic!("log emitter must not fire when signal=NotRootless");
+        };
+        let skipped = rootless_skip_decision(RootlessSignal::NotRootless, &once, log);
+
+        assert!(
+            !skipped,
+            "non-rootless verdict must keep SQPOLL on its normal kernel path"
+        );
+        assert!(
+            !once.is_completed(),
+            "Once guard must stay armed so a later rootless verdict can still log once"
+        );
     }
 
     #[test]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -259,7 +259,7 @@ pub mod sqpoll_basis;
 mod status;
 
 pub use cached_sort::{CachedSortKey, cached_sort_by};
-pub use container::detect_rootless_container;
+pub use container::{RootlessSignal, detect_rootless_container, rootless_signal};
 pub use copy_basis_range::{
     COPY_BASIS_RANGE_MIN_BYTES, copy_basis_range, copy_file_range_supported,
 };


### PR DESCRIPTION
## Summary

- Wire `container::rootless_signal()` into `IoUringConfig::build_ring()` so SQPOLL is structurally skipped inside rootless containers instead of letting `io_uring_setup` fail with EPERM
- Emit one structured `debug_log!(Io, 1, ...)` info-level line per process naming the precise detection marker that triggered the verdict (non-identity `/proc/self/uid_map`, Podman `.containerenv`, or Docker `.dockerenv`)
- Extend `crates/fast_io/src/container.rs` with a `RootlessSignal` enum + `rootless_signal()` accessor; `detect_rootless_container()` becomes a thin `signal.is_rootless()` wrapper so SQP-LAND.3 / SQP-LAND.4 callers stay source-compatible

## Deployer-facing why

In rootless Podman / Docker / Kubernetes (`runAsNonRoot` securityContext) `CAP_SYS_NICE` is structurally unavailable inside the user namespace, so requesting `IORING_SETUP_SQPOLL` is guaranteed to fail with EPERM. Before SQP-LAND.7 the fall-back was silent: operators running daemon workloads on rootless K8s / Podman wondered why io_uring performance was degraded with nothing in the logs to point at. After this PR a single structured info-level decision log fires under `--debug=io1` per process naming the marker so they can map the verdict back to their cgroup / securityContext without grepping `/proc`.

## Where the log emit lives

- `crates/fast_io/src/io_uring/config.rs::build_ring()` short-circuits SQPOLL when `rootless_signal().is_rootless()` and routes the decision through `rootless_skip_decision(signal, once, log)`
- `log_rootless_skip()` is the default emitter, mirroring the IKV-F.1 fallback-log convention (Io target, level 1)
- A `std::sync::Once` guard (`ROOTLESS_SQPOLL_LOG_ONCE`) enforces one fire per process even under daemon workloads that build many rings

## Unit tests

Feasible via the structured-reason approach: `rootless_skip_decision` takes the signal + `Once` + log-emitter as parameters so tests drive every branch (not-rootless / once-fires / already-fired) with a substitute closure. Verifies:

1. `sqpoll_fallback_logs_rootless_reason` - rootless verdict skips SQPOLL, log fires exactly once, captured signal matches the precise marker, second invocation through the same `Once` does not re-fire (guards against daemon-log flooding at hundreds of rings)
2. `sqpoll_fallback_skips_log_when_not_rootless` - non-rootless verdict keeps SQPOLL on its normal kernel path and does not consume the `Once` guard

No new dev-dependency added (`testing_logger` was avoided in favour of the dependency-inverted decision helper).

## Test plan

- [x] `cargo fmt --all` runs clean locally before push
- [ ] CI fmt+clippy
- [ ] CI nextest(stable) cells exercise the new `rootless_skip_decision` + `RootlessSignal` unit tests on Linux/macOS/Windows
- [ ] SQP-LAND.6 integration test (rootless Podman container) covers the runtime end-to-end behaviour