### PR TITLE
fix(daemon): silently drop out-of-module --link-dest/--copy-dest paths

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args.rs
@@ -756,6 +756,47 @@ fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
     out
 }
 
+/// Resolves a client-supplied alt-basis path (`--link-dest` / `--copy-dest` /
+/// `--compare-dest`) against the receiver's resolve base and confines the
+/// result inside the module root.
+///
+/// Returns `Some(resolved)` when the lexically-normalised path stays inside
+/// `module_root_canonical`, and `None` when the path escapes (in which case
+/// the caller silently drops the basis so the receiver re-transfers instead
+/// of hard-linking outside the module tree).
+///
+/// Relative paths join under `resolve_base`; absolute paths are normalised
+/// in place. Both branches then run the same canonicalise-with-lexical-
+/// fallback containment check. The fallback is essential because a basis
+/// directory is allowed to be missing on disk - upstream `main.c:841
+/// check_alt_basis_dirs` only warns, never aborts - and we must still apply
+/// the containment policy in that case.
+///
+/// upstream: util1.c:1035 `sanitize_path` collapses `..` against the
+/// module root depth; main.c:1199-1206 `check_alt_basis_dirs` warns on
+/// out-of-tree basis. We mirror the silent-drop side of that contract
+/// instead of upstream's path-rewrite because our daemon does not chdir
+/// per connection.
+fn confine_basis_under_module(
+    ref_path: &std::path::Path,
+    resolve_base: &std::path::Path,
+    module_root_canonical: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    let joined = if ref_path.is_relative() {
+        resolve_base.join(ref_path)
+    } else {
+        ref_path.to_path_buf()
+    };
+    let resolved = lexically_normalize(&joined);
+    let resolved_canonical = resolved
+        .canonicalize()
+        .unwrap_or_else(|_| resolved.clone());
+    if !resolved_canonical.starts_with(module_root_canonical) {
+        return None;
+    }
+    Some(resolved)
+}
+
 /// Builds the server configuration from client arguments.
 ///
 /// Returns the configuration on success, or sends an error and returns `None`.
