### PR TITLE
fix(filters): apply implicit SENDER_SIDE to merge-expanded rules under --delete-excluded

### DIFF
--- a/crates/core/src/client/config/filters.rs
+++ b/crates/core/src/client/config/filters.rs
@@ -415,10 +415,20 @@ mod tests {
     }
 
     /// Protect/Risk and the merge rule families never trigger the implicit
-    /// flag - they either restrict to the receiver side already
-    /// (`FilterRuleSpec::protect`/`risk` set `sender=false`) or carry their
-    /// own `FILTRULE_MERGE_FILE`/`FILTRULE_PERDIR_MERGE` bits that upstream
-    /// excludes from the mask in `exclude.c:1331`.
+    /// flag at the top-level CLI compile step - they either restrict to the
+    /// receiver side already (`FilterRuleSpec::protect`/`risk` set
+    /// `sender=false`) or carry their own `FILTRULE_MERGE_FILE` /
+    /// `FILTRULE_PERDIR_MERGE` bits that upstream excludes from the mask in
+    /// `exclude.c:1330-1332`.
+    ///
+    /// DirMerge wrappers themselves remain a no-op here because the wrapper
+    /// directive is the "merge file" rule that upstream's mask spares; the
+    /// implicit FILTRULE_SENDER_SIDE flip applies instead to each per-token
+    /// rule expanded out of the merge file. That expansion happens in the
+    /// engine's dir-merge loader (`apply_dir_merge_rule_defaults`) and the
+    /// receiver's filter chain (`FilterChain::with_delete_excluded`), both
+    /// of which thread the same `delete_excluded` flag through their parse
+    /// path so the implicit flip fires once per expanded rule.
     #[test]
     fn delete_excluded_skips_non_include_exclude_kinds() {
         let mut protect = FilterRuleSpec::protect("keep");
@@ -430,7 +440,14 @@ mod tests {
         let mut clear = FilterRuleSpec::clear();
         assert!(!clear.apply_implicit_sender_side_for_delete_excluded());
 
+        // DirMerge wrappers are unchanged at compile_filter_program time so
+        // they are forwarded to the engine unmodified. The engine's
+        // load_dir_merge_rules_recursive path is what applies the implicit
+        // sender-side flip to each per-token rule expanded from the merge
+        // file under --delete-excluded.
         let mut dir_merge = FilterRuleSpec::dir_merge(".rsync-filter", DirMergeOptions::new());
         assert!(!dir_merge.apply_implicit_sender_side_for_delete_excluded());
+        assert!(dir_merge.applies_to_sender());
+        assert!(dir_merge.applies_to_receiver());
     }
 }

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -150,6 +150,7 @@ impl<'a> CopyContext<'a> {
             let mut entries = match load_dir_merge_rules_recursive(
                 candidate.as_path(),
                 &rule.options,
+                self.options.delete_excluded_enabled(),
                 &mut visited,
             ) {
                 Ok(entries) => entries,
@@ -216,6 +217,7 @@ impl<'a> CopyContext<'a> {
             let mut entries = match load_dir_merge_rules_recursive(
                 candidate.as_path(),
                 rule.options(),
+                self.options.delete_excluded_enabled(),
                 &mut visited,
             ) {
                 Ok(entries) => entries,

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -42,9 +42,30 @@ pub(crate) fn resolve_dir_merge_path(base: &Path, pattern: &Path) -> PathBuf {
 /// Anchors the rule to the source root when configured, marks it perishable,
 /// and overrides the sender/receiver flags when the merge directive specified
 /// either side modifier. Returns the rule unchanged when no defaults apply.
+///
+/// When `delete_excluded` is set and neither side modifier was specified on
+/// the merge directive, mirrors upstream's per-token implicit SENDER_SIDE
+/// flag for rules expanded out of merge/dir-merge files.
+///
+/// # Upstream Reference
+///
+/// `exclude.c:1324-1332 parse_rule_tok`:
+///
+/// ```c
+/// if (delete_excluded
+///  && !(rule->rflags & (FILTRULES_SIDES|FILTRULE_MERGE_FILE|FILTRULE_PERDIR_MERGE)))
+///     rule->rflags |= FILTRULE_SENDER_SIDE;
+/// ```
+///
+/// The OR'ing fires for every rule produced by `parse_rule_tok`, including
+/// tokens expanded from a `:C .cvsignore` per-directory merge or the
+/// built-in `get_cvs_excludes()` patterns. Only the wrapper merge/dir-merge
+/// directives themselves are skipped (FILTRULE_MERGE_FILE /
+/// FILTRULE_PERDIR_MERGE bits), not the per-token rules they expand into.
 pub(crate) fn apply_dir_merge_rule_defaults(
     mut rule: FilterRule,
     options: &DirMergeOptions,
+    delete_excluded: bool,
 ) -> FilterRule {
     if options.anchor_root_enabled() {
         rule = rule.anchor_to_root();
@@ -54,12 +75,28 @@ pub(crate) fn apply_dir_merge_rule_defaults(
         rule = rule.with_perishable(true);
     }
 
-    if let Some(sender) = options.sender_side_override() {
+    let sender_override = options.sender_side_override();
+    let receiver_override = options.receiver_side_override();
+
+    if let Some(sender) = sender_override {
         rule = rule.with_sender(sender);
     }
 
-    if let Some(receiver) = options.receiver_side_override() {
+    if let Some(receiver) = receiver_override {
         rule = rule.with_receiver(receiver);
+    }
+
+    if delete_excluded
+        && sender_override.is_none()
+        && receiver_override.is_none()
+        && rule.applies_to_sender()
+        && rule.applies_to_receiver()
+        && matches!(
+            rule.action(),
+            filters::FilterAction::Include | filters::FilterAction::Exclude
+        )
+    {
+        rule = rule.with_receiver(false);
     }
 
     rule
@@ -137,9 +174,17 @@ impl DirMergeEntries {
 /// canonical-path stack used to detect cycles: if `path` would re-enter a file
 /// already on the stack the function returns an error rather than recursing
 /// infinitely. On success the visited entry is popped before returning.
+///
+/// `delete_excluded` propagates upstream's per-token implicit SENDER_SIDE
+/// flag (`exclude.c:1324-1332 parse_rule_tok`) onto every rule produced from
+/// this merge file when neither side modifier was specified on the dir-merge
+/// directive itself. This ensures the receiver's delete-pass treats expanded
+/// per-token rules the same way `add_rule()` flags them when the user passed
+/// `--delete-excluded`.
 pub(crate) fn load_dir_merge_rules_recursive(
     path: &Path,
     options: &DirMergeOptions,
+    delete_excluded: bool,
     visited: &mut Vec<PathBuf>,
 ) -> Result<DirMergeEntries, LocalCopyError> {
     let canonical = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
@@ -200,7 +245,11 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         DirMergeEnforcedKind::Include => FilterRule::include(token.to_owned()),
                         DirMergeEnforcedKind::Exclude => FilterRule::exclude(token.to_owned()),
                     };
-                    entries.push_rule(apply_dir_merge_rule_defaults(rule, options));
+                    entries.push_rule(apply_dir_merge_rule_defaults(
+                        rule,
+                        options,
+                        delete_excluded,
+                    ));
                     continue;
                 }
 
@@ -224,7 +273,11 @@ pub(crate) fn load_dir_merge_rules_recursive(
 
                 match parse_filter_directive_line(&directive) {
                     Ok(Some(ParsedFilterDirective::Rule(rule))) => {
-                        entries.push_rule(apply_dir_merge_rule_defaults(rule, options));
+                        entries.push_rule(apply_dir_merge_rule_defaults(
+                            rule,
+                            options,
+                            delete_excluded,
+                        ));
                     }
                     Ok(Some(ParsedFilterDirective::ExcludeIfPresent(rule))) => {
                         entries.push_exclude_if_present(rule);
@@ -249,12 +302,17 @@ pub(crate) fn load_dir_merge_rules_recursive(
                             let nested_entries = load_dir_merge_rules_recursive(
                                 &nested,
                                 &options_override,
+                                delete_excluded,
                                 visited,
                             )?;
                             entries.extend(nested_entries);
                         } else {
-                            let nested_entries =
-                                load_dir_merge_rules_recursive(&nested, options, visited)?;
+                            let nested_entries = load_dir_merge_rules_recursive(
+                                &nested,
+                                options,
+                                delete_excluded,
+                                visited,
+                            )?;
                             entries.extend(nested_entries);
                         }
                     }
@@ -307,13 +365,21 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         DirMergeEnforcedKind::Include => FilterRule::include(trimmed.to_owned()),
                         DirMergeEnforcedKind::Exclude => FilterRule::exclude(trimmed.to_owned()),
                     };
-                    entries.push_rule(apply_dir_merge_rule_defaults(rule, options));
+                    entries.push_rule(apply_dir_merge_rule_defaults(
+                        rule,
+                        options,
+                        delete_excluded,
+                    ));
                     continue;
                 }
 
                 match parse_filter_directive_line(trimmed) {
                     Ok(Some(ParsedFilterDirective::Rule(rule))) => {
-                        entries.push_rule(apply_dir_merge_rule_defaults(rule, options));
+                        entries.push_rule(apply_dir_merge_rule_defaults(
+                            rule,
+                            options,
+                            delete_excluded,
+                        ));
                     }
                     Ok(Some(ParsedFilterDirective::ExcludeIfPresent(rule))) => {
                         entries.push_exclude_if_present(rule);
@@ -332,12 +398,17 @@ pub(crate) fn load_dir_merge_rules_recursive(
                             let nested_entries = load_dir_merge_rules_recursive(
                                 &nested,
                                 &options_override,
+                                delete_excluded,
                                 visited,
                             )?;
                             entries.extend(nested_entries);
                         } else {
-                            let nested_entries =
-                                load_dir_merge_rules_recursive(&nested, options, visited)?;
+                            let nested_entries = load_dir_merge_rules_recursive(
+                                &nested,
+                                options,
+                                delete_excluded,
+                                visited,
+                            )?;
                             entries.extend(nested_entries);
                         }
                     }

--- a/crates/engine/src/local_copy/tests/execute_delete_excluded.rs
+++ b/crates/engine/src/local_copy/tests/execute_delete_excluded.rs
@@ -236,3 +236,97 @@ fn delete_without_delete_excluded_preserves_filtered_tmp_files() {
         "only the non-excluded extraneous file is deleted"
     );
 }
+
+/// Mirrors the failing upstream-testsuite `exclude` sub-transfer:
+///
+/// ```text
+/// rsync -avv --filter='merge .cvsignore' -f:C -f-C \
+///     --delete-excluded --delete-during from/ to/
+/// ```
+///
+/// Source tree contains `*.bak`, `*.junk`, `*.old`, and a `home-cvs-exclude`
+/// entry that matches a `~/.cvsignore` pattern. The dest tree pre-populates
+/// the same files, expecting `--delete-excluded` to sweep every one of them
+/// because the merge-expanded `:C .cvsignore` rules AND the built-in `-C`
+/// CVS-exclude patterns acquire the implicit `FILTRULE_SENDER_SIDE` flag
+/// upstream's `exclude.c:1324-1332 parse_rule_tok` ORs onto every per-token
+/// rule under `--delete-excluded`.
+///
+/// Without the per-token flip, the receiver's delete-pass sees the
+/// expanded rules with `applies_to_receiver=true`, classifies the matching
+/// files as receiver-side excludes, and skips deletion.
+#[test]
+fn delete_excluded_with_cvs_dir_merge_removes_merge_expanded_matches() {
+    use crate::local_copy::{
+        DirMergeEnforcedKind, DirMergeOptions, DirMergeRule, FilterProgram, FilterProgramEntry,
+    };
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("from");
+    let dest = temp.path().join("to");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    // .cvsignore tokens; the `:C` rule below loads this per-directory file.
+    fs::write(source.join(".cvsignore"), b"*.junk *.bak\n").expect("write .cvsignore");
+    fs::write(source.join("kept.txt"), b"survives the transfer").expect("write kept.txt");
+
+    // Files at the destination that should be swept by --delete-excluded.
+    // Use distinct sizes for any source-matching paths to dodge quick-check skips.
+    fs::write(dest.join("file1.bak"), b"stale backup at dest").expect("write file1.bak");
+    fs::write(dest.join("file4.junk"), b"stale junk at dest").expect("write file4.junk");
+    fs::write(dest.join("file2.old"), b"stale old at dest").expect("write file2.old");
+    fs::write(dest.join("home-cvs-exclude"), b"stale home cvs entry").expect("write home cvs");
+    fs::write(dest.join("kept.txt"), b"old kept content longer").expect("write old kept.txt");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Build a FilterProgram mirroring the CLI input:
+    //  - dir-merge `:C .cvsignore` (per-directory CVS-style ignore)
+    //  - built-in CVS patterns covering `*.bak`, `*.old`, etc.
+    //  - one extra exclude for `home-cvs-exclude` standing in for a
+    //    $HOME/.cvsignore entry the upstream test plants via `home-cvs-exclude`.
+    let cvs_options = DirMergeOptions::default()
+        .with_enforced_kind(Some(DirMergeEnforcedKind::Exclude))
+        .use_whitespace()
+        .allow_comments(false)
+        .inherit(false);
+    let program = FilterProgram::new([
+        FilterProgramEntry::DirMerge(DirMergeRule::new(".cvsignore", cvs_options)),
+        FilterProgramEntry::Rule(FilterRule::exclude("*.bak").with_perishable(true)),
+        FilterProgramEntry::Rule(FilterRule::exclude("*.old").with_perishable(true)),
+        FilterProgramEntry::Rule(FilterRule::exclude("home-cvs-exclude").with_perishable(true)),
+    ])
+    .expect("compile filter program");
+
+    let options = LocalCopyOptions::default()
+        .delete(true)
+        .delete_excluded(true)
+        .with_filter_program(Some(program));
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    assert!(dest.join("kept.txt").exists(), "kept.txt must remain");
+
+    // Each of these files must be deleted because the matching rule was
+    // expanded from a merge directive (or a top-level CVS exclude) under
+    // --delete-excluded, so the receiver's delete-pass treats it as a
+    // sender-side exclude rather than a receiver-side protect.
+    for name in ["file1.bak", "file4.junk", "file2.old", "home-cvs-exclude"] {
+        assert!(
+            !dest.join(name).exists(),
+            "{name} must be deleted by --delete-excluded after merge expansion"
+        );
+    }
+
+    assert!(
+        summary.items_deleted() >= 4,
+        "expected at least 4 deletions, got {}",
+        summary.items_deleted()
+    );
+}

--- a/crates/engine/src/local_copy/tests/filters.rs
+++ b/crates/engine/src/local_copy/tests/filters.rs
@@ -333,7 +333,7 @@ fn deferred_updates_flush_commits_pending_files() {
 fn dir_merge_defaults_preserve_rule_side_overrides() {
     let options = DirMergeOptions::default();
     let rule = FilterRule::exclude("*.tmp").with_receiver(false);
-    let adjusted = apply_dir_merge_rule_defaults(rule, &options);
+    let adjusted = apply_dir_merge_rule_defaults(rule, &options, false);
 
     assert!(adjusted.applies_to_sender());
     assert!(!adjusted.applies_to_receiver());
@@ -345,11 +345,56 @@ fn dir_merge_modifiers_override_rule_side_overrides() {
     let receiver_only_options = DirMergeOptions::default().receiver_modifier();
 
     let rule = FilterRule::include("logs/**").with_receiver(false);
-    let sender_adjusted = apply_dir_merge_rule_defaults(rule.clone(), &sender_only_options);
+    let sender_adjusted =
+        apply_dir_merge_rule_defaults(rule.clone(), &sender_only_options, false);
     assert!(sender_adjusted.applies_to_sender());
     assert!(!sender_adjusted.applies_to_receiver());
 
-    let receiver_adjusted = apply_dir_merge_rule_defaults(rule, &receiver_only_options);
+    let receiver_adjusted = apply_dir_merge_rule_defaults(rule, &receiver_only_options, false);
     assert!(!receiver_adjusted.applies_to_sender());
     assert!(receiver_adjusted.applies_to_receiver());
+}
+
+/// upstream: exclude.c:1324-1332 parse_rule_tok - rules expanded from a
+/// merge file under --delete-excluded carry FILTRULE_SENDER_SIDE when
+/// neither side modifier is set on the wrapper. Per-token rules from
+/// `:C .cvsignore` or built-in CVS patterns must follow the same rule so
+/// the receiver's delete-pass does not skip them.
+#[test]
+fn dir_merge_defaults_apply_implicit_sender_side_under_delete_excluded() {
+    let options = DirMergeOptions::default();
+    let rule = FilterRule::exclude("*.bak");
+    let adjusted = apply_dir_merge_rule_defaults(rule, &options, true);
+
+    assert!(adjusted.applies_to_sender());
+    assert!(!adjusted.applies_to_receiver());
+}
+
+/// Explicit side modifiers on the dir-merge wrapper take precedence over
+/// the implicit `--delete-excluded` flip, mirroring upstream's check on
+/// FILTRULES_SIDES in `exclude.c:1330`.
+#[test]
+fn dir_merge_defaults_respect_explicit_side_modifier_under_delete_excluded() {
+    let receiver_only = DirMergeOptions::default().receiver_modifier();
+    let rule = FilterRule::exclude("*.bak");
+    let adjusted = apply_dir_merge_rule_defaults(rule, &receiver_only, true);
+
+    assert!(!adjusted.applies_to_sender());
+    assert!(adjusted.applies_to_receiver());
+}
+
+/// Protect and risk rules are receiver-only by construction; the implicit
+/// flip must not strip the receiver flag from them.
+#[test]
+fn dir_merge_defaults_skip_protect_risk_under_delete_excluded() {
+    let options = DirMergeOptions::default();
+    let protect = FilterRule::protect("keep");
+    let adjusted = apply_dir_merge_rule_defaults(protect, &options, true);
+    assert!(!adjusted.applies_to_sender());
+    assert!(adjusted.applies_to_receiver());
+
+    let risk = FilterRule::risk("scratch");
+    let adjusted = apply_dir_merge_rule_defaults(risk, &options, true);
+    assert!(!adjusted.applies_to_sender());
+    assert!(adjusted.applies_to_receiver());
 }

--- a/crates/engine/src/local_copy/tests/filters_runtime.rs
+++ b/crates/engine/src/local_copy/tests/filters_runtime.rs
@@ -272,8 +272,8 @@ fn dir_merge_clear_keyword_discards_previous_rules() {
 
     let mut visited = Vec::new();
     let options = DirMergeOptions::default();
-    let entries =
-        load_dir_merge_rules_recursive(&filter, &options, &mut visited).expect("parse filter");
+    let entries = load_dir_merge_rules_recursive(&filter, &options, false, &mut visited)
+        .expect("parse filter");
 
     assert_eq!(entries.rules.len(), 1);
     assert!(entries.rules.iter().any(|rule| {
@@ -292,8 +292,8 @@ fn dir_merge_clear_keyword_discards_rules_in_whitespace_mode() {
     let options = DirMergeOptions::default()
         .use_whitespace()
         .allow_list_clearing(true);
-    let entries =
-        load_dir_merge_rules_recursive(&filter, &options, &mut visited).expect("parse filter");
+    let entries = load_dir_merge_rules_recursive(&filter, &options, false, &mut visited)
+        .expect("parse filter");
 
     assert_eq!(entries.rules.len(), 1);
     assert!(entries.exclude_if_present.is_empty());

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -83,6 +83,14 @@ pub struct FilterChain {
     /// Ordered from outermost to innermost; evaluation iterates in reverse.
     scopes: Vec<DirScope>,
     current_depth: usize,
+    /// Mirrors upstream's `delete_excluded` global. When `true`, per-token
+    /// rules expanded from merge files acquire an implicit FILTRULE_SENDER_SIDE
+    /// flag so that the receiver's delete-pass does not skip matching files.
+    ///
+    /// upstream: exclude.c:1324-1332 parse_rule_tok - the OR fires for every
+    /// parsed rule under --delete-excluded except the merge/dir-merge wrappers
+    /// themselves.
+    delete_excluded: bool,
 }
 
 impl FilterChain {
@@ -97,6 +105,7 @@ impl FilterChain {
             merge_configs: Vec::new(),
             scopes: Vec::new(),
             current_depth: 0,
+            delete_excluded: false,
         }
     }
 
@@ -113,6 +122,25 @@ impl FilterChain {
     /// their rules into scoped filter sets.
     pub fn add_merge_config(&mut self, config: DirMergeConfig) {
         self.merge_configs.push(config);
+    }
+
+    /// Marks this chain as operating under `--delete-excluded`.
+    ///
+    /// When enabled, rules expanded out of per-directory merge files acquire
+    /// an implicit sender-side flag, mirroring upstream's per-token OR in
+    /// `exclude.c:1324-1332 parse_rule_tok`. Without this, the receiver's
+    /// delete-pass would treat merge-expanded excludes as receiver-side
+    /// excludes and skip the matching files instead of deleting them.
+    #[must_use]
+    pub const fn with_delete_excluded(mut self, delete_excluded: bool) -> Self {
+        self.delete_excluded = delete_excluded;
+        self
+    }
+
+    /// Reports whether implicit per-token sender-side promotion is active.
+    #[must_use]
+    pub const fn delete_excluded(&self) -> bool {
+        self.delete_excluded
     }
 
     /// Returns `true` if the path should be included in the transfer.
@@ -284,10 +312,12 @@ impl FilterChain {
             }
 
             let config = &self.merge_configs[config_index];
+            let delete_excluded = self.delete_excluded;
 
             let mut modified_rules: Vec<FilterRule> = rules
                 .into_iter()
                 .map(|rule| config.apply_modifiers(rule))
+                .map(|rule| apply_merge_implicit_sender_side(rule, delete_excluded))
                 .collect();
 
             // upstream: exclude.c - FILTRULE_EXCLUDE_SELF handling
@@ -383,6 +413,12 @@ impl FilterChain {
         if rules.is_empty() {
             return Ok(0);
         }
+
+        let delete_excluded = self.delete_excluded;
+        let rules: Vec<FilterRule> = rules
+            .into_iter()
+            .map(|rule| apply_merge_implicit_sender_side(rule, delete_excluded))
+            .collect();
 
         let filter_set = match FilterSet::from_rules(rules) {
             Ok(set) => set,
@@ -486,6 +522,29 @@ fn parse_cvs_ignore_tokens(content: &str) -> Vec<FilterRule> {
         .filter(|token| !token.is_empty())
         .map(FilterRule::exclude)
         .collect()
+}
+
+/// Applies upstream's per-token implicit FILTRULE_SENDER_SIDE flip to a rule
+/// expanded from a merge file when `--delete-excluded` is active.
+///
+/// Mirrors `exclude.c:1324-1332 parse_rule_tok`: the OR fires for every
+/// include/exclude rule produced by the parser unless the user explicitly
+/// requested a side via the `s` or `r` modifier, in which case the
+/// FILTRULES_SIDES bit is already set and the OR is skipped. Merge and
+/// dir-merge wrappers themselves are excluded by the FILTRULE_MERGE_FILE /
+/// FILTRULE_PERDIR_MERGE check, which oc-rsync handles by extracting those
+/// directives before calling this helper.
+fn apply_merge_implicit_sender_side(rule: FilterRule, delete_excluded: bool) -> FilterRule {
+    if !delete_excluded {
+        return rule;
+    }
+    if !matches!(rule.action(), FilterAction::Include | FilterAction::Exclude) {
+        return rule;
+    }
+    if !(rule.applies_to_sender() && rule.applies_to_receiver()) {
+        return rule;
+    }
+    rule.with_receiver(false)
 }
 
 /// Description of a dir-merge directive parsed from another merge file.

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -791,3 +791,65 @@ fn dir_merge_no_prefixes_bang_clears_list_with_cvs() {
 
     chain.leave_directory(guard);
 }
+
+/// upstream: exclude.c:1324-1332 parse_rule_tok - under --delete-excluded,
+/// tokens expanded from a `:C .cvsignore` per-directory merge acquire the
+/// implicit FILTRULE_SENDER_SIDE flag. The receiver's delete-pass then
+/// observes `applies_to_receiver=false`, so the receiver-side rule
+/// no longer fires and the delete-pass proceeds (file is deleted).
+#[test]
+fn cvs_dir_merge_expands_to_sender_side_under_delete_excluded() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".cvsignore"), "*.junk *.bak").unwrap();
+
+    let config = DirMergeConfig::new(".cvsignore").with_cvs_mode(true);
+    let mut chain = FilterChain::empty().with_delete_excluded(true);
+    chain.add_merge_config(config);
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+    assert!(chain.delete_excluded());
+
+    // Sender-side traversal still excludes these patterns from transfer,
+    // matching upstream's `parse_rule_tok` OR'ing on FILTRULE_SENDER_SIDE.
+    assert!(!chain.allows(Path::new("file.junk"), false));
+    assert!(!chain.allows(Path::new("file.bak"), false));
+
+    // Receiver-side deletion is no longer blocked because the rule lost
+    // its applies_to_receiver bit; without the implicit flip the rule
+    // would have matched on the receiver side and skipped deletion.
+    assert!(
+        chain.allows_deletion(Path::new("file.junk"), false),
+        "merge-expanded rule must not block receiver deletion under delete-excluded"
+    );
+    assert!(
+        chain.allows_deletion(Path::new("file.bak"), false),
+        "merge-expanded rule must not block receiver deletion under delete-excluded"
+    );
+
+    chain.leave_directory(guard);
+}
+
+/// Without --delete-excluded the implicit flip must NOT fire, so the
+/// expanded exclude rules continue to apply to both sides exactly as
+/// upstream's `add_rule()` leaves them in the default case. The receiver
+/// then matches the rule and skips deletion (default behaviour).
+#[test]
+fn cvs_dir_merge_preserves_both_sides_without_delete_excluded() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".cvsignore"), "*.junk").unwrap();
+
+    let config = DirMergeConfig::new(".cvsignore").with_cvs_mode(true);
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(config);
+    assert!(!chain.delete_excluded());
+
+    let guard = chain.enter_directory(dir.path()).unwrap();
+    assert_eq!(guard.pushed_count(), 1);
+
+    // Both sides still see the exclude when --delete-excluded is off.
+    assert!(!chain.allows(Path::new("file.junk"), false));
+    assert!(!chain.allows_deletion(Path::new("file.junk"), false));
+
+    chain.leave_directory(guard);
+}


### PR DESCRIPTION
## Summary
- Merge-file-expanded rules (`:C` per-token, `-C` built-in CVS) now carry FILTRULE_SENDER_SIDE under --delete-excluded
- Mirrors upstream `rsync-3.4.4/exclude.c:1324-1332` per-token OR

Receiver delete-pass at `crates/filters/src/decision.rs:77-98` no longer skips matching files; upstream-testsuite `exclude` failing sub-transfer now deletes *.bak/*.junk/*.old/home-cvs-exclude as upstream does.

## Test plan
- [ ] Existing nextest passes
- [ ] New regression test asserts --delete-excluded with `:C -C` deletes merge-pattern files
- [ ] Upstream-testsuite `exclude` test passes