### PR TITLE
fix(daemon): emit refuse-options error via correct wire frame (UTS-13 + UTS-14)

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -48,6 +48,13 @@ impl<'a> ModuleRequestContext<'a> {
 }
 
 /// Sends an error message and exit marker to the client.
+///
+/// This is the pre-handshake form: the daemon has not yet emitted
+/// `@RSYNCD: OK` so the client still reads raw `@RSYNCD:`-style text.
+/// After OK is sent the client switches its input to the multiplex stream
+/// and any further raw bytes are mis-parsed as multiplex frame headers
+/// (e.g. the 'T' of "The server..." surfaces as `unexpected tag 77`).
+/// Use [`send_multiplexed_error_and_exit`] once OK has been written.
 fn send_error_and_exit(
     stream: &mut DaemonStream,
     limiter: &mut Option<BandwidthLimiter>,
@@ -57,6 +64,35 @@ fn send_error_and_exit(
     write_limited(stream, limiter, payload.as_bytes())?;
     write_limited(stream, limiter, b"\n")?;
     messages.write_exit(stream, limiter)?;
+    stream.flush()
+}
+
+/// Sends a fatal error to the client through the multiplex stream and
+/// terminates the session.
+///
+/// upstream: clientserver.c:1175-1186 - once `io_start_multiplex_out()`
+/// has run (which happens around the `@RSYNCD: OK` exchange) the daemon
+/// emits errors via `rwrite(FERROR, ...)`, encoded as a `MSG_ERROR_XFER`
+/// frame, followed by `MSG_ERROR_EXIT` to synchronize the error exit.
+/// Raw `@ERROR: ...\n` text written here would be decoded by the client's
+/// `read_a_msg()` as a multiplex frame header and surface as
+/// "unexpected tag 77" (the byte 'T' from "The server is configured ..."
+/// minus `MPLEX_BASE = 7`).
+fn send_multiplexed_error_and_exit(
+    stream: &mut DaemonStream,
+    limiter: &mut Option<BandwidthLimiter>,
+    payload: &str,
+    exit_code: i32,
+) -> io::Result<()> {
+    let mut frame_bytes = payload.as_bytes().to_vec();
+    frame_bytes.push(b'\n');
+    let mut buffer = Vec::new();
+    MessageFrame::new(MessageCode::ErrorXfer, frame_bytes)?
+        .encode_into_writer(&mut buffer)?;
+    // upstream: io.c:1060 send_msg_int() - little-endian 4-byte exit code.
+    MessageFrame::new(MessageCode::ErrorExit, exit_code.to_le_bytes().to_vec())?
+        .encode_into_writer(&mut buffer)?;
+    write_limited(stream, limiter, &buffer)?;
     stream.flush()
 }
 
@@ -148,12 +184,42 @@ fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> i
     Ok(())
 }
 
-/// Handles refused options for a module.
+/// Handles refused options for a module (pre-handshake path).
 ///
 /// Sends an error message indicating the option is refused and logs the event.
