### PR TITLE
fix(fast_io): gate sendfile_macos test imports + fixture on unix

### DIFF
--- a/crates/fast_io/src/sendfile_macos.rs
+++ b/crates/fast_io/src/sendfile_macos.rs
@@ -242,7 +242,9 @@ mod macos_impl {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::*;
+    #[cfg(unix)]
     use std::io::{Seek, SeekFrom, Write};
     #[cfg(unix)]
     use std::os::fd::AsFd;
@@ -250,9 +252,11 @@ mod tests {
     use std::os::fd::AsRawFd;
     #[cfg(unix)]
     use std::os::fd::{FromRawFd, OwnedFd};
+    #[cfg(unix)]
     use tempfile::NamedTempFile;
 
     /// Build a temp file containing `content`, leaving its position at 0.
+    #[cfg(unix)]
     fn fixture(content: &[u8]) -> NamedTempFile {
         let mut f = NamedTempFile::new().expect("tempfile");
         f.write_all(content).expect("write");


### PR DESCRIPTION
## Summary

- `crates/fast_io/src/sendfile_macos.rs` tests module gates every `#[test]` on `target_os = "macos"` or `all(unix, not(target_os = "macos"))`, but the shared `use super::*;`, `use tempfile::NamedTempFile;`, `use std::io::{Seek, SeekFrom, Write};` imports and the `fixture()` helper were ungated.
- On a Windows `--features iocp --no-default-features` build, with all tests cfg-gated out, those imports and the helper are unused and trip `-D warnings`, breaking the Windows IOCP CI job.
- Fix: add matching `#[cfg(unix)]` gates so the items vanish on Windows alongside the tests.

## Test plan

- [ ] Windows IOCP (`--features iocp`) cell builds cleanly with `-D warnings`.
- [ ] macOS / Linux nextest still picks up and runs the gated tests.
- [ ] No behavior change in non-test code paths.