### PR TITLE
test(transfer): route remaining generator tests through DOTDIR helper

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3229,7 +3229,11 @@ fn generator_skips_files_matching_per_directory_merge_rules() {
     ctx.filter_chain
         .add_merge_config(::filters::DirMergeConfig::new(".rsync-filter"));
 
-    let count = build_file_list_for(&mut ctx, base);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
+    // walk-base split (flist.c:2338-2349) emits only the source basename.
+    let count = build_file_list_for_contents(&mut ctx, base);
 
     // Should have "." + "keep.txt" + ".rsync-filter" but not "skip.log"
     let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
@@ -3265,7 +3269,12 @@ fn generator_nested_directories_cascading_merge_rules() {
     ctx.filter_chain
         .add_merge_config(::filters::DirMergeConfig::new(".rsync-filter"));
 
-    let _count = build_file_list_for(&mut ctx, base);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
+    // walk-base split (flist.c:2338-2349) prefixes every name with the
+    // source basename.
+    let _count = build_file_list_for_contents(&mut ctx, base);
     let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
 
     // root.bak excluded by root .rsync-filter
@@ -3320,7 +3329,12 @@ fn generator_merge_filters_properly_scoped() {
     ctx.filter_chain
         .add_merge_config(::filters::DirMergeConfig::new(".rsync-filter"));
 
-    let _count = build_file_list_for(&mut ctx, base);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
+    // walk-base split (flist.c:2338-2349) prefixes every name with the
+    // source basename and the exact-equality assertions below would miss.
+    let _count = build_file_list_for_contents(&mut ctx, base);
     let names: Vec<String> = ctx
         .file_list()
         .iter()
@@ -3380,7 +3394,11 @@ fn generator_no_merge_configs_unchanged_behavior() {
     let (_handshake, mut ctx) = test_generator_for_path(base, false);
     // No merge configs added - filter_chain is empty
 
-    let count = build_file_list_for(&mut ctx, base);
+    // Trailing-slash source exercises upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the directory's
+    // children, matching `rsync <dir>/ dst/`. Without it, the non-relative
+    // walk-base split (flist.c:2338-2349) emits only the source basename.
+    let count = build_file_list_for_contents(&mut ctx, base);
 
     // Should have "." + 2 files = 3 entries
     assert_eq!(count, 3);


### PR DESCRIPTION
## Summary

Master CI has been failing on every push since PR #5767 / #5770 because four generator merge tests still asserted the pre-non-relative-split file-list layout. Failures land in `transfer::generator::tests` on:

- Linux nextest (stable / beta / nightly)
- Windows (stable / beta / nightly)
- Windows IOCP (`--features iocp`)
- Windows ACL/xattr
- Feature flag combinations / * (windows-latest, linux)

All cascade from the same three assertions:

- `generator_no_merge_configs_unchanged_behavior` — `assert_eq!(count, 3)` saw `1`
- `generator_merge_filters_properly_scoped` — `b/file.a` not found
- `generator_skips_files_matching_per_directory_merge_rules` — `keep.txt` not found

## Root cause

PR `fix(generator): split non-relative sender positionals on last /` aligned the sender with upstream's `flist.c:2338-2349` semantics: a non-`--relative` positional `/tmp/.tmpXXX` splits to `base=/tmp`, `path=/tmp/.tmpXXX` and the wire-side relative name becomes the source basename (`.tmpXXX`), with children rooted under it. Four filter-application tests had already been routed through the trailing-slash `build_file_list_for_contents` helper by PR #5770, but four sibling generator tests were missed and kept asserting the pre-split layout via `build_file_list_for`. Once master shipped #5770 the gap surfaced as a hard test failure on every platform.

## Fix

Route the four remaining tests through `build_file_list_for_contents` so the trailing-slash source enters upstream's `DOTDIR_NAME` branch (`flist.c:2312-2322`) and the file list collapses to `.` + the directory's children, matching `rsync <dir>/ dst/` and restoring the pre-split layout the assertions were written for. Test-only change; production behaviour and filter logic are unchanged.

## Test plan
- [ ] CI: `nextest (stable)`, `nextest (beta)`, `nextest (nightly)` pass on Linux
- [ ] CI: `Windows (stable)`, `Windows (beta)`, `Windows (nightly)` pass
- [ ] CI: `Windows IOCP (--features iocp)` passes
- [ ] CI: All `Feature flag combinations` jobs (windows-latest + linux) pass
- [ ] CI: fmt+clippy passes