### PR TITLE
fix(daemon): explicit drain barrier on daemon-sender exit before connection drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,6 +4185,7 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "signature 0.6.3",
+ "socket2",
  "tempfile",
  "test-support",
  "thiserror",

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -1102,6 +1102,10 @@ fn process_approved_module(
         // SO_LINGER ensures the final goodbye TX bytes the engine wrote
         // are delivered before the kernel reclaims the socket. The 5s
         // window matches upstream's expected goodbye round-trip latency.
+        // Catastrophic-failure fallback: even if the UTS-V3.A
+        // `shutdown_send_side` barrier below cannot be reached (e.g. the
+        // TcpStream accessor is unavailable on a TLS-wrapped path),
+        // SO_LINGER still bounds the kernel-level drain.
         if let Some(tcp) = stream.tcp_stream() {
             let sock = socket2::SockRef::from(tcp);
             let _ = sock.set_linger(Some(Duration::from_secs(5)));
@@ -1136,6 +1140,32 @@ fn process_approved_module(
             }
         }
         let _ = stream.set_read_timeout(None);
+
+        // UTS-V3.A explicit drain barrier (kernel-level half-close).
+        // Once the peer has FINed (read-drain returned EOF/timeout) and
+        // the generator orchestrator has already flushed every user-space
+        // byte via `ServerWriter::flush_all_pending`, an explicit
+        // `shutdown(SHUT_WR)` is safe and observable: it confirms the
+        // half-close with a bounded SO_LINGER drain. Errors that mean
+        // "peer already closed" are tolerated; any other shutdown error
+        // is logged so the operator sees the failure rather than relying
+        // on the implicit Drop-time close. The companion SO_LINGER set
+        // above is the catastrophic-failure fallback.
+        //
+        // upstream: cleanup.c::handle_cleanup() -> close_all() emits the
+        // kernel FIN as the process exits; the threaded daemon collapses
+        // that pattern into the explicit shutdown here.
+        if let Some(tcp) = stream.tcp_stream() {
+            if let Err(err) =
+                core::server::writer::shutdown_send_side(tcp, Duration::from_secs(5))
+            {
+                if let Some(log) = ctx.log_sink {
+                    let text = format!("daemon-sender drain-barrier shutdown failed: {err}");
+                    let message = rsync_warning!(text).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+            }
+        }
     }
 
     // Drop transfer-engine stream clones after the drain completes.

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -29,6 +29,10 @@ getrandom = "0.4"
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 rayon = { workspace = true }
+# socket2 is used by `writer::server::shutdown_send_side` to drive the
+# explicit SO_LINGER + half-close drain barrier after the daemon-sender's
+# generator orchestrator returns (UTS-V3.A audit).
+socket2 = { workspace = true, features = ["all"] }
 tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -161,16 +161,39 @@ impl GeneratorContext {
             },
         )?;
 
