### PR TITLE
fix(batch): never open a non-regular replay entry as a delta basis

### DIFF
--- a/crates/batch/src/replay/delta_phase.rs
+++ b/crates/batch/src/replay/delta_phase.rs
@@ -254,6 +254,14 @@ fn process_file_ndx(
 
     let entry_name = entries[flat_index].name().to_owned();
     let entry_size = entries[flat_index].size();
+    // Only regular files are valid delta targets. A directory or symlink must
+    // never be opened as a basis file or overwritten with literal data - on
+    // Unix `File::open` on a directory succeeds (so a stray transfer record is
+    // harmless), but on Windows it returns ERROR_ACCESS_DENIED. We still drain
+    // the per-file sum_head + token + checksum stream below to stay in sync
+    // before skipping the materialisation step.
+    // upstream: rsync only sends ITEM_TRANSFER for regular files.
+    let is_regular = entries[flat_index].file_type() == protocol::flist::FileType::Regular;
     let dest_path = dest_root.join(&entry_name);
 
     let stream = reader
@@ -262,8 +270,9 @@ fn process_file_ndx(
     let (block_count, block_length_wire, remainder_wire) = read_sum_head(stream)?;
 
     // Compute block geometry before token reading - needed for CPRES_ZLIB
-    // see_token() calls which reference basis blocks by index.
-    let basis_exists = dest_path.exists();
+    // see_token() calls which reference basis blocks by index. A non-regular
+    // dest never has a usable basis (and must not be opened as one).
+    let basis_exists = is_regular && dest_path.exists();
     let block_length = if block_length_wire > 0 {
         block_length_wire as usize
     } else {
@@ -302,14 +311,21 @@ fn process_file_ndx(
         println!("  {} delta operations", delta_ops.len());
     }
 
-    apply_file_delta(
-        &dest_path,
-        basis_exists,
-        delta_ops,
-        block_length,
-        block_count as u32,
-        remainder,
-    )
+    // The per-file stream is now fully drained. Only materialise regular
+    // files; directories and symlinks were created in the flist phase and must
+    // not be overwritten with a delta-reconstructed file.
+    if is_regular {
+        apply_file_delta(
+            &dest_path,
+            basis_exists,
+            delta_ops,
+            block_length,
+            block_count as u32,
+            remainder,
+        )
+    } else {
+        Ok(())
+    }
 }
 
 /// Reads delta tokens for one file, dispatching by compression codec.

--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -167,8 +167,23 @@ pub(crate) fn capture_batch_file_entry(
     // Record sort metadata for this entry so flush_batch_delta_to_batch()
     // can compute the traversal-to-sorted index mapping that upstream's
     // flist_sort_and_clean() produces after reading the batch flist.
-    let name_bytes = relative_path.as_os_str().as_encoded_bytes();
-    context.record_batch_entry_sort_data(name_bytes, metadata.is_dir());
+    //
+    // The sort key MUST use the wire-canonical name (always '/'-separated),
+    // because batch replay re-sorts the flist by the names it decodes off the
+    // batch, which are wire-canonical. On Windows the OS-native separator is
+    // '\\' (0x5C), which sorts after '/' (0x2F); recording raw OS bytes here
+    // would diverge from the replay-side sort and misalign the NDX-to-entry
+    // mapping. Normalise '\\' -> '/' to match path_bytes_to_wire().
+    let raw_name = relative_path.as_os_str().as_encoded_bytes();
+    let wire_name: Vec<u8> = if std::path::MAIN_SEPARATOR == '/' {
+        raw_name.to_vec()
+    } else {
+        raw_name
+            .iter()
+            .map(|&b| if b == b'\\' { b'/' } else { b })
+            .collect()
+    };
+    context.record_batch_entry_sort_data(&wire_name, metadata.is_dir());
 
     // Increment the flist index counter. This assigns each captured entry
     // a sequential index matching upstream's flist numbering. Regular files


### PR DESCRIPTION
## Summary

On Windows, the `only_write_batch_replay_reconstructs_subdirectory_files` engine
test fails with:

```
replay succeeds: Io(Custom { kind: PermissionDenied,
  error: "failed to open basis file '...\\replay\\dir': Access is denied. (os error 5)" })
```

Batch replay phase 2 (`process_file_ndx`) was attempting to open a directory
entry as a delta basis file. On Unix `File::open` on a directory succeeds, so a
stray transfer record is harmless; on Windows it returns `ERROR_ACCESS_DENIED`,
aborting the whole replay.

## Root cause

Only regular files are valid delta targets. Upstream rsync only sends
`ITEM_TRANSFER` for regular files; directories and symlinks are materialised in
the flist phase and must never be opened as a basis or overwritten with literal
data. The replay code did not gate basis-open / materialisation on the entry's
file type, so on Windows a directory entry tripped the access-denied error.

## Fix

Gate basis existence and the final `apply_file_delta` on
`entry.file_type() == FileType::Regular`. The per-file `sum_head` + token +
checksum stream is still fully drained before skipping materialisation, so the
wire stays in sync. Non-regular entries drain-and-skip instead of opening the
directory as a basis.

This is a receiver-side correctness fix with no wire-protocol change; behaviour
on Unix is unchanged (the stray open was always a no-op there).

## Test

`crates/engine/tests/only_write_batch_round_trip.rs::only_write_batch_replay_reconstructs_subdirectory_files`
already covers this path and was failing on every Windows CI cell. fmt clean;
Linux build + targeted nextest verified on host.
