### PR TITLE
fix(itemize): suppress server-sender itemize on client display channel

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -265,36 +265,43 @@ impl GeneratorContext {
         Ok(())
     }
 
-    /// Emits itemize output when conditions are met.
+    /// Emits the sender-side itemize line for one file when the gate allows.
     ///
-    /// In server mode (daemon/SSH), sends the formatted itemize string
-    /// (`"%i %n%L\n"`) as a MSG_INFO multiplexed message to the client.
-    /// In client mode, writes directly to the process stdout via the
-    /// itemize callback, matching upstream's `rwrite()` `FCLIENT` path.
+    /// Only the terminal-owning CLIENT process writes user-visible itemize
+    /// output (via the FCLIENT callback to stdout). A SERVER-sender is a no-op
+    /// here: upstream `sender.c:211` sets `itemizing = am_server ?
+    /// logfile_format_has_i : stdout_format_has_i`, so a server-sender itemizes
+    /// only into the logfile format, never onto the client-visible display
+    /// channel. On a pull (oc-rsync is the server-sender) the client's
+    /// receiver/generator already emits the `>f` row; echoing a `<f` row back
+    /// over MSG_INFO would make the client print BOTH, duplicating every
+    /// itemized line under `-ii`. (Daemon logfile logging is a separate path
+    /// and is unaffected.)
     ///
