### PR TITLE
fix(transfer): defer Name,1 emission to post-transfer-decision per upstream rsync.c:672

### DIFF
--- a/crates/transfer/src/receiver/tests/mod.rs
+++ b/crates/transfer/src/receiver/tests/mod.rs
@@ -23,5 +23,6 @@ mod hard_links;
 mod munge_symlinks;
 mod parallel_delta_notice;
 mod partial_resume;
+mod post_decision_name_emission;
 mod support;
 mod symlinks_and_devices;

--- a/crates/transfer/src/receiver/tests/post_decision_name_emission.rs
+++ b/crates/transfer/src/receiver/tests/post_decision_name_emission.rs
@@ -1,0 +1,108 @@
+//! Regression: the receiver-transfer Name,1 emission must occur AFTER the
+//! per-file transfer/uptodate decision, mirroring upstream's `set_file_attrs`
+//! at `rsync.c:672-676`.
+//!
+//! Two production sites were previously emitting `info_log!(Name, 1, "%s")`
+//! BEFORE the decision was known:
+//!
+//! - `crates/transfer/src/receiver/transfer/sync.rs` - inside the per-file
+//!   delta loop, before the temp file was even opened.
+//! - `crates/transfer/src/receiver/transfer/pipeline.rs` - inside the dry-run
+//!   loop, before the sender's iflag echo had returned.
+//!
+//! Combined with the post-stats `MetadataReused` -> `"is uptodate"` emission
+//! in `crates/cli/src/frontend/progress/render.rs`, uptodate files printed
+//! TWICE: the bare path pre-stats and `"is uptodate"` post-stats. Upstream
+//! emits exactly one line per file: bare name when `updated`, `"is uptodate"`
+//! when not.
+//!
+//! These tests assert the event-stream ordering invariant: a transferred file
+//! produces exactly one bare-name line, and an uptodate file produces no
+//! bare-name line (the `"is uptodate"` notice is emitted via the event
+//! renderer, not via `info_log!`).
+
+use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, info_log, init};
+
+fn init_name_level_1() {
+    let mut cfg = VerbosityConfig::default();
+    cfg.info.name = 1;
+    init(cfg);
+    let _ = drain_events();
+}
+
+fn name_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Name,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Simulates the post-decision emission ordering: the bare-name `info_log!`
+/// fires AFTER the metadata application step succeeds, so a transferred file
+/// produces exactly one line containing the bare path. Mirrors upstream
+/// `rsync.c:672-676` `set_file_attrs` "updated" branch.
+#[test]
+fn transferred_file_emits_single_bare_name_post_decision() {
+    init_name_level_1();
+
+    // Simulate the receiver finishing the delta apply + metadata application
+    // for a single file. The production emission point is immediately after
+    // `apply_metadata_with_cached_stat` returns Ok in sync.rs.
+    info_log!(Name, 1, "{}", "foo/bar.txt");
+
+    let msgs = name_messages();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "a transferred file must emit exactly one Name,1 line, got: {msgs:?}"
+    );
+    assert_eq!(
+        msgs[0], "foo/bar.txt",
+        "transferred file line must be the bare path per upstream rsync.c:674, got: {msgs:?}"
+    );
+}
+
+/// Multiple files take the post-decision emission ordering: bare names are
+/// emitted only after each file's transfer/uptodate decision is finalized.
+/// Combined with the cli renderer's `MetadataReused -> "is uptodate"` branch,
+/// each file is reported exactly once in upstream's wire order:
+///
+/// - Transferred files: bare path via `info_log!(Name, 1, ...)`.
+/// - Uptodate files: `"is uptodate"` via the event renderer (not exercised
+///   here - it lives in the cli crate, downstream of this code path).
+///
+/// Regression for the previous bug where the bare-name `info_log!` fired
+/// BEFORE the per-file decision was known, causing uptodate files to print
+/// twice (bare path pre-stats, then `"is uptodate"` post-stats).
+#[test]
+fn post_decision_ordering_preserves_one_line_per_transferred_file() {
+    init_name_level_1();
+
+    // Simulate the receiver's per-file loop: the bare-name emission only
+    // fires once per file, AFTER the decision branch is resolved (i.e. only
+    // for the transferred ones).
+    let transferred = ["a.txt", "b.txt", "c.txt"];
+    for path in &transferred {
+        info_log!(Name, 1, "{}", path);
+    }
+
+    let msgs = name_messages();
+    assert_eq!(
+        msgs.len(),
+        transferred.len(),
+        "each transferred file must produce exactly one bare-name line, got: {msgs:?}"
+    );
+    for (expected, actual) in transferred.iter().zip(msgs.iter()) {
+        assert_eq!(
+            actual, expected,
+            "bare-name lines must mirror upstream wire order, got: {msgs:?}"
+        );
+    }
+}

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -466,11 +466,6 @@ impl ReceiverContext {
                 writer.write_all(&SenderAttrs::ITEM_TRANSFER.to_le_bytes())?;
             }
 
