### PR TITLE
refactor(fast_io): wire WindowsChunkedReader into parallel checksum sites

### DIFF
--- a/crates/checksums/src/parallel/files.rs
+++ b/crates/checksums/src/parallel/files.rs
@@ -1,10 +1,16 @@
 //! Parallel file hashing and signature computation.
 //!
 //! Provides concurrent file I/O with digest computation using rayon.
-//! For files above the mmap threshold, memory-mapping is attempted first
-//! to avoid per-chunk read syscalls, with buffered I/O as fallback.
+//! On Unix, files above the mmap threshold are zero-copy hashed from a
+//! `MmapReader` mapping; on Windows the equivalent path streams through
+//! [`WindowsChunkedReader`] so peak RSS stays bounded by the configured
+//! chunk size (default 4 MiB) rather than the file size, mirroring the
+//! WIN-S.LAND.1.b bounded-RSS contract.
 
+#[cfg(unix)]
 use fast_io::mmap_reader::{MMAP_THRESHOLD, MmapReader};
+#[cfg(windows)]
+use fast_io::windows_chunked_reader::WindowsChunkedReader;
 use rayon::prelude::*;
 use std::fs::File;
 use std::io::{self, Read};
@@ -17,8 +23,10 @@ use super::types::{BlockSignature, FileHashConfig, FileHashResult, FileSignature
 
 /// Hashes a single file using the specified digest algorithm.
 ///
-/// For files above [`MMAP_THRESHOLD`], memory-mapping is attempted first to
-/// avoid per-chunk read syscalls. Falls back to buffered I/O on mmap failure.
+/// On Unix, files above the mmap threshold are memory-mapped first to
+/// avoid per-chunk read syscalls, with buffered I/O as fallback. On
+/// Windows, the same size band streams through `WindowsChunkedReader`
+/// so peak RSS stays bounded by the chunk size, not the file size.
 fn hash_file_internal<D>(path: &Path, config: &FileHashConfig) -> FileHashResult<D::Digest>
 where
     D: StrongDigest,
@@ -35,6 +43,11 @@ where
             return Ok((D::digest(&data), size));
         }
 
+        // upstream: checksum.c:402 file_checksum() uses map_file() (mmap) for
+        // zero-copy hashing. On Windows the legacy mmap_reader_stub slurps the
+        // whole file into a Vec<u8>; switch to WindowsChunkedReader streaming
+        // below so peak RSS stays bounded by the chunk size, not the file size.
+        #[cfg(unix)]
         if size >= MMAP_THRESHOLD {
             if let Ok(mmap) = MmapReader::open(path) {
                 let _ = mmap.advise_sequential();
@@ -42,7 +55,12 @@ where
             }
         }
 
-        // upstream: checksum.c - pre-sized read loop avoids trailing EOF probe
+        // upstream: checksum.c - pre-sized read loop avoids trailing EOF probe.
+        // Windows shadows `file` with the bounded-RSS WindowsChunkedReader; the
+        // Unix streaming fallback continues to use the std::fs::File opened
+        // above (mmap unavailable on NFS/FUSE/procfs).
+        #[cfg(windows)]
+        let mut file = WindowsChunkedReader::open(path)?;
         let mut hasher = D::new();
         let mut buffer = vec![0u8; config.buffer_size];
         let mut remaining = size;
@@ -225,6 +243,11 @@ where
             return Ok((D::digest_with_seed(seed, &data), size));
         }
 
+        // upstream: checksum.c:402 file_checksum() uses map_file() (mmap) for
+        // zero-copy hashing. On Windows the legacy mmap_reader_stub slurps the
+        // whole file into a Vec<u8>; switch to WindowsChunkedReader streaming
+        // below so peak RSS stays bounded by the chunk size, not the file size.
+        #[cfg(unix)]
         if size >= MMAP_THRESHOLD {
             if let Ok(mmap) = MmapReader::open(path) {
                 let _ = mmap.advise_sequential();
@@ -232,7 +255,12 @@ where
             }
         }
 
-        // upstream: checksum.c - pre-sized read loop avoids trailing EOF probe
+        // upstream: checksum.c - pre-sized read loop avoids trailing EOF probe.
+        // Windows shadows `file` with the bounded-RSS WindowsChunkedReader; the
+        // Unix streaming fallback continues to use the std::fs::File opened
+        // above (mmap unavailable on NFS/FUSE/procfs).
+        #[cfg(windows)]
+        let mut file = WindowsChunkedReader::open(path)?;
         let mut hasher = D::with_seed(seed);
         let mut buffer = vec![0u8; config.buffer_size];
         let mut remaining = size;
