### PR TITLE
fix(transfer): allow default ACL inheritance when creating destination files

### DIFF
--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -40,20 +40,51 @@ fn cached_umask() -> u32 {
     })
 }
 
+/// Returns the default permission bits a child of `destination`'s parent
+/// directory should inherit.
+///
+/// When the parent has a POSIX default ACL, its `user_obj`/`group_obj`/`other`
+/// bits override the umask-derived default (`ACCESSPERMS & ~orig_umask`).
+/// Mirrors upstream's `default_perms_for_dir(dn)` call at
+/// `generator.c:1339` and `receiver.c:847` so `dest_mode()` folds in the
+/// inherited bits when `!preserve_perms`. Without this, a permissive default
+/// ACL like `u::6,g::6,o:6` on the destination directory would be silently
+/// masked down to the process umask, and the testsuite `acls-default` check
+/// would land a 0600 file under a `rw-rw-rw-` default ACL.
+///
+/// On non-Unix platforms and on Unix targets without POSIX default ACL
+/// support (macOS, etc.) this falls back to the umask-derived default, which
+/// matches upstream's `#ifdef SUPPORT_ACLS` gating.
+#[cfg(unix)]
+fn dflt_perms_for_destination(destination: &Path) -> u32 {
+    let umask_bits = cached_umask();
+    let parent = destination.parent().unwrap_or(Path::new("."));
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    crate::default_perms_for_dir(parent, umask_bits)
+}
+
 /// Computes the destination file mode matching upstream `rsync.c:dest_mode()`.
 ///
 /// When `-p` (preserve permissions) is not active, upstream rsync still applies
-/// the source mode masked by the umask-derived default permissions. This ensures
-/// that execute bits from the source are preserved (masked by umask) instead of
-/// being lost to `open()`'s default `0o666 & ~umask`.
+/// the source mode masked by the destination directory's default permissions.
+/// `dflt_perms` follows upstream `default_perms_for_dir()`: a POSIX default ACL
+/// on the parent directory overrides the umask, so files inherit the ACL bits
+/// instead of being clamped to `0o666 & ~umask`. Without this, `acls-default`
+/// would write a 0600 file under a `rw-rw-rw-` default ACL.
 ///
 /// For new files: `source_mode & (~0o7777 | dflt_perms)`
 /// For existing files: keeps existing permissions (returns `None`)
 ///
 /// upstream: rsync.c:449-472 `dest_mode()`
-/// upstream: generator.c:2280 `dflt_perms = (ACCESSPERMS & ~orig_umask)`
+/// upstream: generator.c:1339 + receiver.c:847 `dflt_perms = default_perms_for_dir(dn)`
+/// upstream: generator.c:2280 `dflt_perms = (ACCESSPERMS & ~orig_umask)` (initial value)
 #[cfg(unix)]
 fn compute_dest_mode(
+    destination: &Path,
     source_mode: u32,
     is_new: bool,
     existing: Option<&fs::Metadata>,
@@ -63,7 +94,7 @@ fn compute_dest_mode(
     if is_new {
         // upstream: dest_mode() for new files:
         // new_mode = flist_mode & (~CHMOD_BITS | dflt_perms)
-        let dflt_perms = 0o777 & !cached_umask();
+        let dflt_perms = dflt_perms_for_destination(destination);
         let new_mode = source_mode & (!0o7777 | dflt_perms);
         // Skip the chmod if the mode already matches
         if let Some(existing) = existing {
@@ -179,16 +210,18 @@ pub(super) fn apply_permissions_with_chmod(
     }
 
     // upstream: rsync.c:dest_mode() - when no explicit permission option is
-    // active, still apply source-mode-based permissions masked by umask.
-    // Without this, newly created files get `0o666 & ~umask` from open()
-    // instead of `source_mode & (~CHMOD_BITS | dflt_perms)`.
+    // active, still apply source-mode-based permissions masked by the parent
+    // directory's default-ACL bits (falling back to umask).
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let source_mode = metadata.permissions().mode();
-        if let Some(new_mode) =
-            compute_dest_mode(source_mode, options.destination_is_new(), existing)
-        {
+        if let Some(new_mode) = compute_dest_mode(
+            destination,
+            source_mode,
+            options.destination_is_new(),
+            existing,
+        ) {
             // upstream: syscall.c:do_chmod_at() - symlink-race-safe variant.
             chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply dest_mode")?;
         }
@@ -267,9 +300,15 @@ pub(super) fn apply_permissions_with_chmod_fd(
     }
 
     // upstream: rsync.c:dest_mode() - when no explicit permission option is
-    // active, still apply source-mode-based permissions masked by umask.
+    // active, still apply source-mode-based permissions masked by the parent
+    // directory's default-ACL bits (falling back to umask).
     let source_mode = metadata.permissions().mode();
-    if let Some(new_mode) = compute_dest_mode(source_mode, options.destination_is_new(), existing) {
+    if let Some(new_mode) = compute_dest_mode(
+        destination,
+        source_mode,
+        options.destination_is_new(),
+        existing,
+    ) {
         if let Some(fd) = fd {
             unix_fs::fchmod(
                 fd,
@@ -351,7 +390,7 @@ fn base_mode_for_permissions(
     let mut destination_permissions = if let Some(existing) = existing {
         (source_mode & !0o7777) | (existing.permissions().mode() & 0o7777)
     } else {
-        let dflt_perms = 0o777 & !cached_umask();
+        let dflt_perms = dflt_perms_for_destination(destination);
         source_mode & (!0o7777 | dflt_perms)
     };
 
@@ -529,7 +568,7 @@ pub(super) fn apply_permissions_from_entry(
                 // existing-file branch (keep destination's perm bits).
                 let source_mode = entry.permissions();
                 if cached_meta.is_none() {
-                    let dflt_perms = 0o777 & !cached_umask();
+                    let dflt_perms = dflt_perms_for_destination(destination);
                     source_mode & (!0o7777 | dflt_perms)
                 } else {
                     (source_mode & !0o7777) | (current_mode & 0o7777)

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1630,3 +1630,68 @@ fn keep_dirlinks_bypass_is_cross_platform_safe() {
         );
     }
 }
+
+/// Regression: when `--no-perms` lands a new file under a directory with a
+/// permissive POSIX default ACL (`u::6,g::6,o:6`), the receiver must honour the
+/// inherited bits instead of clamping to the umask. Mirrors upstream's
+/// `testsuite/acls-default.test` where `RSYNC -rvv` into a default-ACL'd dir
+/// is expected to land `rw-rw-rw-` files. Without folding `default_perms_for_dir`
+/// into `dest_mode()`, the post-rename chmod would write 0o600 on a 0o077 umask
+/// and the test assertion `check_perms ... rw-rw-rw-` would fail.
+///
+/// upstream: rsync.c:449-472 `dest_mode()` + acls.c:1083-1139 `default_perms_for_dir`
+#[cfg(all(unix, feature = "acl", any(target_os = "linux", target_os = "freebsd")))]
+#[test]
+fn dest_mode_inherits_default_acl_bits_under_no_perms() {
+    use exacl::{AclEntry, AclOption, Perm, setfacl};
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let parent = temp.path().join("inherits");
+    fs::create_dir(&parent).expect("create parent");
+
+    // Default ACL `u::6,g::6,o:6` (matches the testsuite scenario at
+    // testsuite/acls-default.test line 55: `da777 u::7,g::7,o:7 rw-rw-rw-`).
+    let default_entries = vec![
+        AclEntry::allow_user("", Perm::READ | Perm::WRITE, None),
+        AclEntry::allow_group("", Perm::READ | Perm::WRITE, None),
+        AclEntry::allow_other(Perm::READ | Perm::WRITE, None),
+    ];
+    if setfacl(&[&parent], &default_entries, Some(AclOption::DEFAULT_ACL)).is_err() {
+        // Filesystem doesn't support POSIX default ACLs (e.g. tmpfs without
+        // `acl` mount option). Upstream's testsuite skips in the same case
+        // via `test_skipped`; mirror that here.
+        return;
+    }
+
+    // Source is mode 0o666 (testsuite line 50: `chmod 666 "$scratchdir/file"`).
+    let source = temp.path().join("source.txt");
+    fs::write(&source, b"file!").expect("write source");
+    fs::set_permissions(&source, PermissionsExt::from_mode(0o666)).expect("source chmod");
+    let source_meta = fs::metadata(&source).expect("source metadata");
+
+    // Simulate the post-rename state: temp open under SEC-1.h created the file
+    // at 0o600 (matching the diagnosed root cause). The receiver then calls
+    // `apply_file_metadata_with_options` with `--no-perms` and
+    // `destination_is_new(true)` - the same path taken from
+    // `disk_commit/process.rs:756`.
+    let dest = parent.join("dest.txt");
+    fs::write(&dest, b"file!").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o600)).expect("dest chmod");
+
+    apply_file_metadata_with_options(
+        &dest,
+        &source_meta,
+        &MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false)
+            .with_destination_is_new(true),
+    )
+    .expect("apply metadata");
+
+    let landed = current_mode(&dest) & 0o777;
+    assert_eq!(
+        landed, 0o666,
+        "dest must inherit default-ACL bits (rw-rw-rw-) not collapse to umask: got {landed:o}"
+    );
+}


### PR DESCRIPTION
## Summary

- Folds the destination directory's POSIX default ACL into `dest_mode()`, mirroring upstream `default_perms_for_dir(dn)` at `generator.c:1339` and `receiver.c:847`.
- Without this, files created under a permissive default ACL (e.g. `u::6,g::6,o:6`) silently landed at `0o600` because `dflt_perms` was being derived only from the umask.
- All four `!preserve_perms` `dest_mode` call sites now route through a single `dflt_perms_for_destination` helper. On platforms without POSIX default ACL support, the helper falls back to the umask-derived default, matching upstream's `#ifdef SUPPORT_ACLS` gating.

## Test plan

- [x] Adds `dest_mode_inherits_default_acl_bits_under_no_perms` regression test gated on `feature = "acl"` + `linux|freebsd`. Installs a `u::6,g::6,o:6` default ACL on the parent dir, runs `apply_file_metadata_with_options` with `--no-perms` and `destination_is_new(true)`, and asserts the dest file lands at `0o666`. Mirrors `testsuite/acls-default.test` (`da777` case).
- [x] `cargo fmt --all` clean.
- [x] Test self-skips when the filesystem doesn't support POSIX default ACLs (e.g. tmpfs without `acl` mount), matching upstream `test_skipped`.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.