### PR TITLE
fix(transfer): clear clippy::manual_non_exhaustive on ServerWriter::Taken

### DIFF
--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -30,9 +30,10 @@ pub enum ServerWriter<W: Write> {
     Multiplex(MultiplexWriter<W>),
     /// Compressed+Multiplex mode - compress then multiplex.
     Compressed(CompressedWriter<MultiplexWriter<W>>),
-    /// Temporary state during in-place transformations.
-    /// Any operation on a Taken writer panics.
-    #[doc(hidden)]
+    /// Temporary sentinel state used during in-place transformations
+    /// (e.g. `mem::replace` in [`Self::activate_multiplex_inplace`] and
+    /// [`Self::finalize_compression`]). Any I/O operation while in this
+    /// state returns an `InvalidInput` error.
     Taken,
 }
 


### PR DESCRIPTION
## Summary

- `crates/transfer/src/writer/server.rs:36` — remove `#[doc(hidden)]` from the `Taken` variant
- Expand the doc comment to explain the runtime sentinel role for `mem::replace` in `activate_multiplex_inplace` / `finalize_compression`

## Why

`-D warnings` + `clippy::manual_non_exhaustive` was failing master CI:

```
error: this seems like a manual implementation of the non-exhaustive pattern
  --> crates/transfer/src/writer/server.rs:26:1
   ...
36 | |     Taken,
   | |_____^
```

The lint fires on the combination of `#[doc(hidden)]` + unit variant, mistaking the runtime sentinel for a non-exhaustive marker. The variant is genuinely used at runtime by the inplace transformation paths — it is NOT a non-exhaustive guard. Removing `#[doc(hidden)]` clears the lint without weakening sentinel semantics (the variant remains pub but its purpose is documented).

This blocks several open PRs (#6006, #6007, #6008) whose CI cells trip on this pre-existing master regression introduced by PR #5984.

## Test plan

- [ ] CI: `fmt + clippy` cell passes (workspace clippy with `-D warnings` and `--all-features`)
- [ ] CI: nextest stable passes (no behavior change since the variant is still public + named identically)
- [ ] Downstream PRs (#6006, #6007, #6008) re-run their CI green after this lands