### PR TITLE
fix(cli): treat require_equals shorts as flags in cluster expander

### DIFF
--- a/crates/cli/src/frontend/arguments/short_options.rs
+++ b/crates/cli/src/frontend/arguments/short_options.rs
@@ -73,13 +73,21 @@ fn classify_short_options(command: &ClapCommand) -> (HashSet<char>, HashSet<char
         let takes_values = num_args.takes_values();
         let min_values = num_args.min_values();
         let action = argument.get_action();
+        // Arguments that require `=` separator (such as `-h` with
+        // `require_equals(true)` + `num_args(0..=1)`) do not consume a packed
+        // remainder. clap routes only `-h=2` to the option; `-hh` clusters two
+        // independent `-h` occurrences. Treat them as flag-like so the cluster
+        // expander emits one `-h` per character and bare flag counts work.
+        let require_equals_with_optional_value =
+            argument.is_require_equals_set() && min_values == 0;
 
         // Arguments that require at least one value (for example `-M`) must
         // only appear at the end of a cluster so the following argument can be
         // treated as their value. Optional arguments (such as `-h`) are
         // treated as simple flags to preserve existing clap behaviour.
-        let requires_value = min_values > 0
-            || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append));
+        let requires_value = !require_equals_with_optional_value
+            && (min_values > 0
+                || (takes_values && matches!(action, ArgAction::Set | ArgAction::Append)));
 
         if requires_value {
             value_options.extend(shorts);


### PR DESCRIPTION
## Summary

The CI failures in the **Feature flag combinations** workflow on master HEAD `f620674` were not the daemon hangs the orphan-process log lines suggested. The nextest cell aborts on a CLI parser panic in `human_readable_double_short_hh_is_combined` at `crates/cli/src/frontend/arguments/parser/tests.rs:353` (`left: Some(Enabled), right: Some(Combined)`), and the runner then reaps the in-flight daemon test processes (`daemon_caps_con`, `auth_flow_proto`, etc.), which is what the harness logs as orphans.

The CLI panic is a regression introduced by #5897 (packed `-f:C` filter form). That PR taught the short-option cluster expander to treat any short with `takes_values + ArgAction::Set/Append` as value-bearing and emit the remainder as a packed value. `human-readable` (`short('h')`, `num_args(0..=1)`, `default_missing_value("__h_count__")`, `require_equals(true)`, `ArgAction::Append`) matches the classifier, so `-hh` was being rewritten to `-h h`. clap with `require_equals(true)` only accepts the value when followed by `=`, so it recorded a single `__h_count__` (the default-missing-value sentinel) instead of two, mapping to `Enabled` instead of `Combined`.

Fix: in `classify_short_options`, exclude args with `require_equals(true)` + `min_values == 0` from `value_options`. The cluster expander then emits one `-h` per character and clap counts two occurrences, matching upstream's `-hh -> level 2 (Combined)` semantics. The fix does not change behaviour for `filter` (which uses `num_args(1)` without `require_equals`), so the #5897 `-f:C` and `-f-C` paths still work.

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI nextest passes `human_readable_double_short_hh_is_combined`
- [ ] CI nextest passes `expand_cluster_filter_packed_*` (no regression on #5897)
- [ ] Feature flag combinations matrix is green on Linux + macOS + Windows
- [ ] No orphan-process termination in default-features / iconv / tracing / async / io_uring / compression / flat-flist / incremental-flist cells