### PR TITLE
fix(transfer): honor /./ anchor and trailing-slash recursion in --files-from (UTS-21)

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -134,22 +134,27 @@ impl GeneratorContext {
         Ok(count)
     }
 
-    /// Builds a file list from `--files-from` entries using a shared base directory.
+    /// Builds a file list from `--files-from` entries.
     ///
-    /// Unlike [`build_file_list`](Self::build_file_list), which treats each path as
-    /// its own base for `walk_path`, this method uses a single `base_dir` for all
-    /// file paths. Each entry's relative name is computed by stripping `base_dir`,
-    /// matching upstream rsync's behaviour of `chdir(argv[0])` before reading
-    /// filenames from the `--files-from` source.
+    /// Unlike [`build_file_list`](Self::build_file_list), which treats each
+    /// positional argument as its own base for `walk_path`, this method honors
+    /// the per-entry base produced by
+    /// [`split_files_from_entry`](super::super::filters::split_files_from_entry).
+    /// Each entry's wire-side relative name is computed by stripping its own
+    /// `base`, matching upstream rsync's `chdir(dir)` + transmit-`fn` split
+    /// (`flist.c:2316-2330`). The `base_dir` argument is the source argument
+    /// shared by entries without a `/./` anchor and is used to emit the
+    /// transfer-root `.` entry.
     ///
     /// # Upstream Reference
     ///
     /// - `flist.c:2240-2264` - `change_dir(argv[0])` then read relative filenames
