### PR TITLE
fix(filters): normalise bare interior ** to match upstream wildmatch

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -282,6 +282,89 @@ mod tests {
         }
     }
 
+    /// `foo**too` must match `bar/down/to/foo/too` as a directory.
+    ///
+    /// upstream: `lib/wildmatch.c:dowild()` - `**` always matches across
+    /// `/` boundaries regardless of surrounding characters. Without
+    /// normalisation, globset's `literal_separator(true)` would treat the
+    /// bare `**` as two single `*` wildcards (neither of which crosses
+    /// `/`), so `foo**too` would only match `fooXYZtoo` within a single
+    /// path segment. Regression test for the UTS-20 `exclude-lsh` followup.
+    #[test]
+    fn double_star_interior_matches_across_path_segments() {
+        let rule = FilterRule {
+            action: FilterAction::Include,
+            pattern: "foo**too".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+
+        // Cross-segment match: `bar/down/to/foo/too` ends in `foo/too` and
+        // the `**` chews the intervening path.
+        use std::path::Path;
+        assert!(compiled.matches(Path::new("bar/down/to/foo/too"), true, true));
+        // Basename-style: `foo/too` is the minimal cross-segment match.
+        assert!(compiled.matches(Path::new("foo/too"), true, true));
+        // In-segment form must still match - upstream `**` consumes zero
+        // or more characters including `/`, so `fooxytoo` matches via the
+        // empty-slice expansion.
+        assert!(compiled.matches(Path::new("fooxytoo"), false, true));
+        // Non-matching tail.
+        assert!(!compiled.matches(Path::new("foo/bar"), false, true));
+    }
+
+    /// `**/bar` continues to match `bar` and `a/b/bar` after normalisation.
+    /// Regression guard: leading `**/` must NOT be over-normalised.
+    #[test]
+    fn double_star_prefix_regression_guard() {
+        let rule = FilterRule {
+            action: FilterAction::Include,
+            pattern: "**/bar".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+        use std::path::Path;
+        assert!(compiled.matches(Path::new("bar"), false, true));
+        assert!(compiled.matches(Path::new("a/b/bar"), false, true));
+        assert!(!compiled.matches(Path::new("baz"), false, true));
+    }
+
+    /// `bar/**` continues to match `bar/x/y` after normalisation.
+    /// Regression guard: trailing `/**` must NOT be over-normalised.
+    #[test]
+    fn double_star_suffix_regression_guard() {
+        let rule = FilterRule {
+            action: FilterAction::Exclude,
+            pattern: "bar/**".to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+        };
+        let compiled = CompiledRule::new(rule).unwrap();
+        use std::path::Path;
+        assert!(compiled.matches(Path::new("bar/x"), false, true));
+        assert!(compiled.matches(Path::new("bar/x/y"), false, true));
+        // `bar` alone does NOT match `bar/**` - the `/` after `bar` is
+        // mandatory in the pattern.
+        assert!(!compiled.matches(Path::new("bar"), true, true));
+    }
+
     #[test]
     fn compiled_rule_negate_flag_preserved() {
         let rule = FilterRule {

--- a/crates/filters/src/compiled/pattern.rs
+++ b/crates/filters/src/compiled/pattern.rs
@@ -10,11 +10,33 @@ use crate::FilterError;
 /// Patterns are sorted for deterministic evaluation order. Each pattern is
 /// built with `literal_separator(true)` so that `*` does not match `/`,
 /// matching upstream rsync's wildcard semantics.
+///
+/// Bare interior `**` sequences carry the upstream wildmatch semantic
+/// "match anything including `/`". globset's `literal_separator(true)`
+/// only treats `**` as recursive when it is bounded by `/`, so the input
+/// pattern is expanded into TWO variants: the original (covers the
+/// in-segment case where `**` behaves like a single-segment `*`) and a
+/// slash-bounded rewrite (covers the cross-segment case). Both are added
+/// to the matcher set so either form can satisfy upstream parity.
+///
+/// upstream: `lib/wildmatch.c:dowild()` - `**` always matches across `/`.
 pub(crate) fn compile_patterns(
     patterns: HashSet<String>,
     original: &str,
 ) -> Result<Vec<GlobMatcher>, FilterError> {
-    let mut unique: Vec<_> = patterns.into_iter().collect();
+    let mut expanded: HashSet<String> = HashSet::with_capacity(patterns.len() * 2);
+    for pattern in patterns {
+        let rewritten = match normalise_recursive_wildcards(&pattern) {
+            Cow::Borrowed(_) => None,
+            Cow::Owned(s) => Some(s),
+        };
+        if let Some(s) = rewritten {
+            expanded.insert(s);
+        }
+        expanded.insert(pattern);
+    }
+
+    let mut unique: Vec<_> = expanded.into_iter().collect();
     unique.sort();
 
     let mut matchers = Vec::with_capacity(unique.len());
@@ -27,6 +49,98 @@ pub(crate) fn compile_patterns(
         matchers.push(glob.compile_matcher());
     }
     Ok(matchers)
+}
+
+/// Rewrites bare interior `**` sequences into slash-delimited `/**/` so
+/// globset treats them as recursive wildcards.
+///
+/// upstream: `lib/wildmatch.c:dowild()` - when `**` is encountered, the
+/// `special` flag is set, and the wildcard matches across `/` boundaries
+/// regardless of surrounding characters. globset only treats `**` as
+/// recursive when it is bounded by `/` (or string boundaries), so a pattern
+/// like `foo**too` must be rewritten to `foo/**/too` to match
+/// `bar/down/to/foo/too`.
+///
+/// Runs of three or more `*` characters are collapsed to `**` first, since
+/// upstream's `dowild()` skips all consecutive `*` after seeing `**`
+/// (`while (*++p == '*') {}`).
+///
+/// Boundary handling:
+/// - `**` at the very start of the pattern keeps its prefix free
+///   (`**foo` -> `**/foo`, `**/foo` unchanged).
+/// - `**` at the very end keeps its suffix free
+///   (`foo**` -> `foo/**`, `foo/**` unchanged).
+/// - `**` already bounded by `/` on both sides is unchanged.
+/// - `**` adjacent to non-`/` is padded with the missing slash.
+///
+/// `*` and `?` outside `**` runs are left intact. Backslash-escaped
+/// characters (`\*`) are passed through verbatim - the escape is consumed
+/// with its escapee so neither participates in `**` detection.
+fn normalise_recursive_wildcards(pattern: &str) -> Cow<'_, str> {
+    if !pattern.contains("**") {
+        return Cow::Borrowed(pattern);
+    }
+
+    // `*`, `\`, and `/` are all single-byte ASCII so byte-indexed scanning
+    // is safe within a UTF-8 string. Multi-byte UTF-8 sequences are copied
+    // verbatim via str slicing between cut points to preserve encoding.
+    let bytes = pattern.as_bytes();
+    let mut out = String::with_capacity(bytes.len() + 4);
+    let mut cut = 0;
+    let mut i = 0;
+    let mut changed = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\\' && i + 1 < bytes.len() {
+            // Skip the escape pair so neither byte participates in `**` detection.
+            i += 2;
+            continue;
+        }
+        if b == b'*' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            // Found `**`. Consume the entire run of `*` (collapses `***+` to `**`).
+            let run_start = i;
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] == b'*' {
+                j += 1;
+            }
+
+            // Flush any pending verbatim slice before the `**` run.
+            out.push_str(&pattern[cut..run_start]);
+
+            if j - run_start > 2 {
+                changed = true;
+            }
+            let at_start = run_start == 0;
+            let at_end = j == bytes.len();
+            let prev_is_slash = run_start > 0 && bytes[run_start - 1] == b'/';
+            let next_is_slash = j < bytes.len() && bytes[j] == b'/';
+
+            let need_leading_slash = !at_start && !prev_is_slash;
+            let need_trailing_slash = !at_end && !next_is_slash;
+
+            if need_leading_slash {
+                out.push('/');
+                changed = true;
+            }
+            out.push_str("**");
+            if need_trailing_slash {
+                out.push('/');
+                changed = true;
+            }
+            i = j;
+            cut = j;
+            continue;
+        }
+        i += 1;
+    }
+
+    if !changed {
+        return Cow::Borrowed(pattern);
+    }
+
+    out.push_str(&pattern[cut..]);
+    Cow::Owned(out)
 }
 
 /// Normalizes a pattern by stripping leading `/` (anchored) and trailing `/` (directory-only).
