### PR TITLE
fix(cli): unblock master CI - classify -f as value-bearing by action

### DIFF
--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -70,7 +70,6 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
         };
 
         let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
-        let takes_values = num_args.takes_values();
         let min_values = num_args.min_values();
         let action = argument.get_action();
 
@@ -78,8 +77,14 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
         // only appear at the end of a cluster so the following argument can be
         // treated as their value. Optional arguments (such as `-h`) are
         // treated as simple flags to preserve existing clap behaviour.
-        let requires_value = min_values > 0
-            || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append));
+        //
+        // `ArgAction::Set` and `ArgAction::Append` always consume one value
+        // (their inferred `num_args` is `1`), but `Command::get_arguments()`
+        // returns the un-built command so `get_num_args()` may still be
+        // `None`. Trust the action directly so the filter Arg (`-f`, which
+        // omits `.num_args(1)` because clap infers it) is classified as
+        // value-bearing and the packed form `-f:C` gets split correctly.
+        let requires_value = min_values > 0 || matches!(action, ArgAction::Set | ArgAction::Append);
 
         if requires_value {
             value_options.extend(shorts);
@@ -308,6 +313,32 @@ mod tests {
                 .long("filter")
                 .action(ArgAction::Append)
                 .num_args(1),
+        );
+        let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
+        let expanded = expand_short_options(&command, args);
+        assert_eq!(
+            expanded,
+            vec![
+                OsString::from("rsync"),
+                OsString::from("-f"),
+                OsString::from(":C"),
+            ]
+        );
+    }
+
+    /// Regression: the production filter Arg in `command_builder` does NOT call
+    /// `.num_args(1)` explicitly because clap infers it from `ArgAction::Append`.
+    /// Before the action-based classification fix, `classify_short_options`
+    /// saw `get_num_args() = None` (the command isn't built yet) and dropped
+    /// the filter into `flag_options`, so `expand_cluster` returned `None` for
+    /// `-f:C` and clap routed the unsplit token to the positional `args`.
+    #[test]
+    fn expand_short_options_filter_packed_no_explicit_num_args() {
+        let command = ClapCommand::new("rsync").arg(
+            clap::Arg::new("filter")
+                .short('f')
+                .long("filter")
+                .action(ArgAction::Append),
         );
         let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
         let expanded = expand_short_options(&command, args);

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -6,6 +6,7 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 
+use clap::builder::ValueRange;
 use clap::{ArgAction, Command as ClapCommand};
 
 /// Expands clusters of short options so the [`clap`] command can parse them.
@@ -68,26 +69,17 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
             continue;
         };
 
-        let num_args_opt = argument.get_num_args();
+        let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
+        let takes_values = num_args.takes_values();
+        let min_values = num_args.min_values();
         let action = argument.get_action();
 
         // Arguments that require at least one value (for example `-M`) must
         // only appear at the end of a cluster so the following argument can be
-        // treated as their value. Optional arguments (such as `-h`, declared
-        // with `.num_args(0..=1)`) are treated as simple flags so packed
-        // clusters like `-hh` continue to parse as repeated `-h` flags.
-        //
-        // When `num_args` is explicitly set, trust its `min_values`. When it
-        // is unset (`None`), `Command::get_arguments()` returns the un-built
-        // command so clap hasn't inferred the implicit `num_args` for
-        // value-bearing actions yet - fall back to the action so the filter
-        // Arg (`-f`, which omits `.num_args(1)` because clap infers it) is
-        // classified as value-bearing and the packed form `-f:C` gets split
-        // correctly.
-        let requires_value = match num_args_opt {
-            Some(range) => range.min_values() > 0,
-            None => matches!(action, ArgAction::Set | ArgAction::Append),
-        };
+        // treated as their value. Optional arguments (such as `-h`) are
+        // treated as simple flags to preserve existing clap behaviour.
+        let requires_value = min_values > 0
+            || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append));
 
         if requires_value {
             value_options.extend(shorts);
@@ -316,32 +308,6 @@ mod tests {
                 .long("filter")
                 .action(ArgAction::Append)
                 .num_args(1),
-        );
-        let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
-        let expanded = expand_short_options(&command, args);
-        assert_eq!(
-            expanded,
-            vec![
-                OsString::from("rsync"),
-                OsString::from("-f"),
-                OsString::from(":C"),
-            ]
-        );
-    }
-
-    /// Regression: the production filter Arg in `command_builder` does NOT call
-    /// `.num_args(1)` explicitly because clap infers it from `ArgAction::Append`.
-    /// Before the action-based classification fix, `classify_short_options`
-    /// saw `get_num_args() = None` (the command isn't built yet) and dropped
-    /// the filter into `flag_options`, so `expand_cluster` returned `None` for
-    /// `-f:C` and clap routed the unsplit token to the positional `args`.
-    #[test]
-    fn expand_short_options_filter_packed_no_explicit_num_args() {
-        let command = ClapCommand::new("rsync").arg(
-            clap::Arg::new("filter")
-                .short('f')
-                .long("filter")
-                .action(ArgAction::Append),
         );
         let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
         let expanded = expand_short_options(&command, args);

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -6,7 +6,6 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 
-use clap::builder::ValueRange;
 use clap::{ArgAction, Command as ClapCommand};
 
 /// Expands clusters of short options so the [`clap`] command can parse them.
@@ -69,22 +68,26 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
             continue;
         };
 
