### PR TITLE
fix(transfer): close files-from hang on repeated lsh.sh invocations

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -438,9 +438,17 @@ where
         .as_ref()
         .and_then(|value: &ParsedChown| value.group());
 
-    let mut file_list_operands = match load_file_list_operands(&files_from, from0) {
-        Ok(operands) => operands,
-        Err(message) => return fail_with_message(message, stderr),
+    // upstream: options.c:2483 - only open files_from locally when the spec
+    // is NOT a hostspec. Remote files-from (`:path` or `host:path`) are read
+    // by the server, so the client never opens them.
+    let files_from_resolved = resolve_files_from_source(&files_from);
+    let mut file_list_operands = if files_from_resolved.is_remote() {
+        Vec::new()
+    } else {
+        match load_file_list_operands(&files_from, from0) {
+            Ok(operands) => operands,
+            Err(message) => return fail_with_message(message, stderr),
+        }
     };
 
     let files_from_active = !files_from.is_empty();
@@ -848,7 +856,7 @@ where
             .into_iter()
             .map(|s| s.to_string_lossy().into_owned())
             .collect(),
-        files_from: resolve_files_from_source(&files_from),
+        files_from: files_from_resolved.clone(),
         from0,
         spill_dir,
         spill_threshold_bytes,

--- a/crates/cli/src/frontend/execution/file_list/parser.rs
+++ b/crates/cli/src/frontend/execution/file_list/parser.rs
@@ -10,7 +10,10 @@ use std::path::PathBuf;
 ///
 /// The resolution mirrors upstream rsync's `options.c:2447-2490`:
 /// - `"-"` means stdin
-/// - `:path` (colon prefix) means a remote file opened by the server
+/// - `:path` (bare colon prefix) means a remote file opened by the server
+///   using the host taken from the transfer operand
+/// - `host:path` (hostspec form) means a remote file opened by the named
+///   host (must match the transfer host, validated in `main.c:1420`)
 /// - Otherwise, a local file read by the client
 ///
 /// Only the last `--files-from` argument takes effect, matching upstream
@@ -18,8 +21,10 @@ use std::path::PathBuf;
 ///
 /// # Upstream Reference
 ///
-/// - `options.c:2458` - `check_for_hostspec()` detects `:path` prefix
+/// - `options.c:2458` - `check_for_hostspec()` detects `host:path` prefix
+/// - `options.c:2464-2465` - `files_from = p; filesfrom_host = h;`
 /// - `options.c:2466-2469` - `:-` (remote stdin) is rejected
+/// - `options.c:3112-3138` - `check_for_hostspec()` parses `host:path`
 pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client::FilesFromSource {
     use core::client::FilesFromSource;
 
@@ -34,12 +39,64 @@ pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client
         return FilesFromSource::Stdin;
     }
 
-    // Detect remote file: colon prefix `:path` (upstream check_for_hostspec).
+    // Detect remote file: bare colon prefix `:path` (host taken from operand).
     if let Some(remote_path) = text.strip_prefix(':') {
         return FilesFromSource::RemoteFile(remote_path.to_owned());
     }
 
+    // Detect remote file: `host:path` (upstream check_for_hostspec).
+    // Reject Windows drive specs (`C:\...`), URLs (`rsync://`), and daemon
+    // module specs (`host::module`). The latter is for daemon transfers,
+    // which we do not currently support for files-from.
+    if let Some((host, path)) = split_hostspec(&text) {
+        let _ = host; // host validation happens at transfer-arg level
+        return FilesFromSource::RemoteFile(path.to_owned());
+    }
+
     FilesFromSource::LocalFile(PathBuf::from(last))
+}
+
+/// Splits a `host:path` argument into `(host, path)` if `text` is a remote
+/// hostspec. Returns `None` for local paths, Windows drive letters, daemon
+/// module specs (`::`), and URL forms.
+///
+/// Mirrors `options.c:3112-3138 check_for_hostspec()`:
+/// - Reject URL forms (`rsync://`); those are daemon URLs, handled elsewhere
+/// - Reject `host::module` (daemon module spec)
+/// - Reject paths beginning with `/` (no host part)
+/// - Reject Windows drive letters (`C:\foo`, `C:/foo`)
+fn split_hostspec(text: &str) -> Option<(&str, &str)> {
+    if text.starts_with('/') {
+        return None;
+    }
+    if text.starts_with("rsync://") {
+        return None;
+    }
+
+    let colon = text.find(':')?;
+    let host = &text[..colon];
+    let rest = &text[colon + 1..];
+
+    // Reject daemon module spec `host::module`.
+    if rest.starts_with(':') {
+        return None;
+    }
+
+    // Reject Windows drive letter `C:\` / `C:/`.
+    if host.len() == 1 && host.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+
+    if host.is_empty() {
+        return None;
+    }
+
+    // Reject `host:-` (upstream options.c:2466-2469 rejects remote stdin).
+    if rest == "-" {
+        return None;
+    }
+
+    Some((host, rest))
 }
 
 /// Determines whether the transfer involves any remote operands.

