### PR TITLE
fix(transfer): emit hardlink uptodate and direct stats to stderr in -vv

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -145,18 +145,26 @@ pub(crate) fn emit_transfer_summary(
             human_readable_mode,
             writer,
         )?;
-        if stats_on {
-            writeln!(writer)?;
-        }
     }
 
     let name_enabled = !matches!(name_level, NameOutputLevel::Disabled);
     let suppress_name_totals =
         suppress_updated_only_totals && matches!(name_level, NameOutputLevel::UpdatedOnly);
+    let emit_trailer_totals =
+        !stats_on && (verbosity > 0 || (name_enabled && !suppress_name_totals));
+
+    // upstream: main.c:461 - `output_summary()` emits a blank
+    // `rprintf(FCLIENT, "\n")` before the INFO_GTE(STATS, 1) totals so the
+    // trailer is visually separated from preceding per-file output.
+    // `testsuite/itemize.test`'s `v_filt` helper relies on this empty line
+    // (`sed -e '/^$/,$d'`) to strip the trailer when matching `-vv` goldens.
+    if emit_verbose_listing && (stats_on || emit_trailer_totals) {
+        writeln!(writer)?;
+    }
 
     if stats_on {
         emit_stats(summary, writer, human_readable_mode, dry_run, stats_level)?;
-    } else if verbosity > 0 || (name_enabled && !suppress_name_totals) {
+    } else if emit_trailer_totals {
         emit_totals(summary, writer, human_readable_mode, dry_run)?;
     }
 
@@ -422,6 +430,19 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     )
 }
 
+/// Returns whether an event represents a no-op uptodate emission. Used to
+/// reorder events so upstream's generator-first / receiver-second wire order
+/// is preserved in verbose mode.
+///
+/// upstream: hlink.c:218-224, generator.c:1010-1022, rsync.c:672-676 - the
+/// generator emits `"is uptodate"` synchronously while the receiver emits
+/// the bare-name notice from `set_file_attrs` only after the transfer
+/// completes. The two processes pipeline so uptodate lines appear ahead of
+/// transferred-file lines in the observable client output.
+fn is_uptodate_event(event: &ClientEvent) -> bool {
+    matches!(event.kind(), ClientEventKind::MetadataReused) || event.is_hardlink_uptodate()
+}
+
 /// Renders verbose listings for the provided transfer events.
 pub(crate) fn emit_verbose<W: Write + ?Sized>(
     events: &[ClientEvent],
@@ -435,7 +456,16 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         return Ok(());
     }
 
-    for event in events {
+    // upstream pipelines the generator (which emits `"is uptodate"`
+    // synchronously) ahead of the receiver (which emits the bare-name
+    // notice only after `set_file_attrs` returns). In our event-stream
+    // pipeline the actions are recorded in traversal order, so partition
+    // them to recover the upstream wire order. The sort is stable so each
+    // group preserves its original relative ordering.
+    let mut ordered_events: Vec<&ClientEvent> = events.iter().collect();
+    ordered_events.sort_by_key(|event| if is_uptodate_event(event) { 0u8 } else { 1 });
+
+    for event in ordered_events {
         let kind = event.kind();
         let include_for_name = event_matches_name_level(event, name_level);
 
@@ -446,9 +476,10 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
 
             // upstream: rsync.c:676 - uptodate notice uses `"%s is uptodate"`
             // wording at INFO_GTE(NAME, 2). `--info=name2` sets name_level to
-            // UpdatedAndUnchanged here, so route MetadataReused through the
-            // uptodate phrasing instead of the bare path.
-            if matches!(kind, ClientEventKind::MetadataReused) {
+            // UpdatedAndUnchanged here, so route MetadataReused (or a
+            // HardLink whose destination was already linked to the leader)
+            // through the uptodate phrasing instead of the bare path.
+            if matches!(kind, ClientEventKind::MetadataReused) || event.is_hardlink_uptodate() {
                 writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
                 continue;
             }
@@ -543,6 +574,17 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // (info_log! events drain AFTER the summary in cli mod.rs);
                 // routing it through the event renderer keeps `is uptodate`
                 // lines ahead of the totals to match upstream's wire order.
+                if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
+                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                }
+                continue;
+            }
+            ClientEventKind::HardLink if event.is_hardlink_uptodate() => {
+                // upstream: hlink.c:218-224 - when the destination already
+                // shares the source group leader's inode, the generator
+                // emits `"%s is uptodate"` at INFO_GTE(NAME, 2) instead of
+                // the bare path. Mirror the same gate so `-vv` without `-i`
+                // matches the upstream `testsuite/itemize.test` golden.
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
                     writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
                 }

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1188,3 +1188,170 @@ fn level_1_all_uptodate_emits_banner_only() {
         "unchanged file must NOT emit a bare-name line under -v without --progress, got: {rendered:?}"
     );
 }
