### PR TITLE
fix(filters): honor XFLG_OLD_PREFIXES in --exclude/--include and -from

### DIFF
--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -6,13 +6,14 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use core::client::{ClientConfigBuilder, DirMergeOptions, FilterRuleKind, FilterRuleSpec};
+use core::message::Message;
 use logging_sink::MessageSink;
 
 use super::messages::fail_with_message;
 use crate::frontend::filter_rules::{
     FilterDirective, append_apple_double_exclude_rules, append_cvs_exclude_rules,
     append_filter_rules_from_files, apply_merge_directive, merge_directive_options,
-    os_string_to_pattern, parse_filter_directive,
+    os_string_to_pattern, parse_filter_directive, parse_old_prefix_rule,
 };
 
 /// Filter configuration supplied by the command line.
@@ -44,12 +45,13 @@ where
         return Err(fail_with_message(message, stderr));
     }
 
-    filter_rules.extend(
-        inputs
-            .includes
-            .into_iter()
-            .map(|pattern| FilterRuleSpec::include(os_string_to_pattern(pattern))),
-    );
+    for pattern in inputs.includes {
+        if let Err(message) =
+            push_old_prefix_rule(&mut filter_rules, pattern, FilterRuleKind::Include)
+        {
+            return Err(fail_with_message(message, stderr));
+        }
+    }
 
     if let Err(message) = append_filter_rules_from_files(
         &mut filter_rules,
@@ -59,12 +61,13 @@ where
         return Err(fail_with_message(message, stderr));
     }
 
-    filter_rules.extend(
-        inputs
-            .excludes
-            .into_iter()
-            .map(|pattern| FilterRuleSpec::exclude(os_string_to_pattern(pattern))),
-    );
+    for pattern in inputs.excludes {
+        if let Err(message) =
+            push_old_prefix_rule(&mut filter_rules, pattern, FilterRuleKind::Exclude)
+        {
+            return Err(fail_with_message(message, stderr));
+        }
+    }
 
     if inputs.cvs_exclude
         && let Err(message) = append_cvs_exclude_rules(&mut filter_rules)
@@ -106,4 +109,27 @@ where
     }
 
     Ok(builder)
+}
+
+/// Adds a CLI-supplied `--exclude`/`--include` pattern to `destination`,
+/// honoring upstream's `XFLG_OLD_PREFIXES` compatibility mode.
+///
+/// upstream: options.c:1512-1519 routes `--exclude`/`--include` through
+/// `parse_filter_str(..., XFLG_OLD_PREFIXES)`, so a value of `- pat` (or
+/// `+ pat`) flips the rule kind and `!` clears the list. Plain patterns
+/// retain `default_kind`.
+fn push_old_prefix_rule(
+    destination: &mut Vec<FilterRuleSpec>,
+    pattern: OsString,
+    default_kind: FilterRuleKind,
+) -> Result<(), Message> {
+    let text = os_string_to_pattern(pattern);
+    match parse_old_prefix_rule(&text, default_kind)? {
+        FilterDirective::Rule(rule) => destination.push(rule),
+        FilterDirective::Clear => destination.push(FilterRuleSpec::clear()),
+        FilterDirective::Merge(_) => {
+            unreachable!("parse_old_prefix_rule never emits FilterDirective::Merge")
+        }
+    }
+    Ok(())
 }

--- a/crates/cli/src/frontend/filter_rules/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use arguments::{collect_filter_arguments, locate_filter_arguments};
 pub(crate) use cvs::append_cvs_exclude_rules;
 pub(crate) use directive::{FilterDirective, merge_directive_options, os_string_to_pattern};
 pub(crate) use merge::apply_merge_directive;
-pub(crate) use parsing::parse_filter_directive;
+pub(crate) use parsing::{parse_filter_directive, parse_old_prefix_rule};
 pub(crate) use sources::append_filter_rules_from_files;
 
 #[cfg(test)]

--- a/crates/cli/src/frontend/filter_rules/parsing/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/mod.rs
@@ -33,6 +33,66 @@ pub(crate) fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective
     parse_rule_directive(trimmed_leading)
 }
 
