### PR TITLE
fix(batch): emit destination operand in BATCH.sh ${1:-<dest>} placeholder

### DIFF
--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -23,7 +23,7 @@ use std::os::unix::fs::PermissionsExt;
 ///   without a shebang line. The `.sh` file is opened with mode `S_IRUSR |
 ///   S_IWUSR | S_IXUSR` (0o700).
 pub fn generate_script(config: &BatchConfig) -> BatchResult<()> {
-    generate_script_with_filters(config, None)
+    generate_script_with_filters(config, None, None)
 }
 
 /// Generate a shell script for replaying a batch file with optional filter rules.
@@ -33,14 +33,23 @@ pub fn generate_script(config: &BatchConfig) -> BatchResult<()> {
 /// heredoc so that the replay applies the same filters used during batch
 /// creation.
 ///
+/// When `destination` is `Some`, it is embedded as the fallback in the
+/// `${1:-<dest>}` placeholder so that `./BATCH.sh` (invoked without
+/// arguments) writes to the destination that was used when the batch was
+/// captured. Mirrors upstream `batch.c:300-304` which writes
+/// `${1:-<cooked_argv[argc-1]>}`. When `None`, a bare `.` is used (legacy
+/// behavior, only suitable when no destination is known).
+///
 /// # Upstream Reference
 ///
 /// - `batch.c:205-222`: `write_filter_rules()` embeds filter rules in the
 ///   shell script using a `<<'#E#'` heredoc.
 /// - `batch.c:262-267`: filter option selection based on protocol version.
+/// - `batch.c:300-304`: destination placeholder `${1:-<dest>}`.
 pub fn generate_script_with_filters(
     config: &BatchConfig,
     filter_rules: Option<&str>,
+    destination: Option<&str>,
 ) -> BatchResult<()> {
     let script_path = config.script_file_path();
     let batch_name = config.batch_file_path().to_string_lossy();
@@ -73,7 +82,13 @@ pub fn generate_script_with_filters(
     write!(file, " --read-batch={}", shell_quote(&batch_name))?;
 
     // upstream: batch.c:300-304 - destination placeholder
-    write!(file, " ${{1:-.}}")?;
+    // write_opt("${1:-", NULL) + write_arg(dest) + "}"
+    write!(file, " ${{1:-")?;
+    match destination {
+        Some(dest) if !dest.is_empty() => write!(file, "{}", shell_quote(dest))?,
+        _ => write!(file, ".")?,
+    }
+    write!(file, "}}")?;
 
     // upstream: batch.c:305-306 - append filter rules as heredoc
     if let Some(rules) = filter_rules {
@@ -608,7 +623,7 @@ mod tests {
 
         let filter_rules = "- *.tmp\n+ */\n+ *.txt\n- *\n";
 
-        let result = generate_script_with_filters(&config, Some(filter_rules));
+        let result = generate_script_with_filters(&config, Some(filter_rules), None);
         assert!(result.is_ok());
 
         let script_path = config.script_file_path();
@@ -641,7 +656,7 @@ mod tests {
             31,
         );
 
-        let result = generate_script_with_filters(&config, None);
+        let result = generate_script_with_filters(&config, None, None);
         assert!(result.is_ok());
 
         let script_path = config.script_file_path();
@@ -675,7 +690,7 @@ mod tests {
 
         let filter_rules = "- *.log\n";
 
-        let result = generate_script_with_filters(&config, Some(filter_rules));
+        let result = generate_script_with_filters(&config, Some(filter_rules), None);
         assert!(result.is_ok());
 
         let script_path = config.script_file_path();
@@ -691,6 +706,92 @@ mod tests {
         );
         assert!(content.contains("<<'#E#'"));
         assert!(content.contains("- *.log"));
+    }
+
+    /// Verify that `generate_script_with_filters` embeds the supplied
+    /// destination as the `${1:-<dest>}` fallback, matching upstream
+    /// `batch.c:300-304` (`write_opt("${1:-", NULL) + write_arg(dest) + "}"`).
+    ///
+    /// Without this, `./BATCH.sh` invoked with no argument falls back to `.`
+    /// (the current working directory) instead of the original destination,
+    /// breaking the upstream testsuite `batch-mode.test` BATCH.sh test which
+    /// expects the captured destination to be written to.
+    #[test]
+    fn test_generate_script_with_filters_embeds_destination() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+
+        let result = generate_script_with_filters(&config, None, Some("/path/to/dest"));
+        assert!(result.is_ok());
+
+        let script_path = config.script_file_path();
+        let content = fs::read_to_string(&script_path).unwrap();
+
+        assert!(
+            content.contains("${1:-/path/to/dest}"),
+            "Script must embed destination in placeholder: {content}"
+        );
+        assert!(
+            !content.contains("${1:-.}"),
+            "Script must not fall back to '.' when destination is supplied: {content}"
+        );
+    }
+
+    /// Verify that destinations containing shell-unsafe characters are
+    /// single-quoted in the `${1:-<dest>}` placeholder, matching upstream
+    /// `batch.c:303` which calls `write_arg(p)` (single-quotes when needed).
+    #[test]
+    fn test_generate_script_with_filters_quotes_destination_with_spaces() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+
+        let result = generate_script_with_filters(&config, None, Some("/path with spaces/dest"));
+        assert!(result.is_ok());
+
+        let script_path = config.script_file_path();
+        let content = fs::read_to_string(&script_path).unwrap();
+
+        assert!(
+            content.contains("${1:-'/path with spaces/dest'}"),
+            "Destination with spaces must be single-quoted: {content}"
+        );
+    }
+
+    /// Verify the legacy `None` destination still writes the `.` fallback so
+    /// any caller that has not yet migrated keeps working.
+    #[test]
+    fn test_generate_script_with_filters_no_destination_falls_back_to_dot() {
+        let temp_dir = TempDir::new().unwrap();
+        let batch_path = temp_dir.path().join("test.batch");
+
+        let config = BatchConfig::new(
+            BatchMode::Write,
+            batch_path.to_string_lossy().to_string(),
+            31,
+        );
+
+        let result = generate_script_with_filters(&config, None, None);
+        assert!(result.is_ok());
+
+        let script_path = config.script_file_path();
+        let content = fs::read_to_string(&script_path).unwrap();
+
+        assert!(
+            content.contains("${1:-.}"),
+            "Without a destination, the script must default to '.': {content}"
+        );
     }
 
     #[test]

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -211,7 +211,20 @@ pub(crate) fn finalize_batch(
         Some(filter_text.as_str())
     };
 
-    if let Err(e) = engine::batch::script::generate_script_with_filters(batch_cfg, filter_opt) {
+    // upstream: batch.c:300-304 - embed the destination operand as the
+    // `${1:-<dest>}` fallback so `./BATCH.sh` (with no argument) writes to
+    // the same destination used when the batch was captured. The destination
+    // is the last positional operand on the original command line.
+    let dest_operand = config
+        .transfer_args()
+        .last()
+        .map(|s| s.to_string_lossy().into_owned());
+
+    if let Err(e) = engine::batch::script::generate_script_with_filters(
+        batch_cfg,
+        filter_opt,
+        dest_operand.as_deref(),
+    ) {
         let msg = format!("failed to generate batch script: {e}");
         return Err(ClientError::new(
             1,
@@ -528,8 +541,11 @@ mod tests {
         ];
         let filter_text = serialize_filter_rules(&rules);
 
-        let result =
-            engine::batch::script::generate_script_with_filters(&batch_cfg, Some(&filter_text));
+        let result = engine::batch::script::generate_script_with_filters(
+            &batch_cfg,
+            Some(&filter_text),
+            None,
+        );
         assert!(result.is_ok());
 
         let script_path = batch_cfg.script_file_path();


### PR DESCRIPTION
## Summary

Closes the UTS `batch-mode.test` failure (task #4676) where
`./BATCH.sh` invoked without arguments writes to the current working
directory instead of the destination used when the batch was
captured.

### Root cause

`engine::batch::script::generate_script_with_filters` (`crates/batch/src/script.rs:76`)
hard-coded the BATCH.sh destination fallback as `${1:-.}`. Upstream
`batch.c:300-304` emits `${1:-<cooked_argv[argc-1]>}` - the last
positional operand passed through `write_arg` for shell-escaping:

```c
err |= write_opt("${1:-", NULL);
err |= write_arg(p);          /* dest path from cooked_argv */
err |= write(batch_sh_fd, "}", 1) != 1;
```

The upstream testsuite at `testsuite/batch-mode.test:42` runs
`./BATCH.sh` with no argument and expects the captured destination
to be written to. With `${1:-.}` the script fell back to `.`, causing
the test to fail with `cd "$todir": No such file or directory`.

### Fix

- Thread an `Option<&str> destination` through `generate_script_with_filters`.
- When `Some(dest)`, emit `${1:-<dest>}` with `shell_quote(dest)` to
  match upstream `write_arg`. When `None`, retain the legacy `.`
  fallback so the public API stays backwards-compatible.
- In `finalize_batch` derive the destination from
  `ClientConfig::transfer_args().last()` - the same `last positional
  operand` rule `replay_batch` already uses.

The companion `generate_script_with_args` function already had this
shape (using `find_destination(original_args)`); this change brings
`generate_script_with_filters` in line with it.

### Tests

Three regression tests added in `crates/batch/src/script.rs`:

- `test_generate_script_with_filters_embeds_destination` - asserts
  the supplied destination appears in `${1:-/path/to/dest}` and
  there is no `${1:-.}` fallback.
- `test_generate_script_with_filters_quotes_destination_with_spaces`
  - asserts shell-unsafe characters trigger single-quoting, matching
  upstream `write_arg`.
- `test_generate_script_with_filters_no_destination_falls_back_to_dot`
  - asserts the legacy `None` destination still emits `${1:-.}` so
  callers that have not migrated keep working.

The first test fails on master and passes with this change.

## Test plan

- [ ] CI fmt+clippy
- [ ] CI nextest (stable) covering the new `batch::script` regression tests
- [ ] CI macOS/Windows/musl
- [ ] UTS `batch-mode.test` BATCH.sh sub-transfer passes after merge