### PR TITLE
feat(fast_io): expose runtime CoW filesystem detection helper

### DIFF
--- a/crates/fast_io/src/platform_copy/cow_detect.rs
+++ b/crates/fast_io/src/platform_copy/cow_detect.rs
@@ -1,6 +1,6 @@
-//! Runtime detection of copy-on-write (CoW) filesystem support on Linux.
+//! Runtime detection of copy-on-write (CoW) filesystem support.
 //!
-//! REFLINK-2 helper. Linux `FICLONE`/`FICLONERANGE` only succeed on
+//! REFLINK-2 foundation. Linux `FICLONE`/`FICLONERANGE` only succeed on
 //! reflink-capable filesystems (btrfs, XFS with `mkfs.xfs -m reflink=1`,
 //! bcachefs). Every other filesystem returns `EOPNOTSUPP` or `EXDEV`,
 //! costing one round-trip syscall plus a destination-file create/unlink
@@ -23,16 +23,25 @@
 //! - ext4 / tmpfs / proc / sysfs / NFS / FUSE / etc.: known not to
 //!   support reflink. Returns [`CowSupport::No`] so the dispatch
 //!   skips FICLONE entirely.
+//! - ZFS-on-Linux (`0x2FC12FC1`) reports itself separately and gates
+//!   reflink on the dataset-level `clone_blocks` feature. We treat it
+//!   as [`CowSupport::Probable`] so a single FICLONE probe confirms.
 //!
 //! The detection result is cached in a process-wide
-//! [`OnceLock<Mutex<HashMap>>`] keyed by the `(dev_major, dev_minor)`
-//! tuple from `statfs.f_fsid` so repeated copies on the same mount
-//! only pay the `statfs` cost once.
+//! [`OnceLock<Mutex<HashMap>>`] keyed by `statfs.f_fsid` so repeated
+//! copies on the same mountpoint only pay the `statfs` cost once.
+//!
+//! # Platform Support
+//!
+//! - **Linux**: full `statfs(2)`-backed probe.
+//! - **Other platforms**: stub that returns `CowSupport::No` /
+//!   `detect_cow_filesystem` -> `Ok(false)`. Cross-platform callers can
+//!   use the public helpers without `#[cfg]` branching at every call
+//!   site; the macOS APFS and Windows ReFS reflink paths are handled
+//!   by their own dispatch layers (`clonefile`, `refs_detect`).
 
-use std::collections::HashMap;
 use std::io;
 use std::path::Path;
-use std::sync::{Mutex, OnceLock};
 
 /// Outcome of a CoW filesystem probe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,116 +54,211 @@ pub enum CowSupport {
     /// (e.g. `copy_file_range` on Linux).
     No,
     /// Filesystem may support reflink but cannot be determined from
-    /// `f_type` alone (XFS requires `-m reflink=1` at mkfs time).
-    /// The caller should attempt a single `FICLONE` probe and cache
-    /// the result.
+    /// `f_type` alone (XFS requires `-m reflink=1` at mkfs time; ZFS
+    /// gates on a dataset feature). The caller should attempt a single
+    /// `FICLONE` probe and cache the result via
+    /// [`record_probe_outcome`].
     Probable,
 }
 
-const BTRFS_SUPER_MAGIC: i64 = 0x9123_683E;
-const XFS_SUPER_MAGIC: i64 = 0x5846_5342;
-const BCACHEFS_SUPER_MAGIC: i64 = 0xCA45_1A4E;
+impl CowSupport {
+    /// Collapses the three-state probe outcome to a boolean answer that
+    /// matches the REFLINK-2 task contract:
+    ///
+    /// - [`CowSupport::Yes`] and [`CowSupport::Probable`] both map to
+    ///   `true`. The caller may attempt `FICLONE`; `Probable` will be
+    ///   resolved on the first attempt and cached.
+    /// - [`CowSupport::No`] maps to `false`; the caller skips the
+    ///   reflink path entirely.
+    #[must_use]
+    pub fn may_attempt_reflink(self) -> bool {
+        matches!(self, Self::Yes | Self::Probable)
+    }
+}
 
 /// Returns the CoW support classification for the filesystem
 /// containing `path`.
 ///
