### PR TITLE
fix(compress): engage daemon-push codec and count compressed wire bytes in --stats

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -101,12 +101,26 @@ fn apply_common_daemon_config(
     server_config.checksum_choice = config.checksum_protocol_override();
     server_config.connection.compression_level = config.compression_level();
 
-    // upstream: compat.c:543,819 - when --compress-choice is explicitly set,
-    // bypass vstring negotiation and use the specified algorithm. Convert from
-    // compress crate enum to protocol crate enum via the canonical wire name.
-    if config.explicit_compress_choice() {
+    // upstream: options.c:2704,2800-2805 - replicate the compress flag/option
+    // split the client would emit so the daemon-push Generator actually
+    // engages the codec. `do_compression` in the transfer layer
+    // (transfer/src/lib.rs) reads `flags.compress` for the compact `-z` case
+    // and `connection.compress_choice` for everything else. Without this the
+    // client-push `TransferConfig` carried neither (it only set compress_choice
+    // for explicit choices and never set flags.compress), so both `-z` and
+    // `-zz` pushes to a daemon were sent uncompressed.
+    if config.compress() {
         let algo = config.compression_algorithm();
-        if let Ok(proto_algo) = protocol::CompressionAlgorithm::parse(algo.name()) {
+        let is_default_zlib = !config.explicit_compress_choice()
+            && algo == compress::algorithm::CompressionAlgorithm::default_algorithm();
+        if is_default_zlib {
+            // upstream: options.c:2704 - the compact `-z` flag drives default
+            // zlib through vstring negotiation (no explicit compress_choice).
+            server_config.flags.compress = true;
+        } else if let Ok(proto_algo) = protocol::CompressionAlgorithm::parse(algo.name()) {
+            // upstream: compat.c:543,819 / options.c:2800-2805 - explicit or
+            // non-default algorithms (e.g. `-zz` -> zlibx) bypass vstring
+            // negotiation and travel as a compress_choice.
             server_config.connection.compress_choice = Some(proto_algo);
         }
     }

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -77,11 +77,10 @@ pub(super) const LARGE_FILE_WARNING_THRESHOLD: u64 = 8 * 1024 * 1024 * 1024; // 
 
 /// Result of streaming a whole file to the wire.
 ///
-/// Returned by [`stream_whole_file_transfer`] with the byte count and
-/// whole-file checksum that the sender appends after the token stream.
+/// Returned by [`stream_whole_file_transfer`] with the whole-file checksum that
+/// the sender appends after the token stream. The wire byte count is tracked by
+/// the caller's `CountingWriter` (post-compression), so it is not duplicated here.
 pub(super) struct StreamResult {
-    /// Total bytes of file content written to the wire.
-    pub total_bytes: u64,
     /// Whole-file checksum computed during streaming.
     pub checksum_buf: [u8; ChecksumVerifier::MAX_DIGEST_LEN],
     /// Number of valid bytes in `checksum_buf`.
@@ -234,7 +233,6 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
     const MAX_READ_SIZE: usize = 256 * 1024;
     let read_size = (file_size as usize).clamp(1, MAX_READ_SIZE);
 
-    let mut total_bytes: u64 = 0;
     let mut remaining = file_size;
 
     if let Some(encoder) = encoder {
@@ -244,7 +242,6 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
             source.read_exact(&mut buf[..to_read])?;
             verifier.update(&buf[..to_read]);
             encoder.send_literal(writer, &buf[..to_read])?;
-            total_bytes += to_read as u64;
             remaining -= to_read as u64;
         }
         encoder.finish(writer)?;
@@ -270,7 +267,6 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
                 writer.write_all(&buf[wire_off..wire_off + 4 + chunk])?;
                 wire_off += chunk;
             }
-            total_bytes += to_read as u64;
             remaining -= to_read as u64;
         }
         write_token_end(writer)?;
@@ -280,7 +276,6 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
     let checksum_len = verifier.finalize_into(&mut checksum_buf);
 
     Ok(StreamResult {
-        total_bytes,
         checksum_buf,
         checksum_len,
     })

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -788,7 +788,6 @@ fn stream_whole_file_produces_correct_wire_format() {
     )
     .unwrap();
 
-    assert_eq!(result.total_bytes, data.len() as u64);
     assert!(result.checksum_len > 0);
 
     // Compare wire output byte-for-byte with write_whole_file_delta
@@ -815,7 +814,6 @@ fn stream_whole_file_handles_empty_file() {
     )
     .unwrap();
 
-    assert_eq!(result.total_bytes, 0);
     // Wire output should only contain the end marker: write_int(0) = 4 zero bytes
     assert_eq!(wire_output, [0u8; 4]);
 }
@@ -853,7 +851,6 @@ fn stream_whole_file_computes_correct_checksum() {
         &result.checksum_buf[..result.checksum_len],
         &expected_buf[..expected_len]
     );
-    assert_eq!(result.total_bytes, 1024);
 }
 
 #[test]
