### PR TITLE
docs(transfer): fix broken intra-doc link in ServerWriter::Taken

### DIFF
--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -31,7 +31,7 @@ pub enum ServerWriter<W: Write> {
     /// Compressed+Multiplex mode - compress then multiplex.
     Compressed(CompressedWriter<MultiplexWriter<W>>),
     /// Temporary sentinel state used during in-place transformations
-    /// (e.g. `mem::replace` in [`Self::activate_multiplex_inplace`] and
+    /// (e.g. `mem::replace` in [`Self::activate_multiplex_in_place`] and
     /// [`Self::finalize_compression`]). Any I/O operation while in this
     /// state returns an `InvalidInput` error.
     Taken,


### PR DESCRIPTION
## Summary

The `Taken` variant doc in `crates/transfer/src/writer/server.rs:34` referenced `[\`Self::activate_multiplex_inplace\`]`, which does not exist. The actual method (line 137) is `activate_multiplex_in_place` (with an underscore between `in` and `place`).

This was tripping the rustdoc broken-intra-doc-links deny set in `crates/transfer/src/lib.rs:3` and failing the **Pages** workflow on master HEAD (`29d543ce9`).

Symptom from CI:

\`\`\`
error: unresolved link to \`Self::activate_multiplex_inplace\`
  --> crates/transfer/src/writer/server.rs:34:35
   |
34 |     /// (e.g. \`mem::replace\` in [\`Self::activate_multiplex_inplace\`] and
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the enum \`ServerWriter\` has no variant or associated item named \`activate_multiplex_inplace\`
\`\`\`

## Test plan

- [ ] Pages workflow turns green on this PR
- [ ] No regression in nextest / fmt+clippy / interop / upstream-testsuite