### PR TITLE
fix(cli): default recursive to false when neither -r, -a, nor --files-from is set

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -67,7 +67,7 @@ where
         tcp_fastopen,
         blocking_io,
         archive,
-        recursive: _recursive,
+        recursive,
         recursive_override,
         inc_recursive,
         dirs,
@@ -494,10 +494,14 @@ where
 
     // upstream: options.c:2169-2177 - --files-from disables default recursion,
     // enables xfer_dirs, and implies --relative.
+    //
+    // Otherwise honour the parser-computed `recursive` flag, which mirrors
+    // upstream's `recurse` default of 0 (options.c:112) and the `-r` / `-a` /
+    // `--no-recursive` precedence rules (parser/mod.rs:152-158).
     let recursive_effective = if files_from_active {
         false // upstream: options.c:2174 - if (recurse == 1) recurse = 0
     } else {
-        !matches!(recursive_override, Some(false))
+        recursive
     };
 
     // upstream: options.c:2176-2177 - xfer_dirs = 1 when files_from is active

--- a/crates/cli/src/frontend/tests/mod.rs
+++ b/crates/cli/src/frontend/tests/mod.rs
@@ -296,6 +296,8 @@ mod tracing_integration_tests;
 mod transfer_request_copies_tests;
 #[path = "transfer_request_reports.rs"]
 mod transfer_request_reports_tests;
+#[path = "transfer_request_skips_directories_without_recursion.rs"]
+mod transfer_request_skips_directories_without_recursion_tests;
 #[path = "transfer_request_with_apple_double.rs"]
 mod transfer_request_with_apple_double_tests;
 #[cfg(unix)]

--- a/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs
@@ -1,0 +1,160 @@
+use super::common::*;
+use super::*;
+
+/// Verifies that `rsync src/ dst/` without `-r`, `-d`, `-a`, or `--files-from`
+/// skips the directory and writes nothing, matching upstream rsync 3.4.4.
+///
+/// Upstream's `recurse` defaults to `0` (options.c:112) and `xfer_dirs` falls
+/// back to `0` when neither `-r` nor `-d` is supplied (options.c:2200-2203).
+/// In `flist.c:2451`, a directory operand with `!xfer_dirs` triggers
+/// `rprintf(FINFO, "skipping directory %s\n", fbuf)` and is omitted from the
+/// flist, so the destination tree remains empty.
+///
+/// # Upstream Reference
+///
+/// - `options.c:112` - `int recurse = 0;` default
+/// - `options.c:2200-2203` - `xfer_dirs = 0` when recurse is off and the user
+///   did not request `-d`
+/// - `flist.c:2451` - `S_ISDIR(st.st_mode) && !xfer_dirs` skips the directory
+#[test]
+fn trailing_slash_source_without_recursion_skips_directory() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    std::fs::create_dir(&source_dir).expect("create source");
+    std::fs::write(source_dir.join("child.txt"), b"payload").expect("write child");
+
+    let dest_dir = tmp.path().join("dst");
+
+    let mut source_arg = source_dir.into_os_string();
+    source_arg.push("/");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-times"),
+        OsString::from("--no-perms"),
+        source_arg,
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "skipping a top-level dir is a success");
+    assert!(
+        !dest_dir.exists()
+            || std::fs::read_dir(&dest_dir)
+                .expect("read dst")
+                .next()
+                .is_none(),
+        "destination must be absent or empty when recursion is disabled, got entries at {}",
+        dest_dir.display()
+    );
+}
+
+/// Verifies that `rsync src dst` (no trailing slash) without recursion skips
+/// the source directory entirely.
+///
+/// Same upstream semantics as the trailing-slash variant: the directory operand
+/// hits the `!xfer_dirs` guard in `flist.c:2451` and is omitted from the flist.
+#[test]
+fn non_trailing_slash_source_without_recursion_skips_directory() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    std::fs::create_dir(&source_dir).expect("create source");
+    std::fs::write(source_dir.join("child.txt"), b"payload").expect("write child");
+
+    let dest_dir = tmp.path().join("dst");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--no-times"),
+        OsString::from("--no-perms"),
+        source_dir.into_os_string(),
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(
+        !dest_dir.exists(),
+        "destination must not be created when the only source is a skipped directory"
+    );
+}
+
+/// Verifies that `-r` re-enables the recursive copy that the default would have
+/// skipped. Guards against an over-broad fix that disables recursion entirely.
+#[test]
+fn trailing_slash_source_with_recursion_copies_contents() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    let nested = source_dir.join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested");
+    std::fs::write(source_dir.join("top.txt"), b"top").expect("write top");
+    std::fs::write(nested.join("inner.txt"), b"inner").expect("write inner");
+
+    let dest_dir = tmp.path().join("dst");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    let mut source_arg = source_dir.into_os_string();
+    source_arg.push("/");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-r"),
+        OsString::from("--no-times"),
+        OsString::from("--no-perms"),
+        source_arg,
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        std::fs::read(dest_dir.join("top.txt")).expect("read top"),
+        b"top"
+    );
+    assert_eq!(
+        std::fs::read(dest_dir.join("nested").join("inner.txt")).expect("read inner"),
+        b"inner"
+    );
+}
+
+/// Verifies that `-d` walks one level of children but does not recurse,
+/// matching upstream's `xfer_dirs && !recurse` behaviour.
+#[test]
+fn trailing_slash_source_with_dirs_only_walks_one_level() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    let nested = source_dir.join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested");
+    std::fs::write(source_dir.join("top.txt"), b"top").expect("write top");
+    std::fs::write(nested.join("inner.txt"), b"inner").expect("write inner");
+
+    let dest_dir = tmp.path().join("dst");
+    std::fs::create_dir(&dest_dir).expect("create dest");
+
+    let mut source_arg = source_dir.into_os_string();
+    source_arg.push("/");
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-d"),
+        OsString::from("--no-times"),
+        OsString::from("--no-perms"),
+        source_arg,
+        dest_dir.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        std::fs::read(dest_dir.join("top.txt")).expect("read top"),
+        b"top"
+    );
+    assert!(
+        !dest_dir.join("nested").join("inner.txt").exists(),
+        "nested children must not be copied with -d alone"
+    );
+}


