### PR TITLE
fix(filters): make directory-only unanchored gate explicit

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -80,21 +80,32 @@ impl CompiledRule {
         // `{core}/**` descendants so that paths like `build/output` are
         // excluded when checked individually (e.g., by the receiver).
         //
-        // Directory-only wildcard patterns (e.g., `foo/*/`, `**/node_modules/`)
-        // must ALSO suppress descendants. The wildcard's match set is decided
-        // per-directory at walk time, so pre-baking `foo/*/**` overreaches
-        // and excludes files inside subdirectories that a later include rule
-        // like `+ foo/s?b/` should keep. Upstream `exclude.c:rule_matches()`
-        // returns "no match" for a non-directory entry when the rule carries
-        // FILTRULE_DIRECTORY (line 938-939), so the file is included by
-        // default and the sender walk handles descent pruning by never
-        // entering the excluded directory. Pre-baked descendants would force
-        // an exclusion that upstream never produces. Regression for
-        // UTS-DD-exclude.3 (upstream `exclude` / `exclude-lsh` testsuite).
+        // Directory-only unanchored wildcard patterns (e.g., `foo/*/`,
+        // `**/node_modules/`) must ALSO suppress descendants. The wildcard's
+        // match set is decided per-directory at walk time, so pre-baking
+        // `foo/*/**` overreaches and excludes files inside subdirectories
+        // that a later include rule like `+ foo/s?b/` should keep. Upstream
+        // `exclude.c:rule_matches()` returns "no match" for a non-directory
+        // entry when the rule carries FILTRULE_DIRECTORY (line 938-939), so
+        // the file is included by default and the sender walk handles descent
+        // pruning by never entering the excluded directory. Pre-baked
+        // descendants would force an exclusion that upstream never produces.
+        // Regression for UTS-DD-exclude.3 (upstream `exclude` / `exclude-lsh`
+        // testsuite).
         let has_glob_wildcard =
             core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
         let slash_anchored = pattern.starts_with('/');
-        let suppress_descendants = has_glob_wildcard && (slash_anchored || directory_only);
+        // Directory-only unanchored wildcard gate: the user wrote `foo/*/`
+        // (or any dir-only wildcard without a leading `/`). Upstream never
+        // synthesises a descendant rule for it; the sender's traversal
+        // pruning is the only exclusion mechanism and pre-baking
+        // `{core}/**` would steal precedence from a later include like
+        // `+ foo/s?b/`. Kept as an explicit predicate so the dir-only
+        // unanchored case is greppable and pinned by unit tests.
+        let is_directory_only_unanchored_wildcard =
+            directory_only && !slash_anchored && has_glob_wildcard;
+        let is_anchored_wildcard = slash_anchored && has_glob_wildcard;
+        let suppress_descendants = is_directory_only_unanchored_wildcard || is_anchored_wildcard;
         if matches!(
             action,
             FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
@@ -537,6 +548,46 @@ mod tests {
     fn implicit_double_star_prefix_skipped_for_trailing_double_star() {
         let compiled = make_exclude("foo/**");
         assert_eq!(direct_pattern_strings(&compiled), vec!["foo/**"]);
+    }
+
+    /// UTS-DD-exclude.3 wire-byte parity: `foo/*/` is directory-only,
+    /// unanchored, and wildcard-bearing. The direct matcher set must
+    /// be exactly `{foo/*, **/foo/*}` (tail-matching for upstream's
+    /// `slash_handling = -1` `wildmatch_array` over the user-written
+    /// pattern). The descendant matcher set MUST be empty - upstream
+    /// emits no `foo/*/**` rule.
+    #[test]
+    fn dir_only_unanchored_wildcard_exact_matcher_set() {
+        let compiled = make_exclude("foo/*/");
+        assert_eq!(direct_pattern_strings(&compiled), vec!["**/foo/*", "foo/*"]);
+        assert!(
+            descendant_pattern_strings(&compiled).is_empty(),
+            "`foo/*/` must not synthesise descendant matchers (upstream FILTRULE_DIRECTORY semantic)"
+        );
+    }
+
+    /// UTS-DD-exclude.3 wire-byte parity for `**/node_modules/`: leading
+    /// `**` already carries the recursive prefix, so direct stays
+    /// `{**/node_modules}` with no descendant `**/node_modules/**`.
+    #[test]
+    fn dir_only_unanchored_double_star_prefix_exact_matcher_set() {
+        let compiled = make_exclude("**/node_modules/");
+        assert_eq!(direct_pattern_strings(&compiled), vec!["**/node_modules"]);
+        assert!(descendant_pattern_strings(&compiled).is_empty());
+    }
+
+    /// UTS-DD-exclude.3 negative guard: a literal directory-only
+    /// unanchored pattern (`cache/`) is NOT covered by the dir-only
+    /// unanchored gate (no wildcard component), so descendants are
+    /// still synthesised for the receiver single-path API. Keeps the
+    /// gate scoped to wildcard patterns.
+    #[test]
+    fn dir_only_unanchored_literal_still_gets_descendants() {
+        let compiled = make_exclude("cache/");
+        assert_eq!(
+            descendant_pattern_strings(&compiled),
+            vec!["**/cache/**", "cache/**"]
+        );
     }
 
     #[test]

--- a/crates/filters/tests/uts_dd_exclude_3_dir_only_unanchored.rs
+++ b/crates/filters/tests/uts_dd_exclude_3_dir_only_unanchored.rs
@@ -1,0 +1,101 @@
+//! UTS-DD-exclude.3 regression: a directory-only unanchored pattern such
+//! as `- foo/*/` must NOT auto-synthesise `/**` descendants. Upstream
+//! `exclude.c:rule_matches()` returns "no match" for a non-directory
+//! candidate when the rule carries `FILTRULE_DIRECTORY` (line 938-939),
+//! so the file is included by default and the sender's walk handles
+//! descent pruning by never entering the matched directory. Pre-baking
+//! `foo/*/**` would steal precedence from a sibling include like
+//! `+ foo/s?b/` and over-delete on the receiver's single-path API.
+//!
+//! Fixture mirrors the upstream `testsuite/exclude.test` /
+//! `exclude-lsh.test` exclude-from file so this test pins the
+//! over-deletion that was visible in CI as "Only in to: new" /
+//! "Only in to/foo: down" before PR #5880 landed and remains pinned
+//! after the explicit dir-only unanchored gate refactor.
+
+use std::path::Path;
+
+use filters::{FilterRule, FilterSet};
+
+/// Builds the exact rule list from the upstream `exclude.test` /
+/// `exclude-lsh.test` exclude-from file.
+fn exclude_lsh_rules() -> Vec<FilterRule> {
+    vec![
+        FilterRule::include("**/bar"),
+        FilterRule::exclude("/bar"),
+        FilterRule::include("foo**too"),
+        FilterRule::include("foo/s?b/"),
+        FilterRule::exclude("foo/*/"),
+        FilterRule::exclude("new/keep/**"),
+        FilterRule::exclude("new/lose/***"),
+        FilterRule::include("t[o]/"),
+        FilterRule::exclude("to"),
+        FilterRule::include("file4"),
+        FilterRule::exclude("file[2-9]"),
+        FilterRule::exclude("/mid/for/foo/extra"),
+    ]
+}
+
+/// `- foo/*/` must NOT exclude files inside the sibling include
+/// `+ foo/s?b/`. Before the dir-only unanchored gate landed, the
+/// synthetic `foo/*/**` descendant matched `foo/sub/file1` on the
+/// receiver single-path path (`set.allows`) and over-deleted.
+#[test]
+fn sibling_include_directory_keeps_its_children() {
+    let set = FilterSet::from_rules(exclude_lsh_rules()).expect("rules compile");
+
+    assert!(
+        set.allows(Path::new("foo/sub"), true),
+        "`+ foo/s?b/` must include foo/sub itself"
+    );
+    assert!(
+        set.allows(Path::new("foo/sub/file1"), false),
+        "`- foo/*/` must NOT synthesise `foo/*/**` descendants and over-exclude foo/sub/file1"
+    );
+    assert!(
+        set.allows(Path::new("foo/sub/.filt2"), false),
+        "`- foo/*/` must NOT block dotted children of foo/sub"
+    );
+}
+
+/// The dir-only unanchored gate is scoped to wildcard patterns only.
+/// Literal `- cache/` continues to exclude `cache/output.bin` via the
+/// existing descendant matcher because the receiver single-path API
+/// has no traversal context to fall back on.
+#[test]
+fn literal_dir_only_unanchored_pattern_keeps_descendant_semantics() {
+    let set = FilterSet::from_rules([FilterRule::exclude("cache/")]).expect("rules compile");
+
+    assert!(!set.allows(Path::new("cache"), true));
+    assert!(!set.allows(Path::new("cache/output.bin"), false));
+}
+
+/// `- foo/*/` must still hide directories that match the wildcard. The
+/// gate only suppresses synthetic descendants; the direct matcher on
+/// the pattern itself still fires for the directory entry.
+#[test]
+fn dir_only_unanchored_wildcard_still_matches_directory_entry() {
+    let set = FilterSet::from_rules([FilterRule::exclude("foo/*/")]).expect("rules compile");
+
+    // `foo/other` (a directory) IS matched by `foo/*/` directly.
+    assert!(!set.allows(Path::new("foo/other"), true));
+    // Children of the matched directory are reported allowed by the
+    // single-path API; upstream relies on the sender's traversal to
+    // skip the subtree, and the receiver's deletion path does the same
+    // via `allows_during_traversal`.
+    assert!(set.allows(Path::new("foo/other/file"), false));
+}
+
+/// Mirrors the upstream `**/node_modules/` idiom: directory-only,
+/// unanchored, leading `**` already supplies recursion. The gate must
+/// suppress the otherwise-synthesised `**/node_modules/**` descendant.
+#[test]
+fn double_star_prefix_dir_only_pattern_suppresses_descendants() {
+    let set =
+        FilterSet::from_rules([FilterRule::exclude("**/node_modules/")]).expect("rules compile");
+
+    assert!(!set.allows(Path::new("a/b/node_modules"), true));
+    // The directory's contents are NOT auto-excluded by a synthetic
+    // descendant; upstream emits no such rule.
+    assert!(set.allows(Path::new("a/b/node_modules/package.json"), false));
+}


### PR DESCRIPTION
## Summary

Refactor the descendant-suppression gate in `CompiledRule::new` so the directory-only unanchored wildcard case (`foo/*/`, `**/node_modules/`) is named explicitly rather than hidden inside the broader `has_glob_wildcard && (slash_anchored || directory_only)` condition. The new predicate `is_directory_only_unanchored_wildcard` is greppable, self-documenting, and pinned by dedicated wire-byte parity tests so a future refactor cannot silently re-introduce the synthetic `foo/*/**` descendant that upstream `exclude.c:rule_matches()` never emits (`FILTRULE_DIRECTORY`, line 938-939).

Adds wire-byte parity tests on the compiled-rule level that assert the exact direct- and descendant-matcher sets for `foo/*/`, `**/node_modules/`, and the negative literal `cache/` case, plus a new integration test that pins the upstream `exclude` / `exclude-lsh` exclude-from fixture so the sibling include `+ foo/s?b/` continues to keep `foo/sub/file1` instead of being stolen by `- foo/*/`.

Regression for UTS-DD-exclude.3 - the test surfaced as "Only in to: new" and "Only in to/foo: down" over-deletion in CI before PR #5880 landed; this change keeps the existing fix and locks the gate down behind an explicit predicate plus wire-byte assertions.

## Test plan

- [x] `cargo fmt --all` clean.
- [ ] CI: fmt+clippy.
- [ ] CI: nextest (stable).
- [ ] CI: Windows (stable).
- [ ] CI: macOS (stable).
- [ ] CI: Linux musl (stable).
- [ ] CI: interop suite (exclude / exclude-lsh upstream testsuite parity).

## Files

- `crates/filters/src/compiled/mod.rs` - explicit `is_directory_only_unanchored_wildcard` predicate plus three new compiled-level wire-byte parity tests.
- `crates/filters/tests/uts_dd_exclude_3_dir_only_unanchored.rs` (new) - integration tests over the upstream `exclude` / `exclude-lsh` exclude-from fixture.