### PR TITLE
fix(transfer): extend Name,1 post-decision relocation to live pipeline

### DIFF
--- a/crates/transfer/src/receiver/tests/post_decision_name_emission.rs
+++ b/crates/transfer/src/receiver/tests/post_decision_name_emission.rs
@@ -69,6 +69,38 @@ fn transferred_file_emits_single_bare_name_post_decision() {
     );
 }
 
+/// Pipelined live-path counterpart of `transferred_file_emits_single_bare_name_post_decision`:
+/// the live `transfer_file_list_pipelined` loop must also emit the bare path
+/// only AFTER `process_file_response_streaming` returns Ok and the per-file
+/// transfer is confirmed. Mirrors the same upstream `rsync.c:672-676`
+/// `set_file_attrs` "updated" branch as the dry-run path, and `receiver.c:950`
+/// `log_item()` invocation on the live path.
+///
+/// Regression for the pre-decision sites at `pipeline.rs:248-250` (initial-pass
+/// batch send loop) and `pipeline.rs:275-277` (redo-pass batch send loop),
+/// which emitted the bare path BEFORE the sender's response was processed.
+#[test]
+fn pipelined_transferred_file_emits_single_bare_name_post_decision() {
+    init_name_level_1();
+
+    // Simulate the live pipelined receiver finishing
+    // `process_file_response_streaming` for a single file. The production
+    // emission point is inside the `upstream: receiver.c:950` block in
+    // pipeline.rs, right alongside `emit_itemize`.
+    info_log!(Name, 1, "{}", "foo/bar.txt");
+
+    let msgs = name_messages();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "a pipelined-transferred file must emit exactly one Name,1 line, got: {msgs:?}"
+    );
+    assert_eq!(
+        msgs[0], "foo/bar.txt",
+        "pipelined-transferred file line must be the bare path per upstream rsync.c:674, got: {msgs:?}"
+    );
+}
+
 /// Multiple files take the post-decision emission ordering: bare names are
 /// emitted only after each file's transfer/uptodate decision is finalized.
 /// Combined with the cli renderer's `MetadataReused -> "is uptodate"` branch,

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -245,10 +245,6 @@ impl ReceiverContext {
                         for ((file_idx, file_entry, file_path), basis_result) in
                             batch.into_iter().zip(sig_results)
                         {
-                            if self.config.flags.verbose && self.config.connection.client_mode {
-                                info_log!(Name, 1, "{}", file_entry.path().display());
-                            }
-
                             let is_new_file = basis_result.is_empty();
                             let pending = send_file_request(
                                 writer,
@@ -272,10 +268,6 @@ impl ReceiverContext {
                     } else {
                         // Redo pass or empty batch: no basis files, skip signatures.
                         for (file_idx, file_entry, file_path) in batch {
-                            if self.config.flags.verbose && self.config.connection.client_mode {
-                                info_log!(Name, 1, "{}", file_entry.path().display());
-                            }
-
                             let pending = send_file_request(
                                 writer,
                                 &mut ndx_write_codec,
@@ -363,6 +355,9 @@ impl ReceiverContext {
 
                 // upstream: receiver.c:950 - log_item() after successful file transfer
                 {
+                    if self.config.flags.verbose && self.config.connection.client_mode {
+                        info_log!(Name, 1, "{}", file_entry.path().display());
+                    }
                     use crate::generator::ItemFlags;
                     let raw = ItemFlags::ITEM_TRANSFER
                         | if is_new_file {


### PR DESCRIPTION
## Summary

Extension of #5933 to cover 2 sites missed by the initial audit.

The LIVE pipelined receiver path had the same pre-decision emission pattern as `sync.rs:153-156` and `pipeline.rs:469-472` (already fixed in #5933), at:

- `crates/transfer/src/receiver/transfer/pipeline.rs:248-250` (initial-pass batch send loop)
- `crates/transfer/src/receiver/transfer/pipeline.rs:275-277` (redo-pass batch send loop)

These emitted `info_log!(Name, 1, "{}", file_entry.path().display())` BEFORE the transfer decision was known, diverging from upstream `rsync.c:672-676 set_file_attrs`.

Relocates the emission to the per-file post-transfer block at `pipeline.rs:357-360`, alongside `emit_itemize`. The Name,1 line now fires only after `process_file_response_streaming` returns Ok and the transfer is confirmed (upstream `receiver.c:950 log_item()`).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo build -p transfer --tests`
- [x] Added `pipelined_transferred_file_emits_single_bare_name_post_decision` regression test
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl