### PR TITLE
fix(daemon): gate groupmap secluded-args tests under cfg(unix)

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -268,6 +268,12 @@ mod module_access_tests {
     // After `merge_secluded_args` the daemon's `apply_long_form_args` sees
     // the wildcard intact and `GroupMapping::parse` consumes it without
     // rejecting the `*` matcher.
+    //
+    // Windows lacks POSIX user/group concepts so the metadata crate ships a
+    // `GroupMapping::parse` stub that always returns `Err` (see
+    // `metadata/src/mapping_win.rs`). The assertion that `config.group_mapping`
+    // is populated therefore only applies on Unix targets.
+    #[cfg(unix)]
     #[test]
     fn merge_secluded_args_preserves_groupmap_wildcard_through_apply_long_form() {
         let phase1 = vec!["--server".to_owned(), "-logDtpr".to_owned()];
@@ -305,6 +311,12 @@ mod module_access_tests {
     // upstream: clientserver.c:303 `.` and module path land in phase 2
     // upstream: options.c:2744-2745 NULL marker between phase 1 and phase 2
     // upstream: options.c:804 `--secluded-args` long-form alias of `-s`
+    //
+    // Windows lacks POSIX user/group concepts so the metadata crate ships a
+    // `GroupMapping::parse` stub that always returns `Err` (see
+    // `metadata/src/mapping_win.rs`). The assertion that `config.group_mapping`
+    // is populated therefore only applies on Unix targets.
+    #[cfg(unix)]
     #[test]
     fn merge_secluded_args_oc_rsync_client_wire_preserves_groupmap_wildcard() {
         // Phase 1 mirrors the fixed `build_minimal_daemon_args` output


### PR DESCRIPTION
## Summary

- Two Windows daemon-crate tests panic on master because they assert that `apply_long_form_args` populates `config.group_mapping` after parsing `--groupmap=*:GID`, but Windows ships a `GroupMapping::parse` stub that always returns `Err` (no POSIX user/group concept).
- Gate both tests with `#[cfg(unix)]` since they verify Unix-only semantics. The string-level secluded-args tests (which check arg ordering and the unbackslash transformation) remain cross-platform.

## Root cause

`apply_long_form_args` (client_args.rs:1224) feeds `--groupmap=*:GID` into `::metadata::GroupMapping::parse`, which on Windows resolves to `metadata::mapping_win::GroupMapping::parse` - a stub that always returns `Err(MappingParseError)`. The daemon code path swallows the error (so the daemon itself still works on Windows), but the two tests then panic on `.expect("groupmap should be parsed")` / `.expect("groupmap=*:4242 must reach GroupMapping::parse intact")`.

CI evidence: https://github.com/oferchen/rsync/actions/runs/27494488836/job/81265914126 - panic frames mention `metadata::mapping_win::GroupMapping`.

## Test plan

- [ ] CI: Windows daemon-crate tests cell turns green
- [ ] CI: Linux nextest stable, macOS nextest, Linux musl nextest still green (tests still run on Unix)
- [ ] CI: fmt+clippy clean