### PR TITLE
fix: silence Windows unused-variable on info_debug stderr binding

### DIFF
--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -285,7 +285,7 @@ fn info_name0_suppresses_verbose_output() {
     let destination = tmp.path().join("quiet.out");
     std::fs::write(&source, b"quiet").expect("write source");
 
-    let (code, stdout, stderr) = run_with_args([
+    let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-v"),
         OsString::from("--info=name0"),
@@ -296,9 +296,9 @@ fn info_name0_suppresses_verbose_output() {
     assert_eq!(code, 0);
     #[cfg(unix)]
     assert!(
-        stderr.is_empty(),
+        _stderr.is_empty(),
         "unexpected stderr: {}",
-        String::from_utf8_lossy(&stderr)
+        String::from_utf8_lossy(&_stderr)
     );
     let rendered = String::from_utf8(stdout).expect("stdout utf8");
     assert!(!rendered.contains("quiet.txt"));
@@ -328,7 +328,7 @@ fn info_name2_reports_unchanged_entries() {
         String::from_utf8_lossy(&initial.2)
     );
 
-    let (code, stdout, stderr) = run_with_args([
+    let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--info=name2"),
         source.into_os_string(),
@@ -338,9 +338,9 @@ fn info_name2_reports_unchanged_entries() {
     assert_eq!(code, 0);
     #[cfg(unix)]
     assert!(
-        stderr.is_empty(),
+        _stderr.is_empty(),
         "unexpected stderr: {}",
-        String::from_utf8_lossy(&stderr)
+        String::from_utf8_lossy(&_stderr)
     );
     let rendered = String::from_utf8(stdout).expect("stdout utf8");
     assert!(rendered.contains("unchanged.txt"));


### PR DESCRIPTION
## Summary
- Renames the `stderr` binding to `_stderr` in two `info_debug.rs` tests where the value is only read inside `#[cfg(unix)]` blocks. On Windows the binding was unused under `-D warnings`, failing the cli crate test build on `Windows (stable)` for every PR that hit master at HEAD.
- Functional behavior unchanged: the `#[cfg(unix)]` assertions still inspect the captured stderr; only the identifier name differs.

## Test plan
- [ ] CI: `Windows (stable)` test build of cli compiles cleanly.
- [ ] CI: Linux nextest still exercises the `stderr.is_empty()` assertions (same `_stderr` identifier, just underscored).