### PR TITLE
fix(files-from): direction-aware single-fd resolution for localhost hostspec

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/parser.rs
+++ b/crates/cli/src/frontend/execution/file_list/parser.rs
@@ -50,14 +50,18 @@ pub(crate) fn resolve_files_from_source(files_from: &[OsString]) -> core::client
     // which we do not currently support for files-from.
     if let Some((host, path)) = split_hostspec(&text) {
         // upstream: options.c:3112-3138 / options.c:2476-2483 -
-        // check_for_hostspec strips the host prefix and forwards the path
-        // to the remote server. When the host resolves to localhost AND the
-        // stripped path is openable on this client, emit a hybrid variant
-        // so a PULL client-receiver can stage the bytes locally while the
-        // wire argv still carries the stripped path for upstream parity.
-        // Without this, PULL with `--files-from=localhost:path` hangs at
-        // recv_filesfrom: the receiver flushes None and the remote sender
-        // blocks waiting for the secluded-args stream.
+        // check_for_hostspec strips the host prefix and forwards the path to
+        // the remote server. When the host resolves to localhost AND the
+        // stripped path is openable on this client, emit the hybrid variant.
+        //
+        // Classification cannot decide local-vs-wire here: it does not know
+        // the transfer direction or whether the src operand is itself remote.
+        // `HybridLocalRemote::resolve_for` makes that single-fd choice per
+        // direction (PUSH opens the file locally; PULL stages its bytes and
+        // forwards `--files-from=-`), so the hybrid variant is safe to emit
+        // unconditionally for a localhost hostspec. Without it, PULL with
+        // `--files-from=localhost:path` hangs at recv_filesfrom: the receiver
+        // flushes None and the remote sender blocks waiting for the bytes.
         if host_is_localhost(host) {
             let local_path = PathBuf::from(path);
             if Path::new(&local_path).is_file() {

--- a/crates/core/src/client/config/enums/files_from.rs
+++ b/crates/core/src/client/config/enums/files_from.rs
@@ -27,21 +27,60 @@ pub enum FilesFromSource {
     ///
     /// - `options.c:2458` - `check_for_hostspec()` detects `:path` prefix
     RemoteFile(String),
-    /// Hybrid local-open + wire-forward source.
+    /// A `localhost:path` hostspec whose stripped path is openable locally.
     ///
-    /// Used when the `--files-from` spec names a `localhost:path` hostspec
-    /// and the stripped path is openable on the client. The client opens
-    /// the file locally and stages its contents into `files_from_data` so a
-    /// PULL client-receiver can flush the bytes back to the remote sender,
-    /// while the wire-arg keeps the stripped form for the remote server's
-    /// argv. Matches upstream `options.c:3112-3138 check_for_hostspec` +
-    /// `options.c:2476-2483` semantics on a single host.
+    /// Upstream rsync keeps a single files-from fd: it either opens the file
+    /// locally or reads it from the wire fd, never both
+    /// (`options.c:2476-2501`). This variant defers that choice to
+    /// [`FilesFromSource::resolve_for`], which collapses it into a plain local
+    /// open in whichever transfer direction applies:
+    ///
+    /// - PUSH: the local sender opens `local_path` directly (like a plain
+    ///   local file); `wire_arg` is not forwarded.
+    /// - PULL: the local receiver stages `local_path`'s bytes and the remote
+    ///   sender reads `--files-from=-`; `wire_arg` is not forwarded.
+    ///
+    /// Matches upstream `options.c:3112-3138 check_for_hostspec` +
+    /// `options.c:2476-2483` single-host semantics.
     HybridLocalRemote {
-        /// Local filesystem path to open for staging into `files_from_data`.
+        /// Local filesystem path to open in the applicable direction.
         local_path: std::path::PathBuf,
-        /// Stripped path forwarded to the remote server's `--files-from`.
+        /// Stripped path from the hostspec. Retained for diagnostics and
+        /// operand classification; never forwarded to the remote peer.
         wire_arg: String,
     },
+}
+
+/// Direction-resolved `--files-from` wiring for a single transfer.
+///
+/// Upstream rsync uses a single files-from file descriptor: a remote
+/// `--files-from` is EITHER opened locally OR read from the live wire fd
+/// (`filesfrom_fd = f_in`), never both (`options.c:2476-2501`,
+/// `main.c:1322-1328`). [`FilesFromSource::resolve_for`] collapses the
+/// hybrid local/remote variant into one of those two single-fd modes based
+/// on transfer direction, so callers never stage local bytes AND forward a
+/// wire arg for the same source.
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct FilesFromPlan {
+    /// `files_from_path` for the local sender's generator config (PUSH side).
+    ///
+    /// `Some("-")` means read from stdin / forwarded wire bytes; `Some(path)`
+    /// means open a local file; `None` means the local side is not the sender
+    /// for this source.
+    pub sender_files_from_path: Option<String>,
+    /// `from0` paired with [`Self::sender_files_from_path`].
+    pub sender_from0: bool,
+    /// The `--files-from` argument to forward to the remote peer's argv.
+    ///
+    /// `None` omits the argument entirely (the remote side does not read the
+    /// list). Wire-forwarded lists carry `"-"`; a remote-hosted file carries
+    /// its path.
+    pub remote_arg: Option<String>,
+    /// `from0` to forward alongside [`Self::remote_arg`].
+    pub remote_from0: bool,
+    /// Whether the local receiver must stage the list bytes into
+    /// `files_from_data` for forwarding to the remote sender (PULL only).
+    pub stage_local_bytes: bool,
 }
 
 impl FilesFromSource {
@@ -51,24 +90,127 @@ impl FilesFromSource {
         !matches!(self, Self::None)
     }
 
-    /// Returns `true` when the file list is read on the remote server.
+    /// Resolves this source into a direction-aware single-fd [`FilesFromPlan`].
     ///
-    /// The hybrid variant counts as remote because the server-side argv
-    /// receives the stripped path, but the client still stages the bytes
-    /// locally - see [`Self::is_local_forwarded`].
+    /// `is_push` is `true` when the local process is the sender (PUSH) and
+    /// `false` when it is the receiver (PULL). `from0` is the client's
+    /// `--from0` setting, applied to the local-file / remote-file fds that
+    /// honour it; wire-forwarded `"-"` fds always force NUL termination to
+    /// match upstream's `start_filesfrom_forwarding` framing.
+    ///
+    /// The [`Self::HybridLocalRemote`] variant - a `localhost:path` hostspec
+    /// whose stripped path is openable locally - is the only variant whose
+    /// behaviour depends on direction. Upstream never opens such a file AND
+    /// forwards it on the wire; it picks one fd:
+    ///
+    /// - PUSH: the local sender opens `local_path` directly, exactly like a
+    ///   plain [`Self::LocalFile`]. The remote receiver gets no `--files-from`
+    ///   and no bytes are staged.
+    /// - PULL: the local receiver stages `local_path`'s bytes and forwards
+    ///   them; the remote sender reads `--files-from=-`, exactly like a plain
+    ///   [`Self::LocalFile`]. The stripped `wire_arg` is never handed to the
+    ///   remote sender (that would be the discarded second fd).
+    ///
+    /// All other variants resolve to their existing upstream behaviour.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2476-2501` - single `filesfrom_fd` (local open or wire fd)
+    /// - `main.c:1322-1328` - `filesfrom_fd = f_in` for remote files-from
+    /// - `options.c:2962` - `server_options()` forwards the arg only when
+    ///   `!am_sender || filesfrom_host`
+    #[must_use]
+    pub fn resolve_for(&self, is_push: bool, from0: bool) -> FilesFromPlan {
+        match self {
+            Self::None => FilesFromPlan::default(),
+            Self::Stdin => {
+                if is_push {
+                    FilesFromPlan {
+                        sender_files_from_path: Some("-".to_owned()),
+                        sender_from0: from0,
+                        ..FilesFromPlan::default()
+                    }
+                } else {
+                    FilesFromPlan {
+                        remote_arg: Some("-".to_owned()),
+                        remote_from0: true,
+                        stage_local_bytes: true,
+                        ..FilesFromPlan::default()
+                    }
+                }
+            }
+            Self::LocalFile(path) => {
+                let local = path.to_string_lossy().into_owned();
+                if is_push {
+                    FilesFromPlan {
+                        sender_files_from_path: Some(local),
+                        sender_from0: from0,
+                        ..FilesFromPlan::default()
+                    }
+                } else {
+                    FilesFromPlan {
+                        remote_arg: Some("-".to_owned()),
+                        remote_from0: true,
+                        stage_local_bytes: true,
+                        ..FilesFromPlan::default()
+                    }
+                }
+            }
+            Self::RemoteFile(path) => {
+                if is_push {
+                    // Remote receiver opens the file and forwards its bytes
+                    // back; the local sender reads them as `--files-from=-`.
+                    // upstream: main.c:1191-1198 start_filesfrom_forwarding.
+                    FilesFromPlan {
+                        sender_files_from_path: Some("-".to_owned()),
+                        sender_from0: true,
+                        remote_arg: Some(path.clone()),
+                        remote_from0: from0,
+                        ..FilesFromPlan::default()
+                    }
+                } else {
+                    // Remote sender opens the file directly via its argv.
+                    FilesFromPlan {
+                        remote_arg: Some(path.clone()),
+                        remote_from0: from0,
+                        ..FilesFromPlan::default()
+                    }
+                }
+            }
+            Self::HybridLocalRemote { local_path, .. } => {
+                // Single-fd collapse: a localhost:path hostspec is treated as
+                // a plain local file in whichever direction applies. The
+                // stripped wire_arg is intentionally discarded so the remote
+                // peer never opens a second fd for the same list.
+                let local = local_path.to_string_lossy().into_owned();
+                if is_push {
+                    FilesFromPlan {
+                        sender_files_from_path: Some(local),
+                        sender_from0: from0,
+                        ..FilesFromPlan::default()
+                    }
+                } else {
+                    FilesFromPlan {
+                        remote_arg: Some("-".to_owned()),
+                        remote_from0: true,
+                        stage_local_bytes: true,
+                        ..FilesFromPlan::default()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns `true` when the `--files-from` operand is a hostspec rather
+    /// than a path the client opens as an operand file list.
+    ///
+    /// Used by operand classification to decide whether to load the file
+    /// list locally. The hybrid variant counts as remote here because its
+    /// operand is a `localhost:path` hostspec; its actual single-fd handling
+    /// is resolved per direction by [`Self::resolve_for`].
     #[must_use]
     pub fn is_remote(&self) -> bool {
         matches!(self, Self::RemoteFile(_) | Self::HybridLocalRemote { .. })
-    }
-
-    /// Returns `true` when the file list is read locally and must be
-    /// forwarded over the protocol to the sender.
-    #[must_use]
-    pub fn is_local_forwarded(&self) -> bool {
-        matches!(
-            self,
-            Self::LocalFile(_) | Self::Stdin | Self::HybridLocalRemote { .. }
-        )
     }
 }
 
@@ -123,26 +265,6 @@ mod tests {
     }
 
     #[test]
-    fn is_local_forwarded_false_for_none() {
-        assert!(!FilesFromSource::None.is_local_forwarded());
-    }
-
-    #[test]
-    fn is_local_forwarded_true_for_local_file() {
-        assert!(FilesFromSource::LocalFile(PathBuf::from("/tmp")).is_local_forwarded());
-    }
-
-    #[test]
-    fn is_local_forwarded_true_for_stdin() {
-        assert!(FilesFromSource::Stdin.is_local_forwarded());
-    }
-
-    #[test]
-    fn is_local_forwarded_false_for_remote() {
-        assert!(!FilesFromSource::RemoteFile("/path".to_owned()).is_local_forwarded());
-    }
-
-    #[test]
     fn clone_eq() {
         let source = FilesFromSource::RemoteFile("/path".to_owned());
         let cloned = source.clone();
@@ -153,5 +275,112 @@ mod tests {
     fn debug_format() {
         assert!(format!("{:?}", FilesFromSource::None).contains("None"));
         assert!(format!("{:?}", FilesFromSource::Stdin).contains("Stdin"));
+    }
+
+    fn hybrid() -> FilesFromSource {
+        FilesFromSource::HybridLocalRemote {
+            local_path: PathBuf::from("/tmp/list"),
+            wire_arg: "/tmp/list".to_owned(),
+        }
+    }
+
+    #[test]
+    fn resolve_none_is_empty_both_directions() {
+        assert_eq!(
+            FilesFromSource::None.resolve_for(true, false),
+            FilesFromPlan::default()
+        );
+        assert_eq!(
+            FilesFromSource::None.resolve_for(false, false),
+            FilesFromPlan::default()
+        );
+    }
+
+    // PUSH-Hybrid behaves as a plain local open: the sender opens local_path,
+    // no wire arg is forwarded, and nothing is staged. This is the fix for
+    // symptom A (duplicate >f+++++++++ from a double files-from source).
+    #[test]
+    fn resolve_hybrid_push_opens_local_path_only() {
+        let plan = hybrid().resolve_for(true, false);
+        assert_eq!(plan.sender_files_from_path.as_deref(), Some("/tmp/list"));
+        assert!(!plan.sender_from0);
+        assert_eq!(plan.remote_arg, None);
+        assert!(!plan.stage_local_bytes);
+    }
+
+    #[test]
+    fn resolve_hybrid_push_honours_from0() {
+        let plan = hybrid().resolve_for(true, true);
+        assert_eq!(plan.sender_files_from_path.as_deref(), Some("/tmp/list"));
+        assert!(plan.sender_from0);
+    }
+
+    // PULL-Hybrid stages the local bytes and forwards `--files-from=-` to the
+    // remote sender - never the stripped wire arg. This is the fix for
+    // symptom B (NDX 101 vs 1 protocol violation from the discarded second fd).
+    #[test]
+    fn resolve_hybrid_pull_stages_bytes_and_forwards_dash() {
+        let plan = hybrid().resolve_for(false, false);
+        assert!(plan.stage_local_bytes);
+        assert_eq!(plan.remote_arg.as_deref(), Some("-"));
+        assert!(plan.remote_from0);
+        assert_eq!(plan.sender_files_from_path, None);
+    }
+
+    #[test]
+    fn resolve_local_file_push_opens_path() {
+        let src = FilesFromSource::LocalFile(PathBuf::from("/tmp/list"));
+        let plan = src.resolve_for(true, true);
+        assert_eq!(plan.sender_files_from_path.as_deref(), Some("/tmp/list"));
+        assert!(plan.sender_from0);
+        assert!(!plan.stage_local_bytes);
+        assert_eq!(plan.remote_arg, None);
+    }
+
+    #[test]
+    fn resolve_local_file_pull_stages_and_forwards_dash() {
+        let src = FilesFromSource::LocalFile(PathBuf::from("/tmp/list"));
+        let plan = src.resolve_for(false, true);
+        assert!(plan.stage_local_bytes);
+        assert_eq!(plan.remote_arg.as_deref(), Some("-"));
+        assert!(plan.remote_from0);
+        assert_eq!(plan.sender_files_from_path, None);
+    }
+
+    #[test]
+    fn resolve_stdin_push_reads_dash() {
+        let plan = FilesFromSource::Stdin.resolve_for(true, false);
+        assert_eq!(plan.sender_files_from_path.as_deref(), Some("-"));
+        assert!(!plan.stage_local_bytes);
+        assert_eq!(plan.remote_arg, None);
+    }
+
+    #[test]
+    fn resolve_stdin_pull_stages_and_forwards_dash() {
+        let plan = FilesFromSource::Stdin.resolve_for(false, false);
+        assert!(plan.stage_local_bytes);
+        assert_eq!(plan.remote_arg.as_deref(), Some("-"));
+        assert!(plan.remote_from0);
+    }
+
+    #[test]
+    fn resolve_remote_file_push_reads_wire_and_forwards_path() {
+        let src = FilesFromSource::RemoteFile("/remote/list".to_owned());
+        let plan = src.resolve_for(true, false);
+        assert_eq!(plan.sender_files_from_path.as_deref(), Some("-"));
+        assert!(plan.sender_from0);
+        assert_eq!(plan.remote_arg.as_deref(), Some("/remote/list"));
+        assert!(!plan.remote_from0);
+        assert!(!plan.stage_local_bytes);
+    }
+
+    #[test]
+    fn resolve_remote_file_pull_forwards_path_only() {
+        let src = FilesFromSource::RemoteFile("/remote/list".to_owned());
+        let plan = src.resolve_for(false, true);
+        assert_eq!(plan.sender_files_from_path, None);
+        assert_eq!(plan.remote_arg.as_deref(), Some("/remote/list"));
+        assert!(plan.remote_from0);
+        assert!(!plan.stage_local_bytes);
     }
 }

--- a/crates/core/src/client/config/enums/mod.rs
+++ b/crates/core/src/client/config/enums/mod.rs
@@ -17,7 +17,7 @@ pub use address::AddressMode;
 pub use checksum::{StrongChecksumAlgorithm, StrongChecksumChoice};
 pub use compression::CompressionSetting;
 pub use delete::DeleteMode;
-pub use files_from::FilesFromSource;
+pub use files_from::{FilesFromPlan, FilesFromSource};
 pub use human_readable::{HumanReadableMode, HumanReadableModeParseError};
 pub use tcp_fastopen::{ParseTcpFastOpenModeError, TcpFastOpenMode};
 pub use timeout::TransferTimeout;

--- a/crates/core/src/client/config/mod.rs
+++ b/crates/core/src/client/config/mod.rs
@@ -35,7 +35,7 @@ pub use client::ClientConfig;
 pub use client::EmbeddedSshOptions;
 pub use compress_env::force_no_compress_from_env;
 pub use enums::{
-    AddressMode, CompressionSetting, DeleteMode, FilesFromSource, HumanReadableMode,
+    AddressMode, CompressionSetting, DeleteMode, FilesFromPlan, FilesFromSource, HumanReadableMode,
     HumanReadableModeParseError, ParseTcpFastOpenModeError, StrongChecksumAlgorithm,
     StrongChecksumChoice, TcpFastOpenMode, TransferTimeout,
 };

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -103,7 +103,7 @@ mod summary;
 pub use self::config::EmbeddedSshOptions;
 pub use self::config::{
     AddressMode, BandwidthLimit, BindAddress, ClientConfig, ClientConfigBuilder,
-    CompressionSetting, ConfigConflict, DeleteMode, FilesFromSource, FilterRuleKind,
+    CompressionSetting, ConfigConflict, DeleteMode, FilesFromPlan, FilesFromSource, FilterRuleKind,
     FilterRuleSpec, HumanReadableMode, HumanReadableModeParseError, IconvParseError, IconvSetting,
     ParseTcpFastOpenModeError, ReferenceDirectory, ReferenceDirectoryKind, StrongChecksumAlgorithm,
     StrongChecksumChoice, TcpFastOpenMode, TransferTimeout, force_no_compress_from_env,

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -359,33 +359,20 @@ pub(super) fn build_full_daemon_args(
         args.push("--remove-source-files".to_owned());
     }
 
-    // upstream: options.c:2944-2956 - --files-from
+    // upstream: options.c:2944-2962 - server_options() forwards the
+    // files-from arg only when the remote peer reads the list. `is_sender`
+    // here means the daemon is the sender (PULL), so the local side pushes
+    // when `!is_sender`. The direction-aware resolver collapses the single
+    // files-from fd so a localhost:path hostspec is never double-sourced.
     {
-        use crate::client::config::FilesFromSource;
-        let client_is_sender = !is_sender;
-        match config.files_from() {
-            FilesFromSource::None => {}
-            FilesFromSource::Stdin | FilesFromSource::LocalFile(_) => {
-                if !client_is_sender {
-                    args.push("--files-from=-".to_owned());
-                    args.push("--from0".to_owned());
-                }
-            }
-            FilesFromSource::RemoteFile(path) => {
-                args.push(format!("--files-from={path}"));
-                if config.from0() {
-                    args.push("--from0".to_owned());
-                }
-            }
-            FilesFromSource::HybridLocalRemote { wire_arg, .. } => {
-                // upstream: options.c:3112-3138 - localhost:path stripped to
-                // wire_arg. The daemon server-side argv carries the stripped
-                // path while the client also stages bytes locally for PULL
-                // flush at crates/transfer/src/lib.rs:570.
-                args.push(format!("--files-from={wire_arg}"));
-                if config.from0() {
-                    args.push("--from0".to_owned());
-                }
+        let local_is_push = !is_sender;
+        let plan = config
+            .files_from()
+            .resolve_for(local_is_push, config.from0());
+        if let Some(arg) = plan.remote_arg {
+            args.push(format!("--files-from={arg}"));
+            if plan.remote_from0 {
+                args.push("--from0".to_owned());
             }
         }
     }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -49,27 +49,15 @@ pub(crate) fn build_server_config_for_generator(
     apply_common_daemon_config(config, &mut server_config, filter_rules);
     server_config.reference_directories = config.reference_directories().to_vec();
 
-    // upstream: clientserver.c - when --files-from references a remote file
-    // (colon prefix), the daemon receiver opens the file locally and forwards
-    // its content to the client sender via start_filesfrom_forwarding().
-    if config.files_from().is_remote() {
-        server_config.file_selection.files_from_path = Some("-".to_owned());
-        server_config.file_selection.from0 = true;
-    }
-
-    // upstream: options.c:2944 - when the client is the sender and --files-from
-    // points to a local file, the sender reads the list directly.
-    use crate::client::config::FilesFromSource;
-    match config.files_from() {
-        FilesFromSource::LocalFile(path) => {
-            server_config.file_selection.files_from_path = Some(path.to_string_lossy().to_string());
-            server_config.file_selection.from0 = config.from0();
-        }
-        FilesFromSource::Stdin => {
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = config.from0();
-        }
-        _ => {}
+    // upstream: options.c:2476-2501 / main.c:1322-1328 - the local sender
+    // resolves a single files-from fd. A local file (LocalFile/Stdin, or a
+    // localhost:path hostspec opened locally) is read directly; a remote-
+    // hosted list is forwarded from the daemon receiver over the wire and
+    // read here as `--files-from=-`.
+    let plan = config.files_from().resolve_for(true, config.from0());
+    if let Some(path) = plan.sender_files_from_path {
+        server_config.file_selection.files_from_path = Some(path);
+        server_config.file_selection.from0 = plan.sender_from0;
     }
 
     flags::apply_common_server_flags(config, &mut server_config);

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -58,7 +58,11 @@ pub(crate) fn run_pull_transfer(
     // upstream: main.c:1354-1356 - when pulling with --files-from pointing to a
     // local file or stdin, the client reads the file list locally and forwards
     // it to the daemon's generator over the protocol stream.
-    if config.files_from().is_local_forwarded() {
+    if config
+        .files_from()
+        .resolve_for(false, config.from0())
+        .stage_local_bytes
+    {
         let data =
             crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding(
                 config,

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -168,7 +168,11 @@ fn run_embedded_pull(
 
     // upstream: main.c:1372-1375 - pull with a local --files-from forwards the
     // file's bytes back to the remote sender via the protocol stream.
-    if config.files_from().is_local_forwarded() {
+    if config
+        .files_from()
+        .resolve_for(false, config.from0())
+        .stage_local_bytes
+    {
         let data =
             crate::client::remote::files_from_forwarding::read_local_files_from_for_forwarding(
                 config,
@@ -497,8 +501,6 @@ fn build_server_config_for_generator(
     config: &ClientConfig,
     local_paths: &[String],
 ) -> Result<ServerConfig, ClientError> {
-    use crate::client::config::FilesFromSource;
-
     let flag_string = flags::build_server_flag_string(config);
     let args: Vec<OsString> = local_paths.iter().map(OsString::from).collect();
 
@@ -510,30 +512,14 @@ fn build_server_config_for_generator(
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
 
-    // upstream: options.c:2473,2501 / main.c:1322-1328 - the sender opens the
-    // local files-from file (Stdin/LocalFile) or reads from the wire when the
-    // list is hosted on the remote receiver (RemoteFile).
-    match config.files_from() {
-        FilesFromSource::None => {}
-        FilesFromSource::Stdin => {
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = config.from0();
-        }
-        FilesFromSource::LocalFile(path) => {
-            server_config.file_selection.files_from_path =
-                Some(path.to_string_lossy().into_owned());
-            server_config.file_selection.from0 = config.from0();
-        }
-        FilesFromSource::RemoteFile(_) => {
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = true;
-        }
-        FilesFromSource::HybridLocalRemote { .. } => {
-            // upstream: options.c:3112-3138 - localhost:path stripped; client
-            // opens locally, server reads bytes from the wire as for RemoteFile.
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = true;
-        }
+    // upstream: options.c:2476-2501 / main.c:1322-1328 - the local sender
+    // resolves a single files-from fd: a local file (Stdin/LocalFile, or a
+    // localhost:path hostspec opened locally) or the wire fd when the list is
+    // hosted on the remote receiver (RemoteFile reads `--files-from=-`).
+    let plan = config.files_from().resolve_for(true, config.from0());
+    if let Some(path) = plan.sender_files_from_path {
+        server_config.file_selection.files_from_path = Some(path);
+        server_config.file_selection.from0 = plan.sender_from0;
     }
 
     flags::apply_common_server_flags(config, &mut server_config);

--- a/crates/core/src/client/remote/files_from_forwarding.rs
+++ b/crates/core/src/client/remote/files_from_forwarding.rs
@@ -54,10 +54,11 @@ pub(crate) fn read_local_files_from_for_forwarding(
             read_path_into(path, &mut wire_data, eol_nulls, iconv_converter.as_ref())?;
         }
         FilesFromSource::HybridLocalRemote { local_path, .. } => {
-            // upstream: options.c:3112-3138 - localhost:path stripped to a
-            // local file; client opens locally so PULL receivers have bytes
-            // to flush at crates/transfer/src/lib.rs:570 while the wire-arg
-            // still carries the stripped path for the remote server.
+            // upstream: options.c:2476-2501 - a localhost:path hostspec is a
+            // single local fd. This function only runs on PULL (gated by the
+            // resolver's stage_local_bytes), where the receiver opens the file
+            // locally and forwards its bytes to the remote sender. The remote
+            // sender reads `--files-from=-`; the stripped path is never sent.
             read_path_into(
                 local_path,
                 &mut wire_data,

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -13,8 +13,8 @@ use std::ffi::OsString;
 use std::time::SystemTime;
 
 use super::super::super::config::{
-    ClientConfig, DeleteMode, FilesFromSource, IconvSetting, ReferenceDirectoryKind,
-    StrongChecksumAlgorithm, TransferTimeout,
+    ClientConfig, DeleteMode, IconvSetting, ReferenceDirectoryKind, StrongChecksumAlgorithm,
+    TransferTimeout,
 };
 use super::{RemoteRole, SecludedInvocation};
 use transfer::setup::build_capability_string_suffix;
@@ -496,30 +496,20 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // `RemoteRole::Sender` here means the local process is the sender
         // (PUSH); `RemoteRole::Receiver` means the local process is the
         // receiver (PULL).
-        let local_is_sender = self.role == RemoteRole::Sender;
-        match self.config.files_from() {
-            FilesFromSource::None => {}
-            FilesFromSource::LocalFile(_) | FilesFromSource::Stdin => {
-                if !local_is_sender {
-                    args.push(OsString::from("--files-from=-"));
-                    args.push(OsString::from("--from0"));
-                }
-            }
-            FilesFromSource::RemoteFile(path) => {
-                args.push(OsString::from(format!("--files-from={path}")));
-                if self.config.from0() {
-                    args.push(OsString::from("--from0"));
-                }
-            }
-            FilesFromSource::HybridLocalRemote { wire_arg, .. } => {
-                // upstream: options.c:3112-3138 - localhost:path stripped to
-                // wire_arg. The remote server still receives the stripped
-                // path in argv just like the RemoteFile case; the client also
-                // stages bytes locally for PULL flush at lib.rs:570.
-                args.push(OsString::from(format!("--files-from={wire_arg}")));
-                if self.config.from0() {
-                    args.push(OsString::from("--from0"));
-                }
+        // upstream: options.c:2962 server_options() - the files-from arg is
+        // forwarded only when the remote peer reads the list (`!am_sender ||
+        // filesfrom_host`). The direction-aware resolver collapses the single
+        // files-from fd so a localhost:path hostspec is treated as a plain
+        // local file in either direction and never double-sourced.
+        let local_is_push = self.role == RemoteRole::Sender;
+        let plan = self
+            .config
+            .files_from()
+            .resolve_for(local_is_push, self.config.from0());
+        if let Some(arg) = plan.remote_arg {
+            args.push(OsString::from(format!("--files-from={arg}")));
+            if plan.remote_from0 {
+                args.push(OsString::from("--from0"));
             }
         }
 

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -364,7 +364,11 @@ fn run_pull_transfer(
     // forwards its bytes back to the remote sender via
     // `start_filesfrom_forwarding(filesfrom_fd)`. The remote sender consumes
     // the forwarded bytes through its protocol stream.
-    if config.files_from().is_local_forwarded() {
+    if config
+        .files_from()
+        .resolve_for(false, config.from0())
+        .stage_local_bytes
+    {
         let data = read_local_files_from_for_forwarding(config)?;
         server_config.connection.files_from_data = Some(data);
     }
@@ -745,33 +749,14 @@ pub(super) fn build_server_config_for_generator(
 ///   `setup_protocol()`; the remote receiver forwards the list bytes over the
 ///   wire via `start_filesfrom_forwarding`.
 fn apply_files_from_for_sender(config: &ClientConfig, server_config: &mut ServerConfig) {
-    use super::super::config::FilesFromSource;
-    match config.files_from() {
-        FilesFromSource::None => {}
-        FilesFromSource::Stdin => {
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = config.from0();
-        }
-        FilesFromSource::LocalFile(path) => {
-            server_config.file_selection.files_from_path =
-                Some(path.to_string_lossy().into_owned());
-            server_config.file_selection.from0 = config.from0();
-        }
-        FilesFromSource::RemoteFile(_) => {
-            // The remote receiver opens the file and forwards its bytes back
-            // to us; the generator reads them as if they came from stdin.
-            // upstream: main.c:1191-1198 start_filesfrom_forwarding(filesfrom_fd)
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = true;
-        }
-        FilesFromSource::HybridLocalRemote { .. } => {
-            // upstream: options.c:3112-3138 - localhost:path stripped; the
-            // client opens the file locally and stages the bytes into
-            // files_from_data, then the server reads them from the wire just
-            // like the plain RemoteFile case.
-            server_config.file_selection.files_from_path = Some("-".to_owned());
-            server_config.file_selection.from0 = true;
-        }
+    // upstream: options.c:2476-2501 / main.c:1322-1328 - the local sender
+    // resolves a single files-from fd. A localhost:path hostspec is opened
+    // locally here (never staged + wire-forwarded), matching a plain local
+    // file; a remote-hosted list is read from the wire as `--files-from=-`.
+    let plan = config.files_from().resolve_for(true, config.from0());
+    if let Some(path) = plan.sender_files_from_path {
+        server_config.file_selection.files_from_path = Some(path);
+        server_config.file_selection.from0 = plan.sender_from0;
     }
 }
 


### PR DESCRIPTION
## Summary

A `--files-from=localhost:path` spec whose stripped path is openable on the
client was being treated as both a local file (opened and staged into the
forwarding buffer) AND a remote file (the stripped path forwarded to the
remote peer's argv). That double-sourced the file list, which violates
rsync's single files-from file-descriptor model.

Upstream rsync keeps exactly one files-from fd (`options.c:2476-2501`,
`main.c:1322-1328`): a remote `--files-from` is EITHER opened locally OR
read from the live wire fd (`filesfrom_fd = f_in`), never both.
`server_options()` (`options.c:2962`) forwards the arg only when
`!am_sender || filesfrom_host`.

## Symptoms fixed

- **A (push):** duplicate `>f+++++++++` itemized output - the same entry
  was emitted once from the locally opened file and once from the wire
  forward.
- **B (pull):** `sender echoed NDX 101 but expected 1 - protocol violation
  (code 12)` crash - the discarded second fd desynchronised the index
  stream.

## Fix

`FilesFromSource::resolve_for(is_push, from0) -> FilesFromPlan` collapses
the hybrid local/remote variant into a single fd per transfer direction:

- **PUSH:** the local sender opens `local_path` directly, exactly like a
  plain local file. No `--files-from` is forwarded and nothing is staged.
- **PULL:** the local receiver stages `local_path`'s bytes and the remote
  sender reads `--files-from=-`, exactly like a plain local file. The
  stripped hostspec path is never handed to the remote sender.

All other variants (`None`, `Stdin`, `LocalFile`, `RemoteFile`) keep their
existing upstream behaviour - the resolver is a single source of truth that
replaces the per-call-site enum matches across the SSH and daemon backends.

## Files changed

- `crates/core/src/client/config/enums/files_from.rs` - new `FilesFromPlan`
  struct and `resolve_for` resolver, plus unit tests; `is_local_forwarded`
  removed (no longer consulted; the resolver gates staging).
- SSH sender/receiver and daemon argv/server-config/staging call sites
  rewired to consult the resolver.
- `parser.rs` classification comment documents why the hybrid variant is
  emitted unconditionally for a localhost hostspec (direction is resolved
  downstream).