### PR TITLE
fix(test): compare verbose monotonicity by line count, not bytes

### DIFF
--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -830,12 +830,21 @@ fn quiet_flag_produces_no_output() {
 /// NOT extend the per-file line with a descriptor prefix or rate-display
 /// wrapper. For a single-file success transfer through the local-copy
 /// executor (no `--stats`, no skipped files), `-v` and `-vv` therefore
-/// emit identical byte counts. The earlier strict-less assertion locked
-/// in the pre-bare-render divergence and started panicking after that
-/// renderer was aligned with upstream.
+/// emit the same set of lines.
+///
+/// The invariant is compared on line counts rather than byte counts
+/// because the `sent X bytes received Y bytes Z bytes/sec` and
+/// `total size is N speedup is N.NN` lines contain timing-derived
+/// numerics (the rate field is `(sent + received) / elapsed`) whose
+/// rendered width varies by a few bytes between runs. Comparing line
+/// counts isolates the monotonicity check from that timing jitter.
 #[test]
 fn higher_verbosity_produces_more_output() {
     use tempfile::tempdir;
+
+    fn line_count(bytes: &[u8]) -> usize {
+        bytes.iter().filter(|b| **b == b'\n').count()
+    }
 
     let tmp = tempdir().expect("tempdir");
     let source = tmp.path().join("progressive.txt");
@@ -867,17 +876,23 @@ fn higher_verbosity_produces_more_output() {
     ]);
     assert_eq!(code, 0);
 
+    let lines0 = line_count(&stdout0);
+    let lines1 = line_count(&stdout1);
+    let lines2 = line_count(&stdout2);
+
     assert!(
-        stdout0.len() < stdout1.len(),
-        "level 0 ({} bytes) should produce less output than level 1 ({} bytes)",
-        stdout0.len(),
-        stdout1.len()
+        lines0 < lines1,
+        "level 0 ({lines0} lines) should produce fewer lines than level 1 ({lines1} lines)\n\
+         level 0 stdout: {:?}\nlevel 1 stdout: {:?}",
+        String::from_utf8_lossy(&stdout0),
+        String::from_utf8_lossy(&stdout1),
     );
     assert!(
-        stdout1.len() <= stdout2.len(),
-        "level 2 ({} bytes) must not drop output relative to level 1 ({} bytes)",
-        stdout2.len(),
-        stdout1.len()
+        lines1 <= lines2,
+        "level 2 ({lines2} lines) must not drop lines relative to level 1 ({lines1} lines)\n\
+         level 1 stdout: {:?}\nlevel 2 stdout: {:?}",
+        String::from_utf8_lossy(&stdout1),
+        String::from_utf8_lossy(&stdout2),
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a flaky-by-design assertion in `cli::frontend::tests::verbose_tests::higher_verbosity_produces_more_output` (crates/cli/src/frontend/tests/verbose.rs). The test compared `stdout1.len()` (bytes at `-v`) against `stdout2.len()` (bytes at `-vv`) and asserted the level-2 byte count was >= level-1. The macOS (stable) nextest cell tripped this:

```
thread '...higher_verbosity_produces_more_output' panicked at crates/cli/src/frontend/tests/verbose.rs:876:5:
level 2 (135 bytes) must not drop output relative to level 1 (136 bytes)
```

CI run: https://github.com/oferchen/rsync/actions/runs/27746631198 (macOS stable cell).

## Root cause

`emit_totals` in `crates/cli/src/frontend/progress/render.rs:394` renders the trailer as:

```
sent {sent_display} bytes  received {received_display} bytes  {rate_display} bytes/sec
total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}
```

`rate_display` is `format!("{rate:.2}")` from `format_summary_rate` (crates/cli/src/frontend/progress/format/rate.rs:7) where `rate = (sent + received) / elapsed_seconds`. `speedup` is `total_size / transmitted`. Both fields take their width from elapsed-time-derived values, so the totals trailer can vary by one or two bytes between consecutive `oc-rsync` invocations on the same source - even though both runs emit the same set of lines.

For a single-file local-copy transfer at `-v` vs `-vv` (no `--stats`, no skipped files), both verbosities walk the same `emit_verbose` and `emit_totals` paths (verified by tracing `emit_transfer_summary` in render.rs: `emit_verbose_listing=true`, `emit_trailer_totals=true`, no `MetadataReused` arm, no `HardLink` arm, no flist banner). The structural output is identical; only the rate/speedup widths differ.

## Fix

Compare line counts instead of byte counts. Line count is the structural invariant the test docstring already describes - timing-derived field widths are isolated from the monotonicity check, but a real drop in the verbose listing (e.g. a future regression that suppresses the per-file row at `-vv`) would still trip the assertion.

The failure message now includes both stdouts so any future drop is diagnosable directly from the CI log.

## Test plan

- [x] Verified that the test was the only assertion using byte length to encode the structural invariant
- [x] Verified that `emit_verbose` at `-v` and `-vv` for a default `DataCopied` event renders the same single `{relative_path}\n` line (crates/cli/src/frontend/progress/render.rs:596-610)
- [x] Verified that `emit_totals` is the only trailer fired without `--stats`
- [x] Verified line-count invariant holds: both runs emit `progressive.txt\n`, blank separator, `sent ... bytes received ... bytes ... bytes/sec\n`, `total size is ... speedup is N.NN\n` = 4 lines
- [ ] CI runs the full nextest cell against the corrected assertion