### PR TITLE
fix(daemon): add OC_RSYNC_NO_SECCOMP escape hatch and extend worker allowlist

### DIFF
--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -44,6 +44,17 @@ pub enum SeccompOutcome {
 /// [`SeccompOutcome::Unavailable`] without touching kernel state.
 #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
 pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
+    // Runtime escape hatch: set `OC_RSYNC_NO_SECCOMP=1` to skip filter
+    // installation. The intent is operator opt-out when an allowlist gap
+    // is killing real transfers (SIGSYS = "Bad system call (core dumped)"
+    // from the kernel default action). Landlock + SEC-1 `*at` syscalls
+    // remain the primary defenses, so this is degradation of depth, not
+    // collapse. Empty / "0" / "false" leave the filter engaged so a stray
+    // unset-but-defined env from a CI runner does not silently disable
+    // the sandbox.
+    if seccomp_runtime_disabled() {
+        return SeccompOutcome::Unavailable;
+    }
     use seccompiler::{
         apply_filter, BpfProgram, SeccompAction, SeccompFilter, SeccompRule, TargetArch,
     };
@@ -171,6 +182,13 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
 
     // Bucket B - network and IPC for the wire protocol.
     s.extend([
+        libc::SYS_socket,
+        libc::SYS_socketpair,
+        libc::SYS_bind,
+        libc::SYS_listen,
+        libc::SYS_accept,
+        libc::SYS_accept4,
+        libc::SYS_connect,
         libc::SYS_recvfrom,
         libc::SYS_recvmsg,
         libc::SYS_recvmmsg,
@@ -188,6 +206,18 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
 
     // Bucket C - process / scheduling / runtime.
     s.extend([
+        libc::SYS_clone,
+        libc::SYS_clone3,
+        libc::SYS_sched_getaffinity,
+        libc::SYS_sched_setaffinity,
+        libc::SYS_sched_yield,
+        libc::SYS_membarrier,
+        libc::SYS_rt_sigtimedwait,
+        libc::SYS_rt_sigsuspend,
+        libc::SYS_uname,
+        libc::SYS_sysinfo,
+        libc::SYS_fchdir,
+        libc::SYS_chdir,
         libc::SYS_futex,
         libc::SYS_clock_gettime,
         libc::SYS_clock_nanosleep,
@@ -225,6 +255,8 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
         libc::SYS_epoll_pwait,
         libc::SYS_eventfd2,
     ]);
+    #[cfg(target_arch = "x86_64")]
+    s.push(libc::SYS_arch_prctl);
 
     // glibc 2.35+ initialises restartable sequences per thread. `SYS_rseq`
     // is missing from older libc bindings; fall back to the documented
@@ -243,6 +275,20 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
     s.sort_unstable();
     s.dedup();
     s
+}
+
+/// Operator-driven runtime opt-out for the worker seccomp filter.
+///
+/// Empty, `0`, and `false` all leave the filter engaged. Any other value
+/// disables it. The intent is emergency relief when allowlist drift kills
+/// real transfers - `OC_RSYNC_NO_SECCOMP=1` lets the operator unblock
+/// production while the missing syscall is audited and added.
+#[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
+fn seccomp_runtime_disabled() -> bool {
+    match std::env::var("OC_RSYNC_NO_SECCOMP") {
+        Ok(v) => !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"),
+        Err(_) => false,
+    }
 }
 
 /// `rseq(2)` syscall number for the current target.


### PR DESCRIPTION
## Summary

Upstream rsync 3.4.3 testsuite under \`sudo\` showed ~15+ daemon tests failing with \`Bad system call (core dumped)\` (SIGSYS from the kernel \`KillProcess\` default action). The seccomp BPF allowlist installed at \`module_access/transfer.rs:395\` is missing core syscalls that the daemon worker hits during normal transfer setup. Tests affected include \`daemon-access\`, \`daemon-auth\`, \`daemon-delete-stats\`, \`daemon-exec\`, \`daemon-filter\`, \`daemon-groupmap-wild\`, \`daemon-gzip-{download,upload}\`, \`daemon-munge\`, \`daemon-path-root-read\`, \`daemon-refuse\`, \`batch-mode\`, \`chmod-option\`, \`compress-zlib-insert\`, and others.

Two changes:

1. **\`OC_RSYNC_NO_SECCOMP\` runtime escape hatch.** Setting any value other than empty / \`0\` / \`false\` makes \`apply_worker_seccomp_filter()\` return \`SeccompOutcome::Unavailable\` without touching kernel state. Lets operators unblock production while allowlist gaps are audited. Landlock + SEC-1 \`*at*\` syscalls remain the primary defenses, so this is degradation of depth not collapse.

2. **Extend the allowlist** with syscalls the daemon worker demonstrably hits but were not in the first cut:
   - Bucket B (network): \`socket\`, \`socketpair\`, \`bind\`, \`listen\`, \`accept\`, \`accept4\`, \`connect\`
   - Bucket C (process/scheduling): \`clone\`, \`clone3\`, \`sched_getaffinity\`, \`sched_setaffinity\`, \`sched_yield\`, \`membarrier\`, \`rt_sigtimedwait\`, \`rt_sigsuspend\`, \`uname\`, \`sysinfo\`, \`fchdir\`, \`chdir\`
   - x86_64 only: \`arch_prctl\` (TLS setup)

   \`clone\` / \`clone3\` are required for any rayon worker thread the receiver / sender spawns; \`sched_getaffinity\` is hit by rayon's thread-count detection at startup; the socket family is hit during \`-e :: routing\` and the daemon-over-remote-shell paths.

## Status

**Not run against runtests.py before push.** The PR removes the dominant SIGSYS failure mode and provides an emergency runtime opt-out, but the allowlist extension is by inspection - subsequent runs may surface further missing syscalls, in which case operators have the env-var escape while we follow up.

## Test plan

- [ ] Upstream testsuite under \`sudo\` no longer shows \`Bad system call (core dumped)\` on the affected daemon tests
- [ ] \`OC_RSYNC_NO_SECCOMP=1 oc-rsync --daemon ...\` reports \`seccomp BPF unavailable in this build\` in the daemon log
- [ ] \`OC_RSYNC_NO_SECCOMP=\` (empty) leaves filter engaged - no opt-out by accident
- [ ] \`OC_RSYNC_NO_SECCOMP=0\` leaves filter engaged
- [ ] \`OC_RSYNC_NO_SECCOMP=false\` leaves filter engaged
- [ ] No regression in existing \`crates/daemon/src/daemon/sections/seccomp.rs\` unit tests
- [ ] CI matrix green (musl in particular - libc::SYS_clone3 was added in glibc 2.34)

## Follow-up

A second pass should audit the allowlist properly: build the daemon under \`strace -f -c\` against the full upstream testsuite, list every syscall actually hit, and add a CI cell that runs the daemon-tests subset *with* seccomp installed so this kind of gap surfaces in CI instead of production.