### PR TITLE
fix(transfer): emit itemize for unchanged entries under -vv (NAME>=2)

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -13,7 +13,7 @@
 use std::io::{self, IoSlice, Read, Write};
 use std::time::{Duration, Instant};
 
-use logging::{PhaseTimer, debug_log, info_log};
+use logging::{InfoFlag, PhaseTimer, debug_log, info_gte, info_log};
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum};
 use protocol::wire::SignatureBlock;
@@ -272,13 +272,17 @@ impl GeneratorContext {
     /// In client mode, writes directly to the process stdout via the
     /// itemize callback, matching upstream's `rwrite()` `FCLIENT` path.
     ///
-    /// Suppresses output when `iflags` has no significant flags set (the file
-    /// is completely unchanged), matching upstream's gate in `itemize()` at
-    /// `generator.c:574-576`.
+    /// Upstream `generator.c:582-583` emits when ANY of four OR'd conditions
+    /// hold: significant flags set, `INFO_GTE(NAME, 2)`, `stdout_format_has_i
+    /// > 1`, or an alternate basis name follows. Mirror the same semantic so
+    /// unchanged entries (`iflags == 0`) still appear under `-vv` (the case
+    /// the upstream `itemize.test` testsuite exercises with `-ivvplrtH`).
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:574-576` - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
+    /// - `generator.c:582-583` - emit gate: `(iflags & (SIGNIFICANT_ITEM_FLAGS
+    ///   | ITEM_REPORT_XATTR)) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
+    ///   || (xname && *xname)`
     /// - `sender.c:287` - `maybe_log_item()` for non-transfer items
     /// - `sender.c:430` - `log_item()` after file transfer
     /// - `log.c:330-340` - `rwrite()`: when `am_server`, sends MSG_INFO;
@@ -293,10 +297,16 @@ impl GeneratorContext {
         if !self.config.flags.info_flags.itemize {
             return Ok(());
         }
-        // upstream: generator.c:574-576 - only emit when significant flags are
-        // set. When iflags == 0 (file is completely up-to-date), no line is
-        // produced.
-        if !iflags.has_significant_flags() {
+        // upstream: generator.c:582-583 - the gate is the OR of four
+        // conditions. Significant flags is the common case; INFO_GTE(NAME, 2)
+        // makes `-vv` surface unchanged entries; ITEM_XNAME_FOLLOWS forces
+        // emission when an alternate basis name trails. `stdout_format_has_i
+        // > 1` is the `-ii` "show even unchanged" knob; oc-rsync does not
+        // distinguish single vs double `-i` yet, so that fourth condition is
+        // omitted here and the other three are honored.
+        let force_emit =
+            info_gte(InfoFlag::Name, 2) || iflags.raw() & ItemFlags::ITEM_XNAME_FOLLOWS != 0;
+        if !iflags.has_significant_flags() && !force_emit {
             return Ok(());
         }
         if ndx >= self.file_list.len() {

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -4143,3 +4143,96 @@ fn batched_flush_mixed_ndx_and_data_parity() {
         batched_data.len()
     );
 }
+
+/// Regression tests for the `maybe_emit_itemize` emit-gate.
+///
+/// Upstream `generator.c:582-583` emits an itemize line when ANY of four
+/// conditions hold: significant flags set, `INFO_GTE(NAME, 2)`,
+/// `stdout_format_has_i > 1`, or `ITEM_XNAME_FOLLOWS`. The previous Rust
+/// gate only honored the first condition, so the `itemize.test` testsuite
+/// FAILed under `-ivvplrtH` because rows for completely unchanged entries
+/// (`iflags == 0`, e.g. `.d ./`, `.f foo/config1`, `.L foo/sym`) were
+/// silently dropped.
+mod itemize_emit_gate {
+    use super::*;
+    use crate::generator::item_flags::ItemFlags;
+    use logging::{VerbosityConfig, init};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// Drives `maybe_emit_itemize` in client mode with a captured callback.
+    fn run_gate(verbose_name_level: u8, iflags_raw: u32) -> Vec<String> {
+        // Seed the thread-local verbosity so `info_gte(InfoFlag::Name, 2)`
+        // reflects the test scenario. Other levels remain at defaults.
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.name = verbose_name_level;
+        init(cfg);
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.connection.client_mode = true;
+        config.flags.info_flags.itemize = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        ctx.file_list.push(protocol::flist::FileEntry::new_file(
+            "config1".into(),
+            42,
+            0o644,
+        ));
+
+        let captured: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let lines = Rc::clone(&captured);
+        let mut sink = move |line: &str| {
+            lines.borrow_mut().push(line.to_owned());
+        };
+        let mut callback: Option<&mut dyn crate::ItemizeCallback> = Some(&mut sink);
+
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let iflags = ItemFlags::from_raw(iflags_raw);
+        ctx.maybe_emit_itemize(&mut writer, &iflags, 0, &mut callback)
+            .expect("maybe_emit_itemize must not error in client mode");
+
+        // Reset the verbosity config so siblings see a clean default.
+        init(VerbosityConfig::default());
+        captured.borrow().clone()
+    }
+
+    /// upstream: generator.c:582 - `INFO_GTE(NAME, 2)` forces emission even
+    /// when `iflags == 0`. Without this branch the upstream `itemize.test`
+    /// testsuite (run under `-ivvplrtH`) lost `.d ./`, `.d bar/`,
+    /// `.f foo/config1`, and `.L foo/sym` rows on master.
+    #[test]
+    fn emits_under_verbose_name_2_with_zero_iflags() {
+        let lines = run_gate(2, 0);
+        assert_eq!(
+            lines.len(),
+            1,
+            "INFO_GTE(NAME, 2) must force an itemize line even when iflags == 0; got: {lines:?}"
+        );
+    }
+
+    /// upstream: generator.c:582 - `INFO_GTE(NAME, 2)` is the gate.
+    /// `-v` (NAME level 1) is below the threshold, so unchanged entries
+    /// must stay silent. This is the existing pre-fix behaviour for
+    /// significant-flag-only emission.
+    #[test]
+    fn suppresses_under_verbose_name_1_with_zero_iflags() {
+        let lines = run_gate(1, 0);
+        assert!(
+            lines.is_empty(),
+            "INFO_GTE(NAME, 1) must not force emission; got: {lines:?}"
+        );
+    }
+
+    /// upstream: generator.c:583 - `(xname && *xname)` (encoded as
+    /// `ITEM_XNAME_FOLLOWS` on the wire) forces emission. Verbose level 0
+    /// proves the new branch alone is sufficient.
+    #[test]
+    fn emits_under_xname_follows_with_zero_verbose() {
+        let lines = run_gate(0, ItemFlags::ITEM_XNAME_FOLLOWS);
+        assert_eq!(
+            lines.len(),
+            1,
+            "ITEM_XNAME_FOLLOWS must force an itemize line under upstream gate; got: {lines:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- The generator-side itemize gate in `crates/transfer/src/generator/protocol_io.rs::maybe_emit_itemize` only honored one of four upstream OR'd conditions, so unchanged entries (`iflags == 0`) were silently dropped under `-ivvplrtH`. This dropped 6 of 9 expected rows in the upstream `testsuite/itemize.test` golden on master.
- Upstream `generator.c:582-583` emits when ANY of `(iflags & (SIGNIFICANT_ITEM_FLAGS | ITEM_REPORT_XATTR)) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1 || (xname && *xname)` holds. This PR extends the Rust gate to honor `INFO_GTE(NAME, 2)` and `ITEM_XNAME_FOLLOWS` as additional emit triggers. `stdout_format_has_i > 1` (the `-ii` knob) is not yet tracked separately from `-i`, so that fourth branch is intentionally deferred.
- Three regression tests cover the new branches (NAME=2 + zero iflags emits; NAME=1 + zero iflags suppresses; XNAME_FOLLOWS + verbose 0 emits).

## Upstream Reference

`target/interop/upstream-src/rsync-3.4.4/generator.c:582-583`:

```c
if ((iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR) || INFO_GTE(NAME, 2)
  || stdout_format_has_i > 1 || (xname && *xname)) && !read_batch) {
```

## Failure Diff

Master `itemize.log` produced only the 3 rows with significant flags set:

```
.f.s..tpog config1
>f+++++++++ foo/config2
*deleting   foo/missing
```

The 6 dropped rows (now restored under `-vv`):

```
.d          ./
.d          bar/
.d          bar/baz/
.f          foo/config1
.d          foo/
.L          foo/sym -> ../bar/baz/rsync
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p transfer --tests --no-deps -- -D warnings`
- [x] `cargo build -p transfer --tests`
- [ ] CI nextest (stable/Windows/macOS/Linux musl)
- [ ] CI Interop / upstream-testsuite confirms `itemize.test` now PASSes on master