### PR TITLE
feat(windows): skip-with-warn on device files (WIND-3+4)

### DIFF
--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -207,70 +207,104 @@ pub(crate) fn copy_device(
         }
     }
 
-    // create the actual device node, or a 0600 placeholder when --fake-super
-    // is active (mirrors upstream syscall.c:do_mknod()'s am_root < 0 branch).
+    // WIND-2: on non-Unix targets the receiver cannot materialise a device
+    // node. Emit a one-shot warning and skip the post-creation bookkeeping
+    // entirely. Previously this arm fell through to
+    // `register_created_path(CreatedEntryKind::Device, ...)` and
+    // `apply_file_metadata_with_options(...)` against an inode that was
+    // never written, silently recording a fake success.
+    #[cfg(not(unix))]
+    {
+        let _ = (metadata_options, destination_previously_existed);
+        eprintln!("{}", format_skip_device_message(destination));
+        if let Some(path) = &record_path {
+            let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+            let total_bytes = Some(metadata_snapshot.len());
+            context.record(LocalCopyRecord::new(
+                path.clone(),
+                LocalCopyAction::SkippedNonRegular,
+                0,
+                total_bytes,
+                Duration::default(),
+                Some(metadata_snapshot),
+            ));
+        }
+        context.register_progress();
+        return Ok(());
+    }
+
     #[cfg(unix)]
     {
+        // create the actual device node, or a 0600 placeholder when
+        // --fake-super is active (mirrors upstream
+        // syscall.c:do_mknod()'s am_root < 0 branch).
         let fake_super = metadata_options.fake_super_enabled();
         create_device_node_with_fake_super(destination, metadata, fake_super)
             .map_err(map_metadata_error)?;
+
+        context.register_created_path(
+            destination,
+            CreatedEntryKind::Device,
+            destination_previously_existed,
+        );
+
+        apply_file_metadata_with_options(destination, metadata, metadata_options)
+            .map_err(map_metadata_error)?;
+        #[cfg(feature = "xattr")]
+        sync_xattrs_if_requested(
+            preserve_xattrs,
+            mode,
+            source,
+            destination,
+            true,
+            context.filter_program(),
+        )?;
+        #[cfg(feature = "acl")]
+        sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+
+        // Under fake-super, capture the would-be device's mode/uid/gid/rdev
+        // in the rsync.%stat xattr so the destination can be restored later.
+        // This is the read-side complement of `apply_ownership_via_fake_super`
+        // for the local-copy path, where we have a full `fs::Metadata` rather
+        // than a wire-protocol `FileEntry`.
+        // upstream: xattrs.c:set_stat_xattr() under am_root < 0
+        #[cfg(feature = "xattr")]
+        if metadata_options.fake_super_enabled() {
+            store_fake_super_for_local_metadata(destination, metadata)?;
+        }
+
+        context.record_hard_link(metadata, destination);
+        context.summary_mut().record_device();
+
+        if let Some(path) = &record_path {
+            let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+            let total_bytes = Some(metadata_snapshot.len());
+            context.record(LocalCopyRecord::new(
+                path.clone(),
+                LocalCopyAction::DeviceCopied,
+                0,
+                total_bytes,
+                Duration::default(),
+                Some(metadata_snapshot),
+            ));
+        }
+
+        context.register_progress();
+        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
     }
-    #[cfg(not(unix))]
-    {
-        // Windows / non-Unix: we can’t actually create a device node.
-        // Do nothing here - the rest (metadata + bookkeeping) still runs so the code compiles.
-    }
-
-    context.register_created_path(
-        destination,
-        CreatedEntryKind::Device,
-        destination_previously_existed,
-    );
-
-    apply_file_metadata_with_options(destination, metadata, metadata_options)
-        .map_err(map_metadata_error)?;
-    #[cfg(all(unix, feature = "xattr"))]
-    sync_xattrs_if_requested(
-        preserve_xattrs,
-        mode,
-        source,
-        destination,
-        true,
-        context.filter_program(),
-    )?;
-    #[cfg(all(any(unix, windows), feature = "acl"))]
-    sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
-
-    // Under fake-super, capture the would-be device's mode/uid/gid/rdev in
-    // the rsync.%stat xattr so the destination can be restored later. This
-    // is the read-side complement of `apply_ownership_via_fake_super` for
-    // the local-copy path, where we have a full `fs::Metadata` rather than
-    // a wire-protocol `FileEntry`.
-    // upstream: xattrs.c:set_stat_xattr() under am_root < 0
-    #[cfg(all(unix, feature = "xattr"))]
-    if metadata_options.fake_super_enabled() {
-        store_fake_super_for_local_metadata(destination, metadata)?;
-    }
-
-    context.record_hard_link(metadata, destination);
-    context.summary_mut().record_device();
-
-    if let Some(path) = &record_path {
-        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
-        let total_bytes = Some(metadata_snapshot.len());
-        context.record(LocalCopyRecord::new(
-            path.clone(),
-            LocalCopyAction::DeviceCopied,
-            0,
-            total_bytes,
-            Duration::default(),
-            Some(metadata_snapshot),
-        ));
-    }
-
-    context.register_progress();
-    remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
     Ok(())
