### PR TITLE
chore(ci): add --locked to tools/ci shell helper scripts

### DIFF
--- a/tools/ci/check_known_failures.sh
+++ b/tools/ci/check_known_failures.sh
@@ -11,7 +11,7 @@ interop_script="${workspace_root}/tools/ci/run_interop.sh"
 # Build oc-rsync if not already built
 if [[ ! -x "$oc_bin" ]]; then
   echo "Building oc-rsync..."
-  cargo build --release --manifest-path "${workspace_root}/Cargo.toml"
+  cargo build --locked --release --manifest-path "${workspace_root}/Cargo.toml"
   mkdir -p "$(dirname "$oc_bin")"
   cp "${workspace_root}/target/release/oc-rsync" "$oc_bin"
 fi

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -99,7 +99,7 @@ ensure_workspace_binaries() {
   if [[ -x "${target_dir}/oc-rsync" ]]; then
     return
   fi
-  cargo build --profile dist --bin oc-rsync
+  cargo build --locked --profile dist --bin oc-rsync
 }
 
 build_jobs() {

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -55,7 +55,7 @@ ensure_oc_rsync() {
         return
     fi
     echo "==> Building oc-rsync (release)..." >&2
-    (cd "$workspace_root" && cargo build --release --bin oc-rsync)
+    (cd "$workspace_root" && cargo build --locked --release --bin oc-rsync)
 }
 
 ensure_upstream_src() {


### PR DESCRIPTION
## Summary

Adds `--locked` to three `cargo build` invocations in shell helper scripts under `tools/ci/`. Without `--locked`, cargo may silently regenerate `Cargo.lock` during CI runs, defeating lockfile reproducibility. These scripts are entry points called by 8+ CI workflows, so the gap had broad blast radius.

## Files Changed

- `tools/ci/run_interop.sh` — called by 6 workflows
- `tools/ci/run_upstream_testsuite.sh` — called by 2 workflows
- `tools/ci/check_known_failures.sh` — called by 1 workflow

## Closes

CIM-LOCKFILE-4

## Test plan

- [ ] CI passes on all required checks (fmt+clippy, nextest, Windows, macOS, Linux musl)
- [ ] Interop workflow continues to build oc-rsync successfully via the patched `run_interop.sh`
- [ ] Upstream testsuite workflow continues to build via the patched `run_upstream_testsuite.sh`
- [ ] Known-failures dashboard workflow continues to build via the patched `check_known_failures.sh`