### PR TITLE
fix(cli): emit bare %n%L per-file at every verbose tier

### DIFF
--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -13,9 +13,8 @@ pub(crate) use self::progress::{
     format_progress_elapsed, format_progress_percent, format_stat_categories,
 };
 pub(crate) use self::rate::{
-    VerboseRateDisplay, compute_rate, format_human_rate, format_progress_rate,
-    format_progress_rate_decimal, format_progress_rate_from_value, format_progress_rate_human,
-    format_summary_rate, format_verbose_rate, format_verbose_rate_decimal,
+    format_human_rate, format_progress_rate, format_progress_rate_decimal,
+    format_progress_rate_from_value, format_progress_rate_human, format_summary_rate,
     format_verbose_rate_human,
 };
 pub(crate) use self::remaining::RemainingTimeEstimator;

--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -4,12 +4,6 @@ use std::time::Duration;
 
 use core::client::HumanReadableMode;
 
-/// Holds a primary rate display and an optional secondary (exact) display for combined mode.
-pub(crate) struct VerboseRateDisplay {
-    pub(crate) primary: (String, &'static str),
-    pub(crate) secondary: Option<(String, &'static str)>,
-}
-
 pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) -> String {
     let decimal = format!("{rate:.2}");
     if !human_readable.is_enabled() {
@@ -45,36 +39,6 @@ pub(crate) fn format_human_rate(rate: f64) -> String {
     }
 
     format!("{rate:.2}")
-}
-
-pub(crate) fn format_verbose_rate(
-    rate: f64,
-    human_readable: HumanReadableMode,
-) -> VerboseRateDisplay {
-    let decimal = format_verbose_rate_decimal(rate);
-    if !human_readable.is_enabled() {
-        return VerboseRateDisplay {
-            primary: decimal,
-            secondary: None,
-        };
-    }
-
-    let human = format_verbose_rate_human(rate);
-    if human_readable.includes_exact() && (human.0 != decimal.0 || human.1 != decimal.1) {
-        VerboseRateDisplay {
-            primary: human,
-            secondary: Some(decimal),
-        }
-    } else {
-        VerboseRateDisplay {
-            primary: human,
-            secondary: None,
-        }
-    }
-}
-
-pub(crate) fn format_verbose_rate_decimal(rate: f64) -> (String, &'static str) {
-    (format!("{rate:.1}"), "B/s")
 }
 
 pub(crate) fn format_verbose_rate_human(rate: f64) -> (String, &'static str) {
@@ -186,20 +150,6 @@ pub(crate) fn format_progress_rate_from_value(
     }
 }
 
-/// Computes the throughput in bytes per second for the provided measurements.
-pub(crate) fn compute_rate(bytes: u64, elapsed: Duration) -> Option<f64> {
-    if elapsed.is_zero() {
-        return None;
-    }
-
-    let seconds = elapsed.as_secs_f64();
-    if seconds <= 0.0 {
-        None
-    } else {
-        Some(bytes as f64 / seconds)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,13 +167,6 @@ mod tests {
     #[test]
     fn format_human_rate_mega() {
         assert_eq!(format_human_rate(2_500_000.0), "2.50M");
-    }
-
-    #[test]
-    fn test_format_verbose_rate_decimal() {
-        let (value, unit) = format_verbose_rate_decimal(1234.5);
-        assert_eq!(value, "1234.5");
-        assert_eq!(unit, "B/s");
     }
 
     #[test]
@@ -245,23 +188,6 @@ mod tests {
         let (value, unit) = format_verbose_rate_human(2_500_000.0);
         assert_eq!(value, "2.50");
         assert_eq!(unit, "MB/s");
-    }
-
-    #[test]
-    fn compute_rate_zero_elapsed() {
-        assert_eq!(compute_rate(1000, Duration::ZERO), None);
-    }
-
-    #[test]
-    fn compute_rate_valid() {
-        let rate = compute_rate(1000, Duration::from_secs(1)).unwrap();
-        assert!((rate - 1000.0).abs() < 0.001);
-    }
-
-    #[test]
-    fn compute_rate_fractional() {
-        let rate = compute_rate(500, Duration::from_millis(500)).unwrap();
-        assert!((rate - 1000.0).abs() < 0.001);
     }
 
     /// Upstream `rprint_progress` (progress.c:108-116) caps its unit scaling

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -10,13 +10,12 @@ mod render;
 pub use self::diagnostic::{DiagnosticEvent, flush_diagnostics, render_diagnostic_events};
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
 pub(crate) use self::format::{
-    VerboseRateDisplay, compute_rate, describe_event_kind, event_matches_name_level,
-    format_decimal_bytes, format_human_bytes, format_human_rate, format_list_permissions,
-    format_list_size, format_list_timestamp, format_progress_bytes, format_progress_elapsed,
-    format_progress_percent, format_progress_rate, format_progress_rate_decimal,
-    format_progress_rate_from_value, format_progress_rate_human, format_size,
-    format_stat_categories, format_summary_rate, format_verbose_rate, format_verbose_rate_decimal,
-    format_verbose_rate_human, is_progress_event, list_only_event,
+    describe_event_kind, event_matches_name_level, format_decimal_bytes, format_human_bytes,
+    format_human_rate, format_list_permissions, format_list_size, format_list_timestamp,
+    format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
+    format_progress_rate_decimal, format_progress_rate_from_value, format_progress_rate_human,
+    format_size, format_stat_categories, format_summary_rate, format_verbose_rate_human,
+    is_progress_event, list_only_event,
 };
 pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -3,10 +3,9 @@ use std::io::{self, Write};
 use core::client::{ClientEvent, ClientEventKind, ClientSummary, HumanReadableMode};
 
 use super::format::{
-    compute_rate, describe_event_kind, event_matches_name_level, format_list_permissions,
-    format_list_size, format_list_timestamp, format_progress_bytes, format_progress_elapsed,
-    format_progress_percent, format_progress_rate, format_size, format_stat_categories,
-    format_summary_rate, format_verbose_rate, is_progress_event, list_only_event,
+    event_matches_name_level, format_list_permissions, format_list_size, format_list_timestamp,
+    format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
+    format_size, format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
 };
 use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
@@ -487,39 +486,12 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             rendered.push_str(&target.to_string_lossy());
         }
 
-        if verbosity == 1 {
-            writeln!(stdout, "{rendered}")?;
-            continue;
-        }
-
-        let descriptor = describe_event_kind(kind);
-        let bytes = event.bytes_transferred();
-        if bytes > 0 {
-            let size_text = format_size(bytes, human_readable);
-            if let Some(rate) = compute_rate(bytes, event.elapsed()) {
-                let rate_display = format_verbose_rate(rate, human_readable);
-                if let Some((secondary_value, secondary_unit)) = rate_display.secondary {
-                    writeln!(
-                        stdout,
-                        "{descriptor}: {rendered} ({size_text} bytes, {} {} ({} {}))",
-                        rate_display.primary.0,
-                        rate_display.primary.1,
-                        secondary_value,
-                        secondary_unit
-                    )?;
-                } else {
-                    writeln!(
-                        stdout,
-                        "{descriptor}: {rendered} ({size_text} bytes, {} {})",
-                        rate_display.primary.0, rate_display.primary.1
-                    )?;
-                }
-            } else {
-                writeln!(stdout, "{descriptor}: {rendered} ({size_text} bytes)")?;
-            }
-        } else {
-            writeln!(stdout, "{descriptor}: {rendered}")?;
-        }
+        // upstream: log.c:log_formatted() emits the default `%n%L` per-file
+        // line at every verbosity tier (set in options.c:2372). The rendered
+        // string already includes the `-> target` suffix for symlinks; higher
+        // tiers only add ancillary log messages, never a per-file descriptor
+        // prefix or byte-count wrapper.
+        writeln!(stdout, "{rendered}")?;
     }
     Ok(())
 }

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -379,7 +379,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     verbosity: u8,
     name_level: NameOutputLevel,
     name_overridden: bool,
-    human_readable: HumanReadableMode,
+    _human_readable: HumanReadableMode,
     stdout: &mut W,
 ) -> io::Result<()> {
     if matches!(name_level, NameOutputLevel::Disabled) && (verbosity == 0 || name_overridden) {

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -688,7 +688,14 @@ fn parity_verbose_directory_names_end_with_slash() {
 }
 
 #[test]
-fn parity_verbose_v2_includes_descriptor_and_bytes() {
+fn parity_verbose_v2_emits_bare_name_per_upstream() {
+    // upstream: log.c:log_formatted() at NAME>=1 emits the default
+    // `%n%L` format set by options.c:2372 - bare name plus optional
+    // ` -> target` for symlinks or ` => hardlink` for hardlinks. Higher
+    // verbosity adds ancillary log frames, never a per-file descriptor
+    // prefix or byte-count wrapper. The upstream testsuite
+    // `duplicates.test` greps for `^<name>$` and `^<name> -> ` to detect
+    // duplicate copies, so any prefix breaks interop.
     let (summary, _temp) = create_known_summary(&[("vv.txt", b"double verbose content")]);
 
     let mut rendered = Vec::new();
@@ -711,18 +718,16 @@ fn parity_verbose_v2_includes_descriptor_and_bytes() {
     .expect("render");
     let output = String::from_utf8(rendered).expect("utf8");
 
-    // At verbosity 2, upstream rsync includes descriptors like "copied:" before filenames
-    // and byte counts for data transfers
-    let has_descriptor_line = output.lines().any(|line| {
-        line.contains("copied:")
-            || line.contains("directory:")
-            || line.contains("symlink:")
-            || line.contains("hard link:")
-    });
     assert!(
-        has_descriptor_line,
-        "verbosity 2 should include descriptor labels (e.g. 'copied:'):\n{output}"
+        output.lines().any(|line| line == "vv.txt"),
+        "verbosity 2 must emit bare `<name>` per upstream `%n%L`:\n{output}"
     );
+    for forbidden in ["copied:", "directory:", "symlink:", "hard link:"] {
+        assert!(
+            !output.contains(forbidden),
+            "verbosity 2 must not emit `{forbidden}` descriptor prefix:\n{output}"
+        );
+    }
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/progress_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/progress_format_upstream.rs
@@ -794,23 +794,3 @@ fn progress_shows_filename_before_progress_line() {
         "filename should appear before xfr# line (fname_pos={fname_pos}, xfr_pos={xfr_pos})"
     );
 }
-
-#[test]
-fn compute_rate_returns_none_for_zero_duration() {
-    use super::compute_rate;
-    assert_eq!(compute_rate(1000, Duration::ZERO), None);
-}
-
-#[test]
-fn compute_rate_returns_bytes_per_second() {
-    use super::compute_rate;
-    let rate = compute_rate(2000, Duration::from_secs(2)).unwrap();
-    assert!((rate - 1000.0).abs() < 0.01);
-}
-
-#[test]
-fn compute_rate_handles_fractional_seconds() {
-    use super::compute_rate;
-    let rate = compute_rate(500, Duration::from_millis(250)).unwrap();
-    assert!((rate - 2000.0).abs() < 0.01);
-}

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -90,7 +90,14 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
 
     let output = String::from_utf8(rendered).expect("utf8");
     assert!(output.contains("(xfr#1, to-chk="));
-    assert!(output.contains("copied:"));
+    // upstream emits bare `%n%L` per-file even at -vv (options.c:2372).
+    // Do not emit descriptor prefixes like `copied:` - upstream testsuite
+    // `duplicates.test` greps for `^name1$` to detect duplicate copies.
+    assert!(
+        !output.contains("copied:"),
+        "verbosity 2 must not prefix lines with `copied:` - upstream `duplicates.test` greps for bare `^<name>$`:\n{output}"
+    );
+    assert!(output.contains("sample.txt"));
     assert!(output.contains("sent "));
     assert!(output.contains("speedup is"));
 }

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -288,10 +288,14 @@ fn verbose_human_readable_combined_formats_sizes() {
     assert!(rendered.contains("1.54K (1,536) bytes"));
 }
 
-/// Verifies that -vv produces a descriptor-prefixed listing (e.g. "data-copied: file").
-/// At verbosity >= 2, the render layer uses `describe_event_kind` for each event.
+/// Verifies that -vv lists files using upstream's bare `%n%L` format
+/// (no `copied:`/`symlink:` descriptor prefix, no byte-count wrapper).
+/// Upstream: options.c:2372 sets `stdout_format = "%n%L"`; log.c:603-659
+/// expands `%n` to the filename and `%L` to ` -> target` for symlinks.
+/// The upstream testsuite `duplicates.test` greps `^name1$` to detect
+/// duplicate copies, so the per-file line must be bare.
 #[test]
-fn level_2_shows_descriptor_prefix() {
+fn level_2_emits_bare_name_per_upstream() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -314,13 +318,15 @@ fn level_2_shows_descriptor_prefix() {
     );
     let rendered = String::from_utf8(stdout).expect("utf8");
     assert!(
-        rendered.contains("descriptor.txt"),
-        "level 2 should list the file name, got: {rendered:?}"
+        rendered.lines().any(|line| line == "descriptor.txt"),
+        "level 2 must emit bare `<name>` per upstream `%n%L`, got: {rendered:?}"
     );
-    assert!(
-        rendered.contains("bytes"),
-        "level 2 should show byte information, got: {rendered:?}"
-    );
+    for forbidden in ["copied:", "symlink:", "hard link:", "directory:"] {
+        assert!(
+            !rendered.contains(forbidden),
+            "level 2 must not emit `{forbidden}` descriptor prefix, got: {rendered:?}"
+        );
+    }
 }
 
 /// Verifies that -vv still includes the summary totals line.
@@ -988,5 +994,56 @@ fn verbose_dry_run_with_stats_shows_statistics() {
     assert!(
         !destination.exists(),
         "dry-run should not create destination"
+    );
+}
+
+/// Mirrors the upstream `testsuite/duplicates.test` scenario: the same
+/// source directory passed multiple times must produce exactly one
+/// bare `name1` line and exactly one `name2 -> target` line on -vv stdout.
+/// The test greps `^name1$` / `^name2 -> ` to detect duplicate copies, so
+/// any prefix (`copied:`, `symlink:`) or byte-count wrapper breaks interop.
+/// Upstream: `testsuite/duplicates.test`, options.c:2372 (`stdout_format = "%n%L"`).
+#[cfg(unix)]
+#[test]
+fn duplicates_testsuite_emits_bare_name_lines() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    fs::create_dir(&from).expect("create from");
+    fs::create_dir(&to).expect("create to");
+
+    let name1 = from.join("name1");
+    let name2 = from.join("name2");
+    fs::write(&name1, b"This is the file\n").expect("write name1");
+    symlink(&name1, &name2).expect("create symlink");
+
+    let mut from_arg = from.clone().into_os_string();
+    from_arg.push("/");
+    let mut argv = vec![OsString::from(RSYNC), OsString::from("-avv")];
+    for _ in 0..10 {
+        argv.push(from_arg.clone());
+    }
+    argv.push(to.into_os_string());
+
+    let (code, stdout, _stderr) = run_with_args(argv);
+    assert_eq!(code, 0, "duplicates transfer should succeed");
+
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    let name1_lines = rendered.lines().filter(|line| *line == "name1").count();
+    let name2_lines = rendered
+        .lines()
+        .filter(|line| line.starts_with("name2 -> "))
+        .count();
+    assert_eq!(
+        name1_lines, 1,
+        "name1 must appear exactly once as a bare line, got: {rendered:?}"
+    );
+    assert_eq!(
+        name2_lines, 1,
+        "name2 must appear exactly once as `name2 -> ...`, got: {rendered:?}"
     );
 }


### PR DESCRIPTION
## Summary

- Upstream sets `stdout_format = "%n%L"` once verbosity reaches NAME>=1 (`options.c:2372`); `log_formatted()` expands that to the bare filename plus optional ` -> target` for symlinks or ` => hardlink` (`log.c:633-659`). Higher verbosity adds ancillary log messages elsewhere - it never prepends a per-file descriptor or appends a byte-count wrapper.
- The upstream `testsuite/duplicates.test` relies on this: it greps `^name1$` and `^name2 -> ` against the `-vv` output to detect duplicate copies. The previous renderer prefixed `copied:` / `symlink:` and a `(N bytes, ...)` suffix at verbosity >= 2, so every line failed the grep and the test reported `name1 was not copied exactly once`.
- Drop the descriptor prefix and rate-display wrapper in `crates/cli/src/frontend/progress/render.rs`, leaving the same bare `<name>[ -> target]` rendering already used at `-v`.

## Test plan

- [x] Update existing assertions that locked in the divergence: `progress_render::emit_transfer_summary_with_progress_and_verbose_listing`, `output_parity::parity_verbose_v2_*`, `verbose::level_2_*`.
- [x] Add `verbose::duplicates_testsuite_emits_bare_name_lines` mirroring the upstream scenario: ten copies of the source dir passed in a single `-avv` invocation must yield exactly one bare `name1` line and one `name2 -> ...` line.
- [ ] CI nextest (Linux + macOS + Windows + musl).
- [ ] CI upstream-testsuite `duplicates` cell.