+/// Parses a line under upstream rsync's `XFLG_OLD_PREFIXES` compatibility mode
+/// used by `--exclude`, `--exclude-from`, `--include`, and `--include-from`.
+///
+/// The only recognized prefixes are `- ` (exclude), `+ ` (include), and `!`
+/// (clear). Everything else is treated as a raw pattern that takes the
+/// `default_kind` (the rule kind associated with the option that introduced
+/// this line). Empty patterns are rejected to match upstream
+/// `exclude.c:parse_rule_tok()` which reports unexpected-end-of-rule.
+///
+/// upstream: exclude.c:parse_rule_tok() XFLG_OLD_PREFIXES branch (lines 1125-1133).
+pub(crate) fn parse_old_prefix_rule(
+    line: &str,
+    default_kind: FilterRuleKind,
+) -> Result<FilterDirective, Message> {
+    debug_assert!(
+        matches!(
+            default_kind,
+            FilterRuleKind::Include | FilterRuleKind::Exclude
+        ),
+        "old-prefix parsing only supports Include or Exclude defaults"
+    );
+
+    if line.is_empty() {
+        let message = rsync_error!(1, "filter rule is empty").with_role(Role::Client);
+        return Err(message);
+    }
+
+    let bytes = line.as_bytes();
+    // upstream: `*s == '!'` triggers FILTRULE_CLEAR_LIST tentatively. Any
+    // trailing non-whitespace then turns the rule back into a pattern, so
+    // we honor `!` (optionally followed by whitespace) as a clear and let
+    // `!pattern` fall through to the default rule kind.
+    if bytes[0] == b'!' && (line.len() == 1 || line[1..].trim().is_empty()) {
+        return Ok(FilterDirective::Clear);
+    }
+
+    let (kind, pattern) = if bytes.len() >= 2 && bytes[1] == b' ' {
+        match bytes[0] {
+            b'-' => (FilterRuleKind::Exclude, &line[2..]),
+            b'+' => (FilterRuleKind::Include, &line[2..]),
+            _ => (default_kind, line),
+        }
+    } else {
+        (default_kind, line)
+    };
+
+    if pattern.is_empty() {
+        let message =
+            rsync_error!(1, "filter rule is missing a pattern: '{}'", line).with_role(Role::Client);
+        return Err(message);
+    }
+
+    let rule = match kind {
+        FilterRuleKind::Include => FilterRuleSpec::include(pattern.to_owned()),
+        FilterRuleKind::Exclude => FilterRuleSpec::exclude(pattern.to_owned()),
+        _ => unreachable!("default_kind is restricted to Include/Exclude above"),
+    };
+    Ok(FilterDirective::Rule(rule))
+}
+
 fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDirective, Message>> {
     let remainder = text.strip_prefix("merge")?;
     let mut remainder =
@@ -784,5 +844,95 @@ mod tests {
             }
             _ => panic!("expected Rule directive"),
         }
