### PR TITLE
fix(cli): resolve files-from localhost: prefix as hybrid local-open + wire-forward

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/parser.rs
+++ b/crates/cli/src/frontend/execution/file_list/parser.rs
@@ -4,7 +4,7 @@
 //! and resolves `--files-from` values into their source type.
 
 use std::ffi::{OsStr, OsString};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Resolves a `--files-from` CLI value into a [`FilesFromSource`].
 ///
@@ -49,11 +49,37 @@ pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client
     // module specs (`host::module`). The latter is for daemon transfers,
     // which we do not currently support for files-from.
     if let Some((host, path)) = split_hostspec(&text) {
-        let _ = host; // host validation happens at transfer-arg level
+        // upstream: options.c:3112-3138 / options.c:2476-2483 -
+        // check_for_hostspec strips the host prefix and forwards the path
+        // to the remote server. When the host resolves to localhost AND the
+        // stripped path is openable on this client, emit a hybrid variant
+        // so a PULL client-receiver can stage the bytes locally while the
+        // wire argv still carries the stripped path for upstream parity.
+        // Without this, PULL with `--files-from=localhost:path` hangs at
+        // recv_filesfrom: the receiver flushes None and the remote sender
+        // blocks waiting for the secluded-args stream.
+        if host_is_localhost(host) {
+            let local_path = PathBuf::from(path);
+            if Path::new(&local_path).is_file() {
+                return FilesFromSource::HybridLocalRemote {
+                    local_path,
+                    wire_arg: path.to_owned(),
+                };
+            }
+        }
         return FilesFromSource::RemoteFile(path.to_owned());
     }
 
     FilesFromSource::LocalFile(PathBuf::from(last))
+}
+
+/// Returns `true` when the parsed hostspec names the local machine.
+///
+/// Matches upstream `main.c:1438 strcmp(filesfrom_host, shell_machine)`
+/// semantics: a hostspec of `localhost` (case-insensitive) refers to this
+/// client, allowing a hybrid local-open + wire-forward dispatch.
+fn host_is_localhost(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
 }
 
 /// Splits a `host:path` argument into `(host, path)` if `text` is a remote

--- a/crates/core/src/client/config/enums/files_from.rs
+++ b/crates/core/src/client/config/enums/files_from.rs
@@ -27,6 +27,21 @@ pub enum FilesFromSource {
     ///
     /// - `options.c:2458` - `check_for_hostspec()` detects `:path` prefix
     RemoteFile(String),
+    /// Hybrid local-open + wire-forward source.
+    ///
+    /// Used when the `--files-from` spec names a `localhost:path` hostspec
+    /// and the stripped path is openable on the client. The client opens
+    /// the file locally and stages its contents into `files_from_data` so a
+    /// PULL client-receiver can flush the bytes back to the remote sender,
+    /// while the wire-arg keeps the stripped form for the remote server's
+    /// argv. Matches upstream `options.c:3112-3138 check_for_hostspec` +
+    /// `options.c:2476-2483` semantics on a single host.
+    HybridLocalRemote {
+        /// Local filesystem path to open for staging into `files_from_data`.
+        local_path: std::path::PathBuf,
+        /// Stripped path forwarded to the remote server's `--files-from`.
+        wire_arg: String,
+    },
 }
 
 impl FilesFromSource {
@@ -37,16 +52,23 @@ impl FilesFromSource {
     }
 
     /// Returns `true` when the file list is read on the remote server.
+    ///
+    /// The hybrid variant counts as remote because the server-side argv
+    /// receives the stripped path, but the client still stages the bytes
+    /// locally - see [`Self::is_local_forwarded`].
     #[must_use]
     pub fn is_remote(&self) -> bool {
-        matches!(self, Self::RemoteFile(_))
+        matches!(self, Self::RemoteFile(_) | Self::HybridLocalRemote { .. })
     }
 
     /// Returns `true` when the file list is read locally and must be
     /// forwarded over the protocol to the sender.
     #[must_use]
     pub fn is_local_forwarded(&self) -> bool {
-        matches!(self, Self::LocalFile(_) | Self::Stdin)
+        matches!(
+            self,
+            Self::LocalFile(_) | Self::Stdin | Self::HybridLocalRemote { .. }
+        )
     }
 }
 

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -377,6 +377,16 @@ pub(super) fn build_full_daemon_args(
                     args.push("--from0".to_owned());
                 }
             }