-        // upstream: main.c:983 io_flush(FULL_FLUSH) is also called AFTER
-        // read_final_goodbye(), so any MSG_INFO diagnostic frame queued
-        // later in `run()` still ships before the transport FIN.
-        // `finalize_compression()` is idempotent on a Multiplex writer
-        // (degrades to a plain flush) so it is safe to call again here as
-        // defense-in-depth.
-        if let Err(e) = writer.finalize_compression() {
-            if !super::super::is_early_close_error(&e) {
-                return Err(e);
-            }
+        // UTS-V3.A drain barrier: explicit user-space drain after
+        // `handle_goodbye_with_finalizer` returns and before the writer
+        // graph drops. The audit traced the cluster-A wire-cutoffs
+        // (~2.25 MB on batch-mode, alt-dest, and daemon-refuse-compress;
+        // ~615 KB on daemon-gzip-download) to bytes still sitting in the
+        // multiplex BufWriter / codec trailer when the daemon's
+        // `SO_LINGER` + `shutdown(SHUT_WR)` teardown fired.
+        //
+        // `flush_all_pending` is idempotent: it re-runs
+        // `finalize_compression` (no-op on a Multiplex writer that has
+        // already been finalised inside `handle_goodbye_with_finalizer`,
+        // emits the codec trailer if any branch returned early), then
+        // flushes the multiplex BufWriter so the next byte goes straight
+        // to the kernel. Peer-already-closed is tolerated; every other
+        // I/O error surfaces.
+        //
+        // Companion call: the daemon teardown invokes
+        // `writer::shutdown_send_side` on the underlying TcpStream after
+        // the read-drain loop completes - that drains the kernel send
+        // buffer and issues the explicit `shutdown(SHUT_WR)`. The two
+        // calls together replace the implicit `Drop` + `SO_LINGER`
+        // hand-off with an observable two-stage barrier.
+        //
+        // Server-side only: client-mode keeps stdio open for the parent
+        // process to own teardown. Stdio (remote-shell daemon mode) is
+        // not server-side here, but the flush still benefits any buffered
+        // byte that needs to reach the pipe before control returns.
+        //
+        // upstream: cleanup.c::handle_cleanup() brackets the sender's
+        // final `io_flush(FULL_FLUSH)` with the process exit so every
+        // user-space byte hits the wire before the kernel queues FIN.
+        if !self.config.connection.client_mode {
+            writer.flush_all_pending()?;
         }
 
         // Calculate timing stats for return value

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -140,7 +140,7 @@ pub mod shared;
 pub mod symlink_safety;
 pub mod temp_cleanup;
 pub mod temp_guard;
-mod writer;
+pub mod writer;
 
 mod parallel_io;
 
@@ -178,7 +178,7 @@ pub use self::receiver::{ReceiverContext, SumHead, TransferStats};
 pub use self::role::ServerRole;
 pub use self::shared::{ChecksumFactory, TransferDeadline};
 pub use self::temp_cleanup::cleanup_stale_temp_files;
-pub use self::writer::{CountingWriter, MsgInfoSender};
+pub use self::writer::{CountingWriter, MsgInfoSender, ServerWriter, shutdown_send_side};
 pub use ack_batcher::{
     AckBatcher, AckBatcherConfig, AckBatcherStats, AckEntry, AckStatus, DEFAULT_BATCH_SIZE,
     DEFAULT_BATCH_TIMEOUT_MS, MAX_BATCH_SIZE, MAX_BATCH_TIMEOUT_MS, MIN_BATCH_SIZE,

--- a/crates/transfer/src/writer/mod.rs
+++ b/crates/transfer/src/writer/mod.rs
@@ -19,7 +19,7 @@ mod server;
 
 pub use self::counting::CountingWriter;
 pub use self::msg_info::MsgInfoSender;
-pub use self::server::ServerWriter;
+pub use self::server::{ServerWriter, shutdown_send_side};
 
 #[cfg(test)]
 mod tests;

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -4,8 +4,10 @@
 //! transitions where the global I/O buffer state is modified at runtime.
 
 use std::io::{self, IoSlice, Write};
+use std::net::{Shutdown, TcpStream};
 use std::num::NonZeroU8;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use compress::algorithm::CompressionAlgorithm;
 use compress::zlib::CompressionLevel;
@@ -13,6 +15,7 @@ use protocol::MessageCode;
 
 use super::multiplex::MultiplexWriter;
 use crate::compressed_writer::CompressedWriter;
+use crate::is_early_close_error;
 
 /// Writer that can switch from plain to multiplex mode after protocol setup.
 ///
@@ -292,6 +295,50 @@ impl<W: Write> ServerWriter<W> {
         }
     }
 
+    /// Drains every user-space buffer in the writer graph so the next byte
+    /// any caller emits goes straight to the kernel.
+    ///
+    /// Idempotent. Calls [`finalize_compression`](Self::finalize_compression)
+    /// to emit the codec end-of-stream trailer (zlib `Z_FINISH`, lz4 footer,
+    /// zstd epilogue), which itself flushes the multiplex `BufWriter`. In
+    /// Multiplex / Plain mode it degrades to a plain [`flush`](Self::flush).
+    ///
+    /// Peer-already-closed errors are downgraded to `Ok(())` because the
+    /// transfer is finished by the time this barrier runs - the peer has
+    /// already FINed in the early-close case and there is no useful byte
+    /// left to deliver. Every other I/O error surfaces (Rule 12: fail loud).
+    ///
+    /// # UTS-V3.A drain-barrier contract
+    ///
+    /// The audit traced the cluster-A wire-cutoffs (~2.25 MB on batch-mode,
+    /// alt-dest, and `daemon-refuse-compress`; ~615 KB on
+    /// `daemon-gzip-download`) to user-space bytes still sitting in the
+    /// multiplex `BufWriter` / codec trailer when the daemon's
+    /// `SO_LINGER` + `shutdown(SHUT_WR)` teardown fired. Driving
+    /// `flush_all_pending` after `handle_goodbye_with_finalizer` returns
+    /// makes the drain observable and error-surfacing instead of relying
+    /// on the implicit `Drop` + `SO_LINGER` hand-off.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `cleanup.c::handle_cleanup()` brackets the sender's final
+    ///   `io_flush(FULL_FLUSH)` with the process exit so every user-space
+    ///   byte hits the wire before the kernel queues `FIN`.
+    /// - `main.c:983` calls `io_flush(FULL_FLUSH)` after
+    ///   `read_final_goodbye()` returns, mirroring the same barrier intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a non-early-close I/O error fires during codec
+    /// finalisation or multiplex flush.
+    pub fn flush_all_pending(&mut self) -> io::Result<()> {
+        match self.finalize_compression() {
+            Ok(()) => Ok(()),
+            Err(e) if is_early_close_error(&e) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Writes raw bytes directly to the underlying stream, bypassing multiplexing.
     ///
     /// Used for protocol exchanges like the final goodbye handshake where
@@ -355,5 +402,63 @@ impl<W: Write> Write for ServerWriter<W> {
                 "ServerWriter in invalid Taken state",
             )),
         }
+    }
+}
+
+/// Half-closes the send side of an accepted daemon connection after every
+/// in-flight TX byte has been ACKed.
+///
+/// Companion to [`ServerWriter::flush_all_pending`]: that drains the
+/// user-space writer graph; this drains the kernel send buffer. Together
+/// they replace the implicit `Drop` + `SO_LINGER` hand-off with an
+/// observable, timeout-bounded, error-surfacing two-stage barrier.
+///
+/// Sequence:
+/// 1. `SO_LINGER(timeout)` so `shutdown(SHUT_WR)` blocks until the queued
+///    TX bytes are ACKed (or the linger window expires). This is the
+///    catastrophic-failure fallback: even if the peer never reads, we
+///    refuse to wait beyond `timeout` before queuing `FIN`.
+/// 2. `shutdown(SHUT_WR)` issues the explicit half-close so the peer
+///    observes `FIN` exactly once `SO_LINGER` has drained the kernel
+///    queue. Any `NotConnected` / `BrokenPipe` is downgraded to `Ok(())`
+///    because that means the peer already closed.
+///
+/// Use only after the application-level write half is fully drained
+/// (e.g. [`ServerWriter::flush_all_pending`] returned `Ok(())`) AND the
+/// daemon-side read-drain loop has consumed the peer's trailing goodbye.
+/// Calling earlier risks the same race the audit fixed.
+///
+/// # Upstream Reference
+///
+/// - `io.c:943-963 noop_io_until_death()` keeps the sender's read side
+///   open until the peer FINs.
+/// - `cleanup.c:265 close_all()` finally drops the fds; the kernel
+///   queues `FIN` on the write side as a side effect of the exit.
+///
+/// # Errors
+///
+/// Returns the underlying `io::Error` from `shutdown` when it is not a
+/// peer-already-closed condition. The `SO_LINGER` set failure is
+/// surfaced because it would silently defeat the drain guarantee.
+pub fn shutdown_send_side(stream: &TcpStream, timeout: Duration) -> io::Result<()> {
+    // SO_LINGER bounds the kernel-level drain. If the peer is wedged,
+    // shutdown(SHUT_WR) will not block past `timeout`. Even if SO_LINGER
+    // is unsupported on the underlying socket, surfacing the failure is
+    // safer than silently degrading: callers can re-fall-back to the
+    // legacy SO_LINGER-then-drop pattern higher up the stack.
+    let sock = socket2::SockRef::from(stream);
+    sock.set_linger(Some(timeout))?;
+
+    match stream.shutdown(Shutdown::Write) {
+        Ok(()) => Ok(()),
+        Err(e)
+            if matches!(
+                e.kind(),
+                io::ErrorKind::NotConnected | io::ErrorKind::BrokenPipe
+            ) =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(e),
     }
 }

