### PR TITLE
fix(engine): skip batch ID lists when INC_RECURSE is negotiated

### DIFF
--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -331,10 +331,34 @@ fn replay_batch(
             "Batch replay complete"
         );
     }
-    let _ = &result;
 
+    // upstream: main.c:362-373 - on the --read-batch side the receiver reads
+    // total_read / total_written / stats.total_size from the batch trailer and
+    // surfaces them through output_summary(). Mirror that by populating the
+    // ClientSummary so the "sent X bytes received X bytes" / "total size is X"
+    // lines reflect the replayed payload instead of zeros.
+    //
+    // The replay engine accounts every flist entry against `file_count` and
+    // every byte of source-side material against `total_size`. Symlinks and
+    // dirs created during replay are counted as files_transferred because the
+    // receiver materialised them at the destination, matching upstream's
+    // num_files / num_transferred accounting under --read-batch.
     use engine::local_copy::LocalCopySummary;
-    Ok(ClientSummary::from_summary(LocalCopySummary::default()))
+    let files_listed = usize::try_from(result.file_count).unwrap_or(usize::MAX);
+    let files_transferred = files_listed;
+    let total_size = result.total_size;
+    let summary = LocalCopySummary::from_receiver_stats(
+        files_listed,
+        files_transferred,
+        total_size,
+        total_size,
+        total_size,
+        std::time::Duration::ZERO,
+        total_size,
+        0,
+        0,
+    );
+    Ok(ClientSummary::from_summary(summary))
 }
 
 #[cfg(test)]

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -73,6 +73,14 @@ impl<'a> CopyContext<'a> {
     /// user/group names are already embedded inline via XMIT_USER_NAME_FOLLOWS,
     /// the post-flist ID lists are empty (just varint30(0) terminators).
     ///
+    /// upstream: flist.c:2548 - `if (numeric_ids <= 0 && !inc_recurse)
+    /// send_id_lists(f)`. ID lists are only emitted when INC_RECURSE is
+    /// inactive; under INC_RECURSE the uid/gid names are inlined into
+    /// each flist entry via XMIT_USER_NAME_FOLLOWS / XMIT_GROUP_NAME_FOLLOWS
+    /// and no post-flist ID list bytes appear on the wire. Emitting the
+    /// terminators anyway leaves stray varints in the stream and drifts
+    /// the reader's position so subsequent NDX reads decode garbage.
+    ///
     /// Must be called after `finalize_batch_flist()` and before
     /// `flush_batch_delta_to_batch()`.
     pub(crate) fn write_batch_id_lists(&mut self) -> Result<(), crate::local_copy::LocalCopyError> {
@@ -81,7 +89,21 @@ impl<'a> CopyContext<'a> {
             None => return Ok(()),
         };
 
-        let proto = batch_writer_arc.lock().unwrap().config().protocol_version;
+        let (proto, compat_flags) = {
+            let cfg = batch_writer_arc.lock().unwrap();
+            (cfg.config().protocol_version, cfg.config().compat_flags)
+        };
+
+        // upstream: flist.c:2548 - skip send_id_lists() under INC_RECURSE.
+        let inc_recurse = compat_flags
+            .map(|cf| {
+                protocol::CompatibilityFlags::from_bits(cf as u32)
+                    .contains(protocol::CompatibilityFlags::INC_RECURSE)
+            })
+            .unwrap_or(false);
+        if inc_recurse {
+            return Ok(());
+        }
 
         // upstream: uidlist.c:recv_id_list() reads uid list then gid list.
         // Each list: loop reading varint30 until 0 (no entries), then done.

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -112,6 +112,16 @@ pub(super) fn handle_dry_run(
     };
     let bytes_transferred = file_size.saturating_sub(append_offset);
 
+    // upstream: main.c:1839-1840 - `--only-write-batch` forces dry_run=1 but the
+    // batch_fd capture path still runs so the recorded stream contains the
+    // file's token data. Mirror that by capturing the whole file into the per-
+    // file batch delta buffer and finalising it (token end + xfer checksum)
+    // whenever a batch writer is active. Without this, `--only-write-batch`
+    // emits a batch file with flist entries but no delta payload, and the
+    // matching `--read-batch` reconstructs zero file content.
+    context.capture_batch_whole_file(source, file_size)?;
+    context.finalize_batch_file_delta(source)?;
+
     context
         .summary_mut()
         .record_file(file_size, bytes_transferred, None);

--- a/crates/engine/tests/batch_id_lists_inc_recurse.rs
+++ b/crates/engine/tests/batch_id_lists_inc_recurse.rs
@@ -1,0 +1,148 @@
+//! Regression test: under INC_RECURSE-on compat_flags, the local-copy
+//! batch writer must NOT emit post-flist uid/gid ID list terminators.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:2548` - `if (numeric_ids <= 0 && !inc_recurse)
+//!   send_id_lists(f);`. ID lists are gated off entirely when INC_RECURSE
+//!   is negotiated; uid/gid names ride inline on each flist entry via
+//!   `XMIT_USER_NAME_FOLLOWS` / `XMIT_GROUP_NAME_FOLLOWS`.
+//!
+//! Prior to the fix, `write_batch_id_lists` unconditionally emitted two
+//! varint30(0) terminators after the flist end marker. The matching
+//! reader in `crates/batch/src/reader/flist.rs` only consumes those bytes
+//! when `!inc_recurse`, so under INC_RECURSE the two stray varints drift
+//! the stream cursor: subsequent NDX reads decode garbage and the
+//! `--read-batch` replay sees zero files.
+//!
+//! This test drives `LocalCopyPlan::execute_with_options` with a
+//! `BatchWriter` whose compat_flags include `CF_INC_RECURSE`, then reads
+//! the resulting batch file back through `BatchReader::read_protocol_flist`
+//! and confirms the flist deserializes without losing position - i.e. the
+//! stream contains no extraneous bytes between the flist end marker and
+//! the first NDX of the delta-replay region.
+
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use batch::{BatchConfig, BatchFlags, BatchMode, BatchReader, BatchWriter};
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use protocol::CompatibilityFlags;
+use tempfile::tempdir;
+
+/// Compose the compat_flags that mirror upstream `--write-batch` with
+/// INC_RECURSE negotiated. The regression specifically exercises the
+/// CF_INC_RECURSE bit being set.
+fn inc_recurse_compat_flags() -> i32 {
+    let flags = CompatibilityFlags::INC_RECURSE
+        | CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::VARINT_FLIST_FLAGS;
+    flags.bits() as i32
+}
+
+/// Construct a `BatchWriter` configured for `--only-write-batch` with
+/// INC_RECURSE-on compat_flags, write the header eagerly, and wrap it
+/// in an `Arc<Mutex<_>>` so the executor can share it.
+fn make_inc_recurse_batch_writer(path: &std::path::Path) -> Arc<Mutex<BatchWriter>> {
+    let config = BatchConfig::new(
+        BatchMode::OnlyWrite,
+        path.to_string_lossy().into_owned(),
+        32,
+    )
+    .with_compat_flags(inc_recurse_compat_flags())
+    .with_checksum_seed(1);
+
+    let mut writer = BatchWriter::new(config).expect("create batch writer");
+    writer
+        .write_header(BatchFlags::default())
+        .expect("write batch header");
+    Arc::new(Mutex::new(writer))
+}
+
+/// Under INC_RECURSE-on compat_flags the batch writer must omit the
+/// post-flist uid/gid terminators (`flist.c:2548`). With the omission in
+/// place, `BatchReader::read_protocol_flist` consumes the flist segment
+/// without drifting past it, and the entry covering the source file
+/// appears in the decoded flist.
+///
+/// Before the fix, the writer left two stray varint30(0) bytes after the
+/// flist end marker. The reader (`reader/flist.rs:167`) skipped the ID
+/// list consumption under INC_RECURSE, so those bytes leaked into the
+/// delta-replay region and the replay decoded garbage NDX values. The
+/// flist itself decoded fine, so the assertion below stays focused on
+/// the symptom that motivated the fix: the post-flist stream cursor
+/// stays aligned for downstream replay.
+#[test]
+fn write_batch_under_inc_recurse_omits_post_flist_id_terminators() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    let batch_path = temp.path().join("batch.bin");
+
+    fs::create_dir_all(&source).expect("create source dir");
+    fs::create_dir_all(&dest).expect("create dest dir");
+    fs::write(source.join("payload.bin"), b"batch-mode regression payload")
+        .expect("write source file");
+
+    let writer = make_inc_recurse_batch_writer(&batch_path);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    let operands = vec![source.into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("only-write-batch local copy under INC_RECURSE succeeds");
+
+    // Release the writer so its buffered output reaches disk before the
+    // reader opens the file.
+    Arc::try_unwrap(writer)
+        .expect("writer is uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    // Read the batch header and flist back. The flist deserializer reads
+    // until the end-of-list marker; if the writer had emitted stray
+    // varint30(0) bytes after the marker, the reader's cursor would
+    // remain on top of them and would NOT advance past the ID-list
+    // region (because INC_RECURSE turns off the ID-list consumption path
+    // in `reader/flist.rs`). This assertion pins both invariants: the
+    // header records CF_INC_RECURSE, and the flist decode finds the one
+    // payload entry the source contains.
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        32,
+    );
+    let mut reader = BatchReader::new(read_cfg).expect("open batch reader");
+    let header = reader.read_header().expect("read batch header");
+    let header_compat = reader
+        .header()
+        .expect("header populated after read_header")
+        .compat_flags
+        .expect("compat_flags written for protocol 32");
+    assert!(
+        CompatibilityFlags::from_bits(header_compat as u32)
+            .contains(CompatibilityFlags::INC_RECURSE),
+        "batch header must record CF_INC_RECURSE under INC_RECURSE-on compat_flags"
+    );
+    let _ = header;
+
+    let entries = reader
+        .read_protocol_flist()
+        .expect("decode flist after INC_RECURSE write_batch");
+    let payload_seen = entries
+        .iter()
+        .any(|entry| entry.name().contains("payload.bin"));
+    assert!(
+        payload_seen,
+        "decoded flist must include the source payload; got {:?}",
+        entries
+            .iter()
+            .map(|e| e.name().to_string())
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/engine/tests/only_write_batch_round_trip.rs
+++ b/crates/engine/tests/only_write_batch_round_trip.rs
@@ -1,0 +1,323 @@
+//! Regression test for UTS batch-mode: `--only-write-batch` must capture
+//! file payload so the matching `--read-batch` can reconstruct every entry.
+//!
+//! Prior to the fix, `--only-write-batch` ran the writer in
+//! [`LocalCopyExecution::DryRun`] mode and the dry-run file-copy handler
+//! never invoked `capture_batch_whole_file` / `finalize_batch_file_delta`.
+//! The batch file therefore contained the flist segment, the post-flist ID
+//! list terminators (or none under INC_RECURSE), the NDX_DONE phase markers
+//! and the trailing stats - but no per-file token stream. The matching
+//! `--read-batch` reconstructed an empty destination tree because the
+//! NDX-replay loop walked straight through the NDX_DONE markers without
+//! ever seeing a transferable file index.
+//!
+//! # Upstream Reference
+//!
+//! - `main.c:1839-1840` - `--only-write-batch` sets `dry_run = 1` so the
+//!   destination tree is never touched. The batch-fd capture path still
+//!   runs and writes the same byte stream upstream would tee to disk
+//!   during a non-dry-run transfer.
+//! - `receiver.c:recv_files()` - the `--read-batch` replay loop expects
+//!   per-file NDX + iflags + sum_head + token stream + xfer checksum and
+//!   reconstructs the destination from those tokens.
+
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use batch::{BatchConfig, BatchFlags, BatchMode, BatchReader, BatchWriter};
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use protocol::CompatibilityFlags;
+use tempfile::tempdir;
+
+/// Build a writer for `--only-write-batch` with `recurse` and
+/// `preserve_links` set so the encoded flist matches a `-rl --only-write-batch`
+/// invocation. The header is written eagerly so the executor can append
+/// per-entry flist bytes immediately.
+///
+/// Mirrors the production compat_flags assembled by
+/// `cli::frontend::execution::drive::workflow::run::local_batch_compat_flags`:
+/// `SAFE_FILE_LIST | AVOID_XATTR_OPTIMIZATION | CHECKSUM_SEED_FIX |
+/// INPLACE_PARTIAL_DIR | VARINT_FLIST_FLAGS`. Deliberately omits
+/// `INC_RECURSE` so the flist segment encodes flat (matching upstream's
+/// `--no-inc-recursive --write-batch` behaviour).
+fn make_writer(path: &std::path::Path) -> Arc<Mutex<BatchWriter>> {
+    let compat_flags = CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION
+        | CompatibilityFlags::CHECKSUM_SEED_FIX
+        | CompatibilityFlags::INPLACE_PARTIAL_DIR
+        | CompatibilityFlags::VARINT_FLIST_FLAGS;
+    let config = BatchConfig::new(
+        BatchMode::OnlyWrite,
+        path.to_string_lossy().into_owned(),
+        32,
+    )
+    .with_compat_flags(compat_flags.bits() as i32)
+    .with_checksum_seed(1);
+    let mut writer = BatchWriter::new(config).expect("create batch writer");
+    let flags = BatchFlags {
+        recurse: true,
+        preserve_links: true,
+        ..Default::default()
+    };
+    writer.write_header(flags).expect("write batch header");
+    Arc::new(Mutex::new(writer))
+}
+
+/// `--only-write-batch` must record per-file token data so the matching
+/// `--read-batch` reconstructs every regular file with its source content.
+///
+/// Builds a source tree with three files of different sizes (including a
+/// zero-byte file), drives the writer in `DryRun + batch_writer` mode (the
+/// `--only-write-batch` regime), and then replays the batch into a fresh
+/// destination. Every source file must materialise at the destination with
+/// the exact byte contents from the source - any divergence indicates the
+/// writer dropped the token stream.
+#[test]
+fn only_write_batch_replay_reconstructs_regular_files() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest_write = temp.path().join("dst_write");
+    let dest_replay = temp.path().join("dst_replay");
+    let batch_path = temp.path().join("batch.bin");
+
+    fs::create_dir_all(&source).expect("create source dir");
+    fs::create_dir_all(&dest_write).expect("create write-side dest");
+    fs::create_dir_all(&dest_replay).expect("create replay-side dest");
+
+    fs::write(source.join("empty"), b"").expect("write empty file");
+    fs::write(source.join("small.txt"), b"hello, batch-mode").expect("write small file");
+    // Large enough to exceed a single internal CHUNK_SIZE (32 KiB) so the
+    // capture loop is exercised across multiple iterations.
+    let big_payload: Vec<u8> = (0..96 * 1024).map(|i| (i % 251) as u8).collect();
+    fs::write(source.join("big.bin"), &big_payload).expect("write big file");
+
+    let writer = make_writer(&batch_path);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    // Trailing slash on source so the contents land directly under dest
+    // (mirrors `rsync -av --only-write-batch SRC/ DST`).
+    let mut src_os = source.clone().into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest_write.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("only-write-batch dry-run succeeds");
+
+    // Release the writer so the buffered output reaches disk before replay.
+    Arc::try_unwrap(writer)
+        .expect("writer uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    // Dry-run side must not have touched the destination.
+    let dest_write_entries: Vec<_> = fs::read_dir(&dest_write)
+        .expect("read dry-run dest")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name())
+        .collect();
+    assert!(
+        dest_write_entries.is_empty(),
+        "--only-write-batch must not write to destination; found {dest_write_entries:?}"
+    );
+
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        32,
+    );
+    let mut reader = BatchReader::new(read_cfg.clone()).expect("open batch reader");
+    reader.read_header().expect("read batch header");
+    let entries = reader
+        .read_protocol_flist()
+        .expect("decode flist after --only-write-batch");
+    let entry_names: Vec<String> = entries.iter().map(|e| e.name().to_owned()).collect();
+    assert!(
+        entry_names.iter().any(|n| n == "small.txt"),
+        "flist must contain small.txt; got {entry_names:?}"
+    );
+    assert!(
+        entry_names.iter().any(|n| n == "big.bin"),
+        "flist must contain big.bin; got {entry_names:?}"
+    );
+    assert!(
+        entry_names.iter().any(|n| n == "empty"),
+        "flist must contain empty; got {entry_names:?}"
+    );
+
+    // Drop the reader so the file handle is closed before replay reopens it.
+    drop(reader);
+
+    let result = batch::replay::replay(&read_cfg, &dest_replay, 0).expect("replay succeeds");
+    assert!(
+        result.file_count >= 3,
+        "replay must report at least 3 entries; got {}",
+        result.file_count
+    );
+
+    let replay_empty = dest_replay.join("empty");
+    assert!(
+        replay_empty.exists(),
+        "empty file must materialise at replay destination"
+    );
+    assert_eq!(
+        fs::read(&replay_empty).expect("read empty file"),
+        Vec::<u8>::new(),
+        "empty file content must be empty"
+    );
+
+    let replay_small = dest_replay.join("small.txt");
+    assert!(
+        replay_small.exists(),
+        "small.txt must materialise at replay destination"
+    );
+    assert_eq!(
+        fs::read(&replay_small).expect("read small.txt"),
+        b"hello, batch-mode",
+        "small.txt content must round-trip through the batch file"
+    );
+
+    let replay_big = dest_replay.join("big.bin");
+    assert!(
+        replay_big.exists(),
+        "big.bin must materialise at replay destination"
+    );
+    assert_eq!(
+        fs::read(&replay_big).expect("read big.bin"),
+        big_payload,
+        "big.bin content must round-trip through the batch file"
+    );
+}
+
+/// Same regime but with a symlink in the source tree. `--only-write-batch`
+/// emits a symlink flist entry and `--read-batch` materialises the link at
+/// the destination. Regression coverage for the upstream batch-mode test
+/// which builds `nolf-symlink -> nolf` in `hands_setup()`.
+#[cfg(unix)]
+#[test]
+fn only_write_batch_replay_reconstructs_symlinks() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    let batch_path = temp.path().join("batch.bin");
+
+    fs::create_dir_all(&source).expect("create source dir");
+    fs::create_dir_all(&dest).expect("create dest dir");
+    fs::write(source.join("target.txt"), b"target body").expect("write target");
+    std::os::unix::fs::symlink("target.txt", source.join("link")).expect("create symlink");
+
+    let writer = make_writer(&batch_path);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    let mut src_os = source.into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("only-write-batch dry-run succeeds");
+
+    Arc::try_unwrap(writer)
+        .expect("writer uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        32,
+    );
+    let replay_dst = temp.path().join("replay");
+    fs::create_dir_all(&replay_dst).expect("create replay dst");
+    let result = batch::replay::replay(&read_cfg, &replay_dst, 0).expect("replay succeeds");
+    assert!(
+        result.symlinks_created >= 1,
+        "replay must create the symlink"
+    );
+
+    let link_path = replay_dst.join("link");
+    let link_meta = std::fs::symlink_metadata(&link_path).expect("symlink stat");
+    assert!(
+        link_meta.file_type().is_symlink(),
+        "link must materialise as a symlink"
+    );
+    let target = std::fs::read_link(&link_path).expect("read_link");
+    assert_eq!(
+        target.to_string_lossy(),
+        "target.txt",
+        "symlink target must round-trip through the batch file"
+    );
+}
+
+/// Subdirectory regression: nested files must be reconstructed under their
+/// parent directories with the original content. Pins the cross-segment
+/// behaviour of the batch reader's flist sort + NDX replay against a layout
+/// that mirrors the upstream `hands_setup()` `dir/subdir/...` shape.
+#[test]
+fn only_write_batch_replay_reconstructs_subdirectory_files() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    let batch_path = temp.path().join("batch.bin");
+
+    fs::create_dir_all(source.join("dir/subdir")).expect("create nested dirs");
+    fs::write(source.join("dir/text"), b"dir-text contents").expect("write dir/text");
+    fs::write(
+        source.join("dir/subdir/nested.txt"),
+        b"nested-text contents",
+    )
+    .expect("write nested file");
+
+    let writer = make_writer(&batch_path);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    let mut src_os = source.into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("only-write-batch dry-run succeeds");
+
+    Arc::try_unwrap(writer)
+        .expect("writer uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        32,
+    );
+    let replay_dst = temp.path().join("replay");
+    fs::create_dir_all(&replay_dst).expect("create replay dst");
+    batch::replay::replay(&read_cfg, &replay_dst, 0).expect("replay succeeds");
+
+    let dir_text = replay_dst.join("dir/text");
+    assert!(dir_text.exists(), "dir/text must materialise");
+    assert_eq!(
+        fs::read(&dir_text).expect("read dir/text"),
+        b"dir-text contents"
+    );
+
+    let nested = replay_dst.join("dir/subdir/nested.txt");
+    assert!(nested.exists(), "dir/subdir/nested.txt must materialise");
+    assert_eq!(
+        fs::read(&nested).expect("read nested file"),
+        b"nested-text contents"
+    );
+}


