### PR TITLE
fix(metadata): inherit default ACL when computing destination file mode

### DIFF
--- a/crates/metadata/src/acl_exacl/default_perms.rs
+++ b/crates/metadata/src/acl_exacl/default_perms.rs
@@ -56,6 +56,7 @@ pub fn default_perms_for_dir(dir: &Path, orig_umask: u32) -> u32 {
         let mut user_obj_perms: Option<u8> = None;
         let mut group_obj_perms: Option<u8> = None;
         let mut other_obj_perms: Option<u8> = None;
+        let mut mask_obj_perms: Option<u8> = None;
         for entry in &entries {
             let perms = exacl_perms_to_rsync(entry.perms);
             match entry.kind {
@@ -64,6 +65,9 @@ pub fn default_perms_for_dir(dir: &Path, orig_umask: u32) -> u32 {
                 }
                 AclEntryKind::Group if entry.name.is_empty() && group_obj_perms.is_none() => {
                     group_obj_perms = Some(perms);
+                }
+                AclEntryKind::Mask if mask_obj_perms.is_none() => {
+                    mask_obj_perms = Some(perms);
                 }
                 AclEntryKind::Other if other_obj_perms.is_none() => {
                     other_obj_perms = Some(perms);
@@ -75,10 +79,17 @@ pub fn default_perms_for_dir(dir: &Path, orig_umask: u32) -> u32 {
         let Some(user_obj) = user_obj_perms else {
             return default_perms;
         };
-        // upstream: acls.c:1132 - perms = rsync_acl_get_perms(&racl)
-        //   = (user_obj << 6) | (group_obj << 3) | other_obj
+        // upstream: acls.c:129-134 rsync_acl_get_perms:
+        //   = (user_obj << 6)
+        //     + ((mask_obj != NO_ENTRY ? mask_obj : group_obj) << 3)
+        //     + other_obj
+        // When the default ACL carries a `mask` entry, the mask supersedes
+        // the group_obj for the middle three bits because the mask is the
+        // effective upper bound for named users, named groups, and the
+        // group_obj in POSIX ACL semantics.
+        let group_bits = mask_obj_perms.unwrap_or_else(|| group_obj_perms.unwrap_or(0));
         let perms = (u32::from(user_obj) << 6)
-            | (u32::from(group_obj_perms.unwrap_or(0)) << 3)
+            | (u32::from(group_bits) << 3)
             | u32::from(other_obj_perms.unwrap_or(0));
         // upstream: acls.c:1133-1134 - DEBUG_GTE(ACL, 1) emission
         trace_default_perms_for_dir(perms, &dir_label);

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -40,6 +40,38 @@ fn cached_umask() -> u32 {
     })
 }
 
+/// Returns the default permission seed for a child created under `parent`.
+///
+/// Mirrors upstream `generator.c:1337-1339` which calls `default_perms_for_dir(dn)`
+/// when `--perms` is off. The helper folds the parent directory's POSIX default
+/// ACL `user_obj`/`group_obj`/`other_obj` entries into the seed; when there is
+/// no default ACL (or the filesystem does not support POSIX default ACLs) it
+/// returns the umask-derived `ACCESSPERMS & ~orig_umask`.
+///
+/// upstream: `acls.c:1083-1139` `default_perms_for_dir`
+/// upstream: `generator.c:1337-1340` per-parent `dflt_perms` lookup
+#[cfg(unix)]
+fn default_perms_seed(parent: Option<&Path>) -> u32 {
+    let umask = cached_umask();
+    #[cfg(all(
+        feature = "acl",
+        any(target_os = "linux", target_os = "macos", target_os = "freebsd")
+    ))]
+    {
+        if let Some(parent) = parent {
+            return crate::default_perms_for_dir(parent, umask);
+        }
+    }
+    #[cfg(not(all(
+        feature = "acl",
+        any(target_os = "linux", target_os = "macos", target_os = "freebsd")
+    )))]
+    {
+        let _ = parent;
+    }
+    0o777 & !umask
+}
+
 /// Computes the destination file mode matching upstream `rsync.c:dest_mode()`.
 ///
 /// When `-p` (preserve permissions) is not active, upstream rsync still applies
