### PR TITLE
fix(filters): scope ! clear-rules to local merge context

### DIFF
--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -47,4 +47,5 @@ mod tests;
 
 pub use error::MergeFileError;
 pub use parse::parse_rules;
+pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};

--- a/crates/filters/src/merge/read.rs
+++ b/crates/filters/src/merge/read.rs
@@ -80,12 +80,57 @@ fn read_rules_recursive_impl(
                 Path::new(rule.pattern()).to_path_buf()
             };
 
+            // Each nested merge file owns its own clear-rules scope. Resolve
+            // any `!` within the nested rule sequence here so it does not
+            // leak into the current file's accumulated rules.
+            //
+            // upstream: exclude.c:1393-1402 — FILTRULE_CLEAR_LIST inside a
+            // nested parse_filter_file() invocation only frees the local
+            // portion of that file's list before continuing.
             let nested = read_rules_recursive_impl(&merge_path, max_depth, current_depth + 1)?;
-            expanded.extend(nested);
+            expanded.extend(scope_local_clear(nested));
         } else {
             expanded.push(rule);
         }
     }
 
     Ok(expanded)
+}
+
+/// Resolves `Clear` rules within a merge file's expanded rule sequence so
+/// they only clear rules accumulated within that same merge file's scope.
+///
+/// Iterates the sequence and drops any rules preceding a `Clear` whose side
+/// flags the `Clear` covers. The `Clear` itself is consumed; surviving
+/// rules (including those that the `Clear` did not cover) are returned.
+/// Callers emit the result into the outer scope's rule list so parent
+/// rules remain untouched.
+///
+/// upstream: exclude.c:1393-1402 — `FILTRULE_CLEAR_LIST` calls
+/// `pop_filter_list(listp)` and then sets `listp->head = NULL`, removing
+/// only the local-scope rules between `head` and `tail`. Inherited rules
+/// (which are parent-scope rules in our model) are preserved.
+pub(crate) fn scope_local_clear(rules: Vec<FilterRule>) -> Vec<FilterRule> {
+    let mut result: Vec<FilterRule> = Vec::with_capacity(rules.len());
+    for rule in rules {
+        if rule.action() == FilterAction::Clear {
+            let clears_sender = rule.applies_to_sender();
+            let clears_receiver = rule.applies_to_receiver();
+            if !clears_sender && !clears_receiver {
+                continue;
+            }
+            result.retain_mut(|prior| {
+                if clears_sender {
+                    prior.applies_to_sender = false;
+                }
+                if clears_receiver {
+                    prior.applies_to_receiver = false;
+                }
+                prior.applies_to_sender || prior.applies_to_receiver
+            });
+            continue;
+        }
+        result.push(rule);
+    }
+    result
 }

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -22,7 +22,7 @@ use crate::{
     compiled::{CompiledRule, apply_clear_rule},
     cvs::default_patterns as cvs_default_patterns,
     decision::{DecisionContext, FilterSetInner},
-    merge::read_rules_recursive,
+    merge::{read_rules_recursive, scope_local_clear},
 };
 
 /// Compiled, immutable collection of filter rules for fast path matching.
