### PR TITLE
fix(itemize): suppress up-to-date hardlink alias row at plain -i

### DIFF
--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use std::io::{self, Write};
 
-use core::client::{ClientEvent, ClientEventKind};
+use core::client::{ClientEntryMetadata, ClientEvent, ClientEventKind};
 
 use super::tokens::{OutFormat, OutFormatContext, OutFormatToken};
 
@@ -67,9 +67,32 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
         // and symlinks that match the source exactly.
         return false;
     }
-    matches!(event.kind(), ClientEventKind::MetadataReused)
+    if matches!(event.kind(), ClientEventKind::MetadataReused)
         && !event.was_created()
         && !event.change_set().has_any_change()
+    {
+        return true;
+    }
+
+    // upstream: hlink.c:215-227 + generator.c:581-583 - an already-correct
+    // hardlink alias is itemized via `itemize(..., ITEM_LOCAL_CHANGE |
+    // ITEM_XNAME_FOLLOWS, 0, "")` with an EMPTY xname. The generator only
+    // writes that row when a significant attribute flag is set, `INFO_GTE(NAME,
+    // 2)` (handled above via `emit_unchanged`), `stdout_format_has_i > 1`
+    // (`-ii`), or the xname is non-empty (a relink occurred). For an up-to-date
+    // alias with no attribute change, empty xname, and plain `-i`, all of those
+    // are false, so the row is suppressed. The shared inode means config1's
+    // perm fix already reached the alias, so itemizing `foo/extra` would
+    // over-report. Detect that case: a hardlink-uptodate record with an empty
+    // change-set and no `=> target` xname (None symlink target).
+    matches!(event.kind(), ClientEventKind::HardLink)
+        && event.is_hardlink_uptodate()
+        && !event.was_created()
+        && !event.change_set().has_any_change()
+        && event
+            .metadata()
+            .and_then(ClientEntryMetadata::symlink_target)
+            .is_none()
 }
 
 /// Emits each event using the supplied `--out-format` specification.

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1864,6 +1864,96 @@ fn emit_out_format_emits_unchanged_directory_under_info_name_2() {
 }
 
 #[test]
