### PR TITLE
test(daemon): port daemon-gzip goodbye scenario to nextest (NXT-2)

### DIFF
--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -5,6 +5,13 @@
 //! This crate provides helpers that multiple test suites need, avoiding
 //! duplicated retry logic and setup boilerplate across crates.
 
+pub mod upstream_compat;
+
+pub use upstream_compat::{
+    UpstreamRsync, UpstreamVersion, locate_upstream_rsync, require_upstream_rsync,
+    upstream_compat_enabled,
+};
+
 use std::thread;
 use std::time::Duration;
 

--- a/crates/test-support/src/upstream_compat.rs
+++ b/crates/test-support/src/upstream_compat.rs
@@ -1,0 +1,152 @@
+//! Cross-binary upstream-compat harness primitives (NXT-1).
+//!
+//! NXT-2..NXT-8 port high-value edge cases from
+//! `tools/ci/run_upstream_testsuite.sh` into nextest. Every port pits
+//! oc-rsync against an installed upstream rsync release. This module
+//! provides the shared primitives those ports use: env-var gate, version
+//! enum, and upstream-binary location with self-skip semantics.
+//!
+//! The companion design is `docs/design/nxt-1-nextest-harness.md`. The
+//! sibling internal-only harness (oc-rsync drives oc-rsync) is specified
+//! in `docs/design/uts-nextest-edge-b-test-harness.md`; this module covers
+//! only the cross-binary surface.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Upstream rsync version pinned by an NXT-* test.
+///
+/// Versions correspond to the `target/interop/upstream-install/<version>/`
+/// layout produced by `tools/ci/run_interop.sh`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UpstreamVersion {
+    /// rsync 3.0.9.
+    V3_0_9,
+    /// rsync 3.1.3.
+    V3_1_3,
+    /// rsync 3.4.4 - default for new NXT-* ports.
+    V3_4_4,
+}
+
+impl UpstreamVersion {
+    /// Short string used in `target/interop/upstream-install/<dir>/`.
+    pub fn directory(self) -> &'static str {
+        match self {
+            UpstreamVersion::V3_0_9 => "3.0.9",
+            UpstreamVersion::V3_1_3 => "3.1.3",
+            UpstreamVersion::V3_4_4 => "3.4.4",
+        }
+    }
+
+    /// Env-var name used to override the resolved binary path.
+    ///
+    /// Example: `OC_RSYNC_UPSTREAM_BIN_3_4_4=/usr/local/bin/rsync`.
+    pub fn env_var(self) -> &'static str {
+        match self {
+            UpstreamVersion::V3_0_9 => "OC_RSYNC_UPSTREAM_BIN_3_0_9",
+            UpstreamVersion::V3_1_3 => "OC_RSYNC_UPSTREAM_BIN_3_1_3",
+            UpstreamVersion::V3_4_4 => "OC_RSYNC_UPSTREAM_BIN_3_4_4",
+        }
+    }
+}
+
+/// Resolved handle to an upstream rsync binary.
+pub struct UpstreamRsync {
+    binary: PathBuf,
+    version: UpstreamVersion,
+}
+
+impl UpstreamRsync {
+    /// Path to the resolved upstream rsync binary.
+    pub fn binary(&self) -> &Path {
+        &self.binary
+    }
+
+    /// Version this handle was resolved for.
+    pub fn version(&self) -> UpstreamVersion {
+        self.version
+    }
+
+    /// New `Command` rooted at the resolved binary, with no args yet.
+    pub fn command(&self) -> Command {
+        Command::new(&self.binary)
+    }
+}
+
+/// Returns `true` when `OC_RSYNC_UPSTREAM_COMPAT=1` is set in the
+/// environment.
+///
+/// Tests early-return without printing a skip line when this is `false`,
+/// matching the `WHICHTESTS` env-gating convention upstream uses to keep
+/// the standard PR nextest cell wall time near zero.
+#[must_use]
+pub fn upstream_compat_enabled() -> bool {
+    matches!(
+        std::env::var("OC_RSYNC_UPSTREAM_COMPAT").ok().as_deref(),
+        Some("1"),
+    )
+}
+
+/// Locate the upstream rsync binary for `version`.
+///
+/// Resolution order:
+/// 1. `OC_RSYNC_UPSTREAM_BIN_<VERSION>` env var (CI override).
+/// 2. `target/interop/upstream-install/<version>/bin/rsync` relative to
+///    the workspace root resolved from `CARGO_MANIFEST_DIR`.
+///
+/// Returns `None` if neither path resolves to an executable. Tests then
+/// self-skip via [`require_upstream_rsync`].
+#[must_use]
+pub fn locate_upstream_rsync(version: UpstreamVersion) -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(version.env_var()) {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+
+    let workspace_root = workspace_root()?;
+    let candidate = workspace_root
+        .join("target")
+        .join("interop")
+        .join("upstream-install")
+        .join(version.directory())
+        .join("bin")
+        .join("rsync");
+    if candidate.is_file() {
+        return Some(candidate);
+    }
+    None
+}
+
+/// Self-skip helper. Returns `Some(UpstreamRsync)` when the binary
+/// exists, else prints a clear reason and returns `None`. Tests early-
+/// return on `None` so nextest reports them as passing with the skip
+/// reason in stderr.
+#[must_use]
+pub fn require_upstream_rsync(version: UpstreamVersion) -> Option<UpstreamRsync> {
+    match locate_upstream_rsync(version) {
+        Some(binary) => Some(UpstreamRsync { binary, version }),
+        None => {
+            eprintln!(
+                "Skipping upstream-compat test: upstream rsync {} not installed at \
+                 target/interop/upstream-install/{}/bin/rsync (override via {})",
+                version.directory(),
+                version.directory(),
+                version.env_var(),
+            );
+            None
+        }
+    }
+}
+
+/// Resolve the workspace root from `CARGO_MANIFEST_DIR`.
+///
+/// `CARGO_MANIFEST_DIR` for the consuming test crate points at
+/// `crates/<crate>/`. The workspace root is its parent's parent.
+fn workspace_root() -> Option<PathBuf> {
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")?;
+    let manifest_dir = PathBuf::from(manifest_dir);
+    let crates_dir = manifest_dir.parent()?;
+    crates_dir.parent().map(Path::to_path_buf)
+}

