### PR TITLE
fix(batch): emit BATCH.sh wrapper with invoking binary path

### DIFF
--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -379,6 +379,18 @@ pub struct BatchConfig {
     /// Used to initialize the rolling checksum algorithm. Must match
     /// between writer and reader for checksums to validate correctly.
     pub checksum_seed: i32,
+
+    /// Binary name or path written to the replay script as the executable
+    /// to invoke for `--read-batch`.
+    ///
+    /// Mirrors upstream rsync's `batch.c:259` which writes `raw_argv[0]`
+    /// literally - the exact invocation path the user passed on the
+    /// command line. Defaults to `"oc-rsync"` when not set, which only
+    /// works if `oc-rsync` is resolvable on `PATH`. Callers that invoke
+    /// the binary by absolute path (test harnesses, CI) should set this
+    /// to the absolute path so the generated `BATCH.sh` runs without
+    /// requiring `PATH` setup.
+    pub invoker: String,
 }
 
 impl BatchConfig {
@@ -417,7 +429,7 @@ impl BatchConfig {
     ///
     /// - Protocol >= 30: `compat_flags` is initialized to `Some(0)`
     /// - Protocol < 30: `compat_flags` is `None`
-    pub const fn new(mode: BatchMode, batch_path: String, protocol_version: i32) -> Self {
+    pub fn new(mode: BatchMode, batch_path: String, protocol_version: i32) -> Self {
         Self {
             mode,
             batch_path,
@@ -428,6 +440,7 @@ impl BatchConfig {
                 None
             },
             checksum_seed: 0,
+            invoker: String::from("oc-rsync"),
         }
     }
 
@@ -472,6 +485,30 @@ impl BatchConfig {
     /// ```
     pub const fn with_checksum_seed(mut self, seed: i32) -> Self {
         self.checksum_seed = seed;
+        self
+    }
+
+    /// Set the binary name or path to embed in the replay shell script.
+    ///
+    /// Mirrors upstream rsync's `batch.c:259` which writes `raw_argv[0]`
+    /// literally to the generated `BATCH.sh`. Pass the path the user
+    /// originally invoked (`std::env::args_os().next()`) so the script
+    /// runs without requiring `PATH` setup. When invoked by absolute
+    /// path, this preserves that path; when invoked by bare name, the
+    /// generated script also uses the bare name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use batch::{BatchConfig, BatchMode};
+    ///
+    /// let config = BatchConfig::new(BatchMode::Write, "/tmp/batch".to_string(), 31)
+    ///     .with_invoker("/usr/local/bin/oc-rsync");
+    ///
+    /// assert_eq!(config.invoker, "/usr/local/bin/oc-rsync");
+    /// ```
+    pub fn with_invoker(mut self, invoker: impl Into<String>) -> Self {
+        self.invoker = invoker.into();
         self
     }
 

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -51,8 +51,11 @@ pub fn generate_script_with_filters(
         ))
     })?;
 
-    // upstream: write_batch_shell_file() writes the command without a shebang
-    write!(file, "oc-rsync")?;
+    // upstream: batch.c:259 - write_arg(raw_argv[0]) - the exact binary the
+    // user invoked. Without this, the generated BATCH.sh fails with
+    // "command not found" when oc-rsync is not on PATH (e.g. test harnesses
+    // and CI that invoke via absolute path).
+    write!(file, "{}", shell_quote(&config.invoker))?;
 
     // upstream: batch.c:262-267 - embed filter option before --read-batch
     // so the heredoc at the end of the script feeds rules into stdin
@@ -315,6 +318,80 @@ mod tests {
         );
         assert!(content.contains("--read-batch="));
         assert!(content.contains("oc-rsync"));
+    }
+
+    /// Verify the script embeds an absolute invoker path verbatim.
+    ///
+    /// Upstream `batch.c:259` writes `raw_argv[0]` literally so the replay
+    /// script works regardless of `PATH`. The CI testsuite invokes oc-rsync
+    /// by absolute path, so the generated BATCH.sh must also use the
+    /// absolute path - otherwise the wrapper script fails with
+    /// `oc-rsync: command not found`.
+    #[test]
+    fn test_generate_script_embeds_absolute_invoker_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+        let absolute_invoker = "/home/runner/work/rsync/rsync/target/release/oc-rsync";
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        )
+        .with_invoker(absolute_invoker);
+
+        generate_script(&config).unwrap();
+
+        let content = fs::read_to_string(config.script_file_path()).unwrap();
+        let first_line = content.lines().next().expect("script must have content");
+        assert!(
+            first_line.starts_with(absolute_invoker),
+            "wrapper script must start with the configured invoker path \
+             (matches upstream batch.c:259 raw_argv[0]); got: {first_line}"
+        );
+        assert!(first_line.contains("--read-batch="));
+    }
+
+    /// Verify shell-unsafe characters in the invoker get quoted.
+    #[test]
+    fn test_generate_script_quotes_invoker_with_spaces() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        )
+        .with_invoker("/path with spaces/oc-rsync");
+
+        generate_script(&config).unwrap();
+
+        let content = fs::read_to_string(config.script_file_path()).unwrap();
+        assert!(
+            content.starts_with("'/path with spaces/oc-rsync'"),
+            "invoker with spaces must be single-quoted: {content}"
+        );
+    }
+
+    /// Verify the default invoker is the bare `oc-rsync` name for
+    /// backwards-compatible callers that don't configure one.
+    #[test]
+    fn test_generate_script_default_invoker_is_bare_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+        assert_eq!(config.invoker, "oc-rsync");
+
+        generate_script(&config).unwrap();
+
+        let content = fs::read_to_string(config.script_file_path()).unwrap();
+        assert!(content.starts_with("oc-rsync "));
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -561,11 +561,21 @@ where
         timestamp ^ (pid << 6)
     };
 
