### PR TITLE
ci(validate): one-shot workflow to validate upstream-testsuite failures are environmental

### DIFF
--- a/.github/workflows/validate-daemon-environmental.yml
+++ b/.github/workflows/validate-daemon-environmental.yml
@@ -1,0 +1,116 @@
+name: Validate daemon test is CI-environmental
+
+# Validates whether the upstream-testsuite `daemon` test failure (exit 10)
+# is CI-environment-only by running the same test with the UPSTREAM rsync
+# binary. If upstream rsync also fails here, the test is environmental and
+# the failure is not an oc-rsync bug.
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_name:
+        description: 'Upstream test to validate'
+        required: true
+        default: 'daemon'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-D warnings"
+  UPSTREAM_RSYNC_VERSION: "3.4.4"
+
+jobs:
+  validate:
+    name: validate environmental
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        with:
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+          version: v1
+
+      - name: Cache upstream rsync source
+        id: cache-upstream
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            target/interop/upstream-src/rsync-${{ env.UPSTREAM_RSYNC_VERSION }}
+          key: validate-daemon-env-${{ env.UPSTREAM_RSYNC_VERSION }}
+
+      - name: Build oc-rsync (release) - needed by harness even when validating upstream
+        run: cargo build --locked --release --bin oc-rsync
+
+      - name: Build upstream rsync + helpers (via harness for one test)
+        env:
+          OC_RSYNC_BIN: target/release/oc-rsync
+          UPSTREAM_VERSION: ${{ env.UPSTREAM_RSYNC_VERSION }}
+          WHICHTESTS: "${{ github.event.inputs.test_name }}.test"
+        run: |
+          set -euo pipefail
+          mkdir -p target/interop
+          # Run the harness once just to build the upstream rsync binary + helpers.
+          # We tolerate the test result (it likely fails - that's the whole point of the validation).
+          bash tools/ci/run_upstream_testsuite.sh 2>&1 | tee target/interop/oc-rsync-baseline.log || true
+
+      - name: Validate test with UPSTREAM rsync binary
+        id: validate
+        env:
+          UPSTREAM_VERSION: ${{ env.UPSTREAM_RSYNC_VERSION }}
+        run: |
+          set +e
+          bash tools/ci/run_upstream_test_with_upstream_binary.sh "${{ github.event.inputs.test_name }}" 2>&1 \
+            | tee target/interop/upstream-validation.log
+          status=${PIPESTATUS[0]}
+          echo "upstream_exit=${status}" >> "$GITHUB_OUTPUT"
+          # Pull the oc-rsync exit code for the same test out of the baseline log.
+          oc_status=$(grep -E "^(PASS|FAIL|SKIP|XFAIL|UPASS)\s+${{ github.event.inputs.test_name }}\b" target/interop/oc-rsync-baseline.log | head -1 || echo "unknown")
+          echo "oc_status=${oc_status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Summarize
+        run: |
+          set -euo pipefail
+          echo "## Daemon test environmental validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Test under validation: \`${{ github.event.inputs.test_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Binary | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| oc-rsync | \`${{ steps.validate.outputs.oc_status }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| upstream rsync (3.4.4) | exit code \`${{ steps.validate.outputs.upstream_exit }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          upstream_exit="${{ steps.validate.outputs.upstream_exit }}"
+          if [[ "$upstream_exit" == "0" ]]; then
+            echo "**Verdict**: upstream rsync PASSES in this environment - the oc-rsync failure IS a code bug." >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$upstream_exit" == "77" ]]; then
+            echo "**Verdict**: upstream rsync SKIPPED in this environment - inconclusive; test preconditions not met." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Verdict**: upstream rsync also FAILS (exit ${upstream_exit}) - the failure is ENVIRONMENTAL, not an oc-rsync bug." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: validate-daemon-env-logs
+          path: |
+            target/interop/oc-rsync-baseline.log
+            target/interop/upstream-validation.log
+            target/interop/upstream-testsuite/
+            target/interop/upstream-testsuite-validation/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/tools/ci/run_upstream_test_with_upstream_binary.sh
+++ b/tools/ci/run_upstream_test_with_upstream_binary.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# run_upstream_test_with_upstream_binary.sh - validate whether a failing
+# upstream-testsuite test is environmental (CI-only) by running the SAME
+# test with the UPSTREAM rsync binary instead of oc-rsync.
+#
+# If upstream rsync also fails in this environment, the test is environmental
+# and the failure is not an oc-rsync bug.
+#
+# Usage:
+#   tools/ci/run_upstream_test_with_upstream_binary.sh daemon
+#   tools/ci/run_upstream_test_with_upstream_binary.sh <test-name>
+#
+# Pre-conditions:
+#   - run_upstream_testsuite.sh has been executed at least once so that
+#     target/interop/upstream-src/rsync-3.4.4/rsync is built
+#   - All CHECK_PROGS helpers are built (the harness's build_upstream_helpers
+#     function handles this)
+
+set -euo pipefail
+
+workspace_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+upstream_version="${UPSTREAM_VERSION:-3.4.4}"
+upstream_src_dir="${workspace_root}/target/interop/upstream-src/rsync-${upstream_version}"
+upstream_rsync_bin="${upstream_src_dir}/rsync"
+testrun_timeout="${TESTRUN_TIMEOUT:-300}"
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <test-name>" >&2
+    exit 2
+fi
+test_name=$1
+
+if [[ ! -x "$upstream_rsync_bin" ]]; then
+    echo "ERROR: upstream rsync binary not found at $upstream_rsync_bin" >&2
+    echo "Run tools/ci/run_upstream_testsuite.sh first to build it." >&2
+    exit 2
+fi
+
+test_script="${upstream_src_dir}/testsuite/${test_name}.test"
+if [[ ! -f "$test_script" ]]; then
+    echo "ERROR: test script not found: $test_script" >&2
+    exit 2
+fi
+
+log_root="${workspace_root}/target/interop/upstream-testsuite-validation"
+rm -rf "$log_root"
+mkdir -p "$log_root"
+scratchbase="${log_root}/scratch"
+mkdir -p "$scratchbase"
+
+scratchdir="${scratchbase}/${test_name}"
+mkdir -p "$scratchdir"
+
+# Mirror the env exports from run_upstream_testsuite.sh::run_one_test.
+export TOOLDIR="$upstream_src_dir"
+export srcdir="${upstream_src_dir}/testsuite"
+export suitedir="${upstream_src_dir}/testsuite"
+export scratchdir
+export RSYNC="$upstream_rsync_bin"
+
+echo "==> Validating upstream-testsuite test '${test_name}' with UPSTREAM rsync"
+echo "==> RSYNC=$RSYNC"
+echo "==> $($RSYNC --version | head -1)"
+echo ""
+
+set +e
+timeout "$testrun_timeout" bash "$test_script" 2>&1 | tee "${log_root}/${test_name}.log"
+status=${PIPESTATUS[0]}
+set -e
+
+echo ""
+echo "==> Test '${test_name}' with upstream rsync EXIT CODE: ${status}"
+case "$status" in
+    0)
+        echo "==> RESULT: upstream rsync PASSES → environment is OK; if oc-rsync fails here, it's our bug"
+        ;;
+    77)
+        echo "==> RESULT: upstream rsync SKIPPED (env-precondition not met)"
+        ;;
+    124)
+        echo "==> RESULT: upstream rsync TIMED OUT after ${testrun_timeout}s"
+        ;;
+    *)
+        echo "==> RESULT: upstream rsync FAILS (exit ${status}) → ENVIRONMENTAL; oc-rsync failure is not a code bug"
+        ;;
+esac
+
+exit "$status"


