### PR TITLE
ci: tolerate offline cargo update failure on cold rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,13 @@ jobs:
       # Regenerate Cargo.lock against Cargo.toml at job start so workspace
       # metadata bumps that didn't refresh the lockfile don't block CI.
       # Runs in --offline mode so no network fetch is required.
+      # continue-on-error: cold rust-cache leaves the registry index
+      # unavailable, which causes --offline regen to fail with "no matching
+      # package" even when the lockfile is already in sync; the subsequent
+      # --locked cargo commands surface any real lockfile mismatch loudly.
       - name: Regenerate Cargo.lock
         run: cargo update --workspace --offline
+        continue-on-error: true
 
       - name: Format check
         run: cargo fmt --all -- --check
@@ -178,8 +183,10 @@ jobs:
         with:
           tool: cargo-nextest
 
+      # See lint job comment above re: continue-on-error on cold rust-cache.
       - name: Regenerate Cargo.lock
         run: cargo update --workspace --offline
+        continue-on-error: true
 
       - name: Run tests
         run: cargo nextest run --locked --profile ci --workspace --all-features


### PR DESCRIPTION
## Summary

- Cold rust-cache leaves the crates.io registry index unavailable, so the defensive `cargo update --workspace --offline` regen step fails with `no matching package named rayon found` even when the lockfile is already in sync with `Cargo.toml`.
- This blocks every PR that touches only `.rs` files (i.e. doesn't change `Cargo.lock`) on first-time matrix cells (nextest stable/beta/nightly, Windows stable/nightly).
- Subsequent `cargo nextest run --locked` and `cargo clippy --locked` commands still enforce real lockfile drift loudly, so allowing the regen to soft-fail does not weaken correctness.

Add `continue-on-error: true` to both regen sites (lint job lines 84-85 and test matrix lines 181-182).

## Test plan

- [ ] First-time matrix cells now proceed past the regen step on cold cache instead of hard-failing with the offline package-resolution error.
- [ ] `cargo nextest run --locked` and `cargo clippy --locked` still flag real lockfile/Cargo.toml drift if the regen step is bypassed.
- [ ] Warm-cache runs remain unchanged (regen still succeeds; soft-fail path never triggers).