### PR TITLE
fix(protocol): guard flist name decode against length overflow

### DIFF
--- a/crates/protocol/src/codec/protocol/legacy.rs
+++ b/crates/protocol/src/codec/protocol/legacy.rs
@@ -80,6 +80,13 @@ impl ProtocolCodec for LegacyProtocolCodec {
     fn read_long_name_len<R: Read + ?Sized>(&self, reader: &mut R) -> io::Result<usize> {
         let mut buf = [0u8; 4];
         reader.read_exact(&mut buf)?;
-        Ok(i32::from_le_bytes(buf) as usize)
+        let value = i32::from_le_bytes(buf);
+        if value < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("negative long-name length on wire: {value}"),
+            ));
+        }
+        Ok(value as usize)
     }
 }

--- a/crates/protocol/src/codec/protocol/modern.rs
+++ b/crates/protocol/src/codec/protocol/modern.rs
@@ -63,6 +63,13 @@ impl ProtocolCodec for ModernProtocolCodec {
     }
 
     fn read_long_name_len<R: Read + ?Sized>(&self, reader: &mut R) -> io::Result<usize> {
-        read_varint(reader).map(|v| v as usize)
+        let value = read_varint(reader)?;
+        if value < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("negative long-name length on wire: {value}"),
+            ));
+        }
+        Ok(value as usize)
     }
 }

--- a/crates/protocol/src/flist/read/name.rs
+++ b/crates/protocol/src/flist/read/name.rs
@@ -86,13 +86,21 @@ impl FileListReader {
 
         // upstream: flist.c `l2 >= MAXPATHLEN - l1` overflow exit
         // Defence-in-depth: reject names that exceed MAXPATHLEN to prevent
-        // unbounded allocation from a malicious sender.
-        if same_len + suffix_len >= MAXPATHLEN {
+        // unbounded allocation from a malicious sender. checked_add guards
+        // against arithmetic overflow when a malicious sender supplies a
+        // wire-encoded suffix length near usize::MAX.
+        let total_len = same_len.checked_add(suffix_len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("filename length overflow: same_len={same_len} suffix_len={suffix_len}"),
+            )
+        })?;
+        if total_len >= MAXPATHLEN {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
                     "filename length {} exceeds maximum {}",
-                    same_len + suffix_len,
+                    total_len,
                     MAXPATHLEN - 1,
                 ),
             ));


### PR DESCRIPTION
## Summary

Closes the libFuzzer crash in the nightly Differential Fuzzer Overnight job (run 27491864218, all three targets: differential_flist / differential_multiplex / differential_outcome).

### Root cause

\`crates/protocol/src/flist/read/name.rs:90\` performs \`same_len + suffix_len\` as plain \`usize\` addition.

The \`suffix_len\` value flows from \`read_long_name_len\`, which on both legacy (proto < 30) and modern (proto >= 30) codecs decodes a wire \`i32\` and casts to \`usize\`. A negative wire value (e.g. \`0xFFFFFFFF\`) silently becomes \`usize::MAX\`. The subsequent \`255 + usize::MAX\` addition then panics in debug builds with arithmetic overflow — exactly the libFuzzer-reported \"deadly signal\".

### Fix (three layers of defense)

1. \`flist/read/name.rs:90\` — replace bare \`+\` with \`checked_add\`. Returns a typed \`InvalidData\` error instead of panicking.
2. \`codec/protocol/legacy.rs::read_long_name_len\` — explicitly reject negative i32 instead of silently widening to \`usize::MAX\`. Matches upstream's protocol-error treatment.
3. \`codec/protocol/modern.rs::read_long_name_len\` — same negative-value guard on the varint path.

### Wire compatibility

Zero wire-format change. Both fixes only convert previously-panicking inputs into typed \`InvalidData\` errors, which is what upstream rsync does for the same conditions.

## Test plan
- [ ] CI fmt+clippy + nextest stays green
- [ ] Differential Fuzzer Overnight on next nightly run no longer crashes on this input