### PR TITLE
docs: clear rustdoc warnings on master (fast_io, protocol)

### DIFF
--- a/crates/bandwidth/src/limiter/backend.rs
+++ b/crates/bandwidth/src/limiter/backend.rs
@@ -60,7 +60,7 @@ pub enum SleepBackend {
 
 /// Active sleep backend for this process.
 ///
-/// Initialised on first call to [`sleep_with_backend`]; the value is
+/// Initialised on first call to `sleep_with_backend`; the value is
 /// fixed for the rest of the process. Reading the active backend is
 /// useful for diagnostics and for the Darwin-only regression test
 /// that asserts the kqueue path is exercised.

--- a/crates/checksums/src/cpu_features.rs
+++ b/crates/checksums/src/cpu_features.rs
@@ -99,7 +99,7 @@ impl SimdLevel {
 ///
 /// Each variant maps to a CPU feature gate the dispatcher verifies before
 /// activating a backend. The override layer answers
-/// [`feature_allowed`](self::feature_allowed) by intersecting the active
+/// [`feature_allowed`] by intersecting the active
 /// override with the host's CPUID-detected capabilities.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SimdFeature {

--- a/crates/engine/src/concurrent_delta/parallel_apply/batch.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/batch.rs
@@ -41,7 +41,7 @@ impl ParallelDeltaApplier {
     ///
     /// Returns the first [`std::io::Error`] encountered while applying the
     /// batch, including any per-chunk strong-checksum mismatch surfaced by
-    /// [`Self::verify_chunk`].
+    /// `Self::verify_chunk`.
     pub fn apply_batch_parallel(&self, chunks: Vec<DeltaChunk>) -> std::io::Result<()> {
         // SAFETY (verify-write overlap contract - ABW-5.c audit:
         //   docs/audit/abw-5c-verify-write-mutex-scope.md)

--- a/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/drain.rs
@@ -90,11 +90,11 @@ impl ParallelDeltaApplier {
         Ok(slot.writer)
     }
 
-    /// Blocks the calling thread until every outstanding [`SlotHandle`]
+    /// Blocks the calling thread until every outstanding `SlotHandle`
     /// for `ndx` has been dropped.
     ///
     /// Each call to [`Self::apply_one_chunk`] or
-    /// [`Self::apply_batch_parallel`] obtains a [`SlotHandle`] from
+    /// [`Self::apply_batch_parallel`] obtains a `SlotHandle` from
     /// [`Self::slot_for`] that bumps the slot's in-flight counter for the
     /// duration of the call (decrement on drop). `flush_workers` parks on
     /// the slot's [`std::sync::Condvar`] until that counter is observed to be zero.
@@ -111,7 +111,6 @@ impl ParallelDeltaApplier {
     /// [`ParallelApplyError::SlotPoisoned`] variant carries the offending
     /// `ndx` and the `"flush_workers"` call-site tag.
     ///
-    /// [`SlotHandle`]: super::SlotHandle
     /// [`Self::slot_for`]: super::ParallelDeltaApplier
     pub fn flush_workers(&self, ndx: impl Into<FileNdx>) -> std::io::Result<()> {
         let ndx = ndx.into();

--- a/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
+++ b/crates/engine/src/concurrent_delta/parallel_apply/mod.rs
@@ -152,7 +152,7 @@ impl From<ParallelApplyError> for io::Error {
 /// per-file sequence number assigned at submission time.
 ///
 /// Chunks are CPU-light at this stage; the heavy step is the strong-checksum
-/// rollup that [`ParallelDeltaApplier::verify_chunk`] runs on a rayon worker
+/// rollup that `ParallelDeltaApplier::verify_chunk` runs on a rayon worker
 /// using the negotiated [`ChecksumStrategy`].
 #[derive(Debug, Clone)]
 pub struct DeltaChunk {
@@ -172,7 +172,7 @@ pub struct DeltaChunk {
     pub is_literal: bool,
     /// Optional expected strong-checksum digest for `data`.
     ///
-    /// When `Some`, [`ParallelDeltaApplier::verify_chunk`] computes the
+    /// When `Some`, `ParallelDeltaApplier::verify_chunk` computes the
     /// digest of `data` using the negotiated strategy and compares it
     /// byte-for-byte against this value. A mismatch produces a typed
     /// [`ParallelApplyError::ChecksumMismatch`] so the receiver can fall
@@ -217,7 +217,7 @@ impl DeltaChunk {
     /// digest to this chunk.
     ///
     /// The receiver pipeline uses this to opt each chunk into real
-    /// per-chunk verification by [`ParallelDeltaApplier::verify_chunk`].
+    /// per-chunk verification by `ParallelDeltaApplier::verify_chunk`.
     /// Callers that have not negotiated per-chunk checksums (or are
     /// driving the applier from a bench/test that does not need the
     /// extra comparison) can leave the field unset.
@@ -493,7 +493,7 @@ impl ParallelDeltaApplier {
     ///
     /// Operators can override this default (and any future adaptive sizing)
     /// by exporting `OC_RSYNC_REORDER_RING_CAP` to a positive integer; see
-    /// [`ring_cap_env`] for the parser contract and ROB-11 (#3678) for the
+    /// `ring_cap_env` for the parser contract and ROB-11 (#3678) for the
     /// rationale.
     pub const DEFAULT_PER_FILE_REORDER_CAPACITY: usize = 64;
 
@@ -529,7 +529,7 @@ impl ParallelDeltaApplier {
     /// default `available_parallelism() * 4`. The heuristic
     /// (`(concurrency * 4).next_power_of_two().clamp(4, 1024)`) trades the
     /// default's CPU-relative sizing for one that tracks the applier's
-    /// worker fan-out. See [`shard_sizing`] and
+    /// worker fan-out. See `shard_sizing` and
     /// `docs/design/dmc-con-adaptive-sharding.md` for the rationale, and
     /// the `OC_RSYNC_DASHMAP_SHARDS` env override for tuning.
     ///
@@ -538,7 +538,7 @@ impl ParallelDeltaApplier {
     /// The per-file reorder-ring capacity defaults to
     /// [`Self::DEFAULT_PER_FILE_REORDER_CAPACITY`] but is overridden when
     /// `OC_RSYNC_REORDER_RING_CAP` is set to a positive integer. The env
-    /// var is read once per process via [`ring_cap_env`] and applies to
+    /// var is read once per process via `ring_cap_env` and applies to
     /// every applier constructed afterwards, including ones built via
     /// [`Self::new`]. Callers that need a per-instance override should
     /// chain [`Self::with_per_file_reorder_capacity`] after construction
@@ -603,9 +603,9 @@ impl ParallelDeltaApplier {
     /// events observed since the applier was constructed (ROB-2, #3667).
     ///
     /// Granularity-invariant: one increment per
-    /// [`IngestError::ReorderSaturated`] regardless of which file
+    /// `IngestError::ReorderSaturated` regardless of which file
     /// produced it. Pairs with the ROB-3 one-shot warning emitted by
-    /// [`Self::note_reorder_saturation`].
+    /// `Self::note_reorder_saturation`.
     #[must_use]
     pub fn reorder_saturations(&self) -> u64 {
         self.reorder_saturations.load(Ordering::Relaxed)

--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -124,7 +124,7 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     /// Sets the per-record compression codec applied to spilled payloads.
     ///
     /// [`SpillCompression::None`] (the default) writes raw encoded bytes,
-    /// matching the historical on-disk format. [`SpillCompression::Zstd`] is
+    /// matching the historical on-disk format. `SpillCompression::Zstd` is
     /// only constructable behind the `spill-compression` Cargo feature, so a
     /// default build cannot reach the Zstd branch at compile time - that
     /// `#[cfg]` gate is the "fail fast at construction" guarantee.

--- a/crates/engine/src/concurrent_delta/spill/policy.rs
+++ b/crates/engine/src/concurrent_delta/spill/policy.rs
@@ -89,7 +89,7 @@ pub enum SpillReclaim {
 /// Optional compression applied to spilled payloads.
 ///
 /// [`SpillCompression::None`] (the default) writes raw encoded bytes, which
-/// is what the existing on-disk format uses. [`SpillCompression::Zstd`] is
+/// is what the existing on-disk format uses. `SpillCompression::Zstd` is
 /// only constructable behind the `spill-compression` feature; this keeps
 /// the default builds free of the codec dependency while leaving the enum
 /// extensible.

--- a/crates/fast_io/src/clone_file_range.rs
+++ b/crates/fast_io/src/clone_file_range.rs
@@ -1,7 +1,7 @@
 //! Linux `FICLONERANGE` ioctl wrapper for partial basis-range reflinks.
 //!
 //! This module exposes the [`try_clone_file_range`] entry point used by the
-//! delta-apply COPY-token fast path. Unlike [`crate::copy_basis_range`], which
+//! delta-apply COPY-token fast path. Unlike `crate::copy_basis_range`, which
 //! drives `copy_file_range(2)` and lets the kernel choose between an
 //! in-kernel byte copy or a CoW reflink, `FICLONERANGE` is unconditional: when
 //! it succeeds, the destination range shares storage extents with the basis

--- a/crates/fast_io/src/io_uring_stub/send_zc.rs
+++ b/crates/fast_io/src/io_uring_stub/send_zc.rs
@@ -5,7 +5,7 @@
 //! `Unsupported`. This keeps cross-platform call sites (and the socket
 //! writer's fallback path) compiling without `cfg`-gating each reference.
 //!
-//! The [`ZeroCopySender`] type is gated on the `iouring-send-zc` feature
+//! The `ZeroCopySender` type is gated on the `iouring-send-zc` feature
 //! and mirrors the Linux constructor surface so cross-platform code can
 //! reference the type behind the feature flag; every method returns
 //! `io::ErrorKind::Unsupported`.

--- a/crates/fast_io/src/sendfile/mod.rs
+++ b/crates/fast_io/src/sendfile/mod.rs
@@ -169,7 +169,7 @@ pub fn send_file_to_fd(source: &File, dest_fd: i32, length: u64) -> io::Result<u
 
 /// macOS dispatch - prefers Darwin's native `sendfile(2)` for sockets.
 ///
-/// Above [`SENDFILE_THRESHOLD`] the function attempts a zero-copy transfer
+/// Above `SENDFILE_THRESHOLD` the function attempts a zero-copy transfer
 /// via `try_sendfile_macos`. The Darwin `sendfile` only accepts socket
 /// destinations, so a non-socket `dest_fd` (pipe, regular file) falls back
 /// to the buffered `read`/`write` loop transparently.

--- a/crates/fast_io/src/sendfile_macos.rs
+++ b/crates/fast_io/src/sendfile_macos.rs
@@ -24,7 +24,7 @@
 //! # Cross-platform
 //!
 //! [`sendfile_macos`] compiles unconditionally. On non-macOS targets
-//! it returns [`io::ErrorKind::Unsupported`] so call sites can be
+//! it returns `io::ErrorKind::Unsupported` so call sites can be
 //! written without `#[cfg]` gates.
 
 use std::fmt;
@@ -43,7 +43,7 @@ use std::os::fd::BorrowedFd;
 /// without re-querying the socket.
 ///
 /// Extract via [`io::Error::get_ref`] and
-/// [`std::error::Error::downcast_ref`].
+/// `<dyn std::error::Error>::downcast_ref::<PartialSend>()`.
 #[derive(Debug, Clone, Copy)]
 pub struct PartialSend {
     /// Bytes delivered to the destination before the would-block fired.

--- a/crates/matching/src/index/builder.rs
+++ b/crates/matching/src/index/builder.rs
@@ -132,7 +132,7 @@ impl DeltaSignatureIndex {
     }
 
     /// Rebuilds the index in-place from a new signature, reusing the
-    /// existing [`CompactLookup`] allocation.
+    /// existing `CompactLookup` allocation.
     ///
     /// Mirrors upstream rsync's hash table reuse pattern (match.c):
     /// the table is cleared and repopulated rather than freed and

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -64,7 +64,7 @@ const NEXT_MATCH_NONE: u32 = u32::MAX;
 
 /// Index over a file signature that accelerates delta matching.
 ///
-/// Uses a chained bucket table ([`CompactLookup`]) addressed by the upper
+/// Uses a chained bucket table (`CompactLookup`) addressed by the upper
 /// half of the rolling sum (`sum2`) for O(1) block lookup with excellent
 /// cache locality. The lower half (`sum1`) lives inside each chain entry as
 /// an in-bucket discriminator, mirroring zsync's `librcksum`

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -93,7 +93,7 @@ pub fn apply_file_metadata_with_options(
 /// Pre-applies upstream's `dest_mode()` chmod for callers that have the
 /// pre-transfer destination stat in hand.
 ///
-/// See [`permissions::apply_dest_mode_pre_transfer`] for the full
+/// See `permissions::apply_dest_mode_pre_transfer` for the full
 /// upstream-reference documentation.
 #[cfg(unix)]
 pub fn apply_dest_mode_pre_transfer(

--- a/crates/rsync_io/src/ssh/connect.rs
+++ b/crates/rsync_io/src/ssh/connect.rs
@@ -171,7 +171,7 @@ impl SshConnection {
     /// This is the synchronous primitive for task #1795. It returns the
     /// existing [`SshConnection`] type so callers can transition without
     /// touching their downstream read/write paths. The async variant
-    /// ([`super::AsyncSshTransport::execute_remote_rsync`], task #1796)
+    /// (`super::AsyncSshTransport::execute_remote_rsync`, task #1796)
     /// is gated behind the `--features async-ssh` cargo feature.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

Clear rustdoc broken intra-doc links surfaced by `cargo doc --workspace --no-deps`. Doc build previously failed with 4 hard errors in `fast_io` (under `#![deny(rustdoc::broken_intra_doc_links)]`) and emitted private-item link warnings across several crates.

All fixes convert public-doc `[`...`]` references targeting feature-gated or `pub(crate)`/private items to backtick-only references, leaving the rendered API surface free of dangling links and removing the leak of private item paths from the rendered docs.

## Errors fixed (fast_io, blocking doc build)

1. `crates/fast_io/src/sendfile_macos.rs` line 27 — `[\`io::ErrorKind::Unsupported\`]` in module-level doc
2. `crates/fast_io/src/sendfile_macos.rs` line 46 — `[\`std::error::Error::downcast_ref\`]` (Error trait has no such associated item)
3. `crates/fast_io/src/io_uring_stub/send_zc.rs` line 8 — `[\`ZeroCopySender\`]` (feature-gated)
4. `crates/fast_io/src/clone_file_range.rs` line 4 — `[\`crate::copy_basis_range\`]` (ambiguous function/module)

## Private-item warnings fixed

- `crates/bandwidth/src/limiter/backend.rs` line 63 — `sleep_with_backend`
- `crates/checksums/src/cpu_features.rs` line 102 — redundant `feature_allowed` explicit target
- `crates/fast_io/src/sendfile/mod.rs` line 172 — `SENDFILE_THRESHOLD` const
- `crates/rsync_io/src/ssh/connect.rs` line 174 — `AsyncSshTransport::execute_remote_rsync`
- `crates/metadata/src/apply/mod.rs` line 96 — `permissions::apply_dest_mode_pre_transfer`
- `crates/matching/src/index/builder.rs` line 135 — `CompactLookup`
- `crates/matching/src/index/mod.rs` line 67 — `CompactLookup`
- `crates/engine/src/concurrent_delta/spill/policy.rs` line 92 — `SpillCompression::Zstd` (feature-gated variant)
- `crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs` line 127 — `SpillCompression::Zstd`
- `crates/engine/src/concurrent_delta/parallel_apply/batch.rs` line 44 — `Self::verify_chunk`
- `crates/engine/src/concurrent_delta/parallel_apply/drain.rs` — `SlotHandle` and references in docstring body
- `crates/engine/src/concurrent_delta/parallel_apply/mod.rs` — multiple `ParallelDeltaApplier::verify_chunk`, `ring_cap_env`, `shard_sizing`, `IngestError::ReorderSaturated`, `Self::note_reorder_saturation`

## Verification

```
cargo doc --workspace --no-deps
```

now succeeds without errors. The only remaining non-blocking warnings are in `core` (pre-existing Unicode box drawing characters in a doc code block) unrelated to this PR.

`cargo fmt --all` ran cleanly.

## Test plan

- [x] `cargo doc --workspace --no-deps` succeeds without errors
- [x] `cargo fmt --all -- --check` passes
- [ ] CI verifies fmt+clippy, nextest stable, Windows, macOS, Linux musl