+fn emit_out_format_suppresses_uptodate_hardlink_alias_by_default() {
+    // upstream: hlink.c:215-227 + generator.c:581-583 - an already-correct
+    // hardlink alias is itemized with an empty xname (no `=> target`) and an
+    // empty change-set. Under plain `-i` (NAME<2, has_i==1) the row must be
+    // suppressed: the shared inode already carries the leader's attributes, so
+    // emitting it would over-report. This is the `foo/extra` case in upstream
+    // `testsuite/itemize.test`.
+    let event = make_event(
+        ClientEventKind::HardLink,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    )
+    .with_hardlink_uptodate_for_test();
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    emit_out_format(&events, &format, &OutFormatContext::default(), &mut output).unwrap();
+    assert!(
+        output.is_empty(),
+        "default context must suppress an up-to-date hardlink alias"
+    );
+}
+
+#[test]
+fn emit_out_format_emits_uptodate_hardlink_alias_under_info_name_2() {
+    // upstream: generator.c:582 `INFO_GTE(NAME, 2)` arm - under `-ivv` (or
+    // `--info=name2`) the same up-to-date alias surfaces as `hf          n`.
+    let event = make_event(
+        ClientEventKind::HardLink,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    )
+    .with_hardlink_uptodate_for_test();
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    let ctx = OutFormatContext::default().with_emit_unchanged(true);
+    emit_out_format(&events, &format, &ctx, &mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+    assert_eq!(rendered, "hf          test.txt\n");
+}
+
+#[test]
+fn emit_out_format_emits_uptodate_hardlink_alias_with_changed_attr() {
+    // A hardlink-uptodate record that DOES carry an attribute change (e.g. a
+    // perm fix that did not propagate via the shared inode) is significant and
+    // must still print at plain `-i`, mirroring upstream's
+    // `iflags & SIGNIFICANT_ITEM_FLAGS` arm.
+    let event = make_event(
+        ClientEventKind::HardLink,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new().with_permissions_changed(true),
+    )
+    .with_hardlink_uptodate_for_test();
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    emit_out_format(&events, &format, &OutFormatContext::default(), &mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+    assert_eq!(rendered, "hf...p..... test.txt\n");
+}
+
+#[test]
+fn emit_out_format_emits_uptodate_hardlink_alias_with_relink_target() {
+    // upstream: generator.c:582 `(xname && *xname)` arm - when the alias was
+    // (re)created the xname is the relink target (`=> %s`), which forces the
+    // row even at plain `-i`. The local-copy engine carries that target in the
+    // metadata symlink_target slot for HardLink events.
+    let metadata = ClientEvent::test_metadata(ClientEntryKind::File)
+        .with_symlink_target_for_test("foo/leader");
+    let event = ClientEvent::for_test(
+        PathBuf::from("test.txt"),
+        ClientEventKind::HardLink,
+        false,
+        Some(metadata),
+        LocalCopyChangeSet::new(),
+    )
+    .with_hardlink_uptodate_for_test();
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n%L")).unwrap();
+    let mut output = Vec::new();
+    emit_out_format(&events, &format, &OutFormatContext::default(), &mut output).unwrap();
+    let rendered = String::from_utf8(output).unwrap();
+    assert_eq!(rendered, "hf          test.txt => foo/leader\n");
+}
+
+#[test]
 fn emit_out_format_emits_unchanged_symlink_under_info_name_2() {
     // upstream `testsuite/itemize.test:123` expects
     // `.L          foo/sym -> ../bar/baz/rsync` under `-ivvplrtH` when the

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -279,6 +279,18 @@ impl ClientEvent {
         }
     }
 
+    /// Marks the event as an up-to-date hardlink alias for testing purposes.
+    ///
+    /// Mirrors the `with_hardlink_uptodate(true)` flag set by the local-copy
+    /// engine for an already-correct hardlink alias, so renderer tests can
+    /// exercise the suppression gate without running a transfer.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_hardlink_uptodate_for_test(mut self) -> Self {
+        self.hardlink_uptodate = true;
+        self
+    }
+
     /// Constructs a [`ClientEntryMetadata`] for testing purposes.
     #[doc(hidden)]
     pub fn test_metadata(kind: ClientEntryKind) -> ClientEntryMetadata {

--- a/crates/core/src/client/summary/metadata.rs
+++ b/crates/core/src/client/summary/metadata.rs
@@ -104,6 +104,17 @@ impl ClientEntryMetadata {
         }
     }
 
+    /// Attaches a symlink/xname target for testing purposes.
+    ///
+    /// Used by renderer tests to model a relinked hardlink alias, whose `%L`
+    /// placeholder renders ` => target`.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_symlink_target_for_test(mut self, target: &str) -> Self {
+        self.symlink_target = Some(std::path::PathBuf::from(target));
+        self
+    }
+
     /// Returns the kind of entry represented by this metadata snapshot.
     #[must_use]
     pub const fn kind(&self) -> ClientEntryKind {


### PR DESCRIPTION
Local-copy itemize over-emitted a row for an up-to-date hardlink alias under plain `-i`.

For `-iplrtH` where `foo/extra` is a hardlink of `foo/config1` and only config1's perms change, the alias already shares config1's inode on the destination, so the perm fix propagates and the alias has no attribute change. Upstream's `maybe_hard_link()` (hlink.c:215-227) itemizes such an already-correct alias with an empty xname, and `itemize()` (generator.c:581-583) only writes that row when a significant change flag is set, `INFO_GTE(NAME,2)` (`-vv`/`--info=name2`), `stdout_format_has_i > 1` (`-ii`), or the xname is non-empty (a relink). Under plain `-i` all are false, so the row is suppressed.

oc-rsync was always emitting `hf          foo/extra`. This adds the matching gate in the `-i` renderer (`should_suppress_event`): suppress the hardlink-uptodate row only when there is no significant attribute change, no `=> target` xname, and not `-vv`/`-ii`. The row is still shown under `-ivv` (`hf          foo/extra`), `-ii`, on a relinked alias (`=> foo/config1`), or when the alias has a real attribute change.

Matches upstream `testsuite/itemize.test` line 135 (plain `-i` omits the alias) and line 122 (`-ivv` shows it).

Regression tests: 4 new cases in `out_format/render/tests.rs` covering plain-`-i` suppression, `--info=name2` keep, changed-attr keep, and relink-target keep.