### PR TITLE
fix(transfer): route --info=backup notice from disk thread to receiver

### DIFF
--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -14,11 +14,12 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use engine::{CleanupManager, compute_backup_path, trace_make_backup_rename};
-use logging::info_log;
 use protocol::acl::AclCache;
 
 use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
-use crate::pipeline::messages::{BeginMessage, CommitResult, ComputedChecksum, FileMessage};
+use crate::pipeline::messages::{
+    BackupNotice, BeginMessage, CommitResult, ComputedChecksum, FileMessage,
+};
 use crate::pipeline::spsc;
 use crate::temp_guard::TempFileGuard;
 #[cfg(not(unix))]
@@ -185,6 +186,7 @@ pub(super) fn process_file(
                     metadata_error,
                     computed_checksum,
                     delayed_path: outcome.delayed_path,
+                    backup_notice: outcome.backup_notice,
                 });
             }
             FileMessage::Abort { reason } => {
@@ -324,6 +326,7 @@ pub(super) fn process_whole_file(
         metadata_error,
         computed_checksum,
         delayed_path: outcome.delayed_path,
+        backup_notice: outcome.backup_notice,
     })
 }
 
@@ -464,6 +467,11 @@ struct CommitOutcome {
     /// When `--delay-updates` staged the file to `.~tmp~`, holds the
     /// staging path. `None` for immediate commits and inplace writes.
     delayed_path: Option<PathBuf>,
+    /// Destination-relative paths recorded when `--backup` renamed an
+    /// existing file. Propagated to the main thread via [`CommitResult`]
+    /// so the upstream `INFO_GTE(BACKUP, 1)` notice can be emitted by the
+    /// thread whose `VerbosityConfig` carries the user's `--info=backup`.
+    backup_notice: Option<BackupNotice>,
 }
 
 /// Performs backup, atomic rename, and inplace truncation after writing.
