### PR TITLE
fix(cli): accept packed -f<rule> short-arg form for --filter

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -901,3 +901,52 @@ fn reflink_never_matches_no_cow() {
     let from_binary = parse_test_args(["--no-cow", "src/", "dst/"]).expect("parse binary form");
     assert_eq!(from_reflink.cow_policy, from_binary.cow_policy);
 }
+
+/// upstream: `testsuite/exclude.test:173` uses `-f:C` to inject the
+/// dir-merge .cvsignore rule via the packed short-arg form. Verify the
+/// pre-Clap expansion routes `:C` through to the filter list as the rule.
+#[test]
+fn filter_short_arg_packed_colon_rule() {
+    let parsed = parse_test_args(["-f:C", "src/", "dst/"]).expect("parse -f:C");
+    assert_eq!(parsed.filters, vec![std::ffi::OsString::from(":C")]);
+}
+
+/// `-f-C` is the packed spelling for `-f` with value `-C` (cvs-style
+/// exclude). It must round-trip through the parser without being mistaken
+/// for an unknown option or the `-C` short.
+#[test]
+fn filter_short_arg_packed_dash_rule() {
+    let parsed = parse_test_args(["-f-C", "src/", "dst/"]).expect("parse -f-C");
+    assert_eq!(parsed.filters, vec![std::ffi::OsString::from("-C")]);
+    assert!(!parsed.cvs_exclude);
+}
+
+/// Spaced form `-f :C` must produce the same filter rule as the packed form.
+#[test]
+fn filter_short_arg_spaced_colon_rule() {
+    let parsed = parse_test_args(["-f", ":C", "src/", "dst/"]).expect("parse -f :C");
+    assert_eq!(parsed.filters, vec![std::ffi::OsString::from(":C")]);
+}
+
+/// Combined invocation from `testsuite/exclude.test`: `-f:C -f-C` injects
+/// the two cvs-exclude filter rules in order.
+#[test]
+fn filter_short_arg_packed_pair_matches_exclude_test() {
+    let parsed = parse_test_args(["-f:C", "-f-C", "src/", "dst/"]).expect("parse -f:C -f-C");
+    assert_eq!(
+        parsed.filters,
+        vec![
+            std::ffi::OsString::from(":C"),
+            std::ffi::OsString::from("-C"),
+        ]
+    );
+}
+
+/// `-f:C` may also appear inside a flag cluster (`-avvf:C`). The leading
+/// flags are split out and the trailing value option keeps its packed rule.
+#[test]
+fn filter_short_arg_packed_inside_flag_cluster() {
+    let parsed = parse_test_args(["-avvf:C", "src/", "dst/"]).expect("parse -avvf:C");
+    assert_eq!(parsed.filters, vec![std::ffi::OsString::from(":C")]);
+    assert!(parsed.archive);
+}

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -17,8 +17,16 @@ use clap::{ArgAction, Command as ClapCommand};
 /// unchanged so it can emit tailored diagnostics for unsupported options. That
 /// behaviour prevents clap from splitting short-option clusters on its own,
 /// so this helper performs the expansion before handing the arguments to the