@@ -214,5 +328,74 @@ mod tests {
         assert!(!anchored);
         assert!(!dir_only);
         assert_eq!(core, "foo***");
+    }
+
+    /// `**` between non-slash characters must be rewritten to `/**/` so
+    /// globset treats it as a recursive wildcard.
+    ///
+    /// upstream: `lib/wildmatch.c:dowild()` - `**` always matches across `/`.
+    #[test]
+    fn normalise_recursive_wildcards_interior_rewrites() {
+        assert_eq!(normalise_recursive_wildcards("foo**too"), "foo/**/too");
+        assert_eq!(normalise_recursive_wildcards("a**b**c"), "a/**/b/**/c");
+    }
+
+    /// `**` already adjacent to `/` on at least one side gets the missing
+    /// slash on the other side.
+    #[test]
+    fn normalise_recursive_wildcards_one_sided_slash() {
+        assert_eq!(normalise_recursive_wildcards("foo/**bar"), "foo/**/bar");
+        assert_eq!(normalise_recursive_wildcards("bar**/foo"), "bar/**/foo");
+    }
+
+    /// `**` already fully slash-bounded must not be touched.
+    #[test]
+    fn normalise_recursive_wildcards_already_bounded() {
+        for p in &["**/bar", "bar/**", "foo/**/bar", "**", "**/foo/**"] {
+            assert_eq!(normalise_recursive_wildcards(p), *p, "pattern {p:?}");
+        }
+    }
+
+    /// `**` at string start/end is treated as bounded by the implicit
+    /// edges, not as needing a slash inserted there.
+    #[test]
+    fn normalise_recursive_wildcards_edges() {
+        assert_eq!(normalise_recursive_wildcards("**foo"), "**/foo");
+        assert_eq!(normalise_recursive_wildcards("foo**"), "foo/**");
+    }
+
+    /// Three or more consecutive `*` characters collapse to `**` then get
+    /// boundary-normalised. This mirrors upstream's
+    /// `while (*++p == '*') {}` consumption.
+    #[test]
+    fn normalise_recursive_wildcards_collapse_runs() {
+        assert_eq!(normalise_recursive_wildcards("foo***too"), "foo/**/too");
+        assert_eq!(normalise_recursive_wildcards("foo****"), "foo/**");
+    }
+
+    /// Single `*` and `?` wildcards are left intact - they retain their
+    /// "match anything except `/`" semantics in globset.
+    #[test]
+    fn normalise_recursive_wildcards_leaves_single_wildcards() {
+        for p in &["*.txt", "foo?bar", "src/*.rs", "?", "*"] {
+            assert_eq!(normalise_recursive_wildcards(p), *p, "pattern {p:?}");
+        }
+    }
+
+    /// Patterns without `**` are returned borrowed without allocation.
+    #[test]
+    fn normalise_recursive_wildcards_no_double_star_is_borrowed() {
+        let p = "foo/bar/baz";
+        assert!(matches!(normalise_recursive_wildcards(p), Cow::Borrowed(_)));
+    }
+
+    /// Escaped `\*` sequences must not be treated as wildcards. The escape
+    /// pair is preserved verbatim and skipped during `**` detection, so a
+    /// pattern like `foo\**bar` decomposes into `foo` + literal `*` +
+    /// single `*` + `bar`, which is NOT a `**` recursive wildcard.
+    #[test]
+    fn normalise_recursive_wildcards_respects_backslash_escape() {
+        assert_eq!(normalise_recursive_wildcards("foo\\**bar"), "foo\\**bar");
+        assert_eq!(normalise_recursive_wildcards("\\*\\*foo"), "\\*\\*foo");
     }
 }

