### PR TITLE
fix(daemon): merge phase-1 cmdline + phase-2 stdin args under secluded-args

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -43,6 +43,49 @@ fn unbackslash_arg(s: &str) -> String {
     })
 }
 
+/// Merges secluded-args phase 1 (cmdline) and phase 2 (stdin) arg lists.
+///
+/// In secluded-args mode upstream rsync splits the daemon argv at the
+/// `NULL` it injects at `options.c:2745`. Phase 1 (read from the cmdline,
+/// `clientserver.c:395-407`) carries the args that precede that NULL:
+/// `--server`, `--sender`, the compact flag string built by `argstr`
+/// (`options.c:2620-2731`), and `--iconv=...` if any. Phase 2 (read from
+/// stdin via `send_protected_args`, `rsync.c:283-320`) carries every arg
+/// that follows, beginning with the synthetic `"rsync"` arg0
+/// (`rsync.c:295`) and ending with the `.` separator plus the positional
+/// paths.
+///
+/// Upstream feeds each phase through `parse_arguments()` in turn
+/// (`clientserver.c:1079, 1085`) so the popt globals carry the union
+/// forward. We do not maintain popt globals, so the equivalent is to
+/// concatenate the two phases and re-run our single-pass option parser
+/// on the result. Without the prepend, the daemon never sees the compact
+/// flag string or `--sender` from phase 1, and the wildcard `--groupmap`
+/// value never reaches the receiver alongside `-z` / `-r` / `-l`,
+/// breaking the `daemon-groupmap-wild` test under secluded-args mode
+/// (upstream issue #829).
+///
+/// The synthetic `"rsync"` arg0 from phase 2 is dropped before the merge
+/// so the daemon's parser does not treat it as a positional path.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:1059-1086` - two-phase `read_args()` + `parse_arguments()`
+/// - `options.c:2614-2745` - `server_options()` placement of `--server`,
+///   `--sender`, `argstr`, and the secluded-args NULL split point
+/// - `rsync.c:283-320` - `send_protected_args()` rewrites the NULL slot
+///   with `"rsync"` and streams the rest as NUL-separated bytes
+fn merge_secluded_args(phase1: Vec<String>, phase2: Vec<String>) -> Vec<String> {
+    let mut phase2 = phase2;
+    if phase2.first().is_some_and(|a| a == "rsync") {
+        phase2.remove(0);
+    }
+    let mut merged = Vec::with_capacity(phase1.len() + phase2.len());
+    merged.extend(phase1);
+    merged.extend(phase2);
+    merged
+}
+
 /// Applies [`unbackslash_arg`] to every option arg that precedes the `.`
 /// CWD marker, mirroring upstream `io.c:1336-1359`'s split between option
 /// and file args. File args after the dot are left verbatim because upstream
