### PR TITLE
fix(filters): cvs_mode implies no_inherit per upstream exclude.c

### DIFF
--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -149,12 +149,17 @@ pub(crate) struct RuleModifiers {
 impl RuleModifiers {
     /// Applies modifiers to a filter rule.
     pub(crate) fn apply(self, rule: FilterRule) -> FilterRule {
+        // upstream: exclude.c:1248-1254 - the `C` modifier on a merge/dir-merge
+        // rule implicitly sets FILTRULE_NO_INHERIT (alongside NO_PREFIXES,
+        // WORD_SPLIT, CVS_IGNORE). Mirror that here so `:C .cvsignore` rules
+        // do not propagate into descendant directories.
+        let no_inherit = self.no_inherit || self.cvs_mode;
         let mut rule = rule
             .with_negate(self.negate)
             .with_perishable(self.perishable)
             .with_xattr_only(self.xattr_only)
             .with_exclude_only(self.exclude_only)
-            .with_no_inherit(self.no_inherit)
+            .with_no_inherit(no_inherit)
             .with_cvs_mode(self.cvs_mode);
 
         if self.sender_only && !self.receiver_only {


### PR DESCRIPTION
## Summary

The `C` modifier on dir-merge rules (e.g. `:C` or `dir-merge,C`) implicitly sets `FILTRULE_NO_INHERIT` in upstream rsync, but oc-rsync treated `cvs_mode` and `no_inherit` as independent flags. A bare `:C` directive loaded the CVS-ignore file with `inherit=true`, leaking its rules into descendant directories.

Under the exclude-lsh upstream-testsuite leg

```
-f dir-merge_.filt -f merge_- --delete-during from/ to/
```

this caused `mid/for/one-in-one-out` to be deleted because the `one-in-one-out` entry from `mid/.cvsignore` (loaded via `mid/.filt`'s `:C`) wrongly applied to the descendant `mid/for/` scope. Per `exclude.c:1248-1254`, the `C` modifier MUST imply NO_INHERIT alongside NO_PREFIXES, WORD_SPLIT, and CVS_IGNORE.

## Fix

In `RuleModifiers::apply()` (`crates/filters/src/merge/parse.rs`), OR `cvs_mode` into the `no_inherit` flag. The wire-rule path also routes through this function, so `-f :C` over the remote shell inherits the fix.

## Test plan

- [x] Architectural fix matches upstream `exclude.c:1248-1254` flag pairing
- [ ] CI fmt + clippy + nextest green
- [ ] Upstream testsuite `exclude-lsh` leg: `mid/for/one-in-one-out` retained
- [ ] Bugs B+C (`foo/file1`, `bar/.../file5.deep` wrongly kept) tracked separately; not in scope here