### PR TITLE
fix(filters): align local-copy filter program with upstream rule_matches semantics

### DIFF
--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -2,6 +2,7 @@
 //! protect/risk, and exclude-if-present rules sequentially with first-match
 //! semantics, mirroring upstream `exclude.c` rule traversal.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -49,7 +50,7 @@ impl FilterSegment {
     /// excluded by a dir-only rule or included, and `None` if no rule matched.
     pub(crate) fn excluded_dir_by_non_dir_rule(&self, path: &Path) -> Option<bool> {
         for rule in &self.include_exclude {
-            if rule.applies_to_sender && rule.matches(path, true) {
+            if rule.applies_to_sender && rule.matches(path, true, false) {
                 if matches!(rule.action, FilterAction::Exclude) {
                     return Some(!rule.directory_only);
                 }
@@ -66,11 +67,18 @@ impl FilterSegment {
         outcome: &mut FilterOutcome,
         context: FilterContext,
     ) {
+        // upstream: exclude.c:rule_matches() has NO descendant matching at all.
+        // The sender's traversal prunes excluded directories so children are
+        // never examined; the receiver's deletion scan only enters dirs that
+        // exist in the file list. Skipping descendants here mirrors upstream's
+        // literal name-match semantics and prevents anchored patterns like
+        // `- /bar` from over-matching deep paths (UTS-V3-B exclude-lsh).
+        let check_descendants = false;
         for rule in &self.include_exclude {
             if outcome.transfer_decided() {
                 break;
             }
-            if rule.matches(path, is_dir) {
+            if rule.matches(path, is_dir, check_descendants) {
                 if matches!(context, FilterContext::Deletion) && rule.applies_to_receiver {
                     outcome.set_delete_excluded(matches!(rule.action, FilterAction::Exclude));
                 }
@@ -100,7 +108,7 @@ impl FilterSegment {
             if matches!(context, FilterContext::Deletion) && rule.perishable {
                 continue;
             }
-            if rule.matches(path, is_dir) {
+            if rule.matches(path, is_dir, check_descendants) {
                 let applies = match context {
                     FilterContext::Transfer => rule.applies_to_sender,
                     FilterContext::Deletion => rule.applies_to_receiver,
@@ -233,10 +241,19 @@ impl CompiledRule {
         // upstream: exclude.c - excluding a directory excludes its contents,
         // but including a directory does NOT include its contents (they must
         // match their own rules). Only Exclude/Protect/Risk get descendants.
+        //
+        // Anchored wildcard patterns (e.g., `/*`, `/*.txt`) must NOT generate
+        // descendant matchers because `*/**` would incorrectly match nested
+        // paths like `down/file.txt`. Traversal control on the sender side
+        // handles directory exclusion for those cases.
+        let has_glob_wildcard =
+            core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
+        let slash_anchored = pattern.starts_with('/');
         if matches!(
             action,
             FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
-        ) {
+        ) && !(slash_anchored && has_glob_wildcard)
+        {
             descendant_patterns.insert(format!("{core_pattern}/**"));
             if !anchored {
                 descendant_patterns.insert(format!("**/{core_pattern}/**"));
@@ -254,16 +271,21 @@ impl CompiledRule {
         })
     }
 
-    fn matches(&self, path: &Path, is_dir: bool) -> bool {
+    fn matches(&self, path: &Path, is_dir: bool, check_descendants: bool) -> bool {
         for matcher in &self.direct_matchers {
             if matcher.is_match(path) && (!self.directory_only || is_dir) {
                 return true;
             }
         }
 
-        for matcher in &self.descendant_matchers {
-            if matcher.is_match(path) {
-                return true;
+        // upstream: exclude.c:rule_matches() does not expand patterns into
+        // descendant matchers. Descendants are only consulted when a caller
+        // explicitly opts in.
+        if check_descendants {
+            for matcher in &self.descendant_matchers {
+                if matcher.is_match(path) {
+                    return true;
+                }
             }
         }
 
@@ -275,7 +297,21 @@ fn compile_patterns(
     patterns: HashSet<String>,
     original: &str,
 ) -> Result<Vec<GlobMatcher>, super::FilterProgramError> {
-    let mut unique: Vec<_> = patterns.into_iter().collect();
+    // upstream: lib/wildmatch.c:dowild() - bare `**` always matches across
+    // `/`. globset's `literal_separator(true)` only treats `**` as recursive
+    // when bounded by `/`, so each pattern expands into two variants: the
+    // original (covers in-segment `*`-like behaviour) and a slash-bounded
+    // rewrite (covers cross-segment matches). Both are added so either form
+    // can satisfy upstream parity.
+    let mut expanded: HashSet<String> = HashSet::with_capacity(patterns.len() * 2);
+    for pattern in patterns {
+        if let Cow::Owned(rewritten) = normalise_recursive_wildcards(&pattern) {
+            expanded.insert(rewritten);
+        }
+        expanded.insert(pattern);
+    }
+
+    let mut unique: Vec<_> = expanded.into_iter().collect();
     unique.sort();
 
     let mut matchers = Vec::with_capacity(unique.len());
@@ -291,25 +327,108 @@ fn compile_patterns(
     Ok(matchers)
 }
 
-/// Normalizes a pattern by stripping leading `/` (anchored) and trailing `/`
-/// (directory-only).
+/// Rewrites bare interior `**` sequences into slash-delimited `/**/` so
+/// globset treats them as recursive wildcards.
 ///
-/// A pattern is anchored if it starts with `/` or contains `/` anywhere in the
-/// core pattern. This mirrors upstream rsync's `exclude.c:parse_filter_str()`
-/// where `FILTRULE_ABS_PATH` is set for patterns containing path separators.
+/// upstream: `lib/wildmatch.c:dowild()` - when `**` is encountered, the
+/// `special` flag is set and the wildcard matches across `/` boundaries
+/// regardless of surrounding characters. A pattern like `foo**too` must be
+/// rewritten to `foo/**/too` so globset matches `bar/down/to/foo/too`.
+///
+/// Runs of three or more `*` characters collapse to `**` first, matching
+/// upstream's `while (*++p == '*') {}` consumption.
+fn normalise_recursive_wildcards(pattern: &str) -> Cow<'_, str> {
+    if !pattern.contains("**") {
+        return Cow::Borrowed(pattern);
+    }
+
+    let bytes = pattern.as_bytes();
+    let mut out = String::with_capacity(bytes.len() + 4);
+    let mut cut = 0;
+    let mut i = 0;
+    let mut changed = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
+        if b == b'*' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
+            let run_start = i;
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] == b'*' {
+                j += 1;
+            }
+
+            out.push_str(&pattern[cut..run_start]);
+
+            if j - run_start > 2 {
+                changed = true;
+            }
+            let at_start = run_start == 0;
+            let at_end = j == bytes.len();
+            let prev_is_slash = run_start > 0 && bytes[run_start - 1] == b'/';
+            let next_is_slash = j < bytes.len() && bytes[j] == b'/';
+
+            let need_leading_slash = !at_start && !prev_is_slash;
+            let need_trailing_slash = !at_end && !next_is_slash;
+
+            if need_leading_slash {
+                out.push('/');
+                changed = true;
+            }
+            out.push_str("**");
+            if need_trailing_slash {
+                out.push('/');
+                changed = true;
+            }
+            i = j;
+            cut = j;
+            continue;
+        }
+        i += 1;
+    }
+
+    if !changed {
+        return Cow::Borrowed(pattern);
+    }
+
+    out.push_str(&pattern[cut..]);
+    Cow::Owned(out)
+}
+
+/// Normalizes a pattern by stripping leading `/` (anchored) and trailing `/`
+/// or `/***` (directory-only).
+///
+/// upstream: `exclude.c:rule_matches()` - `FILTRULE_ABS_PATH` is set only for
+/// patterns starting with `/`. A pattern with internal slashes but no leading
+/// `/` is NOT anchored; upstream tail-matches it against the last N+1 path
+/// components. The glob equivalent is `**/pattern`, which the caller adds for
+/// unanchored patterns.
 fn normalise_pattern(pattern: &str) -> (bool, bool, String) {
     let starts_with_slash = pattern.starts_with('/');
-    let directory_only = pattern.ends_with('/');
-    let mut core = pattern;
-    if starts_with_slash {
-        core = &core[1..];
-    }
-    if directory_only && !core.is_empty() {
-        core = &core[..core.len() - 1];
-    }
-    let has_internal_slash = core.contains('/');
-    let anchored = starts_with_slash || has_internal_slash;
-    (anchored, directory_only, core.to_owned())
+
+    // upstream: exclude.c:243-248 - a trailing `/***` (SLASH_WILD3_SUFFIX)
+    // means "match both the directory and everything inside it". Normalize
+    // by stripping `/***` and treating the result as directory-only.
+    let (stripped, directory_only) = if pattern.ends_with("/***") && pattern.len() > 4 {
+        (&pattern[..pattern.len() - 4], true)
+    } else if pattern.ends_with('/') && pattern.len() > 1 {
+        (&pattern[..pattern.len() - 1], true)
+    } else if pattern == "/" {
+        (pattern, true)
+    } else {
+        (pattern, false)
+    };
+
+    let core_pattern = if starts_with_slash {
+        stripped.strip_prefix('/').unwrap_or(stripped)
+    } else {
+        stripped
+    };
+
+    (starts_with_slash, directory_only, core_pattern.to_owned())
 }
 
 #[cfg(test)]
@@ -421,31 +540,123 @@ mod tests {
     #[test]
     fn include_directory_only_no_descendant_match() {
         let rule = CompiledRule::new(FilterRule::include("*/".to_owned())).unwrap();
-        assert!(rule.matches(Path::new("subdir"), true));
+        assert!(rule.matches(Path::new("subdir"), true, true));
         // Files inside an included directory must still match a separate rule;
         // include never expands to descendants. See `CompiledRule::new`.
-        assert!(!rule.matches(Path::new("file.txt"), false));
-        assert!(!rule.matches(Path::new("subdir/debug.log"), false));
-        assert!(!rule.matches(Path::new("subdir/report.csv"), false));
+        assert!(!rule.matches(Path::new("file.txt"), false, true));
+        assert!(!rule.matches(Path::new("subdir/debug.log"), false, true));
+        assert!(!rule.matches(Path::new("subdir/report.csv"), false, true));
     }
 
-    /// Verifies `--exclude '*/'` DOES match files inside excluded directories.
+    /// `--exclude '*/'` exposes descendant matchers, but the per-entry filter
+    /// path (`FilterSegment::apply`) does NOT consult them. This mirrors
+    /// upstream `exclude.c:rule_matches()` which has no descendant logic at
+    /// all; descendants only fire when a caller explicitly asks for them
+    /// outside the normal traversal-driven evaluation.
     #[test]
-    fn exclude_directory_only_has_descendant_match() {
+    fn exclude_directory_only_descendant_gated_on_check_descendants() {
         let rule = CompiledRule::new(FilterRule::exclude("*/".to_owned())).unwrap();
-        assert!(rule.matches(Path::new("subdir"), true));
-        // Excluded directories also match descendants so their contents are
-        // skipped without a separate rule per file.
-        assert!(rule.matches(Path::new("subdir/debug.log"), false));
+        assert!(rule.matches(Path::new("subdir"), true, false));
+        assert!(rule.matches(Path::new("subdir/debug.log"), false, true));
+        assert!(!rule.matches(Path::new("subdir/debug.log"), false, false));
     }
 
-    /// Verifies patterns with internal `/` are treated as anchored.
+    /// Verifies patterns with internal `/` but no leading `/` are NOT
+    /// anchored - upstream sets `FILTRULE_ABS_PATH` only for a leading `/`.
+    /// Internal slashes drive tail-matching via the `**/pattern` direct
+    /// variant added in `CompiledRule::new`.
     #[test]
-    fn normalise_pattern_internal_slash_anchors() {
+    fn normalise_pattern_internal_slash_is_unanchored() {
         let (anchored, directory_only, core) = normalise_pattern("src/lib/");
-        assert!(anchored);
+        assert!(!anchored);
         assert!(directory_only);
         assert_eq!(core, "src/lib");
+    }
+
+    /// `- /bar` is anchored and must NOT match `bar/down` (or deeper paths)
+    /// through `FilterSegment::apply`. The sender's traversal handles the
+    /// directory-exclusion side-effect; the per-entry filter path mirrors
+    /// upstream `rule_matches()` literal-only matching. Regression coverage
+    /// for the UTS-V3-B exclude-lsh failure.
+    #[test]
+    fn anchored_exclude_does_not_overmatch_children_via_apply() {
+        let mut segment = FilterSegment::default();
+        segment
+            .push_rule(FilterRule::exclude("/bar".to_owned()))
+            .unwrap();
+
+        let mut bar_outcome = FilterOutcome::default();
+        segment.apply(
+            Path::new("bar"),
+            true,
+            &mut bar_outcome,
+            FilterContext::Transfer,
+        );
+        assert!(!bar_outcome.allows_transfer(), "the dir `bar` is excluded");
+
+        let mut child_outcome = FilterOutcome::default();
+        segment.apply(
+            Path::new("bar/down"),
+            true,
+            &mut child_outcome,
+            FilterContext::Transfer,
+        );
+        assert!(
+            child_outcome.allows_transfer(),
+            "`bar/down` must not be over-matched via descendant expansion"
+        );
+
+        let mut deep_outcome = FilterOutcome::default();
+        segment.apply(
+            Path::new("bar/down/to/foo/file1"),
+            false,
+            &mut deep_outcome,
+            FilterContext::Transfer,
+        );
+        assert!(
+            deep_outcome.allows_transfer(),
+            "deep paths under `bar/` must not be over-matched"
+        );
+    }
+
+    /// `- foo/*/` is unanchored despite the internal slash. After the
+    /// anchoring fix it gains a `**/foo/*` direct matcher so `mid/for/foo/and`
+    /// matches via tail anchor and the receiver's `--delete-excluded` path
+    /// removes the dest entry. Regression coverage for UTS-V3-B exclude-lsh.
+    #[test]
+    fn unanchored_internal_slash_matches_via_tail() {
+        let mut segment = FilterSegment::default();
+        segment
+            .push_rule(FilterRule::exclude("foo/*/".to_owned()))
+            .unwrap();
+
+        let mut outcome = FilterOutcome::default();
+        segment.apply(
+            Path::new("mid/for/foo/and"),
+            true,
+            &mut outcome,
+            FilterContext::Deletion,
+        );
+        assert!(
+            !outcome.allows_transfer(),
+            "`mid/for/foo/and` must match `- foo/*/` via tail anchor `**/foo/*`"
+        );
+        assert!(
+            outcome.allows_deletion_when_excluded_removed(),
+            "matching exclude rule must enable --delete-excluded removal"
+        );
+    }
+
+    /// `+ foo**too` must match cross-segment paths after recursive wildcard
+    /// normalisation, preserving UTS-20 parity inside the filter program
+    /// compilation path.
+    #[test]
+    fn bare_double_star_matches_across_segments() {
+        let rule = CompiledRule::new(FilterRule::include("foo**too".to_owned())).unwrap();
+        assert!(rule.matches(Path::new("bar/down/to/foo/too"), true, false));
+        assert!(rule.matches(Path::new("foo/too"), true, false));
+        assert!(rule.matches(Path::new("fooxytoo"), false, false));
+        assert!(!rule.matches(Path::new("foo/bar"), false, false));
     }
 
     #[test]

--- a/crates/engine/src/local_copy/tests/execute_filter_program.rs
+++ b/crates/engine/src/local_copy/tests/execute_filter_program.rs
@@ -1,4 +1,3 @@
-
 // Filter program engine tests
 //
 // Exercises the filter evaluation engine (FilterOutcome, FilterSegment,
@@ -106,10 +105,7 @@ fn filter_segment_include_glob_pattern() {
     );
     // An include rule that doesn't match leaves the outcome unchanged (still
     // at default = allowed).
-    assert!(
-        outcome2.allows_transfer(),
-        "*.rs must not affect readme.md"
-    );
+    assert!(outcome2.allows_transfer(), "*.rs must not affect readme.md");
 }
 
 #[test]
@@ -355,10 +351,7 @@ fn filter_program_multiple_segments_compose() {
         None,
         FilterContext::Transfer,
     );
-    assert!(
-        !outcome2.allows_transfer(),
-        "random.tmp must be blocked"
-    );
+    assert!(!outcome2.allows_transfer(), "random.tmp must be blocked");
 
     // readme.txt is not matched by either rule, stays allowed.
     let outcome3 = program.evaluate(
@@ -368,10 +361,7 @@ fn filter_program_multiple_segments_compose() {
         None,
         FilterContext::Transfer,
     );
-    assert!(
-        outcome3.allows_transfer(),
-        "readme.txt must remain allowed"
-    );
+    assert!(outcome3.allows_transfer(), "readme.txt must remain allowed");
 }
 
 #[test]
@@ -467,14 +457,30 @@ fn filter_segment_directory_only_pattern_matches_dirs() {
 }
 
 #[test]
-fn filter_segment_directory_only_excludes_descendants() {
+fn filter_segment_directory_only_excludes_via_traversal_pruning() {
     let mut segment = FilterSegment::default();
     segment
         .push_rule(FilterRule::exclude("build/"))
         .expect("exclude build/");
 
-    // A file inside the build directory should be excluded because the
-    // descendant matcher "build/**" (and "**/build/**") catches it.
+    // upstream: exclude.c:rule_matches() has no descendant matching. The
+    // directory entry itself matches and the sender's traversal pruning
+    // prevents the children from ever reaching the filter check. The
+    // per-entry filter path mirrors that and does NOT match descendants
+    // by default, so callers that bypass traversal pruning see the
+    // children pass through.
+    let mut dir_outcome = FilterOutcome::default();
+    segment.apply(
+        Path::new("build"),
+        true,
+        &mut dir_outcome,
+        FilterContext::Transfer,
+    );
+    assert!(
+        !dir_outcome.allows_transfer(),
+        "the dir `build/` itself must match the directory-only exclude"
+    );
+
     let mut outcome = FilterOutcome::default();
     segment.apply(
         Path::new("build/output.o"),
@@ -483,8 +489,8 @@ fn filter_segment_directory_only_excludes_descendants() {
         FilterContext::Transfer,
     );
     assert!(
-        !outcome.allows_transfer(),
-        "files inside an excluded directory must be blocked"
+        outcome.allows_transfer(),
+        "files reached without traversal pruning fall through; the directory exclude is honoured by skipping the walk into `build/`"
     );
 }
 
@@ -659,13 +665,8 @@ fn filter_program_empty_allows_everything() {
         ("dir/nested/file.rs", false),
         ("somedir", true),
     ] {
-        let outcome = program.evaluate(
-            Path::new(path),
-            *is_dir,
-            &[],
-            None,
-            FilterContext::Transfer,
-        );
+        let outcome =
+            program.evaluate(Path::new(path), *is_dir, &[], None, FilterContext::Transfer);
         assert!(
             outcome.allows_transfer(),
             "empty program must allow '{path}'"
@@ -838,8 +839,7 @@ fn filter_segment_delete_excluded_protected_path() {
     );
 
     assert!(
-        !outcome.allows_deletion_when_excluded_removed()
-            || !outcome.allows_deletion(),
+        !outcome.allows_deletion_when_excluded_removed() || !outcome.allows_deletion(),
         "protected excluded path must not be deletable even with delete_excluded"
     );
 }
@@ -1047,10 +1047,7 @@ fn filter_program_clear_entry_resets_all_rules() {
         None,
         FilterContext::Transfer,
     );
-    assert!(
-        outcome_txt.allows_transfer(),
-        "*.txt rule must be cleared"
-    );
+    assert!(outcome_txt.allows_transfer(), "*.txt rule must be cleared");
 
     // The *.log exclude added after clear should still be active.
     let outcome_log = program.evaluate(
@@ -1080,9 +1077,7 @@ fn filter_program_exclude_if_present_with_marker() {
     .expect("compile program");
 
     assert!(
-        program
-            .should_exclude_directory(dir)
-            .expect("marker check"),
+        program.should_exclude_directory(dir).expect("marker check"),
         "directory with .nobackup marker must be excluded"
     );
 }
@@ -1125,26 +1120,14 @@ fn filter_program_upstream_typical_pattern() {
     ];
 
     for &(path, expected_transfer, expected_deletion) in cases {
-        let transfer = program.evaluate(
-            Path::new(path),
-            false,
-            &[],
-            None,
-            FilterContext::Transfer,
-        );
+        let transfer = program.evaluate(Path::new(path), false, &[], None, FilterContext::Transfer);
         assert_eq!(
             transfer.allows_transfer(),
             expected_transfer,
             "transfer for '{path}': expected={expected_transfer}"
         );
 
-        let deletion = program.evaluate(
-            Path::new(path),
-            false,
-            &[],
-            None,
-            FilterContext::Deletion,
-        );
+        let deletion = program.evaluate(Path::new(path), false, &[], None, FilterContext::Deletion);
         assert_eq!(
             deletion.allows_deletion(),
             expected_deletion,
@@ -1176,13 +1159,7 @@ fn filter_program_include_only_specific_extensions() {
     ];
 
     for &(path, expected_allowed) in cases {
-        let outcome = program.evaluate(
-            Path::new(path),
-            false,
-            &[],
-            None,
-            FilterContext::Transfer,
-        );
+        let outcome = program.evaluate(Path::new(path), false, &[], None, FilterContext::Transfer);
         assert_eq!(
             outcome.allows_transfer(),
             expected_allowed,
@@ -1193,9 +1170,7 @@ fn filter_program_include_only_specific_extensions() {
 
 #[test]
 fn filter_program_invalid_pattern_returns_error() {
-    let result = FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude(
-        "bad[pattern",
-    ))]);
+    let result = FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude("bad[pattern"))]);
     assert!(
         result.is_err(),
         "invalid glob pattern must produce an error"
@@ -1254,9 +1229,8 @@ fn filter_program_is_empty_true_for_empty_iter() {
 
 #[test]
 fn filter_program_is_empty_false_with_exclude() {
-    let program =
-        FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude("*.tmp"))])
-            .expect("program with exclude");
+    let program = FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude("*.tmp"))])
+        .expect("program with exclude");
     assert!(!program.is_empty());
 }
 

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -32,12 +32,15 @@ impl FilterSetInner {
     ) -> FilterDecision {
         let mut decision = FilterDecision::default();
 
-        // upstream: exclude.c:rule_matches() has NO descendant matching.
-        // Sender-side (Transfer) skips descendants - the walk implicitly
-        // handles them by not descending into excluded directories.
-        // Receiver-side (Deletion) needs descendants because it evaluates
-        // paths individually without traversal context.
-        let check_descendants = matches!(context, DecisionContext::Deletion);
+        // FilterSet callers query the filter chain WITHOUT a traversal-control
+        // context, so they expect descendants of an excluded directory to also
+        // be reported as excluded (e.g. `set.allows("build/output.bin")` after
+        // `- build/`). Descendant matchers are kept active for both contexts.
+        // The traversal-driven local-copy path uses the parallel
+        // engine::local_copy::filter_program implementation which mirrors
+        // upstream `exclude.c:rule_matches()` literal semantics; that path
+        // disables descendants where children would over-match (UTS-V3-B).
+        let check_descendants = true;
 
         let transfer_rule = match context {
             DecisionContext::Transfer => first_matching_rule(

--- a/crates/filters/src/tests.rs
+++ b/crates/filters/src/tests.rs
@@ -138,16 +138,19 @@ fn include_rule_for_directory_restores_descendants() {
 
 #[test]
 fn relative_path_conversion_handles_dot_components() {
-    // Internal slash anchors the pattern to the transfer root. globset does
-    // not normalise `foo/../foo/bar`, so the anchored pattern misses it; use
-    // `**/foo/bar` to match at any depth.
+    // upstream: exclude.c:rule_matches() lines 947-951 - a pattern with an
+    // internal slash but no leading `/` tail-matches against the last N+1
+    // path components. So `- foo/bar` excludes both `foo/bar` and any path
+    // whose last two components are `foo, bar`, including
+    // `foo/../foo/bar`. The glob equivalent is the `**/foo/bar` direct
+    // matcher generated for unanchored patterns with internal slashes.
     let set = FilterSet::from_rules([FilterRule::exclude("foo/bar")]).expect("compiled");
 
     let mut path = PathBuf::from("foo");
     path.push("..");
     path.push("foo");
     path.push("bar");
-    assert!(set.allows(&path, false));
+    assert!(!set.allows(&path, false));
 
     assert!(!set.allows(Path::new("foo/bar"), false));
 }

--- a/crates/filters/tests/glob_patterns.rs
+++ b/crates/filters/tests/glob_patterns.rs
@@ -370,17 +370,25 @@ fn anchored_matches_only_root() {
     assert!(set.allows(Path::new("a/target"), false)); // Not at root
 }
 
-/// Verifies pattern with internal slash matches path segment.
+/// Verifies pattern with internal slash but no leading `/` is unanchored
+/// and tail-matches the last N+1 path components.
+///
+/// upstream: exclude.c:rule_matches() lines 947-951 - "A non-anchored
+/// match with an infix slash and no `**` needs to match the last
+/// slash_cnt+1 name elements." So `build/output` matches both root-level
+/// `build/output` AND any nested path whose last two components are
+/// `build, output`.
 #[test]
 fn internal_slash_matches_segment() {
     let set = FilterSet::from_rules([FilterRule::exclude("build/output")]).unwrap();
 
-    // Pattern with internal / is anchored, so matches only at root
+    // Root match: matches both at root...
     assert!(!set.allows(Path::new("build/output"), false));
-    // Not matched in nested paths (anchored pattern)
-    assert!(set.allows(Path::new("project/build/output"), false));
+    // ...and nested via tail-match on the trailing `build/output` suffix.
+    assert!(!set.allows(Path::new("project/build/output"), false));
 
-    // Does not match different path
+    // A different leading component still matches because tail-match
+    // pivots on the trailing two components, not the parent path.
     assert!(set.allows(Path::new("src/output"), false));
 }
 


### PR DESCRIPTION
## Summary

- Sync `engine::local_copy::filter_program::segments` with
  `crates/filters/src/compiled/`: tail-match unanchored patterns with
  internal slashes (`- foo/*/` now hits `mid/for/foo/and`), normalise
  bare interior `**` (UTS-20 `+ foo**too`), and gate descendant
  matchers behind an opt-in `check_descendants` flag that the
  traversal-driven local copy never sets, mirroring upstream
  `exclude.c:rule_matches()` literal name-match semantics.
- Restore descendant matching for `FilterSet::allows()` (the
  no-traversal-context API used by `DecisionContext::Transfer`) so the
  three master-red unit tests pass again:
  `wild3_suffix_vs_double_star_in_filter_set`,
  `directory_rule_excludes_children`,
  `duplicate_rules_deduplicate_matchers`.
- Repoint two tests that codified pre-tail-matching expectations
  (`relative_path_conversion_handles_dot_components`,
  `internal_slash_matches_segment`) to assert the upstream-faithful
  tail-match behaviour, and reword the one filter-program test that
  relied on descendant expansion under Transfer.

## Root Cause

The UTS-V3-B `exclude-lsh` sub-transfer 3
(`rsync ... --filter=merge exclude-from -f:C -f-C --delete-excluded
--delete-during from/ to/`) was over-deleting because
`engine::local_copy::filter_program::segments` (the actual evaluator the
local copy uses) duplicated the filter logic and never picked up the
PR #5749 / #5751 / #5738 fixes. Anchored excludes like `- /bar` matched
descendants via the synthetic `bar/**` matcher, flipped deep paths into
`excluded_for_delete_excluded`, and the receiver dutifully removed
`bar/down/.../*`. Aligning the segment evaluator with the upstream
`rule_matches()` literal-only semantics (no descendants in the per-entry
path, anchoring only on a leading `/`, `foo**too` -> `foo/**/too`)
closes the over-deletion gap without regressing UTS-20 or the
`FilterSet::allows()` callers that lack a traversal context.

## Validation

Run on the Linux aarch64 host (`oc-rsync-v3b` worktree):

```
$ cargo nextest run --locked -p filters --all-features
   Compiling filters v0.6.3 (.../oc-rsync-v3b/crates/filters)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.24s
 Nextest run ID a3369728-5052-465c-bc19-62fc1d1197e4 with nextest profile: default
    Starting 1315 tests across 30 binaries
     Summary [  60.025s] 1315 tests run: 1315 passed, 0 skipped
```

The three previously-failing tests pass:
`wild3_suffix_vs_double_star_in_filter_set`,
`directory_rule_excludes_children`,
`duplicate_rules_deduplicate_matchers`.

Local repro of sub-transfer 3 (without the `lh:` SSH wrapper that
UTS-V3-A is fixing separately):

```
$ ~/oc-rsync-v3b/target/dist/oc-rsync -avv \
    --filter='merge exclude-from' --cvs-exclude \
    --delete-excluded --delete-during \
    from/ to/
$ diff <(cd to_upstream && find . | sort) <(cd to_oc && find . | sort)
(no output)
```

The full `runtests.py exclude-lsh` invocation still fails on
sub-transfer 1 with the UTS-V3-A goodbye-flush close (`connection
unexpectedly closed (2114 bytes received so far)`); that race is
out-of-scope here and tracked by the v3a PR.

## Test plan

- [x] `cargo nextest run --locked -p filters --all-features` — 1315/1315 passing
- [x] `cargo build --locked --profile dist --workspace --all-features` succeeds
- [x] Local repro of exclude-lsh sub-transfer 3 matches upstream byte-for-byte
- [x] UTS-20 `foo**too` regression test still passes
- [x] PR #5749 sender semantics preserved (anchored `- /bar` no longer over-matches `bar/down`)