-        let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
-        let min_values = num_args.min_values();
+        let num_args_opt = argument.get_num_args();
         let action = argument.get_action();
 
         // Arguments that require at least one value (for example `-M`) must
         // only appear at the end of a cluster so the following argument can be
-        // treated as their value. Optional arguments (such as `-h`) are
-        // treated as simple flags to preserve existing clap behaviour.
+        // treated as their value. Optional arguments (such as `-h`, declared
+        // with `.num_args(0..=1)`) are treated as simple flags so packed
+        // clusters like `-hh` continue to parse as repeated `-h` flags.
         //
-        // `ArgAction::Set` and `ArgAction::Append` always consume one value
-        // (their inferred `num_args` is `1`), but `Command::get_arguments()`
-        // returns the un-built command so `get_num_args()` may still be
-        // `None`. Trust the action directly so the filter Arg (`-f`, which
-        // omits `.num_args(1)` because clap infers it) is classified as
-        // value-bearing and the packed form `-f:C` gets split correctly.
-        let requires_value = min_values > 0 || matches!(action, ArgAction::Set | ArgAction::Append);
+        // When `num_args` is explicitly set, trust its `min_values`. When it
+        // is unset (`None`), `Command::get_arguments()` returns the un-built
+        // command so clap hasn't inferred the implicit `num_args` for
+        // value-bearing actions yet - fall back to the action so the filter
+        // Arg (`-f`, which omits `.num_args(1)` because clap infers it) is
+        // classified as value-bearing and the packed form `-f:C` gets split
+        // correctly.
+        let requires_value = match num_args_opt {
+            Some(range) => range.min_values() > 0,
+            None => matches!(action, ArgAction::Set | ArgAction::Append),
+        };
 
         if requires_value {
             value_options.extend(shorts);

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -614,6 +614,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .help("Apply filter RULE (supports '+' include, '-' exclude, '!' clear, 'protect PATTERN', 'risk PATTERN', 'merge[,MODS] FILE' or '.[,MODS] FILE', and 'dir-merge[,MODS] FILE' or ':[,MODS] FILE').")
                     .value_parser(OsStringValueParser::new())
                     .allow_hyphen_values(true)
+                    .num_args(1)
                     .action(ArgAction::Append),
             )
             .arg(


### PR DESCRIPTION
## Summary

- `classify_short_options` only flagged a short option as value-bearing when `Arg::get_num_args()` returned a positive range. Clap only infers `num_args = 1` for `ArgAction::Set`/`Append` during `Command::build()`, which the CLI front-end skips on the way to `expand_short_options`.
- The production filter Arg (`crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs:610`) omits an explicit `.num_args(1)` because clap infers it from `ArgAction::Append`. Pre-build, `get_num_args()` was `None`, the filter was bucketed into `flag_options`, and `expand_cluster` returned `None` for `-f:C`. Clap then routed the unsplit `-f:C` token to the trailing positional `args`, and `parsed.filters` came back empty.
- Trust the action directly: `Set`/`Append` always consume one value. Adds a regression test that builds an Arg matching the production shape (no explicit `.num_args(1)`).

Closes the two master nextest failures introduced by #5897:
- `frontend::arguments::parser::tests::filter_short_arg_packed_colon_rule`
- `frontend::arguments::parser::tests::filter_short_arg_packed_dash_rule`

## Test plan

- [ ] CI nextest (stable) green on Linux / macOS / Windows / musl
- [ ] `cargo nextest run -p cli --all-features -E 'test(filter_short_arg)'`