### PR TITLE
test: assert cargo-lockfile-sync workflow shape (CIM-LOCKFILE-8)

### DIFF
--- a/.github/workflows/check-locked-flags.yml
+++ b/.github/workflows/check-locked-flags.yml
@@ -1,10 +1,18 @@
-# CIM-LOCKFILE-5: --locked flag regression guard.
+# CIM-LOCKFILE-5 / CIM-LOCKFILE-8: lockfile-machinery regression guards.
 #
 # Runs `tools/ci/check_locked_flags.sh` on every PR (and on push to
 # master) to assert that every cargo invocation in `.github/workflows/`
 # and `tools/ci/*.sh` that calls a gated subcommand (`build`, `check`,
 # `clippy`, `nextest run`, `run`, `test`) also passes `--locked`. The
 # rationale and allowlist live in the script itself.
+#
+# Also runs `tools/ci/check_cargo_lockfile_sync.sh` to assert the PR-side
+# Cargo.lock auto-sync workflow (`cargo-lockfile-sync.yml`) keeps its
+# load-bearing shape (correct trigger paths, `cargo update` step,
+# diff-detection step, conditional push-back, fork/bot guards). A drift
+# in that shape would silently stop dep-drift PRs from receiving an
+# auto-synced lockfile and resurface the original CIM-LOCKFILE failure
+# mode.
 
 name: Check --locked flags
 
@@ -38,3 +46,22 @@ jobs:
         # the matcher (false positives, false negatives, comment handling)
         # surfaces here instead of as a silent gap on a future PR.
         run: bash tools/ci/tests/test_check_locked_flags.sh
+
+      - name: Install PyYAML for workflow-shape gate
+        # ubuntu-latest already ships python3; install PyYAML so the
+        # cargo-lockfile-sync shape gate (CIM-LOCKFILE-8) can parse the
+        # workflow YAML. Pinned to a recent release that stays compatible
+        # with the runner's python3.
+        run: python3 -m pip install --quiet 'pyyaml>=6'
+
+      - name: Run check_cargo_lockfile_sync.sh
+        # CIM-LOCKFILE-8: assert cargo-lockfile-sync.yml still carries the
+        # load-bearing trigger paths, cargo update steps, diff-detection,
+        # conditional push, and fork/bot guards. See script comments.
+        run: bash tools/ci/check_cargo_lockfile_sync.sh
+
+      - name: Self-test check_cargo_lockfile_sync.sh
+        # Exercises the shape gate against mutated copies of the workflow
+        # so a regression that stops enforcing one of the assertions
+        # surfaces here.
+        run: bash tools/ci/tests/test_check_cargo_lockfile_sync.sh

