### PR TITLE
fix(filters): parse :C modifier on per-directory merge rules for CVS-ignore

### DIFF
--- a/crates/filters/src/compiled/clear.rs
+++ b/crates/filters/src/compiled/clear.rs
@@ -30,6 +30,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(true, false);
@@ -50,6 +51,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(false, true);
@@ -70,6 +72,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(true, true);
@@ -97,6 +100,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, false, false);
@@ -115,6 +119,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, true, false);

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -115,6 +115,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Exclude);
@@ -135,6 +136,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
@@ -152,6 +154,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.perishable);
@@ -174,6 +177,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
@@ -198,6 +202,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
@@ -226,6 +231,7 @@ mod tests {
                 negate: false,
                 exclude_only: false,
                 no_inherit: false,
+                cvs_mode: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -251,6 +257,7 @@ mod tests {
                 negate: false,
                 exclude_only: false,
                 no_inherit: false,
+                cvs_mode: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -274,6 +281,7 @@ mod tests {
                 negate: false,
                 exclude_only: false,
                 no_inherit: false,
+                cvs_mode: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -303,6 +311,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -334,6 +343,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         use std::path::Path;
@@ -356,6 +366,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         use std::path::Path;
@@ -378,6 +389,7 @@ mod tests {
             negate: true,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.negate);
@@ -392,6 +404,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled2 = CompiledRule::new(rule2).unwrap();
         assert!(!compiled2.negate);

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -43,6 +43,7 @@ impl CompiledRule {
             negate,
             exclude_only: _,
             no_inherit: _,
+            cvs_mode: _,
         } = rule;
         debug_assert!(
             !xattr_only,

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -139,6 +139,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("file.bak"), false, true));
@@ -158,6 +159,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), false, true));
@@ -176,6 +178,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("node_modules"), true, true));
@@ -194,6 +197,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), true, true));
@@ -213,6 +217,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Protect);
@@ -231,6 +236,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Risk);
@@ -248,6 +254,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
@@ -266,6 +273,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build/main.o"), false, true));
@@ -290,6 +298,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -320,6 +329,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -340,6 +350,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("file.txt"), false, true));
@@ -355,6 +366,7 @@ mod tests {
             negate: true,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled_negated = CompiledRule::new(rule_negated).unwrap();
         assert!(!compiled_negated.matches(Path::new("file.txt"), false, true));
@@ -373,6 +385,7 @@ mod tests {
             negate: true,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -395,6 +408,7 @@ mod tests {
             negate: true,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -420,6 +434,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -452,6 +467,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -479,6 +495,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -511,6 +528,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -542,6 +560,7 @@ mod tests {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -154,7 +154,8 @@ impl RuleModifiers {
             .with_perishable(self.perishable)
             .with_xattr_only(self.xattr_only)
             .with_exclude_only(self.exclude_only)
-            .with_no_inherit(self.no_inherit);
+            .with_no_inherit(self.no_inherit)
+            .with_cvs_mode(self.cvs_mode);
 
         if self.sender_only && !self.receiver_only {
             rule = rule.with_sides(true, false);
@@ -303,6 +304,15 @@ fn try_parse_short_form(
 
     let (mods, pattern) = parse_modifiers(rest);
     if pattern.is_empty() {
+        // upstream: exclude.c:1404-1408 - a merge / dir-merge rule with the
+        // `C` (CVS-ignore) modifier and an empty pattern defaults to the
+        // filename `.cvsignore`. Without `C`, an empty pattern remains
+        // unrecognised here and falls through to long-form parsing.
+        if mods.cvs_mode && matches!(action, ShortFormAction::Merge | ShortFormAction::DirMerge) {
+            validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;
+            let rule = action.to_rule(".cvsignore");
+            return Ok(Some(mods.apply(rule)));
+        }
         return Ok(None);
     }
     validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -714,3 +714,32 @@ fn parse_rejects_side_modifier_with_word_split_on_side_prefix() {
     let err = parse_rules("Hsw foo bar", Path::new("test")).unwrap_err();
     assert!(err.message.contains("invalid modifier 's'"));
 }
+
+// upstream: exclude.c:1404-1408 - merge / dir-merge with the `C`
+// (CVS-ignore) modifier and an empty pattern defaults to `.cvsignore`.
+#[test]
+fn parse_colon_c_empty_pattern_defaults_to_cvsignore() {
+    let rules = parse_rules(":C\n", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), ".cvsignore");
+    assert!(rules[0].is_cvs_mode());
+}
+
+#[test]
+fn parse_colon_c_with_explicit_pattern_preserves_cvs_mode() {
+    let rules = parse_rules(":C my.ignore\n", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), "my.ignore");
+    assert!(rules[0].is_cvs_mode());
+}
+
+#[test]
+fn parse_dot_c_empty_pattern_defaults_to_cvsignore() {
+    let rules = parse_rules(".C\n", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::Merge);
+    assert_eq!(rules[0].pattern(), ".cvsignore");
+    assert!(rules[0].is_cvs_mode());
+}

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -67,6 +67,14 @@ pub struct FilterRule {
     pub(crate) exclude_only: bool,
     /// `n` modifier: on merge rules, do not inherit parent-directory rules.
     pub(crate) no_inherit: bool,
+    /// `C` modifier on merge / dir-merge rules: parse the merged file as
+    /// CVS-style ignores (whitespace-split, no comments, no prefixes,
+    /// no inheritance).
+    ///
+    /// upstream: exclude.c add_rule() ':C' modifier — CVS-ignore semantics
+    /// (sets `FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT
+    /// | FILTRULE_CVS_IGNORE`).
+    pub(crate) cvs_mode: bool,
 }
 
 impl FilterRule {
@@ -97,6 +105,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -127,6 +136,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -157,6 +167,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -177,6 +188,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -198,6 +210,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -222,6 +235,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -246,6 +260,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -274,6 +289,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -302,6 +318,7 @@ impl FilterRule {
             negate: false,
             exclude_only: false,
             no_inherit: false,
+            cvs_mode: false,
         }
     }
 
@@ -428,6 +445,27 @@ impl FilterRule {
     #[must_use]
     pub const fn with_no_inherit(mut self, no_inherit: bool) -> Self {
         self.no_inherit = no_inherit;
+        self
+    }
+
+    /// Returns whether the rule carries the `C` (CVS-ignore) modifier.
+    ///
+    /// On merge / dir-merge rules, this signals that the referenced file
+    /// must be parsed as CVS-style ignores (whitespace-split, no prefixes,
+    /// no inheritance).
+    ///
+    /// upstream: exclude.c add_rule() ':C' modifier — CVS-ignore semantics
+    #[must_use]
+    pub const fn is_cvs_mode(&self) -> bool {
+        self.cvs_mode
+    }
+
+    /// Sets the `C` (CVS-ignore) modifier on this rule.
+    ///
+    /// upstream: exclude.c add_rule() ':C' modifier — CVS-ignore semantics
+    #[must_use]
+    pub const fn with_cvs_mode(mut self, cvs_mode: bool) -> Self {
+        self.cvs_mode = cvs_mode;
         self
     }
 


### PR DESCRIPTION
## Summary

When a filter file read from disk (e.g. a `.rsync-filter` or per-directory
merge file like `mid/.filt`) contains a `:C` (or `.C`) directive with an
empty pattern, oc-rsync's `filters::parse_rules` parser rejected it as
`unrecognized filter rule` instead of defaulting the filename to
`.cvsignore`, and the `C` (CVS-ignore) modifier was never propagated from
`RuleModifiers` onto the resulting `FilterRule`. The wire-format path
(`transfer::generator::filters::wire_rule_to_dir_merge_config`) and the
CLI argv path (`crates/cli/.../parsing/merge.rs`) already handle `:C`
correctly; only the merge-file-on-disk path was broken. The failing
upstream `merge.test` and `exclude-lsh.test` scenarios depend on this
short form. Tracks task #4428 (UTS-V4.B).

## Changes

- `FilterRule` gains a `cvs_mode: bool` field with builder
  `with_cvs_mode` and accessor `is_cvs_mode`.
- `RuleModifiers::apply` propagates `cvs_mode` onto the rule.
- `try_parse_short_form` in `crates/filters/src/merge/parse.rs`
  special-cases empty pattern with `cvs_mode` set on `Merge`/`DirMerge`
  and defaults to `.cvsignore`.
- Destructure in `crates/filters/src/compiled/mod.rs` updated to accept
  the new field via `cvs_mode: _`.
- Three regression tests in `crates/filters/src/merge/tests.rs` cover
  `:C\n`, `:C my.ignore\n`, and `.C\n`.

## Upstream references

- `target/interop/upstream-src/rsync-3.4.4/exclude.c:1248-1255` -- `:C`
  sets `FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT | FILTRULE_CVS_IGNORE`.
- `target/interop/upstream-src/rsync-3.4.4/exclude.c:1324` -- empty
  pattern is only an error when `FILTRULE_CVS_IGNORE` is unset.
- `target/interop/upstream-src/rsync-3.4.4/exclude.c:1404-1408` --
  empty-pattern merge defaults to `.cvsignore`.
- `target/interop/upstream-src/rsync-3.4.4/testsuite/merge.test` and
  `testsuite/exclude-lsh.test:86-88` -- failing fixtures.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo check -p filters --all-features` (clean)
- [ ] CI full nextest matrix
- [ ] Upstream `merge.test` and `exclude-lsh.test` re-run on Linux host

## Notes

Task tracker #4428. Audit document referenced as the spec source.
The pre-existing PR #5817 is orthogonal: it changes the post-load
scope-evaluation path; this PR fixes the pre-load parse path. They
can land independently.