### PR TITLE
fix(cli): unblock master CI - explicit num_args(1) on filter Arg

### DIFF
--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -70,7 +70,6 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
         };
 
         let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
-        let takes_values = num_args.takes_values();
         let min_values = num_args.min_values();
         let action = argument.get_action();
 
@@ -78,8 +77,14 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
         // only appear at the end of a cluster so the following argument can be
         // treated as their value. Optional arguments (such as `-h`) are
         // treated as simple flags to preserve existing clap behaviour.
-        let requires_value = min_values > 0
-            || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append));
+        //
+        // `ArgAction::Set` and `ArgAction::Append` always consume one value
+        // (their inferred `num_args` is `1`), but `Command::get_arguments()`
+        // returns the un-built command so `get_num_args()` may still be
+        // `None`. Trust the action directly so the filter Arg (`-f`, which
+        // omits `.num_args(1)` because clap infers it) is classified as
+        // value-bearing and the packed form `-f:C` gets split correctly.
+        let requires_value = min_values > 0 || matches!(action, ArgAction::Set | ArgAction::Append);
 
         if requires_value {
             value_options.extend(shorts);
@@ -308,6 +313,32 @@ mod tests {
                 .long("filter")
                 .action(ArgAction::Append)
                 .num_args(1),
+        );
+        let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
+        let expanded = expand_short_options(&command, args);
+        assert_eq!(
+            expanded,
+            vec![
+                OsString::from("rsync"),
+                OsString::from("-f"),
+                OsString::from(":C"),
+            ]
+        );
+    }
+
+    /// Regression: the production filter Arg in `command_builder` does NOT call
+    /// `.num_args(1)` explicitly because clap infers it from `ArgAction::Append`.
+    /// Before the action-based classification fix, `classify_short_options`
+    /// saw `get_num_args() = None` (the command isn't built yet) and dropped
+    /// the filter into `flag_options`, so `expand_cluster` returned `None` for
+    /// `-f:C` and clap routed the unsplit token to the positional `args`.
+    #[test]
+    fn expand_short_options_filter_packed_no_explicit_num_args() {
+        let command = ClapCommand::new("rsync").arg(
+            clap::Arg::new("filter")
+                .short('f')
+                .long("filter")
+                .action(ArgAction::Append),
         );
         let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
         let expanded = expand_short_options(&command, args);

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -6,6 +6,7 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 
+use clap::builder::ValueRange;
 use clap::{ArgAction, Command as ClapCommand};
 
 /// Expands clusters of short options so the [`clap`] command can parse them.
@@ -68,26 +69,17 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
             continue;
         };
 
-        let num_args_opt = argument.get_num_args();
+        let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
+        let takes_values = num_args.takes_values();
+        let min_values = num_args.min_values();
         let action = argument.get_action();
 
         // Arguments that require at least one value (for example `-M`) must
         // only appear at the end of a cluster so the following argument can be
-        // treated as their value. Optional arguments (such as `-h`, declared
-        // with `.num_args(0..=1)`) are treated as simple flags so packed
-        // clusters like `-hh` continue to parse as repeated `-h` flags.
-        //
-        // When `num_args` is explicitly set, trust its `min_values`. When it
-        // is unset (`None`), `Command::get_arguments()` returns the un-built
-        // command so clap hasn't inferred the implicit `num_args` for
-        // value-bearing actions yet - fall back to the action so the filter
-        // Arg (`-f`, which omits `.num_args(1)` because clap infers it) is
-        // classified as value-bearing and the packed form `-f:C` gets split
-        // correctly.
-        let requires_value = match num_args_opt {
-            Some(range) => range.min_values() > 0,
-            None => matches!(action, ArgAction::Set | ArgAction::Append),
-        };
+        // treated as their value. Optional arguments (such as `-h`) are
+        // treated as simple flags to preserve existing clap behaviour.
+        let requires_value = min_values > 0
+            || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append));
 
         if requires_value {
             value_options.extend(shorts);
@@ -316,32 +308,6 @@ mod tests {
                 .long("filter")
                 .action(ArgAction::Append)
                 .num_args(1),
-        );
-        let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
-        let expanded = expand_short_options(&command, args);
-        assert_eq!(
-            expanded,
-            vec![
-                OsString::from("rsync"),
-                OsString::from("-f"),
-                OsString::from(":C"),
-            ]
-        );
-    }
-
-    /// Regression: the production filter Arg in `command_builder` does NOT call
-    /// `.num_args(1)` explicitly because clap infers it from `ArgAction::Append`.
-    /// Before the action-based classification fix, `classify_short_options`
-    /// saw `get_num_args() = None` (the command isn't built yet) and dropped
-    /// the filter into `flag_options`, so `expand_cluster` returned `None` for
-    /// `-f:C` and clap routed the unsplit token to the positional `args`.
-    #[test]
-    fn expand_short_options_filter_packed_no_explicit_num_args() {
-        let command = ClapCommand::new("rsync").arg(
-            clap::Arg::new("filter")
-                .short('f')
-                .long("filter")
-                .action(ArgAction::Append),
         );
         let args = vec![OsString::from("rsync"), OsString::from("-f:C")];
         let expanded = expand_short_options(&command, args);

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -6,7 +6,6 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 
-use clap::builder::ValueRange;
 use clap::{ArgAction, Command as ClapCommand};
 
 /// Expands clusters of short options so the [`clap`] command can parse them.
@@ -69,22 +68,26 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
             continue;
         };
 
