### PR TITLE
fix(tests): pass -r to backup test rsync invocations

### DIFF
--- a/crates/cli/src/frontend/tests/backup.rs
+++ b/crates/cli/src/frontend/tests/backup.rs
@@ -25,6 +25,7 @@ fn backup_flag_creates_default_suffix_backups() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("--backup"),
         source_dir.into_os_string(),
         dest_dir.clone().into_os_string(),
@@ -67,6 +68,7 @@ fn backup_dir_flag_places_backups_in_relative_directory() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("--backup-dir"),
         OsString::from("backups"),
         OsString::from("--suffix"),
@@ -119,6 +121,7 @@ fn backup_suffix_flag_overrides_default_suffix() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("--suffix"),
         OsString::from(".bak"),
         source_dir.into_os_string(),


### PR DESCRIPTION
## Summary

The three backup tests in `crates/cli/src/frontend/tests/backup.rs` introduced in PR #5889 transferred a directory operand without `-r`, `-a`, or `--files-from`. PR #5925 (commit `0730dcaa0`) subsequently aligned the default of `recursive` with upstream rsync 3.4.4 (`options.c:112`, `recurse=0`), so the directory operand is now skipped silently. The inner `file.txt` is never transferred, `--backup` finds nothing to back up, and the assertions see the original destination content.

Failing tests (CI run 27756453743 on macOS stable/beta/nightly and Linux musl stable/beta/nightly):

- `backup_flag_creates_default_suffix_backups` (line 38): `"old data"!="new data"` - dest never overwritten.
- `backup_dir_flag_places_backups_in_relative_directory` (line 83): `read backup: NotFound` - no backup directory created.
- `backup_suffix_flag_overrides_default_suffix` (line 125): `"stale"!="fresh"` - dest never overwritten.

## Root cause confirmed

Not a clock-granularity or `filetime` issue (the failure profile is identical on macOS and Linux musl, ruling out FS-specific mtime semantics). The tests pass a directory source operand expecting recursion; after PR #5925 the default is non-recursive, so `flist.c:2451` `skipping directory %s` applies and no file is enqueued for transfer.

## Fix

Add `-r` to all three `run_with_args` invocations so the directory operand recurses and `file.txt` actually transfers, exercising the `--backup`, `--backup-dir`, and `--suffix` code paths the tests were written to cover.

## Test plan

- [ ] CI macOS (stable/beta/nightly) green on `cli::frontend::tests::backup_tests::*`
- [ ] CI Linux musl (stable/beta/nightly) green on the same three tests
- [ ] CI Windows green
- [ ] `cargo fmt --all --check` clean