### PR TITLE
fix(filters): apply implicit FILTRULE_SENDER_SIDE under --delete-excluded

### DIFF
--- a/crates/core/src/client/config/filters.rs
+++ b/crates/core/src/client/config/filters.rs
@@ -213,6 +213,39 @@ impl FilterRuleSpec {
         self.applies_to_receiver
     }
 
+    /// Applies the implicit sender-side flag that upstream rsync sets when
+    /// `--delete-excluded` is active and the rule carries no explicit side
+    /// modifier.
+    ///
+    /// Returns `true` if the rule was mutated.
+    ///
+    /// # Upstream Reference
+    ///
+    /// `exclude.c:1330-1332` (`add_rule`):
+    ///
+    /// ```c
+    /// if (delete_excluded
+    ///  && !(rule->rflags & (FILTRULES_SIDES|FILTRULE_MERGE_FILE|FILTRULE_PERDIR_MERGE)))
+    ///     rule->rflags |= FILTRULE_SENDER_SIDE;
+    /// ```
+    ///
+    /// In oc-rsync, `applies_to_sender == true && applies_to_receiver == true`
+    /// represents "no `FILTRULES_SIDES` bit set" - the rule applies to both
+    /// sides by default. Merge and dir-merge rules are excluded because they
+    /// expand into per-file rules that carry their own side information.
+    /// Protect and Risk rules already restrict themselves to the receiver
+    /// side, so the implicit flag never fires for them.
+    pub fn apply_implicit_sender_side_for_delete_excluded(&mut self) -> bool {
+        if !matches!(self.kind, FilterRuleKind::Include | FilterRuleKind::Exclude) {
+            return false;
+        }
+        if !(self.applies_to_sender && self.applies_to_receiver) {
+            return false;
+        }
+        self.applies_to_receiver = false;
+        true
+    }
+
     /// Applies dir-merge style overrides (anchor, side modifiers) to the rule.
     pub fn apply_dir_merge_overrides(&mut self, options: &DirMergeOptions) {
         if matches!(self.kind, FilterRuleKind::Clear) {
@@ -327,5 +360,77 @@ mod tests {
 
         assert!(rule.applies_to_sender());
         assert!(!rule.applies_to_receiver());
+    }
+
+    /// upstream: exclude.c:1330-1332 add_rule() applies the implicit
+    /// FILTRULE_SENDER_SIDE flag when --delete-excluded is active and the
+    /// rule carries neither FILTRULES_SIDES nor merge/dir-merge. A bare
+    /// `--exclude *.tmp` must therefore become sender-side under
+    /// --delete-excluded so the receiver can still delete matches.
+    #[test]
+    fn delete_excluded_applies_implicit_sender_side_to_exclude() {
+        let mut rule = FilterRuleSpec::exclude("*.tmp");
+        assert!(rule.applies_to_sender());
+        assert!(rule.applies_to_receiver());
+
+        let changed = rule.apply_implicit_sender_side_for_delete_excluded();
+        assert!(changed);
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
+    }
+
+    /// Include rules without an explicit side also gain the implicit
+    /// FILTRULE_SENDER_SIDE flag, matching upstream `exclude.c:1330-1332`.
+    #[test]
+    fn delete_excluded_applies_implicit_sender_side_to_include() {
+        let mut rule = FilterRuleSpec::include("keep/**");
+        let changed = rule.apply_implicit_sender_side_for_delete_excluded();
+        assert!(changed);
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
+    }
+
+    /// Upstream's check at `exclude.c:1331` masks against `FILTRULES_SIDES`.
+    /// A rule that already specifies one side (via `s`, `r`, `show`, `hide`,
+    /// etc.) must not be retargeted.
+    #[test]
+    fn delete_excluded_respects_explicit_sender_only_rule() {
+        let mut rule = FilterRuleSpec::hide("*.tmp"); // sender-only exclude
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
+
+        let changed = rule.apply_implicit_sender_side_for_delete_excluded();
+        assert!(!changed);
+        assert!(rule.applies_to_sender());
+        assert!(!rule.applies_to_receiver());
+    }
+
+    #[test]
+    fn delete_excluded_respects_explicit_receiver_only_rule() {
+        let mut rule = FilterRuleSpec::exclude("*.tmp").with_sender(false);
+        let changed = rule.apply_implicit_sender_side_for_delete_excluded();
+        assert!(!changed);
+        assert!(!rule.applies_to_sender());
+        assert!(rule.applies_to_receiver());
+    }
+
+    /// Protect/Risk and the merge rule families never trigger the implicit
+    /// flag - they either restrict to the receiver side already
+    /// (`FilterRuleSpec::protect`/`risk` set `sender=false`) or carry their
+    /// own `FILTRULE_MERGE_FILE`/`FILTRULE_PERDIR_MERGE` bits that upstream
+    /// excludes from the mask in `exclude.c:1331`.
+    #[test]
+    fn delete_excluded_skips_non_include_exclude_kinds() {
+        let mut protect = FilterRuleSpec::protect("keep");
+        assert!(!protect.apply_implicit_sender_side_for_delete_excluded());
+
+        let mut risk = FilterRuleSpec::risk("scratch");
+        assert!(!risk.apply_implicit_sender_side_for_delete_excluded());
+
+        let mut clear = FilterRuleSpec::clear();
+        assert!(!clear.apply_implicit_sender_side_for_delete_excluded());
+
+        let mut dir_merge = FilterRuleSpec::dir_merge(".rsync-filter", DirMergeOptions::new());
+        assert!(!dir_merge.apply_implicit_sender_side_for_delete_excluded());
     }
 }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -45,7 +45,8 @@ pub(crate) fn run_pull_transfer(
     buffered: Vec<u8>,
     observer: Option<&mut dyn ClientProgressObserver>,
 ) -> Result<ClientSummary, ClientError> {
-    let filter_rules = flags::build_wire_format_rules(config.filter_rules())?;
+    let filter_rules =
+        flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded())?;
 
     // upstream: compat.c:599 - protocol was negotiated via @RSYNCD text exchange,
     // setup_protocol() skips the binary exchange because remote_protocol != 0.
@@ -111,7 +112,8 @@ pub(crate) fn run_push_transfer(
     buffered: Vec<u8>,
     observer: Option<&mut dyn ClientProgressObserver>,
 ) -> Result<ClientSummary, ClientError> {
-    let filter_rules = flags::build_wire_format_rules(config.filter_rules())?;
+    let filter_rules =
+        flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded())?;
 
     // upstream: compat.c:599 - if (remote_protocol == 0) { ... }
     let mut handshake = build_daemon_handshake(config, protocol);

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -127,10 +127,10 @@ fn run_embedded_push(
 
     let mut server_config = build_server_config_for_generator(config, local_sources)?;
     server_config.connection.client_mode = true;
-    server_config.connection.filter_rules = flags::build_wire_format_rules(config.filter_rules())
-        .map_err(|e| {
-        invalid_argument_error(&format!("failed to build filter rules: {e}"), 12)
-    })?;
+    server_config.connection.filter_rules =
+        flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded()).map_err(
+            |e| invalid_argument_error(&format!("failed to build filter rules: {e}"), 12),
+        )?;
     server_config.stop_at = config.stop_at();
 
     let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
@@ -160,10 +160,10 @@ fn run_embedded_pull(
 
     let mut server_config = build_server_config_for_receiver(config, &[local_dest.to_owned()])?;
     server_config.connection.client_mode = true;
-    server_config.connection.filter_rules = flags::build_wire_format_rules(config.filter_rules())
-        .map_err(|e| {
-        invalid_argument_error(&format!("failed to build filter rules: {e}"), 12)
-    })?;
+    server_config.connection.filter_rules =
+        flags::build_wire_format_rules(config.filter_rules(), config.delete_excluded()).map_err(
+            |e| invalid_argument_error(&format!("failed to build filter rules: {e}"), 12),
+        )?;
     server_config.stop_at = config.stop_at();
 
     let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -154,10 +154,27 @@ pub(crate) fn build_server_flag_string(config: &ClientConfig) -> String {
 /// `serialize_rule` here) re-append the trailing `/` for directory-only rules.
 pub(crate) fn build_wire_format_rules(
     client_rules: &[FilterRuleSpec],
+    delete_excluded: bool,
 ) -> Result<Vec<FilterRuleWireFormat>, ClientError> {
     let mut wire_rules = Vec::new();
 
     for spec in client_rules {
+        // upstream: exclude.c:1330-1332 add_rule() applies an implicit
+        // FILTRULE_SENDER_SIDE when --delete-excluded is active and the
+        // rule carries neither FILTRULES_SIDES nor merge/dir-merge. The
+        // flag drives `get_rule_prefix()` (exclude.c:1566-1568) to emit
+        // the `s` modifier on the wire and `send_rules()` (line 1605) to
+        // elide the rule from the receiver's view because it has already
+        // been applied locally on the sender.
+        let mut spec_owned;
+        let spec_ref = if delete_excluded {
+            spec_owned = spec.clone();
+            spec_owned.apply_implicit_sender_side_for_delete_excluded();
+            &spec_owned
+        } else {
+            spec
+        };
+        let spec = spec_ref;
         let rule_type = match spec.kind() {
             FilterRuleKind::Include => RuleType::Include,
             FilterRuleKind::Exclude => RuleType::Exclude,
@@ -414,14 +431,14 @@ mod tests {
 
     #[test]
     fn converts_empty_filter_list() {
-        let rules = build_wire_format_rules(&[]).expect("should convert empty list");
+        let rules = build_wire_format_rules(&[], false).expect("should convert empty list");
         assert_eq!(rules.len(), 0);
     }
 
     #[test]
     fn converts_simple_exclude_rule() {
         let spec = FilterRuleSpec::exclude("*.log");
-        let rules = build_wire_format_rules(&[spec]).expect("should convert exclude rule");
+        let rules = build_wire_format_rules(&[spec], false).expect("should convert exclude rule");
 
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].rule_type, RuleType::Exclude);
@@ -433,7 +450,7 @@ mod tests {
     #[test]
     fn converts_simple_include_rule() {
         let spec = FilterRuleSpec::include("*.txt");
-        let rules = build_wire_format_rules(&[spec]).expect("should convert include rule");
+        let rules = build_wire_format_rules(&[spec], false).expect("should convert include rule");
 
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].rule_type, RuleType::Include);
@@ -445,7 +462,7 @@ mod tests {
     #[test]
     fn detects_anchored_pattern() {
         let spec = FilterRuleSpec::exclude("/tmp");
-        let rules = build_wire_format_rules(&[spec]).expect("should convert anchored rule");
+        let rules = build_wire_format_rules(&[spec], false).expect("should convert anchored rule");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].anchored);
@@ -458,7 +475,8 @@ mod tests {
     #[test]
     fn detects_directory_only_pattern() {
         let spec = FilterRuleSpec::exclude("cache/");
-        let rules = build_wire_format_rules(&[spec]).expect("should convert directory-only rule");
+        let rules =
+            build_wire_format_rules(&[spec], false).expect("should convert directory-only rule");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].directory_only);
@@ -477,7 +495,7 @@ mod tests {
         // matching only at depth 1 and breaking deeper directory traversal
         // when combined with a trailing `--exclude='*'`.
         let spec = FilterRuleSpec::include("*/");
-        let rules = build_wire_format_rules(&[spec]).expect("should convert dir wildcard");
+        let rules = build_wire_format_rules(&[spec], false).expect("should convert dir wildcard");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].directory_only);
@@ -487,8 +505,8 @@ mod tests {
     #[test]
     fn anchored_directory_only_preserves_both_flags() {
         let spec = FilterRuleSpec::exclude("/build/");
-        let rules =
-            build_wire_format_rules(&[spec]).expect("should convert anchored directory rule");
+        let rules = build_wire_format_rules(&[spec], false)
+            .expect("should convert anchored directory rule");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].anchored);
@@ -502,7 +520,8 @@ mod tests {
         // and (formally) directory-only. Keep the slash in the pattern so
         // the wire is not empty after stripping.
         let spec = FilterRuleSpec::exclude("/");
-        let rules = build_wire_format_rules(&[spec]).expect("should convert bare slash rule");
+        let rules =
+            build_wire_format_rules(&[spec], false).expect("should convert bare slash rule");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].anchored);
@@ -515,7 +534,7 @@ mod tests {
         let spec = FilterRuleSpec::exclude("*.tmp")
             .with_sender(true)
             .with_receiver(false);
-        let rules = build_wire_format_rules(&[spec]).expect("should convert side flags");
+        let rules = build_wire_format_rules(&[spec], false).expect("should convert side flags");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].sender_side);
@@ -525,7 +544,8 @@ mod tests {
     #[test]
     fn preserves_perishable_flag() {
         let spec = FilterRuleSpec::exclude("*.swp").with_perishable(true);
-        let rules = build_wire_format_rules(&[spec]).expect("should convert perishable flag");
+        let rules =
+            build_wire_format_rules(&[spec], false).expect("should convert perishable flag");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].perishable);
@@ -534,7 +554,8 @@ mod tests {
     #[test]
     fn preserves_xattr_only_flag() {
         let spec = FilterRuleSpec::exclude("user.*").with_xattr_only(true);
-        let rules = build_wire_format_rules(&[spec]).expect("should convert xattr_only flag");
+        let rules =
+            build_wire_format_rules(&[spec], false).expect("should convert xattr_only flag");
 
         assert_eq!(rules.len(), 1);
         assert!(rules[0].xattr_only);
@@ -553,7 +574,7 @@ mod tests {
             FilterRuleSpec::dir_merge(".rsync-filter", DirMergeOptions::new()),
         ];
 
-        let rules = build_wire_format_rules(&specs).expect("should convert all rule types");
+        let rules = build_wire_format_rules(&specs, false).expect("should convert all rule types");
 
         assert_eq!(rules.len(), 6);
         assert_eq!(rules[0].rule_type, RuleType::Include);
@@ -572,7 +593,8 @@ mod tests {
             FilterRuleSpec::include("*.txt"),
         ];
 
-        let rules = build_wire_format_rules(&specs).expect("should transmit ExcludeIfPresent");
+        let rules =
+            build_wire_format_rules(&specs, false).expect("should transmit ExcludeIfPresent");
 
         assert_eq!(rules.len(), 3);
         assert_eq!(rules[0].rule_type, RuleType::Exclude);
@@ -597,7 +619,8 @@ mod tests {
             .use_whitespace();
 
         let spec = FilterRuleSpec::dir_merge(".rsync-filter", options);
-        let rules = build_wire_format_rules(&[spec]).expect("should convert dir_merge options");
+        let rules =
+            build_wire_format_rules(&[spec], false).expect("should convert dir_merge options");
 
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].rule_type, RuleType::DirMerge);
@@ -625,14 +648,139 @@ mod tests {
             .cvs_mode(true);
 
         let spec = FilterRuleSpec::dir_merge(".cvsignore", options);
-        let rules =
-            build_wire_format_rules(&[spec]).expect("should forward cvs_mode to wire format");
+        let rules = build_wire_format_rules(&[spec], false)
+            .expect("should forward cvs_mode to wire format");
 
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].rule_type, RuleType::DirMerge);
         assert!(rules[0].cvs_exclude);
         assert!(rules[0].no_inherit);
         assert!(rules[0].word_split);
+    }
+
+    /// upstream: exclude.c:1330-1332 - --delete-excluded applies an implicit
+    /// FILTRULE_SENDER_SIDE to bare include/exclude rules. The wire encoder
+    /// is the user-visible surface for this: `get_rule_prefix()` emits an
+    /// `s` modifier in the rule prefix. Without this, oc-rsync's wire output
+    /// would diverge from upstream's `- *.tmp` vs `-s *.tmp` byte stream.
+    #[test]
+    fn delete_excluded_marks_bare_exclude_sender_side() {
+        let spec = FilterRuleSpec::exclude("*.tmp");
+        let rules = build_wire_format_rules(&[spec], true)
+            .expect("delete_excluded should apply implicit sender_side");
+
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, RuleType::Exclude);
+        assert!(
+            rules[0].sender_side,
+            "implicit FILTRULE_SENDER_SIDE must be applied"
+        );
+        assert!(
+            !rules[0].receiver_side,
+            "receiver_side must be cleared by the implicit flag"
+        );
+    }
+
+    #[test]
+    fn delete_excluded_marks_bare_include_sender_side() {
+        let spec = FilterRuleSpec::include("keep/**");
+        let rules = build_wire_format_rules(&[spec], true).expect("delete_excluded include");
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].sender_side);
+        assert!(!rules[0].receiver_side);
+    }
+
+    /// A rule that explicitly carries a side hint (`s`, `r`, `show`, `hide`)
+    /// must be left untouched - upstream `exclude.c:1331` masks against
+    /// `FILTRULES_SIDES` and only applies the implicit flag when neither
+    /// side bit is set.
+    #[test]
+    fn delete_excluded_leaves_explicit_sender_rule_alone() {
+        let spec = FilterRuleSpec::hide("*.tmp");
+        let rules = build_wire_format_rules(&[spec], true).expect("hide rule with delete_excluded");
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].sender_side);
+        assert!(!rules[0].receiver_side);
+    }
+
+    #[test]
+    fn delete_excluded_leaves_explicit_receiver_rule_alone() {
+        let spec = FilterRuleSpec::exclude("keep.txt").with_sender(false);
+        let rules =
+            build_wire_format_rules(&[spec], true).expect("receiver-only with delete_excluded");
+
+        assert_eq!(rules.len(), 1);
+        assert!(!rules[0].sender_side);
+        assert!(rules[0].receiver_side);
+    }
+
+    /// Protect/Risk and DirMerge rules must not gain the implicit flag.
+    /// `exclude.c:1331` excludes merge rules from the mask; Protect/Risk
+    /// already restrict to the receiver side, so neither match the
+    /// "no FILTRULES_SIDES bit" precondition.
+    #[test]
+    fn delete_excluded_leaves_protect_rule_alone() {
+        let spec = FilterRuleSpec::protect("keep");
+        let rules = build_wire_format_rules(&[spec], true).expect("protect with delete_excluded");
+
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, RuleType::Protect);
+        assert!(!rules[0].sender_side);
+        assert!(rules[0].receiver_side);
+    }
+
+    #[test]
+    fn delete_excluded_leaves_dir_merge_rule_alone() {
+        use engine::local_copy::DirMergeOptions;
+
+        let spec = FilterRuleSpec::dir_merge(".rsync-filter", DirMergeOptions::new());
+        let rules = build_wire_format_rules(&[spec], true).expect("dir_merge with delete_excluded");
+
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, RuleType::DirMerge);
+        // DirMerge defaults: sender=true, receiver=true, both retained.
+        assert!(rules[0].sender_side);
+        assert!(rules[0].receiver_side);
+    }
+
+    /// Without --delete-excluded the implicit flag must not be applied even
+    /// for bare include/exclude rules. This guards against future
+    /// over-eager mutation that would silently restrict rule scope.
+    #[test]
+    fn no_delete_excluded_leaves_bare_rule_untouched() {
+        let spec = FilterRuleSpec::exclude("*.tmp");
+        let rules = build_wire_format_rules(&[spec], false).expect("no delete_excluded");
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].sender_side);
+        assert!(rules[0].receiver_side);
+    }
+
+    /// Wire-byte parity: when `--delete-excluded` is active, the rule must
+    /// serialize through `build_rule_prefix()` with the `s` modifier on the
+    /// wire. This is the byte stream upstream rsync 3.4.4 emits for the same
+    /// CLI input.
+    ///
+    /// upstream: exclude.c:1566-1568 `get_rule_prefix()` emits `s` when
+    /// `FILTRULE_SENDER_SIDE` is set and (`!for_xfer` or proto >= 29).
+    #[test]
+    fn delete_excluded_wire_prefix_carries_s_modifier() {
+        use protocol::ProtocolVersion;
+        use protocol::filters::build_rule_prefix;
+
+        let spec = FilterRuleSpec::exclude("*.tmp");
+        let rules = build_wire_format_rules(&[spec], true)
+            .expect("delete_excluded should apply implicit sender_side");
+
+        let proto = ProtocolVersion::from_supported(32).unwrap();
+        let prefix = build_rule_prefix(&rules[0], proto).expect("prefix must serialize");
+
+        // Upstream 3.4.4 emits `-s ` for `--exclude *.tmp` under
+        // `--delete-excluded`. Without the implicit flag, the prefix would
+        // be `- `, diverging from the upstream wire.
+        assert_eq!(prefix, "-s ");
     }
 
     #[test]

