### PR TITLE
fix(cli): accept split --partial-dir / --delay-updates in --server mode (UTS-SLDB)

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -128,6 +128,24 @@ pub(super) struct ServerLongFlags {
     /// string - it only inspects it for `%i` / `%o` tokens to set
     /// `stdout_format_has_i` and `stdout_format_has_o_or_i`.
     pub(super) log_format: Option<String>,
+    /// Partial-directory path forwarded by the client (`--partial-dir=DIR`).
+    ///
+    /// upstream: options.c:2886-2890 - `server_options()` emits the option
+    /// as TWO separate argv entries (`--partial-dir`, then the value) via
+    /// `safe_arg("", partial_dir)`, NOT the `--partial-dir=VALUE` form.
+    /// Without recognising the split form, the value lands in
+    /// `parse_server_flag_string_and_args` and gets parsed as a positional
+    /// destination path - the receiver then creates a directory literally
+    /// named `--partial-dir` at the transfer root and never honours the
+    /// partial-dir semantics. Issue #715 regression test
+    /// (`symlink-dirlink-basis_test.py` test 7) drives this path with
+    /// `--protocol=28 --partial-dir=.rsync-partial`.
+    pub(super) partial_dir: Option<OsString>,
+    /// Whether `--delay-updates` was forwarded by the client.
+    ///
+    /// upstream: options.c:2891-2892 - `server_options()` emits
+    /// `--delay-updates` alongside `--partial-dir` when both are active.
+    pub(super) delay_updates: bool,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -170,9 +188,13 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         info: Vec::new(),
         compress_choice: None,
         log_format: None,
+        partial_dir: None,
+        delay_updates: false,
     };
 
-    for arg in args {
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
         let s = arg.to_string_lossy();
 
         match s.as_ref() {
@@ -209,10 +231,31 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // CompressionAlgorithm in `transfer::run_server_with_handshake`.
             "--new-compress" => flags.compress_choice = Some("zlibx".to_owned()),
             "--old-compress" => flags.compress_choice = Some("zlib".to_owned()),
+            // upstream: options.c:2886-2890 - server_options() emits
+            // `--partial-dir` and its value as TWO separate argv entries.
+            // Consume the next arg verbatim as the directory path.
+            "--partial-dir" => {
+                if let Some(next) = args.get(idx + 1) {
+                    flags.partial_dir = Some(next.clone());
+                    idx += 1;
+                }
+            }
+            // upstream: options.c:2891-2892 - emitted alongside --partial-dir.
+            "--delay-updates" => flags.delay_updates = true,
             _ => {
-                parse_value_bearing_flag(&s, &mut flags);
+                // Accept the joined `--partial-dir=VALUE` form too, even
+                // though upstream's server_options() does not emit it - the
+                // CLI parser accepts both forms for client-side use, and a
+                // forwarder built on a non-upstream client might still send
+                // the joined form.
+                if let Some(value) = s.strip_prefix("--partial-dir=") {
+                    flags.partial_dir = Some(OsString::from(value));
+                } else {
+                    parse_value_bearing_flag(&s, &mut flags);
+                }
             }
         }
+        idx += 1;
     }
 
     flags
@@ -314,6 +357,8 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--ignore-existing"
             | "--existing"
             | "--ignore-non-existing"
+            | "--delay-updates"
+            | "--partial-dir"
     ) || arg == "-s"
         || arg == "--new-compress"
         || arg == "--old-compress"
@@ -336,4 +381,5 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--io-uring-depth=")
         || arg.starts_with("--log-format=")
         || arg.starts_with("--info=")
+        || arg.starts_with("--partial-dir=")
 }

--- a/crates/cli/src/frontend/server/parse.rs
+++ b/crates/cli/src/frontend/server/parse.rs
@@ -15,27 +15,42 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
     let mut positional_args = Vec::new();
     let mut found_flags = false;
 
-    for arg in args {
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
         let arg_str = arg.to_string_lossy();
 
         if is_known_server_long_flag(&arg_str) {
+            // upstream: options.c:2886-2890 - `--partial-dir` is emitted as
+            // TWO separate argv entries by server_options(), so the value
+            // that immediately follows must also be skipped here. Without
+            // this, the partial-dir VALUE leaks into the positional list and
+            // becomes a destination-path argument.
+            if arg_str == "--partial-dir" {
+                idx += 2;
+                continue;
+            }
+            idx += 1;
             continue;
         }
 
         if !found_flags && arg_str.starts_with('-') {
             flag_string = arg_str.into_owned();
             found_flags = true;
+            idx += 1;
             continue;
         }
 
         // upstream uses "." as a placeholder separator between flags and paths
         if found_flags && arg_str == "." {
+            idx += 1;
             continue;
         }
 
         if found_flags {
             positional_args.push(arg.clone());
         }
+        idx += 1;
     }
 
     (flag_string, positional_args)

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -149,6 +149,24 @@ where
     // during the goodbye phase (generator.c:2377,2422).
     config.do_stats = long_flags.stats;
     config.reference_directories = long_flags.reference_directories;
