### PR TITLE
fix(checksums): drop unused mut on Windows signature File binding

### DIFF
--- a/crates/checksums/src/parallel/files.rs
+++ b/crates/checksums/src/parallel/files.rs
@@ -347,7 +347,13 @@ where
     D::Seed: Default,
 {
     let result = (|| -> io::Result<SignatureComputeResult<D::Digest>> {
+        // Unix mutates `file` in the streaming read loop below; Windows only
+        // reads its metadata before shadowing it with WindowsChunkedReader, so
+        // `mut` there would be flagged unused under -D unused-mut.
+        #[cfg(unix)]
         let mut file = File::open(path)?;
+        #[cfg(windows)]
+        let file = File::open(path)?;
         let metadata = file.metadata()?;
         let size = metadata.len();
         let estimated_blocks = (size as usize).div_ceil(block_size);


### PR DESCRIPTION
## Summary

The `Windows nightly daemon` workflow fails to build the daemon crate:

```
error: variable does not need to be mutable
   --> crates\checksums\src\parallel\files.rs:350:13
    |
350 |         let mut file = File::open(path)?;
    |             ----^^^^
    = note: `-D unused-mut` implied by `-D warnings`
```

## Root cause

In `compute_file_signatures_internal`, the std `File` opened at the top is mutated on Unix by the streaming `file.read_exact()` loop, so it needs `mut`. On Windows that same binding is only read for `file.metadata()` before being shadowed by the bounded-RSS `WindowsChunkedReader` (WIN-S.LAND.1.b series), so `mut` is unused and trips `-D unused-mut`.

## Fix

cfg-split the binding: `mut` only on the Unix path where the read loop mutates it; an immutable binding on Windows where only `.metadata()` is read. No `#[allow]` waiver. `unix` + `windows` cover every build target in the CI matrix (Linux/macOS/musl + Windows).

## Verification

Local `rustfmt --edition 2024` clean. Build/clippy/test left to CI; this is a Windows-only build break that the `Windows nightly daemon` cell will confirm.