### PR TITLE
fix(daemon): use multiplexed error framing for all post-OK error paths

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -238,6 +238,35 @@ fn handle_refused_option_post_handshake(
     Ok(())
 }
 
+/// Delivers a fatal error to the client after `@RSYNCD: OK` and client args
+/// have been exchanged, using the multiplexed wire format.
+///
+/// After `@RSYNCD: OK` the client switches its input to the multiplex stream,
+/// so any error must be preceded by the post-OK protocol setup (compat-flags
+/// varint + checksum seed) and then framed as `MSG_ERROR_XFER` +
+/// `MSG_ERROR_EXIT`. Sending raw `@ERROR:` text here surfaces as
+/// `unexpected tag 72` on the receiver (see `handle_refused_option_post_handshake`
+/// for the detailed explanation).
+///
+/// upstream: clientserver.c:1130-1156 - ALL post-OK errors (refused options,
+/// read-only violations, pre-xfer exec failures, chroot errors) go through
+/// the same `setup_protocol() + io_start_multiplex_out() + rwrite(FERROR)`
+/// pipeline. Individual error paths must not bypass this with raw writes.
+fn handle_post_ok_error(
+    ctx: &mut ModuleRequestContext<'_>,
+    payload: &str,
+    protocol_version: Option<ProtocolVersion>,
+    client_args: &[String],
+) -> io::Result<()> {
+    finalize_post_ok_protocol_for_error(ctx, protocol_version, client_args)?;
+    send_multiplexed_error_and_exit(
+        ctx.reader.get_mut(),
+        ctx.limiter,
+        payload,
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+    )
+}
+
 /// Mirrors the prefix of upstream's `setup_protocol(f_out, f_in)` that the
 /// daemon writes before turning on `io_start_multiplex_out()` for an error
 /// it needs to deliver after `@RSYNCD: OK`.

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -22,6 +22,8 @@
 fn apply_privilege_restrictions_with_upstream_errors(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
+    negotiated_protocol: Option<ProtocolVersion>,
+    client_args: &[String],
 ) -> io::Result<bool> {
     let needs_chroot = module.use_chroot;
     let needs_privdrop = module.uid.is_some() || module.gid.is_some();
@@ -51,15 +53,13 @@ fn apply_privilege_restrictions_with_upstream_errors(
             } else {
                 CHROOT_FAILED_PAYLOAD
             };
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, payload)?;
+            handle_post_ok_error(ctx, payload, negotiated_protocol, client_args)?;
             return Ok(false);
         }
     }
 
     if needs_privdrop {
         if let Err(err) = drop_privileges(module.uid, module.gid, log_sink) {
-            // Distinguish upstream error messages based on the error text.
-            // upstream: clientserver.c:1010/1017/1039
             let text = err.to_string();
             let payload = if text.contains("setgroups") {
                 SETGROUPS_FAILED_PAYLOAD
@@ -68,7 +68,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
             } else {
                 SETGID_FAILED_PAYLOAD
             };
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, payload)?;
+            handle_post_ok_error(ctx, payload, negotiated_protocol, client_args)?;
             return Ok(false);
         }
     }
