### PR TITLE
test(fuzz): model ancestor-directory exclusion in filter differential harnesses

### DIFF
--- a/fuzz/fuzz_targets/filter_differential.rs
+++ b/fuzz/fuzz_targets/filter_differential.rs
@@ -472,6 +472,35 @@ fn upstream_verdict(
     Some(included)
 }
 
+/// Model the recursive-walk verdict that upstream's `--recursive --list-only`
+/// reports for a leaf path.
+///
+/// A deep entry is listed only if every ancestor directory is also included:
+/// upstream never descends into an excluded directory, so a leaf under an
+/// excluded parent is absent from the listing even when no rule matches the
+/// leaf's full path. oc-rsync's `FilterSet::allows` is traversal-driven by the
+/// same contract (it does not match descendants of excluded dirs; see
+/// `filters::chain::FilterChain::allows`), so the differential harness must
+/// replicate the ancestor walk to compare like with like.
+fn oc_walk_allows(oc_set: &FilterSet, rel_path: &str, is_dir: bool) -> bool {
+    let components: Vec<&str> = rel_path.split('/').filter(|s| !s.is_empty()).collect();
+    let mut prefix = String::new();
+    for (idx, component) in components.iter().enumerate() {
+        if idx > 0 {
+            prefix.push('/');
+        }
+        prefix.push_str(component);
+        let is_leaf = idx + 1 == components.len();
+        // Ancestor components are always directories; only the leaf carries the
+        // caller's is_dir flag.
+        let component_is_dir = if is_leaf { is_dir } else { true };
+        if !oc_set.allows(Path::new(&prefix), component_is_dir) {
+            return false;
+        }
+    }
+    true
+}
+
 fn run_one(input: Input) {
     if input.rules.is_empty() || input.rules.len() > MAX_RULES {
         return;
@@ -495,7 +524,7 @@ fn run_one(input: Input) {
         Err(_) => return,
     };
 
-    let oc_verdict = oc_set.allows(Path::new(&rel_path), input.is_dir);
+    let oc_verdict = oc_walk_allows(&oc_set, &rel_path, input.is_dir);
 
     // The upstream probe only runs when a real rsync is reachable. Without
     // it, we still exercise the oc-rsync side, which guards against panics

--- a/fuzz/fuzz_targets/filter_rules_vs_upstream.rs
+++ b/fuzz/fuzz_targets/filter_rules_vs_upstream.rs
@@ -300,6 +300,36 @@ fn upstream_verdict(
     Some(included)
 }
 
+/// Model the recursive-walk verdict that upstream's `--recursive --list-only`
+/// reports for a leaf path.
+///
+/// A deep entry is listed only if every ancestor directory is also included:
+/// upstream never descends into an excluded directory, so a leaf under an
+/// excluded parent is absent from the listing even when no rule matches the
+/// leaf's full path. oc-rsync's `FilterSet::allows` is traversal-driven by the
+/// same contract (it does not match descendants of excluded dirs; see
+/// `filters::chain::FilterChain::allows`), so this harness must replicate the
+/// ancestor walk to compare like with like.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn oc_walk_allows(oc_set: &FilterSet, rel_path: &str, is_dir: bool) -> bool {
+    let components: Vec<&str> = rel_path.split('/').filter(|s| !s.is_empty()).collect();
+    let mut prefix = String::new();
+    for (idx, component) in components.iter().enumerate() {
+        if idx > 0 {
+            prefix.push('/');
+        }
+        prefix.push_str(component);
+        let is_leaf = idx + 1 == components.len();
+        // Ancestor components are always directories; only the leaf carries the
+        // caller's is_dir flag.
+        let component_is_dir = if is_leaf { is_dir } else { true };
+        if !oc_set.allows(Path::new(&prefix), component_is_dir) {
+            return false;
+        }
+    }
+    true
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn run_one(input: Input) {
     if input.rules.is_empty() || input.rules.len() > MAX_RULES {
@@ -321,7 +351,7 @@ fn run_one(input: Input) {
         Err(_) => return,
     };
 
-    let oc_verdict = oc_set.allows(Path::new(&rel_path), input.is_dir);
+    let oc_verdict = oc_walk_allows(&oc_set, &rel_path, input.is_dir);
 
     let Some(rsync_bin) = upstream_binary() else {
         return;


### PR DESCRIPTION
## Summary

The overnight Filter Fuzzer found two divergences where oc-rsync includes a path upstream excludes:
- `filter_rules_vs_upstream`: rule `- /*`, path `w/-y` → `oc=true upstream=false`
- `filter_differential`: pattern `???` (matches the 3-char dir `ggg`), path `ggg/D` → `oc=true upstream=false`

Both are the **same class**: a leaf whose ancestor directory is excluded.

## Root cause

The harnesses compared a single-leaf `FilterSet::allows()` verdict against upstream rsync's `--recursive --list-only` output. That listing reflects the recursive walk — upstream never descends into an excluded directory, so a leaf under an excluded parent is absent even when no rule matches the leaf's full path.

oc-rsync's `FilterSet::allows` is traversal-driven by the **same contract** (documented at `filters::chain::FilterChain::allows`, mirroring upstream `exclude.c:rule_matches()` which has no descendant matching). In a real transfer the generator walks top-down and never queries a descendant of an excluded directory, so `allows("w/-y")` returning `true` is correct by design. The fuzz harnesses were the only callers querying a deep leaf directly, without replicating the walk's ancestor short-circuit.

## Fix

Add `oc_walk_allows()` to both targets: a leaf is allowed only when every ancestor directory is also allowed, matching the recursive descent both engines implement. This is a **test-harness correctness fix** — production filter behavior is unchanged. It removes the false divergence the fuzzer reported.