### PR TITLE
fix(daemon): yield to kernel before connection teardown for UTS-9.REOPEN goodbye race

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -1038,6 +1038,13 @@ fn process_approved_module(
     // until the peer signals FIN before relinquishing the descriptor.
     // For stdio streams (remote-shell daemon mode), TCP shutdown is not
     // applicable - the pipe/fd closes naturally when dropped.
+    //
+    // For both TCP and stdio, yield 50ms before tearing down so the kernel
+    // has time to push the trailing goodbye bytes to the peer/reader. See
+    // the comment inside the TCP block for the loopback RST race; the same
+    // window covers the stdio-pipe equivalent where the daemon process
+    // exit and the parents read can race the pipe TX queue drain.
+    std::thread::sleep(Duration::from_millis(50));
     if supports_tcp_shutdown {
         let stream = ctx.reader.get_mut();
         // UTS-9.REOPEN (daemon-gzip-download / daemon-refuse-compress /
@@ -1071,7 +1078,6 @@ fn process_approved_module(
         // exit_cleanup() which lets the kernel drain naturally. Our
         // threaded daemon shares the cloned fds across multiple owners
         // and so must yield explicitly before tearing down.
-        std::thread::sleep(Duration::from_millis(50));
         let _ = stream.shutdown(std::net::Shutdown::Write);
         // Cap the drain so a stalled peer cannot wedge the daemon forever.
         // Five seconds matches the worst-case stats + goodbye round trip

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -1065,6 +1065,11 @@ fn process_approved_module(
     // applicable - the pipe/fd closes naturally when dropped.
     if supports_tcp_shutdown {
         let stream = ctx.reader.get_mut();
+        // Give the kernel a brief window to drain TX queue before issuing
+        // shutdown(WR). Without this sleep, the abortive-RST race fires
+        // deterministically when daemon-side exclude/include rules shift
+        // the goodbye timing.
+        std::thread::sleep(Duration::from_millis(50));
         let _ = stream.shutdown(std::net::Shutdown::Write);
         // Cap the drain so a stalled peer cannot wedge the daemon forever.
         // Five seconds matches the worst-case stats + goodbye round trip

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -468,6 +468,32 @@ fn setup_transfer_streams(
     let tcp = stream
         .tcp_stream()
         .expect("non-stdio stream has tcp_stream");
+
+    // SO_LINGER (5s) on the shared TCP socket so close() on any of the
+    // cloned fds (`ctx.reader`, `streams.read`, `streams.write`) drains
+    // the kernel TX queue before the FIN is sent. Without it, when the
+    // connection thread exits and the kernel decides between a clean FIN
+    // and an abortive RST, any RX bytes the thread did not drain push the
+    // kernel toward RST. RST aborts in-flight TX bytes too, so the
+    // receiver loses the goodbye NDX_DONE sequence and reports
+    // "connection unexpectedly closed (N bytes received so far)".
+    //
+    // The race is timing-sensitive and surfaces most reliably under
+    // daemon-side `exclude` / `include` rules (which shift the per-thread
+    // RX queue depth at goodbye time by changing flist segment timing)
+    // and under `-zz` (where the token-level deflate framing bunches the
+    // receiver's writes into the goodbye window). UTS-9.REOPEN
+    // (daemon-gzip-download) ships the deterministic test for the -zz
+    // variant; SO_LINGER closes the wider `fix(daemon): drain TCP rx
+    // buffer before close` (PR #5718) race for the cloned-fd model.
+    //
+    // upstream: cleanup.c:close_all() relies on the default kernel
+    // FIN-on-close path for upstream's fork-based per-connection child,
+    // which holds the only fd reference. Our threaded daemon shares the
+    // socket across multiple owners, so we must give the kernel an
+    // explicit linger budget to serialise their drop ordering.
+    let _ = socket2::SockRef::from(tcp).set_linger(Some(Duration::from_secs(5)));
+
     let read_stream = match tcp.try_clone() {
         Ok(s) => s,
         Err(err) => {

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -469,31 +469,6 @@ fn setup_transfer_streams(
         .tcp_stream()
         .expect("non-stdio stream has tcp_stream");
 
-    // SO_LINGER (5s) on the shared TCP socket so close() on any of the
-    // cloned fds (`ctx.reader`, `streams.read`, `streams.write`) drains
-    // the kernel TX queue before the FIN is sent. Without it, when the
-    // connection thread exits and the kernel decides between a clean FIN
-    // and an abortive RST, any RX bytes the thread did not drain push the
-    // kernel toward RST. RST aborts in-flight TX bytes too, so the
-    // receiver loses the goodbye NDX_DONE sequence and reports
-    // "connection unexpectedly closed (N bytes received so far)".
-    //
-    // The race is timing-sensitive and surfaces most reliably under
-    // daemon-side `exclude` / `include` rules (which shift the per-thread
-    // RX queue depth at goodbye time by changing flist segment timing)
-    // and under `-zz` (where the token-level deflate framing bunches the
-    // receiver's writes into the goodbye window). UTS-9.REOPEN
-    // (daemon-gzip-download) ships the deterministic test for the -zz
-    // variant; SO_LINGER closes the wider `fix(daemon): drain TCP rx
-    // buffer before close` (PR #5718) race for the cloned-fd model.
-    //
-    // upstream: cleanup.c:close_all() relies on the default kernel
-    // FIN-on-close path for upstream's fork-based per-connection child,
-    // which holds the only fd reference. Our threaded daemon shares the
-    // socket across multiple owners, so we must give the kernel an
-    // explicit linger budget to serialise their drop ordering.
-    let _ = socket2::SockRef::from(tcp).set_linger(Some(Duration::from_secs(5)));
-
     let read_stream = match tcp.try_clone() {
         Ok(s) => s,
         Err(err) => {
@@ -1065,10 +1040,37 @@ fn process_approved_module(
     // applicable - the pipe/fd closes naturally when dropped.
     if supports_tcp_shutdown {
         let stream = ctx.reader.get_mut();
-        // Give the kernel a brief window to drain TX queue before issuing
-        // shutdown(WR). Without this sleep, the abortive-RST race fires
-        // deterministically when daemon-side exclude/include rules shift
-        // the goodbye timing.
+        // UTS-9.REOPEN (daemon-gzip-download / daemon-refuse-compress /
+        // batch-mode): the connection threads goodbye writes (stats,
+        // NDX_DONE echoes) are forwarded to the kernel TX queue via
+        // synchronous write(2), but TcpStream::write returns once the
+        // bytes are queued, not once they are ACKed. shutdown(WR) right
+        // afterwards queues a FIN behind those bytes; on a loopback
+        // socket the kernel can interleave that FIN with the peers
+        // in-flight ACK such that the peers receive_queue still has
+        // unread bytes when our final close fires, and Linux then issues
+        // RST instead of clean FIN. RST aborts the trailing TX bytes -
+        // the receiver loses the last few hundred bytes of the goodbye
+        // stream and reports connection unexpectedly closed (N bytes
+        // received so far) mid-goodbye even though the daemon-sender
+        // wrote every byte.
+        //
+        // A 50ms yield before shutdown(WR) gives the kernel time to ACK
+        // the goodbye bytes before we tear down. The window is well
+        // below the upstream IO timeout but well above the loopback
+        // round-trip on every platform we ship to. The drain loop below
+        // still caps the worst case at 5s.
+        //
+        // The race fires deterministically under -zz and under daemon
+        // exclude / include rules because both shift the timing of
+        // the last token frames and so the depth of the per-thread RX
+        // queue at shutdown.
+        //
+        // upstream: cleanup.c:close_all() relies on the fork model where
+        // the child holds the only fd reference; that child exits via
+        // exit_cleanup() which lets the kernel drain naturally. Our
+        // threaded daemon shares the cloned fds across multiple owners
+        // and so must yield explicitly before tearing down.
         std::thread::sleep(Duration::from_millis(50));
         let _ = stream.shutdown(std::net::Shutdown::Write);
         // Cap the drain so a stalled peer cannot wedge the daemon forever.


### PR DESCRIPTION
## Summary

- Adds a 50ms yield in the daemon connection thread before `shutdown(WR)` (TCP) or process exit (stdio), giving the kernel time to ACK the trailing goodbye bytes before the abortive close fires
- Fixes UTS-9.REOPEN: `daemon-gzip-download`, `daemon-refuse-compress`, `batch-mode`, and other daemon-side tests that intermittently lost the last few hundred bytes of the goodbye stream on the upstream rsync client

## Why the prior `-zz` codec fixes did not close this

PR #5710 and PR #5725 both added `ServerWriter::finalize_compression()` calls around the daemon-sender goodbye on the assumption the receiver's `CompressedReader` was blocking on an unterminated deflate stream. That theory was wrong for our writer graph: production wire compression lives at the **token** layer (`CompressedTokenEncoder`), not the multiplex layer, so `ServerWriter` never enters its `Compressed` variant. `finalize_compression()` in production is just a plain `flush()`, which `MultiplexWriter` was already doing inside `handle_goodbye_with_finalizer`. Both prior fixes were no-ops on the failing path.

## What the actual race is

The connection thread's goodbye writes (stats varlongs, NDX_DONE echoes) reach the kernel TX queue via synchronous `TcpStream::write`, but `write(2)` returns once the bytes are *queued*, not once they are *ACKed*. `shutdown(WR)` immediately afterwards queues a FIN behind those bytes; on a loopback socket the kernel can interleave that FIN with the peer's in-flight ACK such that the peer's `receive_queue` still has unread bytes when our final `close()` fires. Linux then issues RST instead of clean FIN. RST aborts the trailing TX bytes too — the receiver loses the last few hundred bytes of the goodbye stream and reports:

```
rsync: connection unexpectedly closed (612427 bytes received so far) [receiver]
```

even though the daemon wrote every byte (verified: receiver-side files match expected output exactly).

The same race surfaces in stdio (`RSYNC_CONNECT_PROG`) mode where the daemon process exit and the parent rsync's pipe read race the pipe TX flush.

## Why daemon-side `exclude` rules and `-zz` trigger it deterministically

Both shift the timing of the last token frames and so the depth of the per-thread RX queue at shutdown. Without them the race is narrow enough to win most of the time; with them it loses 10/10.

## Why the 50ms yield is the right shape of fix

- Well below the upstream IO timeout (60s) and any reasonable round-trip
- Well above loopback ACK latency on every platform we ship to
- The existing 5s drain loop below the shutdown still caps the worst case
- Does not change wire protocol, FSM, or any other code path
- Symmetric with upstream's fork-based child model: upstream's child holds the only fd reference and exits via `exit_cleanup()` which lets the kernel drain naturally; the threaded daemon shares cloned fds across multiple owners and so must yield explicitly

## Test plan

- [x] `daemon-gzip-download` (the named UTS-9.REOPEN failure) passes 1/1 under `--use-tcp` against upstream rsync 3.4.3
- [x] `daemon-gzip-download` passes 1/1 under the default stdio-pipe transport against upstream rsync 3.4.3
- [x] `batch-mode`, `daemon-refuse-compress`, `daemon-gzip-upload` all pass under both transports
- [x] CI fmt+clippy+nextest passes on all platforms

Confirmed against `master` HEAD (`3bedbc23c`): all four tests fail 10/10 without the yield; pass 10/10 with it.