### PR TITLE
fix(itemize): propagate verbose level to server generator thread

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -25,7 +25,7 @@ where
     Out: Write,
     Err: Write,
 {
-    use core::server::{ServerConfig, ServerRole, run_server_stdio};
+    use core::server::{run_server_stdio, ServerConfig, ServerRole};
 
     let program_brand =
         super::super::detect_program_name(args.first().map(OsString::as_os_str)).brand();
@@ -122,6 +122,24 @@ where
     if let Err(code) = apply_value_flags(&mut config, &long_flags, stderr, program_brand) {
         return code;
     }
+
+    // Install the negotiated verbosity into this thread's verbosity config
+    // before any generator/receiver work runs. The verbosity flags are a
+    // per-thread thread-local (logging::thread_local) and the client-driving
+    // `run.rs` init only touches the client thread; the `--server` path runs
+    // its generator/receiver on this thread, so without this call the config
+    // stays at the default (NAME=0) and `info_gte(Name, 2)` is always false.
+    // That dropped the unchanged dir/file/symlink itemize rows that upstream
+    // emits under `-vv` (upstream: generator.c:582-583 `INFO_GTE(NAME, 2)`).
+    //
+    // upstream: options.c:2044 set_output_verbosity(verbose, DEFAULT_PRIORITY)
+    // maps the `-v` count to info/debug levels. `-vv` reaches the server as
+    // repeated `v` characters in the compact flag string (options.c:2625-2626),
+    // captured here as `flags.verbose_level`. Applied at DEFAULT priority,
+    // so the higher-priority `--info` overrides below still win.
+    logging::init(logging::VerbosityConfig::from_verbose_level(
+        config.flags.verbose_level,
+    ));
 
     // upstream: options.c parse_output_words - server-side info parsing
     // silently ignores unknown tokens so a newer client can forward names
@@ -264,7 +282,7 @@ where
                 .ok()
                 .or_else(|| dest_path.parent().and_then(|p| p.canonicalize().ok()))
             {
-                use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+                use fast_io::landlock::{is_supported, restrict_to_module_paths, LandlockOutcome};
                 if is_supported() {
                     let mut allowed = vec![root];
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -34,6 +34,17 @@ pub struct ParsedServerFlags {
     pub archive: bool,
     /// Verbose output (`v` flag, `--verbose`).
     pub verbose: bool,
+    /// Verbosity level: the number of `v` flags in the compact string.
+    ///
+    /// Upstream forwards `-vv` as repeated `v` characters in `argstr`
+    /// (upstream: options.c:2625-2626 `for (i = 0; i < verbose; i++)
+    /// argstr[x++] = 'v'`). The server side feeds this count into
+    /// `set_output_verbosity()` so `INFO_GTE(NAME, 2)` becomes true under
+    /// `-vv`, which makes the generator itemize every entry including
+    /// unchanged ones (upstream: generator.c:582-583). Collapsing the count
+    /// to a single bool loses that distinction, so the level is preserved
+    /// here alongside the `verbose` predicate.
+    pub verbose_level: u8,
     /// Compress during transfer (`z` flag, `--compress`).
     pub compress: bool,
     /// Checksum-based transfer (`c` flag, `--checksum`).
@@ -255,7 +266,10 @@ impl ParsedServerFlags {
             b'r' => self.recursive = true,
             b'e' => self.rsh = true,
             b'a' => self.archive = true,
-            b'v' => self.verbose = true,
+            b'v' => {
+                self.verbose = true;
+                self.verbose_level = self.verbose_level.saturating_add(1);
+            }
             b'z' => self.compress = true,
             b'c' => self.checksum = true,
             b'H' => self.hard_links = true,
@@ -433,6 +447,56 @@ mod tests {
         let flags = ParsedServerFlags::parse("-rm").unwrap();
         assert!(flags.recursive);
         assert!(flags.prune_empty_dirs);
+    }
+
+    #[test]
+    fn single_verbose_flag_sets_level_one() {
+        let flags = ParsedServerFlags::parse("-rv").unwrap();
+        assert!(flags.verbose);
+        assert_eq!(flags.verbose_level, 1);
+    }
+
+    #[test]
+    fn double_verbose_flag_preserves_count() {
+        // upstream forwards `-vv` as repeated `v` characters in the compact
+        // flag string (options.c:2625-2626); the count must survive so the
+        // server can raise INFO_GTE(NAME, 2) and itemize unchanged entries.
+        let flags = ParsedServerFlags::parse("-rvv").unwrap();
+        assert!(flags.verbose);
+        assert_eq!(flags.verbose_level, 2);
+    }
+
+    #[test]
+    fn verbose_level_defaults_to_zero() {
+        let flags = ParsedServerFlags::parse("-r").unwrap();
+        assert!(!flags.verbose);
+        assert_eq!(flags.verbose_level, 0);
+    }
+
+    // Regression: the server/generator thread must raise INFO_GTE(NAME, 2)
+    // when the client forwarded `-vv`, so the generator itemizes every entry
+    // including unchanged dir/file/symlink rows (upstream: generator.c:582-583).
+    // The `-vv` count is forwarded in the compact flag string and the server
+    // feeds `verbose_level` into `from_verbose_level`. Verifying the
+    // end-to-end mapping guards against silently dropping the count back to a
+    // bool, which is what previously left `info_gte(Name, 2)` false and
+    // suppressed the unchanged rows under server-driven `-ivv`.
+    #[test]
+    fn double_verbose_flag_string_enables_name_level_two() {
+        use logging::{info_gte, init, InfoFlag, VerbosityConfig};
+
+        // Default-config thread cannot itemize unchanged entries.
+        init(VerbosityConfig::default());
+        assert!(!info_gte(InfoFlag::Name, 2));
+
+        // A `-vv` server flag string carries verbose_level == 2.
+        let flags = ParsedServerFlags::parse("-rvv").unwrap();
+        assert_eq!(flags.verbose_level, 2);
+
+        // Installing the negotiated level - exactly what the `--server`
+        // entry now does before running the generator - flips the gate on.
+        init(VerbosityConfig::from_verbose_level(flags.verbose_level));
+        assert!(info_gte(InfoFlag::Name, 2));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Under `-ivv` (info=name level 2), upstream rsync emits an itemize line for
every entry, including unchanged "uptodate" dir/file/symlink rows. In
server-driven mode (the `lsh.sh` CI path), oc-rsync dropped those unchanged
rows, diverging from upstream's output.

## Root cause

Verbosity is stored as a per-thread thread-local (`logging::thread_local`),
mirroring upstream's file-scope `info_levels[]` but scoped per thread because
each thread may drive a separate transfer pipeline. The client-driving
workflow seeds only the client thread. The `--server` entry
(`crates/cli/src/frontend/server/run.rs`) runs its generator on its own
thread but never installed the negotiated verbosity, so the thread-local
stayed at the default (`NAME=0`). The generator's emit-every-entry gate
`info_gte(InfoFlag::Name, 2)` (upstream: `generator.c:582-583
INFO_GTE(NAME, 2)`) was therefore always false, suppressing the unchanged
rows.

Compounding this, the compact server flag string forwards `-vv` as repeated
`v` characters (upstream: `options.c:2625-2626`), but the parser collapsed
them into a single `bool`, discarding the count needed to reach level 2.

## Fix

- Preserve the verbose count: `ParsedServerFlags` gains a `verbose_level: u8`
  that counts each `v` in the flag string, following the existing
  `fuzzy_level` / `one_file_system` counting pattern. The `verbose` bool is
  retained for existing boolean predicates.
- Install the negotiated verbosity on the server/generator thread:
  `run_server_mode` now calls
  `logging::init(VerbosityConfig::from_verbose_level(verbose_level))` before
  running the generator, and before the existing `--info` override so the
  higher-priority `--info` settings still win (mirroring upstream
  `set_output_verbosity(..., DEFAULT_PRIORITY)` followed by
  `parse_output_words`).

The generator runs synchronously on this thread (no rayon worker emits
itemize lines), so a single `init` on the server thread is sufficient. The
itemize gate itself is unchanged.

## Tests

- `single_verbose_flag_sets_level_one`, `double_verbose_flag_preserves_count`,
  `verbose_level_defaults_to_zero` cover the count parsing.
- `double_verbose_flag_string_enables_name_level_two` exercises the
  end-to-end mapping: a `-vv` flag string installed via `from_verbose_level`
  flips `info_gte(Name, 2)` true, encoding why the count must survive.
