### PR TITLE
fix(metadata): bypass dirfd-sandbox chmod under --keep-dirlinks

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/metadata.rs
+++ b/crates/engine/src/local_copy/context_impl/options/metadata.rs
@@ -16,6 +16,7 @@ impl<'a> CopyContext<'a> {
             .with_chmod(self.options.chmod().cloned())
             .with_user_mapping(self.options.user_mapping().cloned())
             .with_group_mapping(self.options.group_mapping().cloned())
+            .with_keep_dirlinks(self.options.keep_dirlinks_enabled())
     }
 
     /// Reports whether ACL preservation is enabled.

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -162,8 +162,7 @@ pub(super) fn apply_permissions_with_chmod(
 
             // upstream: syscall.c:do_chmod_at() - symlink-race-safe variant
             // anchored on the parent dirfd.
-            fast_io::secure_chmod_at(destination, mode, true)
-                .map_err(|error| MetadataError::new("preserve permissions", destination, error))?;
+            chmod_path_honoring_keep_dirlinks(destination, mode, options, "preserve permissions")?;
             return Ok(());
         }
     }
@@ -185,8 +184,7 @@ pub(super) fn apply_permissions_with_chmod(
             compute_dest_mode(source_mode, options.destination_is_new(), existing)
         {
             // upstream: syscall.c:do_chmod_at() - symlink-race-safe variant.
-            fast_io::secure_chmod_at(destination, new_mode, true)
-                .map_err(|error| MetadataError::new("apply dest_mode", destination, error))?;
+            chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply dest_mode")?;
         }
     }
 
@@ -229,8 +227,7 @@ pub(super) fn apply_permissions_with_chmod_fd(
             })?;
         } else {
             // upstream: syscall.c:do_chmod_at() - symlink-race-safe variant.
-            fast_io::secure_chmod_at(destination, mode, true)
-                .map_err(|error| MetadataError::new("preserve permissions", destination, error))?;
+            chmod_path_honoring_keep_dirlinks(destination, mode, options, "preserve permissions")?;
         }
         return Ok(());
     }
@@ -277,11 +274,43 @@ pub(super) fn apply_permissions_with_chmod_fd(
             })?;
         } else {
             // upstream: syscall.c:do_chmod_at() - symlink-race-safe variant.
-            fast_io::secure_chmod_at(destination, new_mode, true)
-                .map_err(|error| MetadataError::new("apply dest_mode", destination, error))?;
+            chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply dest_mode")?;
         }
     }
 
+    Ok(())
+}
+
+/// Issues a path-based chmod that honors `--keep-dirlinks`.
+///
+/// When `--keep-dirlinks` is inactive, dispatches to `fast_io::secure_chmod_at`,
+/// which anchors on the parent dirfd opened through `secure_open_dir` and
+/// rejects symlinked parents (`ELOOP`/`ENOTDIR`) to defeat chmod-symlink-race
+/// attacks against the receiver confinement.
+///
+/// When `--keep-dirlinks` is active, the user has explicitly opted into
+/// following dest-side symlinks-to-dirs, so the sandbox refusal is wrong: the
+/// parent in our test path is a symlink to a real directory and the chmod must
+/// land on the canonical file. Falls back to `std::fs::set_permissions`, which
+/// resolves symlinks through the OS path walk like upstream
+/// `generator.c:1344`'s `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
+///
+/// upstream: rsync.c:set_file_attrs() / generator.c:1344 link_stat
+#[cfg(unix)]
+fn chmod_path_honoring_keep_dirlinks(
+    destination: &Path,
+    mode: u32,
+    options: &MetadataOptions,
+    action: &'static str,
+) -> Result<(), MetadataError> {
+    if options.keep_dirlinks() {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(destination, fs::Permissions::from_mode(mode))
+            .map_err(|error| MetadataError::new(action, destination, error))?;
+    } else {
+        fast_io::secure_chmod_at(destination, mode, true)
+            .map_err(|error| MetadataError::new(action, destination, error))?;
+    }
     Ok(())
 }
 

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1492,3 +1492,69 @@ fn apply_permissions_from_entry_refuses_parent_symlink_escape() {
         "outside file mode must remain 0o600 after refused chmod escape (got {outside_mode:o})"
     );
 }
