### PR TITLE
fix(protocol): encode/parse dir-merge '-'/'+' modifier per upstream exclude.c:1555

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -191,9 +191,6 @@ pub(crate) fn build_wire_format_rules(
                     pattern,
                     anchored,
                     directory_only,
-                    no_inherit: false,
-                    cvs_exclude: false,
-                    word_split: false,
                     // upstream: 'e' flag = FILTRULE_EXCLUDE_SELF.
                     exclude_from_merge: true,
                     xattr_only: spec.is_xattr_only(),
@@ -201,6 +198,7 @@ pub(crate) fn build_wire_format_rules(
                     receiver_side: spec.applies_to_receiver(),
                     perishable: spec.is_perishable(),
                     negate: spec.is_negated(),
+                    ..FilterRuleWireFormat::default()
                 });
                 continue;
             }
@@ -212,15 +210,12 @@ pub(crate) fn build_wire_format_rules(
             pattern,
             anchored,
             directory_only,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
             xattr_only: spec.is_xattr_only(),
             sender_side: spec.applies_to_sender(),
             receiver_side: spec.applies_to_receiver(),
             perishable: spec.is_perishable(),
             negate: spec.is_negated(),
+            ..FilterRuleWireFormat::default()
         };
 
         if let Some(options) = spec.dir_merge_options() {

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -424,18 +424,7 @@ fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
     if strip_keyword_prefix(token, "clear").is_some() {
         return Some(FilterRuleWireFormat {
             rule_type: protocol::filters::RuleType::Clear,
-            pattern: String::new(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
-            receiver_side: false,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         });
     }
 

--- a/crates/protocol/src/filters/prefix.rs
+++ b/crates/protocol/src/filters/prefix.rs
@@ -54,7 +54,8 @@ fn build_old_prefix(rule: &FilterRuleWireFormat) -> Option<String> {
         || rule.xattr_only
         || rule.sender_side
         || rule.receiver_side
-        || rule.perishable;
+        || rule.perishable
+        || rule.no_prefixes;
 
     if has_modifiers {
         return None;
@@ -132,6 +133,13 @@ fn build_modern_prefix(rule: &FilterRuleWireFormat, protocol: ProtocolVersion) -
 
     if rule.word_split {
         prefix.push('w');
+    }
+
+    // upstream: exclude.c:1555-1560 - on a merge/dir-merge rule, emit `-` when
+    // FILTRULE_NO_PREFIXES is set and `+` when FILTRULE_NO_PREFIXES|FILTRULE_INCLUDE
+    // are both set. Order matches upstream: between `w` and `e`.
+    if rule.no_prefixes && matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) {
+        prefix.push(if rule.no_prefixes_include { '+' } else { '-' });
     }
 
     if rule.exclude_from_merge {
@@ -297,18 +305,7 @@ mod tests {
         let protocol = ProtocolVersion::from_supported(32).unwrap();
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::Clear,
-            pattern: String::new(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
-            receiver_side: false,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         };
 
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
@@ -325,17 +322,8 @@ mod tests {
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::Protect,
             pattern: "important".to_owned(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
             receiver_side: true,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         };
 
         let prefix = build_rule_prefix(&rule, protocol).unwrap();
@@ -350,17 +338,8 @@ mod tests {
         let rule = FilterRuleWireFormat {
             rule_type: RuleType::Risk,
             pattern: "scratch".to_owned(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
             receiver_side: true,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         };
 
         let prefix = build_rule_prefix(&rule, protocol).unwrap();

--- a/crates/protocol/src/filters/wire.rs
+++ b/crates/protocol/src/filters/wire.rs
@@ -4,11 +4,12 @@ use crate::ProtocolVersion;
 use std::io::{self, Read, Write};
 
 /// Rule type prefix character.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum RuleType {
     /// Include rule (`+` prefix).
     Include,
     /// Exclude rule (`-` prefix).
+    #[default]
     Exclude,
     /// Clear previously defined rules (`!` prefix).
     Clear,
@@ -60,7 +61,7 @@ impl RuleType {
 }
 
 /// Filter rule in wire format representation.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct FilterRuleWireFormat {
     /// Rule type (Include/Exclude/Clear/etc.).
     pub rule_type: RuleType,
@@ -88,6 +89,17 @@ pub struct FilterRuleWireFormat {
     pub perishable: bool,
     /// No-match-with-this negates (`!` modifier).
     pub negate: bool,
+    /// No-prefixes modifier (`-` or `+` on a merge/dir-merge rule).
+    ///
+    /// upstream: `exclude.c:1227-1237` - `'-'` sets `FILTRULE_NO_PREFIXES`;
+    /// `'+'` additionally sets `FILTRULE_INCLUDE`. Both are only legal when
+    /// `FILTRULE_MERGE_FILE` (merge `.` or dir-merge `:`) is already set.
+    pub no_prefixes: bool,
+    /// Pairs with [`Self::no_prefixes`] to encode the `+` variant.
+    ///
+    /// When `no_prefixes && no_prefixes_include`, the merge file's per-dir
+    /// rules are treated as include-only; otherwise they are exclude-only.
+    pub no_prefixes_include: bool,
 }
 
 impl FilterRuleWireFormat {
@@ -107,6 +119,8 @@ impl FilterRuleWireFormat {
             receiver_side: false,
             perishable: false,
             negate: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -126,6 +140,8 @@ impl FilterRuleWireFormat {
             receiver_side: false,
             perishable: false,
             negate: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -276,18 +292,7 @@ fn parse_wire_rule_old_prefix(text: &str) -> io::Result<FilterRuleWireFormat> {
     if text == "!" {
         return Ok(FilterRuleWireFormat {
             rule_type: RuleType::Clear,
-            pattern: String::new(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
-            receiver_side: false,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         });
     }
 
@@ -304,18 +309,7 @@ fn parse_wire_rule_old_prefix(text: &str) -> io::Result<FilterRuleWireFormat> {
 
     let mut rule = FilterRuleWireFormat {
         rule_type,
-        pattern: String::new(),
-        anchored: false,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
-        sender_side: false,
-        receiver_side: false,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     };
 
     if let Some(stripped) = pattern_text.strip_suffix('/') {
@@ -350,18 +344,7 @@ fn parse_wire_rule_modern(
 
     let mut rule = FilterRuleWireFormat {
         rule_type,
-        pattern: String::new(),
-        anchored: false,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
-        sender_side: false,
-        receiver_side: false,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     };
 
     let mut pattern_start = 1;
@@ -393,6 +376,20 @@ fn parse_wire_rule_modern(
             }
             'x' => {
                 rule.xattr_only = true;
+                pattern_start += 1;
+            }
+            // upstream: exclude.c:1227-1237 - `-` and `+` set FILTRULE_NO_PREFIXES
+            // on merge/dir-merge rules. `+` additionally sets FILTRULE_INCLUDE.
+            // Acceptance is gated on Merge/DirMerge to mirror upstream's
+            // FILTRULE_MERGE_FILE precondition; on other rule types these
+            // characters fall through to `_` and terminate modifier parsing.
+            '-' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
+                rule.no_prefixes = true;
+                pattern_start += 1;
+            }
+            '+' if matches!(rule.rule_type, RuleType::Merge | RuleType::DirMerge) => {
+                rule.no_prefixes = true;
+                rule.no_prefixes_include = true;
                 pattern_start += 1;
             }
             's' if protocol.supports_sender_receiver_modifiers() => {
@@ -595,6 +592,86 @@ mod tests {
         let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(parsed[0].perishable);
+    }
+
+    /// upstream: `exclude.c:1555-1560` get_rule_prefix() emits `-` between `w`
+    /// and `e` when FILTRULE_NO_PREFIXES is set on a merge/dir-merge rule;
+    /// `exclude.c:1227-1231` parse_rule_tok() accepts `-` after `:` or `.`.
+    /// Round-trip ensures encode/decode parity for `:- .excl`.
+    #[test]
+    fn dir_merge_no_prefixes_minus_roundtrip() {
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: ".excl".to_owned(),
+            no_prefixes: true,
+            ..FilterRuleWireFormat::default()
+        };
+
+        let mut buf = Vec::new();
+        write_filter_list(&mut buf, std::slice::from_ref(&rule), protocol).unwrap();
+
+        // Payload: ":- .excl" - 8 bytes.
+        assert_eq!(&buf[..4], &8i32.to_le_bytes()[..]);
+        assert_eq!(&buf[4..12], b":- .excl");
+        assert_eq!(&buf[12..], &0i32.to_le_bytes()[..]);
+
+        let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].rule_type, RuleType::DirMerge);
+        assert_eq!(parsed[0].pattern, ".excl");
+        assert!(parsed[0].no_prefixes);
+        assert!(!parsed[0].no_prefixes_include);
+    }
+
+    /// upstream: `exclude.c:1232-1236` parse_rule_tok() - `+` after `:` or `.`
+    /// sets FILTRULE_NO_PREFIXES|FILTRULE_INCLUDE; `exclude.c:1556-1557`
+    /// get_rule_prefix() emits `+` when both bits are set.
+    #[test]
+    fn dir_merge_no_prefixes_plus_roundtrip() {
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        let rule = FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: ".incl".to_owned(),
+            no_prefixes: true,
+            no_prefixes_include: true,
+            ..FilterRuleWireFormat::default()
+        };
+
+        let mut buf = Vec::new();
+        write_filter_list(&mut buf, std::slice::from_ref(&rule), protocol).unwrap();
+
+        // Payload: ":+ .incl" - 8 bytes.
+        assert_eq!(&buf[..4], &8i32.to_le_bytes()[..]);
+        assert_eq!(&buf[4..12], b":+ .incl");
+
+        let parsed = read_filter_list(&mut &buf[..], protocol).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].rule_type, RuleType::DirMerge);
+        assert_eq!(parsed[0].pattern, ".incl");
+        assert!(parsed[0].no_prefixes);
+        assert!(parsed[0].no_prefixes_include);
+    }
+
+    /// upstream: `exclude.c:1228, 1233` - `-`/`+` modifiers are only valid
+    /// after FILTRULE_MERGE_FILE is set. A plain exclude rule with `-` after
+    /// the type prefix must NOT be parsed as no-prefixes; the modifier loop
+    /// terminates and the remainder becomes the pattern.
+    #[test]
+    fn no_prefixes_modifier_rejected_on_non_merge_rule() {
+        let protocol = ProtocolVersion::from_supported(32).unwrap();
+        // Raw wire bytes: "--foo" - the leading `-` is the rule type prefix
+        // (Exclude); the second `-` is not a legal modifier on Exclude rules
+        // and must fall through to the pattern.
+        let rules = read_filter_list(
+            &mut &[5u8, 0, 0, 0, b'-', b'-', b'f', b'o', b'o', 0, 0, 0, 0][..],
+            protocol,
+        )
+        .unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, RuleType::Exclude);
+        assert!(!rules[0].no_prefixes);
+        assert_eq!(rules[0].pattern, "-foo");
     }
 
     #[test]

--- a/crates/protocol/tests/filter_legal_len_parity.rs
+++ b/crates/protocol/tests/filter_legal_len_parity.rs
@@ -26,17 +26,7 @@ fn dir_merge_rule(pattern: &str) -> FilterRuleWireFormat {
     FilterRuleWireFormat {
         rule_type: RuleType::DirMerge,
         pattern: pattern.to_owned(),
-        anchored: false,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
-        sender_side: false,
-        receiver_side: false,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     }
 }
 

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -606,17 +606,7 @@ mod tests {
         FilterRuleWireFormat {
             rule_type: RuleType::DirMerge,
             pattern: pattern.to_owned(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
-            receiver_side: false,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         }
     }
 

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -182,18 +182,9 @@ fn clear_rule() -> FilterRuleWireFormat {
     use protocol::filters::RuleType;
     FilterRuleWireFormat {
         rule_type: RuleType::Clear,
-        pattern: String::new(),
-        anchored: false,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
         sender_side: true,
         receiver_side: true,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     }
 }
 

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -23,17 +23,7 @@ fn daemon_filter_set_built_from_config_rules() {
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
         pattern: "*.tmp".to_string(),
-        anchored: false,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
-        sender_side: false,
-        receiver_side: false,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
 
@@ -66,32 +56,12 @@ fn daemon_filter_set_include_and_exclude() {
         FilterRuleWireFormat {
             rule_type: RuleType::Include,
             pattern: "*.rs".to_string(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
-            receiver_side: false,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         },
         FilterRuleWireFormat {
             rule_type: RuleType::Exclude,
             pattern: "*".to_string(),
-            anchored: false,
-            directory_only: false,
-            no_inherit: false,
-            cvs_exclude: false,
-            word_split: false,
-            exclude_from_merge: false,
-            xattr_only: false,
-            sender_side: false,
-            receiver_side: false,
-            perishable: false,
-            negate: false,
+            ..FilterRuleWireFormat::default()
         },
     ];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
@@ -119,16 +89,7 @@ fn daemon_filter_set_anchored_pattern() {
         rule_type: RuleType::Exclude,
         pattern: "/secret".to_string(),
         anchored: true,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
-        sender_side: false,
-        receiver_side: false,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
 
@@ -159,17 +120,7 @@ fn daemon_filter_rules_prepended_to_receiver_deletion_chain() {
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
         rule_type: RuleType::Exclude,
         pattern: "secret_*".to_string(),
-        anchored: false,
-        directory_only: false,
-        no_inherit: false,
-        cvs_exclude: false,
-        word_split: false,
-        exclude_from_merge: false,
-        xattr_only: false,
-        sender_side: false,
-        receiver_side: false,
-        perishable: false,
-        negate: false,
+        ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
 


### PR DESCRIPTION
## Summary

Restore wire-format parity with upstream rsync for the dir-merge / merge
`-` and `+` modifier characters (FILTRULE_NO_PREFIXES).

For `-f dir-merge,-_.excl`, upstream emits `:- .excl` on the wire. Our
modern wire path had a struct with no `no_prefixes` field, an encoder
that never produced `-`/`+`, and a parser whose `match` arms ended at
`_ => break`, silently dropping the modifier. The receiver therefore
parsed an empty merge-file pattern and treated the directive as a
no-op, leading to the `exclude-lsh` testsuite divergence.

## Root cause

Upstream `target/interop/upstream-src/rsync-3.4.4/exclude.c`:

- `get_rule_prefix:1555-1560` - emits `-` or `+` between `w` and `e`
  when `FILTRULE_NO_PREFIXES` (and optionally `FILTRULE_INCLUDE`) is
  set on a merge/dir-merge rule.
- `parse_rule_tok:1227-1237` - accepts `-` (sets `FILTRULE_NO_PREFIXES`)
  and `+` (sets `FILTRULE_NO_PREFIXES | FILTRULE_INCLUDE`) only after
  `FILTRULE_MERGE_FILE` is already on the rule.

oc-rsync sites that needed updating:

- `crates/protocol/src/filters/wire.rs:62-91` - `FilterRuleWireFormat`
  struct missing the no-prefixes fields.
- `crates/protocol/src/filters/wire.rs:367-418` - `parse_wire_rule_modern`
  match block silently dropping `-` / `+`.
- `crates/protocol/src/filters/prefix.rs:117-159` - `build_modern_prefix`
  emission block never writing the modifier.

## Fix

- Add `no_prefixes: bool` and `no_prefixes_include: bool` fields to
  `FilterRuleWireFormat`.
- Add `-` and `+` arms in `parse_wire_rule_modern`, gated on
  `RuleType::Merge | RuleType::DirMerge` to mirror upstream's
  `FILTRULE_MERGE_FILE` precondition.
- Emit the character in `build_modern_prefix` between `w` and `e` to
  match upstream byte ordering.
- Reject the modifier on legacy (`legal_len = 1`) protocols in
  `build_old_prefix` (same treatment as the other modern modifiers).
- Derive `Default` on `RuleType` and `FilterRuleWireFormat` so the new
  fields can be added without churning every struct-literal call site;
  remaining literals are converted to `..FilterRuleWireFormat::default()`
  struct update syntax.

## Tests

Three new round-trip tests in `crates/protocol/src/filters/wire.rs`:

- `dir_merge_no_prefixes_minus_roundtrip` - asserts encode/decode of
  `:- .excl` (8 wire bytes) and `no_prefixes = true`.
- `dir_merge_no_prefixes_plus_roundtrip` - asserts encode/decode of
  `:+ .incl` (8 wire bytes) and both `no_prefixes` and
  `no_prefixes_include` set.
- `no_prefixes_modifier_rejected_on_non_merge_rule` - verifies that
  `--foo` on a plain Exclude rule terminates the modifier loop and the
  remaining bytes become the pattern, mirroring upstream's
  `prefix_specifies_side`-style invariant.

No existing golden wire-byte tests are touched.

## Test plan

- [ ] CI: `cargo fmt --all --check` clean.
- [ ] CI: `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- [ ] CI: `cargo nextest run --workspace --all-features` green (Linux musl, macOS, Windows).
- [ ] Interop: upstream `exclude-lsh` testsuite no longer diverges.