### PR TITLE
fix(engine): compare mtime at whole-second granularity in quick check

### DIFF
--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -180,13 +180,45 @@ pub(crate) fn should_skip_copy(params: CopyComparison<'_>) -> bool {
     }
 }
 
+/// Returns the whole-second UNIX timestamp for `time`, discarding any
+/// sub-second component.
+///
+/// Floors toward negative infinity so pre-epoch timestamps map to the same
+/// second regardless of their fractional part, mirroring the `time_t`
+/// truncation upstream applies before comparing modification times.
+fn unix_seconds(time: SystemTime) -> i64 {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(diff) => diff.as_secs() as i64,
+        Err(error) => {
+            let diff = error.duration();
+            // A non-zero sub-second remainder means the instant lands strictly
+            // before the flooring boundary, so subtract one to floor.
+            if diff.subsec_nanos() == 0 {
+                -(diff.as_secs() as i64)
+            } else {
+                -(diff.as_secs() as i64) - 1
+            }
+        }
+    }
+}
+
 /// Returns `true` when two timestamps differ by no more than `window`.
 ///
-/// With a zero window, only exact equality matches.
-// upstream: generator.c:unchanged_file() - modify window comparison
+/// With a zero window the comparison is at whole-second granularity: the
+/// sub-second component of each timestamp is discarded before comparing. This
+/// mirrors upstream, which stores the source `modtime` as a `time_t` and whose
+/// `same_time()` helper reduces to `f1_sec == f2_sec` when `modify_window == 0`,
+/// so a destination that only differs in the fractional second is still treated
+/// as up-to-date by the quick check.
+///
+/// With a non-zero window the original full-resolution duration comparison is
+/// retained so sub-second `--modify-window` tolerances continue to apply.
+///
+/// upstream: generator.c:unchanged_file() -> same_time() - whole-second
+/// comparison when `modify_window == 0`.
 pub(crate) fn system_time_within_window(a: SystemTime, b: SystemTime, window: Duration) -> bool {
     if window.is_zero() {
-        return a.eq(&b);
+        return unix_seconds(a) == unix_seconds(b);
     }
 
     match a.duration_since(b) {
@@ -434,6 +466,33 @@ mod tests {
         };
 
         assert!(should_skip_copy(comparison));
+    }
+
+    #[test]
+    fn system_time_within_zero_window_ignores_subsecond_difference() {
+        // upstream: generator.c:unchanged_file() -> same_time() reduces to
+        // `f1_sec == f2_sec` when modify_window == 0, so a destination written
+        // without `-t` that lands in the same second as the source (but with a
+        // different fractional part) is still treated as up-to-date. Without
+        // this the quick check would re-transfer a content-identical file on
+        // every run, which surfaced as a missing `is uptodate` notice for an
+        // already-hardlinked alias under `-vvH`.
+        let base = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 100_000_000);
+        let same_second = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 900_000_000);
+        assert!(system_time_within_window(base, same_second, Duration::ZERO));
+    }
+
+    #[test]
+    fn system_time_within_zero_window_separates_whole_second_difference() {
+        // A one-second difference must still be observed at zero window so a
+        // genuinely newer source is not skipped.
+        let earlier = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 900_000_000);
+        let next_second = SystemTime::UNIX_EPOCH + Duration::new(1_700_000_001, 0);
+        assert!(!system_time_within_window(
+            earlier,
+            next_second,
+            Duration::ZERO
+        ));
     }
 
     #[test]

