### PR TITLE
fix(filters): wire FILTRULE_NO_PREFIXES into per-dir merge-file processor

### DIFF
--- a/crates/filters/src/chain/config.rs
+++ b/crates/filters/src/chain/config.rs
@@ -47,6 +47,16 @@ pub struct DirMergeConfig {
     /// Treats the merge file as a CVS-style ignore list: each whitespace
     /// separated token is an exclude rule with no filter prefixes.
     cvs_mode: bool,
+    /// upstream: exclude.c:1116-1133 - FILTRULE_NO_PREFIXES (`-`/`+` modifier
+    /// on a dir-merge rule). When set, each line in the per-dir merge file is
+    /// consumed as a literal pattern: the short-prefix dispatch (`+`, `-`,
+    /// `:`, `.`, modifiers) is skipped entirely.
+    no_prefixes: bool,
+    /// Pairs with [`Self::no_prefixes`] to select the `+` variant.
+    ///
+    /// When `no_prefixes && no_prefixes_include`, each literal line becomes
+    /// an include rule; otherwise it becomes an exclude rule.
+    no_prefixes_include: bool,
 }
 
 impl DirMergeConfig {
@@ -65,6 +75,8 @@ impl DirMergeConfig {
             anchor_root: false,
             perishable: false,
             cvs_mode: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -154,6 +166,34 @@ impl DirMergeConfig {
     #[must_use]
     pub const fn cvs_mode(&self) -> bool {
         self.cvs_mode
+    }
+
+    /// Marks this dir-merge as having FILTRULE_NO_PREFIXES set (the `-`/`+`
+    /// modifier on a `:` rule). Per-dir merge file contents are then consumed
+    /// as literal patterns rather than being run through the normal rule
+    /// parser. `include` selects the `+` variant (literal includes); the
+    /// default and `-` variant emit literal excludes.
+    ///
+    /// upstream: exclude.c:1116-1133 parse_rule_tok - prefix dispatch is
+    /// skipped when FILTRULE_NO_PREFIXES is set on the template.
+    #[must_use]
+    pub const fn with_no_prefixes(mut self, no_prefixes: bool, include: bool) -> Self {
+        self.no_prefixes = no_prefixes;
+        self.no_prefixes_include = include;
+        self
+    }
+
+    /// Returns whether FILTRULE_NO_PREFIXES applies to this dir-merge.
+    #[must_use]
+    pub const fn no_prefixes(&self) -> bool {
+        self.no_prefixes
+    }
+
+    /// Returns whether literal lines should be treated as includes (true) or
+    /// excludes (false) when [`Self::no_prefixes`] is set.
+    #[must_use]
+    pub const fn no_prefixes_include(&self) -> bool {
+        self.no_prefixes_include
     }
 
     /// Returns whether the merge file itself should be excluded.

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -39,7 +39,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use crate::merge::parse::parse_rules;
+use crate::merge::parse::{parse_rules, parse_rules_no_prefixes};
 use crate::{FilterAction, FilterRule, FilterSet};
 
 pub use config::DirMergeConfig;
@@ -241,7 +241,19 @@ impl FilterChain {
             // separated tokens with every token implicitly an exclude.
             // Standard parse_rules would reject names like `one-in-one-out`
             // as "unrecognized filter rule", aborting the walk.
-            let rules = if config.cvs_mode() {
+            let rules = if config.no_prefixes() {
+                // upstream: exclude.c:1116-1133 - the `-`/`+` modifier on the
+                // dir-merge template skips short-prefix dispatch, so each
+                // line becomes a literal exclude (or include for `+`). When
+                // CVS_IGNORE is also inherited (e.g. `:-C`), a bare `!` line
+                // clears the list per FILTRULE_CLEAR_LIST.
+                parse_rules_no_prefixes(
+                    &content,
+                    &merge_path,
+                    config.no_prefixes_include(),
+                    config.cvs_mode(),
+                )
+            } else if config.cvs_mode() {
                 parse_cvs_ignore_tokens(&content)
             } else {
                 match parse_rules(&content, &merge_path) {

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -682,3 +682,112 @@ fn filter_chain_per_dir_deletion_does_not_block_via_synthetic_descendant() {
         "scope commit must not let synthetic `bar/**` override the include rule"
     );
 }
+
+// upstream: exclude.c:1116-1133 parse_rule_tok - when FILTRULE_NO_PREFIXES is
+// set on the template, every per-dir merge line is consumed as a literal
+// pattern. `+ foo`, `- bar`, `include baz` become LITERAL excludes - not
+// include/exclude rules - so paths matching those literal strings are blocked.
+#[test]
+fn dir_merge_no_prefixes_minus_literal_excludes() {
+    let dir = TempDir::new().unwrap();
+    let filter_content = "+ foo\n- bar\ninclude baz\n";
+    fs::write(dir.path().join(".filt"), filter_content).unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt").with_no_prefixes(true, false));
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+
+    // Each literal line excludes the EXACT verbatim pattern, so a file
+    // named "foo" (without `+ ` prefix) is NOT excluded by `+ foo`.
+    assert!(chain.allows(Path::new("foo"), false));
+    assert!(chain.allows(Path::new("bar"), false));
+    assert!(chain.allows(Path::new("baz"), false));
+
+    // But a file whose pattern matches the literal IS excluded. Patterns
+    // containing spaces match path components by name; rsync's matcher
+    // treats them as literal globs.
+    assert!(!chain.allows(Path::new("+ foo"), false));
+    assert!(!chain.allows(Path::new("- bar"), false));
+    assert!(!chain.allows(Path::new("include baz"), false));
+
+    chain.leave_directory(guard);
+}
+
+// upstream: exclude.c:1116-1133 with FILTRULE_INCLUDE - the `+` variant of
+// the no-prefixes modifier emits literal include rules instead of excludes.
+#[test]
+fn dir_merge_no_prefixes_plus_literal_includes() {
+    let dir = TempDir::new().unwrap();
+    let filter_content = "+ foo\n- bar\ninclude baz\n";
+    fs::write(dir.path().join(".filt"), filter_content).unwrap();
+
+    let global = FilterSet::from_rules([FilterRule::exclude("*")]).unwrap();
+    let mut chain = FilterChain::new(global);
+    chain.add_merge_config(DirMergeConfig::new(".filt").with_no_prefixes(true, true));
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+
+    // Literal include lines beat the global `- *` for files matching the
+    // literal verbatim pattern.
+    assert!(chain.allows(Path::new("+ foo"), false));
+    assert!(chain.allows(Path::new("- bar"), false));
+    assert!(chain.allows(Path::new("include baz"), false));
+
+    // Files NOT matching the literals are still excluded by the global rule.
+    assert!(!chain.allows(Path::new("other"), false));
+
+    chain.leave_directory(guard);
+}
+
+// upstream: exclude.c:1123-1124 - without FILTRULE_CVS_IGNORE the bare `!`
+// line is just another literal pattern (no FILTRULE_CLEAR_LIST escape).
+#[test]
+fn dir_merge_no_prefixes_bang_is_literal_without_cvs() {
+    let dir = TempDir::new().unwrap();
+    let filter_content = "- foo\n!\n- bar\n";
+    fs::write(dir.path().join(".filt"), filter_content).unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt").with_no_prefixes(true, false));
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+
+    // List was NOT cleared - both literal excludes still bind, AND `!`
+    // itself binds as a literal exclude of the filename "!".
+    assert!(!chain.allows(Path::new("- foo"), false));
+    assert!(!chain.allows(Path::new("- bar"), false));
+    assert!(!chain.allows(Path::new("!"), false));
+
+    chain.leave_directory(guard);
+}
+
+// upstream: exclude.c:1123-1124 - with FILTRULE_CVS_IGNORE inherited from
+// the template (`:-C` modifier combination), a bare `!` line tentatively
+// triggers FILTRULE_CLEAR_LIST and clears any previously parsed rules.
+#[test]
+fn dir_merge_no_prefixes_bang_clears_list_with_cvs() {
+    let dir = TempDir::new().unwrap();
+    let filter_content = "- foo\n!\n- bar\n";
+    fs::write(dir.path().join(".filt"), filter_content).unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(
+        DirMergeConfig::new(".filt")
+            .with_no_prefixes(true, false)
+            .with_cvs_mode(true),
+    );
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+
+    // After the `!` clear, the prior `- foo` literal exclude no longer
+    // applies; only the literal exclude of `- bar` (parsed after the
+    // clear) remains.
+    assert!(chain.allows(Path::new("- foo"), false));
+    assert!(!chain.allows(Path::new("- bar"), false));
+
+    chain.leave_directory(guard);
+}

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -53,6 +53,51 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
     Ok(rules)
 }
 
+/// Parses a per-dir merge file under FILTRULE_NO_PREFIXES semantics.
+///
+/// When a dir-merge rule carries the `-` or `+` modifier, upstream
+/// `exclude.c:1116-1133 parse_rule_tok` skips the entire short-prefix and
+/// long-form dispatch and consumes each non-empty, non-comment line as a
+/// literal pattern. Lines become exclude rules by default; when `force_include`
+/// is set (the `+` variant), they become include rules instead.
+///
+/// When `cvs_ignore` is true (FILTRULE_CVS_IGNORE inherited from the
+/// template), a bare `!` line tentatively clears the list, matching upstream's
+/// FILTRULE_CLEAR_LIST escape hatch at `exclude.c:1123-1124`. Without
+/// CVS_IGNORE, `!` is just another literal pattern.
+pub(crate) fn parse_rules_no_prefixes(
+    content: &str,
+    _source_path: &Path,
+    force_include: bool,
+    cvs_ignore: bool,
+) -> Vec<FilterRule> {
+    let mut rules = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+
+        // upstream: exclude.c:1123-1124 - when FILTRULE_CVS_IGNORE is set on
+        // the template, a bare `!` becomes FILTRULE_CLEAR_LIST. Without
+        // CVS_IGNORE the `!` is taken literally per the no-prefixes contract.
+        if cvs_ignore && trimmed == "!" {
+            rules.push(FilterRule::clear());
+            continue;
+        }
+
+        let rule = if force_include {
+            FilterRule::include(trimmed)
+        } else {
+            FilterRule::exclude(trimmed)
+        };
+        rules.push(rule);
+    }
+
+    rules
+}
+
 /// Parses a single filter rule line, potentially expanding into multiple rules.
 ///
 /// The `w` (word-split) modifier causes the pattern to be split on whitespace,

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -505,6 +505,13 @@ fn wire_rule_to_dir_merge_config(
         }
     }
 
+    // `-`/`+` modifier: FILTRULE_NO_PREFIXES. Per-dir merge file lines are
+    // consumed as literal patterns; the short-prefix dispatch is skipped.
+    // upstream: exclude.c:1116-1133 parse_rule_tok.
+    if wire_rule.no_prefixes {
+        config = config.with_no_prefixes(true, wire_rule.no_prefixes_include);
+    }
+
     config
 }
 


### PR DESCRIPTION
## Summary

PR #5935 shipped the wire encode/parse layer for the `FILTRULE_NO_PREFIXES` modifier (the `-`/`+` variant on a dir-merge rule), but the parsed `no_prefixes` field was dead inside the receiver — `wire_rule_to_dir_merge_config` consumed every other modifier flag and ignored `no_prefixes` / `no_prefixes_include`, and the chain's per-dir merge dispatcher had no third branch to honor the semantic.

This is the follow-up that wires the field through the receiver path so `:-` and `:+` per-dir merge files are consumed as literal patterns rather than re-running every line through the short-prefix dispatch. Closes the `exclude-lsh` upstream-testsuite FAIL on master.

## Root Cause

Upstream `exclude.c:1116-1133 parse_rule_tok` skips the entire short-prefix dispatch (`+`, `-`, `:`, `.`, `H`, `S`, `P`, `R`, `c`, `d`, `e`, `h`, `i`, `m`, `p`, `r`, `s`, `!`) when the template carries `FILTRULE_NO_PREFIXES`:

```c
if (template->rflags & FILTRULE_NO_PREFIXES) {
    if (*s == '!' && template->rflags & FILTRULE_CVS_IGNORE)
        rule->rflags |= FILTRULE_CLEAR_LIST; /* Tentative! */
} else if (xflags & XFLG_OLD_PREFIXES) {
    ...
} else {
    /* full short-prefix dispatch */
}
```

Each line becomes a literal exclude (or include when `FILTRULE_INCLUDE` was inherited via `:+`). Without this, `:- .filt` and `:+ .filt` per-dir merge files mis-parse lines like `+ literal-pattern` as an include rule with pattern `literal-pattern`, instead of as a literal exclude of the verbatim string `+ literal-pattern`.

## Changes

- `crates/filters/src/chain/config.rs` — add `no_prefixes` and `no_prefixes_include` fields to `DirMergeConfig`, plus `with_no_prefixes`, `no_prefixes`, and `no_prefixes_include` accessors.
- `crates/transfer/src/generator/filters.rs` — propagate `wire_rule.no_prefixes` and `wire_rule.no_prefixes_include` into the constructed `DirMergeConfig`.
- `crates/filters/src/merge/parse.rs` — add `parse_rules_no_prefixes` that bypasses every short-form/long-form prefix dispatch and emits literal exclude/include rules; honors the `FILTRULE_CLEAR_LIST` escape (bare `!` line) when `FILTRULE_CVS_IGNORE` is inherited from the template.
- `crates/filters/src/chain/mod.rs` — extend the per-dir merge dispatch with a `no_prefixes` branch ahead of the CVS-mode branch so that `:-C` combinations honor the literal-pattern semantic and the `FILTRULE_CLEAR_LIST` escape.
- `crates/filters/src/chain/tests.rs` — four regression tests for the `:-`/`:+`/`!`/`:-C !` matrix.

The protocol crate's wire layer is untouched — that part shipped in PR #5935.

## Test plan

- [x] `cargo build -p filters --tests` (clean)
- [x] `cargo build -p transfer --tests` (clean)
- [x] `cargo nextest run -p filters --all-features` — 1356 / 1356 pass
- [x] `cargo nextest run -p filters --all-features -E 'test(/no_prefixes/)'` — 4 / 4 pass
- [ ] CI green across fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] Re-run the `exclude-lsh` upstream-testsuite test on Linux host