### PR TITLE
ci: audit cargo commands for --locked and gate against removal

### DIFF
--- a/.github/workflows/check-locked-flags.yml
+++ b/.github/workflows/check-locked-flags.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Run check_locked_flags.sh
         run: bash tools/ci/check_locked_flags.sh
+
+      - name: Self-test check_locked_flags.sh
+        # Exercises the gate against synthetic fixtures so a regression in
+        # the matcher (false positives, false negatives, comment handling)
+        # surfaces here instead of as a silent gap on a future PR.
+        run: bash tools/ci/tests/test_check_locked_flags.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,9 @@ prevents.
   refresh and PR auto-sync workflows below, which must run *without*
   `--locked` to do their job. The allowlist lives inside
   `tools/ci/check_locked_flags.sh`; add to it only with reviewer signoff.
+- `tools/ci/tests/test_check_locked_flags.sh` self-tests the gate against
+  synthetic fixtures and runs in the same workflow job, so a regression in
+  the matcher itself surfaces before it can let a real violation through.
 
 ### Weekly auto-sync
 

--- a/tools/ci/check_locked_flags.sh
+++ b/tools/ci/check_locked_flags.sh
@@ -46,9 +46,23 @@
 # require explicit reviewer signoff - see CONTRIBUTING.md, section
 # "Cargo.lock maintenance".
 #
+# Excluded paths
+# --------------
+# `tools/ci/tests/` is excluded from the scan because its fixtures
+# intentionally embed missing-`--locked` cargo invocations to exercise
+# the gate. The self-test runner (`test_check_locked_flags.sh`) feeds
+# those fixtures back through this script with `OC_RSYNC_LOCKED_SCAN_ROOTS`
+# pointing at a tempdir.
+#
 # Usage
 # -----
 #   tools/ci/check_locked_flags.sh
+#
+# Test override
+# -------------
+#   OC_RSYNC_LOCKED_SCAN_ROOTS=/path/a:/path/b tools/ci/check_locked_flags.sh
+# Replaces the production scan roots with the supplied colon-separated
+# directory list (used by the self-test).
 #
 # Exit codes
 #   0 - all gated cargo invocations carry `--locked` (or are allowlisted).
@@ -58,6 +72,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Optional override used by the unit test in tools/ci/tests/. When set to a
+# colon-separated list of absolute directories the production scan roots below
+# are replaced with that list, and the per-line allowlist is suppressed so the
+# test can exercise the gating logic in isolation.
+OC_RSYNC_LOCKED_SCAN_ROOTS="${OC_RSYNC_LOCKED_SCAN_ROOTS:-}"
 
 # Subcommands that must carry --locked on the same logical command.
 # Order matters only for diagnostic output; the matcher checks all of
@@ -83,11 +103,21 @@ GATED_SUBCOMMANDS=(
 ALLOWLIST=(
 )
 
-# Scan roots.
-SCAN_ROOTS=(
-    "${REPO_ROOT}/.github/workflows"
-    "${REPO_ROOT}/tools/ci"
-)
+# Scan roots. Tests can replace these via OC_RSYNC_LOCKED_SCAN_ROOTS
+# (colon-separated absolute paths) to exercise the gating logic against a
+# controlled fixture tree.
+SCAN_ROOTS=()
+if [[ -n "${OC_RSYNC_LOCKED_SCAN_ROOTS}" ]]; then
+    IFS=':' read -r -a SCAN_ROOTS <<<"${OC_RSYNC_LOCKED_SCAN_ROOTS}"
+    # Re-root rel-path reporting at the first scan root so violation
+    # entries print as `<basename>:<lineno>` rather than full paths.
+    REPO_ROOT="${SCAN_ROOTS[0]}"
+else
+    SCAN_ROOTS=(
+        "${REPO_ROOT}/.github/workflows"
+        "${REPO_ROOT}/tools/ci"
+    )
+fi
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -230,7 +260,10 @@ while IFS= read -r -d '' f; do
     if is_scannable "$f"; then
         files+=("$f")
     fi
-done < <(find "${SCAN_ROOTS[@]}" -type f \( -name '*.yml' -o -name '*.yaml' -o -name '*.sh' \) -print0 | sort -z)
+done < <(find "${SCAN_ROOTS[@]}" -type f \
+    \( -name '*.yml' -o -name '*.yaml' -o -name '*.sh' \) \
+    -not -path '*/tools/ci/tests/*' \
+    -print0 | sort -z)
 
 for file in "${files[@]}"; do
     scanned_files=$((scanned_files + 1))

--- a/tools/ci/tests/test_check_locked_flags.sh
+++ b/tools/ci/tests/test_check_locked_flags.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# test_check_locked_flags.sh - unit tests for check_locked_flags.sh.
+#
+# Builds small synthetic workflow trees under a tempdir, points the gate at
+# them via OC_RSYNC_LOCKED_SCAN_ROOTS, and asserts the expected exit code for
+# each case. This catches regressions in the gate's matcher (e.g., a future
+# refactor that silently stops recognising `cargo nextest run` as a gated
+# subcommand, or one that mis-classifies `cargo fmt` as gated).
+
+set -uo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+target="${script_dir}/../check_locked_flags.sh"
+
+if [[ ! -x "${target}" ]] && [[ ! -r "${target}" ]]; then
+    echo "FAIL: cannot locate check_locked_flags.sh at ${target}" >&2
+    exit 2
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+failures=0
+case_count=0
+
+# Run the gate against a fixture directory and assert exit code.
+#
+# $1 - human-readable label
+# $2 - expected exit code (0 = pass, 1 = violation)
+# $3 - fixture directory under ${tmp}
+run_case() {
+    local label="$1" expected="$2" root="$3"
+    case_count=$((case_count + 1))
+    OC_RSYNC_LOCKED_SCAN_ROOTS="${root}" \
+        bash "${target}" >"${tmp}/out" 2>"${tmp}/err"
+    local actual=$?
+    if [[ "${actual}" -ne "${expected}" ]]; then
+        echo "FAIL ${label}: expected exit ${expected}, got ${actual}" >&2
+        sed 's/^/  out: /' "${tmp}/out" >&2
+        sed 's/^/  err: /' "${tmp}/err" >&2
+        failures=$((failures + 1))
+    else
+        echo "ok ${label} (exit ${actual})"
+    fi
+}
+
+# -------- Case 1: missing --locked on cargo build should fail (exit 1).
+mkdir -p "${tmp}/case1"
+cat >"${tmp}/case1/bad.yml" <<'YAML'
+name: bad
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo build --release --workspace
+YAML
+run_case "missing --locked on cargo build is rejected" 1 "${tmp}/case1"
+
+# -------- Case 2: cargo build with --locked should pass (exit 0).
+mkdir -p "${tmp}/case2"
+cat >"${tmp}/case2/good.yml" <<'YAML'
+name: good
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo build --locked --release --workspace
+YAML
+run_case "cargo build --locked passes" 0 "${tmp}/case2"
+
+# -------- Case 3: cargo fmt is lenient even without --locked.
+mkdir -p "${tmp}/case3"
+cat >"${tmp}/case3/fmt.yml" <<'YAML'
+name: fmt
+on: [pull_request]
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo fmt --all -- --check
+YAML
+run_case "cargo fmt without --locked is lenient" 0 "${tmp}/case3"
+
+# -------- Case 4: cargo update without --locked is lenient (lockfile-sync).
+mkdir -p "${tmp}/case4"
+cat >"${tmp}/case4/sync.yml" <<'YAML'
+name: sync
+on: [pull_request]
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo update --workspace
+YAML
+run_case "cargo update without --locked is lenient" 0 "${tmp}/case4"
+
+# -------- Case 5: backslash-continued cargo nextest run --locked passes.
+mkdir -p "${tmp}/case5"
+cat >"${tmp}/case5/multiline.yml" <<'YAML'
+name: multiline
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cargo nextest run \
+            --locked \
+            -p engine \
+            --no-fail-fast
+YAML
+run_case "multi-line cargo nextest run --locked passes" 0 "${tmp}/case5"
+
+# -------- Case 6: multi-line cargo nextest run WITHOUT --locked fails.
+mkdir -p "${tmp}/case6"
+cat >"${tmp}/case6/multiline_bad.yml" <<'YAML'
+name: multiline_bad
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cargo nextest run \
+            -p engine \
+            --no-fail-fast
+YAML
+run_case "multi-line cargo nextest run missing --locked fails" 1 "${tmp}/case6"
+
+# -------- Case 7: cargo clippy without --locked fails.
+mkdir -p "${tmp}/case7"
+cat >"${tmp}/case7/clippy.yml" <<'YAML'
+name: clippy
+on: [pull_request]
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+YAML
+run_case "cargo clippy without --locked fails" 1 "${tmp}/case7"
+
+# -------- Case 8: cargo check --locked in a shell helper script passes.
+mkdir -p "${tmp}/case8"
+cat >"${tmp}/case8/helper.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cargo check --locked --workspace --all-features
+SH
+chmod +x "${tmp}/case8/helper.sh"
+run_case "cargo check --locked in helper.sh passes" 0 "${tmp}/case8"
+
+# -------- Case 9: a quoted `cargo build` inside an error message does
+# not trip the gate.
+mkdir -p "${tmp}/case9"
+cat >"${tmp}/case9/quoted.yml" <<'YAML'
+name: quoted
+on: [pull_request]
+jobs:
+  notice:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "If 'cargo build' fails, rerun with --locked"
+YAML
+run_case "quoted 'cargo build' in an echo is ignored" 0 "${tmp}/case9"
+
+# -------- Case 10: `cargo nextest list` (non-`run`) without --locked is
+# lenient; only `cargo nextest run` is gated.
+mkdir -p "${tmp}/case10"
+cat >"${tmp}/case10/list.yml" <<'YAML'
+name: list
+on: [pull_request]
+jobs:
+  list:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo nextest list -p engine
+YAML
+run_case "cargo nextest list without --locked is lenient" 0 "${tmp}/case10"
+
+# -------- Case 11: cargo run --locked passes; without --locked fails.
+mkdir -p "${tmp}/case11a"
+cat >"${tmp}/case11a/run_ok.yml" <<'YAML'
+name: run_ok
+on: [pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo run --locked --release -- --version
+YAML
+run_case "cargo run --locked passes" 0 "${tmp}/case11a"
+
+mkdir -p "${tmp}/case11b"
+cat >"${tmp}/case11b/run_bad.yml" <<'YAML'
+name: run_bad
+on: [pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo run --release -- --version
+YAML
+run_case "cargo run without --locked fails" 1 "${tmp}/case11b"
+
+# -------- Case 12: a comment containing `cargo build` does not trip.
+mkdir -p "${tmp}/case12"
+cat >"${tmp}/case12/commented.yml" <<'YAML'
+name: commented
+on: [pull_request]
+# this would have run cargo build --release without --locked
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo skipped
+YAML
+run_case "commented-out cargo build is ignored" 0 "${tmp}/case12"
+
+echo
+echo "ran ${case_count} case(s); ${failures} failure(s)"
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes the CIM-LOCKFILE series. Re-audits every cargo invocation in `.github/workflows/` and `tools/ci/*.sh` for `--locked`, confirms zero gaps after CIM-LOCKFILE-1..4, and adds a self-test harness around the gate (`tools/ci/check_locked_flags.sh`) so a future matcher refactor cannot silently let real violations through.

- Closes CIM-LOCKFILE-4 (audit + in-place fix sweep).
- Closes CIM-LOCKFILE-5 (regression gate, plus self-test added here).

## Audit result

Production gate output against current `master`:

```
Scanned 67 file(s); inspected 73 gated cargo invocation(s).
PASSED: all gated cargo invocations carry --locked.
```

All 73 `cargo build|check|clippy|nextest run|run|test` sites already carry `--locked`. No in-place fixes were required at this round. The lockfile-sync workflows (`cargo-lockfile-sync.yml`, `cargo-lockfile-weekly.yml`) only invoke `cargo update`, which is not a gated subcommand, so they need no allowlist entry.

## Changes

| File | Change |
|------|--------|
| `tools/ci/check_locked_flags.sh` | Add `OC_RSYNC_LOCKED_SCAN_ROOTS` env override so the self-test can target fixtures; exclude `tools/ci/tests/` from production scans (fixtures embed intentional missing-`--locked` examples); document both in the header comment. |
| `tools/ci/tests/test_check_locked_flags.sh` | New: 13 synthetic fixtures covering missing-flag rejection on `build` / `clippy` / `run`, single- and multi-line `nextest run`, leniency for `fmt` / `update` / `nextest list`, and false-positive guards for quoted and commented cargo calls. |
| `.github/workflows/check-locked-flags.yml` | Run the self-test after the gate so matcher regressions surface in the same job. |
| `CONTRIBUTING.md` | One-line note under "How CI enforces it" pointing at the self-test. |

## Test plan

- [x] `bash tools/ci/check_locked_flags.sh` passes against the tree (73 gated invocations, 0 violations).
- [x] `bash tools/ci/tests/test_check_locked_flags.sh` reports `ran 13 case(s); 0 failure(s)` locally.
- [ ] CI: `Check --locked flags` workflow runs gate then self-test on this PR.
- [ ] CI: full required matrix (fmt+clippy, nextest, Windows, macOS, Linux musl) passes.