### PR TITLE
fix(filters): skip implicit '**/' prefix when pattern already contains '**'

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -50,9 +50,19 @@ impl CompiledRule {
             "xattr-only rules should be filtered before compilation"
         );
         let (anchored, directory_only, core_pattern) = normalise_pattern(&pattern);
+        // upstream: exclude.c:903-960 rule_matches() - an unanchored pattern
+        // that already contains `**` is matched with slash_handling = -1
+        // (try after every slash) by wildmatch_array (lib/wildmatch.c:316).
+        // The pattern itself already carries cross-segment semantics, so
+        // prepending an extra `**/` would compound recursion and emit
+        // matchers like `**/foo/**/bar` plus their `/**` descendants. Skip
+        // the prefix when `core_pattern` already contains `**` to keep our
+        // matcher set in lockstep with upstream's match-after-every-slash
+        // behaviour. Regression for UTS-DD-exclude.5.
+        let has_double_star = core_pattern.contains("**");
         let mut direct_patterns = HashSet::new();
         direct_patterns.insert(core_pattern.to_string());
-        if !anchored {
+        if !anchored && !has_double_star {
             direct_patterns.insert(format!("**/{core_pattern}"));
         }
 
@@ -91,7 +101,7 @@ impl CompiledRule {
         ) && !suppress_descendants
         {
             descendant_patterns.insert(format!("{core_pattern}/**"));
-            if !anchored {
+            if !anchored && !has_double_star {
                 descendant_patterns.insert(format!("**/{core_pattern}/**"));
             }
         }
@@ -431,6 +441,102 @@ mod tests {
         // `bar` alone does NOT match `bar/**` - the `/` after `bar` is
         // mandatory in the pattern.
         assert!(!compiled.matches(Path::new("bar"), true, true));
+    }
+
+    /// Collects the source pattern strings of every direct matcher attached
+    /// to `compiled` so wire-byte parity tests can assert exact matcher sets.
+    fn direct_pattern_strings(compiled: &CompiledRule) -> Vec<String> {
+        let mut out: Vec<String> = compiled
+            .direct_matchers
+            .iter()
+            .map(|m| m.glob().glob().to_string())
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// Collects the source pattern strings of every descendant matcher.
+    fn descendant_pattern_strings(compiled: &CompiledRule) -> Vec<String> {
+        let mut out: Vec<String> = compiled
+            .descendant_matchers
+            .iter()
+            .map(|m| m.glob().glob().to_string())
+            .collect();
+        out.sort();
+        out
+    }
+
+    fn make_exclude(pattern: &str) -> CompiledRule {
+        CompiledRule::new(FilterRule {
+            action: FilterAction::Exclude,
+            pattern: pattern.to_owned(),
+            applies_to_sender: true,
+            applies_to_receiver: true,
+            perishable: false,
+            xattr_only: false,
+            negate: false,
+            exclude_only: false,
+            no_inherit: false,
+            cvs_mode: false,
+        })
+        .unwrap()
+    }
+
+    /// UTS-DD-exclude.5 regression: an unanchored pattern that does NOT
+    /// contain `**` must still get the implicit `**/` prefix variant so it
+    /// matches at any depth, mirroring upstream's match-the-name handling
+    /// for `!u.slash_cnt && !FILTRULE_WILD2` (exclude.c:917-922).
+    #[test]
+    fn implicit_double_star_prefix_added_for_plain_pattern() {
+        let compiled = make_exclude("bar");
+        assert_eq!(direct_pattern_strings(&compiled), vec!["**/bar", "bar"]);
+        assert_eq!(
+            descendant_pattern_strings(&compiled),
+            vec!["**/bar/**", "bar/**"]
+        );
+    }
+
+    /// UTS-DD-exclude.5 fix: an unanchored pattern that already contains
+    /// `**` must NOT be wrapped again. Upstream rsync handles this via
+    /// `wildmatch_array(..., slash_handling=-1)` (lib/wildmatch.c:316,
+    /// exclude.c:952-956), so the wire-equivalent matcher set is just the
+    /// original pattern plus its `/**` descendant.
+    #[test]
+    fn implicit_double_star_prefix_skipped_when_pattern_already_has_double_star() {
+        let compiled = make_exclude("foo/**/bar");
+        assert_eq!(direct_pattern_strings(&compiled), vec!["foo/**/bar"]);
+        assert_eq!(descendant_pattern_strings(&compiled), vec!["foo/**/bar/**"]);
+    }
+
+    /// `**/baz` already has the recursive prefix; we must not double it
+    /// up into `**/**/baz` (which globset would collapse but still pollutes
+    /// the matcher set).
+    #[test]
+    fn implicit_double_star_prefix_skipped_for_leading_double_star() {
+        let compiled = make_exclude("**/baz");
+        assert_eq!(direct_pattern_strings(&compiled), vec!["**/baz"]);
+        assert_eq!(descendant_pattern_strings(&compiled), vec!["**/baz/**"]);
+    }
+
+    /// Unanchored pattern with an interior slash but no `**` still gets the
+    /// `**/` variant. Upstream's slash_cnt-based tail matching
+    /// (exclude.c:947-951) is wire-equivalent to globset's `**/foo/bar`.
+    #[test]
+    fn implicit_double_star_prefix_added_for_unanchored_slash_pattern() {
+        let compiled = make_exclude("foo/bar");
+        assert_eq!(
+            direct_pattern_strings(&compiled),
+            vec!["**/foo/bar", "foo/bar"]
+        );
+    }
+
+    /// Trailing `**` (e.g., `foo/**`) is unanchored but already carries
+    /// cross-segment semantics; the implicit prefix would emit
+    /// `**/foo/**` which upstream never produces.
+    #[test]
+    fn implicit_double_star_prefix_skipped_for_trailing_double_star() {
+        let compiled = make_exclude("foo/**");
+        assert_eq!(direct_pattern_strings(&compiled), vec!["foo/**"]);
     }
 
     #[test]

--- a/crates/filters/tests/uts_dd_exclude_5_no_double_recursive_wildcard.rs
+++ b/crates/filters/tests/uts_dd_exclude_5_no_double_recursive_wildcard.rs
@@ -1,0 +1,72 @@
+//! UTS-DD-exclude.5 regression: oc-rsync must not double-wrap unanchored
+//! patterns that already contain a `**` element.
+//!
+//! Upstream rsync (`exclude.c:903-960 rule_matches`) handles an unanchored
+//! pattern with a `**` element by calling
+//! `wildmatch_array(..., slash_handling = -1)` (`lib/wildmatch.c:316`),
+//! which tries the pattern at the start AND after every `/`. There is no
+//! pattern-string rewriting at parse time. oc-rsync historically prepended
+//! an implicit `**/` to every unanchored pattern to mimic the same
+//! semantic, but when the source pattern already contained `**` (e.g.
+//! `foo/**/bar`) the prefix compounded into `**/foo/**/bar`, polluting the
+//! matcher set with rules upstream never emits and breaking byte-for-byte
+//! wire parity on the post-normalisation rule strings.
+//!
+//! This file pins the wire-equivalent pattern set on a corpus lifted from
+//! the upstream `testsuite/exclude.test` (the bare `**/bar` line and the
+//! `foo**too` line) plus the `foo/**/bar` shape that triggered the bug.
+
+use std::path::Path;
+
+use filters::{FilterRule, FilterSet};
+
+/// `+ foo**too` from `testsuite/exclude.test:102`: an interior bare `**`
+/// must still match across path separators after PR #5751's
+/// `normalise_recursive_wildcards` rewrite (`foo**too` -> `foo/**/too`).
+/// Guarded here so the UTS-DD-exclude.5 fix doesn't regress UTS-20.
+#[test]
+fn upstream_exclude_test_bare_interior_double_star_matches_cross_segment() {
+    let rules = [FilterRule::include("foo**too"), FilterRule::exclude("*")];
+    let set = FilterSet::from_rules(rules).unwrap();
+    assert!(set.allows(Path::new("bar/down/to/foo/too"), true));
+    assert!(set.allows(Path::new("foo/too"), true));
+    assert!(set.allows(Path::new("fooxytoo"), false));
+}
+
+/// `+ **/bar` from `testsuite/exclude.test:99`: a leading `**/` already
+/// carries the recursion, so the implicit prefix must be skipped. The
+/// rule still matches `bar` at any depth.
+#[test]
+fn upstream_exclude_test_leading_double_star_matches_any_depth() {
+    let rules = [FilterRule::include("**/bar"), FilterRule::exclude("*")];
+    let set = FilterSet::from_rules(rules).unwrap();
+    assert!(set.allows(Path::new("bar"), false));
+    assert!(set.allows(Path::new("a/b/bar"), false));
+    assert!(!set.allows(Path::new("baz"), false));
+}
+
+/// UTS-DD-exclude.5 happy path: `foo/**/bar` matches the rooted form
+/// (`foo/.../bar`) that globset emits directly from the user-written
+/// pattern. The fix removes the prepended `**/foo/**/bar` variant; the
+/// kept matcher continues to honour `**` cross-segment semantics.
+#[test]
+fn rooted_infix_double_star_pattern_still_matches() {
+    let rules = [FilterRule::exclude("foo/**/bar")];
+    let set = FilterSet::from_rules(rules).unwrap();
+    assert!(!set.allows(Path::new("foo/bar"), false));
+    assert!(!set.allows(Path::new("foo/x/bar"), false));
+    assert!(!set.allows(Path::new("foo/x/y/bar"), false));
+}
+
+/// Unanchored patterns without `**` (the canonical case for the
+/// implicit-prefix injection) MUST still get the `**/` prefix and match
+/// at any depth. Mirrors `exclude.c:917-922` name-only matching for the
+/// `!u.slash_cnt && !FILTRULE_WILD2` branch.
+#[test]
+fn plain_basename_pattern_still_matches_at_any_depth() {
+    let rules = [FilterRule::exclude("bar")];
+    let set = FilterSet::from_rules(rules).unwrap();
+    assert!(!set.allows(Path::new("bar"), false));
+    assert!(!set.allows(Path::new("a/b/bar"), false));
+    assert!(set.allows(Path::new("baz"), false));
+}


### PR DESCRIPTION
## Summary

Upstream rsync's `exclude.c:903-960 rule_matches()` matches an unanchored pattern that already contains `**` via `wildmatch_array(..., slash_handling = -1)` (`lib/wildmatch.c:316`) - it tries the pattern at the start AND after every `/`. The pattern string itself is never rewritten at parse time.

oc-rsync's compiled rule builder (`crates/filters/src/compiled/mod.rs`) prepends an implicit `**/` to every unanchored pattern. When the source pattern already contained `**` (e.g. `foo/**/bar`), the prefix compounded into `**/foo/**/bar` plus a `**/foo/**/bar/**` descendant, polluting the matcher set with rules upstream never emits and breaking byte-for-byte parity on the post-normalisation rule strings.

## Fix

Add a `has_double_star` guard at both implicit `**/` injection sites in `CompiledRule::new` so the prefix and the prefixed descendant are skipped whenever `core_pattern` already contains `**`. Plain patterns (`bar`, `cache/`, `*.bak`) and patterns with internal slashes but no `**` (`foo/bar`) still get the implicit prefix, mirroring upstream's `!u.slash_cnt && !FILTRULE_WILD2` (`exclude.c:917-922`) and `slash_cnt+1` (`exclude.c:947-951`) branches.

## Wire-byte parity matrix

| Input pattern | direct matchers (pre-fix) | direct matchers (post-fix) |
|---|---|---|
| `bar` | `bar`, `**/bar` | `bar`, `**/bar` (unchanged) |
| `foo/bar` | `foo/bar`, `**/foo/bar` | `foo/bar`, `**/foo/bar` (unchanged) |
| `foo/**/bar` | `foo/**/bar`, `**/foo/**/bar` | `foo/**/bar` |
| `**/baz` | `**/baz`, `**/**/baz` | `**/baz` |
| `foo/**` | `foo/**`, `**/foo/**` | `foo/**` |

Tracks UTS-DD-exclude.5.

## Upstream references

- `target/interop/upstream-src/rsync-3.4.4/exclude.c:903-960` - `rule_matches()` and `slash_handling` selection.
- `target/interop/upstream-src/rsync-3.4.4/exclude.c:947-956` - infix-slash vs `**` branch comments.
- `target/interop/upstream-src/rsync-3.4.4/lib/wildmatch.c:316` - `wildmatch_array(..., slash_handling=-1)` "try after every slash".

## Test plan

- [ ] `cargo nextest run -p filters --all-features` (CI).
- [ ] Unit tests in `crates/filters/src/compiled/mod.rs` assert the exact direct/descendant matcher pattern strings for `bar`, `foo/**/bar`, `**/baz`, `foo/bar`, `foo/**`.
- [ ] Integration tests in `crates/filters/tests/uts_dd_exclude_5_no_double_recursive_wildcard.rs` cover the upstream `testsuite/exclude.test` `**/bar` and `foo**too` corpus lines plus the `foo/**/bar` shape that triggered the bug.