### PR TITLE
fix(transfer): keep --files-from entries relative under SSH push

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -59,7 +59,10 @@ pub(crate) fn run_pull_transfer(
     // local file or stdin, the client reads the file list locally and forwards
     // it to the daemon's generator over the protocol stream.
     if config.files_from().is_local_forwarded() {
-        let data = read_files_from_for_forwarding(config)?;
+        let data =
+            crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding(
+                config,
+            )?;
         server_config.connection.files_from_data = Some(data);
     }
 
@@ -260,70 +263,12 @@ impl TransferProgressCallback for DaemonProgressAdapter<'_> {
 /// Reads the `--files-from` source and serializes it into the wire format
 /// for forwarding to a remote daemon.
 ///
-/// Handles both `Stdin` (reads from standard input) and `LocalFile` (reads
-/// from the given path). The output is NUL-separated filenames terminated
-/// by a double-NUL sentinel, matching the format expected by
-/// [`protocol::read_files_from_stream`] on the remote side.
-///
-/// The `--from0` flag controls whether the input is already NUL-delimited.
+/// Re-export of the shared helper - see
+/// [`crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding`]
+/// for the implementation.
 ///
 /// # Upstream Reference
 ///
 /// - `io.c:forward_filesfrom_data()` - reads from local fd, writes to socket
 /// - `main.c:1354-1356` - `start_filesfrom_forwarding(filesfrom_fd)`
-pub(super) fn read_files_from_for_forwarding(
-    config: &ClientConfig,
-) -> Result<Vec<u8>, ClientError> {
-    use crate::client::config::FilesFromSource;
-
-    let eol_nulls = config.from0();
-    // upstream: compat.c:799-806 - filesfrom_convert is set when
-    // protect_args && files_from && (am_sender ? ic_send : ic_recv) != -1.
-    // For pull, this peer is the receiver writing to the wire; the converter
-    // transcodes from local charset to the UTF-8 wire encoding.
-    let iconv_converter = if config.protect_args().unwrap_or(false) {
-        config.iconv().resolve_converter()
-    } else {
-        None
-    };
-    let mut wire_data = Vec::new();
-
-    match config.files_from() {
-        FilesFromSource::Stdin => {
-            let stdin = std::io::stdin();
-            let mut reader = stdin.lock();
-            protocol::forward_files_from(
-                &mut reader,
-                &mut wire_data,
-                eol_nulls,
-                iconv_converter.as_ref(),
-            )
-            .map_err(|e| {
-                invalid_argument_error(&format!("failed to read --files-from stdin: {e}"), 23)
-            })?;
-        }
-        FilesFromSource::LocalFile(path) => {
-            let mut file = std::fs::File::open(path).map_err(|e| {
-                invalid_argument_error(
-                    &format!("failed to open --files-from {}: {e}", path.display()),
-                    23,
-                )
-            })?;
-            protocol::forward_files_from(
-                &mut file,
-                &mut wire_data,
-                eol_nulls,
-                iconv_converter.as_ref(),
-            )
-            .map_err(|e| {
-                invalid_argument_error(
-                    &format!("failed to read --files-from {}: {e}", path.display()),
-                    23,
-                )
-            })?;
-        }
-        FilesFromSource::None | FilesFromSource::RemoteFile(_) => {}
-    }
-
-    Ok(wire_data)
-}
+pub(super) use crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding as read_files_from_for_forwarding;

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -271,4 +271,5 @@ impl TransferProgressCallback for DaemonProgressAdapter<'_> {
 ///
 /// - `io.c:forward_filesfrom_data()` - reads from local fd, writes to socket
 /// - `main.c:1354-1356` - `start_filesfrom_forwarding(filesfrom_fd)`
+#[cfg(test)]
 pub(super) use crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding as read_files_from_for_forwarding;

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -166,6 +166,16 @@ fn run_embedded_pull(
         )?;
     server_config.stop_at = config.stop_at();
 
+    // upstream: main.c:1372-1375 - pull with a local --files-from forwards the
+    // file's bytes back to the remote sender via the protocol stream.
+    if config.files_from().is_local_forwarded() {
+        let data =
+            crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding(
+                config,
+            )?;
+        server_config.connection.files_from_data = Some(data);
+    }
+
     let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
 
     run_transfer_over_embedded_ssh(
@@ -479,10 +489,16 @@ fn build_server_config_for_receiver(
 }
 
 /// Builds server configuration for generator role (push transfer).
+///
+/// Mirrors `ssh_transfer::build_server_config_for_generator`: the sender wires
+/// `--files-from` so the file list is built from the requested entry list, not
+/// from a recursive walk of the source operand.
 fn build_server_config_for_generator(
     config: &ClientConfig,
     local_paths: &[String],
 ) -> Result<ServerConfig, ClientError> {
+    use crate::client::config::FilesFromSource;
+
     let flag_string = flags::build_server_flag_string(config);
     let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
 
@@ -493,6 +509,26 @@ fn build_server_config_for_generator(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+
+    // upstream: options.c:2473,2501 / main.c:1322-1328 - the sender opens the
+    // local files-from file (Stdin/LocalFile) or reads from the wire when the
+    // list is hosted on the remote receiver (RemoteFile).
+    match config.files_from() {
+        FilesFromSource::None => {}
+        FilesFromSource::Stdin => {
+            server_config.file_selection.files_from_path = Some("-".to_owned());
+            server_config.file_selection.from0 = config.from0();
+        }
+        FilesFromSource::LocalFile(path) => {
+            server_config.file_selection.files_from_path =
+                Some(path.to_string_lossy().into_owned());
+            server_config.file_selection.from0 = config.from0();
+        }
+        FilesFromSource::RemoteFile(_) => {
+            server_config.file_selection.files_from_path = Some("-".to_owned());
+            server_config.file_selection.from0 = true;
+        }
+    }
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/files_from_forwarding.rs
+++ b/crates/core/src/client/remote/files_from_forwarding.rs
@@ -1,0 +1,77 @@
+//! Helper for serializing a local `--files-from` source into the wire-format
+//! byte stream consumed by [`protocol::read_files_from_stream`].
+//!
+//! Used by both daemon-transfer pull and SSH-transfer pull paths when the
+//! client (receiver) must forward a local file list to the remote sender.
+//!
+//! # Upstream Reference
+//!
+//! - `io.c:forward_filesfrom_data()` - reads from local fd, writes to socket
+//! - `main.c:1191-1198,1372-1375` - `start_filesfrom_forwarding(filesfrom_fd)`
+
+use crate::client::config::{ClientConfig, FilesFromSource};
+use crate::client::error::{ClientError, invalid_argument_error};
+
+/// Reads the `--files-from` source and serializes it into the wire format
+/// for forwarding to a remote peer.
+///
+/// Handles both `Stdin` (reads from standard input) and `LocalFile` (reads
+/// from the given path). The output is NUL-separated filenames terminated
+/// by a double-NUL sentinel, matching the format expected by
+/// [`protocol::read_files_from_stream`] on the remote side. Returns an empty
+/// `Vec` for sources that do not require local forwarding (`None`,
+/// `RemoteFile`).
+pub(crate) fn read_local_files_from_for_forwarding(
+    config: &ClientConfig,
+) -> Result<Vec<u8>, ClientError> {
+    let eol_nulls = config.from0();
+    // upstream: compat.c:799-806 - filesfrom_convert is set when
+    // protect_args && files_from && (am_sender ? ic_send : ic_recv) != -1.
+    // For pull, this peer is the receiver writing to the wire; the converter
+    // transcodes from local charset to the UTF-8 wire encoding.
+    let iconv_converter = if config.protect_args().unwrap_or(false) {
+        config.iconv().resolve_converter()
+    } else {
+        None
+    };
+    let mut wire_data = Vec::new();
+
+    match config.files_from() {
+        FilesFromSource::Stdin => {
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            protocol::forward_files_from(
+                &mut reader,
+                &mut wire_data,
+                eol_nulls,
+                iconv_converter.as_ref(),
+            )
+            .map_err(|e| {
+                invalid_argument_error(&format!("failed to read --files-from stdin: {e}"), 23)
+            })?;
+        }
+        FilesFromSource::LocalFile(path) => {
+            let mut file = std::fs::File::open(path).map_err(|e| {
+                invalid_argument_error(
+                    &format!("failed to open --files-from {}: {e}", path.display()),
+                    23,
+                )
+            })?;
+            protocol::forward_files_from(
+                &mut file,
+                &mut wire_data,
+                eol_nulls,
+                iconv_converter.as_ref(),
+            )
+            .map_err(|e| {
+                invalid_argument_error(
+                    &format!("failed to read --files-from {}: {e}", path.display()),
+                    23,
+                )
+            })?;
+        }
+        FilesFromSource::None | FilesFromSource::RemoteFile(_) => {}
+    }
+
+    Ok(wire_data)
+}

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -479,16 +479,31 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--log-format=%i"));
         }
 
-        // upstream: options.c:2944-2956 - --files-from forwarding. When the
-        // file is local (or stdin), the client reads it and forwards content
-        // over the socket, so we tell the server `--files-from=- --from0`.
-        // When the file is remote, we send `--files-from=<path>` and
-        // optionally `--from0`.
+        // upstream: options.c:2962-2974 - `if (files_from && (!am_sender ||
+        // filesfrom_host))`. The server-side `--files-from` arg is only added
+        // when we are NOT the sender (i.e. local is receiver, doing pull) OR
+        // the files-from spec was a hostspec (remote filelist).
+        //
+        // - PUSH with local filelist: local sender reads the list locally and
+        //   walks accordingly; the remote receiver gets no `--files-from`.
+        // - PUSH with remote filelist: remote receiver opens the file and
+        //   forwards its bytes back to the local sender (main.c:1191-1198).
+        // - PULL with local filelist: local receiver forwards the file bytes
+        //   on the wire; remote sender reads from `--files-from=-`.
+        // - PULL with remote filelist: remote sender opens the file via
+        //   `--files-from=<path>`.
+        //
+        // `RemoteRole::Sender` here means the local process is the sender
+        // (PUSH); `RemoteRole::Receiver` means the local process is the
+        // receiver (PULL).
+        let local_is_sender = self.role == RemoteRole::Sender;
         match self.config.files_from() {
             FilesFromSource::None => {}
             FilesFromSource::LocalFile(_) | FilesFromSource::Stdin => {
-                args.push(OsString::from("--files-from=-"));
-                args.push(OsString::from("--from0"));
+                if !local_is_sender {
+                    args.push(OsString::from("--files-from=-"));
+                    args.push(OsString::from("--from0"));
+                }
             }
             FilesFromSource::RemoteFile(path) => {
                 args.push(OsString::from(format!("--files-from={path}")));

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -3103,3 +3103,122 @@ fn remote_option_short_flag_forwarded_verbatim() {
         "expected short flag -v from -M in args: {args:?}"
     );
 }
+
+/// SSH push with a local `--files-from` must NOT forward the option to the
+/// remote receiver. Upstream's `options.c:2962` gate
+/// `if (files_from && (!am_sender || filesfrom_host))` skips emission when
+/// the client is the sender and the list lives locally. The local sender
+/// reads the file directly to build the file list; emitting
+/// `--files-from=-` would make the remote receiver wait for entries that
+/// the sender's main loop never forwards.
+#[test]
+fn push_with_local_files_from_omits_remote_arg() {
+    use crate::client::config::FilesFromSource;
+    use std::path::PathBuf;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::LocalFile(PathBuf::from("/tmp/list.txt")))
+        .build();
+    // RemoteRole::Sender == local is sender (push).
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let args = builder.build("/remote/dest");
+
+    assert!(
+        !args.iter().any(|a| {
+            let s = a.to_string_lossy();
+            s.starts_with("--files-from")
+        }),
+        "PUSH with local files-from must not send --files-from to the remote: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--from0"),
+        "PUSH with local files-from must not send --from0 to the remote: {args:?}"
+    );
+}
+
+/// SSH push with `--files-from=-` (stdin) is treated identically to a local
+/// file source: the local sender consumes stdin to build the list and the
+/// remote receiver gets no `--files-from` arg.
+#[test]
+fn push_with_stdin_files_from_omits_remote_arg() {
+    use crate::client::config::FilesFromSource;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::Stdin)
+        .from0(true)
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let args = builder.build("/remote/dest");
+
+    assert!(
+        !args.iter().any(|a| {
+            let s = a.to_string_lossy();
+            s.starts_with("--files-from")
+        }),
+        "PUSH with stdin files-from must not send --files-from to the remote: {args:?}"
+    );
+}
+
+/// SSH push with a remote-hosted `--files-from` (`host:path` or `:path`)
+/// forwards the path to the remote receiver, which opens the file and
+/// forwards its bytes back over the wire via `start_filesfrom_forwarding`.
+#[test]
+fn push_with_remote_files_from_forwards_path() {
+    use crate::client::config::FilesFromSource;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::RemoteFile("/remote/list.txt".to_owned()))
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
+    let args = builder.build("/remote/dest");
+
+    assert!(
+        args.iter()
+            .any(|a| a.to_string_lossy() == "--files-from=/remote/list.txt"),
+        "PUSH with remote files-from must forward the path to the remote: {args:?}"
+    );
+}
+
+/// SSH pull with a local `--files-from` must forward `--files-from=- --from0`
+/// to the remote sender, which reads filenames from the wire. The receiver
+/// (us) forwards the file's bytes after sending the filter list.
+#[test]
+fn pull_with_local_files_from_sends_files_from_stdin_to_remote() {
+    use crate::client::config::FilesFromSource;
+    use std::path::PathBuf;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::LocalFile(PathBuf::from("/tmp/list.txt")))
+        .build();
+    // RemoteRole::Receiver == local is receiver (pull).
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/source");
+
+    assert!(
+        args.iter().any(|a| a == "--files-from=-"),
+        "PULL with local files-from must forward --files-from=- to the remote: {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--from0"),
+        "PULL with local files-from must forward --from0 to the remote: {args:?}"
+    );
+}
+
+/// SSH pull with a remote-hosted `--files-from` forwards the absolute path
+/// (matching upstream `options.c:2964 safe_arg("", files_from)`).
+#[test]
+fn pull_with_remote_files_from_forwards_path() {
+    use crate::client::config::FilesFromSource;
+
+    let config = ClientConfig::builder()
+        .files_from(FilesFromSource::RemoteFile("/remote/list.txt".to_owned()))
+        .build();
+    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver);
+    let args = builder.build("/remote/source");
+
+    assert!(
+        args.iter()
+            .any(|a| a.to_string_lossy() == "--files-from=/remote/list.txt"),
+        "PULL with remote files-from must forward the path to the remote: {args:?}"
+    );
+}

