### PR TITLE
fix(filters): apply directory-only descendants gate universally (not just Deletion)

### DIFF
--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -70,41 +70,54 @@ impl CompiledRule {
         }
 
         let mut descendant_patterns = HashSet::new();
-        // upstream: exclude.c::rule_matches() - excluding a directory excludes
+        // upstream: exclude.c:rule_matches() - excluding a directory excludes
         // its contents, but including a directory does NOT include its contents
-        // (they must match their own rules). Synthesise `pattern/**` descendant
-        // matchers unconditionally for Exclude/Protect/Risk so the receiver's
-        // single-path Deletion query (`allows_deletion`, traversal=false) sees
-        // a candidate like `bar/.filt` excluded by `- /bar`. UTS-V3.B L4 over-
-        // deleted `bar/.filt` because the directory-only unanchored wildcard
-        // suppression gate (PR #5749) was unconditional at compile time and
-        // also stripped descendants from the receiver's single-path API.
+        // (they must match their own rules).
         //
-        // The runtime `check_descendants = !traversal` gate in
-        // [`decision::FilterSetInner::decision_with_traversal`] (decision.rs:69)
-        // remains the suppression point for descendants under
-        // `Transfer/Deletion + Recursive traversal`. That mirrors upstream
-        // exclude.c::rule_matches() which has no descendant matching at all -
-        // descent control is the sender walk's responsibility.
+        // Anchored wildcard patterns (e.g., `/*`, `/*.txt`) must NOT generate
+        // descendant matchers because `*/**` would incorrectly match nested
+        // paths like `down/file.txt`. For these patterns, traversal control
+        // (the sender/generator skips excluded directories) handles exclusion.
         //
-        // Anchored wildcard patterns (e.g. `/*`) still skip descendant
-        // synthesis because `*/**` would match nested paths like
-        // `down/file.txt` for the single-path Deletion query, where the
-        // runtime gate cannot recover the upstream "directory-only wildcard"
-        // semantic. Regression for #5421.
+        // Anchored literal patterns (e.g., `/build`, `/target/`) still need
+        // `{core}/**` descendants so that paths like `build/output` are
+        // excluded when checked individually (e.g., by the receiver).
+        //
+        // Directory-only unanchored wildcard patterns (e.g., `foo/*/`,
+        // `**/node_modules/`) must ALSO suppress descendants. The wildcard's
+        // match set is decided per-directory at walk time, so pre-baking
+        // `foo/*/**` overreaches and excludes files inside subdirectories
+        // that a later include rule like `+ foo/s?b/` should keep. Upstream
+        // `exclude.c:rule_matches()` returns "no match" for a non-directory
+        // entry when the rule carries FILTRULE_DIRECTORY (line 938-939), so
+        // the file is included by default and the sender walk handles descent
+        // pruning by never entering the excluded directory. Pre-baked
+        // descendants would force an exclusion that upstream never produces
+        // on EITHER the Transfer (sender) or Deletion (receiver single-path)
+        // entry point. Regression for UTS-DD-exclude.3 (upstream `exclude` /
+        // `exclude-lsh` testsuite) and `complex_nested_patterns`. The
+        // dir-only suppression must fire for both contexts because
+        // `CompiledRule` is shared across them and upstream's rule_matches()
+        // returns "no match" for FILTRULE_DIRECTORY non-dir candidates
+        // regardless of which call site dispatched the query.
         let has_glob_wildcard =
             core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
         let slash_anchored = pattern.starts_with('/');
-        // Anchored wildcards (e.g. `/*`, `/*.txt`) keep the descendant
-        // suppression so `*/**` cannot match nested paths. Upstream relies
-        // on the sender walk pruning excluded directories rather than
-        // emitting a descendant rule; the runtime gate cannot reproduce
-        // that for the receiver's single-path Deletion query.
-        let suppress_descendants_for_anchored_wildcard = slash_anchored && has_glob_wildcard;
+        // Directory-only unanchored wildcard gate: the user wrote `foo/*/`
+        // (or any dir-only wildcard without a leading `/`). Upstream never
+        // synthesises a descendant rule for it; the sender's traversal
+        // pruning is the only exclusion mechanism and pre-baking
+        // `{core}/**` would steal precedence from a later include like
+        // `+ foo/s?b/`. Kept as an explicit predicate so the dir-only
+        // unanchored case is greppable and pinned by unit tests.
+        let is_directory_only_unanchored_wildcard =
+            directory_only && !slash_anchored && has_glob_wildcard;
+        let is_anchored_wildcard = slash_anchored && has_glob_wildcard;
+        let suppress_descendants = is_directory_only_unanchored_wildcard || is_anchored_wildcard;
         if matches!(
             action,
             FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
-        ) && !suppress_descendants_for_anchored_wildcard
+        ) && !suppress_descendants
         {
             descendant_patterns.insert(format!("{core_pattern}/**"));
             if !anchored && !has_double_star {
@@ -244,20 +257,19 @@ mod tests {
         );
     }
 
-    /// Verifies that `--exclude '*/'` (and other directory-only unanchored
-    /// wildcards) DO generate descendant matchers under the UTS-V3.B
-    /// "narrow-descendants" fix.
+    /// Verifies that `--exclude '*/'` (and other directory-only wildcards)
+    /// does NOT generate descendant matchers.
     ///
-    /// upstream: `exclude.c::rule_matches()` has no descendant matching at
-    /// all - descent control is the sender walk's responsibility. The
-    /// receiver's single-path Deletion query needs synthetic descendants to
-    /// see candidates like `foo/sub/.filt` excluded by `- foo/*/`. The
-    /// runtime `check_descendants = !traversal` gate in `decision.rs`
-    /// suppresses descendants during Recursive walks where the sender's
-    /// descent pruning already covers them, restoring upstream semantics on
-    /// that path.
+    /// upstream: `exclude.c:rule_matches()` line 938-939 returns "no match"
+    /// when the rule carries `FILTRULE_DIRECTORY` and the candidate is not
+    /// itself a directory. Pre-baking `*/**` (or `foo/*/**`) overreaches
+    /// because the wildcard's per-directory match set is decided at walk
+    /// time. The sender skips the directory subtree on a match; the
+    /// receiver consults only the user-written rule and so should NOT see
+    /// a synthetic descendant fire on a file under the matched directory.
+    /// Regression for UTS-DD-exclude.3 and `complex_nested_patterns`.
     #[test]
-    fn dir_only_wildcard_exclude_has_descendant_matchers() {
+    fn dir_only_wildcard_exclude_has_no_descendant_matchers() {
         for pattern in &[
             "*/",
             "foo/*/",
@@ -279,8 +291,8 @@ mod tests {
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
-                !compiled.descendant_matchers.is_empty(),
-                "directory-only wildcard pattern {pattern:?} must have descendant matchers post UTS-V3.B"
+                compiled.descendant_matchers.is_empty(),
+                "directory-only wildcard pattern {pattern:?} must not have descendant matchers"
             );
         }
     }
@@ -560,34 +572,32 @@ mod tests {
         );
     }
 
-    /// UTS-V3.B wire-byte parity: `foo/*/` is directory-only, unanchored,
-    /// and wildcard-bearing. Direct matchers cover the tail-matching that
-    /// upstream's `slash_handling = -1` `wildmatch_array` does over the
-    /// user-written pattern. Descendants now fire so the receiver's
-    /// single-path Deletion query can see files inside an excluded
-    /// directory; the runtime `check_descendants = !traversal` gate in
-    /// `decision.rs` suppresses them during Recursive walks.
+    /// UTS-DD-exclude.3 wire-byte parity: `foo/*/` is directory-only,
+    /// unanchored, and wildcard-bearing. The direct matcher set must
+    /// be exactly `{foo/*, **/foo/*}` (tail-matching for upstream's
+    /// `slash_handling = -1` `wildmatch_array` over the user-written
+    /// pattern). The descendant matcher set MUST be empty - upstream
+    /// emits no `foo/*/**` rule because `exclude.c:rule_matches()`
+    /// returns "no match" for FILTRULE_DIRECTORY against a non-dir
+    /// candidate, regardless of which decision context dispatched.
     #[test]
     fn dir_only_unanchored_wildcard_exact_matcher_set() {
         let compiled = make_exclude("foo/*/");
         assert_eq!(direct_pattern_strings(&compiled), vec!["**/foo/*", "foo/*"]);
-        assert_eq!(
-            descendant_pattern_strings(&compiled),
-            vec!["**/foo/*/**", "foo/*/**"],
+        assert!(
+            descendant_pattern_strings(&compiled).is_empty(),
+            "`foo/*/` must not synthesise descendant matchers (upstream FILTRULE_DIRECTORY semantic)"
         );
     }
 
-    /// UTS-V3.B wire-byte parity for `**/node_modules/`: leading `**`
-    /// already carries the recursive prefix, so direct stays
-    /// `{**/node_modules}` and the descendant is `**/node_modules/**`.
+    /// UTS-DD-exclude.3 wire-byte parity for `**/node_modules/`: leading
+    /// `**` already carries the recursive prefix, so direct stays
+    /// `{**/node_modules}` with no descendant `**/node_modules/**`.
     #[test]
     fn dir_only_unanchored_double_star_prefix_exact_matcher_set() {
         let compiled = make_exclude("**/node_modules/");
         assert_eq!(direct_pattern_strings(&compiled), vec!["**/node_modules"]);
-        assert_eq!(
-            descendant_pattern_strings(&compiled),
-            vec!["**/node_modules/**"],
-        );
+        assert!(descendant_pattern_strings(&compiled).is_empty());
     }
 
     /// UTS-DD-exclude.3 negative guard: a literal directory-only

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -39,20 +39,13 @@ impl FilterSetInner {
     /// When `traversal` is `true`, synthetic descendant matchers (the
     /// `pattern/**` matcher pre-compiled for anchored excludes like
     /// `- /bar`) are skipped because the traversal itself handles descendant
-    /// exclusion - this mirrors upstream's `exclude.c::rule_matches()` which
+    /// exclusion - this mirrors upstream's `exclude.c:rule_matches()` which
     /// has NO descendant matching at all. When `false`, descendants stay
     /// active so single-path API callers (e.g. `set.allows("build/x.bin")`
     /// after `- build/`) still see the expected exclusion without walking
     /// the tree.
     ///
-    /// UTS-V3.B "narrow-descendants" fix: `CompiledRule::new` now emits
-    /// `pattern/**` matchers unconditionally for Exclude/Protect/Risk (the
-    /// PR #5749 dir-only-unanchored-wildcard suppression gate was scoped to
-    /// the call site). The runtime gate below is the single suppression
-    /// point under `DecisionContext::Deletion + Recursive traversal`, so
-    /// synthetic descendants do not contribute to the "include" verdict on
-    /// a candidate-delete path that the user-written rules never matched.
-    /// upstream: exclude.c::rule_matches()
+    /// upstream: exclude.c:rule_matches()
     pub(crate) fn decision_with_traversal(
         &self,
         path: &Path,


### PR DESCRIPTION
## Summary

- Restores the pre-#5981 compile-time suppression of synthetic descendant matchers for directory-only unanchored wildcard patterns (e.g. `foo/*/`, `**/node_modules/`).
- Aligns the dir-only unanchored gate with upstream `exclude.c:rule_matches()` line 938-939, which returns "no match" universally for `FILTRULE_DIRECTORY` rules against a non-directory entry - no Transfer/Deletion distinction at that layer.
- Re-pins the wire-byte parity tests (`foo/*/` and `**/node_modules/` MUST have empty descendant sets).

## Root cause

PR #5981 ("narrow synthesised descendant matchers under deletion traversal") removed the compile-time `is_directory_only_unanchored_wildcard` suppression and relied solely on the runtime `check_descendants = !traversal` gate in `decision.rs`. That gate splits walk-with-pruning from single-path queries but does NOT split Transfer from Deletion. As a result, for both `set.allows(Path::new("node_modules/lodash"), false)` (Transfer single-path) and `set.allows_deletion(...)` (Deletion single-path), `**/node_modules/` synthesised `**/node_modules/**` and matched the non-directory `node_modules/lodash`, over-excluding it.

Upstream `exclude.c:rule_matches()` has no descendant matching at all - descent control belongs to the sender walk. Pre-baking `pattern/**` for a directory-only wildcard pattern produces an exclusion that upstream never produces on either entry point.

## Why this does not regress UTS-V3.B

The three regression tests PR #5981 added in `decision.rs` are preserved:

1. `deletion_include_bar_dir_does_not_force_include_bar_filt` - `+ /bar/` is an Include rule, so no descendants are synthesised regardless of the gate (the action filter blocks Include from getting descendants).
2. `deletion_include_foo_sub_dir_does_not_force_include_file1` - `+ /foo/s?b/` is Include, same as above.
3. `deletion_anchored_literal_exclude_descends_only_off_traversal` - `- /bar` is Exclude, anchored, with no wildcard. Neither `is_anchored_wildcard` nor `is_directory_only_unanchored_wildcard` fires, so descendants `bar/**` are synthesised. Single-path matches; recursive (`traversal=true`) skips them via the runtime gate.

None of those tests exercise the directory-only-unanchored-wildcard path that this PR re-suppresses.

## Fixes master CI

- `filters::edge_cases::complex_nested_patterns`
- `uts_dd_exclude_3_dir_only_unanchored::*` (4 tests)
- `compiled::tests::dir_only_unanchored_wildcard_exact_matcher_set`
- `compiled::tests::dir_only_unanchored_double_star_prefix_exact_matcher_set`

## Test plan

- [ ] nextest stable: `filters::edge_cases::complex_nested_patterns` passes
- [ ] nextest stable: `uts_dd_exclude_3_dir_only_unanchored::*` passes
- [ ] nextest stable: `filters::compiled::tests::dir_only_unanchored_wildcard_exact_matcher_set` passes
- [ ] nextest stable: `filters::decision::tests::deletion_*` (UTS-V3.B regression tests) still pass
- [ ] Linux musl + Windows + macOS nextest cells green
- [ ] Interop validation green (UTS-V3.B exclude-lsh leg L4)