### PR TITLE
ci: add fast PR gate against --locked removal in workflow YAMLs

### DIFF
--- a/.github/workflows/locked-gate.yml
+++ b/.github/workflows/locked-gate.yml
@@ -1,0 +1,150 @@
+# CIM-LOCKFILE-5 fast PR gate.
+#
+# Diffs the PR against its base and asserts every cargo invocation
+# touched on this branch in `.github/workflows/**.yml` that runs a
+# gated subcommand (build, check, clippy, test, run, nextest run) also
+# carries `--locked`. Complementary to `check-locked-flags.yml`, which
+# runs the full historical scan via `tools/ci/check_locked_flags.sh`.
+#
+# Pure bash + grep, no cargo invocation; finishes in seconds and points
+# at the offending file:line. See docs/ci/locked-gate.md for the
+# exemption list and rationale.
+#
+# To make this a required check, add `locked-gate / gate` to the
+# protected-branch rule in repo settings after this workflow lands on
+# master.
+
+name: locked-gate
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**.yml'
+      - '.github/workflows/**.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: locked-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Gate changed workflows for --locked
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Gated subcommands (must carry `--locked` on the same logical
+          # command). Mirrors tools/ci/check_locked_flags.sh.
+          #   - cargo build, check, clippy, run, test
+          #   - cargo nextest run (the `run` subcommand only; `list` etc.
+          #     are not gated because they do not link tests).
+          # Exempt subcommands (intentionally lock-free):
+          #   - fmt, doc, bench, update, tree, metadata, fetch, install,
+          #     xtask, deb, generate-rpm, fuzz, cov, llvm-cov, deny,
+          #     hakari, publish.
+          # See docs/ci/locked-gate.md for the rationale.
+
+          # 1. Enumerate workflow YAMLs that changed on this PR. The
+          #    paths-filter on the workflow event already narrows the
+          #    trigger; this re-derives the precise file set so multi-
+          #    file PRs only scan the files they actually touch.
+          mapfile -t changed < <(
+              git diff --name-only --diff-filter=AM \
+                  "${BASE_SHA}" "${HEAD_SHA}" -- \
+                  '.github/workflows/*.yml' \
+                  '.github/workflows/*.yaml'
+          )
+
+          if [[ "${#changed[@]}" -eq 0 ]]; then
+              echo "locked-gate: no workflow YAMLs changed; nothing to gate."
+              exit 0
+          fi
+
+          echo "locked-gate: inspecting ${#changed[@]} changed workflow file(s)."
+          printf '  %s\n' "${changed[@]}"
+          echo
+
+          # 2. For each changed file, join backslash-continued lines and
+          #    grep for gated cargo invocations. Awk does the line join
+          #    so a `cargo build \` followed by `--locked` on the next
+          #    line is treated as a single logical command. Comments
+          #    (`# ...` at start-of-line or after whitespace) are
+          #    stripped before matching to avoid scanning prose.
+          violations=0
+          gated_re='(^|[^A-Za-z0-9_])cargo([[:space:]]+\+[A-Za-z0-9._-]+)?[[:space:]]+(build|check|clippy|run|test|nextest[[:space:]]+run)([[:space:]]|$)'
+          locked_re='(^|[[:space:]])--locked([[:space:]]|$)'
+
+          for f in "${changed[@]}"; do
+              [[ -f "$f" ]] || continue
+              # Join continuation lines, strip leading-whitespace `#` comments,
+              # then emit "<start-lineno>\t<joined-line>" rows.
+              while IFS=$'\t' read -r lineno joined; do
+                  [[ -z "$joined" ]] && continue
+                  # Skip lines that don't invoke a gated subcommand.
+                  if ! [[ "$joined" =~ $gated_re ]]; then
+                      continue
+                  fi
+                  if [[ "$joined" =~ $locked_re ]]; then
+                      continue
+                  fi
+                  violations=$((violations + 1))
+                  printf '::error file=%s,line=%s::missing --locked on gated cargo invocation\n' \
+                      "$f" "$lineno"
+                  printf 'VIOLATION %s:%s\n  %s\n\n' "$f" "$lineno" "$joined"
+              done < <(
+                  awk '
+                      {
+                          if (buf == "") start = NR
+                          line = $0
+                          # Strip a leading-whitespace `#` comment.
+                          sub(/^[[:space:]]*#.*$/, "", line)
+                          sub(/[[:space:]]+$/, "", line)
+                          if (line ~ /\\$/) {
+                              sub(/\\$/, "", line)
+                              buf = buf line " "
+                              next
+                          }
+                          buf = buf line
+                          if (buf ~ /cargo[[:space:]]/) {
+                              print start "\t" buf
+                          }
+                          buf = ""
+                      }
+                      END {
+                          if (buf != "" && buf ~ /cargo[[:space:]]/) {
+                              print start "\t" buf
+                          }
+                      }
+                  ' "$f"
+              )
+          done
+
+          if [[ "$violations" -gt 0 ]]; then
+              echo
+              echo "locked-gate: FAILED with ${violations} violation(s)."
+              echo
+              echo "Every cargo build|check|clippy|run|test|nextest run in a"
+              echo "workflow must pass --locked so Cargo.lock is honoured"
+              echo "byte-for-byte. If an invocation is genuinely lock-free"
+              echo "(e.g., a one-off plugin), add a line:line allowlist entry"
+              echo "to tools/ci/check_locked_flags.sh ALLOWLIST and call it"
+              echo "out in the PR description. See docs/ci/locked-gate.md."
+              exit 1
+          fi
+
+          echo "locked-gate: PASSED. All gated cargo invocations carry --locked."

--- a/docs/ci/locked-gate.md
+++ b/docs/ci/locked-gate.md
@@ -1,0 +1,71 @@
+# `--locked` regression gate
+
+`Cargo.lock` is committed and every CI build is meant to honour it via
+`--locked`. That guarantees byte-for-byte reproducible builds at a given
+commit, surfaces transitive-dep drift in its own PR rather than letting
+it ride along on an unrelated change, and keeps `cargo-lockfile-weekly`
+as the single intentional path for dep bumps.
+
+CIM-LOCKFILE-1..4 audited and fixed every cargo invocation in CI that
+should carry `--locked`. CIM-LOCKFILE-5 added two gates that prevent
+regressions:
+
+1. **`check-locked-flags.yml`** (full scan): runs
+   `tools/ci/check_locked_flags.sh` on every PR and on push to master.
+   Inspects every `.yml`/`.yaml`/`.sh` under `.github/workflows/` and
+   `tools/ci/` regardless of what changed in the PR.
+2. **`locked-gate.yml`** (fast PR gate): runs only on PRs that touch
+   `.github/workflows/**.yml`. Diffs HEAD against the PR base and only
+   inspects the workflow files that actually changed. Pure bash + grep,
+   no cargo invocation, finishes in seconds.
+
+The two gates intentionally overlap. The fast gate fails first on the
+common case of editing a workflow; the full scan catches anything the
+fast gate misses (renames, sneak-ins via merge commits, drift in shell
+helpers under `tools/ci/`).
+
+## Gated subcommands
+
+Every `cargo` invocation that runs one of these subcommands must carry
+`--locked` on the same logical command (continuation lines via `\` are
+joined before matching):
+
+- `cargo build`
+- `cargo check`
+- `cargo clippy`
+- `cargo run`
+- `cargo test`
+- `cargo nextest run`
+
+`+toolchain` selectors are recognised: `cargo +nightly nextest run`
+also requires `--locked`.
+
+## Exempt subcommands
+
+These subcommands are intentionally lock-free and the gate does not
+inspect them:
+
+| Subcommand | Reason |
+|---|---|
+| `cargo fmt` | Does not consume the workspace lockfile. |
+| `cargo doc` | Already lock-aware where it matters (see `pages.yml`); semantically a docs build. |
+| `cargo bench` | Benchmarks run against the workspace as resolved; lock state is incidental. |
+| `cargo update` | The lockfile-mutation entry point itself (used by `cargo-lockfile-weekly.yml`). |
+| `cargo tree`, `cargo metadata`, `cargo fetch` | Read-only inspection. |
+| `cargo install` | Installs a third-party CLI; carries `--locked` where the upstream supports it, but the gate does not enforce. |
+| `cargo xtask` | Workspace task runner; the underlying build is already gated. |
+| `cargo deb`, `cargo generate-rpm` | Wraps an already-built artifact. |
+| `cargo fuzz`, `cargo cov`, `cargo llvm-cov`, `cargo deny`, `cargo hakari`, `cargo publish` | Third-party plugins with their own resolution semantics. |
+
+## Adding a one-off exemption
+
+If a new invocation is genuinely lock-free (for example, a one-off
+plugin whose `--locked` flag does not exist), add a `path:line` entry
+to the `ALLOWLIST` array in
+[`tools/ci/check_locked_flags.sh`](../../tools/ci/check_locked_flags.sh)
+and document the rationale in the PR description. The fast PR gate
+shares the same conceptual allowlist by virtue of failing on the same
+condition; opting an invocation out means it stops appearing as a gated
+match in both gates.
+
+Routine cargo additions never need an exemption: just pass `--locked`.


### PR DESCRIPTION
## Summary

Add `.github/workflows/locked-gate.yml`, a pure bash + grep gate that runs only on PRs touching `.github/workflows/**.yml`, diffs HEAD against the PR base, and asserts every changed workflow's cargo invocation that runs a gated subcommand (`build`, `check`, `clippy`, `run`, `test`, `nextest run`) also carries `--locked`.

Complementary to `check-locked-flags.yml`, which scans the full history of `.github/workflows/**` and `tools/ci/**` on every PR via `tools/ci/check_locked_flags.sh`. The new gate fails first on the common case of editing a workflow and finishes in seconds; the full scan catches anything the fast gate misses (renames, sneak-ins via merge commits, drift in shell helpers).

## What it gates

- Gated subcommands: `cargo build|check|clippy|run|test|nextest run` (and the `+toolchain` form).
- Exempt subcommands: `fmt`, `doc`, `bench`, `update`, `tree`, `metadata`, `fetch`, `install`, `xtask`, `deb`, `generate-rpm`, `fuzz`, `cov`, `llvm-cov`, `deny`, `hakari`, `publish`. Rationale per row in `docs/ci/locked-gate.md`.
- Multi-line cargo invocations using `\` continuations are joined before matching.

## Local verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/locked-gate.yml'))"` -> OK.
- Synthetic single-line and `\`-continuation regression cases flag correctly; well-formed `--locked` calls and exempt subcommands pass.
- Ran the gate logic against the entire current workflow tree on master: 0 violations (zero false positives).
- `shellcheck` clean on the embedded bash.

## Post-merge action (cannot be done from a PR)

To make this a required check, add `locked-gate / gate` to the protected-branch rule for `master` in repo settings after this PR lands.

## Test plan

- [ ] CI: the new `locked-gate / gate` workflow runs on this PR (paths-filter is satisfied because we add `.github/workflows/locked-gate.yml`) and passes - the only changed workflow has no cargo invocations.
- [ ] `check-locked-flags / check` continues to pass (unchanged).
- [ ] After merge, repo admin adds `locked-gate / gate` as a required check.