### PR TITLE
ci(lockfile-sync): accept pull_request_target trigger + step-level fork guard

### DIFF
--- a/tools/ci/check_cargo_lockfile_sync.sh
+++ b/tools/ci/check_cargo_lockfile_sync.sh
@@ -28,9 +28,11 @@
 # What it checks
 # --------------
 # 1. The workflow file exists and parses as valid YAML.
-# 2. `on.pull_request.paths` includes the root `Cargo.toml` and the
-#    `crates/**/Cargo.toml` glob (the two paths that drive dep drift in
-#    practice).
+# 2. `on.pull_request_target.paths` (or `on.pull_request.paths`) includes
+#    the root `Cargo.toml` and the `crates/**/Cargo.toml` glob (the two
+#    paths that drive dep drift in practice). `pull_request_target` is
+#    the production form because the workflow needs a write-capable
+#    GITHUB_TOKEN against fork PRs to post the fork-fallback comment.
 # 3. The job runs `cargo update --workspace` (the refresh step).
 # 4. The job runs `cargo update --workspace --offline` (the offline
 #    validation step that catches lockfiles that no longer resolve).
@@ -40,9 +42,11 @@
 #    `changed == 'true'`.
 # 7. The workflow has `contents: write` permission (required to push
 #    back to the PR branch).
-# 8. The job gates on first-party PRs (`head.repo.full_name ==
-#    github.repository`) and skips `github-actions[bot]` author to avoid
-#    looping on the weekly cron PR's output.
+# 8. The first-party PR guard is present at either the job level
+#    (`head.repo.full_name == github.repository`) or the step level
+#    (the push step is gated on `fork == 'false'`). The job also skips
+#    the `github-actions[bot]` author so the weekly cron PR does not
+#    loop on its own output.
 #
 # Usage
 # -----
@@ -122,22 +126,33 @@ if not isinstance(on_block, dict):
     fail("`on:` block missing or not a mapping")
     on_block = {}
 
-pr_block = on_block.get("pull_request")
+# Accept either `pull_request` or `pull_request_target` as the trigger.
+# The workflow uses `pull_request_target` so it can run with a write-capable
+# GITHUB_TOKEN against fork-originated PRs (needed to push back the
+# refreshed lockfile or post the fork-fallback comment); `pull_request`
+# was the historical form and is still accepted in case the security
+# posture is later relaxed.
+pr_block = on_block.get("pull_request_target")
+trigger_name = "pull_request_target"
 if not isinstance(pr_block, dict):
-    fail("`on.pull_request:` missing or not a mapping")
+    pr_block = on_block.get("pull_request")
+    trigger_name = "pull_request"
+if not isinstance(pr_block, dict):
+    fail("`on.pull_request_target:` (or `on.pull_request:`) missing or not a mapping")
     pr_block = {}
+    trigger_name = "pull_request_target"
 
 paths = pr_block.get("paths") or []
 if not isinstance(paths, list):
-    fail("`on.pull_request.paths` is not a list")
+    fail(f"`on.{trigger_name}.paths` is not a list")
     paths = []
 
 required_paths = ["Cargo.toml", "crates/**/Cargo.toml"]
 for required in required_paths:
     if required in paths:
-        ok(f"on.pull_request.paths includes {required!r}")
+        ok(f"on.{trigger_name}.paths includes {required!r}")
     else:
-        fail(f"on.pull_request.paths missing required entry {required!r}")
+        fail(f"on.{trigger_name}.paths missing required entry {required!r}")
 
 permissions = doc.get("permissions") or {}
 if isinstance(permissions, dict) and permissions.get("contents") == "write":
@@ -238,11 +253,32 @@ else:
 
 # Author/repo guard: must short-circuit fork PRs (cannot push back) and
 # the weekly cron bot (would loop on its own output).
+#
+# The first-party guard may live at the job level
+# (`head.repo.full_name == github.repository`) or at the step level via a
+# "Classify PR source" step whose `fork` output is then checked on the
+# push step (`steps.<id>.outputs.fork == 'false'`). The latter is the
+# production shape under `pull_request_target` because fork PRs still
+# need to run the workflow (to leave the fork-fallback comment) - they
+# just must not reach the push-back step.
 job_if_blob = "\n".join(job_if_clauses)
-if "head.repo.full_name" in job_if_blob and "github.repository" in job_if_blob:
+push_step_if = str(push_step.get("if") or "") if push_step else ""
+
+has_job_level_guard = (
+    "head.repo.full_name" in job_if_blob and "github.repository" in job_if_blob
+)
+has_step_level_guard = "fork" in push_step_if and "false" in push_step_if
+
+if has_job_level_guard:
     ok("job guards on first-party PRs (head.repo.full_name == github.repository)")
+elif has_step_level_guard:
+    ok("push-back step guards on first-party PRs (fork == 'false')")
 else:
