### PR TITLE
test(platform): gate Windows-incompatible platform tests

### DIFF
--- a/crates/platform/src/name_resolution.rs
+++ b/crates/platform/src/name_resolution.rs
@@ -270,6 +270,7 @@ mod tests {
         assert!(lookup_account_info("nonexistent_user_xyz_99999").is_none());
     }
 
+    #[cfg(unix)]
     #[test]
     fn lookup_account_info_empty_returns_none() {
         assert!(lookup_account_info("").is_none());
@@ -295,8 +296,11 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn rid_500_resolves_to_administrator() {
+        // RID 500 always maps to the built-in administrator account, but the
+        // display name varies on localized Windows installs and renamed admin
+        // accounts. Only assert that the lookup returns a non-empty name.
         if let Some(name) = rid_to_account_name(500) {
-            assert_eq!(name, "Administrator");
+            assert!(!name.is_empty());
         }
     }
 

--- a/crates/platform/src/secrets.rs
+++ b/crates/platform/src/secrets.rs
@@ -67,6 +67,7 @@ pub fn check_secrets_file_permissions(_path: &Path) -> io::Result<()> {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn nonexistent_file_returns_error() {
         let result = check_secrets_file_permissions(Path::new("/nonexistent_secrets_xyz_99999"));


### PR DESCRIPTION
## Summary

Three nightly Windows tests in the platform crate have been failing for three days running on the Windows NTFS ACL round-trip workflow. They assert against locale-specific or implementation-defined OS behavior rather than oc-rsync code paths. Surgical fix: gate two tests cfg(unix) and relax the brittle name check on the third.

- `secrets::nonexistent_file_returns_error` (secrets.rs:71) - asserts the result is an error, but the Windows `check_secrets_file_permissions` impl is a no-op returning `Ok(())` (matches upstream rsync). Gate cfg(unix). No behavior change to the production path.
- `name_resolution::lookup_account_info_empty_returns_none` (name_resolution.rs:275) - expects `None` for empty input, but `LookupAccountNameW("")` on Windows can resolve to the local computer or BUILTIN. Gate cfg(unix); empty-string behavior is OS-defined.
- `name_resolution::rid_500_resolves_to_administrator` (name_resolution.rs:297) - asserted the resolved name equals literal "Administrator", which breaks on localized runners (e.g., "Administrateur") or renamed admin accounts. Keep the test meaningful but locale-independent: assert the resolved name is non-empty.

## Test plan

- [ ] fmt + clippy CI cells green
- [ ] nextest (stable) green on Linux/Windows/macOS/musl
- [ ] Windows (stable) cell green confirms the three tests no longer panic
- [ ] Next nightly Windows NTFS ACL round-trip run on master post-merge green