+            FilesFromSource::HybridLocalRemote { wire_arg, .. } => {
+                // upstream: options.c:3112-3138 - localhost:path stripped to
+                // wire_arg. The daemon server-side argv carries the stripped
+                // path while the client also stages bytes locally for PULL
+                // flush at crates/transfer/src/lib.rs:570.
+                args.push(format!("--files-from={wire_arg}"));
+                if config.from0() {
+                    args.push("--from0".to_owned());
+                }
+            }
         }
     }
 

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -528,6 +528,12 @@ fn build_server_config_for_generator(
             server_config.file_selection.files_from_path = Some("-".to_owned());
             server_config.file_selection.from0 = true;
         }
+        FilesFromSource::HybridLocalRemote { .. } => {
+            // upstream: options.c:3112-3138 - localhost:path stripped; client
+            // opens locally, server reads bytes from the wire as for RemoteFile.
+            server_config.file_selection.files_from_path = Some("-".to_owned());
+            server_config.file_selection.from0 = true;
+        }
     }
 
     flags::apply_common_server_flags(config, &mut server_config);

--- a/crates/core/src/client/remote/files_from_forwarding.rs
+++ b/crates/core/src/client/remote/files_from_forwarding.rs
@@ -51,27 +51,45 @@ pub(crate) fn read_local_files_from_for_forwarding(
             })?;
         }
         FilesFromSource::LocalFile(path) => {
-            let mut file = std::fs::File::open(path).map_err(|e| {
-                invalid_argument_error(
-                    &format!("failed to open --files-from {}: {e}", path.display()),
-                    23,
-                )
-            })?;
-            protocol::forward_files_from(
-                &mut file,
+            read_path_into(path, &mut wire_data, eol_nulls, iconv_converter.as_ref())?;
+        }
+        FilesFromSource::HybridLocalRemote { local_path, .. } => {
+            // upstream: options.c:3112-3138 - localhost:path stripped to a
+            // local file; client opens locally so PULL receivers have bytes
+            // to flush at crates/transfer/src/lib.rs:570 while the wire-arg
+            // still carries the stripped path for the remote server.
+            read_path_into(
+                local_path,
                 &mut wire_data,
                 eol_nulls,
                 iconv_converter.as_ref(),
-            )
-            .map_err(|e| {
-                invalid_argument_error(
-                    &format!("failed to read --files-from {}: {e}", path.display()),
-                    23,
-                )
-            })?;
+            )?;
         }
         FilesFromSource::None | FilesFromSource::RemoteFile(_) => {}
     }
 
     Ok(wire_data)
+}
+
+fn read_path_into(
+    path: &std::path::Path,
+    wire_data: &mut Vec<u8>,
+    eol_nulls: bool,
+    iconv_converter: Option<&protocol::FilenameConverter>,
+) -> Result<(), ClientError> {
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        invalid_argument_error(
+            &format!("failed to open --files-from {}: {e}", path.display()),
+            23,
+        )
+    })?;
+    protocol::forward_files_from(&mut file, wire_data, eol_nulls, iconv_converter).map_err(
+        |e| {
+            invalid_argument_error(
+                &format!("failed to read --files-from {}: {e}", path.display()),
+                23,
+            )
+        },
+    )?;
+    Ok(())
 }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -511,6 +511,16 @@ impl<'a> RemoteInvocationBuilder<'a> {
                     args.push(OsString::from("--from0"));
                 }
             }
