### PR TITLE
feat(cli): add --reflink=auto|always|never flag mirroring upstream

### DIFF
--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -479,7 +479,10 @@ pub struct ParsedArgs {
     /// Orthogonal to `--cow` which controls FS-level reflink cloning.
     pub zero_copy_policy: fast_io::ZeroCopyPolicy,
 
-    /// `--cow` / `--no-cow` - copy-on-write reflink policy for whole-file copies.
+    /// `--cow` / `--no-cow` / `--reflink=<MODE>` - copy-on-write reflink
+    /// policy for whole-file copies. The binary `--cow`/`--no-cow` flags
+    /// map onto `Auto`/`Disabled`; the tri-state `--reflink=<MODE>` adds
+    /// the `Required` variant via `--reflink=always`.
     pub cow_policy: fast_io::CowPolicy,
 
     /// `--simd=<level>` - runtime override for SIMD checksum dispatch.

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -508,11 +508,24 @@ where
     } else {
         fast_io::ZeroCopyPolicy::Auto
     };
-    let cow_policy = if matches.get_flag("no-cow") {
-        fast_io::CowPolicy::Disabled
-    } else {
-        fast_io::CowPolicy::Auto
+    let reflink_value = matches.remove_one::<OsString>("reflink");
+    let reflink_explicit = match reflink_value {
+        Some(value) => {
+            let text = value.to_string_lossy();
+            let policy = parse_reflink_mode(text.as_ref()).ok_or_else(|| {
+                clap::Error::raw(
+                    clap::error::ErrorKind::InvalidValue,
+                    format!(
+                        "invalid value '{text}' for '--reflink <MODE>': \
+                         expected one of auto, always, never\n"
+                    ),
+                )
+            })?;
+            Some(policy)
+        }
+        None => None,
     };
+    let cow_policy = resolve_cow_policy(&matches, reflink_explicit);
     let simd_override = match matches.remove_one::<OsString>("simd") {
         Some(value) => {
             let text = value.to_string_lossy();
@@ -1021,4 +1034,76 @@ fn parse_spill_size(input: &str) -> Option<u64> {
         _ => return None,
     };
     base.checked_mul(multiplier)
+}
+
+/// Parses a `--reflink=<MODE>` value into a [`fast_io::CowPolicy`].
+///
+/// Accepted values mirror the upstream-style tri-state convention used by
+/// `git`, `cp(1)`, and other reflink-aware tools:
+///
+/// - `auto` -> [`fast_io::CowPolicy::Auto`]
+/// - `always` -> [`fast_io::CowPolicy::Required`]
+/// - `never` -> [`fast_io::CowPolicy::Disabled`]
+///
+/// Returns `None` for any other input so the caller can surface a
+/// `clap::Error` with the canonical "expected one of ..." message.
+fn parse_reflink_mode(input: &str) -> Option<fast_io::CowPolicy> {
+    match input {
+        "auto" => Some(fast_io::CowPolicy::Auto),
+        "always" => Some(fast_io::CowPolicy::Required),
+        "never" => Some(fast_io::CowPolicy::Disabled),
+        _ => None,
+    }
+}
+
+/// Resolves the final [`fast_io::CowPolicy`] from the binary
+/// `--cow`/`--no-cow` flags and the optional tri-state `--reflink` value.
+///
+/// The flag that appears last on the command line wins, matching upstream
+/// rsync's left-to-right option processing. When neither `--cow` nor
+/// `--no-cow` is present the `--reflink` value is used directly; when
+/// no form is present the default is [`fast_io::CowPolicy::Auto`].
+///
+/// `--cow` and `--no-cow` share a `clap::overrides_with` pair so only the
+/// later of the two is "present" in matches; we use its index to compare
+/// against the `--reflink` index.
+fn resolve_cow_policy(
+    matches: &clap::ArgMatches,
+    reflink_explicit: Option<fast_io::CowPolicy>,
+) -> fast_io::CowPolicy {
+    let reflink_index = last_occurrence(matches, "reflink");
+
+    let (binary_policy, binary_index) = if matches.get_flag("no-cow") {
+        (
+            Some(fast_io::CowPolicy::Disabled),
+            last_occurrence(matches, "no-cow"),
+        )
+    } else if matches.get_flag("cow") {
+        (
+            Some(fast_io::CowPolicy::Auto),
+            last_occurrence(matches, "cow"),
+        )
+    } else {
+        (None, None)
+    };
+
+    match (reflink_explicit, binary_policy) {
+        (None, None) => fast_io::CowPolicy::Auto,
+        (Some(reflink), None) => reflink,
+        (None, Some(binary)) => binary,
+        (Some(reflink), Some(binary)) => match (reflink_index, binary_index) {
+            (Some(r), Some(b)) if r >= b => reflink,
+            (Some(_), Some(_)) => binary,
+            (Some(_), None) => reflink,
+            (None, Some(_)) => binary,
+            (None, None) => reflink,
+        },
+    }
+}
+
+/// Returns the highest argument index for a given flag id, mirroring the
+/// helper in [`self::flags`]. Inlined here to avoid widening the visibility
+/// of the existing private helper.
+fn last_occurrence(matches: &clap::ArgMatches, id: &str) -> Option<usize> {
+    matches.indices_of(id).and_then(Iterator::max)
 }

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -834,3 +834,70 @@ fn no_spill_combines_with_spill_dir_and_threshold() {
     );
     assert_eq!(parsed.spill_threshold_bytes, Some(64 * 1024));
 }
+
+/// `--reflink` defaults to `auto`, which surfaces as
+/// [`fast_io::CowPolicy::Auto`] so the existing default reflink path is
+/// preserved when neither the binary nor the tri-state form is given.
+#[test]
+fn reflink_default_is_auto() {
+    let parsed = parse_test_args(["src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Auto);
+}
+
+#[test]
+fn reflink_auto_parses() {
+    let parsed = parse_test_args(["--reflink=auto", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Auto);
+}
+
+#[test]
+fn reflink_always_parses_to_required() {
+    let parsed = parse_test_args(["--reflink=always", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Required);
+}
+
+#[test]
+fn reflink_never_parses_to_disabled() {
+    let parsed = parse_test_args(["--reflink=never", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Disabled);
+}
+
+/// Any value outside the tri-state vocabulary must fail at parse time
+/// with the canonical "expected one of ..." error message.
+#[test]
+fn reflink_bogus_value_errors_at_parse_time() {
+    let err = parse_test_args(["--reflink=bogus", "src/", "dst/"]).expect_err("parse must fail");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("--reflink"),
+        "error must mention the flag: {rendered}"
+    );
+    assert!(
+        rendered.contains("auto") && rendered.contains("always") && rendered.contains("never"),
+        "error must list valid values: {rendered}"
+    );
+}
+
+/// `--reflink` after `--cow`/`--no-cow` wins, matching upstream
+/// left-to-right option processing.
+#[test]
+fn reflink_after_binary_form_overrides() {
+    let parsed = parse_test_args(["--no-cow", "--reflink=always", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Required);
+}
+
+/// `--no-cow` after `--reflink=always` wins.
+#[test]
+fn binary_form_after_reflink_overrides() {
+    let parsed = parse_test_args(["--reflink=always", "--no-cow", "src/", "dst/"]).expect("parse");
+    assert_eq!(parsed.cow_policy, fast_io::CowPolicy::Disabled);
+}
+
+/// `--reflink=never` is wire-equivalent to `--no-cow` once parsed.
+#[test]
+fn reflink_never_matches_no_cow() {
+    let from_reflink =
+        parse_test_args(["--reflink=never", "src/", "dst/"]).expect("parse reflink form");
+    let from_binary = parse_test_args(["--no-cow", "src/", "dst/"]).expect("parse binary form");
+    assert_eq!(from_reflink.cow_policy, from_binary.cow_policy);
+}

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -257,6 +257,22 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .overrides_with("cow"),
             )
             .arg(
+                Arg::new("reflink")
+                    .long("reflink")
+                    .value_name("MODE")
+                    .help(
+                        "Copy-on-write reflink policy for whole-file copies. \
+                         MODE is one of auto (default; clone when supported, \
+                         fall back to std::fs::copy otherwise), always \
+                         (require a reflink and fail when the destination \
+                         filesystem cannot honour it), or never (always use \
+                         the portable std::fs::copy fallback). Equivalent to \
+                         the --cow/--no-cow binary form; the last of \
+                         --cow/--no-cow/--reflink on the command line wins.",
+                    )
+                    .value_parser(OsStringValueParser::new()),
+            )
+            .arg(
                 Arg::new("zero-copy")
                     .long("zero-copy")
                     .help(

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -21,7 +21,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--force, --no-force, --fuzzy/-y, --no-fuzzy, --msgs2stderr, --no-msgs2stderr, --8-bit-output, --outbuf, ",
     "--itemize-changes/-i, --no-itemize-changes, --out-format, --stats, --partial, --no-partial, --partial-dir, --temp-dir, --log-file, ",
     "--log-file-format, --delay-updates, --no-delay-updates, --whole-file/-W, --no-whole-file, --xxh64-dedup, --remove-source-files, ",
-    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --no-io-uring-sqpoll, --io-uring-depth, --io-uring-status, --lsm-status, --simd, --cow, --no-cow, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
+    "--remove-sent-files, --append, --no-append, --append-verify, --preallocate, --fsync, --io-uring, --no-io-uring, --no-io-uring-sqpoll, --io-uring-depth, --io-uring-status, --lsm-status, --simd, --cow, --no-cow, --reflink, --zero-copy, --no-zero-copy, --inplace, --no-inplace, ",
     "--human-readable/-h, --no-human-readable, -P, --sparse/-S, --no-sparse/--no-S, --sparse-detect, --links/-l, --no-links/--no-l, ",
     "--copy-links/-L, ",
     "--copy-unsafe-links, --safe-links, --copy-dirlinks/-k, --keep-dirlinks/-K, ",

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -154,6 +154,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --simd=LEVEL Force the SIMD level used by checksum dispatch (auto, avx512, avx2, sse4, neon, none).\n",
             "      --cow        Allow copy-on-write reflinks for whole-file copies (default).\n",
             "      --no-cow     Disable copy-on-write reflinks; always use the portable std::fs::copy fallback.\n",
+            "      --reflink=MODE Copy-on-write reflink policy (auto, always, never).\n",
             "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range; io_uring SEND_ZC only when built with the iouring-send-zc cargo feature, otherwise downgrades to plain io_uring SEND) when supported by the kernel. This is the default (policy=auto/enabled).\n",
             "      --no-zero-copy  Disable I/O-level zero-copy; route through portable userspace read/write loops. Does not affect filesystem-level reflink/CoW cloning.\n",
             "      --inplace    Write updated data directly to destination files.\n",

--- a/crates/cli/tests/reflink_flag.rs
+++ b/crates/cli/tests/reflink_flag.rs
@@ -1,0 +1,74 @@
+//! Integration coverage for `--reflink=<MODE>`.
+//!
+//! Verifies that the tri-state CLI flag parses to the matching
+//! [`fast_io::CowPolicy`] variant, that the binary `--cow`/`--no-cow`
+//! form remains observable through the same field, and that an invalid
+//! value is rejected at parse time so misuse is caught before any I/O
+//! happens.
+
+use cli::test_utils::parse_args;
+
+/// `--reflink=auto` parses cleanly and is wire-equivalent to the default
+/// when no other reflink-related flag is on the command line.
+#[test]
+fn reflink_auto_parses() {
+    let args = parse_args(["oc-rsync", "--reflink=auto", "src", "dst"]).expect("parse");
+    assert_eq!(args.cow_policy, fast_io::CowPolicy::Auto);
+
+    let default = parse_args(["oc-rsync", "src", "dst"]).expect("parse default");
+    assert_eq!(default.cow_policy, args.cow_policy);
+}
+
+/// `--reflink=always` parses to `CowPolicy::Required`, the
+/// no-silent-fallback variant.
+#[test]
+fn reflink_always_parses_to_required() {
+    let args = parse_args(["oc-rsync", "--reflink=always", "src", "dst"]).expect("parse");
+    assert_eq!(args.cow_policy, fast_io::CowPolicy::Required);
+}
+
+/// `--reflink=never` parses to `CowPolicy::Disabled`, equivalent to the
+/// existing `--no-cow` binary form.
+#[test]
+fn reflink_never_parses_to_disabled() {
+    let args = parse_args(["oc-rsync", "--reflink=never", "src", "dst"]).expect("parse");
+    assert_eq!(args.cow_policy, fast_io::CowPolicy::Disabled);
+
+    let from_binary =
+        parse_args(["oc-rsync", "--no-cow", "src", "dst"]).expect("parse binary form");
+    assert_eq!(args.cow_policy, from_binary.cow_policy);
+}
+
+/// Any non-tri-state value must fail at parse time with a message that
+/// names the flag and lists the valid values. This catches typos before
+/// any filesystem work and matches the same error shape used by
+/// `--simd=<LEVEL>`.
+#[test]
+fn reflink_bogus_value_rejected() {
+    let err = parse_args(["oc-rsync", "--reflink=sometimes", "src", "dst"])
+        .expect_err("bogus value must error");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("--reflink"),
+        "error must name the flag: {rendered}"
+    );
+    assert!(
+        rendered.contains("auto") && rendered.contains("always") && rendered.contains("never"),
+        "error must list valid values: {rendered}"
+    );
+}
+
+/// When both `--reflink` and the binary `--cow`/`--no-cow` form appear,
+/// the one later on the command line wins. This mirrors upstream rsync's
+/// left-to-right option processing and matches the existing
+/// `--cow`/`--no-cow` precedence.
+#[test]
+fn last_occurrence_wins_between_reflink_and_binary_form() {
+    let reflink_last =
+        parse_args(["oc-rsync", "--no-cow", "--reflink=always", "src", "dst"]).expect("parse");
+    assert_eq!(reflink_last.cow_policy, fast_io::CowPolicy::Required);
+
+    let binary_last =
+        parse_args(["oc-rsync", "--reflink=always", "--no-cow", "src", "dst"]).expect("parse");
+    assert_eq!(binary_last.cow_policy, fast_io::CowPolicy::Disabled);
+}

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -459,10 +459,13 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         }
     }
 
-    /// Swaps the platform copy strategy when `--no-cow` is in effect.
+    /// Swaps the platform copy strategy when `--no-cow` / `--reflink=never`
+    /// or `--reflink=always` is in effect.
     fn apply_cow_policy(options: LocalCopyOptions, config: &ClientConfig) -> LocalCopyOptions {
         match config.cow_policy() {
             fast_io::CowPolicy::Auto => options,
+            fast_io::CowPolicy::Required => options
+                .with_platform_copy(std::sync::Arc::new(fast_io::RequireCowPlatformCopy::new())),
             fast_io::CowPolicy::Disabled => {
                 options.with_platform_copy(std::sync::Arc::new(fast_io::NoCowPlatformCopy::new()))
             }
@@ -825,6 +828,31 @@ mod cow_policy_wiring_tests {
         assert_eq!(
             options.platform_copy().preferred_method(1024 * 1024 * 1024),
             fast_io::CopyMethod::StandardCopy
+        );
+    }
+
+    /// `--reflink=always` (`CowPolicy::Required`) must install the
+    /// adapter that surfaces an error when the destination filesystem
+    /// cannot honour the reflink request. The preferred method must
+    /// match the platform reflink primitive so callers that inspect
+    /// the trait surface observe the hard-required path.
+    #[test]
+    fn required_policy_installs_require_cow_strategy() {
+        let config = config_with_cow(fast_io::CowPolicy::Required);
+        let options = build_local_copy_options(&config, None);
+        let expected = if cfg!(target_os = "linux") {
+            fast_io::CopyMethod::Ficlone
+        } else if cfg!(target_os = "macos") {
+            fast_io::CopyMethod::Clonefile
+        } else if cfg!(target_os = "windows") {
+            fast_io::CopyMethod::ReFsReflink
+        } else {
+            fast_io::CopyMethod::StandardCopy
+        };
+        assert_eq!(options.platform_copy().preferred_method(0), expected);
+        assert_eq!(
+            options.platform_copy().preferred_method(1024 * 1024 * 1024),
+            expected
         );
     }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -294,8 +294,8 @@ pub use page_aligned::{PageAlignedBuffer, page_size, round_up_to_page};
 pub use parallel::{ParallelExecutor, ParallelResult};
 pub use platform_copy::{
     CopyMethod, CopyResult, DefaultPlatformCopy, NoCowPlatformCopy, NoZeroCopyPlatformCopy,
-    PlatformCopy, try_clonefile, try_fcopyfile, try_ficlone, try_refs_reflink,
-    try_refs_reflink_range,
+    PlatformCopy, RequireCowPlatformCopy, try_clonefile, try_fcopyfile, try_ficlone,
+    try_refs_reflink, try_refs_reflink_range,
 };
 pub use platform_sendfile::{
     LinuxSendFile, MacOsSendFile, PlatformSendFile, SocketHandle, UnsupportedSendFile,

--- a/crates/fast_io/src/platform_copy/mod.rs
+++ b/crates/fast_io/src/platform_copy/mod.rs
@@ -53,6 +53,7 @@ mod cow_detect;
 mod cow_detect;
 mod dispatch;
 mod no_zero_copy;
+mod require_cow;
 #[cfg(test)]
 mod tests;
 mod types;
@@ -61,6 +62,7 @@ use std::io;
 use std::path::Path;
 
 pub use no_zero_copy::NoZeroCopyPlatformCopy;
+pub use require_cow::RequireCowPlatformCopy;
 pub use types::{CopyMethod, CopyResult, PlatformCopy};
 
 /// Default platform copy implementation with automatic mechanism selection.

--- a/crates/fast_io/src/platform_copy/require_cow.rs
+++ b/crates/fast_io/src/platform_copy/require_cow.rs
@@ -1,0 +1,197 @@
+//! Adapter that requires a copy-on-write reflink for whole-file copies.
+//!
+//! Wraps the platform reflink primitives (`FICLONE`/`copy_file_range` on
+//! Linux, `clonefile` on macOS, `FSCTL_DUPLICATE_EXTENTS_TO_FILE` on
+//! Windows ReFS) and surfaces the underlying error when the platform
+//! reflink attempt fails instead of falling back to the portable
+//! [`std::fs::copy`] loop. Selected by the
+//! [`CowPolicy::Required`](crate::CowPolicy::Required) variant when
+//! callers want a hard guarantee that destinations share blocks with
+//! their sources (snapshot dedup, container layer builds).
+//!
+//! Mirrors the structure of [`NoZeroCopyPlatformCopy`](super::NoZeroCopyPlatformCopy)
+//! and [`NoCowPlatformCopy`](super::NoCowPlatformCopy): the policy enum
+//! lives in `lib.rs` and concrete adapters in `platform_copy/` swap into
+//! the engine's [`LocalCopyOptions`](../../../engine/index.html) through
+//! `with_platform_copy`.
+
+use std::fmt;
+use std::io;
+use std::path::Path;
+
+use super::dispatch;
+use super::types::{CopyMethod, CopyResult, PlatformCopy};
+
+/// `PlatformCopy` adapter that forces a CoW reflink and surfaces the
+/// platform error when reflink is unavailable.
+///
+/// Used when [`CowPolicy::Required`](crate::CowPolicy::Required) is in
+/// effect. Returns [`io::ErrorKind::Unsupported`] (or the underlying
+/// platform error) instead of falling back to [`std::fs::copy`] so the
+/// caller observes a hard failure when the destination filesystem cannot
+/// honour the reflink request.
+#[derive(Default)]
+pub struct RequireCowPlatformCopy;
+
+impl RequireCowPlatformCopy {
+    /// Creates a new `RequireCowPlatformCopy` adapter.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl fmt::Debug for RequireCowPlatformCopy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RequireCowPlatformCopy")
+    }
+}
+
+impl PlatformCopy for RequireCowPlatformCopy {
+    fn copy_file(&self, src: &Path, dst: &Path, _size_hint: u64) -> io::Result<CopyResult> {
+        copy_via_reflink(src, dst)
+    }
+
+    fn supports_reflink(&self) -> bool {
+        dispatch::platform_supports_reflink()
+    }
+
+    fn preferred_method(&self, _size: u64) -> CopyMethod {
+        preferred_reflink_method()
+    }
+}
+
+/// Linux: require `FICLONE`. No fallback to `copy_file_range` or
+/// `std::fs::copy`.
+#[cfg(target_os = "linux")]
+fn copy_via_reflink(src: &Path, dst: &Path) -> io::Result<CopyResult> {
+    match dispatch::try_ficlone_impl(src, dst) {
+        Ok(()) => Ok(CopyResult::new(0, CopyMethod::Ficlone)),
+        Err(err) => {
+            let _ = std::fs::remove_file(dst);
+            Err(err)
+        }
+    }
+}
+
+/// macOS: require `clonefile`. No fallback to `fcopyfile` or
+/// `std::fs::copy`.
+#[cfg(target_os = "macos")]
+fn copy_via_reflink(src: &Path, dst: &Path) -> io::Result<CopyResult> {
+    match dispatch::clonefile_impl(src, dst) {
+        Ok(()) => Ok(CopyResult::new(0, CopyMethod::Clonefile)),
+        Err(err) => {
+            let _ = std::fs::remove_file(dst);
+            Err(err)
+        }
+    }
+}
+
+/// Windows: require `FSCTL_DUPLICATE_EXTENTS_TO_FILE` on a ReFS volume.
+/// No fallback to `CopyFileExW` or `std::fs::copy`.
+#[cfg(target_os = "windows")]
+fn copy_via_reflink(src: &Path, dst: &Path) -> io::Result<CopyResult> {
+    match dispatch::try_refs_reflink_impl(src, dst) {
+        Ok(()) => Ok(CopyResult::new(0, CopyMethod::ReFsReflink)),
+        Err(err) => {
+            let _ = std::fs::remove_file(dst);
+            Err(err)
+        }
+    }
+}
+
+/// Other platforms: reflink is not supported.
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn copy_via_reflink(_src: &Path, _dst: &Path) -> io::Result<CopyResult> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "copy-on-write reflinks are not supported on this platform",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+const fn preferred_reflink_method() -> CopyMethod {
+    CopyMethod::Ficlone
+}
+
+#[cfg(target_os = "macos")]
+const fn preferred_reflink_method() -> CopyMethod {
+    CopyMethod::Clonefile
+}
+
+#[cfg(target_os = "windows")]
+const fn preferred_reflink_method() -> CopyMethod {
+    CopyMethod::ReFsReflink
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+const fn preferred_reflink_method() -> CopyMethod {
+    CopyMethod::StandardCopy
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn debug_impl_is_concise() {
+        let copier = RequireCowPlatformCopy::new();
+        assert_eq!(format!("{copier:?}"), "RequireCowPlatformCopy");
+    }
+
+    #[test]
+    fn preferred_method_matches_platform_reflink_primitive() {
+        let copier = RequireCowPlatformCopy::new();
+        assert_eq!(copier.preferred_method(0), preferred_reflink_method());
+        assert_eq!(
+            copier.preferred_method(64 * 1024 * 1024),
+            preferred_reflink_method()
+        );
+    }
+
+    /// On platforms without a reflink primitive, every copy must surface
+    /// `Unsupported` instead of falling through to `std::fs::copy`.
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    #[test]
+    fn copy_surfaces_unsupported_on_unsupported_platform() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.bin");
+        let dst = dir.path().join("dst.bin");
+        std::fs::write(&src, b"payload").unwrap();
+
+        let copier = RequireCowPlatformCopy::new();
+        let err = copier.copy_file(&src, &dst, 7).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert!(!dst.exists());
+    }
+
+    /// When a reflink primitive exists but the underlying filesystem
+    /// does not support it (the common /tmp + tmpfs case on Linux CI
+    /// and most non-APFS macOS test runners), the adapter must surface
+    /// the platform error rather than silently completing via the
+    /// portable copy path. Smoke-test the failure mode opportunistically
+    /// so we do not depend on a specific filesystem being mounted.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn copy_either_clones_or_surfaces_error() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.bin");
+        let dst = dir.path().join("dst.bin");
+        std::fs::write(&src, b"payload").unwrap();
+
+        let copier = RequireCowPlatformCopy::new();
+        match copier.copy_file(&src, &dst, 7) {
+            Ok(result) => {
+                // Reflink succeeded: destination must mirror source.
+                assert_eq!(result.method, preferred_reflink_method());
+                assert_eq!(std::fs::read(&dst).unwrap(), b"payload");
+            }
+            Err(_) => {
+                // Reflink failed: destination must not exist (the adapter
+                // cleans up the half-created file).
+                assert!(!dst.exists());
+            }
+        }
+    }
+}

--- a/crates/fast_io/src/policy.rs
+++ b/crates/fast_io/src/policy.rs
@@ -159,17 +159,26 @@ impl IoUringPolicy {
 /// fallback. Useful for benchmarking, diagnostics, or when downstream
 /// tooling does not handle reflinks correctly.
 ///
-/// The `--cow` (default) and `--no-cow` CLI flags map onto this enum:
-/// - `--cow` selects [`CowPolicy::Auto`].
-/// - `--no-cow` selects [`CowPolicy::Disabled`].
+/// Two CLI surfaces drive this enum:
+///
+/// - `--cow` / `--no-cow` is the binary opt-in/opt-out:
+///   - `--cow` selects [`CowPolicy::Auto`].
+///   - `--no-cow` selects [`CowPolicy::Disabled`].
+/// - `--reflink=<MODE>` is the tri-state form:
+///   - `--reflink=auto` selects [`CowPolicy::Auto`].
+///   - `--reflink=always` selects [`CowPolicy::Required`].
+///   - `--reflink=never` selects [`CowPolicy::Disabled`].
 ///
 /// The default is [`CowPolicy::Auto`], which delegates to
 /// [`platform_copy::DefaultPlatformCopy`] and uses the best available reflink
 /// mechanism with portable fallback.
 ///
-/// Unlike [`BackendPolicy`], reflink is best-effort: there is no `Enabled`
-/// variant because forcing reflink without filesystem support would have no
-/// useful semantics. The two-variant shape keeps this distinction explicit.
+/// [`CowPolicy::Required`] forces every whole-file copy through a CoW
+/// reflink and surfaces the underlying error when the destination
+/// filesystem does not support it (no silent fallback). Use it when a
+/// downstream guarantee depends on block sharing (snapshot dedup,
+/// container layer builds) and a portable `std::fs::copy` fallback would
+/// silently violate that guarantee.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CowPolicy {
     /// Auto-detect reflink support and use it when available (default).
@@ -178,6 +187,14 @@ pub enum CowPolicy {
     /// available copy mechanism per platform with portable fallback.
     #[default]
     Auto,
+    /// Require copy-on-write reflinks; fail when the destination
+    /// filesystem cannot honour the request.
+    ///
+    /// Selected by `--reflink=always`. Mirrors `BackendPolicy::Enabled`
+    /// semantics: the copy returns an error instead of falling back to
+    /// the portable `std::fs::copy` path when the platform reflink
+    /// attempt reports `ErrorKind::Unsupported` (or any other failure).
+    Required,
     /// Disable copy-on-write reflinks; always use portable `std::fs::copy`.
     ///
     /// Forces every whole-file copy through the standard buffered fallback,
@@ -432,7 +449,12 @@ mod tests {
 
     #[test]
     fn cow_policy_variants_are_distinct() {
-        assert_ne!(CowPolicy::Auto, CowPolicy::Disabled);
+        let variants = [CowPolicy::Auto, CowPolicy::Required, CowPolicy::Disabled];
+        for (i, a) in variants.iter().enumerate() {
+            for b in &variants[i + 1..] {
+                assert_ne!(a, b, "{a:?} must differ from {b:?}");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Exposes the existing `CowPolicy` `auto`/`disabled` split through a new tri-state CLI flag `--reflink=<MODE>`, with `auto`, `always`, and `never` values mirroring the convention used by `git`, `cp(1)`, and other reflink-aware tools.
- Adds a new `CowPolicy::Required` variant plus a matching `RequireCowPlatformCopy` strategy that forces a CoW clone (`FICLONE` / `clonefile` / ReFS `FSCTL_DUPLICATE_EXTENTS`) and surfaces the platform error when the destination filesystem cannot honour it, instead of silently falling back to `std::fs::copy`.
- Keeps the existing `--cow`/`--no-cow` binary flags intact; when both forms appear on the command line the later one wins, matching upstream rsync's left-to-right option processing.

## Wiring

`--reflink=auto`   -> `CowPolicy::Auto` (default platform copy chain).
`--reflink=always` -> `CowPolicy::Required` (`RequireCowPlatformCopy`; hard fail on `ErrorKind::Unsupported`).
`--reflink=never`  -> `CowPolicy::Disabled` (wire-equivalent to `--no-cow`; installs `NoCowPlatformCopy`).

The value flows CLI -> `ParsedArgs::cow_policy` -> `ClientConfig::cow_policy()` -> `apply_cow_policy()` in `core::client::run`, which swaps the `LocalCopyOptions::platform_copy` strategy. No wire-protocol impact.

## Test plan

- [x] `cargo fmt --all` clean
- [x] New parser unit tests in `crates/cli/src/frontend/arguments/parser/tests.rs` cover default, `auto`, `always`, `never`, bogus-value error, and last-occurrence precedence between `--reflink` and `--cow`/`--no-cow`.
- [x] New integration tests in `crates/cli/tests/reflink_flag.rs` cover the same matrix end-to-end via `cli::test_utils::parse_args`.
- [x] New strategy tests in `crates/fast_io/src/platform_copy/require_cow.rs` cover the `Required` path: on platforms without a reflink primitive every copy must surface `ErrorKind::Unsupported`; on Linux/macOS the adapter either clones or surfaces an error with no temp file left behind.
- [x] New core wiring test confirms `CowPolicy::Required` installs `RequireCowPlatformCopy` with the expected per-platform `preferred_method`.
- [ ] CI (fmt+clippy, nextest, Windows/macOS/Linux musl)