--- a/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
+++ b/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
@@ -1,0 +1,341 @@
+//! NXT-2: upstream-compat port of `testsuite/daemon-gzip-download.test`.
+//!
+//! Pairs an upstream rsync client (3.4.4 by default) against an oc-rsync
+//! daemon over a real TCP socket. The transfer pulls a ~1 MB fixture with
+//! `-zz` (new-style zlibx codec). The invariant under test is that the
+//! goodbye envelope reaches the upstream client without a premature
+//! connection drop - the regression family that UTS-9.REOPEN /
+//! UTS-10.REOPEN / UTS-V3.A surfaced and which PRs #5520, #5600, #5619,
+//! and #5725 fixed.
+//!
+//! # Design references
+//!
+//! - `docs/design/nxt-1-nextest-harness.md` - NXT-1 harness shape.
+//! - `docs/design/uts-nextest-edge-b-test-harness.md` - sibling internal
+//!   harness (oc-rsync drives oc-rsync). NXT-2 uses the cross-binary
+//!   surface from `test-support::upstream_compat`.
+//! - `docs/audits/uts-9-daemon-gzip-download-goodbye.md` - UTS-9
+//!   regression analysis the original goodbye flush patch addressed.
+//!
+//! # Upstream references
+//!
+//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/daemon-gzip-download.test`
+//!   - upstream script this port replaces.
+//! - `main.c:983` `do_server_sender()` - `io_flush(FULL_FLUSH)` before
+//!   return; contract pinned by UTS-9.
+//! - `options.c:2002` - `-zz` -> `compress_choice = "zlibx"` mapping.
+//!
+//! # Gating
+//!
+//! The test self-skips on three conditions:
+//!
+//! 1. `OC_RSYNC_UPSTREAM_COMPAT` env var is not `1` - the standard PR
+//!    nextest cell does not set this, so the test no-ops in well under
+//!    1 ms.
+//! 2. The upstream rsync 3.4.4 binary cannot be located at
+//!    `target/interop/upstream-install/3.4.4/bin/rsync` (run
+//!    `tools/ci/run_interop.sh` to build it). The `OC_RSYNC_UPSTREAM_BIN_3_4_4`
+//!    env var overrides the path.
+//! 3. The oc-rsync binary cannot be located via `CARGO_BIN_EXE_oc-rsync`
+//!    or by walking up from the current test executable. CI builds it
+//!    before invoking nextest, so this only trips in pathological local
+//!    setups.
+//!
+//! The test is `#[cfg(unix)]` because the daemon TCP layer assumes
+//! POSIX socket semantics. Windows daemon coverage lives in the daemon
+//! crate's chunked tests.
+
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::{TempDir, tempdir};
+use test_support::{UpstreamVersion, require_upstream_rsync, upstream_compat_enabled};
+
+/// Daemon startup deadline. Mirrors the sibling
+/// `uts_nextest_daemon_gzip_zz.rs` so retry budgets stay aligned.
+const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Total payload size. Picked to clear the ~615 KB cutoff observed in
+/// the UTS-9 capture so the goodbye-flush invariant is exercised on the
+/// wire even after the compressible prefix is heavily reduced by zlibx.
+const COMPRESSIBLE_BYTES: usize = 512 * 1024;
+/// Incompressible tail keeps total wire bytes above the cutoff after
+/// compression engages.
+const INCOMPRESSIBLE_BYTES: usize = 512 * 1024;
+
+/// Locate the workspace `oc-rsync` binary the test runner built.
+fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let exe = env::current_exe().ok()?;
+    let mut dir = exe.parent()?;
+    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
+    while !dir.ends_with("target") {
+        let candidate = dir.join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    for sub in ["debug", "release"] {
+        let candidate = dir.join(sub).join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Allocate a free TCP port by binding to ephemeral port 0.
+fn allocate_test_port() -> Option<u16> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    drop(listener);
+    Some(port)
+}
+
+/// Poll until the daemon accepts a TCP connection on `port`, or the
+/// deadline elapses.
+fn wait_for_daemon(port: u16) -> bool {
+    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
+    let mut backoff = Duration::from_millis(20);
+    while Instant::now() < deadline {
+        if TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
+            return true;
+        }
+        thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_millis(200));
+    }
+    false
+}
+
+/// RAII guard that kills the oc-rsync daemon on drop so a panicking
+/// assertion does not leave a dangling listener.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn `oc-rsync --daemon` on `port` against `config_path` and wait
+/// for it to accept connections.
+fn spawn_oc_rsync_daemon(bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
+    let child = Command::new(bin)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--address=127.0.0.1")
+        .arg("--config")
+        .arg(config_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if !wait_for_daemon(port) {
+        let mut guard = DaemonGuard { child };
+        let _ = guard.child.kill();
+        return Err(io::Error::other(format!(
+            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
+        )));
+    }
+    Ok(DaemonGuard { child })
+}
+
+/// Write an `rsyncd.conf` exposing a single read-write module rooted at
+/// `module_root`. Matches the sibling tests' minimum-viable shape.
+fn write_daemon_config(
+    config_path: &Path,
+    log_path: &Path,
+    pid_path: &Path,
+    module_root: &Path,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [gzipmod]\n\
+         path = {module}\n\
+         comment = NXT-2 upstream-compat daemon-gzip goodbye fixture\n\
+         read only = false\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        module = module_root.display(),
+    );
+    fs::write(config_path, body)
+}
+
+/// Deterministic compressible payload - high zlib ratio.
+fn build_compressible(size: usize) -> Vec<u8> {
+    let phrase = b"compressible_repeated_pattern_for_nxt_2_goodbye_flush ";
+    phrase.iter().copied().cycle().take(size).collect()
+}
+
+/// Deterministic incompressible payload via a small LCG so the byte
+/// stream is identical across runs without an external `rand` dep.
+fn build_incompressible(size: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(size);
+    let mut state: u64 = 0x_dead_beef_cafe_babe_u64;
+    while out.len() < size {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(size);
+    out
+}
+
+/// Write the canonical fixture file at `path` and return its raw bytes
+/// for later byte-equality comparison against the destination.
+fn write_fixture(path: &Path) -> io::Result<Vec<u8>> {
+    let mut content = build_compressible(COMPRESSIBLE_BYTES);
+    content.extend_from_slice(&build_incompressible(INCOMPRESSIBLE_BYTES));
+    let mut f = fs::File::create(path)?;
+    f.write_all(&content)?;
+    Ok(content)
+}
+
+/// Bundle of paths and the daemon guard for one fixture instance.
+struct Fixture {
+    _workdir: TempDir,
+    module_root: PathBuf,
+    port: u16,
+    _daemon: DaemonGuard,
+}
+
+impl Fixture {
+    fn start(oc_rsync_bin: &Path) -> io::Result<Self> {
+        let workdir = tempdir()?;
+        let module_root = workdir.path().join("module");
+        fs::create_dir_all(&module_root)?;
+        let config_path = workdir.path().join("rsyncd.conf");
+        let log_path = workdir.path().join("rsyncd.log");
+        let pid_path = workdir.path().join("rsyncd.pid");
+        write_daemon_config(&config_path, &log_path, &pid_path, &module_root)?;
+
+        let port = allocate_test_port()
+            .ok_or_else(|| io::Error::other("could not allocate ephemeral port"))?;
+        let daemon = spawn_oc_rsync_daemon(oc_rsync_bin, &config_path, port)?;
+
+        Ok(Self {
+            _workdir: workdir,
+            module_root,
+            port,
+            _daemon: daemon,
+        })
+    }
+
+    fn url(&self) -> String {
+        format!("rsync://127.0.0.1:{}/gzipmod", self.port)
+    }
+}
+
+/// NXT-2: upstream rsync client pulls a `-zz`-compressed file from an
+/// oc-rsync daemon and observes the full goodbye envelope.
+///
+/// On regression the upstream client surfaces `connection unexpectedly
+/// closed` (or a non-zero exit) when the oc-rsync daemon-sender drops
+/// the trailing frame before flushing the goodbye exchange.
+///
+/// Skips silently when `OC_RSYNC_UPSTREAM_COMPAT` is unset or the
+/// upstream rsync 3.4.4 binary is missing - this keeps the standard PR
+/// nextest cell costless and macOS/Windows cells green.
+#[test]
+fn daemon_gzip_goodbye_does_not_truncate() {
+    if !upstream_compat_enabled() {
+        return;
+    }
+
+    let Some(upstream) = require_upstream_rsync(UpstreamVersion::V3_4_4) else {
+        return;
+    };
+
+    let Some(oc_rsync) = locate_oc_rsync() else {
+        eprintln!("Skipping: oc-rsync binary not located via CARGO_BIN_EXE_oc-rsync or target/");
+        return;
+    };
+
+    let fixture = match Fixture::start(&oc_rsync) {
+        Ok(f) => f,
+        Err(e) => {
+            panic!("upstream-compat fixture: could not start oc-rsync daemon: {e}");
+        }
+    };
+
+    let src_path = fixture.module_root.join("payload.bin");
+    let source = write_fixture(&src_path).expect("write daemon-side source fixture");
+
+    let dest_dir = tempdir().expect("dest tempdir");
+
+    let url = format!("{}/payload.bin", fixture.url());
+    let output = upstream
+        .command()
+        .arg("-a")
+        .arg("-zz")
+        .arg("--stats")
+        .arg("--timeout=30")
+        .arg(&url)
+        .arg(dest_dir.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn upstream rsync client");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "upstream rsync {} client pulling -zz from oc-rsync daemon must exit 0; \
+         status={:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        upstream.version().directory(),
+        output.status.code(),
+    );
+
+    // UTS-9 fail-loud signature: a regression in the daemon-sender
+    // goodbye flush surfaces as `connection unexpectedly closed` on
+    // the upstream client's stderr even when the exit code is masked.
+    assert!(
+        !stderr.contains("connection unexpectedly closed"),
+        "upstream client stderr must not contain 'connection unexpectedly closed' \
+         (UTS-9 signature); stderr:\n{stderr}"
+    );
+
+    // Byte-equality on the destination: a truncated wire produces a
+    // short file even when the exit code is masked.
+    let dest_file = dest_dir.path().join("payload.bin");
+    let received = fs::read(&dest_file).expect("read destination payload");
+    assert_eq!(
+        received.len(),
+        source.len(),
+        "destination size must match source; truncation indicates goodbye flush regression"
+    );
+    assert_eq!(
+        received, source,
+        "destination must be byte-identical to source"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds the NXT-1 cross-binary harness primitives (`UpstreamVersion`, `locate_upstream_rsync`, `require_upstream_rsync`, `upstream_compat_enabled`) to `crates/test-support` so all NXT-2..NXT-8 ports share one definition.
- Ports the upstream `testsuite/daemon-gzip-download.test` goodbye-flush invariant: an upstream rsync 3.4.4 client pulls a ~1 MB `-zz` fixture from an oc-rsync daemon over TCP and asserts byte-equality + absence of the `connection unexpectedly closed` UTS-9 signature.
- The test is sized to clear the ~615 KB cutoff observed in the original UTS-9 capture so the daemon-sender goodbye flush is actually exercised on the wire.

## Self-skip semantics

The test no-ops with a clear stderr line under any of three conditions:

1. `OC_RSYNC_UPSTREAM_COMPAT` env var is not `1`. The standard PR nextest cell does not set this, so the impact on PR wall time is a single early-return.
2. The upstream rsync 3.4.4 binary cannot be located at `target/interop/upstream-install/3.4.4/bin/rsync`. Build via `tools/ci/run_interop.sh`. Override path via `OC_RSYNC_UPSTREAM_BIN_3_4_4`.
3. The oc-rsync binary cannot be located via `CARGO_BIN_EXE_oc-rsync` or by walking up from the test executable.

`#[cfg(unix)]` gate matches the sibling `uts_nextest_daemon_gzip_zz.rs`.

## CI cell wire-up

NXT-1 specifies a new `upstream-compat` matrix entry on the existing nextest workflow that runs `tools/ci/run_interop.sh` to build the upstream binary, sets `OC_RSYNC_UPSTREAM_COMPAT=1`, and runs the upstream-compat tests filtered by name. That cell does **not** exist yet — this PR ships only the test + harness primitives so the workflow change can land in a focused follow-up (NXT-1's section 6 design).

The standard PR nextest cell exercises the early-return path on every build and proves the test compiles and self-skips cleanly across Linux / macOS / Windows. Once the `upstream-compat` cell lands, the test will run as a required check.

## References

- Design: `docs/design/nxt-1-nextest-harness.md` section 4 (test template).
- Upstream test: `target/interop/upstream-src/rsync-3.4.4/testsuite/daemon-gzip-download.test`.
- Regression history: UTS-9.REOPEN / UTS-10.REOPEN / UTS-V3.A (PRs #5520, #5600, #5619, #5725).
- Sibling internal-only nextest port: `crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs` (oc-rsync drives oc-rsync; this PR's port is the upstream-vs-oc-rsync cross-binary half).

## Test plan

- [x] `cargo fmt --all -- --check` clean locally.
- [ ] CI: nextest cells (Linux musl, macOS, Windows) compile the test and self-skip via the env-gate early-return.
- [ ] CI: fmt + clippy green.
- [ ] Once the NXT-1 `upstream-compat` cell lands, the test executes end-to-end against upstream rsync 3.4.4.