### PR TITLE
fix(engine): copy matched blocks from backup when --inplace + --backup-dir

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -19,12 +19,20 @@ impl<'a> CopyContext<'a> {
         total_size: u64,
         initial_bytes: u64,
         start: Instant,
+        basis_separate_from_writer: bool,
     ) -> Result<FileCopyOutcome, LocalCopyError> {
         // In inplace mode the writer IS the destination file; matched blocks
         // are already in place so no separate reader is needed. In normal mode
         // the writer is a temp file and we read matched blocks from the old
         // destination.
-        let inplace_mode = self.inplace_enabled();
+        //
+        // When `basis_separate_from_writer` is true, the basis lives at a
+        // different path than the writer (e.g. `--inplace --backup-dir` moved
+        // the original destination to the backup location before opening a
+        // fresh writer). In that case the inplace optimization is unsafe -
+        // the writer's file is empty, so matched blocks must be copied from
+        // the separate basis path. Fall through to the non-inplace code path.
+        let inplace_mode = self.inplace_enabled() && !basis_separate_from_writer;
 
         let mut destination_reader = if !inplace_mode {
             Some(fs::File::open(destination).map_err(|error| {

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -316,6 +316,7 @@ impl<'a> CopyContext<'a> {
         total_size: u64,
         initial_bytes: u64,
         start: Instant,
+        basis_separate_from_writer: bool,
     ) -> Result<FileCopyOutcome, LocalCopyError> {
         if let Some(index) = delta {
             return self.copy_file_contents_with_delta(
@@ -331,6 +332,7 @@ impl<'a> CopyContext<'a> {
                 total_size,
                 initial_bytes,
                 start,
+                basis_separate_from_writer,
             );
         }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -487,6 +487,14 @@ pub(in crate::local_copy) fn execute_transfer(
     // When backup moved the basis file, point the delta transfer at its new
     // location so it can read matched blocks from the backup copy.
     let delta_basis = delta_basis_override.as_deref().unwrap_or(destination);
+    // upstream: receiver.c:872-876 - when --inplace + --backup runs, upstream
+    // sets `fnamecmp = get_backup_name(fname)` (FNAMECMP_BACKUP) so matched
+    // blocks read from the backup path while the writer overwrites the
+    // (now-empty) destination. If we kept the inplace optimization in this
+    // case, matched-block bytes would never reach the writer (the writer's
+    // file is fresh after the backup rename), and the destination would end
+    // up with only literal bytes plus sparse holes.
+    let basis_separate_from_writer = delta_basis_override.is_some();
     let copy_result = context.copy_file_contents(
         &mut reader,
         &mut writer,
@@ -500,6 +508,7 @@ pub(in crate::local_copy) fn execute_transfer(
         file_size,
         append_offset,
         start,
+        basis_separate_from_writer,
     );
 
     // On Linux, keep writer alive for fd-based metadata (fchmod/fchown/futimens).

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1195,6 +1195,80 @@ fn backup_with_inplace_mode() {
     assert_eq!(fs::read(dest_root.join("file.txt")).expect("read dest"), b"inplace new");
 }
 
+// Regression: --inplace + --no-whole-file + --backup-dir on a delta transfer
+// must copy matched blocks from the renamed-away basis. Before the fix, the
+// inplace optimization (skip reading matched blocks because writer is the
+// basis file) ran against a fresh empty destination, so matched-block bytes
+// never reached the writer. The destination ended up containing only literal
+// bytes, surrounded by sparse holes / truncated to the literal tail.
+//
+// upstream backup.test invocation 5:
+//   rsync -ai --inplace --no-whole-file --backup --backup-dir=$bak from/ to/
+// upstream receiver.c:872-876 sets fnamecmp = get_backup_name(fname)
+// (FNAMECMP_BACKUP) so the basis is read from the backup path while the
+// writer overwrites the (now-empty) destination.
+#[test]
+fn backup_dir_with_inplace_no_whole_file_copies_matched_blocks() {
+    use std::iter::repeat;
+
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+    let backup_root = ctx.dest.join("bak");
+    fs::create_dir_all(&backup_root).expect("create backup dir");
+
+    // Build content large enough that the delta encoder uses multiple blocks
+    // (block_size defaults around 700 bytes for small files). Source and basis
+    // share an identical suffix so the matched-block path is exercised, and
+    // they differ in the prefix so literal writes are also exercised. Without
+    // the fix, the matched-block path is skipped for inplace mode, and the
+    // destination loses the entire suffix.
+    let common_tail: String = repeat('y').take(8 * 1024).collect();
+    let source_content = format!("source-only-prefix-{}\n{}", "x".repeat(2 * 1024), common_tail);
+    let basis_content = format!("BASIS-ONLY-PREFIX-{}\n{}", "Z".repeat(2 * 1024), common_tail);
+
+    let source_file = ctx.source.join("payload.bin");
+    fs::write(&source_file, source_content.as_bytes()).expect("write source");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    let existing = dest_root.join("payload.bin");
+    fs::write(&existing, basis_content.as_bytes()).expect("write basis");
+
+    let operands = vec![
+        ctx.source.into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_directory(Some(backup_root.clone()))
+        .inplace(true)
+        .whole_file(false);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_after = fs::read(dest_root.join("payload.bin")).expect("read dest");
+    assert_eq!(
+        dest_after.len(),
+        source_content.as_bytes().len(),
+        "destination size must match source size after delta with backup-dir",
+    );
+    assert_eq!(
+        dest_after,
+        source_content.as_bytes(),
+        "destination must be byte-identical to source after delta with backup-dir",
+    );
+
+    let backup_path = backup_root.join("payload.bin~");
+    let backed_up = fs::read(&backup_path).expect("read backup");
+    assert_eq!(
+        backed_up,
+        basis_content.as_bytes(),
+        "backup-dir must hold the pre-overwrite basis content",
+    );
+}
+
 #[test]
 fn backup_with_force_directory_replaced_by_file() {
     let ctx = test_helpers::setup_copy_test();

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1209,8 +1209,6 @@ fn backup_with_inplace_mode() {
 // writer overwrites the (now-empty) destination.
 #[test]
 fn backup_dir_with_inplace_no_whole_file_copies_matched_blocks() {
-    use std::iter::repeat;
-
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
     let backup_root = ctx.dest.join("bak");
@@ -1222,7 +1220,7 @@ fn backup_dir_with_inplace_no_whole_file_copies_matched_blocks() {
     // they differ in the prefix so literal writes are also exercised. Without
     // the fix, the matched-block path is skipped for inplace mode, and the
     // destination loses the entire suffix.
-    let common_tail: String = repeat('y').take(8 * 1024).collect();
+    let common_tail = "y".repeat(8 * 1024);
     let source_content = format!("source-only-prefix-{}\n{}", "x".repeat(2 * 1024), common_tail);
     let basis_content = format!("BASIS-ONLY-PREFIX-{}\n{}", "Z".repeat(2 * 1024), common_tail);
 
@@ -1251,7 +1249,7 @@ fn backup_dir_with_inplace_no_whole_file_copies_matched_blocks() {
     let dest_after = fs::read(dest_root.join("payload.bin")).expect("read dest");
     assert_eq!(
         dest_after.len(),
-        source_content.as_bytes().len(),
+        source_content.len(),
         "destination size must match source size after delta with backup-dir",
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

- Fixes destination truncation when `--inplace --no-whole-file --backup --backup-dir=...` is used together (the 5th invocation in upstream backup.test).
- The local-copy delta-transfer inplace optimization assumed writer == basis; that breaks when `backup_existing_entry` renames the original destination to the backup location and opens a fresh empty file at the destination path.
- Threads `basis_separate_from_writer` through `copy_file_contents` and `copy_file_contents_with_delta`, derived from `delta_basis_override.is_some()` at the executor call site. When true, the inplace optimization is bypassed and matched blocks are copied from the backup path. Mirrors upstream `receiver.c:872-876` (FNAMECMP_BACKUP).
- Adds regression test `backup_dir_with_inplace_no_whole_file_copies_matched_blocks` exercising matched-block + literal mix on an 8KB common-tail fixture.

## Test plan

- [ ] `nextest run -p engine --all-features -E 'test(backup_dir_with_inplace_no_whole_file_copies_matched_blocks)'` passes.
- [ ] Full engine nextest suite passes (no regression on existing `backup_with_inplace_mode`).
- [ ] Upstream testsuite `backup` test passes through invocation 5 (`--inplace --no-whole-file --backup --backup-dir=$bak from/ to/`).
- [ ] CI matrix green across Linux/macOS/Windows.