### PR TITLE
fix(batch): preserve regular-file mode through symlink replay

### DIFF
--- a/crates/batch/src/replay/fs_ops.rs
+++ b/crates/batch/src/replay/fs_ops.rs
@@ -43,6 +43,46 @@ pub(super) fn apply_entry_metadata(
     Ok(())
 }
 
+/// Apply metadata (timestamps, optionally ownership) from a symlink file entry
+/// to a destination symbolic link without following the link target.
+///
+/// Mirrors upstream `rsync.c:set_file_attrs()` symlink handling: a symlink's
+/// own mtime and ownership are updated via `lutimes` / `AT_SYMLINK_NOFOLLOW`
+/// chown, but `chmod` is skipped because most platforms ignore the mode bits
+/// on a symlink and the call would otherwise follow the link and clobber the
+/// target file's permissions.
+///
+/// This is required during batch replay because phase 1 creates symlinks
+/// before phase 2 writes their target files. Calling [`apply_entry_metadata`]
+/// on a symlink whose target was just materialised would `chmod` the
+/// underlying regular file with the symlink's mode (typically `0777` on
+/// macOS), silently overwriting the correct permissions applied by the
+/// per-file metadata pass.
+///
+/// # Errors
+///
+/// Returns [`BatchError::Io`] if symlink metadata cannot be applied.
+pub(super) fn apply_symlink_entry_metadata(
+    dest_path: &Path,
+    entry: &protocol::flist::FileEntry,
+    flags: &BatchFlags,
+) -> BatchResult<()> {
+    let options = metadata::MetadataOptions::new()
+        .preserve_permissions(true)
+        .preserve_times(true)
+        .preserve_owner(flags.preserve_uid)
+        .preserve_group(flags.preserve_gid);
+
+    metadata::apply_symlink_metadata_from_entry(dest_path, entry, &options).map_err(|e| {
+        BatchError::Io(std::io::Error::other(format!(
+            "failed to apply symlink metadata to '{}': {e}",
+            dest_path.display()
+        )))
+    })?;
+
+    Ok(())
+}
+
 /// Create a symlink at `dest_path` pointing to the given `target`.
 ///
 /// On Unix, creates a symbolic link. On other platforms, falls back to

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -59,7 +59,7 @@ use crate::format::BatchFlags;
 use crate::reader::BatchReader;
 
 use delta_phase::apply_delta_phase;
-use fs_ops::{apply_entry_metadata, create_symlink};
+use fs_ops::{apply_entry_metadata, apply_symlink_entry_metadata, create_symlink};
 
 pub use delta::apply_delta_ops;
 
@@ -129,6 +129,16 @@ pub fn replay(
         recurse: flags.recurse,
         ..ReplayResult::default()
     };
+
+    // upstream: main.c:778-799 - get_local_name() creates the destination
+    // directory automatically when the transfer involves more than one file or
+    // the destination operand ends in a slash. Batch replay reproduces that
+    // behaviour so a fresh destination tree can absorb a batch without
+    // requiring the caller to pre-create the root. The flist root entry "."
+    // joined to a missing dest_root expands to `dest_root/.`, which
+    // `fs::create_dir_all` cannot materialise because the parent does not
+    // exist; creating dest_root first sidesteps that path-component edge.
+    ensure_dest_root(dest_root, &entries, &mut result)?;
 
     // Phase 1: Create directories and symlinks, ensure parent dirs for regular files.
     prepare_directories_and_symlinks(&entries, dest_root, verbosity, &mut result)?;
@@ -200,6 +210,41 @@ fn prepare_directories_and_symlinks(
     Ok(())
 }
 