+
+/// KDL.8: with `--keep-dirlinks` active, a path-based chmod through a
+/// destination whose parent is a symlink-to-a-real-dir must succeed by
+/// resolving the symlink, instead of being refused by the dirfd-anchored
+/// `secure_chmod_at` sandbox. Mirrors upstream `generator.c:1344`'s
+/// `link_stat(fname, &sx.st, keep_dirlinks && is_dir)` which follows the
+/// symlinked parent at stat time.
+///
+/// Regression coverage for the macOS panic in
+/// `engine::local_copy::tests::execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved`
+/// where the `apply dest_mode` chmod hit `ENOTDIR` because `secure_open_dir`
+/// rejects symlinked parents.
+#[cfg(unix)]
+#[test]
+fn keep_dirlinks_bypasses_secure_chmod_sandbox() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let real_alpha = temp.path().join("real_alpha");
+    fs::create_dir(&real_alpha).expect("create real_alpha");
+
+    let dest_root = temp.path().join("dest");
+    fs::create_dir(&dest_root).expect("create dest");
+    // dest/alpha is a symlink to real_alpha/.
+    std::os::unix::fs::symlink(&real_alpha, dest_root.join("alpha")).expect("symlink alpha");
+
+    let source = temp.path().join("a.txt");
+    fs::write(&source, b"alpha").expect("write source");
+    fs::set_permissions(&source, PermissionsExt::from_mode(0o644)).expect("source mode");
+
+    let dest_file = dest_root.join("alpha").join("a.txt");
+    fs::write(&dest_file, b"alpha").expect("write dest through symlink");
+    fs::set_permissions(&dest_file, PermissionsExt::from_mode(0o600)).expect("dest mode");
+
+    let source_meta = fs::metadata(&source).expect("stat source");
+
+    // Without keep_dirlinks the path-based sandbox refuses the chmod
+    // because dest_root/alpha is a symlink. This is the bug symptom.
+    let strict_opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(false);
+    let strict_result = apply_file_metadata_with_options(&dest_file, &source_meta, &strict_opts);
+    assert!(
+        strict_result.is_err(),
+        "without keep_dirlinks the dirfd sandbox must reject symlinked parents",
+    );
+
+    // With keep_dirlinks the bypass uses std::fs::set_permissions which
+    // follows the symlink, so the chmod lands on real_alpha/a.txt.
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(false)
+        .with_keep_dirlinks(true);
+    apply_file_metadata_with_options(&dest_file, &source_meta, &opts)
+        .expect("chmod must succeed through symlinked parent under --keep-dirlinks");
+
+    let landed_mode = fs::metadata(real_alpha.join("a.txt"))
+        .expect("stat real_alpha/a.txt")
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(
+        landed_mode, 0o644,
+        "chmod must follow the symlink and land on real_alpha/a.txt (got {landed_mode:o})",
+    );
+}

--- a/crates/metadata/src/options/accessors.rs
+++ b/crates/metadata/src/options/accessors.rs
@@ -97,6 +97,19 @@ impl MetadataOptions {
         self.destination_is_new
     }
 
+    /// Reports whether `--keep-dirlinks` is active.
+    ///
+    /// When this returns `true`, callers that would otherwise refuse to walk
+    /// through symlinked parents (e.g. the dirfd-anchored TOCTOU sandbox in
+    /// `fast_io::secure_chmod_at`) must bypass that guard, because the user
+    /// has explicitly opted into following dest-side symlinks-to-dirs.
+    ///
+    /// upstream: generator.c:1344 - `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
+    #[must_use]
+    pub const fn keep_dirlinks(&self) -> bool {
+        self.keep_dirlinks
+    }
+
     /// Returns `true` when at least one metadata preservation flag is active.
     ///
     /// When this returns `false`, `apply_metadata_with_cached_stat` is a no-op

--- a/crates/metadata/src/options/mod.rs
+++ b/crates/metadata/src/options/mod.rs
@@ -38,6 +38,17 @@ pub struct MetadataOptions {
     /// upstream: rsync.c:dest_mode() uses `exists` parameter to distinguish
     /// between new and existing files for permission computation.
     pub(crate) destination_is_new: bool,
+    /// When true, `--keep-dirlinks` is active: dest-side symlinks pointing to
+    /// real directories are followed instead of being replaced.
+    ///
+    /// upstream: generator.c:1344 - `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`
+    /// resolves symlinked dest dirs at stat time, so subsequent chmod/chown
+    /// operations land on the canonical real path. We mirror that by bypassing
+    /// the dirfd-anchored sandbox in `secure_chmod_at` when this flag is set:
+    /// the user has explicitly opted into following dest-side symlinks, which
+    /// is incompatible with `secure_open_dir`'s ELOOP/ENOTDIR rejection of
+    /// symlinked parents.
+    pub(crate) keep_dirlinks: bool,
 }
 
 impl MetadataOptions {
@@ -63,6 +74,7 @@ impl MetadataOptions {
             user_mapping: None,
             group_mapping: None,
             destination_is_new: false,
+            keep_dirlinks: false,
         }
     }
 }

