### PR TITLE
fix: chmod through dirfd to block parent-symlink escape

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls.rs
@@ -29,7 +29,7 @@
 use std::ffi::{CString, OsStr};
 use std::fs::File;
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
@@ -932,6 +932,49 @@ pub fn fchmodat_via_sandbox_or_fallback(
     }
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(link_path, std::fs::Permissions::from_mode(mode))
+}
+
+/// Chmod `path` after walking its parent through [`secure_open_dir`].
+///
+/// Symlink-race-safe variant of [`std::fs::set_permissions`] that
+/// mirrors upstream `syscall.c:do_chmod_at()` (rsync 3.4.3+). The parent
+/// directory of `path` is opened with `openat2(RESOLVE_BENEATH |
+/// RESOLVE_NO_SYMLINKS)` on Linux 5.6+ or `open(O_NOFOLLOW | O_DIRECTORY
+/// | O_CLOEXEC)` elsewhere, then `fchmodat` is anchored on that dirfd
+/// against the leaf basename. A symlink inserted into any parent
+/// component of `path` causes the open to fail with `ELOOP` (or `EXDEV`
+/// for `..` escapes under `openat2`), so a TOCTOU swap cannot redirect
+/// the chmod to an attacker-chosen inode outside the carrier directory.
+///
+/// `follow_symlinks` controls only the leaf: when `false` the helper
+/// passes `AT_SYMLINK_NOFOLLOW` so a swap-to-symlink at the leaf is not
+/// chased into a different inode either.
+///
+/// Falls back to [`std::fs::set_permissions`] when `path` has no parent
+/// component (root, single-component) - there is nothing to walk in that
+/// case.
+///
+/// [`secure_open_dir`]: crate::secure_open_dir
+///
+/// # Errors
+///
+/// Surfaces either the [`secure_open_dir`](crate::secure_open_dir) error
+/// or the [`fchmodat`] error verbatim. The notable security cases are
+/// `ELOOP` (parent symlink), `EXDEV` (parent `..` escape under
+/// `openat2`), and `ENOTDIR` (parent component is not a directory).
+pub fn secure_chmod_at(path: &Path, mode: u32, follow_symlinks: bool) -> io::Result<()> {
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => {
+            use std::os::unix::fs::PermissionsExt;
+            return std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+        }
+    };
+    let leaf = path
+        .file_name()
+        .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+    let dirfd = crate::secure_open_dir(parent)?;
+    fchmodat(dirfd.as_fd(), leaf, mode, follow_symlinks)
 }
 
 /// Issue `fchownat` against `link_path` when the `sandbox` root is the
@@ -2585,6 +2628,67 @@ mod tests {
         assert_eq!(
             std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777,
             0o644
+        );
+    }
+
+    #[test]
+    fn secure_chmod_at_changes_mode_on_clean_path() {
+        let (_keep, root) = canonical_tempdir();
+        let path = root.join("file");
+        std::fs::write(&path, b"x").expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("seed perms");
+
+        super::secure_chmod_at(&path, 0o640, true).expect("secure chmod");
+        assert_eq!(
+            std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777,
+            0o640
+        );
+    }
+
+    #[test]
+    fn secure_chmod_at_refuses_symlinked_parent_leaf() {
+        // chdir-symlink-race regression: a symlink swapped into the
+        // immediate parent component of `path` must reject the chmod
+        // rather than chase the link to an outside target. `O_NOFOLLOW`
+        // on the parent `secure_open_dir` is enough to surface ELOOP on
+        // every Unix target (Linux 5.6+ additionally rejects any
+        // symlink anywhere in the parent path via openat2).
+        let (_keep, root) = canonical_tempdir();
+        let outside = root.join("outside");
+        let module = root.join("module");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        std::fs::create_dir(&module).expect("mkdir module");
+        let outside_target = outside.join("target");
+        std::fs::write(&outside_target, b"OUTSIDE").expect("write outside");
+        std::fs::set_permissions(&outside_target, std::fs::Permissions::from_mode(0o600))
+            .expect("seed outside");
+        // module/subdir -> outside (parent-component symlink trap).
+        symlink(&outside, module.join("subdir")).expect("plant symlink");
+
+        let dest = module.join("subdir").join("target");
+        let err = super::secure_chmod_at(&dest, 0o666, true)
+            .expect_err("chmod through symlinked parent must error");
+        // Platform-dependent: Linux + openat2 surfaces ELOOP or EXDEV;
+        // O_NOFOLLOW | O_DIRECTORY on a symlinked leaf surfaces ELOOP on
+        // Linux without openat2 and ENOTDIR on macOS. All three confirm
+        // the parent open was refused before any chmod issued.
+        let raw = err.raw_os_error();
+        assert!(
+            matches!(
+                raw,
+                Some(libc::ELOOP) | Some(libc::EXDEV) | Some(libc::ENOTDIR)
+            ),
+            "expected ELOOP/EXDEV/ENOTDIR, got {raw:?}"
+        );
+        let outside_mode = std::fs::metadata(&outside_target)
+            .expect("stat")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            outside_mode, 0o600,
+            "outside file must keep 0o600 after refused chmod escape"
         );
     }
 

