### PR TITLE
fix(transfer): repair FIFO/specials walk under --features incremental-flist

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1751,7 +1751,12 @@ fn walk_skips_fifo_when_preserve_specials_is_false() {
     config.flags.recursive = true;
     let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
-    let count = build_file_list_for(&mut ctx, base_path);
+    // Trailing-slash source enters upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list contains `.` + the base
+    // directory's children, matching `rsync <dir>/ dst/`. Without it the
+    // non-relative walk-base split (flist.c:2338-2349) would emit only
+    // the source basename instead of `.` plus its children.
+    let count = build_file_list_for_contents(&mut ctx, base_path);
 
     // FIFO should be skipped, "." root dir + regular file included
     assert_eq!(count, 2);
@@ -1772,7 +1777,10 @@ fn walk_includes_fifo_when_preserve_specials_is_true() {
     config.flags.recursive = true;
     let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
-    let count = build_file_list_for(&mut ctx, base_path);
+    // Trailing-slash source enters upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the wire-side names are `.`, `regular.txt`,
+    // and `test.fifo` instead of `<basename>/regular.txt` etc.
+    let count = build_file_list_for_contents(&mut ctx, base_path);
 
     // "." root dir + regular file + FIFO should be included
     assert_eq!(count, 3);
@@ -1794,7 +1802,9 @@ fn walk_includes_fifo_as_special_entry_type() {
     config.flags.specials = true;
     let mut ctx = GeneratorContext::new_for_test(&handshake, config);
 
-    build_file_list_for(&mut ctx, base_path);
+    // Trailing-slash source enters upstream's DOTDIR_NAME branch
+    // (flist.c:2312-2322) so the file list is `.` + the FIFO child.
+    build_file_list_for_contents(&mut ctx, base_path);
 
     // "." root dir + FIFO
     assert_eq!(ctx.file_list().len(), 2);


### PR DESCRIPTION
## Summary

Fixes the `Feature flag combinations / incremental-flist (linux)` CI cell, which was failing on master with:

- `generator::tests::walk_includes_fifo_as_special_entry_type` - `assertion left == right failed` (`left: 1, right: 2`)
- `generator::tests::walk_includes_fifo_when_preserve_specials_is_true` - `assertion failed: names.contains(&"regular.txt")`

## Root Cause

The three FIFO walk tests in `crates/transfer/src/generator/tests.rs` assert the entry layout produced by upstream's DOTDIR_NAME branch (`flist.c:2312-2322`) - i.e. `.` plus the source directory's children, matching `rsync <dir>/ dst/`. They invoked `build_file_list_for`, which passes the bare temp-directory path (no trailing slash). The non-relative walk-base split (`flist.c:2338-2349`) then treated the temp directory's basename as the wire-side relative name, so the file list contained `<basename>`, `<basename>/regular.txt`, etc. - not the `.`/`regular.txt`/`test.fifo` layout the assertions expected.

`walk_includes_fifo_as_special_entry_type` also relied on the DOTDIR branch's unconditional `scan_directory_batched`, since the test does not set `recursive = true`.

## Fix

Route the three tests through `build_file_list_for_contents`, which appends `/` so `non_relative_walk_base` enters the DOTDIR branch and emits `.` plus the children at the top level. This matches the adjacent `generator_no_merge_configs_unchanged_behavior` and `generator_merge_filter_exclude_self` tests, which already use the same helper for the same reason.

The bug exists under default features too (the `incremental-flist` feature is enabled by default for the `transfer` crate) but is masked there by an earlier `test_remote_invocation_with_multiple_paths` fail-fast in the `default-features` cell.

## Test plan

- [ ] CI: `Feature flag combinations / incremental-flist (linux)` cell goes green.
- [ ] CI: `Feature flag combinations / default-features (linux)` cell no longer regresses on these three tests (independent of the unrelated `test_remote_invocation_with_multiple_paths` failure).
- [ ] No other workflows regress.