+/// Used when refused-options are detected from `OPTION` directives sent before
+/// `@RSYNCD: OK`; at this point the client still reads raw text.
 fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> io::Result<()> {
     let payload = format!("@ERROR: The server is configured to refuse {refused}");
     send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+    if let Some(log) = ctx.log_sink {
+        log_module_refused_option(log, ctx.effective_host(), ctx.peer_ip, ctx.request, refused);
+    }
+    Ok(())
+}
+
+/// Handles refused options for a module after `@RSYNCD: OK` has been emitted.
+///
+/// upstream: clientserver.c:1175-1186 - once the daemon has acknowledged the
+/// module the client switches its input to the multiplexed stream
+/// (`io_start_multiplex_in()` at the OK boundary). Errors detected after that
+/// point - including refused options matched against the real argv in
+/// `parse_arguments()` - must travel as `MSG_ERROR_XFER` followed by
+/// `MSG_ERROR_EXIT`. Raw `@ERROR: ...\n` text would be decoded as a multiplex
+/// frame header and surface as "unexpected tag 77" on the receiver because the
+/// upper byte of the header would be the literal 'T' from "The server ..."
+/// (84 = 77 + `MPLEX_BASE`).
+fn handle_refused_option_post_handshake(
+    ctx: &mut ModuleRequestContext<'_>,
+    refused: &str,
+) -> io::Result<()> {
+    let payload = format!("@ERROR: The server is configured to refuse {refused}");
+    send_multiplexed_error_and_exit(
+        ctx.reader.get_mut(),
+        ctx.limiter,
+        &payload,
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+    )?;
     if let Some(log) = ctx.log_sink {
         log_module_refused_option(log, ctx.effective_host(), ctx.peer_ip, ctx.request, refused);
     }

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -754,8 +754,15 @@ fn process_approved_module(
     // post-OK `read_args()` round-trip. The earlier check at the OPTION-line
     // pre-handshake stage only sees client-supplied dparam overrides, never
     // the real transfer flags (e.g. `-z` packed into `-vlogDtprez.iLsfxCIvu`).
+    //
+    // Because `@RSYNCD: OK` has already been emitted, the client has switched
+    // to multiplexed input. The error must travel as `MSG_ERROR_XFER` +
+    // `MSG_ERROR_EXIT` frames; raw `@ERROR:` text would surface on the
+    // receiver as `unexpected tag 77` (the 'T' from "The server ..." minus
+    // `MPLEX_BASE = 7`). upstream: clientserver.c:1146 io_start_multiplex_out
+    // immediately followed by `rwrite(FERROR, ...)`.
     if let Some(refused) = refused_client_arg(module, &client_args) {
-        return handle_refused_option(ctx, &refused);
+        return handle_refused_option_post_handshake(ctx, &refused);
     }
 
     // Enforce read-only / write-only access restrictions.

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -575,3 +575,136 @@ fn apply_daemon_param_overrides_empty_params() {
     apply_daemon_param_overrides(&[], &mut module).expect("empty params should succeed");
     assert_eq!(module, original);
 }
+
+// UTS-13 + UTS-14: refused-option wire-frame regression tests.
+//
+// Background: when the daemon rejects a client-sent option (e.g. `--delete`,
+// `--compress`) after the `@RSYNCD: OK` handshake, the client has already
+// switched its input to the multiplex stream. Raw `@ERROR: ...\n` text written
+// at that point is decoded by `read_a_msg()` as a multiplex frame header and
+// surfaces as `unexpected tag 77 [Receiver]` because the upper byte of the
+// header is the literal `T` from "The server ..." (84 - MPLEX_BASE = 77).
+// The fix routes post-OK refusals through MSG_ERROR_XFER + MSG_ERROR_EXIT.
+fn build_stdio_stream_with_capture() -> (DaemonStream, std::sync::Arc<std::sync::Mutex<Vec<u8>>>) {
+    let capture: std::sync::Arc<std::sync::Mutex<Vec<u8>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let reader: Box<dyn io::Read + Send> = Box::new(io::Cursor::new(Vec::new()));
+    let writer: Box<dyn io::Write + Send> = Box::new(CaptureWriter(capture.clone()));
+    let pair = crate::daemon_stream::StdioPair::new(reader, writer);
+    (DaemonStream::stdio(pair), capture)
+}
+
+#[test]
+fn refuse_emits_at_error_raw_pre_handshake() {
+    // Pre-handshake path: client has not yet seen `@RSYNCD: OK`, so multiplex
+    // IN has not started. The raw `@ERROR: ...\n` text is the correct wire
+    // encoding here.
+    let (mut stream, capture) = build_stdio_stream_with_capture();
+    let mut limiter: Option<BandwidthLimiter> = None;
+    let messages = LegacyMessageCache::shared();
+    send_error_and_exit(
+        &mut stream,
+        &mut limiter,
+        messages,
+        "@ERROR: The server is configured to refuse --delete",
+    )
+    .expect("send pre-handshake error");
+
+    let bytes = capture.lock().unwrap().clone();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.starts_with("@ERROR: The server is configured to refuse --delete\n"),
+        "pre-handshake refusal must be raw @ERROR text, got: {text:?}"
+    );
+    assert!(
+        text.contains("@RSYNCD: EXIT"),
+        "pre-handshake refusal must end with @RSYNCD: EXIT, got: {text:?}"
+    );
+}
+
+#[test]
+fn refuse_emits_msg_error_xfer_post_handshake() {
+    // Post-handshake path: client has switched its input to the multiplexed
+    // stream after `@RSYNCD: OK`. The daemon must wrap the error in a
+    // MSG_ERROR_XFER frame followed by a MSG_ERROR_EXIT frame. Raw text would
+    // be decoded as a multiplex header (the "unexpected tag 77" bug).
+    //
+    // upstream: clientserver.c:1175-1186 - io_start_multiplex_out() runs at
+    // OK, then rwrite(FERROR, ...) emits a MSG_ERROR_XFER frame.
+    let (mut stream, capture) = build_stdio_stream_with_capture();
+    let mut limiter: Option<BandwidthLimiter> = None;
+    send_multiplexed_error_and_exit(
+        &mut stream,
+        &mut limiter,
+        "@ERROR: The server is configured to refuse --compress",
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+    )
+    .expect("send multiplexed error");
+
+    let bytes = capture.lock().unwrap().clone();
+    assert!(
+        bytes.len() >= 8,
+        "must contain at least two 4-byte multiplex headers, got {} bytes",
+        bytes.len()
+    );
+
+    // Build the expected MSG_ERROR_XFER frame and assert that the capture
+    // starts with it. encode_into_writer writes the 4-byte little-endian
+    // (length | code<<24) header followed by the payload bytes.
+    let mut payload = b"@ERROR: The server is configured to refuse --compress".to_vec();
+    payload.push(b'\n');
+    let mut expected_xfer = Vec::new();
+    MessageFrame::new(MessageCode::ErrorXfer, payload)
+        .expect("frame")
+        .encode_into_writer(&mut expected_xfer)
+        .expect("encode");
+    assert!(
+        bytes.starts_with(&expected_xfer),
+        "post-handshake refusal must begin with a MSG_ERROR_XFER frame; got {bytes:?}"
+    );
+
+    // The remaining bytes must be a MSG_ERROR_EXIT frame carrying the exit
+    // code in little-endian form (upstream io.c:1060 send_msg_int).
+    let mut expected_exit = Vec::new();
+    MessageFrame::new(
+        MessageCode::ErrorExit,
+        FEATURE_UNAVAILABLE_EXIT_CODE.to_le_bytes().to_vec(),
+    )
+    .expect("frame")
+    .encode_into_writer(&mut expected_exit)
+    .expect("encode");
+    assert!(
+        bytes.ends_with(&expected_exit),
+        "post-handshake refusal must end with a MSG_ERROR_EXIT frame; got {bytes:?}"
+    );
+}
+
+#[test]
+fn refuse_compress_message_mentions_compress() {
+    // UTS-14 directly: the matcher already exists, but the refused-name
+    // surfaces in the error string so the user sees `--compress` literally.
+    let module = ModuleDefinition {
+        refuse_options: vec!["compress".to_owned()],
+        ..Default::default()
+    };
+    let options = vec!["--compress".to_owned()];
+    let refused =
+        refused_option(&module, &options).expect("compress must be matched as a refused option");
+    let payload = format!("@ERROR: The server is configured to refuse {refused}");
+    assert!(
+        payload.contains("--compress"),
+        "refusal payload must name the refused option literally, got: {payload}"
+    );
+}


### PR DESCRIPTION
## Summary

UTS-13 (daemon-refuse) and UTS-14 (daemon-refuse-compress) both fail in
the upstream testsuite with the same wire-protocol error:

\`\`\`
rsync error: error in rsync protocol data stream (code 12)
   at io.c(1726) [Receiver=3.4.3-93-g0d0399bb]
unexpected tag 77 [Receiver]
\`\`\`

(Fresh evidence captured 2026-06-11 via \`ssh ofer@192.168.21.226 sudo runtests.py\`.)

### What tag 77 actually is

The client switches its input to the multiplex stream after the daemon
sends \`@RSYNCD: OK\`. Upstream's \`read_a_msg()\` (io.c:1492) decodes the
header byte as \`(tag >> 24) - MPLEX_BASE\` where \`MPLEX_BASE = 7\`. When
oc-rsync continues to emit raw \`@ERROR: The server is configured to
refuse <opt>\n\` text post-OK, the client reads the first four bytes as
a multiplex header. The upper byte is the literal ASCII \`T\` (84) from
\`"The server..."\`, so \`84 - 7 = 77\`. The same encoding error makes the
client treat every post-OK refusal as a malformed frame.

### Scope of the fix - emission only

The matcher (\`refused_client_arg\` / \`refused_option\` in
\`module_parsing.rs\`) is correct - the matching wildcard / negation
tests in this PR still pass against the existing patterns. Only the
post-OK emission path was wrong.

The fix routes the post-handshake refusal through MSG_ERROR_XFER
followed by MSG_ERROR_EXIT, mirroring upstream \`clientserver.c:1175-1186\`:

\`\`\`c
io_start_multiplex_out(f_out);     // around @RSYNCD: OK
...
rwrite(FERROR, ...);                // MSG_ERROR_XFER frame
io_flush(MSG_FLUSH);
exit_cleanup(RERR_UNSUPPORTED);     // MSG_ERROR_EXIT
\`\`\`

The pre-OK path (used while parsing \`OPTION\` directives sent before the
handshake) keeps the raw \`@ERROR\` encoding - the client has not yet
switched to multiplex IN at that point, so raw text is still the
correct wire form.

## Non-regression

- daemon-config, daemon-filter, daemon-access: pre-handshake refuse
  paths unchanged.
- \`send_error_and_exit\` now carries a doc-comment noting it is the
  pre-handshake encoding so future call sites do not regress this.

## Test plan

- [x] \`refuse_emits_at_error_raw_pre_handshake\` - asserts raw \`@ERROR\`
      bytes when called before OK.
- [x] \`refuse_emits_msg_error_xfer_post_handshake\` - asserts the
      capture begins with a MSG_ERROR_XFER frame for the refused-compress
      payload and ends with a MSG_ERROR_EXIT frame carrying the exit code
      in little-endian form (\`send_msg_int\` parity).
- [x] \`refuse_compress_message_mentions_compress\` - UTS-14 string check
      that the refused name reaches the client message verbatim.
- [ ] CI: nextest (stable) + interop matrix must stay green.
- [ ] Upstream-testsuite cell: daemon-refuse and daemon-refuse-compress
      now pass.