### PR TITLE
fix(cli): ensure --server receiver creates dest root with --copy-dest (UTS-12.REOPEN)

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -243,6 +243,23 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // upstream: options.c:2891-2892 - emitted alongside --partial-dir.
             "--delay-updates" => flags.delay_updates = true,
             _ => {
+                // upstream: options.c::server_options() emits a handful of
+                // path-bearing long flags (`--copy-dest`, `--link-dest`,
+                // `--compare-dest`, `--files-from`, `--backup-dir`,
+                // `--temp-dir`) as two adjacent argv slots via
+                // `safe_arg("", value)`. Consume the following slot here so
+                // the value lands in the structured field instead of leaking
+                // through `parse_value_bearing_flag` and being misclassified
+                // as a positional destination path further down.
+                if is_two_arg_server_long_flag(s.as_ref()) {
+                    let value = args
+                        .get(idx + 1)
+                        .map(|v| v.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    apply_two_arg_long_flag(s.as_ref(), &value, &mut flags);
+                    idx += 2;
+                    continue;
+                }
                 // Accept the joined `--partial-dir=VALUE` form too, even
                 // though upstream's server_options() does not emit it - the
                 // CLI parser accepts both forms for client-side use, and a
@@ -259,6 +276,45 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
     }
 
     flags
+}
+
+/// Stores the value of a two-arg long flag (`--flag VALUE`) into the
+/// matching field of [`ServerLongFlags`].
+///
+/// `--backup-dir` and `--temp-dir` are recognised so the value slot does
+/// not leak into the positional argument list, but the corresponding
+/// fields are not currently consumed by `ServerLongFlags`. Recognising
+/// them here is the smallest defence that keeps the alt-dest interop
+/// scenario (`--copy-dest /path . dest/`) from mis-mapping the value to
+/// the destination root.
+///
+/// # Upstream Reference
+///
+/// - `options.c:2807-2808` - `--backup-dir`
+/// - `options.c:2926-2927` - `--temp-dir`
+/// - `options.c:2939-2940` - `--copy-dest` / `--link-dest` / `--compare-dest`
+///   via `alt_dest_opt(0)` + `safe_arg("", basis_dir[i])`
+/// - `options.c:2964-2965` - `--files-from`
+fn apply_two_arg_long_flag(flag: &str, value: &str, flags: &mut ServerLongFlags) {
+    match flag {
+        "--compare-dest" => flags.reference_directories.push(ReferenceDirectory::new(
+            ReferenceDirectoryKind::Compare,
+            PathBuf::from(value),
+        )),
+        "--copy-dest" => flags.reference_directories.push(ReferenceDirectory::new(
+            ReferenceDirectoryKind::Copy,
+            PathBuf::from(value),
+        )),
+        "--link-dest" => flags.reference_directories.push(ReferenceDirectory::new(
+            ReferenceDirectoryKind::Link,
+            PathBuf::from(value),
+        )),
+        "--files-from" => flags.files_from = Some(value.to_owned()),
+        // Values are drained but not currently consumed; recognising the
+        // flag here keeps the value out of the positional list.
+        "--backup-dir" | "--temp-dir" => {}
+        _ => {}
+    }
 }
 
 /// Parses value-bearing `--flag=value` arguments into `ServerLongFlags`.
@@ -382,4 +438,39 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--log-format=")
         || arg.starts_with("--info=")
         || arg.starts_with("--partial-dir=")