--- a/crates/core/src/client/remote/mod.rs
+++ b/crates/core/src/client/remote/mod.rs
@@ -28,6 +28,7 @@ pub mod daemon_transfer;
 /// Embedded SSH transfer orchestration using the russh library.
 #[cfg(feature = "embedded-ssh")]
 pub mod embedded_ssh_transfer;
+pub(crate) mod files_from_forwarding;
 pub(crate) mod flags;
 /// Remote rsync `--server` invocation argument builder.
 pub mod invocation;

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -32,6 +32,7 @@ use super::super::config::ClientConfig;
 use super::super::error::{ClientError, invalid_argument_error, invalid_argument_error_typed};
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
+use super::files_from_forwarding::read_local_files_from_for_forwarding;
 use super::flags;
 use super::invocation::{
     RemoteInvocationBuilder, RemoteOperands, RemoteRole, TransferSpec, determine_transfer_role,
@@ -358,6 +359,16 @@ fn run_pull_transfer(
         )?;
     server_config.stop_at = config.stop_at();
 
+    // upstream: main.c:1372-1375 - when pulling with --files-from pointing to a
+    // local file or stdin, the receiver reads the file list locally and
+    // forwards its bytes back to the remote sender via
+    // `start_filesfrom_forwarding(filesfrom_fd)`. The remote sender consumes
+    // the forwarded bytes through its protocol stream.
+    if config.files_from().is_local_forwarded() {
+        let data = read_local_files_from_for_forwarding(config)?;
+        server_config.connection.files_from_data = Some(data);
+    }
+
     let batch_ctx = batch_writer.map(|bw| build_batch_context(config, bw));
 
     let start = Instant::now();
@@ -679,6 +690,19 @@ pub(super) fn build_server_config_for_receiver(
 }
 
 /// Builds server configuration for generator role (push transfer).
+///
+/// Propagates `--files-from` plumbing for the local sender (generator) so the
+/// file list is built from the requested entry list rather than the source
+/// directory's full tree walk.
+///
+/// # Upstream Reference
+///
+/// - `options.c:2465-2510` - the sender opens a local files-from file (or
+///   sets up filesfrom_fd for remote/stdin sources).
+/// - `flist.c:2275-2298` - `send_file_list()` chdirs to `argv[0]` then reads
+///   filenames from `filesfrom_fd` to emit the file list.
+/// - `main.c:1322-1328` - when `filesfrom_host` is non-NULL, the sender
+///   wires `filesfrom_fd = f_in` so the remote forwards bytes via the wire.
 pub(super) fn build_server_config_for_generator(
     config: &ClientConfig,
     local_paths: &[String],
@@ -696,8 +720,51 @@ pub(super) fn build_server_config_for_generator(
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
 
+    apply_files_from_for_sender(config, &mut server_config);
+
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
+}
+
+/// Wires `--files-from` into a sender (`Generator`) server configuration.
+///
+/// The local sender resolves entries relative to `argv[0]` (the first transfer
+/// operand) and emits a file list constrained to those entries instead of
+/// walking the entire source tree. Without this wiring the generator would
+/// recurse the absolute source directory and (under `--relative`, implied by
+/// `--files-from`) mirror its absolute path on the destination - the exact
+/// failure mode that surfaces in the upstream `files-from.test` SSH-push
+/// invocation.
+///
+/// # Upstream Reference
+///
+/// - `options.c:2473` - `filesfrom_fd = 0` for `--files-from=-` (stdin).
+/// - `options.c:2501` - `filesfrom_fd = open(files_from, O_RDONLY|O_BINARY)`
+///   for local files.
+/// - `main.c:1322-1328` - remote files-from wires `filesfrom_fd = f_in` after
+///   `setup_protocol()`; the remote receiver forwards the list bytes over the
+///   wire via `start_filesfrom_forwarding`.
+fn apply_files_from_for_sender(config: &ClientConfig, server_config: &mut ServerConfig) {
+    use super::super::config::FilesFromSource;
+    match config.files_from() {
+        FilesFromSource::None => {}
+        FilesFromSource::Stdin => {
+            server_config.file_selection.files_from_path = Some("-".to_owned());
+            server_config.file_selection.from0 = config.from0();
+        }
+        FilesFromSource::LocalFile(path) => {
+            server_config.file_selection.files_from_path =
+                Some(path.to_string_lossy().into_owned());
+            server_config.file_selection.from0 = config.from0();
+        }
+        FilesFromSource::RemoteFile(_) => {
+            // The remote receiver opens the file and forwards its bytes back
+            // to us; the generator reads them as if they came from stdin.
+            // upstream: main.c:1191-1198 start_filesfrom_forwarding(filesfrom_fd)
+            server_config.file_selection.files_from_path = Some("-".to_owned());
+            server_config.file_selection.from0 = true;
+        }
+    }
 }
 
 /// Returns `true` when both rsync wire compression and SSH stream
@@ -770,6 +837,97 @@ mod tests {
         assert_eq!(server_config.args.len(), 2);
         assert_eq!(server_config.args[0], "file1.txt");
         assert_eq!(server_config.args[1], "file2.txt");
+    }
+
+    /// UTS files-from SSH push regression: the local sender (Generator) must
+    /// learn the local `--files-from` path so its generator reads entry names
+    /// from the requested list instead of recursing the source operand and
+    /// (under implied `--relative`) mirroring its absolute path on the
+    /// destination.
+    ///
+    /// upstream: `options.c:2501 filesfrom_fd = open(files_from, ...)`,
+    /// `flist.c:2275-2298` send_file_list() walking the open fd.
+    #[test]
+    fn generator_config_sets_files_from_path_for_local_file_push() {
+        use super::super::super::config::FilesFromSource;
+        use std::path::PathBuf;
+
+        let list_path = PathBuf::from("/tmp/filelist.txt");
+        let config = ClientConfig::builder()
+            .files_from(FilesFromSource::LocalFile(list_path.clone()))
+            .build();
+
+        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
+            .expect("generator config builds");
+
+        assert_eq!(
+            server_config.file_selection.files_from_path.as_deref(),
+            Some(list_path.to_string_lossy().as_ref()),
+            "SSH push must point the local generator at the local --files-from \
+             file so entries are emitted with relative wire-side names"
+        );
+    }
+
+    /// SSH push with stdin-sourced `--files-from`: the local sender reads
+    /// filenames from its standard input. The transfer crate signals this with
+    /// the sentinel path "-" mirroring upstream's `options.c:2473
+    /// filesfrom_fd = 0` assignment.
+    #[test]
+    fn generator_config_sets_files_from_path_for_stdin_push() {
+        use super::super::super::config::FilesFromSource;
+
+        let config = ClientConfig::builder()
+            .files_from(FilesFromSource::Stdin)
+            .from0(true)
+            .build();
+
+        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
+            .expect("generator config builds");
+
+        assert_eq!(
+            server_config.file_selection.files_from_path.as_deref(),
+            Some("-")
+        );
+        assert!(server_config.file_selection.from0);
+    }
+
+    /// SSH push with remote-sourced `--files-from`: the local sender consumes
+    /// the list bytes forwarded by the remote receiver over the wire. The
+    /// transfer crate's protocol stream is the "-" sentinel here too;
+    /// upstream wires this via `main.c:1322-1328 filesfrom_fd = f_in`.
+    #[test]
+    fn generator_config_sets_files_from_stdin_for_remote_push() {
+        use super::super::super::config::FilesFromSource;
+
+        let config = ClientConfig::builder()
+            .files_from(FilesFromSource::RemoteFile("/remote/list.txt".to_owned()))
+            .build();
+
+        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
+            .expect("generator config builds");
+
+        assert_eq!(
+            server_config.file_selection.files_from_path.as_deref(),
+            Some("-"),
+            "remote --files-from is read from the wire on the local sender"
+        );
+        assert!(server_config.file_selection.from0);
+    }
+
+    /// SSH push baseline: when `--files-from` is not configured the generator
+    /// performs its usual recursive walk. The `files_from_path` field stays
+    /// empty so the engine falls back to `build_file_list(paths)`.
+    #[test]
+    fn generator_config_leaves_files_from_path_unset_when_disabled() {
+        let config = ClientConfig::builder().recursive(true).build();
+
+        let server_config = build_server_config_for_generator(&config, &["/tmp/source".to_owned()])
+            .expect("generator config builds");
+
+        assert!(
+            server_config.file_selection.files_from_path.is_none(),
+            "no --files-from must leave files_from_path unset"
+        );
     }
 
     #[test]

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -212,7 +212,7 @@ impl GeneratorContext {
     /// - `flist.c:2316-2330` - `/./` anchor split for relative-name emission
     /// - `main.c:681-685` - `filesfrom_fd` set to `STDIN_FILENO` for `--files-from=-`
     /// - `io.c:start_filesfrom_forwarding()` - client forwards local file over socket
-    pub(super) fn resolve_files_from_paths<R: Read>(
+    pub fn resolve_files_from_paths<R: Read>(
         &self,
         original_paths: &[PathBuf],
         reader: &mut R,

--- a/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
+++ b/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
@@ -37,12 +37,12 @@ use transfer::{
 
 /// Builds a `ServerConfig::Generator` that mirrors the shape produced by
 /// the SSH-push path after the fix in `build_server_config_for_generator`.
-fn ssh_push_generator_config(source_root: &PathBuf, list_path: &PathBuf) -> ServerConfig {
+fn ssh_push_generator_config(source_root: &Path, list_path: &Path) -> ServerConfig {
     let flag_string = "-r.iLsfxCIvu".to_owned();
     let mut config = ServerConfig::from_flag_string_and_args(
         ServerRole::Generator,
         flag_string,
-        vec![source_root.clone().into_os_string()],
+        vec![source_root.to_path_buf().into_os_string()],
     )
     .expect("server config");
 
@@ -226,7 +226,7 @@ fn ssh_push_without_files_from_path_walks_source_recursively() {
 
     let handshake = test_handshake();
     let pipeline = test_pipeline();
-    let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+    let ctx = GeneratorContext::new(&handshake, config, pipeline);
     let paths = vec![source_root.clone()];
 
     let mut reader = std::io::Cursor::new(Vec::<u8>::new());

--- a/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
+++ b/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
@@ -1,0 +1,241 @@
+//! UTS regression test for `files-from.test` invocation 2:
+//! `oc-rsync -avse lsh.sh --files-from=LIST source localhost:dest/`.
+//!
+//! Before the fix, the local SSH-push generator did not learn about the
+//! local `--files-from` file. It would recurse the source operand (an
+//! absolute path on disk) and emit wire entries whose relative names still
+//! carried the absolute prefix. The remote receiver - which sees implied
+//! `--relative` because `--files-from` is active - would then create
+//! `./home/runner/work/rsync/rsync/target/interop/upstream-testsuite/...`
+//! at the destination instead of the listed paths (`./dir`, `./empty`,
+//! `./emptydir`, ...).
+//!
+//! This test rebuilds the same generator pipeline that
+//! `core::client::remote::ssh_transfer::build_server_config_for_generator`
+//! produces after the fix: `files_from_path = Some(<local list>)` plus the
+//! source root as the only positional arg. It asserts that the resulting
+//! wire-side file list contains the entries from the list, with names
+//! relative to the destination - never the absolute source path.
+//!
+//! # Upstream Reference
+//!
+//! - `options.c:2473,2501` - filesfrom_fd opens stdin or the local file.
+//! - `flist.c:2275-2298` - send_file_list() chdirs to argv[0] and reads
+//!   one filename at a time from `filesfrom_fd`.
+//! - `flist.c:2316-2330` - per-entry `/./` anchor splits the prefix into
+//!   the per-entry walk base; the suffix is the wire-side relative name.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use protocol::ProtocolVersion;
+use transfer::{
+    GeneratorContext, HandshakeResult, ServerConfig, ServerRole, TransferPhase, TransferPipeline,
+};
+
+/// Builds a `ServerConfig::Generator` that mirrors the shape produced by
+/// the SSH-push path after the fix in `build_server_config_for_generator`.
+fn ssh_push_generator_config(source_root: &PathBuf, list_path: &PathBuf) -> ServerConfig {
+    let flag_string = "-r.iLsfxCIvu".to_owned();
+    let mut config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        flag_string,
+        vec![source_root.clone().into_os_string()],
+    )
+    .expect("server config");
+
+    config.file_selection.files_from_path = Some(list_path.to_string_lossy().into_owned());
+    // The upstream files-from test uses newline-delimited lists, not NUL.
+    config.file_selection.from0 = false;
+    config.connection.client_mode = true;
+    config
+}
+
+/// Builds a minimal handshake matching protocol 32 (current upstream).
+fn test_handshake() -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: true,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+/// Creates a transfer pipeline already advanced to `FileListTransfer`, the
+/// state expected by `build_file_list_with_base`.
+fn test_pipeline() -> TransferPipeline {
+    let mut pipeline = TransferPipeline::new(ServerRole::Generator);
+    pipeline
+        .advance_to(TransferPhase::FilterExchange)
+        .expect("advance to FilterExchange");
+    pipeline
+        .advance_to(TransferPhase::FileListTransfer)
+        .expect("advance to FileListTransfer");
+    pipeline
+}
+
+/// Recreates the upstream `files-from.test` source layout (the subset the
+/// local-mode pass already exercises): a `from/` subdirectory holding
+/// `dir/subdir/{subsubdir,subsubdir2}/...`.
+fn seed_files_from_test_source(root: &std::path::Path) {
+    let from = root.join("from");
+    let subdir = from.join("dir").join("subdir");
+    let subsubdir = subdir.join("subsubdir");
+    let subsubdir2 = subdir.join("subsubdir2");
+    fs::create_dir_all(&subsubdir).expect("mkdir subsubdir");
+    fs::create_dir_all(&subsubdir2).expect("mkdir subsubdir2");
+
+    fs::write(subdir.join("foobar.baz"), b"foobar payload").expect("write foobar.baz");
+    fs::write(subsubdir.join("inner.txt"), b"inner").expect("write inner.txt");
+    fs::write(subsubdir2.join("trailing.txt"), b"trailing").expect("write trailing.txt");
+}
+
+/// The bug surface: the wire-side relative names of the generator's file
+/// list must NOT include the absolute prefix of the source directory. The
+/// destination receiver writes paths relative to its destination root, so
+/// any wire entry whose name starts with the source's absolute path would
+/// reproduce the original failure (`./home/runner/work/...`).
+#[test]
+fn ssh_push_files_from_emits_relative_wire_names() {
+    let scratch = TempDir::new().expect("tempdir");
+    seed_files_from_test_source(scratch.path());
+
+    let list_path = scratch.path().join("filelist");
+    // Same payload as the upstream `files-from.test` 4-invocation matrix.
+    fs::write(
+        &list_path,
+        "from/./\n\
+         from/./dir/subdir\n\
+         from/./dir/subdir/subsubdir\n\
+         from/./dir/subdir/subsubdir2/\n\
+         from/./dir/subdir/foobar.baz\n",
+    )
+    .expect("write filelist");
+
+    let source_root = scratch.path().to_path_buf();
+    let config = ssh_push_generator_config(&source_root, &list_path);
+    let handshake = test_handshake();
+    let pipeline = test_pipeline();
+
+    let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+    let paths = vec![source_root.clone()];
+
+    let mut reader = std::io::Cursor::new(Vec::<u8>::new());
+    let entries = ctx
+        .resolve_files_from_paths(&paths, &mut reader)
+        .expect("resolve_files_from_paths must succeed");
+    assert!(
+        !entries.is_empty(),
+        "the generator must read at least one entry from the local --files-from list"
+    );
+
+    // Drive the production file-list builder with the resolved entries.
+    let base_dir = paths.first().expect("first path").clone();
+    ctx.build_file_list_with_base(&base_dir, &entries)
+        .expect("build_file_list_with_base");
+
+    let file_list = ctx.file_list();
+    assert!(
+        !file_list.is_empty(),
+        "the file list must contain entries; the generator produced none"
+    );
+
+    // The source root is an absolute filesystem path. Any wire-side name
+    // that starts with its absolute prefix would mirror the source's full
+    // path on the destination - the original SSH-push regression.
+    let absolute_prefix = source_root.to_string_lossy().into_owned();
+    let stripped_prefix = absolute_prefix.trim_start_matches('/');
+
+    let mut saw_dir_subdir = false;
+    let mut saw_foobar = false;
+
+    for entry in file_list {
+        let name = entry.name();
+        assert!(
+            !name.starts_with('/'),
+            "wire-side name must be relative, got absolute path: {name:?}"
+        );
+        assert!(
+            !name.contains(stripped_prefix),
+            "wire-side name must not embed the absolute source prefix \
+             {stripped_prefix:?}, got: {name:?}"
+        );
+        assert!(
+            !name.contains(&*absolute_prefix),
+            "wire-side name must not embed the absolute source path, got: {name:?}"
+        );
+
+        if name == "dir/subdir" || name == "./dir/subdir" {
+            saw_dir_subdir = true;
+        }
+        if name == "dir/subdir/foobar.baz" || name == "./dir/subdir/foobar.baz" {
+            saw_foobar = true;
+        }
+    }
+
+    assert!(
+        saw_dir_subdir,
+        "expected wire-side entry 'dir/subdir' (relative to destination root); \
+         file list was: {:?}",
+        file_list.iter().map(|e| e.name()).collect::<Vec<_>>()
+    );
+    assert!(
+        saw_foobar,
+        "expected wire-side entry 'dir/subdir/foobar.baz' (relative to \
+         destination root); file list was: {:?}",
+        file_list.iter().map(|e| e.name()).collect::<Vec<_>>()
+    );
+}
+
+/// The pre-fix bug shape: when the generator config does NOT carry the
+/// local `--files-from` path, the SSH-push sender falls back to walking
+/// the source operand recursively. The wire-side names then come from a
+/// recursive walk of the source root, not from the requested entries.
+///
+/// This case is the inverse of the regression test above: it pins what
+/// the broken wiring would have produced so a future refactor that
+/// re-introduces the bug (silently dropping `files_from_path` in
+/// `build_server_config_for_generator`) flips the assertion in the
+/// previous test.
+#[test]
+fn ssh_push_without_files_from_path_walks_source_recursively() {
+    let scratch = TempDir::new().expect("tempdir");
+    seed_files_from_test_source(scratch.path());
+
+    let source_root = scratch.path().to_path_buf();
+    // Deliberately do NOT populate `files_from_path` - this mirrors the
+    // pre-fix wiring that produced the SSH-push failure.
+    let flag_string = "-r.iLsfxCIvu".to_owned();
+    let mut config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        flag_string,
+        vec![source_root.clone().into_os_string()],
+    )
+    .expect("server config");
+    config.connection.client_mode = true;
+    assert!(
+        config.file_selection.files_from_path.is_none(),
+        "pre-fix wiring leaves files_from_path empty"
+    );
+
+    let handshake = test_handshake();
+    let pipeline = test_pipeline();
+    let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+    let paths = vec![source_root.clone()];
+
+    let mut reader = std::io::Cursor::new(Vec::<u8>::new());
+    let entries = ctx
+        .resolve_files_from_paths(&paths, &mut reader)
+        .expect("resolve_files_from_paths must succeed");
+    assert!(
+        entries.is_empty(),
+        "with no files_from_path the resolver must return no entries; \
+         the generator would fall back to build_file_list()"
+    );
+}

--- a/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
+++ b/crates/transfer/tests/uts_files_from_ssh_push_relative.rs
@@ -26,7 +26,7 @@
 //!   the per-entry walk base; the suffix is the wire-side relative name.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

- SSH-push's `build_server_config_for_generator` no longer leaves `files_from_path` empty on the local sender. With `--files-from` active, the generator now reads filenames from the local list (or the forwarded wire stream for remote files-from) instead of recursing the absolute source operand and mirroring its absolute path on the destination under implied `--relative`.
- `RemoteInvocationBuilder` now matches upstream's `options.c:2962` gate: PUSH with a local list omits `--files-from` to the remote receiver; PULL still forwards `--files-from=- --from0` and the local list bytes over the wire (parity with the daemon path).
- Embedded SSH transport gets the same wiring on both push and pull.

## Root cause

The CI upstream-testsuite run https://github.com/oferchen/rsync/actions/runs/27711564454 (`files-from.log`) showed invocation 2 of `testsuite/files-from.test`:

```
oc-rsync -avse lsh.sh --rsync-path=oc-rsync --files-from=$scratchdir/filelist $scratchdir localhost:.../to/
```

producing destination paths like

```
./home/runner/work/rsync/rsync/target/interop/upstream-testsuite/scratch/files-from/
```

instead of the listed `./dir`, `./empty`, `./emptydir`, ... The local mode invocation 1 passed because the CLI workflow's local-only branch already prefixes file_list_operands with `/./` markers. The SSH-push branch dropped those operands and never propagated `--files-from` to the local sender's `ServerConfig`, so the generator walked the absolute `$scratchdir` and emitted absolute-prefixed wire names. Upstream's behaviour is documented at `flist.c:2275-2298 send_file_list`, `options.c:2962-2974`, and `main.c:1191-1198,1322-1328,1372-1375`.

## Test plan

- [ ] `crates/core/src/client/remote/ssh_transfer.rs::tests` - new unit tests pin `files_from_path` propagation for `LocalFile`, `Stdin`, `RemoteFile`, and the disabled case.
- [ ] `crates/core/src/client/remote/invocation/tests.rs` - new unit tests pin the remote `--files-from` arg across PUSH/PULL x local/remote.
- [ ] `crates/transfer/tests/uts_files_from_ssh_push_relative.rs` - new integration test drives the generator's `resolve_files_from_paths` + `build_file_list_with_base` pipeline against the upstream `files-from.test` source layout and asserts the wire-side file list never embeds the absolute source path.
- [ ] CI `Upstream Testsuite` job runs `files-from.test` to completion.
- [ ] CI required matrices: fmt+clippy, nextest (stable), Windows, macOS, Linux musl.