### PR TITLE
fix(filters): re-anchor per-dir merge rules to merge file directory

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -37,7 +37,7 @@ mod tests;
 
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::merge::parse::{parse_rules, parse_rules_no_prefixes};
 use crate::{FilterAction, FilterRule, FilterSet};
@@ -91,6 +91,17 @@ pub struct FilterChain {
     /// parsed rule under --delete-excluded except the merge/dir-merge wrappers
     /// themselves.
     delete_excluded: bool,
+    /// Transfer-root directory used to re-anchor leading-`/` rules read from a
+    /// per-directory merge file to the merge file's own directory.
+    ///
+    /// upstream: exclude.c:200-228 add_rule - under `XFLG_ANCHORED2ABS` a
+    /// leading-`/` rule in a per-dir merge file is rewritten so its pattern is
+    /// prefixed with the merge file's directory (relative to the module root).
+    /// `/file1` read from `foo/.filt` therefore matches `foo/file1`, not a
+    /// top-level `file1`. When `None`, no re-anchoring is performed (preserving
+    /// the behaviour of callers that pass merge directories already relative to
+    /// the transfer root, e.g. unit tests).
+    transfer_root: Option<PathBuf>,
 }
 
 impl FilterChain {
@@ -106,6 +117,7 @@ impl FilterChain {
             scopes: Vec::new(),
             current_depth: 0,
             delete_excluded: false,
+            transfer_root: None,
         }
     }
 