@@ -491,11 +499,15 @@ fn commit_file(
 ) -> io::Result<CommitOutcome> {
     // upstream: backup.c:make_backup() - rename existing file before overwrite
     // With delay_updates, backup happens during the sweep, not here.
-    if !config.delay_updates {
+    let backup_notice = if !config.delay_updates {
         if let Some(ref backup_config) = config.backup {
-            make_backup(&begin.file_path, backup_config)?;
+            make_backup(&begin.file_path, backup_config)?
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
 
     if needs_rename && config.delay_updates {
         // upstream: receiver.c:916-929 - stage to partial dir (.~tmp~)
@@ -509,6 +521,7 @@ fn commit_file(
         return Ok(CommitOutcome {
             was_copy: result,
             delayed_path: Some(staging_path),
+            backup_notice,
         });
     }
 
@@ -535,6 +548,7 @@ fn commit_file(
     Ok(CommitOutcome {
         was_copy,
         delayed_path: None,
+        backup_notice,
     })
 }
 
@@ -790,10 +804,14 @@ fn apply_metadata_acls_and_xattrs(
 /// Mirrors upstream `backup.c:make_backup()` which renames the existing file
 /// to the backup path. Parent directories are created if needed when using
 /// `--backup-dir`. On success, emits the upstream `--debug=BACKUP` RENAME
-/// notice (`backup.c:216-217`).
-fn make_backup(file_path: &Path, config: &BackupConfig) -> io::Result<()> {
+/// notice (`backup.c:216-217`) and returns a [`BackupNotice`] carrying the
+/// destination-relative paths so the main thread can emit upstream's
+/// `INFO_GTE(BACKUP, 1)` line (`backup.c:352`). The disk thread cannot emit
+/// the info line directly because its thread-local [`logging::VerbosityConfig`]
+/// is never seeded with the user's `--info=backup` selection.
+fn make_backup(file_path: &Path, config: &BackupConfig) -> io::Result<Option<BackupNotice>> {
     if !file_path.exists() {
-        return Ok(());
+        return Ok(None);
     }
 
     let backup_path = compute_backup_path(
@@ -814,26 +832,23 @@ fn make_backup(file_path: &Path, config: &BackupConfig) -> io::Result<()> {
     // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
     // branch of link_or_rename. disk_commit always uses rename here.
     trace_make_backup_rename(&file_path.display().to_string());
-    // upstream: backup.c:352 - INFO_GTE(BACKUP, 1) fires on success label
-    // for every successful backup. The local-copy executor already emits
-    // this via context_impl/state.rs; the wire-transfer receiver path must
-    // mirror it so `--info=backup` reports backups during delta transfers.
-    // Paths are displayed relative to the destination root to match upstream
-    // test assertions (testsuite/backup.test).
+    // upstream: backup.c:352 - INFO_GTE(BACKUP, 1) fires on success label for
+    // every successful backup. Paths are displayed relative to the destination
+    // root to match upstream test assertions (testsuite/backup.test). The
+    // actual `info_log!` emission happens on the main thread; see
+    // `crate::pipeline::receiver::emit_backup_notice`.
     let file_rel = file_path
         .strip_prefix(&config.dest_dir)
-        .unwrap_or(file_path);
+        .unwrap_or(file_path)
+        .to_path_buf();
     let backup_rel = backup_path
         .strip_prefix(&config.dest_dir)
-        .unwrap_or(&backup_path);
-    info_log!(
-        Backup,
-        1,
-        "backed up {} to {}",
-        file_rel.display(),
-        backup_rel.display()
-    );
-    Ok(())
+        .unwrap_or(&backup_path)
+        .to_path_buf();
+    Ok(Some(BackupNotice {
+        original: file_rel,
+        backup: backup_rel,
+    }))
 }
 
 /// Finalizes a checksum verifier into a `ComputedChecksum`.
@@ -1120,25 +1135,18 @@ mod tests {
         assert_eq!(staging, PathBuf::from("/dest/.~tmp~/file.txt"));
     }
 
-    /// Verifies `make_backup` emits the upstream-format `--info=BACKUP`
-    /// notice on success so wire-transfer (`--no-whole-file`) receivers
-    /// surface the same `backed up <fname> to <buf>` line as upstream
-    /// rsync's `backup.c:352`.
+    /// Verifies `make_backup` returns the upstream-format backup notice with
+    /// destination-relative paths so the main thread can surface upstream's
+    /// `INFO_GTE(BACKUP, 1)` line during wire transfers.
     ///
-    /// upstream: backup.c:352 - `INFO_GTE(BACKUP, 1)` fires on the
-    /// `success:` label inside `make_backup` for every backup written
-    /// regardless of whether the receiver took the wire-transfer or
-    /// local-copy code path. Mirrors the local-copy emission already
-    /// covered by `engine/tests/debug_backup_emissions.rs`.
+    /// upstream: backup.c:352 - `rprintf(FINFO, "backed up %s to %s\n",
+    /// fname, buf)` fires on the `success:` label for every backup written.
+    /// We propagate the notice via [`CommitResult::backup_notice`] because
+    /// the disk thread's `VerbosityConfig` is not seeded with the user's
+    /// `--info=backup` selection.
     #[test]
-    fn make_backup_emits_info_backup_message() {
-        use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
+    fn make_backup_returns_destination_relative_notice() {
         use std::ffi::OsString;
-
-        let mut cfg = VerbosityConfig::default();
-        cfg.info.backup = 1;
-        init(cfg);
-        let _ = drain_events();
 
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("payload.bin");
@@ -1149,33 +1157,34 @@ mod tests {
             backup_dir: None,
             suffix: OsString::from("~"),
         };
-        make_backup(&file_path, &config).expect("make_backup succeeds");
+        let notice = make_backup(&file_path, &config)
+            .expect("make_backup succeeds")
+            .expect("notice produced when an existing file is backed up");
 
         let backup_path = file_path.with_extension("bin~");
         assert!(backup_path.exists(), "backup file must exist after rename");
         assert!(!file_path.exists(), "original file must be renamed away");
 
-        let file_rel = file_path.strip_prefix(dir.path()).unwrap_or(&file_path);
-        let backup_rel = backup_path.strip_prefix(dir.path()).unwrap_or(&backup_path);
-        let expected = format!(
-            "backed up {} to {}",
-            file_rel.display(),
-            backup_rel.display()
-        );
-        let messages: Vec<String> = drain_events()
-            .into_iter()
-            .filter_map(|event| match event {
-                DiagnosticEvent::Info {
-                    flag: InfoFlag::Backup,
-                    message,
-                    ..
-                } => Some(message),
-                _ => None,
-            })
-            .collect();
-        assert!(
-            messages.iter().any(|m| m == &expected),
-            "expected upstream-format INFO=BACKUP line {expected:?}; got {messages:?}"
-        );
+        assert_eq!(notice.original, PathBuf::from("payload.bin"));
+        assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
+    }
+
+    /// Verifies `make_backup` is a no-op (and returns `None`) when the file
+    /// does not exist, mirroring upstream `backup.c:make_backup()` which
+    /// short-circuits when `stat(fname, &st) != 0`.
+    #[test]
+    fn make_backup_missing_file_is_noop() {
+        use std::ffi::OsString;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("absent.bin");
+
+        let config = BackupConfig {
+            dest_dir: dir.path().to_path_buf(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        };
+        let notice = make_backup(&file_path, &config).expect("make_backup succeeds");
+        assert!(notice.is_none(), "no notice when nothing was backed up");
     }
 }

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -1,11 +1,12 @@
 //! Tests for the disk commit thread.
 
+use std::ffi::OsString;
 use std::fs;
 
 use crate::pipeline::messages::{BeginMessage, FileMessage};
 use crate::pipeline::spsc::TryRecvError;
 
-use super::config::{DELAY_UPDATES_PARTIAL_DIR, DiskCommitConfig, PartialMode};
+use super::config::{BackupConfig, DELAY_UPDATES_PARTIAL_DIR, DiskCommitConfig, PartialMode};
 use super::process::{DelayedUpdateEntry, delay_updates_staging_path, handle_delayed_updates};
 use super::thread::spawn_disk_thread;
 
@@ -2714,4 +2715,141 @@ fn delay_updates_channel_disconnect_preserves_staged_files() {
         "staged file must persist after channel disconnect"
     );
     assert_eq!(fs::read(&staging).unwrap(), b"disconnect data");
+}
+
+/// Verifies that committing a file through the pipelined disk thread with
+/// `--backup` (default suffix) returns a [`crate::pipeline::messages::BackupNotice`]
+/// on the [`crate::pipeline::messages::CommitResult`] when a pre-existing
+/// destination file is renamed out of the way. This is the wire-transfer
+/// equivalent of upstream `backup.test`'s line 27 invocation:
+///
+/// ```text
+/// rsync -ai --info=backup --no-whole-file --backup '$fromdir/' '$todir/'
+/// ```
+///
+/// Without the notice flowing back to the main thread, the upstream
+/// `grep "backed up $fn to $fn~"` would never match because the disk
+/// thread's `VerbosityConfig` is never seeded with the user's `--info=backup`.
+#[test]
+fn pipelined_backup_default_suffix_returns_destination_relative_notice() {
+    let dir = test_support::create_tempdir();
+    let dest_dir = dir.path().to_path_buf();
+    let file_path = dest_dir.join("payload.bin");
+    fs::write(&file_path, b"pre-existing payload").unwrap();
+
+    let config = DiskCommitConfig {
+        dest_dir: Some(dest_dir.clone()),
+        backup: Some(BackupConfig {
+            dest_dir: dest_dir.clone(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        }),
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 5,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Chunk(b"fresh".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Commit).unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    let notice = result
+        .backup_notice
+        .expect("disk thread must report the backup notice on the CommitResult");
+    assert_eq!(notice.original, std::path::PathBuf::from("payload.bin"));
+    assert_eq!(notice.backup, std::path::PathBuf::from("payload.bin~"));
+
+    let backup_path = dest_dir.join("payload.bin~");
+    assert_eq!(fs::read(&backup_path).unwrap(), b"pre-existing payload");
+    assert_eq!(fs::read(&file_path).unwrap(), b"fresh");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// Verifies that committing a file with `--backup --backup-dir` reports the
+/// backup destination-relative to `dest_dir` so the upstream
+/// `backup.test` grep `backed up $fn to .*/$fn$` matches (line 43, 56).
+/// Mirrors upstream:
+///
+/// ```text
+/// rsync -ai --info=backup --no-whole-file --backup \
+///     --backup-dir='$bakdir' '$fromdir/' '$todir/'
+/// ```
+#[test]
+fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
+    let dir = test_support::create_tempdir();
+    let dest_dir = dir.path().join("todir");
+    let backup_dir = dir.path().join("bakdir");
+    fs::create_dir_all(&dest_dir).unwrap();
+    fs::create_dir_all(&backup_dir).unwrap();
+
+    let deep = dest_dir.join("deep");
+    fs::create_dir_all(&deep).unwrap();
+    let file_path = deep.join("name1");
+    fs::write(&file_path, b"pre-existing content").unwrap();
+
+    let config = DiskCommitConfig {
+        dest_dir: Some(dest_dir.clone()),
+        backup: Some(BackupConfig {
+            dest_dir: dest_dir.clone(),
+            backup_dir: Some(backup_dir.clone()),
+            suffix: OsString::from("~"),
+        }),
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 7,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Chunk(b"updated".to_vec()))
+        .unwrap();
+    h.file_tx.send(FileMessage::Commit).unwrap();
+
+    let result = h.result_rx.recv().unwrap().unwrap();
+    let notice = result
+        .backup_notice
+        .expect("disk thread must report the backup notice when --backup-dir is set");
+    // upstream: backup.c:352 emits paths relative to the destination root
+    // for both `fname` and `buf`, matching upstream test grep
+    // `backed up $fn to .*/$fn$`.
+    assert_eq!(notice.original, std::path::PathBuf::from("deep/name1"));
+    assert!(
+        notice.backup.ends_with("deep/name1"),
+        "backup path must end with the original relative path; got {:?}",
+        notice.backup
+    );
+
+    // Original was moved into the backup-dir tree (with the trailing suffix).
+    let backup_path = backup_dir.join("deep/name1~");
+    assert_eq!(fs::read(&backup_path).unwrap(), b"pre-existing content");
+    // Destination now holds the new content.
+    assert_eq!(fs::read(&file_path).unwrap(), b"updated");
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
 }

--- a/crates/transfer/src/pipeline/messages.rs
+++ b/crates/transfer/src/pipeline/messages.rs
@@ -107,6 +107,22 @@ pub struct ComputedChecksum {
     pub len: usize,
 }
 
+/// Destination-relative paths for a successful `--backup` rename.
+///
+/// Carried back from the disk commit thread so the receiver's main thread
+/// can emit upstream's `INFO_GTE(BACKUP, 1)` line. The disk thread cannot
+/// emit directly because its thread-local [`logging::VerbosityConfig`] is
+/// never seeded, so `info_gte(Backup, 1)` would always be false there.
+///
+/// upstream: backup.c:352 - `rprintf(FINFO, "backed up %s to %s\n", fname, buf)`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackupNotice {
+    /// Destination-relative path of the original file before the rename.
+    pub original: PathBuf,
+    /// Destination-relative path of the renamed backup file.
+    pub backup: PathBuf,
+}
+
 /// Result of committing a file to disk, sent back from the disk thread.
 pub struct CommitResult {
     /// Number of bytes written to the file.
@@ -127,4 +143,8 @@ pub struct CommitResult {
     ///
     /// - `receiver.c:927-928`: `bitbag_set_bit(delayed_bits, ndx)`
     pub delayed_path: Option<PathBuf>,
+    /// Backup notice when `--backup` renamed a pre-existing file. The main
+    /// thread emits this as `INFO_GTE(BACKUP, 1)` so the `--info=backup`
+    /// line surfaces during pipelined wire transfers.
+    pub backup_notice: Option<BackupNotice>,
 }

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -163,6 +163,7 @@ impl PipelinedReceiver {
             match self.result_rx.try_recv() {
                 Ok(Ok(result)) => {
                     self.collect_delayed_update(&result);
+                    Self::emit_backup_notice(&result);
                     self.verify_checksum(&result)?;
                     bytes += result.bytes_written;
                     if let Some(err) = result.metadata_error {
@@ -223,6 +224,7 @@ impl PipelinedReceiver {
             match self.result_rx.recv() {
                 Ok(Ok(result)) => {
                     self.collect_delayed_update(&result);
+                    Self::emit_backup_notice(&result);
                     self.verify_checksum(&result)?;
                     bytes += result.bytes_written;
                     if let Some(err) = result.metadata_error {
@@ -328,6 +330,30 @@ impl PipelinedReceiver {
                 self.delayed_updates
                     .push((staged.clone(), pending.file_path.clone()));
             }
+        }
+    }
+
+    /// Emit the upstream `INFO_GTE(BACKUP, 1)` line for a successful
+    /// `--backup` rename produced by the disk thread.
+    ///
+    /// The disk thread cannot emit this line itself because its thread-local
+    /// [`logging::VerbosityConfig`] is never seeded with the user's
+    /// `--info=backup` selection. Instead, [`crate::disk_commit::make_backup`]
+    /// records destination-relative paths on the [`CommitResult`] and the
+    /// main thread surfaces them here, so the `info_log!` guard runs against
+    /// the correct verbosity configuration.
+    ///
+    /// upstream: backup.c:352 - `rprintf(FINFO, "backed up %s to %s\n",
+    /// fname, buf)` on the `success:` label of `make_backup()`.
+    fn emit_backup_notice(result: &CommitResult) {
+        if let Some(ref notice) = result.backup_notice {
+            logging::info_log!(
+                Backup,
+                1,
+                "backed up {} to {}",
+                notice.original.display(),
+                notice.backup.display()
+            );
         }
     }
 
@@ -544,6 +570,7 @@ mod tests {
                 len: 4,
             }),
             delayed_path: None,
+            backup_notice: None,
         };
 
         // In phase 1 (redo_enabled=true), this should NOT return an error.
@@ -592,6 +619,7 @@ mod tests {
                 len: 4,
             }),
             delayed_path: None,
+            backup_notice: None,
         };
 
         // In phase 2, mismatch should still return Ok (error is logged, not fatal).
@@ -630,6 +658,7 @@ mod tests {
                 len: 4,
             }),
             delayed_path: None,
+            backup_notice: None,
         };
 
         pr.verify_checksum(&result).unwrap();
@@ -749,6 +778,7 @@ mod tests {
             metadata_error: None,
             computed_checksum: None,
             delayed_path: Some(PathBuf::from("/dest/.~tmp~/file.txt")),
+            backup_notice: None,
         };
 
         pr.collect_delayed_update(&result);


### PR DESCRIPTION
## Summary

- Upstream `testsuite/backup.test` asserts `grep "backed up $fn to $fn~"` against the receiver output for `--info=backup`. Wire-transfer (`--no-whole-file`) renames the existing destination file inside `make_backup` on the disk-commit thread, but that thread's thread-local `VerbosityConfig` is never seeded with the user's `--info=backup` selection, so `info_log!(Backup, 1, ...)` always short-circuits and the notice is dropped. Events emitted there also land in a per-thread queue that no caller drains.
- Capture the destination-relative paths in `make_backup` and propagate them to the main thread via a new `BackupNotice` carried on `CommitResult`. `PipelinedReceiver::emit_backup_notice` surfaces them from `drain_ready_results` / `drain_all_results`, where the user's verbosity config is in force. Mirrors upstream `backup.c:352 rprintf(FINFO, "backed up %s to %s\n", fname, buf)`.

## Test plan

- [x] `cargo nextest run -p transfer --all-features -E 'test(backup)'` - 12 tests, all pass (verified in `rsync-profile` container)
- [x] `cargo fmt --all -- --check`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] Re-run upstream `testsuite/backup.test` end-to-end to confirm the three `grep "backed up $fn to ..."` assertions now match across `--backup`, `--backup --backup-dir`, and `--inplace --backup --backup-dir`