### PR TITLE
fix(transfer): correct backup test assertion to include suffix

### DIFF
--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2829,7 +2829,7 @@ fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
     // `backed up $fn to .*/$fn$`.
     assert_eq!(notice.original, std::path::PathBuf::from("deep/name1"));
     assert!(
-        notice.backup.ends_with("deep/name1"),
+        notice.backup.ends_with("deep/name1~"),
         "backup path must end with the original relative path; got {:?}",
         notice.backup
     );


### PR DESCRIPTION
## Summary
Master CI was failing on every Linux nextest cell because the test `pipelined_backup_with_backup_dir_reports_destination_relative_paths` had an internally inconsistent assertion: line 2832 expected `notice.backup.ends_with("deep/name1")` but line 2838 expected the on-disk file at `deep/name1~`. PathBuf::ends_with does component-wise matching, and `name1~` does not match `name1`.

Production code correctly returns the full backup path with suffix per upstream `backup.c:352` semantics. Only the test assertion was wrong — fix it to expect `deep/name1~` matching what's actually on disk.

## Test plan
- [ ] CI nextest (stable/Windows/macOS/musl) goes green on this test
- [ ] No other tests regress