### PR TITLE
fix(metadata): use apply_file_metadata_with_options in test

### DIFF
--- a/crates/metadata/tests/chmod_symlink_race.rs
+++ b/crates/metadata/tests/chmod_symlink_race.rs
@@ -30,7 +30,7 @@ use std::fs;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::PathBuf;
 
-use metadata::{MetadataOptions, apply_file_metadata};
+use metadata::{MetadataOptions, apply_file_metadata_with_options};
 use tempfile::TempDir;
 
 /// `tempdir()` may sit under a symlink prefix on macOS / some CI
@@ -66,7 +66,8 @@ fn receiver_chmod_succeeds_on_clean_path() {
     let source_meta = fs::metadata(&source).expect("source meta");
     let options = MetadataOptions::default().preserve_permissions(true);
 
-    apply_file_metadata(&destination, &source_meta, &options).expect("chmod clean path");
+    apply_file_metadata_with_options(&destination, &source_meta, &options)
+        .expect("chmod clean path");
 
     assert_eq!(
         mode_of(&destination),
@@ -106,7 +107,7 @@ fn receiver_chmod_refuses_symlinked_parent_component() {
 
     let options = MetadataOptions::default().preserve_permissions(true);
 
-    let err = apply_file_metadata(&attack_dest, &source_meta, &options)
+    let err = apply_file_metadata_with_options(&attack_dest, &source_meta, &options)
         .expect_err("chmod through symlinked parent must error");
     let raw = err
         .source()


### PR DESCRIPTION
## Summary

The chmod_symlink_race regression test from #5790 calls `apply_file_metadata` with three arguments, but the public entry point takes only two. The three-argument form is `apply_file_metadata_with_options`, which is what the test needs (it depends on `MetadataOptions::preserve_permissions(true)` to trigger the chmod path).

This slip broke master \`fmt + clippy\` (E0061: \"this function takes 2 arguments but 3 arguments were supplied\" at crates/metadata/tests/chmod_symlink_race.rs:69 and :109) and blocked PRs that rebased onto it.

## Test plan

- [ ] fmt + clippy green
- [ ] nextest stable green on the metadata test