### PR TITLE
fix(transfer): pin source mode in no-perms chmod test for umask parity

### DIFF
--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -1091,12 +1091,20 @@ mod daemon_incoming_chmod_tests {
         let dest = tmp.path().join("bar.dest");
         fs::write(&source, b"payload").expect("write source");
         fs::write(&dest, b"payload").expect("write dest");
-        // Source mode is whatever the sender advertised; with `--no-perms`
-        // the receiver ignores it. The daemon's `incoming chmod` must still
-        // run against the destination's current mode.
-        fs::set_permissions(&source, fs::Permissions::from_mode(0o664)).expect("set source perms");
-        // Newly-renamed temp file lands at a tight 0o600 (the O_TMPFILE
-        // default). The chmod-apply path must lift it to the spec result.
+        // upstream: rsync.c:466-470 dest_mode() - for a fresh transfer under
+        // `--no-perms` the chmod baseline is `source_mode & (~CHMOD_BITS |
+        // dflt_perms)`, where `dflt_perms = ACCESSPERMS & ~orig_umask`. Pin
+        // the source mode at 0o600 so the baseline collapses to 0o600 under
+        // any umask the test host happens to use (0o022 producing
+        // `dflt_perms = 0o755`, 0o002 producing `dflt_perms = 0o775` - both
+        // mask 0o600 to 0o600). Using a wider source mode like 0o664 would
+        // leave the test environment-fragile: `0o664 & 0o775 = 0o664`
+        // already has group-write, so `a+rX` adds nothing and the assertion
+        // would fail on container hosts with a relaxed umask.
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o600)).expect("set source perms");
+        // Existing destination mode is irrelevant for this fresh-transfer
+        // path - upstream's `dest_mode(exists=false)` ignores the stat mode -
+        // but pin it anyway so the test reads symmetrically.
         fs::set_permissions(&dest, fs::Permissions::from_mode(0o600)).expect("set dest perms");
 
         let source_meta = fs::metadata(&source).expect("source metadata");


### PR DESCRIPTION
## Summary

- `no_perms_does_not_suppress_daemon_incoming_chmod` set the source mode at 0o664 and asserted the post-chmod result was 0o644. Under `--no-perms` the receiver mirrors upstream `rsync.c:466-470 dest_mode(exists=false)`: `new_mode = source_mode & (~CHMOD_BITS | dflt_perms)`, where `dflt_perms = ACCESSPERMS & ~orig_umask`. The chmod baseline is therefore the umask-masked source mode, not the destination's post-O_TMPFILE 0o600.
- The original assertion happened to hold on developer hosts running umask 0o022 (`dflt_perms = 0o755`, baseline `0o664 & 0o755 = 0o644`, `a+rX` is a no-op, asserted 0o644 PASS), but failed on container hosts running umask 0o002 (`dflt_perms = 0o775`, baseline `0o664 & 0o775 = 0o664`, `a+rX` still a no-op, actual 0o664). The production code is correct.
- Pin the source mode at 0o600 so the baseline collapses to 0o600 under any umask (`0o600 & 0o755 = 0o600 & 0o775 = 0o600`) and the chmod spec `ug-s,a+rX,D+w` deterministically produces 0o644.

## Test plan

- [x] Local: target macOS umask 0o022 - baseline unchanged, assertion still holds.
- [x] Walked the math for umask 0o002 / 0o022 / 0o077.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl. Linux musl nextest cell is the one that reproduces the original failure (umask 0o002 sandbox).