### PR TITLE
fix(docs): replace remaining broken intra-doc links in compress crate

### DIFF
--- a/crates/compress/src/lz4/frame.rs
+++ b/crates/compress/src/lz4/frame.rs
@@ -7,7 +7,7 @@
 //! streaming across multiple blocks.
 //!
 //! **Note**: This format is NOT compatible with upstream rsync's wire protocol.
-//! For wire protocol compatibility, use the [`super::raw`] module instead.
+//! For wire protocol compatibility, use the `raw` module instead.
 
 use std::io::{self, BufReader, IoSliceMut, Read, Write};
 

--- a/crates/compress/src/lz4/mod.rs
+++ b/crates/compress/src/lz4/mod.rs
@@ -2,16 +2,16 @@
 //!
 //! This module provides two LZ4 compression formats:
 //!
-//! - [`frame`]: Standard LZ4 frame format with magic bytes, checksums, and
+//! - `frame`: Standard LZ4 frame format with magic bytes, checksums, and
 //!   streaming support. Suitable for file compression and storage.
 //!
-//! - [`raw`]: Raw LZ4 blocks with rsync-specific 2-byte framing. Required for
+//! - `raw`: Raw LZ4 blocks with rsync-specific 2-byte framing. Required for
 //!   wire protocol compatibility with upstream rsync 3.4.1.
 //!
 //! # Wire Protocol Compatibility
 //!
 //! Upstream rsync uses raw LZ4 blocks (not frame format) with a custom 2-byte
-//! header encoding the compressed size. Use the [`raw`] module for any code
+//! header encoding the compressed size. Use the `raw` module for any code
 //! that needs to interoperate with upstream rsync's compression.
 //!
 //! # Example

--- a/crates/compress/src/lz4/raw.rs
+++ b/crates/compress/src/lz4/raw.rs
@@ -18,7 +18,7 @@
 //!
 //! # Differences from Frame Format
 //!
-//! Unlike the [`super::frame`] module which uses LZ4 frame format with magic
+//! Unlike the `frame` module which uses LZ4 frame format with magic
 //! bytes, block checksums, and content checksums, this module produces raw
 //! compressed blocks suitable for the rsync wire protocol.
 

--- a/crates/compress/src/strategy/mod.rs
+++ b/crates/compress/src/strategy/mod.rs
@@ -55,7 +55,7 @@
 //!
 //! # Protocol Version Defaults
 //!
-//! Single source of truth: [`profile::ProtocolCompressionProfile`].
+//! Single source of truth: `ProtocolCompressionProfile`.
 //!
 //! | Protocol | Default Algorithm                          |
 //! |----------|--------------------------------------------|

--- a/crates/compress/src/strategy/profile.rs
+++ b/crates/compress/src/strategy/profile.rs
@@ -4,7 +4,7 @@
 //! whether vstring negotiation is supported, and the algorithm advertisement
 //! list) into a single data-driven table. Replaces scattered
 //! `if protocol_version >= N` ladders previously duplicated across
-//! [`super::kind`], [`super::negotiator`], and the `protocol` crate's
+//! `kind`, `negotiator`, and the `protocol` crate's
 //! capability layer.
 //!
 //! # Upstream Reference


### PR DESCRIPTION
## Summary

- Replace 8 broken rustdoc intra-doc links with backtick-only refs in `lz4` and `strategy` submodules
- Follows up on #5745 which fixed the same class of issue in `zlib/mod.rs`
- Submodule path links (`frame`, `raw`, `super::raw`, `super::frame`, `super::kind`, `super::negotiator`, `profile::ProtocolCompressionProfile`) fail to resolve when rendered from the parent module inclusion context

## Files changed

- `crates/compress/src/lz4/mod.rs` - `[`frame`]`, `[`raw`]` (x2)
- `crates/compress/src/lz4/frame.rs` - `[`super::raw`]`
- `crates/compress/src/lz4/raw.rs` - `[`super::frame`]`
- `crates/compress/src/strategy/mod.rs` - `[`profile::ProtocolCompressionProfile`]`
- `crates/compress/src/strategy/profile.rs` - `[`super::kind`]`, `[`super::negotiator`]`

## Test plan

- [ ] CI `cargo doc --workspace --all-features --no-deps` passes without `rustdoc::broken_intra_doc_links` errors