### PR TITLE
fix(cli): engage Landlock sandbox on --server receiver entry (UTS-16)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -53,7 +53,6 @@ protocol = { path = "../protocol" }
 compress = { path = "../compress", default-features = false }
 metadata = { path = "../metadata", default-features = false }
 rsync_io = { path = "../rsync_io", package = "rsync_io" }
-fast_io = { path = "../fast_io", default-features = false }
 rayon = { workspace = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "local-offset", "std"] }
 tempfile = { workspace = true }
@@ -64,6 +63,17 @@ tracing-subscriber = { workspace = true }
 uzers = "0.12"
 xattr = { workspace = true }
 daemon = { path = "../daemon" }
+
+# fast_io's `landlock` feature carries the rust-landlock dispatch used by
+# the `--server` receiver sandbox in `frontend/server/run.rs`. Linux gets the
+# real LSM backend; on every other target the stub module compiles with the
+# same public surface and every call short-circuits to `Unavailable`, so
+# the wire-in does not need `#[cfg]` branching at the call site.
+[target.'cfg(target_os = "linux")'.dependencies]
+fast_io = { path = "../fast_io", default-features = false, features = ["landlock"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+fast_io = { path = "../fast_io", default-features = false }
 
 [target.'cfg(not(windows))'.dependencies]
 checksums = { path = "../checksums" }

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -219,6 +219,51 @@ where
         }
     }
 