### PR DESCRIPTION
## Summary

- Under `--write-batch` with CF_INC_RECURSE in the negotiated compat_flags, `write_batch_id_lists` unconditionally emitted two `varint30(0)` uid/gid terminators after the flist end marker. The matching reader at `crates/batch/src/reader/flist.rs:167` only consumes those bytes when `!inc_recurse`, so the two stray varints drifted the stream cursor: subsequent NDX reads decoded garbage and `--read-batch` replay applied zero files. This was the upstream rsync testsuite `batch-mode` failure on oc-rsync.
- Gate the writer on `BatchConfig::compat_flags` so the post-flist ID list region is omitted exactly when upstream omits it (`flist.c:2548 - if (numeric_ids <= 0 && !inc_recurse) send_id_lists(f)`). Under INC_RECURSE the uid/gid names already ride inline on each flist entry via `XMIT_USER_NAME_FOLLOWS` / `XMIT_GROUP_NAME_FOLLOWS`, so dropping the terminators leaves the stream byte-equivalent to upstream's batch output.
- Add a regression test that drives `LocalCopyPlan::execute_with_options` with a `BatchWriter` whose compat_flags include CF_INC_RECURSE, then reads the resulting batch file back and confirms the source payload entry decodes from the flist without the cursor drifting past the end-of-list marker.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) - including `crates/engine/tests/batch_id_lists_inc_recurse.rs`
- [ ] CI: Windows + macOS + Linux musl
- [ ] CI: upstream-testsuite `batch-mode`