-    /// - `flist.c:2262` - `read_line(filesfrom_fd, ...)` reads one name at a time
+    /// - `flist.c:2316-2330` - per-entry `/./` anchor split
+    /// - `flist.c:2287` - `send_file_name(".", ...)` for the transfer-root entry
     pub fn build_file_list_with_base(
         &mut self,
         base_dir: &Path,
-        file_paths: &[PathBuf],
+        entries: &[super::filters::FilesFromEntry],
     ) -> io::Result<usize> {
         self.timing.flist_build_start = Some(Instant::now());
 
@@ -162,30 +167,38 @@ impl GeneratorContext {
 
         // upstream: flist.c:2287 - emit "." with XMIT_TOP_DIR for the root
         // transfer directory so --delete works correctly on the receiver side.
-        if let Ok(meta) = std::fs::symlink_metadata(base_dir) {
-            if meta.is_dir() {
-                let mut dot_entry = self.create_entry(base_dir, PathBuf::from("."), &meta)?;
-                dot_entry.set_top_dir(true);
-                self.push_file_item(dot_entry, base_dir.to_path_buf());
+        // Skip when any entry's effective walk will already emit a `.` (i.e.
+        // an entry whose `/./` anchor produced `path == base`). Otherwise a
+        // duplicate `.` would race the entry's `.` on the wire and could
+        // overwrite the transfer-root permissions with the per-entry root's
+        // permissions when the upstream receiver dedupes by name.
+        let entry_emits_root_dot = entries.iter().any(|e| e.path == e.base);
+        if !entry_emits_root_dot {
+            if let Ok(meta) = std::fs::symlink_metadata(base_dir) {
+                if meta.is_dir() {
+                    let mut dot_entry = self.create_entry(base_dir, PathBuf::from("."), &meta)?;
+                    dot_entry.set_top_dir(true);
+                    self.push_file_item(dot_entry, base_dir.to_path_buf());
+                }
             }
         }
 
         // Pre-populate the explicit-directory set with every --files-from
         // entry that is itself a directory. The implied-parent loop below
         // skips emission for entries already in this set so the explicit
-        // top-level walk owns their emission, and the set is later used to
-        // distinguish "explicit dir, walk normally" from
-        // "implied-only dir, already emitted, skip the duplicate top-level
-        // walk that upstream's `implied_filter_list` check rejects".
-        let mut explicit_dirs: HashSet<PathBuf> = HashSet::new();
-        for path in file_paths {
-            if let Ok(rel) = path.strip_prefix(base_dir) {
+        // top-level walk owns their emission. Keys are the (base, wire-relative)
+        // pair so two entries that resolve to the same filesystem path but
+        // through different `/./` anchors do not collide on the wire-side
+        // dedup map.
+        let mut explicit_dirs: HashSet<(PathBuf, PathBuf)> = HashSet::new();
+        for entry in entries {
+            if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
                 if rel.as_os_str().is_empty() {
                     continue;
                 }
-                if let Ok(meta) = std::fs::symlink_metadata(path) {
+                if let Ok(meta) = std::fs::symlink_metadata(&entry.path) {
                     if meta.is_dir() {
-                        explicit_dirs.insert(rel.to_path_buf());
+                        explicit_dirs.insert((entry.base.clone(), rel.to_path_buf()));
                     }
                 }
             }
@@ -204,26 +217,29 @@ impl GeneratorContext {
         // `implied_only_dirs` is later consulted by
         // `try_walk_source_entry_dedup` to suppress the duplicate top-level
         // walk that would re-emit an implied parent.
-        let mut emitted_dirs: HashSet<PathBuf> = explicit_dirs.clone();
-        for path in file_paths {
-            if let Ok(rel) = path.strip_prefix(base_dir) {
+        let mut emitted_dirs: HashSet<(PathBuf, PathBuf)> = explicit_dirs.clone();
+        for entry in entries {
+            if let Ok(rel) = entry.path.strip_prefix(&entry.base) {
                 // Walk each ancestor of the relative path and emit a
                 // directory entry when we haven't seen it yet.
                 let mut ancestor = PathBuf::new();
                 for component in rel.parent().into_iter().flat_map(Path::components) {
                     ancestor.push(component);
-                    if emitted_dirs.contains(&ancestor) {
+                    let key = (entry.base.clone(), ancestor.clone());
+                    if emitted_dirs.contains(&key) {
                         continue;
                     }
-                    let full = base_dir.join(&ancestor);
+                    let full = entry.base.join(&ancestor);
                     if let Ok(meta) = std::fs::symlink_metadata(&full) {
                         if meta.is_dir() {
-                            if let Ok(entry) = self.create_entry(&full, ancestor.clone(), &meta) {
-                                self.push_file_item(entry, full);
+                            if let Ok(file_entry) =
+                                self.create_entry(&full, ancestor.clone(), &meta)
+                            {
+                                self.push_file_item(file_entry, full);
                             }
                         }
                     }
-                    emitted_dirs.insert(ancestor.clone());
+                    emitted_dirs.insert(key);
                 }
             }
         }
@@ -234,19 +250,40 @@ impl GeneratorContext {
         // that upstream's `implied_filter_list` check (flist.c:998) would
         // reject as "unrequested". Explicit --files-from dirs remain walkable
         // so their recursive contents continue to flow normally.
-        let implied_only_dirs: HashSet<PathBuf> =
+        let implied_only_dirs: HashSet<(PathBuf, PathBuf)> =
             emitted_dirs.difference(&explicit_dirs).cloned().collect();
 
-        // Walk each listed file using the shared base directory so that
-        // relative paths are computed correctly (e.g., "hello.txt" instead
-        // of an empty string).
-        for path in file_paths {
+        // Walk each listed file using its own per-entry base so that the
+        // wire-side relative name reflects the `/./` anchor split (e.g.
+        // `from/./dir/subdir` transmits as `dir/subdir`, not
+        // `from/dir/subdir`).
+        for entry in entries {
             // upstream: flist.c:2254-2272 - pre-stat each --files-from entry
             // and apply missing_args handling before walk_path. This separates
             // "source never existed" (ENOENT at flist time) from "source vanished
             // during recursive walk" (ENOENT during child traversal).
-            if !self.try_walk_source_entry_dedup(base_dir, path, Some(&implied_only_dirs))? {
+            let scoped: HashSet<PathBuf> = implied_only_dirs
+                .iter()
+                .filter_map(|(b, rel)| (b == &entry.base).then(|| rel.clone()))
+                .collect();
+            if !self.try_walk_source_entry_dedup(&entry.base, &entry.path, Some(&scoped))? {
                 continue;
+            }
+
+            // upstream: flist.c:2329 - SLASH_ENDING_NAME / DOTDIR_NAME entries
+            // recurse into their children even when global `-r` is off. Plain
+            // `try_walk_source_entry_dedup` honours the global `recursive` flag
+            // so the trailing-slash directories would otherwise stop at the
+            // entry itself. Re-scan the directory here so the receiver sees
+            // the listed dir's contents (`from/./dir/subdir/subsubdir2/` must
+            // emit `bin-lt-list`, etc.). The `entry.path == entry.base` case
+            // is already covered by the DOTDIR scan in `walk_path_with_metadata`.
+            if entry.recurse && entry.path != entry.base {
+                if let Ok(meta) = std::fs::symlink_metadata(&entry.path) {
+                    if meta.is_dir() {
+                        self.scan_files_from_marker_dir(&entry.base, &entry.path)?;
+                    }
+                }
             }
         }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -329,6 +329,42 @@ impl GeneratorContext {
         Ok(())
     }
 
+    /// Scans the children of a `--files-from` SLASH_ENDING_NAME directory.
+    ///
+    /// Used by `build_file_list_with_base` to honour the upstream
+    /// `flist.c:2329` rule that trailing-slash `--files-from` entries recurse
+    /// into their named directory's children even when global `-r` is off
+    /// (`options.c:2189` clears `recurse` whenever `--files-from` is active).
+    /// The walk-loop already pushed the directory entry itself via
+    /// `try_walk_source_entry_dedup`; this helper just adds the children at
+    /// the same level a global `-r` would have produced.
+    ///
+    /// Wraps `scan_directory_batched` in the per-directory filter scope
+    /// (`enter_directory` / `leave_directory`) so per-dir merge files are
+    /// honoured for the recursion the way they are during a normal walk.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:send_directory()` - reads directory and stats each child
+    /// - `flist.c:2329` - `SLASH_ENDING_NAME` flag for trailing-slash entries
+    pub(in crate::generator) fn scan_files_from_marker_dir(
+        &mut self,
+        base: &Path,
+        dir_path: &Path,
+    ) -> io::Result<()> {
+        let guard = self.filter_chain.enter_directory(dir_path).map_err(|e| {
+            io::Error::other(format!(
+                "filter chain error in \"{}\": {e} {}{}",
+                dir_path.display(),
+                error_location!(),
+                crate::role_trailer::sender()
+            ))
+        })?;
+        let result = self.scan_directory_batched(base, dir_path);
+        self.filter_chain.leave_directory(guard);
+        result
+    }
+
     /// Reads a directory and batch-stats its children before recursive processing.
     ///
     /// Collects all `DirEntry` paths from `read_dir()`, resolves their metadata

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -15,7 +15,7 @@
 //! - `exclude.c:push_local_filters()` - per-directory merge file loading
 
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub use ::filters::FilterSet;
 use filters::{DirMergeConfig, FilterChain};
@@ -26,6 +26,110 @@ use crate::role_trailer::error_location;
 
 use super::GeneratorContext;
 use ::filters::FilterRule;
+
+/// A resolved `--files-from` entry split into a walk base and a full path.
+///
+/// Upstream rsync's `flist.c:2316-2330` splits each `--files-from` line on its
+/// first `/./` anchor: characters before the anchor name the directory the
+/// sender chdirs into, and characters after become the transmitted relative
+/// name. Entries without an anchor share the original source argument as
+/// their base.
+///
+/// Carrying the split forward lets `build_file_list_with_base` strip the
+/// per-entry `base` so that the wire-side relative name matches what the
+/// receiver's `implied_filter_list` (built from the verbatim `--files-from`
+/// lines) expects. Without the split, the relative name would still include
+/// the anchor prefix and the receiver would reject it as
+/// "unrequested file-list name".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesFromEntry {
+    /// Effective walk base for this entry. Equal to the source argument for
+    /// plain entries; for entries with a `/./` anchor, equal to the source
+    /// argument joined with the prefix before the anchor.
+    pub base: PathBuf,
+    /// Full filesystem path of the entry, i.e. `base` joined with the
+    /// transmitted relative name.
+    pub path: PathBuf,
+    /// True when the original `--files-from` line ended with `/` or with the
+    /// `/./` DOTDIR anchor. Upstream `flist.c:2329` flags these as
+    /// `SLASH_ENDING_NAME`/`DOTDIR_NAME`, which causes the sender to recurse
+    /// into the directory's children even when global `-r` is disabled
+    /// (`options.c:2189` clears `recurse` whenever `--files-from` is active).
+    pub recurse: bool,
+}
+
+/// Splits a sanitized `--files-from` entry on its first `/./` anchor.
+///
+/// Mirrors upstream `flist.c:2316-2330`: anything before the anchor becomes
+/// part of the per-entry walk base; anything after is the transmitted
+/// relative name. Entries without an anchor inherit `base_dir` unchanged.
+///
+/// `raw_trailing_slash` records whether the original `--files-from` line
+/// (before sanitisation) ended with `/`, including the `/./` DOTDIR form.
+/// Upstream `flist.c:2329` flags those lines as `SLASH_ENDING_NAME` /
+/// `DOTDIR_NAME` and recurses into their children even when global `-r` is
+/// off (`options.c:2189` clears `recurse` whenever `--files-from` is
+/// active), so we propagate the flag onto [`FilesFromEntry::recurse`] for
+/// `build_file_list_with_base` to honour.
+///
+/// A trailing `/.` is treated as an anchor with an empty suffix because
+/// [`sanitize_path_keep_dot_dirs`](crate::sanitize_path::sanitize_path_keep_dot_dirs)
+/// collapses the trailing slash that upstream's `sanitize_path` preserves
+/// (`from/./` → `from/.`). Without this, `from/./` would never match the
+/// `/./` substring search and would emit a stray `from/` directory entry
+/// instead of promoting `from` to the per-entry walk base.
+pub(super) fn split_files_from_entry(
+    base_dir: &Path,
+    sanitized: &str,
+    raw_trailing_slash: bool,
+) -> FilesFromEntry {
+    // Anchored form: prefix `/./` suffix.
+    if let Some(anchor) = sanitized.find("/./") {
+        let (head, tail) = sanitized.split_at(anchor);
+        // upstream: flist.c:2321 - skip the `/./` separator and any redundant
+        // leading slashes on the suffix so `dir/./subdir` and `dir/././subdir`
+        // both collapse to a relative name of `subdir`.
+        let rest = tail[3..].trim_start_matches('/');
+        let base = if head.is_empty() {
+            base_dir.to_path_buf()
+        } else {
+            base_dir.join(head)
+        };
+        let path = if rest.is_empty() {
+            base.clone()
+        } else {
+            base.join(rest)
+        };
+        // An empty suffix (e.g. `from/./`) is upstream's DOTDIR_NAME case,
+        // which always recurses. Otherwise honour the raw trailing slash.
+        let recurse = rest.is_empty() || raw_trailing_slash;
+        return FilesFromEntry {
+            base,
+            path,
+            recurse,
+        };
+    }
+
+    // Trailing-anchor form: prefix `/.` (sanitize stripped the trailing slash
+    // upstream would have left). Treat it identically to `prefix/./`.
+    if let Some(head) = sanitized.strip_suffix("/.") {
+        if !head.is_empty() {
+            let base = base_dir.join(head);
+            return FilesFromEntry {
+                base: base.clone(),
+                path: base,
+                // Upstream DOTDIR_NAME always recurses.
+                recurse: true,
+            };
+        }
+    }
+
+    FilesFromEntry {
+        base: base_dir.to_path_buf(),
+        path: base_dir.join(sanitized),
+        recurse: raw_trailing_slash,
+    }
+}
 
 impl GeneratorContext {
     /// Receives filter list from client in server mode.
@@ -93,19 +197,24 @@ impl GeneratorContext {
     /// `Some(path)` for any other value, the file is opened and read locally.
     ///
     /// Each filename is resolved relative to the first positional argument (the
-    /// base source directory). Returns an empty `Vec` when no `--files-from` is
+    /// base source directory). Entries containing a `/./` anchor are split per
+    /// upstream `flist.c:2316`: the prefix before the anchor is joined onto the
+    /// base to form the entry's effective walk base, and the suffix becomes the
+    /// transmitted relative name. Entries without an anchor share `base_dir` as
+    /// their effective base. Returns an empty `Vec` when no `--files-from` is
     /// configured, signaling the caller to use the original positional paths.
     ///
     /// # Upstream Reference
     ///
     /// - `flist.c:2262` - `read_line(filesfrom_fd, ...)` reads one name at a time
+    /// - `flist.c:2316-2330` - `/./` anchor split for relative-name emission
     /// - `main.c:681-685` - `filesfrom_fd` set to `STDIN_FILENO` for `--files-from=-`
     /// - `io.c:start_filesfrom_forwarding()` - client forwards local file over socket
     pub(super) fn resolve_files_from_paths<R: Read>(
         &self,
         original_paths: &[PathBuf],
         reader: &mut R,
-    ) -> io::Result<Vec<PathBuf>> {
+    ) -> io::Result<Vec<FilesFromEntry>> {
         let files_from_path = match &self.config.file_selection.files_from_path {
             Some(path) => path.clone(),
             None => return Ok(Vec::new()),
@@ -137,9 +246,9 @@ impl GeneratorContext {
         };
 
         // upstream: flist.c:2240-2264 - chdir to argv[0] then read relative
-        // filenames. We keep the base_dir separate and return fully resolved
-        // paths so that build_file_list_with_base() can reconstruct correct
-        // relative names by stripping the base prefix.
+        // filenames. Each entry's effective base is base_dir plus any prefix
+        // before its `/./` anchor (upstream's `dir` variable in flist.c:2316),
+        // so the wire-side relative name is the path after the anchor.
         let mut resolved = Vec::with_capacity(filenames.len());
         for name in &filenames {
             if name.is_empty() {
@@ -148,10 +257,19 @@ impl GeneratorContext {
             // upstream: flist.c:2264 - sanitize_path(fbuf, fbuf, "", 0, SP_KEEP_DOT_DIRS)
             // Always sanitize files_from entries to prevent directory traversal.
             // This collapses ".." components and strips leading "/" to confine
-            // paths within the transfer root.
+            // paths within the transfer root. `SP_KEEP_DOT_DIRS` preserves the
+            // `/./` anchor so the split below mirrors upstream exactly.
             let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs(name);
-            let path = base_dir.join(&sanitized);
-            resolved.push(path);
+            // upstream: flist.c:2329 - a raw trailing slash flags the entry
+            // as SLASH_ENDING_NAME, which forces recursion even when global
+            // `-r` is off. Capture it from the original (pre-sanitisation)
+            // line so the split can propagate the flag.
+            let raw_trailing_slash = name.ends_with('/');
+            resolved.push(split_files_from_entry(
+                &base_dir,
+                &sanitized,
+                raw_trailing_slash,
+            ));
         }
 
         info_log!(
@@ -410,5 +528,93 @@ mod tests {
         let wire_rule = make_dir_merge_wire_rule(".rsync-filter");
         let config = wire_rule_to_dir_merge_config(&wire_rule);
         assert_eq!(config.filename(), ".rsync-filter");
+    }
+
+    #[test]
+    fn split_files_from_entry_without_anchor_inherits_base() {
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "dir/file.txt", false);
+        assert_eq!(split.base, PathBuf::from("/src"));
+        assert_eq!(split.path, PathBuf::from("/src/dir/file.txt"));
+        assert!(!split.recurse);
+    }
+
+    #[test]
+    fn split_files_from_entry_with_anchor_promotes_prefix_to_base() {
+        // UTS-21.REOPEN regression: `from/./dir/subdir` must split so that
+        // the wire-side relative name (path.strip_prefix(base)) is just
+        // `dir/subdir`. Otherwise upstream's `implied_filter_list` check
+        // (flist.c:998) rejects `from/dir/subdir` as "unrequested".
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "from/./dir/subdir", false);
+        assert_eq!(split.base, PathBuf::from("/src/from"));
+        assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir"));
+        assert!(!split.recurse);
+        let rel = split.path.strip_prefix(&split.base).unwrap();
+        assert_eq!(rel, std::path::Path::new("dir/subdir"));
+    }
+
+    #[test]
+    fn split_files_from_entry_with_trailing_anchor_keeps_base_as_path() {
+        // upstream: flist.c:2321-2324 - `from/./` (trailing `/.`) emits the
+        // anchor directory itself, with the relative name collapsing to `.`,
+        // and is always recursed into.
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "from/./", true);
+        assert_eq!(split.base, PathBuf::from("/src/from"));
+        assert_eq!(split.path, PathBuf::from("/src/from"));
+        assert!(split.recurse);
+    }
+
+    #[test]
+    fn split_files_from_entry_with_trailing_dot_after_sanitize_keeps_base_as_path() {
+        // UTS-21.REOPEN: `sanitize_path_keep_dot_dirs("from/./")` returns
+        // `"from/."` because our sanitizer strips the trailing slash that
+        // upstream preserves. Without trailing-dot handling, the split would
+        // miss the anchor and emit a `from/` directory entry instead of
+        // promoting `from` to the walk base.
+        let sanitized = crate::sanitize_path::sanitize_path_keep_dot_dirs("from/./");
+        assert_eq!(sanitized, "from/.");
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, &sanitized, true);
+        assert_eq!(split.base, PathBuf::from("/src/from"));
+        assert_eq!(split.path, PathBuf::from("/src/from"));
+        assert!(split.recurse);
+    }
+
+    #[test]
+    fn split_files_from_entry_with_trailing_slash_recurses() {
+        // UTS-21.REOPEN: `from/./dir/subdir/subsubdir2/` (trailing slash) is
+        // upstream's `SLASH_ENDING_NAME` case, which forces recursion into
+        // the named directory even though `--files-from` clears the global
+        // `-r` flag.
+        let base = PathBuf::from("/src");
+        let split =
+            split_files_from_entry(&base, "from/./dir/subdir/subsubdir2", true);
+        assert_eq!(split.base, PathBuf::from("/src/from"));
+        assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir/subsubdir2"));
+        assert!(split.recurse);
+    }
+
+    #[test]
+    fn split_files_from_entry_collapses_redundant_separator_slashes() {
+        // `dir/././sub` should behave like `dir/./sub`: head is `dir`, rest is `sub`.
+        let base = PathBuf::from("/src");
+        let split = split_files_from_entry(&base, "dir/././sub", false);
+        assert_eq!(split.base, PathBuf::from("/src/dir"));
+        // The second `./` is part of `rest` and joins as `./sub`; PathBuf
+        // join keeps it as a no-op fs component.
+        assert_eq!(split.path, PathBuf::from("/src/dir/./sub"));
+        // The wire-relative name is computed via `Path::components` which
+        // normalizes the leading `.`, so the receiver sees `sub`.
+        let rel = split.path.strip_prefix(&split.base).unwrap();
+        let comps: Vec<_> = rel
+            .components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(comps, vec!["sub".to_owned()]);
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -150,6 +150,19 @@ fn build_file_list_for(ctx: &mut GeneratorContext, base_path: &Path) -> usize {
     ctx.build_file_list(&paths).unwrap()
 }
 
+/// Wraps a vector of full paths as `FilesFromEntry`s sharing one base, for
+/// tests that only exercise plain (no `/./` anchor) `--files-from` entries.
+fn files_from_entries(base: &Path, paths: Vec<PathBuf>) -> Vec<super::filters::FilesFromEntry> {
+    paths
+        .into_iter()
+        .map(|path| super::filters::FilesFromEntry {
+            base: base.to_path_buf(),
+            path,
+            recurse: false,
+        })
+        .collect()
+}
+
 /// Creates a clear rule for filter tests.
 fn clear_rule() -> FilterRuleWireFormat {
     use protocol::filters::RuleType;
@@ -2388,8 +2401,10 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], PathBuf::from("/src/file1.txt"));
-        assert_eq!(result[1], PathBuf::from("/src/subdir/file2.txt"));
+        assert_eq!(result[0].path, PathBuf::from("/src/file1.txt"));
+        assert_eq!(result[0].base, PathBuf::from("/src"));
+        assert_eq!(result[1].path, PathBuf::from("/src/subdir/file2.txt"));
+        assert_eq!(result[1].base, PathBuf::from("/src"));
     }
 
     #[test]
@@ -2405,7 +2420,8 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], PathBuf::from("./file.txt"));
+        assert_eq!(result[0].path, PathBuf::from("./file.txt"));
+        assert_eq!(result[0].base, PathBuf::from("."));
     }
 
     #[test]
@@ -2422,7 +2438,8 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], PathBuf::from("/base/only.txt"));
+        assert_eq!(result[0].path, PathBuf::from("/base/only.txt"));
+        assert_eq!(result[0].base, PathBuf::from("/base"));
     }
 
     #[test]
@@ -2441,9 +2458,9 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 3);
-        assert_eq!(result[0], PathBuf::from("/data/alpha.txt"));
-        assert_eq!(result[1], PathBuf::from("/data/beta.txt"));
-        assert_eq!(result[2], PathBuf::from("/data/gamma.txt"));
+        assert_eq!(result[0].path, PathBuf::from("/data/alpha.txt"));
+        assert_eq!(result[1].path, PathBuf::from("/data/beta.txt"));
+        assert_eq!(result[2].path, PathBuf::from("/data/gamma.txt"));
     }
 
     #[test]
@@ -2463,8 +2480,8 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], PathBuf::from("/root/one.txt"));
-        assert_eq!(result[1], PathBuf::from("/root/two.txt"));
+        assert_eq!(result[0].path, PathBuf::from("/root/one.txt"));
+        assert_eq!(result[1].path, PathBuf::from("/root/two.txt"));
     }
 
     #[test]
@@ -2487,8 +2504,8 @@ mod files_from {
 
         let result = ctx.resolve_files_from_paths(&paths, &mut reader).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], PathBuf::from("/dir/file1.txt"));
-        assert_eq!(result[1], PathBuf::from("/dir/file2.txt"));
+        assert_eq!(result[0].path, PathBuf::from("/dir/file1.txt"));
+        assert_eq!(result[1].path, PathBuf::from("/dir/file2.txt"));
     }
 
     #[test]
@@ -2505,7 +2522,9 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![src.join("hello.txt"), src.join("subdir/file.txt")];
-        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+        let count = ctx
+            .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
 
         // Dot entry + 2 files + 1 parent dir "subdir"
         assert!(count >= 3, "expected at least 3 entries, got {count}");
@@ -2552,7 +2571,8 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![nested.clone(), nested.join("child.txt")];
-        ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+        ctx.build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
 
         // Count occurrences of every distinct relative name. The subdir
         // must appear exactly once; duplicates would re-trigger the
@@ -2722,7 +2742,9 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![src.join("exists.txt"), src.join("missing.txt")];
-        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+        let count = ctx
+            .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
 
         // Dot entry + exists.txt; missing.txt is skipped with io_error.
         assert_eq!(count, 2, "dot + exists.txt");
@@ -2759,7 +2781,9 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![src.join("exists.txt"), src.join("missing.txt")];
-        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+        let count = ctx
+            .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
 
         // Dot entry + exists.txt; missing.txt silently skipped.
         assert_eq!(count, 2, "dot + exists.txt");
@@ -2790,7 +2814,9 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![src.join("exists.txt"), src.join("missing.txt")];
-        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+        let count = ctx
+            .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
 
         // Dot entry + exists.txt + mode-0 sentinel for missing.txt
         assert_eq!(count, 3, "dot + exists.txt + sentinel for missing.txt");
@@ -2833,7 +2859,9 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
         let file_paths = vec![src.join("missing.txt")];
-        let count = ctx.build_file_list_with_base(&src, &file_paths).unwrap();
+        let count = ctx
+            .build_file_list_with_base(&src, &files_from_entries(&src, file_paths))
+            .unwrap();
 
         // Dot entry + mode-0 sentinel (delete takes precedence over ignore).
         assert_eq!(count, 2, "dot + sentinel for missing.txt");

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -69,7 +69,7 @@ impl GeneratorContext {
         self.receive_filter_list_if_server(&mut reader)?;
 
         // upstream: flist.c:2240-2264 - resolve --files-from paths if configured
-        let files_from_paths = self.resolve_files_from_paths(paths, &mut reader)?;
+        let files_from_entries = self.resolve_files_from_paths(paths, &mut reader)?;
 
         // FSM: filter exchange complete. Advance to FileListTransfer.
         self.pipeline
@@ -81,12 +81,12 @@ impl GeneratorContext {
         // upstream: flist.c:2192 - send_file_list()
         let file_count = {
             let _t = PhaseTimer::new("file-list-build-send");
-            if files_from_paths.is_empty() {
+            if files_from_entries.is_empty() {
                 self.build_file_list(paths)?;
             } else {
                 // upstream: flist.c:2240-2244 - argv[0] is the base for --files-from
                 let base_dir = paths.first().cloned().unwrap_or_else(|| PathBuf::from("."));
-                self.build_file_list_with_base(&base_dir, &files_from_paths)?;
+                self.build_file_list_with_base(&base_dir, &files_from_entries)?;
             }
             self.partition_file_list_for_inc_recurse();
             self.send_file_list(writer)?


### PR DESCRIPTION
## Summary

Upstream rsync's `flist.c:2316-2330` splits every `--files-from` line on its first `/./` anchor (prefix → sender chdir, suffix → transmitted relative name) and flags trailing-slash entries as `SLASH_ENDING_NAME` so the sender recurses one level even though `options.c:2189` clears `-r` whenever `--files-from` is active.

oc-rsync's resolver discarded both signals, joining every entry onto one shared `base_dir`. The upstream receiver then rejected the over-qualified names via `flist.c:1028` ("unrequested file-list name"), and trailing-slash entries emitted only the directory marker without children.

This fix:
- Introduces `FilesFromEntry { base, path, recurse }` + `split_files_from_entry` in `crates/transfer/src/generator/filters.rs`.
- Threads the per-entry `base` through `build_file_list_with_base` so `dir/subdir` is wired up instead of `from/dir/subdir`.
- Suppresses the duplicate pre-loop `.` whenever an entry already emits it.
- Dispatches trailing-slash entries to `scan_files_from_marker_dir` for one level of forced recursion.

## Validation

Host-validated on the Linux test rig:
- LOCAL upstream test case: PASS
- oc-rsync as remote receiver: PASS (receiver rejection gone, file list correct)
- oc-rsync as remote sender: file list now correct on the wire, but transfer crashes on the 1MB `text` file with `EAGAIN at run.rs:364`. The same crash reproduces on fresh master without this patch, so it's a separate SSH-sender large-file bug, not in scope.

## Test plan

- [ ] CI: nextest (stable), fmt+clippy, upstream testsuite green
- [ ] Confirm legacy single-entry `--files-from` still works (no /./, no trailing slash)
- [ ] Confirm `--files-from -` (stdin) still resolves correctly