+}
+
+/// Returns `true` when the argument is a bare server-mode long flag whose
+/// value is supplied as the next positional argument.
+///
+/// Upstream `options.c::server_options()` emits a handful of path-bearing
+/// long flags as two argv slots: the flag name and the value, joined later
+/// by `safe_arg("", value)`. The split form is used unconditionally for
+/// these flags, independent of `protect_args`. Without this awareness the
+/// flag name is treated as the first positional path and the value as the
+/// second, so the alt-dest interop test (`--copy-dest /path/alt3 . /path/to/`)
+/// lands the source files under `$HOME/--copy-dest/` instead of creating
+/// the dest root at `/path/to/`.
+///
+/// `--partial-dir` is handled separately in `parse_server_long_flags`
+/// because it predates this helper and keeps its own `idx += 1` branch.
+/// All other split-form path flags route through this predicate.
+///
+/// # Upstream Reference
+///
+/// - `options.c:2807-2808` - `--backup-dir`
+/// - `options.c:2926-2927` - `--temp-dir`
+/// - `options.c:2939-2940` - `--copy-dest` / `--link-dest` / `--compare-dest`
+///   (via `alt_dest_opt(0)`)
+/// - `options.c:2964-2965` - `--files-from`
+pub(super) fn is_two_arg_server_long_flag(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--compare-dest"
+            | "--copy-dest"
+            | "--link-dest"
+            | "--backup-dir"
+            | "--temp-dir"
+            | "--files-from"
+    )
 }

--- a/crates/cli/src/frontend/server/parse.rs
+++ b/crates/cli/src/frontend/server/parse.rs
@@ -3,13 +3,21 @@
 use std::ffi::{OsStr, OsString};
 use std::time::SystemTime;
 
-use super::flags::is_known_server_long_flag;
+use super::flags::{is_known_server_long_flag, is_two_arg_server_long_flag};
 
 /// Parses the flag string and positional arguments from server-mode argument list.
 ///
 /// Extracts the compact flag string (first arg starting with `-` that is not
 /// a known long flag) and positional arguments (everything after the flag string
 /// and optional `.` separator).
+///
+/// Upstream `options.c::server_options()` emits a few path-bearing long flags
+/// (`--copy-dest`, `--link-dest`, `--compare-dest`, `--files-from`,
+/// `--backup-dir`, `--partial-dir`, `--temp-dir`) as two argv slots via
+/// `safe_arg("", value)`. This parser recognises the bare flag and skips the
+/// following value slot so the path never lands in `positional_args` as a
+/// stray destination. See [`is_two_arg_server_long_flag`] for the upstream
+/// emission sites.
 pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, Vec<OsString>) {
     let mut flag_string = String::new();
     let mut positional_args = Vec::new();
@@ -31,6 +39,21 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
                 continue;
             }
             idx += 1;
+            continue;
+        }
+
+        // upstream: options.c::server_options() emits path-bearing long
+        // flags (`--copy-dest`, `--link-dest`, `--compare-dest`,
+        // `--files-from`, `--backup-dir`, `--temp-dir`) as `--flag VALUE`
+        // (two argv slots). The `--flag=value` joined form is handled by
+        // `is_known_server_long_flag` above; the split form is consumed
+        // here so the value does not surface as a positional destination
+        // path. Without this, `--copy-dest /alt . dest/` lands `/alt` in
+        // positional_args[0] and `dest/` in positional_args[1], so the
+        // receiver mkdir's the alt-dest basis (already exists) instead of
+        // the actual destination root.
+        if is_two_arg_server_long_flag(&arg_str) {
+            idx += 2;
             continue;
         }
 

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -1248,3 +1248,193 @@ fn server_mode_merges_cmdline_and_stdin_standalone_s_flag() {
     assert_eq!(flag_string, "-logDtpr");
     assert_eq!(positional, vec![OsString::from("/srv/data/")]);
 }