--- a/crates/metadata/src/options/setters.rs
+++ b/crates/metadata/src/options/setters.rs
@@ -155,4 +155,22 @@ impl MetadataOptions {
         self.destination_is_new = is_new;
         self
     }
+
+    /// Records whether `--keep-dirlinks` is active for this transfer.
+    ///
+    /// When enabled, the permission-apply path bypasses the dirfd-anchored
+    /// `secure_chmod_at` sandbox at path-based call sites. The sandbox
+    /// refuses symlinked parents (ELOOP/ENOTDIR), which is the correct
+    /// default but conflicts with the explicit opt-in to follow dest-side
+    /// symlinks-to-dirs that `--keep-dirlinks` represents.
+    ///
+    /// upstream: generator.c:1344 - `link_stat` honors `keep_dirlinks` so
+    /// the canonical target path is what subsequent chmod/chown see.
+    #[must_use]
+    #[doc(alias = "--keep-dirlinks")]
+    #[doc(alias = "-K")]
+    pub const fn with_keep_dirlinks(mut self, keep: bool) -> Self {
+        self.keep_dirlinks = keep;
+        self
+    }
 }

--- a/crates/metadata/src/options/tests.rs
+++ b/crates/metadata/src/options/tests.rs
@@ -218,6 +218,18 @@ fn destination_is_new_defaults_to_false_and_can_be_set() {
 }
 
 #[test]
+fn keep_dirlinks_defaults_to_false_and_can_be_set() {
+    let options = MetadataOptions::new();
+    assert!(!options.keep_dirlinks());
+
+    let options = options.with_keep_dirlinks(true);
+    assert!(options.keep_dirlinks());
+
+    let options = options.with_keep_dirlinks(false);
+    assert!(!options.keep_dirlinks());
+}
+
+#[test]
 fn fake_super_can_be_enabled() {
     let options = MetadataOptions::new().fake_super(true);
     assert!(options.fake_super_enabled());


### PR DESCRIPTION
## Summary

- Fix macOS panic in `engine::local_copy::tests::execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved` where `apply dest_mode` chmod failed with `ENOTDIR` because the destination's parent (`dest/alpha`) was a symlink to a real directory.
- Add `keep_dirlinks` to `MetadataOptions` and wire it from `LocalCopyOptions` through `CopyContext::metadata_options`.
- In `apply_permissions_with_chmod` and `apply_permissions_with_chmod_fd`, route the four path-based `secure_chmod_at` sites through a new helper that falls back to `std::fs::set_permissions` when `--keep-dirlinks` is active, mirroring upstream `generator.c:1344`'s `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.

## Root cause

`fast_io::secure_chmod_at` opens the parent via `secure_open_dir`, which rejects symlinked parents (`ELOOP`/`ENOTDIR`) as a TOCTOU guard against chmod-symlink-race. With `--keep-dirlinks`, the user has explicitly opted into following dest-side symlinks-to-dirs, so the sandbox refusal is semantically wrong. The bypass is gated on `options.keep_dirlinks()`; the default code path keeps the dirfd-anchored guard intact (SEC-1 / CVE-29518 protection preserved). The fd-based `fchmod` sites are unaffected because an already-opened fd cannot be redirected by a parent-symlink swap.

## Upstream reference

`// upstream: generator.c:1344 - link_stat with keep_dirlinks resolves symlinked dirs`

## Test plan

- [x] New unit test `keep_dirlinks_bypasses_secure_chmod_sandbox` in `crates/metadata/src/apply/tests.rs` covers the bypass behavior: without `keep_dirlinks` the chmod through a symlinked parent is refused; with `keep_dirlinks` it succeeds and lands on the canonical target.
- [x] New unit test `keep_dirlinks_defaults_to_false_and_can_be_set` covers the new `MetadataOptions` accessor/setter.
- [x] Existing regression `apply_permissions_from_entry_refuses_parent_symlink_escape` continues to assert the SEC-1 guard still rejects symlinked-parent chmod when `--keep-dirlinks` is NOT active.
- [x] Existing engine test `execute_keep_dirlinks_multiple_symlink_subdirs_all_preserved` (previously failing on macOS) should now pass.
- [x] No wire-protocol changes; receiver-side local-file metadata only.
- [x] CI verifies fmt, clippy, and full test suite on Linux/macOS/Windows.