### PR TITLE
fix(docs): replace broken intra-doc links across workspace

### DIFF
--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -82,7 +82,7 @@ pub(crate) const MAX_ALLOC_CEILING: u64 = u64::MAX / 4;
 ///
 /// # Errors
 ///
-/// Returns a [`Message`] with role [`Role::Client`] and exit code 1 on any
+/// Returns a `Message` with role [`Role::Client`] and exit code 1 on any
 /// rejection, matching upstream's diagnostic style.
 pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
     let text = value.to_string_lossy();

--- a/crates/cli/src/frontend/password.rs
+++ b/crates/cli/src/frontend/password.rs
@@ -155,7 +155,7 @@ fn first_line(bytes: &[u8]) -> Vec<u8> {
 /// Reads a password from `path` while enforcing upstream rsync's permission rules.
 ///
 /// The function accepts either an on-disk file or `-` to read from standard
-/// input. Errors are wrapped in [`Message`] so the caller can preserve the
+/// input. Errors are wrapped in `Message` so the caller can preserve the
 /// workspace's branded diagnostics.
 pub(crate) fn load_password_file(path: &Path) -> Result<Vec<u8>, Message> {
     if path == Path::new("-") {

--- a/crates/cli/src/frontend/progress_format.rs
+++ b/crates/cli/src/frontend/progress_format.rs
@@ -7,8 +7,8 @@
 //! # Overview
 //!
 //! The module provides two main types:
-//! - [`PerFileProgress`]: Displays per-file transfer progress
-//! - [`OverallProgress`]: Displays overall transfer progress (--info=progress2)
+//! - `PerFileProgress`: Displays per-file transfer progress
+//! - `OverallProgress`: Displays overall transfer progress (--info=progress2)
 //!
 //! # Example
 //!

--- a/crates/cli/src/frontend/stats_format.rs
+++ b/crates/cli/src/frontend/stats_format.rs
@@ -5,7 +5,7 @@
 //!
 //! # Overview
 //!
-//! The module provides a [`StatsFormatter`] that takes a [`StatsData`] struct
+//! The module provides a `StatsFormatter` that takes a `StatsData` struct
 //! containing all the transfer statistics and produces a formatted multi-line
 //! string matching upstream rsync's exact output format.
 //!

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -32,7 +32,7 @@ pub const REMOTE_COMMAND_NOT_FOUND_EXIT_CODE: i32 = ExitCode::CommandNotFound.as
 
 /// Error returned when the client orchestration fails.
 ///
-/// Uses the centralized [`ExitCode`] enum to ensure exit codes match
+/// Uses the centralized `ExitCode` enum to ensure exit codes match
 /// upstream rsync behavior. Exit codes are defined in upstream `errcode.h`
 /// and mapped to string names in `log.c`.
 #[derive(Clone, Debug, Error)]
@@ -50,7 +50,7 @@ impl ClientError {
 
     /// Creates a new [`ClientError`] from an i32 exit code and message.
     ///
-    /// If the exit code doesn't map to a known [`ExitCode`] variant,
+    /// If the exit code doesn't map to a known `ExitCode` variant,
     /// [`ExitCode::PartialTransfer`] is used as a fallback.
     ///
     /// This is the primary constructor for backward compatibility with
@@ -168,7 +168,7 @@ pub(crate) fn missing_operands_error() -> ClientError {
 
 /// Creates an invalid argument error from an i32 exit code.
 ///
-/// If the exit code doesn't map to a known [`ExitCode`] variant,
+/// If the exit code doesn't map to a known `ExitCode` variant,
 /// [`ExitCode::PartialTransfer`] is used as a fallback.
 #[cold]
 pub(crate) fn invalid_argument_error(text: &str, exit_code: i32) -> ClientError {
@@ -301,7 +301,7 @@ pub fn connection_unexpectedly_closed_error(bytes_received: u64, role: Role) -> 
 
 /// Creates a daemon error from an i32 exit code.
 ///
-/// If the exit code doesn't map to a known [`ExitCode`] variant,
+/// If the exit code doesn't map to a known `ExitCode` variant,
 /// [`ExitCode::PartialTransfer`] is used as a fallback.
 #[cold]
 pub(crate) fn daemon_error(text: impl Into<String>, exit_code: i32) -> ClientError {

--- a/crates/core/src/client/module_list/connect/tls.rs
+++ b/crates/core/src/client/module_list/connect/tls.rs
@@ -1,6 +1,6 @@
 //! TLS connector for client-side rsync:// connections.
 //!
-//! Wraps a [`TcpStream`] in a rustls TLS session, performing the client
+//! Wraps a `TcpStream` in a rustls TLS session, performing the client
 //! handshake and returning a stream that implements `Read + Write` over
 //! the encrypted channel. This eliminates the need for an external stunnel
 //! wrapper when connecting to TLS-enabled rsync daemons.

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -7,11 +7,11 @@
 //!
 //! # Submodules
 //!
-//! - [`daemon_transfer`] - Daemon protocol (rsync://) connection, handshake, and transfer
-//! - [`ssh_transfer`] - SSH-based remote transfers via `--rsh`/`-e`
-//! - [`invocation`] - Remote rsync `--server` argument construction and role detection
+//! - `daemon_transfer` - Daemon protocol (rsync://) connection, handshake, and transfer
+//! - `ssh_transfer` - SSH-based remote transfers via `--rsh`/`-e`
+//! - `invocation` - Remote rsync `--server` argument construction and role detection
 //! - `flags` - Shared flag builder functions for compact server option strings
-//! - [`remote_to_remote`] - Two-host proxy relay via local machine
+//! - `remote_to_remote` - Two-host proxy relay via local machine
 //!
 //! # Upstream Reference
 //!

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -8,7 +8,7 @@
 //!
 //! # Architecture
 //!
-//! Transfers use the [`SshConnection::split`] method to obtain separate read/write
+//! Transfers use the `SshConnection::split` method to obtain separate read/write
 //! halves, which are then passed to the server infrastructure for protocol handling.
 //!
 //! # Upstream Reference
@@ -540,7 +540,7 @@ use super::batch_support::{BatchContext, build_batch_context, build_batch_record
 
 /// Runs server over an SSH connection using split read/write halves.
 ///
-/// This uses [`SshConnection::split`] to obtain separate reader and writer handles,
+/// This uses `SshConnection::split` to obtain separate reader and writer handles,
 /// avoiding the need for unsafe aliased mutable references.
 ///
 /// When `batch_writer` is provided, the handshake is performed first, then the

--- a/crates/core/src/exit_code/mod.rs
+++ b/crates/core/src/exit_code/mod.rs
@@ -1,6 +1,6 @@
 //! Centralized exit code definitions matching upstream rsync.
 //!
-//! This module provides a unified [`ExitCode`] enum that mirrors the exit codes
+//! This module provides a unified `ExitCode` enum that mirrors the exit codes
 //! defined in upstream rsync's `errcode.h`. All error types across the workspace
 //! should use these codes to ensure consistent behavior with upstream rsync.
 //!

--- a/crates/core/src/message/macros.rs
+++ b/crates/core/src/message/macros.rs
@@ -91,7 +91,7 @@ macro_rules! tracked_message_source {
     () => {{ $crate::message_source_from!(::std::panic::Location::caller()) }};
 }
 
-/// Constructs an error [`Message`](crate::message::Message) with the provided
+/// Constructs an error `Message` with the provided
 /// exit code and payload.
 ///
 /// The macro mirrors upstream diagnostics by automatically attaching the
@@ -100,7 +100,7 @@ macro_rules! tracked_message_source {
 /// accepts either a
 /// string literal/`Cow<'static, str>` payload or a [`format!`] style template.
 /// Callers can further customise the returned
-/// [`Message`](crate::message::Message) by chaining helpers such as
+/// `Message` by chaining helpers such as
 /// [`Message::with_role`](crate::message::Message::with_role).
 ///
 /// # Examples
@@ -141,7 +141,7 @@ macro_rules! rsync_error {
     }};
 }
 
-/// Constructs a warning [`Message`](crate::message::Message) from the provided
+/// Constructs a warning `Message` from the provided
 /// payload.
 ///
 /// Like [`macro@rsync_error`], the macro records the call-site source location so
@@ -175,7 +175,7 @@ macro_rules! rsync_warning {
     }};
 }
 
-/// Constructs an informational [`Message`](crate::message::Message) from the
+/// Constructs an informational `Message` from the
 /// provided payload.
 ///
 /// The macro is a convenience wrapper around
@@ -208,7 +208,7 @@ macro_rules! rsync_info {
     }};
 }
 
-/// Constructs a [`Message`](crate::message::Message) using the canonical
+/// Constructs a `Message` using the canonical
 /// wording for a known exit code.
 ///
 /// The macro delegates to

--- a/crates/core/src/message/mod.rs
+++ b/crates/core/src/message/mod.rs
@@ -1,6 +1,6 @@
 //! Diagnostic message formatting utilities.
 //!
-//! This module provides the [`Message`] type and supporting infrastructure for
+//! This module provides the `Message` type and supporting infrastructure for
 //! constructing formatted error and informational messages that match upstream
 //! rsync's output conventions. Messages carry a severity level, optional role
 //! trailer (e.g. `[sender]`, `[receiver]`), and source location metadata.

--- a/crates/core/src/message/role.rs
+++ b/crates/core/src/message/role.rs
@@ -54,7 +54,7 @@ impl Role {
     /// The returned string matches the suffix rendered by upstream rsync. Keeping the
     /// mapping here allows higher layers to reuse the canonical spelling when
     /// constructing out-of-band logs or telemetry derived from
-    /// [`Message`](crate::message::Message) instances.
+    /// `Message` instances.
     ///
     /// # Examples
     ///

--- a/crates/core/src/message/segments/base.rs
+++ b/crates/core/src/message/segments/base.rs
@@ -4,7 +4,7 @@ use std::slice;
 
 use super::super::MAX_MESSAGE_SEGMENTS;
 
-/// Collection of slices that jointly render a [`Message`](crate::message::Message).
+/// Collection of slices that jointly render a `Message`.
 ///
 /// The segments reference the message payload together with optional exit codes, source
 /// locations, and role trailers. Callers obtain the structure through

--- a/crates/core/src/message/segments/mod.rs
+++ b/crates/core/src/message/segments/mod.rs
@@ -1,4 +1,4 @@
-//! Helpers for rendering [`Message`](crate::message::Message) values as vectored slices.
+//! Helpers for rendering `Message` values as vectored slices.
 //!
 //! The [`MessageSegments`] type exposes the low-level representation that the
 //! logging subsystem streams into stdout/stderr. This submodule keeps the

--- a/crates/core/src/message/severity.rs
+++ b/crates/core/src/message/severity.rs
@@ -18,7 +18,7 @@ impl Severity {
     /// Returns the lowercase label used when rendering the severity.
     ///
     /// The strings mirror upstream rsync's diagnostics and therefore feed directly into
-    /// the formatting helpers implemented by [`Message`](crate::message::Message). Exposing the label keeps
+    /// the formatting helpers implemented by `Message`. Exposing the label keeps
     /// external crates from duplicating the canonical wording while still allowing
     /// call sites to branch on the textual representation when building structured
     /// logs or integration tests.

--- a/crates/core/src/message/strings.rs
+++ b/crates/core/src/message/strings.rs
@@ -13,11 +13,11 @@
 //! The module exposes [`ExitCodeMessage`], a light-weight descriptor capturing
 //! the severity, numeric exit code, and upstream text. Callers obtain instances
 //! through [`exit_code_message`] and can immediately convert them into a
-//! [`Message`] via [`ExitCodeMessage::to_message`] or the blanket
+//! `Message` via [`ExitCodeMessage::to_message`] or the blanket
 //! [`From<ExitCodeMessage>`](ExitCodeMessage#impl-From%3CExitCodeMessage%3E-for-Message)
 //! implementation. When only the severity is required, use
 //! [`exit_code_severity`] to query the table without materialising a full
-//! [`Message`]. This mirrors the behaviour of upstream rsync where exit code 24
+//! `Message`. This mirrors the behaviour of upstream rsync where exit code 24
 //! emits a warning while all other entries are treated as errors.
 //!
 //! # Invariants
@@ -28,7 +28,7 @@
 //!
 //! # Errors
 //!
-//! The helpers themselves never fail. Converting a template into a [`Message`]
+//! The helpers themselves never fail. Converting a template into a `Message`
 //! only allocates when the caller subsequently renders the message into an
 //! owned [`String`].
 //!
@@ -53,7 +53,7 @@
 //! )));
 //! ```
 //!
-//! Convert a template directly into a [`Message`] without calling
+//! Convert a template directly into a `Message` without calling
 //! [`ExitCodeMessage::to_message`].
 //!
 //! ```
@@ -168,7 +168,7 @@ impl ExitCodeMessage {
         self.text
     }
 
-    /// Converts the template into a [`Message`] that mirrors upstream output.
+    /// Converts the template into a `Message` that mirrors upstream output.
     #[must_use = "the constructed Message should be rendered so the exit-code diagnostic reaches the user"]
     pub fn to_message(self) -> Message {
         message_from_template(self)

--- a/crates/daemon/src/async_listener.rs
+++ b/crates/daemon/src/async_listener.rs
@@ -43,7 +43,7 @@ use tokio::runtime::Builder;
 
 /// Sync per-connection worker invoked on the blocking pool.
 ///
-/// The worker owns the converted blocking [`TcpStream`] for the lifetime of
+/// The worker owns the converted blocking `TcpStream` for the lifetime of
 /// the connection. Returning an `io::Result` lets the caller surface
 /// transport errors without panicking; panics in the worker are caught by
 /// the tokio join handle and logged by the dispatcher.

--- a/crates/daemon/src/connection/mod.rs
+++ b/crates/daemon/src/connection/mod.rs
@@ -1,6 +1,6 @@
 //! Typed daemon connection lifecycle management.
 //!
-//! Provides [`ConnectionState`] and transition validation for the daemon
+//! Provides `ConnectionState` and transition validation for the daemon
 //! connection lifecycle: `Greeting -> ModuleSelect -> Authenticating ->
 //! Transferring -> Closing`. Every state can also transition directly to
 //! `Closing`.

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -454,7 +454,7 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
 
 include!("daemon/sections/cli_args.rs");
 
-/// Writes a [`Message`] to the given [`MessageSink`].
+/// Writes a `Message` to the given [`MessageSink`].
 ///
 /// Delegates to `sink.write(message)`, providing a uniform call site for
 /// diagnostic output across daemon entry points.

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -10,7 +10,7 @@
 //!
 //! # Exit Code Integration
 //!
-//! `DaemonError` uses the centralized [`ExitCode`] enum from the `core` crate
+//! `DaemonError` uses the centralized `ExitCode` enum from the `core` crate
 //! internally, ensuring consistent exit code handling across the workspace.
 //! The i32 interface is preserved for backward compatibility.
 //!
@@ -26,7 +26,7 @@ use core::message::Message;
 
 /// Error returned when daemon orchestration fails.
 ///
-/// Uses the centralized [`ExitCode`] enum internally for type-safe exit code
+/// Uses the centralized `ExitCode` enum internally for type-safe exit code
 /// handling while maintaining backward compatibility with i32 interfaces.
 #[derive(Clone, Debug)]
 pub struct DaemonError {

--- a/crates/daemon/src/rsyncd_config/sections.rs
+++ b/crates/daemon/src/rsyncd_config/sections.rs
@@ -179,12 +179,12 @@ impl GlobalConfig {
         self.ssl_ca.as_deref()
     }
 
-    /// Builds a [`TlsConfig`](crate::tls::TlsConfig) from the parsed global
+    /// Builds a `TlsConfig` from the parsed global
     /// TLS directives, if both `ssl cert` and `ssl key` are configured.
     ///
     /// Returns `None` when TLS is not configured (neither directive is set).
     /// The caller receives a ready-to-use `TlsConfig` that can be passed
-    /// directly to [`build_tls_acceptor`](crate::tls::build_tls_acceptor).
+    /// directly to `build_tls_acceptor`.
     #[cfg(feature = "daemon-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "daemon-tls")))]
     pub fn tls_config(&self) -> Option<crate::tls::TlsConfig> {

--- a/crates/daemon/src/tls.rs
+++ b/crates/daemon/src/tls.rs
@@ -9,11 +9,11 @@
 //!
 //! The module exposes two operations:
 //!
-//! 1. **[`build_tls_acceptor`]** - loads PEM certificates and a private key
-//!    from disk and constructs a rustls [`TlsAcceptor`] configured with safe
+//! 1. **`build_tls_acceptor`** - loads PEM certificates and a private key
+//!    from disk and constructs a rustls `TlsAcceptor` configured with safe
 //!    defaults (TLS 1.2+, ring crypto provider).
-//! 2. **[`wrap_stream`]** - performs the TLS handshake on an accepted
-//!    [`TcpStream`], returning a [`rustls::StreamOwned`] that implements
+//! 2. **`wrap_stream`** - performs the TLS handshake on an accepted
+//!    `TcpStream`, returning a [`rustls::StreamOwned`] that implements
 //!    `Read + Write` and can be handed to the synchronous per-connection
 //!    worker unchanged.
 //!
@@ -23,7 +23,7 @@
 //!
 //! # Certificate loading
 //!
-//! [`TlsConfig`] accepts filesystem paths for the certificate chain
+//! `TlsConfig` accepts filesystem paths for the certificate chain
 //! (fullchain PEM), the private key (PKCS#8 or RSA PEM), and an optional
 //! client CA bundle for mutual TLS. Certificate rotation requires a daemon
 //! restart; live reload is a future enhancement.
@@ -35,7 +35,7 @@
 //! - The ring crypto provider is used by default, providing FIPS-grade
 //!   primitives without linking to OpenSSL.
 //! - Client certificate verification is opt-in via the `client_ca_path`
-//!   field on [`TlsConfig`].
+//!   field on `TlsConfig`.
 
 use std::fs;
 use std::io;
@@ -73,7 +73,7 @@ pub struct TlsConfig {
     pub client_ca_path: Option<PathBuf>,
 }
 
-/// Loads certificates and private key, then builds a [`TlsAcceptor`].
+/// Loads certificates and private key, then builds a `TlsAcceptor`.
 ///
 /// The acceptor is configured with the ring crypto provider and supports
 /// TLS 1.2 and TLS 1.3. When `config.client_ca_path` is set, client

--- a/crates/engine/src/delete/cohort_batcher.rs
+++ b/crates/engine/src/delete/cohort_batcher.rs
@@ -5,7 +5,7 @@
 //! DEL-2.a [`super::ReorderBuffer`] primitive. It is the DEL-2.b
 //! deliverable: a synchronous consumer-side adapter that surfaces
 //! sealed cohorts in strict wire-ordering rank order, capped at
-//! [`super::DRAIN_BATCH_CAP`] per batch, with the panic-isolation rules
+//! `DRAIN_BATCH_CAP` per batch, with the panic-isolation rules
 //! from DEL-1.c section 6 layered in. The parallel consumer flag flip
 //! and `Condvar`-driven scope wiring are DEL-2.c.
 //!
@@ -102,7 +102,7 @@ impl CohortBatchEntry {
 /// A contiguous-by-rank group of sealed cohorts the consumer drains in
 /// one wake-up.
 ///
-/// The vector is bounded by [`DRAIN_BATCH_CAP`] entries (DEL-1.c section
+/// The vector is bounded by `DRAIN_BATCH_CAP` entries (DEL-1.c section
 /// 3.2's `CONSUMER_DRAIN_BATCH_CAP = 8`). Entries are in strictly
 /// increasing rank order; an empty batch means no cohort at the head
 /// is sealed and the consumer should park for a producer wake-up.
@@ -158,7 +158,7 @@ impl CohortBatch {
 /// - Every [`Self::enqueue_cohort`] call records exactly one cohort:
 ///   one insert per op (or one [`ReorderBuffer::register_empty`] for the
 ///   zero-op case) followed by one seal.
-/// - [`Self::drain_batch`] surfaces at most [`DRAIN_BATCH_CAP`] cohorts
+/// - [`Self::drain_batch`] surfaces at most `DRAIN_BATCH_CAP` cohorts
 ///   per call in strictly increasing rank order, mirroring DEL-1.c
 ///   section 3.2.
 /// - A producer-side panic recorded via [`Self::record_panic`] is
@@ -262,7 +262,7 @@ impl CohortBatcher {
         self.buffer.seal(&key)
     }
 
-    /// Drains up to [`DRAIN_BATCH_CAP`] contiguous-by-rank sealed
+    /// Drains up to `DRAIN_BATCH_CAP` contiguous-by-rank sealed
     /// cohorts into a [`CohortBatch`].
     ///
     /// Returns an empty batch when the head cohort is unsealed; the
@@ -393,7 +393,7 @@ mod tests {
     }
 
     /// DEL-1.c section 3.2: drain cap caps the batch at
-    /// [`DRAIN_BATCH_CAP`] and the next drain picks up the remaining
+    /// `DRAIN_BATCH_CAP` and the next drain picks up the remaining
     /// cohorts in strict rank order. A still-unsealed cohort at the
     /// head blocks the drain entirely - the contiguous-only rule from
     /// DEL-1.b section 2.3 carries through batching unchanged.

--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -1,6 +1,6 @@
 //! [`DeleteContext`] - per-transfer wiring that ties the flist segment
 //! consumer to the parallel-deterministic-delete pipeline and drives the
-//! [`DeleteEmitter`] for every `--delete-*` timing mode.
+//! `DeleteEmitter` for every `--delete-*` timing mode.
 //!
 //! See the parent module documentation for the wiring tables and
 //! channel-based cursor handoff design.
@@ -75,7 +75,7 @@ pub struct DeleteContext {
     /// segment-extras set before [`compute_extras`] runs (see section 5
     /// of the design).
     pub delete_excluded: bool,
-    /// Policy used to instantiate the [`DeleteEmitter`] when the drain
+    /// Policy used to instantiate the `DeleteEmitter` when the drain
     /// runs.
     pub policy: EmitterErrorPolicy,
     /// Names of entries the segment knows about for the current directory
@@ -369,7 +369,7 @@ impl DeleteContext {
     /// DEL-2.d routes the drain through `ParallelDeleteEmitter` so cohort
     /// dispatch runs on rayon while preserving the DEL-1.a cross-cohort
     /// wire-ordering invariant. The sequential
-    /// [`DeleteEmitter`] remains the default.
+    /// `DeleteEmitter` remains the default.
     ///
     /// # Errors
     ///

--- a/crates/engine/src/delete/entry_accessor.rs
+++ b/crates/engine/src/delete/entry_accessor.rs
@@ -12,8 +12,8 @@
 //! | `extras::segment_basenames` | [`segment_basenames_generic`] |
 //! | `extras::compute_extras` | [`compute_extras_generic`] |
 //! | `extras::compute_extras_with_cohorts` | [`compute_extras_with_cohorts_generic`] |
-//! | `traversal::DirTraversalCursor::observe_segment` | [`observe_segment_generic`] |
-//! | `traversal::DirTraversalCursor::observe_segment` | [`collect_child_dirs_generic`] |
+//! | `traversal::DirTraversalCursor::observe_segment` | `observe_segment_generic` |
+//! | `traversal::DirTraversalCursor::observe_segment` | `collect_child_dirs_generic` |
 //! | `cohort_index::CohortIndex::build_from_flist_segment` | [`GenericCohortIndex::build_from_entries`] |
 //!
 //! # Feature gate
@@ -47,7 +47,7 @@ use super::traversal::DirTraversalCursor;
 /// Collects the leaf basenames from a slice of accessor-backed entries into
 /// a hash set keyed by [`OsString`].
 ///
-/// Mirrors [`super::extras::segment_basenames`] but works with any
+/// Mirrors `super::extras::segment_basenames` but works with any
 /// `T: FileEntryAccessor`. The accessor's [`FileEntryAccessor::name`]
 /// returns the full relative path string; we extract the leaf component
 /// the same way the concrete version uses `entry.path().file_name()`.

--- a/crates/engine/src/delete/error.rs
+++ b/crates/engine/src/delete/error.rs
@@ -1,7 +1,7 @@
 //! Typed error variants for the [`super::DeleteContext`] shutdown path.
 //!
 //! The phase-2 drain (`emit_one` / `emit_all`) hands the shared
-//! [`DeletePlanMap`] off to a freshly-built [`DeleteEmitter`] via
+//! `DeletePlanMap` off to a freshly-built `DeleteEmitter` via
 //! [`Arc::try_unwrap`]. When the receiver still holds a clone of the
 //! plan-map handle, or the cursor receiver channel has already been
 //! taken by a prior drain attempt, the drain cannot proceed.
@@ -21,8 +21,6 @@
 //! context value.
 //!
 //! [`Arc::strong_count`]: std::sync::Arc::strong_count
-//! [`DeletePlanMap`]: super::DeletePlanMap
-//! [`DeleteEmitter`]: super::DeleteEmitter
 
 use std::io;
 

--- a/crates/fast_io/src/io_uring_stub/buffer_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/buffer_ring.rs
@@ -87,7 +87,7 @@ pub fn is_supported() -> bool {
 
 /// Returns `false` on non-Linux platforms.
 ///
-/// Cross-platform alias for [`is_supported`] matching the
+/// Cross-platform alias for `is_supported` matching the
 /// [`crate::pbuf_ring_supported`] re-export.
 #[must_use]
 pub fn pbuf_ring_supported() -> bool {

--- a/crates/fast_io/src/io_uring_stub/linked_chain.rs
+++ b/crates/fast_io/src/io_uring_stub/linked_chain.rs
@@ -1,6 +1,6 @@
 //! Stub linked-chain primitive mirroring [`crate::io_uring::linked_chain`].
 //!
-//! The chain cannot be constructed because the stub [`super::session_pool::RingLease`]
+//! The chain cannot be constructed because the stub `super::session_pool::RingLease`
 //! cannot exist on this platform.
 
 use super::session_pool::RingLease;

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -33,7 +33,7 @@ pub mod linkat;
 /// Stub linked-SQE chain API mirroring the Linux backend.
 pub mod linked_chain;
 /// Stub per-thread io_uring ring primitive mirroring the Linux backend
-/// (IUR-3.a). [`with_ring`] always returns
+/// (IUR-3.a). `with_ring` always returns
 /// [`std::io::ErrorKind::Unsupported`] on this platform.
 pub mod per_thread_ring;
 /// Stub registered-buffer API mirroring the Linux backend.

--- a/crates/fast_io/src/io_uring_stub/per_thread_ring.rs
+++ b/crates/fast_io/src/io_uring_stub/per_thread_ring.rs
@@ -1,8 +1,8 @@
 //! Stub per-thread io_uring ring mirroring [`crate::io_uring::per_thread_ring`].
 //!
 //! The Linux backend lazily constructs an `io_uring::IoUring` per thread on
-//! first call to [`with_ring`]. On every other platform the primitive is
-//! inert: [`with_ring`] always returns [`std::io::ErrorKind::Unsupported`]
+//! first call to `with_ring`. On every other platform the primitive is
+//! inert: `with_ring` always returns [`std::io::ErrorKind::Unsupported`]
 //! without invoking the closure so callers can compile cross-platform
 //! against a single surface and dispatch on the returned error.
 //!
@@ -15,7 +15,7 @@ use std::io;
 ///
 /// The Linux backend uses this value when lazily constructing the
 /// per-thread ring. On non-Linux targets the constant is retained so
-/// callers can compile against the same surface; the stub [`with_ring`]
+/// callers can compile against the same surface; the stub `with_ring`
 /// always returns [`io::ErrorKind::Unsupported`].
 pub const DEFAULT_RING_DEPTH: u32 = 64;
 

--- a/crates/fast_io/src/io_uring_stub/send_zc.rs
+++ b/crates/fast_io/src/io_uring_stub/send_zc.rs
@@ -1,7 +1,7 @@
 //! Stub `IORING_OP_SEND_ZC` module mirroring [`crate::io_uring::send_zc`] on
 //! non-Linux platforms or when the `io_uring` cargo feature is disabled.
 //!
-//! [`is_supported`] always returns `false` and [`try_send_zc`] always returns
+//! `is_supported` always returns `false` and `try_send_zc` always returns
 //! `Unsupported`. This keeps cross-platform call sites (and the socket
 //! writer's fallback path) compiling without `cfg`-gating each reference.
 //!

--- a/crates/fast_io/src/temp_file_strategy.rs
+++ b/crates/fast_io/src/temp_file_strategy.rs
@@ -4,12 +4,12 @@
 //! guard from platform-specific temp file mechanisms. Implementations select
 //! the best available mechanism at runtime:
 //!
-//! - **Linux**: [`AnonymousTempFileStrategy`] uses `O_TMPFILE` + `linkat(2)`
+//! - **Linux**: `AnonymousTempFileStrategy` uses `O_TMPFILE` + `linkat(2)`
 //!   for zero-cleanup atomic writes. No directory entry exists until commit.
 //! - **Windows**: `WindowsTempFileStrategy` uses `FILE_FLAG_DELETE_ON_CLOSE`
 //!   for auto-cleanup temp files. The kernel deletes the file when the last
 //!   handle closes, providing crash-safe cleanup analogous to `O_TMPFILE`.
-//! - **All platforms**: [`NamedTempFileStrategy`] uses a uniquely-named temp
+//! - **All platforms**: `NamedTempFileStrategy` uses a uniquely-named temp
 //!   file + `rename(2)` for atomic commit, with cross-device fallback.
 //!
 //! The [`DefaultTempFileStrategy`] automatically selects the best available
@@ -327,10 +327,10 @@ impl TempFileStrategy for NamedTempFileStrategy {
 /// mechanism at runtime.
 ///
 /// - **Linux**: probes `O_TMPFILE` on the destination filesystem. If available,
-///   uses anonymous temp files via [`AnonymousTempFileStrategy`].
+///   uses anonymous temp files via `AnonymousTempFileStrategy`.
 /// - **Windows**: probes `FILE_FLAG_DELETE_ON_CLOSE`. If available, uses
 ///   delete-on-close temp files via `WindowsTempFileStrategy`.
-/// - **All platforms**: falls back to named temp files via [`NamedTempFileStrategy`].
+/// - **All platforms**: falls back to named temp files via `NamedTempFileStrategy`.
 pub struct DefaultTempFileStrategy {
     named: NamedTempFileStrategy,
 }

--- a/crates/logging-sink/src/sink/message_sink/writing.rs
+++ b/crates/logging-sink/src/sink/message_sink/writing.rs
@@ -18,7 +18,7 @@ where
 
     /// Writes a single message using the sink's current [`LineMode`].
     ///
-    /// Accepts borrowed or owned [`Message`] values via [`Borrow<Message>`] so
+    /// Accepts borrowed or owned `Message` values via [`Borrow<Message>`] so
     /// call sites can forward diagnostics without cloning.
     pub fn write<M>(&mut self, message: M) -> io::Result<()>
     where
@@ -43,7 +43,7 @@ where
 
     /// Streams pre-rendered [`MessageSegments`] into the underlying writer.
     ///
-    /// The helper allows callers that already rendered a [`Message`] into
+    /// The helper allows callers that already rendered a `Message` into
     /// vectored slices (for example, to inspect or buffer them) to forward the
     /// segments without requesting another render. The sink honours its
     /// configured [`LineMode`] when deciding whether to append a trailing
@@ -85,7 +85,7 @@ where
 
     /// Writes each message from the iterator to the underlying writer.
     ///
-    /// Items may be borrowed or owned [`Message`] values via
+    /// Items may be borrowed or owned `Message` values via
     /// [`Borrow<Message>`], so callers can pass collections such as
     /// [`Vec<Message>`] or arrays directly.
     pub fn write_all<I, M>(&mut self, messages: I) -> io::Result<()>

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -483,7 +483,7 @@ pub struct ServerConfig {
     ///
     /// Sourced from the daemon module's `munge symlinks` directive (or its
     /// `!use_chroot` auto default). Mirrors upstream's `munge_symlinks`
-    /// global. Propagated into [`ParsedServerFlags::munge_symlinks`] when the
+    /// global. Propagated into `ParsedServerFlags::munge_symlinks` when the
     /// server config is consumed so the sender (strip on `readlink()`) and
     /// receiver (prepend on `symlink()` write) apply the bidirectional
     /// transform.

--- a/crates/transfer/src/delta_pipeline/chunk_builder.rs
+++ b/crates/transfer/src/delta_pipeline/chunk_builder.rs
@@ -1,7 +1,7 @@
 //! Wire-token to [`DeltaChunk`] adapter for the parallel receive-delta path.
 //!
 //! Closes the receiver-side verify gap left open by BR-3i.c (#4640): the
-//! [`ParallelDeltaApplier`] grew a real `verify_chunk` that compares the
+//! `ParallelDeltaApplier` grew a real `verify_chunk` that compares the
 //! computed strong digest of `chunk.data` against the chunk's
 //! `expected_strong` field, but the receiver had no way to populate that
 //! field for COPY tokens. Without a populated `expected_strong`, the verify
@@ -25,7 +25,7 @@
 //! Literal tokens leave `expected_strong = None`: the sender does not
 //! embed per-literal digests, so there is nothing to verify against. The
 //! applier still computes the digest for parity with the verified path
-//! (see [`ParallelDeltaApplier::verify_chunk`] in
+//! (see `ParallelDeltaApplier::verify_chunk` in
 //! `crates/engine/src/concurrent_delta/parallel_apply.rs`) but skips the
 //! comparison, exactly as BR-3i.c documents.
 //!
@@ -43,8 +43,8 @@
 //! function from `(FileSignature, DeltaToken, basis-bytes, sequence)` to
 //! `Option<DeltaChunk>`, which keeps the per-chunk verify decision local
 //! to the receiver-side staging structure and leaves the live token loop
-//! in [`crate::transfer_ops::token_loop`] untouched until the production
-//! pipeline migrates onto [`ParallelDeltaApplier`].
+//! in `crate::transfer_ops::token_loop` untouched until the production
+//! pipeline migrates onto `ParallelDeltaApplier`.
 
 use checksums::strong::strategy::ChecksumDigest;
 use engine::concurrent_delta::{DeltaChunk, FileNdx};
@@ -92,7 +92,7 @@ pub enum ChunkBuilderError {
 /// One builder lives for the duration of a single file's delta apply. The
 /// caller bumps the sequence counter once per produced chunk, mirroring the
 /// per-file `chunk_sequence` invariant that
-/// [`ParallelDeltaApplier::apply_one_chunk`] documents.
+/// `ParallelDeltaApplier::apply_one_chunk` documents.
 ///
 /// # Per-file lifetime
 ///
@@ -105,7 +105,7 @@ pub enum ChunkBuilderError {
 /// # File-boundary drain contract (PIP-9.b.4)
 ///
 /// After the last chunk for a file has been submitted to the applier, the
-/// receiver must call [`ParallelDeltaApplier::finish_file`] before moving
+/// receiver must call `ParallelDeltaApplier::finish_file` before moving
 /// to the next file. `finish_file` bakes in a [`flush_workers`] barrier
 /// that waits for all in-flight chunks to drain, so callers never need to
 /// call `flush_workers` separately. This ensures that the per-file writer
@@ -123,7 +123,7 @@ pub struct ChunkBuilder<'a> {
 impl<'a> ChunkBuilder<'a> {
     /// Creates a builder for a single file's delta apply.
     ///
-    /// `ndx` is the [`FileNdx`] the [`ParallelDeltaApplier`] uses to route
+    /// `ndx` is the [`FileNdx`] the `ParallelDeltaApplier` uses to route
     /// chunks to the per-file writer; the receiver pipeline derives this
     /// from the wire NDX it assigns when it opens the destination temp
     /// file.

--- a/crates/transfer/src/generator/entry_accessor.rs
+++ b/crates/transfer/src/generator/entry_accessor.rs
@@ -28,10 +28,10 @@ use super::itemize::ItemizeContext;
 
 /// Formats the 11-character itemize string from raw item flags and any entry type.
 ///
-/// Generic counterpart of [`super::itemize::format_iflags`] that accepts any
+/// Generic counterpart of `super::itemize::format_iflags` that accepts any
 /// `FileEntryAccessor` implementor instead of a concrete `FileEntry`.
 ///
-/// Produces the upstream `YXcstpoguax` string. See [`super::itemize::format_iflags`]
+/// Produces the upstream `YXcstpoguax` string. See `super::itemize::format_iflags`
 /// for full documentation of each position.
 ///
 /// # Upstream Reference
@@ -225,7 +225,7 @@ pub fn format_itemize_line_generic<T: FileEntryAccessor>(
 
 /// Pure-function quick-check over any `FileEntryAccessor`.
 ///
-/// Generic counterpart of [`super::super::receiver::quick_check::quick_check_matches`].
+/// Generic counterpart of `super::super::receiver::quick_check::quick_check_matches`.
 /// Returns `true` when the destination file matches the source entry (skip transfer).
 ///
 /// Follows upstream `generator.c:617 quick_check_ok()` evaluation order:

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -139,7 +139,7 @@ impl GeneratorContext {
     /// Unlike [`build_file_list`](Self::build_file_list), which treats each
     /// positional argument as its own base for `walk_path`, this method honors
     /// the per-entry base produced by
-    /// [`split_files_from_entry`](super::super::filters::split_files_from_entry).
+    /// `split_files_from_entry`.
     /// Each entry's wire-side relative name is computed by stripping its own
     /// `base`, matching upstream rsync's `chdir(dir)` + transmit-`fn` split
     /// (`flist.c:2316-2330`). The `base_dir` argument is the source argument

--- a/crates/transfer/src/generator/sender_accessor.rs
+++ b/crates/transfer/src/generator/sender_accessor.rs
@@ -27,7 +27,7 @@ use super::itemize::ItemizeContext;
 
 /// Formats the 11-character itemize string from raw item flags and a generic entry.
 ///
-/// Trait-generic version of [`super::itemize::format_iflags`]. Accepts any type
+/// Trait-generic version of `super::itemize::format_iflags`. Accepts any type
 /// implementing [`FileEntryAccessor`] instead of concrete `&FileEntry`.
 ///
 /// Produces the upstream `YXcstpoguax` string where:


### PR DESCRIPTION
## Summary

Pages CI (run [27489245771](https://github.com/oferchen/rsync/actions/runs/27489245771)) failed with 31 unresolved intra-doc links across 14 unique symbols in `cli`, `core`, `daemon`, `engine`, `fast_io`, `logging-sink`, and `transfer`. The prior fix (#5757) only addressed `rsync_io`; local validation was crate-scoped (`cargo doc -p rsync_io`) and missed the rest of the workspace.

This PR converts each broken `[\`X\`]` link to plain backticks `` `X` ``. The targeted symbols are either cfg-gated (e.g. `AnonymousTempFileStrategy`, `with_ring`, `try_send_zc`), private (`SharedBatcher`), or referenced via paths rustdoc cannot resolve under the workspace docs-build configuration.

## Test plan

- [x] `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --workspace --all-features --no-deps --locked` succeeds locally with zero broken-intra-doc-link errors
- [x] `cargo fmt --all` clean
- [ ] Pages workflow on master goes green after merge