### PR TITLE
ci: DRY release-binary build via composite action

### DIFF
--- a/.github/actions/build-oc-rsync/action.yml
+++ b/.github/actions/build-oc-rsync/action.yml
@@ -1,0 +1,20 @@
+name: Build oc-rsync (release)
+description: >
+  Build the oc-rsync release binary with `cargo build --locked --release`.
+  Accepts an optional `features` input for future reuse; omit it to get the
+  bare release build used by the standard CI matrix.
+
+inputs:
+  features:
+    description: Comma-separated feature flags to pass via --features (optional).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Build oc-rsync
+      shell: bash
+      run: >
+        cargo build --locked --release --bin oc-rsync
+        ${{ inputs.features && format('--features {0}', inputs.features) || '' }}

--- a/.github/workflows/_benchmark-macos.yml
+++ b/.github/workflows/_benchmark-macos.yml
@@ -56,7 +56,7 @@ jobs:
         run: brew install xxhash zstd lz4 openssl@3 autoconf automake || true
 
       - name: Build oc-rsync (release)
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Cache upstream rsync
         id: cache-rsync

--- a/.github/workflows/_interop-windows.yml
+++ b/.github/workflows/_interop-windows.yml
@@ -86,7 +86,7 @@ jobs:
           key: interop-windows
 
       - name: Build oc-rsync
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       # Set up MSYS2 with a current rsync package. MSYS2 ships
       # rsync >= 3.2 with a Cygwin-style runtime; this is the most

--- a/.github/workflows/bench-daemon-coldstart.yml
+++ b/.github/workflows/bench-daemon-coldstart.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install -y rsync hyperfine jq
 
       - name: Build oc-rsync (release)
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Prepare fixture and daemon configs
         id: prep

--- a/.github/workflows/bench-daemon-concurrency.yml
+++ b/.github/workflows/bench-daemon-concurrency.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get install -y rsync hyperfine jq time
 
       - name: Build oc-rsync (release)
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Prepare fixture and daemon config
         id: prep

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -79,7 +79,7 @@ jobs:
         run: bash tools/ci/run_interop.sh build-only
 
       - name: Build oc-rsync
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Stage shared interop artifact
         run: |

--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       - name: Build oc-rsync (release)
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Run MDF-8 diff harness
         run: |

--- a/.github/workflows/upstream-testsuite.yml
+++ b/.github/workflows/upstream-testsuite.yml
@@ -81,7 +81,7 @@ jobs:
           key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh') }}-${{ runner.os }}
 
       - name: Build oc-rsync (release)
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Run upstream testsuite
         id: testsuite

--- a/.github/workflows/validate-daemon-environmental.yml
+++ b/.github/workflows/validate-daemon-environmental.yml
@@ -52,7 +52,7 @@ jobs:
           key: validate-daemon-env-${{ env.UPSTREAM_RSYNC_VERSION }}
 
       - name: Build oc-rsync (release) - needed by harness even when validating upstream
-        run: cargo build --locked --release --bin oc-rsync
+        uses: ./.github/actions/build-oc-rsync
 
       - name: Build upstream rsync + helpers (via harness for one test)
         env:


### PR DESCRIPTION
## Summary

- Adds `.github/actions/build-oc-rsync/action.yml` - a composite action wrapping `cargo build --locked --release --bin oc-rsync`.
- Replaces 8 standalone identical invocations of that command across workflow files with `uses: ./.github/actions/build-oc-rsync`.
- The composite action accepts an optional `features` input (default `""`) for future reuse; all current call sites leave it unset.

## No profile or flag changes

The composite action runs exactly `cargo build --locked --release --bin oc-rsync` with no additional flags. No build profiles, feature flags, or semantics are changed. Lines with differing flags (`--features iocp`, `--profile dist`, `-p <crate>`, debug builds, nextest) are untouched.

## Converted call sites (8)

| File | Step name |
|------|-----------|
| `.github/workflows/validate-daemon-environmental.yml` | Build oc-rsync (release) - needed by harness even when validating upstream |
| `.github/workflows/interop-validation.yml` | Build oc-rsync |
| `.github/workflows/bench-daemon-coldstart.yml` | Build oc-rsync (release) |
| `.github/workflows/bench-daemon-concurrency.yml` | Build oc-rsync (release) |
| `.github/workflows/upstream-testsuite.yml` | Build oc-rsync (release) |
| `.github/workflows/_interop-windows.yml` | Build oc-rsync |
| `.github/workflows/mdf-8-filter-diff.yml` | Build oc-rsync (release) |
| `.github/workflows/_benchmark-macos.yml` | Build oc-rsync (release) |

## Left inline (2)

| File | Reason |
|------|--------|
| `.github/workflows/_interop-macos.yml` | Command is a continuation line of `rustup run ${{ inputs.rust_toolchain }} \` - a different invocation form requiring the toolchain shim |
| `.github/workflows/_interop.yml` | Command is embedded inside a conditional `if [[ ! -x target/release/oc-rsync ]]; then` block within a multi-line `run:` script alongside `bash tools/ci/run_upstream_testsuite.sh` |