--- a/crates/fast_io/src/dir_sandbox/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/mod.rs
@@ -85,8 +85,9 @@ pub use at_syscalls::{
     mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
     read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
     recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
-    unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, symlinkat,
+    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
+    utimensat_via_sandbox_or_fallback,
 };
 
 /// Parent-dirfd carrier threaded through the receiver pipeline.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -280,8 +280,9 @@ pub use dir_sandbox::{
     mkdirat, mkdirat_via_sandbox_or_fallback, openat, openat_via_sandbox_or_fallback,
     read_dir_via_sandbox_or_fallback, readlinkat, readlinkat_via_sandbox_or_fallback,
     recursive_unlinkat, recursive_unlinkat_via_sandbox_or_fallback, renameat,
-    renameat_via_sandbox_or_fallback, symlinkat, symlinkat_via_sandbox_or_fallback,
-    unlink_via_sandbox_or_fallback, unlinkat, utimensat, utimensat_via_sandbox_or_fallback,
+    renameat_via_sandbox_or_fallback, secure_chmod_at, symlinkat,
+    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback, unlinkat, utimensat,
+    utimensat_via_sandbox_or_fallback,
 };
 pub use kernel_version::{
     IO_URING_MIN_KERNEL, IoUringRequirement, KernelVersion, LinkatRequirement, PbufRingRequirement,

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -24,6 +24,7 @@ libc = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
+fast_io = { path = "../fast_io", default-features = false }
 xattr = { workspace = true, optional = true }
 
 # Cross-platform ACL support (Linux, macOS, FreeBSD)

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -425,8 +425,12 @@ pub(super) fn apply_permissions_from_entry(
             };
 
             if needs_chmod {
-                let permissions = PermissionsExt::from_mode(mode);
-                fs::set_permissions(destination, permissions).map_err(|error| {
+                // upstream: syscall.c:do_chmod_at() - chmod the leaf through a
+                // dirfd opened with RESOLVE_BENEATH/RESOLVE_NO_SYMLINKS so a
+                // symlink swapped into any parent component cannot redirect
+                // the chmod outside the receiver's confinement (testsuite
+                // chdir-symlink-race).
+                fast_io::secure_chmod_at(destination, mode, true).map_err(|error| {
                     MetadataError::new("preserve permissions", destination, error)
                 })?;
                 perms_changed = true;
@@ -479,8 +483,8 @@ pub(super) fn apply_permissions_from_entry(
 
             let new_mode = chmod.apply(base_mode, current_meta.file_type());
             if new_mode != current_mode {
-                let new_permissions = PermissionsExt::from_mode(new_mode);
-                fs::set_permissions(destination, new_permissions)
+                // upstream: syscall.c:do_chmod_at() symlink-race-safe variant
+                fast_io::secure_chmod_at(destination, new_mode, true)
                     .map_err(|error| MetadataError::new("apply chmod", destination, error))?;
             }
         }

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1399,3 +1399,60 @@ fn metadata_unchanged_returns_true_when_group_override_matches() {
         "should return true when group override matches current gid"
     );
 }
+
+/// UTS-16.b: applying permissions through a destination path whose parent
+/// component is a symlink to an outside directory must NOT chmod the
+/// outside target. Upstream `syscall.c:do_chmod_at()` (rsync 3.4.3+)
+/// opens the parent under `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` so a
+/// symlink swapped into any parent component is rejected.
+///
+/// Regression coverage for the testsuite `chdir-symlink-race` failure on
+/// the `-r --size-only into upload/ root` flavour: the symlinked
+/// `subdir` was being chased by the path-based chmod, flipping the
+/// outside sentinel from 0o600 to 0o666.
+#[cfg(unix)]
+#[test]
+fn apply_permissions_from_entry_refuses_parent_symlink_escape() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let module = temp.path().join("module");
+    let outside = temp.path().join("outside");
+    fs::create_dir(&module).expect("create module");
+    fs::create_dir(&outside).expect("create outside");
+
+    // Outside-the-module sentinel the attacker is trying to chmod via
+    // the symlink-traversed path.
+    let outside_target = outside.join("target.txt");
+    fs::write(&outside_target, b"OUTSIDE_SECRET_DATA").expect("write outside");
+    fs::set_permissions(&outside_target, PermissionsExt::from_mode(0o600))
+        .expect("set outside mode");
+
+    // Attacker plants a symlink at module/subdir -> outside, then the
+    // receiver tries to chmod module/subdir/target.txt (which resolves
+    // to outside/target.txt via the symlink).
+    std::os::unix::fs::symlink(&outside, module.join("subdir")).expect("plant symlink");
+
+    let dest = module.join("subdir").join("target.txt");
+    let entry = FileEntry::new_file("target.txt".into(), 19, 0o666);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(false);
+
+    let result = apply_metadata_from_file_entry(&dest, &entry, &opts);
+    assert!(
+        result.is_err(),
+        "chmod through a symlinked parent must fail, not silently succeed"
+    );
+
+    let outside_mode = fs::metadata(&outside_target)
+        .expect("stat outside")
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(
+        outside_mode, 0o600,
+        "outside file mode must remain 0o600 after refused chmod escape (got {outside_mode:o})"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace path-based `fs::set_permissions(destination, ...)` calls in `apply_permissions_from_entry` with a new symlink-race-safe helper `fast_io::secure_chmod_at` that opens the parent via `secure_open_dir` (RESOLVE_BENEATH + RESOLVE_NO_SYMLINKS on Linux 5.6+, O_NOFOLLOW + O_DIRECTORY elsewhere) and chmods the leaf through `fchmodat`. A symlink swapped into any parent component of the destination path now fails the parent open with ELOOP/EXDEV/ENOTDIR instead of silently chmodding an attacker-chosen file outside the receiver's confinement.
- Mirrors upstream rsync `syscall.c:do_chmod_at()` (3.4.3+) and closes the `chdir-symlink-race` testsuite failure on the `-r --size-only into upload/ root` flavour, where the receiver's quick-check skip relied on the path-based chmod and chased the planted `upload/subdir -> ../outside` symlink to flip the outside sentinel from 0o600 to 0o666.
- Errors from the helper propagate via `?` rather than being swallowed as `Ok(())`, so the receiver surfaces the rejection in its exit code instead of reporting success with the escape attempted.

## Test plan

- [x] `cargo nextest run -p metadata -E 'test(apply_permissions_from_entry_refuses_parent_symlink_escape)'` -- plants `module/subdir -> outside`, applies entry permissions on `module/subdir/target.txt`, asserts the outside file's mode stays at 0o600 and the call returns `Err`.
- [x] `cargo nextest run -p fast_io -E 'test(secure_chmod_at)'` -- covers the clean-path success case and the parent-symlink rejection path at the helper level.
- [x] `cargo nextest run -p metadata` (429 tests, all green).
- [x] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [ ] CI: chdir-symlink-race upstream testsuite passes on Linux.