-        let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
-        let min_values = num_args.min_values();
+        let num_args_opt = argument.get_num_args();
         let action = argument.get_action();
 
         // Arguments that require at least one value (for example `-M`) must
         // only appear at the end of a cluster so the following argument can be
-        // treated as their value. Optional arguments (such as `-h`) are
-        // treated as simple flags to preserve existing clap behaviour.
+        // treated as their value. Optional arguments (such as `-h`, declared
+        // with `.num_args(0..=1)`) are treated as simple flags so packed
+        // clusters like `-hh` continue to parse as repeated `-h` flags.
         //
-        // `ArgAction::Set` and `ArgAction::Append` always consume one value
-        // (their inferred `num_args` is `1`), but `Command::get_arguments()`
-        // returns the un-built command so `get_num_args()` may still be
-        // `None`. Trust the action directly so the filter Arg (`-f`, which
-        // omits `.num_args(1)` because clap infers it) is classified as
-        // value-bearing and the packed form `-f:C` gets split correctly.
-        let requires_value = min_values > 0 || matches!(action, ArgAction::Set | ArgAction::Append);
+        // When `num_args` is explicitly set, trust its `min_values`. When it
+        // is unset (`None`), `Command::get_arguments()` returns the un-built
+        // command so clap hasn't inferred the implicit `num_args` for
+        // value-bearing actions yet - fall back to the action so the filter
+        // Arg (`-f`, which omits `.num_args(1)` because clap infers it) is
+        // classified as value-bearing and the packed form `-f:C` gets split
+        // correctly.
+        let requires_value = match num_args_opt {
+            Some(range) => range.min_values() > 0,
+            None => matches!(action, ArgAction::Set | ArgAction::Append),
+        };
 
         if requires_value {
             value_options.extend(shorts);

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -614,6 +614,7 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .help("Apply filter RULE (supports '+' include, '-' exclude, '!' clear, 'protect PATTERN', 'risk PATTERN', 'merge[,MODS] FILE' or '.[,MODS] FILE', and 'dir-merge[,MODS] FILE' or ':[,MODS] FILE').")
                     .value_parser(OsStringValueParser::new())
                     .allow_hyphen_values(true)
+                    .num_args(1)
                     .action(ArgAction::Append),
             )
             .arg(


### PR DESCRIPTION
## Summary

Two `cli` nextest tests have been failing on master HEAD (1c0471afc) since the `-f:C` packed short-arg test fixtures landed:

- `cli::frontend::arguments::parser::tests::filter_short_arg_packed_dash_rule`
- `cli::frontend::arguments::parser::tests::filter_short_arg_packed_colon_rule`

Root cause: the filter `Arg` was declared without an explicit `num_args(...)`, so the pre-clap short-option expander (`classify_short_options`) computed `min_values=0`/`takes_values=false` and treated `-f` as a flag. `expand_cluster("-f:C")` then bailed at the unknown `:` character and clap saw the unsplit `-f:C` token, failing the assertion that filters should contain `":C"`.

This PR makes the clap `Arg` definition match the expander's expectations by setting `.num_args(1)` explicitly, and tightens the short-option classifier so action-based fallback only fires when `num_args` is genuinely unset.

## Changes

- `crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs`: add `.num_args(1)` to the filter Arg
- `crates/cli/src/frontend/arguments/short_options.rs`: classify shorts by action when num_args is unset (no behavior change for explicit num_args)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [ ] `nextest (stable)` passes both `filter_short_arg_packed_*` tests
- [ ] All required CI cells stay green (this is a 1-line behavior fix scoped to filter Arg)