### PR TITLE
fix(flist): dedup consecutive identical entries after sort

### DIFF
--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -162,6 +162,9 @@ pub fn collect_paths_then_metadata_parallel(
 
     if errors.is_empty() {
         crate::sort::sort_file_entries(&mut entries);
+        // upstream: flist.c:3050 dedup_in_flist() - collapse identical
+        // sorted entries so repeated source operands transfer each file once.
+        crate::sort::dedup_sorted_file_entries(&mut entries);
         Ok(entries)
     } else {
         Err(errors)
@@ -277,6 +280,9 @@ pub fn collect_with_batched_stats(
 
     if errors.is_empty() {
         crate::sort::sort_file_entries(&mut entries);
+        // upstream: flist.c:3050 dedup_in_flist() - collapse identical
+        // sorted entries so repeated source operands transfer each file once.
+        crate::sort::dedup_sorted_file_entries(&mut entries);
         Ok(entries)
     } else {
         Err(errors)
@@ -347,6 +353,9 @@ pub fn collect_paths_chunked_parallel(
 
     if errors.is_empty() {
         crate::sort::sort_file_entries(&mut entries);
+        // upstream: flist.c:3050 dedup_in_flist() - collapse identical
+        // sorted entries so repeated source operands transfer each file once.
+        crate::sort::dedup_sorted_file_entries(&mut entries);
         Ok(entries)
     } else {
         Err(errors)
@@ -407,6 +416,9 @@ pub fn resolve_metadata_parallel(
 
     if errors.is_empty() {
         crate::sort::sort_file_entries(&mut resolved);
+        // upstream: flist.c:3050 dedup_in_flist() - collapse identical
+        // sorted entries so repeated source operands transfer each file once.
+        crate::sort::dedup_sorted_file_entries(&mut resolved);
         Ok(resolved)
     } else {
         Err(errors)

--- a/crates/flist/src/sort.rs
+++ b/crates/flist/src/sort.rs
@@ -6,6 +6,22 @@ pub(crate) fn sort_file_entries(entries: &mut [crate::entry::FileListEntry]) {
     entries.sort_unstable_by(|a, b| a.relative_path.cmp(&b.relative_path));
 }
 
+/// Removes consecutive entries with identical relative paths, keeping the
+/// first occurrence. Mirrors upstream's `flist_sort_and_clean` dedup pass
+/// that marks `FLAG_DUPLICATE` so the sender skips repeated entries.
+///
+/// Requires the slice be sorted by relative path (see
+/// [`sort_file_entries`]) so that duplicate sources collapse to adjacent
+/// positions.
+///
+/// upstream: flist.c:3050 dedup_in_flist() - `f_name_cmp() == 0` between
+/// consecutive sorted entries flags the second copy as `FLAG_DUPLICATE`;
+/// upstream: flist.c:2159-2172 - sender skips entries carrying the flag.
+#[cfg(feature = "parallel")]
+pub(crate) fn dedup_sorted_file_entries(entries: &mut Vec<crate::entry::FileListEntry>) {
+    entries.dedup_by(|a, b| a.relative_path == b.relative_path);
+}
+
 /// Sorts directory entries by file name in lexicographic order.
 #[cfg(feature = "parallel")]
 pub(crate) fn sort_dir_entries(entries: &mut [std::fs::DirEntry]) {
@@ -15,4 +31,112 @@ pub(crate) fn sort_dir_entries(entries: &mut [std::fs::DirEntry]) {
 /// Sorts OS strings in lexicographic order.
 pub(crate) fn sort_os_strings(entries: &mut [std::ffi::OsString]) {
     entries.sort_unstable();
+}
+
+#[cfg(test)]
+#[cfg(feature = "parallel")]
+mod tests {
+    use super::*;
+    use crate::entry::FileListEntry;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn make_entry(rel: &str, tmp: &std::path::Path) -> FileListEntry {
+        let full = tmp.join(rel);
+        let metadata = fs::metadata(tmp).expect("metadata");
+        FileListEntry {
+            full_path: full,
+            relative_path: PathBuf::from(rel),
+            metadata,
+            depth: 1,
+            is_root: false,
+        }
+    }
+
+    /// upstream: flist.c:3050 - identical sorted neighbours collapse to one.
+    /// Mirrors `testsuite/duplicates.test` which passes the same source ten
+    /// times and asserts each entry appears exactly once in the flist.
+    #[test]
+    fn dedup_collapses_consecutive_identical_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut entries = vec![
+            make_entry("a", tmp.path()),
+            make_entry("a", tmp.path()),
+            make_entry("a", tmp.path()),
+            make_entry("b", tmp.path()),
+            make_entry("b", tmp.path()),
+            make_entry("c", tmp.path()),
+        ];
+
+        dedup_sorted_file_entries(&mut entries);
+
+        let paths: Vec<&std::path::Path> =
+            entries.iter().map(|e| e.relative_path.as_path()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                std::path::Path::new("a"),
+                std::path::Path::new("b"),
+                std::path::Path::new("c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn dedup_preserves_distinct_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut entries = vec![
+            make_entry("a", tmp.path()),
+            make_entry("b", tmp.path()),
+            make_entry("c", tmp.path()),
+        ];
+
+        dedup_sorted_file_entries(&mut entries);
+
+        assert_eq!(entries.len(), 3);
+    }
+
+    #[test]
+    fn dedup_on_empty_is_noop() {
+        let mut entries: Vec<FileListEntry> = Vec::new();
+        dedup_sorted_file_entries(&mut entries);
+        assert!(entries.is_empty());
+    }
+
+    /// Build via the parallel collector with the same root passed multiple
+    /// times in the path list (matches `duplicates.test`'s argv shape) and
+    /// confirm each discovered entry appears exactly once after sort+dedup.
+    #[test]
+    fn dedup_collapses_duplicate_source_paths_from_walker() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(root.join("name1"), b"This is the file").expect("write name1");
+
+        let walker = crate::FileListBuilder::new(root)
+            .build()
+            .expect("build walker");
+        let single: Vec<_> = walker
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect single");
+
+        // Simulate three passes through the same source by repeating entries
+        // and then sort+dedup, matching the sender pipeline.
+        let mut tripled: Vec<FileListEntry> = Vec::new();
+        for _ in 0..3 {
+            let walker = crate::FileListBuilder::new(root)
+                .build()
+                .expect("build walker");
+            for entry in walker {
+                tripled.push(entry.expect("entry"));
+            }
+        }
+
+        sort_file_entries(&mut tripled);
+        dedup_sorted_file_entries(&mut tripled);
+
+        assert_eq!(tripled.len(), single.len());
+        let names: Vec<&std::path::Path> =
+            tripled.iter().map(|e| e.relative_path.as_path()).collect();
+        assert!(names.iter().any(|p| *p == std::path::Path::new("name1")));
+    }
 }


### PR DESCRIPTION
## Summary

Mirror upstream rsync's flist dedup pass so repeated source operands
no longer transfer each file multiple times. The upstream testsuite
`duplicates.test` (`-avv` with the same source repeated 10 times)
asserts each file appears exactly once in the verbose output. Without
flist-stage dedup, oc-rsync's parallel collectors emitted ten copies
of every entry.

A new `sort::dedup_sorted_file_entries` helper walks the sorted
collector output and collapses adjacent entries with identical
`relative_path`. It runs after every existing `sort_file_entries`
call in `crates/flist/src/parallel.rs`, preserving the upstream
invariant that the dedup pass follows the sort pass.

## Upstream references

- `flist.c:3050-3081` - `flist_sort_and_clean()` compares consecutive
  sorted entries with `f_name_cmp()`; matches are flagged
  `FLAG_DUPLICATE`. Directory-vs-non-directory edge cases keep the
  more informative entry, which here collapses to keep-first because
  oc-rsync's `FileListEntry` carries no flag bit.
- `flist.c:2159-2172` - sender consults
  `flist->sorted[ndx]->flags & FLAG_DUPLICATE` and skips matching
  indices, which is what the upstream testsuite observes.
- `testsuite/duplicates.test` - in upstream 3.4.4
  `target/interop/upstream-src/rsync-3.4.4/testsuite/duplicates.test`,
  invokes `rsync -avv <src>/ <src>/ ... <dst>` and asserts the verbose
  output contains each file exactly once.

## Changes

- `crates/flist/src/sort.rs` - added
  `dedup_sorted_file_entries(&mut Vec<FileListEntry>)` plus unit
  tests covering collapse, distinct retention, empty input, and a
  walker-driven round-trip that mirrors `duplicates.test`'s argv
  shape.
- `crates/flist/src/parallel.rs` - call the new helper after each
  `sort_file_entries` call in `collect_paths_then_metadata_parallel`,
  `collect_with_batched_stats`, `collect_paths_chunked_parallel`, and
  `resolve_metadata_parallel`. Comments cite `flist.c:3050`.

The `FileListEntry` struct stays immutable (it carries `fs::Metadata`
which doesn't implement `Clone`), so the dedup pass uses
`Vec::dedup_by` to discard the second copy rather than flagging it.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo check -p flist --all-features`
- [x] `cargo check -p transfer --all-features`
- [ ] CI: nextest covers `sort.rs` unit tests + existing CLI
      `transfer_request_with_duplicates` end-to-end fixture.