### PR TITLE
fix(filters): protect excluded-dir children on the delete pass

### DIFF
--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -74,11 +74,25 @@ impl FilterSegment {
         // literal name-match semantics and prevents anchored patterns like
         // `- /bar` from over-matching deep paths (UTS-V3-B exclude-lsh).
         let check_descendants = false;
+        // upstream: an excluded directory protects its descendants from
+        // deletion because the generator never descends into it. On the
+        // deletion scan a directory-only unanchored wildcard exclude (`foo/*/`)
+        // therefore keeps `foo/sub/file1` off the delete pass via its
+        // deletion-only descendant matchers; the Transfer path must NOT see
+        // those (it would re-trip the #6015 `foo/*/` over-exclusion).
+        let for_deletion = matches!(context, FilterContext::Deletion);
+        let rule_matches = |rule: &CompiledRule, path: &Path, is_dir: bool| {
+            if for_deletion {
+                rule.matches_for_deletion(path, is_dir, check_descendants)
+            } else {
+                rule.matches(path, is_dir, check_descendants)
+            }
+        };
         for rule in &self.include_exclude {
             if outcome.transfer_decided() {
                 break;
             }
-            if rule.matches(path, is_dir, check_descendants) {
+            if rule_matches(rule, path, is_dir) {
                 if matches!(context, FilterContext::Deletion) && rule.applies_to_receiver {
                     outcome.set_delete_excluded(matches!(rule.action, FilterAction::Exclude));
                 }
@@ -108,7 +122,7 @@ impl FilterSegment {
             if matches!(context, FilterContext::Deletion) && rule.perishable {
                 continue;
             }
-            if rule.matches(path, is_dir, check_descendants) {
+            if rule_matches(rule, path, is_dir) {
                 let applies = match context {
                     FilterContext::Transfer => rule.applies_to_sender,
                     FilterContext::Deletion => rule.applies_to_receiver,
@@ -218,6 +232,12 @@ struct CompiledRule {
     directory_only: bool,
     direct_matchers: Vec<GlobMatcher>,
     descendant_matchers: Vec<GlobMatcher>,
+    /// Descendant matchers (`{core}/**`) consulted ONLY on the deletion path.
+    /// Populated for directory-only unanchored wildcard excludes (`foo/*/`) so
+    /// the receiver keeps `foo/sub/file1` off the delete pass while the
+    /// Transfer path never sees `foo/*/**` (mirrors the filters-crate
+    /// `CompiledRule`; preserves the #6015 `foo/*/` over-exclusion fix).
+    deletion_descendant_matchers: Vec<GlobMatcher>,
     applies_to_sender: bool,
     applies_to_receiver: bool,
     perishable: bool,
@@ -253,14 +273,30 @@ impl CompiledRule {
         let has_glob_wildcard =
             core_pattern.contains('*') || core_pattern.contains('?') || core_pattern.contains('[');
         let slash_anchored = pattern.starts_with('/');
+        let is_directory_only_unanchored_wildcard =
+            directory_only && !slash_anchored && has_glob_wildcard;
+        let is_anchored_wildcard = slash_anchored && has_glob_wildcard;
+        let mut deletion_descendant_patterns = HashSet::new();
         if matches!(
             action,
             FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
-        ) && !(slash_anchored && has_glob_wildcard)
-        {
-            descendant_patterns.insert(format!("{core_pattern}/**"));
-            if !anchored {
-                descendant_patterns.insert(format!("**/{core_pattern}/**"));
+        ) {
+            if !(is_anchored_wildcard || is_directory_only_unanchored_wildcard) {
+                descendant_patterns.insert(format!("{core_pattern}/**"));
+                if !anchored {
+                    descendant_patterns.insert(format!("**/{core_pattern}/**"));
+                }
+            } else if is_directory_only_unanchored_wildcard {
+                // upstream: a directory-only unanchored wildcard (`foo/*/`)
+                // emits no `foo/*/**` transfer rule (#6015); the sender walk
+                // prunes the matched directory. The receiver's per-candidate
+                // deletion scan has no such pruning, so route `{core}/**` into
+                // a deletion-only set so excluded-directory children stay off
+                // the delete pass without re-exposing `foo/*/**` to transfer.
+                deletion_descendant_patterns.insert(format!("{core_pattern}/**"));
+                if !anchored {
+                    deletion_descendant_patterns.insert(format!("**/{core_pattern}/**"));
+                }
             }
         }
 
@@ -269,6 +305,7 @@ impl CompiledRule {
             directory_only,
             direct_matchers: compile_patterns(direct_patterns, &pattern)?,
             descendant_matchers: compile_patterns(descendant_patterns, &pattern)?,
+            deletion_descendant_matchers: compile_patterns(deletion_descendant_patterns, &pattern)?,
             applies_to_sender,
             applies_to_receiver,
             perishable: rule.is_perishable(),
@@ -280,6 +317,26 @@ impl CompiledRule {
         let pattern_matched = self.pattern_matches(path, is_dir, check_descendants);
         // upstream: exclude.c:906 - `ret_match = ex->rflags & FILTRULE_NEGATE ? 0 : 1`.
         // A negated rule fires when the pattern does NOT match.
+        if self.negate {
+            !pattern_matched
+        } else {
+            pattern_matched
+        }
+    }
+
+    /// Like [`Self::matches`] but additionally consults the deletion-only
+    /// descendant matchers. An excluded directory protects its descendants
+    /// from deletion regardless of `check_descendants`, because the receiver
+    /// scan evaluates each candidate in isolation with no traversal-pruning
+    /// side effect.
+    ///
+    /// upstream: exclude.c:rule_matches() / name_is_excluded() subtree pruning
+    fn matches_for_deletion(&self, path: &Path, is_dir: bool, check_descendants: bool) -> bool {
+        let pattern_matched = self.pattern_matches(path, is_dir, check_descendants)
+            || self
+                .deletion_descendant_matchers
+                .iter()
+                .any(|matcher| matcher.is_match(path));
         if self.negate {
             !pattern_matched
         } else {
@@ -564,17 +621,24 @@ mod tests {
         assert!(!rule.matches(Path::new("subdir/report.csv"), false, true));
     }
 
-    /// `--exclude '*/'` exposes descendant matchers, but the per-entry filter
-    /// path (`FilterSegment::apply`) does NOT consult them. This mirrors
-    /// upstream `exclude.c:rule_matches()` which has no descendant logic at
-    /// all; descendants only fire when a caller explicitly asks for them
-    /// outside the normal traversal-driven evaluation.
+    /// `--exclude '*/'` (a directory-only unanchored wildcard) routes its
+    /// `*/**` descendant into the deletion-only set, mirroring upstream
+    /// `exclude.c:rule_matches()`: the transfer path emits no `*/**` rule (the
+    /// sender walk prunes the matched directory, #6015), while the receiver
+    /// deletion scan must protect children of the excluded directory from
+    /// over-deletion (`exclude` / `exclude-lsh` regression).
     #[test]
-    fn exclude_directory_only_descendant_gated_on_check_descendants() {
+    fn exclude_directory_only_descendant_gated_by_context() {
         let rule = CompiledRule::new(FilterRule::exclude("*/".to_owned())).unwrap();
+        // Directory entry matches directly in both contexts.
         assert!(rule.matches(Path::new("subdir"), true, false));
-        assert!(rule.matches(Path::new("subdir/debug.log"), false, true));
+        // Transfer path never matches a child via a synthetic descendant, even
+        // with check_descendants requested (#6015 guard).
+        assert!(!rule.matches(Path::new("subdir/debug.log"), false, true));
         assert!(!rule.matches(Path::new("subdir/debug.log"), false, false));
+        // Deletion path protects the child regardless of check_descendants.
+        assert!(rule.matches_for_deletion(Path::new("subdir/debug.log"), false, false));
+        assert!(rule.matches_for_deletion(Path::new("subdir/debug.log"), false, true));
     }
 
     /// Verifies patterns with internal `/` but no leading `/` are NOT
@@ -660,6 +724,39 @@ mod tests {
         assert!(
             outcome.allows_deletion_when_excluded_removed(),
             "matching exclude rule must enable --delete-excluded removal"
+        );
+    }
+
+    /// Regression for the `exclude` / `exclude-lsh` over-deletion: under
+    /// `--delete-during` a directory-only unanchored wildcard exclude
+    /// (`- foo/*/`) must protect the children of the matched directory from
+    /// deletion. `FilterSegment::apply` calls with `check_descendants = false`,
+    /// so the protection rides on the deletion-only descendant matchers. The
+    /// transfer evaluation of the same child must stay "allowed" so #6015's
+    /// `foo/*/` over-exclusion does not return.
+    #[test]
+    fn deletion_dir_only_wildcard_protects_children() {
+        let mut segment = FilterSegment::default();
+        segment
+            .push_rule(FilterRule::exclude("foo/*/".to_owned()))
+            .unwrap();
+
+        let child = Path::new("foo/sub/file1");
+
+        let mut del = FilterOutcome::default();
+        segment.apply(child, false, &mut del, FilterContext::Deletion);
+        assert!(
+            !del.allows_deletion(),
+            "`foo/sub/file1` must be protected from deletion by `- foo/*/`",
+        );
+
+        // The transfer path must NOT exclude the child via a synthetic
+        // descendant - the sender walk prunes the directory instead (#6015).
+        let mut xfer = FilterOutcome::default();
+        segment.apply(child, false, &mut xfer, FilterContext::Transfer);
+        assert!(
+            xfer.allows_transfer(),
+            "`foo/sub/file1` must not be excluded on the transfer path (#6015)",
         );
     }
 

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -114,25 +114,45 @@ impl CompiledRule {
             directory_only && !slash_anchored && has_glob_wildcard;
         let is_anchored_wildcard = slash_anchored && has_glob_wildcard;
         let suppress_descendants = is_directory_only_unanchored_wildcard || is_anchored_wildcard;
+        let mut deletion_descendant_patterns = HashSet::new();
         if matches!(
             action,
             FilterAction::Exclude | FilterAction::Protect | FilterAction::Risk
-        ) && !suppress_descendants
-        {
-            descendant_patterns.insert(format!("{core_pattern}/**"));
-            if !anchored && !has_double_star {
-                descendant_patterns.insert(format!("**/{core_pattern}/**"));
+        ) {
+            if !suppress_descendants {
+                descendant_patterns.insert(format!("{core_pattern}/**"));
+                if !anchored && !has_double_star {
+                    descendant_patterns.insert(format!("**/{core_pattern}/**"));
+                }
+            } else if is_directory_only_unanchored_wildcard {
+                // upstream: exclude.c:rule_matches() emits no `foo/*/**`
+                // transfer rule for a directory-only unanchored wildcard - the
+                // sender walk prunes the matched directory instead (#6015).
+                // The receiver's per-candidate deletion scan has no such
+                // pruning, so route `{core}/**` into a deletion-only set that
+                // keeps children of the excluded directory off the delete pass
+                // without re-exposing `foo/*/**` to the Transfer path. The
+                // anchored-wildcard case (`/*`) stays fully suppressed because
+                // `*/**` would over-match nested paths even on deletion
+                // (regression #5421).
+                deletion_descendant_patterns.insert(format!("{core_pattern}/**"));
+                if !anchored && !has_double_star {
+                    deletion_descendant_patterns.insert(format!("**/{core_pattern}/**"));
+                }
             }
         }
 
         let direct_matchers = compile_patterns(direct_patterns, &pattern)?;
         let descendant_matchers = compile_patterns(descendant_patterns, &pattern)?;
+        let deletion_descendant_matchers =
+            compile_patterns(deletion_descendant_patterns, &pattern)?;
 
         Ok(Self {
             action,
             directory_only,
             direct_matchers,
             descendant_matchers,
+            deletion_descendant_matchers,
             applies_to_sender,
             applies_to_receiver,
             perishable,
@@ -485,6 +505,19 @@ mod tests {
         out
     }
 
+    /// Collects the source pattern strings of every deletion-only descendant
+    /// matcher (those that fire on the receiver delete pass but never on the
+    /// transfer path).
+    fn deletion_descendant_pattern_strings(compiled: &CompiledRule) -> Vec<String> {
+        let mut out: Vec<String> = compiled
+            .deletion_descendant_matchers
+            .iter()
+            .map(|m| m.glob().glob().to_string())
+            .collect();
+        out.sort();
+        out
+    }
+
     fn make_exclude(pattern: &str) -> CompiledRule {
         CompiledRule::new(FilterRule {
             action: FilterAction::Exclude,
@@ -586,8 +619,36 @@ mod tests {
         assert_eq!(direct_pattern_strings(&compiled), vec!["**/foo/*", "foo/*"]);
         assert!(
             descendant_pattern_strings(&compiled).is_empty(),
-            "`foo/*/` must not synthesise descendant matchers (upstream FILTRULE_DIRECTORY semantic)"
+            "`foo/*/` must not synthesise transfer descendant matchers (upstream FILTRULE_DIRECTORY semantic)"
         );
+        // The `{core}/**` descendant is routed to the deletion-only set so the
+        // receiver protects children of the excluded directory (exclude /
+        // exclude-lsh over-deletion regression) without re-exposing `foo/*/**`
+        // to the transfer path (#6015).
+        assert_eq!(
+            deletion_descendant_pattern_strings(&compiled),
+            vec!["**/foo/*/**", "foo/*/**"],
+        );
+    }
+
+    /// The deletion-only descendant matcher must fire only on the deletion
+    /// path. `matches_for_deletion` sees `foo/sub/file1`; the transfer
+    /// `matches` (any `check_descendants`) must not (#6015 guard).
+    #[test]
+    fn deletion_descendant_matches_only_for_deletion() {
+        use std::path::Path;
+        let compiled = make_exclude("foo/*/");
+        let child = Path::new("foo/sub/file1");
+
+        assert!(
+            compiled.matches_for_deletion(child, false, false),
+            "foo/*/ deletion path must protect foo/sub/file1",
+        );
+        assert!(
+            !compiled.matches(child, false, true),
+            "foo/*/ transfer path must NOT match foo/sub/file1 even with check_descendants",
+        );
+        assert!(!compiled.matches(child, false, false));
     }
 
     /// UTS-DD-exclude.3 wire-byte parity for `**/node_modules/`: leading

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -23,6 +23,17 @@ pub(crate) struct CompiledRule {
     pub(super) directory_only: bool,
     pub(super) direct_matchers: Vec<GlobMatcher>,
     pub(super) descendant_matchers: Vec<GlobMatcher>,
+    /// Descendant matchers (`{core}/**`) that must fire ONLY on the deletion
+    /// (receiver) path. Populated for directory-only unanchored wildcard
+    /// excludes such as `foo/*/`. Upstream's sender walk prunes the excluded
+    /// directory and never emits a `foo/*/**` transfer rule (exclude.c:938-939
+    /// FILTRULE_DIRECTORY returns "no match" for a non-dir candidate), so these
+    /// must stay invisible to the Transfer path to preserve the `foo/*/`
+    /// per-directory wildcard semantics that #6015 fixed. The receiver's
+    /// per-candidate deletion scan has no traversal-pruning side effect, so it
+    /// needs these descendants live to protect children of an excluded
+    /// directory from over-deletion.
+    pub(super) deletion_descendant_matchers: Vec<GlobMatcher>,
     pub(crate) applies_to_sender: bool,
     pub(crate) applies_to_receiver: bool,
     pub(crate) perishable: bool,
@@ -59,6 +70,43 @@ impl CompiledRule {
         } else {
             pattern_matched
         }
+    }
+
+    /// Like [`Self::matches`] but for the receiver's deletion scan.
+    ///
+    /// Adds the `deletion_descendant_matchers` set on top of the regular
+    /// matchers. Those descendants encode the
+    /// upstream invariant that an excluded directory protects its descendants
+    /// from deletion (the generator never descends into it). They are
+    /// consulted independently of `check_descendants` because the deletion
+    /// scan evaluates each candidate in isolation - it has no traversal-pruning
+    /// side effect to suppress, and the local-copy delete pass calls with
+    /// `check_descendants = false`. Keeping them out of [`Self::matches`]
+    /// preserves the `foo/*/` per-directory wildcard transfer semantics fixed
+    /// in #6015.
+    ///
+    /// upstream: exclude.c:rule_matches() / name_is_excluded() subtree pruning
+    pub(crate) fn matches_for_deletion(
+        &self,
+        path: &Path,
+        is_dir: bool,
+        check_descendants: bool,
+    ) -> bool {
+        let pattern_matched = self.pattern_matches_impl(path, is_dir, check_descendants)
+            || self.deletion_descendant_matches(path);
+
+        if self.negate {
+            !pattern_matched
+        } else {
+            pattern_matched
+        }
+    }
+
+    /// Returns `true` when a deletion-only descendant matcher fires for `path`.
+    fn deletion_descendant_matches(&self, path: &Path) -> bool {
+        self.deletion_descendant_matchers
+            .iter()
+            .any(|matcher| matcher.is_match(path))
     }
 
     /// Internal pattern matching without negate logic.

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -70,6 +70,7 @@ impl FilterSetInner {
         // `./foo/.cvsignore` fire against the sibling subtree `./bar/x`.
         let check_descendants = !traversal;
 
+        let for_deletion = matches!(context, DecisionContext::Deletion);
         let transfer_rule = match context {
             DecisionContext::Transfer => first_matching_rule(
                 &self.include_exclude,
@@ -78,6 +79,7 @@ impl FilterSetInner {
                 |rule| rule.applies_to_sender,
                 true,
                 check_descendants,
+                false,
             ),
             DecisionContext::Deletion => first_matching_rule(
                 &self.include_exclude,
@@ -86,6 +88,7 @@ impl FilterSetInner {
                 |rule| rule.applies_to_receiver,
                 false,
                 check_descendants,
+                true,
             ),
         };
 
@@ -97,6 +100,7 @@ impl FilterSetInner {
                 |rule| rule.applies_to_receiver,
                 true,
                 check_descendants,
+                for_deletion,
             )
         {
             decision.excluded_for_delete_excluded = matches!(rule.action, FilterAction::Exclude);
@@ -121,6 +125,7 @@ impl FilterSetInner {
                 |rule| rule.applies_to_sender,
                 true,
                 check_descendants,
+                false,
             ),
             DecisionContext::Deletion => first_matching_rule(
                 &self.protect_risk,
@@ -129,6 +134,7 @@ impl FilterSetInner {
                 |rule| rule.applies_to_receiver,
                 false,
                 check_descendants,
+                true,
             ),
         };
 
@@ -170,6 +176,7 @@ impl FilterSetInner {
             DecisionContext::Deletion => |rule| rule.applies_to_receiver,
         };
         let include_perishable = matches!(context, DecisionContext::Transfer);
+        let for_deletion = matches!(context, DecisionContext::Deletion);
         if first_matching_rule(
             &self.include_exclude,
             path,
@@ -177,6 +184,7 @@ impl FilterSetInner {
             applies,
             include_perishable,
             false,
+            for_deletion,
         )
         .is_some()
         {
@@ -189,6 +197,7 @@ impl FilterSetInner {
             applies,
             include_perishable,
             false,
+            for_deletion,
         )
         .is_some()
     }
@@ -210,6 +219,7 @@ impl FilterSetInner {
             |rule| rule.applies_to_sender,
             true,
             false,
+            false,
         ) {
             matches!(rule.action, FilterAction::Exclude) && !rule.is_directory_only()
         } else {
@@ -230,6 +240,12 @@ impl FilterSetInner {
 /// * `is_dir` - Whether the path is a directory (affects trailing-slash patterns)
 /// * `applies` - Predicate filtering which rules are considered (e.g., sender-only rules)
 /// * `include_perishable` - Whether to consider perishable rules (marked with `p` modifier)
+/// * `check_descendants` - Whether to consult the synthetic `pattern/**` descendant matchers
+/// * `for_deletion` - When `true`, also consult the deletion-only descendant
+///   matchers so an excluded directory protects its children from deletion
+///   (upstream subtree-pruning semantic). Kept off the transfer path so a
+///   directory-only unanchored wildcard like `foo/*/` does not over-exclude
+///   files inside subdirectories (#6015).
 ///
 /// # Returns
 ///
@@ -244,6 +260,7 @@ fn first_matching_rule<'a, F>(
     mut applies: F,
     include_perishable: bool,
     check_descendants: bool,
+    for_deletion: bool,
 ) -> Option<&'a CompiledRule>
 where
     F: FnMut(&CompiledRule) -> bool,
@@ -251,7 +268,11 @@ where
     rules.iter().find(|rule| {
         (include_perishable || !rule.perishable)
             && applies(rule)
-            && rule.matches(path, is_dir, check_descendants)
+            && if for_deletion {
+                rule.matches_for_deletion(path, is_dir, check_descendants)
+            } else {
+                rule.matches(path, is_dir, check_descendants)
+            }
     })
 }
 
@@ -500,6 +521,86 @@ mod tests {
         assert!(
             recursive.allows_deletion(),
             "Deletion+Recursive: descendant matchers are suppressed because the walk handles descent",
+        );
+    }
+
+    /// Regression for the `exclude` / `exclude-lsh` over-deletion: a
+    /// directory-only unanchored wildcard exclude (`foo/*/`) must protect the
+    /// children of the matched directory from deletion on the receiver. After
+    /// #6015 suppressed the synthesised `foo/*/**` descendant for BOTH the
+    /// transfer and deletion paths, `foo/sub/file1` fell through to the
+    /// default "allow deletion" and was over-deleted under `--delete-during`.
+    /// The deletion-only descendant matcher restores child protection while
+    /// keeping the descendant invisible to the transfer path (see
+    /// [`deletion_dir_only_wildcard_does_not_affect_transfer`]).
+    ///
+    /// upstream: an excluded directory protects its descendants from deletion
+    /// because the generator never descends into it (exclude.c subtree
+    /// pruning); the receiver scan must reproduce that per-candidate.
+    #[test]
+    fn deletion_dir_only_wildcard_protects_children() {
+        let mut inner = FilterSetInner::default();
+        push_rule(&mut inner, FilterAction::Exclude, "foo/*/");
+
+        let child = Path::new("foo/sub/file1");
+        // Both the single-path API and the per-directory traversal commit must
+        // treat the child of the excluded directory as NOT deletable; the
+        // deletion-only descendants fire independently of the traversal gate.
+        let single = inner.decision_with_traversal(child, false, DecisionContext::Deletion, false);
+        assert!(
+            !single.allows_deletion(),
+            "Deletion single-path: foo/*/ must protect foo/sub/file1 from deletion",
+        );
+        let recursive =
+            inner.decision_with_traversal(child, false, DecisionContext::Deletion, true);
+        assert!(
+            !recursive.allows_deletion(),
+            "Deletion+traversal: foo/*/ must protect foo/sub/file1 from deletion",
+        );
+
+        // A nested grandchild is equally protected.
+        let deep = Path::new("foo/sub/inner/file2");
+        assert!(
+            !inner
+                .decision_with_traversal(deep, false, DecisionContext::Deletion, false)
+                .allows_deletion(),
+            "Deletion: foo/*/ must protect foo/sub/inner/file2 from deletion",
+        );
+    }
+
+    /// #6015 guard: the deletion-only descendant for a directory-only
+    /// unanchored wildcard exclude (`foo/*/`) must NOT leak into the transfer
+    /// path. Upstream emits no `foo/*/**` transfer rule, so `foo/sub/file1`
+    /// stays included for transfer (it must match its own rules, and there is
+    /// none). Re-exposing the descendant here would re-trip the over-exclusion
+    /// #6015 fixed (`complex_nested_patterns`).
+    #[test]
+    fn deletion_dir_only_wildcard_does_not_affect_transfer() {
+        let mut inner = FilterSetInner::default();
+        push_rule(&mut inner, FilterAction::Exclude, "foo/*/");
+
+        let child = Path::new("foo/sub/file1");
+        // The directory itself is excluded for transfer (direct matcher).
+        assert!(
+            !inner
+                .decision(Path::new("foo/sub"), true, DecisionContext::Transfer)
+                .allows_transfer(),
+            "Transfer: foo/*/ excludes the directory foo/sub",
+        );
+        // But a file inside is NOT excluded by the directory-only wildcard on
+        // the transfer path - it would only be skipped because the sender walk
+        // never descends into the pruned directory.
+        assert!(
+            inner
+                .decision(child, false, DecisionContext::Transfer)
+                .allows_transfer(),
+            "Transfer: foo/*/ must NOT exclude foo/sub/file1 via a synthetic descendant (#6015)",
+        );
+        assert!(
+            inner
+                .decision_with_traversal(child, false, DecisionContext::Transfer, true)
+                .allows_transfer(),
+            "Transfer+traversal: foo/*/ must NOT exclude foo/sub/file1 (#6015)",
         );
     }
 }


### PR DESCRIPTION
## Problem

A directory-only unanchored wildcard exclude such as `- foo/*/` combined with `--delete-during` (or `--delete`) over-deletes the children of the matched directory. For example, `foo/sub/file1` and nested entries are deleted on the receiver even though the directory `foo/sub` is excluded.

Upstream rsync protects those children by never descending into an excluded directory during the generator walk (subtree pruning in `exclude.c`). oc-rsync instead evaluates each deletion candidate against the compiled rules per-path, so it needs the synthesised `{core}/**` descendant matcher to be live on the deletion path.

## Root cause

PR #6015 ("apply directory-only descendants gate universally") folded directory-only unanchored wildcards into the compile-time `suppress_descendants` gate. That was the correct fix for a transfer-side over-exclusion: `foo/*/` must not pre-bake a blanket `foo/*/**` rule that would steal precedence from a later `+ foo/s?b/` on the sender path.

But the suppression was unconditional, so the descendant was also stripped from the deletion path - the one place where oc-rsync's per-candidate matcher actually needs it. With the descendant gone, a candidate like `foo/sub/file1` matched no rule, fell through to the default `transfer_allowed = true`, and was deleted.

## Fix

Split the synthesised `{core}/**` descendant for directory-only unanchored wildcard excludes into a separate, deletion-only matcher set:

- **Transfer path** keeps the #6015 behaviour: no `foo/*/**` is ever synthesised, so the per-directory wildcard semantics (and the `+ foo/s?b/` precedence) are preserved.
- **Deletion path** consults the deletion-only descendants, so an excluded directory protects its children from the delete pass, matching upstream's subtree-pruning result.

The change is mirrored in both compiled-rule implementations:

- `crates/filters/src/compiled` (`CompiledRule`) - the receiver / daemon deletion path through `FilterChain`/`FilterSet`.
- `crates/engine/src/local_copy/filter_program/segments.rs` (engine-local `CompiledRule`) - the local-copy delete pass.

Deletion call sites route through a new `matches_for_deletion()` that adds the deletion-only descendants on top of the regular matchers, independent of the `check_descendants`/traversal gate (the local-copy delete pass calls with `check_descendants = false`).

Anchored wildcards (`/*`, `/cache_?/`) remain fully suppressed in both contexts so `*/**` cannot over-match nested paths (regression #5421 stays fixed).

## Tests

- `filters`: deletion protection for `foo/*/` children on both the single-path and traversal entry points, plus an explicit guard that the transfer path stays unaffected (#6015 guard), plus exact deletion-descendant matcher-set assertions.
- `engine`: `FilterSegment::apply` protects `foo/sub/file1` from deletion while leaving the transfer decision allowed.

No wire protocol changes. No public API changes.