### PR TITLE
fix(engine): walk one level beneath trailing-slash --files-from sources

### DIFF
--- a/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_files_from.rs
@@ -155,3 +155,117 @@ fn files_from_embedded_dot_marker_determines_destination_structure() {
         b"hello"
     );
 }
+
+/// Verifies that `--files-from` entries flagged as DOTDIR_NAME (`from/./`) and
+/// SLASH_ENDING_NAME (`dir/`) walk their immediate children even when global
+/// recursion is off, matching upstream `flist.c:2442`.
+///
+/// Upstream's `(xfer_dirs && name_type != NORMAL_NAME)` predicate forces
+/// `send_directory()` to emit one level of contents for the listed directory.
+/// Subdirectories encountered during that walk are NOT recursed into further
+/// (matching `recurse=0` semantics), but flat files and immediate subdirs are
+/// transferred.
+///
+/// # Upstream Reference
+///
+/// - `testsuite/files-from.test` - the local invocation exercises this path
+/// - `flist.c:2329` - SLASH_ENDING_NAME / DOTDIR_NAME flagging
+/// - `flist.c:2442-2456` - `(xfer_dirs && name_type != NORMAL_NAME)` walk
+#[test]
+fn files_from_dotdir_entry_walks_immediate_children() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let scratch = tmp.path().join("scratch");
+    let from = scratch.join("from");
+    std::fs::create_dir_all(&from).expect("create from");
+
+    // Flat files and an immediate subdir under from/.
+    std::fs::write(from.join("alpha.txt"), b"alpha").expect("write alpha");
+    std::fs::write(from.join("beta.txt"), b"beta").expect("write beta");
+    let sub = from.join("sub");
+    std::fs::create_dir(&sub).expect("create sub");
+    // Files nested deeper than one level must NOT appear at the destination
+    // because the DOTDIR walk is one level only.
+    std::fs::write(sub.join("nested.txt"), b"nested").expect("write nested");
+
+    // Filelist with a bare DOTDIR entry: should emit `from/`'s immediate
+    // children at the destination root.
+    let list_path = tmp.path().join("filelist");
+    std::fs::write(&list_path, "from/./\n").expect("write list");
+
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir(&dest).expect("create dest");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-av"),
+        OsString::from(format!("--files-from={}", list_path.display())),
+        scratch.clone().into_os_string(),
+        OsString::from(format!("{}/", dest.display())),
+    ]);
+
+    assert_eq!(code, 0, "transfer should succeed");
+
+    // Flat children of `from/` appear at the destination root.
+    assert!(
+        dest.join("alpha.txt").exists(),
+        "alpha.txt should appear under dest/"
+    );
+    assert!(
+        dest.join("beta.txt").exists(),
+        "beta.txt should appear under dest/"
+    );
+    // The immediate subdirectory must exist (one-level walk emits it).
+    assert!(
+        dest.join("sub").is_dir(),
+        "sub/ should exist as an empty directory at dest/"
+    );
+    // Recursion stops at one level: the nested file must NOT be copied.
+    assert!(
+        !dest.join("sub").join("nested.txt").exists(),
+        "sub/nested.txt must NOT be copied (recursion is off)"
+    );
+}
+
+/// Verifies that a SLASH_ENDING_NAME `--files-from` entry (`dir/`) at a
+/// deeper level walks its immediate children even when global recursion is
+/// off.
+///
+/// Mirrors `testsuite/files-from.test` line 22 (`from/./dir/subdir/subsubdir2/`)
+/// where the trailing slash must pull `bin-lt-list` into the destination.
+#[test]
+fn files_from_slash_ending_entry_walks_immediate_children() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let scratch = tmp.path().join("scratch");
+    let leaf = scratch.join("from").join("dir").join("leaf");
+    std::fs::create_dir_all(&leaf).expect("create leaf");
+    std::fs::write(leaf.join("payload.bin"), b"payload").expect("write payload");
+
+    let list_path = tmp.path().join("filelist");
+    std::fs::write(&list_path, "from/./dir/leaf/\n").expect("write list");
+
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir(&dest).expect("create dest");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-av"),
+        OsString::from(format!("--files-from={}", list_path.display())),
+        scratch.clone().into_os_string(),
+        OsString::from(format!("{}/", dest.display())),
+    ]);
+
+    assert_eq!(code, 0, "transfer should succeed");
+
+    // The leaf directory must exist at dest/dir/leaf/ and contain the file
+    // copied by the one-level walk.
+    let copied = dest.join("dir").join("leaf").join("payload.bin");
+    assert!(
+        copied.exists(),
+        "payload.bin should be copied via SLASH_ENDING_NAME walk"
+    );
+    assert_eq!(std::fs::read(&copied).expect("read"), b"payload");
+}

