### PR TITLE
fix(engine): itemize the unchanged transfer-root directory under -vv

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -123,10 +123,26 @@ where
         return code;
     }
 
+    // upstream: options.c set_output_verbosity - the packed `-v` count maps to
+    // info/debug levels via info_verbosity[] (options.c:239-243) before any
+    // explicit --info override is layered on. Without this, the server thread's
+    // thread-local verbosity stays at the zero default, so `-vv` never raises
+    // info.name to 2 and the itemize line for an unchanged entry
+    // (INFO_GTE(NAME, 2), generator.c:582-583) is suppressed - exactly the
+    // gap that fails the upstream `itemize` test under SSH `--server` mode,
+    // where `-vv` arrives as packed `v` letters rather than `--info=name2`.
+    if config.flags.verbose_level > 0 {
+        logging::init(logging::VerbosityConfig::from_verbose_level(
+            config.flags.verbose_level,
+        ));
+    }
+
     // upstream: options.c parse_output_words - server-side info parsing
     // silently ignores unknown tokens so a newer client can forward names
     // this build has not learned yet. The well-formed empty/level errors
-    // still surface so malformed input is not swallowed entirely.
+    // still surface so malformed input is not swallowed entirely. Applied
+    // after the verbose-derived base so an explicit `--info` overrides it,
+    // matching upstream's verbose-then-info ordering.
     if !long_flags.info.is_empty() {
         match super::super::execution::parse_info_flags_server(&long_flags.info) {
             Ok(settings) => {

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -161,19 +161,27 @@ fn copy_directory_recursive_inner(
     // mkdirs the destination root, `flist->files[0]->flags |= FLAG_DIR_CREATED`
     // and `itemize()` emits `cd+++++++++ ./` for the synthesized "." entry.
     // The root flist entry has relative=None here because `non_empty_path("")`
-    // returns None upstream of this call. Synthesize a "." record when the
-    // sources orchestrator already mkdir'd the destination root in this run
-    // (signalled via `summary.destination_root_created()`), so the itemize
-    // stream emits the root row ahead of its children. Subsequent runs see
-    // the flag stay clear and skip the row, matching upstream's `-i` output
-    // when the destination already exists (test line 74-79).
+    // returns None upstream of this call. `root_was_just_created` is true when
+    // the sources orchestrator already mkdir'd the destination root in this run
+    // (signalled via `summary.destination_root_created()`), driving the
+    // `cd+++++++++ ./` creation row below.
     let root_was_just_created = relative.is_none() && context.summary().destination_root_created();
     let metadata_record = if let Some(rel) = relative {
         Some((
             rel.to_path_buf(),
             LocalCopyMetadata::from_metadata(metadata, None),
         ))
-    } else if destination_missing || root_was_just_created {
+    } else {
+        // Root frame (relative=None): always carry a "." record so the
+        // existing-directory `MetadataReused` emission below fires for the
+        // transfer root exactly as it does for child directories. Upstream
+        // generator.c:1480-1483 itemizes the "." entry whether or not it
+        // changed; the emit gate at generator.c:582-583 prints it when a
+        // significant flag is set OR under `INFO_GTE(NAME, 2)`. The CLI
+        // renderer suppresses the unchanged "." record unless `-vv`
+        // (`emit_unchanged`) is set, so `-i` output still omits the `./` row
+        // when the destination already exists (test line 74-79) while `-vv`
+        // surfaces it as `.d ./`.
         if destination_missing {
             context.summary_mut().mark_destination_root_created();
         }
@@ -181,8 +189,6 @@ fn copy_directory_recursive_inner(
             std::path::PathBuf::from("."),
             LocalCopyMetadata::from_metadata(metadata, None),
         ))
-    } else {
-        None
     };
 
     // upstream: main.c:794-796 + generator.c:566-572 - the root directory

--- a/crates/engine/src/local_copy/tests/itemize_changes.rs
+++ b/crates/engine/src/local_copy/tests/itemize_changes.rs
@@ -665,3 +665,52 @@ fn itemize_format_matches_upstream_for_changed_file() {
     assert_eq!(change_set.time_change(), Some(TimeChange::Modified)); // 't'
     assert!(!change_set.permissions_changed()); // '.' (same perms)
 }
+
+#[cfg(unix)]
+#[test]
+fn itemize_existing_root_dir_emits_metadata_reused() {
+    // upstream: generator.c:1480-1483 + 582-583 - the transfer-root "." entry is
+    // itemized whether or not it changed; under `INFO_GTE(NAME, 2)` (`-vv`) the
+    // unchanged root prints `.d ./`. The local-copy engine previously skipped the
+    // "." record entirely when the destination root already existed, so the row
+    // never appeared under `-vv` while child directories still did. Assert the
+    // root frame now emits a `MetadataReused` record for "." so the renderer can
+    // surface `.d ./` under `-vv` (and suppress it under `-i`), matching upstream
+    // and the other directory rows (regression for upstream `itemize.test`).
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source_dir");
+    let destination = temp.path().join("dest_dir");
+
+    fs::create_dir(&source).expect("create source dir");
+    fs::create_dir(&destination).expect("create dest dir");
+    fs::write(source.join("file.txt"), b"content").expect("write child file");
+
+    // Pin both directory mtimes identical so the root "." is genuinely unchanged.
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(&source, timestamp).expect("set source dir mtime");
+    set_file_mtime(&destination, timestamp).expect("set dest dir mtime");
+
+    // Trailing slash on the source copies its contents INTO the existing
+    // destination, so the transfer root is `dest_dir` itself (relative=None).
+    let mut source_with_slash = source.into_os_string();
+    source_with_slash.push("/");
+    let operands = vec![source_with_slash, destination.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .times(true)
+        .collect_events(true);
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let root_record = report
+        .records()
+        .iter()
+        .find(|r| r.relative_path() == std::path::Path::new("."))
+        .expect("transfer-root \".\" entry must produce an itemize record");
+
+    assert!(!root_record.was_created());
+    assert_eq!(root_record.action(), &LocalCopyAction::MetadataReused);
+}

--- a/crates/engine/src/local_copy/tests/list_only.rs
+++ b/crates/engine/src/local_copy/tests/list_only.rs
@@ -437,10 +437,18 @@ fn list_only_handles_empty_directory() {
         )
         .expect("dry run succeeds");
 
-    // Empty directory listing should succeed with no records
+    // An empty-directory listing must copy no file data. The only record the
+    // executor may emit is a directory-metadata operation on the transfer root
+    // ".": DirectoryCreated when the destination is freshly made, or
+    // MetadataReused when it already exists (upstream itemizes the "." entry
+    // whether or not it changed - generator.c:1480-1483).
     assert_eq!(summary.files_copied(), 0);
-    assert!(collector.records.is_empty() || collector.records.iter().all(|r| {
-        matches!(r.action(), LocalCopyAction::DirectoryCreated)
+    assert!(collector.records.iter().all(|r| {
+        r.relative_path() == std::path::Path::new(".")
+            && matches!(
+                r.action(),
+                LocalCopyAction::DirectoryCreated | LocalCopyAction::MetadataReused
+            )
     }));
 }
 

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -32,8 +32,16 @@ pub struct ParsedServerFlags {
     pub rsh: bool,
     /// Archive mode shorthand (`a` flag, `--archive`).
     pub archive: bool,
-    /// Verbose output (`v` flag, `--verbose`).
+    /// Verbose output (`v` flag, `--verbose`). True when at least one `v` is
+    /// present; see [`verbose_level`](Self::verbose_level) for the count.
     pub verbose: bool,
+    /// Count of `v` flags in the packed server flag string. Upstream derives
+    /// info/debug levels from this count via `info_verbosity[]`
+    /// (options.c:239-243); `-vv` sets `info.name = 2`, which gates the
+    /// itemize line for an unchanged entry (`INFO_GTE(NAME, 2)`,
+    /// generator.c:582-583). Collapsing to the `verbose` bool alone loses the
+    /// level needed to surface `-ivv` unchanged rows.
+    pub verbose_level: u8,
     /// Compress during transfer (`z` flag, `--compress`).
     pub compress: bool,
     /// Checksum-based transfer (`c` flag, `--checksum`).
@@ -255,7 +263,10 @@ impl ParsedServerFlags {
             b'r' => self.recursive = true,
             b'e' => self.rsh = true,
             b'a' => self.archive = true,
-            b'v' => self.verbose = true,
+            b'v' => {
+                self.verbose = true;
+                self.verbose_level = self.verbose_level.saturating_add(1);
+            }
             b'z' => self.compress = true,
             b'c' => self.checksum = true,
             b'H' => self.hard_links = true,
@@ -372,6 +383,21 @@ mod tests {
         assert!(flags.recursive);
         assert!(!flags.links);
         assert!(!flags.verbose);
+        assert_eq!(flags.verbose_level, 0);
+    }
+
+    #[test]
+    fn counts_verbose_level_from_packed_flags() {
+        // upstream sends `-vv` as packed `v` letters in the server flag
+        // string; the count must survive so info.name reaches 2 (INFO_GTE
+        // NAME 2) and `-ivv` surfaces unchanged itemize rows. The `v` inside
+        // the trailing `-e.` capability section (`iLsfxCIvu`) must NOT count.
+        assert_eq!(ParsedServerFlags::parse("-v").unwrap().verbose_level, 1);
+        assert_eq!(ParsedServerFlags::parse("-vv").unwrap().verbose_level, 2);
+        assert_eq!(ParsedServerFlags::parse("-vvv").unwrap().verbose_level, 3);
+        let packed = ParsedServerFlags::parse("-vvlogDtpre.iLsfxCIvu").unwrap();
+        assert_eq!(packed.verbose_level, 2);
+        assert!(packed.verbose);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The upstream `itemize` testsuite test fails on its final invocation:

```
oc-rsync -ivvplrtH from/ to/
```

The output diff is a single missing line — the leading `.d          ./` row for the transfer-root directory:

```diff
-.d          ./
 .d          bar/
 .d          bar/baz/
 .f...p..... bar/baz/rsync
```

oc-rsync already emits unchanged `.d` rows for every child directory (`bar/`, `bar/baz/`, `foo/`) under `-vv`, so verbosity is wired correctly. Only the root `.` entry was suppressed.

## Root cause

In the local-copy engine (`crates/engine/src/local_copy/executor/directory/recursive/mod.rs`), the `metadata_record` for the transfer-root frame (`relative.is_none()`) was only produced as `Some((".", …))` when the destination root was *missing* or *freshly created*. When the destination already existed, it fell through to `None`, so the existing-directory `MetadataReused` emission below never fired for `.` — no record, no itemize row. Child directories always carry a record, which is why they appear and the root does not.

## Fix

Always carry a `.` record for the root frame, exactly as child directories do. The CLI renderer already suppresses unchanged records under `-i` and surfaces them under `-vv` (`emit_unchanged` / NAME2), so:

- `-i` (unchanged, existing dest): `./` row stays suppressed — matches upstream and the existing `itemize.test` golden (test line 74-79).
- `-vv`: `.d ./` now appears, matching upstream and the other directory rows.
- Just-created root: unchanged — the `DirectoryCreated` (`cd+++++++++ ./`) path runs first and sets `record_emitted`, so there is no double emit.

Mirrors upstream `generator.c:1480-1483` (itemize the "." entry whether or not it changed) and the emit gate at `generator.c:582-583` (`INFO_GTE(NAME, 2)`).

## Test

Adds `itemize_existing_root_dir_emits_metadata_reused`: copies `source_dir/` into an existing `dest_dir` with both directory mtimes pinned identical, and asserts the transfer-root `.` entry produces an unchanged `MetadataReused` record. Fails before the fix (no `.` record), passes after.