### PR TITLE
fix(transfer): align filter-application generator tests with non-relative walk base

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2892,7 +2892,7 @@ mod files_from {
             "expected 'payload' entry in {names:?}"
         );
         assert!(
-            names.iter().any(|n| *n == expected_child.as_str()),
+            names.contains(&expected_child.as_str()),
             "expected {expected_child:?} in {names:?}"
         );
         assert!(

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -150,6 +150,20 @@ fn build_file_list_for(ctx: &mut GeneratorContext, base_path: &Path) -> usize {
     ctx.build_file_list(&paths).unwrap()
 }
 
+/// Builds a file list for the *contents* of `base_path`.
+///
+/// Appends a trailing `/` so `build_file_list` enters the upstream
+/// `DOTDIR_NAME` branch (flist.c:2312-2322) and emits `.` plus the
+/// directory's children, matching `rsync <dir>/ dst/` semantics. Used by
+/// tests that pre-populate a flat set of files and want to assert against
+/// the dot-entry-plus-children layout independent of the source basename.
+fn build_file_list_for_contents(ctx: &mut GeneratorContext, base_path: &Path) -> usize {
+    let mut with_slash = base_path.as_os_str().to_owned();
+    with_slash.push("/");
+    let paths = vec![PathBuf::from(with_slash)];
+    ctx.build_file_list(&paths).unwrap()
+}
+
 /// Wraps a vector of full paths as `FilesFromEntry`s sharing one base, for
 /// tests that only exercise plain (no `/./` anchor) `--files-from` entries.
 fn files_from_entries(base: &Path, paths: Vec<PathBuf>) -> Vec<super::filters::FilesFromEntry> {
@@ -605,7 +619,10 @@ fn filter_application_excludes_files() {
         vec![FilterRuleWireFormat::exclude("*.log".to_owned())],
     );
 
-    let count = build_file_list_for(&mut ctx, base_path);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`.
+    let count = build_file_list_for_contents(&mut ctx, base_path);
 
     // Should have 3 entries: "." root dir + 2 .txt files (not the .log file)
     assert_eq!(count, 3);
@@ -635,7 +652,10 @@ fn filter_application_includes_only_matching() {
         ],
     );
 
-    let count = build_file_list_for(&mut ctx, base_path);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`.
+    let count = build_file_list_for_contents(&mut ctx, base_path);
 
     // Should have 2 entries: "." root dir + data.txt (other files excluded by "exclude *")
     assert_eq!(count, 2);
@@ -681,7 +701,10 @@ fn filter_application_no_filters_includes_all() {
 
     let (_handshake, mut ctx) = test_generator_for_path(base_path, false);
 
-    let count = build_file_list_for(&mut ctx, base_path);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`.
+    let count = build_file_list_for_contents(&mut ctx, base_path);
 
     // "." root dir + 3 files when no filters are present.
     assert_eq!(count, 4);
@@ -2855,14 +2878,22 @@ mod files_from {
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
         ctx.build_file_list(&[src_dir]).unwrap();
 
+        // The stored `name()` uses native OS separators; compare against
+        // a platform-appropriate join so Windows backslashes do not trip
+        // the assertion. The on-wire form is normalised to `/` by
+        // `name_bytes()`, but `name()` returns the raw `PathBuf`.
         let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        let expected_child = std::path::PathBuf::from("payload")
+            .join("file.txt")
+            .to_string_lossy()
+            .into_owned();
         assert!(
             names.contains(&"payload"),
             "expected 'payload' entry in {names:?}"
         );
         assert!(
-            names.contains(&"payload/file.txt"),
-            "expected 'payload/file.txt' in {names:?}"
+            names.iter().any(|n| *n == expected_child.as_str()),
+            "expected {expected_child:?} in {names:?}"
         );
         assert!(
             !names.contains(&"."),
@@ -3321,7 +3352,10 @@ fn generator_merge_filter_exclude_self() {
     ctx.filter_chain
         .add_merge_config(::filters::DirMergeConfig::new(".rsync-filter").with_exclude_self(true));
 
-    let _count = build_file_list_for(&mut ctx, base);
+    // Trailing-slash source enters upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list contains `.` + the base
+    // directory's children at the top level, matching `rsync <dir>/ dst/`.
+    let _count = build_file_list_for_contents(&mut ctx, base);
     let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
 
     // .rsync-filter itself should be excluded


### PR DESCRIPTION
## Summary

- Restore green nextest on master across the Linux, musl, Windows, IOCP, and feature-flag cells by realigning the five generator tests left over from the non-relative walk-base split (`flist.c:2338-2349`) introduced in #5761.
- `build_file_list(["/tmp/.tmpXXX"])` now emits the source basename (`.tmpXXX`) as a single non-recursed entry instead of collapsing to `.` + the directory's children, matching upstream `rsync <dir> dst/`. Four `filter_application_*` / `generator_merge_filter_exclude_self` tests were still asserting the pre-split layout, so they panicked with `count==1` against expected 2/3/4.
- Route the affected tests through a new `build_file_list_for_contents` helper that appends a trailing `/` so they hit the upstream DOTDIR_NAME branch (`flist.c:2312-2322`), matching `rsync <dir>/ dst/`. The trailing-slash semantic restores the `.`-plus-children layout the tests were written to exercise without reverting the upstream-correct basename split.
- Also make `non_relative_mode_emits_source_basename` Windows-portable: `FileEntry::name()` stores native OS separators (the on-wire form is normalised by `name_bytes()`), so the expected child name must be joined through `PathBuf` rather than hardcoding `payload/file.txt`.

## Tests touched

- `filter_application_excludes_files`
- `filter_application_includes_only_matching`
- `filter_application_no_filters_includes_all`
- `generator_merge_filter_exclude_self`
- `files_from::non_relative_mode_emits_source_basename` (Windows path-separator fix)

## Test plan
- [ ] nextest (stable / beta / nightly) on Linux passes the affected generator tests
- [ ] Linux musl (stable / beta / nightly) passes the affected generator tests
- [ ] Windows (stable / beta / nightly / IOCP / ACL+xattr) passes `non_relative_mode_emits_source_basename` and the filter-application tests
- [ ] Feature-flag combinations (incremental-flist, io_uring, default-features, compression, flat-flist, iconv, async, daemon-tls, concurrent-sessions, tracing) regreen on the affected generator tests