### PR TITLE
style(transfer): cleanup comments - preserve upstream refs + INC_RECURSE notes

### DIFF
--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -662,8 +662,6 @@ fn whole_file_commit_via_io_uring_or_fallback() {
     h.join_handle.join().unwrap();
 }
 
-// --- PIR-2: Partial file retention tests ---
-
 #[test]
 fn partial_mode_default_is_none() {
     let config = DiskCommitConfig::default();
@@ -984,8 +982,6 @@ fn partial_mode_relative_partial_dir() {
     drop(h.file_tx);
     h.join_handle.join().unwrap();
 }
-
-// --- PIR-4.c: CleanupManager integration tests ---
 
 /// Verifies that the disk commit thread registers temp files with the global
 /// `CleanupManager` during transfer, and that calling `cleanup()` removes
@@ -1339,8 +1335,6 @@ fn cleanup_manager_inplace_skips_registration() {
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();
 }
-// --- PIR-6.b: --partial-dir mid-transfer interrupt interop tests ---
-
 /// Verifies that aborting a multi-chunk transfer mid-stream with
 /// `PartialMode::PartialDir` moves the partial file to the partial-dir,
 /// not the final destination. The partial file should contain only the
@@ -2201,8 +2195,6 @@ fn delay_updates_sweep_replaces_existing_files() {
     );
 }
 
-// --- PIR-3: Partial file mtime=0 stamp tests ---
-
 /// Verifies that a partial file retained via `--partial` has its mtime
 /// stamped to epoch 0. Upstream cleanup.c:174-178 does this so that a
 /// subsequent `--update` run does not skip the partial file as "up to date".
@@ -2407,8 +2399,6 @@ fn partial_mode_partial_stamps_mtime_zero_on_disconnect() {
         "partial file mtime must be stamped to Unix epoch on disconnect"
     );
 }
-
-// --- PIR-5.d: Delay-updates interrupt behavior tests ---
 
 /// Verifies that when a transfer with `delay_updates` is interrupted via
 /// Shutdown after some files have been committed, already-staged files remain

--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -47,9 +47,7 @@ fn test_data(size: usize) -> Vec<u8> {
     (0..size).map(|i| (i % 251) as u8).collect()
 }
 
-// ---------------------------------------------------------------------------
-// Upstream parity: PartialMode::None deletes temp on all interrupt types
-// ---------------------------------------------------------------------------
+// Upstream parity: PartialMode::None deletes temp on all interrupt types.
 
 /// upstream: cleanup.c:55-80 - do_unlink() removes temp on interrupt
 /// when keep_partial is false.
@@ -119,9 +117,7 @@ fn parity_none_disconnect_deletes_temp() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Upstream parity: PartialMode::Partial retains + stamps mtime=0
-// ---------------------------------------------------------------------------
+// Upstream parity: PartialMode::Partial retains + stamps mtime=0.
 
 /// Helper: run a partial-mode transfer with the given interrupt type and
 /// return the file_path and mtime of the retained file.
