### PR TITLE
chore: update release notes template to reference rsync 3.4.4

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## oc-rsync {{VERSION}}
 
-Wire-compatible with upstream rsync 3.4.3 (protocol 32).
+Wire-compatible with upstream rsync 3.4.4 (protocol 32).
 
 ### Install
 


### PR DESCRIPTION
## Summary

The interop matrix, Cargo.toml workspace metadata pin, and CI scripts (`tools/ci/run_interop.sh`, `tools/ci/regenerate_interop_matrix.py`, `tools/ci/run_upstream_testsuite.sh`, etc.) have all been migrated to upstream rsync 3.4.4 as the primary target. rsync 3.4.3 was a buggy release that 3.4.4 superseded with conservative regression fixes; the interop matrix explicitly skips 3.4.3 and uses 3.4.4 alongside 3.0.9 and 3.1.3.

The release notes template still showed a stale "3.4.3 (protocol 32)" wire-compat header line. This change updates it to 3.4.4 so future GitHub release bodies report the correct pinned upstream version.

Other 3.4.3 occurrences in the repo are intentionally retained as historical record:

- ``SECURITY.md`` and ``README.md`` "Upstream rsync 3.4.3 hardening" sections describe security fixes that landed in upstream 3.4.3 and were ported here.
- Test fixtures / comments referencing "3.4.3" as a wire-format string anchor verify protocol-32 behaviour and stay accurate against any 3.4.x peer.

## Test plan

- [ ] CI fmt+clippy passes (one-line docs change)
- [ ] No source code touched; nextest, Windows, macOS, musl, interop should all remain unaffected