### PR TITLE
fix(filters): suppress synthetic descendants in per-dir deletion fall-through

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -167,7 +167,9 @@ impl FilterChain {
             if !scope.filter_set.is_empty()
                 && scope_has_deletion_match(&scope.filter_set, path, is_dir)
             {
-                return scope.filter_set.allows_deletion(path, is_dir);
+                return scope
+                    .filter_set
+                    .allows_deletion_during_traversal(path, is_dir);
             }
         }
 

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -646,3 +646,39 @@ fn filter_chain_deletion_falls_through_when_only_descendant_matches() {
 
     assert!(!chain.allows_deletion(Path::new("foo/x"), false));
 }
+
+/// A per-directory scope whose predicate match is decided by an include
+/// rule must not be overridden in the deletion commit by an earlier
+/// exclude rule's synthetic descendant matcher. The bug was that the
+/// chain's commit step in [`FilterChain::allows_deletion`] called
+/// `FilterSet::allows_deletion`, which re-enables synthetic
+/// `pattern/**` descendant matchers. An earlier `- /bar` rule then
+/// fired its `bar/**` synthetic against `bar/x` and beat the later
+/// include rule that the descendant-free predicate had selected.
+///
+/// Mirrors upstream `exclude.c:rule_matches()`, which has NO descendant
+/// matching: descendant exclusion is a side effect of the sender walk
+/// not descending into excluded directories, never a rule match in its
+/// own right. The receiver-side deletion commit through a per-dir
+/// scope must therefore honour the same descendant-free semantics.
+#[test]
+fn filter_chain_per_dir_deletion_does_not_block_via_synthetic_descendant() {
+    let global = FilterSet::default();
+    let mut chain = FilterChain::new(global);
+
+    // Scope rule order matters: the anchored `- /bar` is first, so
+    // its synthetic `bar/**` descendant would beat the later include
+    // if descendants were active during the scope commit.
+    let scope =
+        FilterSet::from_rules([FilterRule::exclude("/bar"), FilterRule::include("x")]).unwrap();
+    let _guard = chain.push_scope(scope);
+
+    // Descendant-free predicate sees `+ x` match (via `**/x`), so the
+    // chain routes the deletion decision through this scope. The
+    // commit must agree: with descendants suppressed, `+ x` is still
+    // the first matching rule and `bar/x` is deletable.
+    assert!(
+        chain.allows_deletion(Path::new("bar/x"), false),
+        "scope commit must not let synthetic `bar/**` override the include rule"
+    );
+}

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -60,10 +60,13 @@ impl FilterSetInner {
         // Single-path API queries (no traversal context) keep descendants
         // active so callers can still see "build/output.bin" as excluded
         // by a `- build/` rule without walking the tree themselves.
-        // The receiver (Deletion) keeps descendants active for the same
-        // reason as the no-traversal API: it evaluates paths individually
-        // and depends on the descendant matchers to see deep excludes.
-        let check_descendants = !(traversal && matches!(context, DecisionContext::Transfer));
+        // Receiver-side (Deletion) during a per-directory chain commit
+        // suppresses descendants for the same reason: the chain has
+        // already routed the path to the responsible scope via the
+        // descendant-free `has_matching_rule` predicate, so re-enabling
+        // `pattern/**` here would let a per-dir rule like `bar` in
+        // `./foo/.cvsignore` fire against the sibling subtree `./bar/x`.
+        let check_descendants = !traversal;
 
         let transfer_rule = match context {
             DecisionContext::Transfer => first_matching_rule(

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -221,6 +221,26 @@ impl FilterSet {
             .allows_deletion()
     }
 
+    /// Like [`Self::allows_deletion`] but tailored for a per-directory chain
+    /// fall-through that has already pruned non-matching scopes.
+    ///
+    /// Suppresses the synthetic `pattern/**` descendant matchers that
+    /// [`CompiledRule::new`] bakes into anchored excludes like `- /bar`.
+    /// Without this, a per-dir rule installed in `./foo/.cvsignore` would
+    /// match `./bar/x` via its synthetic `bar/**` matcher when the chain
+    /// commits a sibling-subtree deletion decision, contradicting upstream
+    /// `exclude.c:rule_matches()` which has no descendant matching at all.
+    ///
+    /// Use this from per-directory chain code that commits a deletion
+    /// decision after deciding the scope is responsible. Single-path
+    /// API consumers should keep calling [`Self::allows_deletion`].
+    #[must_use]
+    pub fn allows_deletion_during_traversal(&self, path: &Path, is_dir: bool) -> bool {
+        self.inner
+            .decision_with_traversal(path, is_dir, DecisionContext::Deletion, true)
+            .allows_deletion()
+    }
+
     /// Returns `true` if the path may be removed during `--delete-excluded`
     /// processing.
     ///


### PR DESCRIPTION
## Summary

The per-directory `FilterChain::allows_deletion` commit at `crates/filters/src/chain/mod.rs:170` called `scope.filter_set.allows_deletion(...)`, which routed through `decision_with_traversal(traversal=false)` and re-enabled the synthetic `pattern/**` descendant matchers baked into `CompiledRule::new`. The chain has already routed the lookup via the descendant-free `has_matching_rule` predicate, so re-enabling descendants at the commit step let an earlier `- /bar` rule in a per-dir scope fire its synthetic `bar/**` against sibling subtree paths like `bar/x` and beat a later include rule, wrongly blocking deletion. Upstream `exclude.c:rule_matches()` has no descendant matching at all (the sender walk handles descent pruning implicitly), so the receiver-side commit through a per-dir scope must do the same.

Fix:
- Add `FilterSet::allows_deletion_during_traversal`, symmetric to `allows_during_traversal`.
- Lift descendant suppression in `decision_with_traversal` from "Transfer only" to "any `traversal=true`", since both per-dir commit paths share the same invariant.
- Route the per-dir chain commit through the new method; the global fallback at line 174 continues to use `allows_deletion` so single-path API consumers are unaffected.

The transfer-direction commit already went through `allows_during_traversal` and was unaffected.

## Test plan

- [x] `cargo build -p filters --tests` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p filters --all-targets --all-features --no-deps -- -D warnings` clean.
- [x] New regression `chain::tests::filter_chain_per_dir_deletion_does_not_block_via_synthetic_descendant` fails without the fix and passes with it.
- [x] Full `filters` lib suite (323 tests) green; pre-existing `filter_chain_push_scope_exclude_overrides_global_include` and `clear_in_merge_file_does_not_clear_parent_cli_rules` still pass.