### PR TITLE
fix: preserve symlink mtime in receiver create_symlinks

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -347,6 +347,60 @@ pub fn apply_symlink_metadata_with_options(
     Ok(())
 }
 
+/// Applies metadata from a protocol `FileEntry` to a destination symbolic link
+/// without following the link target.
+///
+/// Mirrors [`apply_metadata_from_file_entry`] but uses `lstat` for the cached
+/// stat and `lutimes` / `utimensat(AT_SYMLINK_NOFOLLOW)` for timestamps so the
+/// link's own mtime is updated instead of the target's. Permissions are not
+/// preserved for symlinks because most systems ignore symlink permission bits;
+/// ownership (when applicable) is applied with `AT_SYMLINK_NOFOLLOW`.
+///
+/// This is the receiver-side counterpart to [`apply_symlink_metadata`] that
+/// works directly with `FileEntry` metadata from the wire protocol, so the
+/// network receiver does not need to construct an [`fs::Metadata`] instance
+/// before calling it.
+///
+/// # Upstream Reference
+///
+/// - `rsync.c:set_file_attrs()` - skips chmod for symlinks
+/// - `rsync.c:set_times()` - uses `lutimes` when the target is a symlink
+/// - `generator.c:1592` - `set_file_attrs(fname, file, NULL, NULL, 0)` runs
+///   after `atomic_create` -> `do_symlink` so the new symlink's mtime matches
+///   the sender's `F_MOD_NSEC_or_0(file)`.
+pub fn apply_symlink_metadata_from_entry(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+) -> Result<(), MetadataError> {
+    let cached_meta = fs::symlink_metadata(destination).ok();
+
+    #[cfg(unix)]
+    ownership::apply_symlink_ownership_from_entry(
+        destination,
+        entry,
+        options,
+        cached_meta.as_ref(),
+    )?;
+    #[cfg(not(unix))]
+    {
+        let _ = entry;
+        let _ = options;
+        let _ = cached_meta.as_ref();
+    }
+
+    if options.times() {
+        timestamps::apply_symlink_timestamps_from_entry(
+            destination,
+            entry,
+            options,
+            cached_meta.as_ref(),
+        )?;
+    }
+
+    Ok(())
+}
+
 /// Applies metadata from a protocol `FileEntry` to the destination file.
 ///
 /// This is the receiver-side counterpart to [`apply_file_metadata`] that works

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -355,6 +355,96 @@ pub(super) fn apply_ownership_from_entry(
     Ok(())
 }
 
