### PR TITLE
fix(transfer): bound SSH receiver drain to 200ms after flushing stdout

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -343,8 +343,25 @@ where
     // receiver-child loop on `read_final_goodbye()`; cleanup.c:254
     // `noop_io_until_death()` call in `_exit_cleanup`.
     if role == ServerRole::Receiver {
+        // Flush our final goodbye out of any outer BufWriter before draining
+        // the peer's trailing writes. Without this the upstream sender is
+        // stuck in `read_final_goodbye()` waiting on our NDX_DONE that is
+        // still in our stdout buffer, and we are stuck in the drain waiting
+        // on the sender's EOF that only arrives after its exit_cleanup runs.
+        // The deadlock surfaces as a runner-side timeout on alt-dest /
+        // 00-hello / ssh-basic / symlink-dirlink-basis / hardlinks under
+        // lsh.sh - the SSH leg of UTS-V3 cluster A.
+        let _ = stdout.flush();
+
+        // Bound the drain to a short deadline so we never hang waiting on
+        // EOF that the kernel will not deliver. Sender's exit_cleanup
+        // completes within a few ms once it has read our flushed goodbye;
+        // 200ms is comfortably above the loopback round trip but far below
+        // a runner-side per-test timeout.
+        use std::time::{Duration, Instant};
+        let deadline = Instant::now() + Duration::from_millis(200);
         let mut sink = [0u8; 4096];
-        loop {
+        while Instant::now() < deadline {
             match stdin.read(&mut sink) {
                 Ok(0) => break,
                 Ok(_) => continue,


### PR DESCRIPTION
## Summary

PR #5771 added an unbounded stdin-drain loop on the SSH receiver exit path. Five upstream-testsuite tests under the lsh.sh transport - alt-dest, 00-hello, ssh-basic, symlink-dirlink-basis, and hardlinks - now hit a deadlock between the drain and the upstream sender's read_final_goodbye(), surfacing as 300-600s runner timeouts.

strace on the hung oc-rsync confirms `unix_stream_data_wait` on stdin fd 0, with the upstream client blocked in wait4. The receiver's own NDX_DONE is still sitting in the outer `stdout` BufWriter when the drain starts, so the peer's `read_final_goodbye` never completes and its `exit_cleanup` never closes its write end.

Two minimal changes break the deadlock without losing the original cluster A protection:

- Flush `stdout` before draining so the peer sees our final goodbye and proceeds with `exit_cleanup`.
- Cap the drain at 200ms - well above the loopback round-trip, well below any runner per-test timeout. Sender's exit_cleanup completes within microseconds of receiving our flushed NDX_DONE.

upstream: io.c:943-963 `noop_io_until_death()`; cleanup.c:254 noop_io_until_death() call in _exit_cleanup.

## Test plan

- [ ] cargo fmt + clippy clean
- [ ] Rebuild on Linux host at 192.168.21.226
- [ ] Re-run upstream-testsuite - confirm alt-dest, 00-hello, ssh-basic, symlink-dirlink-basis, hardlinks now pass
- [ ] No regression in cluster A daemon-mode tests already covered by PR #5765