--- a/crates/filters/tests/uts20_exclude_lsh_repro.rs
+++ b/crates/filters/tests/uts20_exclude_lsh_repro.rs
@@ -1,0 +1,66 @@
+//! UTS-20 followup repro: bare interior `**` must match across path
+//! separators, matching upstream rsync's wildmatch semantics.
+//!
+//! Upstream command (from the `exclude-lsh` testsuite case):
+//! `rsync -av -f '+ foo**too' -f '- *' from/ chk/`
+//!
+//! Upstream `lib/wildmatch.c:dowild()` treats `**` as a recursive wildcard
+//! that matches any sequence of characters including `/`, regardless of
+//! the characters surrounding it. Without normalisation, globset's
+//! `literal_separator(true)` interprets bare `**` as two independent `*`
+//! wildcards (each of which stops at `/`), so `foo**too` would only match
+//! within a single path segment.
+//!
+//! Regression assertions: a pattern of `foo**too` must include
+//! `bar/down/to/foo/too` (cross-segment), `foo/too` (basename), AND
+//! `fooxytoo` (in-segment), to retain upstream parity.
+
+use std::path::Path;
+
+use filters::{FilterRule, FilterSet};
+
+/// `+ foo**too` followed by `- *` must include any path whose components
+/// start with `foo` and end with `too`, including the directory
+/// `bar/down/to/foo/too` from the `exclude-lsh` testsuite.
+#[test]
+fn uts20_recursive_glob_matches_cross_segment_directory() {
+    let rules = [FilterRule::include("foo**too"), FilterRule::exclude("*")];
+    let set = FilterSet::from_rules(rules).unwrap();
+
+    // Directory form: `bar/down/to/foo/too/` as a directory must be allowed.
+    assert!(
+        set.allows(Path::new("bar/down/to/foo/too"), true),
+        "directory bar/down/to/foo/too must be included by `+ foo**too`"
+    );
+    // Basename form: minimal cross-segment match.
+    assert!(set.allows(Path::new("foo/too"), true));
+    // In-segment form: `**` must still degenerate to `*` semantics inside
+    // a single path component.
+    assert!(set.allows(Path::new("fooxytoo"), false));
+}
+
+/// Negative companion: paths that neither begin with `foo` nor end with
+/// `too` are NOT included by `+ foo**too`, so the trailing `- *` excludes
+/// them. Guards against an over-broad normalisation.
+#[test]
+fn uts20_recursive_glob_does_not_overmatch() {
+    let rules = [FilterRule::include("foo**too"), FilterRule::exclude("*")];
+    let set = FilterSet::from_rules(rules).unwrap();
+
+    assert!(!set.allows(Path::new("bar"), true));
+    assert!(!set.allows(Path::new("foo/other"), false));
+    assert!(!set.allows(Path::new("prefix/too"), false));
+}
+
+/// Regression guard: existing slash-bounded `**` patterns must continue
+/// to behave identically after normalisation. `**/*.log` still excludes
+/// every `.log` file at any depth.
+#[test]
+fn uts20_existing_double_star_prefix_unchanged() {
+    let rules = [FilterRule::exclude("**/*.log"), FilterRule::include("**")];
+    let set = FilterSet::from_rules(rules).unwrap();
+
+    assert!(!set.allows(Path::new("debug.log"), false));
+    assert!(!set.allows(Path::new("a/b/c/debug.log"), false));
+    assert!(set.allows(Path::new("debug.txt"), false));
+}