-/// parser. Tokens that contain an option requiring a value may only place that
-/// option at the end of the cluster to match upstream semantics.
+/// parser.
+///
+/// Tokens that contain an option requiring a value may only place that option
+/// at the end of the cluster to match upstream semantics. When such an option
+/// has additional characters after it (for example `-f:C`, where `f` is the
+/// short alias for `--filter` and `:C` is the packed value), the remainder is
+/// split off as a separate argument so clap can pair it with the option as the
+/// value. This matches upstream rsync's handling of packed short-arg values
+/// and is required for filter spellings like `-f-C` and `-f:C` that contain
+/// characters clap would otherwise misinterpret as another short option.
 pub(crate) fn expand_short_options(command: &ClapCommand, args: Vec<OsString>) -> Vec<OsString> {
     let (flag_options, value_options) = classify_short_options(command);
 
@@ -98,14 +106,20 @@ fn expand_cluster(
     }
 
     let mut fragments = Vec::with_capacity(cluster.len());
-    let mut chars = cluster.chars().peekable();
 
-    while let Some(short) = chars.next() {
+    for (offset, short) in cluster.char_indices() {
         if value_options.contains(&short) {
-            if chars.peek().is_some() {
-                return None;
-            }
             fragments.push(format!("-{short}"));
+            // Upstream rsync treats any characters after a value-bearing short
+            // option as the packed value (for example `-f:C` becomes `-f` with
+            // value `:C`). Emit the remainder as a separate token so clap pairs
+            // it with the option, instead of misparsing characters like `:` or
+            // `-` as additional short options.
+            let next_offset = offset + short.len_utf8();
+            if next_offset < cluster.len() {
+                fragments.push(cluster[next_offset..].to_owned());
+            }
+            return Some(fragments);
         } else if flag_options.contains(&short) {
             fragments.push(format!("-{short}"));
         } else {
@@ -171,7 +185,13 @@ mod tests {
     fn expand_cluster_value_option_not_at_end() {
         let flags = make_flags("av");
         let values = make_flags("M");
-        assert_eq!(expand_cluster("-aMv", &flags, &values), None);
+        // Characters after the value option become the packed value, matching
+        // upstream rsync's `-T<dir>` / `-f<rule>` behaviour.
+        let result = expand_cluster("-aMv", &flags, &values);
+        assert_eq!(
+            result,
+            Some(vec!["-a".to_owned(), "-M".to_owned(), "v".to_owned()])
+        );
     }
 
     #[test]
@@ -191,10 +211,12 @@ mod tests {
 
     #[test]
     fn expand_cluster_all_value_options() {
+        // `-ee` packs `e` as the value of the first `-e`, mirroring upstream's
+        // packed short-arg form (`-eVALUE`).
         let _flags: HashSet<char> = HashSet::new();
         let values = make_flags("e");
         let result = expand_cluster("-ee", &_flags, &values);
-        assert_eq!(result, None);
+        assert_eq!(result, Some(vec!["-e".to_owned(), "e".to_owned()]));
     }
 
     #[test]
@@ -220,9 +242,11 @@ mod tests {
 
     #[test]
     fn expand_cluster_multiple_value_options() {
+        // `-Me` is `-M` with packed value `e`.
         let flags = HashSet::new();
         let values = make_flags("Me");
-        assert_eq!(expand_cluster("-Me", &flags, &values), None);
+        let result = expand_cluster("-Me", &flags, &values);
+        assert_eq!(result, Some(vec!["-M".to_owned(), "e".to_owned()]));
     }
 
     #[test]
@@ -233,6 +257,88 @@ mod tests {
         assert_eq!(
             result,
             Some(vec!["-z".to_owned(), "-v".to_owned(), "-a".to_owned()])
+        );
+    }
+
+    #[test]
+    fn expand_cluster_filter_packed_colon_rule() {
+        // upstream rsync `testsuite/exclude.test` uses `-f:C` to inject the
+        // `:C` (dir-merge .cvsignore) rule via the packed short-arg form.
+        let flags = HashSet::new();
+        let values = make_flags("f");
+        let result = expand_cluster("-f:C", &flags, &values);
+        assert_eq!(result, Some(vec!["-f".to_owned(), ":C".to_owned()]));
+    }
+
+    #[test]
+    fn expand_cluster_filter_packed_dash_rule() {
+        // `-f-C` packs the `-C` (cvs-style exclude) rule. The remainder retains
+        // its leading dash so the rule parser sees the original spelling.
+        let flags = HashSet::new();
+        let values = make_flags("f");
+        let result = expand_cluster("-f-C", &flags, &values);
+        assert_eq!(result, Some(vec!["-f".to_owned(), "-C".to_owned()]));
+    }
+
+    #[test]
+    fn expand_cluster_value_after_flag_prefix() {
+        // Mirrors `-avf:C`: archive and verbose are flags, filter is the
+        // trailing value option, and `:C` is its packed value.
+        let flags = make_flags("av");
+        let values = make_flags("f");
+        let result = expand_cluster("-avf:C", &flags, &values);
+        assert_eq!(
+            result,
+            Some(vec![
+                "-a".to_owned(),
+                "-v".to_owned(),
+                "-f".to_owned(),
+                ":C".to_owned(),
+            ])
+        );
+    }
+
+    #[test]
+    fn expand_short_options_filter_packed_colon_rule() {
+        // End-to-end check that the public entry point recognises `-f:C` once
+        // the filter Arg is wired as a value-bearing short.
+        let command = ClapCommand::new("rsync").arg(
+            clap::Arg::new("filter")
+                .short('f')
+                .long("filter")
+                .action(ArgAction::Append)
+                .num_args(1),
+        );
+        let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
+        let expanded = expand_short_options(&command, args);
+        assert_eq!(
+            expanded,
+            vec![
+                OsString::from("rsync"),
+                OsString::from("-f"),
+                OsString::from(":C"),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_short_options_filter_packed_dash_rule() {
+        let command = ClapCommand::new("rsync").arg(
+            clap::Arg::new("filter")
+                .short('f')
+                .long("filter")
+                .action(ArgAction::Append)
+                .num_args(1),
+        );
+        let args = vec![OsString::from("rsync"), OsString::from("-f-C")];
+        let expanded = expand_short_options(&command, args);
+        assert_eq!(
+            expanded,
+            vec![
+                OsString::from("rsync"),
+                OsString::from("-f"),
+                OsString::from("-C"),
+            ]
         );
     }
 }

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -613,6 +613,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .value_name("RULE")
                     .help("Apply filter RULE (supports '+' include, '-' exclude, '!' clear, 'protect PATTERN', 'risk PATTERN', 'merge[,MODS] FILE' or '.[,MODS] FILE', and 'dir-merge[,MODS] FILE' or ':[,MODS] FILE').")
                     .value_parser(OsStringValueParser::new())
+                    .allow_hyphen_values(true)
                     .action(ArgAction::Append),
             )
             .arg(


### PR DESCRIPTION
## Summary

`oc-rsync` master HEAD rejected upstream's filter spelling `-f:C` (and `-f-C`) with `unknown option '-f:C'`, so `testsuite/exclude.test` (used by the upstream rsync testsuite job) failed. The failing invocation is:

```
$RSYNC -avv$rpath --filter='merge $excl' -f:C -f-C --delete-excluded \
    --delete-during '$host$fromdir/' '$todir/'
```

(`testsuite/exclude.test:173`; upstream uses `-f:C` to inject the `dir-merge .cvsignore` rule and `-f-C` to inject the `cvs-style exclude` rule via the packed short-arg form.)

## Root cause

`crates/cli/src/frontend/arguments/short_options.rs::expand_cluster` walks the characters after `-` and, for value-bearing shorts, returned `None` whenever there were additional characters in the token. That left `-f:C` unchanged for clap, which then ran into two issues:

1. The trailing `args` positional has `allow_hyphen_values(true)`, and clap's short-arg parser (clap_builder-4.6.0 `parser.rs:909-921`) reroutes any short cluster containing an unknown character to that positional. The `:` in `-f:C` is not a registered short, so the whole token became a positional.
2. The operand extractor (`crates/cli/src/frontend/execution/operands.rs`) then rejected the hyphen-prefixed positional as an unknown option.

## Fix

1. Teach `expand_cluster` to treat any characters following a value-bearing short option as the packed value. `-f:C` becomes `-f`, `:C` (and `-avf:C` becomes `-a`, `-v`, `-f`, `:C`), so clap pairs the rule with the option.
2. Add `allow_hyphen_values(true)` to the `--filter` Arg so the rewritten pair (and the spaced `-f -C` form) accepts values starting with `-`, matching upstream's `POPT_ARG_STRING` semantics for `--filter` (`options.c:729`).

## Tests

- `crates/cli/src/frontend/arguments/short_options.rs` - unit tests for `expand_cluster` and `expand_short_options` covering `-f:C`, `-f-C`, `-avf:C`, and the existing `-aMv` / `-ee` / `-Me` packed forms.
- `crates/cli/src/frontend/arguments/parser/tests.rs` - end-to-end `parse_args` checks asserting that `-f:C`, `-f-C`, `-f :C`, `-f:C -f-C`, and `-avvf:C` all surface in `parsed.filters` with the expected rules.

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] CI: upstream testsuite job re-runs `exclude` / `exclude-lsh` cleanly