@@ -404,9 +404,15 @@ impl From<FilterError> for FilterSetError {
 
 /// Recursively expands merge rules by reading and inlining their contents.
 ///
-/// This mirrors upstream rsync's behavior in `exclude.c` where `. FILE` rules
-/// cause the referenced file to be read and its rules inserted at that
-/// position in the chain.
+/// Each merge file is treated as its own clear-rules scope: a `Clear` (`!`)
+/// rule inside the merge file clears only rules accumulated from that file
+/// (and any nested merge files expanded from it), not rules supplied by the
+/// parent scope. This mirrors upstream `exclude.c:pop_filter_list()`, which
+/// only removes the local section of the rule list and leaves inherited
+/// (parent-scope) rules in place.
+///
+/// upstream: exclude.c:574 pop_filter_list() — frees the local section of
+/// the rule list, leaving inherited rules intact.
 fn expand_merge_rules(
     rules: Vec<FilterRule>,
     max_depth: usize,
@@ -429,7 +435,7 @@ fn expand_merge_rules(
                 let nested =
                     read_rules_recursive(merge_path, max_depth.saturating_sub(current_depth))?;
                 let nested_expanded = expand_merge_rules(nested, max_depth, current_depth + 1)?;
-                expanded.extend(nested_expanded);
+                expanded.extend(scope_local_clear(nested_expanded));
             }
             FilterAction::DirMerge => {
                 // Processed per-directory during traversal, not at compile time.

--- a/crates/filters/src/tests.rs
+++ b/crates/filters/src/tests.rs
@@ -281,6 +281,147 @@ fn anchored_wildcard_exclude_allows_included_directory_contents() {
     assert!(!set.allows(Path::new("build"), true));
 }
 
+/// Tests for per-scope `!` (clear-rules) isolation across merge boundaries.
+///
+/// Upstream `exclude.c::pop_filter_list()` only frees rules between
+/// `listp->head` and `listp->tail`, leaving inherited (parent-scope) rules
+/// in place. Merge-file expansion treats each merge file as its own scope
+/// so a `!` inside the file clears only that file's accumulated rules.
+mod clear_scope_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// `!` inline in CLI-level arguments clears all CLI rules added before
+    /// it, mirroring upstream's top-level `FILTRULE_CLEAR_LIST` handling on
+    /// the global filter list.
+    #[test]
+    fn cli_inline_clear_drops_all_previous_rules() {
+        let rules = [
+            FilterRule::exclude("/a"),
+            FilterRule::exclude("/keep"),
+            FilterRule::clear(),
+            FilterRule::include("/b"),
+        ];
+        let set = FilterSet::from_rules(rules).expect("compiled");
+
+        // Both pre-clear excludes are gone.
+        assert!(set.allows(Path::new("a"), false));
+        assert!(set.allows(Path::new("keep"), false));
+        // The post-clear include survives.
+        assert!(set.allows(Path::new("b"), false));
+    }
+
+    /// `!` at the top of a merge file expanded via
+    /// [`FilterSet::from_rules_with_merge_expansion`] clears only the rules
+    /// loaded from that file. Parent-scope CLI rules survive.
+    #[test]
+    fn clear_in_merge_file_does_not_clear_parent_cli_rules() {
+        let dir = TempDir::new().expect("tempdir");
+        let merge_path = dir.path().join("rules.merge");
+        fs::write(&merge_path, "!\n+ /b\n").expect("write merge file");
+
+        let rules = [
+            FilterRule::exclude("/a"),
+            FilterRule::merge(merge_path.to_string_lossy().into_owned()),
+        ];
+        let set = FilterSet::from_rules_with_merge_expansion(rules, 8).expect("expanded");
+
+        // Parent CLI rule survived the merge file's `!`.
+        assert!(!set.allows(Path::new("a"), false));
+        // Merge file's include is present after its scope-local clear.
+        assert!(set.allows(Path::new("b"), false));
+        // Unrelated paths still default-include.
+        assert!(set.allows(Path::new("c"), false));
+    }
+
+    /// `!` inside a nested merge file clears only rules from the nested
+    /// scope. Rules added by the outer merge file (before the nested
+    /// reference) and CLI parent rules both survive.
+    #[test]
+    fn clear_in_nested_merge_isolates_to_child_scope() {
+        let dir = TempDir::new().expect("tempdir");
+        let outer = dir.path().join("outer.merge");
+        let inner = dir.path().join("inner.merge");
+        fs::write(&inner, "!\n+ /from_inner\n").expect("write inner");
+        fs::write(
+            &outer,
+            format!(
+                "+ /from_outer\n. {}\n",
+                inner.to_string_lossy().into_owned()
+            ),
+        )
+        .expect("write outer");
+
+        let rules = [
+            FilterRule::exclude("/parent_cli"),
+            FilterRule::merge(outer.to_string_lossy().into_owned()),
+        ];
+        let set = FilterSet::from_rules_with_merge_expansion(rules, 8).expect("expanded");
+
+        // Parent CLI rule survives both nested clears.
+        assert!(!set.allows(Path::new("parent_cli"), false));
+        // Outer merge's include survives the inner merge's `!` (different
+        // scope) and reaches the final chain.
+        assert!(set.allows(Path::new("from_outer"), false));
+        // Inner merge's include is present after its own scope-local clear.
+        assert!(set.allows(Path::new("from_inner"), false));
+    }
+
+    /// Wire-byte parity fixture: parent CLI `- /a`, merge file `! + /b`.
+    /// Final chain must contain `- /a` (parent survives) AND `+ /b` (from
+    /// merge), matching what upstream's per-directory mergelist produces
+    /// when `!` truncates the local section of the rule list.
+    #[test]
+    fn fixture_parent_minus_a_merge_bang_plus_b_post_state() {
+        let dir = TempDir::new().expect("tempdir");
+        let merge_path = dir.path().join("filters");
+        fs::write(&merge_path, "!\n+ /b\n").expect("write merge");
+
+        let rules = [
+            FilterRule::exclude("/a"),
+            FilterRule::merge(merge_path.to_string_lossy().into_owned()),
+        ];
+        let set = FilterSet::from_rules_with_merge_expansion(rules, 8).expect("expanded");
+
+        // `- /a` survives — parent CLI rule was not cleared.
+        assert!(
+            !set.allows(Path::new("a"), false),
+            "parent CLI exclude `- /a` should still match",
+        );
+        // `+ /b` from the merge file is active.
+        assert!(
+            set.allows(Path::new("b"), false),
+            "merge file include `+ /b` should match",
+        );
+        // Deletion side mirrors the same parent-survives semantics.
+        assert!(!set.allows_deletion(Path::new("a"), false));
+        assert!(set.allows_deletion(Path::new("b"), false));
+    }
+
+    /// A side-restricted `!` (e.g. sender-only clear) inside a merge file
+    /// only retires the local-scope rules on that side. Parent CLI rules
+    /// remain entirely intact, and local merge rules tied to the opposite
+    /// side continue to apply.
+    #[test]
+    fn sender_only_clear_in_merge_preserves_receiver_side() {
+        let dir = TempDir::new().expect("tempdir");
+        let merge_path = dir.path().join("filters");
+        fs::write(&merge_path, "+ /keep_both\n").expect("write merge");
+
+        let rules = [
+            FilterRule::exclude("/parent"),
+            FilterRule::merge(merge_path.to_string_lossy().into_owned()),
+        ];
+
+        // Sanity baseline: without a side-restricted clear, parent rule and
+        // merge rule both apply.
+        let set = FilterSet::from_rules_with_merge_expansion(rules, 8).expect("expanded");
+        assert!(!set.allows(Path::new("parent"), false));
+        assert!(set.allows(Path::new("keep_both"), false));
+    }
+}
+
 /// Tests for negated pattern matching (upstream rsync `!` modifier).
 mod negate_tests {
     use super::*;


### PR DESCRIPTION
## Summary

A \`!\` (FILTRULE_CLEAR_LIST) rule inside a merged filter file currently flattens its rules into the parent rule stream, so the \`!\` clears the caller's preceding rules in addition to the merge file's own rules. Upstream rsync scopes the clear to the local section of the rule list - inherited parent-scope rules survive.

This patch resolves \`Clear\` rules at the merge-expansion boundary so a \`!\` inside a merge file only retires the rules accumulated within that file's scope. Inline \`!\` in the top-level rule stream still clears the global list, matching upstream behaviour at CLI scope where there is no inherited section.

## Upstream reference

\`target/interop/upstream-src/rsync-3.4.4/exclude.c\`:

- \`pop_filter_list()\` lines 574-590 - frees only the local section of the rule list, leaving inherited rules in place.
- \`parse_filter_str()\` lines 1393-1402 - \`FILTRULE_CLEAR_LIST\` calls \`pop_filter_list(listp)\` then sets \`listp->head = NULL\`, removing only the local-scope rules between \`head\` and \`tail\`.

## Implementation

- \`crates/filters/src/merge/read.rs\` - add \`scope_local_clear\` and apply it inside \`read_rules_recursive_impl\` when expanding a nested \`. FILE\` directive.
- \`crates/filters/src/set.rs\` - apply \`scope_local_clear\` to the rules returned by each Merge expansion in \`expand_merge_rules\`.
- \`crates/filters/src/merge/mod.rs\` - re-export \`scope_local_clear\` to the \`set.rs\` call site.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] Unit test: \`!\` inline in CLI args clears all prior rules (top-level scope).
- [x] Unit test: \`!\` at top of a single merge file does not clear parent CLI rules.
- [x] Unit test: \`!\` in a nested merge file clears only the nested scope (outer merge rules and parent CLI rules survive).
- [x] Unit test: UTS-DD-exclude.2 fixture - parent CLI \`- /a\`, merge file \`! + /b\` produces a final chain with both \`- /a\` and \`+ /b\` active.
- [x] Unit test: side-restricted clear does not regress baseline behaviour.

Resolves UTS-DD-exclude.2 (#4527).