### PR TITLE
fix(generator): match upstream order for -vv per-file uptodate output

### DIFF
--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1355,3 +1355,56 @@ fn level_2_uptodate_lines_precede_transferred_lines() {
         "uptodate notices must precede transferred files (upstream generator/receiver pipeline), got: {rendered:?}"
     );
 }
+
+/// Verifies that `-iplrtH` against a destination already linked to the leader
+/// emits the `hf` itemized row WITHOUT the `=> leader` suffix.
+///
+/// upstream: hlink.c:218-222 - when the destination already shares the source
+/// group leader's inode, `maybe_hard_link()` calls
+/// `itemize(..., ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0, "")` with an
+/// empty xname. `log.c:643-654` skips the `%L` ` => %s` suffix when the
+/// xname is empty. Mirrors `testsuite/itemize.test` at line 122
+/// (`hf$allspace foo/extra`) which has no `=>` suffix because the dest
+/// alias is already linked to `foo/config1`.
+#[cfg(unix)]
+#[test]
+fn itemize_hardlink_already_linked_omits_arrow_suffix() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(&from).expect("mkdir from");
+    std::fs::write(from.join("leader.bin"), b"shared content").expect("write leader");
+    std::fs::hard_link(from.join("leader.bin"), from.join("follower.bin"))
+        .expect("source hardlink");
+
+    let mut from_slash = from.clone().into_os_string();
+    from_slash.push("/");
+
+    // First pass: create the destination alias.
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-plrtH"),
+        from_slash.clone(),
+        to.clone().into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+
+    // Second pass: destination is already linked. Itemize must not emit
+    // the `=> leader.bin` xname suffix on the follower row.
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-iplrtH"),
+        from_slash,
+        to.into_os_string(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        !rendered.contains("=> leader.bin"),
+        "already-linked hardlink row must omit `=> leader.bin` (upstream hlink.c:218-222 passes empty xname to itemize), got: {rendered:?}"
+    );
+}

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -233,9 +233,7 @@ pub(super) fn process_links(
             // and ITEM_REPORT_TIME fires whenever the leader's source mtime
             // differs from the existing destination alias's mtime, even
             // without `-t` (`preserve_mtimes`). Without `-t` upstream's
-            // glyph is `T` (TransferTime), matching the
-            // `testsuite/itemize.test` golden at line 78
-            // (`hf..T...... foo/extra => foo/config1`).
+            // glyph is `T` (TransferTime).
             if !metadata_options.times()
                 && let Some(existing) = existing_metadata
                 && metadata.modified().ok() != existing.modified().ok()
@@ -243,28 +241,21 @@ pub(super) fn process_links(
                 change_set =
                     change_set.with_time_change(Some(crate::local_copy::TimeChange::TransferTime));
             }
-            // upstream: generator.c:1546-1604 - `hard_link_check()` returns
-            // 1 when the destination already shares the source group leader's
-            // inode. The generator then emits `itemize(..., 0, ...)` with
-            // iflags=0, producing an `hf...` row whose attribute slots
-            // reflect only what actually changed (mtime, perms, etc.).
-            // Tagging the record as HardLink keeps position 0 at 'h' instead
-            // of '.'; omitting `.with_creation(true)` keeps positions 2-10
-            // as deltas instead of `+++++++++`. We thread the existing
-            // destination link target through the metadata snapshot's
-            // `symlink_target` slot so the `%L` placeholder can render the
-            // upstream `=> %s` suffix without a separate plumbing channel.
-            // upstream: hlink.c:237 - `"%s => %s\n"` prints `realname`
-            // which is the leader's relative path. Strip the destination
-            // root from the recorded absolute path so the `%L` placeholder
-            // emits the upstream form (`=> foo/config1` rather than
-            // `=> /abs/path/to/foo/config1`).
-            let link_target_display = existing_target
-                .strip_prefix(context.destination_root())
-                .map(std::path::Path::to_path_buf)
-                .unwrap_or_else(|_| existing_target.clone());
-            let reuse_snapshot =
-                LocalCopyMetadata::from_metadata(metadata, Some(link_target_display));
+            // upstream: hlink.c:218-222 - when the destination already
+            // shares the source group leader's inode, `maybe_hard_link()`
+            // calls `itemize(fname, file, ndx, statret, sxp,
+            // ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0, "")` with an
+            // empty xname. `log.c:643-654` skips the `%L` `=> %s` suffix
+            // when the xname is empty, so the upstream `-i` row for an
+            // already-linked alias is `hf<dots>` with no trailer (line
+            // 122 of `testsuite/itemize.test`: `hf$allspace foo/extra`).
+            // Pass `None` for the symlink_target so the `%L` placeholder
+            // renders to the empty string, matching that behaviour.
+            //
+            // Tagging the record as HardLink keeps position 0 at 'h'
+            // instead of '.'; omitting `.with_creation(true)` keeps
+            // positions 2-10 as deltas instead of `+++++++++`.
+            let reuse_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
             context.record(
                 LocalCopyRecord::new(
                     record_path.to_path_buf(),


### PR DESCRIPTION
## Summary

- Pass `None` to the `LocalCopyMetadata::from_metadata` snapshot in the already-linked branch of `process_links` (block 2a) so the `%L` placeholder renders to the empty string. Upstream `hlink.c:218-222` invokes `itemize(..., ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0, "")` with an empty xname when the destination is already linked to the source group leader; `log.c:643-654` then skips the ` => %s` suffix, producing the `hf$allspace foo/extra` row at line 122 of `testsuite/itemize.test`. The previously-passed leader path produced a spurious `=> foo/config1` trailer on otherwise-uptodate hardlink rows under `-i`. The newly-linked branch (block 2b) keeps its `Some(leader_path)` snapshot so the `=> foo/config1` xname suffix continues to render for the `-iplrH` golden at line 78.
- Repair the two SSH call sites of `flags::build_wire_format_rules` to pass `config.delete_excluded()` as the second argument. The signature was extended in #5899 (`fix(filters): apply implicit FILTRULE_SENDER_SIDE under --delete-excluded`) but `crates/core/src/client/remote/ssh_transfer.rs` was not updated, leaving master at `error[E0061]: this function takes 2 arguments but 1 argument was supplied` and blocking the `upstream-testsuite` build (and every other cell).

The primary -vv ordering and "is uptodate" hardlink emission for `testsuite/itemize.test` test 4 (`oc-rsync -vvplrH from/ to/`) were already addressed by #5901 (`fix(transfer): emit hardlink uptodate and direct stats to stderr in -vv`). The CI log in the original task captured the pre-#5901 master HEAD; the PR-#5901 CI artifact (run 27714422985) confirms test 4 passes. This PR closes the residual `-i` divergence on the already-linked path and unblocks the broken build so the testsuite can run end-to-end in CI.

## Test plan

- [x] `cargo fmt --all` clean (verified in podman container).
- [x] New unit test `itemize_hardlink_already_linked_omits_arrow_suffix` runs `-plrtH` to set up the destination alias and then `-iplrtH` to assert the second-pass row carries no `=> leader.bin` trailer.
- [ ] CI: fmt+clippy, nextest (stable), Windows/macOS/Linux musl matrices.
- [ ] CI: `upstream-testsuite` end-to-end (now able to build on master; `itemize.test` invocation 4 should pass and the suite should advance through invocations 5+).