### PR TITLE
refactor(flist): encapsulate generator sort behind DualFileList API

### DIFF
--- a/crates/protocol/src/flist/dual.rs
+++ b/crates/protocol/src/flist/dual.rs
@@ -173,6 +173,46 @@ impl DualFileList {
         self.legacy
     }
 
+    /// Sort the file list using upstream `f_name_cmp` ordering and apply the
+    /// resulting permutation to `parallel` in lockstep so caller-owned arrays
+    /// (e.g. the generator's `full_paths`) stay aligned with the sorted list.
+    ///
+    /// `use_qsort` selects the unstable sort matching upstream `--qsort`. When
+    /// `false`, the stable sort matches upstream's default behaviour. Both
+    /// invariants are preserved from the prior external sort site that called
+    /// [`apply_permutation_in_place`](super::sort::apply_permutation_in_place)
+    /// directly on the legacy Vec.
+    ///
+    /// Sorts only the legacy [`Vec<FileEntry>`]; the shadow [`FlatFileList`]
+    /// stays unsorted because no production read path consumes it yet. Once
+    /// consumers migrate to the flat representation, this method will also
+    /// reorder the flat headers in lockstep.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds when `parallel.len() != self.len()`.
+    ///
+    /// upstream: flist.c:f_name_cmp() with indirect permutation
+    pub fn sort_with_parallel<P>(&mut self, parallel: &mut [P], use_qsort: bool) {
+        let n = self.legacy.len();
+        if n == 0 {
+            return;
+        }
+        debug_assert_eq!(parallel.len(), n);
+
+        let mut indices: Vec<usize> = (0..n).collect();
+        let cmp = |&a: &usize, &b: &usize| {
+            super::sort::compare_file_entries(&self.legacy[a], &self.legacy[b])
+        };
+        if use_qsort {
+            indices.sort_unstable_by(cmp);
+        } else {
+            indices.sort_by(cmp);
+        }
+
+        super::sort::apply_permutation_in_place(&mut self.legacy, parallel, indices);
+    }
+
     /// Reclaims heap data from entries in the range `[start..end)`.
     ///
     /// Calls [`FileEntry::reclaim_heap_data`] on each entry in the range,

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -81,7 +81,8 @@ pub use intern::PathInterner;
 pub use name_cmp::{f_name_cmp, f_name_cmp_components, name_cmp_eq};
 pub use read::{FileListReader, read_file_entry};
 pub use sort::{
-    CleanResult, compare_file_entries, flist_clean, sort_and_clean_file_list, sort_file_list,
+    CleanResult, apply_permutation_in_place, compare_file_entries, flist_clean,
+    sort_and_clean_file_list, sort_file_list,
 };
 #[cfg(feature = "flat-flist")]
 pub use sort::{compare_entries_generic, sort_entries_generic};

--- a/crates/protocol/src/flist/sort.rs
+++ b/crates/protocol/src/flist/sort.rs
@@ -417,6 +417,49 @@ pub fn sort_and_clean_file_list(
     flist_clean(file_list)
 }
 
+/// Apply a precomputed sort permutation to two parallel slices in lockstep.
+///
+/// `source_indices[i] = j` encodes "the entry at position `j` in the source
+/// becomes the entry at position `i` after sorting." Both slices must have
+/// equal length matching `source_indices.len()`. Used by the generator's
+/// file-list sort to reorder a [`FileEntry`] (or arena header) slice alongside
+/// a parallel `Vec<PathBuf>` so both stay aligned after an indirect sort.
+///
+/// Cycle-following algorithm performs `O(n)` swaps and allocates a single
+/// destination-permutation vector of length `n`; no per-element clones.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:f_name_cmp()` - upstream sorts the file list in-place;
+///   we sort via indirect permutation to avoid `O(n)` clones of `FileEntry`.
+pub fn apply_permutation_in_place<A, B>(
+    slice_a: &mut [A],
+    slice_b: &mut [B],
+    source_indices: Vec<usize>,
+) {
+    let n = slice_a.len();
+    debug_assert_eq!(slice_b.len(), n);
+    debug_assert_eq!(source_indices.len(), n);
+
+    if n == 0 {
+        return;
+    }
+
+    let mut dest_perm = vec![0; n];
+    for (new_pos, &old_pos) in source_indices.iter().enumerate() {
+        dest_perm[old_pos] = new_pos;
+    }
+
+    for i in 0..n {
+        while dest_perm[i] != i {
+            let j = dest_perm[i];
+            slice_a.swap(i, j);
+            slice_b.swap(i, j);
+            dest_perm.swap(i, j);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Generic versions for flat-flist migration (RSS-A.7.c)
 // ---------------------------------------------------------------------------

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -460,4 +460,5 @@ fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
     }
 }
 
+#[cfg(test)]
 pub(super) use protocol::flist::apply_permutation_in_place;

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use logging::{PhaseTimer, debug_log, info_log};
-use protocol::flist::{FileEntry, compare_file_entries};
+use protocol::flist::FileEntry;
 
 use super::GeneratorContext;
 
@@ -99,26 +99,8 @@ impl GeneratorContext {
         // --qsort uses unstable sort (flist.c:2991).
         {
             let _t = PhaseTimer::new("file-list-sort");
-            let file_list_slice = self.file_list.as_slice();
-            let mut indices: Vec<usize> = {
-                let len = file_list_slice.len();
-                let mut v = Vec::with_capacity(len);
-                v.extend(0..len);
-                v
-            };
-            let cmp = |&a: &usize, &b: &usize| {
-                compare_file_entries(&file_list_slice[a], &file_list_slice[b])
-            };
-            if self.config.qsort {
-                indices.sort_unstable_by(cmp);
-            } else {
-                indices.sort_by(cmp);
-            }
-
-            // Apply permutation in-place using cycle-following algorithm.
-            // This avoids cloning every element - O(n) swaps instead of O(n) clones.
-            let legacy = self.file_list.as_mut_vec();
-            apply_permutation_in_place(legacy.as_mut_slice(), &mut self.full_paths, indices);
+            self.file_list
+                .sort_with_parallel(&mut self.full_paths, self.config.qsort);
         }
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
@@ -298,24 +280,8 @@ impl GeneratorContext {
         // upstream: flist.c:f_name_cmp() - sort via indirect permutation
         {
             let _t = PhaseTimer::new("file-list-sort");
-            let file_list_slice = self.file_list.as_slice();
-            let mut indices: Vec<usize> = {
-                let len = file_list_slice.len();
-                let mut v = Vec::with_capacity(len);
-                v.extend(0..len);
-                v
-            };
-            let cmp = |&a: &usize, &b: &usize| {
-                compare_file_entries(&file_list_slice[a], &file_list_slice[b])
-            };
-            if self.config.qsort {
-                indices.sort_unstable_by(cmp);
-            } else {
-                indices.sort_by(cmp);
-            }
-
-            let legacy = self.file_list.as_mut_vec();
-            apply_permutation_in_place(legacy.as_mut_slice(), &mut self.full_paths, indices);
+            self.file_list
+                .sort_with_parallel(&mut self.full_paths, self.config.qsort);
         }
 
         // upstream: hlink.c:match_hard_links() - must be called after sort
@@ -494,48 +460,4 @@ fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
     }
 }
 
-/// Applies a source-based permutation to two parallel slices in-place.
-///
-/// Reorders elements according to `source_indices` using cycle-following with
-/// only swaps (no cloning). Used after sorting via indirect permutation to
-/// reorder `file_list` and `full_paths` simultaneously.
-///
-/// The permutation is inverted first (`source_indices[i] = j` becomes
-/// `dest_perm[j] = i`) so that cycle-following can use in-place swaps.
-///
-/// O(n) time and O(n) space for the inverse permutation.
-///
-/// # Upstream Reference
-///
-/// - `flist.c:f_name_cmp()` - upstream sorts the file list in-place;
-///   we sort via indirect permutation to avoid O(n) clones of `FileEntry`.
-pub(super) fn apply_permutation_in_place<A, B>(
-    slice_a: &mut [A],
-    slice_b: &mut [B],
-    source_indices: Vec<usize>,
-) {
-    let n = slice_a.len();
-    debug_assert_eq!(slice_b.len(), n);
-    debug_assert_eq!(source_indices.len(), n);
-
-    if n == 0 {
-        return;
-    }
-
-    // Invert the permutation: source_indices[i] = j becomes dest_perm[j] = i
-    // This converts "element at j goes to i" to "element at i goes to j"
-    let mut dest_perm = vec![0; n];
-    for (new_pos, &old_pos) in source_indices.iter().enumerate() {
-        dest_perm[old_pos] = new_pos;
-    }
-
-    // Apply destination-based permutation using cycle-following
-    for i in 0..n {
-        while dest_perm[i] != i {
-            let j = dest_perm[i];
-            slice_a.swap(i, j);
-            slice_b.swap(i, j);
-            dest_perm.swap(i, j);
-        }
-    }
-}
+pub(super) use protocol::flist::apply_permutation_in_place;


### PR DESCRIPTION
## Summary

Step 1 of 4 toward dropping the legacy `Vec<FileEntry>` from `DualFileList`. Encapsulates the two `as_mut_vec()` sort sites in the generator behind a new `DualFileList::sort_with_parallel` method that owns the indirect-sort + cycle-following permutation. No behavior change.

The dual representation currently shadow-writes both a legacy `Vec<FileEntry>` and a `FlatFileList`, doubling RSS at 1M files. Three legacy back-doors block dropping the legacy field: two `as_mut_vec()` sort sites, four `as_slice()` reads, and one `into_vec()` reorder. This PR removes the first two.

## Changes

- Move `apply_permutation_in_place` from `transfer::generator::file_list` to `protocol::flist::sort` as a public helper; re-export through `protocol::flist`. Transfer-side tests reach it via a `pub(super) use` re-export so the test surface is unchanged.
- Add `DualFileList::sort_with_parallel<P>` that builds an index permutation via `compare_file_entries`, then applies it to both the legacy `Vec<FileEntry>` and a caller-owned parallel slice (the generator's `full_paths`) in lockstep. Sorts only the legacy Vec for now; the shadow `FlatFileList` is never read in production so reordering it is deferred to a follow-up that drops the legacy field entirely.
- Migrate `build_file_list` and `build_file_list_with_base` sort blocks to the new method. Removes the local `compare_file_entries` import and the embedded permutation helper from `generator/file_list/mod.rs`.

Same comparator, same `qsort`/stable choice, same cycle-following permutation as before — just behind a method instead of inline.

## Follow-ups (separate PRs)

- **PR-B**: migrate remaining `as_slice()` / `iter()` / `into_vec()` reads off legacy back-doors.
- **PR-C**: drop the `legacy: Vec<FileEntry>` field from `DualFileList`; sort flat headers in `sort_with_parallel`.
- **PR-D**: remove `#[cfg(feature = "flat-flist")]` gates and the Cargo feature flag.

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest (stable) - full workspace
- [ ] CI Windows (stable)
- [ ] CI macOS (stable)
- [ ] CI Linux musl (stable)
- [ ] CI Interop Validation
- [ ] CI Upstream Testsuite