### PR TITLE
fix(daemon): default listener to dual-stack IPv6-then-IPv4

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -133,21 +133,20 @@ fn serve_connections(
     // `OC_RSYNC_DAEMON_ADDRESS_FAMILY` runtime override (used by CI/test
     // fixtures to force a specific family without rebuilding the CLI).
     //
-    // Default (no flag, no env, no explicit bind address): IPv4-only. This
-    // matches the upstream behaviour observed when `default_af_hint = 0`
-    // collapses to `AF_INET` on systems where the IPv6 stack is configured
-    // but unreachable - the daemon binds the one family that actually
-    // accepts traffic. GitHub Actions Linux runners are the canonical
-    // failure mode: `bind(2)` to `[::]:873` succeeds, but `accept(2)`
-    // returns a non-routable address family and the daemon exited 10
-    // before the IPv4 listener could service the test client. Defaulting
-    // to IPv4-only avoids the silent dual-stack misconfiguration; the
-    // operator opts in explicitly with `--ipv6` or `--ipv4 --ipv6`.
+    // Default (no flag, no env, no explicit bind address): dual-stack with
+    // IPv6 first, IPv4 second. Mirrors upstream's `default_af_hint = 0`
+    // (AF_UNSPEC) which lets `getaddrinfo(NULL, port, AI_PASSIVE, ...)`
+    // return every available family - on glibc that is `::` then `0.0.0.0`.
+    // `bind_listeners_per_family` walks the list in order, logs a warning
+    // for any per-family bind failure, and only fails the daemon when zero
+    // sockets bound. GitHub Actions Linux runners that have IPv6 partially
+    // configured (where `bind(2)` to `[::]:port` returns `EADDRNOTAVAIL`)
+    // cleanly fall back to the IPv4 listener instead of exiting 10 with a
+    // silent dual-stack misconfiguration.
     //
     // upstream: socket.c:402-499 (`open_socket_in`) walks every
     // getaddrinfo result, binds one socket per family, and only returns
-    // NULL when zero sockets bound. The dual-stack arm below preserves
-    // that semantic when the operator asks for both families.
+    // NULL when zero sockets bound.
     let env_family = read_address_family_env_override();
     let bind_addresses: Vec<IpAddr> = if bind_address_overridden {
         vec![bind_address]
@@ -169,7 +168,10 @@ fn serve_connections(
         match address_family {
             Some(AddressFamily::Ipv4) => vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
             Some(AddressFamily::Ipv6) => vec![IpAddr::V6(Ipv6Addr::UNSPECIFIED)],
-            None => vec![IpAddr::V4(Ipv4Addr::UNSPECIFIED)],
+            None => vec![
+                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            ],
         }
     };
 

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1071,6 +1071,53 @@ fn bind_listeners_per_family_fails_only_when_all_families_unreachable() {
 }
 
 #[test]
+fn bind_listeners_per_family_falls_back_from_ipv6_to_ipv4() {
+    // The default dual-stack listener attempts IPv6 first then IPv4. On
+    // GitHub Actions Linux runners the IPv6 stack is partially configured
+    // so `bind(2)` to a non-link-local IPv6 address returns
+    // `EADDRNOTAVAIL`. This test simulates that environment with a
+    // synthetic getaddrinfo-style result list: an unreachable IPv6
+    // documentation address (RFC 3849 2001:db8::/32, which the kernel
+    // cannot bind to a local socket) is followed by IPv4 loopback. The
+    // helper must surface the IPv6 failure as a warning, continue to
+    // IPv4, and produce a working IPv4 listener instead of failing the
+    // whole daemon startup.
+    //
+    // upstream: socket.c::open_socket_in (rsync-3.4.4:432-498) iterates
+    // every getaddrinfo result, accumulates per-family errors via
+    // `errmsgs[ecnt++]`, and only fails when zero sockets bound.
+    let unreachable_v6 = IpAddr::V6(std::net::Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1));
+    let reachable_v4 = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+    let bind_addresses = vec![unreachable_v6, reachable_v4];
+
+    let (listeners, bound_addresses) = bind_listeners_per_family(
+        &bind_addresses,
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        None,
+    )
+    .expect("IPv4 fallback must bind when IPv6 is unreachable");
+
+    assert_eq!(listeners.len(), 1, "only the reachable IPv4 family should bind");
+    assert_eq!(bound_addresses.len(), 1);
+    assert!(
+        bound_addresses[0].is_ipv4(),
+        "fallback listener must be on IPv4, got {}",
+        bound_addresses[0]
+    );
+    assert!(
+        bound_addresses[0].ip() == reachable_v4,
+        "fallback listener must be on IPv4 loopback, got {}",
+        bound_addresses[0]
+    );
+    assert!(
+        bound_addresses[0].port() != 0,
+        "kernel must assign an ephemeral port for the bound listener"
+    );
+}
+
+#[test]
 fn bind_listeners_per_family_single_family_propagates_error() {
     // When only one address is provided (no dual-stack), the helper must
     // propagate the bind failure immediately - there is no other family to

--- a/crates/daemon/tests/listener_address_family.rs
+++ b/crates/daemon/tests/listener_address_family.rs
@@ -1,19 +1,19 @@
 //! Regression tests for UTS-DD-daemon-exit10.1 / .2.
 //!
-//! The default daemon listener must bind IPv4-only when no explicit family
-//! override is given. This avoids the GitHub Actions Linux failure mode
-//! where `bind(2)` to `[::]:873` succeeds but `accept(2)` later returns a
-//! non-routable address family, producing an opaque
+//! The default daemon listener binds IPv6 then IPv4 when no explicit family
+//! override is given, matching upstream rsync's `default_af_hint = 0`
+//! (AF_UNSPEC) behaviour. `bind_listeners_per_family` warns on each
+//! per-family failure and only fails the daemon when zero sockets bound,
+//! so GitHub Actions Linux runners with a partially configured IPv6 stack
+//! (where `bind(2)` to `[::]:port` returns `EADDRNOTAVAIL`) cleanly degrade
+//! to the IPv4 listener instead of producing an opaque
 //! `error in socket I/O (code 10)` daemon exit. These tests drive
 //! `run_daemon` with various `--ipv4` / `--ipv6` and
 //! `OC_RSYNC_DAEMON_ADDRESS_FAMILY` configurations and verify a TCP client
 //! on the expected family receives the `@RSYNCD:` greeting.
 //!
 //! upstream: socket.c:402-499 (`open_socket_in`) iterates every
-//! getaddrinfo result and only fails when zero sockets bound; oc-rsync
-//! reproduces that contract for the dual-stack case but defaults to
-//! IPv4-only when no override is given so the GitHub Actions IPv6 stack
-//! cannot mask the IPv4 listener.
+//! getaddrinfo result and only fails when zero sockets bound.
 
 use std::io::{BufRead, BufReader};
 use std::net::{Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
@@ -144,12 +144,14 @@ impl Drop for EnvGuard {
 }
 
 /// Default daemon (no `--ipv4`/`--ipv6` flags, no env override) must
-/// bind IPv4 successfully and serve an IPv4 client. This is the GitHub
-/// Actions exit-10 regression: before the fix, the daemon bound IPv6
-/// first and the IPv6 accept failed before the IPv4 listener was
-/// considered.
+/// serve an IPv4 client. With dual-stack default the IPv6 bind is
+/// attempted first; the helper logs a warning and falls back to the
+/// IPv4 listener when IPv6 is unavailable on the runner, so the IPv4
+/// client receives `@RSYNCD:` either way. This is the regression for
+/// the GitHub Actions exit-10 failure where the silent IPv6 swallow
+/// previously masked the IPv4 listener startup.
 #[test]
-fn default_daemon_binds_ipv4_and_serves_ipv4_client() {
+fn default_daemon_serves_ipv4_client_via_dual_stack() {
     let port = reserve_port_ipv4();
     let (handle, flags) = spawn_daemon_with_args(vec![
         "--no-detach".to_string(),


### PR DESCRIPTION
## Summary

- The IPv4-only default silently hid the IPv6 bind decision from operators and diverged from upstream rsync's `default_af_hint = 0` (AF_UNSPEC) semantics.
- Default (no flag, no env, no explicit bind) now iterates the same IPv6-then-IPv4 list `getaddrinfo(NULL, port, AI_PASSIVE)` returns on glibc; `bind_listeners_per_family` already warns on per-family failure and only errors when zero sockets bound, so runners with a partially configured IPv6 stack fall back to IPv4 instead of producing an opaque exit 10.
- Adds a unit test that exercises the synthetic getaddrinfo result (unreachable RFC 3849 IPv6 + reachable IPv4 loopback) and asserts the listener ends up bound on IPv4.

## Test plan

- [x] `cargo fmt --all -- --check` (local)
- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) on Linux, Windows, macOS, musl
- [ ] CI: interop / upstream testsuite `daemon` test no longer exits 10 on the GitHub Actions runner