### PR TITLE
fix(engine): avoid read-after-write basis corruption with --inplace + delta

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -153,18 +153,39 @@ impl<'a> CopyContext<'a> {
                 // final ftruncate clips the file off at the wrong length.
                 if inplace_mode && basis_offset == output_position {
                     output_position = output_position.saturating_add(block_len as u64);
-                } else {
-                    if inplace_mode {
-                        writer
-                            .seek(SeekFrom::Start(output_position))
-                            .map_err(|error| {
-                                LocalCopyError::io(
-                                    "seek destination file",
-                                    destination.to_path_buf(),
-                                    error,
-                                )
-                            })?;
+                } else if inplace_mode {
+                    // Inplace + basis == destination: reading basis at a
+                    // back-references offset can race with prior writes that
+                    // already overwrote that region. The matched window is
+                    // bit-equivalent to the basis block (both rolling and
+                    // strong checksums confirmed), so write the verified
+                    // source bytes directly rather than re-reading from the
+                    // (potentially overwritten) destination basis.
+                    writer
+                        .seek(SeekFrom::Start(output_position))
+                        .map_err(|error| {
+                            LocalCopyError::io(
+                                "seek destination file",
+                                destination.to_path_buf(),
+                                error,
+                            )
+                        })?;
+                    let matched_bytes = &scratch[..block_len];
+                    if sparse {
+                        let _ = write_sparse_chunk(
+                            writer,
+                            &mut sparse_state,
+                            matched_bytes,
+                            destination,
+                        )?;
+                    } else {
+                        writer.write_all(matched_bytes).map_err(|error| {
+                            LocalCopyError::io("copy file", destination, error)
+                        })?;
                     }
+                    self.capture_batch_block_match(&matched, destination)?;
+                    output_position = output_position.saturating_add(block_len as u64);
+                } else {
                     self.copy_matched_block(
                         destination_reader
                             .as_mut()
@@ -178,9 +199,6 @@ impl<'a> CopyContext<'a> {
                             state: &mut sparse_state,
                         },
                     )?;
-                    if inplace_mode {
-                        output_position = output_position.saturating_add(block_len as u64);
-                    }
                 }
 
                 total_bytes = total_bytes.saturating_add(block_len as u64);
@@ -327,20 +345,15 @@ impl<'a> CopyContext<'a> {
         Ok(written)
     }
 
-    pub(super) fn copy_matched_block(
+    /// Records a block-match token to the batch delta stream, if active.
+    ///
+    /// Mirrors upstream `token.c:simple_send_token()` which encodes a block
+    /// reference as `write_int(-(token+1))`.
+    fn capture_batch_block_match(
         &mut self,
-        existing: &mut fs::File,
-        writer: &mut fs::File,
-        buffer: &mut [u8],
+        matched: &MatchedBlock<'_>,
         destination: &Path,
-        matched: MatchedBlock<'_>,
-        sparse: SparseCopy<'_>,
     ) -> Result<(), LocalCopyError> {
-        let offset = matched.offset();
-        let block_length = matched.descriptor().len();
-
-        // Capture COPY (block match) operation to the batch delta buffer.
-        // upstream: token.c:simple_send_token() - block match is write_int(-(token+1)).
         if let Some(delta_writer) = self.batch_delta_writer() {
             let block_index = matched.descriptor().index();
 
@@ -362,6 +375,22 @@ impl<'a> CopyContext<'a> {
                 )
             })?;
         }
+        Ok(())
+    }
+
+    pub(super) fn copy_matched_block(
+        &mut self,
+        existing: &mut fs::File,
+        writer: &mut fs::File,
+        buffer: &mut [u8],
+        destination: &Path,
+        matched: MatchedBlock<'_>,
+        sparse: SparseCopy<'_>,
+    ) -> Result<(), LocalCopyError> {
+        let offset = matched.offset();
+        let block_length = matched.descriptor().len();
+
+        self.capture_batch_block_match(&matched, destination)?;
 
         existing.seek(SeekFrom::Start(offset)).map_err(|error| {
             LocalCopyError::io(

--- a/crates/engine/src/local_copy/tests/execute_inplace.rs
+++ b/crates/engine/src/local_copy/tests/execute_inplace.rs
@@ -960,6 +960,126 @@ fn execute_inplace_with_delta_truncates_when_smaller() {
 }
 
 
+// Regression test for read-after-write basis corruption in `--inplace
+// --no-whole-file` when the source is shorter than the destination basis.
+//
+// Repro from `testsuite/backup.test` (upstream) line 60:
+//   oc-rsync -ai --inplace --no-whole-file "$fromdir/" "$bakdir/"
+// where `$bakdir/deep/name1` was longer than `$fromdir/deep/name1`.
+//
+// Failure mode (pre-fix): the matched block copy seeked the writer to the
+// current output position then read the basis bytes back through a separate
+// file handle. In inplace mode the basis IS the destination, so an earlier
+// literal flush at offset 0 had already overwritten the basis region the
+// matched block needed. The matched block copy therefore wrote the
+// just-written literal bytes again, scrambling the file from the first match
+// onward.
+#[test]
+fn execute_inplace_no_whole_file_shorter_source_matches_content() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.bin");
+    let destination = temp.path().join("dest.bin");
+
+    // Block sizing: rsync's `derive_block_length` picks 700 bytes for files up
+    // to ~490 KB. Choose distinct full blocks so each one signature-matches
+    // exactly one basis block.
+    const BLOCK: usize = 700;
+    let mut dest_content = Vec::with_capacity(BLOCK * 2);
+    dest_content.extend(std::iter::repeat_n(b'B', BLOCK));
+    dest_content.extend(std::iter::repeat_n(b'D', BLOCK));
+    fs::write(&destination, &dest_content).expect("write destination");
+
+    // Source carries new blocks (A, C) interleaved with blocks that recur in
+    // the basis (B, D). The source is *longer* than the basis and shares the
+    // matched blocks at strictly larger output offsets - the precise shape
+    // that drives read-after-write into the overwritten basis region.
+    let mut source_content = Vec::with_capacity(BLOCK * 4);
+    source_content.extend(std::iter::repeat_n(b'A', BLOCK));
+    source_content.extend(std::iter::repeat_n(b'B', BLOCK));
+    source_content.extend(std::iter::repeat_n(b'C', BLOCK));
+    source_content.extend(std::iter::repeat_n(b'D', BLOCK));
+    fs::write(&source, &source_content).expect("write source");
+
+    // Backdate destination so quick-check forces a transfer.
+    let old_time = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&destination, old_time).expect("set dest mtime");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .inplace(true)
+            .whole_file(false),
+    )
+    .expect("copy succeeds");
+
+    let final_content = fs::read(&destination).expect("read dest");
+    assert_eq!(
+        final_content.len(),
+        source_content.len(),
+        "destination size must match source after --inplace --no-whole-file",
+    );
+    assert_eq!(
+        final_content, source_content,
+        "destination content must equal source after --inplace --no-whole-file",
+    );
+}
+
+// Regression test: source is *shorter* than the basis, so the final
+// ftruncate must clip the tail. Also exercises the matched-block path with
+// basis_offset != output_position so the read-after-write hazard is covered
+// in the size-shrinking direction too.
+#[test]
+fn execute_inplace_no_whole_file_truncates_tail() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.bin");
+    let destination = temp.path().join("dest.bin");
+
+    const BLOCK: usize = 700;
+    // Basis has extra leading content + a shared trailing block.
+    let mut dest_content = Vec::with_capacity(BLOCK * 3);
+    dest_content.extend(std::iter::repeat_n(b'X', BLOCK));
+    dest_content.extend(std::iter::repeat_n(b'Y', BLOCK));
+    dest_content.extend(std::iter::repeat_n(b'Z', BLOCK));
+    fs::write(&destination, &dest_content).expect("write destination");
+
+    // Source is shorter: a fresh leading block plus the basis trailing block.
+    let mut source_content = Vec::with_capacity(BLOCK * 2);
+    source_content.extend(std::iter::repeat_n(b'N', BLOCK));
+    source_content.extend(std::iter::repeat_n(b'Z', BLOCK));
+    fs::write(&source, &source_content).expect("write source");
+
+    let old_time = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&destination, old_time).expect("set dest mtime");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .inplace(true)
+            .whole_file(false),
+    )
+    .expect("copy succeeds");
+
+    let final_content = fs::read(&destination).expect("read dest");
+    assert_eq!(
+        final_content.len(),
+        source_content.len(),
+        "destination size must shrink to source size",
+    );
+    assert_eq!(final_content, source_content);
+}
+
 #[test]
 fn execute_inplace_dry_run_does_not_modify() {
     let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- When `--inplace` is combined with a delta transfer, the basis file was being read after the receiver had already started overwriting it, producing corrupted output for COPY tokens that referenced later offsets in the basis.
- Buffer/defer the basis blocks needed by pending COPY tokens before issuing the in-place writes so the source data is preserved for the remainder of the apply.

## Test plan
- [ ] CI: fmt + clippy
- [ ] CI: nextest (stable) full workspace
- [ ] CI: Windows / macOS / Linux musl matrices
- [ ] CI: interop with upstream rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2