### PR TITLE
chore(fmt): cargo fmt master drift in windows_chunked_reader.rs

### DIFF
--- a/crates/fast_io/src/windows_chunked_reader.rs
+++ b/crates/fast_io/src/windows_chunked_reader.rs
@@ -113,9 +113,7 @@ fn validate_chunk_size(chunk_size: usize) -> io::Result<()> {
 /// Returns `true` when `chunk_size` satisfies the env-var contract: a power
 /// of two within `MIN_CHUNK_SIZE..=MAX_CHUNK_SIZE`.
 fn is_valid_env_chunk_size(chunk_size: usize) -> bool {
-    chunk_size >= MIN_CHUNK_SIZE
-        && chunk_size <= MAX_CHUNK_SIZE
-        && chunk_size.is_power_of_two()
+    chunk_size >= MIN_CHUNK_SIZE && chunk_size <= MAX_CHUNK_SIZE && chunk_size.is_power_of_two()
 }
 
 /// Returns the cached env override, loading it from the environment on first


### PR DESCRIPTION
## Summary
- Master commit `16547787d` introduced fmt drift in `crates/fast_io/src/windows_chunked_reader.rs`.
- Drift was inherited by every open feature branch, failing the required `fmt + clippy` check uniformly.
- This PR runs `cargo fmt --all` to restore master to a clean state so downstream PRs can rebase + merge.

## Test plan
- [x] `cargo fmt --all -- --check` clean locally
- [ ] CI fmt + clippy passes on this PR