### PR TITLE
fix(protocol): saturate flist stats accumulator to avoid overflow panic

### DIFF
--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -272,11 +272,19 @@ impl FileListReader {
             self.stats.num_dirs += 1;
         } else if entry.is_file() {
             self.stats.num_files += 1;
-            self.stats.total_size += entry.size();
+            // upstream: flist.c:691 `stats.total_size += F_LENGTH(file)` uses
+            // signed int64 and tolerates wrap; this is a cosmetic counter logged
+            // by trace.rs and never gates wire format. Saturate instead of
+            // wrapping so debug builds (overflow-checks=true, e.g. cargo-fuzz)
+            // do not panic on adversarial sizes.
+            self.stats.total_size = self.stats.total_size.saturating_add(entry.size());
         } else if entry.is_symlink() {
             self.stats.num_symlinks += 1;
             if let Some(target) = entry.link_target() {
-                self.stats.total_size += target.as_os_str().len() as u64;
+                self.stats.total_size = self
+                    .stats
+                    .total_size
+                    .saturating_add(target.as_os_str().len() as u64);
             }
         } else if entry.is_device() {
             self.stats.num_devices += 1;

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -2559,6 +2559,44 @@ mod iconv_integration {
     }
 }
 
+// Regression: `update_stats` must not panic when accumulator overflows.
+// Upstream `flist.c:691` uses signed int64 and wraps; oc-rsync used plain `+=`
+// on u64, which panicked under `overflow-checks=true` (cargo-fuzz debug
+// profile, hit by the `differential_flist` target). Saturate instead so the
+// cosmetic counter never aborts the transfer.
+#[test]
+fn update_stats_saturates_on_file_size_overflow() {
+    use crate::flist::entry::FileEntry;
+    use std::path::PathBuf;
+
+    let mut reader = FileListReader::new(test_protocol());
+    let entry = FileEntry::new_file(PathBuf::from("a"), u64::MAX, 0o100644);
+
+    reader.update_stats(&entry);
+    reader.update_stats(&entry);
+
+    assert_eq!(reader.stats().num_files, 2);
+    assert_eq!(reader.stats().total_size, u64::MAX);
+}
+
+#[test]
+fn update_stats_saturates_on_symlink_target_overflow() {
+    use crate::flist::entry::FileEntry;
+    use std::path::PathBuf;
+
+    let mut reader = FileListReader::new(test_protocol());
+
+    // Seed the accumulator at the cap so any further add must saturate.
+    let primer = FileEntry::new_file(PathBuf::from("primer"), u64::MAX, 0o100644);
+    reader.update_stats(&primer);
+
+    let link = FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("target"));
+    reader.update_stats(&link);
+
+    assert_eq!(reader.stats().num_symlinks, 1);
+    assert_eq!(reader.stats().total_size, u64::MAX);
+}
+
 // Parity with upstream rsync 3.4.2 "removal of multiple leading slashes"
 // fix (commit d4c4f67, NEWS.md:71). The upstream fix lives in `support/rrsync`;
 // here we pin the equivalent oc-rsync site (`clean_and_validate_name`) so any

--- a/crates/protocol/src/flist/write/encoding.rs
+++ b/crates/protocol/src/flist/write/encoding.rs
@@ -390,12 +390,20 @@ impl FileListWriter {
             self.stats.num_dirs += 1;
         } else if entry.is_file() {
             self.stats.num_files += 1;
-            self.stats.total_size += entry.size();
+            // upstream: flist.c:691 `stats.total_size += F_LENGTH(file)` uses
+            // signed int64 and tolerates wrap; this is a cosmetic counter logged
+            // by trace.rs and never gates wire format. Saturate instead of
+            // wrapping so debug builds (overflow-checks=true, e.g. cargo-fuzz)
+            // do not panic on adversarial sizes.
+            self.stats.total_size = self.stats.total_size.saturating_add(entry.size());
         } else if entry.is_symlink() {
             self.stats.num_symlinks += 1;
             // Upstream sums symlink target lengths into total_size.
             if let Some(target) = entry.link_target() {
-                self.stats.total_size += target.as_os_str().len() as u64;
+                self.stats.total_size = self
+                    .stats
+                    .total_size
+                    .saturating_add(target.as_os_str().len() as u64);
             }
         } else if entry.is_device() {
             self.stats.num_devices += 1;


### PR DESCRIPTION
## Summary

- Switch the four `self.stats.total_size += ...` call sites in `FileListReader::update_stats` and `FileListWriter::update_stats` to `saturating_add`.
- Stops the `differential_flist` fuzz target from panicking on overflow under `overflow-checks=true` (cargo-fuzz's default debug-instrumented release profile).
- Adds two unit tests in `crates/protocol/src/flist/read/tests.rs` exercising the file-size and symlink-target overflow paths.

## Root cause

The flist stats accumulators use plain `+=` on `u64`. cargo-fuzz builds with `overflow-checks=true`, so summing adversarial entry sizes (e.g. multiple `u64::MAX` files) overflows and panics, aborting the transfer.

Upstream rsync uses signed `int64` here and tolerates silent wrap:

> `flist.c:691  stats.total_size += F_LENGTH(file);`

The accumulator is a cosmetic counter consumed only by a `trace.rs` log line; it never gates wire format or correctness. Saturating preserves upstream's "stat never affects correctness" intent without introducing wrap-around (which is itself a debug-build assertion regression even if upstream allows it).

## Fix

Four substitutions, two on the read side and two on the write side:

- `crates/protocol/src/flist/read/extras.rs:275` (file size)
- `crates/protocol/src/flist/read/extras.rs:279` (symlink target length)
- `crates/protocol/src/flist/write/encoding.rs:393` (file size)
- `crates/protocol/src/flist/write/encoding.rs:398` (symlink target length)

All four now use `self.stats.total_size = self.stats.total_size.saturating_add(...)`.

## Upstream cross-reference

- `flist.c:691  stats.total_size += F_LENGTH(file);` (signed int64, wraps silently)
- `trace.rs` is the sole consumer of `total_size`; never written to the wire.

## Test plan

- [ ] CI: fmt + clippy
- [ ] CI: nextest stable (Linux/macOS/Windows/musl)
- [ ] CI: fuzz job `differential_flist` no longer panics on the seed that previously crashed
- [ ] New unit tests `update_stats_saturates_on_file_size_overflow` and `update_stats_saturates_on_symlink_target_overflow` pass