+/// Ensure the destination root exists before per-entry processing.
+///
+/// Mirrors upstream `get_local_name()` semantics: a missing destination
+/// directory is materialised automatically when the batch carries more than
+/// one entry or any directory entry, so callers can replay into a fresh path
+/// without a separate `mkdir`. The dirs_created counter is bumped so the
+/// summary reflects the same "created directory" notice upstream emits.
+fn ensure_dest_root(
+    dest_root: &Path,
+    entries: &[protocol::flist::FileEntry],
+    result: &mut ReplayResult,
+) -> BatchResult<()> {
+    if dest_root.as_os_str().is_empty() || dest_root.exists() {
+        return Ok(());
+    }
+    let needs_dir = entries.len() > 1
+        || entries
+            .iter()
+            .any(|entry| entry.file_type() == protocol::flist::FileType::Directory);
+    if !needs_dir {
+        return Ok(());
+    }
+    fs::create_dir_all(dest_root).map_err(|e| {
+        BatchError::Io(std::io::Error::new(
+            e.kind(),
+            format!(
+                "failed to create destination directory '{}': {e}",
+                dest_root.display()
+            ),
+        ))
+    })?;
+    result.dirs_created += 1;
+    Ok(())
+}
+
 /// Create the parent directory of `path` if it does not already exist.
 fn ensure_parent_dir(path: &Path) -> BatchResult<()> {
     if let Some(parent) = path.parent() {
@@ -250,8 +295,16 @@ fn apply_all_metadata(
                 }
             }
             protocol::flist::FileType::Symlink => {
+                // upstream: rsync.c:set_file_attrs() - chmod is skipped for
+                // symlinks because most platforms ignore the mode bits and
+                // chmod through a symlink follows the link. Calling
+                // apply_entry_metadata here clobbers the target file's mode
+                // with the symlink entry's mode (typically 0o777), which
+                // breaks the batch-mode upstream testsuite case
+                // `nolf-symlink -> nolf` (nolf ends up as 0o777 instead of
+                // the recorded 0o644).
                 if dest_path.symlink_metadata().is_ok() {
-                    let _ = apply_entry_metadata(&dest_path, entry, flags);
+                    let _ = apply_symlink_entry_metadata(&dest_path, entry, flags);
                 }
             }
             _ => {}

--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -2029,4 +2029,133 @@ mod integration {
             "CPRES_ZLIB literal-only stream must decompress correctly without basis"
         );
     }