--- a/crates/core/src/client/run/filters.rs
+++ b/crates/core/src/client/run/filters.rs
@@ -13,6 +13,7 @@ use super::super::error::{ClientError, compile_filter_error};
 
 pub(crate) fn compile_filter_program(
     rules: &[FilterRuleSpec],
+    delete_excluded: bool,
 ) -> Result<Option<FilterProgram>, ClientError> {
     if rules.is_empty() {
         return Ok(None);
@@ -20,6 +21,14 @@ pub(crate) fn compile_filter_program(
 
     let mut entries = Vec::new();
     for rule in rules {
+        // upstream: exclude.c:1330-1332 add_rule() applies an implicit
+        // FILTRULE_SENDER_SIDE when --delete-excluded is active and the
+        // rule carries neither FILTRULES_SIDES nor merge/dir-merge.
+        let mut rule = rule.clone();
+        if delete_excluded {
+            rule.apply_implicit_sender_side_for_delete_excluded();
+        }
+
         match rule.kind() {
             FilterRuleKind::Include => entries.push(FilterProgramEntry::Rule(
                 EngineFilterRule::include(rule.pattern().to_owned())

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -285,7 +285,8 @@ fn run_client_internal(
         }
     }
 
-    let filter_program = filters::compile_filter_program(config.filter_rules())?;
+    let filter_program =
+        filters::compile_filter_program(config.filter_rules(), config.delete_excluded())?;
     let mut options = build_local_copy_options(&config, filter_program);
 
     let batch_writer_for_options = if let Some(ref writer) = batch_writer {


### PR DESCRIPTION
## Summary

Upstream rsync's `exclude.c::add_rule` (lines 1330-1332 in rsync-3.4.4) applies an implicit `FILTRULE_SENDER_SIDE` flag to every include/exclude rule that carries no explicit side modifier when `--delete-excluded` is active:

```c
/* --delete-excluded turns an un-modified include/exclude into a sender-side rule. */
if (delete_excluded
 && !(rule->rflags & (FILTRULES_SIDES|FILTRULE_MERGE_FILE|FILTRULE_PERDIR_MERGE)))
    rule->rflags |= FILTRULE_SENDER_SIDE;
```

The flag drives two downstream effects:

- `get_rule_prefix()` (exclude.c:1566-1568) emits the `s` modifier on the wire prefix.
- `send_rules()` (exclude.c:1605) marks the rule as `LOCAL_RULE` on the sender so it is NOT transmitted to the receiver - the sender already applied it locally.

oc-rsync was forwarding bare include/exclude rules as both-sided through `compile_filter_program()` (engine path) and `build_wire_format_rules()` (wire path), so a CLI like `--delete-excluded --exclude '*.tmp'` produced `- *.tmp` on the wire instead of upstream's `-s *.tmp`. The receiver still saw the excluded names and (only thanks to the pre-existing `allows_deletion_when_excluded_removed` workaround in the local-copy decision context) deleted them - but the byte stream diverged from upstream and remote receivers running upstream rsync evaluated the rule differently.

## Fix

- New `FilterRuleSpec::apply_implicit_sender_side_for_delete_excluded()` mirrors upstream's mask: it fires only on `Include`/`Exclude` kinds whose `applies_to_sender == applies_to_receiver == true` (i.e. no `FILTRULES_SIDES` bit), clearing the receiver bit so the rule becomes sender-only.
- `compile_filter_program()` and `build_wire_format_rules()` now both take a `delete_excluded` parameter and apply the implicit flag before producing engine rules or wire bytes.
- Call sites in `run/mod.rs`, daemon transfer orchestration, and embedded SSH transfer plumb `config.delete_excluded()` through.

## Tests

- 5 unit tests in `crates/core/src/client/config/filters.rs` cover the spec-side mutation: include/exclude kinds get the flag, explicit sender-only / receiver-only rules are untouched, and Protect / Risk / Clear / DirMerge are all skipped (matching upstream's mask exclusions).
- 7 wire-format tests in `crates/core/src/client/remote/flags.rs` cover the serialization path, including a wire-byte parity check that asserts `build_rule_prefix()` emits `-s ` for a bare `--exclude '*.tmp'` under `--delete-excluded` (vs `- ` without it), matching upstream rsync 3.4.4's wire output.

## Upstream Reference

- `target/interop/upstream-src/rsync-3.4.4/exclude.c:1330-1332` - implicit flag application in `add_rule()` / `parse_filter_str()`
- `target/interop/upstream-src/rsync-3.4.4/exclude.c:1566-1568` - `s` modifier emission in `get_rule_prefix()`
- `target/interop/upstream-src/rsync-3.4.4/exclude.c:1605-1612` - sender-side elision in `send_rules()`

UTS-DD-exclude.4

## Test plan

- [x] `cargo fmt --all`
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) full workspace
- [ ] CI: Windows (stable)
- [ ] CI: macOS (stable)
- [ ] CI: Linux musl (stable)
- [ ] CI: Interop with upstream rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2 over local, SSH, and daemon transports