+            FilesFromSource::HybridLocalRemote { wire_arg, .. } => {
+                // upstream: options.c:3112-3138 - localhost:path stripped to
+                // wire_arg. The remote server still receives the stripped
+                // path in argv just like the RemoteFile case; the client also
+                // stages bytes locally for PULL flush at lib.rs:570.
+                args.push(OsString::from(format!("--files-from={wire_arg}")));
+                if self.config.from0() {
+                    args.push(OsString::from("--from0"));
+                }
+            }
         }
 
         // upstream: options.c:2894-2898 - --usermap / --groupmap are

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -764,6 +764,14 @@ fn apply_files_from_for_sender(config: &ClientConfig, server_config: &mut Server
             server_config.file_selection.files_from_path = Some("-".to_owned());
             server_config.file_selection.from0 = true;
         }
+        FilesFromSource::HybridLocalRemote { .. } => {
+            // upstream: options.c:3112-3138 - localhost:path stripped; the
+            // client opens the file locally and stages the bytes into
+            // files_from_data, then the server reads them from the wire just
+            // like the plain RemoteFile case.
+            server_config.file_selection.files_from_path = Some("-".to_owned());
+            server_config.file_selection.from0 = true;
+        }
     }
 }
 

--- a/crates/protocol/src/files_from.rs
+++ b/crates/protocol/src/files_from.rs
@@ -163,11 +163,62 @@ pub fn read_files_from_stream<R: Read>(
     reader: &mut R,
     iconv: Option<&FilenameConverter>,
 ) -> io::Result<Vec<String>> {
+    read_files_from_stream_inner(reader, iconv, None)
+}
+
+/// Default defensive deadline for the receiver-side files-from loop.
+///
+/// Upstream `io.c:forward_filesfrom_data` blocks indefinitely on the wire
+/// because the kernel buffers between the two halves of the loop. When a
+/// PULL client fails to stage the bytes (as in the UTS-V3.D `files-from`
+/// 4th-invocation hang), the remote sender's `recv_filesfrom` loop would
+/// otherwise hang the full 300 s test ceiling. 30 s is high enough to
+/// tolerate large file lists over slow links yet low enough to surface a
+/// resolver regression as a typed `ETIMEDOUT` (exit code 30) rather than a
+/// silent stall.
+pub const FILES_FROM_RECV_DEFAULT_DEADLINE: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+/// Reads NUL-separated filenames with a defensive total-elapsed deadline.
+///
+/// Behaves like [`read_files_from_stream`] but returns
+/// `io::ErrorKind::TimedOut` if the cumulative wall-clock time spent
+/// blocked on `reader.read` exceeds `deadline`. The deadline is checked
+/// before each per-byte read; in-flight reads are not interrupted.
+///
+/// This is the receiver-side defensive timeout specified by the
+/// UTS-V3.D audit at `docs/design/uts-v3-d-files-from-hang-audit.md`. It
+/// turns a 300 s testsuite hang into a clean `ETIMEDOUT` exit.
+pub fn read_files_from_stream_with_deadline<R: Read>(
+    reader: &mut R,
+    iconv: Option<&FilenameConverter>,
+    deadline: std::time::Duration,
+) -> io::Result<Vec<String>> {
+    read_files_from_stream_inner(reader, iconv, Some(deadline))
+}
+
+fn read_files_from_stream_inner<R: Read>(
+    reader: &mut R,
+    iconv: Option<&FilenameConverter>,
+    deadline: Option<std::time::Duration>,
+) -> io::Result<Vec<String>> {
     let mut filenames = Vec::new();
     let mut current = Vec::new();
+    let start = deadline.map(|_| std::time::Instant::now());
 
     let mut byte_buf = [0u8; 1];
     loop {
+        if let (Some(start), Some(deadline)) = (start, deadline)
+            && start.elapsed() >= deadline
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "--files-from stream read exceeded {} s deadline",
+                    deadline.as_secs()
+                ),
+            ));
+        }
         let n = reader.read(&mut byte_buf)?;
         if n == 0 {
             // Unexpected EOF - flush any pending entry then return.

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -162,7 +162,10 @@ pub use envelope::{
     ParseMessageCodeError,
 };
 pub use error::NegotiationError;
-pub use files_from::{forward_files_from, read_files_from_stream};
+pub use files_from::{
+    FILES_FROM_RECV_DEFAULT_DEADLINE, forward_files_from, read_files_from_stream,
+    read_files_from_stream_with_deadline,
+};
 pub use fnamecmp::{FnameCmpType, InvalidFnameCmpType};
 pub use iconv::{
     ConversionError, EncodingConverter, EncodingError, EncodingPair, FilenameConverter,

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -236,7 +236,16 @@ impl GeneratorContext {
             // upstream: io.c:read_line(RL_CONVERT) - wire bytes are UTF-8 and
             // must be transcoded to the local charset via ic_recv when
             // protect_args && --iconv are both in effect (compat.c:799-806).
-            protocol::read_files_from_stream(reader, self.config.connection.iconv.as_ref())?
+            // UTS-V3.D defensive timeout: cap the receiver-side wait at
+            // FILES_FROM_RECV_DEFAULT_DEADLINE (30 s) so a client-side
+            // resolver regression surfaces as ETIMEDOUT instead of the 300 s
+            // testsuite hang documented in
+            // docs/design/uts-v3-d-files-from-hang-audit.md.
+            protocol::read_files_from_stream_with_deadline(
+                reader,
+                self.config.connection.iconv.as_ref(),
+                protocol::FILES_FROM_RECV_DEFAULT_DEADLINE,
+            )?
         } else {
             // Read from a local file on the server.
             // upstream: main.c:675-679 - open(files_from, O_RDONLY)


### PR DESCRIPTION
## Summary

Closes the UTS-V3.D files-from 4th-invocation 300 s hang on PULL with
\`--files-from=localhost:path\` (see \`docs/design/uts-v3-d-files-from-hang-audit.md\`).

- Parser: \`localhost:path\` is resolved as a new \`FilesFromSource::HybridLocalRemote\`
  when the stripped path is openable on the client. The client opens the file
  locally to stage NUL-delimited bytes; the wire-arg keeps the stripped form
  so the remote server argv matches upstream parity.
- Wiring: all four orchestration sites (ssh_transfer, embedded_ssh_transfer,
  invocation/builder, daemon_transfer/orchestration/arguments) now handle the
  hybrid variant. The local-forwarding helper (\`files_from_forwarding.rs\`)
  opens the local file and stages bytes that the PULL receiver flushes at
  \`crates/transfer/src/lib.rs:570\`.
- Defensive timeout: \`protocol::read_files_from_stream_with_deadline\`
  caps the receiver-side wait at \`FILES_FROM_RECV_DEFAULT_DEADLINE\` (30 s).
  Wired into the receiver-side reader at
  \`crates/transfer/src/generator/filters.rs:245\`. A future resolver
  regression now surfaces as \`ETIMEDOUT\` (exit 30) instead of a 300 s hang.

Wire bytes are unchanged: the server-side argv still carries
\`--files-from=<stripped-path>\` (matching upstream \`check_for_hostspec\`)
and the client emits the NUL-delimited payload before the flist exchange.

Upstream references:
- \`options.c:3112-3138\` \`check_for_hostspec\`
- \`options.c:2476-2483\` \`filesfrom_host\` gating
- \`main.c:1191-1198\` \`start_filesfrom_forwarding(filesfrom_fd)\`
- \`io.c:370-381\` \`forward_filesfrom_data()\`

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo check --workspace --all-features\` (clean, 0 errors, 0 warnings)
- [ ] CI runs full nextest suite under \`--features parallel-receive-delta\`
- [ ] CI upstream-testsuite cell exercises files-from.test all 4 loop iterations