### PR DESCRIPTION
## Summary

- `drive::workflow::run` was recomputing `recursive_effective` as
  `!matches!(recursive_override, Some(false))`, which treats the
  default (no `-r`, no `--no-recursive`) as `true`. Every
  `oc-rsync src/ dst/` invocation was therefore a recursive copy.
- Upstream rsync 3.4.4 defaults `recurse=0` (`options.c:112`) and
  skips directory operands when neither `-r` nor `-d` is supplied
  (`flist.c:2451` -> `skipping directory %s\n`).
- The fix stops discarding `parsed.recursive` (the
  precedence-resolved CLI flag) and feeds it directly into
  `recursive_effective`, keeping the `files_from_active`
  short-circuit intact (`options.c:2174`).

## Repro

Differential fuzzer run [27745961236](https://github.com/oferchen/rsync/actions/runs/27745961236)
panicked in `differential_outcome` at
`fuzz_targets/differential_outcome.rs:436`:

> destination content divergence: name=\"H\" flags=[\"--no-times\", \"--no-perms\"]
> content_len=1 oc_dest_len=Some(1) upstream_dest_len=None

oc-rsync wrote `dst-oc/H`; upstream produced no destination at all.

Manual repro (Linux container):

```
$ oc-rsync --no-times --no-perms src/ dst-oc      # writes dst-oc/H
$ rsync --no-times --no-perms src/ dst-rsync       # 'skipping directory .', no dst-rsync
```

After the fix the CLI honours the parser-resolved `recursive` flag
and matches upstream's skip-and-no-write behaviour.

## Upstream references

- `options.c:112` - `int recurse = 0;` default.
- `options.c:2200-2203` - `xfer_dirs = 0` when recurse is off and
  the user did not request `-d`.
- `flist.c:2451` - `S_ISDIR(st.st_mode) && !xfer_dirs` skips the
  directory and prints `skipping directory %s\n`.
- `options.c:2174` - `--files-from` clears recurse=1 (preserved by
  the surviving short-circuit).
- Parser already resolves `-r / -a / --no-recursive` correctly at
  `crates/cli/src/frontend/arguments/parser/mod.rs:152-158`.

## Test plan

- [x] `cargo fmt --all`
- [ ] New CLI regression tests added in
  `crates/cli/src/frontend/tests/transfer_request_skips_directories_without_recursion.rs`
  covering the four cases:
  - `src/ dst/` (no flags) -> skip directory, dst absent or empty.
  - `src dst` (no flags) -> skip directory, dst absent.
  - `-r src/ dst/` -> recursive copy including nested file.
  - `-d src/ dst/` -> one-level walk, nested file NOT copied.
- [ ] Existing engine-level test
  `crates/engine/src/local_copy/tests/execute_directories.rs::execute_skips_directories_without_recursion`
  continues to pass (engine gate fires when
  `LocalCopyOptions::default().recursive(false).dirs(false)`).
- [ ] `execute_no_implied_dirs::no_implied_dirs_with_trailing_slash_copies_contents`
  still passes - it exercises the engine API with
  `LocalCopyOptions::default()` (engine default `recursive=true`),
  not the CLI default, so its behaviour is unchanged.
- [ ] CI: required checks (fmt+clippy, nextest, Windows, macOS, Linux musl)
  must pass.

## Notes on the original Phase-1 diagnosis

The Phase-1 diagnosis pointed at
`handle_directory_contents_copy`'s `walk_one_level` branch
(added by #5852). That branch only fires when the gate at lines
82-87 does **not** return early, which requires
`recursive_enabled || dirs_enabled`. The gate is correct - it
returned `Ok(true)` for the all-false case as designed. The actual
divergence is upstream of the engine: the CLI was forcing
`recursive=true` whenever the user did not explicitly pass
`--no-recursive`. Fixing the engine alone would have left the
deeper recursion path (`copy_directory_recursive`) still firing
on `oc-rsync src/ dst/`.