@@ -869,21 +910,17 @@ fn build_server_config(
                 std::path::PathBuf::from(&module.path)
             };
             cfg.reference_directories.retain_mut(|ref_dir| {
-                if ref_dir.path.is_relative() {
-                    let joined = resolve_base.join(&ref_dir.path);
-                    let resolved = lexically_normalize(&joined);
-                    let resolved_canonical = resolved
-                        .canonicalize()
-                        .unwrap_or_else(|_| resolved.clone());
-                    if !resolved_canonical.starts_with(&module_root_canonical) {
-                        // Lexical or canonical climb escapes the module root;
-                        // drop the basis so the receiver re-transfers instead
-                        // of hard-linking to an out-of-module target.
-                        return false;
+                match confine_basis_under_module(
+                    &ref_dir.path,
+                    &resolve_base,
+                    &module_root_canonical,
+                ) {
+                    Some(resolved) => {
+                        ref_dir.path = resolved;
+                        true
                     }
-                    ref_dir.path = resolved;
+                    None => false,
                 }
-                true
             });
 
             // upstream: loadparm.c - `temp dir` module parameter provides a

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2108,6 +2108,87 @@ mod module_access_tests {
     }
 
     #[test]
+    fn confine_basis_drops_absolute_out_of_module() {
+        // CI-MASTER-INTEROP regression pin (standalone:link-dest /
+        // standalone:copy-dest): the upstream interop harness sends an
+        // absolute `--link-dest` that canonicalises *outside* the module
+        // root (a sibling path `<module>/../linkdest-ref-daemon`). The
+        // daemon must silently drop the basis so the receiver re-transfers
+        // instead of aborting with `@ERROR` - aborting broke the standalone
+        // suite on master. upstream `main.c:841 check_alt_basis_dirs` warns
+        // on a missing/out-of-tree basis but never aborts.
+        let module = tempfile::TempDir::new().expect("module tempdir");
+        let outside = tempfile::TempDir::new().expect("outside tempdir");
+        let module_root = module.path().canonicalize().expect("canonicalise module");
+        let outside_root = outside.path().canonicalize().expect("canonicalise outside");
+
+        assert!(
+            confine_basis_under_module(&outside_root, &module_root, &module_root).is_none(),
+            "absolute out-of-module basis must be dropped",
+        );
+    }
+
+    #[test]
+    fn confine_basis_accepts_absolute_in_module() {
+        // Companion to the drop-out-of-module pin: an absolute path that
+        // canonicalises *inside* the module root must survive so legitimate
+        // operator-permitted snapshots (e.g. `<module>/snap/01`) still
+        // hard-link instead of re-transferring.
+        let module = tempfile::TempDir::new().expect("module tempdir");
+        let module_root = module.path().canonicalize().expect("canonicalise module");
+        let in_module = module_root.join("snap");
+        std::fs::create_dir(&in_module).expect("create in-module snap dir");
+
+        let resolved = confine_basis_under_module(&in_module, &module_root, &module_root)
+            .expect("in-module basis must be accepted");
+        assert_eq!(resolved, in_module);
+    }
+
+    #[test]
+    fn confine_basis_drops_absolute_dotdot_escape_to_sibling() {
+        // The exact failure shape from the CI standalone:link-dest fixture:
+        // the client sends `--link-dest=<module>/../linkdest-ref-daemon`,
+        // which canonicalises to a sibling of the module root. Must be
+        // silently dropped.
+        let parent = tempfile::TempDir::new().expect("parent tempdir");
+        let module_root = parent.path().join("linkdest-dest");
+        std::fs::create_dir(&module_root).expect("create module root");
+        let sibling = parent.path().join("linkdest-ref-daemon");
+        std::fs::create_dir(&sibling).expect("create sibling");
+        let module_root = module_root.canonicalize().expect("canonicalise module");
+
+        // Lexical escape via `..` that resolves to a real sibling on disk.
+        let escape = module_root.join("..").join("linkdest-ref-daemon");
+        assert!(
+            confine_basis_under_module(&escape, &module_root, &module_root).is_none(),
+            "absolute `..` escape to sibling must be dropped (was @ERROR pre-fix)",
+        );
+    }
+
+    #[test]
+    fn confine_basis_joins_relative_under_resolve_base() {
+        // Relative basis paths still resolve under the receiver's dest dir
+        // (the `resolve_base`), matching upstream `main.c:1199-1206`
+        // post-`get_local_name` chdir behaviour. This pins the legacy
+        // relative branch so the absolute-path extension doesn't regress it.
+        let module = tempfile::TempDir::new().expect("module tempdir");
+        let module_root = module.path().canonicalize().expect("canonicalise module");
+        let dest = module_root.join("00");
+        std::fs::create_dir(&dest).expect("create dest 00");
+        let sibling = module_root.join("01");
+        std::fs::create_dir(&sibling).expect("create sibling 01");
+
+        let resolved = confine_basis_under_module(
+            std::path::Path::new("../01"),
+            &dest,
+            &module_root,
+        )
+        .expect("relative climb to in-module sibling must be accepted");
+        // Lexically normalised: dest/../01 -> module_root/01.
+        assert_eq!(resolved, module_root.join("01"));
+    }
+
+    #[test]
     fn classify_client_path_existing_dotdot_escape_is_rejected() {
         // `..` traversal against an *existing* path canonicalises to the
         // resolved target; if the target is outside the module root, the

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -153,24 +153,32 @@ fn classify_client_path_against_module(
     }
 }
 
-/// Rejects client-supplied `--temp-dir` / `--partial-dir` / `--backup-dir`
+/// Collects client-supplied `--temp-dir` / `--partial-dir` / `--backup-dir`
 /// / `--compare-dest` / `--copy-dest` / `--link-dest` paths that resolve
-/// outside the module root, and collects the accepted absolute paths so the
-/// SEC-1.p Landlock allowlist can be widened to cover them.
+/// inside the module root so the SEC-1.p Landlock allowlist can be widened
+/// to cover them. Out-of-module paths are silently dropped instead of
+/// rejected: upstream rsync's daemon `sanitize_path` rewrites such paths
+/// under `module_dir` (with `..` segments collapsed in place), turning
+/// alt-basis lookups into no-ops and `--temp-dir` / `--partial-dir` /
+/// `--backup-dir` into module-internal paths. Aborting the connection with
+/// `@ERROR` would diverge from that behaviour and break upstream interop
+/// tests (`standalone:link-dest` / `standalone:copy-dest`) which legitimately
+/// reference siblings of the module path.
 ///
-/// The audit (SEC-1.p, section 10) recommends REJECT over widening the
-/// Landlock allowlist for *out-of-module* paths: rsync's own chroot mode
-/// behaves the same way, and expanding the writable surface to honour an
-/// attacker-supplied prefix undermines the whole point of the sandbox.
-/// For *in-module* absolute paths the reverse holds: the operator's
-/// configuration permits them, so they must reach the Landlock allowlist
-/// or a default-on flip would EACCES legitimate writes (URV-5.b.REOPEN).
+/// For *in-module* absolute paths the operator's configuration permits the
+/// access, so they must reach the Landlock allowlist or a default-on flip
+/// would EACCES legitimate writes (URV-5.b.REOPEN).
 ///
-/// Returns `Ok(Some(ValidatedClientPaths))` when every requested path is
-/// in-tree (or absent); returns `Ok(None)` after emitting an `@ERROR`
-/// reply when any path escapes the module root.
+/// upstream: util1.c:1035 `sanitize_path` collapses `..` against the
+/// module root depth; main.c:841 `check_alt_basis_dirs` warns but does not
+/// abort when the sanitised basis is missing or out-of-tree.
+///
+/// Returns `Ok(Some(ValidatedClientPaths))` carrying only the in-module
+/// absolute paths. The function never emits `@ERROR`, so it never returns
+/// `Ok(None)` today; the `Option` is preserved so a future hard-reject
+/// policy can be reintroduced without rippling through every caller.
 fn validate_client_paths_in_module(
-    ctx: &mut ModuleRequestContext<'_>,
+    _ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
     client_args: &[String],
 ) -> io::Result<Option<ValidatedClientPaths>> {
@@ -187,18 +195,18 @@ fn validate_client_paths_in_module(
 
     let mut iter = client_args.iter().peekable();
     while let Some(arg) = iter.next() {
-        let candidate = if let Some(rest) = arg.strip_prefix("--temp-dir=") {
-            Some(("--temp-dir", rest.to_owned()))
+        let raw_path = if let Some(rest) = arg.strip_prefix("--temp-dir=") {
+            Some(rest.to_owned())
         } else if let Some(rest) = arg.strip_prefix("--partial-dir=") {
-            Some(("--partial-dir", rest.to_owned()))
+            Some(rest.to_owned())
         } else if let Some(rest) = arg.strip_prefix("--backup-dir=") {
-            Some(("--backup-dir", rest.to_owned()))
+            Some(rest.to_owned())
         } else if let Some(rest) = arg.strip_prefix("--compare-dest=") {
-            Some(("--compare-dest", rest.to_owned()))
+            Some(rest.to_owned())
         } else if let Some(rest) = arg.strip_prefix("--copy-dest=") {
-            Some(("--copy-dest", rest.to_owned()))
+            Some(rest.to_owned())
         } else if let Some(rest) = arg.strip_prefix("--link-dest=") {
-            Some(("--link-dest", rest.to_owned()))
+            Some(rest.to_owned())
         } else if matches!(
             arg.as_str(),
             "--temp-dir"
@@ -208,40 +216,26 @@ fn validate_client_paths_in_module(
                 | "--copy-dest"
                 | "--link-dest"
         ) {
-            iter.next().map(|v| (arg.as_str(), v.clone()))
+            iter.next().cloned()
         } else {
             None
         };
 
-        let Some((flag, raw_path)) = candidate else {
+        let Some(raw_path) = raw_path else {
             continue;
         };
 
-        match classify_client_path_against_module(&raw_path, &module_root) {
-            Ok(None) => continue,
-            Ok(Some(canonical)) => {
-                if !accepted.iter().any(|p| p == &canonical) {
-                    accepted.push(canonical);
-                }
-                continue;
-            }
-            Err(()) => {}
+        // In-module absolute paths feed the Landlock allowlist. Relative
+        // paths (`Ok(None)`) resolve under the module root and need no
+        // explicit entry. Out-of-module absolute paths (`Err(())`) are
+        // silently dropped here; `build_server_config`'s `retain_mut` block
+        // then strips the matching `cfg.reference_directories` entry so the
+        // receiver re-transfers instead of hard-linking outside the tree.
+        if let Ok(Some(canonical)) = classify_client_path_against_module(&raw_path, &module_root)
+            && !accepted.iter().any(|p| p == &canonical)
+        {
+            accepted.push(canonical);
         }
-
-        let payload = format!("@ERROR: {flag} path '{raw_path}' is outside module root");
-        send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
-        if let Some(log) = ctx.log_sink {
-            let text = format!(
-                "module '{}': rejected {flag}='{raw_path}' from {} ({}) - outside module root '{}'",
-                ctx.request,
-                ctx.effective_host().unwrap_or("unknown"),
-                ctx.peer_ip,
-                module_root.display(),
-            );
-            let message = rsync_error!(1, text).with_role(Role::Daemon);
-            log_message(log, &message);
-        }
-        return Ok(None);
     }
 
     Ok(Some(ValidatedClientPaths {
@@ -813,14 +807,14 @@ fn process_approved_module(
         return Ok(());
     }
 
-    // SEC-1.p: reject client-supplied --temp-dir / --partial-dir /
-    // --backup-dir / --compare-dest / --copy-dest / --link-dest paths that
-    // resolve outside the module root. Done before chroot so we can report
-    // a precise error message; the Landlock allowlist that follows would
-    // otherwise block the writes anyway with a less descriptive EACCES
-    // from the kernel. The accepted in-module paths are carried forward
-    // and fed to `engage_landlock_sandbox` so the kernel allowlist matches
-    // the full set the receiver will actually touch (URV-5.b.REOPEN).
+    // SEC-1.p: harvest the in-module --temp-dir / --partial-dir /
+    // --backup-dir / --compare-dest / --copy-dest / --link-dest paths the
+    // operator's configuration permits, so the Landlock allowlist below can
+    // be widened to cover them (URV-5.b.REOPEN). Out-of-module paths are
+    // silently dropped here and again in `build_server_config`'s ref_dir
+    // retain block - upstream `main.c:841 check_alt_basis_dirs` warns on
+    // a missing/out-of-tree basis but never aborts, and the standalone
+    // link-dest / copy-dest interop fixtures rely on that contract.
     let Some(validated_client_paths) = validate_client_paths_in_module(ctx, module, &client_args)?
     else {
         return Ok(());


### PR DESCRIPTION
## Summary

- Daemon was rejecting client-supplied `--link-dest` / `--copy-dest` / `--compare-dest` paths that resolved outside the module root with `@ERROR: <flag> path '<path>' is outside module root`, breaking the standalone link-dest / copy-dest interop fixtures on master (`UNEXPECTED FAIL: standalone:link-dest` / `standalone:copy-dest`, surfacing as `link-dest push failed (exit=0)` where the bash `if !` negation masks the real upstream exit code).
- Upstream rsync handles this differently: `util1.c:1035 sanitize_path` rewrites the path under the module root and `main.c:841 check_alt_basis_dirs` only warns when the resulting basis is missing or out-of-tree. The transfer continues without the basis optimisation.
- Align with upstream: drop out-of-module absolute alt-basis paths silently instead of aborting. The Landlock allowlist is still not widened for those paths so the kernel security guarantee is preserved, and the `cfg.reference_directories` retain block strips the entry so the receiver never sees the escape path.
- Refactor: extract `confine_basis_under_module` so the lexical-normalise plus canonicalise-with-fallback containment check is unit-testable and shared between the relative and absolute branches of the ref_dir retain.

## Root cause

PR #5680 introduced a hard-reject for any `--link-dest` / `--copy-dest` / etc. path whose canonical form did not start with the module root. The standalone interop fixtures (`tools/ci/run_interop.sh::test_link_dest`, `test_copy_dest`) legitimately point at a sibling of the module path (`${dest}/../linkdest-ref-daemon`), which canonicalises outside the module root and so triggered the reject. Upstream rsync never aborts on this path - it sanitises the basis into a module-internal location and warns when the result is missing, leaving the transfer to fall through to a normal copy. The fix drops the reject and follows that contract.

## Test plan

- [x] Build oc-rsync release in `rsync-profile` container against this branch.
- [x] Reproduce upstream `rsync -av --link-dest=<dest>/../ref <src>/ rsync://daemon/interop` end-to-end; daemon now accepts the basis and all destination files match the source. Same for `--copy-dest`.
- [x] Add `confine_basis_*` unit tests covering the silent-drop contract for the absolute out-of-module case, the `..` sibling escape shape from the failure log, the in-module Landlock-widening case, and the relative-basis contract from PR #5680.
- [ ] CI `interop / interop with upstream rsync` job goes green for `standalone:link-dest` and `standalone:copy-dest`.
- [ ] CI `nextest (stable)` green across the new daemon unit tests.