### PR TITLE
fix(cli): honor -vv/--info=name2 for unchanged itemize rows

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -603,11 +603,6 @@ where
         };
     let itemize_changes_flag = matches.get_flag("itemize-changes");
     let no_itemize_changes_flag = matches.get_flag("no-itemize-changes");
-    let name_level = if itemize_changes_flag && !no_itemize_changes_flag {
-        NameOutputLevel::UpdatedOnly
-    } else {
-        NameOutputLevel::Disabled
-    };
     let name_overridden = itemize_changes_flag || no_itemize_changes_flag;
     let mut verbosity = matches.get_count("verbose") as u8;
     if matches.get_flag("no-verbose") {
@@ -712,10 +707,36 @@ where
     let from0 = matches.get_flag("from0");
     let disable_from0 = matches.get_flag("no-from0");
     let from0 = from0 && !disable_from0;
-    let info = matches
+    let info: Vec<OsString> = matches
         .remove_many::<OsString>("info")
         .map(Iterator::collect)
         .unwrap_or_default();
+    // upstream: generator.c:582-583 - the itemize line for an unchanged entry
+    // is emitted only when `INFO_GTE(NAME, 2)` is in effect, which `-vv` and
+    // `--info=name2` both set. Resolve the effective NAME info level the same
+    // way the logging config does (verbose count + any `--info=` override) so
+    // `-ivv` surfaces unchanged dirs, files, and symlinks like upstream rather
+    // than capping at the updated-only level.
+    let name_info_level = {
+        let mut cfg = logging::VerbosityConfig::from_verbose_level(verbosity);
+        for token in &info {
+            if let Some(text) = token.to_str() {
+                for part in text.split(',') {
+                    let _ = cfg.apply_info_flag(part.trim());
+                }
+            }
+        }
+        cfg.info.get(logging::InfoFlag::Name)
+    };
+    let name_level = if itemize_changes_flag && !no_itemize_changes_flag {
+        if name_info_level >= 2 {
+            NameOutputLevel::UpdatedAndUnchanged
+        } else {
+            NameOutputLevel::UpdatedOnly
+        }
+    } else {
+        NameOutputLevel::Disabled
+    };
     let debug = matches
         .remove_many::<OsString>("debug")
         .map(Iterator::collect)

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -2964,6 +2964,28 @@ mod name_level_tests {
     }
 
     #[test]
+    fn itemize_with_double_verbose_emits_unchanged() {
+        // upstream: generator.c:582 - INFO_GTE(NAME, 2) (set by -vv) forces the
+        // itemize line for unchanged entries, so `-ivv` must surface unchanged
+        // dirs, files, and symlinks rather than capping at the updated-only level.
+        let parsed = parse_test_args(["-i", "-vv", "src/", "dst/"]).expect("parse");
+        assert!(parsed.itemize_changes);
+        assert_eq!(parsed.name_level, NameOutputLevel::UpdatedAndUnchanged);
+    }
+
+    #[test]
+    fn itemize_with_single_verbose_stays_updated_only() {
+        let parsed = parse_test_args(["-i", "-v", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.name_level, NameOutputLevel::UpdatedOnly);
+    }
+
+    #[test]
+    fn itemize_with_info_name2_emits_unchanged() {
+        let parsed = parse_test_args(["-i", "--info=name2", "src/", "dst/"]).expect("parse");
+        assert_eq!(parsed.name_level, NameOutputLevel::UpdatedAndUnchanged);
+    }
+
+    #[test]
     fn itemize_then_no_itemize() {
         let parsed =
             parse_test_args(["-i", "--no-itemize-changes", "src/", "dst/"]).expect("parse");


### PR DESCRIPTION
## Problem

`rsync -ivvplrtH from/ to/` against an unchanged tree drops every unchanged itemize row. Upstream emits one per entry:

```
.d          ./
.f          bar/baz/rsync
.d          foo/
.L          foo/sym -> ../bar/baz/rsync
...
```

oc-rsync emitted nothing for unchanged entries (only changed rows appeared). This is the `itemize` upstream-testsuite divergence.

## Root cause

In the CLI argument parser, the `--itemize-changes` name-output level was derived **only** from `-i`:

```rust
let name_level = if itemize_changes_flag && !no_itemize_changes_flag {
    NameOutputLevel::UpdatedOnly
} else {
    NameOutputLevel::Disabled
};
```

so it could never reach `UpdatedAndUnchanged`. The local-copy renderer suppresses unchanged `MetadataReused` events unless `emit_unchanged` is set, and `emit_unchanged` is driven by `name_level == UpdatedAndUnchanged`.

Upstream gates the itemize line for an unchanged entry on `INFO_GTE(NAME, 2)` (generator.c:582-583), which both `-vv` and `--info=name2` set.

## Fix

Resolve the effective NAME info level the same way the logging config does (verbose count + any `--info=` override) and promote `name_level` to `UpdatedAndUnchanged` when that level reaches 2. Surgical, CLI-only, no wire/behaviour change for transfers.

## Verification

Reproduced on the Linux host (upstream 3.4.4 vs oc-rsync): before, oc emitted only changed rows; the byte-for-byte missing rows are exactly the unchanged `.d`/`.f`/`.L` lines. Added parser regression tests for `-ivv`, `-iv`, and `-i --info=name2`.