### PR TITLE
fix(daemon): wire -v counter to thread-local log-message filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ dependencies = [
  "filetime",
  "fs2",
  "libc",
+ "logging",
  "logging-sink",
  "metadata",
  "nix",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -53,6 +53,7 @@ core = { path = "../core", default-features = false }
 metadata = { path = "../metadata", default-features = false }
 platform = { path = "../platform" }
 protocol = { path = "../protocol" }
+logging = { path = "../logging" }
 logging-sink = { path = "../logging-sink" }
 fs2 = "0.4"
 socket2 = { workspace = true, features = ["all"] }

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -239,6 +239,8 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         config.load_default_paths(),
     )?;
 
+    apply_verbosity(options.verbosity());
+
     // upstream: clientserver.c:1498 - `if (is_a_socket(STDIN_FILENO))`
     // When stdin is a socket, serve a single session over stdio (inetd mode)
     // instead of binding a TCP listener.
@@ -247,6 +249,23 @@ pub fn run_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
     }
 
     serve_connections(options, external_signal_flags, pre_bound_listener)
+}
+
+/// Seeds the thread-local [`logging::VerbosityConfig`] from the daemon's
+/// `-v` / `--verbose` counter so subsequent `info_gte` / `debug_gte` checks
+/// emitted from the protocol and transfer crates respect the operator's
+/// requested verbosity.
+///
+/// upstream: options.c:2062 `set_output_verbosity(verbose, DEFAULT_PRIORITY)`
+/// is invoked once after option parsing in `main.c`/`daemon-main` startup.
+/// Without this seeding the daemon's `INFO_GTE`/`DEBUG_GTE` checks short-
+/// circuit at level 0 regardless of how many `-v` flags were stacked on the
+/// daemon command line, producing diagnostically silent daemons under
+/// `-vv`/`-vvv` and breaking upstream verbosity parity (the bug surfaced
+/// as a UTS testsuite divergence after PR #5887 made the daemon accept
+/// `-v`/`-vv`/`-vvv` without wiring the count to log-message filtering).
+pub(crate) fn apply_verbosity(level: u8) {
+    logging::init(logging::VerbosityConfig::from_verbose_level(level));
 }
 
 /// Runs the daemon protocol over stdin/stdout for remote-shell daemon mode.
@@ -296,6 +315,8 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
         config.arguments().to_vec()
     };
     let options = RuntimeOptions::parse_with_brand(&arguments, brand, config.load_default_paths())?;
+
+    apply_verbosity(options.verbosity());
 
     let RuntimeOptions {
         modules,
@@ -421,6 +442,8 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         config.brand(),
         config.load_default_paths(),
     )?;
