### PR TITLE
fix(transfer): drive pipe stdout to EOF in receiver close path to break SSH/local-rsh deadlock

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -352,19 +352,24 @@ where
     //   1. `stdout.flush()` pushes any bytes buffered in the outer
     //      writer down to the kernel so the peer's
     //      `read_final_goodbye()` actually sees our NDX_DONE.
-    //   2. `shutdown_stdio_write()` issues `shutdown(STDOUT_FILENO,
-    //      SHUT_WR)`. On the SSH / lsh.sh transport stdout is a stream
-    //      socket; the half-close sends FIN to the peer, which unblocks
-    //      its read_final_goodbye loop and lets its `exit_cleanup` run.
-    //      Once the peer exits it closes its own write end of our stdin
-    //      socket, which is what step 3 waits on.
+    //   2. `shutdown_stdio_write()` closes the write side of FD 1.
+    //      On the SSH / lsh.sh transport stdout is a stream socket;
+    //      the helper issues `shutdown(SHUT_WR)`, sending FIN to the
+    //      peer while leaving the read side open. On the
+    //      `--rsh=fake_rsh --rsync-path=oc-rsync` interop transport
+    //      (test_iconv_local_ssh_interop / test_compress_ssh_interop
+    //      in `tools/ci/run_interop.sh`) stdout is a pipe; the
+    //      helper's `shutdown` returns ENOTSOCK and it falls back to
+    //      `dup2(/dev/null, STDOUT_FILENO)` so the peer reading our
+    //      pipe still sees EOF deterministically. Either way the
+    //      peer's `read_final_goodbye` unblocks and its
+    //      `exit_cleanup` runs, which is what step 3 waits on.
     //   3. The drain loop reads stdin to EOF. Because step 2 already
-    //      told the peer we are done writing, the peer's FIN arrives
-    //      promptly - no timer, no race. If stdout was not a socket
-    //      (regular pipe), `shutdown_stdio_write()` returns ENOTSOCK
-    //      and process exit propagates EOF through the normal close
-    //      path; the drain still terminates as soon as the peer closes
-    //      its end.
+    //      told the peer we are done writing - regardless of the
+    //      transport's FD type - the peer's FIN arrives promptly. No
+    //      timer, no race. The pipe (ENOTSOCK) case is handled by
+    //      `stdio_shutdown.rs` falling back to `dup2(/dev/null, FD 1)`
+    //      so the peer reading our pipe still observes EOF.
     let _ = stdout.flush();
     let _ = fast_io::shutdown_stdio_write();
 

--- a/crates/fast_io/src/stdio_shutdown.rs
+++ b/crates/fast_io/src/stdio_shutdown.rs
@@ -1,77 +1,145 @@
-//! Half-close the write side of the inherited stdout descriptor.
+//! Close the write side of the inherited stdout descriptor.
 //!
 //! After the receiver-role `--server` mode finishes writing its final
 //! goodbye (NDX_DONE plus the protocol trailer), it needs to signal the
 //! peer that no more bytes will arrive on the link. The peer's
 //! `read_final_goodbye()` reads until EOF and only then proceeds to its
 //! own `exit_cleanup`. If our process simply returns from the transfer
-//! function without half-closing first, the peer keeps the connection
-//! alive while it streams trailing `MSG_STATS` / `MSG_ERROR_EXIT` bytes,
-//! and the receiver's drain loop on stdin blocks waiting for an EOF that
+//! function without closing first, the peer keeps the connection alive
+//! while it streams trailing `MSG_STATS` / `MSG_ERROR_EXIT` bytes, and
+//! the receiver's drain loop on stdin blocks waiting for an EOF that
 //! never arrives - the symmetric deadlock that surfaced as `alt-dest`,
-//! `00-hello`, `ssh-basic`, `symlink-dirlink-basis`, and `hardlinks`
-//! timing out under lsh.sh in UTS-V3 cluster A.
+//! `00-hello`, `ssh-basic`, `symlink-dirlink-basis`, `hardlinks`,
+//! `test_iconv_local_ssh_interop` direction-b, and
+//! `test_compress_ssh_interop` direction-b timing out under lsh.sh /
+//! `fake_rsh` in the interop harness.
 //!
-//! Calling [`shutdown_stdio_write`] after the final flush issues
-//! `shutdown(STDOUT_FILENO, SHUT_WR)` on Unix. For an SSH or lsh.sh
-//! transport stdout is a `SOCK_STREAM`; the half-close sends FIN to the
-//! peer, which unblocks its `read_final_goodbye` and lets it close its
-//! own write end. Our stdin then reads 0 deterministically and the
-//! drain loop terminates without a wall-clock cap.
+//! Calling [`shutdown_stdio_write`] after the final flush first tries
+//! `shutdown(STDOUT_FILENO, SHUT_WR)`. On an SSH `SOCK_STREAM`
+//! transport this sends FIN to the peer while leaving the read side
+//! open, the canonical half-close. On a pipe (the
+//! `--rsh=fake_rsh --rsync-path=oc-rsync` interop transport configures
+//! upstream rsync to spawn us via `popen2`-style pipes, NOT sockets)
+//! the syscall returns `ENOTSOCK`; the helper then falls back to
+//! `dup2(/dev/null, STDOUT_FILENO)`, which atomically closes the
+//! pipe write end (the peer's read returns 0 deterministically)
+//! while leaving FD 1 a valid writable descriptor so any late stray
+//! write does not error with `EBADF`. Either way our stdin then
+//! reads 0 without a wall-clock cap.
 //!
-//! When stdout is a pipe (daemon mode dispatches through a different
-//! entry point that never reaches this helper, but the cli `--server`
-//! receiver path is also reachable from non-socket configurations), the
-//! syscall returns `ENOTSOCK` and the helper returns the error as-is.
-//! Callers treat it as best-effort: regular pipes propagate EOF via the
-//! same process-exit `close(2)` that already runs, so failing to
-//! half-close is harmless. The Windows build is a no-op because the
-//! inherited stdio handles are not sockets and the SSH transport is not
-//! supported on Windows.
+//! On non-Unix platforms the helper is a no-op: the inherited stdio
+//! handles are not sockets and the SSH / remote-shell transport this
+//! fix targets is Unix-only.
 //!
-//! upstream: io.c:943-963 `noop_io_until_death()`; cleanup.c:254
+//! upstream: io.c:943-963 `noop_io_until_death()` (read loop that
+//! terminates on EOF); io.c:217-232 `whine_about_eof()` treats EOF
+//! inside the `kluge_around_eof` window as a clean exit; cleanup.c:254
 //! `noop_io_until_death()` call in `_exit_cleanup`.
 
 use std::io;
 
-/// Half-close the write side of the inherited stdout descriptor so the
+/// Close the write side of the inherited stdout descriptor so the
 /// peer's `read_final_goodbye()` sees EOF and proceeds to exit cleanup.
 ///
-/// On Unix this issues `shutdown(STDOUT_FILENO, SHUT_WR)`. On a stream
-/// socket (the SSH or `lsh.sh` server transport) it sends FIN to the
-/// peer. On a pipe or a closed descriptor the syscall returns
-/// `ENOTSOCK` / `EBADF`; the error is propagated so callers can log it
-/// when useful, but the caller treats it as best-effort: process exit
-/// will close the descriptor regardless.
+/// On Unix the helper first tries `shutdown(STDOUT_FILENO, SHUT_WR)`.
+/// On a stream socket (SSH transport) the kernel sends FIN to the
+/// peer while leaving the read side open - the canonical half-close.
+/// On a pipe the syscall returns `ENOTSOCK`; the helper falls back to
+/// `dup2(/dev/null, STDOUT_FILENO)`, which atomically closes the
+/// pipe write end (sending EOF to the peer that is reading our pipe)
+/// while keeping FD 1 a valid writable sink so any late stray write
+/// does not error.
 ///
-/// On non-Unix platforms the helper returns `Ok(())` immediately
-/// because the inherited stdio handles are not sockets and the SSH
-/// transport that needs the half-close is Unix-only.
+/// On non-Unix platforms the helper returns `Ok(())` immediately.
+///
+/// # Safety contract
+///
+/// The caller must guarantee that no other thread is writing to
+/// `STDOUT_FILENO` during this call. In the cli `--server` receiver
+/// exit path the goodbye envelope has already been written and the
+/// caller is about to return, so this invariant holds.
 ///
 /// # Errors
 ///
-/// Returns the OS error from `shutdown(2)` when the descriptor is not a
-/// socket (`ENOTSOCK`), has been closed (`EBADF`), or the kernel rejects
-/// the request for another reason. Callers in receiver-role server exit
-/// paths log the error and continue: the half-close is a deadlock
-/// prevention, not a correctness primitive.
+/// Returns the OS error from `shutdown(2)` when the descriptor has
+/// been closed (`EBADF`) or the kernel rejects the request for a
+/// reason other than `ENOTSOCK`. Returns the OS error from `open(2)`
+/// or `dup2(2)` if the `/dev/null` fallback path itself fails.
+/// Callers in receiver-role server exit paths log the error and
+/// continue: the close is a deadlock prevention, not a correctness
+/// primitive.
 pub fn shutdown_stdio_write() -> io::Result<()> {
     #[cfg(unix)]
     {
-        // SAFETY: `libc::shutdown` takes a file descriptor and a flag
-        // constant by value. The descriptor is the inherited stdout FD
-        // (constant `STDOUT_FILENO`), which the calling process owns
-        // for its lifetime; no memory is read or written. The flag
-        // `SHUT_WR` is a kernel-defined integer. On success the kernel
-        // marks the write side of the socket shut down and the call
-        // returns 0; on failure it returns -1 and sets `errno`.
-        #[allow(unsafe_code)]
-        let rc = unsafe { libc::shutdown(libc::STDOUT_FILENO, libc::SHUT_WR) };
-        if rc < 0 {
-            return Err(io::Error::last_os_error());
-        }
+        close_write_side(libc::STDOUT_FILENO)
     }
-    Ok(())
+    #[cfg(not(unix))]
+    {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn close_write_side(fd: libc::c_int) -> io::Result<()> {
+    // SAFETY: `libc::shutdown` takes a file descriptor and a flag
+    // constant by value. The descriptor is owned by the caller for
+    // the lifetime of the call; no memory is read or written. The
+    // flag `SHUT_WR` is a kernel constant. On success the kernel
+    // marks the write side of the socket shut down and the call
+    // returns 0; on failure it returns -1 and sets `errno`.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::shutdown(fd, libc::SHUT_WR) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let err = io::Error::last_os_error();
+    // Non-socket descriptors return ENOTSOCK; pipes are the common
+    // case under the `--rsh=<wrapper>` interop transport. Fall back
+    // to `dup2(/dev/null, fd)` so the peer reading our pipe sees EOF
+    // without depending on process exit. Other errors (EBADF, etc.)
+    // surface to the caller.
+    if err.raw_os_error() != Some(libc::ENOTSOCK) {
+        return Err(err);
+    }
+    redirect_fd_to_devnull(fd)
+}
+
+#[cfg(unix)]
+fn redirect_fd_to_devnull(fd: libc::c_int) -> io::Result<()> {
+    // SAFETY: `libc::open` reads the NUL-terminated literal at the
+    // pointer and returns a fresh file descriptor (or -1 on error).
+    // The C string lives in the binary's read-only segment for the
+    // lifetime of the process. The flag `O_WRONLY` is a kernel
+    // constant; no memory is read or written.
+    #[allow(unsafe_code)]
+    let devnull = unsafe { libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY) };
+    if devnull < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `libc::dup2` atomically reassigns `fd` to refer to the
+    // same open file description as `devnull`. If `fd` was already
+    // open the kernel closes it first, which is exactly what we want:
+    // sending EOF to the peer reading the pipe. On success the call
+    // returns `fd`; on failure -1 with errno set.
+    #[allow(unsafe_code)]
+    let dup_rc = unsafe { libc::dup2(devnull, fd) };
+    let dup_err = if dup_rc < 0 {
+        Some(io::Error::last_os_error())
+    } else {
+        None
+    };
+    // SAFETY: `devnull` was returned by `libc::open` above and is not
+    // shared with any RAII wrapper. Closing it releases the extra
+    // descriptor; `fd` still references the same `/dev/null` open
+    // file description.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::close(devnull);
+    }
+    match dup_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -163,9 +231,12 @@ mod tests {
     }
 
     #[test]
-    fn shutdown_stdio_write_surfaces_enotsock_on_pipe() {
-        // Pipes are not sockets; the helper must surface the kernel's
-        // ENOTSOCK so callers that care can log it.
+    fn shutdown_stdio_write_drives_pipe_peer_to_eof() {
+        // The `--rsh=fake_rsh` interop transport gives the spawned
+        // `--server --receiver` a pipe for stdout, not a socket. The
+        // helper must fall back from `shutdown(SHUT_WR)` (which returns
+        // ENOTSOCK on a pipe) to `dup2(/dev/null, STDOUT_FILENO)` so the
+        // peer reading our pipe still sees EOF deterministically.
         let mut fds = [0_i32; 2];
         // SAFETY: pipe(2) writes two owned descriptors into the array.
         #[allow(unsafe_code)]
@@ -174,14 +245,62 @@ mod tests {
         // SAFETY: take ownership of both pipe ends so they close at
         // scope exit even if a test assertion panics.
         #[allow(unsafe_code)]
-        let _read_end = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let read_end = unsafe { OwnedFd::from_raw_fd(fds[0]) };
         #[allow(unsafe_code)]
         let write_end = unsafe { OwnedFd::from_raw_fd(fds[1]) };
 
         let _guard = StdoutRedirect::install(write_end.as_raw_fd()).expect("redirect stdout");
 
-        let err = shutdown_stdio_write().expect_err("shutdown on a pipe should fail with ENOTSOCK");
-        assert_eq!(err.raw_os_error(), Some(libc::ENOTSOCK));
+        shutdown_stdio_write().expect("close on a pipe should succeed via /dev/null fallback");
+
+        // The original pipe write end on STDOUT_FILENO is now closed
+        // (replaced by /dev/null) while `write_end` is the only other
+        // handle; once the test runner's stdout is also restored on
+        // guard drop, the read end will see EOF. Drop the guard now to
+        // restore stdout and then verify the pipe reader sees EOF.
+        drop(_guard);
+        // After guard drop, the kernel reference count on the pipe
+        // write side drops to zero - `write_end` is the only remaining
+        // handle and we close it now.
+        drop(write_end);
+
+        let mut buf = [0u8; 4];
+        // SAFETY: `libc::read` reads up to `buf.len()` bytes into the
+        // start of `buf`. The descriptor is owned by `read_end`.
+        #[allow(unsafe_code)]
+        let n = unsafe { libc::read(read_end.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
+        assert_eq!(n, 0, "pipe read should return EOF after close fallback");
+    }
+
+    #[test]
+    fn close_write_side_pipe_returns_ok() {
+        // Direct exercise of the `dup2(/dev/null, fd)` fallback on a
+        // pipe FD without redirecting STDOUT_FILENO, so this test runs
+        // safely under parallel threads.
+        let mut fds = [0_i32; 2];
+        // SAFETY: pipe(2) writes two owned descriptors into the array.
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0, "pipe failed: {}", io::Error::last_os_error());
+        // SAFETY: take ownership of both pipe ends so they close at
+        // scope exit even if a test assertion panics.
+        #[allow(unsafe_code)]
+        let read_end = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        #[allow(unsafe_code)]
+        let write_end = unsafe { OwnedFd::from_raw_fd(fds[1]) };
+
+        close_write_side(write_end.as_raw_fd()).expect("close_write_side ok on pipe fd");
+
+        // write_end now points at /dev/null; the original pipe write
+        // side has been closed by dup2. Drop write_end and confirm the
+        // pipe read end sees EOF.
+        drop(write_end);
+        let mut buf = [0u8; 4];
+        // SAFETY: `libc::read` reads up to `buf.len()` bytes into the
+        // start of `buf`. The descriptor is owned by `read_end`.
+        #[allow(unsafe_code)]
+        let n = unsafe { libc::read(read_end.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
+        assert_eq!(n, 0, "pipe read should return EOF after close_write_side");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a pre-existing master CI regression in the `interop / interop with upstream rsync` job. On master HEAD the standalone phase reports `Standalone: 69/72 passed, 1 known, 2 unexpected` because two interop tests deadlock and get terminated by the harness `timeout 30s`:

- `test_iconv_local_ssh_interop` direction-b (`tools/ci/run_interop.sh:3530`)
- `test_compress_ssh_interop` direction-b (`tools/ci/run_interop.sh:3682`)

Both upstream rsync invocations use `--rsh=fake_rsh --rsync-path=oc-rsync`, making oc-rsync the spawned `--server --receiver`.

## Root cause

PR #5781 made the receiver-role `--server` exit path call `shutdown(STDOUT_FILENO, SHUT_WR)` after the goodbye flush so the upstream peer's `read_final_goodbye()` (`io.c:943-963`) sees EOF and proceeds to `exit_cleanup`. That works for the SSH `SOCK_STREAM` transport but is a no-op on the `--rsh=<wrapper>` interop transport: upstream rsync's remote-shell launcher uses `popen2`-style pipes, not socketpairs, so `shutdown(SHUT_WR)` returns `ENOTSOCK` and the receiver's drain-stdin loop deadlocks waiting on a peer FIN that never arrives.

## Fix

Extend `fast_io::shutdown_stdio_write` to fall back to `dup2(/dev/null, STDOUT_FILENO)` when `shutdown(SHUT_WR)` returns `ENOTSOCK`. The `dup2` atomically closes the original pipe write end (the peer's read returns 0 deterministically) while keeping FD 1 a valid writable sink so any late stray write to stdout does not error with `EBADF`. The SSH `SOCK_STREAM` half-close path is unchanged; only the pipe fallback is new.

The wire-protocol goodbye envelope itself still goes out exactly as before through `run_server_stdio`: `flush()` pushes the buffered NDX_DONE down to the kernel before the close, and the peer observes the same bytes followed by EOF on both transports. No timer is introduced; EOF is signalled by the close primitive itself.

## Tests

- Updated the pipe regression test (`shutdown_stdio_write_drives_pipe_peer_to_eof`, formerly `shutdown_stdio_write_surfaces_enotsock_on_pipe`) to assert EOF observability via the new fallback path.
- Added `close_write_side_pipe_returns_ok` exercising the fallback directly on a pipe FD without redirecting `STDOUT_FILENO`, so it runs safely under parallel test threads.
- The existing SSH socket-pair tests (`shutdown_stdio_write_sends_fin_on_socket`, `shutdown_stdio_write_is_observable_to_buffered_writer`) cover the unchanged half-close path and are preserved.

## Prior art

- PR #5771 introduced the unbounded post-goodbye stdin drain.
- PR #5780 (closed) proposed a 200 ms timer bound; closed in favour of a deterministic half-close.
- PR #5781 added `shutdown_stdio_write()` and wired it into the receiver exit path; it fixed the socket transports but the pipe transports still hang. This PR extends that helper rather than duplicating it.

## Test plan

- [ ] CI `interop / interop with upstream rsync` standalone reports 72/72 passing (or matches the known-failure baseline)
- [ ] No regression in `shutdown_stdio_write_sends_fin_on_socket` / `shutdown_stdio_write_is_observable_to_buffered_writer` socket tests
- [ ] No regression in cluster A daemon-mode tests already covered by PR #5765 or SSH-mode tests covered by PR #5771 / PR #5781

upstream: `io.c:943-963` `noop_io_until_death()` (read loop that terminates on EOF); `io.c:217-232` `whine_about_eof()` treats EOF inside the `kluge_around_eof` window as a clean exit; `cleanup.c:254` `noop_io_until_death()` call in `_exit_cleanup`.