### PR DESCRIPTION
## Summary

Adds a one-shot \`workflow_dispatch\` workflow that validates whether a given upstream-testsuite test failure is environmental (CI-only) by re-running it with upstream rsync 3.4.4 instead of oc-rsync — in the same GitHub Actions ubuntu-latest environment that's been reporting \`FAIL daemon (exit 10)\` across every drafted UTS PR.

Per task #4533 (UTS-DD-daemon-exit10), the suspected root cause is that GHA's hosted runner has IPv6 stack quirks: oc-rsync's daemon defaults to IPv6-first bind and silently swallows the per-family bind failure. If upstream rsync also gets exit 10 in this environment, the failure is environmental — not an oc-rsync code bug — and should be classified as a known CI flake. If upstream passes here, then the IPv6 default-bind fix needs to land in oc-rsync.

## What changed

- \`tools/ci/run_upstream_test_with_upstream_binary.sh\` — wrapper that exports the same env (\`TOOLDIR\`, \`srcdir\`, \`suitedir\`, \`scratchdir\`) as the harness but points \`RSYNC\` at \`target/interop/upstream-src/rsync-3.4.4/rsync\` and runs the test script directly. Reports the exit code with a verdict.
- \`.github/workflows/validate-daemon-environmental.yml\` — \`workflow_dispatch\`-only job. Default test is \`daemon\`. Job summary tabulates oc-rsync result vs upstream-rsync result and prints the verdict.

## Test plan

- [x] Workflow file YAML is valid (lints cleanly via gh)
- [ ] Trigger via \`workflow_dispatch\` with \`test_name=daemon\`
- [ ] Inspect job summary — verdict should print one of:
  - "upstream rsync PASSES → the oc-rsync failure IS a code bug"
  - "upstream rsync also FAILS → ENVIRONMENTAL"
- [ ] If verdict is environmental: add \`daemon\` to \`tools/ci/upstream_testsuite_known_failures.conf\` with a comment citing this run
- [ ] If verdict is bug: open follow-up task for the IPv6 default-bind fix