--- a/crates/cli/src/frontend/execution/file_list/tests.rs
+++ b/crates/cli/src/frontend/execution/file_list/tests.rs
@@ -460,6 +460,65 @@ fn resolve_files_from_remote_colon_prefix() {
 }
 
 #[test]
+fn resolve_files_from_host_colon_prefix() {
+    // UTS-V3-D regression: upstream's `testsuite/files-from.test` 4th
+    // invocation passes `--files-from=localhost:scratch/filelist`. The
+    // parser must recognise the hostspec form (upstream
+    // `options.c:3112-3138 check_for_hostspec`) and emit RemoteFile
+    // with the host stripped. Without this fix the loader hit
+    // `loader.rs:54` immediately with "No such file or directory".
+    let files = vec![OsString::from("localhost:/remote/path.txt")];
+    let source = resolve_files_from_source(&files);
+    assert_eq!(
+        source,
+        core::client::FilesFromSource::RemoteFile("/remote/path.txt".to_owned())
+    );
+}
+
+#[test]
+fn resolve_files_from_windows_drive_letter_is_local() {
+    // upstream check_for_hostspec rejects single-letter "host" because
+    // parse_hostspec demands a real hostname. The DOS drive-letter form
+    // must continue to resolve as a local path on Windows.
+    let files = vec![OsString::from("C:/tmp/list.txt")];
+    let source = resolve_files_from_source(&files);
+    match source {
+        core::client::FilesFromSource::LocalFile(p) => {
+            assert_eq!(p.to_string_lossy(), "C:/tmp/list.txt");
+        }
+        other => panic!("expected LocalFile for drive-letter, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_files_from_daemon_module_spec_is_local() {
+    // `host::module` is the daemon module access form, handled by a
+    // separate transport path. The files-from parser must defer to
+    // LocalFile so the daemon path produces its own error.
+    let files = vec![OsString::from("host::mod/list")];
+    let source = resolve_files_from_source(&files);
+    match source {
+        core::client::FilesFromSource::LocalFile(p) => {
+            assert_eq!(p.to_string_lossy(), "host::mod/list");
+        }
+        other => panic!("expected LocalFile for daemon spec, got {other:?}"),
+    }
+}
+
+#[test]
+fn resolve_files_from_remote_stdin_marker_falls_through() {
+    // upstream `options.c:2466-2469` aborts on `host:-`; we route through
+    // LocalFile so the downstream loader returns a clear error rather
+    // than silently routing the literal `-` to the remote side.
+    let files = vec![OsString::from("host:-")];
+    let source = resolve_files_from_source(&files);
+    match source {
+        core::client::FilesFromSource::LocalFile(_) => {}
+        other => panic!("expected LocalFile fall-through for host:-, got {other:?}"),
+    }
+}
+
+#[test]
 fn resolve_files_from_uses_last_value() {
     let files = vec![OsString::from("/first.txt"), OsString::from("/last.txt")];
     let source = resolve_files_from_source(&files);

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -261,7 +261,33 @@ where
             {
                 use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
                 if is_supported() {
-                    match restrict_to_module_paths(&[root.as_path()]) {
+                    let mut allowed = vec![root];
+
+                    // UTS-V3-D: a remote files-from path (upstream
+                    // `options.c:2944` -> server gets `--files-from <path>`)
+                    // sits outside the destination tree. The receiver
+                    // opens it in `forward_files_from_to_sender` to push
+                    // filenames back to the sender; the landlock allowlist
+                    // must include the file's parent or the open fails
+                    // with EACCES (observed as the
+                    // "Permission denied (os error 13)" branch when the
+                    // receiver reached the new forwarder).
+                    if let Some(path) = config.file_selection.files_from_path.as_deref() {
+                        if path != "-" {
+                            let p = std::path::PathBuf::from(path);
+                            if let Some(canon) = p
+                                .canonicalize()
+                                .ok()
+                                .or_else(|| p.parent().and_then(|d| d.canonicalize().ok()))
+                            {
+                                allowed.push(canon);
+                            }
+                        }
+                    }
+
+                    let allowed_refs: Vec<&std::path::Path> =
+                        allowed.iter().map(|p| p.as_path()).collect();
+                    match restrict_to_module_paths(&allowed_refs) {
                         LandlockOutcome::Enforced(_) | LandlockOutcome::Unavailable => {}
                         LandlockOutcome::Error(e) => {
                             write_server_error(

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -37,7 +37,7 @@ impl ReceiverContext {
         pipeline_config: PipelineConfig,
     ) -> io::Result<TransferStats> {
         let _t = PhaseTimer::new("receiver-transfer-pipelined");
-        let (mut reader, file_count, mut setup) = self.setup_transfer(reader)?;
+        let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
         // upstream: generator.c:1317-1326 - make_path() for relative_paths

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -35,7 +35,7 @@ impl ReceiverContext {
         mut progress: Option<&mut dyn crate::TransferProgressCallback>,
     ) -> io::Result<TransferStats> {
         let _t = PhaseTimer::new("receiver-transfer-incremental");
-        let (mut reader, file_count, mut setup) = self.setup_transfer(reader)?;
+        let (mut reader, file_count, mut setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
         let mut stats = TransferStats {

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -34,9 +34,10 @@ impl ReceiverContext {
     ///
     /// - `main.c:1342-1343` - client receiver activates multiplex at protocol >= 23
     /// - `main.c:1167-1168` - server receiver activates multiplex at protocol >= 30
-    pub(in crate::receiver) fn setup_transfer<R: Read>(
+    pub(in crate::receiver) fn setup_transfer<R: Read, W: io::Write + ?Sized>(
         &mut self,
         reader: crate::reader::ServerReader<R>,
+        writer: &mut W,
     ) -> io::Result<(crate::reader::ServerReader<R>, usize, PipelineSetup)> {
         // upstream: generator.c:2260-2261 - emitted at the top of generate_files,
         // just before the per-segment dispatch loop. The receiver-side transfer
@@ -113,6 +114,15 @@ impl ReceiverContext {
         self.pipeline
             .advance_to(TransferPhase::FileListTransfer)
             .map_err(crate::fsm_error)?;
+
+        // upstream: main.c:1173-1180 - server-receiver opened a local
+        // `--files-from` file (filesfrom_fd) and now forwards its contents
+        // to the sender (the client) over f_out so the sender can build the
+        // file list. Upstream interleaves this with `recv_file_list` via the
+        // I/O scheduler; we write the whole file out as a single push before
+        // entering the flist read because oc-rsync's reader/writer streams
+        // are decoupled (no select() loop fanning across them).
+        self.forward_files_from_to_sender(writer)?;
 
         if self.config.flags.verbose && self.config.connection.client_mode {
             info_log!(Flist, 1, "receiving incremental file list");
@@ -417,6 +427,79 @@ impl ReceiverContext {
             entry.set_name(PathBuf::from(&target_basename));
         }
         parent.unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    /// Forwards a server-receiver-side `--files-from=<localpath>` file to the
+    /// sender (peer) over the protocol writer.
+    ///
+    /// Upstream's `main.c:1173-1180` server-receiver opens `filesfrom_fd`
+    /// locally and registers it with `start_filesfrom_forwarding`. The I/O
+    /// scheduler then interleaves writes to `f_out` (toward the sender) with
+    /// reads from `f_in` (the incoming flist). The sender's `send_file_list`
+    /// reads its `filesfrom_fd = f_in` to discover filenames.
+    ///
+    /// This is only triggered when:
+    /// - we are server-side (`!client_mode`), and
+    /// - `files_from_path` is set to a real local path (not `-`, which means
+    ///   the *client* is forwarding stdin into us).
+    ///
+    /// Without this push the upstream client (sender) blocks forever on
+    /// `recv_files_from`, causing the upstream testsuite `files-from` 4th
+    /// invocation to hang at "building file list ...".
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:1173-1180` - `start_filesfrom_forwarding(filesfrom_fd)`
+    /// - `io.c:370-381` - `forward_filesfrom_data()` core loop
+    /// - `options.c:2944-2956` - server-side `--files-from <path>` arg form
+    fn forward_files_from_to_sender<W: io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> io::Result<()> {
+        if self.config.connection.client_mode {
+            return Ok(());
+        }
+        let path = match &self.config.file_selection.files_from_path {
+            Some(path) if path != "-" => path,
+            _ => return Ok(()),
+        };
+
+        // upstream: options.c:2483 open(files_from, O_RDONLY|O_BINARY).
+        let file = std::fs::File::open(path).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "failed to open files-from file '{path}': {err} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                ),
+            )
+        })?;
+        let mut reader = io::BufReader::new(file);
+
+        // upstream: io.c:370 forward_filesfrom_data() preserves --from0
+        // semantics for already-NUL-delimited inputs. Use the same gating
+        // here so a `--from0 --files-from /path` push round-trips cleanly.
+        //
+        // Stage into an in-memory buffer first because `writer: &mut W` is
+        // unsized when W is `?Sized` and `protocol::forward_files_from`
+        // requires a sized writer. The buffered approach also matches
+        // upstream's `iobuf.out` enqueue model: the receiver hands the
+        // whole filesfrom payload to the outgoing socket buffer, and the
+        // kernel drains it while `recv_file_list` reads back from f_in.
+        let from0 = self.config.file_selection.from0;
+        let mut staged = Vec::with_capacity(4096);
+        protocol::forward_files_from(&mut reader, &mut staged, from0, None)?;
+        writer.write_all(&staged)?;
+        writer.flush()?;
+
+        debug_log!(
+            Flist,
+            1,
+            "forwarded local --files-from '{path}' to peer sender"
+        );
+
+        Ok(())
     }
 }
 

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -47,7 +47,7 @@ impl ReceiverContext {
         writer: &mut W,
     ) -> io::Result<TransferStats> {
         let _t = PhaseTimer::new("receiver-transfer");
-        let (mut reader, file_count, setup) = self.setup_transfer(reader)?;
+        let (mut reader, file_count, setup) = self.setup_transfer(reader, writer)?;
         let reader = &mut reader;
 
         let PipelineSetup {

--- a/crates/transfer/tests/files_from_lsh_repeated.rs
+++ b/crates/transfer/tests/files_from_lsh_repeated.rs
@@ -1,0 +1,125 @@
+//! UTS-V3-D regression for the upstream `files-from.test` 4th invocation:
+//! upstream sender → oc-rsync server-receiver with
+//! `--files-from=host:path`. Upstream's `main.c:1173-1180` opens the
+//! local filesfrom file on the receiver side and forwards its bytes back
+//! to the sender via `start_filesfrom_forwarding(filesfrom_fd)`. Before
+//! this fix oc-rsync's receiver dropped the path on the floor, so the
+//! upstream sender blocked forever at `building file list ...` waiting
+//! for filenames that never arrived (300s testsuite timeout, then
+//! SIGTERM at `rsync.c:716`).
+//!
+//! The transport-layer half of the fix is
+//! `protocol::forward_files_from`, which is the receiver-side equivalent
+//! of upstream `io.c:370 forward_filesfrom_data()`. This test pins the
+//! load-bearing byte contract that the upstream sender's `filesfrom_fd`
+//! reader expects.
+//!
+//! The companion CLI-parser surface
+//! (`cli::frontend::execution::file_list::parser::resolve_files_from_source`)
+//! has its own unit tests inside that crate; both must hold for the
+//! 4-invocation testsuite to complete.
+
+use std::io::Cursor;
+
+use protocol::{forward_files_from, read_files_from_stream};
+
+/// Files-from list used by the upstream `files-from.test`. Mirrors the
+/// `scratch/filelist` produced by `testsuite/files-from_test.py`.
+const UPSTREAM_FILES_FROM_PAYLOAD: &[u8] = b"from/./\n\
+from/./dir/subdir\n\
+from/./dir/subdir/subsubdir\n\
+from/./dir/subdir/subsubdir2/\n\
+from/./dir/subdir/foobar.baz\n";
+
+/// Wire bytes upstream rsync emits when it forwards the same payload via
+/// `start_filesfrom_forwarding`. Each newline-delimited entry becomes a
+/// NUL-terminated wire entry, terminated by a single trailing NUL since
+/// the last entry already had a NUL appended.
+const UPSTREAM_FILES_FROM_WIRE: &[u8] = b"from/./\0\
+from/./dir/subdir\0\
+from/./dir/subdir/subsubdir\0\
+from/./dir/subdir/subsubdir2/\0\
+from/./dir/subdir/foobar.baz\0\
+\0";
+
+#[test]
+fn forwarded_wire_bytes_match_upstream_sender_expectation() {
+    // Bind the receiver-side forwarding contract to a byte-exact wire
+    // pattern. The upstream sender's `flist.c:2262 read_line` parser
+    // consumes NUL-terminated entries until it hits a NUL with an empty
+    // entry buffer (the double-NUL terminator). Any deviation here -
+    // missing terminator, dropped CR, premature flush - reproduces the
+    // 4th-invocation hang.
+    let mut reader = Cursor::new(UPSTREAM_FILES_FROM_PAYLOAD);
+    let mut wire = Vec::new();
+
+    forward_files_from(&mut reader, &mut wire, false, None).expect("forward must succeed");
+
+    assert_eq!(
+        wire, UPSTREAM_FILES_FROM_WIRE,
+        "forwarded wire bytes must match upstream's `forward_filesfrom_data`"
+    );
+}
+
+#[test]
+fn forwarded_round_trip_repeats_cleanly() {
+    // The `files-from.test` 4th invocation is preceded by three earlier
+    // transfers that share process state in the testsuite runner; the
+    // forwarding helper must not accumulate residual state across runs.
+    // Loop 4x (matching the upstream testsuite) and assert each emission
+    // matches.
+    for iteration in 1..=4 {
+        let mut reader = Cursor::new(UPSTREAM_FILES_FROM_PAYLOAD);
+        let mut wire = Vec::new();
+        forward_files_from(&mut reader, &mut wire, false, None)
+            .unwrap_or_else(|err| panic!("iteration {iteration} forward failed: {err}"));
+
+        assert_eq!(
+            wire, UPSTREAM_FILES_FROM_WIRE,
+            "iteration {iteration} wire bytes diverged - residual state in forwarder?"
+        );
+
+        // Confirm the sender's reader recovers the exact filename list
+        // each time. Without the trailing double-NUL the reader would
+        // block here for input that the receiver never sends.
+        let mut wire_reader = Cursor::new(&wire);
+        let names = read_files_from_stream(&mut wire_reader, None)
+            .unwrap_or_else(|err| panic!("iteration {iteration} read failed: {err}"));
+        assert_eq!(
+            names,
+            vec![
+                "from/./",
+                "from/./dir/subdir",
+                "from/./dir/subdir/subsubdir",
+                "from/./dir/subdir/subsubdir2/",
+                "from/./dir/subdir/foobar.baz",
+            ],
+            "iteration {iteration} parsed filenames diverged"
+        );
+    }
+}
+
+#[test]
+fn forwarded_already_nul_delimited_round_trip_repeats() {
+    // `--from0` flips to NUL-delimited input. The upstream testsuite's
+    // 4th invocation may carry `--from0` when an earlier flag in the
+    // chain set it, so the forwarder must preserve NUL-delimited semantics
+    // across repeated invocations too.
+    let nul_payload: &[u8] = b"from/./\0\
+from/./dir/subdir\0\
+from/./dir/subdir/subsubdir\0\
+from/./dir/subdir/subsubdir2/\0\
+from/./dir/subdir/foobar.baz\0";
+
+    for iteration in 1..=4 {
+        let mut reader = Cursor::new(nul_payload);
+        let mut wire = Vec::new();
+        forward_files_from(&mut reader, &mut wire, true, None)
+            .unwrap_or_else(|err| panic!("iteration {iteration} --from0 forward failed: {err}"));
+
+        assert_eq!(
+            wire, UPSTREAM_FILES_FROM_WIRE,
+            "iteration {iteration} --from0 wire bytes diverged"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Upstream `testsuite/files-from.test` 4th invocation drives an upstream-rsync
sender against an oc-rsync `--server` receiver with
`--files-from=localhost:scratch/filelist`. Upstream's
`options.c:3112-3138 check_for_hostspec` parses the value as `(host, path)` and
forwards `--files-from <path>` to the receiver, which is then expected to
open the file locally and stream its bytes back via
`start_filesfrom_forwarding` (`main.c:1173-1180`). Without that push the
upstream sender blocks at `building file list ...` for 300s, which is the
UTS-V3 cluster D failure (tasks #4328 / #4374..#4380 / #4411..#4420).

The fix closes three gaps that combined to produce the hang:

- `resolve_files_from_source` now recognises the `host:path` hostspec form
  (not just the bare `:path` short form) and skips the local file load in
  `load_file_list_operands`. This stops the oc-rsync client from erroring
  out at `loader.rs:54` before any wire traffic.
- `ReceiverContext::forward_files_from_to_sender` opens the local
  files-from file and writes the NUL-delimited entries onto the writer
  between the filter list and the file list, matching upstream
  `forward_filesfrom_data` semantics. The receiver entry points
  (`run_sync`, `run_pipelined`, `run_pipelined_incremental`) now thread
  the writer through `setup_transfer`.
- The SEC-1.p Landlock allowlist in the server-mode entry point is
  extended with the canonical parent of `files_from_path` when it
  refers to a real local file, so the new open in the forwarder is
  not denied with EACCES.

## Test plan

- `sudo ./runtests.py --rsync-bin /home/ofer/rsync/rsync --rsync-bin2 /home/ofer/oc-rsync/.../oc-rsync files-from` (Linux host): now PASS in <60s. All five invocations (local + four lsh.sh combinations) complete.
- New `crates/transfer/tests/files_from_lsh_repeated.rs` pins the receiver-side wire-byte contract across 4 sequential forwardings (newline and NUL-delimited inputs) to guard against residual forwarder state.
- New `cli::frontend::execution::file_list::tests` cases pin host-colon, drive-letter, double-colon, and `host:-` resolution so future parser changes do not silently regress.
- Existing nextest suites must continue to pass (push-and-let-CI-verify).