### PR TITLE
fix(engine): drop writer before metadata apply on non-unix inplace path

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
@@ -109,6 +109,13 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
             drop(writer_for_metadata.take());
         }
     } else {
+        // Non-unix inplace path: drop the writer before applying metadata so
+        // path-based metadata syscalls (fs::metadata, fs::set_permissions on
+        // Windows) don't compete with the held exclusive write handle. The
+        // unix path threads the open fd through `with_fd()` so it must stay
+        // open across apply_metadata_and_finalize.
+        #[cfg(not(unix))]
+        drop(writer_for_metadata.take());
         #[allow(unused_mut)] // REASON: mutated on unix for with_fd()
         let mut params = FinalizeMetadataParams::new(
             metadata,


### PR DESCRIPTION
## Summary

Hypothesis-driven fix for the master-CI Windows interop **inplace** divergence (`CI-MASTER-WIN-INPLACE`).

**Hypothesis:** The non-unix inplace finalize branch in `finalize.rs` held the exclusive writer fd open across `apply_metadata_and_finalize`. On Windows, the metadata apply path runs `fs::metadata(destination)` (permissions.rs:123) and `fs::set_permissions()` (permissions.rs:129) — path-based syscalls that compete with the held exclusive write handle.

**Fix:** Drop the writer *before* the apply on `#[cfg(not(unix))]` only. The unix path threads the open fd through `with_fd()` so it must stay open across the apply.

**Why this branch and not the guarded branch:** The guarded (temp-file) finalize already drops the writer on cross-device commit (finalize.rs:84-86); the inplace path was the only `else` arm holding the fd open across apply.

## Why this is the smallest fix

- Affects only the non-unix path. UNIX behavior unchanged.
- Affects only the no-guard (inplace) branch. The guarded branch (which already handles cross-device drop) is unchanged.
- 1 conditional drop + a small comment block explaining the asymmetry vs the unix `with_fd()` path.

## Test plan

- [ ] Windows interop cell (the inplace scenario) goes green - this is the validation gate; if Windows passes, the hypothesis is confirmed.
- [ ] macOS / Linux nextest stays green (no behavior change on unix).
- [ ] fmt + clippy clean.

## Background

Surfaced by master CI run (sha 16ea1cd) showing the Windows interop test "inplace push diverged" failure while link-dest/copy-dest, ACLs, ADS, and other Windows cells passed - isolating the divergence to the path where the writer is held across metadata apply (only `--inplace` keeps the writer alive into finalize).