-    fail("job missing first-party PR guard (head.repo.full_name == github.repository)")
+    fail(
+        "first-party PR guard missing: no job-level "
+        "`head.repo.full_name == github.repository` and no step-level "
+        "`fork == 'false'` condition on the push step"
+    )
 
 if "github-actions[bot]" in job_if_blob:
     ok("job skips `github-actions[bot]` author (weekly cron loop guard)")

--- a/tools/ci/tests/test_check_cargo_lockfile_sync.sh
+++ b/tools/ci/tests/test_check_cargo_lockfile_sync.sh
@@ -95,13 +95,19 @@ PY
 cp "${real_workflow}" "${tmp}/case1.yml"
 run_case "real workflow passes" 0 "${tmp}/case1.yml"
 
-# -------- Case 2: dropping the Cargo.toml pull_request path fails.
+# -------- Case 2: dropping the Cargo.toml trigger paths fails.
+# The workflow uses `pull_request_target` (production form) - strip the
+# Cargo.toml + crates/** entries from whichever trigger block carries
+# them so the assertion fires regardless of which form the workflow uses.
 mutate_workflow "${tmp}/case2.yml" "
 on_block = doc.get('on', doc.get(True))
-on_block['pull_request']['paths'] = [
-    p for p in on_block['pull_request']['paths']
-    if p not in ('Cargo.toml', 'crates/**/Cargo.toml')
-]
+for trigger_key in ('pull_request_target', 'pull_request'):
+    block = on_block.get(trigger_key) if isinstance(on_block, dict) else None
+    if isinstance(block, dict) and isinstance(block.get('paths'), list):
+        block['paths'] = [
+            p for p in block['paths']
+            if p not in ('Cargo.toml', 'crates/**/Cargo.toml')
+        ]
 "
 run_case "missing Cargo.toml + crates/** triggers fail" 1 "${tmp}/case2.yml"
 
@@ -170,12 +176,35 @@ job['steps'] = [
 "
 run_case "removing conditional git push fails" 1 "${tmp}/case7.yml"
 
-# -------- Case 8: dropping the first-party PR guard fails.
+# -------- Case 8: dropping the job-level if (bot-author guard) fails.
+# When the workflow uses pull_request_target with step-level fork
+# classification, the first-party guard lives on the push step, but the
+# bot-author skip still has to live at the job level. Stripping the
+# job-level `if:` removes the bot-author guard and must fail.
 mutate_workflow "${tmp}/case8.yml" "
 job = next(iter(doc['jobs'].values()))
 job.pop('if', None)
 "
-run_case "dropping first-party PR + bot-author guards fails" 1 "${tmp}/case8.yml"
+run_case "dropping job-level bot-author guard fails" 1 "${tmp}/case8.yml"
+
+# -------- Case 11: dropping the step-level fork guard on the push step
+# also fails when the job-level if does not carry a first-party check.
+# This exercises the production shape (pull_request_target + step-level
+# fork classification).
+mutate_workflow "${tmp}/case11.yml" "
+job = next(iter(doc['jobs'].values()))
+for step in job.get('steps') or []:
+    if not isinstance(step, dict):
+        continue
+    run_text = step.get('run') if isinstance(step.get('run'), str) else ''
+    if 'git push' in run_text:
+        cond = str(step.get('if') or '')
+        # Strip any reference to a fork classification so neither job
+        # nor step carries a first-party guard.
+        if 'fork' in cond:
+            step['if'] = \"steps.diff.outputs.changed == 'true'\"
+"
+run_case "dropping step-level fork guard on push step fails" 1 "${tmp}/case11.yml"
 
 # -------- Case 9: a malformed YAML file is reported as a parse failure.
 echo ': : :' >"${tmp}/case9.yml"


### PR DESCRIPTION
## Summary

- CIM-LOCKFILE-7 (commit 09373b67e, PR #6011) switched `cargo-lockfile-sync.yml` from `on.pull_request:` to `on.pull_request_target:` so fork PRs run with a write-capable `GITHUB_TOKEN`. CIM-LOCKFILE-8 (commit 9bdc709d0, PR #6012) landed a shape gate that still asserts the older shape, so master is red on `bash tools/ci/check_cargo_lockfile_sync.sh`.
- Update the gate to accept either trigger form (`pull_request_target` preferred, `pull_request` accepted for backwards compat) and either first-party guard placement (job-level `head.repo.full_name == github.repository`, or step-level `fork == 'false'` on the push step).
- Extend the self-test: case 2 now mutates whichever trigger form is present; case 8 keeps the bot-author skip assertion (now isolated from fork classification); new case 11 strips the step-level fork guard from the push step and asserts the gate rejects a workflow with no first-party guard at all.

## Test plan

- [x] `bash tools/ci/check_cargo_lockfile_sync.sh` passes locally against the current production workflow (`pull_request_target` + step-level fork guard).
- [x] `bash tools/ci/tests/test_check_cargo_lockfile_sync.sh` reports `ran 11 case(s); 0 failure(s)` (case 1 passes; cases 2-11 fail with exit 1 as expected).
- [ ] CI `Check --locked flags` workflow turns green on this PR (the same job is what was red on master HEAD).