### PR TITLE
chore: fix master fmt + clippy hygiene

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -244,9 +244,7 @@ where
                 .ok()
                 .or_else(|| dest_path.parent().and_then(|p| p.canonicalize().ok()))
             {
-                use fast_io::landlock::{
-                    LandlockOutcome, is_supported, restrict_to_module_paths,
-                };
+                use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
                 if is_supported() {
                     match restrict_to_module_paths(&[root.as_path()]) {
                         LandlockOutcome::Enforced(_) | LandlockOutcome::Unavailable => {}

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -359,8 +359,7 @@ fn parse_server_args_skips_split_partial_dir_flag() {
     assert_eq!(flags, "-vlKtpR");
     assert!(
         pos_args.is_empty(),
-        "split --partial-dir and value must not leak into positional args: {:?}",
-        pos_args,
+        "split --partial-dir and value must not leak into positional args: {pos_args:?}",
     );
 }
 

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -264,7 +264,8 @@ impl GeneratorContext {
             // during recursive walk" (ENOENT during child traversal).
             let scoped: HashSet<PathBuf> = implied_only_dirs
                 .iter()
-                .filter_map(|(b, rel)| (b == &entry.base).then(|| rel.clone()))
+                .filter(|(b, _)| *b == &entry.base)
+                .map(|(_, rel)| rel.clone())
                 .collect();
             if !self.try_walk_source_entry_dedup(&entry.base, &entry.path, Some(&scoped))? {
                 continue;

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -264,7 +264,7 @@ impl GeneratorContext {
             // during recursive walk" (ENOENT during child traversal).
             let scoped: HashSet<PathBuf> = implied_only_dirs
                 .iter()
-                .filter(|(b, _)| *b == &entry.base)
+                .filter(|(b, _)| b == &entry.base)
                 .map(|(_, rel)| rel.clone())
                 .collect();
             if !self.try_walk_source_entry_dedup(&entry.base, &entry.path, Some(&scoped))? {

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -589,8 +589,7 @@ mod tests {
         // the named directory even though `--files-from` clears the global
         // `-r` flag.
         let base = PathBuf::from("/src");
-        let split =
-            split_files_from_entry(&base, "from/./dir/subdir/subsubdir2", true);
+        let split = split_files_from_entry(&base, "from/./dir/subdir/subsubdir2", true);
         assert_eq!(split.base, PathBuf::from("/src/from"));
         assert_eq!(split.path, PathBuf::from("/src/from/dir/subdir/subsubdir2"));
         assert!(split.recurse);


### PR DESCRIPTION
## Summary

Master CI is failing fmt+clippy on multiple PRs because of three drifts:

1. **fmt** in \`crates/cli/src/frontend/server/run.rs:244\` — \`use fast_io::landlock::{...}\` collapses to a single line under rustfmt 1.88. Left over from PR #5724's landlock wire-in.
2. **fmt** in \`crates/transfer/src/generator/filters.rs:589\` — \`let split = ...\` long-form collapses to a single line under rustfmt 1.88.
3. **clippy** \`filter_map_bool_then\` in \`crates/transfer/src/generator/file_list/mod.rs:267\` — new lint in clippy 1.88. Rewrote \`filter_map(|(b, rel)| (b == &entry.base).then(|| rel.clone()))\` as the behaviour-identical \`filter(...).map(...)\` pair.

## Test plan

- [ ] CI: fmt + clippy
- [ ] Unblocks #5725, #5726, #5727 after rebase