### PR TITLE
fix(metadata): align Windows ADS test wire-format expectations with upstream

### DIFF
--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -63,16 +63,19 @@ const ZONE_IDENTIFIER_PAYLOAD: &[u8] = b"[ZoneTransfer]\r\nZoneId=3\r\n";
 
 /// Wire-format name for the Zone.Identifier xattr observed by
 /// `read_xattrs_for_wire`. The Windows backend in `xattr_windows.rs`
-/// does not insert a `user.` prefix; stream names cross the wire
-/// verbatim.
-const ZONE_IDENTIFIER_WIRE: &[u8] = b"Zone.Identifier";
+/// returns bare stream names; the wire encoder
+/// (`protocol::xattr::local_to_wire`) prefixes them with `user.` on
+/// non-Linux peers so the bytes match what a Linux peer would emit.
+/// upstream: xattrs.c:518-530.
+const ZONE_IDENTIFIER_WIRE: &[u8] = b"user.Zone.Identifier";
 
 /// Custom non-MOTW stream name used by the multi-stream scenario to
 /// force `FindNextStreamW` iteration beyond the first stream.
 const CUSTOM_STREAM: &str = "oc_rsync_test_stream";
 
-/// Wire-format counterpart of `CUSTOM_STREAM`.
-const CUSTOM_STREAM_WIRE: &[u8] = b"oc_rsync_test_stream";
+/// Wire-format counterpart of `CUSTOM_STREAM`. The non-Linux sender
+/// path prepends `user.` per upstream xattrs.c:518-530.
+const CUSTOM_STREAM_WIRE: &[u8] = b"user.oc_rsync_test_stream";
 
 /// Custom stream payload, distinct from the MOTW payload so the
 /// assertions can tell the two streams apart on the destination.
@@ -284,19 +287,21 @@ fn ads_multi_stream_round_trips() {
 
     // Sanity check the enumeration sees both streams on the source so a
     // failure on the destination side can be attributed to the transfer
-    // rather than the seeding step.
+    // rather than the seeding step. Both names round-trip through
+    // `local_to_wire`, which prepends `user.` on non-Linux peers per
+    // upstream xattrs.c:518-530.
     let src_wire = read_xattrs_for_wire(&src_file, false, true, 0).expect("list source streams");
     let src_names: Vec<String> = src_wire
         .iter()
         .map(|e| String::from_utf8_lossy(e.name()).into_owned())
         .collect();
     assert!(
-        src_names.iter().any(|n| n == "Zone.Identifier"),
-        "source missing Zone.Identifier: {src_names:?}",
+        src_names.iter().any(|n| n == "user.Zone.Identifier"),
+        "source missing user.Zone.Identifier: {src_names:?}",
     );
     assert!(
-        src_names.iter().any(|n| n == "oc_rsync_test_stream"),
-        "source missing oc_rsync_test_stream: {src_names:?}",
+        src_names.iter().any(|n| n == "user.oc_rsync_test_stream"),
+        "source missing user.oc_rsync_test_stream: {src_names:?}",
     );
 
     let oc_rsync = match locate_oc_rsync() {

--- a/crates/metadata/tests/windows_long_path_metadata.rs
+++ b/crates/metadata/tests/windows_long_path_metadata.rs
@@ -225,9 +225,18 @@ fn long_path_reparse_classifier_acquires_handle() {
         file.as_os_str().len(),
     );
 
-    // Plain regular files have no reparse data; the classifier must
-    // succeed in acquiring the underlying handle through
-    // `to_extended_path` and return without an io::Error. A short-path
-    // `CreateFileW` would surface `ERROR_PATH_NOT_FOUND` at >260 chars.
-    classify_path(&file).expect("classify reparse on long path must succeed");
+    // Plain regular files have no reparse data, so the downstream
+    // `FSCTL_GET_REPARSE_POINT` call inside `classify_path` surfaces
+    // `ERROR_NOT_A_REPARSE_POINT` (4390). The point of this test is to
+    // prove the long path was opened successfully: a short-path
+    // `CreateFileW` would surface `ERROR_PATH_NOT_FOUND` (3) at >260
+    // chars before the FSCTL ever runs. Matches the pattern used by
+    // `regular_file_returns_not_a_reparse_point_error` in
+    // `windows_reparse_classify_path.rs`.
+    let err = classify_path(&file).expect_err("plain file must surface FSCTL error");
+    let raw = err.raw_os_error().unwrap_or(0);
+    assert!(
+        raw == 4390 || raw == 0,
+        "expected ERROR_NOT_A_REPARSE_POINT (4390) on long path; got {raw} ({err})",
+    );
 }


### PR DESCRIPTION
## Summary

Three Windows ACL/xattr cell tests were failing on every PR (pre-existing master regression). Root cause: the tests asserted bare ADS stream names on the wire, but `protocol::xattr::local_to_wire` prepends `user.` on non-Linux peers (upstream `xattrs.c:518-530`) so a Linux receiver observes identical bytes from either sender. The `xattr_windows` backend correctly returns bare stream names; the `user.` prefix is applied by the wire encoder, not the backend. The sibling test `long_path_ads_round_trip` already asserted the correct `user.Zone.Identifier` form, confirming the convention.

- Fix `ads_zone_identifier_round_trips_through_xattrs` and `ads_multi_stream_round_trips` in `crates/metadata/tests/windows_ads_xattrs_roundtrip.rs` to expect the `user.`-prefixed wire names on both source and destination.
- Fix `long_path_reparse_classifier_acquires_handle` in `crates/metadata/tests/windows_long_path_metadata.rs`. It called `classify_path` on a plain regular file and asserted success, but `FSCTL_GET_REPARSE_POINT` on a non-reparse file returns `ERROR_NOT_A_REPARSE_POINT` (4390). The test's intent is to prove the long path was opened (otherwise it would surface `ERROR_PATH_NOT_FOUND` (3) before the FSCTL runs). Switch to asserting code 4390, matching the pattern in `windows_reparse_classify_path.rs::regular_file_returns_not_a_reparse_point_error`.

Production code in `crates/metadata/src/xattr_windows.rs`, `crates/metadata/src/xattr.rs`, `crates/protocol/src/xattr/prefix.rs`, and `crates/metadata/src/windows/reparse.rs` is correct and matches upstream `xattrs.c:518-530`. No code changes outside the test files.

## Test plan

- [ ] CI Windows ACL/xattr cell goes green
- [ ] No regression on Linux, macOS, or other Windows cells