-/// Calls `statfs(2)` and inspects `f_type`. The result is computed
-/// once per `(dev, fs_type)` and cached in a process-wide map keyed
-/// by the `statfs.f_fsid` returned by the kernel so subsequent calls
-/// for the same mountpoint return without a syscall.
+/// On Linux this calls `statfs(2)` and inspects `f_type`. The result is
+/// computed once per `(fs_id, fs_type)` and cached in a process-wide
+/// map keyed by the `statfs.f_fsid` returned by the kernel so
+/// subsequent calls for the same mountpoint return without a syscall.
+///
+/// On every other platform this returns [`CowSupport::No`] without
+/// touching the filesystem. macOS APFS and Windows ReFS reflink
+/// support is handled by their dedicated dispatch layers
+/// (`platform_copy::dispatch::clonefile_impl`,
+/// `fast_io::refs_detect`), not by this probe.
 ///
 /// # Errors
 ///
-/// Returns the underlying `io::Error` if `statfs(2)` fails (e.g.
-/// `ENOENT` when `path` does not exist, `EACCES` when the directory
-/// is unreadable).
+/// On Linux, returns the underlying `io::Error` if `statfs(2)` fails
+/// (e.g. `ENOENT` when `path` does not exist, `EACCES` when the
+/// directory is unreadable). The non-Linux stub never errors.
 pub fn detect_cow_support(path: &Path) -> io::Result<CowSupport> {
-    let (fs_id, fs_type) = statfs_for_path(path)?;
-    let cache = cache();
-    if let Some(cached) = lookup(cache, fs_id) {
-        return Ok(cached);
-    }
-    let support = classify(fs_type);
-    insert(cache, fs_id, support);
-    Ok(support)
+    imp::detect_cow_support(path)
+}
+
+/// Boolean front door over [`detect_cow_support`] for callers that do
+/// not need to distinguish `Yes` from `Probable`.
+///
+/// Returns `Ok(true)` when the filesystem may support reflink (btrfs,
+/// XFS, bcachefs, ZFS) and `Ok(false)` when it cannot. This is the
+/// foundation the REFLINK-3 (`FICLONE` whole-file) and REFLINK-4
+/// (`FICLONERANGE` delta) wiring will gate on.
+///
+/// On non-Linux platforms this always returns `Ok(false)` without
+/// touching the filesystem.
+///
+/// # Errors
+///
+/// On Linux, returns the underlying `io::Error` if `statfs(2)` fails.
+/// The non-Linux stub never errors.
+pub fn detect_cow_filesystem(path: &Path) -> io::Result<bool> {
+    detect_cow_support(path).map(CowSupport::may_attempt_reflink)
 }
 
 /// Records the outcome of a confirming FICLONE probe so later callers
-/// for the same mountpoint can skip the syscall when the probe
-/// failed (or treat it as cached success when it worked).
+/// for the same mountpoint can skip the syscall when the probe failed
+/// (or treat it as cached success when it worked).
 ///
-/// Intended for use by the dispatch layer after a `Probable` result
-/// from [`detect_cow_support`] has been confirmed (or refuted) by a
-/// single FICLONE attempt. Idempotent - subsequent calls on the same
-/// key overwrite the previous value.
+/// Intended for use by the dispatch layer after a
+/// [`CowSupport::Probable`] result from [`detect_cow_support`] has
+/// been confirmed (or refuted) by a single FICLONE attempt.
+/// Idempotent - subsequent calls on the same key overwrite the
+/// previous value.
+///
+/// On non-Linux platforms this is a no-op.
 ///
 /// # Errors
 ///
-/// Returns the underlying `io::Error` if `statfs(2)` fails.
+/// On Linux, returns the underlying `io::Error` if `statfs(2)` fails.
+/// The non-Linux stub never errors.
 pub fn record_probe_outcome(path: &Path, outcome: CowSupport) -> io::Result<()> {
-    let (fs_id, _) = statfs_for_path(path)?;
-    insert(cache(), fs_id, outcome);
-    Ok(())
+    imp::record_probe_outcome(path, outcome)
 }
 
