### PR TITLE
test(itemize): enable --checksum for `c` glyph assertions

### DIFF
--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -87,7 +87,12 @@ fn itemize_modified_file_shows_change_indicators() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let options = LocalCopyOptions::default().collect_events(true);
+    // upstream: generator.c:1942 - the position-2 `c` glyph fires only under
+    // `--checksum`; enable it here so `checksum_changed()` reflects the
+    // rewritten data.
+    let options = LocalCopyOptions::default()
+        .checksum(true)
+        .collect_events(true);
     let report = plan
         .execute_with_report(LocalCopyExecution::Apply, options)
         .expect("copy succeeds");
@@ -305,7 +310,10 @@ fn itemize_multiple_changes_shows_all_indicators() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
+    // upstream: generator.c:1942 - position-2 `c` is reserved for `--checksum`
+    // mode, so enable it here to assert the multi-indicator pattern.
     let options = LocalCopyOptions::default()
+        .checksum(true)
         .permissions(true)
         .times(true)
         .collect_events(true);
@@ -625,7 +633,10 @@ fn itemize_format_matches_upstream_for_changed_file() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
+    // upstream: generator.c:1942 - position-2 `c` is reserved for `--checksum`
+    // mode, so enable it here to exercise the `>f.st......` upstream pattern.
     let options = LocalCopyOptions::default()
+        .checksum(true)
         .times(true)
         .collect_events(true);
     let report = plan


### PR DESCRIPTION
## Summary

- PR #5815 gated the position-2 `c` glyph in itemize output behind `--checksum` mode to mirror upstream `generator.c:1942` (`if (always_checksum > 0) iflags |= ITEM_REPORT_CHANGE`).
- Three local-copy itemize tests still asserted `change_set.checksum_changed()` after a content rewrite without enabling `--checksum`, causing panics on master across multiple feature-flag CI cells (compression/linux, async/ubuntu+macos, tracing/ubuntu+macos).
- Enable `.checksum(true)` in the three affected tests so they exercise the upstream-faithful behavior instead of the pre-#5815 always-on path.

Tests touched:
- `itemize_modified_file_shows_change_indicators`
- `itemize_multiple_changes_shows_all_indicators`
- `itemize_format_matches_upstream_for_changed_file`

## Test plan

- [ ] CI fmt + clippy passes.
- [ ] nextest (stable) passes on Linux/macOS/Windows.
- [ ] Feature-flag matrix (compression, async, tracing) recovers to green.