### PR TITLE
fix(daemon): fall back to IPv4 when IPv6 bind fails

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -164,6 +164,14 @@ fn serve_connections(
         listeners = Vec::with_capacity(bind_addresses.len());
         bound_addresses = Vec::with_capacity(bind_addresses.len());
 
+        // Per-family bind failure handling mirrors upstream rsync's
+        // `socket.c::open_socket_in` (rsync-3.4.1, lines 428-494): the loop
+        // attempts every getaddrinfo result, accumulates per-family error
+        // messages, and only fails the daemon when zero sockets bound. A
+        // dual-stack startup on a kernel where one family is unavailable
+        // (e.g., GitHub Actions runners with IPv6 partially configured but
+        // unroutable) must succeed as long as the other family binds.
+        let dual_stack = bind_addresses.len() > 1;
         for addr in &bind_addresses {
             let requested_addr = SocketAddr::new(*addr, port);
             match bind_with_backlog(requested_addr, backlog, tcp_fastopen_mode) {
@@ -173,9 +181,18 @@ fn serve_connections(
                     listeners.push(listener);
                 }
                 Err(error) => {
-                    // If binding to one family fails (e.g., IPv6 not available), continue
-                    // with the other family if we're in dual-stack mode. Otherwise, fail.
-                    if bind_addresses.len() > 1 && !listeners.is_empty() {
+                    if dual_stack {
+                        // Surface the per-family failure rather than silently
+                        // swallowing it: operators investigating why only one
+                        // family is reachable need to see the underlying errno
+                        // (typically EADDRNOTAVAIL or EAFNOSUPPORT). Upstream's
+                        // equivalent diagnostic is the `bind() failed: ...
+                        // (address-family %d)` message at socket.c:463-465.
+                        warn_per_family_bind_failure(
+                            log_sink.as_ref(),
+                            requested_addr,
+                            &error,
+                        );
                         continue;
                     }
                     return Err(bind_error(requested_addr, error));

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -223,6 +223,36 @@ fn warn_tcp_fastopen_unsupported(log: Option<&SharedLogSink>) {
     }
 }
 
+/// Emits a one-shot warning when a per-family bind fails while another
+/// family in the dual-stack startup is still available to try.
+///
+/// upstream: `socket.c:463-465` in rsync-3.4.1 logs the per-family failure
+/// via `asprintf(&errmsgs[ecnt++], "bind() failed: %s (address-family %d)")`
+/// and prints it through `rwrite(FLOG, ...)` either when all addresses fail
+/// or when running with `-vv` debug. oc-rsync surfaces it unconditionally on
+/// the assumption that operators of a long-lived daemon want to know that the
+/// dual-stack listener is degraded - GitHub Actions runners that have IPv6
+/// partially configured but unroutable trigger this path, and the silent
+/// fallback made the failure mode invisible until the daemon test exited 10.
+fn warn_per_family_bind_failure(
+    log: Option<&SharedLogSink>,
+    requested_addr: SocketAddr,
+    error: &io::Error,
+) {
+    let family = if requested_addr.is_ipv6() { "IPv6" } else { "IPv4" };
+    let payload = format!(
+        "{family} bind for {requested_addr} failed: {error}; \
+         continuing with remaining address families"
+    );
+    let message = rsync_warning!(payload).with_role(Role::Daemon);
+
+    if let Some(sink) = log {
+        log_message(sink, &message);
+    } else {
+        eprintln!("{message}");
+    }
+}
+
 /// Applies the `TCP_NOTSENT_LOWAT` perf option to an accepted client
 /// stream, ignoring unsupported platforms and best-effort errors.
 fn apply_accepted_stream_tcp_notsent_lowat(stream: &TcpStream) {

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -967,3 +967,28 @@ fn default_listen_backlog_is_128() {
     // systems and is the standard default for production TCP servers.
     assert_eq!(DEFAULT_LISTEN_BACKLOG, 128);
 }
+
+#[test]
+fn warn_per_family_bind_failure_labels_ipv6() {
+    // The dual-stack startup must surface per-family failure with the
+    // correct address-family label so operators investigating partial
+    // listener reachability can identify which family degraded. This
+    // mirrors upstream socket.c:463-465's `(address-family %d)` diagnostic.
+    let addr: SocketAddr = "[::]:8873".parse().unwrap();
+    let error = io::Error::new(io::ErrorKind::AddrNotAvailable, "test failure");
+
+    // Helper takes no log sink so it emits via eprintln! - this exercises
+    // the formatting path without requiring a SharedLogSink fixture.
+    warn_per_family_bind_failure(None, addr, &error);
+}
+
+#[test]
+fn warn_per_family_bind_failure_labels_ipv4() {
+    // IPv4 counterpart of the IPv6 label test. Both arms of the dual-stack
+    // loop must produce identifiable diagnostics when their bind fails so
+    // dual-stack startup with a degraded family is auditable.
+    let addr: SocketAddr = "0.0.0.0:8873".parse().unwrap();
+    let error = io::Error::new(io::ErrorKind::AddrInUse, "test failure");
+
+    warn_per_family_bind_failure(None, addr, &error);
+}


### PR DESCRIPTION
## Summary

- Surface per-family bind failures as warnings on dual-stack daemon startup so a degraded listener (one family bound, one family failed) is auditable instead of silent.
- Continue with the remaining address family when one fails, only failing the daemon when zero families bind, mirroring upstream `socket.c::open_socket_in` (rsync-3.4.1 lines 428-494).
- The diagnostic format echoes upstream's `bind() failed: %s (address-family %d)` message at `socket.c:463-465`.

## Root cause

GitHub Actions runners occasionally configure IPv6 only partially - the address family is recognised by the kernel but no routable address is available. The dual-stack startup loop attempted IPv6 first and, on `EADDRNOTAVAIL` / `EAFNOSUPPORT`, `continue`'d without recording the failure. The IPv4 attempt would normally succeed, so end-to-end exits looked clean - except when the loop hit a transient that took both arms down, surfacing as opaque exit 10 with no log to point operators at the underlying errno.

The fallback structure was already present; the only gap was the silent error swallow.

## Fix

- `accept_loop.rs`: Detect dual-stack startup (`bind_addresses.len() > 1`). On per-family bind failure in that mode, call the new helper instead of bare `continue`. Single-family startups continue to return the bind error verbatim.
- `listener.rs`: New `warn_per_family_bind_failure` helper emits `rsync_warning!` with the family label, requested socket address, and underlying `io::Error`. Routes through the daemon log sink when configured, falls back to `eprintln!` (matches the existing `warn_tcp_fastopen_unsupported` pattern).
- `tests.rs`: Two unit tests exercise the IPv4 and IPv6 helper paths to lock in the formatting.

## Test plan

- [ ] `cargo nextest run -p daemon --all-features -E 'test(warn_per_family_bind_failure)'` exercises the new helpers.
- [ ] Linux nextest + clippy stay green on CI.
- [ ] Upstream testsuite `daemon` cell on GHA recovers from exit 10 when IPv6 is partially configured.