### PR TITLE
fix(transfer): expect suffix on backup_dir-relocated backup name

### DIFF
--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -321,7 +321,11 @@ mod tests {
             "new-content",
             "staged file must replace destination after backup"
         );
-        let backup_path = backup_root.join("name1");
+        // upstream: backup.c::get_backup_name() appends the configured
+        // suffix even when backup_dir is set. `compute_backup_path` mirrors
+        // that semantic (see `compute_backup_path_with_backup_dir` in
+        // engine::local_copy::tests::executor_file_operations).
+        let backup_path = backup_root.join("name1~");
         assert_eq!(
             fs::read_to_string(&backup_path).unwrap(),
             "old-content",


### PR DESCRIPTION
## Summary

- The new `handle_delayed_updates_backs_up_existing_destination` test from PR #5859 asserts the backup file at `backup_root/name1`, but `compute_backup_path` always appends the configured suffix (here `~`), so the actual file is at `backup_root/name1~`.
- The existing `compute_backup_path_with_backup_dir` test in `engine::local_copy::tests::executor_file_operations` (line 59) pins the same contract: `backup_dir/file.txt~` with `~` appended even when `backup_dir` is set, mirroring upstream `backup.c::get_backup_name()`.
- Surfaced as a Windows IOCP `NotFound` panic at `crates/transfer/src/receiver/transfer.rs:326` on PR #5852's CI (https://github.com/oferchen/rsync/actions/runs/27666666564/job/81823930303). Linux/macOS nextest cells were still queued when the panic was first observed; the bug is platform-agnostic.

## Test plan

- [ ] nextest (stable) passes the renamed test on Linux, macOS, Windows IOCP
- [ ] `cargo nextest run -p transfer -E 'test(handle_delayed_updates_backs_up_existing_destination)'` passes locally
- [ ] No regression in `handle_delayed_updates_no_backup_when_dest_missing` (already asserts `name1`, but only the *negative* presence check, which remains correct because both `name1` and `name1~` are absent in that case)