### PR TITLE
fix(cli): emit FCLIENT flist banner and gate uptodate via render

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -96,6 +96,10 @@ where
     // Threaded into `OutFormatContext` so the itemize renderer picks the correct
     // direction arrow (upstream: log.c:701-704 - `<` for sender, `>` otherwise).
     let is_sender = config.is_local_sender();
+    // upstream: flist.c:2251 emits "sending incremental file list" only when
+    // inc_recurse is on, which compat.c:172 disables when `!recurse`. Mirror
+    // that gate so single-file (`-v`) transfers don't get a spurious banner.
+    let recursive = config.recursive();
 
     let result = {
         let observer = live_progress
@@ -134,6 +138,7 @@ where
                     name_overridden,
                     human_readable_mode,
                     suppress_updated_only_totals,
+                    recursive,
                     writer,
                 )
             }) {
@@ -213,6 +218,9 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         is_sender,
     } = params;
     let context = OutFormatContext::with_is_sender(is_sender);
+    // The log file already carries the parallel "building file list" line via
+    // logging::info_log!(Flist, 1, ...); the FCLIENT "sending incremental file
+    // list" banner is for stdout only (upstream: flist.c:2248 vs 2252).
     emit_transfer_summary(
         summary,
         verbosity,
@@ -226,6 +234,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         name_level,
         name_overridden,
         human_readable_mode,
+        false,
         false,
         &mut log.file,
     )?;

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -42,6 +42,7 @@ pub(crate) fn emit_transfer_summary(
     name_overridden: bool,
     human_readable_mode: HumanReadableMode,
     suppress_updated_only_totals: bool,
+    emit_flist_banner: bool,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
     let events = summary.events();
@@ -67,6 +68,16 @@ pub(crate) fn emit_transfer_summary(
         }
 
         return Ok(());
+    }
+
+    // upstream: flist.c:2252 - rprintf(FCLIENT, "sending incremental file list\n")
+    // is gated on inc_recurse && INFO_GTE(FLIST, 1) && !am_server. The banner
+    // is FCLIENT-only - the parallel `rprintf(FLOG, "building file list\n")`
+    // covers the log file (already emitted via the logging::info_log! pipeline
+    // in the generator). Local-copy mode is treated as inc_recurse-equivalent
+    // because the source enumeration is interleaved with per-file dispatch.
+    if emit_flist_banner && verbosity > 0 {
+        writeln!(writer, "sending incremental file list")?;
     }
 
     // upstream: main.c:787-808 - when the receiver pre-flight-mkdirs the
@@ -433,6 +444,15 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
 
+            // upstream: rsync.c:676 - uptodate notice uses `"%s is uptodate"`
+            // wording at INFO_GTE(NAME, 2). `--info=name2` sets name_level to
+            // UpdatedAndUnchanged here, so route MetadataReused through the
+            // uptodate phrasing instead of the bare path.
+            if matches!(kind, ClientEventKind::MetadataReused) {
+                writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                continue;
+            }
+
             let mut rendered = event.relative_path().to_string_lossy().into_owned();
             if matches!(kind, ClientEventKind::SymlinkCopied)
                 && let Some(metadata) = event.metadata()
@@ -510,6 +530,22 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     "skipping mount point \"{}\"",
                     event.relative_path().display()
                 )?;
+                continue;
+            }
+            ClientEventKind::MetadataReused => {
+                // upstream: rsync.c:672-676 - rprintf(FCLIENT, "%s is uptodate\n", fname)
+                // is gated by INFO_GTE(NAME, 2). At plain -v (verbose=1) the
+                // notice is suppressed and unchanged files leave no per-file
+                // trace. Emit only when NAME>=2 - either via -vv or explicit
+                // --info=name2 (which sets name_level to UpdatedAndUnchanged).
+                // The local-copy engine intentionally does NOT emit this via
+                // info_log! to avoid the diagnostic-flush ordering hazard
+                // (info_log! events drain AFTER the summary in cli mod.rs);
+                // routing it through the event renderer keeps `is uptodate`
+                // lines ahead of the totals to match upstream's wire order.
+                if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
+                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                }
                 continue;
             }
             _ => {}

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -238,6 +238,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         HumanReadableMode::Disabled,
         false,
+        false, // emit_flist_banner
         &mut with_out_format,
     )
     .expect("render with out-format");
@@ -257,6 +258,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         HumanReadableMode::Disabled,
         false,
+        false, // emit_flist_banner
         &mut without_out_format,
     )
     .expect("render without out-format");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -70,6 +70,7 @@ fn render_stats_at_level(
         false,
         human_readable,
         false,
+        false, // emit_flist_banner
         &mut rendered,
     )
     .expect("render stats");
@@ -92,6 +93,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,
         HumanReadableMode::Disabled,
         false,
+        true, // emit_flist_banner
         &mut rendered,
     )
     .expect("render verbose");
