### PR TITLE
fix(cli): scope merge-file '!' to local-only clear per upstream exclude.c:1393-1402

### DIFF
--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -17,12 +17,18 @@ pub(crate) fn append_cvs_exclude_rules(
         .map(|pattern| FilterRuleSpec::exclude((*pattern).to_owned()).with_perishable(true))
         .collect();
 
+    // upstream: exclude.c:1393-1402 scopes FILTRULE_CLEAR_LIST ('!') to the
+    // local list section. Parse ~/.cvsignore and $CVSIGNORE into per-scope
+    // buffers so a '!' inside either source cannot wipe the default
+    // CVS_EXCLUDE_PATTERNS already collected in `cvs_rules`.
     if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
         let path = Path::new(&home).join(".cvsignore");
         match fs::read(&path) {
             Ok(contents) => {
                 let owned = String::from_utf8_lossy(&contents).into_owned();
-                append_cvsignore_tokens(&mut cvs_rules, owned.split_whitespace());
+                let mut local = Vec::new();
+                append_cvsignore_tokens(&mut local, owned.split_whitespace());
+                cvs_rules.extend(local);
             }
             Err(error) if error.kind() == ErrorKind::NotFound => {}
             Err(error) => {
@@ -37,7 +43,9 @@ pub(crate) fn append_cvs_exclude_rules(
 
     if let Some(value) = env::var_os("CVSIGNORE").filter(|value| !value.is_empty()) {
         let owned = value.to_string_lossy().into_owned();
-        append_cvsignore_tokens(&mut cvs_rules, owned.split_whitespace());
+        let mut local = Vec::new();
+        append_cvsignore_tokens(&mut local, owned.split_whitespace());
+        cvs_rules.extend(local);
     }
 
     let options = DirMergeOptions::default()

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -60,6 +60,12 @@ pub(crate) fn apply_merge_directive(
         )
     };
     let next_base = next_base_storage.as_deref().unwrap_or(base_dir);
+    // upstream: exclude.c:1393-1402 resolves FILTRULE_CLEAR_LIST via
+    // pop_filter_list (exclude.c:574-590), which truncates only the local
+    // section of the per-merge-file rule list. Mirror that by parsing the
+    // merge file into a scope-local buffer so a '!' inside the file cannot
+    // wipe parent-scope rules already in `destination`.
+    let mut local: Vec<FilterRuleSpec> = Vec::new();
     let result = (|| -> Result<(), Message> {
         let contents = if is_stdin {
             read_merge_from_standard_input()?
@@ -68,19 +74,17 @@ pub(crate) fn apply_merge_directive(
         };
 
         parse_merge_contents(
-            &contents,
-            &options,
-            next_base,
-            &display,
-            destination,
-            visited,
+            &contents, &options, next_base, &display, &mut local, visited,
         )
     })();
     visited.remove(&guard_key);
-    if result.is_ok() && options.excludes_self() && !is_stdin {
-        let mut rule = FilterRuleSpec::exclude(original_source_text);
-        rule.apply_dir_merge_overrides(&options);
-        destination.push(rule);
+    if result.is_ok() {
+        destination.extend(local);
+        if options.excludes_self() && !is_stdin {
+            let mut rule = FilterRuleSpec::exclude(original_source_text);
+            rule.apply_dir_merge_overrides(&options);
+            destination.push(rule);
+        }
     }
     result
 }

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -31,19 +31,25 @@ pub(crate) fn append_filter_rules_from_files(
     // we keep the legacy raw-pattern behavior to preserve existing semantics.
     let honor_old_prefixes = matches!(kind, FilterRuleKind::Include | FilterRuleKind::Exclude);
 
+    // upstream: exclude.c:1393-1402 resolves FILTRULE_CLEAR_LIST via
+    // pop_filter_list (exclude.c:574-590), truncating only the local section
+    // of the per-file rule list. Buffer each --include-from/--exclude-from
+    // file's rules locally so a `!` inside the file clears only that scope
+    // and parent CLI rules survive.
     for path in files {
         let patterns = load_filter_file_patterns(Path::new(path.as_os_str()))?;
+        let mut local: Vec<FilterRuleSpec> = Vec::new();
         for pattern in patterns {
             if honor_old_prefixes {
                 match parse_old_prefix_rule(&pattern, kind)? {
-                    FilterDirective::Rule(rule) => destination.push(rule),
-                    FilterDirective::Clear => destination.push(FilterRuleSpec::clear()),
+                    FilterDirective::Rule(rule) => local.push(rule),
+                    FilterDirective::Clear => local.clear(),
                     FilterDirective::Merge(_) => {
                         unreachable!("parse_old_prefix_rule never emits FilterDirective::Merge")
                     }
                 }
             } else {
-                destination.push(match kind {
+                local.push(match kind {
                     FilterRuleKind::Include => FilterRuleSpec::include(pattern),
                     FilterRuleKind::Exclude => FilterRuleSpec::exclude(pattern),
                     FilterRuleKind::Clear => FilterRuleSpec::clear(),
@@ -54,6 +60,7 @@ pub(crate) fn append_filter_rules_from_files(
                 });
             }
         }
+        destination.extend(local);
     }
     Ok(())
 }

--- a/crates/cli/src/frontend/tests/apply.rs
+++ b/crates/cli/src/frontend/tests/apply.rs
@@ -48,6 +48,8 @@ fn apply_merge_directive_respects_forced_include() {
         .expect("merge succeeds");
 
     assert!(visited.is_empty());
+    // upstream: exclude.c:1393-1402 - '!' inside a merge file clears only
+    // the local section, so the parent-scope "existing" rule survives.
     let patterns: Vec<_> = rules.iter().map(|rule| rule.pattern().to_owned()).collect();
-    assert_eq!(patterns, vec!["beta"]);
+    assert_eq!(patterns, vec!["existing", "beta"]);
 }

--- a/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
@@ -192,3 +192,170 @@ fn transfer_request_with_filter_merge_detects_recursion() {
     let rendered = String::from_utf8_lossy(&stderr);
     assert!(rendered.contains("recursive filter merge"));
 }
+
+/// upstream: exclude.c:1393-1402 resolves `FILTRULE_CLEAR_LIST` via
+/// `pop_filter_list` which truncates only the local section of the per-merge-file
+/// rule list. A `!` inside a merge file must not clear parent CLI `--filter`
+/// rules collected before the merge directive.
+#[test]
+fn transfer_request_with_filter_merge_bang_preserves_parent_cli_rule() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+    std::fs::write(source_root.join("skip.tmp"), b"skip tmp").expect("write tmp");
+    std::fs::write(source_root.join("skip.log"), b"skip log").expect("write log");
+
+    let filter_file = tmp.path().join("filters.txt");
+    std::fs::write(&filter_file, "!\n- *.log\n").expect("write merge file");
+
+    let merge_arg = OsString::from(format!("merge {}", filter_file.display()));
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter"),
+        OsString::from("- *.tmp"),
+        OsString::from("--filter"),
+        merge_arg,
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_root = dest_root.join("source");
+    assert!(copied_root.join("keep.txt").exists());
+    // Parent `--filter "- *.tmp"` survived the merge file's `!`.
+    assert!(!copied_root.join("skip.tmp").exists());
+    // Merge file's own exclude still applies.
+    assert!(!copied_root.join("skip.log").exists());
+}
+
+/// upstream: exclude.c:1393-1402 - a `!` inside a nested merge file clears only
+/// the nested scope. Rules added by the outer merge file before the nested
+/// reference survive.
+#[test]
+fn transfer_request_with_filter_nested_merge_bang_preserves_outer_scope() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+    std::fs::write(source_root.join("skip.tmp"), b"skip tmp").expect("write tmp");
+    std::fs::write(source_root.join("skip.log"), b"skip log").expect("write log");
+
+    let inner = tmp.path().join("inner.txt");
+    let outer = tmp.path().join("outer.txt");
+    std::fs::write(&inner, "!\n- *.log\n").expect("write inner");
+    std::fs::write(&outer, format!("- *.tmp\nmerge {}\n", inner.display())).expect("write outer");
+
+    let merge_arg = OsString::from(format!("merge {}", outer.display()));
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter"),
+        merge_arg,
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_root = dest_root.join("source");
+    assert!(copied_root.join("keep.txt").exists());
+    // Outer merge's exclude survives the inner merge's `!`.
+    assert!(!copied_root.join("skip.tmp").exists());
+    assert!(!copied_root.join("skip.log").exists());
+}
+
+/// upstream: exclude.c:1393-1402 - `!` inside an `--exclude-from FILE` clears
+/// only the scope of that file. Parent `--filter`/`--exclude` CLI rules survive.
+#[test]
+fn transfer_request_with_exclude_from_bang_preserves_parent_cli_rule() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+    std::fs::write(source_root.join("skip.tmp"), b"skip tmp").expect("write tmp");
+    std::fs::write(source_root.join("skip.log"), b"skip log").expect("write log");
+
+    let exclude_file = tmp.path().join("excludes.txt");
+    std::fs::write(&exclude_file, "!\n*.log\n").expect("write exclude file");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--filter"),
+        OsString::from("- *.tmp"),
+        OsString::from("--exclude-from"),
+        exclude_file.clone().into_os_string(),
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_root = dest_root.join("source");
+    assert!(copied_root.join("keep.txt").exists());
+    // Parent `--filter "- *.tmp"` survived the exclude-from file's `!`.
+    assert!(!copied_root.join("skip.tmp").exists());
+    assert!(!copied_root.join("skip.log").exists());
+}
+
+/// upstream: exclude.c:1393-1402 - `!` inside `~/.cvsignore` (or `$CVSIGNORE`)
+/// clears only that scope. The default CVS_EXCLUDE_PATTERNS already collected
+/// in the parent accumulator survive.
+#[test]
+fn transfer_request_with_cvsignore_bang_preserves_default_cvs_patterns() {
+    use tempfile::tempdir;
+
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _home_guard = EnvGuard::set("HOME", OsStr::new(""));
+    // `$CVSIGNORE` is treated as a per-source scope just like ~/.cvsignore,
+    // so a leading `!` must not wipe the built-in CVS_EXCLUDE_PATTERNS.
+    let _cvs_guard = EnvGuard::set("CVSIGNORE", OsStr::new("! *.skip"));
+
+    let tmp = tempdir().expect("tempdir");
+    let source_root = tmp.path().join("source");
+    let dest_root = tmp.path().join("dest");
+    std::fs::create_dir_all(&source_root).expect("create source root");
+    std::fs::create_dir_all(&dest_root).expect("create dest root");
+    std::fs::write(source_root.join("keep.txt"), b"keep").expect("write keep");
+    // `core` is one of the built-in CVS_EXCLUDE_PATTERNS and must remain excluded.
+    std::fs::write(source_root.join("core"), b"core dump").expect("write core");
+    std::fs::write(source_root.join("drop.skip"), b"drop").expect("write skip");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--cvs-exclude"),
+        source_root.into_os_string(),
+        dest_root.clone().into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
+
+    let copied_root = dest_root.join("source");
+    assert!(copied_root.join("keep.txt").exists());
+    // Default CVS pattern survived the `$CVSIGNORE` scope-local `!`.
+    assert!(!copied_root.join("core").exists());
+    // `$CVSIGNORE`'s own pattern (after the `!`) still excludes `*.skip`.
+    assert!(!copied_root.join("drop.skip").exists());
+}


### PR DESCRIPTION
## Summary

- Upstream `exclude.c:1393-1402` resolves `FILTRULE_CLEAR_LIST` (`!`) via `pop_filter_list` (`exclude.c:574-590`), which truncates only the local section of the per-merge-file rule list. Parent-scope rules survive.
- The CLI front-end at `crates/cli/src/frontend/filter_rules/{merge.rs, sources.rs, cvs.rs}` was calling `Vec::clear()` on the parent caller's accumulator whenever `!` appeared inside `--filter merge FILE`, `--exclude-from FILE`, or a `~/.cvsignore`/`$CVSIGNORE` source. This wiped parent CLI rules cross-scope, diverging from upstream's per-file scope isolation.
- Fix: parse each merge-file / exclude-from / cvsignore source into a per-scope local `Vec<FilterRuleSpec>`, then `destination.extend(local)` on success. The bare `!` token, the `FilterDirective::Clear` arm inside `parse_merge_contents`, and the `sources.rs` clear arm now affect only the local buffer.
- Top-level inline `--filter "!"` retains its existing top-level clear semantic (handled in `drive/filters.rs:102`, unchanged).
- The filters crate already scope-isolates merge expansion via `crates/filters/src/merge/read.rs::scope_local_clear`; this fix brings the CLI front-end into parity with that behavior.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo build -p cli --tests`
- [x] New: `transfer_request_with_filter_merge_bang_preserves_parent_cli_rule` - parent `--filter` survives `!` in `--filter merge FILE`.
- [x] New: `transfer_request_with_filter_nested_merge_bang_preserves_outer_scope` - `!` inside nested merge clears only nested scope.
- [x] New: `transfer_request_with_exclude_from_bang_preserves_parent_cli_rule` - `!` in `--exclude-from FILE` clears only that file's scope.
- [x] New: `transfer_request_with_cvsignore_bang_preserves_default_cvs_patterns` - `!` in `$CVSIGNORE` does not wipe default CVS patterns.
- [x] Updated: `apply_merge_directive_respects_forced_include` now asserts upstream-correct semantics (parent `"existing"` rule survives the merge file's `!`).
- [x] Constraint: `transfer_request_with_filter_merge_clear_resets_rules` (single-scope clear) still passes.
- [x] Constraint: `filters/src/tests.rs::clear_in_merge_file_does_not_clear_parent_cli_rules` (parity oracle) unaffected.