### PR TITLE
feat(daemon): add daemon-async-accept Cargo feature flag

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -33,6 +33,11 @@ tracing = ["dep:tracing", "core/tracing"]
 acl = ["core/acl", "metadata/acl"]
 # Filename charset transcoding via the module `charset =` directive (iconv).
 iconv = ["core/iconv", "protocol/iconv"]
+# Async accept loop for the daemon listener. Flag-only landing step for the
+# DASYNC rollout tracked by `docs/design/daemon-async-accept-sync-workers.md`;
+# no code paths are gated on this feature yet. Subsequent steps will wire the
+# tokio-based listener and sync-worker dispatch behind this flag.
+daemon-async-accept = []
 # Native TLS termination via rustls - single-binary alternative to stunnel/HAProxy
 # sidecar. Opt-in; default builds remain TLS-free. See
 # `docs/design/daemon-async-accept-sync-workers.md` section 11 for the integration


### PR DESCRIPTION
## Summary

- Adds an empty `daemon-async-accept = []` feature to `crates/daemon/Cargo.toml` as the first landing step (DASYNC.3.a) of the DASYNC rollout described in `docs/design/daemon-async-accept-sync-workers.md`.
- The flag carries no dependencies and gates no code paths in this commit; subsequent DASYNC.3.b-h commits will wire the tokio-based async listener and sync-worker dispatch behind it.
- Placed alongside the other `daemon-*` flags with a comment matching the existing convention in the features section.

Tracks: DASYNC.3.a

## Test plan

- [ ] CI fmt+clippy passes
- [ ] CI nextest (stable) passes
- [ ] CI Windows / macOS / Linux musl matrix passes
- [ ] `cargo metadata --format-version=1` reports the new `daemon-async-accept` feature (verified via CI build)
- [ ] Default-feature builds compile unchanged (no implicit activation)