-    /// Upstream `generator.c:582-583` emits when ANY of four OR'd conditions
-    /// hold: significant flags set, `INFO_GTE(NAME, 2)`, `stdout_format_has_i
-    /// > 1`, or an alternate basis name follows. Mirror the same semantic so
-    /// unchanged entries (`iflags == 0`) still appear under `-vv` (the case
-    /// the upstream `itemize.test` testsuite exercises with `-ivvplrtH`).
+    /// The emit gate (which entries produce a line at all) mirrors upstream
+    /// `generator.c:582-583`: significant flags set, `INFO_GTE(NAME, 2)`, or
+    /// `ITEM_XNAME_FOLLOWS`. `stdout_format_has_i > 1` is not yet distinguished.
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:582-583` - emit gate: `(iflags & (SIGNIFICANT_ITEM_FLAGS
-    ///   | ITEM_REPORT_XATTR)) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
-    ///   || (xname && *xname)`
-    /// - `sender.c:287` - `maybe_log_item()` for non-transfer items
-    /// - `sender.c:430` - `log_item()` after file transfer
-    /// - `log.c:330-340` - `rwrite()`: when `am_server`, sends MSG_INFO;
-    ///   when `!am_server`, writes to stdout (FCLIENT)
-    pub(super) fn maybe_emit_itemize<W: Write>(
+    /// - `sender.c:211` - `itemizing = am_server ? logfile_format_has_i : stdout_format_has_i`
+    /// - `log.c:816` - `log_item()`: stdout itemize gated on `!am_server`
+    /// - `log.c:822-836` - `maybe_log_item()`: server routes itemize to FLOG only
+    /// - `generator.c:582-583` - emit gate
+    pub(super) fn maybe_emit_itemize(
         &self,
-        writer: &mut super::super::writer::ServerWriter<W>,
         iflags: &super::item_flags::ItemFlags,
         ndx: usize,
         itemize_cb: &mut Option<&mut dyn super::super::ItemizeCallback>,
     ) -> io::Result<()> {
         if !self.config.flags.info_flags.itemize {
+            return Ok(());
+        }
+        // upstream: sender.c:211 / log.c:816 - a server-sender never writes
+        // itemize to the client display channel; only the client (terminal
+        // owner) prints. Suppressing this here prevents the server-sender's
+        // `<f` row from duplicating the client receiver's `>f` row under `-ii`.
+        if !self.config.connection.client_mode {
             return Ok(());
         }
         // upstream: generator.c:582-583 - the gate is the OR of four
@@ -317,16 +324,11 @@ impl GeneratorContext {
         let ctx = self.itemize_context();
         // Generator role is always the sender side
         let line = super::itemize::format_itemize_line(iflags, entry, true, &ctx);
-
-        if self.config.connection.client_mode {
-            // upstream: log.c:330-340 - when !am_server, rwrite() sends to FCLIENT (stdout)
-            if let Some(cb) = itemize_cb.as_mut() {
-                cb.on_itemize(&line);
-            }
-            Ok(())
-        } else {
-            writer.send_message(protocol::MessageCode::Info, line.as_bytes())
+        // upstream: log.c:330-340 - when !am_server, rwrite() sends to FCLIENT (stdout)
+        if let Some(cb) = itemize_cb.as_mut() {
+            cb.on_itemize(&line);
         }
+        Ok(())
     }
 
     /// Sends the file list to the receiver.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -4166,8 +4166,11 @@ mod itemize_emit_gate {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    /// Drives `maybe_emit_itemize` in client mode with a captured callback.
-    fn run_gate(verbose_name_level: u8, iflags_raw: u32) -> Vec<String> {
+    /// Drives `maybe_emit_itemize` with a captured callback.
+    ///
+    /// `client_mode` selects the role: a CLIENT (terminal owner) writes the
+    /// itemize line through the callback; a SERVER-sender must emit nothing.
+    fn run_gate(client_mode: bool, verbose_name_level: u8, iflags_raw: u32) -> Vec<String> {
         // Seed the thread-local verbosity so `info_gte(InfoFlag::Name, 2)`
         // reflects the test scenario. Other levels remain at defaults.
         let mut cfg = VerbosityConfig::default();
@@ -4176,7 +4179,7 @@ mod itemize_emit_gate {
 
         let handshake = test_handshake();
         let mut config = test_config();
-        config.connection.client_mode = true;
+        config.connection.client_mode = client_mode;
         config.flags.info_flags.itemize = true;
         let mut ctx = GeneratorContext::new_for_test(&handshake, config);
         ctx.file_list.push(protocol::flist::FileEntry::new_file(
@@ -4192,10 +4195,9 @@ mod itemize_emit_gate {
         };
         let mut callback: Option<&mut dyn crate::ItemizeCallback> = Some(&mut sink);
 
-        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
         let iflags = ItemFlags::from_raw(iflags_raw);
-        ctx.maybe_emit_itemize(&mut writer, &iflags, 0, &mut callback)
-            .expect("maybe_emit_itemize must not error in client mode");
+        ctx.maybe_emit_itemize(&iflags, 0, &mut callback)
+            .expect("maybe_emit_itemize must not error");
 
         // Reset the verbosity config so siblings see a clean default.
         init(VerbosityConfig::default());
@@ -4208,7 +4210,7 @@ mod itemize_emit_gate {
     /// `.f foo/config1`, and `.L foo/sym` rows on master.
     #[test]
     fn emits_under_verbose_name_2_with_zero_iflags() {
-        let lines = run_gate(2, 0);
+        let lines = run_gate(true, 2, 0);
         assert_eq!(
             lines.len(),
             1,
@@ -4222,7 +4224,7 @@ mod itemize_emit_gate {
     /// significant-flag-only emission.
     #[test]
     fn suppresses_under_verbose_name_1_with_zero_iflags() {
-        let lines = run_gate(1, 0);
+        let lines = run_gate(true, 1, 0);
         assert!(
             lines.is_empty(),
             "INFO_GTE(NAME, 1) must not force emission; got: {lines:?}"
@@ -4234,11 +4236,27 @@ mod itemize_emit_gate {
     /// proves the new branch alone is sufficient.
     #[test]
     fn emits_under_xname_follows_with_zero_verbose() {
-        let lines = run_gate(0, ItemFlags::ITEM_XNAME_FOLLOWS);
+        let lines = run_gate(true, 0, ItemFlags::ITEM_XNAME_FOLLOWS);
         assert_eq!(
             lines.len(),
             1,
             "ITEM_XNAME_FOLLOWS must force an itemize line under upstream gate; got: {lines:?}"
+        );
+    }
+
+    /// upstream: sender.c:211 + log.c:816 - a SERVER-sender must not echo
+    /// itemize onto the client display channel. On a pull (oc-rsync is the
+    /// server-sender) the client's receiver emits the `>f` row; a server-sender
+    /// `<f` row over MSG_INFO would duplicate every itemized line under `-ii`.
+    /// Even with the emit gate fully satisfied (`ITEM_XNAME_FOLLOWS`), the
+    /// server-sender path produces no itemize output. This is the regression
+    /// guard for the exclude-lsh `-ii` duplicate-arrow failure.
+    #[test]
+    fn server_sender_emits_nothing_even_when_gate_passes() {
+        let lines = run_gate(false, 0, ItemFlags::ITEM_XNAME_FOLLOWS);
+        assert!(
+            lines.is_empty(),
+            "server-sender must not emit itemize to the client display channel; got: {lines:?}"
         );
     }
 }

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -333,7 +333,7 @@ impl GeneratorContext {
                 // so the receiver can pair the response with its outstanding
                 // request and apply xattr-only updates. Without this echo the
                 // wire stream stalls when ITEM_REPORT_XATTR is the only delta.
-                self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
+                self.maybe_emit_itemize(&iflags, ndx, itemize)?;
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
@@ -532,7 +532,7 @@ impl GeneratorContext {
             debug_log!(Send, 1, "sender finished {}", file_entry.path().display());
 
             // upstream: sender.c:430 - log_item(log_code, file, iflags, NULL)
-            self.maybe_emit_itemize(writer, &iflags, ndx, itemize)?;
+            self.maybe_emit_itemize(&iflags, ndx, itemize)?;
 
             if let Some(cb) = progress.as_mut() {
                 // upstream: progress.c:80 - "to" once the final sub-list has been


### PR DESCRIPTION
## Summary

A server-sender must not write itemize output to the client display channel. On a pull, oc-rsync is the server-sender; its generator was emitting `<f` itemize rows over MSG_INFO. The client already prints its own receiver-side `>f` rows, so under `-ii` every itemized line was duplicated with conflicting direction arrows.

## Root cause

Upstream routes server-side itemize to the logfile only, never to the client display channel:

- `sender.c:211` — `itemizing = am_server ? logfile_format_has_i : stdout_format_has_i`
- `log.c:816` — stdout itemize gated on `!am_server`
- `log.c:822-836` — `maybe_log_item()` routes server-side itemize to FLOG only

`maybe_emit_itemize` ignored this and unconditionally sent a MSG_INFO frame in the server role.

## Fix

- `maybe_emit_itemize` returns early for the server role (`!client_mode`); only the client (terminal owner) prints, via the FCLIENT callback.
- The now-unused `ServerWriter` parameter is dropped at both call sites in `transfer_loop.rs`.
- The receiver-side push itemize path (`receiver/mod.rs::emit_itemize`) and the client-pull stdout path are unchanged.

## Validation

On the Linux host against the upstream 3.5.0dev testsuite: `itemize`, `exclude`, `exclude-lsh`, `dirs`, `delete`, and `output-options` all PASS. New regression test `server_sender_emits_nothing_even_when_gate_passes` asserts the server role produces no itemize output even when the emit gate is fully satisfied.