+
+/// UTS-12.REOPEN: upstream `options.c::server_options()` emits
+/// `--copy-dest <path>` as two adjacent argv slots (via
+/// `safe_arg("", basis_dir[i])` on line 2940). The positional parser must
+/// recognise the bare flag and skip its value so the path never lands in
+/// `positional_args` as a stray destination. Before the fix, `--copy-dest`
+/// was treated as an unknown long flag, the alt-dest path followed it as
+/// the first positional, and the actual dest `/tmp/ad/to/` was discarded -
+/// the receiver pre-flight mkdir then ran against the already-existing
+/// alt-dest basis and never created the destination root, so the
+/// alt-dest interop test failed with `FileNotFoundError` when ls-lR'ing
+/// the never-materialised dest.
+///
+/// Mirrors the exact wire from the upstream alt-dest test running over
+/// lsh.sh: `--server -vlogDtpre.iLsfxCIvu --copy-dest /tmp/ad/alt3 . /tmp/ad/to/`.
+// upstream: options.c:2939-2940 `alt_dest_opt(0)` + `safe_arg("", basis_dir[i])`
+#[test]
+fn parse_server_args_handles_split_copy_dest_form() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-vlogDtpre.iLsfxCIvu"),
+        OsString::from("--copy-dest"),
+        OsString::from("/tmp/ad/alt3"),
+        OsString::from("."),
+        OsString::from("/tmp/ad/to/"),
+    ];
+    let (flag_string, positional) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flag_string, "-vlogDtpre.iLsfxCIvu");
+    assert_eq!(
+        positional,
+        vec![OsString::from("/tmp/ad/to/")],
+        "split-form --copy-dest must not leak the basis path into positionals; \
+         the actual dest root must be the sole positional argument so the \
+         receiver pre-flight mkdir runs against `/tmp/ad/to/`"
+    );
+}
+
+/// `--link-dest` and `--compare-dest` share the same `alt_dest_opt(0)`
+/// emission path in upstream, so their split form must also be skipped.
+// upstream: options.c:2939-2940
+#[test]
+fn parse_server_args_handles_split_link_dest_and_compare_dest_forms() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--link-dest"),
+        OsString::from("/tmp/link"),
+        OsString::from("--compare-dest"),
+        OsString::from("/tmp/cmp"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    let (flag_string, positional) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("dest/")]);
+}
+
+/// Upstream also splits `--files-from`, `--backup-dir`, and `--temp-dir`
+/// into two argv slots. Recognising each one drains the value slot so it
+/// cannot masquerade as a positional destination.
+// upstream: options.c:2807-2808 (--backup-dir), 2926-2927 (--temp-dir),
+//           2964-2965 (--files-from)
+#[test]
+fn parse_server_args_handles_remaining_split_path_flags() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--files-from"),
+        OsString::from("/tmp/files.lst"),
+        OsString::from("--backup-dir"),
+        OsString::from("/tmp/bak"),
+        OsString::from("--temp-dir"),
+        OsString::from("/tmp/scratch"),
+        OsString::from("."),
+        OsString::from("final/"),
+    ];
+    let (flag_string, positional) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("final/")]);
+}
+
+/// `--copy-dest=PATH` (joined form) must still resolve to a single
+/// `is_known_server_long_flag` hit and not consume the following positional.
+/// This is the regression direction: the joined form was already correct
+/// before the split-form fix, and the split-form handling must not break it.
+#[test]
+fn parse_server_args_joined_copy_dest_does_not_eat_positional() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--copy-dest=/tmp/alt3"),
+        OsString::from("."),
+        OsString::from("dest/"),
+    ];
+    let (flag_string, positional) = parse_server_flag_string_and_args(&args);
+    assert_eq!(flag_string, "-logDtpr");
+    assert_eq!(positional, vec![OsString::from("dest/")]);
+}
+
+/// `parse_server_long_flags` must capture the split-form `--copy-dest /path`
+/// value into `reference_directories` so the receiver gets the alt-dest
+/// path even when upstream emits it as two argv slots. Without this, the
+/// alt-dest behaviour (basis-file copy-from instead of delta-from-empty)
+/// is lost: the receiver would fall back to whole-file transfer.
+// upstream: options.c:2939-2940
+#[test]
+fn long_flags_captures_split_copy_dest_value() {
+    use engine::ReferenceDirectoryKind;
+    use std::path::PathBuf;
+
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--copy-dest"),
+        OsString::from("/tmp/alt3"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.reference_directories.len(), 1);
+    assert_eq!(
+        flags.reference_directories[0].kind(),
+        ReferenceDirectoryKind::Copy,
+    );
+    assert_eq!(
+        flags.reference_directories[0].path(),
+        PathBuf::from("/tmp/alt3").as_path(),
+    );
+}
+
+/// Multiple stacked `--copy-dest` and `--compare-dest` flags in split
+/// form must all be captured in argv order. Upstream loops over
+/// `basis_dir_cnt` (options.c:2938-2941) so the server can see a sequence
+/// like `--copy-dest /a --copy-dest /b --compare-dest /c`.
+#[test]
+fn long_flags_captures_multiple_split_alt_dest_values() {
+    use engine::ReferenceDirectoryKind;
+    use std::path::PathBuf;
+
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--copy-dest"),
+        OsString::from("/a"),
+        OsString::from("--copy-dest"),
+        OsString::from("/b"),
+        OsString::from("--compare-dest"),
+        OsString::from("/c"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.reference_directories.len(), 3);
+    assert_eq!(
+        flags.reference_directories[0].kind(),
+        ReferenceDirectoryKind::Copy,
+    );
+    assert_eq!(
+        flags.reference_directories[0].path(),
+        PathBuf::from("/a").as_path(),
+    );
+    assert_eq!(
+        flags.reference_directories[1].kind(),
+        ReferenceDirectoryKind::Copy,
+    );
+    assert_eq!(
+        flags.reference_directories[1].path(),
+        PathBuf::from("/b").as_path(),
+    );
+    assert_eq!(
+        flags.reference_directories[2].kind(),
+        ReferenceDirectoryKind::Compare,
+    );
+    assert_eq!(
+        flags.reference_directories[2].path(),
+        PathBuf::from("/c").as_path(),
+    );
+}
+
+/// `parse_server_long_flags` must capture the split-form `--files-from`
+/// value so `--files-from /list` keeps working when upstream emits it
+/// as two argv slots.
+// upstream: options.c:2964-2965 `--files-from`
+#[test]
+fn long_flags_captures_split_files_from_value() {
+    let args = vec![
+        OsString::from("--server"),
+        OsString::from("-logDtpr"),
+        OsString::from("--files-from"),
+        OsString::from("/tmp/list"),
+    ];
+    let flags = parse_server_long_flags(&args);
+    assert_eq!(flags.files_from.as_deref(), Some("/tmp/list"));
+}

