### PR TITLE
fix: keep server stdio blocking + retry WouldBlock in write loop

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -30,6 +30,21 @@ where
     let program_brand =
         super::super::detect_program_name(args.first().map(OsString::as_os_str)).brand();
 
+    // Force inherited stdio to blocking mode before any read/write hits the
+    // multiplex-frame writer. Pipes from a parent rsync process are nominally
+    // blocking, but a parent that left `O_NONBLOCK` set would surface as
+    // `Resource temporarily unavailable (os error 11)` from `write_all_retry`
+    // and abort the transfer with no recovery path. Best-effort: log on
+    // failure but continue, mirroring upstream's tolerance for fcntl edge
+    // cases. upstream: io.c::writefd_unbuffered relies on blocking stdio.
+    if let Err(e) = fast_io::force_blocking_stdio() {
+        write_server_error(
+            stderr,
+            program_brand,
+            format!("failed to set stdio blocking mode: {e}"),
+        );
+    }
+
     // Detect secluded-args mode: `-s` flag appears as a standalone argument
     // after --server. upstream: options.c - protect_args in server mode.
     let secluded_args = detect_secluded_args_flag(args);

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -149,10 +149,10 @@ pub mod sendfile;
 pub mod signal;
 /// Safe wrappers around platform `setsockopt` for integer-valued options.
 pub mod socket_options;
-/// Force inherited stdin/stdout to blocking mode for server-side stdio.
-pub mod stdio_blocking;
 /// Zero-copy socket-to-disk transfer using `splice`/`vmsplice` syscalls.
 pub mod splice;
+/// Force inherited stdin/stdout to blocking mode for server-side stdio.
+pub mod stdio_blocking;
 /// Batched metadata syscall operations with dual-path runtime selection.
 pub mod syscall_batch;
 /// Zero-copy file writer that pushes literal chunks via `vmsplice` + `splice`.
@@ -303,12 +303,12 @@ pub use secure_dir::secure_open_dir;
 #[cfg(unix)]
 pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::set_socket_int_option;
-pub use stdio_blocking::force_blocking_stdio;
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;
 pub use splice::{
     SplicePipe, is_splice_available, is_splice_enabled, try_splice_to_file, try_vmsplice_to_file,
 };
+pub use stdio_blocking::force_blocking_stdio;
 // Non-unix `recv_fd_to_file` stub returns `Unsupported`; gate the public
 // re-export on unix to remove the dead surface area (see WIN-S.LAND.1.a).
 #[cfg(unix)]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -149,6 +149,8 @@ pub mod sendfile;
 pub mod signal;
 /// Safe wrappers around platform `setsockopt` for integer-valued options.
 pub mod socket_options;
+/// Force inherited stdin/stdout to blocking mode for server-side stdio.
+pub mod stdio_blocking;
 /// Zero-copy socket-to-disk transfer using `splice`/`vmsplice` syscalls.
 pub mod splice;
 /// Batched metadata syscall operations with dual-path runtime selection.
@@ -301,6 +303,7 @@ pub use secure_dir::secure_open_dir;
 #[cfg(unix)]
 pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::set_socket_int_option;
