### PR TITLE
fix(itemize): enable --checksum for size-change c-glyph assertion

### DIFF
--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -467,7 +467,12 @@ fn itemize_size_change_detected_correctly() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
+    // The position-2 `c` glyph (ITEM_REPORT_CHANGE) only fires under
+    // --checksum (upstream: generator.c:1929 - `if (always_checksum > 0)
+    // iflags |= ITEM_REPORT_CHANGE`), so enable checksum mode to assert
+    // `checksum_changed()` below.
     let options = LocalCopyOptions::default()
+        .checksum(true)
         .times(true)
         .collect_events(true);
     let report = plan


### PR DESCRIPTION
## Root cause

`itemize_size_change_detected_correctly` in `crates/engine/src/local_copy/tests/itemize_changes.rs` panicked at the `assert!(change_set.checksum_changed())` line under the `--all-features` build.

PR #5815 gated the position-2 `c` glyph (`ITEM_REPORT_CHANGE`) behind `--checksum` mode to match upstream rsync semantics:

> `generator.c:1929` - `if (always_checksum > 0) iflags |= ITEM_REPORT_CHANGE`

When a regular file is transferred without `--checksum`, position 2 stays `.` even though the content was rewritten. The follow-up PR #6018 realigned three local-copy itemize tests with this gating by adding `.checksum(true)`, but missed this fourth case, which still asserted `checksum_changed()` after a content rewrite without enabling checksum mode.

## Fix

Add `.checksum(true)` to the test options, mirroring #6018. The `size_changed()` assertion is unaffected (size drift is reported independently of `--checksum`); only the `c` glyph requires checksum mode. This realigns the test with the upstream-faithful gating rather than the pre-#5815 always-on behavior.

## Verification

- `cargo nextest run -p engine --all-features -E 'test(itemize_size_change_detected_correctly)'` passes (1 passed).
- `cargo nextest run -p engine --all-features -E 'test(itemize)'` passes (16 passed, 0 failed).
- `cargo fmt --all` clean.