### PR TITLE
fix(filters): expand wire `-C`/`:C` to CVS-ignore rules with no-inherit

### DIFF
--- a/crates/filters/src/chain/config.rs
+++ b/crates/filters/src/chain/config.rs
@@ -43,6 +43,10 @@ pub struct DirMergeConfig {
     receiver_only: bool,
     anchor_root: bool,
     perishable: bool,
+    /// upstream: exclude.c - `C` modifier on dir-merge rules (FILTRULE_CVS_IGNORE).
+    /// Treats the merge file as a CVS-style ignore list: each whitespace
+    /// separated token is an exclude rule with no filter prefixes.
+    cvs_mode: bool,
 }
 
 impl DirMergeConfig {
@@ -60,6 +64,7 @@ impl DirMergeConfig {
             receiver_only: false,
             anchor_root: false,
             perishable: false,
+            cvs_mode: false,
         }
     }
 
@@ -117,6 +122,22 @@ impl DirMergeConfig {
         self
     }
 
+    /// Configures this merge file as a CVS-style ignore list.
+    ///
+    /// When enabled, the file's contents are parsed as whitespace-separated
+    /// tokens; each token becomes an exclude rule with no filter prefix
+    /// honoured. This mirrors upstream rsync's `C` modifier on dir-merge rules
+    /// (`FILTRULE_CVS_IGNORE`), which is set when the wire delivers
+    /// `:C .cvsignore`.
+    ///
+    /// upstream: exclude.c:1248 - `C` modifier toggles FILTRULE_NO_PREFIXES |
+    /// FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT | FILTRULE_CVS_IGNORE.
+    #[must_use]
+    pub const fn with_cvs_mode(mut self, cvs_mode: bool) -> Self {
+        self.cvs_mode = cvs_mode;
+        self
+    }
+
     /// Per-directory merge filename configured for this rule.
     #[must_use]
     pub fn filename(&self) -> &str {
@@ -127,6 +148,12 @@ impl DirMergeConfig {
     #[must_use]
     pub const fn inherits(&self) -> bool {
         self.inherit
+    }
+
+    /// Returns whether this dir-merge uses CVS-style parsing.
+    #[must_use]
+    pub const fn cvs_mode(&self) -> bool {
+        self.cvs_mode
     }
 
     /// Returns whether the merge file itself should be excluded.

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -128,10 +128,18 @@ impl FilterChain {
     /// Mirrors upstream `exclude.c:rule_matches()` which has no descendant
     /// matching at all.
     ///
+    /// Scopes pushed by non-inheriting merge configs (`FILTRULE_NO_INHERIT`,
+    /// e.g. `:C`) are consulted only at the depth they were pushed at, so
+    /// rules from a parent directory's `.cvsignore` do not leak into a
+    /// deeper child walk.
+    ///
     /// `is_dir` should be `true` when the path refers to a directory.
     #[must_use]
     pub fn allows(&self, path: &Path, is_dir: bool) -> bool {
         for scope in self.scopes.iter().rev() {
+            if !self.scope_applies_here(scope) {
+                continue;
+            }
             if !scope.filter_set.is_empty() && has_matching_rule(&scope.filter_set, path, is_dir) {
                 return scope.filter_set.allows_during_traversal(path, is_dir);
             }
@@ -145,15 +153,33 @@ impl FilterChain {
     /// Evaluates per-directory scopes from innermost to outermost, then
     /// global rules. A path may be deleted when it is included by
     /// receiver-side rules and no protect rule matches.
+    ///
+    /// Non-inheriting scopes follow the same depth-restricted lookup as
+    /// [`allows`](Self::allows).
     #[must_use]
     pub fn allows_deletion(&self, path: &Path, is_dir: bool) -> bool {
         for scope in self.scopes.iter().rev() {
+            if !self.scope_applies_here(scope) {
+                continue;
+            }
             if !scope.filter_set.is_empty() && has_matching_rule(&scope.filter_set, path, is_dir) {
                 return scope.filter_set.allows_deletion(path, is_dir);
             }
         }
 
         self.global.allows_deletion(path, is_dir)
+    }
+
+    /// Returns `true` if the given scope is in effect at the chain's
+    /// current depth.
+    ///
+    /// Inheriting scopes always apply. Non-inheriting scopes only apply
+    /// at the depth they were pushed at; deeper directories must look
+    /// past them. Mirrors upstream `exclude.c:push_local_filters()` which
+    /// substitutes the inherited list with `lp->head = NULL` for
+    /// `FILTRULE_NO_INHERIT` rules before descending.
+    fn scope_applies_here(&self, scope: &DirScope) -> bool {
+        scope.inherits || scope.depth == self.current_depth
     }
 
     /// Enters a directory, reading any per-directory merge files and pushing
@@ -204,15 +230,24 @@ impl FilterChain {
                 }
             };
 
-            let rules = match parse_rules(&content, &merge_path) {
-                Ok(rules) => rules,
-                Err(e) => {
-                    self.pop_scopes_at_depth(depth);
-                    self.current_depth -= 1;
-                    return Err(FilterChainError::Parse {
-                        path: merge_path,
-                        message: e.to_string(),
-                    });
+            // upstream: exclude.c:1252-1254 - dir-merge files registered as
+            // `:C` (FILTRULE_CVS_IGNORE) parse their content as whitespace
+            // separated tokens with every token implicitly an exclude.
+            // Standard parse_rules would reject names like `one-in-one-out`
+            // as "unrecognized filter rule", aborting the walk.
+            let rules = if config.cvs_mode() {
+                parse_cvs_ignore_tokens(&content)
+            } else {
+                match parse_rules(&content, &merge_path) {
+                    Ok(rules) => rules,
+                    Err(e) => {
+                        self.pop_scopes_at_depth(depth);
+                        self.current_depth -= 1;
+                        return Err(FilterChainError::Parse {
+                            path: merge_path,
+                            message: e.to_string(),
+                        });
+                    }
                 }
             };
 
@@ -242,7 +277,11 @@ impl FilterChain {
             };
 
             if !filter_set.is_empty() {
-                self.scopes.push(DirScope { depth, filter_set });
+                self.scopes.push(DirScope {
+                    depth,
+                    filter_set,
+                    inherits: config.inherits(),
+                });
                 pushed_count += 1;
             }
         }
@@ -305,11 +344,29 @@ impl FilterChain {
         let depth = self.current_depth;
         let is_empty = filter_set.is_empty();
         if !is_empty {
-            self.scopes.push(DirScope { depth, filter_set });
+            self.scopes.push(DirScope {
+                depth,
+                filter_set,
+                inherits: true,
+            });
         }
         DirFilterGuard {
             depth,
             pushed_count: if is_empty { 0 } else { 1 },
         }
     }
+}
+
+/// Parses a CVS-style ignore file into exclude rules.
+///
+/// Splits the content on whitespace and treats each token as an exclude
+/// pattern (no `+`/`-` filter prefixes honoured). Blank input produces no
+/// rules. This mirrors upstream rsync's CVS-mode merge parsing for
+/// `.cvsignore` files registered via `:C` (`exclude.c:1250-1254`).
+fn parse_cvs_ignore_tokens(content: &str) -> Vec<FilterRule> {
+    content
+        .split_whitespace()
+        .filter(|token| !token.is_empty())
+        .map(FilterRule::exclude)
+        .collect()
 }

--- a/crates/filters/src/chain/scope.rs
+++ b/crates/filters/src/chain/scope.rs
@@ -21,6 +21,10 @@ use crate::FilterSet;
 pub(super) struct DirScope {
     pub(super) depth: usize,
     pub(super) filter_set: FilterSet,
+    /// Whether the merge config that produced this scope inherits to
+    /// deeper directories. When `false`, the scope is only consulted at
+    /// its own depth, mirroring upstream `FILTRULE_NO_INHERIT`.
+    pub(super) inherits: bool,
 }
 
 /// Checks whether a `FilterSet` has any rule that matches the given path.

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -14,11 +14,13 @@
 //! - `flist.c:2240-2264` - `--files-from` filename reading and resolution
 //! - `exclude.c:push_local_filters()` - per-directory merge file loading
 
+use std::env;
+use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 pub use ::filters::FilterSet;
-use filters::{DirMergeConfig, FilterChain};
+use filters::{DirMergeConfig, FilterChain, cvs_exclusion_rules};
 use logging::info_log;
 use protocol::filters::{FilterRuleWireFormat, RuleType, read_filter_list};
 
@@ -300,6 +302,9 @@ impl GeneratorContext {
     ) -> io::Result<(FilterSet, Vec<DirMergeConfig>)> {
         let mut rules = Vec::with_capacity(wire_rules.len());
         let mut merge_configs = Vec::new();
+        // upstream: exclude.c:1350 - get_cvs_excludes() flags rules as
+        // FILTRULE_PERISHABLE only when protocol_version >= 30.
+        let cvs_perishable = self.protocol.as_u8() >= 30;
 
         for wire_rule in wire_rules {
             // The wire format stores the bare pattern in `pattern` and carries
@@ -317,7 +322,21 @@ impl GeneratorContext {
             let reconstructed_pattern = reconstruct_pattern(wire_rule);
             let mut rule = match wire_rule.rule_type {
                 RuleType::Include => FilterRule::include(reconstructed_pattern),
-                RuleType::Exclude => FilterRule::exclude(reconstructed_pattern),
+                RuleType::Exclude => {
+                    // upstream: exclude.c:1441-1443 - a `-C` rule (cvs_exclude
+                    // with no pattern) triggers get_cvs_excludes() on the
+                    // local side, populating the filter list with the
+                    // default CVS-ignore patterns, `$HOME/.cvsignore`, and
+                    // `$CVSIGNORE`. Without expansion here, the bare empty
+                    // pattern's synthetic `**/` matcher would exclude every
+                    // top-level entry on the sender, defeating the whole
+                    // file list.
+                    if wire_rule.cvs_exclude && wire_rule.pattern.is_empty() {
+                        rules.extend(cvs_default_exclude_rules(cvs_perishable));
+                        continue;
+                    }
+                    FilterRule::exclude(reconstructed_pattern)
+                }
                 RuleType::Protect => FilterRule::protect(reconstructed_pattern),
                 RuleType::Risk => FilterRule::risk(reconstructed_pattern),
                 RuleType::Clear => {
@@ -332,7 +351,7 @@ impl GeneratorContext {
                     // upstream: exclude.c - dir-merge rules register a per-directory
                     // merge file that is read during walk_path(). The FilterChain
                     // handles reading and scoping.
-                    let config = wire_rule_to_dir_merge_config(wire_rule);
+                    let config = wire_rule_to_dir_merge_config(wire_rule, cvs_perishable);
                     merge_configs.push(config);
                     continue;
                 }
@@ -361,8 +380,10 @@ impl GeneratorContext {
                 rule = rule.with_negate(true);
             }
 
-            // Note: no_inherit, cvs_exclude, word_split, exclude_from_merge
-            // are pattern modifiers handled by the filters crate during compilation.
+            // Note: no_inherit, word_split, exclude_from_merge are pattern
+            // modifiers handled by the filters crate during compilation.
+            // The `C` (cvs_exclude) modifier on Exclude rules is expanded
+            // above into the equivalent CVS-ignore default rules.
 
             rules.push(rule);
         }
@@ -405,10 +426,20 @@ fn reconstruct_pattern(wire_rule: &FilterRuleWireFormat) -> String {
 /// Maps wire protocol modifier flags to the corresponding `DirMergeConfig`
 /// builder methods. The pattern field contains the merge filename.
 ///
+/// When the wire rule carries the `C` modifier (CVS-mode dir-merge, e.g.
+/// `:C .cvsignore`), upstream `exclude.c:1248-1254` implicitly sets
+/// `NO_PREFIXES | WORD_SPLIT | NO_INHERIT | CVS_IGNORE`. Mirror that by
+/// switching the config to CVS-mode parsing and disabling inheritance, and
+/// mark the rules as perishable when the negotiated protocol is >= 30.
+///
 /// # Upstream Reference
 ///
 /// - `exclude.c:parse_filter_str()` - modifier flag parsing for dir-merge rules
-fn wire_rule_to_dir_merge_config(wire_rule: &FilterRuleWireFormat) -> DirMergeConfig {
+/// - `exclude.c:1248-1254` - `C` modifier implies word-split + no-inherit + CVS-mode
+fn wire_rule_to_dir_merge_config(
+    wire_rule: &FilterRuleWireFormat,
+    cvs_perishable: bool,
+) -> DirMergeConfig {
     // upstream: exclude.c - a leading '/' on the merge filename means the
     // file is only looked for in the transfer root directory (anchor_root).
     // Strip the '/' so Path::join() produces a relative path.
@@ -446,7 +477,67 @@ fn wire_rule_to_dir_merge_config(wire_rule: &FilterRuleWireFormat) -> DirMergeCo
         config = config.with_perishable(true);
     }
 
+    // `C` modifier: CVS-style ignore list. Mirror upstream's implicit
+    // NO_PREFIXES | WORD_SPLIT | NO_INHERIT | CVS_IGNORE so that the dir
+    // merge filename's contents are parsed as whitespace-separated exclude
+    // tokens. Without this, `.cvsignore` lines like `one-in-one-out` would
+    // be rejected by the standard merge parser and abort the sender walk.
+    // Upstream's `:C` does NOT imply FILTRULE_EXCLUDE_SELF - only the
+    // explicit `e` modifier does (exclude.c:1256-1260); leave the existing
+    // `e` handling above to drive `excludes_self`.
+    if wire_rule.cvs_exclude {
+        config = config.with_cvs_mode(true).with_inherit(false);
+        if cvs_perishable {
+            config = config.with_perishable(true);
+        }
+    }
+
     config
+}
+
+/// Builds the local CVS-ignore exclude list for a `-C` wire rule.
+///
+/// Mirrors upstream `exclude.c:get_cvs_excludes()`: the built-in
+/// `DEFAULT_CVSIGNORE` patterns, then any tokens from `$HOME/.cvsignore`,
+/// then any tokens from `$CVSIGNORE`. Each entry becomes an exclude rule
+/// with `perishable=true` when the negotiated protocol is >= 30.
+///
+/// # Upstream Reference
+///
+/// - `exclude.c:1340-1358 get_cvs_excludes()` - default patterns, HOME/.cvsignore, env.
+fn cvs_default_exclude_rules(perishable: bool) -> Vec<FilterRule> {
+    let mut out: Vec<FilterRule> = cvs_exclusion_rules(perishable).collect();
+
+    if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        let path = Path::new(&home).join(".cvsignore");
+        if let Ok(contents) = fs::read(&path) {
+            let text = String::from_utf8_lossy(&contents).into_owned();
+            append_cvsignore_tokens(&mut out, &text, perishable);
+        }
+    }
+
+    if let Some(value) = env::var_os("CVSIGNORE").filter(|value| !value.is_empty()) {
+        let text = value.to_string_lossy().into_owned();
+        append_cvsignore_tokens(&mut out, &text, perishable);
+    }
+
+    out
+}
+
+/// Splits a CVS-ignore source on whitespace and appends an exclude rule per
+/// token, mirroring upstream's word-split parsing of `$CVSIGNORE` and
+/// `$HOME/.cvsignore` in `exclude.c:get_cvs_excludes()`.
+fn append_cvsignore_tokens(rules: &mut Vec<FilterRule>, source: &str, perishable: bool) {
+    for token in source.split_whitespace() {
+        if token.is_empty() {
+            continue;
+        }
+        let mut rule = FilterRule::exclude(token.to_owned());
+        if perishable {
+            rule = rule.with_perishable(true);
+        }
+        rules.push(rule);
+    }
 }
 
 /// Reads a `--files-from` list from a local file path on the server.
@@ -519,15 +610,31 @@ mod tests {
     #[test]
     fn wire_rule_to_dir_merge_config_strips_leading_slash() {
         let wire_rule = make_dir_merge_wire_rule("/.rsync-filter");
-        let config = wire_rule_to_dir_merge_config(&wire_rule);
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
         assert_eq!(config.filename(), ".rsync-filter");
     }
 
     #[test]
     fn wire_rule_to_dir_merge_config_no_slash() {
         let wire_rule = make_dir_merge_wire_rule(".rsync-filter");
-        let config = wire_rule_to_dir_merge_config(&wire_rule);
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
         assert_eq!(config.filename(), ".rsync-filter");
+    }
+
+    /// `:C .cvsignore` (FILTRULE_CVS_IGNORE on a DirMerge) must switch the
+    /// `DirMergeConfig` into CVS-mode so the chain parses each whitespace
+    /// token in `.cvsignore` as an exclude rule. Without this, lines like
+    /// `one-in-one-out` fail standard merge parsing and abort the walk.
+    /// Upstream's `:C` does NOT exclude the merge file itself; only the
+    /// explicit `e` modifier does.
+    #[test]
+    fn wire_rule_to_dir_merge_config_cvs_flag_enables_cvs_mode() {
+        let mut wire_rule = make_dir_merge_wire_rule(".cvsignore");
+        wire_rule.cvs_exclude = true;
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
+        assert!(config.cvs_mode());
+        assert!(!config.inherits());
+        assert!(!config.excludes_self());
     }
 
     #[test]

--- a/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
+++ b/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
@@ -1,0 +1,216 @@
+//! UTS-V3-B sub-test 4 regression: the sender's wire-format parser must
+//! expand `-C` (CVS-exclude with no pattern) into the local CVS-ignore
+//! exclude list, and switch `:C .cvsignore` dir-merges into CVS-mode
+//! parsing.
+//!
+//! The cluster B sub-test 4 invocation is:
+//!
+//! ```text
+//! rsync -avv --filter='merge $excl' -f:C -f-C --delete-excluded
+//!     --delete-during lh:from/ to/
+//! ```
+//!
+//! Upstream's client transmits the exclude-from rules then `:C .cvsignore`
+//! and `-C ` (length=3, payload `-C ` with trailing space and no pattern).
+//! Without expansion, the wire `-C ` collapses into a `FilterRule::exclude("")`
+//! whose synthetic `**/` direct matcher silently excludes every top-level
+//! entry the sender visits. Only `bar` survives (matched by the earlier
+//! `+ **/bar` include), leaving the receiver's `--delete-during` pass to
+//! remove every other dest entry.
+//!
+//! These tests pin the upstream-faithful behaviour at the wire-parser
+//! boundary that the sender's filter chain consumes:
+//!
+//! - A wire `-C ` exclude with an empty pattern expands into the default
+//!   `cvs_exclusion_rules` (perishable at proto >= 30) plus tokens from the
+//!   server's `$HOME/.cvsignore` and `$CVSIGNORE` environment, mirroring
+//!   `exclude.c:get_cvs_excludes()`.
+//! - A wire `:C .cvsignore` dir-merge switches the `DirMergeConfig` into
+//!   CVS-mode so the chain parses each whitespace token in `.cvsignore` as
+//!   an exclude rule instead of failing on `unrecognized filter rule:
+//!   one-in-one-out`.
+
+use std::path::Path;
+
+use filters::{DirMergeConfig, FilterChain, FilterRule, FilterSet};
+
+/// The CVS-mode dir-merge config must parse `.cvsignore` as
+/// whitespace-separated exclude tokens; lines like `one-in-one-out` are
+/// rejected by the default parser and would otherwise abort the sender
+/// walk for the `mid/` subtree.
+#[test]
+fn cvs_mode_dir_merge_parses_unprefixed_tokens() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    std::fs::write(dir.join(".cvsignore"), "one-in-one-out *.junk").expect("write .cvsignore");
+    std::fs::write(dir.join("one-in-one-out"), b"x").expect("write target");
+    std::fs::write(dir.join("kept"), b"y").expect("write kept");
+
+    let mut chain = FilterChain::new(FilterSet::default());
+    chain.add_merge_config(
+        DirMergeConfig::new(".cvsignore")
+            .with_cvs_mode(true)
+            .with_inherit(false),
+    );
+
+    let guard = chain
+        .enter_directory(dir)
+        .expect("CVS-mode dir-merge must accept unprefixed tokens");
+
+    assert!(
+        !chain.allows(Path::new("one-in-one-out"), false),
+        "CVS-mode tokens excluded matching paths",
+    );
+    assert!(
+        chain.allows(Path::new("kept"), false),
+        "non-matching paths still included",
+    );
+    // Upstream's `:C` does NOT exclude the merge file itself; only the
+    // explicit `e` modifier does. The default CVS pattern list is what
+    // hides `.cvsignore` from transfers at the file-level rule layer.
+    assert!(
+        chain.allows(Path::new(".cvsignore"), false),
+        ":C alone must not hide the merge file (only `:Ce` does)",
+    );
+
+    chain.leave_directory(guard);
+}
+
+/// `:C` is no-inherit by default. When the sender walks a child directory,
+/// the parent's `.cvsignore` rules must NOT apply unless the child also
+/// declares its own merge file. This pins the `mid/.cvsignore` ->
+/// `mid/for/` behaviour that drives sub-test 4's `mid/for/one-in-one-out`
+/// survival.
+#[test]
+fn cvs_mode_dir_merge_does_not_inherit_to_subdirs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    let mid = root.join("mid");
+    let mid_for = mid.join("for");
+    std::fs::create_dir_all(&mid_for).expect("mkdir");
+    std::fs::write(mid.join(".cvsignore"), "one-in-one-out").expect("write");
+
+    let mut chain = FilterChain::new(FilterSet::default());
+    chain.add_merge_config(
+        DirMergeConfig::new(".cvsignore")
+            .with_cvs_mode(true)
+            .with_inherit(false),
+    );
+
+    let mid_guard = chain.enter_directory(&mid).expect("enter mid");
+    assert!(
+        !chain.allows(Path::new("one-in-one-out"), false),
+        "mid scope excludes one-in-one-out at its own depth",
+    );
+
+    let for_guard = chain.enter_directory(&mid_for).expect("enter mid/for");
+    assert!(
+        chain.allows(Path::new("one-in-one-out"), false),
+        "no-inherit `:C` must not leak `mid/.cvsignore` rules into `mid/for/`",
+    );
+    chain.leave_directory(for_guard);
+    chain.leave_directory(mid_guard);
+}
+
+/// Sanity check that the standard merge parser, used outside CVS-mode,
+/// rejects unprefixed tokens. This pins the failure mode the CVS-mode
+/// fix bypasses.
+#[test]
+fn standard_dir_merge_rejects_unprefixed_cvsignore_token() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+    std::fs::write(dir.join(".cvsignore"), "one-in-one-out").expect("write");
+
+    let mut chain = FilterChain::new(FilterSet::default());
+    chain.add_merge_config(DirMergeConfig::new(".cvsignore"));
+
+    let err = chain
+        .enter_directory(dir)
+        .err()
+        .expect("standard merge parse must fail on unprefixed token");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("one-in-one-out"),
+        "error must mention the offending token: {msg}",
+    );
+}
+
+/// The full exclude-lsh wire-rule stream (without and with the `-C`
+/// expansion) drives top-level dir survival as follows:
+///
+/// - Without expansion, the empty `-C ` rule's `**/` matcher swallows
+///   every top-level entry except `bar` (allowed by `+ **/bar`).
+/// - With expansion, the CVS default patterns leave `.filt`, `foo`, `mid`,
+///   `new` allowed (none match a CVS pattern), and `bar` still matches
+///   `+ **/bar`.
+///
+/// This test simulates the post-fix outcome: build the same filter chain
+/// the wire parser produces after expansion and pin the survivors.
+#[test]
+fn post_expansion_chain_keeps_all_top_level_dirs() {
+    let exclude_lsh = vec![
+        FilterRule::include("**/bar"),
+        FilterRule::exclude("/bar"),
+        FilterRule::include("foo**too"),
+        FilterRule::include("foo/s?b/"),
+        FilterRule::exclude("foo/*/"),
+        FilterRule::exclude("new/keep/**"),
+        FilterRule::exclude("new/lose/***"),
+        FilterRule::include("t[o]/"),
+        FilterRule::exclude("to"),
+        FilterRule::include("file4"),
+        FilterRule::exclude("file[2-9]"),
+        FilterRule::exclude("/mid/for/foo/extra"),
+    ];
+
+    let mut rules = exclude_lsh;
+    rules.extend(filters::cvs_exclusion_rules(true));
+
+    let chain = FilterChain::new(FilterSet::from_rules(rules).expect("compiled"));
+
+    for (path, is_dir, why) in [
+        ("bar", true, "+ **/bar"),
+        (".filt", false, "no rule matches"),
+        ("foo", true, "no rule matches"),
+        ("mid", true, "no rule matches"),
+        ("new", true, "no rule matches"),
+    ] {
+        assert!(
+            chain.allows(Path::new(path), is_dir),
+            "post-expansion chain must keep {path} ({why})",
+        );
+    }
+}
+
+/// Inverse guard: confirm that the wire `-C ` rule, WITHOUT expansion,
+/// would in fact eat every top-level entry except `bar`. This pins the
+/// regression that the wire parser fix addresses.
+#[test]
+fn unexpanded_empty_exclude_swallows_top_level_entries() {
+    let mut rules = vec![
+        FilterRule::include("**/bar"),
+        // Standalone empty exclude reproduces the pre-fix shape of `-C `:
+        // `FilterRule::exclude("")` produces a `**/` direct matcher.
+        FilterRule::exclude(""),
+    ];
+    rules.extend([
+        FilterRule::include("foo**too"),
+        FilterRule::include("foo/s?b/"),
+    ]);
+
+    let chain = FilterChain::new(FilterSet::from_rules(rules).expect("compiled"));
+
+    // Documented broken behaviour: an empty exclude pattern matches every
+    // top-level entry (the unanchored expansion adds `**/` which globset
+    // treats as "any path with at least one component").
+    assert!(
+        !chain.allows(Path::new(".filt"), false),
+        "documented bug: empty exclude eats `.filt`",
+    );
+    assert!(
+        !chain.allows(Path::new("foo"), true),
+        "documented bug: empty exclude eats `foo`",
+    );
+    // `bar` survives because its include rule wins (`+ **/bar`).
+    assert!(chain.allows(Path::new("bar"), true));
+}

--- a/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
+++ b/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
@@ -126,8 +126,7 @@ fn standard_dir_merge_rejects_unprefixed_cvsignore_token() {
 
     let err = chain
         .enter_directory(dir)
-        .err()
-        .expect("standard merge parse must fail on unprefixed token");
+        .expect_err("standard merge parse must fail on unprefixed token");
     let msg = err.to_string();
     assert!(
         msg.contains("one-in-one-out"),


### PR DESCRIPTION
## Summary

Sub-test 4 of the upstream `exclude-lsh` testsuite (`--filter='merge $excl' -f:C -f-C --delete-excluded --delete-during lh:from/ to/`) was failing because:

1. The wire-format parser collapsed upstream's bare `-C ` rule (CVS-exclude with an empty pattern) into `FilterRule::exclude("")`. That rule's synthetic `**/` direct matcher silently swallowed every top-level entry on the sender, leaving `bar` as the only survivor of an `+ **/bar` include. The receiver's `--delete-during` pass then removed 32 of 34 dest entries.
2. `:C .cvsignore` was treated as a plain dir-merge, so the standard merge parser rejected unprefixed `.cvsignore` lines like `one-in-one-out` and aborted the sender walk for the `mid/` subtree.
3. `DirMergeConfig::inherits` existed on the type but was never enforced. Even with `:C` carrying the no-inherit hint, `mid/.cvsignore` rules leaked into `mid/for/`.

This change mirrors `exclude.c:get_cvs_excludes()` at the wire-parser boundary:

- An Exclude wire rule with `cvs_exclude=true` and an empty pattern expands into the built-in `DEFAULT_CVSIGNORE` patterns (perishable at proto >= 30) plus tokens from `$HOME/.cvsignore` and `$CVSIGNORE`.
- A DirMerge wire rule with `cvs_exclude=true` switches the new `DirMergeConfig::with_cvs_mode(true)` and disables inheritance; `FilterChain::enter_directory` then parses the merge file as whitespace-separated exclude tokens.
- `DirScope` now records whether its merge config inherits; `FilterChain::allows` and `allows_deletion` skip non-inheriting scopes at deeper depths, matching `FILTRULE_NO_INHERIT`.

## Test plan

- [x] `runtests.py exclude-lsh` PASS on Linux host (sub-test 4 now matches `chk` exactly)
- [x] `runtests.py exclude` PASS (push-mode CVS expansion regression guard)
- [x] `runtests.py cvs-exclude filter-depth size-filter` all PASS
- [x] New integration tests in `crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs` cover CVS-mode dir-merge parsing, no-inherit scope semantics, and the inverse guard for the broken empty-exclude shape
- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl