### PR TITLE
fix(filters): suppress descendants for dir-only wildcard exclude patterns

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -69,13 +69,27 @@ impl CompiledRule {
         // Anchored literal patterns (e.g., `/build`, `/target/`) still need
         // `{core}/**` descendants so that paths like `build/output` are
         // excluded when checked individually (e.g., by the receiver).
+        //
+        // Directory-only wildcard patterns (e.g., `foo/*/`, `**/node_modules/`)
+        // must ALSO suppress descendants. The wildcard's match set is decided
+        // per-directory at walk time, so pre-baking `foo/*/**` overreaches
+        // and excludes files inside subdirectories that a later include rule
+        // like `+ foo/s?b/` should keep. Upstream `exclude.c:rule_matches()`
+        // returns "no match" for a non-directory entry when the rule carries
+        // FILTRULE_DIRECTORY (line 938-939), so the file is included by
+        // default and the sender walk handles descent pruning by never
+        // entering the excluded directory. Pre-baked descendants would force
+        // an exclusion that upstream never produces. Regression for
+        // UTS-DD-exclude.3 (upstream `exclude` / `exclude-lsh` testsuite).
         let has_glob_wildcard =
             core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
         let slash_anchored = pattern.starts_with('/');
+        let suppress_descendants =
+            (slash_anchored && has_glob_wildcard) || (has_glob_wildcard && directory_only);
         if matches!(
             action,
             FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
-        ) && !(slash_anchored && has_glob_wildcard)
+        ) && !suppress_descendants
         {
             descendant_patterns.insert(format!("{core_pattern}/**"));
             if !anchored {
@@ -187,14 +201,17 @@ mod tests {
         );
     }
 
-    /// Verifies that `--exclude '*/'` DOES generate descendant matchers.
+    /// Verifies that `--exclude 'cache/'` DOES generate descendant matchers.
     ///
-    /// upstream: Excluding a directory excludes all of its contents.
+    /// upstream: Excluding a literal directory excludes all of its contents
+    /// when the receiver checks them individually. Wildcard directory-only
+    /// patterns are handled separately - see
+    /// [`dir_only_wildcard_exclude_has_no_descendant_matchers`].
     #[test]
-    fn exclude_directory_only_has_descendant_matchers() {
+    fn exclude_directory_only_literal_has_descendant_matchers() {
         let rule = FilterRule {
             action: FilterAction::Exclude,
-            pattern: "*/".to_owned(),
+            pattern: "cache/".to_owned(),
             applies_to_sender: true,
             applies_to_receiver: true,
             perishable: false,
@@ -208,8 +225,48 @@ mod tests {
         assert!(compiled.directory_only);
         assert!(
             !compiled.descendant_matchers.is_empty(),
-            "exclude directory-only rules must have descendant matchers"
+            "exclude directory-only literal rules must have descendant matchers"
         );
+    }
+
+    /// Verifies that `--exclude '*/'` (and other directory-only wildcards)
+    /// does NOT generate descendant matchers.
+    ///
+    /// upstream: `exclude.c:rule_matches()` line 938-939 returns "no match"
+    /// when the rule carries `FILTRULE_DIRECTORY` and the candidate is not
+    /// itself a directory. Pre-baking `*/**` (or `foo/*/**`) overreaches
+    /// because the wildcard's per-directory match set is decided at walk
+    /// time. The sender skips the directory subtree on a match; the
+    /// receiver consults only the user-written rule and so should NOT see
+    /// a synthetic descendant fire on a file under the matched directory.
+    /// Regression for UTS-DD-exclude.3.
+    #[test]
+    fn dir_only_wildcard_exclude_has_no_descendant_matchers() {
+        for pattern in &[
+            "*/",
+            "foo/*/",
+            "foo/s?b/",
+            "bar/[a-z]*/",
+            "**/node_modules/",
+        ] {
+            let rule = FilterRule {
+                action: FilterAction::Exclude,
+                pattern: pattern.to_string(),
+                applies_to_sender: true,
+                applies_to_receiver: true,
+                perishable: false,
+                xattr_only: false,
+                negate: false,
+                exclude_only: false,
+                no_inherit: false,
+                cvs_mode: false,
+            };
+            let compiled = CompiledRule::new(rule).unwrap();
+            assert!(
+                compiled.descendant_matchers.is_empty(),
+                "directory-only wildcard pattern {pattern:?} must not have descendant matchers"
+            );
+        }
     }
 
     /// Anchored wildcard exclude patterns must NOT generate descendant

--- a/crates/filters/tests/edge_cases.rs
+++ b/crates/filters/tests/edge_cases.rs
@@ -398,6 +398,15 @@ fn filter_error_access() {
 }
 
 /// Verifies complex nested patterns.
+///
+/// upstream: `exclude.c:rule_matches()` line 938-939 returns "no match"
+/// for a non-directory entry when the rule carries `FILTRULE_DIRECTORY`.
+/// `**/node_modules/` is a wildcard directory-only pattern and so does
+/// NOT match a file like `node_modules/lodash` directly - upstream relies
+/// on the sender's walk skipping descent into the matched directory. The
+/// `.cache` include rule and the `.tmp` specific-exclude still apply on
+/// their own; this test pins that behaviour against single-path queries
+/// that bypass the walk.
 #[test]
 fn complex_nested_patterns() {
     // rsync uses first-match-wins: specific includes/excludes must come before general ones
@@ -408,14 +417,24 @@ fn complex_nested_patterns() {
     ];
     let set = FilterSet::from_rules(rules).unwrap();
 
-    // node_modules excluded (third rule matches)
-    assert!(!set.allows(Path::new("node_modules/lodash"), false));
-    assert!(!set.allows(Path::new("packages/app/node_modules/react"), false));
+    // node_modules directory itself excluded (third rule matches the dir).
+    assert!(!set.allows(Path::new("node_modules"), true));
+    assert!(!set.allows(Path::new("packages/app/node_modules"), true));
 
-    // .cache within node_modules included (second rule matches)
+    // upstream: FILTRULE_DIRECTORY + wildcard pattern returns "no match"
+    // for non-directory entries; the sender's walk handles descent
+    // pruning, so single-path queries for files inside the directory
+    // report "no match" against the directory-only rule and fall through
+    // to defaults (include). Wire-equivalent behaviour with upstream
+    // rsync 3.4.x.
+    assert!(set.allows(Path::new("node_modules/lodash"), false));
+    assert!(set.allows(Path::new("packages/app/node_modules/react"), false));
+
+    // .cache within node_modules included (second rule matches via its
+    // user-written `**` direct matcher).
     assert!(set.allows(Path::new("node_modules/.cache/data"), false));
 
-    // But .tmp within .cache excluded (first rule matches)
+    // But .tmp within .cache excluded (first rule matches).
     assert!(!set.allows(Path::new("node_modules/.cache/scratch.tmp"), false));
 }
 

--- a/crates/filters/tests/glob_patterns.rs
+++ b/crates/filters/tests/glob_patterns.rs
@@ -412,13 +412,23 @@ fn directory_pattern_includes_descendants() {
 }
 
 /// Verifies nested directory patterns.
+///
+/// upstream: `exclude.c:rule_matches()` line 938-939 returns "no match"
+/// for a non-directory entry when the rule carries `FILTRULE_DIRECTORY`.
+/// A wildcard directory-only pattern like `**/node_modules/` matches the
+/// directory entry itself but does NOT match files under it - the sender
+/// walk handles descent pruning by skipping the directory. A single-path
+/// query for a file under such a directory must therefore report "no
+/// match" so the file is included by default, mirroring upstream rsync.
 #[test]
 fn nested_directory_patterns() {
     let set = FilterSet::from_rules([FilterRule::exclude("**/node_modules/")]).unwrap();
 
     assert!(!set.allows(Path::new("node_modules"), true));
     assert!(!set.allows(Path::new("packages/app/node_modules"), true));
-    assert!(!set.allows(Path::new("packages/app/node_modules/pkg"), false));
+    // upstream: FILTRULE_DIRECTORY + wildcard pattern returns "no match"
+    // for a non-directory entry; the file is included by default.
+    assert!(set.allows(Path::new("packages/app/node_modules/pkg"), false));
 }
 
 /// Verifies gitignore-style patterns.

--- a/crates/filters/tests/pattern_matching.rs
+++ b/crates/filters/tests/pattern_matching.rs
@@ -275,13 +275,29 @@ fn directory_pattern_excludes_contents() {
 }
 
 /// Verifies nested directory patterns.
+///
+/// upstream: `exclude.c:rule_matches()` line 938-939 returns "no match"
+/// when the rule carries `FILTRULE_DIRECTORY` and the candidate is not
+/// itself a directory. The directory wildcard `packages/*/node_modules/`
+/// matches the directory entry `packages/app/node_modules` (`is_dir=true`)
+/// but does NOT match `packages/app/node_modules/pkg` (a file under it).
+/// Upstream relies on the sender's walk skipping descent into excluded
+/// directories; a file-level query bypassing the walk must therefore
+/// report "no match" so the file is included by default - any
+/// pre-baked `pattern/**` descendant matcher would diverge from upstream
+/// semantics.
 #[test]
 fn nested_directory_pattern() {
     let set = FilterSet::from_rules([FilterRule::exclude("packages/*/node_modules/")]).unwrap();
 
     assert!(!set.allows(Path::new("packages/app/node_modules"), true));
     assert!(!set.allows(Path::new("packages/lib/node_modules"), true));
-    assert!(!set.allows(Path::new("packages/app/node_modules/pkg"), false));
+    // upstream: FILTRULE_DIRECTORY + wildcard pattern returns "no match"
+    // for a non-directory entry; the file is included by default and the
+    // sender walk handles descent pruning by never entering the excluded
+    // directory in the first place. Wire-equivalent behaviour with
+    // upstream rsync 3.4.x.
+    assert!(set.allows(Path::new("packages/app/node_modules/pkg"), false));
 
     // Root node_modules not matched
     assert!(set.allows(Path::new("node_modules"), true));


### PR DESCRIPTION
## Summary

- Wildcard directory-only patterns (e.g. `foo/*/`, `**/node_modules/`) no longer synthesize `pattern/**` descendant matchers, matching upstream rsync's `exclude.c:rule_matches()` line 938-939 which returns "no match" for non-directory entries when the rule carries `FILTRULE_DIRECTORY`.
- Resolves the upstream `exclude` / `exclude-lsh` testsuite failure on the `--exclude-from + --delete-during` sub-transfer where single-path filter queries diverged from upstream semantics (UTS-DD-exclude.3, #4528).
- Three integration tests previously encoded the legacy descendant behaviour and have been updated to mirror upstream `FILTRULE_DIRECTORY` semantics.

## Root cause

For a pattern like `- foo/*/`, the compiled rule used to generate a `foo/*/**` descendant matcher that fired on any file under any subdirectory of `foo/`. Upstream rsync has no descendant matching at all; instead, it relies on the sender's walk skipping descent into excluded directories. A directory-only wildcard rule:

- matches the directory entry directly (per-directory walk-time decision), and
- returns "no match" for a non-directory entry (line 938-939 in `exclude.c`).

The synthetic `foo/*/**` descendant therefore over-matched whenever a later include rule like `+ foo/s?b/` was supposed to keep a sub-directory's children. The traversal-driven `chain.allows()` was already correct via `FilterSet::allows_during_traversal`'s descendant-skip path; this fix aligns the single-path `FilterSet::allows()` API (used by the receiver deletion path and other non-traversal consumers) with upstream semantics.

## Changes

- `crates/filters/src/compiled/mod.rs`: extend the descendant-suppression predicate to cover directory-only wildcard patterns; add a focused regression test (`dir_only_wildcard_exclude_has_no_descendant_matchers`) covering `*/`, `foo/*/`, `foo/s?b/`, `bar/[a-z]*/`, and `**/node_modules/`.
- `crates/filters/tests/pattern_matching.rs`, `crates/filters/tests/glob_patterns.rs`, `crates/filters/tests/edge_cases.rs`: align the `nested_directory_pattern`, `nested_directory_patterns`, and `complex_nested_patterns` integration tests with upstream `FILTRULE_DIRECTORY` semantics. Literal directory excludes (e.g. `cache/`, `node_modules/`) still produce descendant matchers; only wildcard directory-only patterns are affected.

Files compile, format, and `cargo nextest run -p filters --all-features` reports 1330 tests pass.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run -p filters --all-features` (1330 passed)
- [x] `cargo nextest run -p transfer --all-features` (no new failures; the pre-existing `empty_file_checksum_verification_sha1` failure is unrelated to filters)
- [ ] CI runs the full workspace nextest, Windows / macOS / musl matrices, and the upstream-testsuite interop validation. Confirm `exclude` and `exclude-lsh` move from FAIL to PASS.