### PR TITLE
fix(metadata): gate atimes_crtimes_roundtrip tests on cfg(unix)

### DIFF
--- a/crates/metadata/tests/atimes_crtimes_roundtrip.rs
+++ b/crates/metadata/tests/atimes_crtimes_roundtrip.rs
@@ -24,6 +24,8 @@
 //!   path runs cleanly and gracefully no-ops on filesystems that do not
 //!   surface a creation time.
 
+#![cfg(unix)]
+
 use filetime::{FileTime, set_file_atime, set_file_times};
 use metadata::{MetadataOptions, apply_file_metadata_with_options};
 use std::fs;


### PR DESCRIPTION
## Summary

Master Windows nightly cell `Windows reparse-point + symlink round-trip` is failing on every PR/master push with `-D unused-imports` and `-D dead-code` errors in `crates/metadata/tests/atimes_crtimes_roundtrip.rs`. Both tests in the file are gated `#[cfg(unix)]` (or `cfg(any(target_os = "macos", target_os = "linux"))`), but the file-level imports and constants are unconditional, so on Windows the imports compile and have nothing to use.

Lift the whole test module behind `#![cfg(unix)]` so imports + fixture constants only compile when at least one test will. Matches the project coding standards pattern for unix-only test modules.

Run reproducing the failure: <https://github.com/oferchen/rsync/actions/runs/27765573567>

## Test plan
- [ ] Windows nightly reparse + symlink round-trip cell goes green
- [ ] Linux + macOS nextest cells still exercise both round-trip tests
- [ ] No fmt drift (single `#![cfg(unix)]` addition)