### PR TITLE
fix(cli): recognise --copy-unsafe-links and --safe-links in --server mode

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -427,6 +427,8 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--delete-excluded"
             | "--remove-source-files"
             | "--remove-sent-files"
+            | "--copy-unsafe-links"
+            | "--safe-links"
             | "--stats"
             | "--ignore-existing"
             | "--existing"

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -500,6 +500,18 @@ fn remove_source_files_recognised_as_known_long_flag() {
     assert!(is_known_server_long_flag("--remove-sent-files"));
 }
 
+/// upstream: options.c:2899-2903 - server_options() emits `--copy-unsafe-links`
+/// and `--safe-links` as bare flags when the matching booleans are set on the
+/// client side. The flag-string scanner must register them so the path that
+/// follows is not consumed as a positional argument (which causes the sender
+/// to call `link_stat("--copy-unsafe-links")` and fail with ENOENT, breaking
+/// upstream `exclude-lsh.test` --copy-unsafe-links sub-transfer).
+#[test]
+fn copy_unsafe_links_and_safe_links_recognised_as_known_long_flags() {
+    assert!(is_known_server_long_flag("--copy-unsafe-links"));
+    assert!(is_known_server_long_flag("--safe-links"));
+}
+
 #[test]
 fn long_flags_ignore_errors() {
     let args = vec![


### PR DESCRIPTION
## Summary

Add `--copy-unsafe-links` and `--safe-links` to the `is_known_server_long_flag` whitelist in the `--server` arg-string scanner. Without these entries, the upstream-sent flags leak into the positional source-path list and the sender ends up calling `link_stat("--copy-unsafe-links")` and failing with ENOENT.

Upstream emits these as bare flags in `options.c::server_options()` (lines 2899-2903) whenever the matching booleans are set on the client side, so any client run that toggles `--copy-unsafe-links` or `--safe-links` ends up hitting this code path.

This was the visible blocker for the upstream `exclude-lsh.test` `--copy-unsafe-links` sub-transfer; the test now progresses past that leg.

## Test plan

- [x] Added unit test `copy_unsafe_links_and_safe_links_recognised_as_known_long_flags` pinning the regression with an upstream citation
- [x] Release build clean on Linux host
- [x] Targeted nextest pass for the flags whitelist tests
- [x] Upstream `exclude-lsh.test` `--copy-unsafe-links` sub-transfer progresses (later legs hit a separate itemize-direction issue tracked under #4443-4453)