+    // upstream: batch.c:259 - write_arg(raw_argv[0]) writes the exact binary
+    // path the user invoked into the generated BATCH.sh. Mirror that by
+    // capturing argv[0] now so the replay script does not require oc-rsync
+    // on PATH (e.g. test harnesses and CI invoke by absolute path).
+    let invoker = std::env::args_os()
+        .next()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| String::from("oc-rsync"));
+
     let batch_config = if let Some(ref path) = write_batch {
         Some(
             BatchConfig::new(BatchMode::Write, path.to_string_lossy().into_owned(), 32)
                 .with_compat_flags(local_batch_compat_flags)
-                .with_checksum_seed(batch_checksum_seed),
+                .with_checksum_seed(batch_checksum_seed)
+                .with_invoker(invoker.clone()),
         )
     } else if let Some(ref path) = only_write_batch {
         Some(
@@ -575,7 +585,8 @@ where
                 32,
             )
             .with_compat_flags(local_batch_compat_flags)
-            .with_checksum_seed(batch_checksum_seed),
+            .with_checksum_seed(batch_checksum_seed)
+            .with_invoker(invoker.clone()),
         )
     } else {
         read_batch


### PR DESCRIPTION
## Summary

- Upstream rsync's `batch.c:259` writes `raw_argv[0]` literally into the generated `BATCH.sh` so the replay script works regardless of `PATH`. oc-rsync was hardcoding the bare name `oc-rsync` into the wrapper, which fails with `./BATCH.sh: line 1: oc-rsync: command not found` (exit 127) when the binary is invoked by absolute path - notably from the upstream testsuite and from CI.
- Add an `invoker` field to `BatchConfig` (defaulting to `"oc-rsync"` for backward compatibility) and a `with_invoker` builder method. The CLI workflow captures `std::env::args_os().next()` and threads it into the `BatchConfig` for both `--write-batch` and `--only-write-batch` modes.
- `generate_script_with_filters` now writes `config.invoker` through `shell_quote` so paths with spaces are safely single-quoted.

## CI failure reproduced

CI run [27711564454](https://github.com/oferchen/rsync/actions/runs/27711564454) on master HEAD `f5821c3b5` failed the upstream-testsuite `batch-mode` test at the `BATCH.sh use of --read-batch` step:

```
Test BATCH.sh use of --read-batch: Running: "./BATCH.sh"
./BATCH.sh: line 1: oc-rsync: command not found
Failed:  status=127 dir-diff file-diff
```

The runner invokes the binary by absolute path (`/home/runner/work/rsync/rsync/target/release/oc-rsync`), so the generated wrapper that referenced bare `oc-rsync` could not be resolved through `PATH`.

## Upstream reference

`target/interop/upstream-src/rsync-3.4.4/batch.c:259`:

```c
/* Write argvs info to BATCH.sh file */
err |= write_arg(raw_argv[0]);
```

Upstream writes the literal invocation path the user passed on the command line. This change mirrors that behavior.

## Test plan

- [x] New unit test `test_generate_script_embeds_absolute_invoker_path` exercises the failure mode by configuring an absolute invoker and asserting the wrapper starts with that path.
- [x] New unit test `test_generate_script_quotes_invoker_with_spaces` covers shell-safe quoting of paths with spaces.
- [x] New unit test `test_generate_script_default_invoker_is_bare_name` pins the backward-compatible default for callers that don't configure an invoker.
- [x] The existing `test_generate_script` continues to assert the script contains `oc-rsync`, validating that the default path is preserved.
- [x] Upstream testsuite `batch-mode` should now pass the `BATCH.sh use of --read-batch` phase that was failing with `command not found`.