+/// Applies ownership from a protocol `FileEntry` to a symbolic link on Unix
+/// without following the link target.
+///
+/// Mirrors [`apply_ownership_from_entry`] but uses `AT_SYMLINK_NOFOLLOW` so the
+/// `chownat` syscall targets the link itself, matching upstream's
+/// `do_lchown(fname, uid, gid)` path in `set_file_attrs()`. Fake-super xattr
+/// storage is skipped because `lsetxattr` on symlinks is not portable; upstream
+/// rsync also takes the skip path for symlinks under `am_root < 0`.
+// upstream: rsync.c:set_file_attrs() - do_lchown for symlinks
+#[cfg(unix)]
+pub(super) fn apply_symlink_ownership_from_entry(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    cached_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    use rustix::fs::chownat;
+
+    if !options.owner()
+        && !options.group()
+        && options.owner_override().is_none()
+        && options.group_override().is_none()
+    {
+        return Ok(());
+    }
+
+    // upstream: rsync.c:set_file_attrs() - fake-super skips lsetxattr on symlinks
+    if options.fake_super_enabled() {
+        return Ok(());
+    }
+
+    let owner = if let Some(uid_override) = options.owner_override() {
+        Some(ownership::uid_from_raw(uid_override as RawUid))
+    } else if options.owner() {
+        entry.uid().and_then(|uid| {
+            let mut mapped_uid = uid as RawUid;
+            if let Some(mapping) = options.user_mapping()
+                && let Ok(Some(mapped)) = mapping.map_uid(mapped_uid)
+            {
+                mapped_uid = mapped;
+            }
+            map_uid(mapped_uid, options.numeric_ids_enabled())
+        })
+    } else {
+        None
+    };
+
+    let group = if let Some(gid_override) = options.group_override() {
+        Some(ownership::gid_from_raw(gid_override as RawGid))
+    } else if options.group() {
+        entry.gid().and_then(|gid| {
+            let mut mapped_gid = gid as RawGid;
+            if let Some(mapping) = options.group_mapping()
+                && let Ok(Some(mapped)) = mapping.map_gid(mapped_gid)
+            {
+                mapped_gid = mapped;
+            }
+            map_gid(mapped_gid, options.numeric_ids_enabled())
+        })
+    } else {
+        None
+    };
+
+    if owner.is_none() && group.is_none() {
+        return Ok(());
+    }
+
+    // upstream: rsync.c:set_file_attrs() - skips chown when uid/gid already match
+    let needs_chown = match cached_meta {
+        Some(meta) => {
+            let current_uid = meta.uid();
+            let current_gid = meta.gid();
+            let desired_uid = owner.map(|o| o.as_raw()).unwrap_or(current_uid);
+            let desired_gid = group.map(|g| g.as_raw()).unwrap_or(current_gid);
+            current_uid != desired_uid || current_gid != desired_gid
+        }
+        None => true,
+    };
+
+    if needs_chown {
+        trace_chown_change(destination, owner, group, cached_meta);
+
+        chownat(CWD, destination, owner, group, AtFlags::SYMLINK_NOFOLLOW).map_err(|error| {
+            MetadataError::new("preserve ownership", destination, io::Error::from(error))
+        })?;
+    }
+
+    Ok(())
+}
+
 /// Stores ownership metadata via fake-super xattr instead of applying directly.
 ///
 /// Used when `--fake-super` is enabled, allowing non-root users to

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -242,6 +242,54 @@ pub(super) fn apply_timestamps_from_entry(
     Ok(())
 }
 
+/// Applies mtime (and atime when `--atimes`) from a protocol `FileEntry`
+/// to a symbolic link without following the link target.
+///
+/// Mirrors [`apply_timestamps_from_entry`] but uses `lutimes` /
+/// `utimensat(AT_SYMLINK_NOFOLLOW)` via [`set_symlink_file_times`] so the
+/// symlink's own mtime is updated instead of the link target's. The
+/// receiver invokes this after `do_symlink` so the on-disk link mtime
+/// matches the source-side value.
+// upstream: rsync.c:set_file_attrs() + set_times() - symlink path uses lutimes
+pub(super) fn apply_symlink_timestamps_from_entry(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    cached_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    let mtime = FileTime::from_unix_time(entry.mtime(), entry.mtime_nsec());
+
+    // upstream: rsync.c:600-603 - preserves source atime with --atimes, else mtime for both
+    let atime = if options.atimes() && entry.atime() != 0 {
+        FileTime::from_unix_time(entry.atime(), 0)
+    } else {
+        mtime
+    };
+
+    // upstream: rsync.c:set_file_attrs() - skips utimensat when timestamps match
+    let needs_utime = match cached_meta {
+        Some(meta) => {
+            let current_mtime = FileTime::from_last_modification_time(meta);
+            if current_mtime != mtime {
+                true
+            } else if options.atimes() {
+                let current_atime = FileTime::from_last_access_time(meta);
+                current_atime != atime
+            } else {
+                false
+            }
+        }
+        None => true,
+    };
+
+    if needs_utime {
+        set_symlink_file_times(destination, atime, mtime)
+            .map_err(|error| MetadataError::new("preserve timestamps", destination, error))?;
+    }
+
+    Ok(())
+}
+
 /// Applies only the access time from a `FileEntry`, preserving the
 /// destination's existing mtime.
 ///

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -205,8 +205,8 @@ pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,
     apply_file_metadata_if_changed, apply_file_metadata_with_options,
     apply_metadata_from_file_entry, apply_metadata_with_attrs_flags,
