### PR TITLE
fix(fast_io): gate require_cow test tempfile import on non-Windows

### DIFF
--- a/crates/fast_io/src/platform_copy/require_cow.rs
+++ b/crates/fast_io/src/platform_copy/require_cow.rs
@@ -132,6 +132,7 @@ const fn preferred_reflink_method() -> CopyMethod {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(target_os = "windows"))]
     use tempfile::TempDir;
 
     #[test]


### PR DESCRIPTION
## Summary

- Gate the `tempfile::TempDir` test-module import in `crates/fast_io/src/platform_copy/require_cow.rs` to `not(target_os = "windows")`.
- The only consumers of the import are the Linux/macOS smoke test and the unsupported-platform fallback test; on Windows the import is dead.
- Windows MSVC builds with `--features iocp --locked` were failing `-D warnings` with `unused import: tempfile::TempDir`, blocking the nightly Windows IOCP high-IOPS workflow.

## Test plan

- [ ] CI fmt+clippy
- [ ] Linux nextest (stable)
- [ ] macOS nextest (stable)
- [ ] Windows nextest (stable)
- [ ] Windows nightly IOCP high-IOPS workflow no longer fails on require_cow.rs