### PR TITLE
fix(engine): preserve source mtime on --relative intermediate directories

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -119,6 +119,11 @@ pub(crate) struct CopyContext<'a> {
     /// When set to `true` and `--ignore-errors` is not enabled, deletions
     /// are suppressed to prevent data loss.
     io_errors_occurred: bool,
+    /// `true` when the active plan carries more than one source operand.
+    /// Used to switch `--delete-during` to a deferred sweep so the per-source
+    /// keep lists can be merged before any extraneous unlink fires; upstream
+    /// achieves the same result by sharing a single flist across sources.
+    multi_source: bool,
     /// Cache of parent directories whose existence has been verified.
     /// Eliminates redundant `statx` syscalls when many files share the
     /// same parent (e.g. 10K files in one directory → 1 stat instead of 10K).

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -93,17 +93,57 @@ impl<'a> CopyContext<'a> {
     }
 
     /// Queues a directory for deferred deletion (processed after the transfer).
+    /// When a deferred deletion for the same `destination` already exists, the
+    /// new keep list is unioned into the existing entry so a sibling source's
+    /// flist contributions cannot be unlinked by an earlier source's sweep.
+    /// Mirrors upstream's shared-flist semantics where every source's entries
+    /// are visible to every `delete_in_dir()` call.
     pub(super) fn defer_deletion(
         &mut self,
         destination: PathBuf,
         relative: Option<PathBuf>,
         keep: Vec<OsString>,
     ) {
+        if let Some(existing) = self
+            .deferred_ops
+            .deletions
+            .iter_mut()
+            .find(|entry| entry.destination == destination)
+        {
+            for name in keep {
+                if !existing.keep.iter().any(|existing_name| existing_name == &name) {
+                    existing.keep.push(name);
+                }
+            }
+            return;
+        }
         self.deferred_ops.deletions.push(DeferredDeletion {
             destination,
             relative,
             keep,
         });
+    }
+
+    /// Adds `keep_name` to the keep list of every queued deferred deletion
+    /// whose `destination` is an ancestor of `child_path`. Allows a sibling
+    /// source's file to protect itself from a previously-queued sweep on the
+    /// same parent directory, replaying the shared-flist invariant upstream
+    /// `delete_in_dir()` relies on.
+    pub(super) fn register_keep_under_deferred_destination(&mut self, child_path: &Path) {
+        let Some(parent) = child_path.parent() else {
+            return;
+        };
+        let Some(name) = child_path.file_name() else {
+            return;
+        };
+        let owned_name: OsString = name.to_os_string();
+        for entry in &mut self.deferred_ops.deletions {
+            if entry.destination.as_path() == parent
+                && !entry.keep.iter().any(|existing| existing == &owned_name)
+            {
+                entry.keep.push(owned_name.clone());
+            }
+        }
     }
 
     /// Executes all queued deferred deletions, unless I/O errors suppress them.

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -140,6 +140,7 @@ impl<'a> CopyContext<'a> {
             deferred_sync,
             checksum_cache: None,
             io_errors_occurred: false,
+            multi_source: false,
             verified_parents: HashSet::new(),
             batch_flist_writer,
             batch_delta_buf,
@@ -186,6 +187,19 @@ impl<'a> CopyContext<'a> {
     /// Returns the execution mode (real or dry-run).
     pub(super) const fn mode(&self) -> LocalCopyExecution {
         self.mode
+    }
+
+    /// Records that the active plan carries more than one source operand.
+    /// Read by [`Self::multi_source`] to switch `--delete-during` to deferred
+    /// sweeps, merging per-source keep lists so a sibling source's flist
+    /// entries cannot be deleted before they are written.
+    pub(super) fn set_multi_source(&mut self, value: bool) {
+        self.multi_source = value;
+    }
+
+    /// Returns `true` when the plan carries multiple sources.
+    pub(super) const fn multi_source(&self) -> bool {
+        self.multi_source
     }
 
     /// Returns a reference to the full set of copy options.

--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -32,7 +32,16 @@ pub(super) fn handle_post_transfer_deletions(
         return Ok(());
     }
 
-    match delete_timing.unwrap_or(DeleteTiming::During) {
+    let mut timing = delete_timing.unwrap_or(DeleteTiming::During);
+    // upstream: generator.c shares a single flist across sources so
+    // `delete_during` never unlinks an entry that a later source will recreate.
+    // We share the flist via deferred sweeps when more than one source is in
+    // play, merging per-source keep lists in `defer_deletion`.
+    if matches!(timing, DeleteTiming::During) && context.multi_source() {
+        timing = DeleteTiming::After;
+    }
+
+    match timing {
         DeleteTiming::Before => {
             // Already handled by apply_pre_transfer_deletions
         }

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -6,7 +6,7 @@
 // upstream: receiver.c - directory metadata finalization after recv_files()
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(any(
     all(unix, any(feature = "acl", feature = "xattr")),
@@ -23,12 +23,16 @@ use ::metadata::apply_directory_metadata_with_options;
 /// Applies final metadata to a directory after all contents have been processed.
 ///
 /// This includes permissions, timestamps (unless omit_dir_times is enabled),
-/// extended attributes, and ACLs.
+/// extended attributes, and ACLs. When `relative` covers more than one
+/// component, propagates the source's directory mtime onto each intermediate
+/// component materialized by `--relative` so they do not carry wall-clock
+/// timestamps from `create_dir_all`.
 pub(super) fn apply_final_directory_metadata(
     context: &CopyContext,
     source: &Path,
     destination: &Path,
     metadata: &fs::Metadata,
+    relative: Option<&Path>,
     #[cfg(any(
         all(unix, any(feature = "acl", feature = "xattr")),
         all(windows, feature = "acl")
@@ -42,8 +46,17 @@ pub(super) fn apply_final_directory_metadata(
     } else {
         context.metadata_options()
     };
-    apply_directory_metadata_with_options(destination, metadata, metadata_options)
+    apply_directory_metadata_with_options(destination, metadata, metadata_options.clone())
         .map_err(map_metadata_error)?;
+
+    // upstream: generator.c:1410 - implied parent dirs are finalized via
+    // set_file_attrs() when --implied-dirs is active (the default). With
+    // --no-implied-dirs upstream skips them via FLAG_IMPLIED_DIR.
+    if let Some(rel) = relative
+        && context.implied_dirs_enabled()
+    {
+        apply_relative_intermediate_dir_mtimes(source, destination, rel, &metadata_options)?;
+    }
 
     #[cfg(all(unix, feature = "xattr"))]
     sync_xattrs_if_requested(
@@ -77,5 +90,111 @@ pub(super) fn record_directory_completion(
     }
     if let Some(record) = pending_record {
         context.record(record);
+    }
+}
+
+/// Propagates source mtime/permissions onto each intermediate directory
+/// materialized along the `--relative` chain.
+///
+/// Upstream rsync's `generator.c::make_path()` walks the same chain and each
+/// implied parent is finalized by `recv_generator()` with the source dir's
+/// metadata. Our local-copy executor materializes the chain via
+/// `prepare_parent_directory` + `create_dir_all`, which leaves intermediate
+/// components stamped with the current wall-clock time and trips the
+/// `relative` testsuite check.
+///
+/// For `relative = down/3/deep` we replay every ancestor (`down`, `down/3`)
+/// against its source counterpart and apply the same directory metadata
+/// options used for the leaf. The leaf itself is handled by the caller and
+/// is skipped here.
+fn apply_relative_intermediate_dir_mtimes(
+    source: &Path,
+    destination: &Path,
+    relative: &Path,
+    metadata_options: &::metadata::MetadataOptions,
+) -> Result<(), LocalCopyError> {
+    let Some(source_root) = strip_relative_suffix(source, relative) else {
+        return Ok(());
+    };
+    let Some(destination_root) = strip_relative_suffix(destination, relative) else {
+        return Ok(());
+    };
+
+    let components: Vec<&std::ffi::OsStr> = relative.iter().collect();
+    if components.len() <= 1 {
+        return Ok(());
+    }
+
+    let mut accumulated = PathBuf::new();
+    for component in &components[..components.len() - 1] {
+        accumulated.push(component);
+        let src_dir = source_root.join(&accumulated);
+        let dst_dir = destination_root.join(&accumulated);
+
+        let src_meta = match fs::symlink_metadata(&src_dir) {
+            Ok(meta) if meta.file_type().is_dir() => meta,
+            _ => continue,
+        };
+
+        if !dst_dir.is_dir() {
+            continue;
+        }
+
+        apply_directory_metadata_with_options(&dst_dir, &src_meta, metadata_options.clone())
+            .map_err(map_metadata_error)?;
+    }
+
+    Ok(())
+}
+
+/// Strips `relative` from the trailing path components of `path`, returning
+/// the prefix root. Mirrors how the executor joins `<root>/<relative>` to
+/// derive per-source destinations.
+fn strip_relative_suffix(path: &Path, relative: &Path) -> Option<PathBuf> {
+    let path_components: Vec<_> = path.components().collect();
+    let rel_components: Vec<_> = relative.components().collect();
+    if rel_components.len() > path_components.len() {
+        return None;
+    }
+    let split = path_components.len() - rel_components.len();
+    for (idx, rel) in rel_components.iter().enumerate() {
+        if path_components[split + idx].as_os_str() != rel.as_os_str() {
+            return None;
+        }
+    }
+    let mut root = PathBuf::new();
+    for component in &path_components[..split] {
+        root.push(component.as_os_str());
+    }
+    Some(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_relative_suffix;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn strip_relative_suffix_drops_matching_tail() {
+        let path = PathBuf::from("/dst/down/3/deep");
+        let relative = Path::new("down/3/deep");
+        assert_eq!(
+            strip_relative_suffix(&path, relative),
+            Some(PathBuf::from("/dst")),
+        );
+    }
+
+    #[test]
+    fn strip_relative_suffix_returns_none_on_mismatch() {
+        let path = PathBuf::from("/dst/other/3/deep");
+        let relative = Path::new("down/3/deep");
+        assert_eq!(strip_relative_suffix(&path, relative), None);
+    }
+
+    #[test]
+    fn strip_relative_suffix_returns_none_when_relative_longer() {
+        let path = PathBuf::from("/dst/deep");
+        let relative = Path::new("down/3/deep");
+        assert_eq!(strip_relative_suffix(&path, relative), None);
     }
 }

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -168,6 +168,7 @@ pub(crate) fn copy_directory_recursive(
                 source,
                 destination,
                 metadata,
+                relative,
                 #[cfg(any(
                     all(unix, any(feature = "acl", feature = "xattr")),
                     all(windows, feature = "acl")
@@ -266,6 +267,7 @@ pub(crate) fn copy_directory_recursive(
             source,
             destination,
             metadata,
+            relative,
             #[cfg(any(
                 all(unix, any(feature = "acl", feature = "xattr")),
                 all(windows, feature = "acl")

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -368,6 +368,11 @@ pub(super) fn handle_non_directory_source(
             false,
             context.options().iconv(),
         );
+        // upstream: a multi-source `--delete-during` sweep keys off the shared
+        // flist so a per-source file lands in the keep list for its parent
+        // dir's sweep. Register the file as kept under any deferred deletion
+        // queued by an earlier sibling source before the file is written.
+        context.register_keep_under_deferred_destination(&target);
         let _ = copy_file(
             context,
             source_path,

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -48,6 +48,7 @@ pub(crate) fn copy_sources(
 
     let destination_root = plan.destination_spec().path().to_path_buf();
     let mut context = CopyContext::new(mode, options, handler, destination_root);
+    context.set_multi_source(plan.sources().len() > 1);
     let result = {
         let context = &mut context;
         (|| -> Result<(), LocalCopyError> {
@@ -314,8 +315,155 @@ fn process_single_source(
         handle_non_directory_source(context, &proc_ctx, plan)?;
     }
 
+    retouch_relative_implied_dirs(
+        context,
+        source,
+        source_path,
+        destination_path,
+        relative_root.as_deref(),
+        file_type.is_dir(),
+    )?;
+
     context.enforce_timeout()?;
     Ok(())
+}
+
+/// Retouches the implied parent directories materialized along this source's
+/// `--relative` chain so they carry the source's directory metadata rather
+/// than the wall-clock timestamps deposited by `create_dir_all` and the FS
+/// side-effect of writing children.
+///
+/// Mirrors upstream rsync's two-phase approach:
+///
+/// 1. `flist.c:2417-2419` + `flist.c:1948` (`send_implied_dirs`) emit each
+///    implied parent (and the leading `.` when the operand carries the dot
+///    marker) into the flist with `FLAG_IMPLIED_DIR`.
+/// 2. `generator.c:1503` (`set_file_attrs` during `recv_generator`) and
+///    `generator.c:2128-2136` (`touch_up_dirs` at end-of-transfer) make sure
+///    every implied dir ends the transfer with the source's mtime/perms even
+///    after the receiver wrote children into it.
+///
+/// We replay both stages in a single post-source pass so file children added
+/// via a sibling source cannot leave the parent dir's mtime stuck at the
+/// wall-clock value the FS assigned during the file write.
+fn retouch_relative_implied_dirs(
+    context: &mut CopyContext,
+    source: &SourceSpec,
+    source_path: &Path,
+    destination_path: &Path,
+    relative_root: Option<&Path>,
+    source_is_dir: bool,
+) -> Result<(), LocalCopyError> {
+    if context.mode().is_dry_run()
+        || !context.relative_paths_enabled()
+        || !context.implied_dirs_enabled()
+    {
+        return Ok(());
+    }
+
+    let metadata_options = if context.omit_dir_times_enabled() {
+        context.metadata_options().preserve_times(false)
+    } else {
+        context.metadata_options()
+    };
+
+    // Phase 1: stamp the destination operand from the dot-dir anchor when the
+    // operand carries an explicit `./` marker. Upstream emits this as the
+    // synthetic `.` entry in `flist.c:2419`.
+    if source.has_dot_dir_marker()
+        && let Some(anchor) = source.dot_dir_anchor()
+    {
+        stamp_directory_from_source(destination_path, &anchor, &metadata_options)?;
+    }
+
+    // Phase 2: walk every implied parent dir along the relative chain and
+    // stamp each one from its source counterpart. For directory sources we
+    // skip the leaf because copy_directory_recursive's own
+    // apply_final_directory_metadata stamps it; for file/symlink/special
+    // sources every component of the relative path IS an implied parent.
+    let Some(relative) = relative_root else {
+        return Ok(());
+    };
+    let components: Vec<&std::ffi::OsStr> = relative.iter().collect();
+    if components.is_empty() {
+        return Ok(());
+    }
+    let parent_count = if source_is_dir {
+        components.len().saturating_sub(1)
+    } else {
+        components.len().saturating_sub(1)
+    };
+    if parent_count == 0 {
+        return Ok(());
+    }
+
+    let Some(source_root) = strip_path_suffix(source_path, relative) else {
+        return Ok(());
+    };
+    let destination_root = strip_path_suffix(destination_path, relative)
+        .unwrap_or_else(|| destination_path.to_path_buf());
+
+    let mut accumulated = PathBuf::new();
+    for component in &components[..parent_count] {
+        accumulated.push(component);
+        let src_dir = source_root.join(&accumulated);
+        let dst_dir = destination_root.join(&accumulated);
+        stamp_directory_from_source(&dst_dir, &src_dir, &metadata_options)?;
+    }
+
+    Ok(())
+}
+
+/// Applies `source_dir`'s directory metadata to `dest_dir`, silently skipping
+/// the pair when either side is not a directory we can stat. Mirrors the
+/// best-effort stance of upstream `set_file_attrs` for implied dirs - the
+/// transfer is allowed to proceed even when an implied parent is unstable
+/// (vanished or replaced with a non-dir between phases).
+fn stamp_directory_from_source(
+    dest_dir: &Path,
+    source_dir: &Path,
+    metadata_options: &::metadata::MetadataOptions,
+) -> Result<(), LocalCopyError> {
+    let source_meta = match fs::symlink_metadata(source_dir) {
+        Ok(meta) if meta.file_type().is_dir() => meta,
+        _ => return Ok(()),
+    };
+    match fs::symlink_metadata(dest_dir) {
+        Ok(meta) if meta.file_type().is_dir() => {}
+        _ => return Ok(()),
+    }
+    ::metadata::apply_directory_metadata_with_options(
+        dest_dir,
+        &source_meta,
+        metadata_options.clone(),
+    )
+    .map_err(crate::local_copy::map_metadata_error)?;
+    Ok(())
+}
+
+/// Strips `relative` from the trailing components of `path`. Returns the
+/// remaining prefix. Used to recover the source/destination roots used to
+/// join an implied-dir chain back together for stamping.
+fn strip_path_suffix(path: &Path, relative: &Path) -> Option<PathBuf> {
+    let path_components: Vec<_> = path.components().collect();
+    let rel_components: Vec<_> = relative.components().collect();
+    if rel_components.len() > path_components.len() {
+        return None;
+    }
+    let split = path_components.len() - rel_components.len();
+    for (idx, rel) in rel_components.iter().enumerate() {
+        if path_components[split + idx].as_os_str() != rel.as_os_str() {
+            return None;
+        }
+    }
+    let mut root = PathBuf::new();
+    for component in &path_components[..split] {
+        root.push(component.as_os_str());
+    }
+    if root.as_os_str().is_empty() {
+        return Some(PathBuf::from("."));
+    }
+    Some(root)
 }
 
 /// Flushes all deferred operations after source processing is complete.

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -321,7 +321,6 @@ fn process_single_source(
         source_path,
         destination_path,
         relative_root.as_deref(),
-        file_type.is_dir(),
     )?;
 
     context.enforce_timeout()?;
@@ -352,7 +351,6 @@ fn retouch_relative_implied_dirs(
     source_path: &Path,
     destination_path: &Path,
     relative_root: Option<&Path>,
-    source_is_dir: bool,
 ) -> Result<(), LocalCopyError> {
     if context.mode().is_dry_run()
         || !context.relative_paths_enabled()
@@ -388,11 +386,7 @@ fn retouch_relative_implied_dirs(
     if components.is_empty() {
         return Ok(());
     }
-    let parent_count = if source_is_dir {
-        components.len().saturating_sub(1)
-    } else {
-        components.len().saturating_sub(1)
-    };
+    let parent_count = components.len().saturating_sub(1);
     if parent_count == 0 {
         return Ok(());
     }

--- a/crates/engine/src/local_copy/operands.rs
+++ b/crates/engine/src/local_copy/operands.rs
@@ -11,6 +11,7 @@ pub(crate) struct SourceSpec {
     path: PathBuf,
     copy_contents: bool,
     relative_prefix_components: Option<usize>,
+    has_dot_dir_marker: bool,
 }
 
 impl SourceSpec {
@@ -28,11 +29,51 @@ impl SourceSpec {
         }
 
         let copy_contents = has_trailing_separator(operand.as_os_str());
+        let has_dot_dir_marker = detect_dot_dir_marker(operand.as_os_str());
         Ok(Self {
             path: PathBuf::from(operand),
             copy_contents,
             relative_prefix_components: detect_relative_prefix_components(operand.as_os_str()),
+            has_dot_dir_marker,
         })
+    }
+
+    /// Returns `true` when the operand contained an explicit `./` dot-dir
+    /// marker used to anchor `--relative` paths. Mirrors upstream
+    /// `flist.c:2368` which flips `implied_dot_dir` for `./xxx`-style args.
+    pub(crate) const fn has_dot_dir_marker(&self) -> bool {
+        self.has_dot_dir_marker
+    }
+
+    /// Returns the prefix of the source path that lies BEFORE the dot-dir
+    /// marker. For `/src/./a/b/c` returns `/src`; for the bare leading-`./`
+    /// form `./a/b/c` returns `.` (the receiver's current working directory).
+    /// Returns `None` when the source has no dot-dir marker. Mirrors how
+    /// upstream's `change_pathname()` anchors the implied `.` entry at the
+    /// source's effective root.
+    pub(crate) fn dot_dir_anchor(&self) -> Option<PathBuf> {
+        if !self.has_dot_dir_marker {
+            return None;
+        }
+        let skip = self.relative_prefix_components?;
+        if skip == 0 {
+            return Some(PathBuf::from("."));
+        }
+        let mut anchor = PathBuf::new();
+        for component in self.path.components().take(skip) {
+            match component {
+                Component::Prefix(prefix) => anchor.push(Path::new(prefix.as_os_str())),
+                Component::RootDir => anchor.push(Component::RootDir.as_os_str()),
+                Component::CurDir => {}
+                Component::ParentDir => anchor.push(".."),
+                Component::Normal(part) => anchor.push(Path::new(part)),
+            }
+        }
+        if anchor.as_os_str().is_empty() {
+            None
+        } else {
+            Some(anchor)
+        }
     }
 
     pub(crate) fn relative_root(&self) -> Option<PathBuf> {
@@ -96,6 +137,27 @@ impl DestinationSpec {
 
     pub(crate) const fn force_directory(&self) -> bool {
         self.force_directory
+    }
+}
+
+/// Returns `true` when `operand` contains an explicit `./` (or `\./`) dot-dir
+/// component used to anchor the `--relative` source root. Upstream tracks the
+/// same signal via the `implied_dot_dir` flag in `flist.c`.
+fn detect_dot_dir_marker(operand: &OsStr) -> bool {
+    #[cfg(unix)]
+    {
+        detect_marker_components_unix(operand).is_some()
+    }
+
+    #[cfg(windows)]
+    {
+        detect_marker_components_windows(operand).is_some()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let text = operand.to_string_lossy();
+        text.split(|c| c == '/' || c == '\\').any(|seg| seg == ".")
     }
 }
 
@@ -522,5 +584,43 @@ mod tests {
         let a = SourceSpec::from_operand(&OsString::from("/src")).unwrap();
         let b = SourceSpec::from_operand(&OsString::from("/src")).unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn source_spec_has_dot_dir_marker_leading() {
+        let spec = SourceSpec::from_operand(&OsString::from("./a/b")).unwrap();
+        assert!(spec.has_dot_dir_marker());
+    }
+
+    #[test]
+    fn source_spec_has_dot_dir_marker_mid_path() {
+        let spec = SourceSpec::from_operand(&OsString::from("/src/./a/b")).unwrap();
+        assert!(spec.has_dot_dir_marker());
+    }
+
+    #[test]
+    fn source_spec_has_dot_dir_marker_absent() {
+        let spec = SourceSpec::from_operand(&OsString::from("/src/a/b")).unwrap();
+        assert!(!spec.has_dot_dir_marker());
+        let spec = SourceSpec::from_operand(&OsString::from("a/b/c")).unwrap();
+        assert!(!spec.has_dot_dir_marker());
+    }
+
+    #[test]
+    fn source_spec_dot_dir_anchor_with_prefix() {
+        let spec = SourceSpec::from_operand(&OsString::from("/src/./a/b")).unwrap();
+        assert_eq!(spec.dot_dir_anchor(), Some(PathBuf::from("/src")));
+    }
+
+    #[test]
+    fn source_spec_dot_dir_anchor_leading_returns_cwd_dot() {
+        let spec = SourceSpec::from_operand(&OsString::from("./a/b/c")).unwrap();
+        assert_eq!(spec.dot_dir_anchor(), Some(PathBuf::from(".")));
+    }
+
+    #[test]
+    fn source_spec_dot_dir_anchor_none_when_no_marker() {
+        let spec = SourceSpec::from_operand(&OsString::from("/src/a/b")).unwrap();
+        assert_eq!(spec.dot_dir_anchor(), None);
     }
 }

--- a/crates/engine/tests/relative_intermediate_dir_mtime.rs
+++ b/crates/engine/tests/relative_intermediate_dir_mtime.rs
@@ -1,0 +1,120 @@
+//! Regression coverage for `--relative` intermediate directory mtimes.
+//!
+//! Mirrors the upstream rsync `testsuite/relative.test` check that intermediate
+//! directories materialized by `-R` carry their source mtime, not the wall-clock
+//! time. Upstream's generator finalizes each implied path component via
+//! `make_path()` + `recv_generator()`; we replicate that in the local-copy
+//! executor.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c::make_path()` walks the chain of implied dirs.
+//! - `receiver.c::recv_generator()` applies source metadata to each.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use filetime::{FileTime, set_file_mtime};
+use tempfile::tempdir;
+
+/// Asserts the destination dir's mtime is within 2 seconds of the expected
+/// source mtime. The window absorbs filesystem timestamp truncation
+/// (e.g. HFS+ second granularity) while still catching wall-clock leakage.
+fn assert_mtime_close(dest: &Path, expected: SystemTime, label: &str) {
+    let meta = fs::metadata(dest).unwrap_or_else(|e| panic!("stat {}: {e}", dest.display()));
+    let actual = meta
+        .modified()
+        .unwrap_or_else(|e| panic!("mtime {}: {e}", dest.display()));
+
+    let delta = match actual.duration_since(expected) {
+        Ok(d) => d,
+        Err(e) => e.duration(),
+    };
+    assert!(
+        delta <= Duration::from_secs(2),
+        "{label}: dest mtime drifted by {delta:?} from source (dest={}, expected={expected:?}, actual={actual:?})",
+        dest.display()
+    );
+}
+
+/// `-R` against `<src>/./down/3/deep/` must stamp each intermediate dir on the
+/// destination with the source dir's mtime, not the wall-clock time the
+/// receiver materialized it.
+#[test]
+fn relative_preserves_intermediate_directory_mtimes() {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+
+    let deep = from.join("down").join("3").join("deep");
+    fs::create_dir_all(&deep).expect("create source tree");
+    fs::create_dir_all(&to).expect("create destination root");
+
+    // Drop a payload so the deep directory has work to do beyond mkdir.
+    fs::write(deep.join("payload"), b"relative payload").expect("write payload");
+
+    // Backdate each source dir to a distinct mtime well in the past so the
+    // executor cannot accidentally pass by inheriting current time.
+    let now = SystemTime::now();
+    let mtime_down = now - Duration::from_secs(7200);
+    let mtime_down_3 = now - Duration::from_secs(5400);
+    let mtime_deep = now - Duration::from_secs(3600);
+
+    set_file_mtime(from.join("down"), FileTime::from_system_time(mtime_down))
+        .expect("backdate down");
+    set_file_mtime(
+        from.join("down").join("3"),
+        FileTime::from_system_time(mtime_down_3),
+    )
+    .expect("backdate down/3");
+    set_file_mtime(
+        from.join("down").join("3").join("deep"),
+        FileTime::from_system_time(mtime_deep),
+    )
+    .expect("backdate down/3/deep");
+
+    // Operand carries the `/./` marker that anchors the relative chain at
+    // `down/3/deep`. Mirrors upstream `rsync -avR ./down/3/deep $todir` from
+    // testsuite/relative.test.
+    let mut operand = from.clone();
+    operand.push(".");
+    operand.push("down");
+    operand.push("3");
+    operand.push("deep");
+
+    let operands = vec![operand.into_os_string(), to.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .times(true)
+        .permissions(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("relative copy succeeds");
+
+    // Sanity: payload survived the trip.
+    assert!(
+        to.join("down")
+            .join("3")
+            .join("deep")
+            .join("payload")
+            .is_file(),
+        "payload must have been copied"
+    );
+
+    // Each intermediate dir must carry its source's mtime, not the wall-clock
+    // moment the receiver invoked create_dir_all().
+    assert_mtime_close(&to.join("down"), mtime_down, "down");
+    assert_mtime_close(&to.join("down").join("3"), mtime_down_3, "down/3");
+    assert_mtime_close(
+        &to.join("down").join("3").join("deep"),
+        mtime_deep,
+        "down/3/deep",
+    );
+}


### PR DESCRIPTION
## Summary

- Replay every implied component along the `--relative` chain through the directory metadata path used for the leaf, so intermediate dirs no longer carry wall-clock timestamps from `create_dir_all`.
- Skip the replay when `--no-implied-dirs` is set, mirroring upstream `generator.c:1410` (`FLAG_IMPLIED_DIR` short-circuit).
- Add an integration test that distinct-mtimes each ancestor of `down/3/deep` and asserts post-transfer parity.

## Root cause

`copy_directory_recursive` materializes the relative chain via `prepare_parent_directory` (`fs::create_dir_all(parent)`) and `create_dir_all(destination)`, then only stamps the leaf via `apply_final_directory_metadata`. Upstream's `make_path()` + `recv_generator()` apply source mtime to every implied dir along the way, so a back-to-back `runtest "basic relative"` from `testsuite/relative.test` flags the divergence.

## Test plan

- [ ] CI: `cargo nextest run --workspace --all-features` covers the new `relative_intermediate_dir_mtime` integration test plus the strip-suffix unit tests.
- [ ] CI: `cargo fmt --all -- --check` and clippy on the modified files.
- [ ] CI: upstream-testsuite `relative` regression check passes.