### PR TITLE
fix(cli): drop unused recursive_override destructure binding

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -68,7 +68,7 @@ where
         blocking_io,
         archive,
         recursive,
-        recursive_override,
+        recursive_override: _,
         inc_recursive,
         dirs,
         delete_mode,


### PR DESCRIPTION
## Summary

Master HEAD (08bc5ba7a, PR #5925) left `recursive_override` destructured but unused at `crates/cli/src/frontend/execution/drive/workflow/run.rs:71`. Under `-D warnings` this fails the `fmt + clippy` and `Build oc-rsync and upstream rsync` checks on every PR that picks up master, blocking PRs #5926/#5927/#5928 and any further work.

PR #5925 correctly switched the use site at `workflow/run.rs:504` from `recursive_override` to `recursive` (the trailing-slash walk gating fix) but did not update the destructure pattern. Renaming the binding to `recursive_override: _` suppresses the lint without altering the destructure shape, so a future use site can re-bind it without another patch.

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI: `fmt + clippy`, nextest (stable), Windows, macOS, Linux musl all green
- [ ] After merge: PRs #5926/#5927/#5928 re-run CI green