### PR TITLE
fix(batch): gate --only-write-batch id-list terminators on preserve flags

### DIFF
--- a/crates/batch/src/writer.rs
+++ b/crates/batch/src/writer.rs
@@ -18,6 +18,12 @@ pub struct BatchWriter {
     batch_file: Option<BufWriter<File>>,
     /// Whether the header has been written.
     header_written: bool,
+    /// Stream flags recorded in the batch header.
+    ///
+    /// Captured at [`BatchWriter::write_header`] so the post-flist id-list
+    /// region can be gated on the same `preserve_uid` / `preserve_gid` /
+    /// `preserve_acls` predicates upstream uses in `uidlist.c:send_id_lists()`.
+    stream_flags: BatchFlags,
 }
 
 impl BatchWriter {
@@ -39,7 +45,16 @@ impl BatchWriter {
             config,
             batch_file: Some(BufWriter::new(file)),
             header_written: false,
+            stream_flags: BatchFlags::default(),
         })
+    }
+
+    /// Returns the stream flags recorded in the batch header.
+    ///
+    /// Defaults to [`BatchFlags::default`] until [`BatchWriter::write_header`]
+    /// records the caller's flags.
+    pub const fn stream_flags(&self) -> &BatchFlags {
+        &self.stream_flags
     }
 
     /// Write the batch header with stream flags.
@@ -54,6 +69,7 @@ impl BatchWriter {
         let mut header = BatchHeader::new(self.config.protocol_version, self.config.checksum_seed);
         header.compat_flags = self.config.compat_flags;
         header.stream_flags = flags;
+        self.stream_flags = flags;
 
         if let Some(ref mut writer) = self.batch_file {
             header.write_to(writer).map_err(|e| {

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -89,9 +89,16 @@ impl<'a> CopyContext<'a> {
             None => return Ok(()),
         };
 
-        let (proto, compat_flags) = {
+        let (proto, compat_flags, preserve_uid, preserve_gid, preserve_acls) = {
             let cfg = batch_writer_arc.lock().unwrap();
-            (cfg.config().protocol_version, cfg.config().compat_flags)
+            let flags = cfg.stream_flags();
+            (
+                cfg.config().protocol_version,
+                cfg.config().compat_flags,
+                flags.preserve_uid,
+                flags.preserve_gid,
+                flags.preserve_acls,
+            )
         };
 
         // upstream: flist.c:2548 - skip send_id_lists() under INC_RECURSE.
@@ -105,25 +112,38 @@ impl<'a> CopyContext<'a> {
             return Ok(());
         }
 
-        // upstream: uidlist.c:recv_id_list() reads uid list then gid list.
-        // Each list: loop reading varint30 until 0 (no entries), then done.
-        // Without xmit_id0_names (ID0_NAMES not in compat_flags), the
-        // terminator is just varint30(0) for each list.
+        // upstream: uidlist.c:send_id_lists() - the uid list is emitted only
+        // when (preserve_uid || preserve_acls), and the gid list only when
+        // (preserve_gid || preserve_acls). The matching reader
+        // (crates/batch/src/reader/flist.rs, recv_id_list) gates on the same
+        // predicates, so emitting terminators unconditionally would drift the
+        // stream cursor and corrupt the subsequent NDX reads. Each list, when
+        // present, terminates with a single varint30(0) (no ID0_NAMES inline).
+        let send_uid_list = preserve_uid || preserve_acls;
+        let send_gid_list = preserve_gid || preserve_acls;
+        if !send_uid_list && !send_gid_list {
+            return Ok(());
+        }
+
         let mut buf = Vec::with_capacity(2);
-        protocol::write_varint30_int(&mut buf, 0, proto as u8).map_err(|e| {
-            crate::local_copy::LocalCopyError::io(
-                "write batch uid list terminator",
-                std::path::PathBuf::new(),
-                e,
-            )
-        })?;
-        protocol::write_varint30_int(&mut buf, 0, proto as u8).map_err(|e| {
-            crate::local_copy::LocalCopyError::io(
-                "write batch gid list terminator",
-                std::path::PathBuf::new(),
-                e,
-            )
-        })?;
+        if send_uid_list {
+            protocol::write_varint30_int(&mut buf, 0, proto as u8).map_err(|e| {
+                crate::local_copy::LocalCopyError::io(
+                    "write batch uid list terminator",
+                    std::path::PathBuf::new(),
+                    e,
+                )
+            })?;
+        }
+        if send_gid_list {
+            protocol::write_varint30_int(&mut buf, 0, proto as u8).map_err(|e| {
+                crate::local_copy::LocalCopyError::io(
+                    "write batch gid list terminator",
+                    std::path::PathBuf::new(),
+                    e,
+                )
+            })?;
+        }
 
         let mut writer_guard = batch_writer_arc.lock().unwrap();
         writer_guard.write_data(&buf).map_err(|e| {


### PR DESCRIPTION
## Problem

`--only-write-batch` captured per-file token data into the batch file, but a
matching `--read-batch` reconstructed empty files. The
`only_write_batch_round_trip` engine integration test failed at its content
assertions (`regular_files` line 164, `subdirectory_files` line 311); the
symlinks case passed because symlink targets are rebuilt during flist replay,
not via the NDX delta loop.

## Root cause

Writer/reader asymmetry in the post-flist uid/gid id-list region.

The local-copy batch writer (`write_batch_id_lists`) emitted two
`varint30(0)` uid/gid id-list terminators unconditionally whenever
INC_RECURSE was inactive. The batch reader, however, only consumes those
terminators when `preserve_uid` / `preserve_gid` / `preserve_acls` are set
(`crates/batch/src/reader/flist.rs`, matching upstream `uidlist.c` recv gate).

With the round-trip configuration (none of those preserve flags set), the two
stray `0x00` bytes drifted the replay stream cursor. The per-file NDX delta
loop then read them as `NDX_DONE` and advanced past the phase before applying
the captured delta entries, so reconstruction produced zero file content.

## Fix

Gate writer emission on the same predicates the reader uses, matching upstream
`uidlist.c:send_id_lists()`:

- uid list emitted only when `preserve_uid || preserve_acls`
- gid list emitted only when `preserve_gid || preserve_acls`

`BatchWriter` now records the header `stream_flags` so the engine can read them
back when deciding what to emit. The INC_RECURSE skip and the single
`varint30(0)`-per-list terminator format are unchanged.

This is a production bug in the engine writer; the test expectation was
correct.

## Verification

- `cargo nextest run -p engine --all-features -E 'test(only_write_batch)'` —
  4 passed, 0 failed.
- Full engine suite: 4689 passed, 1 failed. The single failure
  (`itemize_size_change_detected_correctly`) is a pre-existing master issue
  unrelated to this change and is being addressed separately.
- `cargo fmt --all` clean.
