### PR TITLE
fix(filters): skip descendant matchers in Transfer context for upstream parity

### DIFF
--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -35,8 +35,16 @@ impl CompiledRule {
     /// When `negate` is true, the match result is inverted: returns true when
     /// the pattern does NOT match. This mirrors upstream rsync's `!` modifier
     /// behavior from `exclude.c` line 906.
-    pub(crate) fn matches(&self, path: &Path, is_dir: bool) -> bool {
-        let pattern_matched = self.pattern_matches_impl(path, is_dir);
+    /// Tests whether a path matches this rule's pattern.
+    ///
+    /// When `check_descendants` is false, only direct matchers are evaluated -
+    /// descendant matchers are skipped. This matches upstream rsync's
+    /// `rule_matches()` in exclude.c which has NO descendant matching at all;
+    /// descendant exclusion is a side-effect of the sender walk not descending
+    /// into excluded directories. The receiver deletion path needs descendants
+    /// because it evaluates paths individually without traversal context.
+    pub(crate) fn matches(&self, path: &Path, is_dir: bool, check_descendants: bool) -> bool {
+        let pattern_matched = self.pattern_matches_impl(path, is_dir, check_descendants);
 
         // upstream: exclude.c:906 - ret_match = ex->rflags & FILTRULE_NEGATE ? 0 : 1
         if self.negate {
@@ -54,7 +62,7 @@ impl CompiledRule {
     }
 
     /// Internal pattern matching without negate logic.
-    fn pattern_matches_impl(&self, path: &Path, is_dir: bool) -> bool {
+    fn pattern_matches_impl(&self, path: &Path, is_dir: bool, check_descendants: bool) -> bool {
         for matcher in &self.direct_matchers {
             if matcher.is_match(path) && (!self.directory_only || is_dir) {
                 debug_log!(Filter, 2, "direct pattern matched: {:?}", path);
@@ -62,7 +70,12 @@ impl CompiledRule {
             }
         }
 
-        if !self.descendant_matchers.is_empty() {
+        // upstream: exclude.c:rule_matches() has no descendant matching.
+        // Sender-side (Transfer context) skips descendants because the walk
+        // implicitly handles them by not descending into excluded directories.
+        // Receiver-side (Deletion context) needs descendants because it
+        // evaluates paths individually without traversal.
+        if check_descendants && !self.descendant_matchers.is_empty() {
             for matcher in &self.descendant_matchers {
                 if matcher.is_match(path) {
                     debug_log!(Filter, 2, "descendant pattern matched: {:?}", path);
@@ -128,9 +141,9 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        assert!(compiled.matches(Path::new("file.bak"), false));
-        assert!(compiled.matches(Path::new("dir/file.bak"), false));
-        assert!(!compiled.matches(Path::new("file.txt"), false));
+        assert!(compiled.matches(Path::new("file.bak"), false, true));
+        assert!(compiled.matches(Path::new("dir/file.bak"), false, true));
+        assert!(!compiled.matches(Path::new("file.txt"), false, true));
     }
 
     #[test]
@@ -147,8 +160,8 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        assert!(compiled.matches(Path::new("build"), false));
-        assert!(!compiled.matches(Path::new("src/build"), false));
+        assert!(compiled.matches(Path::new("build"), false, true));
+        assert!(!compiled.matches(Path::new("src/build"), false, true));
     }
 
     #[test]
@@ -165,8 +178,8 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        assert!(compiled.matches(Path::new("node_modules"), true));
-        assert!(!compiled.matches(Path::new("node_modules"), false));
+        assert!(compiled.matches(Path::new("node_modules"), true, true));
+        assert!(!compiled.matches(Path::new("node_modules"), false, true));
     }
 
     #[test]
@@ -183,9 +196,9 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        assert!(compiled.matches(Path::new("build"), true));
-        assert!(compiled.matches(Path::new("build/output.o"), false));
-        assert!(compiled.matches(Path::new("build/subdir/file.txt"), false));
+        assert!(compiled.matches(Path::new("build"), true, true));
+        assert!(compiled.matches(Path::new("build/output.o"), false, true));
+        assert!(compiled.matches(Path::new("build/subdir/file.txt"), false, true));
     }
 
     #[test]
@@ -203,7 +216,7 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Protect);
-        assert!(compiled.matches(Path::new("important.dat"), false));
+        assert!(compiled.matches(Path::new("important.dat"), false, true));
     }
 
     #[test]
@@ -238,7 +251,7 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
-        assert!(compiled.matches(Path::new("readme.txt"), false));
+        assert!(compiled.matches(Path::new("readme.txt"), false, true));
     }
 
     #[test]
@@ -255,8 +268,8 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        assert!(compiled.matches(Path::new("build/main.o"), false));
-        assert!(compiled.matches(Path::new("src/lib/util.o"), false));
+        assert!(compiled.matches(Path::new("build/main.o"), false, true));
+        assert!(compiled.matches(Path::new("src/lib/util.o"), false, true));
     }
 
     /// Verifies `--exclude='/*'` matches root-level items but NOT nested paths.
@@ -281,13 +294,13 @@ mod tests {
         let compiled = CompiledRule::new(rule).unwrap();
 
         // Root-level items match the anchored `*` pattern.
-        assert!(compiled.matches(Path::new("file.txt"), false));
-        assert!(compiled.matches(Path::new("down"), true));
+        assert!(compiled.matches(Path::new("file.txt"), false, true));
+        assert!(compiled.matches(Path::new("down"), true, true));
 
         // Nested paths must NOT match - this was the bug in #5421 where
         // descendant matchers (`*/**`) incorrectly matched any nested path.
-        assert!(!compiled.matches(Path::new("down/file.txt"), false));
-        assert!(!compiled.matches(Path::new("down/sub/deep.txt"), false));
+        assert!(!compiled.matches(Path::new("down/file.txt"), false, true));
+        assert!(!compiled.matches(Path::new("down/sub/deep.txt"), false, true));
     }
 
     /// Verifies `--exclude=/build` matches the directory and its descendants.
@@ -310,9 +323,9 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        assert!(compiled.matches(Path::new("build"), false));
-        assert!(compiled.matches(Path::new("build/output.o"), false));
-        assert!(!compiled.matches(Path::new("src/build"), false));
+        assert!(compiled.matches(Path::new("build"), false, true));
+        assert!(compiled.matches(Path::new("build/output.o"), false, true));
+        assert!(!compiled.matches(Path::new("src/build"), false, true));
     }
 
     #[test]
@@ -329,8 +342,8 @@ mod tests {
             no_inherit: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
-        assert!(compiled.matches(Path::new("file.txt"), false));
-        assert!(!compiled.matches(Path::new("file.log"), false));
+        assert!(compiled.matches(Path::new("file.txt"), false, true));
+        assert!(!compiled.matches(Path::new("file.log"), false, true));
 
         let rule_negated = FilterRule {
             action: FilterAction::Exclude,
@@ -344,8 +357,8 @@ mod tests {
             no_inherit: false,
         };
         let compiled_negated = CompiledRule::new(rule_negated).unwrap();
-        assert!(!compiled_negated.matches(Path::new("file.txt"), false));
-        assert!(compiled_negated.matches(Path::new("file.log"), false));
+        assert!(!compiled_negated.matches(Path::new("file.txt"), false, true));
+        assert!(compiled_negated.matches(Path::new("file.log"), false, true));
     }
 
     #[test]
@@ -363,11 +376,11 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        assert!(!compiled.matches(Path::new("cache"), true));
-        assert!(compiled.matches(Path::new("build"), true));
+        assert!(!compiled.matches(Path::new("cache"), true, true));
+        assert!(compiled.matches(Path::new("build"), true, true));
         // directory_only means a file named "cache" never matches the pattern,
         // so the negated rule returns true for it.
-        assert!(compiled.matches(Path::new("cache"), false));
+        assert!(compiled.matches(Path::new("cache"), false, true));
     }
 
     #[test]
@@ -385,10 +398,10 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        assert!(!compiled.matches(Path::new("important"), false));
-        assert!(compiled.matches(Path::new("other"), false));
+        assert!(!compiled.matches(Path::new("important"), false, true));
+        assert!(compiled.matches(Path::new("other"), false, true));
         // Anchored pattern does not match a nested path, so negation gives true.
-        assert!(compiled.matches(Path::new("dir/important"), false));
+        assert!(compiled.matches(Path::new("dir/important"), false, true));
     }
 
     /// Verifies `--include '*/'` matches directories but NOT files inside them.
@@ -410,14 +423,14 @@ mod tests {
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
-        assert!(compiled.matches(Path::new("subdir"), true));
-        assert!(compiled.matches(Path::new("deep/nested"), true));
+        assert!(compiled.matches(Path::new("subdir"), true, true));
+        assert!(compiled.matches(Path::new("deep/nested"), true, true));
 
         // Files inside matched directories still need their own rules to match;
         // an include of `*/` alone does not pull file descendants in.
-        assert!(!compiled.matches(Path::new("file.txt"), false));
-        assert!(!compiled.matches(Path::new("subdir/debug.log"), false));
-        assert!(!compiled.matches(Path::new("subdir/report.csv"), false));
+        assert!(!compiled.matches(Path::new("file.txt"), false, true));
+        assert!(!compiled.matches(Path::new("subdir/debug.log"), false, true));
+        assert!(!compiled.matches(Path::new("subdir/report.csv"), false, true));
     }
 
     /// Verifies that an `exclude = ?` daemon-config rule does not block
@@ -443,11 +456,11 @@ mod tests {
         let compiled = CompiledRule::new(rule).unwrap();
 
         // The bare ? glob matches single-character names only.
-        assert!(compiled.matches(Path::new("a"), false));
+        assert!(compiled.matches(Path::new("a"), false, true));
         // Multi-character names must not match either at the root or at depth.
-        assert!(!compiled.matches(Path::new("delete.txt"), false));
-        assert!(!compiled.matches(Path::new("keep.txt"), false));
-        assert!(!compiled.matches(Path::new("subdir/delete.txt"), false));
+        assert!(!compiled.matches(Path::new("delete.txt"), false, true));
+        assert!(!compiled.matches(Path::new("keep.txt"), false, true));
+        assert!(!compiled.matches(Path::new("subdir/delete.txt"), false, true));
     }
 
     /// upstream: exclude.c:936-937 - `FILTRULE_WILD3_SUFFIX` causes `dir/***`
@@ -470,14 +483,49 @@ mod tests {
         let compiled = CompiledRule::new(rule).unwrap();
 
         // The directory itself is excluded (directory-only match on stem).
-        assert!(compiled.matches(Path::new("new/lose"), true));
+        assert!(compiled.matches(Path::new("new/lose"), true, true));
         // Contents are excluded via descendant matchers.
-        assert!(compiled.matches(Path::new("new/lose/this"), false));
-        assert!(compiled.matches(Path::new("new/lose/this"), true));
+        assert!(compiled.matches(Path::new("new/lose/this"), false, true));
+        assert!(compiled.matches(Path::new("new/lose/this"), true, true));
         // A file named "new/lose" is NOT excluded (directory-only).
-        assert!(!compiled.matches(Path::new("new/lose"), false));
+        assert!(!compiled.matches(Path::new("new/lose"), false, true));
         // Sibling entries are not affected.
-        assert!(!compiled.matches(Path::new("new/keep"), true));
+        assert!(!compiled.matches(Path::new("new/keep"), true, true));
+    }
+
+    /// Anchored literal exclude `/bar` generates descendant pattern `bar/**`.
+    /// With `check_descendants = false` (Transfer/sender context), children
+    /// like `bar/.filt` must NOT match - matching upstream rsync's
+    /// `rule_matches()` in exclude.c which has no descendant matching.
+    /// With `check_descendants = true` (Deletion/receiver context), children
+    /// do match via the descendant pattern.
+    #[test]
+    fn check_descendants_false_skips_descendant_matchers() {
+        let rule = FilterRule {
+            action: FilterAction::Exclude,
+            pattern: "/bar".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+
+        // The directory itself matches via direct matcher in both contexts.
+        assert!(compiled.matches(Path::new("bar"), true, true));
+        assert!(compiled.matches(Path::new("bar"), true, false));
+
+        // Descendant `bar/.filt` matches only when check_descendants = true
+        // (Deletion/receiver context).
+        assert!(compiled.matches(Path::new("bar/.filt"), false, true));
+
+        // With check_descendants = false (Transfer/sender context), the
+        // descendant pattern `bar/**` is skipped - upstream parity.
+        assert!(!compiled.matches(Path::new("bar/.filt"), false, false));
+        assert!(!compiled.matches(Path::new("bar/subdir/file"), false, false));
     }
 
     /// `dir/**` (double star without trailing `*`) should exclude contents
@@ -498,9 +546,9 @@ mod tests {
         let compiled = CompiledRule::new(rule).unwrap();
 
         // The directory entry itself is NOT excluded.
-        assert!(!compiled.matches(Path::new("new/keep"), true));
+        assert!(!compiled.matches(Path::new("new/keep"), true, true));
         // Contents are excluded.
-        assert!(compiled.matches(Path::new("new/keep/this"), false));
-        assert!(compiled.matches(Path::new("new/keep/this"), true));
+        assert!(compiled.matches(Path::new("new/keep/this"), false, true));
+        assert!(compiled.matches(Path::new("new/keep/this"), true, true));
     }
 }

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -32,6 +32,13 @@ impl FilterSetInner {
     ) -> FilterDecision {
         let mut decision = FilterDecision::default();
 
+        // upstream: exclude.c:rule_matches() has NO descendant matching.
+        // Sender-side (Transfer) skips descendants - the walk implicitly
+        // handles them by not descending into excluded directories.
+        // Receiver-side (Deletion) needs descendants because it evaluates
+        // paths individually without traversal context.
+        let check_descendants = matches!(context, DecisionContext::Deletion);
+
         let transfer_rule = match context {
             DecisionContext::Transfer => first_matching_rule(
                 &self.include_exclude,
@@ -39,6 +46,7 @@ impl FilterSetInner {
                 is_dir,
                 |rule| rule.applies_to_sender,
                 true,
+                check_descendants,
             ),
             DecisionContext::Deletion => first_matching_rule(
                 &self.include_exclude,
@@ -46,6 +54,7 @@ impl FilterSetInner {
                 is_dir,
                 |rule| rule.applies_to_receiver,
                 false,
+                check_descendants,
             ),
         };
 
@@ -56,6 +65,7 @@ impl FilterSetInner {
                 is_dir,
                 |rule| rule.applies_to_receiver,
                 true,
+                check_descendants,
             )
         {
             decision.excluded_for_delete_excluded = matches!(rule.action, FilterAction::Exclude);
@@ -79,6 +89,7 @@ impl FilterSetInner {
                 is_dir,
                 |rule| rule.applies_to_sender,
                 true,
+                check_descendants,
             ),
             DecisionContext::Deletion => first_matching_rule(
                 &self.protect_risk,
@@ -86,6 +97,7 @@ impl FilterSetInner {
                 is_dir,
                 |rule| rule.applies_to_receiver,
                 false,
+                check_descendants,
             ),
         };
 
@@ -120,6 +132,7 @@ impl FilterSetInner {
             true,
             |rule| rule.applies_to_sender,
             true,
+            false,
         ) {
             matches!(rule.action, FilterAction::Exclude) && !rule.is_directory_only()
         } else {
@@ -153,12 +166,15 @@ fn first_matching_rule<'a, F>(
     is_dir: bool,
     mut applies: F,
     include_perishable: bool,
+    check_descendants: bool,
 ) -> Option<&'a CompiledRule>
 where
     F: FnMut(&CompiledRule) -> bool,
 {
     rules.iter().find(|rule| {
-        (include_perishable || !rule.perishable) && applies(rule) && rule.matches(path, is_dir)
+        (include_perishable || !rule.perishable)
+            && applies(rule)
+            && rule.matches(path, is_dir, check_descendants)
     })
 }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -18,9 +18,9 @@ use logging::info_log;
 
 use crate::role_trailer::error_location;
 
-use super::super::GeneratorContext;
 use super::super::io_error_flags;
-use super::batch_stat::{StatResult, batch_stat_dir_entries};
+use super::super::GeneratorContext;
+use super::batch_stat::{batch_stat_dir_entries, StatResult};
 
 impl GeneratorContext {
     /// Pre-checks a top-level source entry and walks it if it exists.
@@ -518,6 +518,22 @@ impl GeneratorContext {
         path: &Path,
         base: &Path,
     ) -> io::Result<std::fs::Metadata> {
+        // upstream: flist.c:readlink_stat() operates on paths without trailing
+        // separators. On Linux, lstat("path/") follows symlinks because the
+        // kernel resolves the trailing slash, making a symlink appear as its
+        // target directory. Strip trailing separators via Path::components()
+        // so symlink_metadata correctly returns symlink metadata.
+        let normalized: PathBuf;
+        let path = {
+            let bytes = path.as_os_str().as_encoded_bytes();
+            if bytes.len() > 1 && bytes.ends_with(b"/") {
+                normalized = path.components().collect();
+                normalized.as_path()
+            } else {
+                path
+            }
+        };
+
         if self.config.flags.copy_links {
             return std::fs::metadata(path);
         }
@@ -608,7 +624,7 @@ mod symsafe_emission_tests {
     //! when `--copy-unsafe-links` triggers a dereference. The exact line
     //! emitted (per `rprintf(FINFO, ...)`) is matched byte-for-byte so
     //! interop harnesses that grep for the literal continue to find it.
-    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
+    use logging::{drain_events, info_log, init, DiagnosticEvent, InfoFlag, VerbosityConfig};
 
     fn init_symsafe_level1() {
         let mut cfg = VerbosityConfig::default();

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -18,9 +18,9 @@ use logging::info_log;
 
 use crate::role_trailer::error_location;
 
-use super::super::io_error_flags;
 use super::super::GeneratorContext;
-use super::batch_stat::{batch_stat_dir_entries, StatResult};
+use super::super::io_error_flags;
+use super::batch_stat::{StatResult, batch_stat_dir_entries};
 
 impl GeneratorContext {
     /// Pre-checks a top-level source entry and walks it if it exists.
@@ -624,7 +624,7 @@ mod symsafe_emission_tests {
     //! when `--copy-unsafe-links` triggers a dereference. The exact line
     //! emitted (per `rprintf(FINFO, ...)`) is matched byte-for-byte so
     //! interop harnesses that grep for the literal continue to find it.
-    use logging::{drain_events, info_log, init, DiagnosticEvent, InfoFlag, VerbosityConfig};
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
 
     fn init_symsafe_level1() {
         let mut cfg = VerbosityConfig::default();


### PR DESCRIPTION
## Summary

- Thread `check_descendants: bool` from `DecisionContext` through `first_matching_rule()` to `CompiledRule::matches()`, skipping pre-compiled descendant patterns in Transfer (sender) context
- Transfer context passes `false` - matching upstream rsync's `rule_matches()` in exclude.c which has no descendant matching at all
- Deletion (receiver) context keeps `true` since the receiver evaluates paths individually without traversal context
- Fixes over-filtering where an anchored exclude rule's descendant pattern (e.g. `/bar` generating `bar/**`) would catch children of directories already included by a prior rule

## Root cause

Upstream rsync's descendant exclusion is purely a side-effect of the directory walk not descending into excluded directories. oc-rsync pre-compiles descendant patterns into `CompiledRule` at build time, but these should only apply when the receiver evaluates paths individually (deletion context), not when the sender walks the tree (transfer context).

Two specific bugs fixed:
1. `+ **/bar` then `- /bar`: children like `bar/.filt` incorrectly matched `bar/**` on sender side
2. `+ foo/s?b/` then `- foo/*/`: children like `foo/sub/file1` incorrectly matched `foo/*/**`

## Test plan

- [ ] New unit test `check_descendants_false_skips_descendant_matchers` validates both contexts
- [ ] All ~30 existing `CompiledRule::matches()` test calls updated with explicit `check_descendants` parameter
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] Deploy to Linux host and verify upstream `exclude-lsh` testsuite test passes