--- a/crates/transfer/tests/uts_12_reopen_altdest_server_mkdir.rs
+++ b/crates/transfer/tests/uts_12_reopen_altdest_server_mkdir.rs
@@ -1,0 +1,154 @@
+//! UTS-12.REOPEN-V2 - regression coverage for the `--server` receiver +
+//! split-form `--copy-dest <path>` alt-dest pre-flight mkdir chain.
+//!
+//! The first round of the dest-root pre-flight fix (UTS-2.d.3 / UTS-2.d.4)
+//! wired `ensure_dest_root_exists` into every `setup_transfer` dispatch arm,
+//! but the alt-dest interop test running over `lsh.sh` continued to fail
+//! with `FileNotFoundError: /tmp/alt-dest/to`. The root cause was upstream
+//! of the helper: upstream `options.c::server_options()` emits `--copy-dest`
+//! (and its `--link-dest` / `--compare-dest` siblings) as TWO adjacent argv
+//! slots via `safe_arg("", basis_dir[i])`. The server's `--server` argument
+//! parser only recognised the `--copy-dest=VALUE` joined form, so the bare
+//! `--copy-dest` was treated as unknown and the basis path landed in
+//! `positional_args[0]`, displacing the actual destination root.
+//!
+//! `setup_transfer` reads `config.args.first()` as the dest operand, so
+//! the helper fired against the already-existing alt-dest basis (returning
+//! `Ok(false)`) and the real destination root `/tmp/alt-dest/to/` was
+//! never created. The matching parser fix is pinned by unit tests in
+//! `crates/cli/src/frontend/server/tests.rs`; this integration test pins
+//! the receiver-side half of the contract by driving
+//! [`transfer::receiver::ensure_dest_root_exists`] with the resolved
+//! destination path and asserting the missing root materialises.
+//!
+//! Splitting the regression coverage across both crates avoids the
+//! integration test reaching into `pub(super)` parser surface while still
+//! producing a single failure signal if either layer regresses (the
+//! parser change makes the upstream argv shape yield the correct dest
+//! path; this test proves the helper acts on that dest).
+//!
+//! ## Upstream Reference
+//!
+//! - `main.c:778-792 get_local_name()` - pre-flight `do_mkdir(dest_path, ACCESSPERMS)`
+//!   when `file_total > 1 || trailing_slash`.
+//! - `options.c:2939-2940` - `alt_dest_opt(0)` + `safe_arg("", basis_dir[i])`
+//!   emits `--copy-dest`, `--link-dest`, `--compare-dest` as two argv slots.
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use transfer::receiver::ensure_dest_root_exists;
+
+/// UTS-12.REOPEN-V2: the receiver-side pre-flight must materialise the
+/// destination root reported by the parser when the alt-dest argv shape
+/// (`-a --copy-dest /alt . /dest/`) arrives over remote shell.
+///
+/// Replays the exact destination path the upstream alt-dest interop
+/// test passes (multi-file transfer, trailing-slash dest, non-dry-run)
+/// against an alt-dest basis seeded by the operator. Once the parser
+/// resolves the post-`.` positional as the dest (pinned by the cli
+/// unit tests), the helper must create the missing root before the
+/// per-entry mkdir dispatch runs.
+// upstream: main.c:778-792 get_local_name() pre-flight, exercised by
+// the upstream alt-dest test over lsh.sh.
+#[test]
+fn alt_dest_server_chain_creates_missing_dest_root() {
+    let tmp = tempdir().expect("tempdir");
+    let alt_basis = tmp.path().join("alt3");
+    let dest_root = tmp.path().join("missing/dest/root");
+
+    // Operator-seeded alt-dest basis: upstream's main.c:798-806 only
+    // checks that the basis path resolves. The pre-flight owns the
+    // destination root, NOT the basis.
+    fs::create_dir_all(&alt_basis).expect("seed alt-dest basis");
+    fs::write(alt_basis.join("seed.txt"), b"basis").expect("seed basis file");
+
+    assert!(
+        !dest_root.exists(),
+        "destination root must start missing to prove the pre-flight ran"
+    );
+
+    // The argv shape upstream sends over `lsh.sh`:
+    //     --server -vlogDtpre.iLsfxCIvu --copy-dest /tmp/alt3 . /tmp/to/
+    // After the cli parser fix (pinned by
+    // `parse_server_args_handles_split_copy_dest_form` in
+    // `crates/cli/src/frontend/server/tests.rs`), the `--copy-dest /alt3`
+    // pair is drained out of the positional list and the trailing
+    // `/tmp/to/` becomes `config.args[0]`. `setup_transfer` then reads
+    // that path as `dest_dir` and calls `ensure_dest_root_exists` with
+    // it. The mkdir must materialise the dest.
+    let file_total = 5; // multi-file alt-dest source tree
+    let trailing_slash = true; // upstream argv carries `/tmp/to/`
+    let dry_run = false;
+
+    let created = ensure_dest_root_exists(&dest_root, file_total, trailing_slash, dry_run)
+        .expect("alt-dest --copy-dest pre-flight must auto-create the dest");
+
+    assert!(
+        created,
+        "the helper must report the missing dest root as newly created \
+         under the --server + split-form --copy-dest chain"
+    );
+    assert!(
+        dest_root.is_dir(),
+        "the dest root (multiple directory components deep) must exist \
+         as a directory after the pre-flight (create_dir_all semantics)"
+    );
+    assert!(
+        alt_basis.join("seed.txt").exists(),
+        "the alt-dest basis must remain intact - the pre-flight only \
+         owns the destination root"
+    );
+}
+
+/// UTS-12.REOPEN-V2 + EDG-DESTROOT.1: the helper must NOT mkdir when the
+/// transfer is exactly one non-directory entry without a trailing-slash
+/// dest. This is the upstream `main.c:805-832 get_local_name()` rename
+/// branch, where the lone payload is written to the operand path under
+/// `change_dir(parent)`. The pre-flight returning `Ok(false)` here is
+/// the contract: `setup_transfer::apply_single_file_rename` then rewrites
+/// the lone flist entry's name to the operand basename.
+// upstream: main.c:805-832 single-file rename branch
+#[test]
+fn single_file_without_trailing_slash_does_not_mkdir_destroot() {
+    let tmp = tempdir().expect("tempdir");
+    let dest_root = tmp.path().join("would-be-file");
+
+    let created =
+        ensure_dest_root_exists(&dest_root, 1, false, false).expect("helper must succeed");
+
+    assert!(
+        !created,
+        "single non-directory transfer without trailing slash must not \
+         mkdir the dest root; upstream takes the rename branch instead"
+    );
+    assert!(
+        !dest_root.exists(),
+        "dest root must remain untouched in the single-file rename branch"
+    );
+}
+
+/// UTS-12.REOPEN-V2 + EDG-DESTROOT.4: the helper rejects a destination
+/// that resolves to a regular file with a typed error. Mirrors upstream
+/// `main.c:756-761`: when `file_total > 1` and `S_ISDIR` fails, upstream
+/// emits "destination must be a directory" and exits with
+/// `RERR_FILESELECT`. The Rust port produces an `io::Error::InvalidInput`
+/// with the same semantic.
+// upstream: main.c:756-761
+#[test]
+fn dest_existing_as_file_returns_typed_error() {
+    let tmp = tempdir().expect("tempdir");
+    let dest_file = tmp.path().join("not-a-directory");
+    fs::write(&dest_file, b"existing file").expect("seed dest as a file");
+
+    let err = ensure_dest_root_exists(&dest_file, 3, true, false)
+        .expect_err("dest existing as a regular file must be rejected");
+
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::InvalidInput,
+        "regular-file dest must surface as InvalidInput (got {:?})",
+        err.kind()
+    );
+}