--- a/crates/transfer/tests/uts_v3_a_drain_barrier.rs
+++ b/crates/transfer/tests/uts_v3_a_drain_barrier.rs
@@ -1,0 +1,130 @@
+//! UTS-V3.A regression: the daemon-sender exit path must flush every
+//! user-space byte through the writer graph and then half-close the kernel
+//! send side BEFORE the connection drops.
+//!
+//! Audit (`docs/design/uts-v3-a-goodbye-flush-audit.md`) traced the cluster-A
+//! wire-cutoffs (~2.25 MB on `batch-mode`, `alt-dest`, and
+//! `daemon-refuse-compress`; ~615 KB on `daemon-gzip-download`) to user-space
+//! bytes still sitting in the multiplex `BufWriter` / codec trailer when the
+//! daemon's SO_LINGER + shutdown(SHUT_WR) teardown fired. The fix is a
+//! two-stage barrier:
+//!
+//! 1. [`ServerWriter::flush_all_pending`] drains user-space buffers.
+//! 2. [`shutdown_send_side`] drains the kernel send buffer with bounded
+//!    SO_LINGER and issues an explicit `shutdown(SHUT_WR)`.
+//!
+//! This integration test exercises both methods end-to-end over a real
+//! `TcpListener` bound to port 0, pushes >= 3 MiB of payload (past the A2
+//! cutoff at ~2.25 MB), and asserts the receiver observed every byte before
+//! FIN. The listener is read-to-EOF: any byte still queued in the sender's
+//! user-space buffers when the half-close fires would show up as a short
+//! read on the receive side.
+//!
+//! upstream: `cleanup.c::handle_cleanup()` brackets the sender's final
+//! `io_flush(FULL_FLUSH)` with the process exit so every queued byte hits
+//! the wire before the kernel queues FIN.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::Duration;
+
+use transfer::writer::{ServerWriter, shutdown_send_side};
+
+/// Mirrors the cluster-A boundary: roughly 2.25 MiB of payload pushed through
+/// the multiplex writer, with a comfortable margin so any flush-shortfall is
+/// observable. The receiver thread expects every byte before observing EOF.
+const PAYLOAD_BYTES: usize = 3 * 1024 * 1024;
+
+/// Drain-barrier timeout. Matches the daemon teardown's 5 s SO_LINGER window
+/// in `crates/daemon/src/daemon/sections/module_access/transfer.rs`.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Drives the cluster-A payload through `ServerWriter::flush_all_pending`
+/// followed by `shutdown_send_side` over a real `TcpStream`. Asserts the
+/// receiver sees the entire payload before observing FIN.
+///
+/// Port 0 + `local_addr()` keeps the test isolated from any concurrent
+/// runner that holds well-known ports.
+#[test]
+fn daemon_sender_emits_final_byte_before_fin() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+
+    // Receiver: read to EOF. If the sender drops before flushing user-space
+    // buffers or before half-closing the kernel send queue, the receiver
+    // observes a short read instead of the full payload.
+    let server_thread = thread::spawn(move || {
+        let (mut sock, _) = listener.accept().expect("accept");
+        sock.set_read_timeout(Some(DRAIN_TIMEOUT * 2))
+            .expect("set_read_timeout");
+        let mut buf = Vec::with_capacity(PAYLOAD_BYTES);
+        sock.read_to_end(&mut buf).expect("read_to_end");
+        buf
+    });
+
+    let stream = TcpStream::connect(addr).expect("connect");
+    stream
+        .set_write_timeout(Some(DRAIN_TIMEOUT))
+        .expect("set_write_timeout");
+
+    // The actual daemon-sender writer graph wraps a `CountingWriter`
+    // around the stream and a `ServerWriter::Plain` around that. For the
+    // drain-barrier contract we only need the outermost `ServerWriter`
+    // wired against the socket, since the barrier traverses through
+    // `Write::flush` and `finalize_compression`. Plain mode is the
+    // minimum surface where `flush_all_pending` and the subsequent
+    // `shutdown_send_side` produce an observable wire effect.
+    let mut writer: ServerWriter<TcpStream> =
+        ServerWriter::new_plain(stream.try_clone().expect("clone TcpStream for writer"));
+
+    // Write the full payload. Deterministic pattern lets the receiver
+    // assert byte-for-byte equality, not just length.
+    let payload: Vec<u8> = (0..PAYLOAD_BYTES).map(|i| (i % 251) as u8).collect();
+    writer.write_all(&payload).expect("write payload");
+
+    // Stage 1: drain user-space buffers. Must precede any socket-level
+    // half-close so the multiplex/codec trailer reaches the kernel send
+    // queue before SO_LINGER + shutdown(SHUT_WR) fire.
+    writer.flush_all_pending().expect("flush_all_pending");
+
+    // Stage 2: kernel-level drain + explicit half-close. SO_LINGER
+    // ensures the queued payload + trailer are ACKed before FIN; the
+    // shutdown(SHUT_WR) makes the half-close observable and
+    // error-surfacing.
+    shutdown_send_side(&stream, DRAIN_TIMEOUT).expect("shutdown_send_side");
+
+    // Drop the writer chain so any remaining clone closes. The receive
+    // side has already drained to EOF because shutdown(SHUT_WR) emitted
+    // FIN above; this drop is housekeeping.
+    drop(writer);
+    drop(stream);
+
+    let received = server_thread.join().expect("server thread");
+    assert_eq!(
+        received.len(),
+        PAYLOAD_BYTES,
+        "receiver observed short read: {} of {} bytes (drain barrier missing?)",
+        received.len(),
+        PAYLOAD_BYTES,
+    );
+    assert_eq!(received, payload, "byte content diverged after drain");
+}
+
+/// `flush_all_pending` must be idempotent: calling it twice in a row is the
+/// orchestrator's defense-in-depth pattern when the goodbye finaliser already
+/// ran `finalize_compression` once during `handle_goodbye_with_finalizer`.
+///
+/// A second call against a plain `Vec` sink should not double-flush, double-
+/// finalise, or panic, and must report `Ok(())`.
+#[test]
+fn flush_all_pending_is_idempotent() {
+    let buf: Vec<u8> = Vec::new();
+    let mut writer = ServerWriter::new_plain(buf);
+    writer.write_all(b"hello").expect("write");
+
+    writer.flush_all_pending().expect("first flush_all_pending");
+    writer
+        .flush_all_pending()
+        .expect("second flush_all_pending must be idempotent");
+}


