### PR TITLE
fix(cli): restore -hh and --reflink precedence after #5897

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -508,6 +508,9 @@ where
     } else {
         fast_io::ZeroCopyPolicy::Auto
     };
+    // Capture the reflink index before remove_one drains the match data;
+    // resolve_cow_policy needs it to break ties against --cow / --no-cow.
+    let reflink_index = last_occurrence(&matches, "reflink");
     let reflink_value = matches.remove_one::<OsString>("reflink");
     let reflink_explicit = match reflink_value {
         Some(value) => {
@@ -525,7 +528,7 @@ where
         }
         None => None,
     };
-    let cow_policy = resolve_cow_policy(&matches, reflink_explicit);
+    let cow_policy = resolve_cow_policy(&matches, reflink_explicit, reflink_index);
     let simd_override = match matches.remove_one::<OsString>("simd") {
         Some(value) => {
             let text = value.to_string_lossy();
@@ -1070,9 +1073,8 @@ fn parse_reflink_mode(input: &str) -> Option<fast_io::CowPolicy> {
 fn resolve_cow_policy(
     matches: &clap::ArgMatches,
     reflink_explicit: Option<fast_io::CowPolicy>,
+    reflink_index: Option<usize>,
 ) -> fast_io::CowPolicy {
-    let reflink_index = last_occurrence(matches, "reflink");
-
     let (binary_policy, binary_index) = if matches.get_flag("no-cow") {
         (
             Some(fast_io::CowPolicy::Disabled),

--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -6,8 +6,8 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
 
+use clap::Command as ClapCommand;
 use clap::builder::ValueRange;
-use clap::{ArgAction, Command as ClapCommand};
 
 /// Expands clusters of short options so the [`clap`] command can parse them.
 ///
@@ -70,16 +70,16 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
         };
 
         let num_args = argument.get_num_args().unwrap_or(ValueRange::EMPTY);
-        let takes_values = num_args.takes_values();
         let min_values = num_args.min_values();
-        let action = argument.get_action();
 
-        // Arguments that require at least one value (for example `-M`) must
-        // only appear at the end of a cluster so the following argument can be
-        // treated as their value. Optional arguments (such as `-h`) are
-        // treated as simple flags to preserve existing clap behaviour.
-        let requires_value = min_values > 0
-            || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append));
+        // Arguments that require at least one value (for example `-M` or
+        // `-f<rule>`) must only appear at the end of a cluster so the
+        // following argument can be treated as their value. Optional
+        // arguments (such as `-h`, which accepts `-h` or `-h=2`) are
+        // treated as simple flags to preserve existing clap behaviour;
+        // packing a value onto an optional-value short flag is not
+        // supported by upstream rsync.
+        let requires_value = min_values > 0;
 
         if requires_value {
             value_options.extend(shorts);
@@ -133,6 +133,7 @@ fn expand_cluster(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::ArgAction;
 
     fn make_flags(chars: &str) -> HashSet<char> {
         chars.chars().collect()


### PR DESCRIPTION
## Summary

Two regressions slipped into master with the packed `-f<rule>` short-arg work in #5897 and panicked every nextest matrix cell. The panicking tests are `human_readable_double_short_hh_is_combined` and `reflink_after_binary_form_overrides` in `crates/cli`. Because nextest is configured with `--max-fail`, the matrix aborts after ~73-83 tests on every platform.

**Root cause 1 — `-hh` counted as one occurrence.** `classify_short_options()` in `crates/cli/src/frontend/arguments/short_options.rs` classified a short flag as value-bearing whenever `max_values > 0`. That bucket includes `-h`, which is modelled as `num_args(0..=1)` so users can write `-h=2`. The cluster expander then treated the second `h` in `-hh` as the packed value of the first `-h`, and `-hh` stopped counting as `HumanReadableMode::Combined`. The fix classifies on `min_values > 0` instead, so only truly value-bearing shorts (`-M`, `-f`, `-T`, ...) get the packed-value treatment. Packed values on optional-value shorts are not a thing in upstream rsync.

**Root cause 2 — `--no-cow --reflink=always` resolved to Disabled.** `parse_named_arguments()` in `crates/cli/src/frontend/arguments/parser/mod.rs` called `matches.remove_one::<OsString>("reflink")` to consume the explicit value, then passed `&matches` to `resolve_cow_policy()`. `resolve_cow_policy()` read `last_occurrence(matches, "reflink")` to break the precedence tie against `--cow` / `--no-cow`. `remove_one` drains the underlying value record, so `last_occurrence` returned `None`, the binary form's index always won, and the policy collapsed to `Disabled`. The fix captures `last_occurrence(&matches, "reflink")` before `remove_one` and threads the index through `resolve_cow_policy`.

Both fixes are minimal and surgical: ~15 lines changed, no behavior change for any non-panicking case, and the 4 `filter_short_arg_packed` tests added by #5897 still pass.

## Test plan

- [x] `cargo nextest run -p cli -E 'test(human_readable_double_short_hh_is_combined) | test(reflink_after_binary_form_overrides) | test(filter_short_arg_packed)'` passes locally
- [x] `cargo fmt --all -- --check` passes
- [ ] Full CI matrix green (stable/beta/nightly x Linux gnu / macOS / Linux musl / Windows)