### PR TITLE
fix(fast_io): drop link brackets around OnceLock<Mutex<HashMap>> rustdoc

### DIFF
--- a/crates/fast_io/src/platform_copy/cow_detect.rs
+++ b/crates/fast_io/src/platform_copy/cow_detect.rs
@@ -28,7 +28,7 @@
 //!   as [`CowSupport::Probable`] so a single FICLONE probe confirms.
 //!
 //! The detection result is cached in a process-wide
-//! [`OnceLock<Mutex<HashMap>>`] keyed by `statfs.f_fsid` so repeated
+//! `OnceLock<Mutex<HashMap>>` keyed by `statfs.f_fsid` so repeated
 //! copies on the same mountpoint only pay the `statfs` cost once.
 //!
 //! # Platform Support


### PR DESCRIPTION
## Summary

- Master Pages workflow has been red since #5927 landed `cow_detect.rs`
- Line 31 wraps `` `OnceLock<Mutex<HashMap>>` `` in intra-doc-link brackets; rustdoc cannot resolve the type parameters and emits `unresolved link to \`OnceLock\``
- `lib.rs:79` denies `rustdoc::broken_intra_doc_links`, escalating to a build error
- Strip the brackets - the backticks alone render the intent (a code citation, not a clickable link)

Fixes Pages workflow failure at run 27782471764.

## Test plan
- [x] Edit verified locally
- [ ] CI Pages workflow turns green on this branch