### PR TITLE
fix(transfer): drain stdin to EOF in SSH receiver after goodbye

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::OsString;
 use std::fmt;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 
 use core::branding::Brand;
 use core::message::Role;
@@ -303,13 +303,65 @@ where
         }
     }
 
-    match run_server_stdio(config, &mut stdin, stdout, None) {
+    let exit_code = match run_server_stdio(config, &mut stdin, stdout, None) {
         Ok(_stats) => 0,
         Err(e) => {
             write_server_error(stderr, program_brand, format!("server error: {e}"));
             1
         }
+    };
+
+    // UTS-v3 Cluster A (SSH leg): the upstream sender keeps writing trailing
+    // bytes (MSG_STATS / NDX_DONE / MSG_ERROR_EXIT) onto the SSH stdio pipe
+    // after our final NDX_DONE. Returning from `run_server_stdio` here lets
+    // the process exit immediately, dropping the stdin pipe end. The peer
+    // then sees EOF on its parallel read before the bytes it is still
+    // streaming reach us, and reports "connection unexpectedly closed (N
+    // bytes received so far) [receiver]" - the SSH-leg mirror of the
+    // daemon-as-sender cluster A failures already fixed for TCP in
+    // `daemon::sections::module_access::transfer` (PR 5765).
+    //
+    // Mirror upstream's receiver child: after writing its final goodbye it
+    // enters `noop_io_until_death()` (io.c:943) and loops on
+    // `read_buf(iobuf.in_fd, ...)` until the parent reaps it. We collapse
+    // both sides into one process, so drain stdin to EOF here instead. The
+    // upstream sender FINs its end of the pipe when its own `exit_cleanup`
+    // runs, at which point our read returns 0 and we unblock. Errors are
+    // tolerated: the goodbye has already completed.
+    //
+    // Gated to the receiver role: the generator (sender) side does not face
+    // this race because its peer (the remote receiver) closes its read end
+    // first as soon as it has flushed its own goodbye. Draining there would
+    // only delay exit without preventing any failure.
+    //
+    // Daemon mode never reaches this site (the daemon dispatches into
+    // `run_server_with_handshake` directly and runs its own TCP drain in
+    // `process_approved_module`), so this drain only fires on the SSH /
+    // remote-shell path that produced cluster A's alt-dest regression.
+    //
+    // upstream: io.c:943-963 `noop_io_until_death()`; main.c:1075
+    // receiver-child loop on `read_final_goodbye()`; cleanup.c:254
+    // `noop_io_until_death()` call in `_exit_cleanup`.
+    if role == ServerRole::Receiver {
+        let mut sink = [0u8; 4096];
+        loop {
+            match stdin.read(&mut sink) {
+                Ok(0) => break,
+                Ok(_) => continue,
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
     }
+
+    exit_code
 }
 
 /// Applies value-bearing flags to the server config, returning early on parse errors.


### PR DESCRIPTION
## Summary

- UTS-v3 Cluster A (SSH leg): `alt-dest` reaches oc-rsync through `lsh.sh --rsync-path=oc-rsync` (SSH transport), not through the daemon. PR #5765 fixed the daemon-as-sender leg with `SO_LINGER` + TCP drain in `process_approved_module`, but the SSH receiver path was untouched and continued to fail with `connection unexpectedly closed (2251388 bytes received so far) [receiver]` at the same wire-byte signature as the daemon cluster.
- Root cause: after `finalize_transfer` writes its final NDX_DONE the `--server --receiver` process returns from `run_server_stdio` and exits immediately, dropping the SSH stdio pipe end. The upstream sender, still in `read_final_goodbye()`, sees EOF on the bytes it is still streaming and reports the cluster A diagnostic.
- Fix: drain stdin to EOF at the CLI `--server` boundary for the receiver role. Mirrors upstream's receiver child which loops on `read_buf(iobuf.in_fd, ...)` via `noop_io_until_death()` (io.c:943) until its parent reaps it. The peer FINs as part of its own `exit_cleanup`, our read returns 0, and we unblock cleanly.

## Scope

- Gated to the receiver role; the generator (sender) side does not face this race.
- Daemon mode is unaffected: it dispatches into `run_server_with_handshake` directly and continues to use the existing TCP drain in `daemon::sections::module_access::transfer` (PR #5765).
- Only the SSH / remote-shell `--server --receiver` path picks up the new drain.

## Upstream reference

- `io.c:943-963` `noop_io_until_death()` - receiver-side keep-reading loop.
- `main.c:1075` receiver-child loop on `read_final_goodbye()`.
- `cleanup.c:254` `noop_io_until_death()` call inside `_exit_cleanup`.

## Test plan

- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.
- [ ] Linux interop: rerun `runtests.py alt-dest` against upstream 3.4.3 and confirm the SSH-mode invocation completes without `connection unexpectedly closed`.
- [ ] Verify daemon UTS-v3 cluster A regression test (`daemon_compress_pull_drains_peer_goodbye_for_uts_v3_cluster_a`) still passes - the fix is additive and runs only on the SSH path.