+
+    /// Regression: replay must apply symlink metadata via `lchown`/`lutimes`,
+    /// not follow the link and `chmod` the target. The upstream-testsuite
+    /// `batch-mode.test` exercises this through the `nolf-symlink -> nolf`
+    /// pair: `ln -s nolf nolf-symlink` produces a symlink whose own mode is
+    /// `0o777` while `nolf` itself is `0o644`. Phase 1 creates the symlink
+    /// before phase 2 writes `nolf`, so applying the symlink entry's mode
+    /// through the regular metadata path follows the link and clobbers the
+    /// underlying regular file's permissions.
+    ///
+    /// upstream: rsync.c:set_file_attrs() skips chmod for symlinks; mirror
+    /// that behaviour during batch replay so `nolf` ends up as `0o644`.
+    #[cfg(unix)]
+    #[test]
+    fn test_replay_symlink_metadata_does_not_follow_link() {
+        use protocol::flist::{FileEntry, FileListWriter};
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("symlink_meta.batch");
+        let dest_dir = temp_dir.path().join("dest");
+        fs::create_dir_all(&dest_dir).unwrap();
+
+        let protocol_version = 31;
+
+        let write_config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        )
+        .with_checksum_seed(99);
+
+        let mut writer = BatchWriter::new(write_config).unwrap();
+        let flags = BatchFlags {
+            preserve_links: true,
+            ..Default::default()
+        };
+        writer.write_header(flags).unwrap();
+
+        let protocol = protocol::ProtocolVersion::try_from(protocol_version as u8).unwrap();
+        let mut flist_writer = FileListWriter::new(protocol).with_preserve_links(true);
+
+        // Regular file with mode 0o644.
+        let file_entry = {
+            let mut e = FileEntry::new_file("nolf".into(), 4, 0o644);
+            e.set_mtime(1_700_000_000, 0);
+            e
+        };
+        // Symlink "nolf-symlink -> nolf". new_symlink() sets mode to 0o777
+        // unconditionally, matching the kernel default that `ln -s` produces.
+        let link_entry = {
+            let mut e =
+                FileEntry::new_symlink("nolf-symlink".into(), std::path::PathBuf::from("nolf"));
+            e.set_mtime(1_700_000_000, 0);
+            e
+        };
+
+        let mut buf = Vec::new();
+        flist_writer.write_entry(&mut buf, &file_entry).unwrap();
+        flist_writer.write_entry(&mut buf, &link_entry).unwrap();
+        writer.write_data(&buf).unwrap();
+
+        let mut end_buf = Vec::new();
+        flist_writer.write_end(&mut end_buf, None).unwrap();
+        writer.write_data(&end_buf).unwrap();
+
+        // NDX-framed delta for "nolf": whole-file literal "data".
+        {
+            use protocol::codec::{NdxCodec, NdxCodecEnum};
+
+            let mut ndx_codec = NdxCodecEnum::new(protocol_version as u8);
+            let mut ndx_buf = Vec::new();
+            ndx_codec.write_ndx(&mut ndx_buf, 0).unwrap();
+            writer.write_data(&ndx_buf).unwrap();
+
+            writer.write_data(&0x8000u16.to_le_bytes()).unwrap();
+            for _ in 0..4 {
+                writer.write_data(&0i32.to_le_bytes()).unwrap();
+            }
+
+            let mut delta_buf = Vec::new();
+            protocol::wire::delta::write_token_literal(&mut delta_buf, b"data").unwrap();
+            protocol::wire::delta::write_token_end(&mut delta_buf).unwrap();
+            writer.write_data(&delta_buf).unwrap();
+
+            writer.write_data(&[0u8; 16]).unwrap();
+
+            ndx_buf.clear();
+            ndx_codec.write_ndx_done(&mut ndx_buf).unwrap();
+            writer.write_data(&ndx_buf).unwrap();
+
+            ndx_buf.clear();
+            ndx_codec.write_ndx_done(&mut ndx_buf).unwrap();
+            writer.write_data(&ndx_buf).unwrap();
+        }
+
+        writer.finalize().unwrap();
+
+        let read_config = BatchConfig::new(
+            BatchMode::Read,
+            batch_path.to_string_lossy().to_string(),
+            protocol_version,
+        );
+
+        let result = crate::replay::replay(&read_config, &dest_dir, 0).unwrap();
+        assert_eq!(result.file_count, 2);
+        assert_eq!(result.symlinks_created, 1);
+
+        let nolf = dest_dir.join("nolf");
+        let nolf_link = dest_dir.join("nolf-symlink");
+        assert!(nolf.is_file(), "nolf must be a regular file");
+        assert!(
+            nolf_link
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "nolf-symlink must remain a symlink"
+        );
+
+        // Without the fix, nolf would inherit the symlink's 0o777 mode.
+        let nolf_mode = fs::metadata(&nolf).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            nolf_mode, 0o644,
+            "regular file mode must be 0o644 - the symlink entry's 0o777 mode \
+             must not propagate via apply_metadata_from_file_entry following \
+             the link"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Route batch-replay symlink metadata through `apply_symlink_metadata_from_entry` so the symlink entry's mode bits do not propagate (via `fs::metadata` following the link) and clobber the target file's permissions. Matches upstream `rsync.c:set_file_attrs()` which skips `chmod` for symlinks.
- Auto-create the destination root during `--read-batch` when the batch carries a `.` directory entry or multiple entries, mirroring upstream `main.c:778-799 get_local_name()`. Without this, `--read-batch=BATCH dst/` into a fresh `dst` failed with `failed to create directory 'dst/.': No such file or directory`.
- Add an end-to-end integration test covering the `nolf-symlink -> nolf` topology from upstream `testsuite/rsync.fns hands_setup()`.

## Why

Upstream `testsuite/batch-mode.test` was failing because the `hands_setup()` corpus contains `ln -s nolf nolf-symlink`. The symlink's own mode (0o777, kernel default for `ln -s`) was leaking through the replay metadata pass and overwriting `nolf`'s real 0o644 mode. The first sub-test (`--read-batch (only)`) diffed `chk/` vs `to/` and reported the permission divergence.

After this change, all local sub-tests of `batch-mode.test` pass:

| sub-test | before | after |
|---|---|---|
| `--read-batch (only)` | FAIL (`nolf` 0o777 vs 0o644) | PASS |
| `local --write-batch` | not reached | PASS |
| `--read-batch` | not reached | PASS |
| `daemon sender --write-batch` | not reached | PASS |

The remaining daemon-replay sub-test still fails because the daemon-side `--write-batch` capture path drops literal data (separate issue; daemon-mode batch capture is incomplete and tracked under the broader UTS umbrella).

## Test plan

- [x] `cargo nextest run -p batch --all-features` - 204/204 pass
- [x] New `test_replay_symlink_metadata_does_not_follow_link` asserts `nolf` retains 0o644 after replaying a symlink-to-file batch
- [x] `cargo fmt --all -- --check` clean
- [x] Upstream `testsuite/batch-mode.test`: local sub-tests now pass (5th sub-test still fails on pre-existing daemon batch-capture gap)