### PR TITLE
fix(cli): pass is_sender from ClientConfig into OutFormatContext

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -92,6 +92,11 @@ where
         })
     });
 
+    // Capture the sender role before `config` is consumed by the client driver.
+    // Threaded into `OutFormatContext` so the itemize renderer picks the correct
+    // direction arrow (upstream: log.c:701-704 - `<` for sender, `>` otherwise).
+    let is_sender = config.is_local_sender();
+
     let result = {
         let observer = live_progress
             .as_mut()
@@ -113,7 +118,7 @@ where
                 });
             }
 
-            let out_format_context = OutFormatContext::default();
+            let out_format_context = OutFormatContext::with_is_sender(is_sender);
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                 emit_transfer_summary(
                     &summary,
@@ -150,6 +155,7 @@ where
                     name_level,
                     name_overridden,
                     human_readable_mode,
+                    is_sender,
                 })
             {
                 let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -188,6 +194,9 @@ struct EmitLogOutputParams<'a> {
     name_level: NameOutputLevel,
     name_overridden: bool,
     human_readable_mode: HumanReadableMode,
+    /// Whether the local client is the sender. Threaded through so the
+    /// itemize direction arrow matches upstream `log.c:701-704`.
+    is_sender: bool,
 }
 
 /// Writes the transfer summary to the configured log file.
@@ -201,8 +210,9 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         name_level,
         name_overridden,
         human_readable_mode,
+        is_sender,
     } = params;
