### PR TITLE
fix(transfer): correct sender delta inline-checksum source offset and wire-byte counting

### DIFF
--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -494,6 +494,12 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
                     DeltaOp::Literal(data) => {
                         verifier.update(data);
                         write_token_literal(writer, data)?;
+                        // Advance source cursor past the literal so subsequent
+                        // Copy tokens read source bytes from the correct offset
+                        // for inline checksum computation. upstream:
+                        // match.c:matched() interleaves literal and block-match
+                        // tokens against a single advancing file cursor.
+                        source_offset += data.len() as u64;
                     }
                     DeltaOp::Copy {
                         block_index,
@@ -571,5 +577,88 @@ mod tests {
         let encoder = create_token_encoder(CompressionAlgorithm::LZ4, workers)
             .expect("lz4 encoder should succeed even with workers");
         assert!(encoder.is_some(), "lz4 should produce an encoder");
+    }
+
+    /// Reverse-daemon-delta regression: with a delta script that interleaves
+    /// Copy and Literal tokens, the uncompressed inline-checksum path must
+    /// read source bytes for each Copy from the correct file offset. The bug
+    /// fixed alongside this test left `source_offset` un-incremented after a
+    /// Literal, so any Copy that followed a Literal hashed source data from a
+    /// stale (earlier) offset and the final whole-file checksum disagreed with
+    /// the receiver's reconstructed-file checksum, causing
+    /// "failed verification -- update discarded" on a push that produced a
+    /// byte-correct reconstructed file.
+    ///
+    /// upstream: match.c:matched() advances a single file cursor through both
+    /// literal and block-match tokens; the inline-checksum sender must mirror
+    /// that invariant.
+    #[test]
+    fn write_delta_inline_checksum_advances_source_offset_past_literals() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // Construct a source file with three distinct regions of known
+        // content. A delta script that emits Copy(0), Literal(B), Copy(C)
+        // forces the bug: after writing Literal B, the next Copy must read
+        // source[B+block_a..] not source[block_a..].
+        let block_a: Vec<u8> = (0..16u8).cycle().take(64).collect();
+        let lit_b: Vec<u8> = (32..96u8).collect(); // 64 bytes, distinct
+        let block_c: Vec<u8> = (128..192u8).collect(); // 64 bytes, distinct
+        let mut source = Vec::new();
+        source.extend_from_slice(&block_a);
+        source.extend_from_slice(&lit_b);
+        source.extend_from_slice(&block_c);
+
+        let mut temp = NamedTempFile::new().expect("temp file");
+        temp.write_all(&source).expect("write source");
+        temp.flush().expect("flush");
+        let source_path = temp.path().to_path_buf();
+
+        // Build the wire-op sequence by hand. The block_index values are
+        // wire token indices only; the Copy reads the LOCAL source file for
+        // checksum purposes, which is what this regression exercises.
+        let ops = vec![
+            DeltaOp::Copy {
+                block_index: 0,
+                length: block_a.len() as u32,
+            },
+            DeltaOp::Literal(lit_b.clone()),
+            DeltaOp::Copy {
+                block_index: 1,
+                length: block_c.len() as u32,
+            },
+        ];
+
+        let mut wire = Vec::new();
+        let result = write_delta_with_inline_checksum(
+            &mut wire,
+            &ops,
+            None,
+            false,
+            &source_path,
+            false,
+            ChecksumAlgorithm::MD5,
+        )
+        .expect("write_delta_with_inline_checksum");
+
+        // Compare against the checksum of the actual source bytes - which is
+        // what the receiver computes over the reconstructed file. Pre-fix
+        // these diverged because the second Copy hashed source[block_a.len()..]
+        // (lit_b bytes) instead of source[block_a.len()+lit_b.len()..]
+        // (block_c bytes).
+        let mut expected = ChecksumVerifier::for_algorithm(ChecksumAlgorithm::MD5);
+        expected.update(&source);
+        let mut expected_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        let expected_len = expected.finalize_into(&mut expected_buf);
+
+        assert_eq!(
+            result.checksum_len, expected_len,
+            "checksum length mismatch"
+        );
+        assert_eq!(
+            &result.checksum_buf[..result.checksum_len],
+            &expected_buf[..expected_len],
+            "inline checksum must equal checksum of source bytes covered by the script",
+        );
     }
 }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -426,7 +426,6 @@ impl GeneratorContext {
 
                 let checksum_algorithm = self.get_checksum_algorithm();
                 let use_noatime = self.config.write.open_noatime;
-                let delta_total_bytes = delta_script.total_bytes();
                 let wire_ops = script_to_wire_delta(delta_script, block_length);
                 let use_compression = self.file_compression(source_path).is_some();
                 let is_zlib = matches!(
@@ -437,21 +436,33 @@ impl GeneratorContext {
                 // during the wire-write pass, eliminating the separate
                 // compute_file_checksum() call that re-opened and re-read the
                 // source file.
-                let result = write_delta_with_inline_checksum(
-                    &mut *writer,
-                    &wire_ops,
-                    if use_compression {
-                        token_encoder.as_mut()
-                    } else {
-                        None
-                    },
-                    is_zlib,
-                    source_path,
-                    use_noatime,
-                    checksum_algorithm,
-                )?;
-                writer.write_all(&result.checksum_buf[..result.checksum_len])?;
-                bytes_sent += delta_total_bytes;
+                //
+                // upstream: io.c:859 - stats.total_written counts actual wire
+                // bytes after each write() syscall, not the reconstructed file
+                // size. Wrap the delta+checksum write call in a CountingWriter
+                // so summary "sent N bytes" reflects the wire stream the
+                // receiver actually saw. Using delta_script.total_bytes()
+                // (reconstructed size) trips the testsuite's "delta did not
+                // engage" assertion on delta pushes.
+                let wire_bytes = {
+                    let mut cw = crate::writer::CountingWriter::new(&mut *writer);
+                    let result = write_delta_with_inline_checksum(
+                        &mut cw,
+                        &wire_ops,
+                        if use_compression {
+                            token_encoder.as_mut()
+                        } else {
+                            None
+                        },
+                        is_zlib,
+                        source_path,
+                        use_noatime,
+                        checksum_algorithm,
+                    )?;
+                    cw.write_all(&result.checksum_buf[..result.checksum_len])?;
+                    cw.bytes_written()
+                };
+                bytes_sent += wire_bytes;
             } else {
                 // upstream: sender.c:354-369 - whole-file path; MSG_NO_SEND on open failure
                 // Use unbuffered reader: stream_whole_file_transfer manages its


### PR DESCRIPTION
## Summary

- Two surgical fixes to the sender's delta wire path that together produce a byte-correct push-delta with wire-byte counting that matches upstream.
- Regression test asserts the inline checksum equals the checksum of the actual source bytes covered by the delta script.

## Root cause

`write_delta_with_inline_checksum` (uncompressed branch) advanced `source_offset` only for `Copy` tokens, never for `Literal` tokens. After each Literal the next Copy seeked into the source at a stale offset and the resulting whole-file checksum disagreed with the receiver's reconstructed-file checksum even when every wire token was correct. Push-mode delta transfers tripped `"failed verification -- update discarded"` on the receiver, redrove a phase-2 retransmit, and failed identically. Mirrors `match.c:matched()` advancing a single file cursor through both token kinds, and the existing compressed branch which already advanced.

`bytes_sent` accounting added the reconstructed file size (`delta_script.total_bytes()`) rather than actual wire bytes, so the summary line over-reported on delta pushes and the upstream testsuite's `"delta did not engage"` assertion fired even when the wire stream was small. Wrap the delta + checksum write call in `CountingWriter` to match upstream `io.c:859`.

## Validation

- `cargo nextest run -p transfer --all-features -E 'test(write_delta_inline_checksum_advances_source_offset_past_literals)'` passes on Linux.
- Manual reproducer (oc-rsync push to upstream daemon receiver) confirms byte-identical reconstruction across 5/5 runs with randomized basis.
- The upstream `reverse-daemon-delta` `push` and `push+z` cases now succeed; remaining `pull` failure in that test is an unrelated pre-existing `overflow in read_varint` error on the client-receiver path that also reproduces on master without this change.

## Test plan

- [x] Add regression test: `write_delta_inline_checksum_advances_source_offset_past_literals` builds a `Copy/Literal/Copy` script over a temp source file and asserts the inline checksum equals the checksum of the actual source bytes.
- [x] Manual interop: oc-rsync sender → upstream daemon receiver, 5 randomized 524288-byte basis + 50-byte middle mod + 1792-byte tail, byte-identical 5/5.
- [x] Re-run `python3 ./runtests.py --rsync-bin upstream --rsync-bin2 oc-rsync --use-tcp reverse-daemon-delta` — push and push+z subcases now pass; pull subcase blocked by separate pre-existing bug.