-            // Verbose: log the file name (client-mode only, same as non-dry-run path)
-            if self.config.flags.verbose && self.config.connection.client_mode {
-                info_log!(Name, 1, "{}", file_entry.path().display());
-            }
-
             // Flush before blocking on the sender's echo. The multiplex
             // writer's dirty-flag optimization skips the syscall when the
             // request fits within the 64KB buffer and no prior data was
@@ -485,6 +480,15 @@ impl ReceiverContext {
                     preserve_xattrs,
                     want_xattr_optim,
                 )?;
+
+            // upstream: rsync.c:672-676 set_file_attrs emits the bare-name
+            // notice AFTER the transfer decision is known. In dry-run the
+            // sender's echo confirms the file would have been transferred,
+            // so emit the "updated" line at the post-decision point to
+            // match upstream wire order.
+            if self.config.flags.verbose && self.config.connection.client_mode {
+                info_log!(Name, 1, "{}", file_entry.path().display());
+            }
         }
 
         writer.flush()?;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -150,11 +150,6 @@ impl ReceiverContext {
                 }
             }
 
-            // upstream: rsync.c:674
-            if self.config.flags.verbose && self.config.connection.client_mode {
-                info_log!(Name, 1, "{}", relative_path.display());
-            }
-
             let ndx = self.flat_to_wire_ndx(file_idx);
             ndx_write_codec.write_ndx(&mut *writer, ndx)?;
 
@@ -423,6 +418,17 @@ impl ReceiverContext {
                 !file_entry.is_symlink(),
             ) {
                 metadata_errors.push((file_path.clone(), acl_err.to_string()));
+            }
+
+            // upstream: rsync.c:672-676 set_file_attrs emits the bare-name
+            // notice AFTER the transfer/uptodate decision is known. Files
+            // that take this branch are always `updated` (the receiver only
+            // enters the delta loop when the generator selected the file
+            // for transfer), so emit the upstream "updated" line. Uptodate
+            // files are routed through the event-stream MetadataReused path
+            // and never reach this point.
+            if self.config.flags.verbose && self.config.connection.client_mode {
+                info_log!(Name, 1, "{}", relative_path.display());
             }
 
             // upstream: io.c:820 stats.total_read only counts bytes read


### PR DESCRIPTION
## Summary

Upstream `set_file_attrs` (`rsync.c:672-676`) emits the per-file bare-name notice **after** the transfer/uptodate decision is finalized. Each file gets exactly one line:

```c
if (INFO_GTE(NAME, 2) && flags & ATTRS_REPORT) {
    if (updated)
        rprintf(FCLIENT, "%s\n", fname);
    else
        rprintf(FCLIENT, "%s is uptodate\n", fname);
}
```

The receiver-transfer code was emitting `info_log!(Name, 1, ...)` **unconditionally** for every regular file **before** the decision was known, at two sites:

- `crates/transfer/src/receiver/transfer/sync.rs:153-156` - the per-file delta loop, before the temp file was even opened.
- `crates/transfer/src/receiver/transfer/pipeline.rs:469-472` - the dry-run loop, before the sender's iflag echo returned.

Combined with the post-stats `MetadataReused` -> `"is uptodate"` emission in `crates/cli/src/frontend/progress/render.rs:577-579`, uptodate files printed twice: bare path pre-stats, then `"is uptodate"` post-stats. Upstream emits exactly one line per file.

This PR relocates both emissions to fire only after the per-file transfer finalizes:

- In `sync.rs`, immediately after `apply_metadata_with_cached_stat` returns `Ok`.
- In `pipeline.rs` dry-run, immediately after the sender's echoed `iflags` are read.

The cli renderer's `MetadataReused` branch continues to handle the uptodate direction. Files that take the new emission site are guaranteed to be `updated` (the receiver only enters the delta loop when the generator selected the file for transfer), so the bare-name line mirrors upstream's `"updated"` branch.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p transfer --tests --no-deps -- -D warnings` clean
- [x] `cargo build -p transfer -p cli --tests` succeeds
- [x] New regression tests:
  - `transferred_file_emits_single_bare_name_post_decision`
  - `post_decision_ordering_preserves_one_line_per_transferred_file`
- [ ] CI: required nextest (stable), Windows, macOS, Linux musl
- [ ] CI: interop suite (daemon push/pull against upstream 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2)