### PR TITLE
fix(cli): half-close stdout in both server roles for lsh.sh

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -329,14 +329,17 @@ where
     // runs, at which point our read returns 0 and we unblock. Errors are
     // tolerated: the goodbye has already completed.
     //
-    // Gated to the receiver role: the generator (sender) side does not face
-    // this race because its peer (the remote receiver) closes its read end
-    // first as soon as it has flushed its own goodbye. Draining there would
-    // only delay exit without preventing any failure.
+    // Both server roles need the half-close. The receiver case is the one
+    // the comment above documents (post-goodbye drain). The generator case
+    // is the symmetric leg: under the lsh.sh pipe transport the upstream
+    // peer running as a server-receiver child also parks in
+    // `noop_io_until_death()` waiting for EOF, and the upstream
+    // `runtests.py` cluster of 00-hello, alt-dest, ssh-basic, files-from,
+    // symlink-dirlink-basis, and hardlinks all time out without it.
     //
     // Daemon mode never reaches this site (the daemon dispatches into
     // `run_server_with_handshake` directly and runs its own TCP drain in
-    // `process_approved_module`), so this drain only fires on the SSH /
+    // `process_approved_module`), so this code only fires on the SSH /
     // remote-shell path that produced cluster A's alt-dest regression.
     //
     // upstream: io.c:943-963 `noop_io_until_death()`; main.c:1075
@@ -362,10 +365,12 @@ where
     //      and process exit propagates EOF through the normal close
     //      path; the drain still terminates as soon as the peer closes
     //      its end.
-    if role == ServerRole::Receiver {
-        let _ = stdout.flush();
-        let _ = fast_io::shutdown_stdio_write();
+    let _ = stdout.flush();
+    let _ = fast_io::shutdown_stdio_write();
 
+    // The drain loop stays receiver-only: the generator never expects
+    // post-goodbye stdin bytes, so reading there would just delay exit.
+    if role == ServerRole::Receiver {
         let mut sink = [0u8; 4096];
         loop {
             match stdin.read(&mut sink) {


### PR DESCRIPTION
## Summary

The receiver-goodbye stdout half-close shipped in `30b9ba48` was gated to `ServerRole::Receiver`. The author comment claimed the generator (sender) side did not face the same race, but the upstream testsuite shows otherwise: under the `lsh.sh` remote-shell transport the upstream peer running as a server-receiver child parks in `noop_io_until_death()` (`io.c:943-963`) waiting for EOF on its read end - exactly mirroring the receiver case.

Without the half-close on the generator role, `--server --sender` exits on the goodbye but the inherited pipe write end stays open until the process is reaped. The peer never sees EOF, never runs its exit cleanup, and the runtests.py cases below hang to the per-test timeout.

## Tests this should unblock

Hosted-Linux run (rsync 3.4.3) showed these six TIMEOUT under `lsh.sh`:

- `00-hello` (test4 with `-ais`)
- `alt-dest` (lsh sub-test)
- `ssh-basic`
- `files-from`
- `symlink-dirlink-basis`
- `hardlinks`

All invoke `oc-rsync --server` as the **generator** role under the `lsh.sh` pipe transport. CI runs the upstream testsuite pinned to 3.4.4 (workflow + `tools/ci/run_upstream_testsuite.sh`).

## Fix

`crates/cli/src/frontend/server/run.rs`: move `stdout.flush()` and `fast_io::shutdown_stdio_write()` out of the `if role == ServerRole::Receiver` gate so both Receiver and Generator close their write side. The post-goodbye stdin drain loop stays receiver-only - the generator never expects post-goodbye stdin bytes from the peer, so reading there would only delay exit.

`fast_io::shutdown_stdio_write()` already handles both transports: `shutdown(STDOUT_FILENO, SHUT_WR)` for the SSH `SOCK_STREAM` case and `dup2(/dev/null, FD 1)` for the pipe (`ENOTSOCK`) case used by `lsh.sh`. No new platform code.

## Reference

- `upstream`: `io.c:943-963` `noop_io_until_death()` reads until EOF
- prior receiver-side fix: `30b9ba48` (`fix(transfer): half-close stdout after receiver goodbye`)

## Test plan

- [ ] CI: `fmt+clippy` green
- [ ] CI: `nextest (stable)` green
- [ ] CI: Windows / macOS / Linux musl stable green
- [ ] CI: Upstream Testsuite cluster (`00-hello`, `alt-dest`, `ssh-basic`, `files-from`, `symlink-dirlink-basis`, `hardlinks`) clears