### PR TITLE
feat(fast_io): SQP-LAND.6 SQPOLL rootless fallback integration test + env override

### DIFF
--- a/crates/fast_io/src/container.rs
+++ b/crates/fast_io/src/container.rs
@@ -30,6 +30,17 @@
 //! helper into [`crate::io_uring`] configuration; SQP-LAND.7 added the
 //! [`rootless_signal`] accessor so the SQPOLL fall-back site can log
 //! which marker triggered the decision.
+//!
+//! ## Test override
+//!
+//! Setting the environment variable [`FORCE_ROOTLESS_ENV`]
+//! (`OC_RSYNC_FORCE_ROOTLESS_CONTAINER`) to a truthy value (`1`, `true`,
+//! `yes`, `on`, case-insensitive) makes [`rootless_signal`] report
+//! [`RootlessSignal::NonIdentityUidMap`] regardless of the actual host
+//! state. The override is consulted before the cached `/proc` probe, so
+//! it works inside any process even if detection already ran. SQP-LAND.6
+//! uses this hook to drive the SQPOLL graceful-fallback integration test
+//! without requiring a real rootless Podman container in CI.
 
 /// Returns `true` when the current process is running inside a rootless
 /// container or any user namespace where SQPOLL is structurally unable
@@ -96,7 +107,33 @@ impl RootlessSignal {
 /// invocation.
 #[must_use]
 pub fn rootless_signal() -> RootlessSignal {
+    if force_rootless_via_env() {
+        return RootlessSignal::NonIdentityUidMap;
+    }
     imp::rootless_signal()
+}
+
+/// Environment variable that forces [`rootless_signal`] to report a
+/// rootless verdict.
+///
+/// Setting this to `1`, `true`, `yes`, or `on` (case-insensitive) makes
+/// the helper return [`RootlessSignal::NonIdentityUidMap`] without
+/// consulting `/proc/self/uid_map` or any marker file. Used by the
+/// SQP-LAND.6 integration test so the SQPOLL graceful-fallback path can
+/// be exercised on hosts that are not actually rootless. The check runs
+/// before the cached probe so toggling the variable mid-process is
+/// effective even after detection already cached the host result.
+pub const FORCE_ROOTLESS_ENV: &str = "OC_RSYNC_FORCE_ROOTLESS_CONTAINER";
+
+/// Returns `true` when [`FORCE_ROOTLESS_ENV`] is set to a truthy value.
+fn force_rootless_via_env() -> bool {
+    match std::env::var(FORCE_ROOTLESS_ENV) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -269,7 +269,9 @@ pub mod sqpoll_basis;
 mod status;
 
 pub use cached_sort::{CachedSortKey, cached_sort_by};
-pub use container::{RootlessSignal, detect_rootless_container, rootless_signal};
+pub use container::{
+    FORCE_ROOTLESS_ENV, RootlessSignal, detect_rootless_container, rootless_signal,
+};
 pub use copy_basis_range::{
     COPY_BASIS_RANGE_MIN_BYTES, copy_basis_range, copy_file_range_supported,
 };

--- a/crates/fast_io/tests/sqpoll_rootless_fallback.rs
+++ b/crates/fast_io/tests/sqpoll_rootless_fallback.rs
@@ -1,0 +1,206 @@
+//! SQP-LAND.6: integration test exercising SQPOLL graceful fallback in a
+//! simulated rootless Podman container.
+//!
+//! In a real rootless container, `IORING_SETUP_SQPOLL` fails with `EPERM`
+//! because `CAP_SYS_NICE` is structurally unavailable in the user
+//! namespace. SQP-LAND.3 added [`fast_io::detect_rootless_container`] to
+//! short-circuit that doomed setup syscall, SQP-LAND.4 wired the helper
+//! into [`fast_io::IoUringConfig::build_ring`], and SQP-LAND.7 added the
+//! [`fast_io::rootless_signal`] accessor for logging. This test verifies
+//! the end-to-end contract: with the rootless override env var set, the
+//! public io_uring writer factory returns a working writer (graceful
+//! fallback to a non-SQPOLL ring on Linux, standard-I/O on any platform)
+//! without panicking and without surfacing an error to the caller.
+//!
+//! The test uses [`fast_io::FORCE_ROOTLESS_ENV`] to simulate the
+//! container so the same code path is exercised on CI runners that are
+//! not actually rootless. The env-var override is documented in
+//! `docs/deployment-guide.md` (SQP-LAND.8) as a test-only hook; setting
+//! it in production is operator-visible and harmless on host systems.
+//!
+//! This whole file is Linux-only because the SQPOLL safety story is
+//! Linux-only. On non-Linux targets the same writer factory path uses
+//! [`fast_io::IoUringPolicy::Disabled`] dispatch internally, so there is
+//! nothing platform-specific to assert.
+
+#![cfg(target_os = "linux")]
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard};
+
+use fast_io::{
+    FORCE_ROOTLESS_ENV, IoUringPolicy, RootlessSignal, detect_rootless_container,
+    is_sqpoll_disabled_by_policy, rootless_signal, writer_from_file,
+};
+use tempfile::tempdir;
+
+/// Serialises tests in this binary so concurrent env mutations do not
+/// race the rootless-detection probe. Cargo gives every `tests/*.rs`
+/// file its own binary, isolating this lock from other tests.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Restores a single environment variable to its prior value on drop.
+///
+/// Mirrors the pattern used in `iouring_probe_fallback_mock.rs` so test
+/// authors moving between the two files have a single mental model.
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &OsStr) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let previous = env::var_os(key);
+        // SAFETY: serialised via ENV_LOCK; no other thread mutates this
+        // variable for the lifetime of the returned guard.
+        #[allow(unsafe_code)]
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self {
+            key,
+            previous,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: ENV_LOCK is still held via `_lock` until this Drop
+        // returns, so no other thread observes the in-flight restore.
+        #[allow(unsafe_code)]
+        unsafe {
+            match &self.previous {
+                Some(v) => env::set_var(self.key, v),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// With the override set, [`detect_rootless_container`] must report
+/// `true` and [`rootless_signal`] must classify the verdict as
+/// [`RootlessSignal::NonIdentityUidMap`]. This is the precondition that
+/// makes the SQPOLL fall-back branch reachable from the integration
+/// test without booting a real rootless container.
+#[test]
+fn force_rootless_env_reports_rootless_signal() {
+    let _g = EnvGuard::set(FORCE_ROOTLESS_ENV, OsStr::new("1"));
+
+    assert!(
+        detect_rootless_container(),
+        "{FORCE_ROOTLESS_ENV}=1 must make detect_rootless_container() return true"
+    );
+    assert_eq!(
+        rootless_signal(),
+        RootlessSignal::NonIdentityUidMap,
+        "{FORCE_ROOTLESS_ENV}=1 must surface NonIdentityUidMap so the fall-back \
+         site can log a precise reason"
+    );
+}
+
+/// The override hook must accept the same truthy spellings as the
+/// existing `OC_RSYNC_DISABLE_IOURING` gate. Mismatched accepted-values
+/// across env hooks would surprise operators following the deployment
+/// guide.
+#[test]
+fn force_rootless_env_accepts_common_truthy_spellings() {
+    for value in ["1", "true", "TRUE", "yes", "YES", "on", "On"] {
+        let _g = EnvGuard::set(FORCE_ROOTLESS_ENV, OsStr::new(value));
+        assert!(
+            detect_rootless_container(),
+            "{FORCE_ROOTLESS_ENV}={value} must trigger the rootless verdict"
+        );
+    }
+}
+
+/// Falsy values must NOT trip the rootless override. The override is a
+/// one-way opt-in; reading it as default-on would silently downgrade
+/// SQPOLL on every production host whose operator accidentally exported
+/// `OC_RSYNC_FORCE_ROOTLESS_CONTAINER=0` or similar.
+///
+/// We cannot directly assert `RootlessSignal::NotRootless` because the
+/// fall-through path consults the cached host probe, and a CI runner
+/// that is itself containerised legitimately fires the probe. The
+/// invariant we DO assert is that a falsy override yields the same
+/// signal as the very-first call before the override is touched - i.e.
+/// the env hook stays inactive.
+#[test]
+fn force_rootless_env_ignores_falsy_values() {
+    // Establish the cached baseline first. The probe runs at most once
+    // per process, so subsequent reads return this value regardless of
+    // any falsy override.
+    let baseline = {
+        let _g = EnvGuard::set(FORCE_ROOTLESS_ENV, OsStr::new(""));
+        rootless_signal()
+    };
+
+    for value in ["0", "false", "FALSE", "no", "off", ""] {
+        let _g = EnvGuard::set(FORCE_ROOTLESS_ENV, OsStr::new(value));
+        assert_eq!(
+            rootless_signal(),
+            baseline,
+            "{FORCE_ROOTLESS_ENV}={value} must behave the same as an unset/empty value"
+        );
+    }
+}
+
+/// The end-to-end contract: with the override set, the public io_uring
+/// writer factory must succeed without panicking, even when the caller
+/// asks for [`IoUringPolicy::Auto`] (the production default). The ring
+/// must be built without SQPOLL because the rootless check fires before
+/// the kernel `EPERM`.
+///
+/// We cannot directly observe the SQPOLL flag on the resulting ring
+/// (the type is opaque), but we can prove the graceful-fallback
+/// contract: `writer_from_file` returns `Ok(_)` with the rootless
+/// override active. A failure here would mean the rootless skip branch
+/// surfaces an error instead of degrading silently - the regression
+/// SQP-LAND was designed to prevent.
+#[test]
+fn writer_from_file_succeeds_under_rootless_override() {
+    let _g = EnvGuard::set(FORCE_ROOTLESS_ENV, OsStr::new("1"));
+
+    // Confirm the precondition: the override is in effect.
+    assert!(detect_rootless_container());
+
+    let tmpdir = tempdir().expect("tempdir for sqpoll rootless fallback");
+    let path = tmpdir.path().join("rootless-fallback.bin");
+    let file = std::fs::File::create(&path).expect("create destination file");
+
+    let writer = writer_from_file(file, 4096, IoUringPolicy::Auto)
+        .expect("writer_from_file must succeed when rootless override skips SQPOLL");
+    drop(writer);
+
+    // The explicit policy gate is a separate mechanism (SQP-K8S.3,
+    // --no-io-uring-sqpoll). Confirm we did not accidentally tip it on
+    // through the rootless detection path: the gate is for explicit
+    // operator opt-out, the rootless skip is automatic.
+    assert!(
+        !is_sqpoll_disabled_by_policy(),
+        "rootless skip must not flip the explicit --no-io-uring-sqpoll gate"
+    );
+}
+
+/// Even the most aggressive policy that requests SQPOLL must downgrade
+/// cleanly under the rootless override. [`IoUringPolicy::SqpollOff`]
+/// already routes to a regular ring; the regression-prone path is
+/// `Auto`, which would request SQPOLL on a kernel that supports it.
+/// Re-running the writer factory under `SqpollOff` proves the
+/// override does not destabilise the explicit-opt-out path either.
+#[test]
+fn writer_from_file_succeeds_under_rootless_with_sqpoll_off_policy() {
+    let _g = EnvGuard::set(FORCE_ROOTLESS_ENV, OsStr::new("1"));
+
+    let tmpdir = tempdir().expect("tempdir for sqpoll rootless + policy-off");
+    let path = tmpdir.path().join("rootless-sqpoll-off.bin");
+    let file = std::fs::File::create(&path).expect("create destination file");
+
+    let writer = writer_from_file(file, 4096, IoUringPolicy::SqpollOff)
+        .expect("writer_from_file must succeed under rootless override + SqpollOff policy");
+    drop(writer);
+}

--- a/docs/deployment/container-io-uring.md
+++ b/docs/deployment/container-io-uring.md
@@ -90,6 +90,31 @@ To check whether io_uring is available inside your container:
 podman run --rm myimage oc-rsync --io-uring-status
 ```
 
+#### Detection
+
+oc-rsync detects rootless containers automatically (see
+`docs/design/sqpoll-rootless-container-detection.md`) by probing
+`/proc/self/uid_map`, `/run/.containerenv` (Podman), and `/.dockerenv`
+(Docker). When any of these signals fires, SQPOLL is skipped before the
+kernel can reject it and a single info-level log records the reason
+(see SQP-LAND.7 in `crates/fast_io/src/io_uring/config.rs`).
+
+#### Forcing detection for tests
+
+The environment variable `OC_RSYNC_FORCE_ROOTLESS_CONTAINER` lets
+integration tests and CI cells exercise the SQPOLL fall-back path on
+hosts that are not actually rootless. Setting it to `1`, `true`, `yes`,
+or `on` makes `fast_io::detect_rootless_container` and
+`fast_io::rootless_signal` report rootless regardless of the real host
+state, and the env hook runs before the cached `/proc` probe so it is
+effective even after detection has already cached the host result. The
+override is read by every `IoUringConfig::build_ring` call, so the same
+graceful-fallback path that a real container would take is exercised
+end-to-end. It is a test-only hook; setting it in production is harmless
+on rootless hosts (the verdict was already going to be rootless) but
+forces the SQPOLL skip on host systems, costing a small amount of I/O
+throughput. Do not set it in production manifests.
+
 ### Seccomp Considerations
 
 Default Docker and Podman seccomp profiles allow `io_uring_setup`,


### PR DESCRIPTION
## Summary

- Adds `OC_RSYNC_FORCE_ROOTLESS_CONTAINER` env hook to `fast_io::container::rootless_signal()` so integration tests and CI cells can drive the SQPOLL graceful-fallback path on hosts that are not actually rootless. The override is consulted before the cached `/proc/self/uid_map` probe, so it is effective regardless of when detection first ran.
- New Linux-only `crates/fast_io/tests/sqpoll_rootless_fallback.rs` exercises the end-to-end contract through the public `writer_from_file` factory: under the override, `detect_rootless_container()` / `rootless_signal()` report rootless, and `writer_from_file` succeeds with both `IoUringPolicy::Auto` and `IoUringPolicy::SqpollOff` without panicking or surfacing an error. Truthy / falsy env-value acceptance and one-way-opt-in semantics are covered.
- Documents the env hook in `docs/deployment/container-io-uring.md` under the rootless-container section with an explicit "test-only, do not set in production manifests" warning.

Closes SQP-LAND.6.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p fast_io --tests --test sqpoll_rootless_fallback` (macOS host: file cfg-gates to Linux so just verifies the public re-exports + production code build)
- [ ] CI nextest exercises the new Linux integration test under `is_io_uring_available()` runners
- [ ] CI fmt+clippy passes the new src/container.rs + lib.rs deltas