### PR TITLE
fix(transfer): only count literal bytes off the wire in bytes_received

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -344,8 +344,7 @@ impl ReceiverContext {
                 );
 
                 // Non-blocking: collect any ready disk results.
-                let (disk_bytes, disk_meta_errors) = pipelined_receiver.drain_ready_results()?;
-                bytes_received += disk_bytes;
+                let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_ready_results()?;
                 metadata_errors.extend(disk_meta_errors);
 
                 // Route accumulated warnings through the multiplexed writer
@@ -354,7 +353,10 @@ impl ReceiverContext {
                     let _ = writer.send_msg_info(warning.as_bytes());
                 }
 
-                bytes_received += result.total_bytes;
+                // upstream: io.c:820 stats.total_read only counts bytes read
+                // off the wire. Matched-from-basis bytes never traverse the
+                // read fd, so exclude them from bytes_received.
+                bytes_received += result.literal_bytes;
                 total_literal_bytes += result.literal_bytes;
                 total_matched_bytes += result.matched_bytes;
                 files_transferred += 1;
@@ -390,8 +392,7 @@ impl ReceiverContext {
             }
 
             // Drain all remaining disk results
-            let (disk_bytes, disk_meta_errors) = pipelined_receiver.drain_all_results()?;
-            bytes_received += disk_bytes;
+            let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_all_results()?;
             metadata_errors.extend(disk_meta_errors);
 
             // Route accumulated warnings through the multiplexed writer.

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -224,6 +224,7 @@ impl ReceiverContext {
             let writer_capacity = adaptive_writer_capacity(target_size);
             let mut output = std::io::BufWriter::with_capacity(writer_capacity, file);
             let mut total_bytes: u64 = 0;
+            let mut literal_bytes: u64 = 0;
 
             let use_sparse = self.config.flags.sparse;
             let mut sparse_state = if use_sparse {
@@ -261,6 +262,7 @@ impl ReceiverContext {
                 self.checksum_seed,
                 &file_path,
                 &mut total_bytes,
+                &mut literal_bytes,
             )?;
 
             if let Some(ref mut sparse) = sparse_state {
@@ -423,7 +425,10 @@ impl ReceiverContext {
                 metadata_errors.push((file_path.clone(), acl_err.to_string()));
             }
 
-            bytes_received += total_bytes;
+            // upstream: io.c:820 stats.total_read only counts bytes read
+            // off the wire. Matched-from-basis bytes never traverse the
+            // read fd, so exclude them from bytes_received.
+            bytes_received += literal_bytes;
             files_transferred += 1;
         }
 
@@ -488,6 +493,7 @@ fn apply_delta_tokens<R: Read>(
     checksum_seed: i32,
     file_path: &std::path::Path,
     total_bytes: &mut u64,
+    literal_bytes: &mut u64,
 ) -> io::Result<()> {
     loop {
         match token_reader.read_token(reader)? {
@@ -534,6 +540,7 @@ fn apply_delta_tokens<R: Read>(
                     write_chunk(output, sparse_state, &data)?;
                     checksum_verifier.update(&data);
                     *total_bytes += len as u64;
+                    *literal_bytes += len as u64;
                 }
                 LiteralData::Pending(len) => {
                     if let Some(data) = reader.try_borrow_exact(len)? {
@@ -547,6 +554,7 @@ fn apply_delta_tokens<R: Read>(
                         checksum_verifier.update(data);
                     }
                     *total_bytes += len as u64;
+                    *literal_bytes += len as u64;
                 }
             },
             TokenReaderDeltaToken::BlockRef(block_idx) => {


### PR DESCRIPTION
## Summary
- bytes_received was double-counting delta transfers: the pipelined path added both `disk_bytes` and `result.total_bytes` (= literal + matched); the sync path added `total_bytes` after delta-token apply.
- Upstream rsync's `stats.total_read` (io.c:820) only counts bytes that crossed the wire-read fd, so matched-from-basis bytes must not appear in `bytes_received`.
- The upstream-testsuite `reverse-daemon-delta` heuristic interprets `received > file_size` as "delta did not engage" and tripped any time the file matched its basis and the inflated tally exceeded the file's size on disk.

## Fix
- Track `literal_bytes` alongside `total_bytes` through `apply_delta_tokens` in `sync.rs`.
- Drop redundant `disk_bytes` accumulation in `pipeline.rs`.
- Use `literal_bytes` (not `total_bytes`) when crediting `bytes_received` in both receiver paths.

## Test plan
- [ ] Existing receiver-side unit tests stay green.
- [ ] Upstream-testsuite `reverse-daemon-delta` passes on the Linux host.
- [ ] Wire-byte parity unchanged (only receiver-local stats accounting).

Closes UTS-V4.C.