### PR TITLE
fix(daemon): parse --usermap/--groupmap from daemon client args

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -929,6 +929,28 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                     config.temp_dir = Some(std::path::PathBuf::from(dir));
                 } else if let Some(path) = arg.strip_prefix("--files-from=") {
                     config.file_selection.files_from_path = Some(path.to_owned());
+                // upstream: options.c:2904 / 2907 - --usermap=SPEC / --groupmap=SPEC.
+                // After unbackslash_arg / secluded-args delivery the spec arrives
+                // verbatim (`*:1234` wildcards intact) so we hand it directly to
+                // the metadata parser. Without this step the daemon-mode receiver
+                // would silently discard `--groupmap` / `--usermap` and the
+                // wildcard would never take effect on the destination - the
+                // regression captured by upstream's daemon-groupmap-wild test
+                // (issue #829).
+                //
+                // upstream: uidlist.c:parse_name_map() parses the spec.
+                // A malformed spec leaves the field unset rather than aborting
+                // the session because upstream's daemon path falls through to
+                // its default id-mapping when parsing fails and the receiver
+                // still completes the transfer with unmapped ids.
+                } else if let Some(spec) = arg.strip_prefix("--usermap=") {
+                    if let Ok(mapping) = ::metadata::UserMapping::parse(spec) {
+                        config.user_mapping = Some(mapping);
+                    }
+                } else if let Some(spec) = arg.strip_prefix("--groupmap=") {
+                    if let Ok(mapping) = ::metadata::GroupMapping::parse(spec) {
+                        config.group_mapping = Some(mapping);
+                    }
                 } else if arg == "--from0" {
                     // upstream: options.c:940 - --from0 sets NUL-delimited mode
                     // for --files-from content read from the protocol stream.

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
-use metadata::ChmodModifiers;
+use metadata::{ChmodModifiers, GroupMapping, UserMapping};
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
 use protocol::filters::FilterRuleWireFormat;
@@ -89,6 +89,8 @@ pub struct ServerConfigBuilder {
     fake_super: bool,
     daemon_incoming_chmod: Option<ChmodModifiers>,
     daemon_outgoing_chmod: Option<ChmodModifiers>,
+    user_mapping: Option<UserMapping>,
+    group_mapping: Option<GroupMapping>,
     munge_symlinks: bool,
 }
 
@@ -129,6 +131,8 @@ impl ServerConfigBuilder {
             fake_super: false,
             daemon_incoming_chmod: None,
             daemon_outgoing_chmod: None,
+            user_mapping: None,
+            group_mapping: None,
             munge_symlinks: false,
         }
     }
@@ -605,6 +609,8 @@ impl ServerConfigBuilder {
             fake_super: self.fake_super,
             daemon_incoming_chmod: self.daemon_incoming_chmod.clone(),
             daemon_outgoing_chmod: self.daemon_outgoing_chmod.clone(),
+            user_mapping: self.user_mapping.clone(),
+            group_mapping: self.group_mapping.clone(),
             munge_symlinks: self.munge_symlinks,
         }
     }

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 
 use compress::zlib::CompressionLevel;
 use engine::SkipCompressList;
-use metadata::ChmodModifiers;
+use metadata::{ChmodModifiers, GroupMapping, UserMapping};
 use protocol::FilenameConverter;
 use protocol::ProtocolVersion;
 use protocol::filters::FilterRuleWireFormat;
