### PR TITLE
fix(protocol): omit 'i' capability when local role is receiver

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -199,9 +199,19 @@ pub(super) fn build_full_daemon_args(
     // like `-logDtpre.iLsfxCIvu`. We follow the same format for interop.
     let mut flag_string = flags::build_server_flag_string(config);
     if protocol.as_u8() >= 30 {
-        // upstream: compat.c:177-178 daemon 'i' check, compat.c:720
-        // set_allow_inc_recurse() - capability flags for protocol 30+.
-        let capability_suffix = build_capability_string_suffix(config.inc_recursive_send());
+        // upstream: compat.c:162-181 set_allow_inc_recurse() and
+        // options.c:3036 maybe_add_e_option() - 'i' is only advertised when
+        // the local side actually honors INC_RECURSE on its receive path.
+        // For daemon pull (`is_sender=true` means daemon is sender; we are
+        // receiver) the receiver clears CF_INC_RECURSE in compat.rs after
+        // reading it. If we still advertise 'i' the daemon writes the file
+        // list in INC_RECURSE format (trailing NDX_FLIST_EOF), the receiver
+        // skips `receive_extra_file_lists`, and the leftover 0xFF marker
+        // trips `read_varint` overflow on the next decode.
+        // upstream: io.c:1816 read_varint - rejects encodings with extra > 4.
+        let we_are_receiver = is_sender;
+        let advertise_inc_recurse = config.inc_recursive_send() && !we_are_receiver;
+        let capability_suffix = build_capability_string_suffix(advertise_inc_recurse);
         flag_string.push_str(&capability_suffix);
     }
     if !flag_string.is_empty() {

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -153,10 +153,20 @@ mod protect_args_daemon_tests {
     }
 
     #[test]
-    fn build_full_args_pull_includes_inc_recurse_capability_by_default() {
-        // ISI.h: sender-side INC_RECURSE is default-on, matching upstream
-        // rsync 3.4.x. The daemon pull capability includes 'i' by default.
-        // upstream: capability string is embedded in the compact flag string.
+    fn build_full_args_pull_omits_inc_recurse_capability_to_match_receiver_role() {
+        // Pull means the daemon is sender; the local client side is the
+        // receiver. oc-rsync's receiver path strips CF_INC_RECURSE from
+        // compat_flags (lib.rs::compute_allow_inc_recurse) but does not
+        // tell the peer. Advertising 'i' would cause the remote sender to
+        // write the file list in INC_RECURSE format (trailing NDX_FLIST_EOF),
+        // the receiver would skip `receive_extra_file_lists`, and the
+        // leftover 0xFF byte would trip read_varint overflow on the next
+        // decode.
+        //
+        // upstream: compat.c:162-181 set_allow_inc_recurse(),
+        // options.c:3036 maybe_add_e_option() - 'i' is gated on
+        // allow_inc_recurse which reflects the local side's actual ability
+        // to honor CF_INC_RECURSE.
         let protocol = ProtocolVersion::try_from(32u8).unwrap();
         let request = test_daemon_request();
 
@@ -168,8 +178,8 @@ mod protect_args_daemon_tests {
             .nth(1)
             .expect("capability suffix present");
         assert!(
-            caps_default.contains('i'),
-            "default pull capability must include 'i': {flags_default}"
+            !caps_default.contains('i'),
+            "pull (daemon-is-sender) must omit 'i' to avoid INC_RECURSE wire desync: {flags_default}"
         );
 
         let config_off = ClientConfig::builder().inc_recursive_send(false).build();

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -186,9 +186,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // single argument like `-logDtpre.iLsfxCIvu`. Emitting it as a separate
         // `-e.xxx` argument would confuse the server-side parser which treats
         // only the first short-flag argument as the compact flag string.
-        // upstream: compat.c:720 set_allow_inc_recurse() - capability gate.
-        // upstream: options.c:3003-3050 maybe_add_e_option() - capability string.
-        let capability_suffix = build_capability_string_suffix(self.config.inc_recursive_send());
+        // upstream: compat.c:162-181 set_allow_inc_recurse(),
+        // options.c:3036 maybe_add_e_option() - 'i' is only advertised when
+        // the local side honors INC_RECURSE on its receive path. The local
+        // Receiver role strips CF_INC_RECURSE from compat_flags after reading
+        // (compat.c:723) but receive_extra_file_lists then skips the
+        // NDX_FLIST_EOF the remote still emits, leaving its trailing bytes
+        // to trip read_varint overflow on the next decode.
+        // upstream: io.c:1816 read_varint - rejects encodings with extra > 4.
+        let advertise_inc_recurse =
+            self.config.inc_recursive_send() && self.role != RemoteRole::Receiver;
+        let capability_suffix = build_capability_string_suffix(advertise_inc_recurse);
         flags.push_str(&capability_suffix);
 
         if !flags.is_empty() {

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -15,7 +15,12 @@ use crate::client::config::{ClientConfig, IconvSetting, TransferTimeout};
 fn builds_receiver_invocation_with_sender_flag() {
     // Pull: local is receiver -> remote needs --sender (upstream options.c:2598).
     // upstream: options.c:2710 - capability string is embedded in the compact
-    // flag string, producing one argument like `-re.iLsfxCIvu`.
+    // flag string, producing one argument like `-re.LsfxCIvu`.
+    // The local Receiver does not advertise 'i' because oc-rsync's receiver
+    // path strips CF_INC_RECURSE from compat_flags (lib.rs::compute_allow_inc_recurse).
+    // Advertising 'i' would cause the remote sender to emit NDX_FLIST_EOF that
+    // the receiver never consumes, leaving 0xFF bytes that trip read_varint
+    // overflow on the next decode.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
@@ -25,7 +30,7 @@ fn builds_receiver_invocation_with_sender_flag() {
     assert_eq!(args[2], "--sender");
     let flags = args[3].to_string_lossy();
     assert!(flags.starts_with('-'), "flags should start with -: {flags}");
-    let expected_suffix = build_capability_string_suffix(true);
+    let expected_suffix = build_capability_string_suffix(false);
     assert!(
         flags.contains(&expected_suffix),
         "capability suffix '{expected_suffix}' must be embedded in flag string: {flags}"
@@ -102,10 +107,16 @@ fn ssh_sender_omits_inc_recurse_when_no_inc_recursive_set() {
 }
 
 #[test]
-fn ssh_receiver_includes_inc_recurse_capability_by_default() {
-    // ISI.h: sender-side INC_RECURSE is default-on, matching upstream rsync
-    // 3.4.x. Pull transfers also include the 'i' capability bit by default.
-    // upstream: capability string is embedded in the compact flag string.
+fn ssh_receiver_omits_inc_recurse_capability_by_default() {
+    // The local Receiver never advertises 'i' because its receive path
+    // strips CF_INC_RECURSE from compat_flags (lib.rs::compute_allow_inc_recurse).
+    // Advertising it would cause the remote sender to write the file list
+    // in INC_RECURSE format (trailing NDX_FLIST_EOF), the receiver would
+    // skip `receive_extra_file_lists`, and the leftover 0xFF byte would
+    // trip read_varint overflow on the next decode.
+    //
+    // upstream: compat.c:162-181 set_allow_inc_recurse() ties 'i' to the
+    // local side's actual ability to honor CF_INC_RECURSE.
     let config = ClientConfig::builder().build();
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
     let args = builder.build("/remote/path");
@@ -118,8 +129,8 @@ fn ssh_receiver_includes_inc_recurse_capability_by_default() {
     );
     let caps_portion = flag_str.split("e.").nth(1).expect("e. separator");
     assert!(
-        caps_portion.contains('i'),
-        "default receiver capability string must include 'i': {flag_str}"
+        !caps_portion.contains('i'),
+        "receiver capability string must omit 'i' to avoid INC_RECURSE wire desync: {flag_str}"
     );
 }
 
@@ -1766,9 +1777,12 @@ fn capability_string_embedded_in_sender_flag_string() {
 fn capability_string_embedded_in_receiver_flag_string() {
     // upstream: options.c:2710 - capability suffix is embedded in the compact
     // flag string, not sent as a separate argument.
+    // The local Receiver omits 'i' from its advertised capability because
+    // its receive path strips CF_INC_RECURSE from compat_flags. See
+    // builds_receiver_invocation_with_sender_flag for the rationale.
     let config = ClientConfig::builder().build();
     let args = build_receiver_args(&config);
-    let expected_suffix = build_capability_string_suffix(true);
+    let expected_suffix = build_capability_string_suffix(false);
     let flag_str = find_flag_string(&args);
     assert!(
         flag_str.ends_with(&expected_suffix),


### PR DESCRIPTION
## Summary

- Mirror upstream `compat.c:162-181 set_allow_inc_recurse()` and `options.c:3036 maybe_add_e_option()`: gate the `'i'` capability on whether the local side will actually honor `CF_INC_RECURSE` on its receive path.
- The receiver role strips `CF_INC_RECURSE` from compat_flags (`lib.rs::compute_allow_inc_recurse`) but the capability string still advertised `'i'`. The remote sender then wrote the file list in INC_RECURSE format with a trailing `NDX_FLIST_EOF`, oc-rsync skipped `receive_extra_file_lists`, and the leftover `0xFF` byte tripped `read_varint` overflow on the next decode.
- Fix both code paths that build the capability suffix: daemon (`arguments.rs`) and SSH (`invocation/builder.rs`). Update the existing receiver-capability tests to assert the new shape.

## Reproduction

Upstream-testsuite `reverse-daemon-delta` `pull` leg (upstream daemon = sender, `oc-rsync` = client receiver) aborted with:

```
oc-rsync error: transfer failed: overflow in read_varint (code 23) at error.rs(176) [client=0.6.3]
```

Wire decode: 44-byte daemon mux frame ends in `0x00 0x00 0xff 0x01` — `0xff 0x01` is `NDX_FLIST_EOF` (`-2`). With INC_RECURSE masked locally, `receive_extra_file_lists` returns early without consuming those bytes; the next varint decode then sees `0xff` (`INT_BYTE_EXTRA[63] = 6 > MAX_EXTRA_BYTES = 4`).

## Test plan

- [x] `cargo nextest run -p core` — 247 passed, 2095 skipped (no failures).
- [x] Upstream-testsuite `reverse-daemon-delta` pull leg: overflow gone, file content round-trips byte-for-byte against upstream `rsync 3.4.3` daemon (`md5sum` matches). Remaining `assert_delta` failure is a pre-existing client-summary stats display issue (oc-rsync reports double byte counts), unrelated to this fix.
- [x] Full upstream-testsuite (`--use-tcp`, `rsync_bin=upstream rsync_bin2=oc-rsync`): 106 passed, 2 failed (`exclude-lsh` + `reverse-daemon-delta`, both pre-existing in the 2026-06-13 baseline log).