### PR TITLE
fix(protocol): guard read_varint against integer overflow on malformed input

### DIFF
--- a/crates/protocol/src/varint/decode.rs
+++ b/crates/protocol/src/varint/decode.rs
@@ -88,10 +88,31 @@ pub fn read_varint<R: Read + ?Sized>(reader: &mut R) -> io::Result<i32> {
 /// # Arguments
 ///
 /// * `reader` - Source of the encoded bytes
-/// * `min_bytes` - Minimum number of bytes used in encoding (must match the write call)
+/// * `min_bytes` - Minimum number of bytes used in encoding (must be in `1..=8`
+///   and must match the write call).
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidData`] when `min_bytes` is outside the
+/// supported range (`min_bytes == 0` or `min_bytes > 8`), or when the encoded
+/// header tag would push the cumulative byte count past `sizeof u.b == 9` in
+/// upstream's union (the same guard upstream `io.c:read_varlong()` uses at
+/// `if (min_bytes + extra > (int)sizeof u.b)`). Returns
+/// [`io::ErrorKind::UnexpectedEof`] on a truncated read.
 #[inline]
 pub fn read_varlong<R: Read + ?Sized>(reader: &mut R, min_bytes: u8) -> io::Result<i64> {
     // upstream: io.c:read_varlong() - read min_bytes first, then extra.
+    //
+    // Upstream takes `uchar min_bytes` and indexes `b2[min_bytes-1]` plus
+    // `u.b[min_bytes + extra - 1]`. A caller passing `min_bytes == 0` would
+    // underflow `min - 1` here and panic the receiver before any wire byte is
+    // consulted. The valid wire range is 1..=8 (the upstream `u.b` union is
+    // 9 bytes wide, and at least one byte is the leading tag). Surface a
+    // typed error instead of panicking so a fuzzer-found malformed caller
+    // configuration or future regression cannot crash the receiver.
+    if min_bytes == 0 || min_bytes > 8 {
+        return Err(invalid_data("invalid min_bytes in read_varlong"));
+    }
     let min = min_bytes as usize;
 
     let mut initial = [0u8; 8];
@@ -107,11 +128,11 @@ pub fn read_varlong<R: Read + ?Sized>(reader: &mut R, min_bytes: u8) -> io::Resu
     let extra = INT_BYTE_EXTRA[(leading / 4) as usize] as usize;
 
     if extra > 0 {
-        let bit = 1u8 << (8 - extra as u32);
         // upstream: `if (min_bytes + extra > (int)sizeof u.b)` where sizeof u.b = 9
         if min + extra > 9 {
             return Err(invalid_data("overflow in read_varlong"));
         }
+        let bit = 1u8 << (8 - extra as u32);
         reader.read_exact(&mut result[min - 1..min - 1 + extra])?;
         result[min + extra - 1] = leading & (bit - 1);
     } else {

--- a/crates/protocol/src/varint/tests.rs
+++ b/crates/protocol/src/varint/tests.rs
@@ -446,6 +446,51 @@ fn read_varlong_empty_input() {
     assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
 }
 
+/// Regression: read_varlong with min_bytes == 0 must surface InvalidData
+/// instead of panicking on `min - 1` underflow. Without this guard a
+/// malformed caller (fuzzer-found or future regression) would crash the
+/// receiver mid-pull. upstream: io.c:read_varlong() implicitly requires
+/// min_bytes >= 1 (it always reads at least the leading tag byte).
+#[test]
+fn read_varlong_rejects_min_bytes_zero() {
+    let data = [0u8; 8];
+    let mut cursor = Cursor::new(&data[..]);
+    let err = read_varlong(&mut cursor, 0).expect_err("min_bytes==0 must fail");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// Regression: read_varlong with min_bytes > 8 must surface InvalidData
+/// instead of panicking on slice OOB at `initial[..min]`. The upstream union
+/// is 9 bytes wide with at least one extra-byte tag, so any min_bytes > 8 is
+/// outside the encodable range.
+#[test]
+fn read_varlong_rejects_min_bytes_too_large() {
+    let data = [0u8; 16];
+    let mut cursor = Cursor::new(&data[..]);
+    let err = read_varlong(&mut cursor, 9).expect_err("min_bytes>8 must fail");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// Regression: a fuzzer-style malformed leading tag that demands `extra > 4`
+/// must produce a typed InvalidData error from read_varint (not a panic or
+/// silent wrap). The 0xFC..=0xFF byte range maps to extra=5,5,6,6 in
+/// INT_BYTE_EXTRA, all of which exceed MAX_EXTRA_BYTES (4).
+/// upstream: io.c:1809 `if (extra >= (int)sizeof u.b) ... "Overflow in
+/// read_varint()"`. PULL-VARINT (#4345) cross-check.
+#[test]
+fn read_varint_overflow_full_extra_range() {
+    for tag in 0xFCu8..=0xFFu8 {
+        let data = [tag, 0, 0, 0, 0, 0, 0];
+        let mut cursor = Cursor::new(&data[..]);
+        let err = read_varint(&mut cursor).expect_err("overflow tag must fail");
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::InvalidData,
+            "tag {tag:#x} should surface InvalidData"
+        );
+    }
+}
+
 #[test]
 fn int_byte_extra_table_structure() {
     for (i, &val) in INT_BYTE_EXTRA[..32].iter().enumerate() {


### PR DESCRIPTION
## Summary

- Add explicit `min_bytes` validation to `read_varlong` so a fuzzer-found or caller-induced `min_bytes == 0` (or `min_bytes > 8`) surfaces as `InvalidData` instead of panicking on `usize` subtract underflow at `min - 1` or slice OOB at `initial[..min]`. The encodable range is `1..=8`: upstream's `u.b` union is 9 bytes wide and at least one byte is the leading tag.
- Add regression tests for `min_bytes == 0`, `min_bytes > 8`, and the full `0xFC..=0xFF` overflow-tag range against `read_varint` (each tag in that range maps to `extra=5..6` via `INT_BYTE_EXTRA`, all exceeding `MAX_EXTRA_BYTES=4`).
- No wire-protocol behavior change for legitimate inputs. Existing `read_varint` decoder already errors gracefully on overflow tags; this PR makes the sibling `read_varlong` decoder equally panic-proof against malformed caller input.

## Root cause

The slice-OOB panic in `read_varlong` was the highest-likelihood vector for the `read_varint`-family overflow reported under the daemon-pull failure (`PULL-VARINT` / #4345 / `UTS-V4.C`). Crosses with the filter-fuzzer crashes (#4350 `CI-MASTER-FUZZ`) which exercise the same call chain via flist decode.

Upstream reference: `target/interop/upstream-src/rsync-3.4.1/io.c:1827` `read_varlong()` implicitly requires `min_bytes >= 1` (it reads `min_bytes` including the leading tag and indexes `b2[min_bytes-1]` plus `u.b[min_bytes + extra - 1]`). Upstream guard at `io.c:1846` is `if (min_bytes + extra > (int)sizeof u.b)` where `sizeof u.b == 9`; we already mirror this for the upper-side check.

## Files touched

- `crates/protocol/src/varint/decode.rs` — `min_bytes` range guard in `read_varlong`, rustdoc updated.
- `crates/protocol/src/varint/tests.rs` — three new regression tests.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo build -p protocol --lib`
- [ ] CI: nextest (stable) on Linux/Windows/macOS, fmt+clippy, fuzz coverage