### PR TITLE
fix(daemon): symmetric safe_arg/unbackslash_arg for wildcards (UTS-8.REOPEN)

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -614,6 +614,72 @@ mod safe_arg_tests {
         let escaped = safe_arg_for_daemon("--groupmap=\\*:1234");
         assert_eq!(escaped, "--groupmap=\\\\\\*:1234");
     }
+
+    // UTS-8.REOPEN: pin the client-side `--groupmap=*:GID` wire format.
+    // Mirrors upstream `options.c:2912-2916` which calls
+    // `safe_arg("--groupmap", value)` for the option-arg branch
+    // (`is_filename_arg=false`, escape set = `WILD_CHARS + SHELL_CHARS`).
+    // The escaped output must be reversible by the daemon's
+    // `unbackslash_arg` (mirrored from upstream `io.c:1295-1306`); any drift
+    // here would resurface upstream #829 for the wildcard.
+    #[test]
+    fn groupmap_wildcard_matches_upstream_safe_arg_byte_for_byte() {
+        // upstream's safe_arg("--groupmap", "*:42") yields "--groupmap=\*:42":
+        //   "--groupmap" + "=" + escape("*") + ":" + "4" + "2"
+        // where escape(*) = `\*` because `*` is in WILD_CHARS.
+        assert_eq!(safe_arg_for_daemon("--groupmap=*:42"), "--groupmap=\\*:42");
+
+        // Reversing the escape with the daemon-side algorithm
+        // (`\X -> X` for any X) must recover the original. This is the
+        // round-trip parity asserted on both sides of the wire.
+        let original = "--groupmap=*:42";
+        let escaped = safe_arg_for_daemon(original);
+        let bytes = escaped.as_bytes();
+        let mut decoded = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                i += 1;
+            }
+            decoded.push(bytes[i]);
+            i += 1;
+        }
+        assert_eq!(String::from_utf8(decoded).unwrap(), original);
+    }
+
+    // UTS-8.REOPEN: verify every escape character upstream `safe_arg`
+    // emits for an option arg (`WILD_CHARS + SHELL_CHARS`) survives the
+    // `safe_arg_for_daemon` -> daemon-side `unbackslash_arg` round trip.
+    // Drift in either escape set would resurface upstream #829 for the
+    // dropped character. Mirrors upstream `options.c:2541-2544`.
+    #[test]
+    fn every_safe_arg_escape_char_round_trips_through_unbackslash() {
+        let escape_chars = [
+            '*', '?', '[', ']', '!', '#', '$', '&', ';', '|', '<', '>', '(', ')', '{', '}', '"',
+            '\'', '`', ' ', '\t', '\\',
+        ];
+        for &ch in &escape_chars {
+            let original = format!("--groupmap=prefix{ch}suffix");
+            let escaped = safe_arg_for_daemon(&original);
+            // Reverse with the same algorithm the daemon's `unbackslash_arg`
+            // uses (`\X -> X` for any X).
+            let bytes = escaped.as_bytes();
+            let mut decoded = Vec::with_capacity(bytes.len());
+            let mut i = 0;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    i += 1;
+                }
+                decoded.push(bytes[i]);
+                i += 1;
+            }
+            let round_trip = String::from_utf8(decoded).unwrap();
+            assert_eq!(
+                round_trip, original,
+                "round-trip failed for {ch:?} (escaped to {escaped:?})",
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2057,4 +2057,109 @@ mod module_access_tests {
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
         );
     }
