### PR TITLE
fix(docs): broken rustdoc links in compress crate + fmt fix

### DIFF
--- a/crates/compress/src/zlib/mod.rs
+++ b/crates/compress/src/zlib/mod.rs
@@ -5,11 +5,11 @@
 //! Raw deflate compression helpers for rsync wire protocol compatibility.
 //!
 //! This module uses raw deflate format (no zlib header/trailer) to match
-//! upstream rsync's compression wire format. [`CountingZlibEncoder`] accepts
+//! upstream rsync's compression wire format. `CountingZlibEncoder` accepts
 //! incremental input while tracking the number of bytes produced by the
 //! compressor so higher layers can report accurate compressed sizes without
 //! buffering the resulting payload in memory. The complementary
-//! [`CountingZlibDecoder`] wraps a reader that produces decompressed bytes
+//! `CountingZlibDecoder` wraps a reader that produces decompressed bytes
 //! while recording how much output has been yielded so far, keeping the
 //! counter accurate for both scalar and vectored reads so downstream bandwidth
 //! accounting mirrors upstream behaviour.
@@ -35,7 +35,7 @@
 //! ```
 //!
 //! Obtain a compressed buffer, stream it through
-//! [`CountingZlibDecoder`], and collect the decompressed output:
+//! `CountingZlibDecoder`, and collect the decompressed output:
 //!
 //! ```
 //! use compress::zlib::{


### PR DESCRIPTION
## Summary
- Replace `[CountingZlibEncoder]` and `[CountingZlibDecoder]` doc links with backtick-only refs in `crates/compress/src/zlib/mod.rs` - these break rustdoc at the crate-root inclusion point because re-exported types aren't in scope for module-level `//!` docs
- Fix import ordering in `crates/filters/src/set.rs` from PR #5743

Fixes the Pages workflow (`cargo doc --workspace --all-features --no-deps`) which has been failing on all recent master pushes.

## Test plan
- [ ] Pages workflow succeeds (rustdoc builds without broken-link errors)
- [ ] `cargo fmt --all -- --check` passes