+pub use stdio_blocking::force_blocking_stdio;
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;
 pub use splice::{

--- a/crates/fast_io/src/stdio_blocking.rs
+++ b/crates/fast_io/src/stdio_blocking.rs
@@ -1,0 +1,125 @@
+//! Force the standard input/output streams to blocking mode at server entry.
+//!
+//! Pipes inherited from a parent process are normally blocking on Unix, but a
+//! misbehaving parent (or a future runtime change) could leave `O_NONBLOCK`
+//! set on stdin/stdout. The multiplex-frame writer in `transfer` assumes
+//! blocking I/O semantics matching upstream rsync's `io.c::writefd_unbuffered`,
+//! which retries on `EAGAIN` via `select()`/`poll()`. When our writer sees a
+//! `WouldBlock` error it currently propagates immediately, surfacing as
+//! `Resource temporarily unavailable (os error 11)` and aborting the transfer.
+//!
+//! Calling [`force_blocking_stdio`] at server entry clears `O_NONBLOCK` on FDs
+//! 0 and 1 so the writer's blocking contract holds regardless of how stdio
+//! was inherited.
+//!
+//! On Windows the helper is a no-op: there is no `O_NONBLOCK` equivalent on
+//! the inherited stdio handles.
+//!
+//! upstream: `io.c::writefd_unbuffered` relies on blocking stdin/stdout.
+
+use std::io;
+
+/// Clear `O_NONBLOCK` on the inherited stdin and stdout file descriptors so
+/// they match upstream rsync's blocking-I/O contract.
+///
+/// On Unix this calls `fcntl(F_GETFL)` and `fcntl(F_SETFL)` to clear the
+/// `O_NONBLOCK` bit on FDs 0 and 1. The call is idempotent: if the flag is
+/// already cleared, the second `fcntl` is a no-op from the kernel's
+/// perspective.
+///
+/// On non-Unix platforms this returns `Ok(())` immediately.
+///
+/// # Errors
+///
+/// Returns the OS error from `fcntl(2)` on the first descriptor that fails.
+/// Typical failures (`EBADF`) only occur if the calling process closed its
+/// stdin or stdout before invoking this helper.
+pub fn force_blocking_stdio() -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        clear_nonblock(libc::STDIN_FILENO)?;
+        clear_nonblock(libc::STDOUT_FILENO)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn clear_nonblock(fd: libc::c_int) -> io::Result<()> {
+    // SAFETY: `libc::fcntl` with `F_GETFL` takes a file descriptor and
+    // returns the current flags (or `-1` on error). The descriptor is the
+    // inherited stdio FD, which is owned by the process for its lifetime.
+    // No memory is read or written; only the kernel-side flags are queried.
+    #[allow(unsafe_code)]
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if flags & libc::O_NONBLOCK == 0 {
+        return Ok(());
+    }
+    let cleared = flags & !libc::O_NONBLOCK;
+    // SAFETY: `libc::fcntl` with `F_SETFL` writes the supplied integer flag
+    // mask back to the descriptor. The flags value originated from a
+    // preceding `F_GETFL` on the same descriptor with `O_NONBLOCK` masked
+    // off, so the kernel will accept it without altering any other state.
+    #[allow(unsafe_code)]
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFL, cleared) };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    #[test]
+    fn force_blocking_stdio_is_idempotent() {
+        // First call clears any inherited O_NONBLOCK (typically already
+        // clear in cargo test); the second call must still succeed on the
+        // now-blocking descriptors and report Ok.
+        force_blocking_stdio().expect("first call succeeds on inherited stdio");
+        force_blocking_stdio().expect("second call is idempotent");
+    }
+
+    #[test]
+    fn clear_nonblock_removes_flag_on_owned_fd() {
+        // Use a pipe so we can flip the flag on a real FD and verify the
+        // helper clears it without affecting any other bits.
+        let mut fds = [0_i32; 2];
+        // SAFETY: `libc::pipe` writes two file descriptors into the
+        // 2-element array. The call is a standard syscall with no aliasing
+        // requirements; the returned FDs are owned by this test and closed
+        // through `OwnedFd` Drop.
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe(2) failed: {}", io::Error::last_os_error());
+        // SAFETY: `fds[0]` and `fds[1]` are fresh descriptors returned by
+        // `pipe(2)` and not yet owned by any other RAII wrapper, so it is
+        // valid to take ownership here.
+        #[allow(unsafe_code)]
+        let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        #[allow(unsafe_code)]
+        let _write_fd = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+        let raw = read_fd.as_raw_fd();
+        // SAFETY: setting flags via fcntl on an owned descriptor; no memory aliasing.
+        #[allow(unsafe_code)]
+        let prev = unsafe { libc::fcntl(raw, libc::F_GETFL) };
+        assert!(prev >= 0);
+        // SAFETY: writing a valid flags integer back to the same owned descriptor.
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::fcntl(raw, libc::F_SETFL, prev | libc::O_NONBLOCK) };
+        assert_eq!(rc, 0);
+
+        clear_nonblock(raw).expect("clear_nonblock succeeds on owned pipe fd");
+
+        // SAFETY: reading flags on the same owned descriptor.
+        #[allow(unsafe_code)]
+        let post = unsafe { libc::fcntl(raw, libc::F_GETFL) };
+        assert!(post >= 0);
+        assert_eq!(post & libc::O_NONBLOCK, 0, "O_NONBLOCK should be cleared");
+    }
+}

--- a/crates/transfer/src/error.rs
+++ b/crates/transfer/src/error.rs
@@ -186,10 +186,13 @@ pub fn read_exact_retry<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<(
     Ok(())
 }
 
