### PR TITLE
fix(metadata): mirror upstream dest_mode for -E exec-bit pattern

### DIFF
--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -318,12 +318,18 @@ fn base_mode_for_permissions(
         source_mode & (!0o7777 | dflt_perms)
     };
 
-    if options.executability() && metadata.is_file() {
-        let source_exec = source_mode & 0o111;
-        if source_exec == 0 {
+    if options.executability() && metadata.is_file() && existing.is_some() {
+        // upstream: rsync.c:457-465 dest_mode() - for existing files only,
+        // copy source's exec presence: if source has no exec bits, clear
+        // them on dest; else if dest has no exec bits, grant exec to
+        // everyone who can already read (`new_mode & 0444 >> 2`). When dest
+        // already has some exec bits they are preserved verbatim. Upstream
+        // skips this branch for new files - the umask-masked source mode
+        // already encodes the right answer there.
+        if source_mode & 0o111 == 0 {
             destination_permissions &= !0o111;
-        } else {
-            destination_permissions |= 0o111;
+        } else if destination_permissions & 0o111 == 0 {
+            destination_permissions |= (destination_permissions & 0o444) >> 2;
         }
     }
 
@@ -370,11 +376,15 @@ fn apply_permissions_without_chmod(
                     .mode()
             };
 
-            let source_exec = metadata.permissions().mode() & 0o111;
-            if source_exec == 0 {
+            // upstream: rsync.c:457-465 dest_mode() - if source has no exec
+            // bits, clear them on dest; else if dest has no exec bits, grant
+            // exec to everyone who can already read (`new_mode & 0444 >> 2`).
+            // When dest already has some exec bits they are preserved
+            // verbatim.
+            if metadata.permissions().mode() & 0o111 == 0 {
                 destination_permissions &= !0o111;
-            } else {
-                destination_permissions |= 0o111;
+            } else if destination_permissions & 0o111 == 0 {
+                destination_permissions |= (destination_permissions & 0o444) >> 2;
             }
 
             if let Some(existing) = existing {

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -143,9 +143,45 @@ fn file_executability_can_be_preserved_without_other_bits() {
     )
     .expect("apply metadata");
 
+    // upstream: rsync.c:457-465 - source has exec bits and dest has none,
+    // so dest gets exec granted to whoever can already read: 0o620 has
+    // owner-read so owner-exec is added, group has only write, other has
+    // nothing. Result is 0o720, not 0o731 / 0o751.
     let mode = current_mode(&dest) & 0o777;
-    assert_eq!(mode & 0o111, 0o751 & 0o111);
-    assert_eq!(mode & 0o666, 0o620);
+    assert_eq!(mode, 0o720);
+}
+
+#[cfg(unix)]
+#[test]
+fn file_executability_matches_upstream_dest_mode_fixture() {
+    // upstream testsuite/executability.test (rsync 3.4.4) check_perms 3:
+    // source mode 0o601, dest mode 0o604, expected 0o705 after `-E`.
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source-2");
+    let dest = temp.path().join("dest-2");
+
+    fs::write(&source, b"#!/bin/sh\necho Program Two!\n").expect("write source");
+    fs::write(&dest, b"#!/bin/sh\necho Program Two!\n").expect("write dest");
+
+    fs::set_permissions(&source, PermissionsExt::from_mode(0o601)).expect("set source perms");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o604)).expect("set dest perms");
+
+    let metadata = fs::metadata(&source).expect("metadata");
+
+    apply_file_metadata_with_options(
+        &dest,
+        &metadata,
+        &MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_executability(true)
+            .preserve_times(false),
+    )
+    .expect("apply metadata");
+
+    let mode = current_mode(&dest) & 0o777;
+    assert_eq!(mode, 0o705, "expected 0o705 per upstream rsync.c:457-465");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- The `--executability` (`-E`) handling was OR-ing all three exec bits whenever the source had any exec presence, instead of mirroring upstream `rsync.c:457-465 dest_mode()`.
- On the upstream testsuite `executability` fixture (source `0o601`, dest `0o604`) the broken code produced `0o777` instead of the expected `0o705`.
- Both `base_mode_for_permissions` and `apply_permissions_without_chmod` now follow upstream semantics: source has no exec bits → clear all dest exec; else dest has no exec bits → grant exec to whoever can read (`new_mode & 0o444 >> 2`); else leave dest exec bits untouched.
- The chmod-baseline path also gates the executability tweak on `existing.is_some()` so upstream's "new file" branch (which skips the `-E` adjustment) is matched.

## Test plan

- [x] Regression: `file_executability_can_be_preserved_without_other_bits` updated to the upstream-correct expectation (`0o720` instead of `0o751`).
- [x] New regression `file_executability_matches_upstream_dest_mode_fixture` encodes the upstream `executability.test` check 3 fixture (source `0o601` + dest `0o604` → `0o705`).
- [x] Existing `executability_removed_when_source_not_executable` still holds (source has no exec → dest cleared).
- [x] `cargo fmt --all` clean.
- [ ] CI nextest (Linux/macOS/Windows) verifies the broader metadata + transfer suite is green.
- [ ] Upstream `executability.test` runs clean against the new binary.