### PR TITLE
fix(daemon): unhang upstream daemon testsuite and pass all 5 subtests

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -269,8 +269,33 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
 /// encounters an I/O error.
 pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
     let brand = config.brand();
-    let options =
-        RuntimeOptions::parse_with_brand(config.arguments(), brand, config.load_default_paths())?;
+    // upstream: clientserver.c:1275-1283 `load_config()` - when invoked as
+    // `--server --daemon` (rsh-spawned, am_daemon < 0) without an explicit
+    // `--config`, upstream picks `RSYNCD_USERCONF` (`./rsyncd.conf` - relative
+    // to CWD) before falling back to `/etc/rsyncd.conf`. The test harness
+    // (`testsuite/daemon_test.py`) drops a `rsyncd.conf` symlink in the
+    // scratch dir and invokes `rsync -e lsh.sh --rsync-path=oc-rsync host::`
+    // - lsh.sh stays in CWD via `--no-cd`, so the CWD lookup is what makes
+    // the per-test config visible. Without this branch, the daemon parses
+    // an empty config, serves an empty module listing, and the upstream
+    // `daemon` test fails with "module list did not contain the expected
+    // modules". Inject `--config=rsyncd.conf` ahead of parse when a usable
+    // CWD config exists and the caller did not supply one; the absolute
+    // brand paths take over otherwise via `parse_with_brand`.
+    let arguments: Vec<OsString> = if config.load_default_paths()
+        && !config_argument_present(config.arguments())
+        && PathBuf::from("rsyncd.conf").is_file()
+    {
+        let mut augmented = Vec::with_capacity(config.arguments().len() + 1);
+        let mut config_flag = OsString::from("--config=");
+        config_flag.push("rsyncd.conf");
+        augmented.push(config_flag);
+        augmented.extend(config.arguments().iter().cloned());
+        augmented
+    } else {
+        config.arguments().to_vec()
+    };
+    let options = RuntimeOptions::parse_with_brand(&arguments, brand, config.load_default_paths())?;
 
     let RuntimeOptions {
         modules,

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -447,14 +447,14 @@ fn resolve_sender_sources(
 ) -> Option<Vec<std::path::PathBuf>> {
     let positionals = extract_module_relative_paths(client_args, module_name);
     if positionals.is_empty() {
-        return Some(vec![module_path.to_path_buf()]);
+        return Some(vec![module_root_dotdir(module_path)]);
     }
     let mut sources = Vec::with_capacity(positionals.len());
     let mut all_empty = true;
     for raw in &positionals {
         let tail = raw.trim();
         if tail.is_empty() || tail == "." {
-            sources.push(module_path.to_path_buf());
+            sources.push(module_root_dotdir(module_path));
             continue;
         }
         all_empty = false;
@@ -496,7 +496,7 @@ fn resolve_sender_sources(
         sources.push(std::path::PathBuf::from(buf));
     }
     if all_empty {
-        return Some(vec![module_path.to_path_buf()]);
+        return Some(vec![module_root_dotdir(module_path)]);
     }
     // upstream: util1.c:804 `glob_expand_module()` runs each module-relative
     // positional through `glob_expand()` (util1.c:755) which in turn calls
@@ -523,6 +523,32 @@ fn resolve_sender_sources(
     //     `..` rejection above the loop runs before this, so a pattern
     //     containing `..` is already rejected.
     Some(expand_sender_source_globs(module_path, sources))
+}
+
+/// Returns the module root path with a trailing `/` appended (idempotent).
+///
+/// The trailing slash signals "transfer contents" through
+/// `non_relative_walk_base` in the engine - it keeps `base == path` so the
+/// walk emits a `.` entry for the root and child names without the module
+/// basename prefix. A sub-path positional (e.g. `<mod>/foo`) is left
+/// without a trailing slash so the engine's last-`/` split assigns the
+/// parent as the base, giving wire-side entries `foo` and `foo/one`
+/// instead of the post-strip-prefix `.` and `one` that would otherwise
+/// trip the receiver's "rejecting unrequested file-list name" check.
+///
+/// upstream: `flist.c:2312-2322` - `fbuf[len-1] == '/'` enters the
+/// `DOTDIR_NAME` branch, which is how the daemon distinguishes
+/// "transfer module contents" from "transfer a named sub-path".
+fn module_root_dotdir(module_path: &std::path::Path) -> std::path::PathBuf {
+    let mut buf = module_path.as_os_str().to_owned();
+    if !buf
+        .as_encoded_bytes()
+        .last()
+        .is_some_and(|b| *b == b'/' || *b == b'\\')
+    {
+        buf.push("/");
+    }
+    std::path::PathBuf::from(buf)
 }
 
 /// Returns `true` if `name` contains a shell glob metacharacter recognised

--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -496,10 +496,201 @@ fn resolve_sender_sources(
         sources.push(std::path::PathBuf::from(buf));
     }
     if all_empty {
-        Some(vec![module_path.to_path_buf()])
-    } else {
-        Some(sources)
+        return Some(vec![module_path.to_path_buf()]);
     }
+    // upstream: util1.c:804 `glob_expand_module()` runs each module-relative
+    // positional through `glob_expand()` (util1.c:755) which in turn calls
+    // POSIX `glob(3)` to expand shell metacharacters (`*`, `?`, `[...]`)
+    // against the on-disk module tree. Without this expansion, a request
+    // like `rsync rsync://host/mod/f*` walks a literal path `<module>/f*`
+    // that does not exist, the sender returns 0 entries, and the server
+    // sits in `recv_filter_list -> read_int(0)` waiting for the receiver's
+    // phase-transition NDX while the receiver is still waiting for the
+    // file list - a wire-level deadlock that surfaces as the upstream
+    // `daemon` testsuite timing out on subtest 4 (test-from/f*) and
+    // subtest 5 (test-from/f* with -U).
+    //
+    // Upstream behaviour, mirrored here:
+    //   * Only positionals containing a glob metacharacter are expanded.
+    //     Plain paths fall straight through.
+    //   * A pattern that matches nothing is preserved verbatim, matching
+    //     `glob_expand()`'s `glob.argc == save_argc` branch at util1.c:786
+    //     (the literal arg surfaces downstream as a normal `link_stat`
+    //     failure instead of a silent drop).
+    //   * Expansion is rooted at the module path so the resulting absolute
+    //     paths land inside the module's tree, the same containment
+    //     guarantee that the chroot / Landlock allowlist enforces. The
+    //     `..` rejection above the loop runs before this, so a pattern
+    //     containing `..` is already rejected.
+    Some(expand_sender_source_globs(module_path, sources))
+}
+
+/// Returns `true` if `name` contains a shell glob metacharacter recognised
+/// by `glob(3)`.
+///
+/// upstream: util1.c:743 - `wildcard_chars[] = "*?["` is the metaset.
+fn path_has_glob_metachar(name: &std::ffi::OsStr) -> bool {
+    name.as_encoded_bytes()
+        .iter()
+        .any(|&b| matches!(b, b'*' | b'?' | b'['))
+}
+
+/// Expands each source path under `module_path` that contains a glob
+/// metacharacter via a single-component walk. Mirrors upstream's
+/// `glob_expand()` (util1.c:755) with the simpler subset rsync's daemon
+/// path actually receives: each positional is a relative path joined to
+/// the module root, so we expand component-by-component. A pattern that
+/// matches nothing is left in place so the sender surfaces the normal
+/// link_stat error instead of silently dropping the arg.
+fn expand_sender_source_globs(
+    module_path: &std::path::Path,
+    sources: Vec<std::path::PathBuf>,
+) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::with_capacity(sources.len());
+    for path in sources {
+        match path.strip_prefix(module_path) {
+            Ok(rel) if rel.components().any(|c| {
+                matches!(c, std::path::Component::Normal(s) if path_has_glob_metachar(s))
+            }) =>
+            {
+                let matches = expand_relative_glob(module_path, rel);
+                if matches.is_empty() {
+                    out.push(path);
+                } else {
+                    out.extend(matches);
+                }
+            }
+            _ => out.push(path),
+        }
+    }
+    out
+}
+
+/// Expands a relative path that may contain glob metacharacters in any
+/// component, rooted at `base`. Returns the matching absolute paths.
+fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut current = vec![base.to_path_buf()];
+    for component in rel.components() {
+        let segment = match component {
+            std::path::Component::Normal(s) => s,
+            // RootDir / Prefix should not appear in a stripped relative path,
+            // and ParentDir is rejected upstream. CurDir is a no-op.
+            std::path::Component::CurDir => continue,
+            _ => return Vec::new(),
+        };
+        let mut next = Vec::new();
+        if path_has_glob_metachar(segment) {
+            let pattern = match segment.to_str() {
+                Some(s) => s,
+                None => return Vec::new(),
+            };
+            for dir in &current {
+                let entries = match std::fs::read_dir(dir) {
+                    Ok(it) => it,
+                    Err(_) => continue,
+                };
+                for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    if let Some(name_str) = name.to_str() {
+                        // Skip dotfiles unless the pattern starts with `.`,
+                        // matching POSIX glob default behaviour.
+                        if name_str.starts_with('.') && !pattern.starts_with('.') {
+                            continue;
+                        }
+                        if glob_match_segment(pattern, name_str) {
+                            next.push(dir.join(&name));
+                        }
+                    }
+                }
+            }
+            next.sort();
+        } else {
+            for dir in &current {
+                next.push(dir.join(segment));
+            }
+        }
+        if next.is_empty() {
+            return Vec::new();
+        }
+        current = next;
+    }
+    current
+}
+
+/// Single-segment glob matcher: `*` matches any run, `?` matches one byte,
+/// `[abc]` / `[!abc]` matches a character class. Mirrors `glob(3)` for the
+/// subset of patterns rsync emits.
+fn glob_match_segment(pattern: &str, name: &str) -> bool {
+    let pat = pattern.as_bytes();
+    let s = name.as_bytes();
+    fn go(p: &[u8], s: &[u8]) -> bool {
+        let mut pi = 0;
+        let mut si = 0;
+        let mut star: Option<(usize, usize)> = None;
+        while si < s.len() {
+            if pi < p.len() {
+                match p[pi] {
+                    b'?' => {
+                        pi += 1;
+                        si += 1;
+                        continue;
+                    }
+                    b'*' => {
+                        star = Some((pi + 1, si));
+                        pi += 1;
+                        continue;
+                    }
+                    b'[' => {
+                        // Find matching `]`.
+                        let mut end = pi + 1;
+                        let negate = end < p.len() && p[end] == b'!';
+                        if negate {
+                            end += 1;
+                        }
+                        let class_start = end;
+                        while end < p.len() && p[end] != b']' {
+                            end += 1;
+                        }
+                        if end >= p.len() {
+                            // Malformed class - treat `[` as literal.
+                            if p[pi] == s[si] {
+                                pi += 1;
+                                si += 1;
+                                continue;
+                            }
+                        } else {
+                            let class = &p[class_start..end];
+                            let matched = class.contains(&s[si]);
+                            if matched != negate {
+                                pi = end + 1;
+                                si += 1;
+                                continue;
+                            }
+                        }
+                    }
+                    c => {
+                        if c == s[si] {
+                            pi += 1;
+                            si += 1;
+                            continue;
+                        }
+                    }
+                }
+            }
+            if let Some((ps, ss)) = star {
+                pi = ps;
+                si = ss + 1;
+                star = Some((ps, ss + 1));
+            } else {
+                return false;
+            }
+        }
+        while pi < p.len() && p[pi] == b'*' {
+            pi += 1;
+        }
+        pi == p.len()
+    }
+    go(pat, s)
 }
 
 /// Collapses `.` and `..` segments lexically without touching the filesystem.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2136,26 +2136,31 @@ mod module_access_tests {
     #[test]
     fn resolve_sender_sources_returns_module_root_without_positional() {
         // upstream: clientserver.c:1073 - bare module request (no sub-path)
-        // means the sender walks the module root directly. Pre-fix behaviour
-        // must be preserved exactly to avoid regressing the existing pull
-        // tests that target `rsync://h/module/`.
+        // means the sender walks the module root directly. The trailing `/`
+        // signals "transfer the module contents" so the engine's
+        // non_relative_walk_base keeps base == path and the walk emits a
+        // `.` entry with FLAG_TOP_DIR (upstream `flist.c:2312-2322`
+        // `DOTDIR_NAME` branch). Without the trailing slash, the engine
+        // would split on the last `/` and emit `upload`/`upload/...`
+        // instead of `./...`.
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
         let sources = resolve_sender_sources(module_path, &args, "upload")
             .expect("bare module request must resolve");
-        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload")]);
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
     #[test]
     fn resolve_sender_sources_returns_module_root_for_empty_subpath() {
         // upstream: util1.c:813-814 - `module/` strips to "" after
         // glob_expand_module; the daemon sender should still walk the module
-        // root and emit "." with FLAG_TOP_DIR.
+        // root and emit "." with FLAG_TOP_DIR. The trailing slash is the
+        // engine-side `DOTDIR_NAME` signal (see the bare-module test).
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload")
             .expect("empty sub-path must resolve");
-        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload")]);
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
     #[test]
@@ -2216,6 +2221,105 @@ mod module_access_tests {
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
         );
+    }
+
+    // Glob expansion - upstream util1.c:804 glob_expand_module + util1.c:755
+    // glob_expand. These tests cover the regression that surfaced as the
+    // upstream `daemon` testsuite hanging on subtest 4 (`test-from/f*`):
+    // without glob expansion the daemon walked a literal `<mod>/f*` that
+    // did not exist, shipped an empty file list, and wire-deadlocked.
+
+    #[test]
+    fn resolve_sender_sources_glob_expands_module_relative_pattern() {
+        // Recreate the upstream `daemon` testsuite layout: a module dir
+        // with `foo/` and `bar/` subdirs. `test-from/f*` must expand to
+        // `<mod>/foo` and leave `bar` alone, matching upstream's
+        // glob_expand_module() behaviour.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::create_dir(module_path.join("foo")).expect("foo dir");
+        std::fs::create_dir(module_path.join("bar")).expect("bar dir");
+        std::fs::write(module_path.join("foo").join("one"), b"one\n").expect("foo/one");
+
+        let args = vec![".".to_owned(), "mod/f*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod")
+            .expect("glob pattern must resolve");
+        assert_eq!(sources, vec![module_path.join("foo")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_keeps_literal_when_no_match() {
+        // upstream: util1.c:786 - `glob.argc == save_argc` branch preserves
+        // the literal arg when nothing matches so the sender surfaces a
+        // normal link_stat failure (exit 23) instead of dropping silently.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::create_dir(module_path.join("bar")).expect("bar dir");
+
+        let args = vec![".".to_owned(), "mod/z*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod")
+            .expect("non-matching glob must resolve to literal");
+        assert_eq!(sources, vec![module_path.join("z*")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_handles_question_mark() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::write(module_path.join("a"), b"a").expect("a");
+        std::fs::write(module_path.join("ab"), b"ab").expect("ab");
+        std::fs::write(module_path.join("b"), b"b").expect("b");
+
+        // `?` matches exactly one character; `?b` must match only `ab`.
+        let args = vec![".".to_owned(), "mod/?b".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod")
+            .expect("? glob must resolve");
+        assert_eq!(sources, vec![module_path.join("ab")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_handles_char_class() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::write(module_path.join("a"), b"a").expect("a");
+        std::fs::write(module_path.join("b"), b"b").expect("b");
+        std::fs::write(module_path.join("c"), b"c").expect("c");
+
+        // `[ab]` matches `a` or `b` but not `c`.
+        let args = vec![".".to_owned(), "mod/[ab]".to_owned()];
+        let mut sources = resolve_sender_sources(module_path, &args, "mod")
+            .expect("[class] glob must resolve");
+        sources.sort();
+        assert_eq!(sources, vec![module_path.join("a"), module_path.join("b")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_skips_dotfiles_by_default() {
+        // POSIX glob default: a leading `.` is only matched when the pattern
+        // itself starts with `.`. `*` must not match `.hidden`.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::write(module_path.join(".hidden"), b"hidden").expect(".hidden");
+        std::fs::write(module_path.join("visible"), b"visible").expect("visible");
+
+        let args = vec![".".to_owned(), "mod/*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod")
+            .expect("* glob must resolve");
+        assert_eq!(sources, vec![module_path.join("visible")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_non_glob_paths_bypass_expansion() {
+        // Plain paths without glob metachars must fall through unchanged,
+        // even when the file does not exist on disk - upstream defers the
+        // existence check to the sender's link_stat.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+
+        let args = vec![".".to_owned(), "mod/missing/file".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod")
+            .expect("plain path must resolve");
+        assert_eq!(sources, vec![module_path.join("missing/file")]);
     }
 
     // UTS-3.b.5 - cross-platform parity for daemon sub-path resolution.

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -418,6 +418,12 @@ mod seccomp_tests {
             libc::SYS_exit_group,
             libc::SYS_recvfrom,
             libc::SYS_sendto,
+            // SYS_fcntl is pinned as a regression for the upstream
+            // `daemon` testsuite: subtests 3-5 (test-hidden listing,
+            // test-from glob, test-from glob -U) all triggered SIGSYS
+            // on aarch64 when fcntl was missing. Sender file open and
+            // socket non-blocking toggling both require it.
+            libc::SYS_fcntl,
         ] {
             assert!(
                 list.binary_search(&required).is_ok(),

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -153,6 +153,15 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
         libc::SYS_newfstatat,
         libc::SYS_statx,
         libc::SYS_lseek,
+        // SYS_fcntl is required by std::fs::File operations and socket I/O:
+        // F_GETFL/F_SETFL toggle non-blocking, F_DUPFD clones descriptors, and
+        // F_GETFD/F_SETFD manage CLOEXEC. Without it, the worker dies with
+        // SIGSYS the moment a transfer issues its first fcntl - any recursive
+        // module listing crashes immediately because the sender's open+read
+        // path probes F_GETFL on the source fd. Verified via aarch64
+        // audit type=1326 syscall=25 (`__NR3264_fcntl`) on a
+        // `rsync rsync://host/module` recursive listing.
+        libc::SYS_fcntl,
         libc::SYS_ftruncate,
         libc::SYS_fsync,
         libc::SYS_fdatasync,

--- a/crates/protocol/src/flist/read/metadata.rs
+++ b/crates/protocol/src/flist/read/metadata.rs
@@ -111,19 +111,17 @@ impl FileListReader {
         // Determine if this is a directory (needed for atime and content_dir)
         let is_dir = (mode & 0o170000) == 0o040000;
 
-        // 5. Read atime if preserving atimes (AFTER mode, non-directories only)
+        // 5. Read atime if preserving atimes (AFTER mode, non-directories only).
+        // upstream: flist.c:894-895 - atime is a single `read_varlong(f, 4)`;
+        // there is no atime nsec field on the wire regardless of protocol
+        // version (unlike mtime nsec which is gated by XMIT_MOD_NSEC).
         let (atime, atime_nsec) = if self.preserve_atimes && !is_dir {
             if flags.same_atime() {
                 (Some(self.state.prev_atime()), 0)
             } else {
                 let atime = crate::read_varlong(reader, 4)?;
-                let nsec = if self.protocol.as_u8() >= 32 {
-                    crate::read_varint(reader)? as u32
-                } else {
-                    0
-                };
                 self.state.update_atime(atime);
-                (Some(atime), nsec)
+                (Some(atime), 0)
             }
         } else {
             (None, 0)

--- a/crates/protocol/src/flist/write/metadata.rs
+++ b/crates/protocol/src/flist/write/metadata.rs
@@ -92,8 +92,15 @@ impl FileListWriter {
 
     /// Writes atime field if preserving and different (non-directories only).
     ///
-    /// For protocol >= 32, also writes atime nanoseconds as a varint
-    /// after the atime seconds value.
+    /// upstream: `flist.c:607-608` - atime is encoded as a single
+    /// `write_varlong(f, atime, 4)` regardless of protocol version. There
+    /// is NO atime nsec field in the wire format - unlike mtime which has
+    /// `XMIT_MOD_NSEC` (bit 14 in the extended byte) gating an optional
+    /// varint nsec for protocol >= 31. Writing an extra varint here
+    /// desynchronises the receiver's parser one byte into the next entry,
+    /// surfacing as `File-list index N not in 0 - K (read_ndx_and_attrs)`
+    /// or `Invalid packet at end of run` once the receiver tries to read
+    /// the goodbye.
     #[inline]
     fn write_atime<W: Write + ?Sized>(
         &mut self,
@@ -106,9 +113,6 @@ impl FileListWriter {
             && (xflags & ((XMIT_SAME_ATIME as u32) << 8)) == 0
         {
             crate::write_varlong(writer, entry.atime(), 4)?;
-            if self.protocol.as_u8() >= 32 {
-                write_varint(writer, entry.atime_nsec() as i32)?;
-            }
             self.state.update_atime(entry.atime());
         }
         Ok(())

--- a/crates/protocol/tests/proptest_file_entry_roundtrip.rs
+++ b/crates/protocol/tests/proptest_file_entry_roundtrip.rs
@@ -713,9 +713,18 @@ proptest! {
         assert_eq!(decoded.atime(), atime, "atime mismatch");
     }
 
-    /// Atime nanoseconds are preserved on protocol 32 when preserve_atimes is enabled.
+    /// Atime nanoseconds are NOT transmitted on the wire at any protocol
+    /// version. upstream `flist.c:607-608` (sender) and `flist.c:894-895`
+    /// (receiver) encode atime as a single \`varlong(atime, 4)\` and never
+    /// emit an nsec component; mtime is the only timestamp whose nsec is
+    /// gated by a transmission flag (\`XMIT_MOD_NSEC\`). Encode-only nsec
+    /// state on the sender's in-memory \`FileEntry\` must be ignored across
+    /// the wire so a round-trip yields \`atime_nsec == 0\`. Test pinned at
+    /// protocol 32 so a future bump to nsec-carrying atimes - which would
+    /// require a wire protocol revision and matching upstream change -
+    /// updates this test deliberately.
     #[test]
-    fn atime_nsec_roundtrip_proto32(
+    fn atime_nsec_dropped_on_wire_proto32(
         name in basename_strategy(),
         size in file_size_strategy(),
         perms in permissions_strategy(),
@@ -737,7 +746,7 @@ proptest! {
         let decoded = roundtrip(&mut writer, &mut reader, &entry);
         assert_core_fields_match(&entry, &decoded);
         assert_eq!(decoded.atime(), atime, "atime mismatch");
-        assert_eq!(decoded.atime_nsec(), atime_nsec, "atime nsec mismatch");
+        assert_eq!(decoded.atime_nsec(), 0, "atime nsec must be dropped on the wire");
     }
 
     /// Directories do not carry atime even when preserve_atimes is enabled.

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -68,14 +68,21 @@ impl GeneratorContext {
         // emitted ancestors across sources to avoid duplicate entries.
         let mut implied_ancestors: HashSet<PathBuf> = HashSet::new();
         for base_path in base_paths {
-            // upstream: flist.c:2316 - --relative splits on "/./" so the dir
-            // before the anchor is the base and everything after is the
-            // transmitted relative name. Without an anchor the entire path is
-            // the relative name (with the leading "/" stripped post-sort).
+            // upstream: flist.c:2338-2349 - non-relative mode splits each
+            // positional on the LAST `/`: `dir = strrchr(fbuf, '/')` becomes
+            // the parent and `fn` becomes the basename, then `chdir(dir)`
+            // walks `fn`. This makes the wire-side relative names carry the
+            // source basename (e.g. `foo` and `foo/one` for source
+            // `<mod>/foo`) instead of the post-strip-prefix names (which
+            // would be empty for the source dir and `one` for its child,
+            // mismatching upstream's wire output and tripping the
+            // receiver's `rejecting unrequested file-list name` check).
+            // upstream: flist.c:2316 - --relative additionally honours the
+            // `/./` anchor and emits implied parent directories.
             let (base, path) = if relative_paths {
                 relative_walk_base(base_path)
             } else {
-                (base_path.clone(), base_path.clone())
+                non_relative_walk_base(base_path)
             };
             // upstream: flist.c:2254-2272 - pre-stat each top-level source and
             // apply missing_args handling. Separates "source never existed" from
@@ -442,6 +449,49 @@ fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
 fn find_dot_dir_anchor(path: &Path) -> Option<usize> {
     let s = path.as_os_str().to_str()?;
     s.find("/./")
+}
+
+/// Picks the `(base, path)` pair for a non-`--relative` positional, matching
+/// upstream `flist.c:2338-2349`: split the path on its LAST `/`, take the
+/// prefix as the base directory and the suffix as the file name. The full
+/// path is preserved so callers can pass it to `link_stat`, but `base` is
+/// what `walk_path_with_metadata` strips to compute the wire-side relative
+/// name. For a path with no `/` separator (i.e. a bare basename), the base
+/// is `.` so `strip_prefix` is a no-op and the entry surfaces under its
+/// own name.
+///
+/// Examples:
+///   * `/srv/mod/foo`  -> base=`/srv/mod`,  path=`/srv/mod/foo`
+///   * `/srv/mod/foo/` -> base=`/srv/mod`,  path=`/srv/mod/foo/`
+///   * `/srv/mod/`     -> base=`/srv/mod/`, path=`/srv/mod/`     (dotdir)
+///   * `/`             -> base=`/`,         path=`/`             (dotdir)
+///   * `foo`           -> base=`.`,         path=`foo`
+fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
+    // Upstream's DOTDIR_NAME branch (flist.c:2312-2322) preserves a
+    // trailing slash to signal "transfer the contents only". Preserve
+    // base == path so `walk_path_with_metadata`'s `relative.is_empty()`
+    // branch still emits `.` for the source root.
+    let s = path.as_os_str();
+    let bytes = s.as_encoded_bytes();
+    if bytes.last() == Some(&b'/') {
+        return (path.to_path_buf(), path.to_path_buf());
+    }
+    // `Path::parent()` returns the parent directory or `None` for a path
+    // whose final component is the root or a bare basename. The bare-name
+    // case is normalised to `.` so `strip_prefix` becomes a no-op and the
+    // entry surfaces under its own name, matching upstream's
+    // `fn = fbuf; dir = NULL -> chdir(NULL)` no-op.
+    let parent = path.parent().map(|p| {
+        if p.as_os_str().is_empty() {
+            PathBuf::from(".")
+        } else {
+            p.to_path_buf()
+        }
+    });
+    match parent {
+        Some(base) => (base, path.to_path_buf()),
+        None => (path.to_path_buf(), path.to_path_buf()),
+    }
 }
 
 /// Applies a source-based permutation to two parallel slices in-place.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2834,10 +2834,15 @@ mod files_from {
     }
 
     #[test]
-    fn non_relative_mode_uses_basename() {
-        // Without --relative, a directory source still collapses to "." with
-        // children named by basename only. Guards against the relative-mode
-        // fix accidentally changing default behaviour.
+    fn non_relative_mode_emits_source_basename() {
+        // upstream: flist.c:2338-2349 - non-relative mode splits each
+        // positional on its last `/`: `dir` becomes the chdir target,
+        // `fn` is link_stat'd. For source `<tmp>/payload`, dir = <tmp>
+        // and fn = payload, so the wire entries carry the basename
+        // (`payload`, `payload/file.txt`) - matching upstream rsync's
+        // behaviour for `rsync -r payload dst/`. A trailing slash
+        // (DOTDIR_NAME branch) still collapses to `.` + children; that
+        // path is covered by the trailing-slash test below.
         let temp_dir = TempDir::new().unwrap();
         let src_dir = temp_dir.path().join("payload");
         std::fs::create_dir_all(&src_dir).unwrap();
@@ -2851,10 +2856,50 @@ mod files_from {
         ctx.build_file_list(&[src_dir]).unwrap();
 
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(
+            names.contains(&"payload"),
+            "expected 'payload' entry in {names:?}"
+        );
+        assert!(
+            names.contains(&"payload/file.txt"),
+            "expected 'payload/file.txt' in {names:?}"
+        );
+        assert!(
+            !names.contains(&"."),
+            "expected no `.` entry for sub-path source in {names:?}"
+        );
+    }
+
+    #[test]
+    fn non_relative_mode_trailing_slash_collapses_to_dot() {
+        // upstream: flist.c:2312-2322 DOTDIR_NAME branch - a trailing
+        // slash makes the engine emit `.` for the source root and
+        // children without the basename prefix, mirroring upstream's
+        // "transfer the contents only" semantic.
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("payload");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(src_dir.join("file.txt"), b"x").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.flags.relative = false;
+        config.flags.recursive = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        let mut with_slash = src_dir.as_os_str().to_owned();
+        with_slash.push("/");
+        ctx.build_file_list(&[std::path::PathBuf::from(with_slash)])
+            .unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
         assert!(names.contains(&"."), "expected '.' entry in {names:?}");
         assert!(
             names.contains(&"file.txt"),
             "expected 'file.txt' in {names:?}"
+        );
+        assert!(
+            !names.contains(&"payload"),
+            "expected no `payload` entry for trailing-slash source in {names:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Five root-caused bugs were tripping the upstream rsync 3.4.3 testsuite's `daemon` test against oc-rsync, with the overall run hanging at the runner's 300-second wall-clock budget. This branch lands the five upstream-aligned fixes the test exercises, in dependency order. After the changes the full `daemon` test (all five subtests) passes against the rsync-bin2 oc-rsync server in ~2.3 seconds, well inside the 60-second budget.

The fixes (one commit each):

1. **fix(daemon): load ./rsyncd.conf for rsh-spawned --server --daemon** - upstream's `clientserver.c:1275-1283 load_config()` falls back to `RSYNCD_USERCONF` ("./rsyncd.conf") when invoked as `--server --daemon` without an explicit `--config` and the process is not root. oc-rsync's `run_daemon_stdio` only checked the absolute brand paths, so the testsuite's `lsh.sh --no-cd` invocation served an empty module list, failing subtest 1 ("module list via lsh.sh").

2. **fix(daemon): allow SYS_fcntl in worker seccomp BPF filter** - the worker seccomp allowlist (PR #5741) omitted `SYS_fcntl`. Every TCP worker that survived auth + module selection died with SIGSYS on the first `fcntl` syscall, which is the very first call the sender issues when it opens a source file. Subtests 3-5 trip it; subtests 1-2 don't reach `engage_seccomp_sandbox` so the gap was masked.

3. **fix(daemon): glob-expand sender positional args per upstream glob_expand_module** - upstream's `util1.c:804 glob_expand_module()` runs each module-relative positional through `glob(3)`. oc-rsync's `resolve_sender_sources` treated `f*` as a literal path, the sender shipped zero entries, and the wire deadlocked. Adds a minimal POSIX-glob-shaped expander (`* ? [...]`) gated on the upstream metacharacter set, with the same "no match -> preserve literal" fallback (util1.c:786).

4. **fix(generator): split non-relative sender positionals on last / per upstream** - upstream's `flist.c:2338-2349` does a `dir/fn` split on every non-`--relative` sender positional so wire-side relative names carry the basename prefix (`foo`, `foo/one` for source `<mod>/foo`). oc-rsync's `build_file_list` short-circuited the split, emitting `.` / `one`, which the receiver rejected with `rejecting unrequested file-list name`. The new `non_relative_walk_base` mirrors upstream's split; module-root pulls now signal `DOTDIR_NAME` via an explicit trailing slash so the existing `.`+children path stays unchanged.

5. **fix(protocol): drop spurious atime-nsec varint from file list wire format** - upstream encodes atime as a single `varlong(atime, 4)` per non-directory entry (sender: `flist.c:607-608`, receiver: `flist.c:894-895`); there is NO atime nsec field at any protocol version. oc-rsync was emitting an extra `varint(atime_nsec)` for protocol >= 32, desynchronising the upstream receiver one byte into the next entry and surfacing as `File-list index N not in 0 - K` (mid-list) or `Invalid packet at end of run` (at goodbye). Subtest 5 (`-rU test-from/f*`) trips it.

## Test plan

- [x] Upstream `daemon` testsuite passes in 2.3s against the new build:
  ```
  python3 ./runtests.py --rsync-bin /home/ofer/rsync/rsync \
                        --rsync-bin2 .../target/dist/oc-rsync \
                        --use-tcp daemon
  ```
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo build --locked --profile dist --workspace --all-features` green.
- [x] Per-PR regression tests added: SYS_fcntl pin in the worker seccomp essentials list; glob expansion (`*`, `?`, `[...]`, no-match, dotfile) tests in `resolve_sender_sources`; `non_relative_mode_emits_source_basename` + `non_relative_mode_trailing_slash_collapses_to_dot` for the engine split; atime nsec wire-drop proptest pin.
- [x] CI: relying on the workspace nextest matrix to validate the engine changes don't regress wire-mode SSH transfers (no behavioural change for paths that already had a parent in the source argv).