--- a/tools/ci/check_cargo_lockfile_sync.sh
+++ b/tools/ci/check_cargo_lockfile_sync.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# CIM-LOCKFILE-8: shape assertion for the PR-side Cargo.lock auto-sync workflow.
+#
+# Why this exists
+# ---------------
+# `.github/workflows/cargo-lockfile-sync.yml` closes the gap between the
+# `fmt + clippy` gate (which auto-regenerates `Cargo.lock` offline so a
+# stale lockfile does not block CI) and the `--locked` workflows (interop,
+# parallel-determinism, MSRV). On every PR that touches a workspace
+# `Cargo.toml` it refreshes `Cargo.lock` and pushes the result back to the
+# PR branch.
+#
+# That workflow is load-bearing: if its `on.pull_request.paths` triggers,
+# `cargo update` step, or push-back commit shape regress, dep-drift PRs
+# silently stop receiving auto-sync and resurface the original CIM-LOCKFILE
+# failure mode (PRs blocked on `--locked` mismatches).
+#
+# Approach
+# --------
+# A full integration test that opens a synthetic dep-drift PR and asserts
+# the workflow ran is feasible but expensive (self-PR loop, requires repo
+# write tokens, races with normal CI). This gate takes the static-analysis
+# path instead: it parses `cargo-lockfile-sync.yml` and asserts every load-
+# bearing piece of its shape. A regression that drops the `Cargo.toml`
+# trigger path, the `cargo update` step, the diff detection, or the push-
+# back step fails the gate with a precise message.
+#
+# What it checks
+# --------------
+# 1. The workflow file exists and parses as valid YAML.
+# 2. `on.pull_request.paths` includes the root `Cargo.toml` and the
+#    `crates/**/Cargo.toml` glob (the two paths that drive dep drift in
+#    practice).
+# 3. The job runs `cargo update --workspace` (the refresh step).
+# 4. The job runs `cargo update --workspace --offline` (the offline
+#    validation step that catches lockfiles that no longer resolve).
+# 5. The job has a `git diff --quiet -- Cargo.lock` detection step that
+#    sets a `changed` output.
+# 6. The job has a conditional `git push` step that fires only when
+#    `changed == 'true'`.
+# 7. The workflow has `contents: write` permission (required to push
+#    back to the PR branch).
+# 8. The job gates on first-party PRs (`head.repo.full_name ==
+#    github.repository`) and skips `github-actions[bot]` author to avoid
+#    looping on the weekly cron PR's output.
+#
+# Usage
+# -----
+#   tools/ci/check_cargo_lockfile_sync.sh
+#
+# Test override
+# -------------
+#   OC_RSYNC_LOCKFILE_SYNC_WORKFLOW=/path/to/workflow.yml \
+#     tools/ci/check_cargo_lockfile_sync.sh
+# Replaces the production workflow path with a supplied file (used by the
+# self-test to feed in mutated fixtures).
+#
+# Exit codes
+#   0 - workflow shape matches every assertion.
+#   1 - one or more assertions failed; stdout names the missing piece.
+#   2 - environment problem (workflow file missing, python3 unavailable,
+#       PyYAML unavailable).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+WORKFLOW="${OC_RSYNC_LOCKFILE_SYNC_WORKFLOW:-${REPO_ROOT}/.github/workflows/cargo-lockfile-sync.yml}"
+
+if [[ ! -r "${WORKFLOW}" ]]; then
+    echo "ERROR: workflow file not readable: ${WORKFLOW}" >&2
+    exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required to parse the workflow YAML" >&2
+    exit 2
+fi
+
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
+    echo "ERROR: python3 PyYAML module is required (pip install pyyaml)" >&2
+    exit 2
+fi
+
+printf '=== CIM-LOCKFILE-8: cargo-lockfile-sync workflow shape gate ===\n'
+printf 'Checking: %s\n\n' "${WORKFLOW}"
+
+# All assertions live in a single python pass so we get a YAML parse once
+# and report every missing piece in one shot rather than failing on the
+# first mismatch. The script returns a non-zero exit if any check fails.
+python3 - "${WORKFLOW}" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    try:
+        doc = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        print(f"FAIL: workflow YAML did not parse: {exc}")
+        sys.exit(1)
+
+if not isinstance(doc, dict):
+    print("FAIL: workflow root is not a mapping")
+    sys.exit(1)
+
+failures = []
+
+def fail(msg):
+    failures.append(msg)
+    print(f"FAIL: {msg}")
+
+def ok(msg):
+    print(f"ok: {msg}")
+
+# PyYAML parses the bare `on:` key as the Python boolean True (YAML 1.1
+# "norway problem"). Accept either spelling so the gate keeps working if
+# the workflow is later rewritten with quoted "on":.
+on_block = doc.get("on", doc.get(True))
+if not isinstance(on_block, dict):
+    fail("`on:` block missing or not a mapping")
+    on_block = {}
+
+pr_block = on_block.get("pull_request")
+if not isinstance(pr_block, dict):
+    fail("`on.pull_request:` missing or not a mapping")
+    pr_block = {}
+
+paths = pr_block.get("paths") or []
+if not isinstance(paths, list):
+    fail("`on.pull_request.paths` is not a list")
+    paths = []
+
+required_paths = ["Cargo.toml", "crates/**/Cargo.toml"]
+for required in required_paths:
+    if required in paths:
+        ok(f"on.pull_request.paths includes {required!r}")
+    else:
+        fail(f"on.pull_request.paths missing required entry {required!r}")
+
+permissions = doc.get("permissions") or {}
+if isinstance(permissions, dict) and permissions.get("contents") == "write":
+    ok("permissions.contents == 'write'")
+else:
+    fail("permissions.contents must be 'write' to push back to PR branch")
+
+jobs = doc.get("jobs") or {}
+if not isinstance(jobs, dict) or not jobs:
+    fail("workflow has no jobs")
+    print()
+    sys.exit(1 if failures else 0)
+
+# The workflow has one job today; tolerate future renames by scanning all
+# jobs for the load-bearing pieces.
+all_steps = []
+job_if_clauses = []
+for name, job in jobs.items():
+    if not isinstance(job, dict):
+        continue
+    if "if" in job:
+        job_if_clauses.append(str(job["if"]))
+    steps = job.get("steps") or []
+    if isinstance(steps, list):
+        all_steps.extend(steps)
+
+def step_run_text(step):
+    if isinstance(step, dict):
+        run = step.get("run")
+        if isinstance(run, str):
+            return run
+    return ""
+
+run_blob = "\n".join(step_run_text(s) for s in all_steps)
+
+# Refresh step: cargo update --workspace must appear without --offline on
+# at least one logical line. Match by stripping --offline matches from the
+# blob and checking what remains still contains `cargo update --workspace`.
+def has_cargo_update_refresh(text):
+    for line in text.splitlines():
+        # A logical command line that runs cargo update --workspace and
+        # is NOT the --offline variant counts as the refresh step.
+        if "cargo update" in line and "--workspace" in line and "--offline" not in line:
+            return True
+    return False
+
+if has_cargo_update_refresh(run_blob):
+    ok("step runs `cargo update --workspace` (refresh)")
+else:
+    fail("no step runs `cargo update --workspace` (refresh)")
+
+if "cargo update" in run_blob and "--offline" in run_blob and "--workspace" in run_blob:
+    # Confirm the --offline appears on the same line as cargo update.
+    found = False
+    for line in run_blob.splitlines():
+        if "cargo update" in line and "--workspace" in line and "--offline" in line:
+            found = True
+            break
+    if found:
+        ok("step runs `cargo update --workspace --offline` (offline validation)")
+    else:
+        fail("no step runs `cargo update --workspace --offline` on a single command line")
+else:
+    fail("no step runs `cargo update --workspace --offline` (offline validation)")
+
+# Diff detection: a step must run `git diff --quiet -- Cargo.lock` and
+# emit a `changed` output to drive the conditional push step.
+diff_step = None
+for step in all_steps:
+    text = step_run_text(step)
+    if "git diff --quiet" in text and "Cargo.lock" in text and "changed=" in text:
+        diff_step = step
+        break
+
+if diff_step is not None:
+    ok("diff-detection step runs `git diff --quiet -- Cargo.lock` and sets `changed=` output")
+else:
+    fail("no step detects lockfile changes via `git diff --quiet -- Cargo.lock` + `changed=` output")
+
+# Conditional push step: must be gated on `changed == 'true'` from the
+# diff step and must call `git push` to the PR head ref.
+push_step = None
+for step in all_steps:
+    if not isinstance(step, dict):
+        continue
+    text = step_run_text(step)
+    if "git push" not in text:
+        continue
+    cond = str(step.get("if") or "")
+    if "changed" in cond and "true" in cond:
+        push_step = step
+        break
+
+if push_step is not None:
+    ok("push-back step is conditional on `changed == 'true'` and runs `git push`")
+else:
+    fail("no conditional `git push` step gated on the diff-detection `changed` output")
+
+# Author/repo guard: must short-circuit fork PRs (cannot push back) and
+# the weekly cron bot (would loop on its own output).
+job_if_blob = "\n".join(job_if_clauses)
+if "head.repo.full_name" in job_if_blob and "github.repository" in job_if_blob:
+    ok("job guards on first-party PRs (head.repo.full_name == github.repository)")
+else:
+    fail("job missing first-party PR guard (head.repo.full_name == github.repository)")
+
+if "github-actions[bot]" in job_if_blob:
+    ok("job skips `github-actions[bot]` author (weekly cron loop guard)")
+else:
+    fail("job missing `github-actions[bot]` author skip (weekly cron loop guard)")
+
+print()
+if failures:
+    print(f"FAILED: {len(failures)} assertion(s) did not hold.")
+    print("The cargo-lockfile-sync workflow shape has regressed; restore the")
+    print("missing piece(s) above so dep-drift PRs continue to receive an")
+    print("auto-synced Cargo.lock. See CONTRIBUTING.md > Cargo.lock maintenance.")
+    sys.exit(1)
+
+print("PASSED: cargo-lockfile-sync workflow shape is intact.")
+sys.exit(0)
+PY