@@ -267,9 +263,7 @@ fn parity_partial_content_is_valid_prefix() {
     h.join_handle.join().unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Upstream parity: PartialMode::PartialDir retains WITHOUT mtime=0
-// ---------------------------------------------------------------------------
+// Upstream parity: PartialMode::PartialDir retains WITHOUT mtime=0.
 
 fn run_partial_dir_interrupt(
     dir: &tempfile::TempDir,
@@ -391,9 +385,7 @@ fn parity_partial_dir_disconnect_retains_without_mtime_zero() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Upstream parity: zero-byte transfers suppress partial retention
-// ---------------------------------------------------------------------------
+// Upstream parity: zero-byte transfers suppress partial retention.
 
 /// upstream: cleanup.c:130 - keep_partial && got_literal guard.
 /// If no literal data was received (bytes_written == 0), the partial file
@@ -458,9 +450,7 @@ fn parity_zero_bytes_suppresses_partial_dir_retention() {
     h.join_handle.join().unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Upstream parity: CleanupManager unregisters temp on partial retention
-// ---------------------------------------------------------------------------
+// Upstream parity: CleanupManager unregisters temp on partial retention.
 
 /// When a partial file is retained via --partial (renamed to dest), it must
 /// be unregistered from CleanupManager so a subsequent cleanup() call does
@@ -559,9 +549,7 @@ fn parity_partial_dir_retention_unregisters_from_cleanup_manager() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Upstream parity: multi-chunk partial captures all written data
-// ---------------------------------------------------------------------------
+// Upstream parity: multi-chunk partial captures all written data.
 
 /// When multiple chunks are written before interrupt, the retained partial
 /// must contain the concatenation of all chunks - not just the last one.

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_partial_cutoff.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_partial_cutoff.rs
@@ -40,10 +40,6 @@ use crate::config::ServerConfig;
 use crate::handshake::HandshakeResult;
 use crate::role::ServerRole;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 /// Builds a `HandshakeResult` for the given protocol version.
 fn handshake_for(protocol_version: u8) -> HandshakeResult {
     HandshakeResult {
@@ -82,10 +78,6 @@ fn drive_handle_goodbye(ctx: &ReceiverContext, sender_bytes: Vec<u8>) -> io::Res
     ctx.handle_goodbye(&mut reader, &mut writer, &mut ndx_write, &mut ndx_read)
 }
 
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4.a: EOF mid-byte inside the goodbye frame
-// ---------------------------------------------------------------------------
-//
 // Protocol-coverage note: `handle_goodbye` only *reads* a goodbye echo on
 // protocols >= 31 (the extended-goodbye gate). On protocol 28/29 the
 // receiver-side `handle_goodbye` is a pure write; the equivalent
@@ -139,10 +131,6 @@ fn handle_goodbye_proto32_eof_mid_modern_negative_prefix() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4.b: EOF before goodbye frame
-// ---------------------------------------------------------------------------
-
 /// Sender closes the connection without ever sending a goodbye byte.
 /// Receiver's first `read_exact` must surface `UnexpectedEof` rather than
 /// hang or panic.
@@ -176,10 +164,6 @@ fn read_expected_ndx_done_proto29_immediate_eof() {
         "immediate EOF before legacy goodbye must surface UnexpectedEof, got {err:?}",
     );
 }
-
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4.c: garbage in place of NDX_DONE
-// ---------------------------------------------------------------------------
 
 /// Sender sends a perfectly framed but wrong-valued NDX (a positive file
 /// index) instead of `NDX_DONE`. The receiver must reject it with
@@ -238,10 +222,6 @@ fn read_expected_ndx_done_proto29_rejects_garbage() {
         "error message should include the context string; got: {msg}"
     );
 }
-
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4.d: receiver does not hang on a non-progressing sender
-// ---------------------------------------------------------------------------
 
 /// A blocking reader that never produces bytes. Mimics a sender that
 /// connects, completes the transfer, and then hangs forever instead of
@@ -340,10 +320,6 @@ fn handle_goodbye_does_not_silently_complete_on_hung_sender() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4.e: garbage NDX_DEL_STATS without trailing varints
-// ---------------------------------------------------------------------------
-
 /// Protocol 32 receiver accepts an `NDX_DEL_STATS` sentinel in
 /// `handle_goodbye` and then drains five varints before reading
 /// `NDX_DONE`. A sender that emits `NDX_DEL_STATS` and then cuts the
@@ -374,10 +350,6 @@ fn handle_goodbye_proto32_eof_inside_del_stats_payload() {
         "EOF inside del-stats payload must surface UnexpectedEof, got {err:?}",
     );
 }
-
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4.f: contract sanity - happy path still passes
-// ---------------------------------------------------------------------------
 
 /// Sanity check: a well-formed single `NDX_DONE` byte from the sender
 /// drives `handle_goodbye` cleanly on protocol 32. This guards against

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_timeout_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/goodbye_timeout_tests.rs
@@ -49,10 +49,6 @@ use crate::config::ServerConfig;
 use crate::handshake::HandshakeResult;
 use crate::role::ServerRole;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 /// Wall-clock ceiling for any single test in this module. All readers
 /// honour an inner deadline well below this so a regression that breaks
 /// the typed-error surface fails fast instead of stalling CI.
@@ -98,10 +94,6 @@ fn drive_handle_goodbye<R: Read>(ctx: &ReceiverContext, mut reader: R) -> io::Re
     let mut ndx_read = create_ndx_codec(ctx.protocol.as_u8());
     ctx.handle_goodbye(&mut reader, &mut writer, &mut ndx_write, &mut ndx_read)
 }
-
-// ---------------------------------------------------------------------------
-// Synthetic `Read` impls
-// ---------------------------------------------------------------------------
 
 /// Reader that drains an in-memory prefix then surfaces
 /// `io::ErrorKind::TimedOut` once the configured deadline elapses.
@@ -188,10 +180,6 @@ impl Read for DisconnectAfterPrefixReader {
         Ok(0)
     }
 }
-
-// ---------------------------------------------------------------------------
-// EDG-GOODBYE.4: timeout-band tests
-// ---------------------------------------------------------------------------
 
 /// The sender delivers a single byte of the modern goodbye frame (the
 /// `0xFF` negative prefix that announces a negative NDX) and then

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -571,8 +571,6 @@ mod tests {
         );
     }
 
-    // --- PIR-5.d: Interrupt behavior ---
-
     /// Verifies that staged files in `.~tmp~/` persist as valid partials when
     /// the sweep is never called (simulating an interrupted transfer).
     ///


### PR DESCRIPTION
## Summary

Surgical comment cleanup across `crates/transfer/src/**/*.rs`:

- Remove decorative banner/divider comments (`// ---- ... ----`) inside test modules.
- Flatten upstream-parity captions into single-line comments where the caption itself referenced upstream rsync behavior.
- Preserve every comment that references upstream rsync source, encodes a non-obvious invariant, or describes an INC_RECURSE/protocol quirk.

The non-test source files were already well-curated: nearly every internal `//` comment in this crate cites an upstream rsync source location or explains a non-obvious wire invariant. The cleanup focused on the few in-src test files that retained pure decorative dividers.

No runtime, public-API, rustdoc, or behavior changes.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo nextest run -p transfer --all-features` on the modules touched (parity_*, handle_delayed_updates, handle_goodbye_*, read_expected_ndx_done) - 51 tests pass.
- [x] CI nextest (stable) for the workspace