### PR TITLE
fix(daemon): match refuse-options rules against short letters

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing.rs
@@ -26,7 +26,7 @@ const VITAL_OPTIONS: &[&str] = &[
     "sender",
     "dry-run",
     "n",
-    "seclude-args",
+    "secluded-args",
     "s",
     "from0",
     "0",
@@ -55,7 +55,8 @@ fn refused_option<'a>(module: &ModuleDefinition, options: &'a [String]) -> Optio
 
     options.iter().find_map(|candidate| {
         let canonical = canonical_option(candidate);
-        if is_option_refused(&module.refuse_options, &canonical) {
+        let short = long_option_short_letter(&canonical);
+        if is_option_refused(&module.refuse_options, &canonical, short) {
             Some(candidate.as_str())
         } else {
             None
@@ -125,6 +126,66 @@ fn short_option_long_name(letter: char) -> &'static str {
     }
 }
 
+/// Maps a canonical long-option name to its single-letter short form, when one
+/// exists in upstream's `long_options[]` table.
+///
+/// Inverse of `short_option_long_name` for the subset of options that have a
+/// short-letter alias. Used by the refuse-list matcher so rules can reference
+/// either the long or short form (`!verbose` and `!v` are equivalent).
+///
+/// upstream: options.c:594-... - the `shortName` column on each `long_options[]`
+/// entry; upstream's `parse_one_refuse_match` calls `wildmatch(ref, shortName)`
+/// as a fallback when the long-name comparison fails.
+fn long_option_short_letter(long_name: &str) -> Option<char> {
+    match long_name {
+        "verbose" => Some('v'),
+        "quiet" => Some('q'),
+        "human-readable" => Some('h'),
+        "dry-run" => Some('n'),
+        "archive" => Some('a'),
+        "recursive" => Some('r'),
+        "dirs" => Some('d'),
+        "perms" => Some('p'),
+        "executability" => Some('E'),
+        "acls" => Some('A'),
+        "xattrs" => Some('X'),
+        "times" => Some('t'),
+        "atimes" => Some('U'),
+        "crtimes" => Some('N'),
+        "omit-dir-times" => Some('O'),
+        "omit-link-times" => Some('J'),
+        "owner" => Some('o'),
+        "group" => Some('g'),
+        "devices" => Some('D'),
+        "links" => Some('l'),
+        "copy-links" => Some('L'),
+        "copy-dirlinks" => Some('k'),
+        "keep-dirlinks" => Some('K'),
+        "hard-links" => Some('H'),
+        "relative" => Some('R'),
+        "ignore-times" => Some('I'),
+        "one-file-system" => Some('x'),
+        "update" => Some('u'),
+        "sparse" => Some('S'),
+        "cvs-exclude" => Some('C'),
+        "whole-file" => Some('W'),
+        "checksum" => Some('c'),
+        "fuzzy" => Some('y'),
+        "compress" => Some('z'),
+        "partial" => Some('P'),
+        "prune-empty-dirs" => Some('m'),
+        "itemize-changes" => Some('i'),
+        "backup" => Some('b'),
+        "secluded-args" => Some('s'),
+        "version" => Some('V'),
+        "block-size" => Some('B'),
+        "temp-dir" => Some('T'),
+        "remote-option" => Some('M'),
+        "filter" => Some('f'),
+        _ => None,
+    }
+}
+
 /// Checks whether any client argument is refused by the module's refuse list.
 ///
 /// Expands bundled short options (e.g. `-vlogDtprez.iLsfxCIvu`) into their
@@ -151,7 +212,8 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
             if canonical.is_empty() {
                 continue;
             }
-            if is_option_refused(&module.refuse_options, &canonical) {
+            let short = long_option_short_letter(&canonical);
+            if is_option_refused(&module.refuse_options, &canonical, short) {
                 return Some(format!("--{canonical}"));
             }
             continue;
@@ -165,12 +227,13 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
                     break;
                 }
                 let long = short_option_long_name(letter);
-                let candidate = if long.is_empty() {
+                let long_canonical = if long.is_empty() {
                     letter.to_ascii_lowercase().to_string()
                 } else {
                     long.to_owned()
                 };
-                if is_option_refused(&module.refuse_options, &candidate) {
+                let short_letter = if long.is_empty() { None } else { Some(letter) };
+                if is_option_refused(&module.refuse_options, &long_canonical, short_letter) {
                     return Some(if long.is_empty() {
                         format!("-{letter}")
                     } else {
@@ -183,38 +246,73 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
     None
 }
 
-/// Evaluates a canonical option name against an ordered refuse list.
+/// Evaluates a canonical option (long name + optional short letter) against an
+/// ordered refuse list.
 ///
-/// Processes rules left-to-right. A rule starting with `!` negates a previous
-/// match, keeping the option allowed. A plain rule (possibly with globs) marks
-/// the option as refused. The last matching rule wins.
+/// Mirrors upstream `set_refuse_options` / `parse_one_refuse_match`
+/// (options.c:895): each rule is compared against BOTH the option's `longName`
+/// and its `shortName`, and rules are applied in the order they appear so the
+/// last match wins. A rule starting with `!` un-refuses a previously matched
+/// option, enabling allow-list configurations like
+/// `refuse options = * !verbose !archive` or pure `refuse options = !verbose`
+/// inverses to function the same way `rsyncd.conf(5)` documents.
 ///
-/// When a pattern contains glob metacharacters (`*`, `?`, `[`), vital options
-/// are exempt from matching.
+/// `a` and `archive` are special-cased to expand to the wildcard
+/// `[ardlptgoD]` so they refuse every short letter implied by upstream's
+/// `OPT_a` POPT alias, matching the `parse_one_refuse_match` rewrite at
+/// options.c:904.
 ///
-/// upstream: clientserver.c - refuse list is evaluated with fnmatch(3) semantics;
-/// vital options are skipped during wildcard expansion.
-fn is_option_refused(refuse_list: &[String], canonical: &str) -> bool {
+/// When a rule is a wildcard (`*`, `?`, `[`), it cannot affect vital options
+/// (`--server`, `--sender`, `--dry-run`, `-e`, `-s`, ...). Non-wild rules
+/// can refuse or un-refuse vital options when named explicitly.
+fn is_option_refused(refuse_list: &[String], long_name: &str, short_letter: Option<char>) -> bool {
+    let vital = is_option_vital(long_name, short_letter);
     let mut refused = false;
+    let short_lower = short_letter.map(|c| c.to_ascii_lowercase().to_string());
+
     for rule in refuse_list {
         let (negated, pattern_raw) = if let Some(rest) = rule.strip_prefix('!') {
             (true, rest)
         } else {
             (false, rule.as_str())
         };
-        let pattern = canonical_option(pattern_raw);
-
-        let is_glob = pattern.contains('*') || pattern.contains('?') || pattern.contains('[');
-
-        // upstream: clientserver.c - vital options are immune to wildcard patterns
-        if is_glob && is_vital_option(canonical) {
+        let mut pattern = canonical_option(pattern_raw);
+        if pattern.is_empty() {
             continue;
         }
 
+        // upstream: options.c:904 - `a` / `archive` rules expand to the
+        // character class containing every short letter implied by `-a`.
+        let mut is_glob = pattern.contains('*') || pattern.contains('?') || pattern.contains('[');
+        if pattern == "a" || pattern == "archive" {
+            pattern = "[ardlptgoD]".to_owned();
+            is_glob = true;
+        }
+
+        // upstream: options.c:953-968 - vital options carry `descrip = "a="`
+        // and `parse_one_refuse_match` only updates them when the rule is
+        // exact, never wild. Mirror that here so administrators cannot wreck
+        // the handshake with `refuse options = *`.
+        if is_glob && vital {
+            continue;
+        }
+
+        // upstream: options.c:909-921 - the rule is tried against both
+        // `op->longName` and `op->shortName` so `!verbose` and `!v` refer to
+        // the same option. Glob patterns additionally need the original-case
+        // short letter (so `[ardlptgoD]` matches `-D` via the upper-case `D`).
         let matches = if is_glob {
-            wildcard_match(&pattern, canonical)
+            refuse_glob_match(&pattern, long_name)
+                || short_lower
+                    .as_deref()
+                    .is_some_and(|s| refuse_glob_match(&pattern, s))
+                || short_letter.is_some_and(|c| {
+                    let mut buf = [0u8; 4];
+                    let original = c.encode_utf8(&mut buf);
+                    refuse_glob_match(&pattern, original)
+                })
         } else {
-            pattern == canonical
+            pattern == long_name || short_lower.as_deref() == Some(pattern.as_str())
         };
 
         if matches {
@@ -224,9 +322,102 @@ fn is_option_refused(refuse_list: &[String], canonical: &str) -> bool {
     refused
 }
 
+/// Returns true when either the long-form name or the short-letter form is in
+/// the vital list, mirroring upstream's check of both `op->longName` and
+/// `op->shortName` at options.c:953-965.
+fn is_option_vital(long_name: &str, short_letter: Option<char>) -> bool {
+    if is_vital_option(long_name) {
+        return true;
+    }
+    if let Some(letter) = short_letter {
+        let mut buf = [0u8; 4];
+        let as_str = letter.encode_utf8(&mut buf);
+        if is_vital_option(as_str) {
+            return true;
+        }
+        let lower = letter.to_ascii_lowercase();
+        if lower != letter {
+            let lower_str = lower.encode_utf8(&mut buf);
+            if is_vital_option(lower_str) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Returns whether an option is in the vital set that is immune to wildcards.
 fn is_vital_option(canonical: &str) -> bool {
     VITAL_OPTIONS.contains(&canonical)
+}
+
+/// Matches a refuse-list glob pattern against a candidate option name.
+///
+/// Supports `*` (zero or more chars), `?` (one char), and `[...]` character
+/// classes (case-sensitive, no negation `[!...]` since upstream's
+/// `[ardlptgoD]` expansion never uses one). Falls back to the daemon's shared
+/// `wildcard_match` when no character class is present so non-class globs keep
+/// going through a single, well-tested matcher.
+fn refuse_glob_match(pattern: &str, text: &str) -> bool {
+    if !pattern.contains('[') {
+        return wildcard_match(pattern, text);
+    }
+
+    let pat = pattern.as_bytes();
+    let txt = text.as_bytes();
+    let mut p = 0usize;
+    let mut t = 0usize;
+    let mut star_p: Option<usize> = None;
+    let mut star_t = 0usize;
+
+    while t < txt.len() {
+        if p < pat.len() {
+            match pat[p] {
+                b'?' => {
+                    p += 1;
+                    t += 1;
+                    continue;
+                }
+                b'*' => {
+                    star_p = Some(p);
+                    star_t = t;
+                    p += 1;
+                    continue;
+                }
+                b'[' => {
+                    let class_end = pat[p + 1..].iter().position(|&b| b == b']');
+                    if let Some(end) = class_end {
+                        let class = &pat[p + 1..p + 1 + end];
+                        if class.contains(&txt[t]) {
+                            p += end + 2;
+                            t += 1;
+                            continue;
+                        }
+                    }
+                    // Unterminated or non-matching class: fall through to backtrack.
+                }
+                ch if ch == txt[t] => {
+                    p += 1;
+                    t += 1;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(sp) = star_p {
+            p = sp + 1;
+            star_t += 1;
+            t = star_t;
+        } else {
+            return false;
+        }
+    }
+
+    while p < pat.len() && pat[p] == b'*' {
+        p += 1;
+    }
+    p == pat.len()
 }
 
 /// Extracts the canonical form of an option name for refuse-list matching.
@@ -399,9 +590,10 @@ fn parse_module_definition(
 
     if module.auth_users.is_empty() {
         if module.secrets_file.is_none()
-            && let Some(path) = default_secrets {
-                module.secrets_file = Some(path.to_path_buf());
-            }
+            && let Some(path) = default_secrets
+        {
+            module.secrets_file = Some(path.to_path_buf());
+        }
         if module.incoming_chmod.is_none() {
             module.incoming_chmod = default_incoming_chmod.map(str::to_string);
         }
@@ -699,17 +891,13 @@ fn apply_daemon_param_overrides(
             }
             "numeric ids" | "numeric-ids" => {
                 let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                    config_error(format!(
-                        "invalid boolean value '{value}' for 'numeric ids'"
-                    ))
+                    config_error(format!("invalid boolean value '{value}' for 'numeric ids'"))
                 })?;
                 module.numeric_ids = parsed;
             }
             "use chroot" | "use-chroot" => {
                 let parsed = parse_boolean_directive(value).ok_or_else(|| {
-                    config_error(format!(
-                        "invalid boolean value '{value}' for 'use chroot'"
-                    ))
+                    config_error(format!("invalid boolean value '{value}' for 'use chroot'"))
                 })?;
                 module.use_chroot = parsed;
             }

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -3,7 +3,10 @@ use super::*;
 #[test]
 fn parse_daemon_option_extracts_option_payload() {
     assert_eq!(parse_daemon_option("OPTION --list"), Some("--list"));
-    assert_eq!(parse_daemon_option("option --max-verbosity"), Some("--max-verbosity"));
+    assert_eq!(
+        parse_daemon_option("option --max-verbosity"),
+        Some("--max-verbosity")
+    );
 }
 
 #[test]
@@ -18,7 +21,6 @@ fn canonical_option_trims_prefix_and_normalises_case() {
     assert_eq!(canonical_option(" -P --info"), "p");
     assert_eq!(canonical_option("   CHECKSUM=md5"), "checksum");
 }
-
 
 #[test]
 fn refused_option_exact_match() {
@@ -66,7 +68,12 @@ fn refused_option_glob_star_matches_multiple_variants() {
         refuse_options: vec!["delete*".to_owned()],
         ..Default::default()
     };
-    for variant in &["--delete", "--delete-before", "--delete-after", "--delete-during"] {
+    for variant in &[
+        "--delete",
+        "--delete-before",
+        "--delete-after",
+        "--delete-during",
+    ] {
         let options = vec![variant.to_string()];
         assert_eq!(
             refused_option(&module, &options),
@@ -187,10 +194,7 @@ fn refused_option_wildcard_all_with_negation_allowlist() {
     assert_eq!(refused_option(&module, &options_allowed), None);
 
     let options_refused = vec!["--delete".to_owned()];
-    assert_eq!(
-        refused_option(&module, &options_refused),
-        Some("--delete")
-    );
+    assert_eq!(refused_option(&module, &options_refused), Some("--delete"));
 }
 
 #[test]
@@ -246,11 +250,8 @@ fn refused_option_returns_first_refused() {
 
 #[test]
 fn is_option_refused_last_rule_wins() {
-    let refuse = vec![
-        "delete".to_owned(),
-        "!delete".to_owned(),
-    ];
-    assert!(!is_option_refused(&refuse, "delete"));
+    let refuse = vec!["delete".to_owned(), "!delete".to_owned()];
+    assert!(!is_option_refused(&refuse, "delete", None));
 }
 
 #[test]
@@ -260,16 +261,49 @@ fn is_option_refused_re_refuse_after_negation() {
         "!delete-during".to_owned(),
         "delete-during".to_owned(),
     ];
-    assert!(is_option_refused(&refuse, "delete-during"));
+    assert!(is_option_refused(&refuse, "delete-during", None));
+}
+
+#[test]
+fn is_option_refused_short_letter_rule_matches_long_option() {
+    // upstream: options.c:909-921 `parse_one_refuse_match` compares each rule
+    // against BOTH `op->longName` and `op->shortName`. A `!v` rule must
+    // un-refuse the same option that `!verbose` would, so allow-list
+    // configurations that use short-letter shorthands behave the same as
+    // long-name shorthands.
+    let allow_list = vec!["*".to_owned(), "!v".to_owned(), "!a".to_owned()];
+    assert!(!is_option_refused(&allow_list, "verbose", Some('v')));
+    assert!(!is_option_refused(&allow_list, "archive", Some('a')));
+}
+
+#[test]
+fn is_option_refused_archive_rule_expands_to_short_letter_set() {
+    // upstream: options.c:904-906 - the `archive` (and `a`) rules expand to
+    // the character class `[ardlptgoD]` and so refuse every short letter that
+    // `-a` implies, not just the `--archive` long name.
+    let refuse = vec!["archive".to_owned()];
+    assert!(is_option_refused(&refuse, "recursive", Some('r')));
+    assert!(is_option_refused(&refuse, "links", Some('l')));
+    assert!(is_option_refused(&refuse, "devices", Some('D')));
+    assert!(!is_option_refused(&refuse, "compress", Some('z')));
+}
+
+#[test]
+fn is_option_refused_pure_allowlist_does_not_refuse_anything() {
+    // upstream: options.c:947-968 - every option starts marked as accepted
+    // (`a*` or `a=`). A refuse list of only negations therefore touches
+    // nothing - no option flips to refused. Sanity-check the obvious cases.
+    let allow_list = vec!["!verbose".to_owned(), "!archive".to_owned()];
+    assert!(!is_option_refused(&allow_list, "verbose", Some('v')));
+    assert!(!is_option_refused(&allow_list, "archive", Some('a')));
+    assert!(!is_option_refused(&allow_list, "compress", Some('z')));
+    assert!(!is_option_refused(&allow_list, "delete", None));
 }
 
 #[test]
 fn is_vital_option_recognises_all_vitals() {
     for &vital in VITAL_OPTIONS {
-        assert!(
-            is_vital_option(vital),
-            "expected '{vital}' to be vital"
-        );
+        assert!(is_vital_option(vital), "expected '{vital}' to be vital");
     }
 }
 
@@ -362,6 +396,85 @@ fn refused_client_arg_short_n_dry_run_spared_by_wildcard() {
     assert_eq!(refused_client_arg(&module, &args), None);
 }
 
+#[test]
+fn refused_client_arg_allowlist_module_passes_bundled_av() {
+    // Regression for the upstream `daemon-refuse` testsuite scenario where a
+    // module exposes an allow-list `refuse options = * !verbose !archive ...`
+    // and the client sends `-av`. Both `-a` and `-v` must survive the
+    // refuse-list matcher; upstream rsync flips each option's `descrip` back
+    // to "accepted" once the explicit `!verbose` / `!archive` rule lands.
+    //
+    // upstream: options.c:977-991 - rules are processed in order and the last
+    // match wins; the negated rule after the catch-all wildcard un-refuses
+    // both the long-form name and its short-letter alias.
+    let module = ModuleDefinition {
+        refuse_options: vec![
+            "*".to_owned(),
+            "!verbose".to_owned(),
+            "!archive".to_owned(),
+            "!iconv".to_owned(),
+            "!no-iconv".to_owned(),
+        ],
+        ..Default::default()
+    };
+    let args = vec!["-av".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_allowlist_short_letter_negation_passes_av() {
+    // upstream: options.c:909-921 - `parse_one_refuse_match` matches each
+    // rule against both `op->longName` and `op->shortName`. A short-letter
+    // allow-list `!v !a` therefore un-refuses the same options that
+    // `!verbose !archive` would. Pinning this behaviour prevents a relapse of
+    // the over-refusal bug where short-letter negations were silently
+    // ignored against long-name option canonicals.
+    let module = ModuleDefinition {
+        refuse_options: vec!["*".to_owned(), "!v".to_owned(), "!a".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["-av".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_pure_negation_allowlist_passes_av() {
+    // A pure-negation refuse list never marks anything as refused (nothing
+    // was refused to begin with), so an `-av` transfer must succeed.
+    // upstream: options.c:947-968 - every option starts as `a*`/`a=`
+    // (accepted); only explicit non-negated rules flip the descrip to
+    // `r*`/`r=`.
+    let module = ModuleDefinition {
+        refuse_options: vec!["!verbose".to_owned(), "!archive".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["-av".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_archive_rule_refuses_implied_short_letters() {
+    // upstream: options.c:904-906 - the `archive` rule rewrites itself to the
+    // character class `[ardlptgoD]`. A module configured with
+    // `refuse options = archive` must therefore reject `-r`, `-l`, `-D`, etc.
+    // (and not just `--archive` itself).
+    let module = ModuleDefinition {
+        refuse_options: vec!["archive".to_owned()],
+        ..Default::default()
+    };
+    assert_eq!(
+        refused_client_arg(&module, &["-r".to_owned()]),
+        Some("--recursive".to_owned()),
+    );
+    assert_eq!(
+        refused_client_arg(&module, &["-l".to_owned()]),
+        Some("--links".to_owned()),
+    );
+    assert_eq!(
+        refused_client_arg(&module, &["-D".to_owned()]),
+        Some("--devices".to_owned()),
+    );
+}
 
 #[test]
 fn program_name_rsyncd_as_str() {
@@ -407,7 +520,6 @@ fn program_name_debug() {
     let debug = format!("{name:?}");
     assert!(debug.contains("OcRsyncd"));
 }
-
 
 #[test]
 fn parse_args_empty_defaults_to_program_name() {
@@ -495,7 +607,6 @@ fn parse_args_hyphenated_values_in_remainder() {
     assert!(parsed.remainder.iter().any(|a| a == "--no-detach"));
 }
 
-
 #[test]
 fn clap_command_creates_command() {
     let cmd = clap_command("test-program");
@@ -516,7 +627,6 @@ fn clap_command_has_version_arg() {
     assert!(args.iter().any(|a| a.get_id() == "version"));
 }
 
-
 #[test]
 fn render_help_rsyncd_contains_program_name() {
     let help = render_help(ProgramName::Rsyncd);
@@ -528,7 +638,6 @@ fn render_help_oc_rsyncd_contains_program_name() {
     let help = render_help(ProgramName::OcRsyncd);
     assert!(!help.is_empty());
 }
-
 
 #[test]
 fn apply_daemon_param_overrides_sets_read_only() {


### PR DESCRIPTION
## Summary

- Fix `daemon-refuse` over-refusal: a module configured with an allow-list `refuse options` line (e.g. `* !verbose !archive ...` or short-letter `* !v !a`) incorrectly refused `rsync -av` with `@ERROR: The server is configured to refuse --verbose`.
- Match each refuse rule against BOTH the option's long-name and its short-letter form, mirroring upstream `parse_one_refuse_match` at `options.c:909-921`.
- Expand `a` / `archive` rules to the `[ardlptgoD]` character class on the fly so the negation un-refuses every short letter `-a` implies (upstream `options.c:904-906`).
- Check vital-option status against both forms so wildcard rules continue to spare `--server`, `--sender`, `-e`, `-n`, `-s`, ...
- Fix the lone `seclude-args` typo in the vital list so `-s` remains exempt under its upstream long-name spelling (`secluded-args`).

## Why

PR #5734 fixed the multiplex tag emission so post-OK refuse errors reach the client correctly. The remaining `daemon-refuse` failure was a matcher bug: `refused_client_arg` expanded `-av` to the long-name canonical (`verbose` / `archive`) before consulting `is_option_refused`, but the matcher only compared each rule against the long-name canonical. A rule like `!v` therefore never lined up with the option being evaluated, leaving the catch-all wildcard's earlier refusal in place. Upstream's matcher walks each option's `long_options[]` entry and matches every rule against both `op->longName` and `op->shortName`, so `!v` and `!verbose` are equivalent.

## Test plan

- [x] `cargo fmt --all` before push
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) - new pins `refused_client_arg_allowlist_module_passes_bundled_av`, `refused_client_arg_allowlist_short_letter_negation_passes_av`, `refused_client_arg_pure_negation_allowlist_passes_av`, `refused_client_arg_archive_rule_refuses_implied_short_letters`, `is_option_refused_short_letter_rule_matches_long_option`, `is_option_refused_archive_rule_expands_to_short_letter_set`, `is_option_refused_pure_allowlist_does_not_refuse_anything`
- [ ] CI: Windows, macOS, Linux musl
- [ ] Existing pins preserved: `run_daemon_refuses_disallowed_module_options`, `daemon_negotiation_error_refused_options`, `run_daemon_post_ok_refused_option_uses_multiplexed_error`

Upstream reference: rsync-3.4.1 `options.c:895-991` (`parse_one_refuse_match` + `set_refuse_options`).