### PR DESCRIPTION
## Summary

- Drains split-form `--copy-dest <path>` (and `--link-dest`, `--compare-dest`, `--files-from`, `--backup-dir`, `--temp-dir`) in the `--server` argument parser so the value slot never lands as a positional destination.
- Captures the value in `ServerLongFlags::reference_directories` / `files_from` so the receiver still honours alt-dest semantics. `--partial-dir` keeps its existing UTS-SLDB branch.
- Adds regression tests in `crates/cli/src/frontend/server/tests.rs` (parser fix) and `crates/transfer/tests/uts_12_reopen_altdest_server_mkdir.rs` (helper materialises the missing dest once the parser hands it the correct path).

## Root cause

Upstream `options.c::server_options()` emits these path-bearing flags as two argv slots via `safe_arg("", value)` (`alt_dest_opt(0)` at options.c:2939-2940 et al.). The previous parser only recognised the `--flag=value` joined form, so the bare form left the basis path in `positional_args[0]`. `setup_transfer` then called `ensure_dest_root_exists` against the already-existing alt-dest basis (returning `Ok(false)`), so the actual destination root was never created.

The alt-dest interop test running over `lsh.sh`
(`-ave lsh.sh --copy-dest=/alt /src/ host:/dest/`) failed with `FileNotFoundError: /dest` because the test harness ls-lR'd the never-materialised dest.

## Constraints honoured

- Wire-byte parity preserved: the mkdir stays receiver-local; no `MSG_*` frame is emitted (UTS-2.d.6).
- Existing UTS-2.d.5 + EDG-DESTROOT.1-5 helper contracts unchanged - the helper itself is untouched, only the dest-path resolution upstream of it is corrected.
- No clippy waivers; no `#[allow(...)]` added.
- No AI/tooling references in any artifact.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable)
- [ ] CI: Windows / macOS / Linux musl (stable)
- [ ] CI: interop (alt-dest test must now pass over `lsh.sh`)