### PR TITLE
ci(benchmark): point benchmark.py at upstream rsync 3.4.4

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -15,7 +15,9 @@ import sys
 import tempfile
 import time
 
-UPSTREAM = "target/interop/upstream-src/rsync-3.4.2/rsync"
+UPSTREAM = os.environ.get(
+    "UPSTREAM_RSYNC", "target/interop/upstream-src/rsync-3.4.4/rsync"
+)
 OC_RSYNC = "target/release/oc-rsync"
 OC_RSYNC_OPENSSL = os.environ.get("OC_RSYNC_OPENSSL", "")
 OC_RSYNC_RUSSH = os.environ.get("OC_RSYNC_RUSSH", "")


### PR DESCRIPTION
## Problem

The scheduled `Benchmark` workflow on master HEAD (`6e957d3b8`) fails:

```
FileNotFoundError: [Errno 2] No such file or directory: 'target/interop/upstream-src/rsync-3.4.2/rsync'
```

The workflow builds and installs upstream rsync **3.4.4** (`target/interop/upstream-src/rsync-3.4.4/rsync`, also copied to `/usr/local/bin/rsync`), but `.github/scripts/benchmark.py` still hard-coded the **3.4.2** path. The earlier 3.4.4 version-pin sweep missed this Python script, so both the Linux "Performance Benchmark" job and the best-effort macOS throughput job (which share this script) error out before running.

## Fix

Point the `UPSTREAM` default at the 3.4.4 build path and allow an env override (`UPSTREAM_RSYNC`).

## Validation

Single-line path-constant change; the referenced binary is produced by the workflow's existing "Build upstream rsync 3.4.4" step.