+}
+
+/// Builds the WIND-2 skip-with-warn message for a device entry the Windows
+/// receiver cannot materialise. Exposed for regression tests so they can
+/// assert the wording without capturing stderr.
+// WIND-2: docs/design/windows-device-file-strategy.md
+#[cfg(not(unix))]
+pub(crate) fn format_skip_device_message(destination: &Path) -> String {
+    format!(
+        "skipping device entry \"{path}\": Windows targets cannot create device nodes [receiver]",
+        path = destination.display(),
+    )
 }
 
 /// Stores the would-be device/special metadata in the `rsync.%stat` xattr.

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -289,9 +289,33 @@ fn create_device_node_inner(
         .map_err(|error| MetadataError::new("create device", destination, error))
 }
 
+/// Emits the WIND-2 skip-with-warn diagnostic for a special-file entry
+/// the receiver cannot materialise on this target and returns `Ok(())` so
+/// the surrounding transfer continues with the next entry.
+///
+/// Mirrors the `xattr_stub::warn_xattr_unsupported` stderr convention used
+/// elsewhere in this crate for unsupported metadata operations.
+// WIND-2: skip-with-warn strategy for Windows device files.
+// docs/design/windows-device-file-strategy.md
+#[cfg(not(unix))]
+fn warn_skip_special(destination: &Path, kind_label: &'static str) {
+    eprintln!("{}", format_skip_special_message(destination, kind_label));
+}
+
+/// Builds the WIND-2 skip-with-warn message body so tests can assert the
+/// exact wording without capturing stderr.
+#[cfg(not(unix))]
+#[must_use]
+pub(crate) fn format_skip_special_message(destination: &Path, kind_label: &'static str) -> String {
+    format!(
+        "skipping {kind_label} \"{path}\": Windows targets cannot create device nodes [receiver]",
+        path = destination.display(),
+    )
+}
+
 #[cfg(not(unix))]
 fn create_fifo_inner(destination: &Path, _metadata: &fs::Metadata) -> Result<(), MetadataError> {
-    let _ = destination;
+    warn_skip_special(destination, "fifo entry");
     Ok(())
 }
 
@@ -300,7 +324,12 @@ fn create_device_node_inner(
     destination: &Path,
     _metadata: &fs::Metadata,
 ) -> Result<(), MetadataError> {
-    let _ = destination;
+    // `fs::FileType` on non-Unix targets cannot distinguish block vs
+    // character device or FIFO vs socket; the caller has already routed
+    // by entry kind, so we report the broadest accurate label and let the
+    // surrounding receiver layer refine wording when it knows more from
+    // the wire-protocol `FileEntry`.
+    warn_skip_special(destination, "device entry");
     Ok(())
 }
 
@@ -445,28 +474,57 @@ mod tests {
         );
     }
 
+    /// WIND-2 skip-with-warn: a FIFO request on a non-Unix target must
+    /// return `Ok(())`, must NOT create a destination inode, and the
+    /// diagnostic helper must surface the path and entry kind so operators
+    /// can see what was skipped.
     #[cfg(not(unix))]
     #[test]