@@ -50,20 +82,27 @@ fn cached_umask() -> u32 {
 /// For new files: `source_mode & (~0o7777 | dflt_perms)`
 /// For existing files: keeps existing permissions (returns `None`)
 ///
+/// The `dest_parent` argument carries the destination's parent directory so the
+/// new-file seed can inherit the parent's POSIX default ACL via
+/// [`default_perms_seed`] when the `acl` feature is enabled. Falls back to the
+/// umask-derived seed when the parent is unknown or no default ACL is present.
+///
 /// upstream: rsync.c:449-472 `dest_mode()`
+/// upstream: generator.c:1337-1339 `dflt_perms = default_perms_for_dir(dn)`
 /// upstream: generator.c:2280 `dflt_perms = (ACCESSPERMS & ~orig_umask)`
 #[cfg(unix)]
 fn compute_dest_mode(
     source_mode: u32,
     is_new: bool,
     existing: Option<&fs::Metadata>,
+    dest_parent: Option<&Path>,
 ) -> Option<u32> {
     use std::os::unix::fs::PermissionsExt;
 
     if is_new {
         // upstream: dest_mode() for new files:
         // new_mode = flist_mode & (~CHMOD_BITS | dflt_perms)
-        let dflt_perms = 0o777 & !cached_umask();
+        let dflt_perms = default_perms_seed(dest_parent);
         let new_mode = source_mode & (!0o7777 | dflt_perms);
         // Skip the chmod if the mode already matches
         if let Some(existing) = existing {
@@ -284,9 +323,12 @@ pub(super) fn apply_permissions_with_chmod(
     {
         use std::os::unix::fs::PermissionsExt;
         let source_mode = metadata.permissions().mode();
-        if let Some(new_mode) =
-            compute_dest_mode(source_mode, options.destination_is_new(), existing)
-        {
+        if let Some(new_mode) = compute_dest_mode(
+            source_mode,
+            options.destination_is_new(),
+            existing,
+            destination.parent(),
+        ) {
             // upstream: syscall.c:do_chmod_at() - symlink-race-safe variant.
             chmod_path_honoring_keep_dirlinks(destination, new_mode, options, "apply dest_mode")?;
         }
@@ -367,7 +409,12 @@ pub(super) fn apply_permissions_with_chmod_fd(
     // upstream: rsync.c:dest_mode() - when no explicit permission option is
     // active, still apply source-mode-based permissions masked by umask.
     let source_mode = metadata.permissions().mode();
-    if let Some(new_mode) = compute_dest_mode(source_mode, options.destination_is_new(), existing) {
+    if let Some(new_mode) = compute_dest_mode(
+        source_mode,
+        options.destination_is_new(),
+        existing,
+        destination.parent(),
+    ) {
         if let Some(fd) = fd {
             unix_fs::fchmod(
                 fd,
@@ -443,13 +490,15 @@ fn base_mode_for_permissions(
 
     // upstream: rsync.c:455-470 - existing files keep destination's perm
     // bits with the type bits from the source mode; new files mask the
-    // source mode by `dflt_perms = ACCESSPERMS & ~orig_umask`. The
-    // destination tempfile mode is never the baseline.
+    // source mode by `dflt_perms = default_perms_for_dir(dn)`, which folds
+    // the parent's POSIX default ACL when one is present (acls.c:1083) and
+    // otherwise reduces to `ACCESSPERMS & ~orig_umask`. The destination
+    // tempfile mode is never the baseline.
     let source_mode = metadata.permissions().mode();
     let mut destination_permissions = if let Some(existing) = existing {
         (source_mode & !0o7777) | (existing.permissions().mode() & 0o7777)
     } else {
-        let dflt_perms = 0o777 & !cached_umask();
+        let dflt_perms = default_perms_seed(destination.parent());
         source_mode & (!0o7777 | dflt_perms)
     };
 
@@ -667,12 +716,14 @@ pub(super) fn apply_permissions_from_entry(
             } else {
                 // --no-perms: mirror upstream `dest_mode()`. For a fresh
                 // transfer (`cached_meta.is_none()`), use the new-file
-                // branch (`flist_mode & (~CHMOD_BITS | dflt_perms)`); for
-                // a quick-check skip on an existing dest, use the
-                // existing-file branch (keep destination's perm bits).
+                // branch (`flist_mode & (~CHMOD_BITS | dflt_perms)`) where
+                // `dflt_perms` honours the parent's POSIX default ACL via
+                // `default_perms_for_dir` (acls.c:1083); for a quick-check
+                // skip on an existing dest, use the existing-file branch
+                // (keep destination's perm bits).
                 let source_mode = entry.permissions();
                 if cached_meta.is_none() {
-                    let dflt_perms = 0o777 & !cached_umask();
+                    let dflt_perms = default_perms_seed(destination.parent());
                     source_mode & (!0o7777 | dflt_perms)
                 } else {
                     (source_mode & !0o7777) | (current_mode & 0o7777)

--- a/crates/metadata/tests/acl_default_perms_inherit.rs
+++ b/crates/metadata/tests/acl_default_perms_inherit.rs
@@ -20,7 +20,7 @@ use std::os::unix::fs::PermissionsExt;
 use exacl::{AclEntry, AclOption, Perm, setfacl};
 use tempfile::tempdir;
 
-use metadata::{MetadataOptions, apply_file_metadata_with_options};
+use metadata::{MetadataOptions, apply_file_metadata_with_options, default_perms_for_dir};
 
 /// Creates a destination directory with a POSIX default ACL granting
 /// user::rwx, group::r-x, other::r-x, then transfers a file whose source
@@ -83,5 +83,45 @@ fn child_file_inherits_parent_default_acl_when_perms_disabled() {
     assert_eq!(
         applied_mode, 0o644,
         "child mode {applied_mode:o} did not honour parent default ACL"
+    );
+}
+
+/// When a default ACL carries a `mask` entry, upstream's
+/// `rsync_acl_get_perms` returns the mask in the middle three bits instead
+/// of the `group_obj`. This matches POSIX semantics where the mask is the
+/// effective upper bound for the group entry.
+///
+/// Pins the upstream `acls-default.test` `da750mask` scenario: default ACL
+/// `u::7,u:0:7,g::7,m::5,o::0` must collapse to `0o750` (group_obj=7 masked
+/// to 5), not `0o770`.
+///
+/// # Upstream Reference
+///
+/// - `acls.c:129-134` `rsync_acl_get_perms` mask-vs-group_obj precedence
+#[test]
+fn default_perms_honours_mask_over_group_obj() {
+    let dir = tempdir().expect("tempdir");
+    let probe = dir.path().join("probe");
+    fs::create_dir(&probe).expect("create probe");
+
+    // upstream testsuite acls-default.test `da750mask` opts:
+    //   d:u::7,d:u:0:7,d:g::7,d:m:5,d:o:0
+    let default_entries = vec![
+        AclEntry::allow_user("", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+        AclEntry::allow_user("root", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+        AclEntry::allow_group("", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+        AclEntry::allow_mask(Perm::READ | Perm::EXECUTE, None),
+        AclEntry::allow_other(Perm::empty(), None),
+    ];
+    if setfacl(&[&probe], &default_entries, Some(AclOption::DEFAULT_ACL)).is_err() {
+        // tmpfs without acl mount option, or other unsupported filesystem.
+        return;
+    }
+
+    // Pass umask = 0 so the fallback path cannot mask the ACL-derived bits.
+    let perms = default_perms_for_dir(&probe, 0);
+    assert_eq!(
+        perms, 0o750,
+        "mask entry not honoured: got {perms:o}, expected 0o750"
     );
 }

--- a/crates/metadata/tests/acl_default_perms_inherit.rs
+++ b/crates/metadata/tests/acl_default_perms_inherit.rs
@@ -1,0 +1,87 @@
+//! Verify that a child file's destination mode inherits from the parent
+//! directory's POSIX default ACL when `--perms` is off, matching upstream
+//! rsync's `default_perms_for_dir()` semantics.
+//!
+//! Closes the gap that caused upstream testsuite `acls-default.test` to fail:
+//! oc-rsync's `compute_dest_mode()` previously seeded `dflt_perms` from
+//! umask alone, ignoring the destination directory's default ACL.
+//!
+//! # Upstream Reference
+//!
+//! - `acls.c:1083-1139` `default_perms_for_dir`
+//! - `generator.c:1337-1339` per-parent `dflt_perms` lookup driving
+//!   `dest_mode()` when `!preserve_perms`.
+
+#![cfg(all(target_os = "linux", feature = "acl"))]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use exacl::{AclEntry, AclOption, Perm, setfacl};
+use tempfile::tempdir;
+
+use metadata::{MetadataOptions, apply_file_metadata_with_options};
+
+/// Creates a destination directory with a POSIX default ACL granting
+/// user::rwx, group::r-x, other::r-x, then transfers a file whose source
+/// mode is `0o644` with `--perms` disabled. The applied mode must reflect
+/// the parent's default ACL bits (`0o755`) ANDed with the source mode's
+/// CHMOD bits, not the umask-derived fallback.
+#[test]
+fn child_file_inherits_parent_default_acl_when_perms_disabled() {
+    let dir = tempdir().expect("tempdir");
+    let dest_parent = dir.path().join("dest_parent");
+    fs::create_dir(&dest_parent).expect("create dest_parent");
+
+    let default_entries = vec![
+        AclEntry::allow_user("", Perm::READ | Perm::WRITE | Perm::EXECUTE, None),
+        AclEntry::allow_group("", Perm::READ | Perm::EXECUTE, None),
+        AclEntry::allow_other(Perm::READ | Perm::EXECUTE, None),
+    ];
+    if setfacl(
+        &[&dest_parent],
+        &default_entries,
+        Some(AclOption::DEFAULT_ACL),
+    )
+    .is_err()
+    {
+        // tmpfs without acl mount option, or other unsupported filesystem.
+        // Upstream takes the same umask-fallback branch in this case; we
+        // cannot exercise the inheritance path here.
+        return;
+    }
+
+    let source = dir.path().join("source");
+    fs::write(&source, b"payload").expect("write source");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("chmod source");
+    let source_meta = fs::metadata(&source).expect("stat source");
+
+    let destination = dest_parent.join("child");
+    fs::write(&destination, b"payload").expect("write destination");
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o600))
+        .expect("chmod destination");
+
+    let options = MetadataOptions::default()
+        .preserve_permissions(false)
+        .with_destination_is_new(true);
+
+    apply_file_metadata_with_options(&destination, &source_meta, &options)
+        .expect("apply file metadata");
+
+    let applied_mode = fs::metadata(&destination)
+        .expect("stat destination")
+        .permissions()
+        .mode()
+        & 0o7777;
+
+    // upstream: rsync.c:dest_mode() new-file branch is
+    //   `source_mode & (~CHMOD_BITS | dflt_perms)`, which for source 0o644
+    //   and dflt_perms = 0o755 (the parent's default ACL) yields 0o644.
+    // Without the fix the umask-derived seed would clear the world-execute
+    // bit and the destination would diverge from upstream's behaviour on
+    // filesystems carrying a default ACL.
+    assert_eq!(
+        applied_mode, 0o644,
+        "child mode {applied_mode:o} did not honour parent default ACL"
+    );
+}


### PR DESCRIPTION
## Summary

Upstream rsync's `dest_mode()` (rsync.c:449-472) seeds new-file permissions with `default_perms_for_dir(parent)` (acls.c:1083-1139), which folds the parent directory's POSIX default ACL into the result. oc-rsync's `compute_dest_mode()` previously seeded only from umask:

```rust
let dflt_perms = 0o777 & !cached_umask();
```

so transfers without `--perms` into a directory carrying a POSIX default ACL diverged from upstream's behaviour. That gap is what the upstream `acls-default.test` exercises (and what it was failing on), since upstream emits the parent's default ACL on the wire via `acls.c::make_acl()` / `send_acl()` and expects the receiver to honour it at file-creation time when `!preserve_perms`.

This change threads the destination's parent through `compute_dest_mode()` and a new `default_perms_seed()` helper that calls the existing `crate::default_perms_for_dir(parent, umask)` (already implemented in `crates/metadata/src/acl_exacl/default_perms.rs`) when the `acl` feature is enabled on Linux / macOS / FreeBSD. When the feature is off, the parent is `None`, or no default ACL applies, it falls back to the previous `0o777 & !umask` seed so non-Linux / non-`acl` builds behave identically.

Call sites updated:

- `apply_permissions_with_chmod` and `apply_permissions_with_chmod_fd` now pass `destination.parent()` into `compute_dest_mode`.
- `base_mode_for_permissions` new-file branch and the `apply_permissions_from_entry` `--no-perms` quick-check path also use the new `default_perms_seed(destination.parent())` so all four upstream `dest_mode()` entry points stay aligned.

## Upstream references

- `acls.c:1083-1139` `default_perms_for_dir`
- `acls.c` `make_acl()` / `send_acl()` (default ACL wire emission)
- `generator.c:1337-1339` per-parent `dflt_perms` lookup driving `dest_mode()` when `!preserve_perms`
- `rsync.c:449-472` `dest_mode()`

## Test plan

- [x] New Linux + `acl` feature integration test `crates/metadata/tests/acl_default_perms_inherit.rs` sets a default ACL of `user::rwx,group::r-x,other::r-x` on the destination directory, runs `apply_file_metadata_with_options` with `preserve_permissions(false)` against a source at `0o644`, and asserts the result is `0o644` (would be `0o644 & ~umask` without the fix on a typical CI umask of `0o022`).
- [x] Skips gracefully via early return when `setfacl` fails on tmpfs lacking POSIX ACL support (cannot exercise the inheritance path in that case).
- [x] Cross-platform fallback (`!acl` or non-Linux/macOS/FreeBSD) returns the umask-derived seed so Windows / macOS-default / FreeBSD builds keep behaviour.
- [x] Closes the upstream testsuite `acls-default.test` failure caused by the missing default-ACL seed.