### PR TITLE
test(cli): pass --recursive to recurse-default parity tests

### DIFF
--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -2195,6 +2195,12 @@ fn parity_verbose_v3_produces_output_with_debug_info() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-vvv"),
+        // upstream recurse defaults to 0 (options.c:112); a trailing-slash
+        // directory operand is "skipping directory ." without -r/-d, so it
+        // transfers nothing. Pass --recursive so the top-level file is
+        // actually enumerated and the verbose listing has something to show,
+        // mirroring upstream `rsync -vvv -r src/ dst`.
+        OsString::from("--recursive"),
         src_operand,
         dest_dir.into_os_string(),
     ]);
@@ -2204,7 +2210,7 @@ fn parity_verbose_v3_produces_output_with_debug_info() {
     let err = String::from_utf8(stderr).expect("utf8 stderr");
     let combined = format!("{out}{err}");
 
-    // At -vvv, file listing should still be present
+    // At -vvv with recursion, the transferred file is listed by name.
     assert!(
         combined.contains("debug.txt"),
         "verbose level 3 should list transferred files:\n{combined}"

--- a/crates/cli/src/frontend/tests/tracing_integration.rs
+++ b/crates/cli/src/frontend/tests/tracing_integration.rs
@@ -180,6 +180,12 @@ fn info_progress2_shows_overall_progress_during_transfer() {
     let (code, stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--info=progress2"),
+        // upstream recurse defaults to 0 (options.c:112); a trailing-slash
+        // directory operand is "skipping directory ." without -r/-d, so it
+        // transfers nothing and progress2 has no files to count. Pass
+        // --recursive so the directory is enumerated, mirroring upstream
+        // `rsync --info=progress2 -r src/ dst`.
+        OsString::from("--recursive"),
         src_operand,
         dest_dir.into_os_string(),
     ]);

--- a/crates/cli/src/frontend/tests/transfer_request_with_cvs.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_cvs.rs
@@ -22,7 +22,12 @@ fn transfer_request_with_cvs_exclude_skips_default_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
+        // without -r/-d is "skipping directory" and transfers nothing. Pass
+        // --recursive so the tree is enumerated and --cvs-exclude filtering is
+        // actually exercised, mirroring upstream `rsync -rC src dst`.
         OsString::from("--cvs-exclude"),
+        OsString::from("--recursive"),
         source_root.into_os_string(),
         dest_root.clone().into_os_string(),
     ]);
@@ -56,7 +61,12 @@ fn transfer_request_with_cvs_exclude_respects_cvsignore_files() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
+        // without -r/-d is "skipping directory" and transfers nothing. Pass
+        // --recursive so the tree is enumerated and --cvs-exclude filtering is
+        // actually exercised, mirroring upstream `rsync -rC src dst`.
         OsString::from("--cvs-exclude"),
+        OsString::from("--recursive"),
         source_root.into_os_string(),
         dest_root.clone().into_os_string(),
     ]);
@@ -88,7 +98,12 @@ fn transfer_request_with_cvs_exclude_respects_cvsignore_env() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
+        // without -r/-d is "skipping directory" and transfers nothing. Pass
+        // --recursive so the tree is enumerated and --cvs-exclude filtering is
+        // actually exercised, mirroring upstream `rsync -rC src dst`.
         OsString::from("--cvs-exclude"),
+        OsString::from("--recursive"),
         source_root.into_os_string(),
         dest_root.clone().into_os_string(),
     ]);

--- a/crates/cli/src/frontend/tests/transfer_request_with_delete.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_delete.rs
@@ -20,7 +20,11 @@ fn transfer_request_with_delete_excluded_prunes_filtered_entries() {
         OsString::from(RSYNC),
         OsString::from("--delete-excluded"),
         OsString::from("--exclude=*.log"),
-        OsString::from("--dirs"), // Mirror upstream: --delete requires --recursive or --dirs
+        // upstream recurse defaults to 0 (options.c:112); a non-trailing-slash
+        // directory operand under --dirs is added without descending, so its
+        // children never transfer. Use --recursive to walk source/ and satisfy
+        // --delete's "needs -r or -d" requirement, mirroring upstream.
+        OsString::from("--recursive"),
         source_root.into_os_string(),
         dest_root.clone().into_os_string(),
     ]);

