### PR TITLE
ci(upstream-testsuite): surface per-test FAIL through step conclusion

### DIFF
--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -92,7 +92,12 @@ jobs:
           set -euo pipefail
           mkdir -p target/interop
           bash tools/ci/run_upstream_testsuite.sh 2>&1 | tee target/interop/upstream-testsuite-output.log
-        continue-on-error: true
+        # No step-level continue-on-error: a non-zero exit from the harness
+        # (UNEXPECTED FAIL outside known_failures.conf or UPASS regression)
+        # MUST surface to the job conclusion so PRs that claim to fix an
+        # upstream test can be validated against the per-test result. The
+        # job-level continue-on-error (above) keeps this from blocking
+        # branch protection while the failure list stabilizes.
 
       - name: Generate job summary
         if: always()


### PR DESCRIPTION
## Summary

The Upstream Testsuite workflow had \`continue-on-error: true\` at BOTH the job AND step level. With both in place, the workflow check conclusion is always \`SUCCESS\` regardless of whether any upstream test FAILed in the harness output.

This caused multiple PRs claiming to fix specific upstream tests to ship/queue as \"green\" while the per-test log still showed FAIL for the very test they claimed to fix:

| PR | Claimed test(s) | Per-test result on that PR's head |
|----|-----------------|-----------------------------------|
| #5815 | itemize | FAIL itemize (exit 1) |
| #5817 | exclude-lsh, exclude, files-from | FAIL on all three |
| #5811 | batch-mode | FAIL batch-mode (exit 1) |
| #5822 | backup | FAIL backup (exit 1) |
| #5842 (merged) | exclude-lsh, exclude | FAIL exclude-lsh + FAIL exclude |

Workflow checks all reported \`SUCCESS\` because the step-level \`continue-on-error\` swallowed the harness exit code before the job-level one could.

## Fix

Remove the step-level \`continue-on-error\` so the harness exit reaches the job conclusion. Keep the job-level \`continue-on-error: true\` so this check remains non-required for branch protection.

After this lands, the upstream testsuite check will show \`FAILURE\` whenever the harness exits non-zero (unexpected FAIL outside \`upstream_testsuite_known_failures.conf\`, or UPASS regression). It still does not block merges - branch protection does not require this check.

## Test plan
- [ ] CI run on this PR shows the upstream testsuite check resolving to its actual harness conclusion (not always SUCCESS)
- [ ] PRs in flight (#5815, #5817, #5811, #5822) show a FAILURE conclusion on the upstream testsuite check after they update from this fix, reflecting their still-FAILing claimed tests