### PR TITLE
fix(daemon): unbackslash --groupmap=*:GID wildcard in non-protect_args path

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -18,8 +18,10 @@ use crate::client::remote::flags;
 ///
 /// When `--protect-args` / `-s` is active, uses a two-phase protocol
 /// matching upstream `clientserver.c:393-408`:
-/// - Phase 1: minimal args (`--server [-s] .`) so the daemon knows to
-///   expect protected args
+/// - Phase 1: role markers + `--secluded-args` so the daemon knows to
+///   expect protected args (see [`build_minimal_daemon_args`] for why
+///   the long-form alias is used in place of a bare `-s` and why no
+///   standalone `.` is emitted)
 /// - Phase 2: full argument list via `send_secluded_args()` wire format
 ///
 /// Without protect-args, sends all arguments in a single phase.
@@ -37,7 +39,7 @@ pub(crate) fn send_daemon_arguments<W: Write>(
 
     // upstream: clientserver.c:393-405 - phase 1 sends args over the daemon text
     // protocol; with protect-args, only the minimal set is sent so the daemon
-    // detects `-s` and stops at the NULL marker, expecting phase-2 secluded args.
+    // detects the secluded-args marker and expects phase-2 secluded args.
     let phase1_args = if protect {
         build_minimal_daemon_args(is_sender)
     } else {
@@ -120,17 +122,47 @@ pub(crate) fn send_daemon_arguments<W: Write>(
 
 /// Builds the minimal phase-1 argument list for protect-args daemon mode.
 ///
-/// The daemon only needs `--server [--sender] -s .` to know that
-/// secluded args follow in phase 2.
+/// Upstream's phase 1 wire (`clientserver.c:395-402`) emits each `sargs[]`
+/// entry up to the `NULL` marker that `server_options()` inserts at
+/// `options.c:2745`. That marker sits AFTER the compact flag string and
+/// `--iconv=...` but BEFORE every post-NULL long-form option and the
+/// trailing `.` / module path which `do_cmd` appends at `clientserver.c:303`.
+/// As a result upstream's phase 1 wire never contains a standalone `.` or
+/// a bare `-s`: the `s` for `--secluded-args` is embedded inside the
+/// compact flag string (`argstr[x++] = 's'`, `options.c:2622-2623`).
 ///
-/// upstream: clientserver.c:393-405 - sargs has a NULL marker after `-s .`
+/// We emit only the role markers plus `--secluded-args` here so that:
+///
+/// 1. The daemon's `has_secluded_args_flag` check still trips and reads
+///    phase 2 via `recv_secluded_args` (`--secluded-args` is in the same
+///    detection set as `-s`).
+/// 2. The merged arg list never carries a spurious standalone `.` from
+///    phase 1 - the only `.` is the one phase 2 supplies as the positional
+///    separator, so `apply_long_form_args`'s first-`.` dot_position lookup
+///    correctly bounds the option region. A stray phase-1 `.` was dropping
+///    every long-form option emitted after the merge boundary, including
+///    `--groupmap=*:GID` (upstream issue #829 / daemon-groupmap-wild).
+/// 3. The merged arg list never carries a bare `-s` short-form arg that
+///    would shadow the real compact flag string in `build_server_config`'s
+///    first-short-form-arg picker. The real flag string arrives in phase 2
+///    via `build_full_daemon_args`.
+///
+/// Upstream daemons accept `--secluded-args` as the long-form alias of `-s`
+/// (`options.c:804`), so this remains wire-compatible with upstream rsync.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:303` - `sargs[sargc++] = "."` AFTER `server_options()`
+/// - `clientserver.c:395-402` - phase 1 wire writes args until `!sargs[i]`
+/// - `options.c:2622-2623` - `argstr[x++] = 's'` when `protect_args`
+/// - `options.c:2744-2745` - NULL marker between phase 1 / phase 2 args
+/// - `options.c:804` - `--secluded-args` long-form alias for `-s`
 pub(super) fn build_minimal_daemon_args(is_sender: bool) -> Vec<String> {
     let mut args = vec!["--server".to_owned()];
     if is_sender {
         args.push("--sender".to_owned());
     }
-    args.push("-s".to_owned());
-    args.push(".".to_owned());
+    args.push("--secluded-args".to_owned());
     args
 }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -23,16 +23,38 @@ mod protect_args_daemon_tests {
         }
     }
 
+    // upstream: clientserver.c:395-402 - phase 1 wire emits sargs[0..NULL].
+    // Upstream's phase 1 NEVER contains a standalone `.` (which only enters
+    // sargs after server_options() returns, AFTER the NULL marker at
+    // options.c:2745). Upstream's phase 1 also never contains a bare `-s`:
+    // the `s` is embedded in the compact flag string `argstr` at
+    // options.c:2622-2623. We mirror that shape by emitting only the role
+    // markers + `--secluded-args` (the long-form alias of `-s` per
+    // options.c:804) so the merged daemon arg list does not carry a stray
+    // `.` that would short-circuit `apply_long_form_args`' dot_position
+    // bound, nor a bare `-s` that would shadow phase 2's real compact flag
+    // string in the daemon's first-short-form-arg picker.
     #[test]
-    fn build_minimal_args_receiver() {
+    fn build_minimal_args_receiver_excludes_dot_and_bare_short_flag() {
         let args = build_minimal_daemon_args(false);
-        assert_eq!(args, vec!["--server", "-s", "."]);
+        assert_eq!(args, vec!["--server", "--secluded-args"]);
+        assert!(
+            !args.iter().any(|a| a == "."),
+            "phase 1 must not emit a standalone `.` - upstream's wire never does",
+        );
+        assert!(
+            !args.iter().any(|a| a == "-s"),
+            "phase 1 must not emit a bare `-s` - the daemon's flag-string \
+             picker would shadow the real compact flag string from phase 2",
+        );
     }
 
     #[test]
-    fn build_minimal_args_sender() {
+    fn build_minimal_args_sender_excludes_dot_and_bare_short_flag() {
         let args = build_minimal_daemon_args(true);
-        assert_eq!(args, vec!["--server", "--sender", "-s", "."]);
+        assert_eq!(args, vec!["--server", "--sender", "--secluded-args"]);
+        assert!(!args.iter().any(|a| a == "."));
+        assert!(!args.iter().any(|a| a == "-s"));
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -286,6 +286,82 @@ mod module_access_tests {
         assert_eq!(mapping.spec(), "*:1234");
     }
 
+    // UTS-8.REOPEN regression: the client's actual phase-1 wire for
+    // secluded-args daemon push is `[--server, --sender, --secluded-args]`
+    // (no standalone `.` or bare `-s`), and phase 2 carries the real
+    // compact flag string plus `--groupmap=*:GID`. The previous client
+    // emitted a stray `.` in phase 1 which made `apply_long_form_args`'
+    // first-`.` dot_position lookup short-circuit the option region, so
+    // `--groupmap` was silently dropped before reaching
+    // `GroupMapping::parse`. The previous client also emitted a bare `-s`
+    // in phase 1 which shadowed phase 2's real compact flag string in
+    // `build_server_config`'s first-short-form-arg picker, breaking
+    // compression / recursion negotiation. The merged arg list emitted
+    // by the fixed client must round-trip `--groupmap=*:GID` intact AND
+    // expose phase 2's real compact flag string as the first short-form
+    // arg so the daemon's option region parser sees both correctly.
+    //
+    // upstream: clientserver.c:395-402 phase 1 wire layout
+    // upstream: clientserver.c:303 `.` and module path land in phase 2
+    // upstream: options.c:2744-2745 NULL marker between phase 1 and phase 2
+    // upstream: options.c:804 `--secluded-args` long-form alias of `-s`
+    #[test]
+    fn merge_secluded_args_oc_rsync_client_wire_preserves_groupmap_wildcard() {
+        // Phase 1 mirrors the fixed `build_minimal_daemon_args` output
+        // for a daemon-push (client is sender, daemon is receiver).
+        let phase1 = vec![
+            "--server".to_owned(),
+            "--sender".to_owned(),
+            "--secluded-args".to_owned(),
+        ];
+        // Phase 2 mirrors `build_full_daemon_args` output: leading
+        // synthetic "rsync" arg0, then `--server`, `--sender`, the real
+        // compact flag string, the long-form options including the
+        // wildcard `--groupmap`, the `.` separator, and the positional
+        // module path. The leading `--server` / `--sender` are duplicated
+        // because oc-rsync builds the full arg list once and ships it in
+        // phase 2 (vs upstream which splits server_options() output at
+        // the NULL marker). The duplication is harmless: `apply_long_form_args`
+        // ignores `--server` / `--sender` (role determination uses a
+        // separate scan).
+        let phase2 = vec![
+            "rsync".to_owned(),
+            "--server".to_owned(),
+            "--sender".to_owned(),
+            "-logDtprIze.LsfxCIvu".to_owned(),
+            "--log-format=%i".to_owned(),
+            "--groupmap=*:4242".to_owned(),
+            ".".to_owned(),
+            "upload/".to_owned(),
+        ];
+        let merged = merge_secluded_args(phase1, phase2);
+
+        // `apply_long_form_args` finds the first standalone `.` at the
+        // expected position (after `--groupmap`), so the wildcard option
+        // is parsed instead of being treated as a positional file arg.
+        let mut config = ServerConfig::default();
+        let unknown = apply_long_form_args(&merged, &mut config);
+        assert!(
+            unknown.is_none(),
+            "no client-only batch flag should reach the daemon",
+        );
+        let mapping = config
+            .group_mapping
+            .expect("groupmap=*:4242 must reach GroupMapping::parse intact");
+        assert_eq!(mapping.spec(), "*:4242");
+
+        // The real compact flag string is the first short-form arg in the
+        // merged list (the daemon's `build_server_config` picks the first
+        // arg matching `starts_with('-') && !starts_with("--")`). A bare
+        // `-s` in phase 1 would have shadowed it; `--secluded-args` is
+        // long-form and so does not.
+        let first_short = merged
+            .iter()
+            .find(|a| a.starts_with('-') && !a.starts_with("--"))
+            .expect("merged args must include a short-form compact flag string");
+        assert_eq!(first_short, "-logDtprIze.LsfxCIvu");
+    }
+
     #[test]
     fn apply_module_bandwidth_limit_disables_when_module_configured_none() {
         let mut limiter = Some(BandwidthLimiter::new(NonZeroU64::new(1024).unwrap()));


### PR DESCRIPTION
## Summary

- Phase 1 of the secluded-args daemon-push wire was `--server [--sender] -s .`, which diverges from upstream's `clientserver.c:395-402` wire layout. Upstream phase 1 never contains a standalone `.` (`do_cmd` only appends `.` to `sargs` AFTER `server_options()` returns past the NULL marker at `options.c:2745`) and never contains a bare `-s` (the `s` is embedded inside the compact flag string `argstr` per `options.c:2622-2623`).
- The stray phase-1 `.` made the daemon's `apply_long_form_args` first-`.` dot_position lookup bound the option region BEFORE the merge boundary, so every long-form option emitted in phase 2 - including `--groupmap=*:GID` - was silently dropped before reaching `GroupMapping::parse`. The bare `-s` also shadowed phase 2's real compact flag string in `build_server_config`'s first-short-form-arg picker, breaking compression/recursion negotiation. UTS-8.REOPEN / upstream issue #829 / `daemon-groupmap-wild`: `[secluded-args] groupmap upload failed (rc=12) + connection unexpectedly closed (23 bytes received) [sender]`.
- Switch phase 1 to `--server [--sender] --secluded-args`. The long-form alias is in the daemon's `has_secluded_args_flag` detection set, so phase 2 reading still trips, and upstream daemons accept the alias per `options.c:804` so this remains wire-compatible with upstream rsync.

## Test plan

- [x] Pin client-side phase 1 wire layout: `build_minimal_daemon_args` emits neither a standalone `.` nor a bare `-s` for push or pull, and is exactly `[--server, [--sender], --secluded-args]`.
- [x] Pin daemon-side round trip: with the new phase 1 + a representative phase 2 (real compact flag string + `--groupmap=*:4242`), `merge_secluded_args` -> `apply_long_form_args` reaches `GroupMapping::parse` with `*:4242` intact, and the real compact flag string (`-logDtprIze.LsfxCIvu`) is the first short-form arg in the merged list.
- [x] `cargo fmt --all` clean before push (no formatting drift).
- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.
- [ ] Upstream testsuite: `daemon-groupmap-wild` (`[secluded-args] groupmap upload`) passes.

upstream: clientserver.c:303 - `sargs[sargc++] = "."` after server_options()
upstream: clientserver.c:395-402 - phase 1 wire writes args until `!sargs[i]`
upstream: options.c:2622-2623 - `argstr[x++] = 's'` when `protect_args`
upstream: options.c:2744-2745 - NULL marker between phase 1 / phase 2 args
upstream: options.c:804 - `--secluded-args` long-form alias for `-s`