### PR TITLE
fix(filters): parse :C cvs-modifier to merge .cvsignore per-dir

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -40,7 +40,7 @@ use std::io;
 use std::path::Path;
 
 use crate::merge::parse::parse_rules;
-use crate::{FilterRule, FilterSet};
+use crate::{FilterAction, FilterRule, FilterSet};
 
 pub use config::DirMergeConfig;
 pub use error::FilterChainError;
@@ -251,7 +251,17 @@ impl FilterChain {
                 }
             };
 
-            if rules.is_empty() && !config.excludes_self() {
+            // upstream: exclude.c:1419-1428 - a `:` (FILTRULE_PERDIR_MERGE)
+            // directive inside a merge file registers a new per-directory
+            // merge that takes effect for the current directory and below.
+            // `:C` is the common case: register `.cvsignore` as a CVS-style
+            // ignore list (no_inherit, word_split). Standard FilterSet
+            // compilation drops DirMerge rules, so handle them here by
+            // loading the named file from the current directory and folding
+            // its tokens into this scope.
+            let (rules, dir_merge_descriptors) = split_dir_merge_rules(rules);
+
+            if rules.is_empty() && dir_merge_descriptors.is_empty() && !config.excludes_self() {
                 continue;
             }
 
@@ -284,12 +294,101 @@ impl FilterChain {
                 });
                 pushed_count += 1;
             }
+
+            // upstream: exclude.c:1419-1428 - for each `:`/`:C` directive
+            // encountered in the merge file body, attempt to load the named
+            // file from the current directory now. The dir-merge rule itself
+            // carries the modifier flags (cvs_mode, no_inherit) that decide
+            // how to parse the file and whether descendant scopes inherit.
+            for descriptor in dir_merge_descriptors {
+                pushed_count += self.load_inline_dir_merge(directory, depth, &descriptor)?;
+            }
         }
 
         Ok(DirFilterGuard {
             depth,
             pushed_count,
         })
+    }
+
+    /// Loads a `:C` style per-directory merge declared inside another merge
+    /// file. Returns the number of scopes successfully pushed.
+    ///
+    /// Reads `directory/<filename>` if present and folds its rules into a
+    /// new scope at `depth`. CVS-mode entries are tokenised with
+    /// [`parse_cvs_ignore_tokens`]; other dir-merge variants reuse the
+    /// standard rule parser. The scope inherits to descendant directories
+    /// only when the source rule does not carry the no-inherit modifier.
+    ///
+    /// upstream: exclude.c:1419-1428 - a `:` directive inside a merge file
+    /// expands to a fresh per-directory merge for the current scope.
+    fn load_inline_dir_merge(
+        &mut self,
+        directory: &Path,
+        depth: usize,
+        descriptor: &InlineDirMerge,
+    ) -> Result<usize, FilterChainError> {
+        let merge_path = directory.join(&descriptor.filename);
+        let content = match fs::read_to_string(&merge_path) {
+            Ok(content) => content,
+            // upstream: exclude.c:push_local_filters() - parse_filter_file()
+            // silently skips missing files. Mirror that here so a `:C`
+            // without an accompanying `.cvsignore` is a no-op.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(0),
+            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => return Ok(0),
+            Err(e) => {
+                self.pop_scopes_at_depth(depth);
+                self.current_depth -= 1;
+                return Err(FilterChainError::Io {
+                    path: merge_path,
+                    source: e,
+                });
+            }
+        };
+
+        let rules = if descriptor.cvs_mode {
+            parse_cvs_ignore_tokens(&content)
+        } else {
+            match parse_rules(&content, &merge_path) {
+                Ok(rules) => rules,
+                Err(e) => {
+                    self.pop_scopes_at_depth(depth);
+                    self.current_depth -= 1;
+                    return Err(FilterChainError::Parse {
+                        path: merge_path,
+                        message: e.to_string(),
+                    });
+                }
+            }
+        };
+
+        if rules.is_empty() {
+            return Ok(0);
+        }
+
+        let filter_set = match FilterSet::from_rules(rules) {
+            Ok(set) => set,
+            Err(e) => {
+                self.pop_scopes_at_depth(depth);
+                self.current_depth -= 1;
+                return Err(FilterChainError::Filter(e));
+            }
+        };
+
+        if filter_set.is_empty() {
+            return Ok(0);
+        }
+
+        // upstream: exclude.c:1248-1254 - `:C` implies FILTRULE_NO_INHERIT,
+        // so the loaded rules apply only to the directory containing the
+        // outer merge file, not to descendants. Other dir-merge variants
+        // preserve their explicit no-inherit setting.
+        self.scopes.push(DirScope {
+            depth,
+            filter_set,
+            inherits: !descriptor.no_inherit,
+        });
+        Ok(1)
     }
 
     /// Leaves a directory, removing all scopes pushed at the given depth.