@@ -324,8 +352,12 @@ where
         let size = metadata.len();
         let estimated_blocks = (size as usize).div_ceil(block_size);
 
-        // For files above the mmap threshold, slice blocks directly from
-        // mapped memory - zero read syscalls.
+        // For files above the mmap threshold on Unix, slice blocks directly
+        // from mapped memory - zero read syscalls. On Windows the legacy
+        // mmap_reader_stub would slurp the whole file into a Vec<u8>; switch
+        // to WindowsChunkedReader streaming below so peak RSS stays bounded
+        // by the chunk size, not the file size.
+        #[cfg(unix)]
         if size >= MMAP_THRESHOLD {
             if let Ok(mmap) = MmapReader::open(path) {
                 let _ = mmap.advise_sequential();
@@ -346,6 +378,11 @@ where
             }
         }
 
+        // Windows shadows `file` with the bounded-RSS WindowsChunkedReader;
+        // Unix retains the std::fs::File opened above for the streaming
+        // fallback (mmap unavailable on NFS/FUSE/procfs).
+        #[cfg(windows)]
+        let mut file = WindowsChunkedReader::open(path)?;
         let mut signatures = Vec::with_capacity(estimated_blocks);
         let _ = buffer_size; // size known from metadata; BufReader not needed
         let mut buffer = vec![0u8; block_size];

--- a/crates/checksums/src/parallel/mod.rs
+++ b/crates/checksums/src/parallel/mod.rs
@@ -621,4 +621,110 @@ mod tests {
             expected.as_ref()
         );
     }
+
+    /// Parity test for the WIN-S.LAND.1.b.4 wire-up: on Windows the mmap
+    /// branch of the parallel hashers now streams through
+    /// `WindowsChunkedReader` instead of slurping into a `Vec<u8>`. Hashes
+    /// must remain byte-identical to a direct `std::fs::read` digest across
+    /// sizes that span the empty / 1-byte / sub-mmap-threshold /
+    /// at-threshold / over-threshold / multi-buffer boundaries.
+    #[test]
+    fn hash_files_parallel_matches_std_fs_read_across_size_boundaries() {
+        let dir = TempDir::new().unwrap();
+
+        // Sizes chosen to exercise every branch in hash_file_internal:
+        //   - empty file (size <= max_memory_file_size, read_to_end)
+        //   - 1 byte (same branch)
+        //   - just below MMAP_THRESHOLD (64 KiB) on Unix; streaming on Windows
+        //   - exactly MMAP_THRESHOLD: mmap path on Unix, streaming on Windows
+        //   - MMAP_THRESHOLD + 1: same as above plus a trailing partial buffer
+        //   - multi-buffer (320 KiB): drains the chunked reader across refills
+        let sizes: &[usize] = &[0, 1, 64 * 1024 - 1, 64 * 1024, 64 * 1024 + 1, 320 * 1024];
+
+        let mut paths = Vec::with_capacity(sizes.len());
+        let mut expected_digests = Vec::with_capacity(sizes.len());
+
+        for (i, &n) in sizes.iter().enumerate() {
+            let path = dir.path().join(format!("fixture_{i}_{n}.bin"));
+            // Deterministic non-trivial pattern so a one-byte truncation or
+            // off-by-one in the streaming path produces a different digest.
+            let content: Vec<u8> = (0..n).map(|j| ((j * 31 + i) & 0xFF) as u8).collect();
+            std::fs::write(&path, &content).unwrap();
+
+            let observed = std::fs::read(&path).unwrap();
+            assert_eq!(
+                observed, content,
+                "tempfile round-trip mismatch at size {n}"
+            );
+            expected_digests.push(Sha256::digest(&observed));
+            paths.push(path);
+        }
+
+        // max_memory_file_size = 0 forces every non-empty file past the small
+        // branch into the mmap-or-streaming code path under test.
+        let config = FileHashConfig::new()
+            .with_buffer_size(64 * 1024)
+            .with_max_memory_file_size(0);
+        let results = hash_files_parallel_with_config::<Sha256>(&paths, &config);
+
+        assert_eq!(results.len(), sizes.len());
+        for (i, (result, &n)) in results.iter().zip(sizes.iter()).enumerate() {
+            let digest = &result.digest;
+            assert!(digest.is_ok(), "digest failed at size {n}: {digest:?}");
+            assert_eq!(result.size, n as u64, "size mismatch at fixture {i}");
+            assert_eq!(
+                result.digest.as_ref().unwrap().as_ref(),
+                expected_digests[i].as_ref(),
+                "digest mismatch at size {n}: parallel hasher diverged from std::fs::read",
+            );
+        }
+    }
+
+    /// Parity test for the block-signature wire-up: the per-block rolling +
+    /// strong checksums must agree between the mmap fast path (Unix) /
+    /// `WindowsChunkedReader` streaming (Windows) and a direct read-then-hash
+    /// reference. Exercised at MMAP_THRESHOLD + tail so the file straddles
+    /// the threshold and the trailing partial block.
+    #[test]
+    fn compute_file_signatures_parallel_matches_direct_read_at_boundary() {
+        use crate::rolling::RollingChecksum;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("signatures_boundary.bin");
+
+        let size = 64 * 1024 + 777; // straddles MMAP_THRESHOLD and ends on a partial block
+        let data: Vec<u8> = (0..size).map(|i| (i & 0xFF) as u8).collect();
+        std::fs::write(&path, &data).unwrap();
+
+        let block_size = 4096;
+        let results = compute_file_signatures_parallel::<Sha256>(&[path], block_size, 64 * 1024);
+
+        assert_eq!(results.len(), 1);
+        let signatures = results[0].signatures.as_ref().unwrap();
+
+        let expected_blocks = size.div_ceil(block_size);
+        assert_eq!(signatures.len(), expected_blocks);
+        assert_eq!(results[0].size, size as u64);
+
+        for (i, sig) in signatures.iter().enumerate() {
+            let start = i * block_size;
+            let end = (start + block_size).min(size);
+            let block = &data[start..end];
+
+            let mut expected_rolling = RollingChecksum::new();
+            expected_rolling.update(block);
+            assert_eq!(
+                sig.rolling,
+                expected_rolling.value(),
+                "rolling mismatch in block {i}"
+            );
+
+            let expected_strong = Sha256::digest(block);
+            assert_eq!(
+                sig.strong.as_ref(),
+                expected_strong.as_ref(),
+                "strong digest mismatch in block {i}",
+            );
+        }
+    }
 }

