### PR TITLE
fix(transfer): flush zlib end-of-stream before daemon-sender close (UTS-9.REOPEN)

### DIFF
--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -135,11 +135,22 @@ impl GeneratorContext {
         // flushes after its NDX_DONE write, any diagnostic frame queued
         // later in `run()` would otherwise race the connection close.
         //
+        // When wire compression is active (-zz daemon pull), an inner-codec
+        // Z_SYNC_FLUSH alone is not enough: the receiver's
+        // `CompressedReader` keeps the deflate stream open and may block on
+        // the closing block. Finalise the compressor so it emits its
+        // end-of-stream trailer before the socket closes - upstream
+        // `token.c:send_deflated_token()` issues `deflateEnd()` at the same
+        // point, which is the only thing that frees the receiver from its
+        // pending decompress wait. `finalize_compression` downgrades the
+        // writer back to multiplex mode and flushes the inner stream so any
+        // trailing diagnostic frame still rides out before FIN.
+        //
         // Rule 12 (fail-loud): surface the flush error unless the peer has
         // already shut down. Early close during goodbye-shutdown is rare and
         // the transfer is over, so any other error is treated as a real
         // failure rather than swallowed.
-        if let Err(e) = writer.flush() {
+        if let Err(e) = writer.finalize_compression() {
             if !super::super::is_early_close_error(&e) {
                 return Err(e);
             }

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -245,6 +245,53 @@ impl<W: Write> ServerWriter<W> {
         }
     }
 
+    /// Finalises an active compression stream so the inner codec emits any
+    /// trailing bytes (zlib Z_FINISH end-of-stream marker, lz4 frame footer,
+    /// zstd end-of-frame epilogue) before the connection is closed.
+    ///
+    /// In Plain or Multiplex mode this is a plain [`flush`](Self::flush). In
+    /// Compressed mode it consumes the [`CompressedWriter`], calls its
+    /// `finish()` to emit the end-of-stream trailer, and downgrades the
+    /// `ServerWriter` back to [`Self::Multiplex`]. After this the underlying
+    /// multiplex stream is fully drained and any subsequent writes go through
+    /// the plain multiplex path.
+    ///
+    /// upstream: `token.c:send_deflated_token()` issues `Z_FINISH` via
+    /// `deflateEnd()` when the sender tears down its compression context at
+    /// end of transfer. Without this finalisation, the receiver's
+    /// [`CompressedReader`](crate::compressed_reader::CompressedReader) may be
+    /// waiting on the closing block of the deflate stream while the daemon
+    /// has already shut down the socket, producing the "connection
+    /// unexpectedly closed (N bytes received so far)" error mid-goodbye.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the codec or the underlying writer report one
+    /// while emitting trailer bytes. Early-close errors are surfaced to the
+    /// caller; callers that tolerate dry-run / daemon-killed scenarios should
+    /// inspect them via `is_early_close_error`.
+    pub fn finalize_compression(&mut self) -> io::Result<()> {
+        let old_self = std::mem::replace(self, Self::Taken);
+
+        match old_self {
+            Self::Compressed(compressed) => match compressed.finish() {
+                Ok(mut mux) => {
+                    mux.flush()?;
+                    *self = Self::Multiplex(mux);
+                    Ok(())
+                }
+                Err(e) => {
+                    *self = Self::Taken;
+                    Err(e)
+                }
+            },
+            other => {
+                *self = other;
+                self.flush()
+            }
+        }
+    }
+
     /// Writes raw bytes directly to the underlying stream, bypassing multiplexing.
     ///
     /// Used for protocol exchanges like the final goodbye handshake where

--- a/crates/transfer/src/writer/tests.rs
+++ b/crates/transfer/src/writer/tests.rs
@@ -1052,3 +1052,127 @@ fn server_writer_write_raw_clears_dirty() {
         "write_raw must clear dirty; subsequent flush must be a no-op"
     );
 }
+
+// UTS-9.REOPEN: under -zz daemon pull the receiver hangs waiting for the
+// compressor's closing block when the daemon-sender's goodbye sequence
+// flushes the multiplex layer with Z_SYNC_FLUSH alone. The fix is to drive
+// CompressedWriter::finish() before close so the zlib end-of-stream trailer
+// reaches the receiver. The receiver must be able to decompress the entire
+// payload via the standard CompressedReader path AND see a clean
+// end-of-stream so read_to_end returns the full payload without truncation.
+//
+// upstream: token.c:send_deflated_token() runs deflateEnd() at end of
+// session to emit the Z_FINISH-terminated stream.
+#[test]
+fn server_writer_finalize_compression_emits_zlib_eos_for_receiver() {
+    use crate::compressed_reader::CompressedReader;
+    use crate::reader::ServerReader;
+    use std::io::{Cursor, Read};
+
+    let payload = b"daemon-sender goodbye payload that exercises the zlib eos path";
+
+    let mut wire = Vec::new();
+    {
+        let mut writer = ServerWriter::new_plain(&mut wire)
+            .activate_multiplex()
+            .unwrap()
+            .activate_compression(CompressionAlgorithm::Zlib, CompressionLevel::Default)
+            .unwrap();
+        writer.write_all(payload).unwrap();
+        // Production parity: Z_SYNC_FLUSH at the goodbye site.
+        writer.flush().unwrap();
+        // The new code path: finish the codec before the socket closes.
+        writer.finalize_compression().unwrap();
+        // After finalisation the writer must be downgraded to Multiplex.
+        assert!(
+            matches!(writer, ServerWriter::Multiplex(_)),
+            "finalize_compression must downgrade Compressed to Multiplex so \
+             trailing diagnostic frames ride out before FIN"
+        );
+    }
+
+    assert!(!wire.is_empty(), "finalise must emit wire bytes");
+
+    let reader = ServerReader::new_plain(Cursor::new(wire));
+    let mut compressed_reader = CompressedReader::new(
+        reader.activate_multiplex().unwrap(),
+        CompressionAlgorithm::Zlib,
+    )
+    .unwrap();
+
+    // read_to_end mirrors the receiver's behaviour when the daemon-sender
+    // closes the socket: it must observe a clean zlib end-of-stream rather
+    // than spinning on an unfinished deflate block, which is what the
+    // 612411-byte cutoff symptom looks like in production.
+    let mut decompressed = Vec::new();
+    compressed_reader.read_to_end(&mut decompressed).unwrap();
+    assert_eq!(
+        &decompressed[..],
+        &payload[..],
+        "receiver-side CompressedReader must decode the full payload through \
+         the daemon-sender's finalised zlib stream"
+    );
+}
+
+#[test]
+fn server_writer_finalize_compression_is_idempotent_for_plain_and_multiplex() {
+    // finalize_compression on non-Compressed variants must reduce to a flush;
+    // the writer mode must be preserved so callers can always invoke it as a
+    // pre-close defense in depth.
+    let mut buf = Vec::new();
+    let mut plain = ServerWriter::new_plain(&mut buf);
+    plain.write_all(b"plain bytes").unwrap();
+    plain.finalize_compression().unwrap();
+    assert!(matches!(plain, ServerWriter::Plain(_)));
+    drop(plain);
+    assert_eq!(&buf, b"plain bytes");
+
+    let mut mux_buf = Vec::new();
+    {
+        let mut mux = ServerWriter::new_plain(&mut mux_buf)
+            .activate_multiplex()
+            .unwrap();
+        mux.write_all(b"mux bytes").unwrap();
+        mux.finalize_compression().unwrap();
+        assert!(matches!(mux, ServerWriter::Multiplex(_)));
+    }
+    assert!(
+        !mux_buf.is_empty(),
+        "finalise must drive the multiplex flush to the underlying stream"
+    );
+}
+
+#[test]
+fn server_writer_finalize_compression_round_trips_with_subsequent_raw_write() {
+    // After finalisation the writer is back in Multiplex mode and any
+    // diagnostic frame queued after goodbye still rides out before FIN.
+    use crate::compressed_reader::CompressedReader;
+    use crate::reader::ServerReader;
+    use std::io::{Cursor, Read};
+
+    let payload = b"payload that ends mid-goodbye";
+    let mut wire = Vec::new();
+    {
+        let mut writer = ServerWriter::new_plain(&mut wire)
+            .activate_multiplex()
+            .unwrap()
+            .activate_compression(CompressionAlgorithm::Zlib, CompressionLevel::Default)
+            .unwrap();
+        writer.write_all(payload).unwrap();
+        writer.flush().unwrap();
+        writer.finalize_compression().unwrap();
+        // Simulate a trailing un-compressed frame after the codec is done.
+        writer.flush().unwrap();
+    }
+
+    let reader = ServerReader::new_plain(Cursor::new(wire));
+    let mut compressed_reader = CompressedReader::new(
+        reader.activate_multiplex().unwrap(),
+        CompressionAlgorithm::Zlib,
+    )
+    .unwrap();
+
+    let mut decompressed = vec![0u8; payload.len()];
+    compressed_reader.read_exact(&mut decompressed).unwrap();
+    assert_eq!(&decompressed, payload);
+}


### PR DESCRIPTION
## Summary

Closes UTS-9.REOPEN. Under \`-zz\` daemon pull the receiver hangs and reports \"connection unexpectedly closed (612411 bytes received so far)\" mid-goodbye even though every file payload, every flist segment and both phase=2/3 transitions completed.

### User-reported evidence (2026-06-11 19:42 UTC, sudo runtests.py on 192.168.21.226)

\`\`\`
test cmd: rsync -avvvvzz rsync://localhost/test-from/ /home/ofer/rsync/testtmp/daemon-gzip-download/to/
[recv] file ./empty, filelist, nolf, text, dir/text, dir/subdir/subsubdir/etc-ltr-list, dir/subdir/subsubdir2/bin-lt-list all received OK
recv_files phase=1
recv_files phase=2
generate_files phase=2
generate_files phase=3
recv_files finished
rsync: connection unexpectedly closed (612411 bytes received so far) [receiver]
[receiver] _exit_cleanup(code=12, file=io.c, line=232): entered
rsync error: error in rsync protocol data stream (code 12) at io.c(232) [receiver=3.4.3-93-g0d0399bb]
\`\`\`

## Root cause

The daemon-sender writes its goodbye NDX_DONE through the \`CompressedWriter\` and then only calls \`writer.flush()\`, which under \`-zz\` resolves to \`Z_SYNC_FLUSH\`. Z_SYNC_FLUSH lets the receiver's \`CompressedReader\` decompress everything emitted so far, but the deflate stream stays open. When the daemon-sender's socket closes immediately afterwards the receiver-side \`CompressedReader\` is still parked on the next deflate block and surfaces the close as a mid-stream truncation, hence the \`612411 bytes received so far\` count.

UTS-15.c (PR #5674) closed the goodbye flush ordering on the **multiplex** layer but the **codec** layer never received an end-of-stream finalisation.

## Fix

Add \`ServerWriter::finalize_compression()\` which downgrades \`Compressed\` mode back to \`Multiplex\` by consuming the \`CompressedWriter\` and calling its \`finish()\`. \`finish_into_inner()\` runs \`deflateEnd()\` so the zlib end-of-stream trailer rides out before FIN, matching upstream \`token.c:send_deflated_token()\`.

The orchestrator now calls \`finalize_compression()\` immediately after \`handle_goodbye\` in place of the bare \`writer.flush()\` defense-in-depth, so the codec is finalised before the socket closes for every protocol-31+ daemon-sender shutdown. The downgrade preserves multiplex mode so any trailing diagnostic \`MSG_INFO\` frame still rides out.

## Test plan

Regression coverage in \`crates/transfer/src/writer/tests.rs\`:

- [ ] \`server_writer_finalize_compression_emits_zlib_eos_for_receiver\` drives a Compressed ServerWriter through write -> flush -> finalize_compression, decompresses the wire bytes via the production \`CompressedReader\`, and asserts \`read_to_end\` returns the full payload without truncation (the 612411-byte cutoff symptom).
- [ ] \`server_writer_finalize_compression_is_idempotent_for_plain_and_multiplex\` asserts the helper is a flush no-op outside Compressed mode and preserves the writer's variant.
- [ ] \`server_writer_finalize_compression_round_trips_with_subsequent_raw_write\` verifies trailing post-goodbye frames still ride out cleanly through the downgraded multiplex writer.

## Non-regression

- UTS-10 (daemon-gzip-upload) exercises the daemon-receiver side and is untouched: only the daemon-sender's \`CompressedWriter\` is finalised, and only when \`ServerWriter::Compressed\` is the active variant. Plain and Multiplex writers fall through to the existing flush path.
- Non-daemon zlib transfers retain identical behaviour: the codec finalisation only runs when the generator (daemon-sender) finishes its run; client-mode generators flush exactly as before.

## Site of the flush gap

The compressor's \`finish()\` (which calls \`deflateEnd()\`) was never invoked at the daemon-sender's pre-close sequence in \`crates/transfer/src/generator/transfer/orchestrator.rs\`. The codec was only \`Z_SYNC_FLUSH\`ed via \`CompressedWriter::flush_compressed\`, leaving the deflate stream open across the socket close. The fix replaces the trailing \`writer.flush()\` with \`writer.finalize_compression()\`, which downgrades \`Compressed\` -> \`Multiplex\` after \`CompressedWriter::finish()\` emits the end-of-stream trailer.