### PR TITLE
ci(upstream-testsuite): include build-script hash in upstream-src cache key

### DIFF
--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           path: |
             target/interop/upstream-src/rsync-${{ env.UPSTREAM_RSYNC_VERSION }}
-          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ runner.os }}
+          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh') }}-${{ runner.os }}
 
       - name: Build oc-rsync (release)
         run: cargo build --locked --release --bin oc-rsync


### PR DESCRIPTION
## Summary

The upstream-src cache in `.github/workflows/upstream-testsuite.yml` keyed only on `UPSTREAM_RSYNC_VERSION` and `runner.os`. Whenever the version and OS matched a prior run, the cached `target/interop/upstream-src/rsync-3.4.4` directory was restored as-is, including the pre-built upstream helper binaries.

PR #5806 added `t_chmod_secure` and `t_secure_relpath` to the make targets in `tools/ci/run_upstream_testsuite.sh`, but the post-merge CI keeps using the cached upstream-src that was built before those targets were added. Result: `chmod-symlink-race` and `secure-relpath-validation` continue to fail with `No such file or directory` on the helper binaries, and the testsuite step finishes in ~14 seconds because no `make` actually runs.

Adding `hashFiles('tools/ci/run_upstream_testsuite.sh')` to the cache key invalidates the cache whenever the build script changes, so the new helper targets actually get built on the next run.

## Test plan

- [ ] CI on this PR rebuilds upstream-src (build step shows the `./configure` + `make` log instead of restoring from cache).
- [ ] After merge to master, the next upstream-testsuite run on master no longer reports `chmod-symlink-race` or `secure-relpath-validation` as failures.