### PR TITLE
fix: use tail-matching for filter patterns with internal slashes

### DIFF
--- a/crates/filters/src/compiled/pattern.rs
+++ b/crates/filters/src/compiled/pattern.rs
@@ -58,8 +58,14 @@ pub(super) fn normalise_pattern(pattern: &str) -> (bool, bool, Cow<'_, str>) {
         core_pattern
     };
 
-    let has_internal_slash = core_pattern_no_leading.contains('/');
-    let anchored = starts_with_slash || has_internal_slash;
+    // upstream: exclude.c:rule_matches() - FILTRULE_ABS_PATH is only set
+    // for patterns that start with `/` (or when XFLG_ABS_IF_SLASH is in
+    // effect, which is restricted to daemon module configs). A pattern
+    // with internal slashes but no leading `/` is NOT anchored; instead
+    // upstream tail-matches it against the last N+1 path components (line
+    // 947-951). The glob equivalent is `**/pattern`, which our caller
+    // adds for unanchored patterns.
+    let anchored = starts_with_slash;
 
     if !starts_with_slash && !directory_only {
         return (anchored, false, Cow::Borrowed(pattern));
@@ -138,7 +144,17 @@ mod tests {
     #[test]
     fn normalise_pattern_nested_path() {
         let (anchored, dir_only, core) = normalise_pattern("src/lib/");
-        // Pattern contains internal slash, so it should be anchored
+        // upstream: internal slashes without a leading `/` are NOT anchored;
+        // they use tail-matching (match last N+1 path components via `**/pattern`).
+        assert!(!anchored);
+        assert!(dir_only);
+        assert_eq!(core, "src/lib");
+    }
+
+    #[test]
+    fn normalise_pattern_anchored_nested_path() {
+        // Leading `/` anchors even with internal slashes.
+        let (anchored, dir_only, core) = normalise_pattern("/src/lib/");
         assert!(anchored);
         assert!(dir_only);
         assert_eq!(core, "src/lib");

--- a/crates/filters/tests/anchored_patterns.rs
+++ b/crates/filters/tests/anchored_patterns.rs
@@ -3,7 +3,8 @@
 //! In rsync filter rules:
 //! - Anchored patterns start with `/` and match from the root of the transfer
 //! - Unanchored patterns can match at any level in the directory tree
-//! - Patterns containing `/` (other than leading) are anchored by default
+//! - Patterns with internal `/` but no leading `/` use tail-matching (match
+//!   the last N+1 path components at any depth)
 
 use filters::{FilterRule, FilterSet};
 use std::path::Path;
@@ -56,17 +57,18 @@ fn wildcard_unanchored() {
 }
 
 #[test]
-fn pattern_with_internal_slash_is_anchored() {
+fn pattern_with_internal_slash_tail_matches() {
     let rules = [
         FilterRule::exclude("src/test.txt"),
         FilterRule::include("**"),
     ];
     let set = FilterSet::from_rules(rules).unwrap();
 
-    // Pattern with / is anchored to root
+    // upstream: exclude.c:rule_matches() - a pattern with internal slashes
+    // but no leading `/` tail-matches against the last N+1 path components.
     assert!(!set.allows(Path::new("src/test.txt"), false));
-    // Does not match in nested paths
-    assert!(set.allows(Path::new("project/src/test.txt"), false));
+    // Also matches at deeper paths where the tail matches.
+    assert!(!set.allows(Path::new("project/src/test.txt"), false));
 }
 
 #[test]
@@ -271,13 +273,13 @@ fn trailing_slash_does_not_anchor() {
 }
 
 #[test]
-fn multiple_slashes_in_pattern() {
+fn multiple_slashes_in_pattern_tail_matches() {
     let rules = [FilterRule::exclude("a/b/c/"), FilterRule::include("**")];
     let set = FilterSet::from_rules(rules).unwrap();
 
-    // Pattern with / is anchored
+    // upstream: tail-matching - matches last 3 components.
     assert!(!set.allows(Path::new("a/b/c"), true));
-    assert!(set.allows(Path::new("x/a/b/c"), true));
+    assert!(!set.allows(Path::new("x/a/b/c"), true));
 }
 
 #[test]
@@ -368,4 +370,41 @@ fn monorepo_structure() {
     // Package configs included (unanchored pattern matched first due to ordering)
     assert!(set.allows(Path::new("packages/foo/package.json"), false));
     assert!(set.allows(Path::new("packages/bar/tsconfig.json"), false));
+}
+
+/// Mirrors the upstream `exclude-lsh` testsuite scenario.
+///
+/// Upstream command: `rsync -av -f -_foo/too/ -f -_foo/down/ -f -_foo/and/ -f -_new/ lh:from/ chk/`
+///
+/// The `-_` prefix is an exclude (`-`) with `_` as the pattern separator.
+/// Patterns `foo/too/`, `foo/down/`, `foo/and/` have internal slashes
+/// (and trailing `/` for directory-only) but no leading `/`, so they use
+/// tail-matching and exclude matching directories at any depth.
+///
+/// upstream: exclude.c:rule_matches() lines 947-951
+#[test]
+fn exclude_lsh_scenario_tail_matching() {
+    let rules = [
+        FilterRule::exclude("foo/too/"),
+        FilterRule::exclude("foo/down/"),
+        FilterRule::exclude("foo/and/"),
+        FilterRule::exclude("new/"),
+    ];
+    let set = FilterSet::from_rules(rules).unwrap();
+
+    // Direct matches at root.
+    assert!(!set.allows(Path::new("foo/too"), true));
+    assert!(!set.allows(Path::new("foo/down"), true));
+    assert!(!set.allows(Path::new("new"), true));
+
+    // Tail-matching: `bar/down/to/foo/too` ends in `foo/too`, so excluded.
+    assert!(!set.allows(Path::new("bar/down/to/foo/too"), true));
+
+    // Tail-matching: `mid/for/foo/and` ends in `foo/and`, so excluded.
+    assert!(!set.allows(Path::new("mid/for/foo/and"), true));
+
+    // Non-matching paths allowed.
+    assert!(set.allows(Path::new("bar/down/to/bar/baz"), true));
+    assert!(set.allows(Path::new("foo/sub"), true));
+    assert!(set.allows(Path::new("bar/down/to/foo/file1"), false));
 }

--- a/crates/filters/tests/filter_chain_edge_cases.rs
+++ b/crates/filters/tests/filter_chain_edge_cases.rs
@@ -323,16 +323,19 @@ fn anchored_include_before_unanchored_exclude() {
     assert!(!chain.allows(Path::new("sub/keep"), false));
 }
 
-/// Patterns containing internal slashes are implicitly anchored.
+/// Patterns containing internal slashes use tail-matching, not anchoring.
+///
+/// upstream: exclude.c:rule_matches() lines 947-951 - a pattern with internal
+/// slashes but no leading `/` matches the last N+1 path components.
 #[test]
-fn internal_slash_implicit_anchor() {
+fn internal_slash_tail_matches() {
     let global = FilterSet::from_rules([FilterRule::exclude("src/gen")]).unwrap();
     let chain = FilterChain::new(global);
 
-    // Implicitly anchored - matches at root.
+    // Matches at root.
     assert!(!chain.allows(Path::new("src/gen"), false));
-    // Does not match at arbitrary depth.
-    assert!(chain.allows(Path::new("lib/src/gen"), false));
+    // Also matches at depth via tail-matching.
+    assert!(!chain.allows(Path::new("lib/src/gen"), false));
 }
 
 /// Scoped exclude overrides global include for the same anchored path.

--- a/crates/filters/tests/include_patterns.rs
+++ b/crates/filters/tests/include_patterns.rs
@@ -344,19 +344,20 @@ fn include_anchored_with_wildcard() {
     assert!(!set.allows(Path::new("config/app.yaml"), false));
 }
 
-/// Verifies unanchored pattern with slash is matched at any depth.
+/// Verifies unanchored pattern with slash tail-matches at any depth.
+///
+/// upstream: exclude.c:rule_matches() - patterns with internal slashes
+/// but no leading `/` match the last N+1 path components (tail-match).
 #[test]
 fn include_unanchored_with_slash() {
-    // Pattern with internal slash is anchored (rsync semantics)
     let rules = [FilterRule::include("src/main.rs"), FilterRule::exclude("*")];
     let set = FilterSet::from_rules(rules).unwrap();
 
-    // Should match at root
+    // Matches at root.
     assert!(set.allows(Path::new("src/main.rs"), false));
 
-    // Pattern with internal slash is anchored, so only matches at root
-    // To match at any depth, use **/src/main.rs
-    assert!(!set.allows(Path::new("project/src/main.rs"), false));
+    // Also matches at depth via tail-matching.
+    assert!(set.allows(Path::new("project/src/main.rs"), false));
 }
 
 /// Verifies anchor_to_root method.

--- a/crates/filters/tests/pattern_matching.rs
+++ b/crates/filters/tests/pattern_matching.rs
@@ -228,20 +228,21 @@ fn unanchored_pattern_matches_at_any_depth() {
     assert!(!set.allows(Path::new("a/b/c/temp.dat"), false));
 }
 
-/// Verifies patterns with internal slashes become anchored.
+/// Verifies patterns with internal slashes use tail-matching.
 ///
-/// From rsync man page: "if the pattern contains a / (not counting a
-/// trailing /) then it is anchored to the root of the transfer."
+/// upstream: exclude.c:rule_matches() - a pattern with internal slashes
+/// but no leading `/` matches the last N+1 path components (tail-match),
+/// rather than being anchored to the root.
 #[test]
-fn pattern_with_slash_is_implicitly_anchored() {
+fn pattern_with_slash_tail_matches() {
     let set = FilterSet::from_rules([FilterRule::exclude("src/temp")]).unwrap();
 
-    // Pattern with internal / is anchored, matches only at root
+    // Pattern with internal / matches at root.
     assert!(!set.allows(Path::new("src/temp"), false));
-    // Not matched in nested paths (pattern is anchored)
-    assert!(set.allows(Path::new("project/src/temp"), false));
+    // Also matches at deeper paths via tail-matching.
+    assert!(!set.allows(Path::new("project/src/temp"), false));
 
-    // Different path doesn't match
+    // Different tail doesn't match.
     assert!(set.allows(Path::new("lib/temp"), false));
 }
 

--- a/crates/filters/tests/proptest_rule_evaluation.rs
+++ b/crates/filters/tests/proptest_rule_evaluation.rs
@@ -565,16 +565,17 @@ proptest! {
 }
 
 // ---------------------------------------------------------------------------
-// Property: Internal slash implies anchoring
+// Property: Internal slash uses tail-matching (NOT anchored)
 // ---------------------------------------------------------------------------
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(500))]
 
-    /// A pattern containing an internal `/` (e.g., `dir/file`) is implicitly
-    /// anchored - it matches from the transfer root, not at any depth.
+    /// upstream: exclude.c:rule_matches() lines 947-951 - a pattern with
+    /// internal slashes but no leading `/` tail-matches against the last
+    /// N+1 path components. Both the direct path and the nested path match.
     #[test]
-    fn internal_slash_implies_anchored(
+    fn internal_slash_tail_matches(
         dir in path_segment(),
         file in path_segment(),
         outer in path_segment(),
@@ -584,17 +585,17 @@ proptest! {
         let pattern = format!("{dir}/{file}");
         let set = FilterSet::from_rules([FilterRule::exclude(&pattern)]).unwrap();
 
-        // Direct path should be excluded (matches from root).
+        // Direct path should be excluded.
         prop_assert!(
             !set.allows(Path::new(&pattern), false),
             "{} should exclude {} at root", pattern, pattern
         );
 
-        // Nested under a different parent should be allowed (anchored).
+        // Nested path also matches via tail-matching.
         let nested = format!("{outer}/{dir}/{file}");
         prop_assert!(
-            set.allows(Path::new(&nested), false),
-            "{} (internal slash) should NOT exclude {}", pattern, nested
+            !set.allows(Path::new(&nested), false),
+            "{} (tail-match) should exclude {}", pattern, nested
         );
     }
 }


### PR DESCRIPTION
## Summary

- Fix filter pattern matching for patterns containing internal slashes (e.g., `foo/too/`) but no leading `/`. Previously these were incorrectly treated as anchored (root-only), but upstream rsync tail-matches them against the last N+1 path components at any depth.
- This resolves the `exclude-lsh` upstream testsuite failure where the sender included `bar/down/to/foo/too` in the flist despite a `-f -_foo/too/` exclude rule, causing the receiver to reject it with "ERROR: rejecting excluded file-list name" (exit 4).
- The fix changes `normalise_pattern()` in `crates/filters/src/compiled/pattern.rs` to only anchor patterns starting with `/`, matching upstream `exclude.c:rule_matches()` FILTRULE_ABS_PATH semantics.

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platform matrices)
- [ ] Run upstream testsuite on Linux host: `sudo OC_RSYNC_NO_SECCOMP=1 python3 ./runtests.py --rsync-bin /home/ofer/rsync/rsync --rsync-bin2 /home/ofer/oc-rsync/target/dist/oc-rsync --use-tcp exclude-lsh`
- [ ] Verify existing `exclude` (non-lsh variant) testsuite still passes