--- a/crates/checksums/src/parallel/mod.rs
+++ b/crates/checksums/src/parallel/mod.rs
@@ -692,7 +692,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("signatures_boundary.bin");
 
-        let size = 64 * 1024 + 777; // straddles MMAP_THRESHOLD and ends on a partial block
+        let size: usize = 64 * 1024 + 777; // straddles MMAP_THRESHOLD and ends on a partial block
         let data: Vec<u8> = (0..size).map(|i| (i & 0xFF) as u8).collect();
         std::fs::write(&path, &data).unwrap();
 

--- a/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
+++ b/crates/engine/src/local_copy/executor/directory/parallel_checksum.rs
@@ -19,6 +19,7 @@
 //!    checksums, maintaining correct ordering.
 
 use std::collections::HashMap;
+#[cfg(unix)]
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -27,7 +28,12 @@ use std::sync::Arc;
 use rayon::prelude::*;
 
 use checksums::strong::{Md4, Md5, Sha1, StrongDigest, Xxh3, Xxh3_128, Xxh64};
-use fast_io::mmap_reader::{MMAP_THRESHOLD, MmapReader};
+#[cfg(any(unix, test))]
+use fast_io::mmap_reader::MMAP_THRESHOLD;
+#[cfg(unix)]
+use fast_io::mmap_reader::MmapReader;
+#[cfg(windows)]
+use fast_io::windows_chunked_reader::WindowsChunkedReader;
 
 use crate::local_copy::buffer_pool::{BufferPool, global_buffer_pool};
 use crate::signature::SignatureAlgorithm;
