### PR TITLE
fix(cli): normalize itemize paths to forward slashes on Windows

### DIFF
--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -127,6 +127,14 @@ pub(super) fn render_placeholder_value(
 /// Renders the path from an event, optionally appending a trailing slash for directories.
 fn render_path(event: &ClientEvent, ensure_trailing_slash: bool) -> String {
     let mut rendered = event.relative_path().to_string_lossy().into_owned();
+    // upstream: flist.c / log.c - itemize and out-format paths use POSIX
+    // forward-slash separators regardless of host OS. Normalize Windows
+    // native backslashes here at the rendering boundary; storage retains
+    // the platform-native form.
+    #[cfg(windows)]
+    {
+        rendered = rendered.replace('\\', "/");
+    }
     if ensure_trailing_slash
         && !rendered.ends_with('/')
         && event.metadata().map(ClientEntryMetadata::kind).map_or_else(


### PR DESCRIPTION
## Summary

Fixes a master Windows nextest regression where `--itemize-changes` rows emit native backslash separators instead of upstream rsync's POSIX forward slashes.

### Failing test (CI run 27746631198, job 82087334848)

`cli::frontend::tests::itemize_format_upstream_tests::itemize_initial_recursive_transfer_emits_dir_rows_for_each_subdir` panicked on every master Windows nextest cell:

```
assertion `left == right` failed: itemize must emit root, every intermediate subdir,
and file rows in upstream order
  left: ["cd+++++++++ ./", "cd+++++++++ bar/", "cd+++++++++ bar\\baz/",
         ">f+++++++++ bar\\baz\\rsync", "cd+++++++++ foo/", ">f+++++++++ foo\\config1"]
 right: ["cd+++++++++ ./", "cd+++++++++ bar/", "cd+++++++++ bar/baz/",
         ">f+++++++++ bar/baz/rsync", "cd+++++++++ foo/", ">f+++++++++ foo/config1"]
```

Linux and macOS cells pass; the divergence is Windows-only.

### Root cause

`crates/cli/src/frontend/out_format/render/placeholder.rs::render_path` rendered the relative path via `Path::to_string_lossy()`, which preserves the platform-native separator. On Windows that produces backslashes in itemize/out-format output. Upstream rsync always uses POSIX forward slashes in wire format and itemize emission (see `flist.c` and `log.c`), regardless of host OS.

### Fix (crates/cli/src/frontend/out_format/render/placeholder.rs:128)

Normalize backslashes to forward slashes at the render boundary under `#[cfg(windows)]`. Storage retains the platform-native form; only the itemize/out-format rendering hot path is touched.

Upstream cross-reference: `target/interop/upstream-src/rsync-3.4.1/flist.c`, `log.c` (all path strings on the wire and in itemize output use `/`).

## Test plan

- [ ] CI nextest (stable) Windows cell now passes `itemize_initial_recursive_transfer_emits_dir_rows_for_each_subdir`
- [ ] Linux / macOS / musl nextest cells remain green (fix is `#[cfg(windows)]`-gated)
- [ ] fmt + clippy clean