+
+/// Verifies that `-vvplrH` against an already-hardlinked destination emits the
+/// upstream `is uptodate` notice for the hardlink companion instead of the
+/// bare path.
+///
+/// upstream: hlink.c:218-224 - when the destination already shares the source
+/// group leader's inode, the generator emits `"%s is uptodate"` at
+/// `INFO_GTE(NAME, 2) && maybe_ATTRS_REPORT`. Mirrors `testsuite/itemize.test`
+/// at line 106 (`foo/extra is uptodate`).
+#[cfg(unix)]
+#[test]
+fn level_2_hardlink_uptodate_emits_is_uptodate_notice() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(&from).expect("mkdir from");
+    std::fs::write(from.join("leader.txt"), b"leader content").expect("write leader");
+    std::fs::hard_link(from.join("leader.txt"), from.join("follower.txt"))
+        .expect("source hardlink");
+
+    let mut from_slash = from.clone().into_os_string();
+    from_slash.push("/");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-plrH"),
+        from_slash.clone(),
+        to.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-vvplrH"),
+        from_slash,
+        to.into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        rendered.contains("leader.txt is uptodate"),
+        "leader must emit `is uptodate` under -vv, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("follower.txt is uptodate"),
+        "hardlink follower must emit `is uptodate` under -vv (upstream hlink.c:218-224), got: {rendered:?}"
+    );
+    assert!(
+        !rendered.lines().any(|line| line == "follower.txt"),
+        "hardlink follower must not emit the bare path under -vv, got: {rendered:?}"
+    );
+}
+
+/// Verifies that `-vvplr` (no `--stats`) emits a blank line separating the
+/// per-file listing from the totals trailer so the upstream
+/// `testsuite/itemize.test` `v_filt` helper (`sed -e '/^$/,$d'`) can strip the
+/// trailer before diffing.
+///
+/// upstream: main.c:461 - `output_summary()` emits `rprintf(FCLIENT, "\n")`
+/// before the `INFO_GTE(STATS, 1)` totals block.
+#[test]
+fn level_2_blank_line_precedes_totals_trailer() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(&from).expect("mkdir from");
+    std::fs::write(from.join("trailer.txt"), b"separator").expect("write source");
+
+    let mut from_slash = from.clone().into_os_string();
+    from_slash.push("/");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-vvplr"),
+        from_slash,
+        to.into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    let lines: Vec<&str> = rendered.lines().collect();
+    let trailer_index = lines
+        .iter()
+        .position(|line| line.starts_with("sent "))
+        .expect("totals trailer must be present");
+    assert!(
+        trailer_index > 0,
+        "totals trailer must follow at least one listing line, got: {rendered:?}"
+    );
+    assert!(
+        lines[trailer_index - 1].is_empty(),
+        "an empty line must precede the totals trailer so v_filt strips it correctly, got: {rendered:?}"
+    );
+}
+
+/// Verifies that under `-vv` without `-i`, uptodate notices are emitted
+/// before transferred-file lines so the observable wire order matches
+/// upstream's pipelined generator-first / receiver-second emission.
+///
+/// upstream: generator.c emits `"is uptodate"` synchronously while the
+/// receiver emits the bare-name notice from `set_file_attrs` (rsync.c:672-676)
+/// only after the transfer completes. Mirrors `testsuite/itemize.test`
+/// lines 102-109 which expect uptodate notices to precede the transferred
+/// `foo/config2` line even though `foo/config2` precedes `foo/extra` and
+/// `foo/sym` alphabetically.
+#[test]
+fn level_2_uptodate_lines_precede_transferred_lines() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(&from).expect("mkdir from");
+    std::fs::write(from.join("aaa.txt"), b"alpha content").expect("write aaa");
+    std::fs::write(from.join("bbb.txt"), b"bravo content").expect("write bbb");
+    std::fs::write(from.join("zzz.txt"), b"zulu content").expect("write zzz");
+
+    let mut from_slash = from.clone().into_os_string();
+    from_slash.push("/");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-tplr"),
+        from_slash.clone(),
+        to.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+
+    // Rewrite only `aaa.txt` so that the next run transfers `aaa.txt` while
+    // `bbb.txt` and `zzz.txt` stay uptodate.
+    std::fs::write(from.join("aaa.txt"), b"alpha modified content").expect("rewrite aaa");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-vvplr"),
+        from_slash,
+        to.into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    let lines: Vec<&str> = rendered.lines().collect();
+    let bbb_idx = lines
+        .iter()
+        .position(|l| *l == "bbb.txt is uptodate")
+        .unwrap_or_else(|| panic!("missing `bbb.txt is uptodate`: {rendered:?}"));
+    let zzz_idx = lines
+        .iter()
+        .position(|l| *l == "zzz.txt is uptodate")
+        .unwrap_or_else(|| panic!("missing `zzz.txt is uptodate`: {rendered:?}"));
+    let aaa_idx = lines
+        .iter()
+        .position(|l| *l == "aaa.txt")
+        .unwrap_or_else(|| panic!("missing transferred `aaa.txt`: {rendered:?}"));
+    assert!(
+        bbb_idx < aaa_idx && zzz_idx < aaa_idx,
+        "uptodate notices must precede transferred files (upstream generator/receiver pipeline), got: {rendered:?}"
+    );
+}

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -77,6 +77,7 @@ pub struct ClientEvent {
     destination_root: Arc<Path>,
     destination_path: PathBuf,
     change_set: LocalCopyChangeSet,
+    hardlink_uptodate: bool,
 }
 
 impl ClientEvent {
@@ -92,6 +93,7 @@ impl ClientEvent {
             metadata,
             was_created,
             change_set,
+            hardlink_uptodate,
         ) = record.into_parts();
         let kind = match &action {
             LocalCopyAction::DataCopied => ClientEventKind::DataCopied,
@@ -155,6 +157,7 @@ impl ClientEvent {
             destination_root,
             destination_path,
             change_set,
+            hardlink_uptodate,
         }
     }
 
@@ -177,6 +180,7 @@ impl ClientEvent {
             destination_root,
             destination_path,
             change_set: LocalCopyChangeSet::new(),
+            hardlink_uptodate: false,
         }
     }
 
