### PR TITLE
ci: auto-sync Cargo.lock on PRs that change Cargo.toml (CIM-LOCKFILE-2)

### DIFF
--- a/.github/workflows/cargo-lockfile-sync.yml
+++ b/.github/workflows/cargo-lockfile-sync.yml
@@ -1,0 +1,88 @@
+# PR-side Cargo.lock auto-sync
+#
+# Why this exists
+#   The CI `fmt + clippy` gate regenerates `Cargo.lock` with
+#   `cargo update --workspace --offline` so workspace-metadata bumps that
+#   forgot to refresh the lockfile do not block CI. That keeps CI green but
+#   leaves the committed `Cargo.lock` stale on the PR branch, which the
+#   `--locked` workflows (interop, parallel-determinism, MSRV) then trip on.
+#
+#   This workflow closes that gap. On every PR that touches a workspace
+#   `Cargo.toml`, it runs `cargo update --workspace` and pushes the refreshed
+#   `Cargo.lock` back to the PR branch as a follow-up commit. The push-back
+#   commit re-triggers the normal PR CI through GitHub's standard flow; no
+#   workflow-to-workflow dispatch is involved.
+#
+# Scope
+#   - First-party PRs only. Fork PRs cannot use `GITHUB_TOKEN` to push back;
+#     a fork fallback is tracked separately (CIM-LOCKFILE-7).
+#   - Skips PRs authored by `github-actions[bot]` so the weekly cron PR
+#     (CIM-LOCKFILE-3) does not loop on its own output.
+#   - This workflow does not enforce `--locked`; that is CIM-LOCKFILE-4's
+#     scope.
+
+name: Cargo.lock PR Auto-sync
+
+on:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'crates/**/Cargo.toml'
+      - 'xtask/Cargo.toml'
+      - 'fuzz/Cargo.toml'
+
+concurrency:
+  group: cargo-lockfile-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync-lockfile:
+    name: Sync Cargo.lock
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Validate lockfile resolves offline
+        run: cargo update --workspace --offline
+
+      - name: Refresh Cargo.lock
+        run: cargo update --workspace
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- Cargo.lock; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push refreshed Cargo.lock
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GIT_AUTHOR_NAME: 'github-actions[bot]'
+          GIT_AUTHOR_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
+          GIT_COMMITTER_NAME: 'github-actions[bot]'
+          GIT_COMMITTER_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com'
+        run: |
+          set -euo pipefail
+          git add Cargo.lock
+          git commit -m 'chore: sync Cargo.lock'
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/cargo-lockfile-sync.yml`, a PR-side companion to the weekly Cargo.lock cron (PR #5701 / CIM-LOCKFILE-3) that closes the drift gap left by that cron between scheduled runs.
- Triggers on `pull_request` events that touch `Cargo.toml`, `crates/**/Cargo.toml`, `xtask/Cargo.toml`, or `fuzz/Cargo.toml`. Runs `cargo update --workspace --offline` as a validation pass, then `cargo update --workspace`, and pushes a `chore: sync Cargo.lock` commit back to the PR branch when the lockfile actually changed.
- Skips PRs from forks (`github.event.pull_request.head.repo.full_name == github.repository` guard) because `GITHUB_TOKEN` cannot push back to a fork. The fork-PR fallback (post a comment with the regen diff) is deferred to CIM-LOCKFILE-7.
- Skips PRs authored by `github-actions[bot]` so the weekly cron PR does not loop on its own output.
- All actions are SHA-pinned to the same SHAs used by the weekly workflow for consistency (`actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10` v6.0.3, `dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7` stable), matching the CII-4 supply-chain hardening posture.

## Why this is wire-safe to ci.yml
This workflow does **not** invoke `ci.yml` directly. The push-back commit re-triggers the normal PR CI through GitHub's standard PR event flow, so the existing `fmt + clippy` gate (which already regenerates the lockfile in `--offline` mode per PR #5699) and the `--locked` workflows (interop, parallel-determinism, MSRV) see the refreshed lockfile on their next normal run.

## Scope boundaries
- `--locked` enforcement audit / regression gating is **not** in this PR. That is CIM-LOCKFILE-4's scope.
- Fork-PR comment-with-diff fallback is **not** in this PR. That is CIM-LOCKFILE-7's scope.

## Test plan
- [ ] CI green on this PR (no Cargo.toml changes here, so the new workflow is a no-op trigger for this PR; structural fmt + clippy + nextest gates exercise the workflow file presence).
- [ ] Next PR that touches a workspace `Cargo.toml` exercises the auto-sync path; a follow-up `chore: sync Cargo.lock` commit should land automatically on the PR branch when the lockfile actually drifts.
- [ ] Manual smoke - open a throwaway test PR that bumps a dep version to confirm the bot commits + pushes, and that PRs from forks are correctly skipped (the `if:` guard short-circuits the job).