### PR TITLE
fix(metadata): apply executability bits in entry-based permissions path

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -188,6 +188,14 @@ pub(crate) struct FinalizeMetadataParams<'a> {
     mode: LocalCopyExecution,
     path_context: MetadataPathContext<'a>,
 
+    /// Pre-transfer destination metadata captured before the temp-file
+    /// rename. Mirrors upstream's `stat_mode` argument to `dest_mode()`:
+    /// `Some(meta)` when the destination existed at transfer start;
+    /// `None` for a brand-new destination. Used by
+    /// [`::metadata::apply_dest_mode_pre_transfer`] to reproduce the
+    /// upstream `rsync.c:954-965` chmod-on-rename loop.
+    pre_transfer_meta: Option<&'a fs::Metadata>,
+
     #[cfg(unix)]
     fd: Option<std::os::fd::BorrowedFd<'a>>,
 
@@ -212,6 +220,7 @@ impl<'a> FinalizeMetadataParams<'a> {
             metadata_options,
             mode,
             path_context,
+            pre_transfer_meta: None,
             #[cfg(unix)]
             fd: None,
             #[cfg(all(unix, feature = "xattr"))]
@@ -225,6 +234,17 @@ impl<'a> FinalizeMetadataParams<'a> {
     #[cfg(unix)]
     pub(crate) const fn with_fd(mut self, fd: std::os::fd::BorrowedFd<'a>) -> Self {
         self.fd = Some(fd);
+        self
+    }
+
+    /// Attach the pre-transfer destination metadata so the apply path can
+    /// reproduce upstream `dest_mode()` semantics for the chmod-on-rename
+    /// loop.
+    pub(crate) const fn with_pre_transfer_meta(
+        mut self,
+        pre_transfer_meta: Option<&'a fs::Metadata>,
+    ) -> Self {
+        self.pre_transfer_meta = pre_transfer_meta;
         self
     }
 }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -271,6 +271,7 @@ impl<'a> CopyContext<'a> {
             metadata_options,
             mode,
             path_context,
+            pre_transfer_meta,
             #[cfg(unix)]
             fd,
             #[cfg(all(unix, feature = "xattr"))]
@@ -291,6 +292,23 @@ impl<'a> CopyContext<'a> {
             CreatedEntryKind::File,
             destination_previously_existed,
         );
+
+        // upstream: rsync.c:954-965 - when `-p`/`--chmod` are off, the
+        // receiver rewrites `file->mode` via `dest_mode()` BEFORE the
+        // transfer; `set_file_attrs()` then chmods the freshly-renamed
+        // temp file to that mode. Reproduce that chmod here so a re-
+        // transferred regular file holds its pre-transfer permission bits
+        // and a new regular file lands at `source_mode & dflt_perms`. The
+        // call short-circuits when `-p`/`--chmod` are active so the
+        // existing chmod chain owns the syscall.
+        #[cfg(unix)]
+        ::metadata::apply_dest_mode_pre_transfer(
+            destination,
+            metadata,
+            &metadata_options,
+            pre_transfer_meta,
+        )
+        .map_err(map_metadata_error)?;
 
         // Use fd-based metadata operations when an open fd is available (Unix).
         // Stat the destination first to skip redundant chown/chmod/utimensat
@@ -747,6 +765,11 @@ impl<'a> CopyContext<'a> {
                     file_type: path_context.file_type,
                     destination_previously_existed: path_context.destination_previously_existed,
                 },
+                // upstream: rsync.c:954-965 - deferred updates have already
+                // committed the rename + applied dest_mode at the original
+                // commit site, so there is no pre-transfer stat to recover
+                // here.
+                pre_transfer_meta: None,
                 #[cfg(unix)]
                 fd: None, // No fd available for deferred updates
                 #[cfg(all(unix, feature = "xattr"))]

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -192,6 +192,7 @@ pub(super) fn try_clone(
         destination_previously_existed,
         false,
         &mut None,
+        existing_metadata,
         #[cfg(all(unix, feature = "xattr"))]
         flags.preserve_xattrs,
         #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
@@ -158,6 +158,7 @@ pub(super) fn try_dispatch(
         destination_previously_existed,
         false,
         &mut writer_for_metadata,
+        existing_metadata,
         #[cfg(all(unix, feature = "xattr"))]
         flags.preserve_xattrs,
         #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -609,6 +609,7 @@ pub(in crate::local_copy) fn execute_transfer(
         destination_previously_existed,
         delay_updates_enabled,
         &mut writer_for_metadata,
+        existing_metadata,
         #[cfg(all(unix, feature = "xattr"))]
         preserve_xattrs,
         #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/finalize.rs
@@ -25,6 +25,12 @@ use super::super::super::guard::DestinationWriteGuard;
 /// commit. Otherwise the guard is committed immediately and metadata is applied.
 /// If no guard is present (inplace path), metadata is applied directly to
 /// `destination`.
+///
+/// `pre_transfer_meta` is the destination's metadata captured before the
+/// temp-file rename. It mirrors upstream's `stat_mode` argument to
+/// `rsync.c:dest_mode()` and lets the apply path chmod a fresh temp file
+/// back to the destination's prior permission bits (`-p`/`--chmod` paths
+/// already drive their own chmod chain).
 #[allow(clippy::too_many_arguments)]
 pub(in crate::local_copy) fn finalize_guard_and_metadata(
     context: &mut CopyContext,
@@ -40,6 +46,7 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
     destination_previously_existed: bool,
     delay_updates_enabled: bool,
     writer_for_metadata: &mut Option<fs::File>,
+    pre_transfer_meta: Option<&fs::Metadata>,
     #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
     #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<(), LocalCopyError> {
@@ -99,7 +106,8 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
                 preserve_xattrs,
                 #[cfg(all(any(unix, windows), feature = "acl"))]
                 preserve_acls,
-            );
+            )
+            .with_pre_transfer_meta(pre_transfer_meta);
             #[cfg(unix)]
             if let Some(ref w) = *writer_for_metadata {
                 use std::os::fd::AsFd;
@@ -124,7 +132,8 @@ pub(in crate::local_copy) fn finalize_guard_and_metadata(
             preserve_xattrs,
             #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
-        );
+        )
+        .with_pre_transfer_meta(pre_transfer_meta);
         #[cfg(unix)]
         if let Some(ref w) = *writer_for_metadata {
             use std::os::fd::AsFd;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
@@ -136,6 +136,7 @@ pub(in crate::local_copy) fn copy_special_as_regular_file(
         destination_previously_existed,
         delay_updates_enabled,
         &mut no_writer,
+        existing_metadata,
         #[cfg(all(unix, feature = "xattr"))]
         flags.preserve_xattrs,
         #[cfg(all(any(unix, windows), feature = "acl"))]

--- a/crates/engine/src/local_copy/tests/execute_executability.rs
+++ b/crates/engine/src/local_copy/tests/execute_executability.rs
@@ -163,9 +163,9 @@ fn execute_executability_without_permissions_preserves_only_execute_bits() {
     fs::write(&source, b"payload").expect("write source");
     fs::write(&destination, b"existing").expect("write dest");
 
-    // Source has specific permissions including execute
+    // Source has specific permissions including execute. Destination starts at
+    // `0o620` so the pre-transfer destination mode lacks any x bit.
     fs::set_permissions(&source, PermissionsExt::from_mode(0o751)).expect("set source perms");
-    // Destination has different permissions
     fs::set_permissions(&destination, PermissionsExt::from_mode(0o620)).expect("set dest perms");
 
     let operands = vec![
@@ -183,10 +183,23 @@ fn execute_executability_without_permissions_preserves_only_execute_bits() {
 
     let metadata = fs::metadata(&destination).expect("dest metadata");
     let mode = metadata.permissions().mode() & 0o777;
-    // Only execute bits should match source, other bits should remain from dest
-    assert_eq!(mode & 0o111, 0o751 & 0o111, "execute bits should match source");
-    // Non-execute bits should be different from source (not preserved)
-    assert_ne!(mode & 0o666, 0o751 & 0o666, "non-execute bits should not be preserved");
+    // upstream: rsync.c:457-465 dest_mode() - when `-E` is on without `-p`,
+    // the receiver keeps the destination's pre-transfer permission bits and
+    // grants execute "to everyone who can already read" (`new_mode & 0444 >> 2`)
+    // when the source has any x bit and the destination has none. Starting
+    // from dest=0o620, only owner has read, so only owner gains x → 0o720.
+    // The non-x bits stay at the pre-transfer destination mode, not the
+    // source's; this matches upstream rsync 3.4.4 exactly.
+    assert_eq!(
+        mode, 0o720,
+        "expected upstream dest_mode() result 0o720 (rwx-w-----) for pre-transfer dest 0o620 + source 0o751"
+    );
+    assert_eq!(mode & 0o111, 0o100, "only owner x is granted (dest had only owner-read)");
+    assert_eq!(
+        mode & 0o666,
+        0o620,
+        "non-x bits stay at the pre-transfer destination's mode, not the source's"
+    );
     assert_eq!(summary.files_copied(), 1);
 }
 

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -90,6 +90,26 @@ pub fn apply_file_metadata_with_options(
     Ok(())
 }
 
+/// Pre-applies upstream's `dest_mode()` chmod for callers that have the
+/// pre-transfer destination stat in hand.
+///
+/// See [`permissions::apply_dest_mode_pre_transfer`] for the full
+/// upstream-reference documentation.
+#[cfg(unix)]
+pub fn apply_dest_mode_pre_transfer(
+    destination: &Path,
+    source_metadata: &fs::Metadata,
+    options: &MetadataOptions,
+    pre_transfer_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    permissions::apply_dest_mode_pre_transfer(
+        destination,
+        source_metadata,
+        options,
+        pre_transfer_meta,
+    )
+}
+
 /// Applies file metadata using an open file descriptor for efficiency.
 ///
 /// When an fd is available (e.g. after writing a file), this avoids redundant
@@ -445,12 +465,34 @@ pub fn apply_metadata_with_cached_stat(
     options: &MetadataOptions,
     cached_meta: Option<fs::Metadata>,
 ) -> Result<(), MetadataError> {
-    apply_metadata_with_attrs_flags(
+    apply_metadata_with_pre_transfer_stat(destination, entry, options, cached_meta, None)
+}
+
+/// Applies metadata using both a cached post-rename stat and a pre-transfer
+/// stat.
+///
+/// Identical to [`apply_metadata_with_cached_stat`] except the additional
+/// `pre_transfer_meta` argument lets the receiver mirror upstream
+/// `rsync.c:dest_mode()`: when `-p`/`-E`/`--chmod` are all off, upstream
+/// still chmods a freshly-renamed temp file back to the pre-transfer
+/// destination's permission bits (`exists=true` branch) or to the
+/// umask-masked source mode (`exists=false` branch). Without the pre-
+/// transfer stat the receiver would feed the temp file's `0o600`/umask-
+/// default mode into the heuristic.
+pub fn apply_metadata_with_pre_transfer_stat(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    cached_meta: Option<fs::Metadata>,
+    pre_transfer_meta: Option<fs::Metadata>,
+) -> Result<(), MetadataError> {
+    apply_metadata_with_attrs_flags_and_pre_transfer(
         destination,
         entry,
         options,
         cached_meta,
         AttrsFlags::empty(),
+        pre_transfer_meta,
     )
 }
 
@@ -476,9 +518,40 @@ pub fn apply_metadata_with_attrs_flags(
     cached_meta: Option<fs::Metadata>,
     attrs_flags: AttrsFlags,
 ) -> Result<(), MetadataError> {
+    apply_metadata_with_attrs_flags_and_pre_transfer(
+        destination,
+        entry,
+        options,
+        cached_meta,
+        attrs_flags,
+        None,
+    )
+}
+
+/// Like [`apply_metadata_with_attrs_flags`] but accepts a pre-transfer
+/// destination stat so the permission-apply path can reproduce upstream
+/// `rsync.c:dest_mode()` for the receiver chmod loop.
+///
+/// `pre_transfer_meta` is the destination's metadata captured before any
+/// temp-file rename. Pass `Some(meta)` when a destination file existed at
+/// transfer start; pass `None` when the destination is brand new.
+pub fn apply_metadata_with_attrs_flags_and_pre_transfer(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    cached_meta: Option<fs::Metadata>,
+    attrs_flags: AttrsFlags,
+    pre_transfer_meta: Option<fs::Metadata>,
+) -> Result<(), MetadataError> {
     ownership::apply_ownership_from_entry(destination, entry, options, cached_meta.as_ref())?;
 
-    permissions::apply_permissions_from_entry(destination, entry, options, cached_meta.as_ref())?;
+    permissions::apply_permissions_from_entry(
+        destination,
+        entry,
+        options,
+        cached_meta.as_ref(),
+        pre_transfer_meta.as_ref(),
+    )?;
 
     // upstream: rsync.c:597 - `if (!(flags & ATTRS_SKIP_MTIME) && !same_mtime(...))`
     if options.times() && !attrs_flags.skip_mtime() {

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -88,6 +88,104 @@ fn compute_dest_mode(
     }
 }
 
+/// Pre-applies the upstream `rsync.c:dest_mode()` chmod for the source-
+/// `Metadata` apply path used by the local-copy executor and the receiver
+/// data fast path.
+///
+/// Mirrors upstream's `file->mode = dest_mode(...)` rewrite that runs
+/// BEFORE the temp file is opened; the freshly-renamed temp file then gets
+/// chmod'd to that mode by `set_file_attrs()`. Without this pre-chmod the
+/// destination would silently inherit the temp file's `0o600`/umask-default
+/// permissions instead of upstream's `dest_mode()` result.
+///
+/// Returns without acting when `-p`/`--chmod` are in effect: those paths
+/// already drive the chmod through `metadata.permissions().mode()` or the
+/// chmod modifier chain.
+///
+/// upstream: rsync.c:954-965 (`dest_mode()` invocation) + rsync.c:457-465
+/// (`dest_mode()` body)
+#[cfg(unix)]
+pub fn apply_dest_mode_pre_transfer(
+    destination: &Path,
+    source_metadata: &fs::Metadata,
+    options: &MetadataOptions,
+    pre_transfer_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !source_metadata.file_type().is_file() {
+        return Ok(());
+    }
+    if options.permissions() || options.chmod().is_some() {
+        return Ok(());
+    }
+
+    let source_mode = source_metadata.permissions().mode();
+    let base_mode = if let Some(existing) = pre_transfer_meta {
+        // Existing destination: keep its prior permission bits.
+        let stat_mode = existing.permissions().mode();
+        (source_mode & !0o7777) | (stat_mode & 0o7777)
+    } else {
+        // New destination: source mode masked by default permissions.
+        let dflt_perms = 0o777 & !cached_umask();
+        source_mode & (!0o7777 | dflt_perms)
+    };
+
+    let mut target_perms = base_mode & 0o7777;
+    if options.executability() {
+        // upstream: rsync.c:457-465 - layer `-E` executability on top of the
+        // dest_mode() base.
+        if source_mode & 0o111 == 0 {
+            target_perms &= !0o111;
+        } else if target_perms & 0o111 == 0 {
+            target_perms |= (target_perms & 0o444) >> 2;
+        }
+    }
+    let new_mode = (base_mode & !0o7777) | target_perms;
+
+    // Compare against the file's CURRENT (post-rename) mode. If the temp
+    // file already happens to match the target we skip the chmod syscall.
+    let current_mode = fs::metadata(destination)
+        .map_err(|error| MetadataError::new("inspect destination permissions", destination, error))?
+        .permissions()
+        .mode();
+    if (current_mode & 0o7777) != (new_mode & 0o7777) {
+        chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply dest_mode")?;
+    }
+    Ok(())
+}
+
+/// Computes the upstream `dest_mode()` result for the receiver entry path.
+///
+/// Returns the mode bits the destination would have AFTER upstream rewrites
+/// `file->mode = dest_mode(...)`. The `-E` layer (if active) goes on top of
+/// this base mode. Used both by the no-flag chmod fallback (which mirrors
+/// upstream's unconditional `set_file_attrs()` chmod) and by the `-E`
+/// without `-p` path.
+///
+/// upstream: rsync.c:449-472 `dest_mode()`
+#[cfg(unix)]
+fn dest_mode_for_existing_or_new(
+    entry: &protocol::flist::FileEntry,
+    pre_transfer_meta: Option<&fs::Metadata>,
+) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+
+    let source_mode = entry.permissions();
+    if let Some(existing) = pre_transfer_meta {
+        // Existing file: `(flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS)`
+        // - keep the destination's prior permission bits.
+        let stat_mode = existing.permissions().mode();
+        (source_mode & !0o7777) | (stat_mode & 0o7777)
+    } else {
+        // New file: `flist_mode & (~CHMOD_BITS | dflt_perms)` so exec bits
+        // survive the umask wash while special bits (suid/sgid/sticky) drop
+        // out.
+        let dflt_perms = 0o777 & !cached_umask();
+        source_mode & (!0o7777 | dflt_perms)
+    }
+}
+
 /// Sets permissions on `destination` to match `metadata` (full mode on Unix,
 /// read-only flag on Windows).
 ///
@@ -448,18 +546,63 @@ fn apply_permissions_without_chmod(
 /// Handles the receiver-side chmod path: applies the entry's permission bits
 /// directly, then layers any `--chmod` modifiers on top. Skips the syscall
 /// when the resulting mode already matches `cached_meta`.
+///
+/// `pre_transfer_meta` is the destination's metadata captured BEFORE the
+/// transfer started (before any temp-file rename). It mirrors upstream
+/// `rsync.c:dest_mode()`'s `stat_mode` argument: the receiver runs
+/// `dest_mode()` against the pre-transfer destination so the dest's prior
+/// permission bits (or umask-masked source bits for new files) propagate
+/// onto the freshly-renamed temp file. `Some(meta)` means "the file existed
+/// pre-transfer at this mode"; `None` means "no pre-transfer destination
+/// state available" - either the file is new or the caller cannot supply
+/// it.
 // upstream: rsync.c:set_file_attrs() - receiver-side permission application
 pub(super) fn apply_permissions_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
     options: &MetadataOptions,
     cached_meta: Option<&fs::Metadata>,
+    pre_transfer_meta: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
 
         if !options.permissions() && !options.executability() && options.chmod().is_none() {
+            // upstream: rsync.c:954-965 - even when `!preserve_perms` and
+            // `!preserve_executability`, the receiver mutates `file->mode` via
+            // `dest_mode()` and `set_file_attrs()` chmods the post-rename
+            // destination to it. For an existing destination this preserves
+            // the prior mode (so a re-transfer never silently downgrades to
+            // the temp file's `0o600`/umask-default permissions); for a new
+            // destination it applies `source_mode & (~CHMOD_BITS | dflt_perms)`.
+            // Only the regular-file branch ships - upstream restricts the
+            // `S_ISREG(flist_mode)` chmod-on-rename loop to data files. Skip
+            // when the caller has supplied neither a pre-transfer stat nor a
+            // cached post-rename stat: we cannot distinguish a fresh-from-
+            // rename temp file from an untouched destination, and the source-
+            // `Metadata` apply path already handles both cases via
+            // `apply_dest_mode_pre_transfer`.
+            if entry.file_type().is_regular() && pre_transfer_meta.is_some() {
+                let new_mode = dest_mode_for_existing_or_new(entry, pre_transfer_meta);
+                let fresh_meta;
+                let current_meta = if let Some(meta) = cached_meta {
+                    meta
+                } else {
+                    fresh_meta = fs::metadata(destination).map_err(|error| {
+                        MetadataError::new("inspect destination permissions", destination, error)
+                    })?;
+                    &fresh_meta
+                };
+                if (current_meta.permissions().mode() & 0o7777) != (new_mode & 0o7777) {
+                    chmod_path_honoring_keep_dirlinks(
+                        destination,
+                        new_mode,
+                        options,
+                        "apply dest_mode",
+                    )?;
+                }
+            }
             return Ok(());
         }
 
@@ -549,10 +692,25 @@ pub(super) fn apply_permissions_from_entry(
         {
             // upstream: rsync.c:457-465 dest_mode() - `-E` without `-p` and
             // without `--chmod` transfers only the executability bits from
-            // source to destination: if the source has no exec bits, clear
-            // them on dest; else if dest has no exec bits, grant exec to
-            // everyone who can already read (`new_mode & 0444 >> 2`). When
-            // dest already has some exec bits they are preserved verbatim.
+            // source to destination, layered on top of the pre-transfer
+            // destination mode (or the source-mode-masked-by-dflt-perms when
+            // the file is fresh). Using the post-rename temp file's
+            // `0o600`/umask-default bits would silently drop bits like the
+            // world-read bit upstream preserves. When the caller hasn't
+            // separately tracked the pre-transfer stat (e.g. quick-check
+            // path, public `apply_metadata_from_file_entry` API), fall back
+            // to `cached_meta` because no rename happened and the current
+            // stat IS the pre-transfer stat.
+            let base_meta = pre_transfer_meta.or(cached_meta);
+            let new_mode = dest_mode_for_existing_or_new(entry, base_meta);
+            let mut destination_permissions = new_mode & 0o7777;
+
+            if entry.permissions() & 0o111 == 0 {
+                destination_permissions &= !0o111;
+            } else if destination_permissions & 0o111 == 0 {
+                destination_permissions |= (destination_permissions & 0o444) >> 2;
+            }
+
             let fresh_meta;
             let current_meta = if let Some(meta) = cached_meta {
                 meta
@@ -562,15 +720,7 @@ pub(super) fn apply_permissions_from_entry(
                 })?;
                 &fresh_meta
             };
-            let mut destination_permissions = current_meta.permissions().mode();
-
-            if entry.permissions() & 0o111 == 0 {
-                destination_permissions &= !0o111;
-            } else if destination_permissions & 0o111 == 0 {
-                destination_permissions |= (destination_permissions & 0o444) >> 2;
-            }
-
-            if destination_permissions != current_meta.permissions().mode() {
+            if (current_meta.permissions().mode() & 0o7777) != destination_permissions {
                 // upstream: syscall.c:do_chmod_at() symlink-race-safe variant.
                 // Helper follows symlinked parents under `--keep-dirlinks` to
                 // mirror upstream `generator.c:1344`.

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -543,6 +543,44 @@ pub(super) fn apply_permissions_from_entry(
                 // mirror upstream `generator.c:1344`.
                 chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply chmod")?;
             }
+        } else if options.executability()
+            && !options.permissions()
+            && entry.file_type().is_regular()
+        {
+            // upstream: rsync.c:457-465 dest_mode() - `-E` without `-p` and
+            // without `--chmod` transfers only the executability bits from
+            // source to destination: if the source has no exec bits, clear
+            // them on dest; else if dest has no exec bits, grant exec to
+            // everyone who can already read (`new_mode & 0444 >> 2`). When
+            // dest already has some exec bits they are preserved verbatim.
+            let fresh_meta;
+            let current_meta = if let Some(meta) = cached_meta {
+                meta
+            } else {
+                fresh_meta = fs::metadata(destination).map_err(|error| {
+                    MetadataError::new("inspect destination permissions", destination, error)
+                })?;
+                &fresh_meta
+            };
+            let mut destination_permissions = current_meta.permissions().mode();
+
+            if entry.permissions() & 0o111 == 0 {
+                destination_permissions &= !0o111;
+            } else if destination_permissions & 0o111 == 0 {
+                destination_permissions |= (destination_permissions & 0o444) >> 2;
+            }
+
+            if destination_permissions != current_meta.permissions().mode() {
+                // upstream: syscall.c:do_chmod_at() symlink-race-safe variant.
+                // Helper follows symlinked parents under `--keep-dirlinks` to
+                // mirror upstream `generator.c:1344`.
+                chmod_path_honoring_keep_dirlinks(
+                    destination,
+                    destination_permissions,
+                    options,
+                    "preserve permissions",
+                )?;
+            }
         }
     }
 

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -201,15 +201,19 @@ pub use acl_windows::{
 )))]
 pub use acl_noop::{apply_acls_from_cache, default_perms_for_dir, get_rsync_acl, sync_acls};
 
+#[cfg(unix)]
+pub use apply::{
+    apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,
+    apply_file_metadata_with_fd_if_changed,
+};
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,
     apply_file_metadata_if_changed, apply_file_metadata_with_options,
     apply_metadata_from_file_entry, apply_metadata_with_attrs_flags,
-    apply_metadata_with_cached_stat, apply_symlink_metadata, apply_symlink_metadata_from_entry,
-    apply_symlink_metadata_with_options, metadata_unchanged,
+    apply_metadata_with_attrs_flags_and_pre_transfer, apply_metadata_with_cached_stat,
+    apply_metadata_with_pre_transfer_stat, apply_symlink_metadata,
+    apply_symlink_metadata_from_entry, apply_symlink_metadata_with_options, metadata_unchanged,
 };
-#[cfg(unix)]
-pub use apply::{apply_file_metadata_with_fd, apply_file_metadata_with_fd_if_changed};
 
 pub use chmod::{ChmodError, ChmodModifiers};
 

--- a/crates/metadata/tests/executability_entry_path.rs
+++ b/crates/metadata/tests/executability_entry_path.rs
@@ -1,0 +1,83 @@
+//! Regression test for the `--executability` (`-E`) wire path that flows
+//! through `apply_metadata_from_file_entry` rather than the source-`Metadata`
+//! variant.
+//!
+//! upstream: rsync.c:457-465 `dest_mode()` - when `-E` is on without `-p`,
+//! the receiver transfers only the executability bits from source to
+//! destination: if source has no exec bits, clear them on dest; else if dest
+//! has no exec bits, grant exec to everyone who can already read
+//! (`new_mode & 0444 >> 2`). Exec bits already present on dest are kept.
+//!
+//! Pre-fix, the entry-based code path returned early without applying the
+//! exec-bit transfer when `--executability` was set without `--perms`,
+//! producing the upstream testsuite `executability` failure where a file
+//! ended up `rw-r--r--` instead of `rwx------`.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use metadata::{MetadataOptions, apply_metadata_from_file_entry};
+use protocol::flist::FileEntry;
+use tempfile::tempdir;
+
+fn mode_of(path: &std::path::Path) -> u32 {
+    fs::metadata(path).expect("stat dest").permissions().mode() & 0o7777
+}
+
+/// Source has exec bits, dest does not: receiver must grant exec on dest
+/// for every class that can already read (`(dest & 0444) >> 2`).
+#[test]
+fn executability_entry_path_grants_exec_when_source_is_executable() {
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("dest.bin");
+    fs::write(&dest, b"data").expect("write dest");
+    // Start dest at rw------- so only the owner can read; after `-E` the
+    // owner should additionally gain x (rwx------).
+    fs::set_permissions(&dest, fs::Permissions::from_mode(0o600)).expect("seed dest mode");
+
+    // Source mode includes x bits; entry permissions are the source mode.
+    let entry = FileEntry::new_file("dest.bin".into(), 4, 0o755);
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_executability(true)
+        .preserve_times(false);
+    apply_metadata_from_file_entry(&dest, &entry, &opts).expect("apply -E from entry");
+
+    assert_eq!(
+        mode_of(&dest),
+        0o700,
+        "source-with-x must grant x on dest for every class that can already read"
+    );
+}
+
+/// Source has no exec bits, dest does: receiver must clear all exec bits.
+#[test]
+fn executability_entry_path_clears_exec_when_source_is_not_executable() {
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("dest.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    // Dest starts with x for every class; source has no x at all.
+    fs::set_permissions(&dest, fs::Permissions::from_mode(0o755)).expect("seed dest mode");
+
+    let entry = FileEntry::new_file("dest.txt".into(), 4, 0o644);
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_executability(true)
+        .preserve_times(false);
+    apply_metadata_from_file_entry(&dest, &entry, &opts).expect("apply -E from entry");
+
+    assert_eq!(
+        mode_of(&dest) & 0o111,
+        0,
+        "source-without-x must clear all x bits on dest"
+    );
+    assert_eq!(
+        mode_of(&dest) & 0o666,
+        0o644,
+        "non-exec permission bits on dest must be preserved"
+    );
+}


### PR DESCRIPTION
## Summary

- `apply_permissions_from_entry` returned without acting on the executability bits when `-E` was set without `-p` (and without `--chmod`). The sister function `apply_permissions_without_chmod` already handled the exec-only case on the source-`Metadata` path, but the entry-based wire path the receiver actually runs had no equivalent branch.
- Mirror upstream `rsync.c:dest_mode()` (lines 457-465) inside the entry-based path: if the source has any x bit, OR x bits into every destination class that can already read (`(dest & 0444) >> 2`); if the source has no x bits, clear all x bits on the destination. Symlink-race-safe chmod is reused via `chmod_path_honoring_keep_dirlinks`, matching the perms and chmod branches above. Gated to regular files - upstream restricts the exec transfer to `S_ISREG`.

## Reproduction

Pre-fix, the upstream testsuite `executability` case ended with `rw-r--r--` instead of `rwx------` when `-E` was given without `-p`. Post-fix, the entry-based path applies the exec transfer that the source-`Metadata` path already implemented.

## Test plan

- [x] Added `crates/metadata/tests/executability_entry_path.rs` covering both directions through `apply_metadata_from_file_entry`:
  - source-with-x (`0o755`) on a dest seeded at `0o600` ends at `0o700` (exec granted on every readable class)
  - source-without-x (`0o644`) on a dest seeded at `0o755` ends at `0o644` (all x bits cleared, non-exec bits preserved)
- [ ] CI: fmt + clippy, nextest stable, Windows/macOS/Linux musl matrix
- [ ] CI: upstream-testsuite `executability` case turns green