@@ -218,6 +222,14 @@ impl ClientEvent {
     #[must_use]
     pub const fn was_created(&self) -> bool {
         self.created
+    }
+
+    /// Returns whether the event describes a hardlink whose destination
+    /// already shared the source group leader's inode (upstream:
+    /// hlink.c:218-224).
+    #[must_use]
+    pub const fn is_hardlink_uptodate(&self) -> bool {
+        self.hardlink_uptodate
     }
 
     /// Returns the change flags associated with this event.
@@ -263,6 +275,7 @@ impl ClientEvent {
             destination_root,
             destination_path,
             change_set,
+            hardlink_uptodate: false,
         }
     }
 

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -274,7 +274,13 @@ pub(super) fn process_links(
                     Duration::default(),
                     Some(reuse_snapshot),
                 )
-                .with_change_set(change_set),
+                .with_change_set(change_set)
+                // upstream: hlink.c:218-224 - when the destination already
+                // shares the source group leader's inode, the generator
+                // emits `"%s is uptodate"` at INFO_GTE(NAME, 2). Mark the
+                // record so the CLI verbose renderer prints that suffix
+                // instead of the bare path.
+                .with_hardlink_uptodate(true),
             );
             remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
             return Ok(LinkOutcome {

--- a/crates/engine/src/local_copy/plan/record.rs
+++ b/crates/engine/src/local_copy/plan/record.rs
@@ -14,6 +14,7 @@ pub struct LocalCopyRecord {
     metadata: Option<LocalCopyMetadata>,
     created: bool,
     change_set: LocalCopyChangeSet,
+    hardlink_uptodate: bool,
 }
 
 impl LocalCopyRecord {
@@ -35,6 +36,7 @@ impl LocalCopyRecord {
             metadata,
             created: false,
             change_set: LocalCopyChangeSet::new(),
+            hardlink_uptodate: false,
         }
     }
 
@@ -42,6 +44,16 @@ impl LocalCopyRecord {
     #[must_use]
     pub(in crate::local_copy) const fn with_creation(mut self, created: bool) -> Self {
         self.created = created;
+        self
+    }
+
+    /// Marks a `HardLink` record whose destination already shared the source
+    /// group leader's inode. Used by the verbose renderer to emit the
+    /// upstream `"is uptodate"` notice (upstream: hlink.c:218-224, gated by
+    /// `INFO_GTE(NAME, 2) && maybe_ATTRS_REPORT`).
+    #[must_use]
+    pub(in crate::local_copy) const fn with_hardlink_uptodate(mut self, uptodate: bool) -> Self {
+        self.hardlink_uptodate = uptodate;
         self
     }
 
@@ -85,6 +97,14 @@ impl LocalCopyRecord {
         self.created
     }
 
+    /// Returns whether this record describes a hardlink whose destination
+    /// already shared the source group leader's inode (upstream:
+    /// hlink.c:218-224).
+    #[must_use]
+    pub const fn is_hardlink_uptodate(&self) -> bool {
+        self.hardlink_uptodate
+    }
+
     /// Returns the change flags associated with this record.
     #[must_use]
     pub const fn change_set(&self) -> LocalCopyChangeSet {
@@ -118,6 +138,7 @@ impl LocalCopyRecord {
         Option<LocalCopyMetadata>,
         bool,
         LocalCopyChangeSet,
+        bool,
     ) {
         (
             self.relative_path,
@@ -128,6 +149,7 @@ impl LocalCopyRecord {
             self.metadata,
             self.created,
             self.change_set,
+            self.hardlink_uptodate,
         )
     }
 }
@@ -317,7 +339,8 @@ mod tests {
     #[test]
     fn into_parts_moves_relative_path() {
         let record = test_record().with_creation(true);
-        let (path, action, bytes, total, elapsed, meta, created, change_set) = record.into_parts();
+        let (path, action, bytes, total, elapsed, meta, created, change_set, hardlink_uptodate) =
+            record.into_parts();
         assert_eq!(path, Path::new("test/file.txt"));
         assert_eq!(action, LocalCopyAction::DataCopied);
         assert_eq!(bytes, 1024);
@@ -325,6 +348,19 @@ mod tests {
         assert_eq!(elapsed, Duration::from_millis(100));
         assert!(meta.is_none());
         assert!(created);
+        assert!(!hardlink_uptodate);
         assert_eq!(change_set, LocalCopyChangeSet::new());
+    }
+
+    #[test]
+    fn record_hardlink_uptodate_default_false() {
+        let record = test_record();
+        assert!(!record.is_hardlink_uptodate());
+    }
+
+    #[test]
+    fn record_with_hardlink_uptodate_true() {
+        let record = test_record().with_hardlink_uptodate(true);
+        assert!(record.is_hardlink_uptodate());
     }
 }


### PR DESCRIPTION
## Summary

Fixes the upstream-testsuite `itemize` failure on CI run [27711564454](https://github.com/oferchen/rsync/actions/runs/27711564454), which surfaced two distinct divergences in the `-vvplrH from/ to/` invocation (test 4 of `testsuite/itemize.test`):

1. **Hardlink-uptodate notice missing.** When the destination already shares the source group leader's inode, upstream rsync emits `\"%s is uptodate\"` (`hlink.c:218-224`, gated by `INFO_GTE(NAME, 2) && maybe_ATTRS_REPORT`) instead of the bare path. We were recording the event as `HardLink` with no marker, so the CLI renderer fell through to the default arm and wrote the bare path (`foo/extra` instead of `foo/extra is uptodate`).

2. **Stats trailer not separated.** Upstream's `output_summary()` (`main.c:461`) emits a blank `rprintf(FCLIENT, \"\\n\")` before the `INFO_GTE(STATS, 1)` totals so the testsuite's `v_filt` helper (`sed -e '/^$/,$d'`) can strip the trailer when matching `-vv` goldens. The pre-existing separator in `emit_transfer_summary` only covered the verbose-listing -> stats path; the verbose-listing -> totals path was missing the blank line, so `v_filt` could not isolate the per-file region.

Additionally, mirror upstream's pipelined generator-first / receiver-second wire order in `-vv` mode by stable-partitioning events so the synchronous `\"is uptodate\"` notices precede the post-`set_file_attrs` bare-name lines.

## Changes

- `engine::local_copy::LocalCopyRecord`: add `hardlink_uptodate` field with `with_hardlink_uptodate()` setter and `is_hardlink_uptodate()` getter.
- `engine::local_copy::executor::file::copy::links`: mark the `is_already_hardlinked` branch with `with_hardlink_uptodate(true)`.
- `core::client::summary::ClientEvent`: thread the flag through `from_record_owned`, `from_progress`, and `for_test`; expose `is_hardlink_uptodate()`.
- `cli::frontend::progress::render`:
  - Stable-partition events so uptodate emissions precede transferred lines in `emit_verbose`.
  - Add a `HardLink if event.is_hardlink_uptodate()` arm that emits `\"is uptodate\"` at the same `INFO_GTE(NAME, 2)` gate as `MetadataReused`.
  - Emit the blank separator line whenever a verbose listing is followed by a trailer (stats or totals), matching `output_summary()`.

## Upstream references

- `target/interop/upstream-src/rsync-3.4.4/hlink.c:218-224` - hardlink-uptodate notice.
- `target/interop/upstream-src/rsync-3.4.4/main.c:425-470` - `output_summary()` and `\\n` separator.
- `target/interop/upstream-src/rsync-3.4.4/testsuite/itemize.test:102-109` - the golden expecting `foo/extra is uptodate` and the transferred `foo/config2` line last.

## Test plan

- [x] `cargo fmt --all -- --check`
- [ ] `level_2_hardlink_uptodate_emits_is_uptodate_notice` (Unix)
- [ ] `level_2_blank_line_precedes_totals_trailer`
- [ ] `level_2_uptodate_lines_precede_transferred_lines`
- [ ] All existing verbose-mode tests still pass
- [ ] `interop / upstream-testsuite (itemize)` job goes green