@@ -141,6 +153,33 @@ impl FilterChain {
     #[must_use]
     pub const fn delete_excluded(&self) -> bool {
         self.delete_excluded
+    }
+
+    /// Records the transfer-root directory so that leading-`/` rules read from
+    /// per-directory merge files are re-anchored to the merge file's directory.
+    ///
+    /// Callers walking a tree (e.g. the sender generator) pass the same base
+    /// directory they strip from each path before calling
+    /// [`allows`](Self::allows). With the root set, a `- /file1` rule inside
+    /// `<root>/foo/.filt` is rewritten to match `foo/file1`, mirroring upstream
+    /// rsync's `XFLG_ANCHORED2ABS` handling in `exclude.c:add_rule`.
+    pub fn set_transfer_root(&mut self, root: impl Into<PathBuf>) {
+        self.transfer_root = Some(root.into());
+    }
+
+    /// Returns the directory of a per-dir merge file relative to the transfer
+    /// root, as a forward-slash string, or `None` when re-anchoring is not in
+    /// effect (no root set, the path is the root itself, or it is not below the
+    /// root). The returned prefix never has leading or trailing slashes.
+    fn merge_rel_dir(&self, directory: &Path) -> Option<String> {
+        let root = self.transfer_root.as_ref()?;
+        let rel = directory.strip_prefix(root).ok()?;
+        let joined = path_to_forward_slash(rel);
+        if joined.is_empty() {
+            None
+        } else {
+            Some(joined)
+        }
     }
 
     /// Returns `true` if the path should be included in the transfer.
@@ -244,6 +283,12 @@ impl FilterChain {
         let depth = self.current_depth;
         let mut pushed_count = 0;
 
+        // upstream: exclude.c:200-228 - leading-`/` rules in a per-dir merge
+        // file are re-anchored to the merge file's directory (relative to the
+        // module root). Compute that directory once for every merge file read
+        // in this directory.
+        let rel_dir_prefix = self.merge_rel_dir(directory);
+
         for config_index in 0..self.merge_configs.len() {
             let config = &self.merge_configs[config_index];
             let merge_path = directory.join(config.filename());
@@ -317,6 +362,7 @@ impl FilterChain {
             let mut modified_rules: Vec<FilterRule> = rules
                 .into_iter()
                 .map(|rule| config.apply_modifiers(rule))
+                .map(|rule| reanchor_merge_rule(rule, rel_dir_prefix.as_deref()))
                 .map(|rule| apply_merge_implicit_sender_side(rule, delete_excluded))
                 .collect();
 
@@ -349,6 +395,27 @@ impl FilterChain {
             // carries the modifier flags (cvs_mode, no_inherit) that decide
             // how to parse the file and whether descendant scopes inherit.
             for descriptor in dir_merge_descriptors {
+                // upstream: exclude.c:294 - a `dir-merge` directive parsed from
+                // inside a merge file is appended to the global
+                // `mergelist_parents`, so `push_local_filters()` re-reads it in
+                // every descendant directory. An inheriting dir-merge must
+                // therefore become a persistent per-directory config, not just
+                // a one-shot read of the current directory. Non-inheriting
+                // (`:C`, no-inherit) variants stay one-shot to avoid leaking
+                // into sibling subtrees. Dedupe by filename like upstream's
+                // "already mentioned" guard (exclude.c:262-279).
+                if !descriptor.no_inherit
+                    && !self
+                        .merge_configs
+                        .iter()
+                        .any(|c| c.filename() == descriptor.filename)
+                {
+                    self.merge_configs.push(
+                        DirMergeConfig::new(descriptor.filename.clone())
+                            .with_cvs_mode(descriptor.cvs_mode)
+                            .with_inherit(true),
+                    );
+                }
                 pushed_count += self.load_inline_dir_merge(directory, depth, &descriptor)?;
             }
         }
@@ -571,6 +638,38 @@ struct InlineDirMerge {
 /// upstream: exclude.c:1419-1428 - `FILTRULE_PERDIR_MERGE` inside
 /// `parse_filter_str()` adds a new per-dir rule rather than expanding the
 /// file at parse time.
+/// Joins a relative path's normal components with `/`, ignoring any leading
+/// `./`, `..`, or root components. Produces the module-root-relative directory
+/// string used to re-anchor merge-file rules.
+fn path_to_forward_slash(path: &Path) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for component in path.components() {
+        if let Component::Normal(part) = component {
+            if let Some(s) = part.to_str() {
+                parts.push(s);
+            }
+        }
+    }
+    parts.join("/")
+}
+
+/// Re-anchors a single rule read from a per-directory merge file.
+///
+/// upstream: exclude.c:200-228 add_rule - under `XFLG_ANCHORED2ABS`, a rule
+/// whose pattern begins with `/` is rewritten to be anchored at the merge
+/// file's directory rather than the module root. oc-rsync expresses root
+/// anchoring as a leading `/` in the pattern, so `/file1` from merge directory
+/// `foo` becomes `/foo/file1`. Rules without a leading `/` (and the root merge
+/// file, where `rel_dir` is `None`) are returned unchanged.
+fn reanchor_merge_rule(mut rule: FilterRule, rel_dir: Option<&str>) -> FilterRule {
+    if let Some(dir) = rel_dir {
+        if let Some(rest) = rule.pattern.strip_prefix('/') {
+            rule.pattern = format!("/{dir}/{rest}");
+        }
+    }
+    rule
+}
+
 fn split_dir_merge_rules(rules: Vec<FilterRule>) -> (Vec<FilterRule>, Vec<InlineDirMerge>) {
     let mut keep = Vec::with_capacity(rules.len());
     let mut dir_merges = Vec::new();

--- a/crates/filters/src/chain/tests.rs
+++ b/crates/filters/src/chain/tests.rs
@@ -506,6 +506,100 @@ fn dir_merge_inline_colon_c_missing_cvsignore_is_noop() {
     chain.leave_directory(guard);
 }
 
+/// A leading-`/` rule read from a per-directory merge file is anchored at
+/// the merge file's own directory, not the transfer root. With the
+/// transfer root recorded, `- /file1` inside `<root>/foo/.filt` must match
+/// `foo/file1` and leave a top-level `file1` untouched.
+///
+/// upstream: exclude.c:200-228 add_rule under XFLG_ANCHORED2ABS prepends
+/// the merge directory (relative to the module root) to a leading-`/`
+/// pattern. oc-rsync expresses root anchoring as a leading `/`, so the
+/// rewrite is `/file1` -> `/foo/file1`.
+#[test]
+fn dir_merge_leading_slash_rule_reanchors_to_merge_dir() {
+    let root = TempDir::new().unwrap();
+    fs::create_dir(root.path().join("foo")).unwrap();
+    fs::write(root.path().join("foo/.filt"), "- /file1\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt"));
+    chain.set_transfer_root(root.path());
+
+    let root_guard = chain.enter_directory(root.path()).unwrap();
+    let foo_guard = chain.enter_directory(&root.path().join("foo")).unwrap();
+    assert_eq!(
+        foo_guard.pushed_count(),
+        1,
+        "expected `foo/.filt` scope push"
+    );
+
+    // `- /file1` from `foo/.filt` re-anchors to `/foo/file1`.
+    assert!(
+        !chain.allows(Path::new("foo/file1"), false),
+        "re-anchored rule must exclude foo/file1"
+    );
+    // A top-level `file1` is at the module root, not below `foo`, so the
+    // re-anchored rule must not touch it.
+    assert!(
+        chain.allows(Path::new("file1"), false),
+        "re-anchored rule must not exclude top-level file1"
+    );
+
+    chain.leave_directory(foo_guard);
+    chain.leave_directory(root_guard);
+}
+
+/// A `dir-merge` directive parsed from inside a per-directory merge file
+/// becomes a persistent per-directory config that is re-read in every
+/// descendant directory, not a one-shot read of the declaring directory.
+/// Sibling subtrees each load their own copy of the named file.
+///
+/// upstream: exclude.c:294 appends a `dir-merge` parsed from a merge file
+/// to the global `mergelist_parents`, so `push_local_filters()` re-reads
+/// it at every directory below the declaration.
+#[test]
+fn dir_merge_nested_directive_inherits_into_every_descendant() {
+    let root = TempDir::new().unwrap();
+    fs::create_dir_all(root.path().join("bar/d1")).unwrap();
+    fs::create_dir_all(root.path().join("bar/d2")).unwrap();
+    fs::write(root.path().join("bar/.filt"), "dir-merge .filt2\n").unwrap();
+    fs::write(root.path().join("bar/d1/.filt2"), "- a.deep\n").unwrap();
+    fs::write(root.path().join("bar/d2/.filt2"), "- b.deep\n").unwrap();
+
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".filt"));
+    chain.set_transfer_root(root.path());
+
+    let root_guard = chain.enter_directory(root.path()).unwrap();
+    // Reading `bar/.filt` registers the nested `dir-merge .filt2`.
+    let bar_guard = chain.enter_directory(&root.path().join("bar")).unwrap();
+
+    // First descendant re-reads its own `.filt2`.
+    let d1_guard = chain.enter_directory(&root.path().join("bar/d1")).unwrap();
+    assert!(
+        !chain.allows(Path::new("bar/d1/a.deep"), false),
+        "bar/d1/.filt2 must exclude a.deep"
+    );
+    assert!(
+        chain.allows(Path::new("bar/d1/b.deep"), false),
+        "b.deep is only named in the sibling d2/.filt2"
+    );
+    chain.leave_directory(d1_guard);
+
+    // Sibling descendant re-reads its own `.filt2`; without persistent
+    // registration the nested dir-merge would have been one-shot at `bar`
+    // and this exclusion would never fire.
+    let d2_guard = chain.enter_directory(&root.path().join("bar/d2")).unwrap();
+    assert!(
+        !chain.allows(Path::new("bar/d2/b.deep"), false),
+        "bar/d2/.filt2 must be re-read and exclude b.deep"
+    );
+    chain.leave_directory(d2_guard);
+
+    chain.leave_directory(bar_guard);
+    chain.leave_directory(root_guard);
+}
+
 /// An inner scope's anchored exclude (`- /foo`) synthesizes a
 /// `foo/**` descendant matcher in the compiled rule. When the outer
 /// scope's `- down` rule is the only rule that *actually* applies to

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -75,6 +75,11 @@ impl GeneratorContext {
         path: &Path,
         emitted_dirs: Option<&HashSet<PathBuf>>,
     ) -> io::Result<bool> {
+        // Record the transfer root so per-directory merge files re-anchor their
+        // leading-`/` rules to the merge file's own directory (upstream
+        // exclude.c add_rule XFLG_ANCHORED2ABS). Idempotent across source
+        // entries; `base` is the same root for the whole walk.
+        self.filter_chain.set_transfer_root(base.to_path_buf());
         // upstream: flist.c:2390 - link_stat() once, then pass &st to
         // send_file_name(). Reuse the metadata to avoid a redundant stat
         // inside walk_path_with_metadata.


### PR DESCRIPTION
## Summary

Two related per-directory merge-filter correctness gaps in `FilterChain` (the wire/remote transfer filter path) that diverge from upstream rsync's `exclude.c`:

1. **Leading-slash anchoring.** A `- /file1` rule read from `<root>/foo/.filt` was anchored at the top-level transfer root, so it never matched `foo/file1`. Upstream (`exclude.c:200-228` `add_rule` under `XFLG_ANCHORED2ABS`) anchors such a rule at the merge file's own directory relative to the module root. `FilterChain` now records the transfer root and rewrites `/file1` read from merge directory `foo` to `/foo/file1`.

2. **Nested dir-merge inheritance.** A `dir-merge .filt2` directive parsed from *inside* a merge file was read only once, at the declaring directory. Upstream appends it to the global `mergelist_parents` (`exclude.c:294`), so `push_local_filters()` re-reads the named file in every descendant directory. `FilterChain` now promotes such a directive to a persistent per-directory config.

The transfer root is wired through the sender generator's source walk; the existing unit-test call sites are unaffected because re-anchoring is a no-op when no root is recorded.

## Verification

Validated on a Linux host against upstream rsync 3.4.3 (protocol 32):

- The per-directory-merge `--delete-during` legs of the upstream `exclude-lsh` testsuite no longer leak `foo/file1` or the deep nested file that previously diverged.
- The local `exclude` testsuite test stays green (no-regression guard — its engine `FilterProgram` twin already handled this).
- Two new `filters` unit tests cover both behaviours and pass via `cargo nextest`.

A separate, pre-existing `-ii` itemize-duplication issue over the remote-shell path remains in `exclude-lsh` and is tracked independently; it is unrelated to filter evaluation.