+
+    // Ground-truth `safe_arg` reference port of upstream
+    // `options.c:2539-2594` (rsync 3.4.4), option-arg branch only:
+    //
+    //   opt != NULL  =>  is_filename_arg = 0
+    //   escapes = WILD_CHARS SHELL_CHARS
+    //   WILD_CHARS  = "*?[]"
+    //   SHELL_CHARS = "!#$&;|<>(){}\"'` \t\\"
+    //
+    // Used by the round-trip parity tests below to assert that the daemon's
+    // `unbackslash_arg` reverses every character upstream's client-side
+    // `safe_arg` is allowed to emit. Independent of the oc-rsync
+    // `safe_arg_for_daemon` implementation so the contract is locked
+    // against upstream wire output rather than against our own escape code.
+    fn upstream_safe_arg_option(opt: &str, value: &str) -> String {
+        const SHELL_CHARS: &[u8] = b"!#$&;|<>(){}\"'` \t\\";
+        const WILD_CHARS: &[u8] = b"*?[]";
+        let mut out = String::with_capacity(opt.len() + value.len() + 8);
+        out.push_str(opt);
+        if !opt.is_empty() {
+            out.push('=');
+        }
+        for &byte in value.as_bytes() {
+            if byte == b'\\' {
+                // upstream options.c:2584-2586 - option args
+                // (is_filename_arg=0) always double a literal backslash.
+                out.push('\\');
+            } else if WILD_CHARS.contains(&byte) || SHELL_CHARS.contains(&byte) {
+                out.push('\\');
+            }
+            out.push(byte as char);
+        }
+        out
+    }
+
+    // UTS-8.REOPEN: lock the contract that the daemon's `unbackslash_arg`
+    // reverses every escape upstream's `safe_arg` can emit for an option
+    // arg. The asymmetric case is `--groupmap=*:GID` (upstream issue #829):
+    // a 3.4.3+ non-protect_args client wraps the value with
+    // `safe_arg("--groupmap", ...)`, which backslash-escapes `*` (a
+    // `WILD_CHARS` member). The daemon must reverse the escape before
+    // option parsing, or `--groupmap=\*:GID` reaches `parse_name_map()`
+    // and the wildcard silently mismatches.
+    //
+    // upstream: options.c:2539-2594 safe_arg() (client-side escape)
+    // upstream: io.c:1295-1306 unbackslash_arg() (daemon-side un-escape)
+    #[test]
+    fn unbackslash_arg_reverses_upstream_safe_arg_groupmap_wildcard() {
+        let original = "--groupmap=*:42";
+        let escaped = upstream_safe_arg_option("--groupmap", "*:42");
+        assert_eq!(escaped, "--groupmap=\\*:42");
+        assert_eq!(unbackslash_arg(&escaped), original);
+    }
+
+    // upstream: options.c:2541-2544 - `escapes = WILD_CHARS SHELL_CHARS`
+    // for option args. The daemon's `unbackslash_arg` must reverse every
+    // member of that set: `*?[]` (wildcards) plus `!#$&;|<>(){}\"'` \t\\`
+    // (shell). A regression that drops any character from the un-escape
+    // set would resurface upstream #829 for that character.
+    #[test]
+    fn unbackslash_arg_reverses_every_safe_arg_escape_character() {
+        let escape_chars = [
+            '*', '?', '[', ']', '!', '#', '$', '&', ';', '|', '<', '>', '(', ')', '{', '}', '"',
+            '\'', '`', ' ', '\t', '\\',
+        ];
+        for &ch in &escape_chars {
+            let value = format!("prefix{ch}suffix");
+            let escaped = upstream_safe_arg_option("--groupmap", &value);
+            // Every escape char must appear backslash-prefixed in the
+            // upstream escape output so the round-trip below exercises
+            // that specific char.
+            assert!(
+                escaped.contains(&format!("\\{ch}")),
+                "upstream safe_arg should backslash-escape {ch:?}; got {escaped:?}",
+            );
+            let round_trip = unbackslash_arg(&escaped);
+            assert_eq!(
+                round_trip,
+                format!("--groupmap={value}"),
+                "unbackslash_arg must reverse safe_arg escape for {ch:?}",
+            );
+        }
+    }
+
+    // Round-trip parity for the wildcard family across `--usermap` and
+    // `--groupmap` together. Mirrors upstream `options.c:2912-2916` which
+    // routes both options through `safe_arg("--usermap"|"--groupmap", ...)`.
+    #[test]
+    fn unbackslash_arg_round_trips_usermap_groupmap_wildcards() {
+        for (opt, value) in [
+            ("--usermap", "*:1234"),
+            ("--groupmap", "*:1234"),
+            ("--usermap", "alice:bob,*:1234"),
+            ("--groupmap", "wheel:0,*:1234"),
+            ("--groupmap", "*:1234;dangerous"),
+        ] {
+            let original = format!("{opt}={value}");
+            let escaped = upstream_safe_arg_option(opt, value);
+            assert_eq!(
+                unbackslash_arg(&escaped),
+                original,
+                "round-trip failed for {original:?} (escaped to {escaped:?})",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Locks the round-trip parity between client-side `safe_arg_for_daemon`
and daemon-side `unbackslash_arg` for the option-arg escape set.
Mirrors upstream `options.c:2539-2594` (`safe_arg`, rsync 3.4.4) and
`io.c:1295-1306` (`unbackslash_arg`).

The asymmetric case is upstream issue #829: under non-protect_args
daemon mode a 3.4.3+ client wraps `--groupmap=*:GID` with
`safe_arg("--groupmap", "*:GID")` which backslash-escapes `*`. The
daemon must reverse the escape before option parsing or
`--groupmap=\*:GID` reaches `parse_name_map()` and the wildcard
silently mismatches.

The existing implementations of `safe_arg_for_daemon` (client) and
`unbackslash_arg` (daemon) are symmetric by construction:
`unbackslash_arg` collapses `\X -> X` for any `X` (mirroring
upstream's `if (*f == '\\' && f[1]) f++;` loop). This PR adds the
character-level tests that pin the contract so a future drift in
either escape set is caught at unit-test time instead of resurfacing
as `daemon-groupmap-wild` interop failure.

## Changes

- `crates/core/.../arguments.rs`: byte-for-byte pin
  `safe_arg_for_daemon("--groupmap=*:42") == "--groupmap=\*:42"`
  plus a full-set round-trip across
  `WILD_CHARS + SHELL_CHARS` (`*?[]!#$&;|<>(){}\"'` \t\\`).
- `crates/daemon/.../tests.rs`: ground-truth port of upstream
  `safe_arg` (option-arg branch) used to assert
  `unbackslash_arg(safe_arg("--groupmap", value)) == value` for the
  wildcard, every escape character, and the `--usermap`/`--groupmap`
  wildcard family.

The ground-truth `safe_arg` helper in the daemon test module is
independent of `safe_arg_for_daemon` so the contract is locked
against upstream wire output rather than against our own escape
code.

## Test plan

- [ ] `cargo nextest run -p oc-rsync-daemon -E 'test(unbackslash)'` green
- [ ] `cargo nextest run -p oc-rsync-core -E 'test(safe_arg)'` green
- [ ] `cargo nextest run -p oc-rsync-core -E 'test(every_safe_arg_escape_char_round_trips_through_unbackslash)'` green
- [ ] daemon-groupmap-wild upstream runtest cell green in both
  default-args and secluded-args variants