### PR DESCRIPTION
## Summary

- Introduce a two-stage drain barrier on the daemon-sender exit path so user-space writer buffers are flushed AND the kernel send queue is drained before `FIN` ever leaves the host. Closes the cluster-A wire-cutoff at ~2.25 MB (`batch-mode daemon --write-batch`, `alt-dest --copy-dest (lsh.sh)`, `daemon-refuse-compress`) and at ~615 KB (`daemon-gzip-download`) traced in `docs/design/uts-v3-a-goodbye-flush-audit.md`.
- New API on `transfer::writer`: `ServerWriter::flush_all_pending(&mut self) -> io::Result<()>` (idempotent codec-finalise + multiplex flush, peer-already-closed downgraded to `Ok(())`, all other errors surfaced) and free helper `shutdown_send_side(stream: &TcpStream, timeout: Duration) -> io::Result<()>` (bounded `SO_LINGER` + explicit `shutdown(SHUT_WR)`).
- Wire the new sequence into the generator orchestrator (after `handle_goodbye_with_finalizer` returns) and the daemon teardown (after the read-drain loop drains the peer's trailing goodbye). `SO_LINGER` remains as catastrophic-failure fallback inside `shutdown_send_side` AND as the legacy fallback at the daemon site for TLS-wrapped paths that have no raw `TcpStream`.

## Wire effect

No new bytes on the wire. The change is pure ordering: the user-space `BufWriter` + codec trailer are now guaranteed to reach the kernel before `SO_LINGER` + `shutdown(SHUT_WR)` fire, and the half-close is observable + timeout-bounded instead of an implicit `Drop`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo check --workspace --all-features --tests`
- [x] New regression test `crates/transfer/tests/uts_v3_a_drain_barrier.rs::daemon_sender_emits_final_byte_before_fin` - drives 3 MiB through `ServerWriter::flush_all_pending` + `shutdown_send_side` over a `TcpListener` bound to port 0, asserts the receiver observes every byte before EOF. Past the A2 2.25 MB cutoff with margin.
- [x] New regression test `flush_all_pending_is_idempotent` - calling the barrier twice in a row is the orchestrator's defense-in-depth pattern and must remain `Ok(())`.
- [ ] CI: nextest (stable), Windows, macOS, Linux musl
- [ ] CI: interop validation
- [ ] Post-merge: re-run cluster-A upstream-testsuite cases on the Linux host (UTS-V3.A.E.9 / #4360)

## Cluster-A tests expected to recover

| Test                                | Sub-cluster | Cutoff byte |
|------------------------------------:|------------:|------------:|
| `batch-mode daemon --write-batch`   | A2          |   2 251 135 |
| `alt-dest --copy-dest (lsh.sh)`     | A2          |   2 251 388 |
| `daemon-refuse-compress`            | A2          |   2 251 130 |
| `daemon-gzip-download`              | A1          |     615 161 |

## Upstream reference

- `cleanup.c::handle_cleanup()` brackets the sender's final `io_flush(FULL_FLUSH)` with the process exit so every user-space byte hits the wire before the kernel queues `FIN`.
- `io.c:943-963 noop_io_until_death()` keeps the sender's read side open until the peer FINs (the threaded daemon collapses this pattern into the existing read-drain loop, now followed by the explicit half-close).

## Linked work

- Audit: `docs/design/uts-v3-a-goodbye-flush-audit.md` (PR #5974, merged)
- Suspect commit: `4cbd5146d` (PR #5740) - replaced 50 ms `thread::sleep` with `SO_LINGER` + drain-close
- Partial mitigation: `cbb4128d7` (PR #5765) - removed half-close but never added the explicit drain barrier