### PR TITLE
feat(fast_io): runtime CoW filesystem detection on Linux for FICLONE

### DIFF
--- a/crates/fast_io/src/platform_copy/cow_detect.rs
+++ b/crates/fast_io/src/platform_copy/cow_detect.rs
@@ -1,0 +1,227 @@
+//! Runtime detection of copy-on-write (CoW) filesystem support on Linux.
+//!
+//! REFLINK-2 helper. Linux `FICLONE`/`FICLONERANGE` only succeed on
+//! reflink-capable filesystems (btrfs, XFS with `mkfs.xfs -m reflink=1`,
+//! bcachefs). Every other filesystem returns `EOPNOTSUPP` or `EXDEV`,
+//! costing one round-trip syscall plus a destination-file create/unlink
+//! per failed probe. This module exposes a cheap `statfs(2)` probe that
+//! short-circuits the FICLONE attempt when the filesystem is known not
+//! to support reflinks.
+//!
+//! Detection rules (`f_type` magic per Linux super-block):
+//!
+//! - btrfs (`0x9123683E`) and bcachefs (`0xCA451A4E`) unambiguously
+//!   support reflink at the kernel level. Returns
+//!   [`CowSupport::Yes`].
+//! - XFS (`0x58465342`) supports reflink only when the volume was
+//!   formatted with `-m reflink=1`. There is no cheap runtime probe
+//!   short of `FICLONE` itself, so this layer returns
+//!   [`CowSupport::Probable`] and lets the caller run a single
+//!   FICLONE attempt to confirm. The first-attempt outcome is cached
+//!   per-device, so subsequent files on the same mountpoint pay no
+//!   extra syscall.
+//! - ext4 / tmpfs / proc / sysfs / NFS / FUSE / etc.: known not to
+//!   support reflink. Returns [`CowSupport::No`] so the dispatch
+//!   skips FICLONE entirely.
+//!
+//! The detection result is cached in a process-wide
+//! [`OnceLock<Mutex<HashMap>>`] keyed by the `(dev_major, dev_minor)`
+//! tuple from `statfs.f_fsid` so repeated copies on the same mount
+//! only pay the `statfs` cost once.
+
+#![cfg(target_os = "linux")]
+
+use std::collections::HashMap;
+use std::io;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+/// Outcome of a CoW filesystem probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CowSupport {
+    /// Filesystem unambiguously supports reflink. The caller should
+    /// attempt `FICLONE` and treat failure as a real error.
+    Yes,
+    /// Filesystem does not support reflink. The caller should skip
+    /// `FICLONE` entirely and fall through to the next dispatch tier
+    /// (e.g. `copy_file_range` on Linux).
+    No,
+    /// Filesystem may support reflink but cannot be determined from
+    /// `f_type` alone (XFS requires `-m reflink=1` at mkfs time).
+    /// The caller should attempt a single `FICLONE` probe and cache
+    /// the result.
+    Probable,
+}
+
+const BTRFS_SUPER_MAGIC: i64 = 0x9123_683E;
+const XFS_SUPER_MAGIC: i64 = 0x5846_5342;
+const BCACHEFS_SUPER_MAGIC: i64 = 0xCA45_1A4E;
+
+/// Returns the CoW support classification for the filesystem
+/// containing `path`.
+///
+/// Calls `statfs(2)` and inspects `f_type`. The result is computed
+/// once per `(dev, fs_type)` and cached in a process-wide map keyed
+/// by the `statfs.f_fsid` returned by the kernel so subsequent calls
+/// for the same mountpoint return without a syscall.
+///
+/// # Errors
+///
+/// Returns the underlying `io::Error` if `statfs(2)` fails (e.g.
+/// `ENOENT` when `path` does not exist, `EACCES` when the directory
+/// is unreadable).
+pub fn detect_cow_support(path: &Path) -> io::Result<CowSupport> {
+    let (fs_id, fs_type) = statfs_for_path(path)?;
+    let cache = cache();
+    if let Some(cached) = lookup(cache, fs_id) {
+        return Ok(cached);
+    }
+    let support = classify(fs_type);
+    insert(cache, fs_id, support);
+    Ok(support)
+}
+
+/// Records the outcome of a confirming FICLONE probe so later callers
+/// for the same mountpoint can skip the syscall when the probe
+/// failed (or treat it as cached success when it worked).
+///
+/// Intended for use by the dispatch layer after a `Probable` result
+/// from [`detect_cow_support`] has been confirmed (or refuted) by a
+/// single FICLONE attempt. Idempotent - subsequent calls on the same
+/// key overwrite the previous value.
+///
+/// # Errors
+///
+/// Returns the underlying `io::Error` if `statfs(2)` fails.
+pub fn record_probe_outcome(path: &Path, outcome: CowSupport) -> io::Result<()> {
+    let (fs_id, _) = statfs_for_path(path)?;
+    insert(cache(), fs_id, outcome);
+    Ok(())
+}
+
+fn classify(fs_type: i64) -> CowSupport {
+    match fs_type {
+        BTRFS_SUPER_MAGIC | BCACHEFS_SUPER_MAGIC => CowSupport::Yes,
+        XFS_SUPER_MAGIC => CowSupport::Probable,
+        _ => CowSupport::No,
+    }
+}
+
+type Cache = OnceLock<Mutex<HashMap<u64, CowSupport>>>;
+
+fn cache() -> &'static Cache {
+    static CACHE: Cache = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    &CACHE
+}
+
+fn lookup(cache: &Cache, fs_id: u64) -> Option<CowSupport> {
+    let guard = cache.get()?.lock().ok()?;
+    guard.get(&fs_id).copied()
+}
+
+fn insert(cache: &Cache, fs_id: u64, support: CowSupport) {
+    let Some(lock) = cache.get() else {
+        return;
+    };
+    if let Ok(mut guard) = lock.lock() {
+        guard.insert(fs_id, support);
+    }
+}
+
+#[allow(unsafe_code)]
+fn statfs_for_path(path: &Path) -> io::Result<(u64, i64)> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let cpath = CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    // SAFETY: `cpath` is a NUL-terminated C string owned for the call
+    // and `buf` is a stack-resident `libc::statfs` whose address is
+    // valid for the duration of the syscall. Standard `libc::statfs`
+    // invocation idiom (mirrors `looks_like_nfs` in
+    // `engine/benches/per_op_thresholds.rs`).
+    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::statfs(cpath.as_ptr(), &mut buf) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let fs_id = fsid_to_u64(&buf.f_fsid);
+    Ok((fs_id, buf.f_type as i64))
+}
+
+#[allow(unsafe_code)]
+fn fsid_to_u64(fsid: &libc::fsid_t) -> u64 {
+    // SAFETY: `libc::fsid_t` is a POD wrapper around `[i32; 2]` (glibc)
+    // or `[c_int; 2]` (musl); both are 8 bytes total with no padding.
+    // Reading the bytes as a `u64` is well-defined for any bit pattern.
+    let bytes: [u8; 8] = unsafe { std::mem::transmute_copy(fsid) };
+    u64::from_ne_bytes(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp_dir() -> PathBuf {
+        std::env::temp_dir()
+    }
+
+    #[test]
+    fn detect_handles_tmpdir_without_error() {
+        let support = detect_cow_support(&tmp_dir()).expect("statfs on tmpdir");
+        // tmpdir is typically tmpfs (No) or btrfs (Yes); Probable would
+        // indicate XFS-backed /tmp which is rare but legal. All three
+        // are valid outcomes - the test only asserts the probe runs.
+        assert!(matches!(
+            support,
+            CowSupport::Yes | CowSupport::No | CowSupport::Probable
+        ));
+    }
+
+    #[test]
+    fn detect_handles_root_without_error() {
+        let support = detect_cow_support(Path::new("/")).expect("statfs on /");
+        assert!(matches!(
+            support,
+            CowSupport::Yes | CowSupport::No | CowSupport::Probable
+        ));
+    }
+
+    #[test]
+    fn detect_cache_is_consistent_for_repeated_calls() {
+        let path = tmp_dir();
+        let first = detect_cow_support(&path).expect("first probe");
+        let second = detect_cow_support(&path).expect("second probe");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn detect_returns_enoent_for_missing_path() {
+        let err = detect_cow_support(Path::new("/nonexistent-cow-detect-target"))
+            .expect_err("missing path should error");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn classify_known_magics() {
+        assert_eq!(classify(BTRFS_SUPER_MAGIC), CowSupport::Yes);
+        assert_eq!(classify(BCACHEFS_SUPER_MAGIC), CowSupport::Yes);
+        assert_eq!(classify(XFS_SUPER_MAGIC), CowSupport::Probable);
+        // ext4 (0xEF53), tmpfs (0x01021994), proc (0x9fa0): all No.
+        assert_eq!(classify(0xEF53), CowSupport::No);
+        assert_eq!(classify(0x0102_1994), CowSupport::No);
+        assert_eq!(classify(0x9fa0), CowSupport::No);
+    }
+
+    #[test]
+    fn record_probe_outcome_overrides_classification() {
+        let path = tmp_dir();
+        // Force a cache entry to No, then verify lookup returns it
+        // regardless of the underlying filesystem magic.
+        record_probe_outcome(&path, CowSupport::No).expect("record outcome");
+        let after = detect_cow_support(&path).expect("post-record probe");
+        assert_eq!(after, CowSupport::No);
+    }
+}

--- a/crates/fast_io/src/platform_copy/cow_detect.rs
+++ b/crates/fast_io/src/platform_copy/cow_detect.rs
@@ -29,8 +29,6 @@
 //! tuple from `statfs.f_fsid` so repeated copies on the same mount
 //! only pay the `statfs` cost once.
 
-#![cfg(target_os = "linux")]
-
 use std::collections::HashMap;
 use std::io;
 use std::path::Path;

--- a/crates/fast_io/src/platform_copy/cow_detect_stub.rs
+++ b/crates/fast_io/src/platform_copy/cow_detect_stub.rs
@@ -1,0 +1,59 @@
+//! Non-Linux stub for [`super::cow_detect`].
+//!
+//! macOS and Windows have their own CoW dispatch paths (`clonefile`,
+//! `FSCTL_DUPLICATE_EXTENTS_TO_FILE`) with platform-specific runtime
+//! detection elsewhere in this crate. This stub keeps the
+//! cross-platform call signature uniform so callers in
+//! `platform_copy::dispatch` do not need extra `#[cfg]` branches at
+//! every site - the helper simply returns `No` so the Linux-only
+//! FICLONE branch is skipped.
+
+#![cfg(not(target_os = "linux"))]
+
+use std::io;
+use std::path::Path;
+
+/// Stub mirror of the Linux [`super::cow_detect::CowSupport`] enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CowSupport {
+    /// Unreachable on non-Linux but kept for API symmetry.
+    Yes,
+    /// Always returned on non-Linux platforms.
+    No,
+    /// Unreachable on non-Linux but kept for API symmetry.
+    Probable,
+}
+
+/// Always returns [`CowSupport::No`] on non-Linux.
+///
+/// # Errors
+///
+/// Never errors on the stub path.
+pub fn detect_cow_support(_path: &Path) -> io::Result<CowSupport> {
+    Ok(CowSupport::No)
+}
+
+/// No-op on non-Linux.
+///
+/// # Errors
+///
+/// Never errors on the stub path.
+pub fn record_probe_outcome(_path: &Path, _outcome: CowSupport) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_always_returns_no() {
+        let support = detect_cow_support(Path::new("/")).expect("stub never errors");
+        assert_eq!(support, CowSupport::No);
+    }
+
+    #[test]
+    fn stub_record_outcome_is_noop() {
+        record_probe_outcome(Path::new("/"), CowSupport::Yes).expect("stub never errors");
+    }
+}

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -286,7 +286,7 @@ pub(super) fn try_refs_reflink_impl(src: &Path, dst: &Path) -> io::Result<()> {
 
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, GetDiskFreeSpaceW, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ,
+        CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GetDiskFreeSpaceW,
         OPEN_EXISTING,
     };
     use windows_sys::Win32::System::IO::DeviceIoControl;
@@ -507,7 +507,7 @@ pub(super) fn try_refs_reflink_range_impl(
 
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, GetDiskFreeSpaceW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, OPEN_EXISTING,
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GetDiskFreeSpaceW, OPEN_EXISTING,
     };
     use windows_sys::Win32::System::IO::DeviceIoControl;
 
@@ -702,7 +702,7 @@ pub(super) fn try_ficlone_impl(src: &Path, dst: &Path) -> io::Result<()> {
     use std::fs::File;
     use std::os::fd::AsFd;
 
-    use super::cow_detect::{detect_cow_support, record_probe_outcome, CowSupport};
+    use super::cow_detect::{CowSupport, detect_cow_support, record_probe_outcome};
 
     let probe_path = dst
         .parent()

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -286,7 +286,7 @@ pub(super) fn try_refs_reflink_impl(src: &Path, dst: &Path) -> io::Result<()> {
 
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::Storage::FileSystem::{
-        CREATE_ALWAYS, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GetDiskFreeSpaceW,
+        CreateFileW, GetDiskFreeSpaceW, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ,
         OPEN_EXISTING,
     };
     use windows_sys::Win32::System::IO::DeviceIoControl;
@@ -507,7 +507,7 @@ pub(super) fn try_refs_reflink_range_impl(
 
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, GetDiskFreeSpaceW, OPEN_EXISTING,
+        CreateFileW, GetDiskFreeSpaceW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, OPEN_EXISTING,
     };
     use windows_sys::Win32::System::IO::DeviceIoControl;
 
@@ -686,6 +686,14 @@ pub(super) fn try_refs_reflink_impl(_src: &Path, _dst: &Path) -> io::Result<()> 
 
 /// Linux `FICLONE` ioctl wrapper using `rustix::fs::ioctl_ficlone`.
 ///
+/// REFLINK-2: consults [`super::cow_detect::detect_cow_support`] against
+/// the destination's parent directory before attempting the ioctl. When
+/// the per-mountpoint cache says `No`, returns `ErrorKind::Unsupported`
+/// immediately so the dispatch falls through without paying the
+/// create-destination + EOPNOTSUPP round-trip. For `Yes`/`Probable` the
+/// FICLONE attempt runs, and any error outcome is recorded so the next
+/// caller on the same mount skips the syscall.
+///
 /// Creates the destination file, then attempts a reflink clone from the source.
 /// On success, source and destination share storage blocks (copy-on-write).
 /// On failure, the caller is responsible for cleaning up the destination.
@@ -694,13 +702,40 @@ pub(super) fn try_ficlone_impl(src: &Path, dst: &Path) -> io::Result<()> {
     use std::fs::File;
     use std::os::fd::AsFd;
 
+    use super::cow_detect::{detect_cow_support, record_probe_outcome, CowSupport};
+
+    let probe_path = dst
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(dst);
+    match detect_cow_support(probe_path) {
+        Ok(CowSupport::No) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "destination filesystem does not support FICLONE",
+            ));
+        }
+        Ok(CowSupport::Yes | CowSupport::Probable) | Err(_) => {}
+    }
+
     let source = File::open(src)?;
     let destination = File::create(dst)?;
 
     // rustix::fs::ioctl_ficlone is fully safe - it uses AsFd/BorrowedFd
     // for compile-time fd validity, and wraps the FICLONE ioctl internally.
-    rustix::fs::ioctl_ficlone(destination.as_fd(), source.as_fd())
-        .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))
+    match rustix::fs::ioctl_ficlone(destination.as_fd(), source.as_fd()) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // EOPNOTSUPP / EXDEV / EINVAL all mean reflink is unavailable
+            // on this mount. Cache the outcome so future copies bypass
+            // the syscall on this mountpoint.
+            let raw = e.raw_os_error();
+            if matches!(raw, libc::EOPNOTSUPP | libc::EXDEV | libc::EINVAL) {
+                let _ = record_probe_outcome(probe_path, CowSupport::No);
+            }
+            Err(io::Error::from_raw_os_error(raw))
+        }
+    }
 }
 
 /// Stub for non-Linux platforms where FICLONE is unavailable.