--- a/tools/ci/tests/test_check_cargo_lockfile_sync.sh
+++ b/tools/ci/tests/test_check_cargo_lockfile_sync.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# test_check_cargo_lockfile_sync.sh - unit tests for
+# check_cargo_lockfile_sync.sh.
+#
+# Builds mutated copies of `.github/workflows/cargo-lockfile-sync.yml`
+# under a tempdir, points the gate at each one via
+# OC_RSYNC_LOCKFILE_SYNC_WORKFLOW, and asserts the expected exit code for
+# each case. This catches regressions in the gate's matcher (e.g., a
+# future refactor that silently stops requiring the diff-detection step,
+# or one that mis-classifies the offline validation step as the refresh
+# step).
+#
+# Each fixture starts from the real workflow and strips a single load-
+# bearing piece so we exercise one assertion failure at a time. A fixture
+# that fails to trigger the corresponding failure means the gate is no
+# longer enforcing that piece.
+
+set -uo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+target="${script_dir}/../check_cargo_lockfile_sync.sh"
+repo_root=$(cd "${script_dir}/../../.." && pwd)
+real_workflow="${repo_root}/.github/workflows/cargo-lockfile-sync.yml"
+
+if [[ ! -r "${target}" ]]; then
+    echo "FAIL: cannot locate check_cargo_lockfile_sync.sh at ${target}" >&2
+    exit 2
+fi
+
+if [[ ! -r "${real_workflow}" ]]; then
+    echo "FAIL: cannot locate workflow at ${real_workflow}" >&2
+    exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 unavailable" >&2
+    exit 0
+fi
+
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
+    echo "SKIP: python3 PyYAML unavailable" >&2
+    exit 0
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+failures=0
+case_count=0
+
+# Run the gate against a fixture workflow file and assert exit code.
+#
+# $1 - human-readable label
+# $2 - expected exit code (0 = pass, 1 = violation)
+# $3 - fixture workflow path
+run_case() {
+    local label="$1" expected="$2" fixture="$3"
+    case_count=$((case_count + 1))
+    OC_RSYNC_LOCKFILE_SYNC_WORKFLOW="${fixture}" \
+        bash "${target}" >"${tmp}/out" 2>"${tmp}/err"
+    local actual=$?
+    if [[ "${actual}" -ne "${expected}" ]]; then
+        echo "FAIL ${label}: expected exit ${expected}, got ${actual}" >&2
+        sed 's/^/  out: /' "${tmp}/out" >&2
+        sed 's/^/  err: /' "${tmp}/err" >&2
+        failures=$((failures + 1))
+    else
+        echo "ok ${label} (exit ${actual})"
+    fi
+}
+
+# Copy the real workflow into the fixture tempdir and apply a `sed`
+# mutation. The python helper makes it easy to surgically drop a key from
+# the YAML without having to maintain a separate fixture file per case.
+mutate_workflow() {
+    local out="$1"
+    shift
+    local script="$*"
+    python3 - "${real_workflow}" "${out}" <<PY
+import sys
+import yaml
+
+src, dst = sys.argv[1], sys.argv[2]
+with open(src, "r", encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh)
+
+${script}
+
+with open(dst, "w", encoding="utf-8") as fh:
+    yaml.safe_dump(doc, fh, sort_keys=False)
+PY
+}
+
+# -------- Case 1: the unmodified workflow passes.
+cp "${real_workflow}" "${tmp}/case1.yml"
+run_case "real workflow passes" 0 "${tmp}/case1.yml"
+
+# -------- Case 2: dropping the Cargo.toml pull_request path fails.
+mutate_workflow "${tmp}/case2.yml" "
+on_block = doc.get('on', doc.get(True))
+on_block['pull_request']['paths'] = [
+    p for p in on_block['pull_request']['paths']
+    if p not in ('Cargo.toml', 'crates/**/Cargo.toml')
+]
+"
+run_case "missing Cargo.toml + crates/** triggers fail" 1 "${tmp}/case2.yml"
+
+# -------- Case 3: dropping contents: write permission fails.
+mutate_workflow "${tmp}/case3.yml" "
+doc['permissions'] = {'contents': 'read'}
+"
+run_case "permissions.contents != 'write' fails" 1 "${tmp}/case3.yml"
+
+# -------- Case 4: removing the cargo update --workspace refresh fails.
+mutate_workflow "${tmp}/case4.yml" "
+job = next(iter(doc['jobs'].values()))
+job['steps'] = [
+    s for s in job['steps']
+    if not (
+        isinstance(s, dict)
+        and 'run' in s
+        and 'cargo update --workspace' in s['run']
+        and '--offline' not in s['run']
+    )
+]
+"
+run_case "removing cargo update --workspace refresh fails" 1 "${tmp}/case4.yml"
+
+# -------- Case 5: removing the offline validation step fails.
+mutate_workflow "${tmp}/case5.yml" "
+job = next(iter(doc['jobs'].values()))
+job['steps'] = [
+    s for s in job['steps']
+    if not (
+        isinstance(s, dict)
+        and 'run' in s
+        and 'cargo update' in s['run']
+        and '--offline' in s['run']
+    )
+]
+"
+run_case "removing cargo update --offline fails" 1 "${tmp}/case5.yml"
+
+# -------- Case 6: removing the diff-detection step fails.
+mutate_workflow "${tmp}/case6.yml" "
+job = next(iter(doc['jobs'].values()))
+job['steps'] = [
+    s for s in job['steps']
+    if not (
+        isinstance(s, dict)
+        and 'run' in s
+        and 'git diff --quiet' in s['run']
+        and 'Cargo.lock' in s['run']
+    )
+]
+"
+run_case "removing git diff detection fails" 1 "${tmp}/case6.yml"
+
+# -------- Case 7: removing the conditional push step fails.
+mutate_workflow "${tmp}/case7.yml" "
+job = next(iter(doc['jobs'].values()))
+job['steps'] = [
+    s for s in job['steps']
+    if not (
+        isinstance(s, dict)
+        and 'run' in s
+        and 'git push' in s['run']
+    )
+]
+"
+run_case "removing conditional git push fails" 1 "${tmp}/case7.yml"
+
+# -------- Case 8: dropping the first-party PR guard fails.
+mutate_workflow "${tmp}/case8.yml" "
+job = next(iter(doc['jobs'].values()))
+job.pop('if', None)
+"
+run_case "dropping first-party PR + bot-author guards fails" 1 "${tmp}/case8.yml"
+
+# -------- Case 9: a malformed YAML file is reported as a parse failure.
+echo ': : :' >"${tmp}/case9.yml"
+run_case "malformed YAML is rejected" 1 "${tmp}/case9.yml"
+
+# -------- Case 10: a missing workflow file exits with environment error.
+case_count=$((case_count + 1))
+OC_RSYNC_LOCKFILE_SYNC_WORKFLOW="${tmp}/does-not-exist.yml" \
+    bash "${target}" >"${tmp}/out" 2>"${tmp}/err"
+actual=$?
+if [[ "${actual}" -ne 2 ]]; then
+    echo "FAIL missing workflow should exit 2: got ${actual}" >&2
+    sed 's/^/  err: /' "${tmp}/err" >&2
+    failures=$((failures + 1))
+else
+    echo "ok missing workflow exits 2 (env error)"
+fi
+
+echo
+echo "ran ${case_count} case(s); ${failures} failure(s)"
+if [[ "${failures}" -ne 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Add `tools/ci/check_cargo_lockfile_sync.sh` (CIM-LOCKFILE-8): parses `.github/workflows/cargo-lockfile-sync.yml` and asserts every load-bearing piece of its shape - the `Cargo.toml` / `crates/**/Cargo.toml` `pull_request.paths` triggers, `contents: write` permission, the `cargo update --workspace` refresh step, the `cargo update --workspace --offline` validation step, the `git diff --quiet -- Cargo.lock` detection step, the conditional `git push` back-step, and the first-party PR + `github-actions[bot]` author guards.
- Add `tools/ci/tests/test_check_cargo_lockfile_sync.sh`: mutates the real workflow nine ways (one per assertion) and confirms the gate rejects each mutation; also asserts a malformed YAML and a missing workflow are surfaced with the right exit codes.
- Wire both into the existing `Check --locked flags` workflow alongside the CIM-LOCKFILE-5 gate, with a `pip install pyyaml` step.

## Why

The CIM-LOCKFILE-* series shipped a PR-side Cargo.lock auto-sync workflow that closes the gap between the `fmt + clippy` lockfile regeneration and the `--locked` workflows (interop, parallel-determinism, MSRV). That workflow is load-bearing: if its trigger paths, `cargo update` step, diff detection, or push-back step regress, dep-drift PRs silently stop receiving auto-sync and resurface the original CIM-LOCKFILE failure mode. This regression test pins the shape so a future refactor cannot break it unobserved.

Approach (a) - a self-PR loop opening a synthetic dep-drift PR - was rejected as expensive and racy. Approach (b) - static YAML shape gate plus self-test against mutated copies - exercises the same regression surface in one short CI job.

## Test plan

- [x] `bash tools/ci/check_cargo_lockfile_sync.sh` passes against the real workflow (9 assertions ok).
- [x] `bash tools/ci/tests/test_check_cargo_lockfile_sync.sh` exercises 10 mutated fixtures and confirms each load-bearing piece is independently enforced.
- [x] Existing `tools/ci/check_locked_flags.sh` + its self-test still pass.
- [ ] CI: `Check --locked flags` workflow runs both gates green.