### PR DESCRIPTION
## Summary

Upstream rsync's `wildmatch()` (lib/wildmatch.c:dowild) treats `**` as a recursive wildcard that matches any sequence of characters including `/`, regardless of surrounding characters. globset's `literal_separator(true)` only treats `**` as recursive when it is bounded by `/`, so a filter pattern like `foo**too` was interpreted as two independent `*` wildcards (neither of which crosses `/`).

As a result, `+ foo**too` did NOT match `bar/down/to/foo/too` from the upstream `exclude-lsh` testsuite, even though upstream's `wildmatch_array()` with `slash_handling = -1` does match it.

## Fix

Before passing patterns to globset, expand each pattern into two variants:

1. The original (covers the in-segment case where `**` degenerates to single-segment `*` semantics, e.g. `fooxytoo`).
2. A slash-bounded rewrite where bare interior `**` is padded with the missing slashes (covers the cross-segment case, e.g. `bar/down/to/foo/too`).

The rewrite:
- Collapses runs of three or more `*` to `**` (matching upstream's `while (*++p == '*') {}`).
- Pads missing slashes around interior `**` runs (`foo**too` -> `foo/**/too`).
- Leaves `**` already adjacent to `/` or string boundaries alone (`**/bar`, `bar/**`, `foo/**/bar`, `**` are unchanged).
- Honours backslash escapes so `\*\*` is not rewritten.

Both variants are added to the matcher set so either form can satisfy upstream parity. The descendant-matcher expansion picks up the same normalisation because the descendant patterns flow through the same `compile_patterns` entry point.

## Files

- `crates/filters/src/compiled/pattern.rs`: new `normalise_recursive_wildcards` helper plus the two-variant expansion in `compile_patterns`; unit tests cover interior rewrites, one-sided slash, already-bounded forms, edges, triple-star collapse, single-wildcard preservation, no-op borrowed path, and backslash escapes.
- `crates/filters/src/compiled/mod.rs`: three new matching tests - `double_star_interior_matches_across_path_segments`, `double_star_prefix_regression_guard`, `double_star_suffix_regression_guard`.
- `crates/filters/tests/uts20_exclude_lsh_repro.rs`: dedicated UTS-20 followup integration test asserting `bar/down/to/foo/too` is included by `+ foo**too` plus regression guards.

## Upstream Reference

- `lib/wildmatch.c:dowild()` - `**` always matches across `/` (no `t_ch == '/'` early-return for the `special = TRUE` branch).
- `exclude.c:rule_matches()` - `slash_handling = -1` when an infix `**` is present without a leading `**` prefix, retrying at every slash.

## Test plan

- [x] `crates/filters/src/compiled/pattern.rs` unit tests
- [x] `crates/filters/src/compiled/mod.rs` matching tests
- [x] `crates/filters/tests/uts20_exclude_lsh_repro.rs` integration test
- [x] Existing tests using slash-bounded `**` (e.g. `**/*.log`, `**/*.o`, `**/build/**`, `**/node_modules/`) unchanged - normalisation borrows when no rewrite is needed
- [x] `cargo fmt --all` clean
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl