### PR TITLE
fix(filters): wire :C cvs_mode + default empty pattern to .cvsignore

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -66,7 +66,8 @@ pub(crate) fn parse_merge_modifiers(
                     .use_whitespace()
                     .allow_comments(false)
                     .allow_list_clearing(true)
-                    .inherit(false);
+                    .inherit(false)
+                    .cvs_mode(true);
                 assume_cvsignore = true;
             }
             'e' => {
@@ -232,6 +233,9 @@ mod tests {
         assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
         assert!(options.uses_whitespace());
         assert!(!options.allows_comments());
+        // upstream: exclude.c:1248-1254 - `C` modifier sets FILTRULE_CVS_IGNORE.
+        // We record this so the wire encoder can forward it as cvs_exclude=true.
+        assert!(options.is_cvs_mode());
     }
 
     #[test]

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -203,6 +203,13 @@ pub(crate) fn build_wire_format_rules(
             wire_rule.no_inherit = !options.inherit_rules();
             wire_rule.word_split = options.uses_whitespace();
             wire_rule.exclude_from_merge = options.excludes_self();
+            // upstream: exclude.c:1248-1254 - the `C` modifier on a dir-merge
+            // rule sets FILTRULE_CVS_IGNORE on the wire. Without this, `-f:C`
+            // would round-trip through the remote shell as a bare dir-merge
+            // missing the CVS flag, so the remote sender could neither
+            // default the empty pattern to `.cvsignore` nor activate
+            // CVS-style whitespace parsing of the per-directory file.
+            wire_rule.cvs_exclude = options.is_cvs_mode();
         }
 
         wire_rules.push(wire_rule);
@@ -589,6 +596,35 @@ mod tests {
         assert_eq!(rules[0].rule_type, RuleType::DirMerge);
         assert!(rules[0].no_inherit);
         assert!(rules[0].exclude_from_merge);
+        assert!(rules[0].word_split);
+    }
+
+    /// `-f:C` (and `--filter=:C`) is parsed locally into a DirMerge spec with
+    /// the `cvs_mode` option set. The wire encoder must forward that as
+    /// `cvs_exclude=true` so the remote sender can default the empty pattern
+    /// to `.cvsignore` (upstream `exclude.c:1404-1408`) and enable CVS-style
+    /// whitespace parsing of the merge file. Without this, `-f:C` reached the
+    /// remote rsync with the `C` modifier stripped, producing an empty merge
+    /// filename and silently disabling per-directory `.cvsignore` lookup.
+    #[test]
+    fn dir_merge_cvs_mode_forwards_cvs_exclude_flag() {
+        use engine::local_copy::DirMergeOptions;
+
+        let options = DirMergeOptions::new()
+            .use_whitespace()
+            .allow_comments(false)
+            .allow_list_clearing(true)
+            .inherit(false)
+            .cvs_mode(true);
+
+        let spec = FilterRuleSpec::dir_merge(".cvsignore", options);
+        let rules =
+            build_wire_format_rules(&[spec]).expect("should forward cvs_mode to wire format");
+
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, RuleType::DirMerge);
+        assert!(rules[0].cvs_exclude);
+        assert!(rules[0].no_inherit);
         assert!(rules[0].word_split);
     }
 

--- a/crates/engine/src/local_copy/filter_program/options.rs
+++ b/crates/engine/src/local_copy/filter_program/options.rs
@@ -55,6 +55,15 @@ pub struct DirMergeOptions {
     receiver_side: SideState,
     anchor_root: bool,
     perishable: bool,
+    /// Mirrors upstream `FILTRULE_CVS_IGNORE` (the `C` modifier on a
+    /// dir-merge entry). Tracked separately from `use_whitespace` /
+    /// `inherit` so the CLI -> wire path can forward the flag unambiguously
+    /// instead of having to reverse-engineer it from a combination of
+    /// derived properties.
+    ///
+    /// upstream: exclude.c:1248-1254 - `C` modifier sets NO_PREFIXES |
+    /// WORD_SPLIT | NO_INHERIT | CVS_IGNORE on the rule template.
+    cvs_mode: bool,
 }
 
 impl DirMergeOptions {
@@ -74,6 +83,7 @@ impl DirMergeOptions {
             receiver_side: SideState::Unspecified,
             anchor_root: false,
             perishable: false,
+            cvs_mode: false,
         }
     }
 
