### PR TITLE
fix(server): seed verbosity from packed -v count for itemize parity

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -123,10 +123,26 @@ where
         return code;
     }
 
+    // upstream: options.c set_output_verbosity - the packed `-v` count maps to
+    // info/debug levels via info_verbosity[] (options.c:239-243) before any
+    // explicit --info override is layered on. Without this, the server thread's
+    // thread-local verbosity stays at the zero default, so `-vv` never raises
+    // info.name to 2 and the itemize line for an unchanged entry
+    // (INFO_GTE(NAME, 2), generator.c:582-583) is suppressed - exactly the
+    // gap that fails the upstream `itemize` test under SSH `--server` mode,
+    // where `-vv` arrives as packed `v` letters rather than `--info=name2`.
+    if config.flags.verbose_level > 0 {
+        logging::init(logging::VerbosityConfig::from_verbose_level(
+            config.flags.verbose_level,
+        ));
+    }
+
     // upstream: options.c parse_output_words - server-side info parsing
     // silently ignores unknown tokens so a newer client can forward names
     // this build has not learned yet. The well-formed empty/level errors
-    // still surface so malformed input is not swallowed entirely.
+    // still surface so malformed input is not swallowed entirely. Applied
+    // after the verbose-derived base so an explicit `--info` overrides it,
+    // matching upstream's verbose-then-info ordering.
     if !long_flags.info.is_empty() {
         match super::super::execution::parse_info_flags_server(&long_flags.info) {
             Ok(settings) => {

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -32,8 +32,16 @@ pub struct ParsedServerFlags {
     pub rsh: bool,
     /// Archive mode shorthand (`a` flag, `--archive`).
     pub archive: bool,
-    /// Verbose output (`v` flag, `--verbose`).
+    /// Verbose output (`v` flag, `--verbose`). True when at least one `v` is
+    /// present; see [`verbose_level`](Self::verbose_level) for the count.
     pub verbose: bool,
+    /// Count of `v` flags in the packed server flag string. Upstream derives
+    /// info/debug levels from this count via `info_verbosity[]`
+    /// (options.c:239-243); `-vv` sets `info.name = 2`, which gates the
+    /// itemize line for an unchanged entry (`INFO_GTE(NAME, 2)`,
+    /// generator.c:582-583). Collapsing to the `verbose` bool alone loses the
+    /// level needed to surface `-ivv` unchanged rows.
+    pub verbose_level: u8,
     /// Compress during transfer (`z` flag, `--compress`).
     pub compress: bool,
     /// Checksum-based transfer (`c` flag, `--checksum`).
@@ -255,7 +263,10 @@ impl ParsedServerFlags {
             b'r' => self.recursive = true,
             b'e' => self.rsh = true,
             b'a' => self.archive = true,
-            b'v' => self.verbose = true,
+            b'v' => {
+                self.verbose = true;
+                self.verbose_level = self.verbose_level.saturating_add(1);
+            }
             b'z' => self.compress = true,
             b'c' => self.checksum = true,
             b'H' => self.hard_links = true,
@@ -372,6 +383,21 @@ mod tests {
         assert!(flags.recursive);
         assert!(!flags.links);
         assert!(!flags.verbose);
+        assert_eq!(flags.verbose_level, 0);
+    }
+
+    #[test]
+    fn counts_verbose_level_from_packed_flags() {
+        // upstream sends `-vv` as packed `v` letters in the server flag
+        // string; the count must survive so info.name reaches 2 (INFO_GTE
+        // NAME 2) and `-ivv` surfaces unchanged itemize rows. The `v` inside
+        // the trailing `-e.` capability section (`iLsfxCIvu`) must NOT count.
+        assert_eq!(ParsedServerFlags::parse("-v").unwrap().verbose_level, 1);
+        assert_eq!(ParsedServerFlags::parse("-vv").unwrap().verbose_level, 2);
+        assert_eq!(ParsedServerFlags::parse("-vvv").unwrap().verbose_level, 3);
+        let packed = ParsedServerFlags::parse("-vvlogDtpre.iLsfxCIvu").unwrap();
+        assert_eq!(packed.verbose_level, 2);
+        assert!(packed.verbose);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The upstream `itemize` testsuite test FAILs against oc-rsync. The test drives transfers over a remote shell (lsh.sh), where oc-rsync runs in `--server` mode and the client's `-vv` arrives as packed `v` letters in the server flag string (not as `--info=name2`).

Upstream gates the itemize line for an *unchanged* entry on `INFO_GTE(NAME, 2)` (generator.c:582-583), which `-vv` sets via `info_verbosity[]` (options.c:239-243). In oc-rsync the `--server` entry (`crates/cli/src/frontend/server/run.rs`) seeded thread-local verbosity **only** from an explicit `--info` long flag, so a packed `-vv` left the server thread at the zero-default and `info.name` never reached 2 — the unchanged itemize rows were suppressed.

Two compounding gaps:
1. `ParsedServerFlags` collapsed every `v` to a single `bool`, discarding the count needed to distinguish `-v` from `-vv`.
2. `run.rs` never called `logging::init(from_verbose_level(n))` for the packed-letter path (the client path at `drive/workflow/run.rs:272` does).

PR #6036 fixed the equivalent on the **client** arg parser; it did not touch the server path the SSH itemize test exercises.

## Fix

- Track the `v` count in `ParsedServerFlags::verbose_level` (incremented in `parse_transfer_flag`; the `v` inside the trailing `-e.` capability section is routed to `parse_info_flag` and correctly ignored).
- In the `--server` entry, seed thread-local verbosity from `from_verbose_level(verbose_level)` before layering any explicit `--info`, mirroring upstream `set_output_verbosity` (verbose-then-info ordering).

`verbose: bool` is retained for the ~15 existing `flags.verbose && client_mode` consumers; `verbose_level` is additive.

## Tests

- `counts_verbose_level_from_packed_flags`: `-v`/`-vv`/`-vvv` count 1/2/3, and the capability-suffix `v` does not inflate the count.

End-to-end coverage is the upstream `itemize` cell in the upstream-testsuite workflow.

upstream: options.c set_output_verbosity, options.c:239-243 info_verbosity[], generator.c:582-583.