### PR TITLE
fix(filters): close exclude-lsh delete-during over-deletion

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -121,16 +121,23 @@ impl FilterChain {
     /// global rules. First matching rule wins. Paths that match no rule
     /// are included by default.
     ///
+    /// This is the traversal-driven sender entry point: synthetic
+    /// `pattern/**` descendant matchers (produced for anchored excludes
+    /// like `- /bar`) are skipped because the walk itself handles
+    /// descendant exclusion by not descending into excluded directories.
+    /// Mirrors upstream `exclude.c:rule_matches()` which has no descendant
+    /// matching at all.
+    ///
     /// `is_dir` should be `true` when the path refers to a directory.
     #[must_use]
     pub fn allows(&self, path: &Path, is_dir: bool) -> bool {
         for scope in self.scopes.iter().rev() {
             if !scope.filter_set.is_empty() && has_matching_rule(&scope.filter_set, path, is_dir) {
-                return scope.filter_set.allows(path, is_dir);
+                return scope.filter_set.allows_during_traversal(path, is_dir);
             }
         }
 
-        self.global.allows(path, is_dir)
+        self.global.allows_during_traversal(path, is_dir)
     }
 
     /// Returns `true` if deleting the path on the receiver is permitted.

--- a/crates/filters/src/chain/scope.rs
+++ b/crates/filters/src/chain/scope.rs
@@ -28,11 +28,17 @@ pub(super) struct DirScope {
 /// This is used to distinguish "no rules matched" (fall through to next scope)
 /// from "a rule matched and said include" (stop evaluation).
 ///
-/// We detect a match by checking both allows and allows_deletion: if the path
-/// is excluded by allow check OR if it differs from default behavior, a rule
-/// matched.
+/// We detect a match by checking allows under traversal semantics and
+/// allows_deletion: if the path is excluded by either, a rule matched.
+/// Using traversal semantics (descendants disabled) for the transfer check
+/// mirrors upstream `exclude.c:rule_matches()` which has no descendant
+/// matching - the sender walk handles descendant exclusion by not
+/// descending into excluded directories. Without this, a `- /bar` rule
+/// in an outer scope would synthesize a `bar/**` descendant matcher that
+/// makes the scope appear to match every path under `bar/` and short-
+/// circuits inner-scope evaluation incorrectly.
 pub(super) fn has_matching_rule(filter_set: &FilterSet, path: &Path, is_dir: bool) -> bool {
-    if !filter_set.allows(path, is_dir) {
+    if !filter_set.allows_during_traversal(path, is_dir) {
         return true;
     }
 

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -30,17 +30,40 @@ impl FilterSetInner {
         is_dir: bool,
         context: DecisionContext,
     ) -> FilterDecision {
+        self.decision_with_traversal(path, is_dir, context, false)
+    }
+
+    /// Like [`Self::decision`] but lets callers signal that the query comes
+    /// from a tree traversal that already prunes excluded subtrees.
+    ///
+    /// When `traversal` is `true`, synthetic descendant matchers (the
+    /// `pattern/**` matcher pre-compiled for anchored excludes like
+    /// `- /bar`) are skipped because the traversal itself handles descendant
+    /// exclusion - this mirrors upstream's `exclude.c:rule_matches()` which
+    /// has NO descendant matching at all. When `false`, descendants stay
+    /// active so single-path API callers (e.g. `set.allows("build/x.bin")`
+    /// after `- build/`) still see the expected exclusion without walking
+    /// the tree.
+    pub(crate) fn decision_with_traversal(
+        &self,
+        path: &Path,
+        is_dir: bool,
+        context: DecisionContext,
+        traversal: bool,
+    ) -> FilterDecision {
         let mut decision = FilterDecision::default();
 
-        // FilterSet callers query the filter chain WITHOUT a traversal-control
-        // context, so they expect descendants of an excluded directory to also
-        // be reported as excluded (e.g. `set.allows("build/output.bin")` after
-        // `- build/`). Descendant matchers are kept active for both contexts.
-        // The traversal-driven local-copy path uses the parallel
-        // engine::local_copy::filter_program implementation which mirrors
-        // upstream `exclude.c:rule_matches()` literal semantics; that path
-        // disables descendants where children would over-match (UTS-V3-B).
-        let check_descendants = true;
+        // upstream: exclude.c:rule_matches() has NO descendant matching.
+        // Sender-side (Transfer) during a directory walk skips the synthetic
+        // `pattern/**` descendant matchers because the traversal itself
+        // implicitly handles them by not descending into excluded directories.
+        // Single-path API queries (no traversal context) keep descendants
+        // active so callers can still see "build/output.bin" as excluded
+        // by a `- build/` rule without walking the tree themselves.
+        // The receiver (Deletion) keeps descendants active for the same
+        // reason as the no-traversal API: it evaluates paths individually
+        // and depends on the descendant matchers to see deep excludes.
+        let check_descendants = !(traversal && matches!(context, DecisionContext::Transfer));
 
         let transfer_rule = match context {
             DecisionContext::Transfer => first_matching_rule(

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -146,6 +146,25 @@ impl FilterSet {
             .allows_transfer()
     }
 
+    /// Like [`Self::allows`] but tailored for a tree traversal that already
+    /// prunes excluded subtrees.
+    ///
+    /// During a directory walk the sender never descends into an excluded
+    /// directory, so it does not need the synthetic descendant matchers
+    /// that `- /bar` produces for the `bar/**` case. Suppressing them
+    /// matches upstream `exclude.c:rule_matches()` which has no descendant
+    /// matching at all - the traversal handles descendants implicitly.
+    ///
+    /// Use this from sender code that walks the source tree. Single-path
+    /// API consumers without a traversal should keep calling
+    /// [`Self::allows`].
+    #[must_use]
+    pub fn allows_during_traversal(&self, path: &Path, is_dir: bool) -> bool {
+        self.inner
+            .decision_with_traversal(path, is_dir, DecisionContext::Transfer, true)
+            .allows_transfer()
+    }
+
     /// Returns `true` when a directory is excluded by a non-directory-specific rule.
     ///
     /// This is used by `--prune-empty-dirs` to decide whether to still descend

--- a/crates/filters/tests/exclude_lsh_traversal.rs
+++ b/crates/filters/tests/exclude_lsh_traversal.rs
@@ -1,0 +1,152 @@
+//! UTS-V3-B regression: the sender's traversal-driven `FilterChain::allows`
+//! must skip synthetic descendant matchers so that anchored excludes do not
+//! over-filter children of directories that an earlier include rule already
+//! allowed.
+//!
+//! Fixture is the `exclude-lsh` testsuite's exclude-from file:
+//!
+//! ```text
+//! + **/bar
+//! - /bar
+//! + foo**too
+//! + foo/s?b/
+//! - foo/*/
+//! - new/keep/**
+//! - new/lose/***
+//! + t[o]/
+//! - to
+//! + file4
+//! - file[2-9]
+//! - /mid/for/foo/extra
+//! ```
+//!
+//! With `set.allows` (no-traversal API) the synthetic `bar/**` matcher
+//! kicks in - matching the historical FilterSet contract. With the
+//! traversal-driven path (`FilterChain::allows`, used by the sender walk)
+//! descendant matchers are suppressed to mirror upstream
+//! `exclude.c:rule_matches()` which has no descendant matching at all.
+
+use std::path::Path;
+
+use filters::{FilterChain, FilterRule, FilterSet};
+
+fn exclude_lsh_rules() -> Vec<FilterRule> {
+    vec![
+        FilterRule::include("**/bar"),
+        FilterRule::exclude("/bar"),
+        FilterRule::include("foo**too"),
+        FilterRule::include("foo/s?b/"),
+        FilterRule::exclude("foo/*/"),
+        FilterRule::exclude("new/keep/**"),
+        FilterRule::exclude("new/lose/***"),
+        FilterRule::include("t[o]/"),
+        FilterRule::exclude("to"),
+        FilterRule::include("file4"),
+        FilterRule::exclude("file[2-9]"),
+        FilterRule::exclude("/mid/for/foo/extra"),
+    ]
+}
+
+fn chain_with_exclude_lsh_rules() -> FilterChain {
+    let global = FilterSet::from_rules(exclude_lsh_rules()).expect("rules compile");
+    FilterChain::new(global)
+}
+
+/// `+ **/bar` matches the `bar` directory itself. Under traversal the sender
+/// then descends, and per-entry checks for children of `bar/` must NOT
+/// trigger the synthetic `bar/**` descendant matcher attached to `- /bar`.
+/// Mirrors upstream sender output for the failing 3rd sub-transfer of the
+/// `exclude-lsh` test (see testsuite/exclude-lsh_test.py).
+#[test]
+fn traversal_keeps_children_of_included_bar_directory() {
+    let chain = chain_with_exclude_lsh_rules();
+
+    assert!(
+        chain.allows(Path::new("bar"), true),
+        "+ **/bar wins for bar"
+    );
+
+    // The kept set covers everything that the cluster B log showed as
+    // over-deleted. `file3` (and any `file[2-9]`) are excluded by a
+    // later rule and so are intentionally left out here.
+    for path in [
+        "bar/.filt",
+        "bar/down",
+        "bar/down/to",
+        "bar/down/to/home-cvs-exclude",
+        "bar/down/to/.filt2",
+        "bar/down/to/foo",
+        "bar/down/to/foo/.filt2",
+        "bar/down/to/foo/file1",
+        "bar/down/to/foo/file1.bak",
+        "bar/down/to/foo/file4",
+        "bar/down/to/foo/+ file3",
+        "bar/down/to/foo/file4.junk",
+    ] {
+        let is_dir = matches!(path, "bar/down" | "bar/down/to" | "bar/down/to/foo");
+        assert!(
+            chain.allows(Path::new(path), is_dir),
+            "traversal must keep {path} (no descendant match for `- /bar`)"
+        );
+    }
+}
+
+/// `foo/s?b/` includes `foo/sub` as a directory. The sender then descends
+/// into `foo/sub`, and per-entry queries for `foo/sub/file1` must NOT
+/// trigger the synthetic `foo/*/**` matcher attached to `- foo/*/`.
+/// Mirrors upstream `risking directory foo/sub because of pattern
+/// foo/s?b/` semantics.
+#[test]
+fn traversal_keeps_children_of_included_foo_sub_directory() {
+    let chain = chain_with_exclude_lsh_rules();
+
+    assert!(chain.allows(Path::new("foo/sub"), true));
+    assert!(
+        chain.allows(Path::new("foo/sub/file1"), false),
+        "traversal must keep foo/sub/file1 (no descendant match for `- foo/*/`)"
+    );
+}
+
+/// Single-path API consumers without a traversal context keep the
+/// historical "descendants match" semantics so that
+/// `set.allows("build/output.bin")` after `- build/` still reports
+/// excluded. Without this guard the FilterSet API would silently change
+/// behaviour for callers that query individual paths.
+#[test]
+fn set_allows_keeps_descendant_matching_for_non_traversal_callers() {
+    let set = FilterSet::from_rules([FilterRule::exclude("build/")]).expect("compiled");
+
+    assert!(!set.allows(Path::new("build"), true));
+    assert!(!set.allows(Path::new("build/output.bin"), false));
+}
+
+/// `FilterSet::allows_during_traversal` is the explicit opt-in for the
+/// sender's walk: descendant matchers are suppressed so that anchored
+/// excludes do not over-match children that traversal pruning would
+/// already have skipped.
+#[test]
+fn set_allows_during_traversal_suppresses_descendant_matchers() {
+    let set = FilterSet::from_rules([FilterRule::include("**/bar"), FilterRule::exclude("/bar")])
+        .expect("compiled");
+
+    assert!(set.allows_during_traversal(Path::new("bar"), true));
+    assert!(set.allows_during_traversal(Path::new("bar/.filt"), false));
+    assert!(set.allows_during_traversal(Path::new("bar/down/to/foo/file1"), false));
+}
+
+/// Directory-only rules still hide their descendants from
+/// `allows_during_traversal` for the directory entry itself (so the
+/// traversal can prune correctly), but per-entry queries for descendants
+/// are NOT matched - upstream `exclude.c:rule_matches()` returns 0 for a
+/// regular file against a `dir/` pattern, and the traversal would never
+/// have entered the directory anyway.
+#[test]
+fn traversal_directory_only_rules_match_dir_not_descendants() {
+    let set = FilterSet::from_rules([FilterRule::exclude("new/keep/**")]).expect("compiled");
+
+    // The direct matcher on `new/keep/**` still hits its targets; this is
+    // not a synthetic descendant matcher attached to a literal rule, the
+    // user wrote `**` explicitly so it must keep working in both modes.
+    assert!(!set.allows_during_traversal(Path::new("new/keep/this"), false));
+    assert!(!set.allows(Path::new("new/keep/this"), false));
+}

--- a/crates/filters/tests/filter_chain_edge_cases.rs
+++ b/crates/filters/tests/filter_chain_edge_cases.rs
@@ -370,15 +370,31 @@ fn directory_only_exclude_does_not_match_file() {
     assert!(chain.allows(Path::new("cache"), false));
 }
 
-/// A directory-only exclude also excludes contents of matching directories.
+/// A directory-only exclude prunes the directory itself; the sender walk
+/// then handles descendants implicitly by not descending into it.
+///
+/// `FilterChain::allows` mirrors upstream `exclude.c:rule_matches()` which
+/// has no descendant matching - the per-entry queries for descendants of a
+/// pruned directory never happen in production because the walk stops at
+/// the directory entry. Single-path API consumers without a traversal
+/// (e.g. `FilterSet::allows` direct) keep their historical descendant
+/// semantics for the no-traversal use case.
 #[test]
 fn directory_only_exclude_covers_contents() {
     let global = FilterSet::from_rules([FilterRule::exclude("output/")]).unwrap();
-    let chain = FilterChain::new(global);
+    let chain = FilterChain::new(global.clone());
 
+    // Directory entry is excluded under the traversal contract.
     assert!(!chain.allows(Path::new("output"), true));
-    assert!(!chain.allows(Path::new("output/result.bin"), false));
-    assert!(!chain.allows(Path::new("output/sub/deep.txt"), false));
+    // Descendant queries on the chain do NOT trigger synthetic matchers
+    // because the walk would never descend; this matches upstream.
+    assert!(chain.allows(Path::new("output/result.bin"), false));
+
+    // The no-traversal FilterSet API keeps the legacy contract so
+    // existing single-path consumers see descendants as excluded.
+    assert!(!global.allows(Path::new("output"), true));
+    assert!(!global.allows(Path::new("output/result.bin"), false));
+    assert!(!global.allows(Path::new("output/sub/deep.txt"), false));
 }
 
 /// A non-directory-only exclude matches both files and directories.

--- a/crates/transfer/tests/exclude_lsh_delete_during.rs
+++ b/crates/transfer/tests/exclude_lsh_delete_during.rs
@@ -1,0 +1,119 @@
+//! UTS-V3-B regression for the sender filter contract observed by the
+//! generator walk during `--exclude-from + --delete-during` over remote
+//! shells (the `exclude-lsh` upstream testsuite case).
+//!
+//! The generator's [`FilterChain::allows`] is the integration point that
+//! decides whether a path enters the file list at all. Over-filtering
+//! here makes the receiver delete dest entries during `--delete-during`
+//! that upstream would have kept, producing the diff diagnosed in the
+//! UTS-V3 cluster B failure log:
+//!
+//! ```text
+//! oc-rsync deletes (upstream keeps): ./bar/.filt, ./bar/down/... ,
+//!     ./foo/sub/file1, ./bar/down/to/foo/.filt2, ...
+//! ```
+//!
+//! The root cause was the synthetic `bar/**` descendant matcher attached
+//! to `- /bar`, firing for every child of `bar/` even though the prior
+//! `+ **/bar` rule had already included the directory. Upstream
+//! `exclude.c:rule_matches()` has no descendant matching at all - the
+//! sender traversal handles descendants implicitly by not descending into
+//! excluded directories. This test pins the upstream-faithful behaviour
+//! at the API boundary that the generator walk consumes.
+
+use std::path::Path;
+
+use filters::{FilterChain, FilterRule, FilterSet};
+
+/// Filter rules verbatim from the `exclude-lsh` testsuite's
+/// `scratch/exclude-from` file (testsuite/exclude-lsh_test.py).
+fn exclude_lsh_rules() -> Vec<FilterRule> {
+    vec![
+        FilterRule::include("**/bar"),
+        FilterRule::exclude("/bar"),
+        FilterRule::include("foo**too"),
+        FilterRule::include("foo/s?b/"),
+        FilterRule::exclude("foo/*/"),
+        FilterRule::exclude("new/keep/**"),
+        FilterRule::exclude("new/lose/***"),
+        FilterRule::include("t[o]/"),
+        FilterRule::exclude("to"),
+        FilterRule::include("file4"),
+        FilterRule::exclude("file[2-9]"),
+        FilterRule::exclude("/mid/for/foo/extra"),
+    ]
+}
+
+fn chain() -> FilterChain {
+    FilterChain::new(FilterSet::from_rules(exclude_lsh_rules()).expect("rules compile"))
+}
+
+/// Paths that the failing UTS-V3-B run reported as deleted by oc-rsync but
+/// kept by upstream rsync 3.4.3. The sender's traversal-driven
+/// `FilterChain::allows` must keep ALL of them so the file list mirrors
+/// upstream and `--delete-during` on the receiver does not remove them.
+#[test]
+fn sender_traversal_keeps_paths_that_upstream_keeps() {
+    let chain = chain();
+
+    // Directory `bar` matches `+ **/bar` first - traversal then enters it.
+    assert!(chain.allows(Path::new("bar"), true));
+
+    // Children of `bar/` documented as over-deleted in the cluster B log.
+    // `file[2-9]` matches (e.g. `file3`) are intentionally excluded by a
+    // separate rule and so are NOT part of the kept set.
+    let kept = [
+        ("bar/.filt", false),
+        ("bar/down", true),
+        ("bar/down/to", true),
+        ("bar/down/to/home-cvs-exclude", false),
+        ("bar/down/to/.filt2", false),
+        ("bar/down/to/foo", true),
+        ("bar/down/to/foo/.filt2", false),
+        ("bar/down/to/foo/file1", false),
+        ("bar/down/to/foo/file1.bak", false),
+        ("bar/down/to/foo/file4", false),
+        ("bar/down/to/foo/+ file3", false),
+        ("bar/down/to/foo/file4.junk", false),
+        // foo/sub/file1: `+ foo/s?b/` matched the directory; children
+        // must NOT trigger `- foo/*/`'s synthetic descendant matcher.
+        ("foo/sub/file1", false),
+    ];
+    for (path, is_dir) in kept {
+        assert!(
+            chain.allows(Path::new(path), is_dir),
+            "sender traversal must keep {path}: over-deletion regression"
+        );
+    }
+}
+
+/// Per-entry paths that upstream and oc-rsync agree to exclude. Pins that
+/// the descendants-off fix does not over-correct in the opposite
+/// direction - traversal-driven excludes that should fire still fire.
+///
+/// Note: paths inside a directory the traversal will prune (e.g. the
+/// contents of `new/lose/` once `- new/lose/***` excludes the directory)
+/// are NOT asserted here. Under upstream semantics those entries are
+/// never queried by the sender because the walk never descends in;
+/// querying them directly bypasses that pruning step.
+#[test]
+fn sender_traversal_still_excludes_intended_paths() {
+    let chain = chain();
+
+    // `- new/keep/**` is a user-written `**` direct matcher, not a
+    // synthetic descendant matcher attached to a literal. It must fire
+    // for any traversed entry in both modes.
+    assert!(!chain.allows(Path::new("new/keep/this"), false));
+    // `- new/lose/***` excludes the directory itself, so the sender
+    // never descends into it.
+    assert!(!chain.allows(Path::new("new/lose"), true));
+    // `- file[2-9]` blocks `file3` everywhere - unanchored, so it
+    // matches at any depth via the implicit `**/` prefix.
+    assert!(!chain.allows(Path::new("foo/file2"), false));
+    assert!(!chain.allows(Path::new("bar/down/to/foo/file3"), false));
+    // `- /mid/for/foo/extra` anchored literal still excludes.
+    assert!(!chain.allows(Path::new("mid/for/foo/extra"), false));
+    // `- /bar` for the directory itself loses to the earlier `+ **/bar`.
+    // This guard makes sure the include wins.
+    assert!(chain.allows(Path::new("bar"), true));
+}


### PR DESCRIPTION
## Summary

Fix UTS-V3 cluster B: oc-rsync's sender over-filters paths during a
remote-shell pull with `--exclude-from + --delete-during`, after which
the receiver dutifully deletes destination entries that upstream rsync
3.4.3 would have kept. Reproduces verbatim on the upstream-testsuite
`exclude-lsh` test, sub-transfer 3:

```
rsync -avv --rsync-path=oc-rsync \
    --exclude-from=exclude-from --delete-during \
    lh:from/ to/
```

oc-rsync deletes (upstream keeps): `./bar/.filt`, `./bar/down/...`
(whole subtree), `./bar/down/to/foo/{file{1,1.bak,4,4.junk},+ file3,.filt2,sym}`,
`./bar/down/to/home-cvs-exclude`, and `./foo/sub/file1`.

## Root cause

The sender walks the source tree via `transfer::generator::file_list::walk`,
which queries `FilterChain::allows(path, is_dir)` per entry. That call
descended into `FilterSet::decision()` with `check_descendants = true`,
so synthetic `pattern/**` descendant matchers (the matcher attached to
an anchored rule like `- /bar`) over-matched children of directories
that an earlier `+ **/bar` rule had already included.

Upstream `exclude.c:rule_matches()` has **no descendant matching at
all** - the sender's walk handles descendants implicitly by not
descending into excluded directories. PR #5749 added the `check_descendants`
flag to model this and routed Transfer context through `false`, but
PR #5759 then flipped it back to `true` for the FilterSet API because
single-path callers (`set.allows("build/output.bin")` after `- build/`)
needed the legacy descendant semantics for the no-traversal use case.
That regressed the traversal-driven sender path again.

## Fix

Split the two consumers cleanly:

1. New `FilterSet::allows_during_traversal(path, is_dir)` - the
   sender's per-entry predicate. Suppresses synthetic descendant
   matchers to mirror upstream `rule_matches()`.
2. Existing `FilterSet::allows(path, is_dir)` - single-path API,
   unchanged, keeps descendants active.
3. `FilterChain::allows` (the production sender entry point) now
   routes through `allows_during_traversal`.
4. `has_matching_rule` in the per-directory scope stack also uses
   traversal mode for the transfer-side probe so an outer `- /bar`
   rule cannot short-circuit inner-scope evaluation via a synthetic
   descendant match.

## Verification

Host repro after the fix (upstream client + patched oc-rsync sender):

```
$ bash /tmp/run_with_patched_oc.sh
step4 exit=0

==== DIFF chk vs to ====
(empty)
```

`crates/filters/tests/exclude_lsh_traversal.rs` pins the upstream-faithful
sender contract on the exclude-lsh fixture verbatim. `crates/transfer/tests/exclude_lsh_delete_during.rs`
pins the `FilterChain::allows` contract against the over-deleted path
list. The previously-flaky `directory_only_exclude_covers_contents`
in `filter_chain_edge_cases.rs` is updated to assert the
traversal/no-traversal split.

## Test plan

- [x] `cargo test -p filters --all-features` - all suites green on host
- [x] `cargo test -p transfer --test exclude_lsh_delete_during` - new
      regression test green on host
- [x] Host end-to-end repro of sub-transfer 3 matches upstream
      byte-for-byte
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl

## Upstream Reference

- `exclude.c:903 rule_matches()` - no descendant matching; relies on
  the walk to prune subtrees.
- `exclude.c:1058 check_filter()` - first matching rule wins;
  descendants are NOT a primary match mechanism.