@@ -473,6 +475,7 @@ fn parity_totals_only_without_stats_flag() {
         false,
         HumanReadableMode::Disabled,
         false,
+        true, // emit_flist_banner
         &mut rendered,
     )
     .expect("render");
@@ -713,6 +716,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,
         HumanReadableMode::Disabled,
         false,
+        true, // emit_flist_banner
         &mut rendered,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -54,6 +54,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false,
         HumanReadableMode::Enabled,
         false,
+        false, // emit_flist_banner (list_only path)
         &mut rendered,
     )
     .expect("render summary");
@@ -84,6 +85,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,
         HumanReadableMode::Enabled,
         false,
+        true, // emit_flist_banner
         &mut rendered,
     )
     .expect("render summary");
@@ -122,6 +124,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         false,
         HumanReadableMode::Disabled,
         false,
+        false, // emit_flist_banner (out_format path: starts_with assertion)
         &mut rendered,
     )
     .expect("render summary");

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1057,3 +1057,134 @@ fn duplicates_testsuite_emits_bare_name_lines() {
         "name2 must appear exactly once as `name2 -> ...`, got: {rendered:?}"
     );
 }
+
+/// Verifies that `-vv` on an all-uptodate tree mirrors upstream rsync 3.4.4:
+///
+/// 1. The first stdout line is `sending incremental file list` (flist.c:2252).
+/// 2. Unchanged files emit `<name> is uptodate` (rsync.c:676) at NAME>=2.
+/// 3. Files are NOT pre-listed as bare names before the uptodate notice -
+///    upstream gates the bare per-file emission on `INFO_EQ(PROGRESS, 1)`
+///    (receiver.c:1011, sender.c:450), and no `--progress` was requested here.
+#[test]
+fn level_2_all_uptodate_matches_upstream_banner_and_uptodate_lines() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(from.join("foo")).expect("mkdir from/foo");
+    std::fs::write(from.join("foo").join("a.txt"), b"alpha").expect("write a");
+    std::fs::write(from.join("foo").join("b.txt"), b"bravo").expect("write b");
+
+    let mut from_slash = from.clone().into_os_string();
+    from_slash.push("/");
+
+    // Seed the destination so the second invocation finds everything uptodate.
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-tplr"),
+        from_slash.clone(),
+        to.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0, "seeding initial sync must succeed");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-vvplrH"),
+        from_slash,
+        to.into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(
+        stderr.is_empty(),
+        "stderr: {:?}",
+        String::from_utf8_lossy(&stderr)
+    );
+
+    let rendered = String::from_utf8(stdout).expect("verbose stdout utf8");
+    let lines: Vec<&str> = rendered.lines().collect();
+
+    assert!(
+        !lines.is_empty(),
+        "expected at least the `sending incremental file list` banner, got: {rendered:?}"
+    );
+    assert_eq!(
+        lines[0], "sending incremental file list",
+        "first line must be the FCLIENT banner (flist.c:2252), got: {rendered:?}"
+    );
+
+    // Per upstream rsync.c:676 + sender.c:450, no bare `<name>` lines should
+    // precede the `is uptodate` notice when --progress is absent. A regression
+    // would surface as e.g. `foo/a.txt` on its own line right after the banner.
+    let uptodate_count = lines.iter().filter(|l| l.ends_with(" is uptodate")).count();
+    assert_eq!(
+        uptodate_count, 2,
+        "expected `is uptodate` for each unchanged file, got: {rendered:?}"
+    );
+
+    let bare_path_count = lines
+        .iter()
+        .filter(|l| *l == &"foo/a.txt" || *l == &"foo/b.txt")
+        .count();
+    assert_eq!(
+        bare_path_count, 0,
+        "unchanged files must NOT emit a bare-name line before their `is uptodate` \
+         notice (upstream gates this on INFO_EQ(PROGRESS, 1)), got: {rendered:?}"
+    );
+
+    // Summary still appears.
+    assert!(
+        rendered.contains("sent "),
+        "expected sent/received summary line, got: {rendered:?}"
+    );
+}
+
+/// Verifies that `-v` (verbose=1) on an all-uptodate tree emits the banner
+/// but suppresses both `is uptodate` notices (which need NAME>=2) and bare
+/// per-file lines (which need `--progress`).
+#[test]
+fn level_1_all_uptodate_emits_banner_only() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(&from).expect("mkdir from");
+    std::fs::write(from.join("only.txt"), b"only").expect("write");
+
+    let mut from_slash = from.clone().into_os_string();
+    from_slash.push("/");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-tplr"),
+        from_slash.clone(),
+        to.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-vplrH"),
+        from_slash,
+        to.into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    let lines: Vec<&str> = rendered.lines().collect();
+    assert_eq!(
+        lines.first().copied(),
+        Some("sending incremental file list"),
+        "first line must be the FCLIENT banner at -v, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("is uptodate"),
+        "-v (NAME<2) must NOT emit `is uptodate` lines, got: {rendered:?}"
+    );
+    assert!(
+        !lines.iter().any(|l| *l == "only.txt"),
+        "unchanged file must NOT emit a bare-name line under -v without --progress, got: {rendered:?}"
+    );
+}

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -426,8 +426,11 @@ pub(super) fn process_links(
             ReferenceDecision::Skip => {
                 // upstream: generator.c:1010,1133 / rsync.c:676 - "is uptodate"
                 // emitted at INFO_GTE(NAME, 2) when a reference-directory match
-                // means no transfer is needed.
-                info_log!(Name, 2, "{} is uptodate", record_path.display());
+                // means no transfer is needed. Rendered by the CLI from the
+                // MetadataReused event (cli::frontend::progress::render) so
+                // the line lands ahead of the totals; emitting it via
+                // info_log! would route it through the post-summary
+                // diagnostic drain and break upstream ordering.
                 context.summary_mut().record_regular_file_matched();
                 let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
                 let total_bytes = Some(metadata_snapshot.len());

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use logging::{debug_log, info_log};
+use logging::debug_log;
 
 use ::metadata::MetadataOptions;
 
@@ -137,8 +137,12 @@ pub(super) fn record_metadata_only_skip(
     );
     // upstream: rsync.c:672-676 - rprintf(FCLIENT, "%s is uptodate\n", fname)
     // at INFO_GTE(NAME, 2) when a quick-check or content-equal path reuses
-    // the existing destination instead of transferring.
-    info_log!(Name, 2, "{} is uptodate", record_path.display());
+    // the existing destination instead of transferring. The CLI renders this
+    // line from the MetadataReused event so it lands ahead of the summary
+    // (matching upstream's in-line FCLIENT emission); the diagnostic queue
+    // drains after the summary, so emitting via info_log! here would race the
+    // banner+totals ordering. Keep the record-based render as the single
+    // source of truth.
     ::metadata::apply_file_metadata_if_changed(destination, metadata, existing, metadata_options)
         .map_err(crate::local_copy::map_metadata_error)?;
 


### PR DESCRIPTION
## Summary

Local-copy verbose output (`-v` / `-vv`) diverged from upstream rsync 3.4.4. Two visible issues fixed:

1. **Missing banner.** Upstream emits `sending incremental file list` at `flist.c:2252` when `inc_recurse && INFO_GTE(FLIST, 1) && !am_server`. Oc-rsync's local-copy path never produced it because the banner sits in `send_file_list()` (which only runs in the remote/wire flow).
2. **Spurious per-file lines for uptodate files.** `emit_verbose` fell through to the bare-name branch for `MetadataReused` events, so every unchanged file printed `<path>` at `-v`/`-vv`. The local-copy executor *also* queued `info_log!(Name, 2, "{} is uptodate", ...)`, which drained AFTER `emit_transfer_summary` wrote the totals - so the `is uptodate` notice landed below `sent N bytes` instead of inline.

### Changes

- `emit_transfer_summary` writes `sending incremental file list` when `verbose > 0`, gated by `config.recursive()` (mirrors upstream `compat.c:172 set_allow_inc_recurse` which clears `inc_recurse` when `!recurse`). Log-file output keeps the parallel `info_log!(Flist, 1, "building file list")` path; the banner is FCLIENT-only per `flist.c:2248` vs `2252`.
- `emit_verbose` adds a `MetadataReused` arm that emits `<path> is uptodate` at `verbose>=2` (matches `rsync.c:676` `INFO_GTE(NAME, 2)`) or when `name_level == UpdatedAndUnchanged` (`--info=name2`). Falls through silently otherwise.
- The local-copy executor's two `info_log!(Name, 2, "{} is uptodate", ...)` emissions (`skip.rs::record_metadata_only_skip`, `links.rs::ReferenceDecision::Skip`) are removed - the line is now rendered exactly once, from the event, ahead of the summary, matching upstream's in-line FCLIENT order. Engine test cases that exercise the `is uptodate` wording on `info_log!` directly are untouched.

### Out of scope (left for follow-up)

- `delta-transmission disabled for local transfer or --whole-file` (upstream `generator.c:2291`, gated on `DEBUG_GTE(FLIST, 1)`) - generator-side debug emission, separate path.
- `sent N received N` with `N==N` for local copy. The summary derives sent/received from the same counter; needs a per-direction split.
- `total: matches=0 hash_hits=0 false_alarms=0 data=0` deltasum summary.

## Test plan

- [x] `cargo nextest run -p cli --all-features -E 'test(/level_2_all_uptodate/) | test(/level_1_all_uptodate/) | test(/verbose_transfer_emits_event_lines/) | test(/output_parity/) | test(/emit_transfer_summary/)'` - 103/103 pass locally
- [x] `cargo nextest run -p engine --all-features -E 'test(/uptodate/) | test(/metadata_reused/) | test(/skip/)'` - 226/226 pass locally
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p cli -p engine --all-features --no-deps -- -D warnings` clean
- [x] Manual reproduction against upstream rsync 3.4.4 on macOS confirms banner appears, `is uptodate` notices land before the summary, and unchanged files no longer leak a bare-path line
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl