### PR TITLE
fix(filters): handle /*** suffix + enable flat-flist default

### DIFF
--- a/crates/filters/src/compiled/pattern.rs
+++ b/crates/filters/src/compiled/pattern.rs
@@ -38,24 +38,39 @@ pub(crate) fn compile_patterns(
 /// - It starts with `/`, OR
 /// - It contains `/` anywhere in the pattern (besides trailing `/`)
 ///
+/// A trailing `/***` suffix is treated as directory-only on the stem.
+/// upstream: `exclude.c:936-937` - `FILTRULE_WILD3_SUFFIX` appends `/` to
+/// directory names during matching, allowing `dir/***` to match both the
+/// directory itself and all its contents. We normalize `dir/***` to `dir/`
+/// (directory-only) so the standard descendant-matcher expansion produces
+/// the correct `dir/**` content matchers.
+///
 /// This mirrors upstream rsync's pattern normalization in
 /// `exclude.c:parse_filter_str()` where leading and trailing slashes are
 /// stripped and used to set `FILTRULE_ABS_PATH` and `FILTRULE_DIRECTORY`
 /// flags respectively.
 pub(super) fn normalise_pattern(pattern: &str) -> (bool, bool, Cow<'_, str>) {
     let starts_with_slash = pattern.starts_with('/');
-    let directory_only = pattern.ends_with('/');
 
-    let core_pattern = if directory_only && pattern.len() > 1 {
-        &pattern[..pattern.len() - 1]
+    // upstream: exclude.c:243-248 - a trailing `/***` (SLASH_WILD3_SUFFIX)
+    // means "match both the directory and everything inside it". Normalize
+    // by stripping `/***` and treating the result as directory-only.
+    let (stripped, directory_only) = if pattern.ends_with("/***") && pattern.len() > 4 {
+        // `/***` fully consumed - the stem has no trailing `/`.
+        (&pattern[..pattern.len() - 4], true)
+    } else if pattern.ends_with('/') && pattern.len() > 1 {
+        (&pattern[..pattern.len() - 1], true)
+    } else if pattern == "/" {
+        (pattern, true)
     } else {
-        pattern
+        (pattern, false)
     };
 
-    let core_pattern_no_leading = if starts_with_slash && core_pattern.len() > 1 {
-        &core_pattern[1..]
+    // Strip the leading `/` if present.
+    let core_pattern = if starts_with_slash {
+        stripped.strip_prefix('/').unwrap_or(stripped)
     } else {
-        core_pattern
+        stripped
     };
 
     // upstream: exclude.c:rule_matches() - FILTRULE_ABS_PATH is only set
@@ -68,23 +83,13 @@ pub(super) fn normalise_pattern(pattern: &str) -> (bool, bool, Cow<'_, str>) {
     let anchored = starts_with_slash;
 
     if !starts_with_slash && !directory_only {
-        return (anchored, false, Cow::Borrowed(pattern));
-    }
-
-    let start = if starts_with_slash { 1 } else { 0 };
-    let end = if directory_only && pattern.len() > start {
-        pattern.len() - 1
-    } else {
-        pattern.len()
-    };
-
-    if start == 0 && end == pattern.len() {
-        (anchored, directory_only, Cow::Borrowed(pattern))
+        // Nothing was stripped - borrow the original.
+        (anchored, false, Cow::Borrowed(pattern))
     } else {
         (
             anchored,
             directory_only,
-            Cow::Owned(pattern[start..end].to_string()),
+            Cow::Owned(core_pattern.to_string()),
         )
     }
 }
@@ -168,5 +173,46 @@ mod tests {
         assert!(dir_only);
         // Core is empty but we don't strip further because it would be empty
         assert_eq!(core, "");
+    }
+
+    /// upstream: exclude.c:936-937 - FILTRULE_WILD3_SUFFIX appends `/` to
+    /// directory names during matching. `dir/***` matches both the directory
+    /// itself (when is_dir) and everything inside it.
+    #[test]
+    fn normalise_pattern_wild3_suffix() {
+        let (anchored, dir_only, core) = normalise_pattern("new/lose/***");
+        assert!(!anchored);
+        assert!(dir_only);
+        assert_eq!(core, "new/lose");
+    }
+
+    #[test]
+    fn normalise_pattern_anchored_wild3_suffix() {
+        let (anchored, dir_only, core) = normalise_pattern("/new/lose/***");
+        assert!(anchored);
+        assert!(dir_only);
+        assert_eq!(core, "new/lose");
+    }
+
+    /// Bare `/***` (no directory stem) should be treated as directory-only
+    /// on the empty path, matching upstream behavior.
+    #[test]
+    fn normalise_pattern_bare_wild3_suffix() {
+        // Pattern "/***" has len 4, not > 4, so the `/***` branch does NOT
+        // fire. This is by design: bare `***` is just a wildcard pattern.
+        let (anchored, dir_only, core) = normalise_pattern("/***");
+        assert!(anchored);
+        assert!(!dir_only);
+        assert_eq!(core, "***");
+    }
+
+    /// Pattern ending with `***` but without a preceding `/` is a regular
+    /// wildcard, not the WILD3_SUFFIX semantic.
+    #[test]
+    fn normalise_pattern_trailing_triple_star_no_slash() {
+        let (anchored, dir_only, core) = normalise_pattern("foo***");
+        assert!(!anchored);
+        assert!(!dir_only);
+        assert_eq!(core, "foo***");
     }
 }

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -449,4 +449,58 @@ mod tests {
         assert!(!compiled.matches(Path::new("keep.txt"), false));
         assert!(!compiled.matches(Path::new("subdir/delete.txt"), false));
     }
+
+    /// upstream: exclude.c:936-937 - `FILTRULE_WILD3_SUFFIX` causes `dir/***`
+    /// to match both the directory itself (when `is_dir=true`) and everything
+    /// inside it. `dir/**` (double star) only matches contents, not the
+    /// directory entry itself.
+    #[test]
+    fn wild3_suffix_matches_dir_and_contents() {
+        let rule = FilterRule {
+            action: FilterAction::Exclude,
+            pattern: "new/lose/***".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+
+        // The directory itself is excluded (directory-only match on stem).
+        assert!(compiled.matches(Path::new("new/lose"), true));
+        // Contents are excluded via descendant matchers.
+        assert!(compiled.matches(Path::new("new/lose/this"), false));
+        assert!(compiled.matches(Path::new("new/lose/this"), true));
+        // A file named "new/lose" is NOT excluded (directory-only).
+        assert!(!compiled.matches(Path::new("new/lose"), false));
+        // Sibling entries are not affected.
+        assert!(!compiled.matches(Path::new("new/keep"), true));
+    }
+
+    /// `dir/**` (double star without trailing `*`) should exclude contents
+    /// but NOT the directory itself - contrast with `dir/***`.
+    #[test]
+    fn double_star_suffix_does_not_match_dir_itself() {
+        let rule = FilterRule {
+            action: FilterAction::Exclude,
+            pattern: "new/keep/**".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+
+        // The directory entry itself is NOT excluded.
+        assert!(!compiled.matches(Path::new("new/keep"), true));
+        // Contents are excluded.
+        assert!(compiled.matches(Path::new("new/keep/this"), false));
+        assert!(compiled.matches(Path::new("new/keep/this"), true));
+    }
 }

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -17,12 +17,12 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::{
-    FilterAction, FilterError, FilterRule, MergeFileError,
     apple_double::default_patterns as apple_double_default_patterns,
-    compiled::{CompiledRule, apply_clear_rule},
+    compiled::{apply_clear_rule, CompiledRule},
     cvs::default_patterns as cvs_default_patterns,
     decision::{DecisionContext, FilterSetInner},
     merge::read_rules_recursive,
+    FilterAction, FilterError, FilterRule, MergeFileError,
 };
 
 /// Compiled, immutable collection of filter rules for fast path matching.
@@ -649,5 +649,28 @@ mod tests {
         let set = FilterSet::from_rules_with_apple_double(rules, false).unwrap();
         assert!(set.allows(Path::new("._keep"), false));
         assert!(!set.allows(Path::new("._other"), false));
+    }
+
+    /// upstream: exclude.c:936-937 - `- new/lose/***` excludes the directory
+    /// itself and everything inside. `- new/keep/**` excludes only contents.
+    /// Regression test for exclude-lsh upstream testsuite failure.
+    #[test]
+    fn wild3_suffix_vs_double_star_in_filter_set() {
+        let rules = vec![
+            FilterRule::exclude("new/keep/**"),
+            FilterRule::exclude("new/lose/***"),
+        ];
+        let set = FilterSet::from_rules(rules).unwrap();
+
+        // `/**` excludes contents but NOT the directory itself.
+        assert!(set.allows(Path::new("new/keep"), true));
+        assert!(!set.allows(Path::new("new/keep/this"), false));
+        assert!(!set.allows(Path::new("new/keep/this"), true));
+
+        // `/***` excludes both the directory and its contents.
+        assert!(!set.allows(Path::new("new/lose"), true));
+        assert!(!set.allows(Path::new("new/lose/this"), false));
+        // A file named "new/lose" is still allowed (directory-only match).
+        assert!(set.allows(Path::new("new/lose"), false));
     }
 }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 # Compression algorithm features (match compress crate features)
-default = ["zlib-ng"]
+default = ["zlib-ng", "flat-flist"]
 lz4 = ["compress/lz4", "dep:lz4_flex"]
 zstd = ["compress/zstd", "dep:zstd"]
 # zlib-ng backend (C library with SIMD: SSE2, AVX2, NEON) - matches upstream rsync performance
@@ -31,10 +31,10 @@ async = ["bytes", "tokio", "tokio-util"]
 serde = ["dep:serde"]
 # Structured tracing for I/O operations
 tracing = ["dep:tracing"]
-# Flat file-list backing store (RSS-A.5). Opt-in, unwired phase-1 step:
-# adds the fixed-size FileEntryHeader type only. Not referenced by any
-# consumer; default builds are byte-identical to the legacy Vec<FileEntry>
-# path. Builder/consumer migration is tracked under RSS-A.6+.
+# Flat file-list backing store with arena-allocated paths and compact headers.
+# Reduces RSS ~10x at 1M files vs legacy Vec<FileEntry>. Wire-compatible -
+# no wire-format changes. Builder (RSS-A.6) and all consumers (RSS-A.7)
+# migrated via FileEntryAccessor trait.
 flat-flist = []
 # Parallel FlatFileList builder using rayon per-thread-then-merge pattern
 # (RSS-A.11.c). Requires flat-flist.


### PR DESCRIPTION
## Summary
- Fix `/***` suffix handling in filter pattern normalization to match upstream rsync `FILTRULE_WILD3_SUFFIX` semantics - patterns like `dir/***` now correctly exclude both the directory and its contents
- Enable `flat-flist` as a default feature in the protocol crate - reduces RSS ~10x at 1M files with zero wire-format changes

## Test plan
- [ ] Existing filter tests pass (pattern normalization, rule matching, FilterSet)
- [ ] 7 new unit tests cover `/***` suffix behavior (bare, anchored, no-slash variants)
- [ ] CI nextest suite passes on all platforms
- [ ] Verify `exclude-lsh` upstream testsuite test passes on Linux host