--- a/crates/engine/src/local_copy/executor/directory/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/mod.rs
@@ -10,4 +10,5 @@ mod parallel_planner;
 pub(crate) use parallel_checksum::ChecksumCache;
 pub(crate) use recursive::capture_batch_file_entry;
 pub(crate) use recursive::copy_directory_recursive;
+pub(crate) use recursive::copy_directory_walk_one_level;
 pub(crate) use support::{is_device, is_fifo};

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -52,6 +52,52 @@ pub(crate) fn copy_directory_recursive(
     relative: Option<&Path>,
     root_device: Option<u64>,
 ) -> Result<bool, LocalCopyError> {
+    copy_directory_recursive_inner(
+        context,
+        source,
+        destination,
+        metadata,
+        relative,
+        root_device,
+        false,
+    )
+}
+
+/// Walks a directory's immediate children even when global recursion is off.
+///
+/// Mirrors upstream `flist.c:2442` which honours `(xfer_dirs && name_type != NORMAL_NAME)`
+/// to walk one level beneath SLASH_ENDING_NAME / DOTDIR_NAME source arguments
+/// (and `--files-from` entries with the corresponding markers). Subdirectories
+/// encountered during this one-level walk are NOT recursed into further,
+/// matching upstream's `recurse=0` semantics inside `send_directory()`.
+pub(crate) fn copy_directory_walk_one_level(
+    context: &mut CopyContext,
+    source: &Path,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    relative: Option<&Path>,
+    root_device: Option<u64>,
+) -> Result<bool, LocalCopyError> {
+    copy_directory_recursive_inner(
+        context,
+        source,
+        destination,
+        metadata,
+        relative,
+        root_device,
+        true,
+    )
+}
+
+fn copy_directory_recursive_inner(
+    context: &mut CopyContext,
+    source: &Path,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    relative: Option<&Path>,
+    root_device: Option<u64>,
+    force_walk_one_level: bool,
+) -> Result<bool, LocalCopyError> {
     #[cfg(any(
         all(unix, any(feature = "acl", feature = "xattr")),
         all(windows, feature = "acl")
@@ -159,7 +205,11 @@ pub(crate) fn copy_directory_recursive(
         Ok(())
     };
 
-    if !context.recursive_enabled() {
+    // upstream: flist.c:2442 - global recursion off AND not a trailing-slash
+    // / DOTDIR source: emit the directory entry only and stop. Trailing-slash
+    // sources (`force_walk_one_level`) fall through to walk one level so
+    // upstream's `(xfer_dirs && name_type != NORMAL_NAME)` semantics hold.
+    if !context.recursive_enabled() && !force_walk_one_level {
         ensure_directory(context)?;
         record_directory_completion(context, creation_record_pending, None);
         if !context.mode().is_dry_run() {

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -12,7 +12,8 @@ mod util;
 pub(crate) use cleanup::{delete_extraneous_entries, remove_source_entry_if_requested};
 pub(crate) use directory::ChecksumCache;
 pub(crate) use directory::{
-    capture_batch_file_entry, copy_directory_recursive, is_device, is_fifo,
+    capture_batch_file_entry, copy_directory_recursive, copy_directory_walk_one_level, is_device,
+    is_fifo,
 };
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -13,8 +13,8 @@ use crate::local_copy::{is_device, is_fifo};
 use ::metadata::MetadataOptions;
 
 use super::super::{
-    capture_batch_file_entry, copy_device, copy_directory_recursive, copy_fifo, copy_file,
-    copy_symlink, non_empty_path, transcode_filename_component,
+    capture_batch_file_entry, copy_device, copy_directory_recursive, copy_directory_walk_one_level,
+    copy_fifo, copy_file, copy_symlink, non_empty_path, transcode_filename_component,
 };
 use super::destination::{compute_special_target_path, compute_target_path};
 use super::metadata::resolve_effective_metadata;
@@ -100,14 +100,29 @@ pub(super) fn handle_directory_contents_copy(
     // so the batch file matches upstream's wire format.
     capture_batch_file_entry(context, source_path, Path::new("."), metadata, true)?;
 
-    copy_directory_recursive(
-        context,
-        source_path,
-        &target_root,
-        metadata,
-        relative_root.and_then(|root| non_empty_path(root.as_path())),
-        root_device,
-    )?;
+    // upstream: flist.c:2442 - trailing-slash sources (DOTDIR_NAME /
+    // SLASH_ENDING_NAME) walk their immediate children even when global
+    // recursion is off, so `--files-from` entries like `from/./` and
+    // `subsubdir2/` populate the destination with one level of contents.
+    if context.recursive_enabled() {
+        copy_directory_recursive(
+            context,
+            source_path,
+            &target_root,
+            metadata,
+            relative_root.and_then(|root| non_empty_path(root.as_path())),
+            root_device,
+        )?;
+    } else {
+        copy_directory_walk_one_level(
+            context,
+            source_path,
+            &target_root,
+            metadata,
+            relative_root.and_then(|root| non_empty_path(root.as_path())),
+            root_device,
+        )?;
+    }
 
     Ok(true)
 }


### PR DESCRIPTION
## Summary

Fixes the upstream-testsuite `files-from.test` local invocation, which had been failing because `--files-from` entries flagged as `DOTDIR_NAME` (`from/./`) and `SLASH_ENDING_NAME` (`subsubdir2/`) only created the destination directory and never walked its immediate children. The chk/to diff diverged on every flat child (`empty`, `emptydir`, `filelist`, `nolf`, `nolf-symlink`, `text`) and on `dir/subdir/subsubdir2/bin-lt-list`.

Upstream `flist.c:2442` honours `(xfer_dirs && name_type != NORMAL_NAME)` so `send_directory()` runs for trailing-slash entries even when global `recurse` is off (`options.c:2189` clears it whenever `--files-from` is active). Subdirectories encountered during that walk are not recursed into further, matching `recurse=0`.

- Introduce `copy_directory_walk_one_level` so `handle_directory_contents_copy` can request the one-level walk on trailing-slash sources.
- Share the inner routine with `copy_directory_recursive` via a `force_walk_one_level` flag threaded through the bail-out.
- Child directories reached via `process_planned_entry::CopyDirectory` still go through the normal entry and bail out, preserving `recurse=0` semantics inside the walk.
- Add two CLI-level regression tests covering the DOTDIR (`from/./`) and SLASH_ENDING (`leaf/`) flows on the local code path.

## Scope

This PR addresses the **local** (first) invocation of `testsuite/files-from.test`. The 4 SSH-mode invocations (deep-dive sub-tasks #4507-#4511) are deliberately out of scope for this PR; they will surface as separate failures once the local case flips green and require generator-side / push-forwarding work. Splitting them avoids blending unrelated fixes.

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI: `Upstream Testsuite` workflow flips `files-from` from FAIL to PASS on its local invocation
- [ ] CI: existing `cargo nextest` workspace remains green (`execute_with_trailing_separator_copies_contents`, `execute_skips_directories_when_recursion_disabled_without_dirs`, `execute_creates_directories_when_dirs_enabled_without_recursion`, `files_from_*` CLI tests, etc.)
- [ ] CI: `fmt+clippy`, Windows / macOS / Linux musl stable matrices