### PR TITLE
fix(rustdoc): backtick-only links to private items in filters/engine/transfer

### DIFF
--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -83,7 +83,7 @@ pub struct ParallelDrainOutcome<F: DeleteFs> {
 
 /// Cohort-coordinated parallel `DeleteEmitter` consumer.
 ///
-/// The emitter owns the shared [`SharedBatcher`] (a `Mutex<CohortBatcher>`
+/// The emitter owns the shared `SharedBatcher` (a `Mutex<CohortBatcher>`
 /// paired with a `Condvar`) plus the configuration the consumer thread
 /// needs to dispatch each [`DeleteOperation`] through the configured
 /// [`DeleteFs`]. The producer-facing API is intentionally minimal -

--- a/crates/filters/src/set.rs
+++ b/crates/filters/src/set.rs
@@ -225,7 +225,7 @@ impl FilterSet {
     /// fall-through that has already pruned non-matching scopes.
     ///
     /// Suppresses the synthetic `pattern/**` descendant matchers that
-    /// [`CompiledRule::new`] bakes into anchored excludes like `- /bar`.
+    /// `CompiledRule::new` bakes into anchored excludes like `- /bar`.
     /// Without this, a per-dir rule installed in `./foo/.cvsignore` would
     /// match `./bar/x` via its synthetic `bar/**` matcher when the chain
     /// commits a sibling-subtree deletion decision, contradicting upstream

--- a/crates/transfer/src/generator/entry_accessor.rs
+++ b/crates/transfer/src/generator/entry_accessor.rs
@@ -180,7 +180,7 @@ pub fn format_iflags_generic<T: FileEntryAccessor>(
 
 /// Formats a complete itemize output line for MSG_INFO emission.
 ///
-/// Generic counterpart of [`super::itemize::format_itemize_line`] that
+/// Generic counterpart of `super::itemize::format_itemize_line` that
 /// accepts any `FileEntryAccessor` implementor. Uses `name()` and
 /// `link_target_bytes()` from the trait instead of `path()` and
 /// `link_target()` on the concrete `FileEntry`.

--- a/crates/transfer/src/generator/sender_accessor.rs
+++ b/crates/transfer/src/generator/sender_accessor.rs
@@ -181,7 +181,7 @@ pub fn format_iflags_generic<T: FileEntryAccessor>(
 
 /// Formats a complete itemize output line for MSG_INFO emission.
 ///
-/// Trait-generic version of [`super::itemize::format_itemize_line`]. Uses
+/// Trait-generic version of `super::itemize::format_itemize_line`. Uses
 /// [`FileEntryAccessor::name`] for the path string and
 /// [`FileEntryAccessor::link_target_bytes`] for the symlink target.
 ///

--- a/crates/transfer/src/receiver/entry_accessor.rs
+++ b/crates/transfer/src/receiver/entry_accessor.rs
@@ -7,10 +7,10 @@
 //!
 //! Each function mirrors its concrete counterpart in the same crate:
 //!
-//! - [`quick_check_matches_generic`] - [`super::quick_check::quick_check_matches`]
-//! - [`dest_mtime_newer_generic`] - [`super::quick_check::dest_mtime_newer`]
-//! - [`is_hardlink_follower_generic`] - [`super::quick_check::is_hardlink_follower`]
-//! - [`apply_acls_generic`] - [`super::apply_acls_from_receiver_cache`]
+//! - [`quick_check_matches_generic`] - `super::quick_check::quick_check_matches`
+//! - [`dest_mtime_newer_generic`] - `super::quick_check::dest_mtime_newer`
+//! - [`is_hardlink_follower_generic`] - `super::quick_check::is_hardlink_follower`
+//! - [`apply_acls_generic`] - `super::apply_acls_from_receiver_cache`
 //!
 //! # Feature Gate
 //!
@@ -24,7 +24,7 @@ use protocol::flist::FileEntryAccessor;
 /// Pure-function quick-check: compares destination stat against a generic entry.
 ///
 /// Returns `true` when the destination file matches the source entry (skip
-/// transfer). Equivalent to [`super::quick_check::quick_check_matches`] but
+/// transfer). Equivalent to `super::quick_check::quick_check_matches` but
 /// accepts any `T: FileEntryAccessor` instead of a concrete `&FileEntry`.
 ///
 /// Follows upstream `generator.c:617 quick_check_ok()` evaluation order:
@@ -80,7 +80,7 @@ pub fn quick_check_matches_generic<T: FileEntryAccessor + ?Sized>(
 /// Returns `true` when the destination mtime is strictly newer than the source.
 ///
 /// Used by `--update` (`-u`) to skip files where the destination is already
-/// newer. Equivalent to [`super::quick_check::dest_mtime_newer`] but accepts
+/// newer. Equivalent to `super::quick_check::dest_mtime_newer` but accepts
 /// any `T: FileEntryAccessor`.
 ///
 /// upstream: generator.c:1709
@@ -107,7 +107,7 @@ pub fn dest_mtime_newer_generic<T: FileEntryAccessor + ?Sized>(
 /// a hard link rather than transferred via delta.
 ///
 /// A follower has XMIT_HLINKED set but NOT XMIT_HLINK_FIRST. Leaders have
-/// both flags set. Equivalent to [`super::quick_check::is_hardlink_follower`]
+/// both flags set. Equivalent to `super::quick_check::is_hardlink_follower`
 /// but accepts any `T: FileEntryAccessor`.
 ///
 /// # Upstream Reference
@@ -124,7 +124,7 @@ pub fn is_hardlink_follower_generic<T: FileEntryAccessor + ?Sized>(entry: &T) ->
 /// applies the corresponding ACL to `destination`. No-op when `acl_cache` is
 /// `None` or the entry has no ACL index.
 ///
-/// Equivalent to [`super::apply_acls_from_receiver_cache`] but accepts any
+/// Equivalent to `super::apply_acls_from_receiver_cache` but accepts any
 /// `T: FileEntryAccessor`.
 ///
 /// # Upstream Reference


### PR DESCRIPTION
## Summary
- Replace broken intra-doc links to private items with backtick-only references in `filters`, `engine`, and `transfer` crates
- Mirrors the minimal-fix pattern from PR #5940 (cow_detect.rs)
- Unblocks master Pages workflow

## Test plan
- [ ] Pages workflow passes on master