### PR TITLE
fix(transfer): align ssh_transport test expected capability with receiver-role omission of 'i'

### DIFF
--- a/tests/ssh_transport.rs
+++ b/tests/ssh_transport.rs
@@ -651,8 +651,11 @@ fn test_remote_invocation_with_multiple_paths() {
     let flags = args[flags_idx].to_string_lossy();
     assert!(flags.starts_with('-'));
     // upstream: options.c:2710 - capability string is embedded in the compact
-    // flag string (e.g. `-re.iLsfxCIvu`), not a separate argument.
-    let expected_suffix = build_capability_string_suffix(true);
+    // flag string (e.g. `-re.LsfxCIvu`), not a separate argument.
+    // upstream: compat.c:162-181 set_allow_inc_recurse(),
+    // options.c:3036 maybe_add_e_option() - 'i' is omitted when the local role
+    // is Receiver because the receiver path strips CF_INC_RECURSE after read.
+    let expected_suffix = build_capability_string_suffix(false);
     assert!(
         flags.ends_with(&expected_suffix),
         "capability suffix '{expected_suffix}' must be embedded in flag string: {flags}"


### PR DESCRIPTION
## Summary

- `tests/ssh_transport.rs::test_remote_invocation_with_multiple_paths` went stale when #5769 landed: the remote invocation builder now omits the `i` (INC_RECURSE) capability from the wire flag string when the local role is `Receiver`, mirroring upstream `compat.c:162-181 set_allow_inc_recurse()` and `options.c:3036 maybe_add_e_option()`.
- The test constructs a `Receiver`-role builder but still expected the suffix from `build_capability_string_suffix(true)` (`e.iLsfxCIvu`), so it panicked on the actual emission `-re.LsfxCIvu` and broke nextest (stable/beta/nightly), Linux musl (stable/beta/nightly), and the `default-features (linux)` feature-flag matrix on master.
- Pass `false` to `build_capability_string_suffix` so the expectation matches post-#5769 receiver-role wire output, and refresh the neighbouring comment to cite the upstream code path that governs the omission.

## Test plan

- [x] `cargo fmt --all` (clean).
- [ ] CI: `fmt+clippy`, `nextest (stable)`, Windows (stable), macOS (stable), Linux musl (stable) all pass.
- [ ] CI: `Feature flag combinations / default-features (linux)` passes.