-    fn create_fifo_noop_on_non_unix() {
+    fn create_fifo_skips_with_warn_on_non_unix() {
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
         fs::File::create(&source).expect("create source");
         let metadata = fs::metadata(&source).expect("metadata");
         let fifo_path = temp.path().join("fifo");
+
         let result = create_fifo(&fifo_path, &metadata);
-        assert!(result.is_ok());
+
+        assert!(result.is_ok(), "skip-with-warn must not surface an error");
+        assert!(
+            !fifo_path.exists(),
+            "skip path must not register a destination inode"
+        );
+
+        let message = format_skip_special_message(&fifo_path, "fifo entry");
+        assert!(message.contains("skipping fifo entry"));
+        assert!(message.contains("[receiver]"));
+        assert!(message.contains(&fifo_path.display().to_string()));
     }
 
+    /// WIND-2 skip-with-warn: a device request on a non-Unix target must
+    /// return `Ok(())`, must NOT create a destination inode, and the
+    /// diagnostic helper must identify it as a device entry.
     #[cfg(not(unix))]
     #[test]
-    fn create_device_node_noop_on_non_unix() {
+    fn create_device_node_skips_with_warn_on_non_unix() {
         let temp = tempfile::tempdir().expect("tempdir");
         let source = temp.path().join("source");
         fs::File::create(&source).expect("create source");
         let metadata = fs::metadata(&source).expect("metadata");
         let device_path = temp.path().join("device");
+
         let result = create_device_node(&device_path, &metadata);
-        assert!(result.is_ok());
+
+        assert!(result.is_ok(), "skip-with-warn must not surface an error");
+        assert!(
+            !device_path.exists(),
+            "skip path must not register a destination inode"
+        );
+
+        let message = format_skip_special_message(&device_path, "device entry");
+        assert!(message.contains("skipping device entry"));
+        assert!(message.contains("[receiver]"));
+        assert!(message.contains(&device_path.display().to_string()));
     }
 
     /// Under `--fake-super`, `create_fifo_with_fake_super` must never call

--- a/crates/metadata/tests/windows_special_skip_with_warn.rs
+++ b/crates/metadata/tests/windows_special_skip_with_warn.rs
@@ -1,0 +1,102 @@
+//! Regression coverage for the WIND-2 skip-with-warn strategy on Windows
+//! targets (WIND-3 implementation, WIND-4 test).
+//!
+//! Upstream rsync's `syscall.c:do_mknod()` materialises FIFOs, sockets, and
+//! device nodes via `mknod(2)` / `mkfifo(3)` / `bind(AF_UNIX)`. None of
+//! these are available on native (non-Cygwin) Windows, so the receiver
+//! cannot reproduce the source-side inode. Per
+//! `docs/design/windows-device-file-strategy.md` the documented behaviour
+//! is: emit a warning identifying the path and entry kind, leave the
+//! destination untouched, and return `Ok(())` so the surrounding transfer
+//! continues with the next entry rather than aborting or silently
+//! reporting success.
+//!
+//! Before WIND-3, the `cfg(not(unix))` arms of `create_fifo_inner` and
+//! `create_device_node_inner` were silent `Ok(())` no-ops with no
+//! diagnostic. This test pins the new contract:
+//!
+//! 1. The call returns `Ok(())`.
+//! 2. No destination inode is created.
+//! 3. A second call against the same path remains a no-op (idempotency).
+//!
+//! Message-text assertions live in `special.rs`'s in-crate test module
+//! where the `pub(crate)` formatting helper is reachable; this file
+//! covers the public-API behavioural contract.
+
+#![cfg(not(unix))]
+
+use std::fs;
+
+use metadata::{create_device_node, create_fifo};
+
+/// WIND-2 contract for FIFO entries on a non-Unix target.
+#[test]
+fn create_fifo_skips_without_writing_destination() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let source_path = temp.path().join("source");
+    fs::File::create(&source_path).expect("create source placeholder");
+    let metadata = fs::metadata(&source_path).expect("read source metadata");
+
+    let fifo_path = temp.path().join("would-be.fifo");
+    assert!(
+        !fifo_path.exists(),
+        "precondition: destination must not exist before the call",
+    );
+
+    create_fifo(&fifo_path, &metadata).expect("skip-with-warn returns Ok");
+
+    assert!(
+        !fifo_path.exists(),
+        "skip-with-warn must not register a destination inode",
+    );
+}
+
+/// WIND-2 contract for device entries on a non-Unix target.
+#[test]
+fn create_device_node_skips_without_writing_destination() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let source_path = temp.path().join("source");
+    fs::File::create(&source_path).expect("create source placeholder");
+    let metadata = fs::metadata(&source_path).expect("read source metadata");
+
+    let device_path = temp.path().join("would-be.dev");
+    assert!(
+        !device_path.exists(),
+        "precondition: destination must not exist before the call",
+    );
+
+    create_device_node(&device_path, &metadata).expect("skip-with-warn returns Ok");
+
+    assert!(
+        !device_path.exists(),
+        "skip-with-warn must not register a destination inode",
+    );
+}
+
+/// Repeated invocations against the same path must remain a no-op: nothing
+/// is created on the first call, nothing on subsequent calls. This guards
+/// against a future regression that, for example, caches the path and then
+/// writes a placeholder on the second invocation.
+#[test]
+fn skip_with_warn_is_idempotent_across_repeated_calls() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let source_path = temp.path().join("source");
+    fs::File::create(&source_path).expect("create source placeholder");
+    let metadata = fs::metadata(&source_path).expect("read source metadata");
+
+    let fifo_path = temp.path().join("repeated.fifo");
+    create_fifo(&fifo_path, &metadata).expect("first call returns Ok");
+    create_fifo(&fifo_path, &metadata).expect("second call returns Ok");
+    assert!(
+        !fifo_path.exists(),
+        "neither invocation may create a destination inode",
+    );
+
+    let device_path = temp.path().join("repeated.dev");
+    create_device_node(&device_path, &metadata).expect("first call returns Ok");
+    create_device_node(&device_path, &metadata).expect("second call returns Ok");
+    assert!(
+        !device_path.exists(),
+        "neither invocation may create a destination inode",
+    );
+}