--- a/crates/fast_io/src/platform_copy/mod.rs
+++ b/crates/fast_io/src/platform_copy/mod.rs
@@ -46,6 +46,11 @@
 //! println!("Copied {} bytes via {:?}", result.bytes_copied, result.method);
 //! ```
 
+#[cfg(target_os = "linux")]
+mod cow_detect;
+#[cfg(not(target_os = "linux"))]
+#[path = "cow_detect_stub.rs"]
+mod cow_detect;
 mod dispatch;
 mod no_zero_copy;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `crates/fast_io/src/platform_copy/cow_detect.rs` exposing `CowSupport::{Yes,No,Probable}` and `detect_cow_support(path)`. Uses `libc::statfs` to read `f_type` and classifies btrfs/bcachefs as `Yes`, XFS as `Probable` (reflink requires `mkfs.xfs -m reflink=1`), everything else as `No`.
- Caches outcomes per-device via `OnceLock<Mutex<HashMap<u64, CowSupport>>>` keyed by `statfs.f_fsid` so subsequent copies on the same mount skip the syscall. `record_probe_outcome` lets the FICLONE caller seal the cache after a confirming attempt.
- Rewires `try_ficlone_impl` to consult the cache before opening files, returning `ErrorKind::Unsupported` immediately on `No`. FICLONE failures with EOPNOTSUPP/EXDEV/EINVAL update the cache so the next caller skips the syscall.
- Adds a non-Linux stub at `cow_detect_stub.rs` that always returns `CowSupport::No`, keeping the dispatch site cfg-free.

## Test plan

- [ ] `cargo nextest run -p fast_io --all-features` on Linux (CI)
- [ ] `cargo nextest run -p fast_io --all-features` on macOS (CI - stub path)
- [ ] `cargo nextest run -p fast_io --all-features` on Windows (CI - stub path)
- [ ] `cargo fmt --all -- --check` (CI)
- [ ] `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` (CI)