@@ -453,6 +453,32 @@ pub struct ServerConfig {
     /// - `loadparm.c` - `outgoing chmod` module parameter
     /// - `flist.c:make_file()` - `daemon_chmod_modes` applied during flist build
     pub daemon_outgoing_chmod: Option<ChmodModifiers>,
+    /// Parsed `--usermap=SPEC` rules forwarded by the client.
+    ///
+    /// Receiver-side: applied at metadata-apply time to remap each entry's UID
+    /// before it is written to disk. The client encodes the spec as a single
+    /// `--usermap=VAL` arg in `server_options()` and the daemon's option
+    /// parser (`apply_long_form_args`) restores it here.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2904` - `args[ac++] = safe_arg("--usermap", usermap)`
+    /// - `uidlist.c:parse_name_map()` - parses the spec into the recv-side map
+    /// - `uidlist.c:recv_id_list()` - applies the map per file-list entry
+    pub user_mapping: Option<UserMapping>,
+    /// Parsed `--groupmap=SPEC` rules forwarded by the client.
+    ///
+    /// Receiver-side: applied at metadata-apply time to remap each entry's GID
+    /// before it is written to disk. The client encodes the spec as a single
+    /// `--groupmap=VAL` arg in `server_options()` and the daemon's option
+    /// parser (`apply_long_form_args`) restores it here.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2907` - `args[ac++] = safe_arg("--groupmap", groupmap)`
+    /// - `uidlist.c:parse_name_map()` - parses the spec into the recv-side map
+    /// - `uidlist.c:recv_id_list()` - applies the map per file-list entry
+    pub group_mapping: Option<GroupMapping>,
     /// When true, munge symlink targets with the `/rsyncd-munged/` prefix.
     ///
     /// Sourced from the daemon module's `munge symlinks` directive (or its
@@ -500,6 +526,8 @@ impl Default for ServerConfig {
             fake_super: false,
             daemon_incoming_chmod: None,
             daemon_outgoing_chmod: None,
+            user_mapping: None,
+            group_mapping: None,
             munge_symlinks: false,
         }
     }

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -154,7 +154,17 @@ impl ReceiverContext {
             // `ChmodModifiers`; we hand it to MetadataOptions so the existing
             // chmod-application site in `apply_permissions_with_chmod`
             // performs the rewrite without a separate code path.
-            .with_chmod(self.config.daemon_incoming_chmod.clone());
+            .with_chmod(self.config.daemon_incoming_chmod.clone())
+            // upstream: uidlist.c:recv_id_list() applies parsed --usermap /
+            // --groupmap rules at file-list receive time on the receiver.
+            // The daemon parsed the wire arg in `apply_long_form_args` and
+            // stashed the typed mapping on `ServerConfig`; hand it to
+            // `MetadataOptions` so `metadata::apply::ownership` consults it
+            // when remapping uid/gid before chown. Without this the wildcard
+            // spec `--groupmap=*:GID` from the client is silently dropped on
+            // daemon uploads (upstream regression #829 / daemon-groupmap-wild).
+            .with_user_mapping(self.config.user_mapping.clone())
+            .with_group_mapping(self.config.group_mapping.clone());
 
         let dest_arg = self.config.args.first();
         let trailing_slash = dest_arg.is_some_and(|arg| dest_arg_has_trailing_slash(arg));


### PR DESCRIPTION
## Summary

- Daemon's `apply_long_form_args` now consumes `--usermap=SPEC` / `--groupmap=SPEC` via `metadata::UserMapping::parse` / `GroupMapping::parse`. Before this change the daemon silently dropped the option and the receiver completed with unmapped ids - the regression captured by upstream's daemon-groupmap-wild test (rsync issue #829).
- Threads `user_mapping` / `group_mapping` through `ServerConfigBuilder` so they reach `TransferConfig`. Malformed specs leave the field unset (matches upstream's daemon path, which falls through to default mapping rather than aborting).
- Targets UTS-8.REOPEN daemon-groupmap-wild.

## Status

**Unvalidated WIP — not run against runtests.py before push.** Reviewer/CI verifies.

## Test plan

- [ ] `cargo nextest run -p daemon --all-features -E 'test(groupmap)'`
- [ ] Upstream testsuite `daemon-groupmap-wild` cell passes against the patched binary
- [ ] safe_arg backslash escape path (URV-2.a) still produces correct wire bytes