-    apply_metadata_with_cached_stat, apply_symlink_metadata, apply_symlink_metadata_with_options,
-    metadata_unchanged,
+    apply_metadata_with_cached_stat, apply_symlink_metadata, apply_symlink_metadata_from_entry,
+    apply_symlink_metadata_with_options, metadata_unchanged,
 };
 #[cfg(unix)]
 pub use apply::{apply_file_metadata_with_fd, apply_file_metadata_with_fd_if_changed};

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -9,6 +9,8 @@ use std::fs;
 use std::path::Path;
 
 use logging::{debug_log, info_log};
+#[cfg(unix)]
+use metadata::{MetadataOptions, apply_symlink_metadata_from_entry};
 use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_first};
 
 use crate::generator::ItemFlags;
@@ -90,6 +92,27 @@ impl ReceiverContext {
             // upstream: generator.c:1561 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
                 if existing_target == *target {
+                    // upstream: generator.c:1563 - even on the up-to-date branch
+                    // `set_file_attrs(fname, file, &sx, NULL, maybe_ATTRS_REPORT)`
+                    // still runs so a stale on-disk mtime is corrected.
+                    let symlink_options = MetadataOptions::new()
+                        .preserve_owner(self.config.flags.owner)
+                        .preserve_group(self.config.flags.group)
+                        .preserve_times(self.config.flags.times)
+                        .preserve_atimes(self.config.flags.atimes)
+                        .numeric_ids(self.config.flags.numeric_ids)
+                        .fake_super(self.config.fake_super);
+                    if let Err(error) =
+                        apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
+                    {
+                        debug_log!(
+                            Recv,
+                            1,
+                            "failed to refresh symlink metadata for {}: {}",
+                            link_path.display(),
+                            error
+                        );
+                    }
                     // upstream: generator.c:1565 - symlink up-to-date, metadata only
                     let iflags = ItemFlags::from_raw(0);
                     let _ = self.emit_itemize(writer, &iflags, entry);
@@ -180,6 +203,30 @@ impl ReceiverContext {
                     continue;
                 }
                 return Err(e);
+            }
+            // upstream: generator.c:1592 - `set_file_attrs(fname, file, NULL, NULL, 0)`
+            // runs immediately after `atomic_create` -> `do_symlink` so the new
+            // symlink's mtime matches the sender-supplied value. Without this
+            // step the receiver-created symlink wears the wall-clock time from
+            // `symlinkat(2)`, breaking the `--copy-dest` parity that
+            // `testsuite/alt-dest.test` enforces over SSH.
+            let symlink_options = MetadataOptions::new()
+                .preserve_owner(self.config.flags.owner)
+                .preserve_group(self.config.flags.group)
+                .preserve_times(self.config.flags.times)
+                .preserve_atimes(self.config.flags.atimes)
+                .numeric_ids(self.config.flags.numeric_ids)
+                .fake_super(self.config.fake_super);
+            if let Err(error) =
+                apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
+            {
+                debug_log!(
+                    Recv,
+                    1,
+                    "failed to apply symlink metadata for {}: {}",
+                    link_path.display(),
+                    error
+                );
             }
             // upstream: generator.c:1594 - itemize new symlink after creation
             let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -171,6 +171,72 @@ fn create_symlinks_surfaces_non_eacces_error() {
     );
 }
 
