### PR TITLE
fix(daemon): drain peer goodbye without half-close to unblock UTS-v3 cluster A

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -284,7 +284,7 @@ fn engage_landlock_sandbox(
     module: &ModuleRuntime,
     extra_allowed_paths: &[&Path],
 ) -> io::Result<bool> {
-    use fast_io::landlock::{is_supported, restrict_to_module_paths, LandlockOutcome};
+    use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
 
     if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
         if let Some(log) = ctx.log_sink {
@@ -1043,34 +1043,61 @@ fn process_approved_module(
         module,
     );
 
-    // Graceful TCP shutdown: linger + half-close + drain.
+    // Graceful TCP shutdown: drain peer's goodbye, then linger + close.
     //
-    // Without this pattern, close() on a TCP socket with unread RX bytes
-    // causes the kernel to send RST instead of FIN (`tcp(7)`). RST aborts
-    // any in-flight TX bytes that have not yet reached userspace, so the
-    // peer reports "connection unexpectedly closed (N bytes received so
-    // far)" even though the daemon wrote every goodbye byte. Under `-zz`
-    // the loss window is widened by trailing MSG_INFO itemize frames
-    // before the stats / NDX_DONE goodbye sequence.
+    // Background:
     //
-    // The structural pattern is:
-    //   1. SO_LINGER(5s) - ensures close() blocks until TX data is ACKed
-    //   2. shutdown(Write) - sends FIN, tells the peer no more data
-    //   3. read() in a loop until EOF - drains peer's final goodbye bytes
-    //      and lets the kernel complete the FIN handshake
-    //   4. close() the socket - safe because linger ensures TX delivery
-    //      and drain cleared any unread RX data
+    // Upstream rsync forks a child process per connection; the child holds
+    // the sole fd reference and exits via `exit_cleanup` which calls
+    // `_exit()`. The kernel closes the orphaned fd, the TCP stack delivers
+    // any pending TX bytes, and FIN is queued AFTER the kernel finishes
+    // processing the receive buffer. In particular, the sender's
+    // `read_final_goodbye()` returns AFTER reading the receiver's final
+    // NDX_DONE, but the kernel still has room to receive whatever the
+    // receiver writes immediately afterward (its MSG_STATS / extra
+    // NDX_DONE pair) before the process exit triggers FIN.
     //
-    // SO_LINGER is the key structural element. Without it, close() on a
-    // socket with multiple dup'd fd references (our cloned TcpStreams)
-    // can return immediately with unACKed TX data, and the kernel races
-    // to deliver the trailing goodbye bytes before the peer times out.
-    // With SO_LINGER, close() blocks until the kernel confirms delivery.
+    // Our daemon uses threads, not fork. The connection thread holds
+    // multiple cloned `TcpStream` handles (a read clone, a write clone,
+    // and the original `DaemonStream`) for the same kernel socket. When
+    // the thread function returns, those drop and the kernel closes the
+    // last fd. The structural challenge is that calling
+    // `shutdown(SHUT_WR)` BEFORE the receiver has finished writing its
+    // goodbye causes the receiver to see FIN immediately, abort its
+    // pending writes (which our `read_final_goodbye()` equivalent has not
+    // yet drained), and report
+    // "connection unexpectedly closed (N bytes received so far)".
     //
-    // upstream: cleanup.c:close_all() relies on the fork model where the
-    // child holds the only fd reference; _exit() lets the kernel drain
-    // naturally. Our threaded daemon shares cloned fds across multiple
-    // owners and needs SO_LINGER + half-close + drain explicitly.
+    // The failure cluster (batch-mode, alt-dest, daemon-gzip-download,
+    // daemon-refuse-compress) all hit this race: the engine's
+    // `handle_goodbye_with_finalizer` reads the receiver's first NDX_DONE,
+    // writes the daemon's NDX_DONE, and reads the receiver's second
+    // NDX_DONE; but upstream's receiver then writes MSG_STATS + a final
+    // NDX_DONE on its side, relayed through the generator-to-sender pipe.
+    // Closing the socket immediately after our `handle_goodbye` returns
+    // races those trailing bytes.
+    //
+    // The structural fix mirrors upstream's
+    // `noop_io_until_death()` semantics for the sender side: keep reading
+    // from the peer until it sends FIN (EOF). The peer FINs once its own
+    // `exit_cleanup` runs, which only happens after it has flushed its
+    // goodbye. Bounded by a generous timeout (5 seconds) so a wedged
+    // peer cannot block the daemon thread indefinitely.
+    //
+    // Sequence:
+    //   1. SO_LINGER(5s) - kernel blocks close() until TX data is ACKed
+    //      or the linger window expires, so the final goodbye bytes our
+    //      engine wrote reach the peer even after we drop the socket.
+    //   2. Drain read until EOF - waits for the peer to finish its own
+    //      goodbye and FIN. We do NOT call `shutdown(Write)` first;
+    //      sending FIN early would tell the peer "I'm done" before the
+    //      peer has written its trailing goodbye, which is the race.
+    //   3. close() - the linger window guarantees in-flight TX bytes are
+    //      delivered before the close completes.
+    //
+    // upstream: io.c:943-963 noop_io_until_death() loops on read() until
+    // the peer sends FIN; cleanup.c:265 then calls close_all(). Our
+    // sequence collapses that pattern to fit the threaded daemon model.
     //
     // For stdio streams (remote-shell daemon mode), TCP shutdown is not
     // applicable - the pipe/fd closes naturally when dropped.
@@ -1078,34 +1105,24 @@ fn process_approved_module(
     if supports_tcp_shutdown {
         let stream = ctx.reader.get_mut();
 
-        // SO_LINGER with a non-zero timeout ensures that when close() is
-        // called (via drop), the kernel blocks until all data in the send
-        // buffer has been acknowledged by the peer - or until the timeout
-        // expires. Without this, close() on a dup'd socket with pending
-        // TX data can return immediately while the kernel races to deliver
-        // the trailing goodbye bytes.
-        //
-        // upstream: the fork model avoids this because _exit() triggers
-        // implicit close on the only fd, and the kernel lingers by default
-        // for orphaned sockets. Our threaded daemon has multiple cloned
-        // fds and explicit close() calls, which bypass the implicit linger.
+        // SO_LINGER ensures the final goodbye TX bytes the engine wrote
+        // are delivered before the kernel reclaims the socket. The 5s
+        // window matches upstream's expected goodbye round-trip latency.
         if let Some(tcp) = stream.tcp_stream() {
             let sock = socket2::SockRef::from(tcp);
             let _ = sock.set_linger(Some(Duration::from_secs(5)));
         }
 
-        // Half-close the write side: sends FIN to the peer, signalling
-        // that no more data will be sent from our end.
-        let _ = stream.shutdown(std::net::Shutdown::Write);
-
-        // Drain the read side until the peer sends FIN (EOF) or the
-        // timeout expires. This ensures all peer goodbye bytes are
-        // consumed and the kernel completes the FIN handshake before
-        // close() is called, preventing RST from unread RX data.
+        // Drain the read side until the peer sends FIN (EOF). We do NOT
+        // shutdown(Write) first: that would tell the peer "I'm done"
+        // before it has written its trailing MSG_STATS / NDX_DONE, which
+        // the peer abandons on receipt of FIN. Mirrors upstream's
+        // `noop_io_until_death()` for the sender side: read until peer
+        // FINs (which it does on its own `exit_cleanup`), then close.
         //
-        // Two seconds is generous for the goodbye round-trip (stats +
-        // NDX_DONE) and prevents a stalled peer from wedging the daemon.
-        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+        // Cap at 5s so a wedged peer cannot pin the daemon thread; the
+        // window is generous enough for any reasonable goodbye exchange.
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
         let mut sink = [0u8; 4096];
         loop {
             match stream.read(&mut sink) {
@@ -1127,11 +1144,12 @@ fn process_approved_module(
         let _ = stream.set_read_timeout(None);
     }
 
-    // Drop transfer-engine stream clones after the shutdown+drain
-    // sequence completes. These cloned TcpStream handles share the
-    // same kernel socket as the DaemonStream; keeping them alive during
-    // shutdown(Write) and drain-read preserves the fd refcount that was
-    // present during the transfer, matching the original lifecycle.
+    // Drop transfer-engine stream clones after the drain completes.
+    // These cloned TcpStream handles share the same kernel socket as the
+    // DaemonStream; keeping them alive during the drain preserves the fd
+    // refcount that was present during the transfer. Dropping now lets
+    // the kernel queue FIN + close once the SO_LINGER window completes
+    // delivery of any in-flight TX bytes.
     drop(streams);
 
     // upstream: clientserver.c - post_exec() runs after the transfer, regardless of outcome

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -382,6 +382,8 @@ include!("tests/chunks/daemon_inc_recurse_push.rs");
 include!("tests/chunks/daemon_checksum_push.rs");
 // Daemon compress push end-to-end test
 include!("tests/chunks/daemon_compress_push.rs");
+// Daemon compress pull goodbye-drain regression (UTS-v3 Cluster A)
+include!("tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs");
 // Daemon delete push end-to-end test
 include!("tests/chunks/daemon_delete_push.rs");
 // Daemon delete push NDX_DEL_STATS regression (URV-6 upload-direction gap)

--- a/crates/daemon/src/tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs
+++ b/crates/daemon/src/tests/chunks/daemon_compress_pull_drains_peer_goodbye.rs
@@ -1,0 +1,152 @@
+/// Regression test for UTS-v3 Cluster A: the daemon-as-sender goodbye race.
+///
+/// Cluster A surfaced 4 upstream testsuite failures (`batch-mode`,
+/// `alt-dest`, `daemon-gzip-download`, `daemon-refuse-compress`) all reporting
+/// "connection unexpectedly closed (N bytes received so far) [receiver]" at
+/// near-identical byte cutoffs. Wire-byte capture against the upstream rsync
+/// 3.4.3 client showed the oc-rsync daemon-as-sender writing its final
+/// `NDX_DONE` / `MSG_STATS` correctly, then immediately calling
+/// `shutdown(SHUT_WR)`. The receiver process saw `FIN` before its own
+/// generator had relayed the trailing `MSG_STATS` / `NDX_DONE` pair through
+/// the receiver-to-generator pipe, abandoned its writes, and emitted the
+/// "connection unexpectedly closed" diagnostic.
+///
+/// Upstream avoids this via its fork model: the sender child holds the only
+/// fd reference and `FIN` is queued only after the kernel reaps the exited
+/// process - long after the receiver has flushed its goodbye. The threaded
+/// daemon's fix in `process_approved_module` drops the half-close and relies
+/// on `SO_LINGER` + a read-until-EOF loop, mirroring upstream's
+/// `noop_io_until_death()` for the sender side.
+///
+/// This test exercises the daemon-as-sender + `--compress` (`-z`) pull
+/// pattern that triggers the race under upstream's testsuite: a multi-file
+/// tree pulled through `core::client::run_client`, with compression enabled
+/// on both ends. A successful run requires the daemon to drain the
+/// receiver's goodbye writes before closing the socket; if the half-close
+/// regresses, `run_client` will surface an early-EOF error from the receiver
+/// path.
+///
+/// # Upstream Reference
+///
+/// - `cleanup.c:265 close_all()` - sender-side close after `_exit_cleanup`.
+/// - `io.c:943-963 noop_io_until_death()` - receiver-side drain pattern.
+/// - `main.c:893-923 read_final_goodbye()` - sender's NDX exchange.
+#[cfg(unix)]
+#[test]
+fn daemon_compress_pull_drains_peer_goodbye_for_uts_v3_cluster_a() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+
+    // Source tree: mix sizes that span single and multi-frame MSG_DATA
+    // chunks under -z. The 1 MB file forces the engine through the
+    // io_uring fast path (threshold 1 MB) which writes through `writev`,
+    // matching the wire pattern that triggers the cluster A race.
+    let module_dir = temp.path().join("module");
+    fs::create_dir(&module_dir).expect("create module");
+
+    let small: Vec<u8> = b"compressible repeated pattern\n"
+        .iter()
+        .copied()
+        .cycle()
+        .take(28)
+        .collect();
+    let medium: Vec<u8> = b"another compressible repeated pattern line\n"
+        .iter()
+        .copied()
+        .cycle()
+        .take(52_802)
+        .collect();
+    let large: Vec<u8> = b"large file content for compression and chunking test\n"
+        .iter()
+        .copied()
+        .cycle()
+        .take(1_088_091)
+        .collect();
+
+    fs::write(module_dir.join("small.txt"), &small).expect("write small");
+    fs::write(module_dir.join("medium.txt"), &medium).expect("write medium");
+    fs::write(module_dir.join("large.txt"), &large).expect("write large");
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir(&dest_dir).expect("create dest");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[mod]\n\
+         path = {}\n\
+         read only = true\n\
+         use chroot = false\n",
+        module_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--max-sessions"),
+            OsString::from("2"),
+        ])
+        .build();
+
+    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    drop(probe_stream);
+
+    let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
+
+    let client_config = core::client::ClientConfig::builder()
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
+        .compress(true)
+        .build();
+
+    let result = core::client::run_client(client_config);
+
+    match &result {
+        Ok(summary) => {
+            assert!(
+                summary.files_copied() >= 3,
+                "compressed pull must copy 3 files, got {}",
+                summary.files_copied()
+            );
+        }
+        Err(e) => {
+            let _ = daemon_handle.join();
+            panic!(
+                "compressed pull failed - cluster A regression? error: {e}\n\
+                 if this is 'connection unexpectedly closed (N bytes received so far)' \
+                 the daemon goodbye drain has regressed; see \
+                 crates/daemon/src/daemon/sections/module_access/transfer.rs"
+            );
+        }
+    }
+
+    assert_eq!(
+        fs::read(dest_dir.join("small.txt")).expect("read small"),
+        small,
+        "small.txt content mismatch after compressed pull"
+    );
+    assert_eq!(
+        fs::read(dest_dir.join("medium.txt")).expect("read medium"),
+        medium,
+        "medium.txt content mismatch after compressed pull"
+    );
+    assert_eq!(
+        fs::read(dest_dir.join("large.txt")).expect("read large"),
+        large,
+        "large.txt content mismatch after compressed pull"
+    );
+
+    let daemon_result = daemon_handle.join().expect("daemon thread");
+    let _ = daemon_result;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: oc-rsync daemon-as-sender called `shutdown(SHUT_WR)` immediately after the engine returned, sending FIN before the receiver had a chance to write its trailing `MSG_STATS` + `NDX_DONE` through the receiver-to-generator pipe. The receiver saw FIN, abandoned its writes, and emitted `connection unexpectedly closed (N bytes received so far) [receiver]`. The four upstream UTS-v3 cluster A failures (`batch-mode`, `alt-dest`, `daemon-gzip-download`, `daemon-refuse-compress`) all clustered near the daemon's last write because the cutoff byte count = exactly the bytes the daemon sent before the half-close.

- **Fix**: drop the half-close. Keep `SO_LINGER(5s)` so the daemon's TX bytes reach the peer before `close()` returns, and drain reads in a loop until peer FIN (EOF), bounded at 5s. Mirrors upstream's fork-model behaviour (`cleanup.c:close_all()` is a no-op on Linux without `SHUTDOWN_ALL_SOCKETS`; the kernel handles cleanup once the sender child exits) and the `noop_io_until_death()` drain pattern (`io.c:943`).

- **Verification**: rebuilt on Linux/aarch64 from `master + this fix`, ran the upstream rsync 3.4.3 testsuite (`--rsync-bin=rsync --rsync-bin2=oc-rsync --use-tcp`) for the four cluster A tests. All 4 pass. Wire-byte capture (strace -ff -y on the daemon worker) before/after confirms the daemon now drains the receiver's trailing 20-byte goodbye instead of closing on the first 5 bytes.

## Test plan

- [x] `cargo nextest run -p daemon --all-features -E 'test(daemon_compress_pull_drains_peer_goodbye)'` - new regression test passes locally
- [x] `cargo nextest run -p daemon --all-features -E 'test(daemon_compress_push) | test(daemon_pull_lifecycle) | test(daemon_push_then_pull) | test(daemon_compress_pull) | test(run_daemon_post_ok)'` - adjacent daemon tests pass locally
- [x] Upstream UTS-v3 cluster A scenarios pass: `daemon-gzip-download`, `daemon-refuse-compress`, `batch-mode`, `alt-dest` (verified on Linux/aarch64 against upstream rsync 3.4.3)
- [ ] CI: fmt+clippy, nextest stable (full), Windows, macOS, Linux musl