### PR TITLE
style(metadata, filters): cleanup comments — preserve upstream refs + SAFETY

### DIFF
--- a/crates/filters/src/entry_filter.rs
+++ b/crates/filters/src/entry_filter.rs
@@ -22,10 +22,6 @@ use protocol::flist::FileEntryAccessor;
 
 use crate::{FilterChain, FilterSet};
 
-// ---------------------------------------------------------------------------
-// FilterSet extensions
-// ---------------------------------------------------------------------------
-
 impl FilterSet {
     /// Returns `true` if the entry should be included in the transfer.
     ///
@@ -70,10 +66,6 @@ impl FilterSet {
     }
 }
 
-// ---------------------------------------------------------------------------
-// FilterChain extensions
-// ---------------------------------------------------------------------------
-
 impl FilterChain {
     /// Returns `true` if the entry should be included in the transfer.
     ///
@@ -96,17 +88,11 @@ impl FilterChain {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use protocol::flist::FileEntry;
 
     use crate::{FilterChain, FilterRule, FilterSet};
-
-    // -- FilterSet::allows_entry --
 
     #[test]
     fn allows_entry_includes_unmatched_file() {
@@ -139,8 +125,6 @@ mod tests {
         assert!(set.allows_entry(&entry));
     }
 
-    // -- FilterSet::allows_entry_deletion --
-
     #[test]
     fn allows_entry_deletion_protected() {
         let set = FilterSet::from_rules([FilterRule::protect("important.dat")]).unwrap();
@@ -154,8 +138,6 @@ mod tests {
         let entry = FileEntry::new_file("data.txt".into(), 512, 0o644);
         assert!(set.allows_entry_deletion(&entry));
     }
-
-    // -- FilterSet::allows_entry_deletion_when_excluded_removed --
 
     #[test]
     fn allows_entry_deletion_when_excluded_removed_excluded_file() {
@@ -171,8 +153,6 @@ mod tests {
         assert!(!set.allows_entry_deletion_when_excluded_removed(&entry));
     }
 
-    // -- FilterSet::entry_excluded_dir_by_non_dir_rule --
-
     #[test]
     fn entry_excluded_dir_by_non_dir_rule_generic_pattern() {
         let set = FilterSet::from_rules([FilterRule::exclude("*")]).unwrap();
@@ -186,8 +166,6 @@ mod tests {
         let dir = FileEntry::new_directory("cache".into(), 0o755);
         assert!(!set.entry_excluded_dir_by_non_dir_rule(&dir));
     }
-
-    // -- FilterChain::allows_entry --
 
     #[test]
     fn chain_allows_entry_global_rules() {
@@ -205,8 +183,6 @@ mod tests {
         assert!(chain.allows_entry(&entry));
     }
 
-    // -- FilterChain::allows_entry_deletion --
-
     #[test]
     fn chain_allows_entry_deletion_protected() {
         let global = FilterSet::from_rules([FilterRule::protect("*.conf")]).unwrap();
@@ -223,8 +199,6 @@ mod tests {
         assert!(chain.allows_entry_deletion(&entry));
     }
 
-    // -- Scoped chain evaluation --
-
     #[test]
     fn chain_scoped_allows_entry() {
         let global = FilterSet::default();
@@ -239,8 +213,6 @@ mod tests {
         assert!(chain.allows_entry(&included));
     }
 
-    // -- Equivalence with path-based API --
-
     #[test]
     fn allows_entry_matches_path_based_api() {
         let set = FilterSet::from_rules([FilterRule::exclude("*.o")]).unwrap();
@@ -252,8 +224,6 @@ mod tests {
         assert_eq!(path_result, entry_result);
         assert!(!entry_result);
     }
-
-    // -- Multi-rule interaction --
 
     #[test]
     fn allows_entry_first_match_wins() {
@@ -267,8 +237,6 @@ mod tests {
         assert!(set.allows_entry(&kept));
         assert!(!set.allows_entry(&dropped));
     }
-
-    // -- Directory entries --
 
     #[test]
     fn allows_entry_directory_excluded() {

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1169,8 +1169,6 @@ fn fake_super_off_does_not_write_stat_xattr_via_local_metadata() {
     );
 }
 
-// --- metadata_unchanged tests ---
-
 #[cfg(unix)]
 #[test]
 fn metadata_unchanged_returns_true_when_all_attrs_match() {


### PR DESCRIPTION
## Summary

Surgical comment cleanup across the `metadata` and `filters` crates as part of the per-crate comment-cleanup pass (CCL-1..25):

- Drop decorative banner/divider comments (e.g. `// --- section ---`, `// -- subtitle --`) that purely segment the file without conveying information.
- Preserve all rustdoc, every `// upstream:` reference, every `// SAFETY:` block, and substantive explanatory comments verbatim.
- No logic changes, no signature changes, no test removals.

Affected files:

- `crates/filters/src/entry_filter.rs` — drop FilterSet/FilterChain/Tests section banners and per-test sub-section dividers.
- `crates/metadata/src/apply/tests.rs` — drop `// --- metadata_unchanged tests ---` divider.

## Test plan

- [ ] CI: `cargo nextest run -p filters -p metadata --all-features` passes on Linux / macOS / Windows.
- [ ] CI: `cargo fmt --all -- --check` clean.
- [ ] CI: `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.