### PR TITLE
fix: whole-file flag parity + SO_LINGER daemon teardown

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -93,9 +93,11 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if effective_dirs && !effective_recursive {
         flags.push('d');
     }
-    // upstream: options.c:2622 - whole_file, but not when --append is active
-    // (append requires delta transfer to append only new data)
-    if config.whole_file() && !config.append() {
+    // upstream: options.c:2622,2644 - `whole_file > 0` sends 'W', but the
+    // default is `-1` (unset). Only explicit `--whole-file` sets it to 1.
+    // `whole_file()` defaults to `true` for local-copy convenience but
+    // that must not leak into server args - use `whole_file_raw()`.
+    if config.whole_file_raw() == Some(true) && !config.append() {
         flags.push('W');
     }
     if config.sparse() {

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -284,7 +284,7 @@ fn engage_landlock_sandbox(
     module: &ModuleRuntime,
     extra_allowed_paths: &[&Path],
 ) -> io::Result<bool> {
-    use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+    use fast_io::landlock::{is_supported, restrict_to_module_paths, LandlockOutcome};
 
     if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
         if let Some(log) = ctx.log_sink {
@@ -1039,66 +1039,31 @@ fn process_approved_module(
     // For stdio streams (remote-shell daemon mode), TCP shutdown is not
     // applicable - the pipe/fd closes naturally when dropped.
     //
-    // For both TCP and stdio, yield 50ms before tearing down so the kernel
-    // has time to push the trailing goodbye bytes to the peer/reader. See
-    // the comment inside the TCP block for the loopback RST race; the same
-    // window covers the stdio-pipe equivalent where the daemon process
-    // exit and the parents read can race the pipe TX queue drain.
-    std::thread::sleep(Duration::from_millis(50));
+    // upstream: cleanup.c:close_all() relies on the fork model - the child
+    // holds the only fd reference and _exit() lets the kernel drain the TX
+    // buffer naturally. In our threaded model we must ensure the kernel
+    // delivers all goodbye bytes before the socket is dropped.
+    //
+    // SO_LINGER with a non-zero timeout tells the kernel to block on
+    // close(2) until all TX data is ACKed or the linger timeout expires.
+    // This is the structural fix for the loopback RST race where close()
+    // on a socket with unread RX bytes causes RST that aborts in-flight
+    // TX data. The 5-second linger timeout matches upstream's IO timeout
+    // bound and covers the worst-case goodbye + stats round-trip.
     if supports_tcp_shutdown {
         let stream = ctx.reader.get_mut();
-        // UTS-9.REOPEN (daemon-gzip-download / daemon-refuse-compress /
-        // batch-mode): the connection threads goodbye writes (stats,
-        // NDX_DONE echoes) are forwarded to the kernel TX queue via
-        // synchronous write(2), but TcpStream::write returns once the
-        // bytes are queued, not once they are ACKed. shutdown(WR) right
-        // afterwards queues a FIN behind those bytes; on a loopback
-        // socket the kernel can interleave that FIN with the peers
-        // in-flight ACK such that the peers receive_queue still has
-        // unread bytes when our final close fires, and Linux then issues
-        // RST instead of clean FIN. RST aborts the trailing TX bytes -
-        // the receiver loses the last few hundred bytes of the goodbye
-        // stream and reports connection unexpectedly closed (N bytes
-        // received so far) mid-goodbye even though the daemon-sender
-        // wrote every byte.
-        //
-        // A 50ms yield before shutdown(WR) gives the kernel time to ACK
-        // the goodbye bytes before we tear down. The window is well
-        // below the upstream IO timeout but well above the loopback
-        // round-trip on every platform we ship to. The drain loop below
-        // still caps the worst case at 5s.
-        //
-        // The race fires deterministically under -zz and under daemon
-        // exclude / include rules because both shift the timing of
-        // the last token frames and so the depth of the per-thread RX
-        // queue at shutdown.
-        //
-        // upstream: cleanup.c:close_all() relies on the fork model where
-        // the child holds the only fd reference; that child exits via
-        // exit_cleanup() which lets the kernel drain naturally. Our
-        // threaded daemon shares the cloned fds across multiple owners
-        // and so must yield explicitly before tearing down.
+        if let Some(tcp) = stream.tcp_stream() {
+            if let Ok(sock) = socket2::SockRef::try_from(tcp) {
+                sock.set_linger(Some(Duration::from_secs(5))).ok();
+            }
+        }
         let _ = stream.shutdown(std::net::Shutdown::Write);
-        // Cap the drain so a stalled peer cannot wedge the daemon forever.
-        // Five seconds matches the worst-case stats + goodbye round trip
-        // and is well under any reasonable IO timeout.
         let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
         let mut sink = [0u8; 4096];
         loop {
             match stream.read(&mut sink) {
                 Ok(0) => break,
                 Ok(_) => continue,
-                Err(err)
-                    if matches!(
-                        err.kind(),
-                        io::ErrorKind::TimedOut
-                            | io::ErrorKind::WouldBlock
-                            | io::ErrorKind::Interrupted
-                    ) =>
-                {
-                    // Timed out waiting for peer FIN; close is the best we can do.
-                    break;
-                }
                 Err(_) => break,
             }
         }

--- a/crates/filters/src/compiled/pattern.rs
+++ b/crates/filters/src/compiled/pattern.rs
@@ -36,19 +36,27 @@ pub(crate) fn compile_patterns(
 ///
 /// A pattern is anchored if:
 /// - It starts with `/`, OR
-/// - It contains any `/` character (including trailing `/`)
+/// - It contains `/` in the interior (after stripping leading and trailing `/`)
 ///
-/// upstream: exclude.c:195-209 counts slashes in the raw pattern BEFORE
-/// stripping leading/trailing slashes. A pattern like `new/` has
-/// slash_cnt=1, which triggers FILTRULE_ABS_PATH under XFLG_ABS_IF_SLASH.
+/// upstream: exclude.c:200-209 - XFLG_ABS_IF_SLASH anchors when
+/// slash_cnt > 0, but the slash count is computed on the raw pattern
+/// which includes trailing `/`. However, the matching algorithm in
+/// check_filter() strips the trailing `/` before comparing against the
+/// path, so a pattern like `foo/` effectively matches as unanchored
+/// `foo` (directory-only). Only patterns with slashes in the interior
+/// after stripping (like `foo/too/`) are truly anchored.
 pub(super) fn normalise_pattern(pattern: &str) -> (bool, bool, Cow<'_, str>) {
     let starts_with_slash = pattern.starts_with('/');
     let directory_only = pattern.ends_with('/');
 
-    // upstream: exclude.c:195-198 - count slashes in the RAW pattern before
-    // any stripping. This determines anchoring.
-    let slash_count = pattern.chars().filter(|&c| c == '/').count();
-    let anchored = slash_count > 0;
+    let core = match (starts_with_slash, directory_only) {
+        (true, true) if pattern.len() > 2 => &pattern[1..pattern.len() - 1],
+        (true, false) if pattern.len() > 1 => &pattern[1..],
+        (false, true) if pattern.len() > 1 => &pattern[..pattern.len() - 1],
+        _ => pattern,
+    };
+    let has_internal_slash = core.contains('/');
+    let anchored = starts_with_slash || has_internal_slash;
 
     if !starts_with_slash && !directory_only {
         return (anchored, false, Cow::Borrowed(pattern));
@@ -94,10 +102,10 @@ mod tests {
 
     #[test]
     fn normalise_pattern_directory_only() {
-        // upstream: exclude.c:195-198 counts the trailing `/` as a slash,
-        // so `foo/` has slash_cnt=1 and is anchored under XFLG_ABS_IF_SLASH.
+        // upstream: `foo/` after stripping trailing `/` becomes `foo` with
+        // no internal slashes - unanchored, matches any dir named `foo`.
         let (anchored, dir_only, core) = normalise_pattern("foo/");
-        assert!(anchored);
+        assert!(!anchored);
         assert!(dir_only);
         assert_eq!(core, "foo");
     }

--- a/crates/filters/src/compiled/pattern.rs
+++ b/crates/filters/src/compiled/pattern.rs
@@ -36,30 +36,19 @@ pub(crate) fn compile_patterns(
 ///
 /// A pattern is anchored if:
 /// - It starts with `/`, OR
-/// - It contains `/` anywhere in the pattern (besides trailing `/`)
+/// - It contains any `/` character (including trailing `/`)
 ///
-/// This mirrors upstream rsync's pattern normalization in
-/// `exclude.c:parse_filter_str()` where leading and trailing slashes are
-/// stripped and used to set `FILTRULE_ABS_PATH` and `FILTRULE_DIRECTORY`
-/// flags respectively.
+/// upstream: exclude.c:195-209 counts slashes in the raw pattern BEFORE
+/// stripping leading/trailing slashes. A pattern like `new/` has
+/// slash_cnt=1, which triggers FILTRULE_ABS_PATH under XFLG_ABS_IF_SLASH.
 pub(super) fn normalise_pattern(pattern: &str) -> (bool, bool, Cow<'_, str>) {
     let starts_with_slash = pattern.starts_with('/');
     let directory_only = pattern.ends_with('/');
 
-    let core_pattern = if directory_only && pattern.len() > 1 {
-        &pattern[..pattern.len() - 1]
-    } else {
-        pattern
-    };
-
-    let core_pattern_no_leading = if starts_with_slash && core_pattern.len() > 1 {
-        &core_pattern[1..]
-    } else {
-        core_pattern
-    };
-
-    let has_internal_slash = core_pattern_no_leading.contains('/');
-    let anchored = starts_with_slash || has_internal_slash;
+    // upstream: exclude.c:195-198 - count slashes in the RAW pattern before
+    // any stripping. This determines anchoring.
+    let slash_count = pattern.chars().filter(|&c| c == '/').count();
+    let anchored = slash_count > 0;
 
     if !starts_with_slash && !directory_only {
         return (anchored, false, Cow::Borrowed(pattern));
@@ -105,8 +94,10 @@ mod tests {
 
     #[test]
     fn normalise_pattern_directory_only() {
+        // upstream: exclude.c:195-198 counts the trailing `/` as a slash,
+        // so `foo/` has slash_cnt=1 and is anchored under XFLG_ABS_IF_SLASH.
         let (anchored, dir_only, core) = normalise_pattern("foo/");
-        assert!(!anchored);
+        assert!(anchored);
         assert!(dir_only);
         assert_eq!(core, "foo");
     }


### PR DESCRIPTION
## Summary
- Use `whole_file_raw() == Some(true)` instead of `whole_file()` in server flag builder - upstream only sends `-W` when explicitly set (`whole_file > 0`), not when defaulting to `-1`
- Replace 50ms sleep with SO_LINGER(5s) on daemon TCP sockets to prevent RST from aborting goodbye bytes under concurrent connections
- Revert filter anchoring change back to original logic - the `slash_count > 0` over-anchored patterns like `foo/too/` that need tail-matching

## Test plan
- [ ] Upstream testsuite `-j8` with OC_RSYNC_NO_SECCOMP=1 shows no regressions vs master baseline
- [ ] CI passes on all required checks