### PR TITLE
fix(docs): replace broken intra-doc links in rsync_io crate

### DIFF
--- a/crates/rsync_io/src/channel_adapter.rs
+++ b/crates/rsync_io/src/channel_adapter.rs
@@ -1,22 +1,22 @@
 //! In-process channel adapters that bridge `tokio::sync::mpsc` to
-//! [`AsyncRead`]/[`AsyncWrite`].
+//! `AsyncRead`/`AsyncWrite`.
 //!
 //! These adapters let an async transport (for example, the embedded SSH
 //! transport) expose its stdio over an in-process duplex channel while still
-//! satisfying APIs that require raw [`tokio::io::AsyncRead`] and
-//! [`tokio::io::AsyncWrite`] implementations.
+//! satisfying APIs that require raw `tokio::io::AsyncRead` and
+//! `tokio::io::AsyncWrite` implementations.
 //!
 //! # Overview
 //!
-//! - [`ChannelReader`] consumes byte chunks from an `mpsc::Receiver<Vec<u8>>`
-//!   and presents them through [`AsyncRead`]. Oversized chunks that do not fit
-//!   in the caller-provided [`ReadBuf`] are buffered internally and drained on
+//! - `ChannelReader` consumes byte chunks from an `mpsc::Receiver<Vec<u8>>`
+//!   and presents them through `AsyncRead`. Oversized chunks that do not fit
+//!   in the caller-provided `ReadBuf` are buffered internally and drained on
 //!   subsequent reads.
-//! - [`ChannelWriter`] forwards each [`AsyncWrite::poll_write`] call to an
+//! - `ChannelWriter` forwards each `AsyncWrite::poll_write` call to an
 //!   `mpsc::Sender<Vec<u8>>`. When the channel is full, the writer registers
-//!   the task waker and returns [`Poll::Pending`]; the writer wakes when
+//!   the task waker and returns `Poll::Pending`; the writer wakes when
 //!   capacity becomes available.
-//! - [`pair`] returns two cross-connected `(ChannelReader, ChannelWriter)`
+//! - `pair` returns two cross-connected `(ChannelReader, ChannelWriter)`
 //!   halves so a single duplex channel can be split between two peers.
 //!
 //! # Invariants
@@ -40,7 +40,7 @@ use tokio::sync::mpsc;
 /// Asynchronous reader that drains byte chunks delivered through an
 /// `mpsc::Receiver<Vec<u8>>`.
 ///
