### PR TITLE
chore(daemon): reconcile duplicate async-listener feature flags

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -20,8 +20,10 @@ sd-notify = ["dep:sd-notify", "core/sd-notify"]
 async = ["dep:tokio", "core/async"]
 # Hybrid async listener: tokio accept loop dispatching sync workers via
 # spawn_blocking. Skeleton path tracked under issue #1935; opt-in at build time
-# and not yet wired as the default. See
-# `docs/design/daemon-tokio-async-listener-impl.md` for the rollout plan.
+# and not yet wired as the default. This is also the landing flag for the
+# DASYNC rollout - the long-form rationale lives in
+# `docs/design/daemon-async-accept-sync-workers.md` and the concrete
+# implementation steps in `docs/design/daemon-tokio-async-listener-impl.md`.
 async-daemon = ["dep:tokio"]
 # Concurrent session tracking - enables efficient shared state for multi-session daemons
 concurrent-sessions = ["dep:dashmap"]
@@ -33,11 +35,6 @@ tracing = ["dep:tracing", "core/tracing"]
 acl = ["core/acl", "metadata/acl"]
 # Filename charset transcoding via the module `charset =` directive (iconv).
 iconv = ["core/iconv", "protocol/iconv"]
-# Async accept loop for the daemon listener. Flag-only landing step for the
-# DASYNC rollout tracked by `docs/design/daemon-async-accept-sync-workers.md`;
-# no code paths are gated on this feature yet. Subsequent steps will wire the
-# tokio-based listener and sync-worker dispatch behind this flag.
-daemon-async-accept = []
 # Native TLS termination via rustls - single-binary alternative to stunnel/HAProxy
 # sidecar. Opt-in; default builds remain TLS-free. See
 # `docs/design/daemon-async-accept-sync-workers.md` section 11 for the integration

--- a/docs/design/daemon-async-accept-sync-workers.md
+++ b/docs/design/daemon-async-accept-sync-workers.md
@@ -4,6 +4,12 @@ Status: Design (TODO #1674)
 Audience: daemon maintainers, transfer-pipeline maintainers, operators
 Scope: hybrid async/sync execution model for the rsync daemon at high concurrency
 
+> Feature flag: the rollout described here lands behind the existing
+> `async-daemon` Cargo feature on `crates/daemon` (see `crates/daemon/Cargo.toml`).
+> The concrete implementation steps live in
+> `docs/design/daemon-tokio-async-listener-impl.md`; this document covers the
+> long-form design rationale.
+
 ## 1. Problem Statement
 
 `oc-rsync` runs as a long-lived daemon serving the rsync wire protocol over TCP. The current accept path is a synchronous loop that spawns one OS thread per accepted connection and then runs the full transfer state machine on that thread until the connection terminates. The model is simple, panic-isolated (`catch_unwind` per worker), and zero-allocation for the steady state. It works well into the low hundreds of concurrent connections and is the path that has been hardened against upstream interop.

--- a/docs/design/daemon-tokio-async-listener-impl.md
+++ b/docs/design/daemon-tokio-async-listener-impl.md
@@ -6,6 +6,11 @@ Scope: concrete implementation steps for replacing the synchronous accept loop i
 `crates/daemon` with a Tokio-driven listener that bridges to the existing sync
 transfer worker via `spawn_blocking`.
 
+> Feature flag: the implementation described here lands behind the existing
+> `async-daemon` Cargo feature on `crates/daemon` (see `crates/daemon/Cargo.toml`).
+> The long-form design rationale lives in
+> `docs/design/daemon-async-accept-sync-workers.md`.
+
 ## 1. Background
 
 - Issue #1934 captured the RFC for a Tokio-based async accept loop. The RFC has


### PR DESCRIPTION
## Summary

PR #5986 introduced a new Cargo feature `daemon-async-accept = []` on `crates/daemon` as a flag-only landing step for the DASYNC rollout. The crate already had `async-daemon = ["dep:tokio"]` whose comment described the same hybrid tokio-accept + sync-worker model. Two flags + two design docs (`docs/design/daemon-async-accept-sync-workers.md` and `docs/design/daemon-tokio-async-listener-impl.md`) for the same rollout.

This PR picks **Option A**: remove `daemon-async-accept` and consolidate on the existing `async-daemon` flag.

### Why Option A (remove the new flag)

- **Source code only references `async-daemon`.** `crates/daemon/src/async_listener.rs`, `daemon.rs`, and `lib.rs` all gate on `#[cfg(feature = "async-daemon")]`. Zero source files reference `daemon-async-accept`.
- **README.md, `crates/daemon/README.md`, the operator migration guide, and 40+ design/audit docs** already document `async-daemon`.
- **`docs/design/daemon-tokio-async-listener-impl.md` already specifies** `async-daemon = ["dep:tokio"]` as the gate (section 3.1) and is described as the implementation companion to `daemon-async-accept-sync-workers.md` (line 18-20). Both docs describe the same plan from different angles (rationale vs. implementation).
- **Smaller blast radius:** keeping the older flag preserves any external CI matrices, downstream tooling, or operator runbooks that already reference `--features async-daemon`.

### Changes

- `crates/daemon/Cargo.toml`: remove the `daemon-async-accept = []` entry. Expand the existing comment on `async-daemon` to reference both design docs so future readers see the connection.
- `docs/design/daemon-async-accept-sync-workers.md`: add a top-of-file note pointing at the `async-daemon` Cargo feature and the implementation-companion doc.
- `docs/design/daemon-tokio-async-listener-impl.md`: add a reciprocal top-of-file note pointing at `async-daemon` and the rationale doc.

Neither design doc is deleted; both remain as the long-form record of the rollout.

## Test plan

- [ ] CI fmt + clippy on `crates/daemon` pass (no source-level changes, no clippy surface affected).
- [ ] CI nextest passes on stable / Windows / macOS / Linux musl (no source-level changes).
- [ ] Confirm `cargo build -p daemon --features async-daemon` still builds (no API change; this PR only removes an unused parallel flag).