### PR TITLE
fix(transfer): scan dotdir entries in --files-from marker-dir rescan

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -266,9 +266,12 @@ impl GeneratorContext {
             // so the trailing-slash directories would otherwise stop at the
             // entry itself. Re-scan the directory here so the receiver sees
             // the listed dir's contents (`from/./dir/subdir/subsubdir2/` must
-            // emit `bin-lt-list`, etc.). The `entry.path == entry.base` case
-            // is already covered by the DOTDIR scan in `walk_path_with_metadata`.
-            if entry.recurse && entry.path != entry.base {
+            // emit `bin-lt-list`, etc.). DOTDIR entries (`from/./` and
+            // `from/.`) produce `entry.path == entry.base`; they still need
+            // the rescan because `flags.recursive` is cleared whenever
+            // `--files-from` is active (upstream `options.c:2189`), so
+            // `walk_path_with_metadata` would emit only the root entry.
+            if entry.recurse {
                 if let Ok(meta) = std::fs::symlink_metadata(&entry.path) {
                     if meta.is_dir() {
                         self.scan_files_from_marker_dir(&entry.base, &entry.path)?;

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -2766,6 +2766,53 @@ mod files_from {
         );
     }
 
+    #[test]
+    fn build_file_list_with_base_dotdir_entry_scans_children() {
+        // Upstream `files-from.test` regression: a `--files-from` entry of
+        // the form `from/./` parses to a `FilesFromEntry` with
+        // `path == base` and `recurse == true` (upstream's DOTDIR_NAME
+        // case at `flist.c:2329`). With `--files-from` active,
+        // `options.c:2189` clears the global `recurse` flag, so
+        // `walk_path_with_metadata` emits only the root entry; the
+        // marker-dir rescan in `build_file_list_with_base` is the only
+        // path that re-injects the directory's children. The previous
+        // `entry.path != entry.base` gate skipped that rescan for the
+        // DOTDIR shape and the transfer collapsed to zero files.
+        let temp_dir = TempDir::new().unwrap();
+        let src = temp_dir.path().join("src");
+        let from_dir = src.join("from");
+        std::fs::create_dir_all(&from_dir).unwrap();
+        std::fs::write(from_dir.join("alpha.txt"), b"a").unwrap();
+        std::fs::write(from_dir.join("beta.txt"), b"b").unwrap();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.args = vec![OsString::from(&src)];
+        // Mirror upstream `options.c:2189` - `--files-from` disables
+        // global recursion; the per-entry `recurse` flag drives the
+        // DOTDIR rescan instead.
+        config.flags.recursive = false;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+        let dotdir_entry = super::filters::FilesFromEntry {
+            base: from_dir.clone(),
+            path: from_dir.clone(),
+            recurse: true,
+        };
+        ctx.build_file_list_with_base(&src, std::slice::from_ref(&dotdir_entry))
+            .unwrap();
+
+        let names: Vec<&str> = ctx.file_list().iter().map(|e| e.name()).collect();
+        assert!(
+            names.contains(&"alpha.txt"),
+            "DOTDIR entry must rescan children: expected alpha.txt in {names:?}"
+        );
+        assert!(
+            names.contains(&"beta.txt"),
+            "DOTDIR entry must rescan children: expected beta.txt in {names:?}"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn relative_absolute_source_preserves_full_prefix() {


### PR DESCRIPTION
## Summary

- `build_file_list_with_base` gated the SLASH_ENDING_NAME/DOTDIR_NAME marker-dir rescan on `entry.path != entry.base`, but DOTDIR entries (`from/./`, `from/.`) split with `path == base`. With `--files-from` clearing the global `recurse` flag (upstream `options.c:2189`), `walk_path_with_metadata` emits only the root entry, so the rescan is the only path that injects children - and the gate was silently swallowing it. Transfers driven by `from/./` collapsed to zero files, breaking the upstream `files-from.test`.
- Drop the `path != base` condition so any entry with `recurse == true` (matching upstream `flist.c:2329`) triggers `scan_files_from_marker_dir`. SLASH_ENDING_NAME entries (`path != base`) continue to work as before; DOTDIR entries now also recurse, mirroring upstream semantics exactly.

## Test plan

- [x] New `build_file_list_with_base_dotdir_entry_scans_children` regression test added under `crates/transfer/src/generator/tests.rs::files_from`. It builds a fixture with a `from/` directory containing two files, drives `build_file_list_with_base` with a DOTDIR `FilesFromEntry` (`base == path == from/`, `recurse = true`) and `flags.recursive = false`, and asserts both child filenames appear in the file list.
- [ ] CI: fmt+clippy, nextest (stable), Windows/macOS/Linux musl.
- [ ] Upstream `files-from.test` interop run.