+    }
+
+    #[test]
+    fn old_prefix_minus_space_flips_to_exclude() {
+        let result = parse_old_prefix_rule("- to", FilterRuleKind::Include).unwrap();
+        match result {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+                assert_eq!(spec.pattern(), "to");
+            }
+            other => panic!("expected Rule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_prefix_plus_space_flips_to_include() {
+        let result = parse_old_prefix_rule("+ *.rs", FilterRuleKind::Exclude).unwrap();
+        match result {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Include);
+                assert_eq!(spec.pattern(), "*.rs");
+            }
+            other => panic!("expected Rule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_prefix_bang_emits_clear() {
+        assert!(matches!(
+            parse_old_prefix_rule("!", FilterRuleKind::Exclude).unwrap(),
+            FilterDirective::Clear
+        ));
+        assert!(matches!(
+            parse_old_prefix_rule("!   ", FilterRuleKind::Exclude).unwrap(),
+            FilterDirective::Clear
+        ));
+    }
+
+    #[test]
+    fn old_prefix_bang_with_pattern_is_raw_pattern() {
+        // upstream: `!pattern` (no space) is NOT a clear - it's the raw
+        // pattern because XFLG_OLD_PREFIXES only recognizes `!` as clear
+        // when followed by whitespace or end-of-line.
+        let result = parse_old_prefix_rule("!keepme", FilterRuleKind::Exclude).unwrap();
+        match result {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+                assert_eq!(spec.pattern(), "!keepme");
+            }
+            other => panic!("expected Rule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_prefix_bare_pattern_uses_default_kind() {
+        let result = parse_old_prefix_rule("*.log", FilterRuleKind::Include).unwrap();
+        match result {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Include);
+                assert_eq!(spec.pattern(), "*.log");
+            }
+            other => panic!("expected Rule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_prefix_minus_without_space_is_raw_pattern() {
+        // upstream: `-` without a trailing space is not the exclude prefix -
+        // it's a literal pattern character. Same for `+`.
+        let result = parse_old_prefix_rule("-foo", FilterRuleKind::Exclude).unwrap();
+        match result {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+                assert_eq!(spec.pattern(), "-foo");
+            }
+            other => panic!("expected Rule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_prefix_empty_is_error() {
+        assert!(parse_old_prefix_rule("", FilterRuleKind::Exclude).is_err());
+    }
+
+    #[test]
+    fn old_prefix_short_prefix_only_is_error() {
+        // upstream: `parse_rule_tok` reports "unexpected end of filter rule"
+        // when no pattern follows the prefix.
+        assert!(parse_old_prefix_rule("- ", FilterRuleKind::Include).is_err());
+        assert!(parse_old_prefix_rule("+ ", FilterRuleKind::Exclude).is_err());
     }
 }

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -7,6 +7,9 @@ use core::client::{FilterRuleKind, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
 
+use super::directive::FilterDirective;
+use super::parsing::parse_old_prefix_rule;
+
 pub(crate) fn append_filter_rules_from_files(
     destination: &mut Vec<FilterRuleSpec>,
     files: &[OsString],
@@ -21,17 +24,36 @@ pub(crate) fn append_filter_rules_from_files(
         return Err(message);
     }
 
+    // upstream: options.c:1541-1543 - --exclude-from and --include-from
+    // feed parse_filter_file with XFLG_OLD_PREFIXES so per-line `- pat`,
+    // `+ pat`, and `!` prefixes flip the rule kind or clear the list. Kinds
+    // other than Include/Exclude have no upstream OLD_PREFIXES analogue, so
+    // we keep the legacy raw-pattern behavior to preserve existing semantics.
+    let honor_old_prefixes = matches!(kind, FilterRuleKind::Include | FilterRuleKind::Exclude);
+
     for path in files {
         let patterns = load_filter_file_patterns(Path::new(path.as_os_str()))?;
-        destination.extend(patterns.into_iter().map(|pattern| match kind {
-            FilterRuleKind::Include => FilterRuleSpec::include(pattern),
-            FilterRuleKind::Exclude => FilterRuleSpec::exclude(pattern),
-            FilterRuleKind::Clear => FilterRuleSpec::clear(),
-            FilterRuleKind::ExcludeIfPresent => FilterRuleSpec::exclude_if_present(pattern),
-            FilterRuleKind::Protect => FilterRuleSpec::protect(pattern),
-            FilterRuleKind::Risk => FilterRuleSpec::risk(pattern),
-            FilterRuleKind::DirMerge => unreachable!("dir-merge handled above"),
-        }));
+        for pattern in patterns {
+            if honor_old_prefixes {
+                match parse_old_prefix_rule(&pattern, kind)? {
+                    FilterDirective::Rule(rule) => destination.push(rule),
+                    FilterDirective::Clear => destination.push(FilterRuleSpec::clear()),
+                    FilterDirective::Merge(_) => {
+                        unreachable!("parse_old_prefix_rule never emits FilterDirective::Merge")
+                    }
+                }
+            } else {
+                destination.push(match kind {
+                    FilterRuleKind::Include => FilterRuleSpec::include(pattern),
+                    FilterRuleKind::Exclude => FilterRuleSpec::exclude(pattern),
+                    FilterRuleKind::Clear => FilterRuleSpec::clear(),
+                    FilterRuleKind::ExcludeIfPresent => FilterRuleSpec::exclude_if_present(pattern),
+                    FilterRuleKind::Protect => FilterRuleSpec::protect(pattern),
+                    FilterRuleKind::Risk => FilterRuleSpec::risk(pattern),
+                    FilterRuleKind::DirMerge => unreachable!("dir-merge handled above"),
+                });
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Route `--exclude`, `--include`, `--exclude-from`, and `--include-from` through a parser that honors upstream's `XFLG_OLD_PREFIXES` semantics so patterns may carry `- pat` / `+ pat` to flip kind, or `!` to clear the current rule list.
- Mirrors upstream `exclude.c:parse_rule_tok` and `options.c:1512-1543` behavior; previously these prefixes were treated as part of the pattern, silently breaking standard upstream syntax (e.g. testsuite `exclude.test` rules `!`, `+ **/bar`, `- to`, `- new/keep/**`).
- New `parse_old_prefix_rule` is restricted to the Include/Exclude default kinds upstream supports.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) — workspace
- [ ] CI: Windows / macOS / Linux musl stable
- [ ] CI: interop validation against upstream 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2
- [ ] Upstream testsuite `exclude.test` exercises the affected prefix syntax