@@ -151,6 +157,10 @@ fn compute_file_checksum(
     // upstream: checksum.c:415 - map_file(fd, len, MAX_MAP_SIZE, CHUNK_SIZE)
     // Try mmap first for files at or above the threshold - eliminates all
     // read syscalls and enables zero-copy hashing directly from mapped pages.
+    // On Windows the legacy mmap_reader_stub slurps the whole file into a
+    // Vec<u8>; use WindowsChunkedReader streaming below instead so peak RSS
+    // stays bounded by the chunk size (default 4 MiB), not the file size.
+    #[cfg(unix)]
     if file_size >= MMAP_THRESHOLD {
         if let Ok(mmap) = MmapReader::open(path) {
             let _ = mmap.advise_sequential();
@@ -162,7 +172,10 @@ fn compute_file_checksum(
         }
     }
 
+    #[cfg(unix)]
     let file = File::open(path).ok()?;
+    #[cfg(windows)]
+    let file = WindowsChunkedReader::open(path).ok()?;
     let digest = hash_file_contents(file, file_size, algorithm, buffer_pool).ok()?;
 
     Some(FileChecksum {
@@ -175,11 +188,12 @@ fn compute_file_checksum(
 ///
 /// Uses a pre-sized read loop based on the known `file_size` to avoid
 /// the extra read() syscall that EOF-probe patterns (BufReader, loop-until-0)
-/// issue per file.
+/// issue per file. Generic over `R: Read` so the caller can pass `std::fs::File`
+/// (Unix streaming fallback) or `WindowsChunkedReader` (Windows bounded-RSS).
 ///
 /// upstream: checksum.c - sized read loop: `while (remaining > 0) { read(); remaining -= n; }`
-fn hash_file_contents(
-    mut file: File,
+fn hash_file_contents<R: Read>(
+    mut file: R,
     file_size: u64,
     algorithm: SignatureAlgorithm,
     buffer_pool: &Arc<BufferPool>,
@@ -189,8 +203,8 @@ fn hash_file_contents(
 
     /// Reads exactly `remaining` bytes from `file` into `hasher` using
     /// pre-sized chunks, avoiding a trailing EOF probe syscall.
-    fn read_into_hasher(
-        file: &mut File,
+    fn read_into_hasher<R: Read>(
+        file: &mut R,
         mut remaining: u64,
         buffer: &mut [u8],
         buf_len: usize,
@@ -258,7 +272,12 @@ fn hash_file_contents(
 /// read syscalls. This mirrors upstream rsync's `file_checksum()` which
 /// uses `map_file()` + `map_ptr()` to hash directly from mapped pages.
 ///
+/// Compiled on Unix only: the Windows production and test paths stream
+/// through `WindowsChunkedReader` to keep RSS bounded by the chunk size,
+/// so no caller feeds a full-file slice into this helper there.
+///
 /// upstream: checksum.c:415-492 - all hash algorithms operate on map_ptr() slices
+#[cfg(unix)]
 fn hash_mapped_contents(data: &[u8], algorithm: SignatureAlgorithm) -> Vec<u8> {
     match algorithm {
         SignatureAlgorithm::Md4 => Md4::digest(data).as_ref().to_vec(),
@@ -593,6 +612,7 @@ mod tests {
         assert!(!result.checksums_match());
     }
 
+    #[cfg(unix)]
     #[test]
     fn hash_mapped_matches_buffered_for_all_algorithms() {
         let dir = create_tempdir();
@@ -663,5 +683,57 @@ mod tests {
         let result = should_skip_with_prefetched_checksum(&prefetched, &source);
 
         assert_eq!(result, Some(true));
+    }
+
+    /// Parity test for the WIN-S.LAND.1.b.4 wire-up in `compute_file_checksum`:
+    /// on Windows the mmap branch now streams through `WindowsChunkedReader`
+    /// instead of slurping into a `Vec<u8>`. The prefetch digest must remain
+    /// byte-identical to a direct `std::fs::read` + algorithm digest across
+    /// sizes spanning the MMAP_THRESHOLD boundary and several chunk widths.
+    #[test]
+    fn prefetch_checksums_matches_direct_digest_across_size_boundaries() {
+        let dir = create_tempdir();
+        let algorithm = SignatureAlgorithm::Xxh3_128 { seed: 0 };
+        let sizes: &[usize] = &[
+            0,
+            1,
+            MMAP_THRESHOLD as usize - 1,
+            MMAP_THRESHOLD as usize,
+            MMAP_THRESHOLD as usize + 1,
+            (MMAP_THRESHOLD as usize) * 5 + 17,
+        ];
+
+        let mut pairs = Vec::with_capacity(sizes.len());
+        for (i, &n) in sizes.iter().enumerate() {
+            let source = dir.path().join(format!("src_{i}_{n}.bin"));
+            let destination = dir.path().join(format!("dst_{i}_{n}.bin"));
+            let content: Vec<u8> = (0..n).map(|j| ((j * 7 + i) & 0xFF) as u8).collect();
+            fs::write(&source, &content).unwrap();
+            fs::write(&destination, &content).unwrap();
+            pairs.push(FilePair {
+                source,
+                destination,
+                source_size: n as u64,
+                destination_size: n as u64,
+            });
+        }
+
+        let results = prefetch_checksums(&pairs, algorithm);
+        assert_eq!(results.len(), sizes.len());
+        for (pair, &n) in pairs.iter().zip(sizes.iter()) {
+            let result = results.get(&pair.source).expect("result for source");
+            assert!(
+                result.checksums_match(),
+                "checksums diverged at size {n}: {result:?}",
+            );
+            let src_observed = fs::read(&pair.source).unwrap();
+            assert_eq!(src_observed.len(), n);
+            let src_digest = &result
+                .source_checksum
+                .as_ref()
+                .expect("source digest present")
+                .digest;
+            assert!(!src_digest.is_empty() || n == 0);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes WIN-S.LAND.1.b.4.1 - 4.5 by replacing the legacy
`mmap_reader_stub` `Vec<u8>`-per-file slurp on Windows with bounded-RSS
`WindowsChunkedReader` streaming across four production call sites in
the parallel checksum pipeline. Peak RSS is now capped at the
configured chunk size (4 MiB default, tunable via
`OC_RSYNC_WIN_CHUNK_BYTES`) instead of the file size.

## Migrated call sites

| # | Site | Status |
| - | ---- | ------ |
| 1 | `transfer::map_file::mmap::MmapStrategy` (`crates/transfer/src/map_file/mmap.rs:36`) | Already gated `#[cfg(unix)]` at the parent module (`crates/transfer/src/map_file/mod.rs:35-38`); never reachable on Windows. Documented, no code change. |
| 2 | `checksums::parallel::files::hash_file_internal` mmap branch | Migrated: Unix mmap fast path preserved behind `#[cfg(unix)]`; Windows shadows `file` with `WindowsChunkedReader::open` for the streaming hash. |
| 3 | `checksums::parallel::files::hash_file_with_seed_internal` mmap branch | Migrated: same pattern as site 2. |
| 4 | `checksums::parallel::files::compute_file_signatures_internal` mmap branch | Migrated: same pattern; block signatures streamed through `WindowsChunkedReader` on Windows. |
| 5 | `engine::local_copy::executor::directory::parallel_checksum::compute_file_checksum` | Migrated: `hash_file_contents` generalized to `<R: Read>` so the engine site can pass `WindowsChunkedReader` on Windows and `std::fs::File` on Unix. |

The Unix `MmapReader` fast path is preserved unchanged behind
`#[cfg(unix)]` at every site; wire-byte parity is unaffected (internal
I/O refactor only). `hash_mapped_contents` is now `#[cfg(unix)]` since
the Windows production path streams rather than feeding a full-file
slice into the helper.

## Test plan

- [x] `cargo fmt --all -- --check` passes locally.
- [ ] New parity regression test
      `hash_files_parallel_matches_std_fs_read_across_size_boundaries` in
      `crates/checksums/src/parallel/mod.rs` covers empty / 1 byte /
      `MMAP_THRESHOLD - 1` / `MMAP_THRESHOLD` / `MMAP_THRESHOLD + 1` /
      multi-buffer fixtures with `max_memory_file_size = 0` to force
      every non-empty file through the mmap-or-streaming code path.
- [ ] New parity regression test
      `compute_file_signatures_parallel_matches_direct_read_at_boundary`
      asserts per-block rolling + strong checksums match a direct
      read-then-hash reference for a file that straddles `MMAP_THRESHOLD`
      and ends on a partial block.
- [ ] New parity regression test
      `prefetch_checksums_matches_direct_digest_across_size_boundaries`
      in the engine module exercises `compute_file_checksum` end-to-end
      via `prefetch_checksums` across the same size boundaries.
- [ ] Existing tests `prefetch_checksums_mmap_path_matches_identical_large_files`
      and `prefetch_checksums_mmap_detects_different_large_files` now
      exercise the Windows `WindowsChunkedReader` streaming path on
      Windows CI and the Unix mmap path on Unix CI.
- [ ] Required CI checks: fmt+clippy, nextest (stable), Windows
      (stable), macOS (stable), Linux musl (stable). The Windows cell
      is the CI assertion that closes WIN-S.LAND.1.b.4.6.