@@ -82,6 +82,8 @@ fn apply_privilege_restrictions_with_upstream_errors(
 fn validate_module_path(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
+    negotiated_protocol: Option<ProtocolVersion>,
+    client_args: &[String],
 ) -> io::Result<bool> {
     if Path::new(&module.path).exists() {
         return Ok(true);
@@ -92,7 +94,7 @@ fn validate_module_path(
         sanitize_module_identifier(ctx.request),
         module.path.display()
     );
-    send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+    handle_post_ok_error(ctx, &payload, negotiated_protocol, client_args)?;
 
     if let Some(log) = ctx.log_sink {
         let text = format!(
@@ -173,6 +175,7 @@ fn validate_client_paths_in_module(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
     client_args: &[String],
+    negotiated_protocol: Option<ProtocolVersion>,
 ) -> io::Result<Option<ValidatedClientPaths>> {
     let Ok(module_root) = module.path.canonicalize() else {
         // Module path failed to canonicalize - the existence check above
@@ -229,7 +232,7 @@ fn validate_client_paths_in_module(
         }
 
         let payload = format!("@ERROR: {flag} path '{raw_path}' is outside module root");
-        send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+        handle_post_ok_error(ctx, &payload, negotiated_protocol, client_args)?;
         if let Some(log) = ctx.log_sink {
             let text = format!(
                 "module '{}': rejected {flag}='{raw_path}' from {} ({}) - outside module root '{}'",
@@ -785,31 +788,31 @@ fn process_approved_module(
     }
 
     // Enforce read-only / write-only access restrictions.
-    // upstream: clientserver.c:rsync_module() - after reading args, check
-    // am_sender against lp_read_only(i) and lp_write_only(i).
-    // When --sender is absent the client is pushing (server = Receiver).
-    // A read-only module must reject pushes; a write-only module must reject pulls.
+    // upstream: main.c:1148-1151 - the read-only check runs inside
+    // server_recv() which is reached AFTER setup_protocol() and
+    // io_start_multiplex_out(). Errors therefore travel as MSG_ERROR_XFER
+    // frames, not raw @ERROR text. We must mirror that here because
+    // @RSYNCD: OK has already been sent and the client has switched its
+    // input to the multiplex stream.
     let role = determine_server_role(&client_args);
     if module.read_only && matches!(role, ServerRole::Receiver) {
-        send_error_and_exit(
-            ctx.reader.get_mut(),
-            ctx.limiter,
-            ctx.messages,
+        return handle_post_ok_error(
+            ctx,
             MODULE_READ_ONLY_PAYLOAD,
-        )?;
-        return Ok(());
+            negotiated_protocol,
+            &client_args,
+        );
     }
     if module.write_only && matches!(role, ServerRole::Generator) {
-        send_error_and_exit(
-            ctx.reader.get_mut(),
-            ctx.limiter,
-            ctx.messages,
+        return handle_post_ok_error(
+            ctx,
             MODULE_WRITE_ONLY_PAYLOAD,
-        )?;
-        return Ok(());
+            negotiated_protocol,
+            &client_args,
+        );
     }
 
-    if !validate_module_path(ctx, module)? {
+    if !validate_module_path(ctx, module, negotiated_protocol, &client_args)? {
         return Ok(());
     }
 
@@ -821,7 +824,8 @@ fn process_approved_module(
     // from the kernel. The accepted in-module paths are carried forward
     // and fed to `engage_landlock_sandbox` so the kernel allowlist matches
     // the full set the receiver will actually touch (URV-5.b.REOPEN).
-    let Some(validated_client_paths) = validate_client_paths_in_module(ctx, module, &client_args)?
+    let Some(validated_client_paths) =
+        validate_client_paths_in_module(ctx, module, &client_args, negotiated_protocol)?
     else {
         return Ok(());
     };
@@ -833,7 +837,12 @@ fn process_approved_module(
     // after auth and arg reading but before the transfer starts.
     // Split into separate steps so each failure sends the correct upstream
     // error message: `@ERROR: chroot failed` vs `@ERROR: setuid failed` etc.
-    if !apply_privilege_restrictions_with_upstream_errors(ctx, module)? {
+    if !apply_privilege_restrictions_with_upstream_errors(
+        ctx,
+        module,
+        negotiated_protocol,
+        &client_args,
+    )? {
         return Ok(());
     }
 
@@ -854,8 +863,12 @@ fn process_approved_module(
             Ok(nc) => Some(install_name_converter(nc)),
             Err(err) => {
                 let payload = format!("@ERROR: name-converter exec failed: {err}");
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
-                return Ok(());
+                return handle_post_ok_error(
+                    ctx,
+                    &payload,
+                    negotiated_protocol,
+                    &client_args,
+                );
             }
         }
     } else {
@@ -887,8 +900,12 @@ fn process_approved_module(
         Ok(rules) => config.daemon_filter_rules = rules,
         Err(err) => {
             let payload = format!("@ERROR: failed to load module filter rules: {err}");
-            send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
-            return Ok(());
+            return handle_post_ok_error(
+                ctx,
+                &payload,
+                negotiated_protocol,
+                &client_args,
+            );
         }
     }
 
@@ -990,19 +1007,17 @@ fn process_approved_module(
                 }
             }
             Ok(Err(err)) => {
-                // upstream: clientserver.c - stdout from the script is sent to the
-                // client before the @ERROR line.
-                if !err.stdout.is_empty() {
-                    write_limited(ctx.reader.get_mut(), ctx.limiter, err.stdout.as_bytes())?;
-                    write_limited(ctx.reader.get_mut(), ctx.limiter, b"\n")?;
-                }
                 let payload = format!("@ERROR: {}", err.message);
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
                 if let Some(log) = ctx.log_sink {
                     let message = rsync_error!(1, err.message).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
-                return Ok(());
+                return handle_post_ok_error(
+                    ctx,
+                    &payload,
+                    negotiated_protocol,
+                    &client_args,
+                );
             }
             Err(io_err) => {
                 let error_msg = format!(
@@ -1010,12 +1025,16 @@ fn process_approved_module(
                     ctx.request
                 );
                 let payload = format!("@ERROR: {error_msg}");
-                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
                 if let Some(log) = ctx.log_sink {
                     let message = rsync_error!(1, error_msg).with_role(Role::Daemon);
                     log_message(log, &message);
                 }
-                return Ok(());
+                return handle_post_ok_error(
+                    ctx,
+                    &payload,
+                    negotiated_protocol,
+                    &client_args,
+                );
             }
         }
     }

--- a/crates/daemon/src/daemon/sections/xfer_exec.rs
+++ b/crates/daemon/src/daemon/sections/xfer_exec.rs
@@ -123,16 +123,10 @@ struct PreXferOutput {
 }
 
 /// Error from a failed pre-xfer exec invocation.
-///
-/// Carries both the error message (for the `@ERROR` response) and any captured
-/// stdout (to relay to the client before the error).
 #[derive(Debug)]
 struct PreXferError {
     /// Human-readable error description including exit code and module name.
     message: String,
-    /// Captured stdout from the script, trimmed. Sent to the client before the
-    /// `@ERROR` line, matching upstream behaviour.
-    stdout: String,
 }
 
 /// Runs the pre-xfer exec command for a daemon module.
@@ -204,7 +198,7 @@ fn run_pre_xfer_exec(
             )
         };
 
-        Ok(Err(PreXferError { message, stdout }))
+        Ok(Err(PreXferError { message }))
     }
 }
 
@@ -604,12 +598,11 @@ mod xfer_exec_tests {
 
     #[cfg(unix)]
     #[test]
-    fn run_pre_xfer_exec_captures_stdout_on_failure() {
+    fn run_pre_xfer_exec_captures_message_on_failure() {
         let ctx = test_context();
         let result = run_pre_xfer_exec("echo 'pre-xfer info'; exit 1", &ctx, None)
             .expect("command should run");
         let err = result.unwrap_err();
-        assert_eq!(err.stdout, "pre-xfer info");
         assert!(err.message.contains("pre-xfer exec returned"));
     }
 


### PR DESCRIPTION
## Summary

- After `@RSYNCD: OK` the client expects multiplexed framing, but 8 post-OK error paths used raw `@ERROR` text, causing `unexpected tag 72` on the receiver
- Extract `handle_post_ok_error()` helper that writes compat-flags + checksum seed + `MSG_ERROR_XFER`/`MSG_ERROR_EXIT` frames
- Convert all post-args error sites: read-only, write-only, chroot/setuid/setgid, name-converter, filter rules, module path validation, client path validation, pre-xfer exec
- Early-exec errors (pre-args) left as raw `@ERROR`, matching upstream `clientserver.c:939-947`

Fixes the `unexpected tag 72` symptom reported in the daemon-refuse and daemon-refuse-compress upstream test suite failures (UTS-13.REOPEN).

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] Re-run daemon-refuse and daemon-refuse-compress in upstream test suite on Linux host
- [ ] Existing `run_daemon_post_ok_refused_option_uses_multiplexed_error` unit test still passes