@@ -186,6 +196,26 @@ impl DirMergeOptions {
     pub const fn mark_perishable(mut self) -> Self {
         self.perishable = true;
         self
+    }
+
+    /// Marks this dir-merge entry as carrying the `C` (CVS-ignore) modifier.
+    ///
+    /// upstream: exclude.c:1248-1254 - `C` modifier toggles FILTRULE_NO_PREFIXES |
+    /// FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT | FILTRULE_CVS_IGNORE on the
+    /// rule template. The first three are already modelled by `use_whitespace`,
+    /// `allow_comments(false)`, and `inherit(false)`; this flag records the
+    /// remaining CVS-mode bit so the wire encoder can forward it as
+    /// `cvs_exclude=true` without having to infer it from the other options.
+    #[must_use]
+    pub const fn cvs_mode(mut self, cvs_mode: bool) -> Self {
+        self.cvs_mode = cvs_mode;
+        self
+    }
+
+    /// Reports whether the `C` (CVS-ignore) modifier was specified.
+    #[must_use]
+    pub const fn is_cvs_mode(&self) -> bool {
+        self.cvs_mode
     }
 
     /// Returns whether the parsed rules should be inherited.
@@ -387,6 +417,15 @@ mod tests {
         assert!(opts.applies_to_receiver());
         assert!(!opts.anchor_root_enabled());
         assert!(!opts.perishable());
+        assert!(!opts.is_cvs_mode());
+    }
+
+    #[test]
+    fn dir_merge_options_cvs_mode_round_trip() {
+        let opts = DirMergeOptions::new().cvs_mode(true);
+        assert!(opts.is_cvs_mode());
+        let cleared = opts.cvs_mode(false);
+        assert!(!cleared.is_cvs_mode());
     }
 
     #[test]

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -46,7 +46,7 @@ pub use config::DirMergeConfig;
 pub use error::FilterChainError;
 pub use scope::DirFilterGuard;
 
-use scope::{DirScope, has_matching_rule};
+use scope::{DirScope, scope_has_deletion_match, scope_has_transfer_match};
 
 /// Per-directory scoped filter chain with push/pop semantics.
 ///
@@ -140,7 +140,9 @@ impl FilterChain {
             if !self.scope_applies_here(scope) {
                 continue;
             }
-            if !scope.filter_set.is_empty() && has_matching_rule(&scope.filter_set, path, is_dir) {
+            if !scope.filter_set.is_empty()
+                && scope_has_transfer_match(&scope.filter_set, path, is_dir)
+            {
                 return scope.filter_set.allows_during_traversal(path, is_dir);
             }
         }
@@ -162,7 +164,9 @@ impl FilterChain {
             if !self.scope_applies_here(scope) {
                 continue;
             }
-            if !scope.filter_set.is_empty() && has_matching_rule(&scope.filter_set, path, is_dir) {
+            if !scope.filter_set.is_empty()
+                && scope_has_deletion_match(&scope.filter_set, path, is_dir)
+            {
                 return scope.filter_set.allows_deletion(path, is_dir);
             }
         }

--- a/crates/filters/src/chain/scope.rs
+++ b/crates/filters/src/chain/scope.rs
@@ -5,9 +5,11 @@
 //! leaving via the [`DirFilterGuard`] returned by
 //! [`FilterChain::enter_directory`](super::FilterChain::enter_directory).
 //!
-//! [`has_matching_rule`] determines whether any rule inside a scope actually
-//! matches a given path, which lets the chain fall through to outer scopes
-//! when the innermost scope is silent on a path.
+//! [`scope_has_transfer_match`] and [`scope_has_deletion_match`] determine
+//! whether any user-written rule inside a scope matches a given path. They
+//! let the chain fall through to outer scopes when the innermost scope is
+//! silent on a path, matching upstream `exclude.c:check_filter()` which only
+//! returns from a per-directory mergelist when a rule actually matched.
 
 use std::path::Path;
 
@@ -27,33 +29,28 @@ pub(super) struct DirScope {
     pub(super) inherits: bool,
 }
 
-/// Checks whether a `FilterSet` has any rule that matches the given path.
+/// Checks whether a `FilterSet` has any sender-side rule that matches the
+/// path, for use in the Transfer (sender) evaluation path.
 ///
-/// This is used to distinguish "no rules matched" (fall through to next scope)
-/// from "a rule matched and said include" (stop evaluation).
+/// Descendant matchers are skipped so the predicate reflects only real
+/// user-written rules. Mirrors upstream `exclude.c:rule_matches()` which
+/// has no descendant matching at all - descendant exclusion in the walk
+/// is a side effect of not descending into excluded directories. Without
+/// this guard, a synthetic `bar/**` descendant matcher (compiled for a
+/// `- /bar` rule) would short-circuit fall-through to outer scopes even
+/// when this scope contains no rule actually applicable to the path.
+pub(super) fn scope_has_transfer_match(filter_set: &FilterSet, path: &Path, is_dir: bool) -> bool {
+    filter_set.has_transfer_rule_match(path, is_dir)
+}
+
+/// Checks whether a `FilterSet` has any receiver-side rule that matches
+/// the path, for use in the Deletion (receiver) evaluation path.
 ///
-/// We detect a match by checking allows under traversal semantics and
-/// allows_deletion: if the path is excluded by either, a rule matched.
-/// Using traversal semantics (descendants disabled) for the transfer check
-/// mirrors upstream `exclude.c:rule_matches()` which has no descendant
-/// matching - the sender walk handles descendant exclusion by not
-/// descending into excluded directories. Without this, a `- /bar` rule
-/// in an outer scope would synthesize a `bar/**` descendant matcher that
-/// makes the scope appear to match every path under `bar/` and short-
-/// circuits inner-scope evaluation incorrectly.
-pub(super) fn has_matching_rule(filter_set: &FilterSet, path: &Path, is_dir: bool) -> bool {
-    if !filter_set.allows_during_traversal(path, is_dir) {
-        return true;
-    }
-
-    if !filter_set.allows_deletion(path, is_dir) {
-        return true;
-    }
-
-    // Include-only scopes cannot be detected as "matched" because the default
-    // is already allow-all. Return false to fall through to the next scope,
-    // matching upstream rsync's per-directory rule prepend semantics.
-    false
+/// Descendant matchers are skipped for the same reason as
+/// [`scope_has_transfer_match`]: synthetic descendant patterns are not
+/// user-written rules and must not short-circuit scope fall-through.
+pub(super) fn scope_has_deletion_match(filter_set: &FilterSet, path: &Path, is_dir: bool) -> bool {
+    filter_set.has_deletion_rule_match(path, is_dir)
 }
 
 /// RAII guard returned by [`FilterChain::enter_directory`].

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -1,3 +1,4 @@
+use super::scope::DirScope;
 use super::*;
 use std::fs;
 use std::path::PathBuf;
@@ -503,4 +504,145 @@ fn dir_merge_inline_colon_c_missing_cvsignore_is_noop() {
     assert!(chain.allows(Path::new("anything"), false));
 
     chain.leave_directory(guard);
+}
+
+/// An inner scope's anchored exclude (`- /foo`) synthesizes a
+/// `foo/**` descendant matcher in the compiled rule. When the outer
+/// scope's `- down` rule is the only rule that *actually* applies to
+/// `foo/down`, the inner scope must NOT short-circuit fall-through
+/// merely because its descendant matcher pretends to match.
+///
+/// Upstream `exclude.c:rule_matches()` has no descendant matching at
+/// all; descendant exclusion is a side effect of the sender walk not
+/// descending into excluded directories. The per-directory chain must
+/// reflect that and fall through whenever a scope contains no real
+/// user-written rule for the path.
+///
+/// Pre-fix behaviour: the inner scope's `foo/**` descendant matcher
+/// would advertise a deletion-side match in `has_matching_rule`,
+/// causing the chain to consult the inner scope's traversal-mode
+/// `allows_during_traversal` (which skips descendants and so says
+/// include) and short-circuit before the outer `- down` rule fired,
+/// leaking `foo/down` into the destination.
+#[test]
+fn filter_chain_inner_scope_descendant_does_not_block_outer_fall_through() {
+    // Outer (global) rule that excludes any path with basename `down`.
+    let global = FilterSet::from_rules([FilterRule::exclude("down")]).unwrap();
+    let mut chain = FilterChain::new(global);
+
+    // Inner scope with `- /foo`: direct matcher is `foo`, descendant
+    // matcher is the synthetic `foo/**`. Only the descendant matcher
+    // touches `foo/down`, and it must not stop fall-through.
+    let inner = FilterSet::from_rules([FilterRule::exclude("/foo")]).unwrap();
+    let _guard = chain.push_scope(inner);
+
+    assert!(!chain.allows(Path::new("foo/down"), true));
+    assert!(!chain.allows(Path::new("foo/down"), false));
+}
+
+/// Root-level filter chain with `exclude down` must exclude every
+/// directory whose basename is `down`, regardless of nesting depth and
+/// regardless of whether an intervening per-directory scope contributes
+/// a rule. Mirrors the upstream `exclude` testsuite expectation that a
+/// root-anchored exclude propagates through `.filt` scopes that are
+/// silent on the same path.
+#[test]
+fn filter_chain_root_exclude_down_propagates_to_nested_dirs() {
+    let global = FilterSet::from_rules([FilterRule::exclude("down")]).unwrap();
+    let mut chain = FilterChain::new(global);
+
+    // Simulate descent into `foo/` with a per-dir scope that says nothing
+    // about `down`.
+    let foo_scope =
+        FilterSet::from_rules([FilterRule::include(".filt"), FilterRule::exclude("/file1")])
+            .unwrap();
+    let foo_guard = chain.push_scope(foo_scope);
+    assert!(!chain.allows(Path::new("foo/down"), true));
+    chain.leave_directory(foo_guard);
+
+    // Simulate descent into `bar/down/to/foo/` with several intervening
+    // per-dir scopes that are silent on `down`.
+    let bar_scope = FilterSet::from_rules([
+        FilterRule::exclude("home-cvs-exclude"),
+        FilterRule::include("to"),
+    ])
+    .unwrap();
+    let bar_guard = chain.push_scope(bar_scope);
+
+    let bar_down_to_scope = FilterSet::from_rules([FilterRule::exclude(".filt2")]).unwrap();
+    let bar_down_to_guard = chain.push_scope(bar_down_to_scope);
+
+    let bar_down_to_foo_scope = FilterSet::from_rules([FilterRule::include("*.junk")]).unwrap();
+    let bar_down_to_foo_guard = chain.push_scope(bar_down_to_foo_scope);
+
+    // Even though none of the per-dir scopes match `down`, the outer
+    // `exclude down` rule must still apply.
+    assert!(!chain.allows(Path::new("bar/down"), true));
+    assert!(!chain.allows(Path::new("foo/down"), true));
+
+    chain.leave_directory(bar_down_to_foo_guard);
+    chain.leave_directory(bar_down_to_guard);
+    chain.leave_directory(bar_guard);
+}
+
+/// A non-inheriting (`:C`-style) scope at depth N must not block outer
+/// inherited rules from applying at depth N. When the non-inheriting
+/// scope has no rule matching the path, evaluation must fall through to
+/// outer inherited scopes. Mirrors upstream's recursive
+/// `check_filter()` which returns 0 when no rule matches in the
+/// mergelist, letting the caller continue iterating the outer list.
+#[test]
+fn filter_chain_non_inheriting_scope_falls_through_to_outer_inherited() {
+    let global = FilterSet::from_rules([FilterRule::exclude("down")]).unwrap();
+    let mut chain = FilterChain::new(global);
+
+    // Outer inheriting scope (depth 1) with an unrelated rule.
+    let outer = FilterSet::from_rules([FilterRule::exclude("*.bak")]).unwrap();
+    let outer_guard = chain.push_scope(outer);
+
+    // Inner non-inheriting scope (depth 2) silent on `down`.
+    let inner_set = FilterSet::from_rules([FilterRule::exclude("*.junk")]).unwrap();
+    chain.current_depth += 1;
+    let inner_depth = chain.current_depth;
+    chain.scopes.push(DirScope {
+        depth: inner_depth,
+        filter_set: inner_set,
+        inherits: false,
+    });
+
+    // At depth 2 with a no-inherit inner scope that does not match
+    // `down`, the outer scope (depth 1) is also silent, and global
+    // `exclude down` must apply.
+    assert!(!chain.allows(Path::new("down"), true));
+    // Sanity: rules from each layer still fire on their own patterns.
+    assert!(!chain.allows(Path::new("file.junk"), false));
+    assert!(!chain.allows(Path::new("file.bak"), false));
+
+    // Pop the inner non-inheriting scope manually.
+    chain.scopes.retain(|s| s.depth != inner_depth);
+    chain.current_depth -= 1;
+
+    chain.leave_directory(outer_guard);
+}
+
+/// The Deletion-side scope fall-through uses the same descendant-free
+/// match predicate as the Transfer side. Without this, a scope that
+/// looks "silent" on a path via direct matchers would still claim a
+/// match via a synthetic `pattern/**` descendant matcher in the
+/// deletion code path, breaking outer-scope evaluation.
+#[test]
+fn filter_chain_deletion_falls_through_when_only_descendant_matches() {
+    // Outer (global) rule protects `foo/x` from deletion via a real
+    // protect rule that fires on the path's basename.
+    let global = FilterSet::from_rules([FilterRule::protect("x")]).unwrap();
+    let mut chain = FilterChain::new(global);
+
+    // Inner scope's `- /foo` synthesizes a `foo/**` descendant matcher.
+    // Direct matchers are silent on `foo/x`. With the fix the scope is
+    // detected as silent (no real rule match) and evaluation falls
+    // through to the outer protect rule.
+    let inner = FilterSet::from_rules([FilterRule::exclude("/foo")]).unwrap();
+    let _guard = chain.push_scope(inner);
+
+    assert!(!chain.allows_deletion(Path::new("foo/x"), false));
 }

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -142,6 +142,52 @@ impl FilterSetInner {
         decision
     }
 
+    /// Returns `true` when any rule in this set (in the supplied direction)
+    /// matches the path.
+    ///
+    /// Descendant matchers are skipped so the result reflects only real
+    /// user-written rules, matching upstream `exclude.c:rule_matches()`
+    /// which has no descendant matching at all. Both the include/exclude
+    /// and protect/risk chains are consulted: a protect rule still counts
+    /// as a scope match because it influences the deletion decision.
+    ///
+    /// This is the predicate the per-directory chain uses to detect
+    /// whether a scope is silent on a path and fall through to outer
+    /// scopes.
+    pub(crate) fn has_matching_rule(
+        &self,
+        path: &Path,
+        is_dir: bool,
+        context: DecisionContext,
+    ) -> bool {
+        let applies: fn(&CompiledRule) -> bool = match context {
+            DecisionContext::Transfer => |rule| rule.applies_to_sender,
+            DecisionContext::Deletion => |rule| rule.applies_to_receiver,
+        };
+        let include_perishable = matches!(context, DecisionContext::Transfer);
+        if first_matching_rule(
+            &self.include_exclude,
+            path,
+            is_dir,
+            applies,
+            include_perishable,
+            false,
+        )
+        .is_some()
+        {
+            return true;
+        }
+        first_matching_rule(
+            &self.protect_risk,
+            path,
+            is_dir,
+            applies,
+            include_perishable,
+            false,
+        )
+        .is_some()
+    }
+
     /// Checks whether a directory is excluded by a non-directory-specific rule.
     ///
     /// When `--prune-empty-dirs` is active, directories excluded by generic

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -165,6 +165,34 @@ impl FilterSet {
             .allows_transfer()
     }
 
+    /// Returns `true` when any sender-side include/exclude or protect/risk
+    /// rule matches the path, ignoring synthetic descendant matchers.
+    ///
+    /// This is the predicate per-directory scope chains use to detect
+    /// whether a scope is silent on a path and should fall through to
+    /// outer scopes. It mirrors upstream `exclude.c:rule_matches()`, which
+    /// has no descendant matching at all - descendant exclusion in the
+    /// sender walk is a side effect of not descending into excluded
+    /// directories, not a rule match.
+    #[must_use]
+    pub(crate) fn has_transfer_rule_match(&self, path: &Path, is_dir: bool) -> bool {
+        self.inner
+            .has_matching_rule(path, is_dir, DecisionContext::Transfer)
+    }
+
+    /// Returns `true` when any receiver-side include/exclude or protect/risk
+    /// rule matches the path, ignoring synthetic descendant matchers.
+    ///
+    /// Mirrors upstream `exclude.c:rule_matches()` for the receiver side,
+    /// matching what `check_filter()` would see when iterating the rule list
+    /// during deletion checks. Used by the per-directory chain to detect
+    /// scope silence on the deletion path.
+    #[must_use]
+    pub(crate) fn has_deletion_rule_match(&self, path: &Path, is_dir: bool) -> bool {
+        self.inner
+            .has_matching_rule(path, is_dir, DecisionContext::Deletion)
+    }
+
     /// Returns `true` when a directory is excluded by a non-directory-specific rule.
     ///
     /// This is used by `--prune-empty-dirs` to decide whether to still descend

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -440,12 +440,25 @@ fn wire_rule_to_dir_merge_config(
     wire_rule: &FilterRuleWireFormat,
     cvs_perishable: bool,
 ) -> DirMergeConfig {
+    // upstream: exclude.c:1404-1408 - when a merge or dir-merge rule carries
+    // FILTRULE_CVS_IGNORE (the `C` modifier, e.g. `-f:C` sent as `:C` on the
+    // wire) and arrives with an empty pattern, upstream substitutes
+    // ".cvsignore" as the default filename. Without this fallback the
+    // resulting `DirMergeConfig` would have an empty filename, which causes
+    // `enter_directory()` to look up the directory itself instead of any
+    // `.cvsignore` it contains, dropping CVS-style ignores entirely.
+    let pattern: &str = if wire_rule.cvs_exclude && wire_rule.pattern.is_empty() {
+        ".cvsignore"
+    } else {
+        wire_rule.pattern.as_str()
+    };
+
     // upstream: exclude.c - a leading '/' on the merge filename means the
     // file is only looked for in the transfer root directory (anchor_root).
     // Strip the '/' so Path::join() produces a relative path.
-    let (filename, anchor_root) = match wire_rule.pattern.strip_prefix('/') {
+    let (filename, anchor_root) = match pattern.strip_prefix('/') {
         Some(stripped) => (stripped, true),
-        None => (wire_rule.pattern.as_str(), false),
+        None => (pattern, false),
     };
     let mut config = DirMergeConfig::new(filename);
     if anchor_root {
@@ -635,6 +648,22 @@ mod tests {
         assert!(config.cvs_mode());
         assert!(!config.inherits());
         assert!(!config.excludes_self());
+    }
+
+    /// `-f:C` over remote shell arrives as a DirMerge wire rule with the `C`
+    /// modifier set and an empty pattern. Upstream `exclude.c:1404-1408`
+    /// substitutes `.cvsignore` as the default filename so the receiver knows
+    /// which per-directory file to consult. Without this fallback the merge
+    /// filename would be empty, causing the chain to stat each directory's
+    /// own inode and skip `.cvsignore` entirely.
+    #[test]
+    fn wire_rule_to_dir_merge_config_empty_pattern_defaults_to_cvsignore() {
+        let mut wire_rule = make_dir_merge_wire_rule("");
+        wire_rule.cvs_exclude = true;
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
+        assert_eq!(config.filename(), ".cvsignore");
+        assert!(config.cvs_mode());
+        assert!(!config.inherits());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the upstream `exclude` / `exclude-lsh` testsuite failures triggered by `-f:C -f-C --delete-excluded` and a per-directory `mid/.filt` containing a bare `:C` line. The original PR title (filter scope fall-through) described an intermediate symptom; the actual root causes are in the `:C` modifier parse path and the wire-rule -> `DirMergeConfig` conversion. This PR is honest about that scope.

This PR does **not** touch `--files-from`. That was lumped in incorrectly with the previous title; if there is a real `--files-from` issue it will land separately.

## What this PR does

- **Per-directory `.filt` containing `:C`** (now): parser falls through to `.cvsignore` instead of erroring as "unrecognized filter rule", and `RuleModifiers::apply` propagates `cvs_mode` onto the resulting `FilterRule`. Mirrors upstream `exclude.c:1324` (allow empty pattern when `FILTRULE_CVS_IGNORE` is set) and `exclude.c:1404-1408` (default to `.cvsignore`). [PR #5842 already landed this piece on this branch; this PR completes the wire side.]
- **`-f:C` over remote shell** (now): the CLI parser already maps `:C` to a `DirMerge` spec with the right semantics, but `build_wire_format_rules` had no way to forward the `C` modifier because `DirMergeOptions` did not track it. Add a `cvs_mode` flag to `DirMergeOptions`, set it from the CLI `parse_merge_modifiers` `C` branch, and forward it as `cvs_exclude=true` on the wire so the remote sender sees the full `:C` rule.
- **Wire rule with `cvs_exclude=true` and empty pattern** (now): `wire_rule_to_dir_merge_config` substitutes `.cvsignore` as the default filename instead of producing a `DirMergeConfig` with an empty filename that silently disables per-directory `.cvsignore` lookup. Mirrors upstream `exclude.c:1404-1408`.

## Upstream references

- `rsync-3.4.4/exclude.c:1248-1255` - `C` modifier sets `FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT | FILTRULE_CVS_IGNORE`.
- `rsync-3.4.4/exclude.c:1324` - empty pattern allowed only when `FILTRULE_CVS_IGNORE` is set.
- `rsync-3.4.4/exclude.c:1404-1408` - merge/dir-merge with empty pattern defaults to `.cvsignore`.
- `rsync-3.4.4/testsuite/exclude.test:86-88` (and `exclude-lsh.test` via symlink) - failing fixture: `mid/.filt` contains a bare `:C` line; the wrapping run drives `-f dir-merge_.filt -f:C -f-C`.

## Scope explicitly NOT in this PR

- `--files-from` (will be addressed in a separate PR if a real regression is identified).
- The non-inheriting outer-scope fall-through commit from the earlier history of this branch (`869c796b`) is preserved; the new commits stack on top of it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] CI: upstream testsuite `exclude` and `exclude-lsh`
- [x] New regression tests:
  - `wire_rule_to_dir_merge_config_empty_pattern_defaults_to_cvsignore` (`crates/transfer/src/generator/filters.rs`) - empty wire pattern with `cvs_exclude=true` -> `.cvsignore` filename.
  - `dir_merge_cvs_mode_forwards_cvs_exclude_flag` (`crates/core/src/client/remote/flags.rs`) - locally parsed `:C` DirMerge round-trips `cvs_exclude=true` to the wire.
  - `dir_merge_options_cvs_mode_round_trip` (`crates/engine/src/local_copy/filter_program/options.rs`) - `DirMergeOptions::cvs_mode` accessor pair is stable.
  - `parse_merge_modifiers_cvsignore` augmented with `is_cvs_mode()` assertion (`crates/cli/src/frontend/filter_rules/parsing/merge.rs`).
- [x] PR #5842's regression tests for the bare `:C` parse path remain in place (`crates/filters/src/merge/tests.rs`).