### PR TITLE
fix(transfer): flush -zz codec state before daemon-sender goodbye (UTS-9.REOPEN)

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2347,6 +2347,136 @@ mod legacy_goodbye_tests {
         );
     }
 
+    // UTS-9.REOPEN (daemon-gzip-download): the daemon-sender's `-zz` goodbye
+    // path deadlocked because the codec finalize step happened only AFTER
+    // `handle_goodbye` returned, but `handle_goodbye` could never return
+    // since it was blocked reading the receiver's final NDX_DONE while the
+    // receiver was simultaneously blocked decompressing an unterminated
+    // deflate block. The fix introduces `handle_goodbye_with_finalizer`,
+    // which runs a caller-supplied hook BETWEEN the goodbye write+flush and
+    // the goodbye read. This test asserts that ordering invariant: the hook
+    // must observe the goodbye write already in the wire buffer, AND must
+    // run before any further reader byte is consumed.
+    //
+    // upstream: token.c:367 send_deflated_token() emits the Z_FINISH-
+    // terminated stream at end of transfer; main.c:979-983
+    // do_server_sender() brackets read_final_goodbye() with
+    // io_flush(FULL_FLUSH).
+    #[test]
+    fn handle_goodbye_with_finalizer_runs_between_write_and_read() {
+        use std::cell::Cell;
+
+        let handshake = test_handshake_with_protocol(31);
+        let mut config = test_config();
+        config.protocol = ProtocolVersion::try_from(31u8).unwrap();
+        config.do_stats = false;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        // Receiver wire: first NDX_DONE (consumed BEFORE the finalizer)
+        // followed by the final NDX_DONE (consumed AFTER). The thread-local
+        // byte counter lets the finalizer assert which side of that boundary
+        // it ran on.
+        let receiver_input = [NDX_DONE_MODERN.as_slice(), NDX_DONE_MODERN.as_slice()].concat();
+        let mut reader = TrackingReader::new(receiver_input);
+
+        let mut output = FlushTrackingWriter::default();
+        let mut ndx_read = create_ndx_codec(31);
+        let mut ndx_write = MonotonicNdxWriter::new(31);
+
+        let finalizer_called = Cell::new(false);
+        let bytes_written_when_finalizer_ran = Cell::new(0usize);
+        let bytes_read_when_finalizer_ran = Cell::new(0usize);
+
+        ctx.handle_goodbye_with_finalizer(
+            &mut reader,
+            &mut output,
+            &mut ndx_read,
+            &mut ndx_write,
+            |w: &mut FlushTrackingWriter| {
+                finalizer_called.set(true);
+                bytes_written_when_finalizer_ran.set(w.buffer.len());
+                bytes_read_when_finalizer_ran.set(reader_bytes_consumed());
+                w.flush()
+            },
+        )
+        .expect("goodbye completes");
+
+        assert!(
+            finalizer_called.get(),
+            "the finalizer must run on the proto-31+ goodbye path"
+        );
+
+        // Ordering invariant: when the finalizer runs the sender's
+        // goodbye NDX_DONE must already be in the wire buffer (this is
+        // the "after write" half).
+        assert!(
+            bytes_written_when_finalizer_ran.get() >= NDX_DONE_MODERN.len(),
+            "finalizer ran before the goodbye NDX_DONE was written: \
+             buffer had {} bytes (need >= {})",
+            bytes_written_when_finalizer_ran.get(),
+            NDX_DONE_MODERN.len(),
+        );
+
+        // Ordering invariant: when the finalizer runs the receiver's
+        // FIRST NDX_DONE must already be consumed, but the FINAL
+        // NDX_DONE must NOT yet be consumed (this is the "before read"
+        // half - the deflate stream must be closed before the receiver
+        // is asked to advance another byte).
+        assert_eq!(
+            bytes_read_when_finalizer_ran.get(),
+            NDX_DONE_MODERN.len(),
+            "finalizer must run after the first NDX_DONE is read but \
+             before the final NDX_DONE is read"
+        );
+
+        // The wire payload must still end with the NDX_DONE marker
+        // byte even with the finalizer hooked in.
+        assert!(
+            output.buffer.ends_with(&NDX_DONE_MODERN),
+            "wire output must end with NDX_DONE even after finalizer: {:?}",
+            output.buffer
+        );
+    }
+
+    /// Module-level byte counter used by the ordering test above. We expose
+    /// it via a thread-local because the test's `Read` impl needs to record
+    /// how much was consumed before the finalizer ran, and the finalizer
+    /// closure cannot borrow `reader` mutably (it already borrows `writer`).
+    fn reader_bytes_consumed() -> usize {
+        READER_BYTES_CONSUMED.with(|c| c.get())
+    }
+
+    thread_local! {
+        static READER_BYTES_CONSUMED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    }
+
+    /// `Read` implementation that tracks how many bytes have been consumed
+    /// in a thread-local so the `handle_goodbye_with_finalizer` ordering
+    /// test can detect whether the finalizer ran before or after the final
+    /// receiver NDX_DONE was read.
+    struct TrackingReader {
+        data: Vec<u8>,
+        pos: usize,
+    }
+
+    impl TrackingReader {
+        fn new(data: Vec<u8>) -> Self {
+            READER_BYTES_CONSUMED.with(|c| c.set(0));
+            Self { data, pos: 0 }
+        }
+    }
+
+    impl std::io::Read for TrackingReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let remaining = self.data.len().saturating_sub(self.pos);
+            let n = remaining.min(buf.len());
+            buf[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            READER_BYTES_CONSUMED.with(|c| c.set(self.pos));
+            Ok(n)
+        }
+    }
+
     /// Writer that records every `write` and `flush` so tests can assert
     /// upstream's `io_flush(FULL_FLUSH)` contract is honoured before the
     /// goodbye handshake returns. Mirrors the `main.c:912` flush-before-

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -50,6 +50,49 @@ impl GeneratorContext {
         ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
         ndx_write_codec: &mut MonotonicNdxWriter,
     ) -> io::Result<()> {
+        self.handle_goodbye_with_finalizer(
+            reader,
+            writer,
+            ndx_read_codec,
+            ndx_write_codec,
+            |_writer| Ok(()),
+        )
+    }
+
+    /// Variant of [`handle_goodbye`](Self::handle_goodbye) that runs an
+    /// arbitrary finalizer between writing the sender's goodbye NDX_DONE and
+    /// blocking on the receiver's final NDX_DONE reply.
+    ///
+    /// The finalizer is the hook that lets the daemon-sender flush codec
+    /// state (e.g. emit the zlib `Z_FINISH` end-of-stream trailer under `-zz`
+    /// daemon pull) before the read side blocks. Without this hook, a
+    /// receiver running through `CompressedReader` can deadlock waiting on a
+    /// closing deflate block that the sender has not yet emitted, while the
+    /// sender simultaneously waits on the receiver's final NDX_DONE.
+    ///
+    /// upstream: `main.c:979-983 do_server_sender()` runs
+    /// `io_flush(FULL_FLUSH)` immediately before `read_final_goodbye()` so
+    /// the FIN is preceded by every buffered byte. Under `-zz` upstream's
+    /// `write_buf()` bypasses the deflate stream entirely (see
+    /// `io.c:2255 write_buf()`), so no codec finalisation is required there.
+    /// In our writer-graph the goodbye NDX_DONE rides through
+    /// `CompressedWriter`, so we additionally need the finalizer to emit
+    /// `Z_FINISH` (`token.c:367 send_deflated_token()` performs the matching
+    /// `deflateEnd()` at end of transfer) before the receiver tries to
+    /// decompress past the in-flight block.
+    pub(in crate::generator) fn handle_goodbye_with_finalizer<R, W, F>(
+        &mut self,
+        reader: &mut R,
+        writer: &mut W,
+        ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
+        ndx_write_codec: &mut MonotonicNdxWriter,
+        mut finalize_between_write_and_read: F,
+    ) -> io::Result<()>
+    where
+        R: Read,
+        W: Write,
+        F: FnMut(&mut W) -> io::Result<()>,
+    {
         if !self.protocol.supports_goodbye_exchange() {
             return Ok(());
         }
@@ -103,6 +146,25 @@ impl GeneratorContext {
             })();
 
             if let Err(e) = write_result {
+                if is_early_close_error(&e) {
+                    return Ok(());
+                }
+                return Err(e);
+            }
+
+            // UTS-9.REOPEN: under -zz daemon pull the receiver's
+            // CompressedReader cannot decode past an unterminated deflate
+            // block while we block on read_ndx below, producing a deadlock
+            // that surfaces to the user as "connection unexpectedly closed
+            // (N bytes received so far) [receiver]" once the daemon times
+            // out and FINs. Drive the finalizer here, between the goodbye
+            // write and the goodbye read, so the codec can emit its
+            // end-of-stream trailer before the receiver tries to advance.
+            //
+            // upstream: token.c:367 send_deflated_token() emits the
+            // Z_FINISH-terminated stream at end of transfer; main.c:982
+            // read_final_goodbye() is bracketed by io_flush(FULL_FLUSH).
+            if let Err(e) = finalize_between_write_and_read(writer) {
                 if is_early_close_error(&e) {
                     return Ok(());
                 }

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -43,6 +43,7 @@ impl GeneratorContext {
     /// - `main.c:225-238` - `write_del_stats()` format
     /// - `generator.c:2376-2381` - early del_stats path
     /// - `generator.c:2420-2425` - late del_stats path
+    #[cfg(test)]
     pub(in crate::generator) fn handle_goodbye<R: Read, W: Write>(
         &mut self,
         reader: &mut R,

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -125,31 +125,48 @@ impl GeneratorContext {
 
         let mut ndx_read_codec = transfer_result.ndx_read_codec;
         let mut ndx_write_codec = transfer_result.ndx_write_codec;
-        self.handle_goodbye(reader, writer, &mut ndx_read_codec, &mut ndx_write_codec)?;
 
-        // upstream: main.c:968 do_server_sender() and main.c:912 client_run()
-        // both call io_flush(FULL_FLUSH) immediately before returning so the
-        // kernel ships the final NDX_DONE (and any trailing multiplexed
-        // MSG_INFO frames) before the transport FIN. We mirror that contract
-        // here as defense-in-depth: even though `handle_goodbye` already
-        // flushes after its NDX_DONE write, any diagnostic frame queued
-        // later in `run()` would otherwise race the connection close.
+        // UTS-9.REOPEN (daemon-gzip-download): under `-zz` daemon pull the
+        // receiver decodes the goodbye NDX_DONE through `CompressedReader`,
+        // so the deflate stream must be closed before we block on its
+        // reply. Run `finalize_compression()` BETWEEN our goodbye write and
+        // the receiver's goodbye read; finalising AFTER `handle_goodbye`
+        // returns would never happen because the read would deadlock on
+        // the unterminated deflate block.
         //
-        // When wire compression is active (-zz daemon pull), an inner-codec
-        // Z_SYNC_FLUSH alone is not enough: the receiver's
-        // `CompressedReader` keeps the deflate stream open and may block on
-        // the closing block. Finalise the compressor so it emits its
-        // end-of-stream trailer before the socket closes - upstream
-        // `token.c:send_deflated_token()` issues `deflateEnd()` at the same
-        // point, which is the only thing that frees the receiver from its
-        // pending decompress wait. `finalize_compression` downgrades the
-        // writer back to multiplex mode and flushes the inner stream so any
-        // trailing diagnostic frame still rides out before FIN.
+        // upstream: `main.c:979-983 do_server_sender()` brackets
+        // `read_final_goodbye()` with `io_flush(FULL_FLUSH)`. Upstream's
+        // goodbye NDX_DONE rides through `write_buf()` (`io.c:2255`) which
+        // bypasses the deflate stream entirely. Our writer-graph routes
+        // it through `CompressedWriter`, so we additionally need to drive
+        // `CompressedWriter::finish()` here (matching
+        // `token.c:367 send_deflated_token()`'s end-of-transfer
+        // `deflateEnd()` contract). `finalize_compression` downgrades the
+        // writer back to multiplex mode so any trailing diagnostic frame
+        // still rides out before FIN.
         //
         // Rule 12 (fail-loud): surface the flush error unless the peer has
-        // already shut down. Early close during goodbye-shutdown is rare and
-        // the transfer is over, so any other error is treated as a real
-        // failure rather than swallowed.
+        // already shut down. Early close during goodbye-shutdown is rare
+        // and the transfer is over, so any other error is treated as a
+        // real failure rather than swallowed.
+        self.handle_goodbye_with_finalizer(
+            reader,
+            writer,
+            &mut ndx_read_codec,
+            &mut ndx_write_codec,
+            |w| match w.finalize_compression() {
+                Ok(()) => Ok(()),
+                Err(e) if super::super::is_early_close_error(&e) => Ok(()),
+                Err(e) => Err(e),
+            },
+        )?;
+
+        // upstream: main.c:983 io_flush(FULL_FLUSH) is also called AFTER
+        // read_final_goodbye(), so any MSG_INFO diagnostic frame queued
+        // later in `run()` still ships before the transport FIN.
+        // `finalize_compression()` is idempotent on a Multiplex writer
+        // (degrades to a plain flush) so it is safe to call again here as
+        // defense-in-depth.
         if let Err(e) = writer.finalize_compression() {
             if !super::super::is_early_close_error(&e) {
                 return Err(e);


### PR DESCRIPTION
## Summary

- The previous UTS-9.REOPEN landing (PR #5710) called `ServerWriter::finalize_compression()` AFTER `handle_goodbye` returned, but under `-zz` daemon pull `handle_goodbye` deadlocks: the sender blocks on the receiver's final `NDX_DONE` while the receiver blocks on an unterminated deflate block held in our `CompressedWriter` buffer. The receiver surfaces this as `"connection unexpectedly closed (612423 bytes received so far) [receiver]"` once the daemon times out and FINs - the same shape as `UTS-9.REOPEN.4` / `UTS-15.c`, but on the compressed daemon-pull path.
- Mirror upstream's `main.c:979-983 do_server_sender()` flush-bracketing of `read_final_goodbye()` by introducing `handle_goodbye_with_finalizer`. It runs a caller-supplied hook BETWEEN the goodbye write+flush and the goodbye read. The generator orchestrator passes `|w| w.finalize_compression()` so the deflate end-of-stream trailer ships before the receiver is asked to decompress past the closing block (matching `token.c:367 send_deflated_token()`'s end-of-transfer `deflateEnd()` contract). Upstream's `NDX_DONE` rides through `io.c:2255 write_buf()` uncompressed; our writer-graph routes it through `CompressedWriter`, so we additionally need to drive the codec finalisation here.
- A regression test asserts the new ordering invariant: the finalizer must observe the goodbye `NDX_DONE` already in the wire buffer AND must run before the final receiver `NDX_DONE` is consumed. Without this, the prior fix's post-goodbye finalisation is unreachable.

## What this preserves

- `UTS-9.REOPEN.4` / `UTS-15.c`: the legacy `handle_goodbye` flush-before-close contract is preserved. The non-finalizer variant delegates with a no-op hook, and the existing `handle_goodbye_proto31_flushes_ndx_done_before_close` `FlushTrackingWriter` test still asserts `last_op_was_flush` and trailing `NDX_DONE` bytes.
- `IUS-4` / `SZC SEND_ZC`: no changes to data-phase send paths or zero-copy dispatch.
- Defense-in-depth `finalize_compression()` call after the goodbye still runs (idempotent on `Multiplex`, degrades to a plain flush) so trailing `MSG_INFO` frames still ship before FIN.

## Test plan

- [x] New `handle_goodbye_with_finalizer_runs_between_write_and_read` regression test in `crates/transfer/src/generator/tests.rs` pins the write-then-finalize-then-read ordering using a `TrackingReader` + thread-local byte counter.
- [x] Existing `server_writer_finalize_compression_*` tests in `crates/transfer/src/writer/tests.rs` still cover zlib end-of-stream decode round-trip on the receiver side.
- [x] Existing `handle_goodbye_proto31_flushes_ndx_done_before_close` test still passes through the no-op-finalizer delegate (`handle_goodbye` -> `handle_goodbye_with_finalizer(...|_w| Ok(()))`).
- [ ] CI Linux runtests `daemon-gzip-download` upstream interop case.