@@ -369,4 +468,45 @@ fn parse_cvs_ignore_tokens(content: &str) -> Vec<FilterRule> {
         .filter(|token| !token.is_empty())
         .map(FilterRule::exclude)
         .collect()
+}
+
+/// Description of a dir-merge directive parsed from another merge file.
+///
+/// Captures the pieces of the source [`FilterRule`] that drive how the
+/// referenced file should be loaded: the filename (e.g. `.cvsignore`),
+/// whether to treat its contents as a CVS-style ignore list, and whether
+/// the loaded rules should propagate to descendant directories.
+#[derive(Clone, Debug)]
+struct InlineDirMerge {
+    filename: String,
+    cvs_mode: bool,
+    no_inherit: bool,
+}
+
+/// Splits parsed rules into ordinary entries plus dir-merge descriptors.
+///
+/// Standard [`FilterSet`] compilation discards [`FilterAction::DirMerge`]
+/// rules because they neither match paths nor encode a single decision.
+/// Pull them out here so the caller can load each referenced file inline,
+/// mirroring upstream's `:` directive that registers a fresh per-directory
+/// merge from inside another merge file.
+///
+/// upstream: exclude.c:1419-1428 - `FILTRULE_PERDIR_MERGE` inside
+/// `parse_filter_str()` adds a new per-dir rule rather than expanding the
+/// file at parse time.
+fn split_dir_merge_rules(rules: Vec<FilterRule>) -> (Vec<FilterRule>, Vec<InlineDirMerge>) {
+    let mut keep = Vec::with_capacity(rules.len());
+    let mut dir_merges = Vec::new();
+    for rule in rules {
+        if matches!(rule.action(), FilterAction::DirMerge) {
+            dir_merges.push(InlineDirMerge {
+                filename: rule.pattern().to_owned(),
+                cvs_mode: rule.is_cvs_mode(),
+                no_inherit: rule.is_no_inherit(),
+            });
+        } else {
+            keep.push(rule);
+        }
+    }
+    (keep, dir_merges)
 }

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -442,3 +442,65 @@ fn filter_chain_protect_in_scope() {
     chain.leave_directory(guard);
     assert!(chain.allows_deletion(Path::new("important"), false));
 }
+
+/// `:C` inside a per-directory merge file must register a CVS-style
+/// `.cvsignore` for the current directory only, loading its whitespace
+/// tokens as exclude rules. Without this, the `:C` rule is silently dropped
+/// by [`FilterSet`] compilation and the named file is never consulted -
+/// the failing path that drives the upstream `exclude` / `exclude-lsh`
+/// testsuite checks.
+///
+/// upstream: exclude.c:parse_rule_tok() (rsync-3.4.3) - the `:C` token
+/// expands to `:s n,e+ .cvsignore` (no-prefix, word-split, no-inherit,
+/// FILTRULE_CVS_IGNORE), and exclude.c:1419-1428 registers the resulting
+/// per-dir merge so the named file is read at the current scope.
+#[test]
+fn dir_merge_inline_colon_c_loads_cvsignore_no_inherit() {
+    let parent = TempDir::new().unwrap();
+    fs::create_dir(parent.path().join("child")).unwrap();
+    fs::write(parent.path().join(".filt"), ":C\n").unwrap();
+    fs::write(parent.path().join(".cvsignore"), "one-in-one-out\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt"));
+
+    let parent_guard = chain.enter_directory(parent.path()).unwrap();
+    assert!(parent_guard.pushed_count() >= 1, "expected `:C` scope push");
+
+    // The `.cvsignore` token excludes `one-in-one-out` inside the parent dir.
+    assert!(!chain.allows(Path::new("one-in-one-out"), false));
+    assert!(chain.allows(Path::new("other-file"), false));
+
+    // upstream `:C` is FILTRULE_NO_INHERIT: descending into a child
+    // directory must not carry the parent's `.cvsignore` rules along.
+    let child_guard = chain.enter_directory(&parent.path().join("child")).unwrap();
+    assert!(
+        chain.allows(Path::new("one-in-one-out"), false),
+        "no-inherit `:C` must not propagate parent rules into descendants"
+    );
+    chain.leave_directory(child_guard);
+
+    chain.leave_directory(parent_guard);
+    assert!(chain.allows(Path::new("one-in-one-out"), false));
+}
+
+/// `:C` inside a per-directory merge file must be a no-op when the
+/// referenced `.cvsignore` is absent, matching upstream's silent skip
+/// for missing per-dir merge files.
+///
+/// upstream: exclude.c:push_local_filters() - missing files are skipped
+/// without error.
+#[test]
+fn dir_merge_inline_colon_c_missing_cvsignore_is_noop() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".filt"), ":C\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt"));
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 0, "missing `.cvsignore` is silent");
+    assert!(chain.allows(Path::new("anything"), false));
+
+    chain.leave_directory(guard);
+}


### PR DESCRIPTION
## Summary

- Recognise the `:C` cvs-modifier when it appears inside another per-directory merge file: the chain now loads the referenced `.cvsignore` from the current directory as a CVS-style ignore list, scoped (no-inherit) to that directory only.
- Previously the parser produced the correct `FilterRule::dir_merge(".cvsignore")` with `cvs_mode=true`, but `FilterSet::from_rules` silently discarded every `DirMerge` rule, so the named file was never read.

Upstream reference: `target/interop/upstream-src/rsync-3.4.3/exclude.c` `parse_rule_tok()` handles `'C'` at lines 1248-1254, and `exclude.c:1419-1428` registers a perdir merge when a parsed rule carries `FILTRULE_PERDIR_MERGE`.

Closes the upstream testsuite `exclude` and `exclude-lsh` failures, which both drive `:C` via `mid/.filt` (loaded through `dir-merge_.filt`).

## Test plan

- [ ] `cargo nextest run -p filters -E 'test(dir_merge_inline_colon_c)'` covers the new regression tests:
  - `dir_merge_inline_colon_c_loads_cvsignore_no_inherit`
  - `dir_merge_inline_colon_c_missing_cvsignore_is_noop`
- [ ] Existing chain tests (`filter_chain_enter_directory_*`) keep passing - the new code path is gated on `DirMerge` rules being present in parsed merge content, so other configurations are unaffected.
- [ ] Upstream `exclude` and `exclude-lsh` testsuite checks pass in the interop workflow.