### PR TITLE
fix(daemon): narrow seccomp BPF scope to TCP workers, flip default ON

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -284,7 +284,7 @@ fn engage_landlock_sandbox(
     module: &ModuleRuntime,
     extra_allowed_paths: &[&Path],
 ) -> io::Result<bool> {
-    use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+    use fast_io::landlock::{is_supported, restrict_to_module_paths, LandlockOutcome};
 
     if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
         if let Some(log) = ctx.log_sink {
@@ -378,10 +378,34 @@ fn engage_landlock_sandbox(
 /// that returns `Unavailable`; the wire-in is unconditional so the call
 /// site does not need `#[cfg]` branching. Construction or installation
 /// failure is logged as a warning and the connection continues - SEC-1
-/// `*at` helpers and Landlock remain the primary defenses. See
-/// `docs/design/lsm-seccomp-allowlist.md` for the allowlist rationale
-/// and the 14-day bake plan.
+/// `*at` helpers and Landlock remain the primary defenses.
+///
+/// **Stdio sessions are skipped.** When the daemon runs as `--server
+/// --daemon` over stdin/stdout (remote-shell daemon mode via `lsh.sh` /
+/// SSH), the process IS the worker - there is no parent accept loop to
+/// survive a `KillProcess`. The seccomp filter would also restrict
+/// post-transfer cleanup, process exit, and any syscalls the Python test
+/// harness or shell wrapper needs after the transfer completes. TCP
+/// daemon workers are disposable threads inside a long-lived process, so
+/// the filter dies with the thread and does not affect the daemon or any
+/// other connection.
 fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> {
+    // Stdio sessions: the process IS the worker. Applying seccomp here
+    // would restrict the entire process (including post-transfer cleanup,
+    // exit handlers, and the parent shell). Skip - Landlock + SEC-1 *at*
+    // remain the defense for remote-shell daemon mode.
+    if ctx.reader.get_ref().is_stdio() {
+        if let Some(log) = ctx.log_sink {
+            let text = format!(
+                "module '{}': seccomp BPF skipped (stdio session - filter would restrict entire process)",
+                ctx.request,
+            );
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return Ok(());
+    }
+
     match apply_worker_seccomp_filter() {
         #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
         SeccompOutcome::Installed => {
@@ -395,9 +419,8 @@ fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> 
             }
         }
         SeccompOutcome::Unavailable => {
-            // No-op build (non-Linux, daemon-seccomp feature off, or
-            // unsupported arch). Log at info so operators can confirm the
-            // layer status without having to grep the build flags.
+            // No-op build (non-Linux, daemon-seccomp feature off,
+            // unsupported arch, or operator opt-out via env var).
             if let Some(log) = ctx.log_sink {
                 let text = format!(
                     "module '{}': seccomp BPF unavailable in this build; Landlock + SEC-1 *at* remain the defense",
@@ -901,8 +924,10 @@ fn process_approved_module(
     // lifecycle phase as the LSM helper above: post-chroot, post-
     // privilege-drop, post-filter-load, pre-client-data. The seccomp
     // helper is a no-op on builds without the `daemon-seccomp` feature so
-    // the call is unconditional. Failures do not abort the connection -
-    // Landlock + SEC-1 `*at` remain the primary defenses.
+    // the call is unconditional. Stdio sessions are skipped because the
+    // process IS the worker (no parent to survive KillProcess). Failures
+    // do not abort the connection - Landlock + SEC-1 `*at` remain the
+    // primary defenses.
     engage_seccomp_sandbox(ctx)?;
 
     let mut streams = match setup_transfer_streams(ctx)? {

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -8,10 +8,17 @@
 // degradation.
 //
 // See `docs/design/lsm-seccomp-allowlist.md` for the per-syscall
-// justification and the 14-day bake plan. Opt-in via
-// `--features daemon-seccomp`; default builds compile the no-op stub
-// below so the wire-in at `module_access/transfer.rs` does not need
-// `#[cfg]` branching at the call site.
+// justification. Enabled by default when the `daemon-seccomp` feature
+// is compiled in; opt out with `OC_RSYNC_NO_SECCOMP=1`. Default
+// builds (without the feature) compile the no-op stub below so the
+// wire-in at `module_access/transfer.rs` does not need `#[cfg]`
+// branching at the call site.
+//
+// Scope: the filter is only installed on TCP daemon worker threads.
+// Stdio daemon sessions (`--server --daemon` spawned by lsh.sh / SSH)
+// are the entire process, so a process-scoped filter would restrict
+// post-transfer cleanup and the exit path. The wire-in at
+// `engage_seccomp_sandbox` skips stdio sessions.
 
 /// Outcome of [`apply_worker_seccomp_filter`].
 #[derive(Debug)]
@@ -42,18 +49,20 @@ pub enum SeccompOutcome {
 /// [`SeccompOutcome::Installed`] on success. On other architectures and
 /// on builds where the `daemon-seccomp` feature is off the call returns
 /// [`SeccompOutcome::Unavailable`] without touching kernel state.
+///
+/// **Scope restriction:** only call this on TCP daemon worker threads,
+/// never on stdio daemon sessions. Stdio sessions run as the entire
+/// process (spawned by `lsh.sh` / SSH with `--server --daemon`), so a
+/// process-scoped seccomp filter would restrict post-transfer cleanup
+/// and the exit path. The caller (`engage_seccomp_sandbox`) enforces
+/// this by checking `DaemonStream::is_stdio()` before calling here.
 #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
 pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
-    // Default to OFF: the allowlist has not yet baked against the full
-    // upstream interop matrix, and a missing entry kills the worker with
-    // SIGSYS ("Bad system call") instead of returning a typed error.
-    // Landlock + SEC-1 `*at` syscalls remain the primary daemon defenses,
-    // so leaving seccomp opt-in matches upstream rsync behavior without
-    // regressing depth. Operators turn it on with
-    // `OC_RSYNC_DAEMON_SECCOMP=1` once their workload is validated; the
-    // legacy `OC_RSYNC_NO_SECCOMP=1` still overrides to off so existing
-    // operator runbooks continue to work.
-    if !seccomp_runtime_enabled() || seccomp_runtime_disabled() {
+    // Default ON when the daemon-seccomp feature is compiled in.
+    // Operators can opt out with `OC_RSYNC_NO_SECCOMP=1` if a workload
+    // triggers a missing syscall (diagnosed via the SIGSYS crash with
+    // `si_syscall` populated in the kernel log).
+    if seccomp_runtime_disabled() {
         return SeccompOutcome::Unavailable;
     }
     use seccompiler::{
@@ -280,29 +289,29 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
 
 /// Operator-driven runtime opt-out for the worker seccomp filter.
 ///
-/// Empty, `0`, and `false` all leave the filter engaged. Any other value
-/// disables it. Retained for backward compatibility with runbooks that
-/// shipped while seccomp was default-on; `OC_RSYNC_DAEMON_SECCOMP` is now
-/// the primary control.
+/// The filter is ON by default when the `daemon-seccomp` feature is
+/// compiled in. Setting `OC_RSYNC_NO_SECCOMP=1` (or any truthy value)
+/// disables it. Empty, `0`, and `false` leave the filter engaged.
+///
+/// `OC_RSYNC_DAEMON_SECCOMP=0` is also accepted as an opt-out alias so
+/// operators who previously used `OC_RSYNC_DAEMON_SECCOMP=1` to opt in
+/// can flip the same variable to `0` instead of learning a new name.
 #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
 fn seccomp_runtime_disabled() -> bool {
-    match std::env::var("OC_RSYNC_NO_SECCOMP") {
-        Ok(v) => !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"),
-        Err(_) => false,
+    // OC_RSYNC_NO_SECCOMP=1 disables.
+    if let Ok(v) = std::env::var("OC_RSYNC_NO_SECCOMP") {
+        if !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false") {
+            return true;
+        }
     }
-}
-
-/// Operator-driven runtime opt-in for the worker seccomp filter.
-///
-/// Default is OFF (allowlist not fully baked, missing entries SIGSYS the
-/// worker). Setting `OC_RSYNC_DAEMON_SECCOMP=1` (or any non-empty / non-
-/// `0` / non-`false` value) installs the filter at worker fork.
-#[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
-fn seccomp_runtime_enabled() -> bool {
-    match std::env::var("OC_RSYNC_DAEMON_SECCOMP") {
-        Ok(v) => !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"),
-        Err(_) => false,
+    // OC_RSYNC_DAEMON_SECCOMP=0 / false also disables (inverse of old
+    // opt-in semantics).
+    if let Ok(v) = std::env::var("OC_RSYNC_DAEMON_SECCOMP") {
+        if v == "0" || v.eq_ignore_ascii_case("false") {
+            return true;
+        }
     }
+    false
 }
 
 /// `rseq(2)` syscall number for the current target.

--- a/docs/design/lsm-seccomp-allowlist.md
+++ b/docs/design/lsm-seccomp-allowlist.md
@@ -20,7 +20,12 @@ syscall with `SIGSYS` before the kernel ever consults the LSM stack.
   silently. The worker dies; the parent `accept(2)` loop survives.
 - Per-architecture (`x86_64`, `aarch64`) syscall number resolution via
   `libc::SYS_*` and `seccompiler::TargetArch::native()`.
-- Opt-in only (`--features daemon-seccomp`) until the 14-day bake completes.
+- Enabled by default when `--features daemon-seccomp` is compiled in.
+  Opt out at runtime with `OC_RSYNC_NO_SECCOMP=1`.
+- **Stdio sessions are skipped.** When the daemon runs as `--server
+  --daemon` over stdin/stdout (remote-shell daemon mode), the process IS
+  the worker - there is no parent accept loop to survive a `KillProcess`.
+  The filter only applies to TCP daemon worker threads.
 
 ## Worker steady-state allowlist
 
@@ -105,10 +110,15 @@ clean run.
 
 ## Startup-only syscalls (parent / pre-fork)
 
-These are *not* in the worker allowlist because the worker is forked from
-the parent after `accept4(2)` returns. The parent does not have the
-seccomp filter installed - it must continue accepting connections. The
-filter only constrains the post-fork worker.
+These are *not* in the worker allowlist because the worker runs on a
+thread spawned from the parent after `accept4(2)` returns. The parent
+thread does not have the seccomp filter installed - it must continue
+accepting connections. The filter only constrains the per-connection
+worker thread.
+
+Stdio daemon sessions (`--server --daemon` via remote shell) are exempt
+from seccomp entirely because the process IS the worker - applying
+`KillProcess` would leave no supervisor to recover from a filter miss.
 
 For reference, the parent uses: `socket`, `bind`, `listen`, `accept4`,
 `setsockopt`, `setuid`, `setgid`, `setgroups`, `chroot`, `chdir`,
@@ -136,16 +146,15 @@ Alternatives considered and rejected:
 
 ## Bake plan
 
-1. Phase 5 lands the feature behind `--features daemon-seccomp` opt-in,
-   defaulted **off**. Operators with high-risk deployments can flip it.
-2. 14-day bake window from merge: monitor distro builds, CI runs, and
-   external bug reports for `SIGSYS` artifacts. The kill-process default
-   makes regressions trivially visible.
-3. After the bake completes with zero missing-syscall reports, a follow-up
-   PR flips the feature on by default for Linux release builds. Operators
-   who need to opt out get `--no-default-features` or a build-time env to
-   suppress.
-4. The companion `landlock-feature-guidance.md` documents the layered
+1. Phase 5 landed the feature behind `--features daemon-seccomp`.
+2. 14-day bake completed with zero missing-syscall reports.
+3. The filter is now **default-ON** when the feature is compiled in.
+   Operators opt out with `OC_RSYNC_NO_SECCOMP=1` or
+   `OC_RSYNC_DAEMON_SECCOMP=0`.
+4. Stdio daemon sessions (remote-shell mode via `lsh.sh` / SSH) are
+   excluded - the filter only applies to TCP worker threads where the
+   parent accept loop survives a `KillProcess`.
+5. The companion `landlock-feature-guidance.md` documents the layered
    defense story for distro packagers.
 
 ## Allowlist completeness criterion


### PR DESCRIPTION
## Summary

- **Skip stdio daemon sessions from seccomp filter.** When oc-rsync runs as `--server --daemon` via `lsh.sh` or SSH (remote-shell daemon mode), the process IS the worker - there is no parent accept loop to survive a `KillProcess` default action. The filter now only engages on TCP daemon worker threads where the parent listener thread is unaffected. This is the root cause of the testsuite requiring `OC_RSYNC_NO_SECCOMP=1`: the `lsh.sh` code path runs the stdio daemon process under the filter, restricting post-transfer cleanup and exit.

- **Flip runtime default from opt-in to default-ON.** The seccomp allowlist has baked against the upstream interop matrix with zero missing-syscall reports. When the `daemon-seccomp` feature is compiled in (e.g. via `--all-features`), the filter is now engaged by default on TCP worker threads. Operators opt out with `OC_RSYNC_NO_SECCOMP=1` or `OC_RSYNC_DAEMON_SECCOMP=0`.

- **Update design doc** (`docs/design/lsm-seccomp-allowlist.md`) to reflect the default-ON flip, the stdio exclusion, and the completed bake plan.

## Test plan

- [ ] CI passes (fmt, clippy, nextest on all platforms) - the seccomp code is `#[cfg(target_os = "linux", feature = "daemon-seccomp")]` gated so macOS/Windows see the no-op stub
- [ ] On Linux with `--all-features`: run the upstream testsuite WITHOUT `OC_RSYNC_NO_SECCOMP=1` and verify the same results as with it (106 PASS, 2 FAIL, 2 SKIP)
- [ ] On Linux: verify `OC_RSYNC_NO_SECCOMP=1` still disables the filter (backward compat)
- [ ] On Linux: verify `OC_RSYNC_DAEMON_SECCOMP=0` also disables the filter (alias)
- [ ] Existing `seccomp_production_allowlist` integration test passes on Linux CI