--- a/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
+++ b/crates/engine/src/local_copy/tests/execute_timestamp_preservation.rs
@@ -501,7 +501,7 @@ fn copy_file_when_timestamps_differ() {
 // 1ns difference is invisible to Windows NTFS (100ns resolution).
 #[cfg(not(target_os = "windows"))]
 #[test]
-fn nanosecond_difference_triggers_copy() {
+fn subsecond_difference_does_not_trigger_copy() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
@@ -510,9 +510,16 @@ fn nanosecond_difference_triggers_copy() {
     fs::write(&source, content).expect("write source");
     fs::write(&destination, content).expect("write dest");
 
-    // Set timestamps that differ only in nanoseconds
-    let source_mtime = FileTime::from_unix_time(1_700_000_000, 1);  // 1 nanosecond
-    let dest_mtime = FileTime::from_unix_time(1_700_000_000, 0);     // 0 nanoseconds
+    // Timestamps land in the same whole second but differ in the fractional
+    // part. Upstream's quick check stores the source modtime as a `time_t` and
+    // compares whole seconds (`cmp_time(st->st_mtime, file->modtime)`), so a
+    // sub-second-only difference is invisible: the file is reported `is
+    // uptodate` and never transferred, even with `-t`.
+    //
+    // upstream: generator.c:unchanged_file() -> cmp_time() compares time_t
+    // seconds.
+    let source_mtime = FileTime::from_unix_time(1_700_000_000, 1); // 1 nanosecond
+    let dest_mtime = FileTime::from_unix_time(1_700_000_000, 0); // 0 nanoseconds
     set_file_mtime(&source, source_mtime).expect("set source mtime");
     set_file_mtime(&destination, dest_mtime).expect("set dest mtime");
 
@@ -529,8 +536,12 @@ fn nanosecond_difference_triggers_copy() {
         )
         .expect("copy succeeds");
 
-    // File should be copied because nanoseconds differ
-    assert_eq!(summary.files_copied(), 1, "1ns timestamp difference should trigger copy");
+    // Same whole second -> quick check treats the destination as up-to-date.
+    assert_eq!(
+        summary.files_copied(),
+        0,
+        "sub-second timestamp difference must not trigger a copy (whole-second quick check)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`frontend::tests::verbose_tests::level_2_hardlink_uptodate_emits_is_uptodate_notice` panics on master HEAD, failing `nextest(stable)` on every platform. Under `-vvplrH` against an already-hardlinked destination it expected both `leader.txt is uptodate` and `follower.txt is uptodate`, but observed a transferred `follower.txt` plus a stray `leader.txt => .../follower.txt` arrow.

## Root cause

The local-copy quick check (`should_skip_copy` -> `system_time_within_window`) compared modification times at full `SystemTime` resolution, including nanoseconds. Upstream stores the source modtime as a `time_t` and its `unchanged_file()`/`same_time()` compares whole seconds when `modify_window == 0`.

Without `-t`, a destination written in the same wall-clock second as the source gets a slightly different sub-second mtime. Upstream treats it as up-to-date and skips; oc-rsync re-transferred it.

With `-H` this cascaded: the hardlink group leader (alphabetically first) was transferred via temp-file-and-rename, giving its destination a fresh inode. When the follower was then processed, its destination no longer shared an inode with the leader, so the already-linked fast path failed and it re-created the link, emitting the `=>` arrow instead of the `is uptodate` notice.

Verified against upstream rsync 3.4.4: a sub-second-only mtime difference yields `is uptodate` and no transfer, even with `-t`, both with and without `-H`.

## Fix

Truncate both timestamps to whole seconds in the zero-window quick-check comparison, mirroring upstream `same_time()` when `modify_window == 0`. The non-zero-window path keeps full-resolution duration handling so sub-second `--modify-window` tolerances continue to apply.

With the leader now skipped (no temp-file rename), its destination inode is preserved, so the follower correctly matches the already-linked fast path and both aliases report `is uptodate`.

## Tests

- `level_2_hardlink_uptodate_emits_is_uptodate_notice` now passes.
- `itemize_hardlink_already_linked_omits_arrow_suffix` still passes (no `-i` regression).
- Added `system_time_within_zero_window_ignores_subsecond_difference` and `system_time_within_zero_window_separates_whole_second_difference`.
- Corrected `nanosecond_difference_triggers_copy` -> `subsecond_difference_does_not_trigger_copy`: it asserted the opposite of upstream behaviour (that a 1ns difference forces a copy) and encoded the very divergence being fixed.
- Full `cli` suite green; full `engine` suite green except two pre-existing failures on master unrelated to this change (`itemize_size_change_detected_correctly`, the `only_write_batch_round_trip` cluster), both confirmed failing on a clean checkout.
- `cargo fmt --all --check` and `cargo clippy -p engine` clean.
