### PR TITLE
feat(itemize): emit per-directory itemize rows on receiver creation (UTS-IT.14)

### DIFF
--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -35,11 +35,15 @@ impl ReceiverContext {
     ///
     /// - `receiver.c:693` - `dry_run` skips all filesystem modifications
     /// - `generator.c:1432-1500` - directory creation and metadata in `recv_generator()`
-    pub(in crate::receiver) fn create_directories(
+    /// - `generator.c:1480-1483` - `itemize()` is invoked once per directory entry,
+    ///   so a freshly mkdir'd dir emits `cd+++++++++ <name>/` and an existing one
+    ///   emits a metadata-only `.d ...` row gated by the standard significance check
+    pub(in crate::receiver) fn create_directories<W: crate::writer::MsgInfoSender + ?Sized>(
         &self,
         dest_dir: &Path,
         metadata_opts: &MetadataOptions,
         acl_cache: Option<&AclCache>,
+        writer: &mut W,
         #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> io::Result<Vec<(PathBuf, String)>> {
         // upstream: receiver.c:693 - dry_run skips all filesystem modifications
@@ -77,6 +81,12 @@ impl ReceiverContext {
 
         let mut failed_dir_paths: std::collections::HashSet<PathBuf> =
             std::collections::HashSet::new();
+        // Track whether each directory was freshly created (true) or already
+        // existed (false). Drives the iflags passed to `emit_itemize` so the
+        // receiver matches upstream `generator.c:1480-1483`: a new dir emits
+        // `cd+++++++++ <name>/`, an existing one emits a metadata-only row
+        // gated by the standard significance check.
+        let mut dir_was_new: Vec<bool> = Vec::with_capacity(dir_entries.len());
         // upstream: generator.c:1337-1340 - probe each new parent directory's
         // default POSIX ACL when !preserve_perms so dest_mode() folds the bits
         // in. The probe also drives the `DEBUG_GTE(ACL, 1)` emission in
@@ -97,7 +107,9 @@ impl ReceiverContext {
             // `relative_path` is only read on Unix (mkdirat fast path).
             #[cfg(not(unix))]
             let _ = relative_path;
-            if !dir_path.exists() {
+            let is_new = !dir_path.exists();
+            dir_was_new.push(is_new);
+            if is_new {
                 #[cfg(all(
                     feature = "acl",
                     any(target_os = "linux", target_os = "macos", target_os = "freebsd")
@@ -160,6 +172,40 @@ impl ReceiverContext {
                     }
                     return Err(e);
                 }
+            }
+        }
+
+        // upstream: generator.c:1480-1483 - emit per-directory itemize rows
+        // after the mkdir pass and before metadata application, so the row
+        // ordering matches upstream's recv_generator() pass over the flist.
+        // Skipped dirs (PermissionDenied during mkdir) do not emit a row.
+        // The `should_emit_itemize` gate avoids touching the writer when
+        // the client did not request itemize output (or the receiver runs
+        // in client mode, where the CLI front-end emits via local-copy
+        // records instead of MSG_INFO frames).
+        if self.should_emit_itemize() {
+            for ((idx, _, dir_path), is_new) in dir_entries.iter().zip(dir_was_new.iter()) {
+                if failed_dir_paths.contains(dir_path) {
+                    continue;
+                }
+                let entry = &self.file_list[*idx];
+                let iflags = if *is_new {
+                    // upstream: generator.c:1481 - new dir is itemize()'d with
+                    // statret < 0, which ORs ITEM_LOCAL_CHANGE | ITEM_IS_NEW.
+                    crate::generator::ItemFlags::from_raw(
+                        crate::generator::ItemFlags::ITEM_LOCAL_CHANGE
+                            | crate::generator::ItemFlags::ITEM_IS_NEW,
+                    )
+                } else {
+                    // upstream: generator.c:1482 - existing dir is itemize()'d
+                    // with statret == 0 and iflags == 0; emit_itemize's
+                    // standard gate then drops the row when nothing is
+                    // significant, while the root-dir compensation in
+                    // emit_itemize still fires `cd+++++++++ ./` when the
+                    // pre-flight mkdir created the destination root.
+                    crate::generator::ItemFlags::from_raw(0)
+                };
+                let _ = self.emit_itemize(writer, &iflags, entry);
             }
         }
 

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -46,6 +46,7 @@ impl ReceiverContext {
             &setup.dest_dir,
             &setup.metadata_opts,
             setup.acl_cache.as_deref(),
+            writer,
             #[cfg(unix)]
             setup.sandbox.as_deref(),
         )?;

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -70,6 +70,7 @@ impl ReceiverContext {
             &dest_dir,
             &metadata_opts,
             acl_cache.as_deref(),
+            writer,
             #[cfg(unix)]
             sandbox.as_deref(),
         )?;


### PR DESCRIPTION
## Summary

- Plumbs a `MsgInfoSender` writer into `ReceiverContext::create_directories` and emits `emit_itemize` once per directory entry after the mkdir pass, closing the audit gap surfaced by `docs/design/uts-it-flist-walk-audit.md`.
- Tracks `is_new` per entry at mkdir time so freshly created dirs render as `cd+++++++++ <name>/` (via `ITEM_LOCAL_CHANGE | ITEM_IS_NEW`) and pre-existing dirs pass `iflags == 0`, letting the standard significance gate suppress no-op rows and the existing root-dir compensation in `emit_itemize` still fire `cd+++++++++ ./`.
- Mirrors upstream `generator.c:1480-1483` where every directory entry in the flist walk emits an itemize line.

## Behavior gating

- `should_emit_itemize()` already requires server mode (daemon or SSH receiver) AND the client having requested `--itemize-changes`. Client-mode local copy is unchanged because the CLI front-end emits via `LocalCopyAction::DirectoryCreated` records, not MSG_INFO frames.
- Skipped dirs (`PermissionDenied` on mkdir) do not emit a row.
- Cross-platform parity: the new block is unconditional on the OS, so Windows behavior is identical to Unix at this site.

## Tests

- The CLI golden `itemize_initial_recursive_transfer_emits_dir_rows_for_each_subdir` in `crates/cli/src/frontend/tests/itemize_format_upstream.rs:513-565` already covers the local-copy emission path and remains live.
- Existing receiver unit tests in `crates/transfer/src/receiver/tests/symlinks_and_devices.rs` (`emit_itemize_directory_creation`, `emit_itemize_root_directory_emits_creation_glyph_when_iflags_zero`) lock in the per-directory glyph and root-dir compensation that this change now drives end-to-end from the receiver walk.

## Test plan

- [ ] CI: fmt+clippy
- [ ] CI: nextest (stable) full workspace
- [ ] CI: Windows, macOS, Linux musl (stable)
- [ ] CI: Interop suite against upstream rsync 3.0.9 / 3.1.3 / 3.4.1 / 3.4.2

## Upstream reference

- `generator.c:1480-1483` - per-directory `itemize()` call in `recv_generator()`.
- `generator.c:566-572` - `ITEM_IS_NEW` -> `cd+++++++++` glyph.
- `main.c:794-796` - `FLAG_DIR_CREATED` -> synthetic `statret < 0` for the root entry.