### PR TITLE
test(cli): add -r to dry_run tests that expect file listing

### DIFF
--- a/crates/cli/src/frontend/tests/dry_run.rs
+++ b/crates/cli/src/frontend/tests/dry_run.rs
@@ -68,7 +68,7 @@ fn dry_run_with_verbose_lists_files_on_stdout() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        OsString::from("-nv"),
+        OsString::from("-rnv"),
         source_operand,
         dest_dir.clone().into_os_string(),
     ]);
@@ -81,6 +81,8 @@ fn dry_run_with_verbose_lists_files_on_stdout() {
     );
 
     // upstream: -v lists the files that would be transferred on stdout.
+    // Recurse is required for upstream to descend the source directory
+    // (options.c:112 defaults recurse=0).
     let output = String::from_utf8_lossy(&stdout);
     assert!(
         output.contains("file1.txt"),
@@ -293,7 +295,7 @@ fn dry_run_with_exclude_filter() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
-        OsString::from("-nv"),
+        OsString::from("-rnv"),
         OsString::from("--exclude=*.log"),
         source_operand,
         dest_dir.clone().into_os_string(),

--- a/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
+++ b/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
@@ -522,6 +522,7 @@ fn exclude_and_filter_exclude_produce_same_result() {
 
     let (code1, _, _) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("--exclude"),
         OsString::from("*.tmp"),
         source_root1.into_os_string(),
@@ -539,6 +540,7 @@ fn exclude_and_filter_exclude_produce_same_result() {
 
     let (code2, _, _) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("-f"),
         OsString::from("- *.tmp"),
         source_root2.into_os_string(),
@@ -583,6 +585,7 @@ fn filter_include_then_exclude_all_via_short_f() {
 
     let (code, _, _) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("-f"),
         OsString::from("+ *.txt"),
         OsString::from("-f"),
@@ -617,6 +620,7 @@ fn exclude_from_and_filter_merge_produce_same_result() {
 
     let (code1, _, _) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("--exclude-from"),
         filter_file1.as_os_str().to_os_string(),
         source_root1.into_os_string(),
@@ -643,6 +647,7 @@ fn exclude_from_and_filter_merge_produce_same_result() {
     let merge_arg = format!("merge,- {}", filter_file2.display());
     let (code2, _, _) = run_with_args([
         OsString::from(RSYNC),
+        OsString::from("-r"),
         OsString::from("-f"),
         OsString::from(merge_arg),
         source_root2.into_os_string(),


### PR DESCRIPTION
## Summary
Two dry_run tests use \`-nv source/ dst/\` and expect source files to appear in stdout. PR #5929 made recursive default to false (matching upstream \`options.c:112\`), so \`-nv\` no longer walks the source directory and these tests broke.

Adding \`-r\` to both invocations restores the verbose listing assertion while keeping \`recursive_effective=false\` correct as the production default.

Affected tests:
- \`dry_run_with_verbose_lists_files_on_stdout\` (dry_run.rs:85)
- \`dry_run_with_exclude_filter\` (dry_run.rs:310)

This unblocks master CI nextest cells (stable, beta, nightly across linux, musl, macOS).

## Test plan
- [ ] nextest (stable, beta, nightly) green
- [ ] Confirm no other tests rely on the old implicit-recursive behavior