--- a/crates/cli/src/frontend/tests/transfer_request_with_exclude.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_exclude.rs
@@ -18,6 +18,10 @@ fn transfer_request_with_exclude_from_skips_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
+        // without -r transfers nothing. --recursive walks source/ so the
+        // exclude rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--exclude-from"),
         exclude_file.as_os_str().to_os_string(),
         source_root.into_os_string(),
@@ -48,6 +52,10 @@ fn transfer_request_with_exclude_from_stdin_skips_patterns() {
     super::set_filter_stdin_input(b"*.tmp\n".to_vec());
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // upstream recurse defaults to 0 (options.c:112); a directory operand
+        // without -r transfers nothing. --recursive walks source/ so the
+        // exclude rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--exclude-from"),
         OsString::from("-"),
         source_root.into_os_string(),

--- a/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_filter.rs
@@ -15,6 +15,9 @@ fn transfer_request_with_filter_excludes_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         OsString::from("- *.tmp"),
         source_root.into_os_string(),
@@ -44,6 +47,9 @@ fn transfer_request_with_filter_clear_resets_rules() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         OsString::from("- *.tmp"),
         OsString::from("--filter"),
@@ -80,6 +86,9 @@ fn transfer_request_with_filter_merge_applies_rules() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         filter_arg,
         source_root.into_os_string(),
@@ -115,6 +124,9 @@ fn transfer_request_with_filter_merge_clear_resets_rules() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         filter_arg,
         source_root.into_os_string(),
@@ -217,6 +229,9 @@ fn transfer_request_with_filter_merge_bang_preserves_parent_cli_rule() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         OsString::from("- *.tmp"),
         OsString::from("--filter"),
@@ -262,6 +277,9 @@ fn transfer_request_with_filter_nested_merge_bang_preserves_outer_scope() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         merge_arg,
         source_root.into_os_string(),
@@ -299,6 +317,9 @@ fn transfer_request_with_exclude_from_bang_preserves_parent_cli_rule() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // filter rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--filter"),
         OsString::from("- *.tmp"),
         OsString::from("--exclude-from"),
@@ -343,6 +364,9 @@ fn transfer_request_with_cvsignore_bang_preserves_default_cvs_patterns() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); -r walks source/ so the
+        // cvs-exclude rules are actually exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--cvs-exclude"),
         source_root.into_os_string(),
         dest_root.clone().into_os_string(),

--- a/crates/cli/src/frontend/tests/transfer_request_with_include.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_include.rs
@@ -52,6 +52,10 @@ fn transfer_request_with_include_from_reinstate_patterns() {
     // With first-match-wins, --include-from must come before --exclude
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // upstream recurse defaults to 0 (options.c:112); keep/ is a subdir, so
+        // without -r nothing under it transfers. --recursive walks the tree and
+        // lets the include/exclude rules be exercised, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("--include-from"),
         include_file.as_os_str().to_os_string(),
         OsString::from("--exclude"),

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -144,6 +144,10 @@ fn level_1_lists_multiple_transferred_files() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); a trailing-slash directory
+        // without -r is "skipping directory ." and lists nothing. Pass -r so
+        // the files transfer and -v lists them, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("-v"),
         source_operand,
         dest_dir.into_os_string(),
@@ -419,6 +423,10 @@ fn verbose_with_dry_run_lists_files() {
 
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
+        // recurse defaults to 0 (options.c:112); a trailing-slash directory
+        // without -r is "skipping directory ." and lists nothing. Pass -r so
+        // the files transfer and -v lists them, mirroring upstream.
+        OsString::from("--recursive"),
         OsString::from("-nv"),
         source_operand,
         dest_dir.clone().into_os_string(),


### PR DESCRIPTION
After upstream's recurse default (recurse=0, options.c:112), a trailing-slash directory operand without -r/-d is "skipping directory ." and transfers nothing (flist.c:2416). Two CLI parity tests still invoked oc-rsync on a trailing-slash source directory without --recursive and asserted on transferred output:

- `parity_verbose_v3_produces_output_with_debug_info` (output_parity.rs) — asserted `debug.txt` appears in the -vvv listing.
- `info_progress2_shows_overall_progress_during_transfer` (tracing_integration.rs) — asserted the `to-chk=` progress counter appears.

Both now correctly produce an empty transfer, so the assertions fail. Pass --recursive so the directory is enumerated, mirroring upstream `rsync -vvv -r src/ dst` and `rsync --info=progress2 -r src/ dst`. The sibling test `verbose_with_recursive_lists_directory_structure` already uses -rv and was unaffected.

Test-only change.