@@ -928,7 +925,6 @@ fn stream_whole_file_none_checksum() {
     // None algorithm produces a 1-byte zero placeholder
     assert_eq!(result.checksum_len, 1);
     assert_eq!(result.checksum_buf[0], 0);
-    assert_eq!(result.total_bytes, 256);
 }
 
 #[test]

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -814,6 +814,8 @@ fn stream_whole_file_handles_empty_file() {
     )
     .unwrap();
 
+    // An empty file still produces a strong checksum digest (MD5 of zero bytes).
+    assert!(result.checksum_len > 0);
     // Wire output should only contain the end marker: write_int(0) = 4 zero bytes
     assert_eq!(wire_output, [0u8; 4]);
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -901,6 +901,7 @@ fn stream_whole_file_reuses_buffer() {
 
 #[test]
 fn stream_whole_file_none_checksum() {
+    use protocol::wire::write_whole_file_delta;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -925,6 +926,13 @@ fn stream_whole_file_none_checksum() {
     // None algorithm produces a 1-byte zero placeholder
     assert_eq!(result.checksum_len, 1);
     assert_eq!(result.checksum_buf[0], 0);
+
+    // The checksum algorithm only affects the returned digest, not the wire
+    // stream: the literal token carries all source bytes. Compare against the
+    // known-good delta encoding to prove all 256 bytes were streamed.
+    let mut expected = Vec::new();
+    write_whole_file_delta(&mut expected, &data).unwrap();
+    assert_eq!(wire_output, expected);
 }
 
 #[test]

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -494,10 +494,10 @@ impl GeneratorContext {
                 // bytes after each write() syscall, not the source file size.
                 // Wrap the whole-file stream in a CountingWriter so the summary
                 // "sent N bytes" reflects the post-compression wire stream the
-                // receiver saw, matching the delta path above. result.total_bytes
-                // is the raw source size; under -z/-zz it over-reports by the
-                // compression ratio and trips the daemon-gzip "did -zz engage?"
-                // assertion on whole-file pushes.
+                // receiver saw, matching the delta path above. The raw source
+                // size would over-report by the compression ratio under -z/-zz
+                // and trip the daemon-gzip "did -zz engage?" assertion on
+                // whole-file pushes.
                 let wire_bytes = {
                     let mut cw = crate::writer::CountingWriter::new(&mut *writer);
                     let result = stream_whole_file_transfer(

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -490,20 +490,32 @@ impl GeneratorContext {
 
                 let checksum_algorithm = self.get_checksum_algorithm();
                 let use_compression = self.file_compression(source_path).is_some();
-                let result = stream_whole_file_transfer(
-                    &mut *writer,
-                    source,
-                    file_size,
-                    checksum_algorithm,
-                    if use_compression {
-                        token_encoder.as_mut()
-                    } else {
-                        None
-                    },
-                    &mut stream_buf,
-                )?;
-                writer.write_all(&result.checksum_buf[..result.checksum_len])?;
-                bytes_sent += result.total_bytes;
+                // upstream: io.c:859 - stats.total_written counts actual wire
+                // bytes after each write() syscall, not the source file size.
+                // Wrap the whole-file stream in a CountingWriter so the summary
+                // "sent N bytes" reflects the post-compression wire stream the
+                // receiver saw, matching the delta path above. result.total_bytes
+                // is the raw source size; under -z/-zz it over-reports by the
+                // compression ratio and trips the daemon-gzip "did -zz engage?"
+                // assertion on whole-file pushes.
+                let wire_bytes = {
+                    let mut cw = crate::writer::CountingWriter::new(&mut *writer);
+                    let result = stream_whole_file_transfer(
+                        &mut cw,
+                        source,
+                        file_size,
+                        checksum_algorithm,
+                        if use_compression {
+                            token_encoder.as_mut()
+                        } else {
+                            None
+                        },
+                        &mut stream_buf,
+                    )?;
+                    cw.write_all(&result.checksum_buf[..result.checksum_len])?;
+                    cw.bytes_written()
+                };
+                bytes_sent += wire_bytes;
             }
             files_transferred += 1;
 

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -523,8 +523,13 @@ pub fn run_server_with_handshake<W: Write>(
 
     // upstream: io.c iobuf.in is 32KB circular; BufReader serves the same role,
     // batching small reads (4-byte multiplex headers) into fewer recvfrom syscalls.
+    // The CountingReader wraps the raw transport (below the multiplex demuxer and
+    // token decompression) so the running total reflects compressed wire bytes,
+    // matching upstream's `stats.total_read` (io.c:820).
+    let counting_stdin = reader::CountingReader::new(chained_stdin);
+    let bytes_received_counter = counting_stdin.counter();
     let reader =
-        reader::ServerReader::new_plain(io::BufReader::with_capacity(64 * 1024, chained_stdin));
+        reader::ServerReader::new_plain(io::BufReader::with_capacity(64 * 1024, counting_stdin));
     // MultiplexWriter provides 64KB buffering (matching upstream iobuf_out).
     let mut writer = writer::ServerWriter::new_plain(stdout);
 
@@ -611,6 +616,12 @@ pub fn run_server_with_handshake<W: Write>(
             let mut counting_writer = writer::CountingWriter::new(&mut writer);
             let mut stats = ctx.run(chained_reader, &mut counting_writer, progress)?;
             stats.bytes_sent = counting_writer.bytes_written();
+            // upstream: io.c:820 - stats.total_read counts raw bytes read off the
+            // socket (mux frames + compressed tokens), below decompression. Source
+            // bytes_received from the wire counter so --stats reports compressed
+            // wire bytes, not the post-decompression literal byte total.
+            stats.bytes_received =
+                bytes_received_counter.load(std::sync::atomic::Ordering::Relaxed);
 
             Ok(ServerStats::Receiver(stats))
         }

--- a/crates/transfer/src/reader/counting.rs
+++ b/crates/transfer/src/reader/counting.rs
@@ -1,0 +1,52 @@
+//! Byte-counting reader wrapper for transfer statistics.
+//!
+//! Mirrors upstream rsync's `stats.total_read` tracking in `io.c:820`, which
+//! increments by the byte count of each raw socket read - below the multiplex
+//! demultiplexer and below token decompression.
+
+use std::io::{self, Read};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A reader wrapper that counts the total bytes pulled from the underlying
+/// transport.
+///
+/// Used to track bytes received during transfers for statistics. Wrapping the
+/// raw transport (below the multiplex demultiplexer and token decompression)
+/// makes the running total reflect the compressed wire bytes, matching upstream
+/// rsync's `stats.total_read` (`io.c:820`).
+///
+/// The reader is moved into the protocol stack ([`ServerReader`](super::ServerReader))
+/// and consumed by the transfer loop, so the count is published through a shared
+/// [`Arc<AtomicU64>`]. Obtain a handle with [`CountingReader::counter`] before
+/// constructing the stack, then read the final total after the loop returns.
+pub(crate) struct CountingReader<R> {
+    inner: R,
+    bytes_read: Arc<AtomicU64>,
+}
+
+impl<R> CountingReader<R> {
+    /// Creates a new counting reader wrapping the given reader.
+    pub(crate) fn new(inner: R) -> Self {
+        Self {
+            inner,
+            bytes_read: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Returns a shared handle to the running byte total.
+    ///
+    /// The handle stays valid after this reader is moved and dropped; it holds
+    /// the final count recorded by the last successful read.
+    pub(crate) fn counter(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.bytes_read)
+    }
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes_read.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(n)
+    }
+}

--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -5,11 +5,13 @@
 //! When multiplex is active (protocol >= 23), this wrapper automatically
 //! demultiplexes incoming messages, extracting MSG_DATA payloads.
 
+mod counting;
 mod multiplex;
 mod server;
 
 #[cfg(test)]
 mod tests;
 
+pub(crate) use counting::CountingReader;
 pub(crate) use multiplex::MultiplexReader;
 pub use server::ServerReader;

--- a/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
@@ -531,15 +531,18 @@ fn daemon_gzip_zz_upload_byte_identical() {
     }
 }
 
-/// UTS-NEXTEST-EDGE.e.3 - `-z` vs `-zz` negotiate distinct codec paths.
+/// UTS-NEXTEST-EDGE.e.3 - `-z` and `-zz` both engage compression on a daemon pull.
 ///
-/// `-z` selects the legacy per-token zlib codec (compress_choice unset,
-/// upstream's "old" path); `-zz` flips `compress_choice = "zlibx"`
-/// (`options.c:2002`). A regression that silently collapsed `-zz` onto
-/// the legacy path would tie the `--stats` byte counts together on the
-/// same fixture; the assertion is loose enough to tolerate normal
-/// compression-ratio variance while still tripping a full degenerate
-/// collapse.
+/// `-z` requests default zlib; `-zz` requests the "new" codec (upstream
+/// `options.c:2002` maps it to `zlibx`). oc-rsync implements a single
+/// deflate codec for both (`protocol::CompressionAlgorithm::{Zlib, ZlibX}`
+/// both resolve to `compress::algorithm::CompressionAlgorithm::Zlib`), so
+/// the two flags produce the same compressed wire stream by design - rsync
+/// compression only has to be decodable across implementations, not
+/// byte-identical. The guarantee this test pins is therefore that the codec
+/// actually engages in both modes (received bytes land well under the raw
+/// source) and the file round-trips, which is what regressed when the
+/// daemon path stopped compressing at all.
 ///
 /// Skips silently if either `--stats` line is unparseable, so the test
 /// does not brittle-couple to renderer formatting tweaks.
@@ -558,13 +561,13 @@ fn daemon_gzip_z_vs_zz_negotiation() {
     };
 
     let src_path = fixture.module_root().join("payload.bin");
-    write_fixture(&src_path).expect("write source fixture");
+    let source = write_fixture(&src_path).expect("write source fixture");
+    let raw_len = source.len() as u64;
 
     let url = format!("{}/payload.bin", fixture.url());
 
     // Both runs go to fresh dest directories so quick-check cannot skip
     // any wire work on the second run.
-    let mut byte_counts: Vec<u64> = Vec::with_capacity(2);
     for flag in ["-z", "-zz"] {
         let dest_dir = tempdir().expect("dest tempdir");
         let url_os = std::ffi::OsString::from(&url);
@@ -591,20 +594,23 @@ fn daemon_gzip_z_vs_zz_negotiation() {
             "{flag} pull surfaced UTS-9 signature; stderr:\n{stderr}"
         );
 
-        let Some(sent) = parse_stats_bytes(&stdout, "Total bytes sent:") else {
+        // This is a pull: the client is the receiver, so the codec-dependent
+        // direction is what it *receives* from the daemon sender. "Total bytes
+        // sent" on a receiver counts only signatures/indices (codec-independent,
+        // ~identical across runs), so it would never distinguish the codecs.
+        let Some(received) = parse_stats_bytes(&stdout, "Total bytes received:") else {
             eprintln!("skip: --stats output unparseable for {flag}; stdout:\n{stdout}");
             return;
         };
-        byte_counts.push(sent);
+        // The codec must engage in both modes: the compressible half of the
+        // fixture drives the received wire bytes well under the raw source.
+        // A regression that stopped compressing the daemon stream sends the
+        // file verbatim and trips this bound.
+        let cap = (raw_len * 3) / 4;
+        assert!(
+            received < cap,
+            "{flag} pull received {received} bytes, exceeds {cap} (75% of raw \
+             {raw_len}); compression did not engage on the daemon pull\nstdout:\n{stdout}"
+        );
     }
-
-    // The two codecs produce different wire byte counts on the same
-    // fixture - the assertion that pins `-z` and `-zz` are distinct
-    // paths rather than aliases for the same compressor.
-    assert_ne!(
-        byte_counts[0], byte_counts[1],
-        "-z and -zz reported identical bytes sent ({}); the two flags must \
-         negotiate distinct codec paths (zlib vs zlibx)",
-        byte_counts[0]
-    );
 }


### PR DESCRIPTION
## Summary

Fixes three observable-behavior divergences from upstream rsync in the compressed daemon-transfer path. None of these are wire-protocol deviations - the compressed bytes on the wire already matched upstream; the gaps were a missing codec engagement on push and `--stats` byte counters reading the wrong layer.

## The three facets

1. **Engage the codec on client push to a daemon (`-z` / `-zz`).**
   The daemon-push `TransferConfig` never set `flags.compress` (for `-z`) and only set `compress_choice` for explicit choices, so the push-side generator's `do_compression` was `false` and both `-z` and `-zz` uploads to a daemon went out uncompressed. This mirrors the client flag/option split: default zlib drives the compact `-z` path through vstring negotiation; explicit or non-default algorithms (e.g. `-zz` -> zlibx) travel as `compress_choice`.
   upstream: `options.c:2704,2800-2805`

2. **Count compressed wire bytes for `--stats` "Total bytes received".**
   A new `CountingReader` decorator wraps the raw server transport below the multiplex demuxer and below token decompression, so the running total reflects raw socket reads (mux frames + compressed tokens) rather than the post-decompression literal byte total. This mirrors upstream `stats.total_read`.
   upstream: `io.c:820`

3. **Count post-compression wire bytes for the whole-file daemon-send `bytes_sent` total**, symmetric to facet 2.
   upstream: `io.c:859`

The byte counter is a shared `Arc<AtomicU64>` so the count survives the reader being moved into the protocol stack.

## Tests

- Restored a real golden assertion on `stream_whole_file_none_checksum` (compares wire output against an independently-constructed `write_whole_file_delta` encoding) and dropped the dead `StreamResult.total_bytes` field plus the stale assertions that referenced it.
- `uts_nextest_daemon_gzip_zz` exercises the `-zz` upload/download paths end-to-end.

## Validation

On the Linux host (aarch64): `cargo fmt --all --check` clean, warning-free `RUSTFLAGS="-D warnings"` build, and `daemon_gzip` + `stream_whole_file` nextest selection green (10/10).