+    // upstream: options.c:2886-2890 - `--partial-dir DIR` forwarded by the
+    // sender. The server-side receiver moves interrupted temp files into this
+    // directory and looks for resume basis files there. Without applying this
+    // value, transfers that pin `--protocol=28` (where the client cannot
+    // forward `partial_dir` in the compat flag string) leave the receiver
+    // with no partial-dir at all - in that case the receiver's normal commit
+    // path runs, which is what the regression test
+    // `symlink-dirlink-basis_test.py` exercises through `lsh.sh`.
+    if let Some(dir) = &long_flags.partial_dir {
+        let path = std::path::PathBuf::from(dir);
+        config.partial_dir = Some(path);
+        config.has_partial_dir = true;
+    }
+    // upstream: options.c:2891-2892 - `--delay-updates` rides alongside
+    // `--partial-dir` whenever both are active.
+    if long_flags.delay_updates {
+        config.write.delay_updates = true;
+    }
 
     // upstream: options.c:2327-2338 - server parses --log-format to determine
     // whether itemize data is needed. %i or %I in the format sets

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -339,6 +339,81 @@ fn parse_server_args_skips_value_bearing_long_flags() {
     assert_eq!(pos_args, vec![OsString::from("dest/")]);
 }
 
+/// Regression for UTS-SLDB.REOPEN (`symlink-dirlink-basis_test.py` test 7):
+/// upstream `server_options()` (options.c:2886-2890) emits `--partial-dir`
+/// and its value as TWO separate argv entries. Both `--partial-dir` itself
+/// and the value that follows must be stripped from the positional list,
+/// otherwise the value (`.rsync-partial`) shows up as a destination path
+/// and the receiver creates a directory literally named `--partial-dir`.
+#[test]
+fn parse_server_args_skips_split_partial_dir_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-vlKtpR"),
+        OsString::from("--partial-dir"),
+        OsString::from(".rsync-partial"),
+        OsString::from("."),
+        OsString::from("."),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-vlKtpR");
+    assert!(
+        pos_args.is_empty(),
+        "split --partial-dir and value must not leak into positional args: {:?}",
+        pos_args,
+    );
+}
+
+/// Companion to the split-form test above: `--partial-dir=VALUE` is the
+/// joined form used by the client-side CLI parser. The server parser must
+/// also recognise it so non-upstream clients that emit the joined form do
+/// not corrupt the positional list.
+#[test]
+fn parse_server_args_skips_joined_partial_dir_flag() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-vlKtpR"),
+        OsString::from("--partial-dir=.rsync-partial"),
+        OsString::from("."),
+        OsString::from("dest"),
+    ];
+    let (flags, pos_args) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flags, "-vlKtpR");
+    assert_eq!(pos_args, vec![OsString::from("dest")]);
+}
+
+/// `parse_server_long_flags` must capture both split and joined
+/// `--partial-dir` forms into `ServerLongFlags::partial_dir`.
+#[test]
+fn long_flags_captures_split_partial_dir() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--partial-dir"),
+        OsString::from(".rsync-partial"),
+        OsString::from("--delay-updates"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(
+        flags.partial_dir.as_deref(),
+        Some(std::ffi::OsStr::new(".rsync-partial")),
+    );
+    assert!(flags.delay_updates);
+}
+
+#[test]
+fn long_flags_captures_joined_partial_dir() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("--partial-dir=.rsync-partial"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(
+        flags.partial_dir.as_deref(),
+        Some(std::ffi::OsStr::new(".rsync-partial")),
+    );
+    assert!(!flags.delay_updates);
+}
+
 #[test]
 fn long_flags_defaults() {
     let args: Vec<OsString> = vec![OsString::from("--server")];


### PR DESCRIPTION
## Summary

Upstream `server_options()` (`options.c:2886-2890`) emits `--partial-dir` and its value as two separate argv entries via `safe_arg(\"\", partial_dir)`, not as the `--partial-dir=VALUE` joined form. oc-rsync's server-mode arg parser only recognised the joined form, so under `--protocol=28 --partial-dir=.rsync-partial` the bare `--partial-dir` and `.rsync-partial` words fell through to `parse_server_flag_string_and_args` as positional destination arguments. The receiver then created a directory literally named `--partial-dir` at the transfer root and never honoured the partial-dir semantics — test 7 of `symlink-dirlink-basis_test.py`.

- Adds split form to `is_known_server_long_flag` and `ServerLongFlags`; `parse_server_long_flags` / `parse_server_flag_string_and_args` consume both `--partial-dir`/`--delay-updates` and the next arg.
- Wires `long_flags.partial_dir` / `long_flags.delay_updates` into `ServerConfig.partial_dir` + `config.write.delay_updates` so the receiver places interrupted temp files in the configured partial dir and commits the final file to the real destination through the resolved symlink.
- 4 new regression tests covering both flag forms.

## Status

**Validated on the Linux host against the upstream testsuite:**
- \`runtests.py symlink-dirlink-basis\` → \`PASS    symlink-dirlink-basis\`
- \`cargo test -p cli --release --lib partial_dir\` — 10/10 pass
- \`cargo test -p cli --release --lib frontend::server\` — 110/110 pass, no regressions

## Test plan

- [x] Upstream testsuite \`symlink-dirlink-basis\` passes
- [x] No regressions in \`frontend::server\` cli tests
- [ ] CI matrix green
- [ ] Existing \`--partial-dir=VALUE\` (joined-form) callers still work