### PR TITLE
fix(transfer): correct backup-dir test assertion to include suffix

### DIFF
--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -2829,8 +2829,8 @@ fn pipelined_backup_with_backup_dir_reports_destination_relative_paths() {
     // `backed up $fn to .*/$fn$`.
     assert_eq!(notice.original, std::path::PathBuf::from("deep/name1"));
     assert!(
-        notice.backup.ends_with("deep/name1"),
-        "backup path must end with the original relative path; got {:?}",
+        notice.backup.ends_with("deep/name1~"),
+        "backup path must end with the suffixed relative path; got {:?}",
         notice.backup
     );
 


### PR DESCRIPTION
## Summary
- `pipelined_backup_with_backup_dir_reports_destination_relative_paths` was failing on master across the `incremental-flist (linux)` and `io_uring (linux)` feature-flag cells, blocking all open PRs.
- The on-disk file assertion (line 2838) expects `deep/name1~` (with the explicit `~` suffix the test passes via `BackupConfig.suffix`), but the `notice.backup` PathBuf assertion (line 2832) expected `deep/name1` (no suffix). `PathBuf::ends_with` is component-wise, so `".../deep/name1~".ends_with("deep/name1")` is false.
- Production code is correct: `make_backup` calls `compute_backup_path`, which unconditionally appends the configured suffix (matching upstream `backup.c:74` `stringjoin(rel, backup_dir_remainder, fname, backup_suffix, NULL)`). The sibling test `pipelined_backup_default_suffix_returns_destination_relative_notice` already asserts the suffixed path (`payload.bin~`); this aligns the backup-dir variant.

## Test plan
- [ ] CI green on `fmt+clippy`, `nextest (stable)`, Windows, macOS, Linux musl
- [ ] `incremental-flist (linux)` and `io_uring (linux)` cells pass `pipelined_backup_with_backup_dir_reports_destination_relative_paths`