@@ -189,17 +232,32 @@ fn read_and_log_client_args(
 
     let client_args = if has_secluded {
         // Phase 2: read the real args via secluded-args wire format.
-        // upstream: clientserver.c:1068-1071 - read_args with rl_nulls=1
+        // upstream: clientserver.c:1068-1071 - read_args with rl_nulls=1.
+        //
+        // The two phases carry disjoint slices of the original argv:
+        // - Phase 1 (cmdline): `--server`, `--sender`, the compact flag
+        //   string (`-slogDtprIzxe.iLsfxCIvu`), and `--iconv=...` if any.
+        //   These appear before the `NULL` upstream inserts at
+        //   `options.c:2745` and must reach the daemon's option parser
+        //   or the negotiated compact flags (`-r`, `-l`, `-z`, ...) and
+        //   the role marker `--sender` are silently dropped.
+        // - Phase 2 (stdin): every long-form option emitted after that
+        //   NULL (`--list-only`, `--log-format`, `--usermap`, `--groupmap`,
+        //   ...), the `.` separator, and the positional paths.
+        //
+        // Upstream feeds each phase through `parse_arguments()` in turn
+        // (`clientserver.c:1079, 1085`) so the popt globals carry the
+        // union forward. We mirror that by concatenating phase 1 ahead
+        // of phase 2 so a single pass over the merged list sees both the
+        // compact flag string and the long options that fix the
+        // `daemon-groupmap-wild` test (`--groupmap=*:GID`).
+        //
+        // Phase 2 args are emitted verbatim by upstream `safe_arg()` -
+        // the `if (!protect_args ...)` guard at `options.c:2551` skips
+        // the WILD_CHARS escape when `protect_args` is set - so no
+        // `unbackslash_arg()` pass is needed on either phase.
         match protocol::secluded_args::recv_secluded_args(ctx.reader, None) {
-            Ok(full_args) => {
-                // First element is "rsync" (set by upstream send_protected_args),
-                // skip it to get the actual server arguments.
-                if full_args.first().is_some_and(|a| a == "rsync") {
-                    full_args.into_iter().skip(1).collect()
-                } else {
-                    full_args
-                }
-            }
+            Ok(full_args) => merge_secluded_args(phase1_args, full_args),
             Err(err) => {
                 let payload = format!("@ERROR: failed to read secluded args: {err}");
                 send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -75,8 +75,7 @@ fn unbackslash_arg(s: &str) -> String {
 ///   `--sender`, `argstr`, and the secluded-args NULL split point
 /// - `rsync.c:283-320` - `send_protected_args()` rewrites the NULL slot
 ///   with `"rsync"` and streams the rest as NUL-separated bytes
-fn merge_secluded_args(phase1: Vec<String>, phase2: Vec<String>) -> Vec<String> {
-    let mut phase2 = phase2;
+fn merge_secluded_args(phase1: Vec<String>, mut phase2: Vec<String>) -> Vec<String> {
     if phase2.first().is_some_and(|a| a == "rsync") {
         phase2.remove(0);
     }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -202,6 +202,90 @@ mod module_access_tests {
         );
     }
 
+    // upstream: clientserver.c:1073,1083 - the daemon parses BOTH phase 1
+    // (cmdline) and phase 2 (stdin / secluded-args) and the union of their
+    // options drives the transfer. The compact flag string (`-slogDtprIzxe...`)
+    // and the role marker `--sender` live in phase 1; long-form options such
+    // as `--groupmap=*:GID` live in phase 2. Dropping phase 1 (the prior
+    // oc-rsync behaviour) silently removed `-l`, `-r`, `-z`, `--sender`, ...
+    // and broke `daemon-groupmap-wild` under secluded-args mode because
+    // compression negotiation diverged before the transfer could start.
+    #[test]
+    fn merge_secluded_args_prepends_phase1_and_skips_rsync_arg0() {
+        let phase1 = vec![
+            "--server".to_owned(),
+            "--sender".to_owned(),
+            "-slogDtprIze.LsfxCIvu".to_owned(),
+            "--iconv=UTF-8".to_owned(),
+        ];
+        let phase2 = vec![
+            "rsync".to_owned(),
+            "--log-format=%i".to_owned(),
+            "--groupmap=*:1000".to_owned(),
+            ".".to_owned(),
+            "upload/".to_owned(),
+        ];
+        let merged = merge_secluded_args(phase1, phase2);
+        assert_eq!(
+            merged,
+            vec![
+                "--server".to_owned(),
+                "--sender".to_owned(),
+                "-slogDtprIze.LsfxCIvu".to_owned(),
+                "--iconv=UTF-8".to_owned(),
+                "--log-format=%i".to_owned(),
+                "--groupmap=*:1000".to_owned(),
+                ".".to_owned(),
+                "upload/".to_owned(),
+            ],
+        );
+    }
+
+    // Phase 2 wire output drops the "rsync" arg0 only when it really is at
+    // index 0 (upstream `rsync.c:295` `args[i] = "rsync"`). A legitimate
+    // user-visible arg literally equal to "rsync" never appears at index 0
+    // of phase 2 because upstream emits it only as the synthetic arg0; the
+    // first arg the client supplies is `--server`, so the heuristic is safe.
+    #[test]
+    fn merge_secluded_args_passes_phase2_through_when_no_synthetic_arg0() {
+        let phase1 = vec!["--server".to_owned(), "-logDtpr".to_owned()];
+        let phase2 = vec![".".to_owned(), "mod/".to_owned()];
+        let merged = merge_secluded_args(phase1, phase2);
+        assert_eq!(
+            merged,
+            vec![
+                "--server".to_owned(),
+                "-logDtpr".to_owned(),
+                ".".to_owned(),
+                "mod/".to_owned(),
+            ],
+        );
+    }
+
+    // upstream issue #829: under secluded-args mode the client emits
+    // `--groupmap=*:GID` literally on the phase 2 wire (`safe_arg()` skips
+    // the WILD_CHARS escape when `protect_args` is set, `options.c:2551`).
+    // After `merge_secluded_args` the daemon's `apply_long_form_args` sees
+    // the wildcard intact and `GroupMapping::parse` consumes it without
+    // rejecting the `*` matcher.
+    #[test]
+    fn merge_secluded_args_preserves_groupmap_wildcard_through_apply_long_form() {
+        let phase1 = vec!["--server".to_owned(), "-logDtpr".to_owned()];
+        let phase2 = vec![
+            "rsync".to_owned(),
+            "--groupmap=*:1234".to_owned(),
+            ".".to_owned(),
+            "upload/".to_owned(),
+        ];
+        let merged = merge_secluded_args(phase1, phase2);
+
+        let mut config = ServerConfig::default();
+        let unknown = apply_long_form_args(&merged, &mut config);
+        assert!(unknown.is_none());
+        let mapping = config.group_mapping.expect("groupmap should be parsed");
+        assert_eq!(mapping.spec(), "*:1234");
+    }
+
     #[test]
     fn apply_module_bandwidth_limit_disables_when_module_configured_none() {
         let mut limiter = Some(BandwidthLimiter::new(NonZeroU64::new(1024).unwrap()));


### PR DESCRIPTION
## Summary

- Under secluded-args mode upstream rsync emits a two-phase argv: phase 1 (cmdline) carries `--server`, `--sender`, the compact flag string (`-slogDtprIzxe.iLsfxCIvu`) and `--iconv=...`; phase 2 (stdin via `send_protected_args`) carries every long-form option (`--list-only`, `--log-format`, `--usermap`, `--groupmap`, ...), the `.` separator and the positional paths.
- The daemon was discarding phase 1 entirely and parsing only phase 2, so the compact flag string, `--sender`, and `--iconv` never reached `ServerConfig`. Compression / recursion / role negotiation diverged before the transfer started, explaining the early connection drop on the `daemon-groupmap-wild` secluded-args case (upstream issue #829): the wildcard groupmap was actually parsed correctly by #5717, but the missing `-z` from phase 1 broke the protocol handshake.
- The fix concatenates the two phases (dropping the synthetic `"rsync"` arg0 upstream rewrites into the NULL slot) and feeds the merged list through the same single-pass option parser.

## Why this fixes `daemon-groupmap-wild` [secluded-args]

Upstream sender connects with `-s` (secluded-args). Wire trace at the cutoff:

1. Daemon → client: `@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n` (greeting).
2. Client → daemon: `@RSYNCD: 32.0\n`, module name, then phase 1 args (`--server\0--sender\0-slogDtprIze.LsfxCIvu\0\0`).
3. Daemon → client: `@RSYNCD: OK\n`.
4. Client → daemon: phase 2 args (`rsync\0--log-format=%i\0--groupmap=*:1000\0.\0upload/\0\0`).
5. Daemon parses phase 2 ONLY. `-z` from phase 1 is gone; `ServerConfig.flags.compress = false`.
6. Both sides start `setup_protocol()`. Sender uses zlib; receiver expects raw. After `@RSYNCD: OK\n` is read the sender's `stats.total_read` is around 23 bytes (legacy greeting + OK frame), then the receiver mis-decodes the post-OK compat-flags varint and EOFs the socket. Sender surfaces `connection unexpectedly closed (23 bytes received so far) [sender]` and `error in rsync protocol data stream (code 12)`.

Merging the two phases restores the compact flag string into `ServerConfig` so `-z`, `-l`, `-r`, ..., `--sender` all reach `parse_arguments`-equivalent state. The wildcard `--groupmap=*:GID` already round-trips through #5717's typed mapping parser.

## What this preserves

- URV-2.a `unbackslash_arg` on the non-protect_args path - the `else` branch is untouched.
- PR #5734 daemon-refuse-options multiplex error path - only touches `client_args.rs`, not the refused-option handler.
- `validate_client_paths_in_module` path traversal checks - the merged argv still flows through the same path-component splitter; the fix only widens the *options* that reach the parser, never widens what counts as a positional path.

## Upstream references

- `clientserver.c:1059-1086` - two-phase `read_args()` + `parse_arguments()`
- `options.c:2614-2745` - `server_options()` placement of `--server`, `--sender`, `argstr` and the secluded-args NULL split point
- `options.c:2551` - `safe_arg()` `if (!protect_args ...)` guard that emits `*` verbatim under secluded-args
- `rsync.c:283-320` - `send_protected_args()` NULL/arg0 rewrite

## Test plan

- [x] `merge_secluded_args_prepends_phase1_and_skips_rsync_arg0` - locks the canonical phase 1 + phase 2 layout.
- [x] `merge_secluded_args_passes_phase2_through_when_no_synthetic_arg0` - guards the no-rsync-arg0 fallback.
- [x] `merge_secluded_args_preserves_groupmap_wildcard_through_apply_long_form` - end-to-end: parse `--groupmap=*:1234` through the merged argv, assert `ServerConfig.group_mapping.spec() == "*:1234"`.
- [ ] CI: `daemon-groupmap-wild` upstream-testsuite must transition from `[secluded-args] groupmap upload failed (rc=12)` to PASS.
- [ ] CI: existing `unescape_phase1_option_args_*` and `read_client_arguments_with_secluded_flag` tests must keep passing (no regression on the non-secluded path).