### PR TITLE
style(daemon): cleanup comments - preserve upstream refs + useful info

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -348,21 +348,16 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut start = 0;
 
-    // Walk through the string looking for rule boundaries.
-    // A new rule starts when we see whitespace followed by a rule prefix.
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b' ' || bytes[i] == b'\t' {
-            // Found whitespace - check if what follows is a new rule prefix
             let rest = &s[i..].trim_start();
             if !rest.is_empty() && starts_with_rule_prefix(rest) {
-                // Save current token
                 let token = s[start..i].trim();
                 if !token.is_empty() {
                     tokens.push(token.to_string());
                 }
-                // Advance past whitespace
                 let ws_len = s[i..].len() - rest.len();
                 start = i + ws_len;
                 i = start;


### PR DESCRIPTION
## Summary

- Surgical comment cleanup on the `daemon` crate per the CCL series.
- After auditing all 91 non-test files (~26.7K LoC, ~1,200 line comments), the crate is already very well-maintained: 445 comments cite upstream rsync source and the vast majority of the rest carry substantive design rationale (cross-platform quirks, security invariants, FSM phases, timing constraints, etc.).
- Found a single localized pocket of pure restatement inside `split_filter_tokens` in `crates/daemon/src/daemon/sections/module_access/helpers.rs`: five inline comments that echoed the surrounding control flow ("Walk through the string", "A new rule starts...", "Found whitespace", "Save current token", "Advance past whitespace"). The function's rustdoc already documents the parsing intent.

## Scope

- Touched: `crates/daemon/src/daemon/sections/module_access/helpers.rs` (1 file, 5 deletions).
- Preserved: every `// upstream:` reference, every SAFETY block, every comment explaining non-obvious invariants, all rustdoc.
- Did not touch: tests, benches, examples, other crates.

## Test plan

- [ ] CI fmt + clippy
- [ ] CI nextest (stable, Windows, macOS, Linux musl)