### PR TITLE
fix(transfer): open basis with O_NOFOLLOW on basename

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -104,6 +104,9 @@ pub mod kernel_version;
 /// the SEC-1.l audit) and do not depend on this module.
 #[cfg(unix)]
 pub mod linux_capabilities;
+/// Receiver-side basis open with `O_NOFOLLOW` on the basename, matching
+/// upstream rsync's `do_open_at()` dirname/basename split.
+pub mod nofollow_open;
 /// Page-aligned buffer pool for IOCP no-buffering mode.
 pub mod page_aligned;
 /// Parallel file I/O operations using rayon.
@@ -322,6 +325,7 @@ pub use kernel_version::{
 };
 #[cfg(unix)]
 pub use linux_capabilities::openat2_supported;
+pub use nofollow_open::open_basis_nofollow;
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]
 pub use secure_dir::secure_open_dir;

--- a/crates/fast_io/src/nofollow_open.rs
+++ b/crates/fast_io/src/nofollow_open.rs
@@ -1,0 +1,206 @@
+//! Receiver-side basis file open with `O_NOFOLLOW` on the basename.
+//!
+//! Mirrors upstream rsync's `do_open_at()` / `secure_relative_open()`
+//! dirname/basename split in `syscall.c:705` and `syscall.c:1769`: the
+//! parent directory is opened with normal symlink resolution (so a
+//! legitimate directory symlink such as the one created by
+//! `--copy-dirlinks` continues to work) while the final path component
+//! is opened with `openat(dirfd, basename, O_RDONLY | O_NOFOLLOW)` so a
+//! pre-planted symlinked basename cannot redirect the basis read to an
+//! attacker-chosen file.
+//!
+//! The receiver basis lookup is the call site this helper exists for:
+//! it must follow directory symlinks (issue #715 regression test
+//! `symlink-dirlink-basis.test`) while still refusing to follow a
+//! symlinked leaf component. Path-confinement (`RESOLVE_BENEATH`) is
+//! handled separately by [`crate::secure_dir::secure_open_dir`] and
+//! [`crate::DirSandbox`]; this helper deliberately does not enforce it,
+//! because the receiver already resolves the destination root before
+//! reaching the basis lookup.
+//!
+//! # Platform behaviour
+//!
+//! - Unix: dirname/basename split with `O_NOFOLLOW` on the basename via
+//!   `openat(2)`. Top-level paths (no slash) bypass the split and call
+//!   `open(2)` directly, matching upstream's `if (!slash) return
+//!   do_open(...)` short-circuit.
+//! - Windows: falls back to [`std::fs::File::open`]. The standard NTFS
+//!   open path does not auto-follow reparse-point symlinks in a way that
+//!   the receiver tree creates, and the rsync upstream guarantee is
+//!   limited to platforms with `O_NOFOLLOW`. See the `WPC-*` audit for
+//!   the broader Windows symlink/reparse story.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Open `path` for reading with upstream `do_open_at()` semantics: the
+/// parent directory is resolved normally (symlinks followed) and the
+/// basename is opened with `O_NOFOLLOW` so a symlinked leaf component
+/// is rejected with `ELOOP`.
+///
+/// Top-level paths (no `/`) short-circuit to [`File::open`] because
+/// there is no dirname to split, matching upstream `syscall.c:727`.
+///
+/// # Errors
+///
+/// - `ELOOP` (`io::ErrorKind::FilesystemLoop` on Rust 1.78+ where
+///   available, otherwise the raw OS error) when the basename is a
+///   symlink.
+/// - Any other I/O error from opening the parent directory or the
+///   basename (forwarded verbatim from the underlying syscall).
+pub fn open_basis_nofollow(path: &Path) -> io::Result<File> {
+    imp::open_basis_nofollow(path)
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+    use std::os::fd::AsFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    use crate::dir_sandbox::openat;
+
+    pub(super) fn open_basis_nofollow(path: &Path) -> io::Result<File> {
+        let Some(basename) = path.file_name() else {
+            // No basename (e.g. "/" or ""): defer to the plain open and
+            // let the kernel report the appropriate error. Mirrors
+            // upstream's pass-through for degenerate inputs.
+            return File::open(path);
+        };
+
+        // Upstream `syscall.c:727`: `if (!slash) return do_open(...)`.
+        // Treat the empty parent ("foo" with no slash) and the lone
+        // root component identically: there is no dirname to split.
+        let dirname = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => return File::open(path),
+        };
+
+        let dir = open_dir_follow(dirname)?;
+        let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        openat(dir.as_fd(), basename, flags, 0)
+    }
+
+    /// Open `dirname` as a directory file descriptor with normal symlink
+    /// resolution. Legitimate directory symlinks (e.g. created by
+    /// `--copy-dirlinks` on the receiver) must be followed, so this
+    /// deliberately does not use `O_NOFOLLOW`.
+    fn open_dir_follow(dirname: &Path) -> io::Result<File> {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+            .open(dirname)
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    use super::*;
+
+    pub(super) fn open_basis_nofollow(path: &Path) -> io::Result<File> {
+        // Windows / other non-Unix: NTFS reparse-point resolution is
+        // governed by separate flags on `CreateFileW` and is not part
+        // of the rsync upstream `O_NOFOLLOW` contract. Fall through to
+        // the standard open; receiver-side reparse handling is audited
+        // under WPC-3/4.
+        File::open(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
+    /// Test 1 mirror: basis file at `<temp>/real-dir/basis` reached via
+    /// the directory symlink `<temp>/dir -> real-dir`. The receiver must
+    /// open it. This is the `symlink-dirlink-basis.test` regression.
+    #[cfg(unix)]
+    #[test]
+    fn opens_basis_through_directory_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("real-dir");
+        std::fs::create_dir(&real_dir).expect("mkdir real-dir");
+        let basis_path = real_dir.join("basis");
+        std::fs::write(&basis_path, b"hello").expect("write basis");
+
+        let dir_link = tmp.path().join("dir");
+        symlink("real-dir", &dir_link).expect("symlink dir -> real-dir");
+
+        let through_link = dir_link.join("basis");
+        let mut file = open_basis_nofollow(&through_link).expect("open via dir symlink");
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut file, &mut buf).expect("read");
+        assert_eq!(buf, "hello");
+    }
+
+    /// Negative: basis basename is itself a symlink. The receiver must
+    /// refuse to follow it (matches upstream's `O_NOFOLLOW` on the leaf
+    /// component in `do_open_at()` / `secure_relative_open()`).
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_basename() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("secret");
+        std::fs::write(&target, b"do-not-leak").expect("write target");
+
+        let dir = tmp.path().join("dir");
+        std::fs::create_dir(&dir).expect("mkdir");
+        let basis = dir.join("basis");
+        symlink(&target, &basis).expect("symlink basis -> secret");
+
+        let err = open_basis_nofollow(&basis).expect_err("must not follow symlinked basename");
+        // `ELOOP` is the canonical errno for an `O_NOFOLLOW` refusal.
+        assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+    }
+
+    /// Nested directory symlinks (test 3 mirror):
+    /// `<temp>/nested -> nested_real`, basis at
+    /// `<temp>/nested_real/sub/data`.
+    #[cfg(unix)]
+    #[test]
+    fn opens_basis_through_nested_directory_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested_real_sub = tmp.path().join("nested_real").join("sub");
+        std::fs::create_dir_all(&nested_real_sub).expect("mkdir nested_real/sub");
+        let basis_path = nested_real_sub.join("data");
+        std::fs::write(&basis_path, b"nested").expect("write");
+
+        symlink("nested_real", tmp.path().join("nested")).expect("symlink");
+
+        let through_link = tmp.path().join("nested").join("sub").join("data");
+        let mut file = open_basis_nofollow(&through_link).expect("open through nested symlink");
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut file, &mut buf).expect("read");
+        assert_eq!(buf, "nested");
+    }
+
+    /// Top-level basis (test 6 mirror): no dirname split needed.
+    #[test]
+    fn opens_top_level_basis_without_split() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let basis = tmp.path().join("topfile");
+        {
+            let mut f = std::fs::File::create(&basis).expect("create");
+            f.write_all(b"top").expect("write");
+        }
+        let mut file = open_basis_nofollow(&basis).expect("open top-level");
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut file, &mut buf).expect("read");
+        assert_eq!(buf, "top");
+    }
+
+    /// Missing path surfaces `ENOENT` so receiver fallback logic
+    /// (reference dirs, fuzzy match) keeps working.
+    #[test]
+    fn missing_path_returns_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        let err = open_basis_nofollow(&missing).expect_err("missing path must fail");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -105,18 +105,24 @@ impl SignatureGenerationConfig {
 /// Tries to find a basis file in the reference directories.
 ///
 /// Iterates through reference directories in order, checking if the relative
-/// path exists in each one. Returns the first match found.
+/// path exists in each one. Returns the first match found. The basis open
+/// goes through [`fast_io::open_basis_nofollow`], which follows directory
+/// symlinks (so `--copy-dirlinks` continues to work) but refuses to follow
+/// a symlinked leaf component, mirroring upstream `syscall.c:705`
+/// (`do_open_at`).
 ///
 /// # Upstream Reference
 ///
 /// - `generator.c:1400` - Reference directory basis file lookup
+/// - `syscall.c:705` (`do_open_at`) - dirname/basename split with
+///   `O_NOFOLLOW` on the basename.
 pub(super) fn try_reference_directories(
     relative_path: &std::path::Path,
     reference_directories: &[ReferenceDirectory],
 ) -> Option<(fs::File, u64, PathBuf)> {
     for ref_dir in reference_directories {
         let candidate = ref_dir.path.join(relative_path);
-        if let Ok(file) = fs::File::open(&candidate) {
+        if let Ok(file) = fast_io::open_basis_nofollow(&candidate) {
             if let Ok(meta) = file.metadata() {
                 if meta.is_file() {
                     return Some((file, meta.len(), candidate));
@@ -127,11 +133,16 @@ pub(super) fn try_reference_directories(
     None
 }
 
-/// Opens a file and returns it with metadata.
+/// Opens a basis file and returns it with metadata.
 ///
-/// Returns the file handle, size, and path if successful.
+/// Returns the file handle, size, and path if successful. The open is
+/// routed through [`fast_io::open_basis_nofollow`] so a symlinked
+/// basename is refused (`ELOOP`), matching upstream's `do_open_at()`
+/// receiver-side defence against pre-planted leaf symlinks while still
+/// honouring `--copy-dirlinks` directory symlinks at every intermediate
+/// component.
 fn try_open_file(path: &std::path::Path) -> Option<(fs::File, u64, PathBuf)> {
-    let file = fs::File::open(path).ok()?;
+    let file = fast_io::open_basis_nofollow(path).ok()?;
     let size = file.metadata().ok()?.len();
     Some((file, size, path.to_path_buf()))
 }
@@ -260,4 +271,110 @@ pub fn find_basis_file_with_config(config: &BasisFileConfig<'_>) -> BasisFileRes
 
     let sig_config = SignatureGenerationConfig::from_basis_config(config);
     generate_basis_signature(file, size, path, sig_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    /// Issue #715 regression (`symlink-dirlink-basis.test` test 1): when
+    /// the destination directory is a symlink to a real directory, the
+    /// receiver must open the basis file through the directory symlink.
+    /// Upstream sets this expectation in `syscall.c:705 do_open_at()` -
+    /// the dirname is resolved with normal symlink-following semantics.
+    #[cfg(unix)]
+    #[test]
+    fn try_open_file_follows_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("real-dir");
+        std::fs::create_dir(&real_dir).expect("mkdir");
+        std::fs::write(real_dir.join("basis"), b"basis-bytes").expect("write basis");
+
+        symlink("real-dir", tmp.path().join("dir")).expect("symlink dir -> real-dir");
+
+        let through_link = tmp.path().join("dir").join("basis");
+        let (mut file, size, path) =
+            try_open_file(&through_link).expect("basis open must succeed through dir symlink");
+        assert_eq!(size, b"basis-bytes".len() as u64);
+        assert_eq!(path, through_link);
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).expect("read");
+        assert_eq!(buf, b"basis-bytes");
+    }
+
+    /// Security regression: the receiver must NOT follow a symlinked
+    /// basename pointing outside the destination tree (matches
+    /// upstream's `O_NOFOLLOW` on the basename in `do_open_at()` and
+    /// `secure_relative_open()` - the CVE-class defence the upstream
+    /// test header references). A symlinked basis basename is treated
+    /// as "no basis", forcing whole-file transfer.
+    #[cfg(unix)]
+    #[test]
+    fn try_open_file_rejects_symlinked_basename() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let secret = tmp.path().join("secret");
+        std::fs::write(&secret, b"do-not-leak").expect("write secret");
+
+        let dir = tmp.path().join("dir");
+        std::fs::create_dir(&dir).expect("mkdir dir");
+        let basis = dir.join("basis");
+        symlink(&secret, &basis).expect("symlink basis -> secret");
+
+        assert!(
+            try_open_file(&basis).is_none(),
+            "symlinked basename must be refused so the receiver falls back to whole-file"
+        );
+    }
+
+    /// Top-level basis path (`symlink-dirlink-basis.test` test 6): no
+    /// dirname split needed. Equivalent to upstream's `if (!slash)
+    /// return do_open(...)` short-circuit at `syscall.c:727`.
+    #[test]
+    fn try_open_file_handles_top_level_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let basis = tmp.path().join("topfile");
+        std::fs::write(&basis, b"top-bytes").expect("write");
+
+        let (mut file, size, path) = try_open_file(&basis).expect("top-level open");
+        assert_eq!(size, b"top-bytes".len() as u64);
+        assert_eq!(path, basis);
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).expect("read");
+        assert_eq!(buf, b"top-bytes");
+    }
+
+    /// Reference directory lookup (`--copy-dest` / `--link-dest`) goes
+    /// through the same hardened open path. A symlinked basename inside
+    /// a reference directory must also be rejected.
+    #[cfg(unix)]
+    #[test]
+    fn try_reference_directories_rejects_symlinked_basename() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ref_root = tmp.path().join("ref");
+        std::fs::create_dir(&ref_root).expect("mkdir ref");
+        let secret = tmp.path().join("secret");
+        std::fs::write(&secret, b"leak").expect("write secret");
+
+        let sub = ref_root.join("sub");
+        std::fs::create_dir(&sub).expect("mkdir sub");
+        symlink(&secret, sub.join("basis")).expect("symlink basis -> secret");
+
+        let ref_dirs = vec![ReferenceDirectory {
+            kind: crate::config::ReferenceDirectoryKind::Compare,
+            path: ref_root.clone(),
+        }];
+        let rel = std::path::Path::new("sub").join("basis");
+
+        assert!(
+            try_reference_directories(&rel, &ref_dirs).is_none(),
+            "reference-dir lookup must refuse symlinked basename"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Receiver-side basis open went through `fs::File::open(path)`, which follows every symlink including a pre-planted symlinked basename. That breaks the upstream `symlink-dirlink-basis.test` security contract and diverges from upstream `syscall.c:705 do_open_at()`, which splits dirname / basename: the dirname is resolved with normal symlink semantics (so `--copy-dirlinks` directory symlinks keep working), while the basename is opened with `openat(dirfd, basename, O_NOFOLLOW)` so a symlinked leaf is rejected with `ELOOP`.
- Adds `fast_io::open_basis_nofollow()` exposing that split (Unix: `openat(O_NOFOLLOW)`; non-Unix: standard open) and routes both `try_open_file()` and `try_reference_directories()` in `receiver/basis.rs` through it.
- Closes the upstream `symlink-dirlink-basis.test` failure (issue #715 regression + 7 edge-case sub-tests covering `-K`, `--backup`, `--inplace`, `--partial-dir`, `--protocol=28`, top-level files, and nested directory symlinks).

Upstream reference (`target/interop/upstream-src/rsync-3.4.3/syscall.c:705-756`):

```c
int do_open_at(const char *pathname, int flags, mode_t mode)
{
        ...
        slash = strrchr(pathname, '/');
        if (!slash)
                return do_open(pathname, flags, mode);
        ...
        dfd = secure_relative_open(NULL, dirpath, O_RDONLY | O_DIRECTORY, 0);
        if (dfd < 0)
                return -1;
        ...
        ret = openat(dfd, bname, flags | O_NOFOLLOW | O_BINARY, mode);
        ...
}
```

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable) - new tests under `crates/transfer/src/receiver/basis.rs` and `crates/fast_io/src/nofollow_open.rs`:
  - `try_open_file_follows_directory_symlink` - positive case (issue #715 main regression)
  - `try_open_file_rejects_symlinked_basename` - security regression
  - `try_open_file_handles_top_level_path` - upstream `if (!slash)` short-circuit
  - `try_reference_directories_rejects_symlinked_basename` - `--copy-dest` / `--link-dest` path
  - `opens_basis_through_directory_symlink` / `opens_basis_through_nested_directory_symlink` / `rejects_symlinked_basename` / `opens_top_level_basis_without_split` / `missing_path_returns_not_found`
- [ ] CI Linux musl / macOS / Windows matrix (non-Unix fallback is a plain `File::open`)
- [ ] CI interop with upstream 3.4.3 - `symlink-dirlink-basis.test` (8 sub-tests covering `-K`, `--backup`, `--inplace`, `--partial-dir`, `--protocol=28`, top-level files, nested dir symlinks)