### PR TITLE
fix(transfer): load per-directory merge filters during --delete pass

### DIFF
--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -98,14 +98,22 @@ impl ReceiverContext {
         // upstream: main.c:1367 - deletion_count >= max_delete
         let deletions_performed = Arc::new(AtomicU64::new(0));
 
-        // Share directory children map and filter chain across workers.
-        // The filter chain clone captures the global rules snapshot for
-        // allows_deletion() checks. Per-directory merge files are not
-        // re-read during deletion (upstream also only evaluates the
-        // pre-loaded filter list in delete_in_dir).
+        // Share directory children map across workers, plus a filter-chain
+        // template each worker clones into an owned, mutable chain.
+        //
+        // Each parallel worker re-reads the per-directory merge files for the
+        // directory it is about to scan via `enter_directory`, mirroring
+        // upstream's per-directory filter reload before deletion. The template
+        // carries the global rules plus the registered merge configs; the
+        // transfer root is set to the destination directory so leading-`/`
+        // merge rules re-anchor to the merge file's own directory.
+        // upstream: generator.c:308 change_local_filter_dir in delete_in_dir -
+        // push_local_filters() reloads `.rsync-filter`/`:C`/dir-merge files
+        // for each directory before it is scanned for extraneous entries.
         let dir_children = Arc::new(dir_children);
-        let filter_chain = Arc::new(self.filter_chain.clone());
         let dest_dir_owned = dest_dir.to_path_buf();
+        let mut filter_chain_template = self.filter_chain.clone();
+        filter_chain_template.set_transfer_root(dest_dir_owned.clone());
         // SEC-1.q2: clone the sandbox `Arc` into the worker closure so
         // every per-directory job can route its scan and per-entry
         // deletions through the sandbox-anchored `*at` helpers without
@@ -145,6 +153,45 @@ impl ReceiverContext {
                         Some(set) => set,
                         None => return (DeleteStats::new(), Vec::new(), None),
                     };
+
+                    // upstream: generator.c:308 change_local_filter_dir in
+                    // delete_in_dir - reload the per-directory merge files for
+                    // the scan target before listing it. Upstream pushes every
+                    // merge file from the transfer root down to the target so
+                    // inheriting parent rules apply, so walk the ancestors here
+                    // too. Each worker owns a fresh chain clone, so entering a
+                    // directory never races a sibling (scopes are path-local).
+                    // The scopes live in this owned chain clone until it is
+                    // dropped at the end of the closure, so the returned guards
+                    // need not be retained explicitly.
+                    let mut filter_chain = filter_chain_template.clone();
+                    // Directories to enter: the transfer root first, then each
+                    // ancestor component down to the scan target.
+                    let mut enter_dirs = vec![dest_dir_owned.clone()];
+                    let mut walk = dest_dir_owned.clone();
+                    for component in dir_relative.components() {
+                        if let std::path::Component::Normal(part) = component {
+                            walk.push(part);
+                            enter_dirs.push(walk.clone());
+                        }
+                    }
+                    let mut walk_failed = None;
+                    for dir in enter_dirs {
+                        match filter_chain.enter_directory(&dir) {
+                            Ok(_guard) => {}
+                            Err(filters::FilterChainError::Io { source, .. }) => {
+                                walk_failed = Some(source);
+                                break;
+                            }
+                            Err(e) => {
+                                walk_failed = Some(io::Error::other(e.to_string()));
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(err) = walk_failed {
+                        return classify_scan_error(err);
+                    }
 
                     #[cfg(unix)]
                     let sandbox_ref = sandbox_for_workers.as_deref();
@@ -210,7 +257,8 @@ impl ReceiverContext {
 
                         // upstream: generator.c:delete_in_dir() - is_excluded()
                         // check before deletion. allows_deletion() evaluates
-                        // protect/risk rules from the global filter chain.
+                        // protect/risk rules from this directory's per-directory
+                        // merge scopes (loaded above) plus the global chain.
                         //
                         // Strip the implicit "." directory prefix when scanning
                         // the deletion root so a glob like `?` does not see the

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -245,6 +245,151 @@ fn per_dir_merge_filter_protects_during_deletion() {
     );
 }
 
+/// Regression: an inheriting per-directory merge rule defined in an
+/// ancestor must protect a deletion candidate several levels below it,
+/// the way upstream `exclude-lsh` relies on `bar/down/to/bar/.filt2`
+/// (`- *.deep`) protecting `bar/down/to/bar/baz/file5.deep`.
+///
+/// The receiver re-enters every ancestor of the scan target before
+/// listing it, so the inheriting scope pushed at the ancestor's depth
+/// must still apply at the deeper scan depth. The per-entry deletion
+/// check passes a transfer-root-relative path (`top/mid/protected.deep`),
+/// matching the path convention the generator uses for `allows`, so the
+/// inherited rule fires. Pins that the deeper candidate is protected
+/// while a sibling the rule does not name is still deleted.
+///
+/// upstream: exclude-lsh.test:75-78, generator.c:308 change_local_filter_dir.
+#[test]
+fn inherited_per_dir_merge_protects_deeper_deletion_candidate() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // dest/top/.filt2 = `- *.deep` (inheriting); the candidate lives two
+    // levels below in dest/top/mid/leaf.
+    let top = dest.join("top");
+    let mid = top.join("mid");
+    std::fs::create_dir_all(&mid).unwrap();
+    std::fs::write(top.join(".filt2"), b"- *.deep\n").unwrap();
+
+    std::fs::write(mid.join("keep.txt"), b"keep").unwrap();
+    std::fs::write(mid.join("protected.deep"), b"deep").unwrap();
+    std::fs::write(mid.join("extraneous.txt"), b"extra").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("top".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("top/.filt2".into(), 8, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_directory("top/mid".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("top/mid/keep.txt".into(), 4, 0o644));
+
+    let mut chain = ::filters::FilterChain::empty();
+    chain.add_merge_config(::filters::DirMergeConfig::new(".filt2"));
+    ctx.set_filter_chain(chain);
+
+    let mut writer = TestDeletionWriter;
+    ctx.delete_extraneous_files(
+        dest,
+        #[cfg(unix)]
+        None,
+        &mut writer,
+    )
+    .unwrap();
+
+    assert!(
+        mid.join("protected.deep").exists(),
+        "protected.deep must survive: the ancestor `top/.filt2 - *.deep` inherits down to `top/mid`",
+    );
+    assert!(
+        !mid.join("extraneous.txt").exists(),
+        "extraneous.txt must be deleted: no merge rule protects it",
+    );
+    assert!(
+        mid.join("keep.txt").exists(),
+        "keep.txt must survive: it is in the source file list",
+    );
+}
+
+/// Regression: a non-inheriting `:C`/.cvsignore scope must protect a
+/// candidate in the directory it was loaded in, but must NOT leak into a
+/// child directory. Mirrors upstream `exclude-lsh` where `mid/.filt`
+/// (`:C`) loads `mid/.cvsignore` for `mid` only.
+///
+/// The receiver pushes the `:C` scope at the scan directory's depth; the
+/// depth-gated `scope_applies_here` check (filters chain `scope_applies_here`)
+/// keeps it from suppressing deletions one level deeper. Pins both halves
+/// so a regression in the per-worker ancestor-walk depth bookkeeping is
+/// caught.
+///
+/// upstream: exclude-lsh.test:80-88, exclude.c FILTRULE_NO_INHERIT.
+#[test]
+fn non_inheriting_cvsignore_scope_is_depth_local_during_deletion() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    // dest/.cvsignore protects `ignored` in the root only (non-inheriting).
+    let sub = dest.join("sub");
+    std::fs::create_dir(&sub).unwrap();
+    std::fs::write(dest.join(".cvsignore"), b"ignored\n").unwrap();
+
+    std::fs::write(dest.join("ignored"), b"top").unwrap();
+    std::fs::write(sub.join("ignored"), b"deep").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file(".cvsignore".into(), 8, 0o644));
+    ctx.file_list
+        .push(FileEntry::new_directory("sub".into(), 0o755));
+
+    // `.cvsignore` registered as a non-inheriting CVS-mode dir-merge, the
+    // way upstream's `:C` directive expands it.
+    let mut chain = ::filters::FilterChain::empty();
+    chain.add_merge_config(
+        ::filters::DirMergeConfig::new(".cvsignore")
+            .with_cvs_mode(true)
+            .with_inherit(false),
+    );
+    ctx.set_filter_chain(chain);
+
+    let mut writer = TestDeletionWriter;
+    ctx.delete_extraneous_files(
+        dest,
+        #[cfg(unix)]
+        None,
+        &mut writer,
+    )
+    .unwrap();
+
+    assert!(
+        dest.join("ignored").exists(),
+        "root `ignored` must survive: dest/.cvsignore protects it at the root depth",
+    );
+    assert!(
+        !sub.join("ignored").exists(),
+        "sub/ignored must be deleted: the non-inheriting `.cvsignore` scope does not leak into `sub`",
+    );
+}
+
 #[test]
 fn receiver_set_and_get_filter_chain() {
     let handshake = test_handshake();

--- a/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_chain.rs
@@ -164,6 +164,87 @@ fn single_char_wildcard_exclude_does_not_block_top_level_deletion() {
     assert_eq!(stats.files, 1);
 }
 
+/// Regression: a per-directory merge file must be honored during the
+/// `--delete` pass, mirroring upstream `delete_in_dir` which calls
+/// `change_local_filter_dir` to reload that directory's merge filters
+/// before scanning it for extraneous entries.
+///
+/// Before the fix, the receiver cloned a shared `FilterChain` carrying
+/// only the global rules and never called `enter_directory`, so a
+/// `.rsync-filter` placed inside a subdirectory was ignored. An
+/// extraneous file the merge file protected (`- *.deep`) was therefore
+/// wrongly deleted, while the upstream tests `exclude` / `exclude-lsh`
+/// expect it to survive. This pins the per-worker per-directory reload:
+/// the protected file must survive and an unprotected sibling must still
+/// be deleted.
+///
+/// upstream: generator.c:308 change_local_filter_dir in delete_in_dir.
+#[test]
+fn per_dir_merge_filter_protects_during_deletion() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let dest = temp_dir.path();
+
+    let subdir = dest.join("sub");
+    std::fs::create_dir(&subdir).unwrap();
+
+    // Per-directory merge file protecting `*.deep` from deletion.
+    std::fs::write(subdir.join(".rsync-filter"), b"- *.deep\n").unwrap();
+
+    // keep.txt is in the source flist; protected.deep and extraneous.txt
+    // are both extraneous (absent from the flist).
+    std::fs::write(subdir.join("keep.txt"), b"keep").unwrap();
+    std::fs::write(subdir.join("protected.deep"), b"protected").unwrap();
+    std::fs::write(subdir.join("extraneous.txt"), b"extraneous").unwrap();
+
+    let handshake = test_handshake();
+    let mut config = test_config();
+    config.flags.delete = true;
+    config.args = vec![OsString::from(dest.to_str().unwrap())];
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_directory("sub".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("sub/keep.txt".into(), 4, 0o644));
+    // The merge file is in the flist so it is not itself a deletion
+    // candidate; the test isolates the `*.deep` protection.
+    ctx.file_list
+        .push(FileEntry::new_file("sub/.rsync-filter".into(), 8, 0o644));
+
+    // Global chain carries no path rules; the protection lives entirely in
+    // the per-directory `.rsync-filter`, registered as a dir-merge config.
+    let mut chain = ::filters::FilterChain::empty();
+    chain.add_merge_config(::filters::DirMergeConfig::new(".rsync-filter"));
+    ctx.set_filter_chain(chain);
+
+    let mut writer = TestDeletionWriter;
+    let (_stats, _, _) = ctx
+        .delete_extraneous_files(
+            dest,
+            #[cfg(unix)]
+            None,
+            &mut writer,
+        )
+        .unwrap();
+
+    assert!(
+        subdir.join("protected.deep").exists(),
+        "protected.deep must survive: the per-dir .rsync-filter excludes it from deletion",
+    );
+    assert!(
+        !subdir.join("extraneous.txt").exists(),
+        "extraneous.txt must be deleted: no merge rule protects it",
+    );
+    assert!(
+        subdir.join("keep.txt").exists(),
+        "keep.txt must survive: it is in the source file list",
+    );
+}
+
 #[test]
 fn receiver_set_and_get_filter_chain() {
     let handshake = test_handshake();


### PR DESCRIPTION
## Summary

The receiver `--delete` pass never loaded per-directory merge-filter scopes,
so per-directory merge files (`.rsync-filter`, `:C` dir-merge, `.cvsignore`)
were ignored when deciding which extraneous files to delete. Files that a
per-directory merge rule protects were wrongly deleted, and files such a rule
excludes from the transfer were wrongly kept. This is purely a receiver-side
caller bug in `delete_extraneous_files`.

## Root cause

`crates/transfer/src/receiver/directory/deletion.rs` cloned a single shared
`FilterChain` whose `scopes` stack was always empty because `enter_directory`
was never called on the receiver side. Deletion decisions therefore ran only
against the global `FilterSet`. Upstream `delete_in_dir`
(`generator.c:308`) calls `change_local_filter_dir` -> `push_local_filters`
to reload a directory's merge filters before scanning it for extraneous
entries.

## Why prior fixes missed it

Recent work (#5749/#5751/#5932/#5981/#6015/#6041) fixed the generator walk
and the decision-context synthetic-descendants logic. None of those touched
the receiver delete pass, which is a separate caller that owns its own
filter-chain clone and never entered any directory. The gap was on the
deletion-gate side, not the generator/decision-context side.

## Fix (per-worker owned chain clone)

The deletion scan is a parallel `map_blocking` whose closure is `Fn + Sync`,
so a shared `Arc<FilterChain>` cannot be mutated. `FilterChain` derives
`Clone` and its per-directory scopes are path-local (a scope for directory D
depends only on D's path and the merge files on the path to D, never on a
sibling worker). So:

- A filter-chain template is built once with `transfer_root` set to the
  destination root (re-anchors leading-`/` merge rules to the merge file's
  own directory).
- Each parallel worker clones the template into its own owned, mutable chain.
- Before listing a directory, the worker walks from the transfer root down
  to the scan target and calls `enter_directory` on each component, loading
  inheriting parent merge files plus the target's own. Scopes live in the
  owned clone and are dropped when the closure iteration ends, mirroring
  upstream's push/pop.
- `enter_directory` errors are classified through the existing
  `classify_scan_error` helper (EACCES/NotFound non-fatal, every other class
  fail-loud), never silently skipped.
- The per-entry deletion gate now evaluates `allows_deletion` against the
  per-worker chain with scopes loaded.

The generator walk and decision-context descendant logic are untouched.

## Test

Adds `per_dir_merge_filter_protects_during_deletion` to the receiver deletion
filter-chain test module. It sets up a destination subtree where a
`.rsync-filter` (`- *.deep`) protects an extraneous file, runs the delete
pass, and asserts the protected file survives while an unprotected extraneous
sibling is deleted. Deterministic (present/absent assertions, no mtime
dependence).