-    let context = OutFormatContext::default();
+    let context = OutFormatContext::with_is_sender(is_sender);
     emit_transfer_summary(
         summary,
         verbosity,

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -157,6 +157,21 @@ pub(crate) struct OutFormatContext {
     pub(super) is_sender: bool,
 }
 
+impl OutFormatContext {
+    /// Builds a context with the supplied sender flag, leaving other fields default.
+    ///
+    /// Used by the transfer driver to thread the sender role from the parsed
+    /// `ClientConfig` through to the itemize renderer so the direction arrow
+    /// matches upstream `log.c:701-704`.
+    #[must_use]
+    pub(crate) fn with_is_sender(is_sender: bool) -> Self {
+        Self {
+            is_sender,
+            ..Self::default()
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::assertions_on_constants)]
 mod tests {

--- a/crates/core/src/client/config/client/arguments.rs
+++ b/crates/core/src/client/config/client/arguments.rs
@@ -37,6 +37,40 @@ impl ClientConfig {
     pub const fn batch_config(&self) -> Option<&engine::batch::BatchConfig> {
         self.batch_config.as_ref()
     }
+
+    /// Returns `true` when the local client is the sender (push transfer).
+    ///
+    /// Inspects `transfer_args`: when no source operand is remote the local
+    /// client acts as the sender. Pure-local transfers (no remote operands at
+    /// all) also report the local client as sender by upstream convention -
+    /// they hit the `local_server` branch in `log.c:704` which independently
+    /// selects `>`, so the polarity is harmless there.
+    ///
+    /// Used by the output formatter to pick the itemize direction arrow:
+    /// upstream emits `<` for sender-via-SSH, `>` otherwise.
+    ///
+    /// upstream: log.c:701-704 - `!local_server && *op == 's' ? '<' : '>'`
+    #[must_use]
+    pub fn is_local_sender(&self) -> bool {
+        use crate::client::remote::operand_is_remote;
+
+        if self.transfer_args.len() < 2 {
+            return true;
+        }
+
+        let (sources, _destination) = self.transfer_args.split_at(self.transfer_args.len() - 1);
+        let any_source_remote = sources.iter().any(|s| operand_is_remote(s));
+
+        // Pull (any remote source): local is the receiver -> false.
+        // Push (remote dest, no remote sources): local is the sender -> true.
+        // Local copy (no remote operands): treated as sender by upstream
+        //   convention - itemize hits `local_server` and emits `>` regardless,
+        //   so the polarity is harmless.
+        // Proxy (both remote): no per-file itemize lines render locally; the
+        //   value is unobservable. Reporting `false` keeps the arrow defaulting
+        //   to `>` for the unreachable case.
+        !any_source_remote
+    }
 }
 
 #[cfg(test)]
@@ -75,5 +109,66 @@ mod tests {
     fn batch_config_default_is_none() {
         let config = default_config();
         assert!(config.batch_config().is_none());
+    }
+
+    #[test]
+    fn is_local_sender_local_copy_reports_sender() {
+        // Pure-local copy: `oc-rsync src/ dst/`. Upstream's `log.c:704` falls
+        // into the `local_server` branch which emits `>` regardless of am_sender,
+        // so the polarity is harmless. Lock the upstream convention here.
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src/"), OsString::from("dst/")])
+            .build();
+        assert!(config.is_local_sender());
+    }
+
+    #[test]
+    fn is_local_sender_push_reports_sender() {
+        // Push: `oc-rsync src/ host:dst/`. Local client is the sender; upstream
+        // log.c:704 emits `<` because !local_server && am_sender.
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src/"), OsString::from("host:dst/")])
+            .build();
+        assert!(config.is_local_sender());
+    }
+
+    #[test]
+    fn is_local_sender_pull_reports_receiver() {
+        // Pull: `oc-rsync host:src/ dst/`. Local client is the receiver; upstream
+        // log.c:704 emits `>` because *op != 's'.
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("host:src/"), OsString::from("dst/")])
+            .build();
+        assert!(!config.is_local_sender());
+    }
+
+    #[test]
+    fn is_local_sender_rsync_url_pull_reports_receiver() {
+        // Daemon pull via rsync:// URL.
+        let config = ClientConfig::builder()
+            .transfer_args([
+                OsString::from("rsync://host/mod/src/"),
+                OsString::from("dst/"),
+            ])
+            .build();
+        assert!(!config.is_local_sender());
+    }
+
+    #[test]
+    fn is_local_sender_double_colon_push_reports_sender() {
+        // Daemon push via `host::module` syntax.
+        let config = ClientConfig::builder()
+            .transfer_args([OsString::from("src/"), OsString::from("host::mod/dst/")])
+            .build();
+        assert!(config.is_local_sender());
+    }
+
+    #[test]
+    fn is_local_sender_empty_args_reports_sender() {
+        // No transfer args (module-list mode etc.). Default to sender so the
+        // itemize formatter doesn't flip arrows for callers that never render
+        // per-file lines.
+        let config = ClientConfig::default();
+        assert!(config.is_local_sender());
     }
 }


### PR DESCRIPTION
## Summary

- Itemize direction-arrow polarity fix: oc-rsync as SSH-push sender was emitting `>f+++++++++` where upstream rsync emits `<f+++++++++`.
- The formatter logic was already correct (`< if is_sender else >`); the bug was that both call sites in `crates/cli/src/frontend/execution/drive/summary.rs` built `OutFormatContext` via `::default()`, leaving `is_sender = false`.
- Thread the actual sender role from `ClientConfig` through to `OutFormatContext` via a new `ClientConfig::is_local_sender()` accessor and an `OutFormatContext::with_is_sender(bool)` constructor.

## Upstream reference

```c
// log.c:701-704
c[0] = iflags & ITEM_LOCAL_CHANGE
     ? iflags & ITEM_XNAME_FOLLOWS ? 'h' : 'c'
     : !(iflags & ITEM_TRANSFER) ? '.'
     : !local_server && *op == 's' ? '<' : '>';
```

SSH-sender emits `<`; everything else emits `>`.

## Root cause

`crates/cli/src/frontend/execution/drive/summary.rs:116` (`execute_transfer` -> live summary path) and `:205` (`emit_log_output` -> `--log-file` path) constructed `OutFormatContext::default()` which leaves `is_sender = false`. The formatter at `crates/cli/src/frontend/out_format/render/itemize.rs:28` correctly selected `<` vs `>` from `context.is_sender`, but never saw the true value. Result: every SSH-push transfer emitted the wrong direction arrow.

## Fix

- `ClientConfig::is_local_sender()` (new): inspects `transfer_args` via the existing `client::remote::operand_is_remote` classifier.
  - Push (remote dest, all-local sources) -> `true` (local is sender)
  - Pull (any remote source) -> `false` (local is receiver)
  - Local copy / empty args -> `true` (sender by upstream convention; upstream `log.c:704` hits the `local_server` branch which emits `>` regardless, so polarity is harmless)
  - Proxy (all remote) -> `false` (no local itemize lines render; value unobservable)
- `execute_transfer` captures `let is_sender = config.is_local_sender();` before `config` is consumed by `run_client_with_observer`.
- `OutFormatContext::with_is_sender(bool)` constructor added; both summary.rs call sites use it.
- `EmitLogOutputParams` gains an `is_sender: bool` field so the log-file path renders with the same polarity as stdout.

## Wire protocol

Unaffected. The change touches the user-facing log layer only.

## Test plan

- [x] Add unit tests in `crates/core/src/client/config/client/arguments.rs` covering push (`src host:dst`), pull (`host:src dst`), pure-local, daemon push (`host::mod/dst`), daemon pull (`rsync://host/mod/src`), and empty transfer args.
- [ ] CI required checks (fmt+clippy, nextest stable, Windows, macOS, Linux musl).
- [ ] Re-run SSH sweep against the merged binary and confirm SSH-push scenarios now emit `<` to match upstream.