### PR TITLE
fix(engine): pair => hardlink arrow with is uptodate notice at -vv

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -323,6 +323,14 @@ pub(super) fn process_links(
             record_path.display(),
             existing_target.display()
         );
+        // upstream: hlink.c:223 - "%s is uptodate" at INFO_GTE(NAME, 2) when
+        // the destination's content is already in sync with the source group
+        // leader's inode. Upstream emits both the `=> realname` arrow (NAME>=1)
+        // and the `is uptodate` notice (NAME>=2) for the same alias when the
+        // generator pipes the row through `maybe_hard_link()` against a matched
+        // basis. Mirror that pairing here so `-vv` reports the leader-uptodate
+        // status alongside the freshly-linked alias.
+        info_log!(Name, 2, "{} is uptodate", record_path.display());
 
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();


### PR DESCRIPTION
## Summary

Restores `level_2_hardlink_uptodate_emits_is_uptodate_notice` on the Linux nextest cells + every Linux feature-flag matrix cell of master CI (run 27746631198, job 82087334875). The test panics at `crates/cli/src/frontend/tests/verbose.rs:1234` because the `-vvplrH` run on an already-hardlinked destination emits the `leader.txt => /tmp/.../to/follower.txt` arrow but no `leader.txt is uptodate` notice.

## Root cause

`process_links` block 2b in `crates/engine/src/local_copy/executor/file/copy/links.rs` handles the case where the source group leader's inode is already cached but the destination does not yet share it (because the prior file's data-path rewrite landed on a fresh inode). It emits the NAME>=1 `=>` arrow via `info_log!` but never emits the NAME>=2 `is uptodate` companion that upstream pairs with it. The renderer then falls through to its default arm and prints the bare path for the alias.

## Fix

Pair the `=>` arrow with `info_log!(Name, 2, "{} is uptodate", record_path.display())` immediately afterwards. This is what upstream's `hlink.c:223` does at `INFO_GTE(NAME, 2) && maybe_ATTRS_REPORT` when the generator pipes the alias through `maybe_hard_link()` against a matched basis (see `target/interop/upstream-src/rsync-3.4.4/hlink.c`).

Surgical change: one `info_log!` call added at `crates/engine/src/local_copy/executor/file/copy/links.rs:326`. No other paths touched, no event-type or renderer changes.

## Test plan

- [ ] CI: `level_2_hardlink_uptodate_emits_is_uptodate_notice` passes on every Linux nextest cell + feature-flag matrix cell
- [ ] CI: existing `itemize_hardlink_already_linked_omits_arrow_suffix` (block 2a path) still passes
- [ ] CI: existing `level_2_uptodate_lines_precede_transferred_lines` still passes
- [ ] CI: fmt + clippy + Windows + macOS + Linux musl all green