+/// UTS-12 regression: the receiver's `create_symlinks` must apply the
+/// sender-supplied mtime to the on-disk symlink via
+/// `utimensat(AT_SYMLINK_NOFOLLOW)`. Without this step every receiver-created
+/// symlink wears the wall-clock time from `symlinkat(2)`, which makes upstream
+/// `testsuite/alt-dest.test` fail over SSH because the `--copy-dest` checkit
+/// diff catches the 1-2 second drift on `nolf-symlink`.
+///
+/// The local-copy path already preserves the source link's mtime via
+/// `apply_symlink_metadata_with_options`. This test pins the same invariant on
+/// the network receiver path (`create_symlinks`) by:
+///
+/// 1. Constructing a `FileEntry::new_symlink` with an explicit backdated mtime
+///    well before the test run started (mirrors upstream's `nolf-symlink`
+///    fixture being older than the `to/` directory is fresh).
+/// 2. Driving `create_symlinks` directly so the test exercises the SSH-server
+///    code path (the same call site that fires under `oc-rsync` invoked via
+///    `lsh.sh`) without spinning up an SSH transport.
+/// 3. Asserting `lstat` on the destination link returns the entry's mtime to
+///    the exact second. Upstream's diff drops nanoseconds; matching seconds is
+///    the load-bearing invariant.
+///
+/// upstream: generator.c:1592 `set_file_attrs(fname, file, NULL, NULL, 0)`
+/// upstream: rsync.c:set_times() uses `lutimes`/`utimensat(AT_SYMLINK_NOFOLLOW)`
+#[cfg(unix)]
+#[test]
+fn receiver_preserves_symlink_mtime_on_creation() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut config = plain_receiver_config();
+    // Mirrors what the SSH-server-side receiver sees when the client passes
+    // `-ave .../lsh.sh ...`: archive mode implies `-tlogD` so `times`, `owner`,
+    // and `group` are all enabled on `ParsedServerFlags`. The bug only
+    // surfaces when `times` is true (without it, upstream emits no utimensat
+    // syscall either).
+    config.flags.times = true;
+    config.flags.owner = true;
+    config.flags.group = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    // Backdated mtime: epoch + 2 hours. Pinned constants so the assertion is
+    // exact and the test never races against the wall clock the way the
+    // pre-fix receiver did.
+    const SOURCE_MTIME_SECS: i64 = 7_200;
+    let mut entry = FileEntry::new_symlink("nolf-symlink".into(), "nolf".into());
+    entry.set_mtime(SOURCE_MTIME_SECS, 0);
+    ctx.file_list = vec![entry];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed on a writable tempdir");
+
+    let on_disk = std::fs::symlink_metadata(dest.join("nolf-symlink"))
+        .expect("symlink_metadata must read the link itself, not its target");
+    assert_eq!(
+        on_disk.mtime(),
+        SOURCE_MTIME_SECS,
+        "receiver must propagate the entry's mtime to the on-disk symlink \
+         (upstream rsync.c set_times -> utimensat(AT_SYMLINK_NOFOLLOW)); \
+         without it `testsuite/alt-dest.test` diff trips on `nolf-symlink`",
+    );
+}
+
 #[test]
 fn receiver_writes_unmunged_target_when_disabled() {
     // Negative control: the same flist with `munge_symlinks=false` must


### PR DESCRIPTION
## Summary

- Network-side receiver was creating symlinks via `symlinkat(2)` and never applying the sender-supplied mtime, so on-disk symlinks wore the receiver's wall-clock time and upstream `testsuite/alt-dest.test` tripped on the SSH-mode `--copy-dest` sub-test (`nolf-symlink` showed a 1-2s drift).
- Added `apply_symlink_metadata_from_entry` to the `metadata` crate (timestamps via `lutimes` / `utimensat(AT_SYMLINK_NOFOLLOW)`, ownership via `chownat` with `AT_SYMLINK_NOFOLLOW`). Local-copy already preserved this through `apply_symlink_metadata_with_options`; the new entrypoint is the receiver-side counterpart that works directly with a `FileEntry` from the wire.
- Called from `create_symlinks` on both the fresh-create branch and the up-to-date branch, mirroring upstream `generator.c:1563` and `generator.c:1592` where `set_file_attrs` runs unconditionally after `atomic_create` / `quick_check_ok`.

## Test plan

- [ ] CI fmt + clippy + nextest pass.
- [ ] New regression test `receiver_preserves_symlink_mtime_on_creation` in `crates/transfer/src/receiver/tests/munge_symlinks.rs` drives `create_symlinks` with a backdated `FileEntry` and asserts the on-disk lstat mtime matches the entry's mtime exactly.
- [ ] Upstream interop `alt-dest.test` SSH-mode `--copy-dest` sub-test passes on Linux runtests (the original failure surface for this bug).

## Upstream References

- `generator.c:1591-1592` - `atomic_create(... do_symlink ...); set_file_attrs(fname, file, NULL, NULL, 0);`
- `generator.c:1561-1563` - up-to-date branch also runs `set_file_attrs`.
- `rsync.c:set_file_attrs` / `set_times` - symlink path uses `lutimes` / `utimensat(AT_SYMLINK_NOFOLLOW)`.