+    // SEC-1.p extension: engage the Landlock allowlist on the receiver-side
+    // `--server` path before any token-loop work. The lsh.sh-style invocation
+    // exercises upstream `chdir-symlink-race` and `bare-do-open-symlink-race`
+    // tests that swap a destination subdir for a symlink pointing outside the
+    // requested root; without a kernel-enforced ruleset the receiver follows
+    // the symlink and chmod's a file outside the destination tree. We confine
+    // the calling thread to the (already-canonicalised, pre-flight-mkdir'd)
+    // destination root so any subsequent path-based syscall that escapes the
+    // tree gets EACCES from the kernel.
+    //
+    // Apply only when the receiver actually has a destination root to confine
+    // to: the sender role and stat-only invocations have no write target, and
+    // engaging an empty allowlist would deny their reads. Sandbox failures
+    // surface as Unavailable on pre-5.13 kernels (SEC-1 *at* helpers remain
+    // the sole defense) and Error on a kernel that advertised support but
+    // returned an unexpected status; the latter is treated as a hard refusal
+    // because the intended sandbox did not engage.
+    if role == ServerRole::Receiver {
+        if let Some(dest) = config.args.last() {
+            let dest_path = std::path::PathBuf::from(dest);
+            if let Some(root) = dest_path
+                .canonicalize()
+                .ok()
+                .or_else(|| dest_path.parent().and_then(|p| p.canonicalize().ok()))
+            {
+                use fast_io::landlock::{
+                    LandlockOutcome, is_supported, restrict_to_module_paths,
+                };
+                if is_supported() {
+                    match restrict_to_module_paths(&[root.as_path()]) {
+                        LandlockOutcome::Enforced(_) | LandlockOutcome::Unavailable => {}
+                        LandlockOutcome::Error(e) => {
+                            write_server_error(
+                                stderr,
+                                program_brand,
+                                format!("landlock sandbox engage failed: {e}"),
+                            );
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     match run_server_stdio(config, &mut stdin, stdout, None) {
         Ok(_stats) => 0,
         Err(e) => {

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -70,12 +70,13 @@ pub fn is_supported() -> bool {
 /// Restricts the current thread to read+write access only under
 /// `allowed_roots`.
 ///
-/// The helper requests `AccessFs::from_all(ABI::V3)` (read / write / create /
-/// delete / rename / symlink / refer / truncate) with best-effort downgrade
-/// enabled, so a kernel that understands only v1 or v2 accepts the subset it
-/// supports and silently drops the rest. The returned [`LandlockOutcome`]
-/// carries the [`RulesetStatus`] so callers can log the actual enforcement
-/// level.
+/// The helper requests `AccessFs::from_all(ABI::V5)` (read / write / create /
+/// delete / rename / symlink / refer / truncate / ioctl-dev) with best-effort
+/// downgrade enabled, so a kernel that understands only v1-v4 accepts the
+/// subset it supports and silently drops the rest. ABI::V5 lands on Linux
+/// 6.7+ and adds the IPC scoping surface; older kernels degrade to V4/V3
+/// without surfacing as an error. The returned [`LandlockOutcome`] carries
+/// the [`RulesetStatus`] so callers can log the actual enforcement level.
 ///
 /// Call exactly once per daemon connection, after privilege drop and any
 /// chroot have completed, before any user-controlled file operation begins.
@@ -94,9 +95,13 @@ pub fn is_supported() -> bool {
 pub fn restrict_to_module_paths(allowed_roots: &[&Path]) -> LandlockOutcome {
     // Request the highest ABI we support; BestEffort lets the crate silently
     // drop rights the running kernel cannot honour (REFER on 5.13-5.18,
-    // TRUNCATE on 5.13-6.1). The final enforcement tier surfaces in the
-    // RulesetStatus returned by restrict_self below.
-    let access = AccessFs::from_all(ABI::V3);
+    // TRUNCATE on 5.13-6.1, IoctlDev on 5.13-6.6, network scopes on 5.13-6.6,
+    // signal scopes on 5.13-6.6). ABI::V5 (Linux 6.7+) adds the IPC scoping
+    // surface; on the target test host (kernel 7.0) it engages fully, and on
+    // older kernels BestEffort downgrade preserves the V3 rights we relied on
+    // historically. The final enforcement tier surfaces in the RulesetStatus
+    // returned by restrict_self below.
+    let access = AccessFs::from_all(ABI::V5);
 
     let ruleset = match Ruleset::default()
         .set_compatibility(CompatLevel::BestEffort)


### PR DESCRIPTION
## Summary

Wires \`fast_io::landlock::restrict_to_module_paths\` into the lsh.sh-style \`--server\` receiver path before the token loop. This closes the chdir-symlink-race chmod-escape surfaced by the upstream testsuite once seccomp was disabled:

\`\`\`
chdir-symlink-race: -r --size-only into upload/ root:
outside file mode changed from 600 to 666 (chmod escape)
\`\`\`

The receiver was following an attacker-planted symlink and chmod-ing a file outside the destination tree. The daemon path already has the SEC-1.p Landlock sandbox via \`engage_landlock_sandbox\` in \`module_access/transfer.rs:292\`; the SSH \`--server\` entry never engaged it.

## Changes

1. **\`crates/cli/src/frontend/server/run.rs\`** — Engage \`restrict_to_module_paths(&[dest_root])\` after parsing positional args, before \`run_server_stdio\`. Receiver-only (sender / stat-only have no write target). Engage failures abort with a typed server error so the intended sandbox is never silently skipped.

2. **\`crates/fast_io/src/landlock.rs\`** — Bump \`AccessFs::from_all(ABI::V3)\` → \`ABI::V5\` so kernels 6.7+ (including the target test host on 7.0) pick up the IPC scoping surface. BestEffort downgrade preserves V3 rights on older kernels.

3. **\`crates/cli/Cargo.toml\`** — Forward the \`landlock\` feature into the CLI's \`fast_io\` dep on Linux. Mirrors the daemon pattern: non-Linux targets compile the stub module with the same public surface, so the call site needs no \`#[cfg]\` branching.

## Test plan

- [ ] CI: nextest (stable) — covers existing \`landlock_overhead\` bench + landlock unit tests
- [ ] Upstream testsuite: \`chdir-symlink-race\` and \`bare-do-open-symlink-race\` flip from \"positive control fails\" to PASS
- [ ] Verify legitimate in-module symlinks still transfer (no over-correction on \`acls\`, \`alt-dest\`, \`atimes\`)