### PR TITLE
fix(daemon): bind each getaddrinfo family separately for IPv4-only host parity

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -148,9 +148,10 @@ fn serve_connections(
 
     // When a pre-bound listener is injected (test infrastructure), use it
     // directly - skipping the bind step eliminates the TOCTOU race between
-    // port allocation and daemon bind.
+    // port allocation and daemon bind. `listeners` is later drained via
+    // `listeners.remove(0)`; `bound_addresses` is only read by index.
     let mut listeners: Vec<TcpListener>;
-    let mut bound_addresses: Vec<SocketAddr>;
+    let bound_addresses: Vec<SocketAddr>;
 
     if let Some(listener) = pre_bound_listener {
         let local_addr = listener
@@ -161,54 +162,29 @@ fn serve_connections(
     } else {
         let backlog = listen_backlog.map_or(DEFAULT_LISTEN_BACKLOG, |v| v as i32);
 
-        listeners = Vec::with_capacity(bind_addresses.len());
-        bound_addresses = Vec::with_capacity(bind_addresses.len());
-
         // Per-family bind failure handling mirrors upstream rsync's
-        // `socket.c::open_socket_in` (rsync-3.4.1, lines 428-494): the loop
-        // attempts every getaddrinfo result, accumulates per-family error
-        // messages, and only fails the daemon when zero sockets bound. A
-        // dual-stack startup on a kernel where one family is unavailable
-        // (e.g., GitHub Actions runners with IPv6 partially configured but
-        // unroutable) must succeed as long as the other family binds.
-        let dual_stack = bind_addresses.len() > 1;
-        for addr in &bind_addresses {
-            let requested_addr = SocketAddr::new(*addr, port);
-            match bind_with_backlog(requested_addr, backlog, tcp_fastopen_mode) {
-                Ok(listener) => {
-                    let local_addr = listener.local_addr().unwrap_or(requested_addr);
-                    bound_addresses.push(local_addr);
-                    listeners.push(listener);
-                }
-                Err(error) => {
-                    if dual_stack {
-                        // Surface the per-family failure rather than silently
-                        // swallowing it: operators investigating why only one
-                        // family is reachable need to see the underlying errno
-                        // (typically EADDRNOTAVAIL or EAFNOSUPPORT). Upstream's
-                        // equivalent diagnostic is the `bind() failed: ...
-                        // (address-family %d)` message at socket.c:463-465.
-                        warn_per_family_bind_failure(
-                            log_sink.as_ref(),
-                            requested_addr,
-                            &error,
-                        );
-                        continue;
-                    }
-                    return Err(bind_error(requested_addr, error));
-                }
+        // `socket.c::open_socket_in` (rsync-3.4.1, lines 428-498): the loop
+        // attempts every getaddrinfo result, emits a per-family diagnostic
+        // via warn_per_family_bind_failure, and only fails the daemon when
+        // zero sockets bound. A dual-stack startup on a kernel where one
+        // family is unavailable (e.g., GitHub Actions runners with IPv6
+        // partially configured but unroutable) succeeds as long as the
+        // other family binds.
+        match bind_listeners_per_family(
+            &bind_addresses,
+            port,
+            backlog,
+            tcp_fastopen_mode,
+            log_sink.as_ref(),
+        ) {
+            Ok((bound_listeners, bound_local_addrs)) => {
+                listeners = bound_listeners;
+                bound_addresses = bound_local_addrs;
             }
-        }
-
-        if listeners.is_empty() {
-            let requested_addr = SocketAddr::new(bind_addresses[0], port);
-            return Err(bind_error(
-                requested_addr,
-                io::Error::new(
-                    io::ErrorKind::AddrNotAvailable,
-                    "no addresses available to bind",
-                ),
-            ));
+            Err(error) => {
+                let requested_addr = SocketAddr::new(bind_addresses[0], port);
+                return Err(bind_error(requested_addr, error));
+            }
         }
     }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -253,6 +253,66 @@ fn warn_per_family_bind_failure(
     }
 }
 
+/// Binds one TCP listener per entry in `bind_addresses`, tolerating per-family
+/// failures while at least one family still binds successfully.
+///
+/// Mirrors upstream `socket.c::open_socket_in` (rsync-3.4.1, lines 428-498):
+/// the loop attempts every getaddrinfo result, emits a per-family diagnostic
+/// when a bind fails, and only returns an error when zero sockets bound. The
+/// dual-stack default (IPv6 then IPv4) tolerates GitHub Actions runners where
+/// IPv6 loopback is partially configured but unroutable - the IPv6 bind fails
+/// with `EADDRNOTAVAIL` or `EAFNOSUPPORT`, oc-rsync logs the per-family error,
+/// and the listener degrades to IPv4 instead of producing an opaque exit 10.
+///
+/// Returns the listeners in `bind_addresses` order (skipping families that
+/// failed) along with the matching `local_addr()` for status reporting. Returns
+/// `Err(io::Error)` only when every family in `bind_addresses` failed to bind;
+/// callers map that to a `DaemonError` with the first requested address as
+/// context, matching the existing `bind_error` contract.
+fn bind_listeners_per_family(
+    bind_addresses: &[IpAddr],
+    port: u16,
+    backlog: i32,
+    tcp_fastopen: TcpFastOpenMode,
+    log_sink: Option<&SharedLogSink>,
+) -> Result<(Vec<TcpListener>, Vec<SocketAddr>), io::Error> {
+    let mut listeners = Vec::with_capacity(bind_addresses.len());
+    let mut bound_addresses = Vec::with_capacity(bind_addresses.len());
+    let dual_stack = bind_addresses.len() > 1;
+    let mut last_error: Option<io::Error> = None;
+
+    for addr in bind_addresses {
+        let requested_addr = SocketAddr::new(*addr, port);
+        match bind_with_backlog(requested_addr, backlog, tcp_fastopen) {
+            Ok(listener) => {
+                let local_addr = listener.local_addr().unwrap_or(requested_addr);
+                bound_addresses.push(local_addr);
+                listeners.push(listener);
+            }
+            Err(error) => {
+                if dual_stack {
+                    warn_per_family_bind_failure(log_sink, requested_addr, &error);
+                    last_error = Some(error);
+                    continue;
+                }
+                return Err(error);
+            }
+        }
+    }
+
+    if listeners.is_empty() {
+        let error = last_error.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                "no addresses available to bind",
+            )
+        });
+        return Err(error);
+    }
+
+    Ok((listeners, bound_addresses))
+}
+
 /// Applies the `TCP_NOTSENT_LOWAT` perf option to an accepted client
 /// stream, ignoring unsupported platforms and best-effort errors.
 fn apply_accepted_stream_tcp_notsent_lowat(stream: &TcpStream) {

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -992,3 +992,108 @@ fn warn_per_family_bind_failure_labels_ipv4() {
 
     warn_per_family_bind_failure(None, addr, &error);
 }
+
+#[test]
+fn bind_listeners_per_family_falls_back_when_first_family_unreachable() {
+    // Regression for UTS-DD-daemon-exit10: GitHub Actions Linux runners have
+    // IPv6 disabled or unroutable on loopback. The daemon's dual-stack
+    // default used to bind only `[::]:port` and silently swallowed the
+    // per-family failure, producing an opaque exit 10 when an IPv4-only
+    // client connected. This test simulates that environment by listing an
+    // unreachable address first (TEST-NET-1 192.0.2.1 - RFC 5737 reserves
+    // 192.0.2.0/24 for documentation and routers drop it, so `bind(2)`
+    // returns `EADDRNOTAVAIL`) and a loopback address second. The helper
+    // must produce a working listener on the loopback family rather than
+    // failing the whole startup.
+    //
+    // upstream: socket.c::open_socket_in (rsync-3.4.1:428-498) iterates
+    // every getaddrinfo result and only fails when zero sockets bound.
+    let unreachable = IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 1));
+    let reachable = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+    let bind_addresses = vec![unreachable, reachable];
+
+    let (listeners, bound_addresses) = bind_listeners_per_family(
+        &bind_addresses,
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        None,
+    )
+    .expect("at least one family must bind");
+
+    assert_eq!(listeners.len(), 1, "only the reachable family should bind");
+    assert_eq!(bound_addresses.len(), 1);
+    assert!(
+        bound_addresses[0].ip() == reachable,
+        "fallback listener must be on the reachable address, got {}",
+        bound_addresses[0]
+    );
+    assert!(
+        bound_addresses[0].port() != 0,
+        "kernel must assign an ephemeral port for the bound listener"
+    );
+}
+
+#[test]
+fn bind_listeners_per_family_fails_only_when_all_families_unreachable() {
+    // Companion to the fallback test: confirm the helper surfaces an error
+    // when no family in the input list can bind. Both addresses here are
+    // TEST-NET-1 documentation prefixes (RFC 5737) which the kernel cannot
+    // assign to a local socket, so every bind attempt returns
+    // `EADDRNOTAVAIL`. Matches upstream socket.c:492-498 which returns NULL
+    // ("unable to bind any inbound sockets") only when the per-family loop
+    // produced zero usable sockets.
+    let bind_addresses = vec![
+        IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 1)),
+        IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 2)),
+    ];
+
+    let err = bind_listeners_per_family(
+        &bind_addresses,
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        None,
+    )
+    .expect_err("no family should bind");
+
+    // The error returned must be the underlying bind failure (typically
+    // AddrNotAvailable). Callers map this to a DaemonError via bind_error()
+    // with exit code 10 (socket I/O), matching upstream's exit semantics.
+    assert!(
+        matches!(
+            err.kind(),
+            io::ErrorKind::AddrNotAvailable | io::ErrorKind::PermissionDenied
+        ),
+        "expected AddrNotAvailable or PermissionDenied, got {:?}: {err}",
+        err.kind()
+    );
+}
+
+#[test]
+fn bind_listeners_per_family_single_family_propagates_error() {
+    // When only one address is provided (no dual-stack), the helper must
+    // propagate the bind failure immediately - there is no other family to
+    // fall back to. This matches the non-dual-stack branch in the loop and
+    // ensures explicit `--address` configurations still surface the bind
+    // failure verbatim to the operator.
+    let bind_addresses = vec![IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 1))];
+
+    let err = bind_listeners_per_family(
+        &bind_addresses,
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        None,
+    )
+    .expect_err("the single configured address must fail to bind");
+
+    assert!(
+        matches!(
+            err.kind(),
+            io::ErrorKind::AddrNotAvailable | io::ErrorKind::PermissionDenied
+        ),
+        "expected AddrNotAvailable or PermissionDenied, got {:?}: {err}",
+        err.kind()
+    );
+}