-/// Each received chunk is copied into the caller's [`ReadBuf`]. When a chunk
+/// Each received chunk is copied into the caller's `ReadBuf`. When a chunk
 /// exceeds the buffer's remaining capacity, the unread tail is retained and
 /// served on subsequent calls before another chunk is pulled from the channel.
 pub struct ChannelReader {
@@ -50,7 +50,7 @@ pub struct ChannelReader {
 }
 
 impl ChannelReader {
-    /// Wraps the supplied receiver in an [`AsyncRead`] adapter.
+    /// Wraps the supplied receiver in an `AsyncRead` adapter.
     pub fn new(rx: mpsc::Receiver<Vec<u8>>) -> Self {
         Self {
             rx,
@@ -108,7 +108,7 @@ impl AsyncRead for ChannelReader {
     }
 }
 
-/// Boxed reservation future used by [`ChannelWriter`] to preserve the
+/// Boxed reservation future used by `ChannelWriter` to preserve the
 /// channel's wait-queue registration across `poll_write` invocations.
 type ReservationFuture = Pin<
     Box<dyn Future<Output = Result<mpsc::OwnedPermit<Vec<u8>>, mpsc::error::SendError<()>>> + Send>,
@@ -118,7 +118,7 @@ type ReservationFuture = Pin<
 /// `mpsc::Sender<Vec<u8>>`.
 ///
 /// Backpressure is honored: when the channel is full, `poll_write` parks the
-/// current task and returns [`Poll::Pending`] until capacity is available. A
+/// current task and returns `Poll::Pending` until capacity is available. A
 /// closed channel surfaces as [`io::ErrorKind::BrokenPipe`]. `poll_shutdown`
 /// drops the internal sender, signalling EOF to the reader half.
 pub struct ChannelWriter {
@@ -129,7 +129,7 @@ pub struct ChannelWriter {
 }
 
 impl ChannelWriter {
-    /// Wraps the supplied sender in an [`AsyncWrite`] adapter.
+    /// Wraps the supplied sender in an `AsyncWrite` adapter.
     pub fn new(tx: mpsc::Sender<Vec<u8>>) -> Self {
         Self {
             tx: Some(tx),
@@ -226,8 +226,8 @@ impl AsyncWrite for ChannelWriter {
 /// duplex `mpsc` channel pair of the requested capacity.
 ///
 /// The first half reads what the second writes, and vice versa, providing a
-/// fully in-memory duplex stream that can stand in for any [`AsyncRead`] +
-/// [`AsyncWrite`] transport.
+/// fully in-memory duplex stream that can stand in for any `AsyncRead` +
+/// `AsyncWrite` transport.
 #[must_use]
 pub fn pair(
     capacity: usize,

--- a/crates/rsync_io/src/ssh/async_transport.rs
+++ b/crates/rsync_io/src/ssh/async_transport.rs
@@ -412,7 +412,7 @@ mod tests {
     }
 
     /// Compile-time check that the [`AsyncSshTransport::split`] halves
-    /// implement the documented [`AsyncRead`] / [`AsyncWrite`] traits.
+    /// implement the documented `AsyncRead` / `AsyncWrite` traits.
     /// The body is never executed; it exists purely so a type mismatch
     /// surfaces as a compile error during normal test builds rather than
     /// a runtime test failure that requires the `ssh` binary.

--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -234,7 +234,7 @@ impl SshConfig {
         self
     }
 
-    /// Variant of [`apply_ssh_config`] that reads from a caller-supplied
+    /// Variant of [`Self::apply_ssh_config`] that reads from a caller-supplied
     /// path. Exposed for testing and for callers that ship a non-default
     /// config location.
     pub fn apply_ssh_config_from(&mut self, path: &Path, host_alias: &str) -> &mut Self {

--- a/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
+++ b/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
@@ -14,10 +14,10 @@
 //!   `std::io::Read + std::io::Write` by driving an internal current-thread
 //!   tokio runtime via [`tokio::runtime::Runtime::block_on`] on every call.
 //! - [`into_sync_halves`] takes ownership of a [`russh::Channel`] and returns
-//!   ([`SyncReader`], [`SyncWriter`]) halves backed by a background tokio task
+//!   (`SyncReader`, `SyncWriter`) halves backed by a background tokio task
 //!   that pumps channel data into bounded `std::sync::mpsc` /
 //!   `tokio::sync::mpsc` queues. This is the bridge variant used by
-//!   [`connect_and_exec`](super::connect::connect_and_exec); it is re-exposed
+//!   `connect_and_exec`; it is re-exposed
 //!   here so other call-sites can construct the same wiring around channels
 //!   they own.
 //!
@@ -51,7 +51,7 @@ use tokio::sync::mpsc as tokio_mpsc;
 
 /// Default capacity for the in-process queues used by [`into_sync_halves`].
 ///
-/// Matches the queue depth used by [`super::connect::connect_and_exec`] so
+/// Matches the queue depth used by `super::connect::connect_and_exec` so
 /// the two paths behave identically under load.
 pub const DEFAULT_CHANNEL_CAPACITY: usize = 64;
 
@@ -189,7 +189,7 @@ impl io::Read for SyncReader {
     }
 }
 
-/// Internal write buffer capacity for [`SyncWriter`].
+/// Internal write buffer capacity for `SyncWriter`.
 ///
 /// Small writes (4-byte multiplex headers, NDX values, etc.) are coalesced
 /// into this staging buffer instead of allocating a `Vec` per write and
@@ -286,7 +286,7 @@ impl Drop for SyncWriter {
 /// Spawns a background task on the current tokio runtime to pump channel
 /// data into bounded queues that the returned halves drain synchronously.
 /// This is the channel-based bridge variant used by
-/// [`super::connect::connect_and_exec`]; it is exposed here for callers who
+/// `super::connect::connect_and_exec`; it is exposed here for callers who
 /// already own a channel and need the same wiring (for example, after
 /// opening a session channel for a custom subsystem).
 ///

--- a/crates/rsync_io/src/ssh/socketpair_stderr.rs
+++ b/crates/rsync_io/src/ssh/socketpair_stderr.rs
@@ -24,7 +24,7 @@
 //!   (workspace `#![deny(unsafe_code)]` policy). SSE-5 (#2374) lands
 //!   the Windows shim in coordination with `fast_io`; until then the
 //!   Windows implementation here returns
-//!   [`io::ErrorKind::Unsupported`] so the caller falls back to
+//!   `io::ErrorKind::Unsupported` so the caller falls back to
 //!   `Stdio::piped()` exactly like the Unix FD-exhaustion path does
 //!   in `aux_channel.rs::configure_stderr_channel`.
 //!
@@ -66,7 +66,7 @@ use std::os::unix::net::UnixStream;
 ///
 /// On Unix the result is the parent/child halves of a
 /// `socketpair(AF_UNIX, SOCK_STREAM, 0)`. On Windows the call returns
-/// [`io::ErrorKind::Unsupported`] until SSE-5 lands the loopback shim
+/// `io::ErrorKind::Unsupported` until SSE-5 lands the loopback shim
 /// alongside the safe handle wrapper in `fast_io`.
 ///
 /// Returning [`File`] on both halves lets the caller store the handles
@@ -76,7 +76,7 @@ use std::os::unix::net::UnixStream;
 ///
 /// Returns the underlying [`io::Error`] when the kernel refuses to
 /// create the pair. On Windows always returns
-/// [`io::ErrorKind::Unsupported`].
+/// `io::ErrorKind::Unsupported`.
 pub fn make_stderr_socketpair() -> io::Result<(File, File)> {
     make_stderr_socketpair_impl()
 }


### PR DESCRIPTION
Pages workflow on master is failing with 14+ unresolved intra-doc links in rsync_io. Converts intra-doc-link syntax to plain backticks for tokio re-exports and forward references that don't resolve under -D rustdoc::broken_intra_doc_links. Same pattern as the prior logging-crate fix (#5756); validated locally with cargo doc -p rsync_io --all-features --no-deps --locked.