+
+    apply_verbosity(options.verbosity());
 
     let RuntimeOptions {
         bind_address, port, ..

--- a/crates/daemon/src/daemon/runtime_options/accessors.rs
+++ b/crates/daemon/src/daemon/runtime_options/accessors.rs
@@ -59,8 +59,11 @@ impl RuntimeOptions {
     ///
     /// Mirrors upstream `verbose` in `options.c`. Each `-v`, stacked short
     /// form (`-vv`, `-vvv`, ...), or `--verbose` increments the counter;
-    /// `--no-verbose` / `--no-v` reset it to zero.
-    #[allow(dead_code)] // REASON: accessor consumed by tests; runtime wiring tracked separately.
+    /// `--no-verbose` / `--no-v` reset it to zero. Consumed by
+    /// `apply_verbosity` at startup to seed the thread-local
+    /// `logging::VerbosityConfig` so subsequent `info_gte` / `debug_gte`
+    /// checks gate log output per upstream's `set_output_verbosity()`
+    /// semantics (upstream: options.c:2062).
     pub(crate) fn verbosity(&self) -> u8 {
         self.verbosity
     }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -34,6 +34,8 @@ use crate::daemon::{
     advertised_capability_lines,
     // From sections/module_access.rs
     apply_module_bandwidth_limit,
+    // From daemon.rs apply_verbosity helper
+    apply_verbosity,
     cached_legacy_daemon_greeting,
     clap_command,
     clear_test_hostname_overrides,
@@ -89,6 +91,7 @@ use support::*;
 include!("tests/chunks/advertised_capability_lines_empty_without_modules.rs");
 include!("tests/chunks/advertised_capability_lines_include_authlist_when_required.rs");
 include!("tests/chunks/advertised_capability_lines_report_modules_without_auth.rs");
+include!("tests/chunks/apply_verbosity_seeds_logging_levels.rs");
 include!("tests/chunks/builder_allows_brand_override.rs");
 include!("tests/chunks/builder_collects_arguments.rs");
 include!("tests/chunks/clap_parse_error_is_reported_via_message.rs");

--- a/crates/daemon/src/tests/chunks/apply_verbosity_seeds_logging_levels.rs
+++ b/crates/daemon/src/tests/chunks/apply_verbosity_seeds_logging_levels.rs
@@ -1,0 +1,72 @@
+/// Verifies that the daemon's `-v` counter seeds the thread-local
+/// [`logging::VerbosityConfig`] so subsequent `info_gte` / `debug_gte`
+/// checks gate log output per upstream's `set_output_verbosity()` semantics.
+///
+/// Before this wire-up landed (PR #5887 follow-up), the daemon stored the
+/// `-v` count in `RuntimeOptions.verbosity` but never translated it into
+/// the logging crate's flag-level state, so any `info_gte(NAME, 2)` /
+/// `debug_gte(CMD, 1)` check anywhere in the protocol or transfer crates
+/// short-circuited at the default of 0 regardless of how many `-v` flags
+/// the operator stacked. Result: daemons were diagnostically silent under
+/// `-vv` / `-vvv`, breaking upstream parity and surfacing as a UTS test
+/// divergence.
+///
+/// Each subtest spawns a fresh thread because [`logging::init`] writes to
+/// thread-local storage; running everything in the test thread would
+/// pollute other tests sharing the harness's main thread.
+#[test]
+fn apply_verbosity_seeds_logging_levels() {
+    use logging::{DebugFlag, InfoFlag};
+
+    // verbosity = 0 -> only the default `nonreg` flag is set; nothing else
+    // crosses the gate. Mirrors upstream's `info_verbosity[0] = "NONREG"`
+    // table entry in `options.c:228`.
+    std::thread::spawn(|| {
+        apply_verbosity(0);
+        assert!(logging::info_gte(InfoFlag::Nonreg, 1));
+        assert!(!logging::info_gte(InfoFlag::Name, 1));
+        assert!(!logging::info_gte(InfoFlag::Copy, 1));
+        assert!(!logging::debug_gte(DebugFlag::Cmd, 1));
+    })
+    .join()
+    .expect("verbosity 0 thread");
+
+    // verbosity = 1 -> COPY,DEL,FLIST,MISC,NAME,STATS,SYMSAFE info flags
+    // are enabled at level 1 (upstream `info_verbosity[1]`).
+    std::thread::spawn(|| {
+        apply_verbosity(1);
+        assert!(logging::info_gte(InfoFlag::Name, 1));
+        assert!(logging::info_gte(InfoFlag::Copy, 1));
+        assert!(logging::info_gte(InfoFlag::Flist, 1));
+        assert!(!logging::info_gte(InfoFlag::Name, 2));
+        assert!(!logging::debug_gte(DebugFlag::Cmd, 1));
+    })
+    .join()
+    .expect("verbosity 1 thread");
+
+    // verbosity = 2 -> debug flags BIND,CMD,CONNECT,DEL,DELTASUM,... cross
+    // their gates at level 1, and info NAME/MISC bump to level 2 (upstream
+    // `debug_verbosity[2]` + `info_verbosity[2]`).
+    std::thread::spawn(|| {
+        apply_verbosity(2);
+        assert!(logging::info_gte(InfoFlag::Name, 2));
+        assert!(logging::info_gte(InfoFlag::Misc, 2));
+        assert!(logging::debug_gte(DebugFlag::Cmd, 1));
+        assert!(logging::debug_gte(DebugFlag::Flist, 1));
+        assert!(!logging::debug_gte(DebugFlag::Recv, 1));
+    })
+    .join()
+    .expect("verbosity 2 thread");
+
+    // verbosity = 3 -> RECV/SEND/GENR/OWN debug flags activate at level 1
+    // (upstream `debug_verbosity[3]`). This is the cumulative behaviour
+    // documented in `set_output_verbosity()` (upstream: options.c:530).
+    std::thread::spawn(|| {
+        apply_verbosity(3);
+        assert!(logging::debug_gte(DebugFlag::Recv, 1));
+        assert!(logging::debug_gte(DebugFlag::Send, 1));
+        assert!(logging::debug_gte(DebugFlag::Genr, 1));
+    })
+    .join()
+    .expect("verbosity 3 thread");
+}


### PR DESCRIPTION
## Summary

- Add a private `apply_verbosity` helper in `crates/daemon/src/daemon.rs` that calls `logging::init(VerbosityConfig::from_verbose_level(level))` after `RuntimeOptions` parsing in `run_daemon`, `run_daemon_stdio`, and `run_async_daemon`.
- Translate the `-v` / `--verbose` counter stored in `RuntimeOptions.verbosity` (added in #5887) into the thread-local `info_levels[]` / `debug_levels[]` state that the protocol and transfer crates already gate emissions on via `info_gte` / `debug_gte`.
- Drop the now-obsolete `#[allow(dead_code)]` on the `verbosity()` accessor and document its real consumer.
- Add an `apply_verbosity_seeds_logging_levels` regression test that spawns a fresh thread per level (0/1/2/3) so thread-local writes do not pollute siblings, asserting the gates cross at upstream-documented thresholds.

## Context

PR #5887 made the daemon arg parser accept `-v`, `-vv`, `-vvv`, and `--verbose`, but stopped at storing the count - the daemon-side log output still emitted at the default filter. Upstream rsync invokes `set_output_verbosity(verbose, DEFAULT_PRIORITY)` once after option parsing (`target/interop/upstream-src/rsync-3.4.4/options.c:2062`), which expands the integer count across the `info_verbosity[]` / `debug_verbosity[]` tables (`options.c:228-243`). Without this expansion, every `INFO_GTE` / `DEBUG_GTE` gate short-circuits at 0 regardless of how many `-v` flags were stacked - daemons stay diagnostically silent under `-vv` / `-vvv`, which surfaced as a UTS testsuite divergence.

This change mirrors the existing CLI wire-up in `crates/cli/src/frontend/execution/drive/workflow/run.rs:273` and reuses the `VerbosityConfig::from_verbose_level` table that already encodes the upstream cumulative mapping. Internal log-level filtering only - no wire-protocol change, no new frames.

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI: fmt+clippy, nextest (stable), Windows, macOS, Linux musl
- [ ] Regression: `apply_verbosity_seeds_logging_levels` asserts `InfoFlag::Name >= 2`, `DebugFlag::Cmd >= 1`, `DebugFlag::Recv >= 1` at `-vv` and `-vvv` per upstream `set_output_verbosity()` semantics