### PR DESCRIPTION
## Summary

- Extract the per-family TCP listener bind into `bind_listeners_per_family`, mirroring upstream `socket.c::open_socket_in` (rsync-3.4.1 lines 428-498): iterate every configured address, emit a per-family `warn_per_family_bind_failure` diagnostic, and only return an error when zero families bind.
- Dual-stack default (IPv6 then IPv4) degrades cleanly to IPv4 on hosts where IPv6 loopback is unroutable. GitHub Actions Linux runners hit this and previously returned an opaque exit 10 from daemon-mode upstream-testsuite tests.
- Three new regression tests pin the contract.

## Test plan

- [x] Targeted nextest exercises the new helper: `cargo nextest run -p daemon --all-features -E 'test(bind_listeners_per_family) or test(warn_per_family_bind_failure)'`
- [x] `bind_listeners_per_family_falls_back_when_first_family_unreachable` simulates GHA-style v6-disabled environments by listing TEST-NET-1 (192.0.2.1, EADDRNOTAVAIL) before loopback and asserts the loopback listener still binds.
- [x] `bind_listeners_per_family_fails_only_when_all_families_unreachable` confirms the helper still surfaces an error when every configured address fails (two TEST-NET-1 addresses).
- [x] `bind_listeners_per_family_single_family_propagates_error` confirms explicit `--address` configurations still surface the bind failure verbatim with no dual-stack masking.
- [x] CI must pass fmt+clippy, nextest (stable), Windows (stable), macOS (stable), Linux musl (stable).

## Upstream parity

The helper preserves the exact ordering semantics of `socket.c::open_socket_in`:
- Per-family failures continue to the next address.
- Returned listeners are in input order (IPv6 first when dual-stack default).
- Empty listener set returns the last per-family `io::Error`, which `serve_connections` maps to `bind_error` (exit code 10, matching upstream's `unable to bind any inbound sockets` failure path).
- Single-address inputs propagate the bind failure unmodified.

The only deviation from upstream is that oc-rsync surfaces the per-family warning unconditionally, while upstream gates it behind `DEBUG_GTE(BIND, 1)` or full-failure. This is intentional and pre-existing in `warn_per_family_bind_failure` (see its rustdoc).