### PR TITLE
fix(filters): expand bare -C/+C cvs-convenience filter rule

### DIFF
--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -12,8 +12,8 @@ use logging_sink::MessageSink;
 use super::messages::fail_with_message;
 use crate::frontend::filter_rules::{
     FilterDirective, append_apple_double_exclude_rules, append_cvs_exclude_rules,
-    append_filter_rules_from_files, apply_merge_directive, merge_directive_options,
-    os_string_to_pattern, parse_filter_directive, parse_old_prefix_rule,
+    append_filter_rules_from_files, apply_merge_directive, cvs_default_exclude_rules,
+    merge_directive_options, os_string_to_pattern, parse_filter_directive, parse_old_prefix_rule,
 };
 
 /// Filter configuration supplied by the command line.
@@ -100,6 +100,10 @@ where
                 }
             }
             Ok(FilterDirective::Clear) => filter_rules.clear(),
+            Ok(FilterDirective::CvsDefaults) => match cvs_default_exclude_rules() {
+                Ok(rules) => filter_rules.extend(rules),
+                Err(message) => return Err(fail_with_message(message, stderr)),
+            },
             Err(message) => return Err(fail_with_message(message, stderr)),
         }
     }
@@ -127,8 +131,8 @@ fn push_old_prefix_rule(
     match parse_old_prefix_rule(&text, default_kind)? {
         FilterDirective::Rule(rule) => destination.push(rule),
         FilterDirective::Clear => destination.push(FilterRuleSpec::clear()),
-        FilterDirective::Merge(_) => {
-            unreachable!("parse_old_prefix_rule never emits FilterDirective::Merge")
+        FilterDirective::Merge(_) | FilterDirective::CvsDefaults => {
+            unreachable!("parse_old_prefix_rule only emits Rule or Clear")
         }
     }
     Ok(())

--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -12,6 +12,31 @@ use crate::frontend::defaults::CVS_EXCLUDE_PATTERNS;
 pub(crate) fn append_cvs_exclude_rules(
     destination: &mut Vec<FilterRuleSpec>,
 ) -> Result<(), Message> {
+    let mut cvs_rules = cvs_default_exclude_rules()?;
+
+    let options = DirMergeOptions::default()
+        .with_enforced_kind(Some(DirMergeEnforcedKind::Exclude))
+        .use_whitespace()
+        .allow_comments(false)
+        .inherit(false)
+        .allow_list_clearing(true);
+    cvs_rules.push(FilterRuleSpec::dir_merge(".cvsignore".to_owned(), options));
+
+    destination.extend(cvs_rules);
+    Ok(())
+}
+
+/// Builds the global CVS default exclude rules: the built-in pattern list,
+/// `$HOME/.cvsignore`, and the `$CVSIGNORE` environment variable, in that
+/// order. Unlike [`append_cvs_exclude_rules`], this does NOT add the
+/// per-directory `.cvsignore` dir-merge - that layer is contributed
+/// separately by a `:C` filter rule.
+///
+/// upstream: exclude.c:1340 get_cvs_excludes() - the `-C` convenience filter
+/// rule (FILTRULE_CVS_IGNORE without a merge flag) populates the global cvs
+/// list from these three sources only; the per-directory merge is the
+/// separate `:C` rule.
+pub(crate) fn cvs_default_exclude_rules() -> Result<Vec<FilterRuleSpec>, Message> {
     let mut cvs_rules: Vec<FilterRuleSpec> = CVS_EXCLUDE_PATTERNS
         .iter()
         .map(|pattern| FilterRuleSpec::exclude((*pattern).to_owned()).with_perishable(true))
@@ -48,16 +73,7 @@ pub(crate) fn append_cvs_exclude_rules(
         cvs_rules.extend(local);
     }
 
-    let options = DirMergeOptions::default()
-        .with_enforced_kind(Some(DirMergeEnforcedKind::Exclude))
-        .use_whitespace()
-        .allow_comments(false)
-        .inherit(false)
-        .allow_list_clearing(true);
-    cvs_rules.push(FilterRuleSpec::dir_merge(".cvsignore".to_owned(), options));
-
-    destination.extend(cvs_rules);
-    Ok(())
+    Ok(cvs_rules)
 }
 
 fn append_cvsignore_tokens<'a, I>(destination: &mut Vec<FilterRuleSpec>, tokens: I)

--- a/crates/cli/src/frontend/filter_rules/directive.rs
+++ b/crates/cli/src/frontend/filter_rules/directive.rs
@@ -11,6 +11,12 @@ pub(crate) enum FilterDirective {
     Merge(MergeDirective),
     /// Clears all existing filter rules.
     Clear,
+    /// The `-C` cvs-convenience rule: expands to the global CVS default
+    /// excludes (built-in list + `$HOME/.cvsignore` + `$CVSIGNORE`).
+    ///
+    /// upstream: exclude.c:1441-1443 get_cvs_excludes() on a non-merge
+    /// FILTRULE_CVS_IGNORE rule.
+    CvsDefaults,
 }
 
 /// Describes a filter merge directive including its source and options.

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -6,6 +6,7 @@ use core::client::{DirMergeEnforcedKind, DirMergeOptions, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
 
+use super::cvs::cvs_default_exclude_rules;
 use super::directive::{
     FilterDirective, MergeDirective, merge_directive_options, os_string_to_pattern,
 };
@@ -217,6 +218,20 @@ pub(crate) fn process_merge_directive(
             })?;
         }
         Ok(FilterDirective::Clear) => destination.clear(),
+        // upstream: exclude.c:1441-1443 a non-merge FILTRULE_CVS_IGNORE rule
+        // (`-C`) inside a merge file expands to the global CVS defaults at this
+        // position in the chain.
+        Ok(FilterDirective::CvsDefaults) => {
+            let rules = cvs_default_exclude_rules().map_err(|error| {
+                let detail = error.to_string();
+                rsync_error!(
+                    1,
+                    format!("failed to process merge file '{display}': {detail}")
+                )
+                .with_role(Role::Client)
+            })?;
+            destination.extend(rules);
+        }
         Err(error) => {
             let detail = error.to_string();
             let message = rsync_error!(

--- a/crates/cli/src/frontend/filter_rules/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/mod.rs
@@ -10,7 +10,7 @@ mod sources;
 
 pub(crate) use apple_double::append_apple_double_exclude_rules;
 pub(crate) use arguments::{collect_filter_arguments, locate_filter_arguments};
-pub(crate) use cvs::append_cvs_exclude_rules;
+pub(crate) use cvs::{append_cvs_exclude_rules, cvs_default_exclude_rules};
 pub(crate) use directive::{FilterDirective, merge_directive_options, os_string_to_pattern};
 pub(crate) use merge::apply_merge_directive;
 pub(crate) use parsing::{parse_filter_directive, parse_old_prefix_rule};

--- a/crates/cli/src/frontend/filter_rules/parsing/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/mod.rs
@@ -162,6 +162,10 @@ fn parse_rule_directive(text: &str) -> Result<FilterDirective, Message> {
         return Ok(FilterDirective::Clear);
     }
 
+    if is_cvs_convenience_rule(trimmed) {
+        return Ok(FilterDirective::CvsDefaults);
+    }
+
     if let Some(result) = parse_shorthand_rules(trimmed) {
         return result;
     }
@@ -183,6 +187,30 @@ fn parse_rule_directive(text: &str) -> Result<FilterDirective, Message> {
     }
 
     parse_keyword_rule(trimmed)
+}
+
+/// Detects the cvs-convenience filter rule (`-C` or `+C`, with an optional
+/// comma between the action and the modifier). Such a rule carries only the
+/// `C` (cvs-ignore) modifier and no pattern; upstream expands it into the
+/// global CVS default excludes rather than treating it as a literal pattern.
+///
+/// The per-directory `:C` / `.C` merge forms are handled earlier by the
+/// merge-directive parser, so they never reach this check.
+///
+/// upstream: exclude.c:1441-1443 - a FILTRULE_CVS_IGNORE rule that is not a
+/// merge triggers get_cvs_excludes().
+fn is_cvs_convenience_rule(trimmed: &str) -> bool {
+    let body = match trimmed
+        .strip_prefix('-')
+        .or_else(|| trimmed.strip_prefix('+'))
+    {
+        Some(rest) => rest,
+        None => return false,
+    };
+    let body = body.strip_prefix(',').unwrap_or(body);
+    // upstream: exclude.c:1252 the cvs-ignore modifier is uppercase `C`; a
+    // lowercase `c` is rejected as an invalid modifier, so match exactly.
+    body == "C"
 }
 
 fn parse_shorthand_rules(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
@@ -934,5 +962,58 @@ mod tests {
         // when no pattern follows the prefix.
         assert!(parse_old_prefix_rule("- ", FilterRuleKind::Include).is_err());
         assert!(parse_old_prefix_rule("+ ", FilterRuleKind::Exclude).is_err());
+    }
+
+    #[test]
+    fn is_cvs_convenience_rule_detects_exclude_and_include_forms() {
+        // upstream: exclude.c:1252 - the `C` (cvs-ignore) modifier is valid on
+        // both `-` and `+` rule chars, with an optional comma separator.
+        assert!(is_cvs_convenience_rule("-C"));
+        assert!(is_cvs_convenience_rule("+C"));
+        assert!(is_cvs_convenience_rule("-,C"));
+        assert!(is_cvs_convenience_rule("+,C"));
+    }
+
+    #[test]
+    fn is_cvs_convenience_rule_rejects_non_cvs_forms() {
+        // A lowercase `c` is an invalid modifier upstream, and a space or any
+        // trailing pattern means this is an ordinary exclude/include rule.
+        assert!(!is_cvs_convenience_rule("-c"));
+        assert!(!is_cvs_convenience_rule("- C"));
+        assert!(!is_cvs_convenience_rule("-Cp"));
+        assert!(!is_cvs_convenience_rule("-foo"));
+        assert!(!is_cvs_convenience_rule("C"));
+        assert!(!is_cvs_convenience_rule(":C"));
+    }
+
+    #[test]
+    fn parse_cvs_convenience_rule_emits_cvs_defaults() {
+        // `-C` / `+C` as a filter rule expand to the global CVS default
+        // excludes rather than a literal pattern "C".
+        assert_eq!(
+            parse_filter_directive(OsStr::new("-C")).unwrap(),
+            FilterDirective::CvsDefaults
+        );
+        assert_eq!(
+            parse_filter_directive(OsStr::new("+C")).unwrap(),
+            FilterDirective::CvsDefaults
+        );
+        assert_eq!(
+            parse_filter_directive(OsStr::new("-,C")).unwrap(),
+            FilterDirective::CvsDefaults
+        );
+    }
+
+    #[test]
+    fn parse_literal_dash_pattern_is_not_cvs() {
+        // `- C` (with a space) is an ordinary exclude of the pattern "C", not
+        // the cvs-convenience rule.
+        match parse_filter_directive(OsStr::new("- C")).unwrap() {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::Exclude);
+                assert_eq!(spec.pattern(), "C");
+            }
+            other => panic!("expected exclude Rule, got {other:?}"),
+        }
     }
 }

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -44,8 +44,10 @@ pub(crate) fn append_filter_rules_from_files(
                 match parse_old_prefix_rule(&pattern, kind)? {
                     FilterDirective::Rule(rule) => local.push(rule),
                     FilterDirective::Clear => local.clear(),
-                    FilterDirective::Merge(_) => {
-                        unreachable!("parse_old_prefix_rule never emits FilterDirective::Merge")
+                    FilterDirective::Merge(_) | FilterDirective::CvsDefaults => {
+                        unreachable!(
+                            "parse_old_prefix_rule never emits FilterDirective::Merge or CvsDefaults"
+                        )
                     }
                 }
             } else {


### PR DESCRIPTION
## Problem

The CLI filter-rule parser treated a bare `-C` / `+C` rule as a literal
exclude of the pattern `C` rather than the cvs-convenience rule. As a
result `--filter='-C'` (`-f-C`) injected no rules at all, so the built-in
CVS default excludes, `$HOME/.cvsignore`, and `$CVSIGNORE` were never
applied through the filter-rule path. Only the `--cvs-exclude` (`-C`)
option and the per-directory `:C` merge worked.

The upstream `exclude` / `exclude-lsh` testsuite cases decompose
`--cvs-exclude` into its two halves and pass them as filter rules:

```
$RSYNC -avv --filter='merge $excl' -f:C -f-C --delete-excluded ...
```

`:C` (per-directory `.cvsignore` merge) was already handled; the `-f-C`
half (the global CVS defaults) was the missing piece.

## Fix

Recognise `-C` / `+C` (with an optional comma; uppercase `C` only,
matching the cvs-ignore modifier handling in `exclude.c:1252`) as a new
`FilterDirective::CvsDefaults`. The consumer expands it into the global
CVS default excludes — built-in `CVS_EXCLUDE_PATTERNS` + `$HOME/.cvsignore`
+ `$CVSIGNORE`, **without** the per-directory merge — mirroring
`get_cvs_excludes()` (`exclude.c:1340`).

`check_filter()` (`exclude.c:1052`) consults the global `cvs_filter_list`
at the position of the non-merge `FILTRULE_CVS_IGNORE` rule in the chain,
so the defaults are inline-expanded at the position the `-C` rule occupied
to preserve ordering.

The shared default-rule construction is refactored out of
`append_cvs_exclude_rules()` into `cvs_default_exclude_rules()` so the
`--cvs-exclude` option and the filter-rule path build identical specs.

## Tests

Four new unit tests cover `is_cvs_convenience_rule` detection
(`-C`/`+C`/`-,C`/`+,C` accepted; `-c`/`- C`/`-Cp`/`:C` rejected) and the
end-to-end parse (`-f-C` -> `CvsDefaults`; `- C` stays a literal exclude
of `C`).