### PR TITLE
test(cli): add --recursive to list_only tests that expect recursive directory listing

### DIFF
--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -24,6 +24,7 @@ fn list_only_lists_entries_without_copying() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         OsString::from("--links"),
         source_dir.into_os_string(),
         destination_dir.clone().into_os_string(),
@@ -54,7 +55,7 @@ fn list_only_formats_directory_without_trailing_slash() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
-        OsString::from("-r"),
+        OsString::from("--recursive"),
         source_dir.into_os_string(),
         dest_dir.into_os_string(),
     ]);
@@ -104,6 +105,7 @@ fn list_only_matches_rsync_format_for_regular_file() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.clone().into_os_string(),
     ]);
@@ -133,6 +135,7 @@ fn list_only_matches_rsync_format_for_regular_file() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         OsString::from("--human-readable"),
         source_arg,
         dest_dir.into_os_string(),
@@ -187,7 +190,7 @@ fn list_only_formats_special_permission_bits_like_rsync() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
-        OsString::from("-r"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -381,6 +384,7 @@ fn list_only_symlink_shows_arrow_target_in_exact_format() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         OsString::from("--links"),
         source_arg,
         dest_dir.into_os_string(),
@@ -439,6 +443,7 @@ fn list_only_zero_byte_file_shows_zero_size() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -557,6 +562,7 @@ fn list_only_size_field_right_aligned_in_15_chars() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -680,6 +686,7 @@ fn list_only_large_file_size_has_thousands_separators() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -734,6 +741,7 @@ fn list_only_with_verbose_still_shows_listing_format() {
     let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         OsString::from("--verbose"),
         source_arg,
         dest_dir.into_os_string(),
@@ -787,6 +795,7 @@ fn list_only_read_only_file_permissions() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -835,7 +844,7 @@ fn list_only_executable_file_permissions() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
-        OsString::from("-r"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -885,7 +894,7 @@ fn list_only_human_readable_size_format() {
         OsString::from(RSYNC),
         OsString::from("--list-only"),
         OsString::from("--human-readable"),
-        OsString::from("-r"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -948,6 +957,7 @@ fn list_only_multiple_files_have_consistent_column_alignment() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -1026,7 +1036,7 @@ fn list_only_implies_dry_run_no_files_transferred() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
-        OsString::from("-r"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.clone().into_os_string(),
     ]);
@@ -1077,7 +1087,7 @@ fn list_only_fifo_shows_pipe_type() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
-        OsString::from("-r"),
+        OsString::from("--recursive"),
         OsString::from("--specials"),
         source_arg,
         dest_dir.into_os_string(),
@@ -1123,6 +1133,7 @@ fn list_only_with_stats_appends_summary() {
     let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         OsString::from("--stats"),
         source_arg,
         dest_dir.into_os_string(),
@@ -1177,6 +1188,7 @@ fn list_only_timestamp_matches_yyyy_mm_dd_hh_mm_ss_format() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         source_arg,
         dest_dir.into_os_string(),
     ]);
@@ -1254,6 +1266,7 @@ fn list_only_verbose_appends_totals() {
     let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--list-only"),
+        OsString::from("--recursive"),
         OsString::from("--verbose"),
         source_arg,
         dest_dir.into_os_string(),


### PR DESCRIPTION
## Summary

PR #5929 (commit 0730dcaa0) defaulted recursive to false unless `-r`, `-a`, or `--files-from` is explicitly set, matching upstream `options.c:112`. This regressed 13 `cli::frontend::tests::list_only` tests that pass a source directory with files inside and assert those inner file names appear in stdout — they implicitly relied on the old default-recursive behavior.

This PR adds explicit `--recursive` to each affected `run_with_args` invocation so the test reflects user intent (recurse into the listed directory). Mirrors the pattern from PR #5946 (`--list-only --links`) and PR #5955 (`filter_behavior_comprehensive`).

Also flips 6 pre-existing `-r` short-form sites in the same file to `--recursive` so the file uses one consistent spelling. Long-form reads better in tests (which double as documentation) and the change is semantically identical.

## Why the full class, not just the 2 failing in CI

CI `nextest (stable)` shards each test cell with `--partition` flags. The "3064 filtered out" per shard means each cell only samples a few tests; the most recent run surfaced 2 failures, but auditing `list_only.rs` reveals 11 more invocations with the same broken pattern (directory source + assertion on inner file). A partial fix would have produced follow-up regressions on the next shard sample. This PR closes the entire class.

## Affected tests (added `--recursive`)

- `list_only_lists_entries_without_copying`
- `list_only_large_file_size_has_thousands_separators`
- `list_only_matches_rsync_format_for_regular_file` (2 invocations)
- `list_only_symlink_shows_arrow_target_in_exact_format`
- `list_only_zero_byte_file_shows_zero_size`
- `list_only_size_field_right_aligned_in_15_chars`
- `list_only_with_verbose_still_shows_listing_format`
- `list_only_read_only_file_permissions`
- `list_only_multiple_files_have_consistent_column_alignment`
- `list_only_with_stats_appends_summary`
- `list_only_timestamp_matches_yyyy_mm_dd_hh_mm_ss_format`
- `list_only_verbose_appends_totals`

## Test plan

- [x] `cargo fmt --all` clean
- [ ] CI `nextest (stable)` cells go green
- [ ] No other workspace tests regress