### PR DESCRIPTION
## Summary

- Implements the WIND-2 [skip-with-warn strategy](../blob/master/docs/design/windows-device-file-strategy.md) for Windows device, FIFO, and socket entries (WIND-3) and ships the regression test (WIND-4).
- Replaces the silent `Ok(())` no-ops in `crates/metadata/src/special.rs` (`create_fifo_inner` / `create_device_node_inner` non-Unix arms) with a stderr warning identifying path and entry kind, matching the `xattr_stub::warn_xattr_unsupported` convention already used in this crate.
- Fixes the bookkeeping bug `crates/engine/src/local_copy/executor/special/device.rs` had on Windows, where it called `register_created_path(CreatedEntryKind::Device, ...)` and `apply_file_metadata_with_options(...)` against an inode that was never written. The non-Unix arm now early-returns with a `LocalCopyAction::SkippedNonRegular` record and the warning, leaving Unix behaviour fully intact.

## Behavioural contract pinned by the new test

`crates/metadata/tests/windows_special_skip_with_warn.rs` (gated on `#![cfg(not(unix))]`) asserts:

1. `create_fifo` / `create_device_node` return `Ok(())` on non-Unix targets.
2. No destination inode is created.
3. Repeated invocations against the same path remain a no-op (idempotent).

Message wording is asserted via the `pub(crate) format_skip_special_message` helper from the in-crate unit tests (`create_fifo_skips_with_warn_on_non_unix` / `create_device_node_skips_with_warn_on_non_unix`) so the integration test does not need stderr capture.

## Scope discipline

- Only the two `cfg(not(unix))` arms called out in the WIND-2 spec (`special.rs` + `device.rs`) are touched. The Unix paths are bit-for-bit unchanged.
- No new feature flag, no protocol change, no wire format change — WIND-2 is a receiver-local policy fix.
- No clippy waivers and no `#[allow(...)]` attributes were added.
- The `fifo.rs` executor has a parallel anti-pattern (creates an empty file + registers `CreatedEntryKind::Fifo` on non-Unix); that lives outside the WIND-3 scope this PR is targeting and is left for a follow-up.

## Test plan

- [ ] CI: fmt + clippy clean.
- [ ] CI: Windows nextest exercises `windows_special_skip_with_warn` integration tests and the new `create_*_skips_with_warn_on_non_unix` unit tests.
- [ ] CI: Linux + macOS nextest confirm Unix arms still pass (existing `create_fifo_applies_metadata_permissions`, `create_device_node_rejects_non_device_metadata`, `fake_super_replaces_*` tests).
- [ ] CI: musl + interop matrix unchanged.

Refs: docs/design/windows-device-file-strategy.md