-/// Writes all bytes, retrying on EINTR (interrupted system call).
+/// Writes all bytes, retrying on `EINTR` (interrupted system call) and
+/// `EAGAIN`/`EWOULDBLOCK` (transient back-pressure).
 ///
-/// This matches upstream rsync's behavior in `fileio.c:60-65` where writes are
-/// retried immediately when interrupted by a signal.
+/// This matches upstream rsync's behavior in `fileio.c:60-65` (EINTR) and
+/// `io.c::writefd_unbuffered` (EAGAIN via `select()`/`poll()`). When the
+/// kernel reports a pipe buffer is temporarily full, yield the current thread
+/// and retry instead of aborting the transfer.
 ///
 /// # Upstream Reference
 ///
@@ -210,6 +213,13 @@ pub fn write_all_retry<W: Write>(writer: &mut W, buf: &[u8]) -> io::Result<()> {
             }
             Ok(n) => total_written += n,
             Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            // EAGAIN/EWOULDBLOCK indicates a transient back-pressure
+            // situation (kernel pipe buffer full). Yield and retry to match
+            // upstream io.c::writefd_unbuffered's select/poll behaviour.
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::yield_now();
+                continue;
+            }
             Err(e) => return Err(e),
         }
     }
@@ -430,6 +440,39 @@ mod tests {
         let mut buf = Vec::new();
         write_all_retry(&mut buf, b"hello world").unwrap();
         assert_eq!(&buf, b"hello world");
+    }
+
+    #[test]
+    fn write_all_retry_handles_wouldblock() {
+        // Mirrors the upstream io.c::writefd_unbuffered behaviour: a single
+        // EAGAIN must not abort the transfer. The writer reports WouldBlock
+        // on the first call, then accepts all bytes on the second.
+        struct FlakyWriter {
+            inner: Vec<u8>,
+            blocked: bool,
+        }
+
+        impl Write for FlakyWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                if !self.blocked {
+                    self.blocked = true;
+                    return Err(io::Error::from(io::ErrorKind::WouldBlock));
+                }
+                self.inner.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut writer = FlakyWriter {
+            inner: Vec::new(),
+            blocked: false,
+        };
+        write_all_retry(&mut writer, b"hello world").expect("retry survives WouldBlock");
+        assert_eq!(&writer.inner, b"hello world");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `fast_io::force_blocking_stdio()` which clears `O_NONBLOCK` on FDs 0/1 at server entry so inherited stdio matches upstream rsync's blocking-I/O contract. New helper lives in `fast_io` to keep the `fcntl` unsafe block out of `cli`/`core`/`transfer`.
- Extends `transfer::error::write_all_retry` to also retry on `io::ErrorKind::WouldBlock` (EAGAIN/EWOULDBLOCK) with `std::thread::yield_now()`, matching upstream `io.c::writefd_unbuffered`'s `select()`/`poll()` behaviour.
- Calls `force_blocking_stdio()` at the top of `run_server_mode` (best-effort: log on failure but continue, mirroring upstream's tolerance for fcntl edge cases).

## Why
Surfaced as

```
oc-rsync error: server error: Resource temporarily unavailable (os error 11) at run.rs(407) [server=0.6.3]
rsync: connection unexpectedly closed (281712 bytes received so far) [receiver]
```

on the SSH-server-sender path when upstream rsync 3.4.3 acts as receiver and invokes `oc-rsync` through `support/lsh.sh` (failing `alt-dest` interop test). The `run.rs(407)` site is just the error formatter; the underlying `io::Error{kind: WouldBlock}` comes from `run_server_stdio` and propagates because `write_all_retry` previously only retried on `Interrupted`.

Two layered defenses:
1. Force-blocking stdio at entry covers the inherited-pipe case directly.
2. `WouldBlock` retry is defense-in-depth so any other component that flips `O_NONBLOCK` after entry does not break transfers.

## Test plan
- [ ] `cargo nextest run -p fast_io --all-features -E 'test(stdio_blocking)'`
- [ ] `cargo nextest run -p transfer --all-features -E 'test(write_all_retry_handles_wouldblock)'`
- [ ] Re-run upstream `alt-dest.test` with `--rsync-path=.../oc-rsync` via `support/lsh.sh` and confirm no EAGAIN abort
- [ ] CI: fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable)