### PR TITLE
fix(cli): emit --backup as 'b' short flag, not a long arg

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -433,6 +433,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--ignore-non-existing"
             | "--delay-updates"
             | "--partial-dir"
+            | "--backup"
     ) || arg == "-s"
         || arg == "--new-compress"
         || arg == "--old-compress"

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -341,9 +341,10 @@ pub(super) fn build_full_daemon_args(
         args.push("--inplace".to_owned());
     }
 
-    // upstream: options.c:2787-2795
+    // upstream: options.c:2630-2631 - `make_backups` rides in the compact
+    // flag string as `b` (added by `build_server_flag_string`). `--backup-dir`
+    // and `--suffix` remain long-form (`options.c:2807,2813`).
     if config.backup() {
-        args.push("--backup".to_owned());
         if let Some(dir) = config.backup_directory() {
             args.push("--backup-dir".to_owned());
             args.push(dir.display().to_string());

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -114,6 +114,13 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
     if config.partial() {
         flags.push('P');
     }
+    // upstream: options.c:2630-2631 - `make_backups` rides in the compact
+    // flag string as `b`. Emitting `--backup` as a separate long arg lands
+    // as a positional path on upstream server arg parsers that do not
+    // consult popt for long flags.
+    if config.backup() {
+        flags.push('b');
+    }
     if config.update() {
         flags.push('u');
     }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -428,8 +428,11 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--delay-updates"));
         }
 
+        // upstream: options.c:2630-2631 - bare `make_backups` is emitted as the
+        // `b` character in the compact flag string by `build_flag_string`. Only
+        // `--backup-dir` and `--suffix` are forwarded as long-form arguments
+        // (`options.c:2807,2813`).
         if self.config.backup() {
-            args.push(OsString::from("--backup"));
             if let Some(dir) = self.config.backup_directory() {
                 let mut arg = OsString::from("--backup-dir=");
                 arg.push(dir.as_os_str());
@@ -639,6 +642,16 @@ impl<'a> RemoteInvocationBuilder<'a> {
         }
         if self.config.partial() {
             flags.push('P');
+        }
+        // upstream: options.c:2630-2631 - `make_backups` is `b` in the compact
+        // flag string. Emitting `--backup` as a separate long arg lands as a
+        // positional path on upstream server arg parsers that do not consult
+        // popt for long flags - the receiver then mkdir's a literal `--backup`
+        // directory under `$HOME` instead of routing through the real
+        // destination tree, breaking the `symlink-dirlink-basis` regression
+        // test 4 (the `--backup` update-through-directory-symlink case).
+        if self.config.backup() {
+            flags.push('b');
         }
         if self.config.update() {
             flags.push('u');

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -762,9 +762,17 @@ fn includes_backup_related_args() {
     let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
     let args = builder.build("/path");
 
+    // upstream: options.c:2630-2631 - `make_backups` rides in the compact
+    // flag string as `b`, NOT as a standalone `--backup` long arg.
+    let flag_string = find_flag_string(&args);
     assert!(
-        args.iter().any(|a| a == "--backup"),
-        "expected --backup in args: {args:?}"
+        transfer_flags_portion(flag_string).contains('b'),
+        "expected 'b' in transfer flags portion: {flag_string}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--backup"),
+        "must not emit --backup as a long arg (upstream emits 'b' in flag \
+         string instead, options.c:2630-2631): {args:?}"
     );
     assert!(
         args.iter()
@@ -1920,10 +1928,17 @@ fn partial_dir_also_emits_partial_flag_string() {
 }
 
 #[test]
-fn backup_without_dir_or_suffix_emits_only_backup() {
+fn backup_without_dir_or_suffix_emits_only_b_short_flag() {
     let config = ClientConfig::builder().backup(true).build();
     let args = build_sender_args(&config);
-    assert!(args.iter().any(|a| a == "--backup"));
+    // upstream: options.c:2630-2631 - bare `--backup` is `b` in the compact
+    // flag string, not a standalone long arg.
+    let flag_string = find_flag_string(&args);
+    assert!(
+        transfer_flags_portion(flag_string).contains('b'),
+        "expected 'b' in transfer flags portion: {flag_string}"
+    );
+    assert!(!args.iter().any(|a| a == "--backup"));
     assert!(!args.iter().any(|a| a.starts_with("--backup-dir=")));
     assert!(!args.iter().any(|a| a.starts_with("--suffix=")));
 }
@@ -2076,6 +2091,11 @@ fn omits_backup_args_when_disabled() {
         !args.iter().any(|a| a == "--backup"),
         "should not emit --backup when disabled: {args:?}"
     );
+    let flag_string = find_flag_string(&args);
+    assert!(
+        !transfer_flags_portion(flag_string).contains('b'),
+        "should not contain 'b' in transfer flags when disabled: {flag_string}"
+    );
 }
 
 #[test]
@@ -2215,6 +2235,7 @@ fn all_flags_enabled_produces_valid_invocation() {
         ('y', "fuzzy"),
         ('R', "relative_paths"),
         ('P', "partial"),
+        ('b', "backup"),
         ('u', "update"),
         ('N', "crtimes"),
         ('m', "prune_empty_dirs"),
@@ -2259,7 +2280,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--omit-dir-times",
         "--omit-link-times",
         "--delay-updates",
-        "--backup",
         "--copy-devices",
         "--write-devices",
         "--open-noatime",


### PR DESCRIPTION
## Summary

- Upstream rsync 3.4.4 emits `make_backups` as the `b` character in the compact server flag string (`options.c:2630-2631`), never as a separate `--backup` long argument. Emitting `--backup` standalone lands as a positional path in upstream-style server arg parsers that do not consult popt for long flags - the receiver then opens a literal `--backup` directory under the destination root instead of routing through the real destination tree.
- This broke the upstream testsuite `symlink-dirlink-basis.test` test 4 (`--backup` with directory-symlink destination): the server interpreted `--backup` as the positional dest and tried to back up files inside a non-existent `--backup/` subdirectory, so the real destination was never updated and no backup file was created.
- Fix: emit `b` in the compact server flag string (both SSH and daemon code paths); stop emitting `--backup` as a long-form arg; defensively add `--backup` to `is_known_server_long_flag` so older oc-rsync clients (or any sender still using the long form) do not land the flag as a positional on the new server. `--backup-dir` and `--suffix` continue to ride as long-form args, matching `options.c:2807,2813`.

## Test plan

- [ ] CI: fmt + clippy green
- [ ] CI: nextest (stable) green - updated tests assert `b` appears in the transfer-flag portion and `--backup` does not appear as a standalone long arg
- [ ] CI: Windows / macOS / Linux musl green
- [ ] Interop: upstream testsuite `symlink-dirlink-basis.test` test 4 (--backup with directory-symlink destination) passes