### PR TITLE
test(upstream-testsuite): mark daemon test as known CI-env failure

### DIFF
--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -15,6 +15,21 @@
 
 KNOWN_FAILURES=(
 
+  # "daemon" - CI-environment-only failure on GitHub Actions hosted runners.
+  #   The upstream daemon.test exits with code 10 (daemon startup) because
+  #   GitHub Actions runners disable IPv6 on the loopback interface; the
+  #   default dual-stack IPv6-first bind path the daemon takes when handed
+  #   port=0 cannot acquire `::1`, surfaces only as an IPv4 listener, and
+  #   trips a per-family bind error that the harness reads as exit 10.
+  #   The same binary passes the test on every developer host (Linux,
+  #   macOS) and inside the rsync-profile podman container, where IPv6
+  #   loopback is available. Documented in UTS-DD-daemon-exit10 deep dive.
+  #   Track real fixes under UTS-DD-daemon-exit10.1 (IPv4-only default)
+  #   and UTS-DD-daemon-exit10.2 (surface per-family bind errors as
+  #   warnings) before removing this entry.
+
+  "daemon"
+
   # -----------------------------------------------------------------------
   # Removed entries:
   #


### PR DESCRIPTION
## Summary
- Add `daemon` upstream test to `tools/ci/upstream_testsuite_known_failures.conf` so the harness reports it as XFAIL instead of an unexpected FAIL on CI.
- Document the root cause (UTS-DD-daemon-exit10): GitHub Actions hosted runners disable IPv6 on the loopback interface, which trips the daemon's IPv6-first dual-stack bind path with exit 10. The same binary passes the test on developer hosts and the podman container.
- Track real fixes under UTS-DD-daemon-exit10.1 (IPv4-only fallback) and UTS-DD-daemon-exit10.2 (surface per-family bind warnings); remove this entry when they land.

## Test plan
- [x] `bash -c '. tools/ci/upstream_testsuite_known_failures.conf && echo "${KNOWN_FAILURES[*]}"'` reports `daemon`.
- [ ] Upstream testsuite CI cell reports `XFAIL` for `daemon` (was: unexpected FAIL).
- [ ] No other UTS test regresses.