### PR TITLE
fix(generator): emit -vv uptodate itemize rows mirroring upstream INFO_GTE(NAME,2) gate

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -122,7 +122,14 @@ where
                 });
             }
 
-            let out_format_context = OutFormatContext::with_is_sender(is_sender);
+            // upstream: generator.c:582-583 - `INFO_GTE(NAME, 2)` (i.e. `-vv`
+            // or `--info=name2`) keeps emitting itemize lines for unchanged
+            // entries. Thread the resolved name-level into the renderer so it
+            // bypasses the empty-change-set suppression and surfaces all-dot
+            // rows for unchanged dirs, files, and symlinks.
+            let emit_unchanged = matches!(name_level, NameOutputLevel::UpdatedAndUnchanged);
+            let out_format_context =
+                OutFormatContext::with_is_sender(is_sender).with_emit_unchanged(emit_unchanged);
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                 emit_transfer_summary(
                     &summary,
@@ -217,7 +224,11 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         human_readable_mode,
         is_sender,
     } = params;
-    let context = OutFormatContext::with_is_sender(is_sender);
+    // upstream: generator.c:582-583 - mirror the `INFO_GTE(NAME, 2)` arm of
+    // the itemize emit gate in the log-file renderer so `-vv` / `--info=name2`
+    // surfaces unchanged entries in the log alongside stdout.
+    let emit_unchanged = matches!(name_level, NameOutputLevel::UpdatedAndUnchanged);
+    let context = OutFormatContext::with_is_sender(is_sender).with_emit_unchanged(emit_unchanged);
     // The log file already carries the parallel "building file list" line via
     // logging::info_log!(Flist, 1, ...); the FCLIENT "sending incremental file
     // list" banner is for stdout only (upstream: flist.c:2248 vs 2252).

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -50,14 +50,23 @@ impl OutFormat {
 
 /// Returns `true` when the event should be suppressed from `--out-format` output.
 ///
-/// Mirrors the upstream gate in `generator.c:574-576`: when `iflags == 0`
+/// Mirrors the upstream emit gate in `generator.c:582-583`: when `iflags == 0`
 /// (no significant attribute changes and the file was not transferred), the
-/// itemize line is suppressed. In the local-copy path, this corresponds to
-/// `MetadataReused` events whose `change_set` reports no changes and that
+/// itemize line is suppressed UNLESS `INFO_GTE(NAME, 2)` is in effect (`-vv`
+/// or `--info=name2`). In the local-copy path the unchanged case corresponds
+/// to `MetadataReused` events whose `change_set` reports no changes and that
 /// were not newly created.
 ///
-/// upstream: generator.c:574-576 - `iflags & (SIGNIFICANT_ITEM_FLAGS|ITEM_REPORT_XATTR)`
-fn should_suppress_event(event: &ClientEvent) -> bool {
+/// upstream: generator.c:582-583 - emit when `iflags & (SIGNIFICANT_ITEM_FLAGS
+/// | ITEM_REPORT_XATTR) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
+/// || (xname && *xname)`.
+fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> bool {
+    if context.emit_unchanged() {
+        // upstream: generator.c:582 - the `INFO_GTE(NAME, 2)` arm forces the
+        // itemize line for unchanged entries so `-vv` surfaces dirs, files,
+        // and symlinks that match the source exactly.
+        return false;
+    }
     matches!(event.kind(), ClientEventKind::MetadataReused)
         && !event.was_created()
         && !event.change_set().has_any_change()
@@ -71,7 +80,7 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
     writer: &mut W,
 ) -> io::Result<()> {
     for event in events {
-        if should_suppress_event(event) {
+        if should_suppress_event(event, context) {
             continue;
         }
         format.render(event, context, writer)?;

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1791,3 +1791,89 @@ fn render_binary_units_below_threshold_falls_back_to_separator() {
     // Values below 1024 fall back to separator format
     assert_eq!(format_numeric_value(1023, &format), "1,023");
 }
+
+// Regression: upstream `testsuite/itemize.test` line 113-124 expects `-ivvplrtH`
+// to emit all-dot itemize rows for unchanged dirs, files, and symlinks,
+// mirroring the upstream gate `INFO_GTE(NAME, 2)` in `generator.c:582-583`.
+// The renderer's empty-change-set suppression must be bypassed when the
+// context flags `emit_unchanged`.
+
+#[test]
+fn emit_out_format_suppresses_unchanged_metadata_reused_by_default() {
+    // Without `emit_unchanged`, a `MetadataReused` event whose change set
+    // reports no change and was not created must be omitted from output
+    // (upstream `generator.c:582` default gate).
+    let event = make_event(
+        ClientEventKind::MetadataReused,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    emit_out_format(&events, &format, &OutFormatContext::default(), &mut output).unwrap();
+    assert!(
+        output.is_empty(),
+        "default context must suppress unchanged MetadataReused"
+    );
+}
+
+#[test]
+fn emit_out_format_emits_unchanged_metadata_reused_under_info_name_2() {
+    // With `emit_unchanged` (mirroring `INFO_GTE(NAME, 2)`), the same
+    // unchanged file row must surface as `.f          test.txt`.
+    let event = make_event(
+        ClientEventKind::MetadataReused,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    let ctx = OutFormatContext::default().with_emit_unchanged(true);
+    emit_out_format(&events, &format, &ctx, &mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+    assert_eq!(rendered, ".f          test.txt\n");
+}
+
+#[test]
+fn emit_out_format_emits_unchanged_directory_under_info_name_2() {
+    // upstream `testsuite/itemize.test:115-117` expects `.d          ./`,
+    // `.d          bar/`, `.d          bar/baz/` under `-ivvplrtH`. The
+    // unchanged directory row must surface when `emit_unchanged` is set.
+    let event = make_event(
+        ClientEventKind::MetadataReused,
+        false,
+        Some(ClientEntryKind::Directory),
+        LocalCopyChangeSet::new(),
+    );
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    let ctx = OutFormatContext::default().with_emit_unchanged(true);
+    emit_out_format(&events, &format, &ctx, &mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+    assert_eq!(rendered, ".d          test.txt\n");
+}
+
+#[test]
+fn emit_out_format_emits_unchanged_symlink_under_info_name_2() {
+    // upstream `testsuite/itemize.test:123` expects
+    // `.L          foo/sym -> ../bar/baz/rsync` under `-ivvplrtH` when the
+    // symlink already points at the right target.
+    let event = make_event(
+        ClientEventKind::MetadataReused,
+        false,
+        Some(ClientEntryKind::Symlink),
+        LocalCopyChangeSet::new(),
+    );
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    let ctx = OutFormatContext::default().with_emit_unchanged(true);
+    emit_out_format(&events, &format, &ctx, &mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+    assert_eq!(rendered, ".L          test.txt\n");
+}

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1570,6 +1570,7 @@ fn render_remote_host_with_context_populated() {
         module_name: Some("backup".to_owned()),
         module_path: Some("/var/backup".to_owned()),
         is_sender: false,
+        emit_unchanged: false,
     };
     assert_eq!(
         render_format_with_context("%h", &event, &context),
@@ -1591,6 +1592,7 @@ fn render_remote_address_with_context_populated() {
         module_name: None,
         module_path: None,
         is_sender: false,
+        emit_unchanged: false,
     };
     assert_eq!(
         render_format_with_context("%a", &event, &context),
@@ -1612,6 +1614,7 @@ fn render_module_name_with_context_populated() {
         module_name: Some("data".to_owned()),
         module_path: None,
         is_sender: false,
+        emit_unchanged: false,
     };
     assert_eq!(render_format_with_context("%m", &event, &context), "data\n");
 }
@@ -1630,6 +1633,7 @@ fn render_module_path_with_context_populated() {
         module_name: None,
         module_path: Some("/srv/data".to_owned()),
         is_sender: false,
+        emit_unchanged: false,
     };
     assert_eq!(
         render_format_with_context("%P", &event, &context),
@@ -1651,6 +1655,7 @@ fn render_all_remote_placeholders_with_full_context() {
         module_name: Some("mod".to_owned()),
         module_path: Some("/path".to_owned()),
         is_sender: false,
+        emit_unchanged: false,
     };
     let rendered = render_format_with_context("%h %a %m %P", &event, &context);
     assert_eq!(rendered, "host addr mod /path\n");

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -155,6 +155,15 @@ pub(crate) struct OutFormatContext {
     /// `<` for sender (push), `>` for receiver (pull).
     /// (upstream: log.c:704 - uses `<` when am_sender && !am_server)
     pub(super) is_sender: bool,
+    /// Whether `INFO_GTE(NAME, 2)` is in effect (i.e. `-vv` or
+    /// `--info=name2`).
+    ///
+    /// Upstream `generator.c:582-583` keeps emitting itemize lines for
+    /// entries whose `iflags == 0` when this is set, so unchanged dirs,
+    /// files, and symlinks still surface as all-dot rows. The render path
+    /// uses this to bypass the empty-change-set suppression that mirrors
+    /// the default upstream gate.
+    pub(super) emit_unchanged: bool,
 }
 
 impl OutFormatContext {
@@ -169,6 +178,25 @@ impl OutFormatContext {
             is_sender,
             ..Self::default()
         }
+    }
+
+    /// Sets the `INFO_GTE(NAME, 2)` flag (`-vv` / `--info=name2`).
+    ///
+    /// Upstream `generator.c:582-583` ORs `INFO_GTE(NAME, 2)` into the
+    /// itemize emit gate; mirroring that semantic locally requires the
+    /// renderer to skip the "no change set, no creation" suppression so
+    /// unchanged entries still print as all-dot rows.
+    #[must_use]
+    pub(crate) fn with_emit_unchanged(mut self, emit_unchanged: bool) -> Self {
+        self.emit_unchanged = emit_unchanged;
+        self
+    }
+
+    /// Returns whether the renderer should bypass empty-change-set
+    /// suppression to mirror upstream `INFO_GTE(NAME, 2)` semantics.
+    #[must_use]
+    pub(crate) const fn emit_unchanged(&self) -> bool {
+        self.emit_unchanged
     }
 }
 

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -333,6 +333,7 @@ mod tests {
             module_name: Some("backup".to_owned()),
             module_path: Some("/var/backup".to_owned()),
             is_sender: false,
+            emit_unchanged: false,
         };
         assert_eq!(ctx.remote_host.as_deref(), Some("server.example.com"));
         assert_eq!(ctx.remote_address.as_deref(), Some("192.168.1.1"));

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -1,7 +1,10 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use core::client::{ClientEvent, ClientEventKind, ClientSummary, HumanReadableMode};
+use core::client::{
+    ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind, ClientSummary,
+    HumanReadableMode,
+};
 
 /// Renders a path string with any trailing platform path separators trimmed,
 /// mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:789`
@@ -479,7 +482,18 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // UpdatedAndUnchanged here, so route MetadataReused (or a
             // HardLink whose destination was already linked to the leader)
             // through the uptodate phrasing instead of the bare path.
+            //
+            // Skip directory MetadataReused events: upstream invokes
+            // `set_file_attrs(..., 0)` for dirs (generator.c:1503), so the
+            // rsync.c:676 "is uptodate" notice is gated off for them.
             if matches!(kind, ClientEventKind::MetadataReused) || event.is_hardlink_uptodate() {
+                if event
+                    .metadata()
+                    .map(ClientEntryMetadata::kind)
+                    .is_some_and(|kind| matches!(kind, ClientEntryKind::Directory))
+                {
+                    continue;
+                }
                 writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
                 continue;
             }
@@ -574,6 +588,20 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // (info_log! events drain AFTER the summary in cli mod.rs);
                 // routing it through the event renderer keeps `is uptodate`
                 // lines ahead of the totals to match upstream's wire order.
+                //
+                // upstream: generator.c:1503 calls `set_file_attrs(..., 0)`
+                // for directories (no ATTRS_REPORT flag), so dirs never trigger
+                // the rsync.c:676 "is uptodate" notice. Symlinks (line 1575)
+                // and regular files (line 1827) DO pass `maybe_ATTRS_REPORT`
+                // and therefore surface. Skip directory MetadataReused events
+                // here so the `-vv` golden in `testsuite/itemize.test` matches.
+                if event
+                    .metadata()
+                    .map(ClientEntryMetadata::kind)
+                    .is_some_and(|kind| matches!(kind, ClientEntryKind::Directory))
+                {
+                    continue;
+                }
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
                     writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
                 }

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -210,15 +210,17 @@ fn copy_directory_recursive_inner(
     // upstream: generator.c:1480-1483 - when the destination directory already
     // exists (`statret == 0`), the generator still calls `itemize()` with
     // `iflags=0`; `itemize()` then ORs in `ITEM_REPORT_TIME|PERMS|...` based
-    // on the existing-vs-source metadata drift. The line is emitted only when
-    // the resulting `iflags` carries `SIGNIFICANT_ITEM_FLAGS`
-    // (`generator.c:582-583`); otherwise it is suppressed.
+    // on the existing-vs-source metadata drift. The emit gate at
+    // `generator.c:582-583` then prints the row when any significant flag is
+    // set OR when `INFO_GTE(NAME, 2)` is in effect, so unchanged dirs still
+    // appear as all-dot `.d` rows under `-vv`.
     //
-    // Mirror that here: when the directory already exists and any attribute
-    // differs from the source, emit a `MetadataReused` record carrying the
-    // computed change-set so the renderer produces lines like
-    // `.d..t...... foo/`. When nothing differs, the record stays unemitted
-    // and the renderer skips the directory row entirely.
+    // Mirror that here: always emit a `MetadataReused` record for an existing
+    // destination directory so the event stream carries the entry. The CLI
+    // renderer suppresses records whose `change_set` reports no change unless
+    // the context flags `emit_unchanged` (mirroring `INFO_GTE(NAME, 2)`), so
+    // non-verbose runs continue to omit unchanged dirs while `-vv` surfaces
+    // them as `.d` rows.
     if !record_emitted
         && let Some((ref rel_path, ref snapshot)) = metadata_record
         && let Some(existing_meta) = existing_destination_metadata.as_ref()
@@ -237,20 +239,18 @@ fn copy_directory_recursive_inner(
             false,
             false,
         );
-        if change_set.has_any_change() {
-            context.record(
-                LocalCopyRecord::new(
-                    rel_path.clone(),
-                    LocalCopyAction::MetadataReused,
-                    0,
-                    Some(snapshot.len()),
-                    Duration::default(),
-                    Some(snapshot.clone()),
-                )
-                .with_change_set(change_set),
-            );
-            record_emitted = true;
-        }
+        context.record(
+            LocalCopyRecord::new(
+                rel_path.clone(),
+                LocalCopyAction::MetadataReused,
+                0,
+                Some(snapshot.len()),
+                Duration::default(),
+                Some(snapshot.clone()),
+            )
+            .with_change_set(change_set),
+        );
+        record_emitted = true;
     }
 
     let mut kept_any = !prune_enabled;


### PR DESCRIPTION
## Summary
- Add INFO_GTE(NAME,2) arm to the itemize gate so unchanged entries produce all-dot rows under -vv
- Emit per-flist-entry uptodate itemize from the generator's unchanged-file dispatch

Upstream parity: `rsync-3.4.4/generator.c:582-605` (itemize() gate) and `generator.c:1010-1148` (try_dests_reg uptodate dispatch).

## Test plan
- [ ] Existing nextest passes
- [ ] Upstream-testsuite `itemize` test passes in CI