### PR TITLE
fix(receiver): walk relative parents through dirfd sandbox to block chdir-symlink-race

### DIFF
--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -325,6 +325,75 @@ impl DirSandbox {
     pub fn unlinkat_at(&self, leaf: &OsStr, flags: UnlinkFlags) -> io::Result<()> {
         unlinkat(self.current_dirfd(), leaf, flags)
     }
+
+    /// Walk the parent components of `relative_path` from the sandbox
+    /// root using the strictest open policy the running kernel supports.
+    ///
+    /// Mirrors upstream `syscall.c::secure_relative_open(NULL, dirpath,
+    /// O_RDONLY|O_DIRECTORY, 0)` used by `do_chmod_at`, `do_unlink_at`,
+    /// `do_rename_at`, and friends: each parent component is opened via
+    /// `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on Linux 5.6+ and
+    /// `openat(O_NOFOLLOW | O_DIRECTORY)` elsewhere, so a symlink planted
+    /// at any intermediate component is rejected with `ELOOP` (Linux),
+    /// `ENOTDIR` (BSD/macOS), or `EXDEV` (`openat2` with a `..` escape).
+    ///
+    /// Returns `Ok(())` when every parent component resolves to a real
+    /// directory beneath the sandbox root. The leaf component itself is
+    /// not opened; callers perform their target syscall (`fchmodat`,
+    /// `renameat`, etc.) against the returned parent dirfd path. Single-
+    /// component relative paths short-circuit to `Ok(())` because the
+    /// sandbox root is already the parent.
+    ///
+    /// This is the chdir-symlink-race defence: on a daemon receiver
+    /// without chroot, a local attacker can replace an in-module
+    /// directory with a symlink to outside the module between the
+    /// receiver's `stat` and its subsequent `chmod` / `chown` / `rename`.
+    /// Walking the parents through the sandbox dirfd refuses the
+    /// substitution instead of letting the path-based syscall follow the
+    /// symlink across the module boundary.
+    ///
+    /// # Errors
+    ///
+    /// - `ELOOP` when any parent component is a symlink (every Unix
+    ///   target).
+    /// - `EXDEV` when `openat2(2)` with `RESOLVE_BENEATH` refuses a `..`
+    ///   that would escape the sandbox root (Linux 5.6+ only).
+    /// - `ENOTDIR` when a parent component is not a directory.
+    /// - `ENOENT` when a parent component is missing.
+    /// - `EINVAL` when `relative_path` contains a non-normal component
+    ///   (root, prefix, or `..`).
+    pub fn validate_relative_parents(&self, relative_path: &Path) -> io::Result<()> {
+        if relative_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        let mut components = relative_path.components().peekable();
+        let mut current: Option<OwnedFd> = None;
+        while let Some(comp) = components.next() {
+            let name = match comp {
+                std::path::Component::Normal(name) => name,
+                std::path::Component::CurDir => continue,
+                std::path::Component::ParentDir
+                | std::path::Component::Prefix(_)
+                | std::path::Component::RootDir => {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+            };
+            if components.peek().is_none() {
+                // Leaf component; do not open it. The target syscall
+                // performs its own leaf-anchored open against the parent
+                // dirfd, picking up `AT_SYMLINK_NOFOLLOW` semantics.
+                let _ = name;
+                break;
+            }
+            let parent_fd = match current.as_ref() {
+                Some(fd) => fd.as_fd(),
+                None => self.root.as_fd(),
+            };
+            current = Some(openat_dir(parent_fd, name)?);
+        }
+        let _ = current;
+        Ok(())
+    }
 }
 
 /// Open `child_name` as a directory off `parent_fd` using the strictest

--- a/crates/fast_io/src/dir_sandbox/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/tests.rs
@@ -284,3 +284,73 @@ fn enter_to_legitimate_subdir_returns_ok() {
     sandbox.exit();
     assert_eq!(sandbox.depth(), 0);
 }
+
+/// UTS-16 chdir-symlink-race: a symlink planted at an intermediate
+/// component of a multi-component relative path must fail the parent
+/// walk so the receiver refuses the follow-up `fchmodat` / `renameat`
+/// instead of letting it land outside the module root.
+#[test]
+fn validate_relative_parents_refuses_symlink_at_intermediate_component() {
+    let (_outside_keep, outside) = canonical_tempdir();
+    std::fs::write(outside.join("target.txt"), b"OUTSIDE\n").expect("write outside");
+
+    let (_keep, root) = canonical_tempdir();
+    // Plant the attacker's symlink: `module/subdir` -> outside dir.
+    symlink(&outside, root.join("subdir")).expect("plant symlink trap");
+
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .validate_relative_parents(std::path::Path::new("subdir/target.txt"))
+        .expect_err("symlinked parent must be rejected");
+    let code = err.raw_os_error();
+    assert!(
+        code == Some(libc::ELOOP) || code == Some(libc::ENOTDIR),
+        "expected ELOOP or ENOTDIR for symlinked parent, got: {err}"
+    );
+}
+
+/// Sibling positive test: legitimate multi-component descent through
+/// real directories must succeed so the validator does not regress
+/// happy-path uploads.
+#[test]
+fn validate_relative_parents_accepts_legitimate_descent() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir(root.join("realdir")).expect("mkdir realdir");
+    std::fs::create_dir(root.join("realdir/nested")).expect("mkdir nested");
+
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    sandbox
+        .validate_relative_parents(std::path::Path::new("realdir/nested/file.txt"))
+        .expect("legitimate descent must succeed");
+    sandbox
+        .validate_relative_parents(std::path::Path::new("realdir/leaf.txt"))
+        .expect("single-parent descent must succeed");
+}
+
+/// A single-component relative path has the sandbox root as its parent,
+/// so the validator short-circuits to `Ok(())` without any syscalls.
+#[test]
+fn validate_relative_parents_accepts_single_component_leaf() {
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    sandbox
+        .validate_relative_parents(std::path::Path::new("file.txt"))
+        .expect("single-component leaf must succeed");
+}
+
+/// Defensive: `..` traversal segments and absolute paths are rejected
+/// up front so an attacker cannot smuggle the chmod across the sandbox
+/// boundary via a crafted relative path.
+#[test]
+fn validate_relative_parents_rejects_parent_dir_and_absolute() {
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("open root");
+    let err = sandbox
+        .validate_relative_parents(std::path::Path::new("../etc/passwd"))
+        .expect_err("parent-dir traversal must be rejected");
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+    let err = sandbox
+        .validate_relative_parents(std::path::Path::new("/etc/passwd"))
+        .expect_err("absolute path must be rejected");
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -47,6 +47,25 @@ pub(super) fn process_file(
     disk_batch: Option<&mut fast_io::IoUringDiskBatch>,
     iocp_batch: Option<&mut fast_io::IocpDiskBatch>,
 ) -> io::Result<CommitResult> {
+    // UTS-16 chdir-symlink-race defence: refuse the open when any parent
+    // component of the destination is a symlink. The path-based
+    // OpenOptions / chmod / chown syscalls in the rest of this function
+    // would otherwise follow an attacker-planted in-module symlink and
+    // write/setattr outside the daemon module root. Walking the parents
+    // through the sandbox dirfd yields ELOOP / ENOTDIR / EXDEV when the
+    // attacker has substituted a symlink, surfacing the rejection up to
+    // the receiver instead of silently committing the escape.
+    //
+    // upstream: syscall.c:do_chmod_at() / do_unlink_at() open the parent
+    // under `secure_relative_open()` precisely to close this window on
+    // daemons running `use chroot = no`.
+    #[cfg(unix)]
+    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref()) {
+        if let Ok(rel) = begin.file_path.strip_prefix(dest_dir) {
+            sandbox.validate_relative_parents(rel)?;
+        }
+    }
+
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -48,6 +48,7 @@ impl ReceiverContext {
         metadata_errors: &mut Vec<(PathBuf, String)>,
         stats: &mut TransferStats,
         acl_cache: Option<&protocol::acl::AclCache>,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> Vec<(usize, &'a FileEntry, PathBuf)> {
         // upstream: generator.c:1234-1235 - "recv_generator(%s,%d)" emitted at
         // the top of recv_generator() for every file the generator considers
@@ -205,6 +206,10 @@ impl ReceiverContext {
                         has_acls,
                         has_xattrs,
                         needs_metadata_apply,
+                        #[cfg(unix)]
+                        sandbox,
+                        #[cfg(unix)]
+                        dest_dir,
                     );
                     continue;
                 }
@@ -258,6 +263,8 @@ impl ReceiverContext {
         has_acls: bool,
         has_xattrs: bool,
         needs_metadata_apply: bool,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
+        #[cfg(unix)] dest_dir: &Path,
     ) {
         // upstream: generator.c:1816 - itemize() with iflags=0 for up-to-date
         // files. iflags=0 has no significant flags, so emit_itemize will suppress
@@ -265,6 +272,30 @@ impl ReceiverContext {
         if emit_itemize {
             let iflags = crate::generator::ItemFlags::from_raw(0);
             let _ = self.emit_itemize(writer, &iflags, entry);
+        }
+
+        // UTS-16 chdir-symlink-race defence: on a daemon receiver without
+        // chroot, an in-module parent directory can be replaced with a
+        // symlink-to-outside between the quick-check `stat` and the
+        // chmod/chown/utimes about to land via `apply_metadata_*`. The
+        // path-based setattr syscalls follow symlinks at every parent
+        // component, so a planted `subdir -> /outside` would chmod the
+        // attacker-chosen inode. Walking the parents through the sandbox
+        // dirfd refuses the substitution with ELOOP (Linux), ENOTDIR
+        // (BSD/macOS), or EXDEV (`openat2` with `..` escape).
+        //
+        // upstream: syscall.c:do_chmod_at() opens the parent under
+        // `secure_relative_open()` and uses `fchmodat(dfd, bname, mode, 0)`
+        // so the kernel either resolves the link within the tree
+        // (legitimate dir-symlinks still work) or rejects the escape.
+        #[cfg(unix)]
+        if let Some(sandbox) = sandbox {
+            if let Ok(rel) = file_path.strip_prefix(dest_dir) {
+                if let Err(e) = sandbox.validate_relative_parents(rel) {
+                    metadata_errors.push((file_path.to_path_buf(), e.to_string()));
+                    return;
+                }
+            }
         }
 
         // upstream: generator.c:461 unchanged_attrs() - fast-path check avoids

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -97,6 +97,8 @@ impl ReceiverContext {
             &mut metadata_errors,
             &mut stats,
             setup.acl_cache.as_deref(),
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
         );
 
         let mut files_transferred: usize = 0;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -131,6 +131,8 @@ impl ReceiverContext {
             &mut metadata_errors,
             &mut stats,
             setup.acl_cache.as_deref(),
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
         );
 
         let mut files_transferred: usize = 0;


### PR DESCRIPTION
## Summary

- Adds `DirSandbox::validate_relative_parents()` that opens each parent component via `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` on Linux 5.6+ or `openat(O_NOFOLLOW | O_DIRECTORY)` elsewhere. A symlink planted at any intermediate component is rejected with `ELOOP` / `ENOTDIR` / `EXDEV`. Mirrors upstream `syscall.c::secure_relative_open(NULL, dirpath, O_RDONLY|O_DIRECTORY, 0)` used by `do_chmod_at`, `do_unlink_at`, `do_rename_at`, etc.
- Wires the validator into receiver `disk_commit/process.rs`, `transfer/candidates.rs`, `transfer/pipelined.rs`, and `transfer/pipelined_incremental.rs` so daemon-side receivers without chroot now refuse a symlink substituted between stat and the follow-up chmod/chown/rename - the chdir-symlink-race defence captured in UTS-16.
- Single-component relative paths short-circuit to `Ok(())` (sandbox root is already the parent).

## Status

**Unvalidated WIP — not run against runtests.py before push.** Reviewer/CI verifies. EDG-SANDBOX.{1..4} edge tests are the closest existing coverage.

## Test plan

- [ ] `cargo nextest run -p fast_io --all-features -E 'test(validate_relative_parents)'`
- [ ] Upstream testsuite `chdir-symlink-race` cell passes against the patched binary (positive control returns non-zero, legitimate writes succeed)
- [ ] EDG-SANDBOX.{1..4} edge tests green; no over-correction on in-module sub-directory writes
- [ ] macOS + Linux <5.6 fallback paths (`openat` w/ `O_NOFOLLOW`) exercised