### PR TITLE
fix(engine): pass pre_transfer_meta=None at FICLONE finalize call

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -177,6 +177,7 @@ pub(super) fn try_clone(
         destination_previously_existed,
         false,
         &mut None,
+        None,
         #[cfg(all(unix, feature = "xattr"))]
         flags.preserve_xattrs,
         #[cfg(all(any(unix, windows), feature = "acl"))]


### PR DESCRIPTION
## Summary

Master is broken with E0061 "this function takes 16 arguments but 15 arguments were supplied" at `crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs:166`.

PR #5839 added a `pre_transfer_meta: Option<&fs::Metadata>` parameter to `finalize_guard_and_metadata` to mirror upstream `rsync.c:dest_mode()` semantics, but the FICLONE caller introduced in PR #5836 was not updated.

FICLONE clones onto a freshly-created destination, so there is no pre-rename destination metadata to forward. `None` is the same value the macOS clonefile and inplace paths use.

## Test plan
- [ ] fmt + clippy passes
- [ ] all subsequent CI cells unblocked