-fn classify(fs_type: i64) -> CowSupport {
-    match fs_type {
-        BTRFS_SUPER_MAGIC | BCACHEFS_SUPER_MAGIC => CowSupport::Yes,
-        XFS_SUPER_MAGIC => CowSupport::Probable,
-        _ => CowSupport::No,
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::CowSupport;
+    use std::collections::HashMap;
+    use std::io;
+    use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
+
+    const BTRFS_SUPER_MAGIC: i64 = 0x9123_683E;
+    const XFS_SUPER_MAGIC: i64 = 0x5846_5342;
+    const BCACHEFS_SUPER_MAGIC: i64 = 0xCA45_1A4E;
+    const ZFS_SUPER_MAGIC: i64 = 0x2FC1_2FC1;
+
+    pub(super) fn detect_cow_support(path: &Path) -> io::Result<CowSupport> {
+        let (fs_id, fs_type) = statfs_for_path(path)?;
+        let cache = cache();
+        if let Some(cached) = lookup(cache, fs_id) {
+            return Ok(cached);
+        }
+        let support = classify(fs_type);
+        insert(cache, fs_id, support);
+        Ok(support)
+    }
+
+    pub(super) fn record_probe_outcome(path: &Path, outcome: CowSupport) -> io::Result<()> {
+        let (fs_id, _) = statfs_for_path(path)?;
+        insert(cache(), fs_id, outcome);
+        Ok(())
+    }
+
+    pub(super) fn classify(fs_type: i64) -> CowSupport {
+        match fs_type {
+            BTRFS_SUPER_MAGIC | BCACHEFS_SUPER_MAGIC => CowSupport::Yes,
+            XFS_SUPER_MAGIC | ZFS_SUPER_MAGIC => CowSupport::Probable,
+            _ => CowSupport::No,
+        }
+    }
+
+    type Cache = OnceLock<Mutex<HashMap<u64, CowSupport>>>;
+
+    fn cache() -> &'static Cache {
+        static CACHE: Cache = OnceLock::new();
+        CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        &CACHE
+    }
+
+    fn lookup(cache: &Cache, fs_id: u64) -> Option<CowSupport> {
+        let guard = cache.get()?.lock().ok()?;
+        guard.get(&fs_id).copied()
+    }
+
+    fn insert(cache: &Cache, fs_id: u64, support: CowSupport) {
+        let Some(lock) = cache.get() else {
+            return;
+        };
+        if let Ok(mut guard) = lock.lock() {
+            guard.insert(fs_id, support);
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn statfs_for_path(path: &Path) -> io::Result<(u64, i64)> {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let cpath = CString::new(path.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        // SAFETY: `cpath` is a NUL-terminated C string owned for the call
+        // and `buf` is a stack-resident `libc::statfs` whose address is
+        // valid for the duration of the syscall. Standard `libc::statfs`
+        // invocation idiom (mirrors `looks_like_nfs` in
+        // `engine/benches/per_op_thresholds.rs`).
+        let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::statfs(cpath.as_ptr(), &mut buf) };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let fs_id = fsid_to_u64(&buf.f_fsid);
+        Ok((fs_id, buf.f_type as i64))
+    }
+
+    #[allow(unsafe_code)]
+    fn fsid_to_u64(fsid: &libc::fsid_t) -> u64 {
+        // SAFETY: `libc::fsid_t` is a POD wrapper around `[i32; 2]` (glibc)
+        // or `[c_int; 2]` (musl); both are 8 bytes total with no padding.
+        // Reading the bytes as a `u64` is well-defined for any bit pattern.
+        let bytes: [u8; 8] = unsafe { std::mem::transmute_copy(fsid) };
+        u64::from_ne_bytes(bytes)
+    }
+
+    #[cfg(test)]
+    pub mod test_hooks {
+        use super::{
+            BCACHEFS_SUPER_MAGIC, BTRFS_SUPER_MAGIC, XFS_SUPER_MAGIC, ZFS_SUPER_MAGIC, classify,
+        };
+        use crate::platform_copy::cow_detect::CowSupport;
+
+        pub fn classify_magic(fs_type: i64) -> CowSupport {
+            classify(fs_type)
+        }
+
+        pub const BTRFS: i64 = BTRFS_SUPER_MAGIC;
+        pub const XFS: i64 = XFS_SUPER_MAGIC;
+        pub const BCACHEFS: i64 = BCACHEFS_SUPER_MAGIC;
+        pub const ZFS: i64 = ZFS_SUPER_MAGIC;
     }
 }
 
-type Cache = OnceLock<Mutex<HashMap<u64, CowSupport>>>;
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use super::CowSupport;
+    use std::io;
+    use std::path::Path;
 
-fn cache() -> &'static Cache {
-    static CACHE: Cache = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    &CACHE
-}
-
-fn lookup(cache: &Cache, fs_id: u64) -> Option<CowSupport> {
-    let guard = cache.get()?.lock().ok()?;
-    guard.get(&fs_id).copied()
-}
-
-fn insert(cache: &Cache, fs_id: u64, support: CowSupport) {
-    let Some(lock) = cache.get() else {
-        return;
-    };
-    if let Ok(mut guard) = lock.lock() {
-        guard.insert(fs_id, support);
+    pub(super) fn detect_cow_support(_path: &Path) -> io::Result<CowSupport> {
+        Ok(CowSupport::No)
     }
-}
 
-#[allow(unsafe_code)]
-fn statfs_for_path(path: &Path) -> io::Result<(u64, i64)> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-
-    let cpath = CString::new(path.as_os_str().as_bytes())
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-    // SAFETY: `cpath` is a NUL-terminated C string owned for the call
-    // and `buf` is a stack-resident `libc::statfs` whose address is
-    // valid for the duration of the syscall. Standard `libc::statfs`
-    // invocation idiom (mirrors `looks_like_nfs` in
-    // `engine/benches/per_op_thresholds.rs`).
-    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
-    let rc = unsafe { libc::statfs(cpath.as_ptr(), &mut buf) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
+    pub(super) fn record_probe_outcome(_path: &Path, _outcome: CowSupport) -> io::Result<()> {
+        Ok(())
     }
-    let fs_id = fsid_to_u64(&buf.f_fsid);
-    Ok((fs_id, buf.f_type as i64))
-}
-
-#[allow(unsafe_code)]
-fn fsid_to_u64(fsid: &libc::fsid_t) -> u64 {
-    // SAFETY: `libc::fsid_t` is a POD wrapper around `[i32; 2]` (glibc)
-    // or `[c_int; 2]` (musl); both are 8 bytes total with no padding.
-    // Reading the bytes as a `u64` is well-defined for any bit pattern.
-    let bytes: [u8; 8] = unsafe { std::mem::transmute_copy(fsid) };
-    u64::from_ne_bytes(bytes)
 }
 
 #[cfg(test)]
@@ -179,6 +283,16 @@ mod tests {
     }
 
     #[test]
+    fn detect_cow_filesystem_handles_tmpdir() {
+        let answer = detect_cow_filesystem(&tmp_dir()).expect("detect on tmpdir");
+        // Whatever the underlying FS is, the bool must agree with the
+        // three-state probe's `may_attempt_reflink` collapse.
+        let support = detect_cow_support(&tmp_dir()).expect("statfs on tmpdir");
+        assert_eq!(answer, support.may_attempt_reflink());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn detect_handles_root_without_error() {
         let support = detect_cow_support(Path::new("/")).expect("statfs on /");
         assert!(matches!(
@@ -195,6 +309,7 @@ mod tests {
         assert_eq!(first, second);
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn detect_returns_enoent_for_missing_path() {
         let err = detect_cow_support(Path::new("/nonexistent-cow-detect-target"))
@@ -202,17 +317,33 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn classify_known_magics() {
-        assert_eq!(classify(BTRFS_SUPER_MAGIC), CowSupport::Yes);
-        assert_eq!(classify(BCACHEFS_SUPER_MAGIC), CowSupport::Yes);
-        assert_eq!(classify(XFS_SUPER_MAGIC), CowSupport::Probable);
+        use imp::test_hooks;
+        assert_eq!(
+            test_hooks::classify_magic(test_hooks::BTRFS),
+            CowSupport::Yes
+        );
+        assert_eq!(
+            test_hooks::classify_magic(test_hooks::BCACHEFS),
+            CowSupport::Yes
+        );
+        assert_eq!(
+            test_hooks::classify_magic(test_hooks::XFS),
+            CowSupport::Probable
+        );
+        assert_eq!(
+            test_hooks::classify_magic(test_hooks::ZFS),
+            CowSupport::Probable
+        );
         // ext4 (0xEF53), tmpfs (0x01021994), proc (0x9fa0): all No.
-        assert_eq!(classify(0xEF53), CowSupport::No);
-        assert_eq!(classify(0x0102_1994), CowSupport::No);
-        assert_eq!(classify(0x9fa0), CowSupport::No);
+        assert_eq!(test_hooks::classify_magic(0xEF53), CowSupport::No);
+        assert_eq!(test_hooks::classify_magic(0x0102_1994), CowSupport::No);
+        assert_eq!(test_hooks::classify_magic(0x9fa0), CowSupport::No);
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn record_probe_outcome_overrides_classification() {
         let path = tmp_dir();
@@ -221,5 +352,29 @@ mod tests {
         record_probe_outcome(&path, CowSupport::No).expect("record outcome");
         let after = detect_cow_support(&path).expect("post-record probe");
         assert_eq!(after, CowSupport::No);
+    }
+
+    #[test]
+    fn may_attempt_reflink_collapses_correctly() {
+        assert!(CowSupport::Yes.may_attempt_reflink());
+        assert!(CowSupport::Probable.may_attempt_reflink());
+        assert!(!CowSupport::No.may_attempt_reflink());
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_stub_always_returns_false() {
+        let answer = detect_cow_filesystem(&tmp_dir()).expect("stub does not error");
+        assert!(!answer);
+        let support = detect_cow_support(&tmp_dir()).expect("stub does not error");
+        assert_eq!(support, CowSupport::No);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_record_probe_is_noop() {
+        // Should not error and should not change the answer.
+        record_probe_outcome(&tmp_dir(), CowSupport::Yes).expect("stub no-ops");
+        assert!(!detect_cow_filesystem(&tmp_dir()).expect("stub no-ops"));
     }
 }

--- a/crates/fast_io/src/platform_copy/mod.rs
+++ b/crates/fast_io/src/platform_copy/mod.rs
@@ -46,8 +46,7 @@
 //! println!("Copied {} bytes via {:?}", result.bytes_copied, result.method);
 //! ```
 
-#[cfg(target_os = "linux")]
-mod cow_detect;
+pub mod cow_detect;
 mod dispatch;
 mod no_zero_copy;
 mod require_cow;
@@ -58,6 +57,7 @@ mod types;
 use std::io;
 use std::path::Path;
 
+pub use cow_detect::{CowSupport, detect_cow_filesystem, detect_cow_support, record_probe_outcome};
 pub use no_zero_copy::NoZeroCopyPlatformCopy;
 pub use require_cow::RequireCowPlatformCopy;
 pub use types::{CopyMethod, CopyResult, PlatformCopy};

--- a/docs/design/reflink-acceleration.md
+++ b/docs/design/reflink-acceleration.md
@@ -1,0 +1,193 @@
+# Reflink Acceleration
+
+Status: FOUNDATION (REFLINK-2). Tracks the runtime CoW filesystem
+detection layer that the REFLINK-3 (`FICLONE` whole-file), REFLINK-4
+(`FICLONERANGE` delta-apply COPY-token), and REFLINK-9 (engine
+local-copy wiring) tiers build on. This document does not specify the
+FICLONE wiring itself.
+
+Related:
+- REFLINK-1 inventory: `docs/design/reflink-1-local-copy-dispatch-audit.md`
+- Windows ReFS reflink: `docs/design/windows-refs-reflink.md`
+
+## Motivation
+
+`FICLONE`/`FICLONERANGE` succeed only on reflink-capable filesystems
+(btrfs, XFS with `mkfs.xfs -m reflink=1`, bcachefs, ZFS-on-Linux with
+`clone_blocks`). Every other filesystem - ext4, tmpfs, NFS, FUSE,
+overlayfs, sysfs - rejects the ioctl with `EOPNOTSUPP`, `EXDEV`, or
+`EINVAL`. The reject is cheap on its own, but the dispatch path pays
+extra costs around it: a destination file gets created (and must be
+unlinked after the failed reflink), and on a busy directory the
+syscall round-trip plus filesystem state churn is measurable on the
+sender critical path.
+
+A cheap per-mountpoint pre-flight that says "this filesystem cannot
+ever support reflink" lets the dispatch skip those costs and fall
+straight through to the next tier (`copy_file_range` on Linux,
+`std::fs::copy` everywhere else).
+
+## Mechanism Survey (REFLINK-2.a)
+
+Two viable Linux mechanisms for "what filesystem is this path on":
+
+| Mechanism | Pros | Cons | Verdict |
+| --- | --- | --- | --- |
+| `statfs(2)` / `fstatfs(2)` with the `f_type` magic | One syscall per probe; returns the kernel's authoritative super-block magic; pairs naturally with `f_fsid` for cache keying. | Magic-to-name mapping is informal (no public header lists all of them); XFS reports the same magic whether reflink is enabled or not. | **Picked.** Cheapest, most direct, and the XFS ambiguity is handled at the dispatch layer via a single FICLONE confirming probe. |
+| Parse `/proc/self/mountinfo` and match by `fs_type` string | No syscall per probe (file read); includes mount options like `crc=1,reflink=1` for XFS so the ambiguity collapses. | mountinfo is line-oriented text; parsing every line on a 1K-mount host costs more than `statfs(2)`; format changes between kernels (e.g. fields after the dash separator); not available inside chroots / mount namespaces that hide the mount table. | Rejected for the hot path; kept as a possible diagnostic fallback. |
+
+Reference: `statfs(2)` man page; magic constants in
+`include/uapi/linux/magic.h` in the Linux kernel tree.
+
+## API (REFLINK-2.b)
+
+`crates/fast_io/src/platform_copy/cow_detect.rs` exposes:
+
+```rust
+pub enum CowSupport {
+    Yes,       // btrfs, bcachefs
+    No,        // ext4, tmpfs, NFS, FUSE, overlayfs, sysfs, proc, ...
+    Probable,  // XFS, ZFS - confirm with a single FICLONE probe
+}
+
+impl CowSupport {
+    pub fn may_attempt_reflink(self) -> bool { ... }
+}
+
+pub fn detect_cow_support(path: &Path) -> io::Result<CowSupport>;
+pub fn detect_cow_filesystem(path: &Path) -> io::Result<bool>;
+pub fn record_probe_outcome(path: &Path, outcome: CowSupport) -> io::Result<()>;
+```
+
+`detect_cow_filesystem` is the boolean front door for the REFLINK-3/4
+wiring; it collapses `Yes` and `Probable` to `true` and `No` to
+`false`. Callers that need to distinguish "attempt FICLONE and treat
+failure as a real error" from "attempt FICLONE as a confirming probe
+and cache the outcome" use `detect_cow_support` instead.
+
+### Magic table
+
+| FS | Magic | Mapping |
+| --- | --- | --- |
+| btrfs | `0x9123683E` | `Yes` |
+| bcachefs | `0xCA451A4E` | `Yes` |
+| XFS | `0x58465342` | `Probable` (reflink gated on `-m reflink=1` at mkfs) |
+| ZFS-on-Linux | `0x2FC12FC1` | `Probable` (reflink gated on dataset `clone_blocks` feature) |
+| ext4 | `0xEF53` | `No` |
+| tmpfs | `0x01021994` | `No` |
+| proc | `0x9FA0` | `No` |
+| sysfs | `0x62656572` | `No` |
+| NFS | `0x6969` | `No` |
+| FUSE | `0x65735546` | `No` |
+| overlayfs | `0x794C7630` | `No` |
+
+Magics not in this list collapse to `No`. That is conservative on
+purpose - it costs us nothing more than a `copy_file_range` fallback
+on a CoW filesystem we have not catalogued, and it avoids spurious
+FICLONE attempts on filesystems whose reflink semantics differ from
+the Linux kernel's.
+
+### Platform stubs
+
+- **Linux**: full `statfs(2)`-backed probe and cache, as described
+  above.
+- **Non-Linux** (macOS, Windows, FreeBSD, illumos): the public
+  functions are still defined and link, but `detect_cow_support`
+  always returns `Ok(CowSupport::No)`, `detect_cow_filesystem` always
+  returns `Ok(false)`, and `record_probe_outcome` is a no-op.
+  Cross-platform callers do not need `#[cfg]` branching at the call
+  site. macOS APFS reflink is handled by the `clonefile` dispatch
+  layer in `platform_copy::dispatch`, and Windows ReFS reflink is
+  handled by `fast_io::refs_detect` plus the `try_refs_reflink`
+  dispatch arm; neither path consults `cow_detect`.
+
+## Caching (REFLINK-2.c)
+
+A process-wide `OnceLock<Mutex<HashMap<u64, CowSupport>>>` keyed by
+the `statfs.f_fsid` value returned by the kernel. `f_fsid` is unique
+per mounted filesystem within a Linux mount namespace - bind mounts
+of the same source filesystem share the same fsid, so a single cache
+entry covers all bind-mount aliases.
+
+- First probe on a mountpoint: 1 `statfs(2)` syscall, populates the
+  cache.
+- Subsequent probes on any path within the same mountpoint: pure
+  in-memory `HashMap` lookup, no syscall.
+- `record_probe_outcome` lets the dispatch layer overwrite the
+  cached value after a confirming FICLONE attempt resolves the
+  XFS / ZFS ambiguity. The slot is overwritten in place, so the
+  next caller on the same mount skips the FICLONE syscall too.
+
+### Key choice rationale
+
+`f_fsid` was picked over `(dev_t, fs_type)` from `stat(2)`. The
+trade-off:
+
+- `stat(2)` returns `st_dev` which is unique per *device*, but a
+  device can host multiple filesystems via subvolumes (btrfs) or
+  partitions, and the FS type is reported separately via
+  `f_type` from `statfs(2)` anyway. So we are calling `statfs(2)`
+  regardless, and using its `f_fsid` saves one syscall over the
+  `stat(2)` + `statfs(2)` pairing.
+- `f_fsid` is opaque (kernel-internal) and we treat it that way;
+  the cache key is the raw 8 bytes interpreted as a `u64` in
+  native byte order. The interpretation matters only for hash
+  uniqueness, not for any semantic meaning.
+
+### Eviction
+
+None. The cache lives for the process lifetime. Filesystem type is
+immutable for a mounted filesystem - it cannot change without
+unmounting and remounting, at which point the `f_fsid` changes too.
+An rsync invocation never sees a mount change in practice, and even
+if it did, the stale cache entry would only cause a benign FICLONE
+attempt failure that gets cached as `No`.
+
+## Tests (REFLINK-2.d)
+
+`crates/fast_io/src/platform_copy/cow_detect.rs::tests` covers:
+
+- `detect_handles_tmpdir_without_error` - the probe runs on the
+  process tmpdir and returns one of the three states without
+  panicking. Cross-platform.
+- `detect_cow_filesystem_handles_tmpdir` - the boolean front door
+  agrees with `detect_cow_support(...).may_attempt_reflink()`.
+- `detect_handles_root_without_error` - the probe runs on `/`.
+  Linux-only.
+- `detect_cache_is_consistent_for_repeated_calls` - the second
+  call returns the same answer as the first. Cross-platform.
+- `detect_returns_enoent_for_missing_path` - missing paths
+  surface `ErrorKind::NotFound` cleanly. Linux-only.
+- `classify_known_magics` - btrfs/bcachefs map to `Yes`, XFS/ZFS
+  to `Probable`, ext4/tmpfs/proc to `No`. Reached via a test-only
+  hook so the magic constants and the `classify` function stay
+  private to the Linux `imp` submodule. Linux-only.
+- `record_probe_outcome_overrides_classification` - the dispatch
+  layer's after-probe write is honoured by the next lookup.
+  Linux-only.
+- `may_attempt_reflink_collapses_correctly` - the boolean
+  collapse maps `Yes`/`Probable` to `true` and `No` to `false`.
+  Cross-platform.
+- `non_linux_stub_always_returns_false` - the non-Linux stub
+  returns `Ok(CowSupport::No)` / `Ok(false)`. macOS/Windows only.
+- `non_linux_record_probe_is_noop` - the non-Linux
+  `record_probe_outcome` does not error and does not alter the
+  answer. macOS/Windows only.
+
+## Out of scope (NOT in REFLINK-2)
+
+This PR ships the detection layer only. The following are tracked
+separately:
+
+- **REFLINK-3**: FICLONE whole-file dispatch arm in
+  `engine::local_copy::executor::file::copy::transfer::execute::ficlone`,
+  consuming `detect_cow_filesystem` for pre-flight gating and
+  `record_probe_outcome` for after-FICLONE caching.
+- **REFLINK-4**: FICLONERANGE delta-apply COPY-token reflink ranges,
+  symmetric to ReFS `FSCTL_DUPLICATE_EXTENTS_TO_FILE` ranges
+  (PR #5824).
+- **REFLINK-9**: wiring `RequireCowPlatformCopy` against the
+  `--reflink={auto,always,never}` CLI flag.
+- **REFLINK-10**: in-process bench comparing FICLONE +
+  `detect_cow_filesystem` against the existing `copy_file_range`
+  fallback at a range of file counts and sizes.


### PR DESCRIPTION
## Summary

REFLINK-2 foundation. Promotes the previously-internal `cow_detect` module to a public surface so callers outside `platform_copy` can pre-flight reflink-capable filesystems before the REFLINK-3 (`FICLONE` whole-file) and REFLINK-4 (`FICLONERANGE` delta-apply) tiers attempt the ioctl.

- Adds `detect_cow_filesystem(path: &Path) -> io::Result<bool>` as the boolean front door (`Yes` / `Probable` -> `true`, `No` -> `false`).
- Keeps `detect_cow_support` -> `CowSupport` for callers that need to distinguish unambiguous reflink support (btrfs, bcachefs) from `Probable` filesystems whose reflink answer requires a confirming FICLONE probe (XFS gated on `-m reflink=1`, ZFS gated on dataset `clone_blocks`).
- Adds `CowSupport::may_attempt_reflink()` for the same collapse.
- Caches results in a process-wide `OnceLock<Mutex<HashMap<u64, CowSupport>>>` keyed by `statfs.f_fsid` so subsequent calls on any path within the same mountpoint return without a syscall. `record_probe_outcome` lets the dispatch layer overwrite a `Probable` entry once the confirming FICLONE has resolved the ambiguity.
- Non-Linux builds compile a stub that returns `Ok(false)` / no-ops on `record_probe_outcome`. Cross-platform callers do not need `#[cfg]` branching at the call site; macOS APFS reflink is handled by the existing `clonefile` dispatch arm and Windows ReFS reflink by `fast_io::refs_detect`.

Design note at `docs/design/reflink-acceleration.md` covers the mechanism survey (statfs(2) vs `/proc/self/mountinfo`), the magic table, cache semantics, and the explicit out-of-scope list.

## Not included

This PR ships the detection layer only. The following are tracked separately:

- **REFLINK-3**: FICLONE whole-file dispatch arm in `engine::local_copy::executor::file::copy::transfer::execute::ficlone` that consumes `detect_cow_filesystem`.
- **REFLINK-4**: FICLONERANGE delta-apply COPY-token reflink ranges (PR #5824).
- **REFLINK-9**: wiring `RequireCowPlatformCopy` against the `--reflink={auto,always,never}` CLI flag.

The existing `platform_copy::dispatch::try_ficlone_impl` already consults `detect_cow_support` (the consumer that motivated REFLINK-2); no behaviour change there - the import path is unchanged because the module is still named `cow_detect` and still lives under `platform_copy`.

## Test plan

- [ ] CI: fmt + clippy, nextest stable (Linux x86_64, Linux musl, macOS, Windows)
- [ ] Unit tests in `cow_detect::tests` cover Linux statfs probe, cache consistency, `ENOENT` propagation, magic classification (btrfs/bcachefs/XFS/ZFS/ext4/tmpfs/proc), `record_probe_outcome` override, and the boolean collapse.
- [ ] Non-Linux stub tests verify `detect_cow_filesystem` returns `Ok(false)` and `record_probe_outcome` is a no-op without altering the answer.