### PR TITLE
fix(engine): register nested dir-merge as per-directory rule, not eager merge

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -15,8 +15,9 @@ use super::ActiveCompressor;
 use super::buffer_pool::{BufferPool, global_buffer_pool};
 use super::deferred_sync::{DeferredSync, SyncStrategy};
 use super::filter_program::{
-    ExcludeIfPresentLayers, ExcludeIfPresentStack, FilterContext, FilterProgram, FilterSegment,
-    FilterSegmentLayers, FilterSegmentStack, directory_has_marker,
+    ExcludeIfPresentLayers, ExcludeIfPresentRule, ExcludeIfPresentStack, FilterContext,
+    FilterOutcome, FilterProgram, FilterSegment, FilterSegmentLayers, FilterSegmentStack,
+    directory_has_marker,
 };
 
 #[cfg(all(any(unix, windows), feature = "acl"))]
@@ -30,7 +31,7 @@ use super::{
     CopyComparison, DeleteTiming, DestinationWriteGuard, HardLinkTracker, LocalCopyAction,
     LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyExecution,
     LocalCopyMetadata, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
-    LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, ReferenceDirectory,
+    LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, NestedDirMerge, ReferenceDirectory,
     SparseWriteState, SparseWriter, compute_backup_path, copy_entry_to_backup,
     delete_extraneous_entries, filter_program_local_error, follow_symlink_metadata,
     load_dir_merge_rules_recursive, map_metadata_error, remove_source_entry_if_requested,
@@ -92,6 +93,19 @@ pub(crate) struct CopyContext<'a> {
     observer: Option<&'a mut dyn LocalCopyRecordHandler>,
     dir_merge_ephemeral: Rc<RefCell<FilterSegmentStack>>,
     dir_merge_marker_ephemeral: Rc<RefCell<ExcludeIfPresentStack>>,
+    /// Per-directory stack of dynamic `dir-merge` rules registered while
+    /// loading parent per-directory merge files.
+    ///
+    /// upstream: exclude.c:1419-1428 - `dir-merge .filt2` inside `bar/.filt`
+    /// registers `.filt2` for lookup in every subdirectory entered beneath
+    /// `bar/`. Each stack frame matches one `enter_directory_for_path` call:
+    /// the frame's `active_rules` is the cumulative set inherited from the
+    /// parent frame plus any rules newly registered while processing the
+    /// current directory's merge files. `loaded_segments` and
+    /// `loaded_markers` are the segments / markers produced by looking up
+    /// the active rules against the current directory. The
+    /// [`DirectoryFilterGuard`] pops the frame on drop.
+    dynamic_dir_merge_stack: Rc<RefCell<Vec<DynamicDirMergeFrame>>>,
     deferred_ops: DeferredOperationQueue,
     timeout: Option<Duration>,
     stop_deadline: Option<Instant>,
@@ -430,6 +444,27 @@ include!("context_impl/transfer.rs");
 include!("context_impl/delta_transfer.rs");
 include!("context_impl/reporting.rs");
 
+/// Per-directory frame for runtime-registered `dir-merge` rules.
+///
+/// upstream: exclude.c:1419-1428 - tracks the cumulative set of nested
+/// `dir-merge` directives that are active at the current traversal depth
+/// (`active_rules`), and the segments / markers produced by looking those
+/// rules up against the directory being entered (`loaded_segments` and
+/// `loaded_markers`). The frame is pushed by `enter_directory_for_path` and
+/// popped by [`DirectoryFilterGuard`].
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DynamicDirMergeFrame {
+    /// All dynamic dir-merge rules active at this depth, inherited from the
+    /// parent frame plus rules newly registered while loading this
+    /// directory's merge files.
+    pub(crate) active_rules: Vec<NestedDirMerge>,
+    /// Filter segments loaded by resolving `active_rules` against the
+    /// current directory's filesystem entries.
+    pub(crate) loaded_segments: Vec<FilterSegment>,
+    /// `exclude-if-present` markers loaded from the same files.
+    pub(crate) loaded_markers: Vec<ExcludeIfPresentRule>,
+}
+
 /// Shared references to the layered filter stacks, used by
 /// [`DirectoryFilterGuard`] to push and pop per-directory filter rules.
 #[derive(Clone)]
@@ -438,6 +473,7 @@ struct DirectoryFilterHandles {
     marker_layers: Rc<RefCell<ExcludeIfPresentLayers>>,
     ephemeral: Rc<RefCell<FilterSegmentStack>>,
     marker_ephemeral: Rc<RefCell<ExcludeIfPresentStack>>,
+    dynamic: Rc<RefCell<Vec<DynamicDirMergeFrame>>>,
 }
 
 /// RAII guard that reverts per-directory filter rules when dropped.
@@ -450,6 +486,7 @@ pub(crate) struct DirectoryFilterGuard {
     indices: Vec<usize>,
     marker_counts: Vec<(usize, usize)>,
     ephemeral_active: bool,
+    dynamic_active: bool,
     excluded: bool,
 }
 
@@ -459,6 +496,7 @@ impl DirectoryFilterGuard {
         indices: Vec<usize>,
         marker_counts: Vec<(usize, usize)>,
         ephemeral_active: bool,
+        dynamic_active: bool,
         excluded: bool,
     ) -> Self {
         Self {
@@ -466,6 +504,7 @@ impl DirectoryFilterGuard {
             indices,
             marker_counts,
             ephemeral_active,
+            dynamic_active,
             excluded,
         }
     }
@@ -478,6 +517,11 @@ impl DirectoryFilterGuard {
 
 impl Drop for DirectoryFilterGuard {
     fn drop(&mut self) {
+        if self.dynamic_active {
+            let mut stack = self.handles.dynamic.borrow_mut();
+            stack.pop();
+        }
+
         if self.ephemeral_active {
             let mut stack = self.handles.ephemeral.borrow_mut();
             stack.pop();

--- a/crates/engine/src/local_copy/context_impl/options/filter.rs
+++ b/crates/engine/src/local_copy/context_impl/options/filter.rs
@@ -11,6 +11,13 @@ impl<'a> CopyContext<'a> {
     /// transfer. Returns `true` if the entry passes all filters.
     pub(super) fn allows(&self, relative: &Path, is_dir: bool) -> bool {
         if let Some(program) = &self.filter_program {
+            if let Some(outcome) =
+                self.evaluate_dynamic_segments(relative, is_dir, FilterContext::Transfer)
+                && outcome.transfer_decided()
+            {
+                return outcome.allows_transfer();
+            }
+
             let layers = self.dir_merge_layers.borrow();
             let ephemeral = self.dir_merge_ephemeral.borrow();
             let temp_layers = ephemeral.last().map(|entries| entries.as_slice());
@@ -39,6 +46,9 @@ impl<'a> CopyContext<'a> {
     /// exclude patterns (trailing `/`) should prevent traversal outright.
     pub(super) fn excluded_dir_by_non_dir_rule(&self, relative: &Path) -> bool {
         if let Some(program) = &self.filter_program {
+            if let Some(result) = self.dynamic_excluded_dir_by_non_dir_rule(relative) {
+                return result;
+            }
             let layers = self.dir_merge_layers.borrow();
             let ephemeral = self.dir_merge_ephemeral.borrow();
             let temp_layers = ephemeral.last().map(|entries| entries.as_slice());
@@ -55,6 +65,16 @@ impl<'a> CopyContext<'a> {
     pub(super) fn allows_deletion(&self, relative: &Path, is_dir: bool) -> bool {
         let delete_excluded = self.options.delete_excluded_enabled();
         if let Some(program) = &self.filter_program {
+            if let Some(outcome) =
+                self.evaluate_dynamic_segments(relative, is_dir, FilterContext::Deletion)
+                && outcome.transfer_decided()
+            {
+                return if delete_excluded {
+                    outcome.allows_deletion() || outcome.allows_deletion_when_excluded_removed()
+                } else {
+                    outcome.allows_deletion()
+                };
+            }
             let layers = self.dir_merge_layers.borrow();
             let ephemeral = self.dir_merge_ephemeral.borrow();
             let temp_layers = ephemeral.last().map(|entries| entries.as_slice());
@@ -80,5 +100,45 @@ impl<'a> CopyContext<'a> {
         } else {
             true
         }
+    }
+
+    /// Applies the top-of-stack dynamic per-directory merge segments against
+    /// `relative` using upstream's first-match-wins semantics.
+    ///
+    /// upstream: exclude.c:check_filter() - local child rules precede inherited
+    /// parent rules. Dynamic per-directory rules registered by a parent merge
+    /// file fire BEFORE the parent's own static rules so that a `.filt2` rule
+    /// in a subdirectory overrides any conflicting rule inherited from
+    /// `bar/.filt`.
+    fn evaluate_dynamic_segments(
+        &self,
+        relative: &Path,
+        is_dir: bool,
+        context: FilterContext,
+    ) -> Option<FilterOutcome> {
+        let stack = self.dynamic_dir_merge_stack.borrow();
+        let frame = stack.last()?;
+        if frame.loaded_segments.is_empty() {
+            return None;
+        }
+        let mut outcome = FilterOutcome::default();
+        for segment in frame.loaded_segments.iter().rev() {
+            if outcome.transfer_decided() {
+                break;
+            }
+            segment.apply(relative, is_dir, &mut outcome, context);
+        }
+        Some(outcome)
+    }
+
+    fn dynamic_excluded_dir_by_non_dir_rule(&self, relative: &Path) -> Option<bool> {
+        let stack = self.dynamic_dir_merge_stack.borrow();
+        let frame = stack.last()?;
+        for segment in frame.loaded_segments.iter().rev() {
+            if let Some(result) = segment.excluded_dir_by_non_dir_rule(relative) {
+                return Some(result);
+            }
+        }
+        None
     }
 }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -31,6 +31,7 @@ impl<'a> CopyContext<'a> {
             .unwrap_or_default();
         let dir_merge_ephemeral = Vec::new();
         let dir_merge_marker_ephemeral = Vec::new();
+        let dynamic_dir_merge_stack: Vec<DynamicDirMergeFrame> = Vec::new();
         let timeout = options.timeout();
 
         let buffer_pool = global_buffer_pool();
@@ -128,6 +129,7 @@ impl<'a> CopyContext<'a> {
             observer,
             dir_merge_ephemeral: Rc::new(RefCell::new(dir_merge_ephemeral)),
             dir_merge_marker_ephemeral: Rc::new(RefCell::new(dir_merge_marker_ephemeral)),
+            dynamic_dir_merge_stack: Rc::new(RefCell::new(dynamic_dir_merge_stack)),
             deferred_ops: DeferredOperationQueue::default(),
             timeout,
             stop_deadline,

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -89,11 +89,13 @@ impl<'a> CopyContext<'a> {
                 marker_layers: Rc::clone(&self.dir_merge_marker_layers),
                 ephemeral: Rc::clone(&self.dir_merge_ephemeral),
                 marker_ephemeral: Rc::clone(&self.dir_merge_marker_ephemeral),
+                dynamic: Rc::clone(&self.dynamic_dir_merge_stack),
             };
             return Ok(DirectoryFilterGuard::new(
                 handles,
                 Vec::new(),
                 Vec::new(),
+                false,
                 false,
                 false,
             ));
@@ -107,6 +109,87 @@ impl<'a> CopyContext<'a> {
         let mut marker_ephemeral_stack = self.dir_merge_marker_ephemeral.borrow_mut();
         ephemeral_stack.push(Vec::new());
         marker_ephemeral_stack.push(Vec::new());
+
+        // upstream: exclude.c:1419-1428 - inherit the parent frame's active
+        // nested dir-merge rules and look each one up in the current directory.
+        // Newly-registered rules (encountered while loading the files below)
+        // become active for subdirectories but are NOT looked up against the
+        // current directory.
+        let inherited_active: Vec<NestedDirMerge> = self
+            .dynamic_dir_merge_stack
+            .borrow()
+            .last()
+            .map(|frame| frame.active_rules.clone())
+            .unwrap_or_default();
+        let mut new_frame = DynamicDirMergeFrame {
+            active_rules: inherited_active.clone(),
+            loaded_segments: Vec::new(),
+            loaded_markers: Vec::new(),
+        };
+
+        for rule in &inherited_active {
+            let candidate = resolve_dir_merge_path(source, &rule.pattern);
+            let metadata = match fs::metadata(&candidate) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    ephemeral_stack.pop();
+                    marker_ephemeral_stack.pop();
+                    return Err(LocalCopyError::io(
+                        "inspect filter file",
+                        candidate,
+                        error,
+                    ));
+                }
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+
+            let mut visited = Vec::new();
+            let mut entries = match load_dir_merge_rules_recursive(
+                candidate.as_path(),
+                &rule.options,
+                &mut visited,
+            ) {
+                Ok(entries) => entries,
+                Err(error) => {
+                    ephemeral_stack.pop();
+                    marker_ephemeral_stack.pop();
+                    return Err(error);
+                }
+            };
+
+            let mut segment = FilterSegment::default();
+            for compiled in entries.rules.drain(..) {
+                if let Err(error) = segment.push_rule(compiled) {
+                    ephemeral_stack.pop();
+                    marker_ephemeral_stack.pop();
+                    return Err(filter_program_local_error(&candidate, &error));
+                }
+            }
+
+            if rule.options.excludes_self() {
+                let pattern = rule.pattern.to_string_lossy().into_owned();
+                if let Err(error) = segment.push_rule(FilterRule::exclude(pattern)) {
+                    ephemeral_stack.pop();
+                    marker_ephemeral_stack.pop();
+                    return Err(filter_program_local_error(&candidate, &error));
+                }
+            }
+
+            if !segment.is_empty() {
+                new_frame.loaded_segments.push(segment);
+            }
+            if !entries.exclude_if_present.is_empty() {
+                new_frame
+                    .loaded_markers
+                    .extend(entries.exclude_if_present.drain(..));
+            }
+            new_frame
+                .active_rules
+                .append(&mut entries.nested_dir_merges);
+        }
 
         for (index, rule) in program.dir_merge_rules().iter().enumerate() {
             let candidate = resolve_dir_merge_path(source, rule.pattern());
@@ -165,6 +248,13 @@ impl<'a> CopyContext<'a> {
             let markers = entries.exclude_if_present;
             let clear_inherited = entries.clear_inherited;
 
+            // upstream: exclude.c:1419-1428 - any `dir-merge`/`:` directives
+            // inside the loaded file register new per-directory rules that
+            // apply to subdirectories of `source`, not to `source` itself.
+            new_frame
+                .active_rules
+                .append(&mut entries.nested_dir_merges);
+
             // If the filter file had a clear directive, we should clear inherited rules
             // from parent directories before adding any new rules from this directory.
             if clear_inherited && rule.options().inherit_rules() {
@@ -209,6 +299,8 @@ impl<'a> CopyContext<'a> {
         drop(ephemeral_stack);
         drop(marker_ephemeral_stack);
 
+        self.dynamic_dir_merge_stack.borrow_mut().push(new_frame);
+
         let excluded = if check_directory_excluded {
             self.directory_excluded(source, program)?
         } else {
@@ -220,11 +312,13 @@ impl<'a> CopyContext<'a> {
             marker_layers: Rc::clone(&self.dir_merge_marker_layers),
             ephemeral: Rc::clone(&self.dir_merge_ephemeral),
             marker_ephemeral: Rc::clone(&self.dir_merge_marker_ephemeral),
+            dynamic: Rc::clone(&self.dynamic_dir_merge_stack),
         };
         Ok(DirectoryFilterGuard::new(
             handles,
             added_indices,
             marker_counts,
+            true,
             true,
             excluded,
         ))
@@ -256,6 +350,15 @@ impl<'a> CopyContext<'a> {
                         return Ok(true);
                     }
                 }
+            }
+        }
+
+        {
+            let stack = self.dynamic_dir_merge_stack.borrow();
+            if let Some(frame) = stack.last()
+                && directory_has_marker(&frame.loaded_markers, directory)?
+            {
+                return Ok(true);
             }
         }
 

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -65,6 +65,22 @@ pub(crate) fn apply_dir_merge_rule_defaults(
     rule
 }
 
+/// Nested per-directory merge declaration encountered while loading another
+/// filter file.
+///
+/// upstream: exclude.c:1419-1428 - a `dir-merge` directive inside a merge file
+/// registers a new per-directory merge rule whose filename gets looked up in
+/// every subdirectory subsequently entered. The rule is NOT expanded against
+/// the enclosing file's directory.
+#[derive(Clone, Debug)]
+pub(crate) struct NestedDirMerge {
+    /// Bare merge-file name to look up in each subdirectory entered beneath
+    /// the scope where this directive appeared.
+    pub(crate) pattern: PathBuf,
+    /// Parser configuration for the registered per-directory merge rule.
+    pub(crate) options: DirMergeOptions,
+}
+
 /// Accumulated rules and `exclude-if-present` markers loaded from a single
 /// per-directory merge file (and any files it transitively merges).
 #[derive(Default)]
@@ -73,6 +89,9 @@ pub(crate) struct DirMergeEntries {
     pub(crate) rules: Vec<FilterRule>,
     /// `exclude-if-present` marker rules parsed from the merge file.
     pub(crate) exclude_if_present: Vec<ExcludeIfPresentRule>,
+    /// Nested `dir-merge`/`:` declarations to register as per-directory rules
+    /// for subsequent subdirectory traversal.
+    pub(crate) nested_dir_merges: Vec<NestedDirMerge>,
     /// Indicates a clear directive was encountered, meaning inherited rules
     /// from parent directories should also be cleared.
     pub(crate) clear_inherited: bool,
@@ -87,6 +106,10 @@ impl DirMergeEntries {
         self.exclude_if_present.push(rule);
     }
 
+    fn push_nested_dir_merge(&mut self, nested: NestedDirMerge) {
+        self.nested_dir_merges.push(nested);
+    }
+
     /// Merges another set of entries into this one.
     ///
     /// A `clear_inherited` flag in the nested entries propagates to this set,
@@ -97,11 +120,13 @@ impl DirMergeEntries {
         if other.clear_inherited {
             self.rules.clear();
             self.exclude_if_present.clear();
+            self.nested_dir_merges.clear();
             self.clear_inherited = true;
         }
         self.rules.append(&mut other.rules);
         self.exclude_if_present
             .append(&mut other.exclude_if_present);
+        self.nested_dir_merges.append(&mut other.nested_dir_merges);
     }
 }
 
@@ -207,6 +232,7 @@ pub(crate) fn load_dir_merge_rules_recursive(
                     Ok(Some(ParsedFilterDirective::Clear)) => {
                         entries.rules.clear();
                         entries.exclude_if_present.clear();
+                        entries.nested_dir_merges.clear();
                         entries.clear_inherited = true;
                     }
                     Ok(Some(ParsedFilterDirective::Merge {
@@ -231,6 +257,18 @@ pub(crate) fn load_dir_merge_rules_recursive(
                                 load_dir_merge_rules_recursive(&nested, options, visited)?;
                             entries.extend(nested_entries);
                         }
+                    }
+                    Ok(Some(ParsedFilterDirective::DirMerge {
+                        pattern,
+                        options: merge_options,
+                    })) => {
+                        // upstream: exclude.c:1419-1428 - register the merge
+                        // filename for lookup in each subdirectory; do NOT
+                        // load anything from the enclosing file's directory.
+                        entries.push_nested_dir_merge(NestedDirMerge {
+                            pattern,
+                            options: merge_options,
+                        });
                     }
                     Ok(None) => {}
                     Err(error) => return Err(map_error(error)),
@@ -303,9 +341,22 @@ pub(crate) fn load_dir_merge_rules_recursive(
                             entries.extend(nested_entries);
                         }
                     }
+                    Ok(Some(ParsedFilterDirective::DirMerge {
+                        pattern,
+                        options: merge_options,
+                    })) => {
+                        // upstream: exclude.c:1419-1428 - register the merge
+                        // filename for lookup in each subdirectory; do NOT
+                        // load anything from the enclosing file's directory.
+                        entries.push_nested_dir_merge(NestedDirMerge {
+                            pattern,
+                            options: merge_options,
+                        });
+                    }
                     Ok(Some(ParsedFilterDirective::Clear)) => {
                         entries.rules.clear();
                         entries.exclude_if_present.clear();
+                        entries.nested_dir_merges.clear();
                         entries.clear_inherited = true;
                     }
                     Ok(None) => {}

--- a/crates/engine/src/local_copy/dir_merge/mod.rs
+++ b/crates/engine/src/local_copy/dir_merge/mod.rs
@@ -8,7 +8,7 @@ mod load;
 mod parse;
 
 pub(crate) use load::{
-    apply_dir_merge_rule_defaults, filter_program_local_error, load_dir_merge_rules_recursive,
-    resolve_dir_merge_path,
+    NestedDirMerge, apply_dir_merge_rule_defaults, filter_program_local_error,
+    load_dir_merge_rules_recursive, resolve_dir_merge_path,
 };
 pub(crate) use parse::{FilterParseError, ParsedFilterDirective, parse_filter_directive_line};

--- a/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
@@ -119,9 +119,9 @@ pub(super) fn parse_dir_merge_directive(
         remainder
     };
 
-    Ok(Some(ParsedFilterDirective::Merge {
-        path: PathBuf::from(path_text),
-        options: Some(options),
+    Ok(Some(ParsedFilterDirective::DirMerge {
+        pattern: PathBuf::from(path_text),
+        options,
     }))
 }
 
@@ -157,11 +157,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { path, options } => {
-                assert_eq!(path, PathBuf::from(".rsync-filter"));
-                assert!(options.is_some());
+            ParsedFilterDirective::DirMerge { pattern, .. } => {
+                assert_eq!(pattern, PathBuf::from(".rsync-filter"));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -171,11 +170,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { path, options } => {
-                assert_eq!(path, PathBuf::from(".rsync-filter"));
-                assert!(options.is_some());
+            ParsedFilterDirective::DirMerge { pattern, .. } => {
+                assert_eq!(pattern, PathBuf::from(".rsync-filter"));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -185,10 +183,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { path, .. } => {
-                assert_eq!(path, PathBuf::from(".rsync-filter"));
+            ParsedFilterDirective::DirMerge { pattern, .. } => {
+                assert_eq!(pattern, PathBuf::from(".rsync-filter"));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -198,12 +196,11 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { path, options } => {
-                assert_eq!(path, PathBuf::from(".rsync-filter"));
-                let opts = options.unwrap();
-                assert!(!opts.inherit_rules());
+            ParsedFilterDirective::DirMerge { pattern, options } => {
+                assert_eq!(pattern, PathBuf::from(".rsync-filter"));
+                assert!(!options.inherit_rules());
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -213,11 +210,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { options, .. } => {
-                let opts = options.unwrap();
-                assert!(opts.excludes_self());
+            ParsedFilterDirective::DirMerge { options, .. } => {
+                assert!(options.excludes_self());
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -227,11 +223,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { options, .. } => {
-                let opts = options.unwrap();
-                assert_eq!(opts.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
+            ParsedFilterDirective::DirMerge { options, .. } => {
+                assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -241,11 +236,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { options, .. } => {
-                let opts = options.unwrap();
-                assert_eq!(opts.enforced_kind(), Some(DirMergeEnforcedKind::Include));
+            ParsedFilterDirective::DirMerge { options, .. } => {
+                assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Include));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -279,12 +273,11 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { path, options } => {
-                assert_eq!(path, PathBuf::from(".cvsignore"));
-                let opts = options.unwrap();
-                assert_eq!(opts.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
+            ParsedFilterDirective::DirMerge { pattern, options } => {
+                assert_eq!(pattern, PathBuf::from(".cvsignore"));
+                assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 
@@ -294,12 +287,11 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { options, .. } => {
-                let opts = options.unwrap();
-                assert!(!opts.inherit_rules());
-                assert!(opts.excludes_self());
+            ParsedFilterDirective::DirMerge { options, .. } => {
+                assert!(!options.inherit_rules());
+                assert!(options.excludes_self());
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 }

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -399,4 +399,27 @@ mod tests {
         let result = parse_filter_directive_line("- ");
         assert!(result.is_err());
     }
+
+    /// upstream: exclude.c:1419-1428 - the `dir-merge` keyword and the `:`
+    /// short form both register a per-directory merge rule. Both forms must
+    /// produce [`ParsedFilterDirective::DirMerge`] so the runtime can defer
+    /// the file lookup to each subdirectory rather than loading it eagerly
+    /// against the enclosing directory.
+    #[test]
+    fn parse_filter_directive_line_dir_merge_keyword_emits_dir_merge_variant() {
+        let result = parse_filter_directive_line("dir-merge .filt2").unwrap();
+        assert!(
+            matches!(result, Some(ParsedFilterDirective::DirMerge { .. })),
+            "dir-merge keyword must emit DirMerge variant"
+        );
+    }
+
+    #[test]
+    fn parse_filter_directive_line_colon_short_form_emits_dir_merge_variant() {
+        let result = parse_filter_directive_line(": .filt2").unwrap();
+        assert!(
+            matches!(result, Some(ParsedFilterDirective::DirMerge { .. })),
+            "':' short form must emit DirMerge variant"
+        );
+    }
 }

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -111,9 +111,12 @@ pub(super) fn parse_short_merge_directive_line(
     };
 
     if allow_extended {
-        return Ok(Some(ParsedFilterDirective::Merge {
-            path: PathBuf::from(pattern),
-            options: Some(options),
+        // upstream: exclude.c:1419-1428 - ':' short form is a per-directory
+        // merge that registers a filename to look up in each subdirectory,
+        // not an eager merge of the parent file's adjacent rule file.
+        return Ok(Some(ParsedFilterDirective::DirMerge {
+            pattern: PathBuf::from(pattern),
+            options,
         }));
     }
 
@@ -233,11 +236,10 @@ mod tests {
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
-            ParsedFilterDirective::Merge { path, options } => {
-                assert_eq!(path, PathBuf::from(".rsync-filter"));
-                assert!(options.is_some());
+            ParsedFilterDirective::DirMerge { pattern, .. } => {
+                assert_eq!(pattern, PathBuf::from(".rsync-filter"));
             }
-            _ => panic!("expected Merge directive"),
+            _ => panic!("expected DirMerge directive"),
         }
     }
 

--- a/crates/engine/src/local_copy/dir_merge/parse/types.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/types.rs
@@ -11,7 +11,8 @@ pub(crate) enum ParsedFilterDirective {
     /// A concrete filter rule (`+`, `-`, `include`, `exclude`, `show`, `hide`,
     /// `protect`, `risk`).
     Rule(FilterRule),
-    /// A `merge` or `dir-merge` directive that pulls in another filter file.
+    /// A `merge` directive that pulls in another filter file eagerly,
+    /// resolved against the enclosing file's parent directory.
     Merge {
         /// Path to the merged file, resolved relative to the enclosing file's
         /// parent directory unless absolute.
@@ -20,6 +21,22 @@ pub(crate) enum ParsedFilterDirective {
         /// `None` indicates the merged file inherits the current parser
         /// configuration unchanged.
         options: Option<DirMergeOptions>,
+    },
+    /// A `dir-merge` (or `:` short form, `per-dir`) directive that registers
+    /// a per-directory merge filename to be looked up in each subdirectory
+    /// visited beneath the enclosing scope.
+    ///
+    /// upstream: exclude.c:1419-1428 - `FILTRULE_PERDIR_MERGE` rules are added
+    /// to the rule list with `parse_merge_name` rather than being expanded
+    /// immediately. They fire when the receiver descends into a subdirectory
+    /// that contains a matching file.
+    DirMerge {
+        /// Bare merge-file name (e.g. `.filt2`) as it appears in the directive,
+        /// NOT a parent-relative path. The actual file is resolved against
+        /// each subdirectory entered.
+        pattern: PathBuf,
+        /// Parser configuration for the registered per-directory merge rule.
+        options: DirMergeOptions,
     },
     /// An `exclude-if-present` directive naming a marker file whose presence
     /// excludes the containing directory.

--- a/crates/engine/src/local_copy/filter_program/mod.rs
+++ b/crates/engine/src/local_copy/filter_program/mod.rs
@@ -24,9 +24,6 @@ pub(crate) use rules::directory_has_marker;
 pub use rules::{DirMergeRule, ExcludeIfPresentRule};
 
 pub(crate) use segments::{
-    ExcludeIfPresentLayers, ExcludeIfPresentStack, FilterContext, FilterSegment,
+    ExcludeIfPresentLayers, ExcludeIfPresentStack, FilterContext, FilterOutcome, FilterSegment,
     FilterSegmentLayers, FilterSegmentStack,
 };
-
-#[cfg(test)]
-pub(crate) use segments::FilterOutcome;

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -113,7 +113,7 @@ pub(crate) use context::{
 
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
 pub(crate) use dir_merge::{
-    FilterParseError, ParsedFilterDirective, apply_dir_merge_rule_defaults,
+    FilterParseError, NestedDirMerge, ParsedFilterDirective, apply_dir_merge_rule_defaults,
     filter_program_local_error, load_dir_merge_rules_recursive, parse_filter_directive_line,
     resolve_dir_merge_path,
 };

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -130,17 +130,16 @@ fn parse_filter_directive_dir_merge_without_modifiers() {
         .expect("parse")
         .expect("directive");
 
-    let (path, options) = match directive {
-        ParsedFilterDirective::Merge { path, options } => (path, options),
+    let (pattern, options) = match directive {
+        ParsedFilterDirective::DirMerge { pattern, options } => (pattern, options),
         other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
-    assert_eq!(path, PathBuf::from(".rsync-filter"));
-    let opts = options.expect("options");
-    assert!(opts.inherit_rules());
-    assert!(opts.allows_comments());
-    assert!(!opts.uses_whitespace());
-    assert_eq!(opts.enforced_kind(), None);
+    assert_eq!(pattern, PathBuf::from(".rsync-filter"));
+    assert!(options.inherit_rules());
+    assert!(options.allows_comments());
+    assert!(!options.uses_whitespace());
+    assert_eq!(options.enforced_kind(), None);
 }
 
 #[test]
@@ -149,17 +148,16 @@ fn parse_filter_directive_per_dir_alias_without_modifiers() {
         .expect("parse")
         .expect("directive");
 
-    let (path, options) = match directive {
-        ParsedFilterDirective::Merge { path, options } => (path, options),
+    let (pattern, options) = match directive {
+        ParsedFilterDirective::DirMerge { pattern, options } => (pattern, options),
         other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
-    assert_eq!(path, PathBuf::from(".rsync-filter"));
-    let opts = options.expect("options");
-    assert!(opts.inherit_rules());
-    assert!(opts.allows_comments());
-    assert!(!opts.uses_whitespace());
-    assert_eq!(opts.enforced_kind(), None);
+    assert_eq!(pattern, PathBuf::from(".rsync-filter"));
+    assert!(options.inherit_rules());
+    assert!(options.allows_comments());
+    assert!(!options.uses_whitespace());
+    assert_eq!(options.enforced_kind(), None);
 }
 
 #[test]
@@ -168,16 +166,15 @@ fn parse_filter_directive_dir_merge_with_modifiers() {
         .expect("parse")
         .expect("directive");
 
-    let (path, options) = match directive {
-        ParsedFilterDirective::Merge { path, options } => (path, options),
+    let (pattern, options) = match directive {
+        ParsedFilterDirective::DirMerge { pattern, options } => (pattern, options),
         other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
-    assert_eq!(path, PathBuf::from("rules/filter.txt"));
-    let opts = options.expect("options");
-    assert!(!opts.inherit_rules());
-    assert!(opts.excludes_self());
-    assert_eq!(opts.enforced_kind(), Some(DirMergeEnforcedKind::Include));
+    assert_eq!(pattern, PathBuf::from("rules/filter.txt"));
+    assert!(!options.inherit_rules());
+    assert!(options.excludes_self());
+    assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Include));
 }
 
 #[test]
@@ -186,17 +183,16 @@ fn parse_filter_directive_dir_merge_cvs_default_path() {
         .expect("parse")
         .expect("directive");
 
-    let (path, options) = match directive {
-        ParsedFilterDirective::Merge { path, options } => (path, options),
+    let (pattern, options) = match directive {
+        ParsedFilterDirective::DirMerge { pattern, options } => (pattern, options),
         other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
-    assert_eq!(path, PathBuf::from(".cvsignore"));
-    let opts = options.expect("options");
-    assert!(!opts.inherit_rules());
-    assert!(opts.list_clear_allowed());
-    assert!(opts.uses_whitespace());
-    assert_eq!(opts.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
+    assert_eq!(pattern, PathBuf::from(".cvsignore"));
+    assert!(!options.inherit_rules());
+    assert!(options.list_clear_allowed());
+    assert!(options.uses_whitespace());
+    assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
 }
 
 #[test]
@@ -238,14 +234,13 @@ fn parse_filter_directive_short_dir_merge_with_modifiers() {
         .expect("parse")
         .expect("directive");
 
-    let (path, options) = match directive {
-        ParsedFilterDirective::Merge { path, options } => (path, options),
+    let (pattern, options) = match directive {
+        ParsedFilterDirective::DirMerge { pattern, options } => (pattern, options),
         other => panic!("expected dir-merge directive, got {other:?}"),
     };
 
-    assert_eq!(path, PathBuf::from("per-dir"));
-    let opts = options.expect("options");
-    assert_eq!(opts.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
+    assert_eq!(pattern, PathBuf::from("per-dir"));
+    assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/filters_runtime.rs
+++ b/crates/engine/src/local_copy/tests/filters_runtime.rs
@@ -298,3 +298,61 @@ fn dir_merge_clear_keyword_discards_rules_in_whitespace_mode() {
     assert_eq!(entries.rules.len(), 1);
     assert!(entries.exclude_if_present.is_empty());
 }
+
+/// Nested `dir-merge` inside a per-directory merge file should register the
+/// referenced filename for lookup in each visited subdirectory, NOT load it
+/// eagerly against the enclosing file's directory.
+///
+/// upstream: exclude.c:1419-1428 - mirrors the testsuite `exclude-lsh.test`
+/// fixture where `bar/.filt` declares `dir-merge .filt2`, and the actual
+/// `.filt2` exclusion rules live in subdirectories like `bar/baz/.filt2`.
+#[test]
+fn nested_dir_merge_registers_per_directory_rule() {
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    let destination_root = temp.path().join("dest");
+    fs::create_dir_all(&source_root).expect("create source");
+    fs::create_dir_all(&destination_root).expect("create dest");
+
+    // bar/.filt declares a nested per-directory merge. Without the fix this
+    // tries to load bar/.filt2 (which does not exist) instead of registering
+    // .filt2 for subdirectory lookup.
+    let bar = source_root.join("bar");
+    fs::create_dir_all(&bar).expect("create bar");
+    fs::write(bar.join(".filt"), b"dir-merge .filt2\n").expect("write bar/.filt");
+
+    // bar/baz holds the per-subdir filter that the dir-merge should resolve.
+    let baz = bar.join("baz");
+    fs::create_dir_all(&baz).expect("create baz");
+    fs::write(baz.join(".filt2"), b"- *.deep\n").expect("write baz/.filt2");
+    fs::write(baz.join("file5.deep"), b"filtout").expect("write file5.deep");
+    fs::write(baz.join("keep.txt"), b"keep").expect("write keep");
+
+    let operands = vec![
+        source_root.into_os_string(),
+        destination_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        PathBuf::from(".filt"),
+        DirMergeOptions::default(),
+    ))])
+    .expect("compile filter program");
+
+    let options = LocalCopyOptions::default().with_filter_program(Some(program));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let target_root = destination_root.join("source");
+    let copied_baz = target_root.join("bar").join("baz");
+    assert!(
+        copied_baz.join("keep.txt").exists(),
+        "unfiltered file should be copied"
+    );
+    assert!(
+        !copied_baz.join("file5.deep").exists(),
+        "nested dir-merge from bar/.filt should register .filt2 lookup in subdirectories and exclude bar/baz/file5.deep"
+    );
+}


### PR DESCRIPTION
## Summary

UTS-DD-exclude.1 (#4526). A per-directory merge file containing `dir-merge`
or `:` short-form was treated like a plain `merge`: oc-rsync eagerly loaded
the referenced filter file from the enclosing file's parent directory. The
upstream behavior (`exclude.c:1419-1428`) is to register the referenced
filename as a NEW per-directory rule that gets looked up in each
subsequently entered subdirectory.

Concrete divergence reproduced from the upstream testsuite `exclude-lsh`
fixture: `bar/.filt` contains `dir-merge .filt2` and the per-subdir rules
live at `bar/down/to/.filt2`, `bar/down/to/foo/.filt2`,
`bar/down/to/bar/.filt2`. The eager load looked for `bar/.filt2`, which
does not exist; the per-dir rule was never enforced, and oc-rsync
over-deleted files such as `bar/down/to/bar/baz/file5.deep` that the
per-dir `- *.deep` rule should have protected.

- Split parser AST: `merge`/`.` keep `Merge` (eager); `dir-merge`/`per-dir`/`:`
  emit a new `DirMerge` variant carrying the bare filename.
- Load: `DirMergeEntries` now collects nested per-dir registrations in
  `nested_dir_merges` instead of recursing eagerly.
- Runtime: `CopyContext` maintains a per-directory stack of
  `DynamicDirMergeFrame`s scoped by `DirectoryFilterGuard`. On
  `enter_directory_for_path`, inherited active rules are resolved against
  the current directory, segments and markers are collected, and any
  freshly-registered `dir-merge` rules become active for subdirectories.
- Evaluation: dynamic top-of-stack segments fire before the static program,
  giving child-directory rules first-match priority over inherited parent
  rules per `exclude.c:check_filter()`.

## Test plan

- [x] Unit tests in `crates/engine/src/local_copy/dir_merge/parse/` confirm
  `parse_dir_merge_directive` and the `:` short form both emit
  `ParsedFilterDirective::DirMerge`.
- [x] Integration test
  `nested_dir_merge_registers_per_directory_rule` in
  `crates/engine/src/local_copy/tests/filters_runtime.rs` builds a
  source tree with `bar/.filt` containing `dir-merge .filt2` and
  `bar/baz/.filt2` containing `- *.deep`, then asserts
  `bar/baz/file5.deep` is excluded from the transfer while
  `bar/baz/keep.txt` is copied.
- [x] `cargo fmt --all` clean.
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.

Refs upstream-src/rsync-3.4.4/exclude.c:1419-1428,
testsuite/exclude-lsh.test.