### PR TITLE
fix(transfer): parse compact -K to honour --keep-dirlinks on receiver

### DIFF
--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -77,6 +77,25 @@ pub struct ParsedServerFlags {
     pub ignore_times: bool,
     /// Copy symlinks as the referent file/dir (`L` flag, `--copy-links`).
     pub copy_links: bool,
+    /// Treat dest-side directory symlinks as the directories they point to
+    /// (`K` flag, `--keep-dirlinks`).
+    ///
+    /// Upstream: options.c:688 `{"keep-dirlinks", 'K', ...}` and
+    /// generator.c:1344 `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`.
+    /// On the receiver this prevents replacing a destination symlink-to-dir
+    /// with a real directory and lets per-file operations (basis open, chmod
+    /// of the file leaf) follow the dir-symlink instead of being refused by
+    /// the dirfd sandbox. Issue #715 regression covered by
+    /// `testsuite/symlink-dirlink-basis.test`.
+    pub keep_dirlinks: bool,
+    /// Follow symlinks that point at directories on the sender (`k` flag,
+    /// `--copy-dirlinks`).
+    ///
+    /// Upstream: options.c:687 `{"copy-dirlinks", 'k', ...}`. Sender-only
+    /// semantics: the file list reports each dir-symlink as the directory
+    /// it resolves to. Captured here so the server-side sender process
+    /// honours `-k` when the client requested it.
+    pub copy_dirlinks: bool,
     /// Copy unsafe symlinks as files (long-form `--copy-unsafe-links`).
     ///
     /// Not part of the compact flag string; set via long-form args.
@@ -260,6 +279,19 @@ impl ParsedServerFlags {
             b'N' => self.crtimes = true,
             // upstream: options.c:764 - 'L' = copy_links (resolve symlinks).
             b'L' => self.copy_links = true,
+            // upstream: options.c:688 - 'K' = keep_dirlinks (preserve
+            // destination dir-symlinks instead of replacing them). The
+            // receiver also routes path-based chmod through the
+            // keep_dirlinks bypass so the leaf chmod follows the
+            // symlinked parent (PR #5793). Without parsing this, the
+            // server runs as if --keep-dirlinks was off and every per-
+            // file operation on `dir/file` (basis open, chmod) is
+            // refused by the dirfd sandbox because `dir` is a symlink.
+            b'K' => self.keep_dirlinks = true,
+            // upstream: options.c:687 - 'k' = copy_dirlinks (sender-side
+            // follow dir-symlinks). Sender-only knob; recorded for parity
+            // so the server-side sender process honours -k.
+            b'k' => self.copy_dirlinks = true,
             // upstream: options.c:764 - fuzzy_basis++ for each 'y'
             b'y' => self.fuzzy_level = self.fuzzy_level.saturating_add(1),
             b'm' => self.prune_empty_dirs = true,
@@ -441,6 +473,41 @@ mod tests {
         let flags = ParsedServerFlags::parse("-rb").unwrap();
         assert!(flags.recursive);
         assert!(flags.backup);
+    }
+
+    /// Issue #715 regression: the client emits `-K` in the compact flag
+    /// string whenever `--keep-dirlinks` is active (upstream
+    /// `options.c:688`). Without recognising the byte the receiver runs
+    /// with `keep_dirlinks=false`, so the dirfd sandbox refuses every
+    /// chmod through a destination dir-symlink and the
+    /// `symlink-dirlink-basis` test fails before any delta transfer.
+    #[test]
+    fn parses_keep_dirlinks_flag() {
+        let flags = ParsedServerFlags::parse("-KRlptv").unwrap();
+        assert!(flags.keep_dirlinks);
+        assert!(flags.relative);
+        assert!(flags.links);
+        assert!(flags.perms);
+        assert!(flags.times);
+        assert!(flags.verbose);
+    }
+
+    #[test]
+    fn keep_dirlinks_not_set_by_default() {
+        let flags = ParsedServerFlags::parse("-rlptv").unwrap();
+        assert!(!flags.keep_dirlinks);
+    }
+
+    /// upstream: options.c:687 - 'k' is `--copy-dirlinks`, captured for
+    /// parity even though it only affects the sender. The receiver
+    /// process must still ignore unknown bytes silently rather than
+    /// reject the flag string.
+    #[test]
+    fn parses_copy_dirlinks_flag() {
+        let flags = ParsedServerFlags::parse("-rk").unwrap();
+        assert!(flags.recursive);
+        assert!(flags.copy_dirlinks);
+        assert!(!flags.keep_dirlinks);
     }
 
     #[test]

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -153,6 +153,17 @@ impl ReceiverContext {
             .preserve_owner(self.config.flags.owner)
             .preserve_group(self.config.flags.group)
             .numeric_ids(self.config.flags.numeric_ids)
+            // upstream: generator.c:1344 - `link_stat(fname, &sx.st,
+            // keep_dirlinks && is_dir)` follows a destination symlink-to-dir
+            // at stat time instead of rejecting it. The
+            // `chmod_path_honoring_keep_dirlinks` helper in
+            // `crates/metadata/src/apply/permissions.rs` consults this flag
+            // to route past the dirfd sandbox when the symlinked parent
+            // would otherwise surface `ELOOP`/`ENOTDIR`. Without this the
+            // SSH receiver runs with `keep_dirlinks: false` even when the
+            // client sent `K` in the compact flag string, breaking the
+            // `symlink-dirlink-basis` regression test (Issue #715).
+            .with_keep_dirlinks(self.config.flags.keep_dirlinks)
             // upstream: clientserver.c:1106-1107 - `fake super = yes` on the
             // daemon module forces fake-super metadata storage on the receiver
             // (ownership and special-file metadata go to user.rsync.%stat


### PR DESCRIPTION
## Summary

The server-side compact flag parser silently dropped the `K` byte the client emits whenever `--keep-dirlinks` is active. With the flag absent from `ParsedServerFlags`, the receiver constructed `MetadataOptions` with `keep_dirlinks: false`, so the dirfd-anchored chmod bypass added in PR #5793 never engaged: every per-file chmod through a destination dir-symlink (`$HOME/dir/file` when `dir -> real-dir`) was refused with `ELOOP`/`ENOTDIR` before any delta could land. Every basis-symlink scenario in `testsuite/symlink-dirlink-basis.test` (Issue #715, eight topologies covering basic / nested / `--backup` / `--inplace` / top-level / proto-28 / `--partial-dir`) bottoms out on this same gap.

## Root cause

`crates/transfer/src/flags.rs` mapped every transfer byte except `K` and `k` to a structured field. The unknown-byte catch-all swallowed both, so `flags.keep_dirlinks` was permanently `false` no matter what the client sent.

Downstream, `crates/transfer/src/receiver/transfer/setup.rs` built `MetadataOptions` from `self.config.flags` without calling `with_keep_dirlinks`. Even after fixing the parser, the receiver would still take the strict chmod path because the bypass is gated on `options.keep_dirlinks()`.

## Fix

1. Add `keep_dirlinks: bool` (and `copy_dirlinks: bool` for parity with the sender-side `k`) to `ParsedServerFlags`.
2. Decode `K` and `k` in `parse_transfer_flag` with `upstream: options.c:687,688` references.
3. Chain `.with_keep_dirlinks(self.config.flags.keep_dirlinks)` into the receiver's `MetadataOptions` construction so `chmod_path_honoring_keep_dirlinks` (`crates/metadata/src/apply/permissions.rs:451`) routes past the dirfd sandbox when the symlinked parent would otherwise surface `ELOOP`/`ENOTDIR`.

The default code path (`--keep-dirlinks` off) is unchanged: `secure_chmod_at` and the dirfd sandbox keep the SEC-1 / CVE-29518 guard intact for every other transfer.

## Upstream reference

- `options.c:688` `{"keep-dirlinks", 'K', POPT_ARG_NONE, &keep_dirlinks, 0, 0, 0}`
- `generator.c:1344` `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`

## Test plan

- [x] New unit tests `parses_keep_dirlinks_flag`, `keep_dirlinks_not_set_by_default`, and `parses_copy_dirlinks_flag` pin the new bytes in the compact server flag parser.
- [ ] Upstream Testsuite job runs `testsuite/symlink-dirlink-basis.test` end-to-end (all eight topologies) over `lsh.sh`. Marked DRAFT pending that signal.
- [ ] Existing `keep_dirlinks_bypasses_secure_chmod_sandbox` and `keep_dirlinks_bypass_is_cross_platform_safe` in `crates/metadata/src/apply/tests.rs` continue to assert the bypass landing site is wired correctly.
- [ ] CI verifies fmt, clippy, and the full nextest matrix on Linux / macOS / Windows.