### PR TITLE
fix(itemize): render alt-dest matches as local change, not new transfer

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -15,7 +15,9 @@ import sys
 import tempfile
 import time
 
-UPSTREAM = "target/interop/upstream-src/rsync-3.4.2/rsync"
+UPSTREAM = os.environ.get(
+    "UPSTREAM_RSYNC", "target/interop/upstream-src/rsync-3.4.4/rsync"
+)
 OC_RSYNC = "target/release/oc-rsync"
 OC_RSYNC_OPENSSL = os.environ.get("OC_RSYNC_OPENSSL", "")
 OC_RSYNC_RUSSH = os.environ.get("OC_RSYNC_RUSSH", "")

--- a/crates/cli/src/frontend/out_format/render/checksum.rs
+++ b/crates/cli/src/frontend/out_format/render/checksum.rs
@@ -18,7 +18,10 @@ pub(super) fn format_full_checksum(event: &ClientEvent) -> String {
 
     if !matches!(
         event.kind(),
-        ClientEventKind::DataCopied | ClientEventKind::MetadataReused | ClientEventKind::HardLink,
+        ClientEventKind::DataCopied
+            | ClientEventKind::ReferenceCopied
+            | ClientEventKind::MetadataReused
+            | ClientEventKind::HardLink,
     ) {
         return EMPTY_CHECKSUM.to_owned();
     }

--- a/crates/cli/src/frontend/out_format/render/itemize.rs
+++ b/crates/cli/src/frontend/out_format/render/itemize.rs
@@ -32,6 +32,9 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
             }
         }
         HardLink => 'h',
+        // upstream: generator.c:1039 - copy-dest reconstruction itemizes with
+        // ITEM_LOCAL_CHANGE, rendered as 'c' by log.c:707-708.
+        ReferenceCopied => 'c',
         DirectoryCreated | SymlinkCopied | FifoCopied | DeviceCopied | SourceRemoved => 'c',
         MetadataReused
         | SkippedExisting
@@ -54,6 +57,7 @@ pub(super) fn format_itemized_changes(event: &ClientEvent, is_sender: bool) -> S
             DeviceCopied => ClientEntryKind::CharDevice,
             HardLink
             | DataCopied
+            | ReferenceCopied
             | MetadataReused
             | SkippedExisting
             | SkippedMissingDestination

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -114,19 +114,25 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
 
     // upstream: hlink.c:215-227 + generator.c:581-583 - a hardlink alias is
     // itemized via `itemize(..., ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0,
-    // xname)`. The generator only writes the row when a significant attribute
+    // xname)`. The generator writes the row only when a significant attribute
     // flag is set, `INFO_GTE(NAME, 2)` (handled above via `emit_unchanged`),
-    // `stdout_format_has_i > 1` (`-ii`), or the xname is non-empty (a `=> leader`
-    // trailer). A hardlink alias with no attribute change and an empty xname is
-    // therefore suppressed at plain `-i`, whether it is an already-shared inode
-    // (`is_hardlink_uptodate`) or a fresh link from a `--link-dest` basis. The
-    // `=> leader` case (in-transfer cluster) carries a non-None symlink_target
-    // and is preserved; a hard-linked symlink's `-> target` is handled by the
-    // earlier Symlink rule.
-    matches!(event.kind(), ClientEventKind::HardLink)
-        && !event.was_created()
-        && !event.change_set().has_any_change()
-        && event
+    // `-ii`, or the alias was freshly atomic_create'd with a non-empty xname.
+    // Two blank cases are suppressed at plain `-i`:
+    //   1. An alias with no attribute change and no `=> leader` trailer (empty
+    //      xname) - a fresh `--link-dest`/basis hardlink.
+    //   2. An already-shared-inode cluster alias (`is_hardlink_uptodate`): even
+    //      though it carries a `=> leader` trailer for the `-vv` view, upstream
+    //      itemizes it with an EMPTY xname (hlink.c:219-221), so the plain-`-i`
+    //      gate drops it.
+    // A hard-linked symlink's `-> target` is handled by the earlier Symlink rule.
+    if !matches!(event.kind(), ClientEventKind::HardLink)
+        || event.was_created()
+        || event.change_set().has_any_change()
+    {
+        return false;
+    }
+    event.is_hardlink_uptodate()
+        || event
             .metadata()
             .and_then(ClientEntryMetadata::symlink_target)
             .is_none()

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -112,19 +112,18 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
         return true;
     }
 
-    // upstream: hlink.c:215-227 + generator.c:581-583 - an already-correct
-    // hardlink alias is itemized via `itemize(..., ITEM_LOCAL_CHANGE |
-    // ITEM_XNAME_FOLLOWS, 0, "")` with an EMPTY xname. The generator only
-    // writes that row when a significant attribute flag is set, `INFO_GTE(NAME,
-    // 2)` (handled above via `emit_unchanged`), `stdout_format_has_i > 1`
-    // (`-ii`), or the xname is non-empty (a relink occurred). For an up-to-date
-    // alias with no attribute change, empty xname, and plain `-i`, all of those
-    // are false, so the row is suppressed. The shared inode means config1's
-    // perm fix already reached the alias, so itemizing `foo/extra` would
-    // over-report. Detect that case: a hardlink-uptodate record with an empty
-    // change-set and no `=> target` xname (None symlink target).
+    // upstream: hlink.c:215-227 + generator.c:581-583 - a hardlink alias is
+    // itemized via `itemize(..., ITEM_LOCAL_CHANGE | ITEM_XNAME_FOLLOWS, 0,
+    // xname)`. The generator only writes the row when a significant attribute
+    // flag is set, `INFO_GTE(NAME, 2)` (handled above via `emit_unchanged`),
+    // `stdout_format_has_i > 1` (`-ii`), or the xname is non-empty (a `=> leader`
+    // trailer). A hardlink alias with no attribute change and an empty xname is
+    // therefore suppressed at plain `-i`, whether it is an already-shared inode
+    // (`is_hardlink_uptodate`) or a fresh link from a `--link-dest` basis. The
+    // `=> leader` case (in-transfer cluster) carries a non-None symlink_target
+    // and is preserved; a hard-linked symlink's `-> target` is handled by the
+    // earlier Symlink rule.
     matches!(event.kind(), ClientEventKind::HardLink)
-        && event.is_hardlink_uptodate()
         && !event.was_created()
         && !event.change_set().has_any_change()
         && event

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use std::io::{self, Write};
 
-use core::client::{ClientEntryMetadata, ClientEvent, ClientEventKind};
+use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 
 use super::tokens::{OutFormat, OutFormatContext, OutFormatToken};
 
@@ -93,6 +93,21 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
             | ClientEventKind::DeviceCopied
     ) && !event.was_created()
         && !event.change_set().has_any_change()
+    {
+        return true;
+    }
+
+    // upstream: generator.c:1119-1147 - a `--link-dest` symlink hard-linked
+    // from the basis (`hL`) carries only ITEM_LOCAL_CHANGE and no `=> leader`
+    // xname, so it is suppressed at plain `-i`. Its `-> target` is the `%L`
+    // field, not an xname, so it does not force emission.
+    if matches!(event.kind(), ClientEventKind::HardLink)
+        && !event.was_created()
+        && !event.change_set().has_any_change()
+        && event
+            .metadata()
+            .map(ClientEntryMetadata::kind)
+            .is_some_and(|kind| matches!(kind, ClientEntryKind::Symlink))
     {
         return true;
     }

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -74,6 +74,29 @@ fn should_suppress_event(event: &ClientEvent, context: &OutFormatContext) -> boo
         return true;
     }
 
+    // upstream: generator.c:582-583 + rsync.h:258 - a `--copy-dest`
+    // reconstruction that exactly matches the basis is itemized with only
+    // ITEM_LOCAL_CHANGE, which is excluded from `SIGNIFICANT_ITEM_FLAGS`. At
+    // plain `-i` (NAME < 2, no `-ii`) the emit gate therefore drops the row.
+    // A directory, symlink, fifo, device, or regular-file copy reconstructed
+    // from the basis with no attribute drift and no creation is suppressed;
+    // only the `-vv` path (`emit_unchanged`, handled above) surfaces it. The
+    // symlink's own `-> target` is the `%L` field, not an xname, so it does NOT
+    // force emission - only a hardlink alias's `=> leader` xname does, which the
+    // dedicated HardLink rule below preserves.
+    if matches!(
+        event.kind(),
+        ClientEventKind::ReferenceCopied
+            | ClientEventKind::DirectoryCreated
+            | ClientEventKind::SymlinkCopied
+            | ClientEventKind::FifoCopied
+            | ClientEventKind::DeviceCopied
+    ) && !event.was_created()
+        && !event.change_set().has_any_change()
+    {
+        return true;
+    }
+
     // upstream: hlink.c:215-227 + generator.c:581-583 - an already-correct
     // hardlink alias is itemized via `itemize(..., ITEM_LOCAL_CHANGE |
     // ITEM_XNAME_FOLLOWS, 0, "")` with an EMPTY xname. The generator only

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -19,6 +19,24 @@ use super::checksum::format_full_checksum;
 use super::format::format_numeric_value;
 use super::itemize::format_itemized_changes;
 
+/// Returns the `%L` connector for an event carrying a target in its metadata.
+///
+/// upstream: log.c:643-654 - `%L` renders ` -> %s` when the entry itself is a
+/// symlink (`S_ISLNK`) and ` => %s` for a hard-link xname (`=> leader`). A
+/// hard-linked symlink is still a symlink, so it uses ` -> `; only a hard-linked
+/// regular file uses ` => `.
+fn symlink_target_connector(event: &ClientEvent) -> &'static str {
+    let is_symlink = event
+        .metadata()
+        .map(ClientEntryMetadata::kind)
+        .is_some_and(|kind| matches!(kind, ClientEntryKind::Symlink));
+    if matches!(event.kind(), ClientEventKind::HardLink) && !is_symlink {
+        " => "
+    } else {
+        " -> "
+    }
+}
+
 /// Resolves a placeholder token to its string value for the given event and context.
 ///
 /// Returns `None` when the placeholder is inapplicable (e.g., symlink target on a regular file).
@@ -35,16 +53,7 @@ pub(super) fn render_placeholder_value(
                 .metadata()
                 .and_then(ClientEntryMetadata::symlink_target)
             {
-                // upstream: log.c:643-654 - `%L` renders ` => %s` for
-                // hard-link references and ` -> %s` for symlink targets.
-                // The two cases are mutually exclusive on a single record
-                // because a hardlink alias never carries a symlink target.
-                let connector = if matches!(event.kind(), ClientEventKind::HardLink) {
-                    " => "
-                } else {
-                    " -> "
-                };
-                rendered.push_str(connector);
+                rendered.push_str(symlink_target_connector(event));
                 rendered.push_str(&target.to_string_lossy());
             }
             Some(rendered)
@@ -77,14 +86,7 @@ pub(super) fn render_placeholder_value(
             .metadata()
             .and_then(ClientEntryMetadata::symlink_target)
             .map(|target| {
-                // upstream: log.c:643-654 - `%L` standalone also renders the
-                // ` => %s` vs ` -> %s` distinction.
-                let connector = if matches!(event.kind(), ClientEventKind::HardLink) {
-                    " => "
-                } else {
-                    " -> "
-                };
-                let mut rendered = String::from(connector);
+                let mut rendered = String::from(symlink_target_connector(event));
                 rendered.push_str(&target.to_string_lossy());
                 rendered
             }),

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1972,3 +1972,71 @@ fn emit_out_format_emits_unchanged_symlink_under_info_name_2() {
     let rendered = String::from_utf8(output).unwrap();
     assert_eq!(rendered, ".L          test.txt\n");
 }
+
+// upstream: generator.c:1039 / log.c:707-749 - a `--copy-dest` reconstruction
+// itemizes the regular file with ITEM_LOCAL_CHANGE (`c`) and, when the source
+// already matched the basis, leaves the attribute columns blank. ITEM_IS_NEW is
+// never set, so the row is `cf` + 9 spaces rather than `>f+++++++++`.
+#[test]
+fn itemize_reference_copied_file_is_c_with_blank_attrs() {
+    let event = make_event(
+        ClientEventKind::ReferenceCopied,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    assert_eq!(format_itemized_changes(&event, false), "cf         ");
+}
+
+// A copy-dest reconstruction that differs from the basis in mtime keeps the `c`
+// update char but reports the drift (`cf...t.....`), never collapsing to `+`.
+#[test]
+fn itemize_reference_copied_file_reports_basis_drift() {
+    let cs = LocalCopyChangeSet::new().with_time_change(Some(TimeChange::Modified));
+    let event = make_event(
+        ClientEventKind::ReferenceCopied,
+        false,
+        Some(ClientEntryKind::File),
+        cs,
+    );
+    assert_eq!(format_itemized_changes(&event, false), "cf..t......");
+}
+
+// upstream: generator.c:1127 do_link_at() - a `--link-dest` exact match
+// hard-links from the basis and itemizes as `hf` + blank when identical.
+#[test]
+fn itemize_link_dest_hardlink_is_h_with_blank_attrs() {
+    let event = make_event(
+        ClientEventKind::HardLink,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    assert_eq!(format_itemized_changes(&event, false), "hf         ");
+}
+
+// A copy-dest directory reconstruction itemizes as `cd` + blank against the
+// basis, never `cd+++++++++`.
+#[test]
+fn itemize_reference_copied_directory_is_cd_with_blank_attrs() {
+    let event = make_event(
+        ClientEventKind::DirectoryCreated,
+        false,
+        Some(ClientEntryKind::Directory),
+        LocalCopyChangeSet::new(),
+    );
+    assert_eq!(format_itemized_changes(&event, false), "cd         ");
+}
+
+// A copy-dest symlink reconstruction itemizes as `cL` + blank against the
+// basis when the reconstructed link is identical.
+#[test]
+fn itemize_reference_copied_symlink_is_cl_with_blank_attrs() {
+    let event = make_event(
+        ClientEventKind::SymlinkCopied,
+        false,
+        Some(ClientEntryKind::Symlink),
+        LocalCopyChangeSet::new(),
+    );
+    assert_eq!(format_itemized_changes(&event, false), "cL         ");
+}

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1930,11 +1930,12 @@ fn emit_out_format_emits_uptodate_hardlink_alias_with_changed_attr() {
 }
 
 #[test]
-fn emit_out_format_emits_uptodate_hardlink_alias_with_relink_target() {
-    // upstream: generator.c:582 `(xname && *xname)` arm - when the alias was
-    // (re)created the xname is the relink target (`=> %s`), which forces the
-    // row even at plain `-i`. The local-copy engine carries that target in the
-    // metadata symlink_target slot for HardLink events.
+fn emit_out_format_suppresses_uptodate_hardlink_alias_at_plain_i() {
+    // upstream: hlink.c:219-221 - an already-shared-inode cluster alias (e.g. a
+    // `--link-dest` member that links from the basis and ends up sharing its
+    // leader's inode) is itemized with an EMPTY xname, so the plain-`-i` emit
+    // gate drops it even though the engine carries a `=> leader` trailer for the
+    // `-vv` view. Verified against upstream rsync 3.4.4 `-iplrtH --link-dest`.
     let metadata = ClientEvent::test_metadata(ClientEntryKind::File)
         .with_symlink_target_for_test("foo/leader");
     let event = ClientEvent::for_test(
@@ -1945,6 +1946,39 @@ fn emit_out_format_emits_uptodate_hardlink_alias_with_relink_target() {
         LocalCopyChangeSet::new(),
     )
     .with_hardlink_uptodate_for_test();
+    let events = [event];
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n%L")).unwrap();
+
+    // Plain `-i`: suppressed.
+    let mut plain = Vec::new();
+    emit_out_format(&events, &format, &OutFormatContext::default(), &mut plain).unwrap();
+    assert_eq!(String::from_utf8(plain).unwrap(), "");
+
+    // `-vv` (`emit_unchanged`): shown with the `=> leader` trailer.
+    let mut verbose = Vec::new();
+    let ctx = OutFormatContext::default().with_emit_unchanged(true);
+    emit_out_format(&events, &format, &ctx, &mut verbose).unwrap();
+    assert_eq!(
+        String::from_utf8(verbose).unwrap(),
+        "hf          test.txt => foo/leader\n"
+    );
+}
+
+#[test]
+fn emit_out_format_emits_fresh_hardlink_alias_with_relink_target() {
+    // upstream: generator.c:582 `(xname && *xname)` arm / hlink.c:232-234 - a
+    // freshly atomic_create'd alias (NOT sharing the leader inode, e.g. a
+    // `--copy-dest` cluster member linked to a copied leader) itemizes with the
+    // relink target as the xname (`=> %s`), forcing the row even at plain `-i`.
+    let metadata = ClientEvent::test_metadata(ClientEntryKind::File)
+        .with_symlink_target_for_test("foo/leader");
+    let event = ClientEvent::for_test(
+        PathBuf::from("test.txt"),
+        ClientEventKind::HardLink,
+        false,
+        Some(metadata),
+        LocalCopyChangeSet::new(),
+    );
     let events = [event];
     let format = parse_out_format(std::ffi::OsStr::new("%i %n%L")).unwrap();
     let mut output = Vec::new();

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -2040,3 +2040,40 @@ fn itemize_reference_copied_symlink_is_cl_with_blank_attrs() {
     );
     assert_eq!(format_itemized_changes(&event, false), "cL         ");
 }
+
+// upstream: generator.c:582-583 + rsync.h:258 - at plain `-i` (no `-vv`) the
+// blank copy-dest reconstruction rows carry only ITEM_LOCAL_CHANGE, which is
+// excluded from SIGNIFICANT_ITEM_FLAGS, so the emit gate drops them. Only `-vv`
+// (`emit_unchanged`) surfaces the `cf`/`cd`/`cL` rows.
+#[test]
+fn copy_dest_blank_rows_suppressed_at_plain_itemize() {
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    for (kind, entry) in [
+        (ClientEventKind::ReferenceCopied, ClientEntryKind::File),
+        (
+            ClientEventKind::DirectoryCreated,
+            ClientEntryKind::Directory,
+        ),
+        (ClientEventKind::SymlinkCopied, ClientEntryKind::Symlink),
+    ] {
+        let event = make_event(kind, false, Some(entry), LocalCopyChangeSet::new());
+        let events = [event];
+
+        // Plain `-i`: suppressed.
+        let mut plain = Vec::new();
+        emit_out_format(&events, &format, &OutFormatContext::default(), &mut plain).unwrap();
+        assert!(
+            String::from_utf8(plain).unwrap().is_empty(),
+            "blank copy-dest row must be suppressed at plain -i"
+        );
+
+        // `-vv` (`emit_unchanged`): surfaced.
+        let mut verbose = Vec::new();
+        let ctx = OutFormatContext::default().with_emit_unchanged(true);
+        emit_out_format(&events, &format, &ctx, &mut verbose).unwrap();
+        assert!(
+            !String::from_utf8(verbose).unwrap().is_empty(),
+            "blank copy-dest row must surface under -vv"
+        );
+    }
+}

--- a/crates/cli/src/frontend/progress/format/event.rs
+++ b/crates/cli/src/frontend/progress/format/event.rs
@@ -15,6 +15,7 @@ pub(crate) const fn event_matches_name_level(event: &ClientEvent, level: NameOut
         NameOutputLevel::UpdatedOnly => matches!(
             event.kind(),
             ClientEventKind::DataCopied
+                | ClientEventKind::ReferenceCopied
                 | ClientEventKind::HardLink
                 | ClientEventKind::SymlinkCopied
                 | ClientEventKind::FifoCopied
@@ -25,6 +26,7 @@ pub(crate) const fn event_matches_name_level(event: &ClientEvent, level: NameOut
         NameOutputLevel::UpdatedAndUnchanged => matches!(
             event.kind(),
             ClientEventKind::DataCopied
+                | ClientEventKind::ReferenceCopied
                 | ClientEventKind::MetadataReused
                 | ClientEventKind::HardLink
                 | ClientEventKind::SymlinkCopied
@@ -40,6 +42,7 @@ pub(crate) const fn event_matches_name_level(event: &ClientEvent, level: NameOut
 pub(crate) const fn describe_event_kind(kind: &ClientEventKind) -> &'static str {
     match kind {
         ClientEventKind::DataCopied => "copied",
+        ClientEventKind::ReferenceCopied => "copied from reference",
         ClientEventKind::MetadataReused => "metadata reused",
         ClientEventKind::HardLink => "hard link",
         ClientEventKind::SymlinkCopied => "symlink",

--- a/crates/cli/src/frontend/progress/format/list.rs
+++ b/crates/cli/src/frontend/progress/format/list.rs
@@ -11,6 +11,7 @@ pub(crate) const fn list_only_event(kind: &ClientEventKind) -> bool {
     matches!(
         kind,
         ClientEventKind::DataCopied
+            | ClientEventKind::ReferenceCopied
             | ClientEventKind::MetadataReused
             | ClientEventKind::HardLink
             | ClientEventKind::SymlinkCopied

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -455,16 +455,32 @@ fn is_uptodate_event(event: &ClientEvent) -> bool {
         ClientEventKind::DirectoryCreated | ClientEventKind::SymlinkCopied => {
             !event.was_created() && !event.change_set().has_any_change()
         }
+        // A `--link-dest` symlink hard-linked from the basis is `hL` + blank and
+        // emits `"%s is uptodate"` like the other alt-dest matches.
+        ClientEventKind::HardLink => is_hardlinked_symlink_event(event),
         _ => false,
     }
 }
 
+/// Returns `true` for a HardLink event describing a hard-linked symlink (`hL`).
+/// Its metadata kind is `Symlink` and its `symlink_target` slot holds the link
+/// target, not a `=> leader` trailer.
+fn is_hardlinked_symlink_event(event: &ClientEvent) -> bool {
+    matches!(event.kind(), ClientEventKind::HardLink)
+        && event
+            .metadata()
+            .map(ClientEntryMetadata::kind)
+            .is_some_and(|kind| matches!(kind, ClientEntryKind::Symlink))
+}
+
 /// Returns `true` for a hardlink alias freshly linked to a leader placed during
 /// this run. Upstream defers the `"%s => %s"` notice to the hardlink-finishing
-/// phase (hlink.c:236), so it appears after the regular per-file lines.
+/// phase (hlink.c:236), so it appears after the regular per-file lines. A
+/// hard-linked symlink is excluded (its trailer is `-> target`, not `=> leader`).
 fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
     matches!(event.kind(), ClientEventKind::HardLink)
         && !event.is_hardlink_uptodate()
+        && !is_hardlinked_symlink_event(event)
         && event
             .metadata()
             .and_then(ClientEntryMetadata::symlink_target)
@@ -662,6 +678,14 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // blank change set and no creation flag. Genuine new entries keep
             // `was_created`, so they fall through to the bare-path emission.
             ClientEventKind::ReferenceCopied => {
+                if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
+                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                }
+                continue;
+            }
+            // upstream: generator.c:1145-1147 - a `--link-dest` symlink
+            // hard-linked from the basis prints `"%s is uptodate"` at NAME>=2.
+            ClientEventKind::HardLink if is_hardlinked_symlink_event(event) => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
                     writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
                 }

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -618,6 +618,37 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 }
                 continue;
             }
+            // upstream: generator.c:1021-1022 / 1044-1046 / 1145-1147 - a
+            // `--copy-dest` match that needs no transfer prints `"%s%s is
+            // uptodate\n"` at INFO_GTE(NAME, 2), with a trailing `/` for
+            // directories, and prints nothing at lower verbosity (the bare
+            // per-file name is only emitted for entries that were actually
+            // transferred). Regular files are recorded as `ReferenceCopied`;
+            // directories and symlinks reconstructed from the basis carry a
+            // blank change set and no creation flag. Genuine new entries keep
+            // `was_created`, so they fall through to the bare-path emission.
+            ClientEventKind::ReferenceCopied => {
+                if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
+                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                }
+                continue;
+            }
+            ClientEventKind::DirectoryCreated
+                if !event.was_created() && !event.change_set().has_any_change() =>
+            {
+                if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
+                    writeln!(stdout, "{}/ is uptodate", event.relative_path().display())?;
+                }
+                continue;
+            }
+            ClientEventKind::SymlinkCopied
+                if !event.was_created() && !event.change_set().has_any_change() =>
+            {
+                if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
+                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                }
+                continue;
+            }
             _ => {}
         }
 

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -86,14 +86,13 @@ pub(crate) fn emit_transfer_summary(
     // upstream: main.c:787-808 - when the receiver pre-flight-mkdirs the
     // destination root because `file_total > 1 || trailing_slash`, it lops
     // off the trailing slash (`*cp = '\0'`) and prints `created directory
-    // %s\n` gated on `INFO_GTE(NAME, 1) || stdout_format_has_i`. Mirror the
-    // same gate plus trailing-slash trim here so `-i` and `-v` invocations
-    // emit the notice ahead of the per-entry itemize lines, matching the
-    // upstream `testsuite/itemize.test` golden. The notice is only emitted
-    // when the local-copy executor reports that it materialised the
-    // destination root during this run.
+    // %s\n` gated on `INFO_GTE(NAME, 1) || stdout_format_has_i`. The print at
+    // main.c:808 precedes the `dry_run++` at main.c:810, so a dry-run still
+    // reports the directory it would create. Mirror the same gate plus
+    // trailing-slash trim here so `-i` and `-v` invocations - including
+    // `--dry-run` - emit the notice ahead of the per-entry itemize lines,
+    // matching the upstream `testsuite/itemize.test` golden.
     if summary.destination_root_created()
-        && !dry_run
         && (out_format.is_some() || verbosity > 0)
         && let Some(dest_root) = events.iter().map(ClientEvent::destination_root).next()
     {

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -443,7 +443,32 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
 /// completes. The two processes pipeline so uptodate lines appear ahead of
 /// transferred-file lines in the observable client output.
 fn is_uptodate_event(event: &ClientEvent) -> bool {
-    matches!(event.kind(), ClientEventKind::MetadataReused) || event.is_hardlink_uptodate()
+    if matches!(event.kind(), ClientEventKind::MetadataReused) || event.is_hardlink_uptodate() {
+        return true;
+    }
+    // upstream: generator.c:1019-1022 / 1145-1147 - a `--copy-dest` match emits
+    // its `"is uptodate"` notice from the generator, ahead of the receiver's
+    // bare-name lines. Regular files are `ReferenceCopied`; dirs and symlinks
+    // reconstructed from the basis carry a blank change set and no creation.
+    match event.kind() {
+        ClientEventKind::ReferenceCopied => true,
+        ClientEventKind::DirectoryCreated | ClientEventKind::SymlinkCopied => {
+            !event.was_created() && !event.change_set().has_any_change()
+        }
+        _ => false,
+    }
+}
+
+/// Returns `true` for a hardlink alias freshly linked to a leader placed during
+/// this run. Upstream defers the `"%s => %s"` notice to the hardlink-finishing
+/// phase (hlink.c:236), so it appears after the regular per-file lines.
+fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
+    matches!(event.kind(), ClientEventKind::HardLink)
+        && !event.is_hardlink_uptodate()
+        && event
+            .metadata()
+            .and_then(ClientEntryMetadata::symlink_target)
+            .is_some()
 }
 
 /// Renders verbose listings for the provided transfer events.
@@ -466,7 +491,16 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     // them to recover the upstream wire order. The sort is stable so each
     // group preserves its original relative ordering.
     let mut ordered_events: Vec<&ClientEvent> = events.iter().collect();
-    ordered_events.sort_by_key(|event| if is_uptodate_event(event) { 0u8 } else { 1 });
+    ordered_events.sort_by_key(|event| {
+        if is_uptodate_event(event) {
+            0u8
+        } else if is_deferred_hardlink_event(event) {
+            // Hardlink aliases linked to a this-run leader are finished last.
+            2
+        } else {
+            1
+        }
+    });
 
     for event in ordered_events {
         let kind = event.kind();
@@ -659,6 +693,14 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         {
             rendered.push_str(" -> ");
             rendered.push_str(&target.to_string_lossy());
+        } else if matches!(kind, ClientEventKind::HardLink)
+            && let Some(metadata) = event.metadata()
+            && let Some(leader) = metadata.symlink_target()
+        {
+            // upstream: hlink.c:236 - a freshly-linked alias prints
+            // `"%s => %s"` with the group leader's relative path.
+            rendered.push_str(" => ");
+            rendered.push_str(&leader.to_string_lossy());
         }
 
         // upstream: log.c:log_formatted() emits the default `%n%L` per-file

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -134,11 +134,14 @@ impl ClientEvent {
             | LocalCopyAction::HardLink
             | LocalCopyAction::SymlinkCopied
             | LocalCopyAction::FifoCopied
-            | LocalCopyAction::DeviceCopied => was_created,
-            // DirectoryCreated retains the unconditional `true` because the
-            // local-copy executor only emits it when the directory was
-            // actually mkdir'd this run.
-            LocalCopyAction::DirectoryCreated => true,
+            | LocalCopyAction::DeviceCopied
+            // DirectoryCreated honours the explicit `was_created` bit: genuine
+            // mkdirs set `.with_creation(true)`, while a directory reconstructed
+            // from a `--copy-dest` basis records a change set without creation so
+            // its row stays `cd` + blank instead of `cd+++++++++`.
+            // upstream: generator.c:1480-1482 - the copy-dest match itemizes with
+            // ITEM_LOCAL_CHANGE, never ITEM_IS_NEW.
+            | LocalCopyAction::DirectoryCreated => was_created,
             // upstream: generator.c:1039 itemizes the copy-dest reconstruction
             // with statret == 0 (the basis was stat'd successfully), so
             // ITEM_IS_NEW is never set and attribute slots are never `+`.

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -17,6 +17,9 @@ use super::metadata::{ClientEntryKind, ClientEntryMetadata};
 pub enum ClientEventKind {
     /// File data was copied into place.
     DataCopied,
+    /// A regular file was reconstructed locally from a `--copy-dest` basis.
+    /// Itemizes with the local-change indicator (`c`).
+    ReferenceCopied,
     /// The destination already matched the source and metadata was reused.
     MetadataReused,
     /// A hard link was created to a previously copied destination file.
@@ -55,6 +58,7 @@ impl ClientEventKind {
         matches!(
             self,
             Self::DataCopied
+                | Self::ReferenceCopied
                 | Self::MetadataReused
                 | Self::HardLink
                 | Self::SymlinkCopied
@@ -97,6 +101,7 @@ impl ClientEvent {
         ) = record.into_parts();
         let kind = match &action {
             LocalCopyAction::DataCopied => ClientEventKind::DataCopied,
+            LocalCopyAction::ReferenceCopied => ClientEventKind::ReferenceCopied,
             LocalCopyAction::MetadataReused => ClientEventKind::MetadataReused,
             LocalCopyAction::HardLink => ClientEventKind::HardLink,
             LocalCopyAction::SymlinkCopied => ClientEventKind::SymlinkCopied,
@@ -134,7 +139,11 @@ impl ClientEvent {
             // local-copy executor only emits it when the directory was
             // actually mkdir'd this run.
             LocalCopyAction::DirectoryCreated => true,
-            LocalCopyAction::MetadataReused
+            // upstream: generator.c:1039 itemizes the copy-dest reconstruction
+            // with statret == 0 (the basis was stat'd successfully), so
+            // ITEM_IS_NEW is never set and attribute slots are never `+`.
+            LocalCopyAction::ReferenceCopied
+            | LocalCopyAction::MetadataReused
             | LocalCopyAction::SkippedExisting
             | LocalCopyAction::SkippedMissingDestination
             | LocalCopyAction::SkippedNewerDestination

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -455,6 +455,58 @@ impl<'a> CopyContext<'a> {
         Ok(None)
     }
 
+    /// Locates a `--link-dest` basis symlink at `relative` that points at the
+    /// same `target`.
+    ///
+    /// Returns the basis symlink path when a link-dest entry holds a symlink
+    /// with a matching target, so the receiver can hard-link the symlink into
+    /// place (`hL`) instead of recreating it.
+    ///
+    /// upstream: generator.c:1117-1134 try_dests_non() - LINK_DEST hard-links a
+    /// matching symlink from the basis when CAN_HARDLINK_SYMLINK is supported.
+    pub(super) fn link_dest_symlink_target(
+        &self,
+        relative: &Path,
+        target: &Path,
+    ) -> Result<Option<PathBuf>, LocalCopyError> {
+        if self.options.link_dest_entries().is_empty() {
+            return Ok(None);
+        }
+
+        for entry in self.options.link_dest_entries() {
+            let candidate = entry.resolve(self.destination_root(), relative);
+            let candidate_metadata = match fs::symlink_metadata(&candidate) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(LocalCopyError::io(
+                        "inspect link-dest symlink",
+                        candidate,
+                        error,
+                    ));
+                }
+            };
+
+            if !candidate_metadata.file_type().is_symlink() {
+                continue;
+            }
+
+            match fs::read_link(&candidate) {
+                Ok(basis_target) if basis_target == target => return Ok(Some(candidate)),
+                Ok(_) => continue,
+                Err(error) => {
+                    return Err(LocalCopyError::io(
+                        "read link-dest symlink",
+                        candidate,
+                        error,
+                    ));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Returns the configured `--link-dest` / `--copy-dest` / `--compare-dest`
     /// reference directories.
     pub(super) fn reference_directories(&self) -> &[ReferenceDirectory] {

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -127,6 +127,18 @@ fn copy_directory_recursive_inner(
     let existing_destination_metadata: Option<fs::Metadata> =
         destination_state.existing_metadata().cloned();
 
+    // upstream: generator.c:1469-1483 - when a directory is absent from the
+    // destination but present in a `--copy-dest` basis, the generator itemizes
+    // it as a local change (`cd` + blank) against the basis instead of a new
+    // entry (`cd+++++++++`). Capture the basis metadata so the creation records
+    // below can compute the basis-relative change set.
+    let copy_dest_basis: Option<fs::Metadata> = if destination_missing {
+        let lookup_relative = relative.unwrap_or_else(|| Path::new("."));
+        super::super::find_copy_dest_basis(context, destination, lookup_relative)?
+    } else {
+        None
+    };
+
     if destination_missing && context.existing_only_enabled() {
         record_skipped_missing_destination(context, metadata, relative);
         return Ok(false);
@@ -199,17 +211,29 @@ fn copy_directory_recursive_inner(
     // closure's `record(...)` site never fires. Emit the synthetic "."
     // record up-front so it precedes child entries in the event stream.
     if root_was_just_created && let Some((ref rel_path, ref snapshot)) = metadata_record {
-        context.record(
-            LocalCopyRecord::new(
-                rel_path.clone(),
-                LocalCopyAction::DirectoryCreated,
-                0,
-                Some(snapshot.len()),
-                Duration::default(),
-                Some(snapshot.clone()),
-            )
-            .with_creation(true),
+        let record = LocalCopyRecord::new(
+            rel_path.clone(),
+            LocalCopyAction::DirectoryCreated,
+            0,
+            Some(snapshot.len()),
+            Duration::default(),
+            Some(snapshot.clone()),
         );
+        // upstream: generator.c:1480-1482 - a copy-dest match itemizes the
+        // directory against the basis (ITEM_LOCAL_CHANGE, no ITEM_IS_NEW).
+        let record = if let Some(basis_meta) = copy_dest_basis.as_ref() {
+            record.with_change_set(LocalCopyChangeSet::for_existing_directory(
+                metadata,
+                basis_meta,
+                &context.metadata_options(),
+                context.omit_dir_times_enabled(),
+                false,
+                false,
+            ))
+        } else {
+            record.with_creation(true)
+        };
+        context.record(record);
         record_emitted = true;
     }
 
@@ -294,17 +318,29 @@ fn copy_directory_recursive_inner(
         // BEFORE their children in the itemize output. Emit the record
         // immediately so it precedes child entries in the record stream.
         if !record_emitted && let Some((ref rel_path, ref snapshot)) = metadata_record {
-            context.record(
-                LocalCopyRecord::new(
-                    rel_path.clone(),
-                    LocalCopyAction::DirectoryCreated,
-                    0,
-                    Some(snapshot.len()),
-                    Duration::default(),
-                    Some(snapshot.clone()),
-                )
-                .with_creation(true),
+            let record = LocalCopyRecord::new(
+                rel_path.clone(),
+                LocalCopyAction::DirectoryCreated,
+                0,
+                Some(snapshot.len()),
+                Duration::default(),
+                Some(snapshot.clone()),
             );
+            // upstream: generator.c:1480-1482 - a copy-dest match itemizes the
+            // directory against the basis (ITEM_LOCAL_CHANGE, no ITEM_IS_NEW).
+            let record = if let Some(basis_meta) = copy_dest_basis.as_ref() {
+                record.with_change_set(LocalCopyChangeSet::for_existing_directory(
+                    metadata,
+                    basis_meta,
+                    &context.metadata_options(),
+                    context.omit_dir_times_enabled(),
+                    false,
+                    false,
+                ))
+            } else {
+                record.with_creation(true)
+            };
+            context.record(record);
             record_emitted = true;
         }
 

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -127,12 +127,16 @@ fn copy_directory_recursive_inner(
     let existing_destination_metadata: Option<fs::Metadata> =
         destination_state.existing_metadata().cloned();
 
-    // upstream: generator.c:1469-1483 - when a directory is absent from the
-    // destination but present in a `--copy-dest` basis, the generator itemizes
-    // it as a local change (`cd` + blank) against the basis instead of a new
-    // entry (`cd+++++++++`). Capture the basis metadata so the creation records
-    // below can compute the basis-relative change set.
-    let copy_dest_basis: Option<fs::Metadata> = if destination_missing {
+    // upstream: generator.c:1469-1483 - when a directory is freshly created in
+    // the destination but present in a `--copy-dest` basis, the generator
+    // itemizes it as a local change (`cd` + blank) against the basis instead of
+    // a new entry (`cd+++++++++`). The transfer root is materialised by the
+    // sources orchestrator before this frame runs, so `destination_missing` is
+    // false there even though the row is a creation; gate on whether a creation
+    // record will be emitted (`destination_missing` for children, the root's
+    // just-created marker for the root).
+    let root_just_created = relative.is_none() && context.summary().destination_root_created();
+    let copy_dest_basis: Option<fs::Metadata> = if destination_missing || root_just_created {
         let lookup_relative = relative.unwrap_or_else(|| Path::new("."));
         super::super::find_copy_dest_basis(context, destination, lookup_relative)?
     } else {
@@ -177,7 +181,7 @@ fn copy_directory_recursive_inner(
     // the sources orchestrator already mkdir'd the destination root in this run
     // (signalled via `summary.destination_root_created()`), driving the
     // `cd+++++++++ ./` creation row below.
-    let root_was_just_created = relative.is_none() && context.summary().destination_root_created();
+    let root_was_just_created = root_just_created;
     let metadata_record = if let Some(rel) = relative {
         Some((
             rel.to_path_buf(),

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -137,7 +137,9 @@ fn copy_directory_recursive_inner(
     // just-created marker for the root).
     let root_just_created = relative.is_none() && context.summary().destination_root_created();
     let copy_dest_basis: Option<fs::Metadata> = if destination_missing || root_just_created {
-        let lookup_relative = relative.unwrap_or_else(|| Path::new("."));
+        // The transfer root has `relative == None`; use an empty path so the
+        // basis lookup resolves the copy-dest directory itself.
+        let lookup_relative = relative.unwrap_or_else(|| Path::new(""));
         super::super::find_copy_dest_basis(context, destination, lookup_relative)?
     } else {
         None

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -174,27 +174,10 @@ fn simulate_reference_match(
     let checksum = context.checksum_enabled();
     let metadata_options = context.metadata_options();
 
-    // An intra-transfer hard-link leader placed earlier this run takes
-    // precedence: the alias itemizes as `hf <path> => <leader>`.
-    if let Some(leader) = context.existing_hard_link_target(metadata) {
-        let leader_display = leader
-            .strip_prefix(context.destination_root())
-            .map(std::path::Path::to_path_buf)
-            .ok()
-            .filter(|relative| relative != record_path);
-        context.record_hard_link(metadata, destination);
-        context.summary_mut().record_hard_link();
-        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
-        record_match(
-            context,
-            record_path,
-            LocalCopyAction::HardLink,
-            &metadata_snapshot,
-        );
-        return Ok(true);
-    }
-
-    // --link-dest hardlink of a matching basis file.
+    // --link-dest hardlink of a matching basis file takes precedence, matching
+    // `process_links`. The alias links directly from the basis, so its itemize
+    // carries an empty xname (no `=> leader` trailer) and is suppressed at plain
+    // `-i`.
     if context
         .link_dest_target(
             record_path,
@@ -209,6 +192,26 @@ fn simulate_reference_match(
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+        record_match(
+            context,
+            record_path,
+            LocalCopyAction::HardLink,
+            &metadata_snapshot,
+        );
+        return Ok(true);
+    }
+
+    // An intra-transfer hard-link leader placed earlier this run: the alias
+    // itemizes as `hf <path> => <leader>` against the in-transfer leader.
+    if let Some(leader) = context.existing_hard_link_target(metadata) {
+        let leader_display = leader
+            .strip_prefix(context.destination_root())
+            .map(std::path::Path::to_path_buf)
+            .ok()
+            .filter(|relative| relative != record_path);
+        context.record_hard_link(metadata, destination);
+        context.summary_mut().record_hard_link();
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
         record_match(
             context,
             record_path,

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -197,12 +197,14 @@ fn simulate_reference_match(
             record_path,
             LocalCopyAction::HardLink,
             &metadata_snapshot,
+            true,
         );
         return Ok(true);
     }
 
     // An intra-transfer hard-link leader placed earlier this run: the alias
-    // itemizes as `hf <path> => <leader>` against the in-transfer leader.
+    // itemizes as `hf <path> => <leader>` against the in-transfer leader (fresh
+    // atomic_create, shown even at plain `-i`).
     if let Some(leader) = context.existing_hard_link_target(metadata) {
         let leader_display = leader
             .strip_prefix(context.destination_root())
@@ -217,6 +219,7 @@ fn simulate_reference_match(
             record_path,
             LocalCopyAction::HardLink,
             &metadata_snapshot,
+            false,
         );
         return Ok(true);
     }
@@ -278,18 +281,25 @@ fn simulate_reference_match(
 }
 
 /// Records a hard-link dry-run match with no attribute drift.
+///
+/// `uptodate` flags a `--link-dest` basis hardlink, which is reported as
+/// `"<path> is uptodate"` under `-vv` and suppressed at plain `-i`.
 fn record_match(
     context: &mut CopyContext,
     record_path: &Path,
     action: LocalCopyAction,
     metadata_snapshot: &LocalCopyMetadata,
+    uptodate: bool,
 ) {
-    context.record(LocalCopyRecord::new(
-        record_path.to_path_buf(),
-        action,
-        0,
-        Some(metadata_snapshot.len()),
-        Duration::default(),
-        Some(metadata_snapshot.clone()),
-    ));
+    context.record(
+        LocalCopyRecord::new(
+            record_path.to_path_buf(),
+            action,
+            0,
+            Some(metadata_snapshot.len()),
+            Duration::default(),
+            Some(metadata_snapshot.clone()),
+        )
+        .with_hardlink_uptodate(uptodate),
+    );
 }

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -239,32 +239,25 @@ fn simulate_reference_match(
     };
 
     let (action, basis) = match decision {
-        ReferenceDecision::Skip => (LocalCopyAction::MetadataReused, None),
-        ReferenceDecision::Copy(path) => (LocalCopyAction::ReferenceCopied, Some(path)),
+        ReferenceDecision::Skip(path) => (LocalCopyAction::MetadataReused, path),
+        ReferenceDecision::Copy(path) => (LocalCopyAction::ReferenceCopied, path),
         // A degraded link-dest copy still itemizes as a local change.
-        ReferenceDecision::Link(path) => (LocalCopyAction::ReferenceCopied, Some(path)),
+        ReferenceDecision::Link(path) => (LocalCopyAction::ReferenceCopied, path),
     };
     context.summary_mut().record_regular_file_matched();
-    let change_set = match basis.as_deref() {
-        Some(path) => {
-            let basis_metadata = fs::symlink_metadata(path)
-                .map_err(|error| LocalCopyError::io("inspect reference basis", path, error))?;
-            LocalCopyChangeSet::for_file(
-                metadata,
-                Some(&basis_metadata),
-                &metadata_options,
-                true,
-                false,
-                false,
-                false,
-            )
-        }
-        None => {
-            // compare-dest: itemize against the basis the same way the real run
-            // does (no transfer, blank columns when identical).
-            LocalCopyChangeSet::new()
-        }
-    };
+    // Itemize against the basis (compare/copy/link) so identical files stay
+    // blank, matching generator.c:1140 and the real-run change set.
+    let basis_metadata = fs::symlink_metadata(&basis)
+        .map_err(|error| LocalCopyError::io("inspect reference basis", basis, error))?;
+    let change_set = LocalCopyChangeSet::for_file(
+        metadata,
+        Some(&basis_metadata),
+        &metadata_options,
+        true,
+        false,
+        false,
+        false,
+    );
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -9,7 +9,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::local_copy::{
-    CopyContext, LocalCopyAction, LocalCopyError, LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, LocalCopyAction, LocalCopyChangeSet, LocalCopyError, LocalCopyMetadata,
+    LocalCopyRecord, ReferenceDecision, ReferenceQuery, find_reference_action,
     remove_source_entry_if_requested,
 };
 
@@ -79,6 +80,17 @@ pub(super) fn handle_dry_run(
         return Ok(());
     }
 
+    // upstream: generator.c:1469-1483 - in dry-run mode the generator still
+    // evaluates `--link-dest` / `--copy-dest` / `--compare-dest` and itemizes
+    // the file against the matched basis (`hf`/`cf`/`.f` + blank) rather than
+    // reporting a full transfer (`>f+++++++++`). Mirror that here so a dry-run
+    // produces the same itemize stream as the real run.
+    if existing_metadata.is_none()
+        && simulate_reference_match(context, source, destination, metadata, record_path)?
+    {
+        return Ok(());
+    }
+
     let mut reader = fs::File::open(source)
         .map_err(|error| LocalCopyError::io("open source file", source, error))?;
 
@@ -140,4 +152,141 @@ pub(super) fn handle_dry_run(
     );
     remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
     Ok(())
+}
+
+/// Records the dry-run itemize for a regular file that would be satisfied by a
+/// `--link-dest` / `--copy-dest` / `--compare-dest` basis or an in-transfer
+/// hard-link leader, without performing any I/O.
+///
+/// Returns `true` when a match was recorded, mirroring the real-run itemize:
+/// `hf` for a link-dest hardlink or an intra-transfer alias, `cf` for a
+/// copy-dest reconstruction, and `.f` for a compare-dest match. The change set
+/// is computed against the basis so identical files leave the columns blank.
+fn simulate_reference_match(
+    context: &mut CopyContext,
+    source: &Path,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    record_path: &Path,
+) -> Result<bool, LocalCopyError> {
+    let size_only = context.size_only_enabled();
+    let ignore_times = context.ignore_times_enabled();
+    let checksum = context.checksum_enabled();
+    let metadata_options = context.metadata_options();
+
+    // An intra-transfer hard-link leader placed earlier this run takes
+    // precedence: the alias itemizes as `hf <path> => <leader>`.
+    if let Some(leader) = context.existing_hard_link_target(metadata) {
+        let leader_display = leader
+            .strip_prefix(context.destination_root())
+            .map(std::path::Path::to_path_buf)
+            .ok()
+            .filter(|relative| relative != record_path);
+        context.record_hard_link(metadata, destination);
+        context.summary_mut().record_hard_link();
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
+        record_match(
+            context,
+            record_path,
+            LocalCopyAction::HardLink,
+            &metadata_snapshot,
+        );
+        return Ok(true);
+    }
+
+    // --link-dest hardlink of a matching basis file.
+    if context
+        .link_dest_target(
+            record_path,
+            source,
+            metadata,
+            size_only,
+            ignore_times,
+            checksum,
+        )?
+        .is_some()
+    {
+        context.record_hard_link(metadata, destination);
+        context.summary_mut().record_hard_link();
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+        record_match(
+            context,
+            record_path,
+            LocalCopyAction::HardLink,
+            &metadata_snapshot,
+        );
+        return Ok(true);
+    }
+
+    // --copy-dest / --compare-dest matches.
+    let query = ReferenceQuery {
+        destination,
+        relative: record_path,
+        source,
+        metadata,
+        size_only,
+        ignore_times,
+        checksum,
+    };
+    let Some(decision) = find_reference_action(context, query)? else {
+        return Ok(false);
+    };
+
+    let (action, basis) = match decision {
+        ReferenceDecision::Skip => (LocalCopyAction::MetadataReused, None),
+        ReferenceDecision::Copy(path) => (LocalCopyAction::ReferenceCopied, Some(path)),
+        // A degraded link-dest copy still itemizes as a local change.
+        ReferenceDecision::Link(path) => (LocalCopyAction::ReferenceCopied, Some(path)),
+    };
+    context.summary_mut().record_regular_file_matched();
+    let change_set = match basis.as_deref() {
+        Some(path) => {
+            let basis_metadata = fs::symlink_metadata(path)
+                .map_err(|error| LocalCopyError::io("inspect reference basis", path, error))?;
+            LocalCopyChangeSet::for_file(
+                metadata,
+                Some(&basis_metadata),
+                &metadata_options,
+                true,
+                false,
+                false,
+                false,
+            )
+        }
+        None => {
+            // compare-dest: itemize against the basis the same way the real run
+            // does (no transfer, blank columns when identical).
+            LocalCopyChangeSet::new()
+        }
+    };
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    context.record(
+        LocalCopyRecord::new(
+            record_path.to_path_buf(),
+            action,
+            0,
+            Some(metadata_snapshot.len()),
+            Duration::default(),
+            Some(metadata_snapshot),
+        )
+        .with_change_set(change_set),
+    );
+    Ok(true)
+}
+
+/// Records a hard-link dry-run match with no attribute drift.
+fn record_match(
+    context: &mut CopyContext,
+    record_path: &Path,
+    action: LocalCopyAction,
+    metadata_snapshot: &LocalCopyMetadata,
+) {
+    context.record(LocalCopyRecord::new(
+        record_path.to_path_buf(),
+        action,
+        0,
+        Some(metadata_snapshot.len()),
+        Duration::default(),
+        Some(metadata_snapshot.clone()),
+    ));
 }

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -357,11 +357,24 @@ pub(super) fn process_links(
         // existing inode was reused. Build a change_set so the attribute
         // slots reflect the real deltas (mtime / perms / etc.) instead of
         // collapsing to all-dots-or-spaces.
+        //
+        // upstream: generator.c:1009-1013 - the itemize for a hardlinked alias
+        // is computed with `statret = 1` against the group leader's stat
+        // (`sxp->st`), not a (possibly absent) prior destination. Comparing the
+        // source against the leader (`existing_target`) keeps the size/time/perm
+        // columns blank when the alias is identical to its leader, even though
+        // the alias path itself is being created this run. Fall back to the
+        // prior-destination comparison when the leader stat is unavailable.
+        let leader_metadata = fs::symlink_metadata(&existing_target).ok();
+        let (compare_against, compare_existed) = match leader_metadata.as_ref() {
+            Some(leader) => (Some(leader), true),
+            None => (existing_metadata, destination_previously_existed),
+        };
         let mut change_set = LocalCopyChangeSet::for_file(
             metadata,
-            existing_metadata,
+            compare_against,
             &metadata_options,
-            destination_previously_existed,
+            compare_existed,
             false,
             {
                 #[cfg(all(unix, feature = "xattr"))]

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -169,7 +169,6 @@ pub(super) fn process_links(
                     .ok()
                     .filter(|relative| relative != record_path)
             });
-        let is_cluster_alias = leader_display.is_some();
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
@@ -183,7 +182,10 @@ pub(super) fn process_links(
                 Duration::default(),
                 Some(metadata_snapshot),
             )
-            .with_hardlink_uptodate(is_cluster_alias),
+            // A `--link-dest` hardlink reproduces the basis file exactly, so it
+            // is reported as `"<path> is uptodate"` under `-vv` and suppressed at
+            // plain `-i` - the same gate as an already-shared-inode alias.
+            .with_hardlink_uptodate(true),
         );
         context.register_created_path(
             destination,

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -61,6 +61,10 @@ fn is_already_hardlinked(destination: &Path, target: &Path) -> bool {
 /// Result of hard-link and reference-directory processing for a file.
 pub(super) struct LinkOutcome {
     pub(super) copy_source_override: Option<PathBuf>,
+    /// When set, the pending copy reconstructs the file from this
+    /// `--copy-dest` basis and must itemize as a local change (`c`) compared
+    /// against the basis rather than as a network transfer (`>`).
+    pub(super) reference_basis: Option<PathBuf>,
     pub(super) completed: bool,
 }
 
@@ -93,6 +97,7 @@ pub(super) fn process_links(
     let _ = mode;
 
     let mut copy_source_override: Option<PathBuf> = None;
+    let mut reference_basis: Option<PathBuf> = None;
 
     // 1. --link-dest style linking
     if let Some(link_target) = context.link_dest_target(
@@ -167,6 +172,7 @@ pub(super) fn process_links(
         remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
         return Ok(LinkOutcome {
             copy_source_override: None,
+            reference_basis: None,
             completed: true,
         });
     }
@@ -276,6 +282,7 @@ pub(super) fn process_links(
             remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
             return Ok(LinkOutcome {
                 copy_source_override: None,
+                reference_basis: None,
                 completed: true,
             });
         }
@@ -407,6 +414,7 @@ pub(super) fn process_links(
         remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
         return Ok(LinkOutcome {
             copy_source_override: None,
+            reference_basis: None,
             completed: true,
         });
     }
@@ -481,10 +489,17 @@ pub(super) fn process_links(
                 remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
                 return Ok(LinkOutcome {
                     copy_source_override: None,
+                    reference_basis: None,
                     completed: true,
                 });
             }
             ReferenceDecision::Copy(path) => {
+                // upstream: generator.c:1033-1039 - copy_altdest_file() copies
+                // the basis into place and itemizes as ITEM_LOCAL_CHANGE (`c`).
+                // The copy still flows through the transfer pipeline via
+                // `copy_source_override`; `reference_basis` flags the record so
+                // it is attributed to the basis instead of a network transfer.
+                reference_basis = Some(path.clone());
                 copy_source_override = Some(path);
             }
             ReferenceDecision::Link(path) => {
@@ -524,6 +539,10 @@ pub(super) fn process_links(
                 }
 
                 if degrade_to_copy {
+                    // upstream: generator.c:1031 try_a_copy - a cross-device
+                    // hard-link failure falls back to copy_altdest_file(), which
+                    // still itemizes as a local change (`c`).
+                    reference_basis = Some(path.clone());
                     copy_source_override = Some(path);
                 } else if copy_source_override.is_none() {
                     apply_file_metadata_with_options(destination, metadata, &metadata_options)
@@ -580,6 +599,7 @@ pub(super) fn process_links(
                     )?;
                     return Ok(LinkOutcome {
                         copy_source_override: None,
+                        reference_basis: None,
                         completed: true,
                     });
                 }
@@ -589,6 +609,7 @@ pub(super) fn process_links(
 
     Ok(LinkOutcome {
         copy_source_override,
+        reference_basis,
         completed: false,
     })
 }

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -152,12 +152,14 @@ pub(super) fn process_links(
             link_target.display()
         );
 
-        // upstream: generator.c:1008-1009 / 1048-1049 - when the matched file is
-        // a member of a hard-link cluster whose leader was already placed this
-        // run, `finish_hard_link()` itemizes the alias with the in-transfer
-        // leader as the xname (`=> foo/config1`), not the basis path. Thread the
-        // leader's relative path through the snapshot's symlink_target slot so
-        // the `%L` placeholder renders the `=> leader` trailer.
+        // upstream: hlink.c:215-224 / generator.c:1008-1013 - a `--link-dest`
+        // cluster member is linked from the basis, so it ends up sharing the
+        // same inode as its already-placed in-transfer leader. `maybe_hard_link`
+        // then takes the same-inode branch, itemizing with an empty xname and
+        // emitting `"%s is uptodate"` at NAME>=2: the row is suppressed at plain
+        // `-i` but shown blank with a `=> leader` trailer under `-vv`. Thread the
+        // leader through the symlink_target slot for the `%L` trailer and flag
+        // the record uptodate so the plain-`-i` gate drops it.
         let leader_display = context
             .existing_hard_link_target(metadata)
             .and_then(|leader| {
@@ -167,18 +169,22 @@ pub(super) fn process_links(
                     .ok()
                     .filter(|relative| relative != record_path)
             });
+        let is_cluster_alias = leader_display.is_some();
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
         let total_bytes = Some(metadata_snapshot.len());
-        context.record(LocalCopyRecord::new(
-            record_path.to_path_buf(),
-            LocalCopyAction::HardLink,
-            0,
-            total_bytes,
-            Duration::default(),
-            Some(metadata_snapshot),
-        ));
+        context.record(
+            LocalCopyRecord::new(
+                record_path.to_path_buf(),
+                LocalCopyAction::HardLink,
+                0,
+                total_bytes,
+                Duration::default(),
+                Some(metadata_snapshot),
+            )
+            .with_hardlink_uptodate(is_cluster_alias),
+        );
         context.register_created_path(
             destination,
             CreatedEntryKind::HardLink,

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -152,9 +152,24 @@ pub(super) fn process_links(
             link_target.display()
         );
 
+        // upstream: generator.c:1008-1009 / 1048-1049 - when the matched file is
+        // a member of a hard-link cluster whose leader was already placed this
+        // run, `finish_hard_link()` itemizes the alias with the in-transfer
+        // leader as the xname (`=> foo/config1`), not the basis path. Thread the
+        // leader's relative path through the snapshot's symlink_target slot so
+        // the `%L` placeholder renders the `=> leader` trailer.
+        let leader_display = context
+            .existing_hard_link_target(metadata)
+            .and_then(|leader| {
+                leader
+                    .strip_prefix(context.destination_root())
+                    .map(std::path::Path::to_path_buf)
+                    .ok()
+                    .filter(|relative| relative != record_path)
+            });
         context.record_hard_link(metadata, destination);
         context.summary_mut().record_hard_link();
-        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, leader_display);
         let total_bytes = Some(metadata_snapshot.len());
         context.record(LocalCopyRecord::new(
             record_path.to_path_buf(),

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -472,7 +472,7 @@ pub(super) fn process_links(
         )?
     {
         match decision {
-            ReferenceDecision::Skip => {
+            ReferenceDecision::Skip(basis) => {
                 // upstream: generator.c:1010,1133 / rsync.c:676 - "is uptodate"
                 // emitted at INFO_GTE(NAME, 2) when a reference-directory match
                 // means no transfer is needed. Rendered by the CLI from the
@@ -480,12 +480,22 @@ pub(super) fn process_links(
                 // the line lands ahead of the totals; emitting it via
                 // info_log! would route it through the post-summary
                 // diagnostic drain and break upstream ordering.
+                //
+                // upstream: generator.c:1140 - a `--compare-dest` match itemizes
+                // `.f` against the compare basis (`sxp->st`), so the attribute
+                // columns reflect drift vs the basis, not the absent
+                // destination. Compare source against the basis with
+                // `destination_previously_existed = true` so identical files
+                // stay blank.
                 context.summary_mut().record_regular_file_matched();
+                let basis_metadata = fs::symlink_metadata(&basis).map_err(|error| {
+                    LocalCopyError::io("inspect compare-dest basis", basis.clone(), error)
+                })?;
                 let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
                 let total_bytes = Some(metadata_snapshot.len());
                 let change_set = LocalCopyChangeSet::for_file(
                     metadata,
-                    existing_metadata,
+                    Some(&basis_metadata),
                     &metadata_options,
                     true,
                     false,

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -247,6 +247,7 @@ pub(crate) fn copy_file(
         transfer_flags,
         mode,
         link_outcome.copy_source_override,
+        link_outcome.reference_basis,
     )?;
     Ok(true)
 }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -72,6 +72,11 @@ pub(in crate::local_copy) fn execute_transfer(
     flags: TransferFlags,
     mode: LocalCopyExecution,
     copy_source_override: Option<PathBuf>,
+    // When `Some`, the copy reconstructs the file from a `--copy-dest` basis.
+    // The transfer itemizes as a local change (`c`) compared against the basis
+    // rather than a network transfer (`>`).
+    // upstream: generator.c:1039 - itemize(..., ITEM_LOCAL_CHANGE, ...).
+    reference_basis: Option<PathBuf>,
 ) -> Result<(), LocalCopyError> {
     #[cfg(not(all(unix, any(feature = "xattr", feature = "acl"))))]
     let _ = mode;
@@ -603,27 +608,56 @@ pub(in crate::local_copy) fn execute_transfer(
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
     let total_bytes = Some(metadata_snapshot.len());
     let wrote_data = outcome.literal_bytes() > 0 || append_offset > 0;
+
+    // upstream: generator.c:1039 - a `--copy-dest` reconstruction itemizes the
+    // attribute columns against the alternate basis (`sxp->st`), not the
+    // (absent) prior destination, and never sets ITEM_IS_NEW. Comparing source
+    // against the basis with `destination_previously_existed = true` keeps the
+    // size/time/perm slots blank when the source already matched the basis.
+    let basis_metadata = match reference_basis.as_deref() {
+        Some(path) => match fs::symlink_metadata(path) {
+            Ok(meta) => Some(meta),
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "inspect reference basis",
+                    path.to_path_buf(),
+                    error,
+                ));
+            }
+        },
+        None => None,
+    };
+    let is_reference_copy = basis_metadata.is_some();
     let change_set = LocalCopyChangeSet::for_file_with_checksum(
         metadata,
-        existing_metadata,
+        if is_reference_copy {
+            basis_metadata.as_ref()
+        } else {
+            existing_metadata
+        },
         &metadata_options,
-        destination_previously_existed,
-        wrote_data,
+        is_reference_copy || destination_previously_existed,
+        wrote_data && !is_reference_copy,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
         flags.checksum_enabled,
     );
+    let action = if is_reference_copy {
+        LocalCopyAction::ReferenceCopied
+    } else {
+        LocalCopyAction::DataCopied
+    };
     context.record(
         LocalCopyRecord::new(
             record_path.to_path_buf(),
-            LocalCopyAction::DataCopied,
+            action,
             outcome.literal_bytes(),
             total_bytes,
             elapsed,
             Some(metadata_snapshot),
         )
         .with_change_set(change_set)
-        .with_creation(!destination_previously_existed),
+        .with_creation(!is_reference_copy && !destination_previously_existed),
     );
 
     if let Err(timeout_error) = context.enforce_timeout() {

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -36,8 +36,8 @@ pub(crate) use file::{
 };
 pub(crate) use iconv::transcode_filename_component;
 pub(crate) use reference::{
-    ReferenceDecision, ReferenceQuery, find_copy_dest_basis, find_copy_dest_symlink,
-    find_reference_action,
+    ReferenceDecision, ReferenceQuery, find_compare_dest_symlink, find_copy_dest_basis,
+    find_copy_dest_symlink, find_reference_action,
 };
 pub(crate) use sources::copy_sources;
 pub(crate) use special::{

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -35,7 +35,10 @@ pub(crate) use file::{
     temporary_destination_path,
 };
 pub(crate) use iconv::transcode_filename_component;
-pub(crate) use reference::{ReferenceDecision, ReferenceQuery, find_reference_action};
+pub(crate) use reference::{
+    ReferenceDecision, ReferenceQuery, find_copy_dest_basis, find_copy_dest_symlink,
+    find_reference_action,
+};
 pub(crate) use sources::copy_sources;
 pub(crate) use special::{
     copy_device, copy_fifo, copy_symlink, create_symlink, symlink_target_is_safe,

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -159,26 +159,29 @@ pub(crate) fn find_copy_dest_symlink(
     Ok(None)
 }
 
-/// Locates a `--copy-dest` basis directory at `relative`.
+/// Locates an alternate-basis directory at `relative` (`--copy-dest` or
+/// `--link-dest`).
 ///
-/// Returns the basis metadata when a `Copy` (copy-dest) reference contains a
-/// directory at `relative`. A directory reconstructed from a copy-dest basis
-/// itemizes as a local change (`cd`) compared against the basis rather than as
-/// a new entry (`cd+++++++++`).
+/// Returns the basis metadata when a `Copy` or `Link` reference contains a
+/// directory at `relative`. A directory matched against either basis itemizes
+/// as a local change (`cd`) compared to the basis rather than as a new entry
+/// (`cd+++++++++`); directories are never hard-linked, so both kinds behave
+/// identically here.
 ///
-/// upstream: generator.c:1117-1148 try_dests_non() - a copy-dest match itemizes
-/// with ITEM_LOCAL_CHANGE and never sets ITEM_IS_NEW.
+/// upstream: generator.c:1117-1148 try_dests_non() - a match itemizes with
+/// ITEM_LOCAL_CHANGE and never sets ITEM_IS_NEW (the LINK_DEST hard-link branch
+/// is skipped for directories at line 1126).
 pub(crate) fn find_copy_dest_basis(
     context: &CopyContext<'_>,
     destination: &Path,
     relative: &Path,
 ) -> Result<Option<fs::Metadata>, LocalCopyError> {
-    // An empty `relative` is the transfer root: the basis is the copy-dest
+    // An empty `relative` is the transfer root: the basis is the reference
     // directory itself, resolved from the destination root. Unlike the file and
     // symlink lookups, the directory lookup must handle this case so the `./`
     // row itemizes against the basis root.
     for reference in context.reference_directories() {
-        if reference.kind() != ReferenceDirectoryKind::Copy {
+        if matches!(reference.kind(), ReferenceDirectoryKind::Compare) {
             continue;
         }
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -37,34 +37,8 @@ pub(crate) fn resolve_reference_candidate(
                 break;
             }
         }
-        lexically_normalize(&ancestor.join(base).join(relative))
+        crate::local_copy::lexically_normalize(&ancestor.join(base).join(relative))
     }
-}
-
-/// Collapses `.` and `..` components purely lexically, without touching the
-/// filesystem. A leading `..` that cannot be cancelled is preserved so the
-/// path stays valid relative to its anchor.
-fn lexically_normalize(path: &Path) -> PathBuf {
-    use std::path::Component;
-
-    let mut normalized: Vec<Component<'_>> = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => match normalized.last() {
-                Some(Component::Normal(_)) => {
-                    normalized.pop();
-                }
-                Some(Component::RootDir) => {}
-                _ => normalized.push(component),
-            },
-            other => normalized.push(other),
-        }
-    }
-    if normalized.is_empty() {
-        return PathBuf::from(".");
-    }
-    normalized.iter().collect()
 }
 
 /// Parameters for finding a matching file in reference directories.

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -18,7 +18,10 @@ pub(crate) enum ReferenceDecision {
 /// Computes the full path for a reference directory candidate.
 ///
 /// Absolute bases are joined directly; relative bases are resolved from
-/// the destination ancestor at the same depth as `relative`.
+/// the destination ancestor at the same depth as `relative`. The result is
+/// lexically normalized (collapsing `..`/`.`) so the candidate resolves even
+/// when an intermediate directory (e.g. a not-yet-created dry-run destination)
+/// does not exist on disk.
 pub(crate) fn resolve_reference_candidate(
     base: &Path,
     relative: &Path,
@@ -34,8 +37,34 @@ pub(crate) fn resolve_reference_candidate(
                 break;
             }
         }
-        ancestor.join(base).join(relative)
+        lexically_normalize(&ancestor.join(base).join(relative))
     }
+}
+
+/// Collapses `.` and `..` components purely lexically, without touching the
+/// filesystem. A leading `..` that cannot be cancelled is preserved so the
+/// path stays valid relative to its anchor.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized: Vec<Component<'_>> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match normalized.last() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
+                }
+                Some(Component::RootDir) => {}
+                _ => normalized.push(component),
+            },
+            other => normalized.push(other),
+        }
+    }
+    if normalized.is_empty() {
+        return PathBuf::from(".");
+    }
+    normalized.iter().collect()
 }
 
 /// Parameters for finding a matching file in reference directories.
@@ -232,9 +261,9 @@ mod tests {
         let destination = Path::new("/home/user/dest");
         let result = resolve_reference_candidate(base, relative, destination);
         // destination "/home/user/dest" -> pop 1 level (for relative depth 1) -> "/home/user"
-        // then join "../backup" -> "/home/backup"
+        // then join "../backup" -> "/home/user/../backup" -> normalized "/home/backup"
         // then join "file.txt" -> "/home/backup/file.txt"
-        assert_eq!(result, PathBuf::from("/home/user/../backup/file.txt"));
+        assert_eq!(result, PathBuf::from("/home/backup/file.txt"));
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -10,7 +10,9 @@ use super::{CopyComparison, should_skip_copy};
 
 /// Outcome of evaluating a reference directory candidate against source metadata.
 pub(crate) enum ReferenceDecision {
-    Skip,
+    /// A `--compare-dest` match: the file is skipped and itemized as `.f`
+    /// against the carried basis path (blank columns when identical).
+    Skip(PathBuf),
     Copy(PathBuf),
     Link(PathBuf),
 }
@@ -100,7 +102,7 @@ pub(crate) fn find_reference_action(
             prefetched_match: None,
         }) {
             return Ok(Some(match reference.kind() {
-                ReferenceDirectoryKind::Compare => ReferenceDecision::Skip,
+                ReferenceDirectoryKind::Compare => ReferenceDecision::Skip(candidate),
                 ReferenceDirectoryKind::Copy => ReferenceDecision::Copy(candidate),
                 ReferenceDirectoryKind::Link => ReferenceDecision::Link(candidate),
             }));
@@ -123,11 +125,43 @@ pub(crate) fn find_copy_dest_symlink(
     relative: &Path,
     target: &Path,
 ) -> Result<Option<fs::Metadata>, LocalCopyError> {
+    find_reference_symlink(context, destination, relative, target, |kind| {
+        kind == ReferenceDirectoryKind::Copy
+    })
+}
+
+/// Locates a `--compare-dest` basis symlink at `relative` whose target matches.
+///
+/// A compare-dest match means the symlink already exists elsewhere, so the
+/// receiver neither recreates it nor reports a transfer; it itemizes `.L`
+/// against the basis.
+///
+/// upstream: generator.c:1140 - COMPARE_DEST forces `chg = 0` for non-directory
+/// matches, so the update char stays `.`.
+pub(crate) fn find_compare_dest_symlink(
+    context: &CopyContext<'_>,
+    destination: &Path,
+    relative: &Path,
+    target: &Path,
+) -> Result<Option<fs::Metadata>, LocalCopyError> {
+    find_reference_symlink(context, destination, relative, target, |kind| {
+        kind == ReferenceDirectoryKind::Compare
+    })
+}
+
+/// Shared symlink lookup across reference directories whose kind passes `accept`.
+fn find_reference_symlink(
+    context: &CopyContext<'_>,
+    destination: &Path,
+    relative: &Path,
+    target: &Path,
+    accept: impl Fn(ReferenceDirectoryKind) -> bool,
+) -> Result<Option<fs::Metadata>, LocalCopyError> {
     if relative.as_os_str().is_empty() {
         return Ok(None);
     }
     for reference in context.reference_directories() {
-        if reference.kind() != ReferenceDirectoryKind::Copy {
+        if !accept(reference.kind()) {
             continue;
         }
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);
@@ -162,18 +196,19 @@ pub(crate) fn find_copy_dest_symlink(
     Ok(None)
 }
 
-/// Locates an alternate-basis directory at `relative` (`--copy-dest` or
-/// `--link-dest`).
+/// Locates an alternate-basis directory at `relative` (`--copy-dest`,
+/// `--link-dest`, or `--compare-dest`).
 ///
-/// Returns the basis metadata when a `Copy` or `Link` reference contains a
-/// directory at `relative`. A directory matched against either basis itemizes
-/// as a local change (`cd`) compared to the basis rather than as a new entry
-/// (`cd+++++++++`); directories are never hard-linked, so both kinds behave
-/// identically here.
+/// Returns the basis metadata when any reference contains a directory at
+/// `relative`. A directory matched against any basis itemizes as a local change
+/// (`cd`) compared to the basis rather than as a new entry (`cd+++++++++`);
+/// directories are never hard-linked, so all three kinds behave identically
+/// here.
 ///
 /// upstream: generator.c:1117-1148 try_dests_non() - a match itemizes with
 /// ITEM_LOCAL_CHANGE and never sets ITEM_IS_NEW (the LINK_DEST hard-link branch
-/// is skipped for directories at line 1126).
+/// is skipped for directories at line 1126, and COMPARE_DEST forces
+/// ITEM_LOCAL_CHANGE for directories at line 1140).
 pub(crate) fn find_copy_dest_basis(
     context: &CopyContext<'_>,
     destination: &Path,
@@ -184,9 +219,6 @@ pub(crate) fn find_copy_dest_basis(
     // symlink lookups, the directory lookup must handle this case so the `./`
     // row itemizes against the basis root.
     for reference in context.reference_directories() {
-        if matches!(reference.kind(), ReferenceDirectoryKind::Compare) {
-            continue;
-        }
         let candidate = resolve_reference_candidate(reference.path(), relative, destination);
         let candidate_metadata = match fs::symlink_metadata(&candidate) {
             Ok(meta) => meta,
@@ -296,8 +328,12 @@ mod tests {
 
     #[test]
     fn reference_decision_skip_variant() {
-        let decision = ReferenceDecision::Skip;
-        assert!(matches!(decision, ReferenceDecision::Skip));
+        let path = PathBuf::from("/compare/basis");
+        let decision = ReferenceDecision::Skip(path.clone());
+        match decision {
+            ReferenceDecision::Skip(p) => assert_eq!(p, path),
+            _ => panic!("Expected Skip variant"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -107,6 +107,98 @@ pub(crate) fn find_reference_action(
     Ok(None)
 }
 
+/// Locates a `--copy-dest` basis symlink at `relative` whose target matches.
+///
+/// Returns the basis symlink metadata when a `Copy` reference holds a symlink
+/// pointing at `target`. A copy-dest match reconstructs the link from the basis
+/// and itemizes it as a local change (`cL`) instead of a new entry.
+///
+/// upstream: generator.c:1094 quick_check_ok(FT_SYMLINK) compares link targets.
+pub(crate) fn find_copy_dest_symlink(
+    context: &CopyContext<'_>,
+    destination: &Path,
+    relative: &Path,
+    target: &Path,
+) -> Result<Option<fs::Metadata>, LocalCopyError> {
+    if relative.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    for reference in context.reference_directories() {
+        if reference.kind() != ReferenceDirectoryKind::Copy {
+            continue;
+        }
+        let candidate = resolve_reference_candidate(reference.path(), relative, destination);
+        let candidate_metadata = match fs::symlink_metadata(&candidate) {
+            Ok(meta) => meta,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "inspect reference symlink",
+                    candidate,
+                    error,
+                ));
+            }
+        };
+        if !candidate_metadata.file_type().is_symlink() {
+            continue;
+        }
+        match fs::read_link(&candidate) {
+            Ok(basis_target) if basis_target == target => {
+                return Ok(Some(candidate_metadata));
+            }
+            Ok(_) => continue,
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "read reference symlink",
+                    candidate,
+                    error,
+                ));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Locates a `--copy-dest` basis directory at `relative`.
+///
+/// Returns the basis metadata when a `Copy` (copy-dest) reference contains a
+/// directory at `relative`. A directory reconstructed from a copy-dest basis
+/// itemizes as a local change (`cd`) compared against the basis rather than as
+/// a new entry (`cd+++++++++`).
+///
+/// upstream: generator.c:1117-1148 try_dests_non() - a copy-dest match itemizes
+/// with ITEM_LOCAL_CHANGE and never sets ITEM_IS_NEW.
+pub(crate) fn find_copy_dest_basis(
+    context: &CopyContext<'_>,
+    destination: &Path,
+    relative: &Path,
+) -> Result<Option<fs::Metadata>, LocalCopyError> {
+    if relative.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    for reference in context.reference_directories() {
+        if reference.kind() != ReferenceDirectoryKind::Copy {
+            continue;
+        }
+        let candidate = resolve_reference_candidate(reference.path(), relative, destination);
+        let candidate_metadata = match fs::symlink_metadata(&candidate) {
+            Ok(meta) => meta,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "inspect reference directory",
+                    candidate,
+                    error,
+                ));
+            }
+        };
+        if candidate_metadata.file_type().is_dir() {
+            return Ok(Some(candidate_metadata));
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -173,9 +173,10 @@ pub(crate) fn find_copy_dest_basis(
     destination: &Path,
     relative: &Path,
 ) -> Result<Option<fs::Metadata>, LocalCopyError> {
-    if relative.as_os_str().is_empty() {
-        return Ok(None);
-    }
+    // An empty `relative` is the transfer root: the basis is the copy-dest
+    // directory itself, resolved from the destination root. Unlike the file and
+    // symlink lookups, the directory lookup must handle this case so the `./`
+    // row itemizes against the basis root.
     for reference in context.reference_directories() {
         if reference.kind() != ReferenceDirectoryKind::Copy {
             continue;

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -372,6 +372,78 @@ pub(crate) fn copy_symlink(
         remove_existing_destination(destination)?;
     }
 
+    // upstream: generator.c:1117-1134 try_dests_non() - a `--link-dest` basis
+    // symlink with the same target is hard-linked into place rather than
+    // recreated, itemizing as `hL` + blank against the basis. Only applies when
+    // the destination is being created fresh (no prior symlink to recreate).
+    if !mode.is_dry_run() && pre_replace_symlink_metadata.is_none() {
+        let link_relative = relative.unwrap_or(record_path.as_deref().unwrap_or(Path::new("")));
+        if !link_relative.as_os_str().is_empty()
+            && let Some(basis_symlink) = context.link_dest_symlink_target(link_relative, &target)?
+        {
+            let mut attempted_commit = false;
+            loop {
+                match create_hard_link(&basis_symlink, destination) {
+                    Ok(()) => break,
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                        remove_existing_destination(destination)?;
+                        create_hard_link(&basis_symlink, destination).map_err(|link_error| {
+                            LocalCopyError::io(
+                                "create hard link",
+                                destination.to_path_buf(),
+                                link_error,
+                            )
+                        })?;
+                        break;
+                    }
+                    Err(error)
+                        if error.kind() == io::ErrorKind::NotFound
+                            && context.delay_updates_enabled()
+                            && !attempted_commit =>
+                    {
+                        context.commit_deferred_update_for(&basis_symlink)?;
+                        attempted_commit = true;
+                        continue;
+                    }
+                    Err(error) => {
+                        return Err(LocalCopyError::io(
+                            "create hard link",
+                            destination.to_path_buf(),
+                            error,
+                        ));
+                    }
+                }
+            }
+
+            context.record_hard_link(metadata, destination);
+            context.summary_mut().record_hard_link();
+            context.summary_mut().record_symlink();
+            if let Some(path) = &record_path {
+                let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
+                let total_bytes = Some(metadata_snapshot.len());
+                // The hard-linked symlink shares the basis inode, so it matches
+                // the source exactly: itemize `hL` + blank with the `-> target`
+                // trailer from the symlink's own metadata.
+                context.record(LocalCopyRecord::new(
+                    path.clone(),
+                    LocalCopyAction::HardLink,
+                    0,
+                    total_bytes,
+                    Duration::default(),
+                    Some(metadata_snapshot),
+                ));
+            }
+            context.register_created_path(
+                destination,
+                CreatedEntryKind::HardLink,
+                destination_previously_existed,
+            );
+            context.register_progress();
+            remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+            return Ok(());
+        }
+    }
+
     if let Some(existing_target) = context.existing_hard_link_target(metadata) {
         if mode.is_dry_run() {
             context.summary_mut().record_symlink();

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -287,6 +287,49 @@ pub(crate) fn copy_symlink(
         return Ok(());
     }
 
+    // upstream: generator.c:1140 + try_dests_non() - a `--compare-dest` symlink
+    // whose target matches the basis is neither recreated nor transferred; it
+    // itemizes `.L` against the basis. Detect that before any creation work so
+    // the destination stays empty (compare-dest semantics) and the row collapses
+    // to `.L` + blank, suppressed at plain `-i`.
+    if destination_metadata.is_none()
+        && let Some(path) = record_path.as_ref()
+        && !path.as_os_str().is_empty()
+        && let Some(basis_meta) =
+            super::super::find_compare_dest_symlink(context, destination, path, &target)?
+    {
+        let symlink_options = if context.omit_link_times_enabled() {
+            metadata_options.clone().preserve_times(false)
+        } else {
+            metadata_options.clone()
+        };
+        let change_set = LocalCopyChangeSet::for_file(
+            metadata,
+            Some(&basis_meta),
+            &symlink_options,
+            true,
+            false,
+            false,
+            false,
+        );
+        context.summary_mut().record_symlink();
+        let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
+        context.record(
+            LocalCopyRecord::new(
+                path.clone(),
+                LocalCopyAction::MetadataReused,
+                0,
+                Some(metadata_snapshot.len()),
+                Duration::default(),
+                Some(metadata_snapshot),
+            )
+            .with_change_set(change_set),
+        );
+        context.register_progress();
+        remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;
+        return Ok(());
+    }
+
     if let Some(parent) = destination.parent() {
         context.prepare_parent_directory(parent)?;
     }

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -524,6 +524,16 @@ pub(crate) fn copy_symlink(
     context.record_hard_link(metadata, destination);
     context.summary_mut().record_symlink();
     if let Some(path) = &record_path {
+        // upstream: generator.c:1119-1148 try_dests_non() - a symlink absent
+        // from the destination but present (with the same target) in a
+        // `--copy-dest` basis itemizes as a local change (`cL` + blank)
+        // against the basis instead of a new entry (`cL+++++++++`).
+        let copy_dest_basis = if !destination_previously_existed {
+            super::super::find_copy_dest_symlink(context, destination, path, &target)?
+        } else {
+            None
+        };
+
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
         let total_bytes = Some(metadata_snapshot.len());
 
@@ -532,7 +542,8 @@ pub(crate) fn copy_symlink(
         // path flips `statret = -1` so `itemize()` lights up `ITEM_IS_NEW`
         // and the row renders `cL+++++++++`. Mirror that by treating a
         // non-symlink replacement as a fresh creation.
-        let was_created = !destination_previously_existed || pre_replace_symlink_metadata.is_none();
+        let was_created = copy_dest_basis.is_none()
+            && (!destination_previously_existed || pre_replace_symlink_metadata.is_none());
 
         let mut record = LocalCopyRecord::new(
             path.clone(),
@@ -557,6 +568,24 @@ pub(crate) fn copy_symlink(
                 existing_symlink,
                 metadata_options,
                 context.omit_link_times_enabled(),
+            );
+            record = record.with_change_set(change_set);
+        } else if let Some(basis_meta) = copy_dest_basis.as_ref() {
+            // Compare source against the copy-dest basis symlink so the row
+            // stays blank when the reconstructed link is identical.
+            let symlink_options = if context.omit_link_times_enabled() {
+                metadata_options.clone().preserve_times(false)
+            } else {
+                metadata_options.clone()
+            };
+            let change_set = LocalCopyChangeSet::for_file(
+                metadata,
+                Some(basis_meta),
+                &symlink_options,
+                true,
+                false,
+                false,
+                false,
             );
             record = record.with_change_set(change_set);
         }

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -527,29 +527,71 @@ pub(crate) fn copy_symlink(
     if mode.is_dry_run() {
         context.summary_mut().record_symlink();
         if let Some(path) = &record_path {
+            // upstream: generator.c:1117-1147 - a dry-run still evaluates
+            // alt-dest bases. A `--link-dest` symlink with a matching target
+            // itemizes as `hL`; a `--copy-dest` symlink as `cL` against the
+            // basis. Both leave attribute columns blank when identical.
+            let link_dest_match = pre_replace_symlink_metadata.is_none()
+                && !path.as_os_str().is_empty()
+                && context.link_dest_symlink_target(path, &target)?.is_some();
+            let copy_dest_basis = if pre_replace_symlink_metadata.is_none() && !link_dest_match {
+                super::super::find_copy_dest_symlink(context, destination, path, &target)?
+            } else {
+                None
+            };
+
             let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
             let total_bytes = Some(metadata_snapshot.len());
-            let was_created =
-                !destination_previously_existed || pre_replace_symlink_metadata.is_none();
-            let mut record = LocalCopyRecord::new(
-                path.clone(),
-                LocalCopyAction::SymlinkCopied,
-                0,
-                total_bytes,
-                Duration::default(),
-                Some(metadata_snapshot),
-            )
-            .with_creation(was_created);
-            if let Some(existing_symlink) = pre_replace_symlink_metadata.as_ref() {
-                let change_set = LocalCopyChangeSet::for_recreated_symlink(
-                    metadata,
-                    existing_symlink,
-                    metadata_options,
-                    context.omit_link_times_enabled(),
-                );
-                record = record.with_change_set(change_set);
+
+            if link_dest_match {
+                context.summary_mut().record_hard_link();
+                context.record(LocalCopyRecord::new(
+                    path.clone(),
+                    LocalCopyAction::HardLink,
+                    0,
+                    total_bytes,
+                    Duration::default(),
+                    Some(metadata_snapshot),
+                ));
+            } else {
+                let was_created = copy_dest_basis.is_none()
+                    && (!destination_previously_existed || pre_replace_symlink_metadata.is_none());
+                let mut record = LocalCopyRecord::new(
+                    path.clone(),
+                    LocalCopyAction::SymlinkCopied,
+                    0,
+                    total_bytes,
+                    Duration::default(),
+                    Some(metadata_snapshot),
+                )
+                .with_creation(was_created);
+                if let Some(existing_symlink) = pre_replace_symlink_metadata.as_ref() {
+                    let change_set = LocalCopyChangeSet::for_recreated_symlink(
+                        metadata,
+                        existing_symlink,
+                        metadata_options,
+                        context.omit_link_times_enabled(),
+                    );
+                    record = record.with_change_set(change_set);
+                } else if let Some(basis_meta) = copy_dest_basis.as_ref() {
+                    let symlink_options = if context.omit_link_times_enabled() {
+                        metadata_options.clone().preserve_times(false)
+                    } else {
+                        metadata_options.clone()
+                    };
+                    let change_set = LocalCopyChangeSet::for_file(
+                        metadata,
+                        Some(basis_meta),
+                        &symlink_options,
+                        true,
+                        false,
+                        false,
+                        false,
+                    );
+                    record = record.with_change_set(change_set);
+                }
+                context.record(record);
             }
-            context.record(record);
         }
         context.register_progress();
         remove_source_entry_if_requested(context, source, record_path.as_deref(), file_type)?;

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -216,6 +216,36 @@ const CROSS_DEVICE_ERROR_CODE: i32 = 17;
 #[cfg(not(any(unix, windows)))]
 const CROSS_DEVICE_ERROR_CODE: i32 = 18;
 
+/// Collapses `.` and `..` components in `path` purely lexically, without
+/// touching the filesystem. A leading `..` that cannot be cancelled is
+/// preserved so the path stays valid relative to its anchor.
+///
+/// Used when resolving relative `--link-dest` / `--copy-dest` / `--compare-dest`
+/// candidates so they resolve even when an intermediate directory (e.g. a
+/// not-yet-created dry-run destination) is absent from disk.
+pub(crate) fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
+    use std::path::{Component, PathBuf};
+
+    let mut normalized: Vec<Component<'_>> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match normalized.last() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
+                }
+                Some(Component::RootDir) => {}
+                _ => normalized.push(component),
+            },
+            other => normalized.push(other),
+        }
+    }
+    if normalized.is_empty() {
+        return PathBuf::from(".");
+    }
+    normalized.iter().collect()
+}
+
 #[cfg(test)]
 pub(crate) fn with_hard_link_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
 where

--- a/crates/engine/src/local_copy/options/link_dest.rs
+++ b/crates/engine/src/local_copy/options/link_dest.rs
@@ -85,12 +85,16 @@ impl LinkDestEntry {
     }
 
     pub(crate) fn resolve(&self, destination_root: &Path, relative: &Path) -> PathBuf {
-        let base = if self.is_relative {
-            destination_root.join(&self.path)
+        if self.is_relative {
+            // Lexically collapse `..`/`.` so the candidate resolves even when an
+            // intermediate directory (e.g. a not-yet-created dry-run
+            // destination) is absent from disk.
+            crate::local_copy::lexically_normalize(
+                &destination_root.join(&self.path).join(relative),
+            )
         } else {
-            self.path.clone()
-        };
-        base.join(relative)
+            self.path.join(relative)
+        }
     }
 }
 

--- a/crates/engine/src/local_copy/plan/action.rs
+++ b/crates/engine/src/local_copy/plan/action.rs
@@ -3,6 +3,13 @@
 pub enum LocalCopyAction {
     /// File data was copied into place.
     DataCopied,
+    /// A regular file was reconstructed locally from a `--copy-dest` basis
+    /// directory because it matched the source. Itemizes as a local change
+    /// (`c`) rather than a network transfer (`>`).
+    ///
+    /// upstream: generator.c:1039 - `itemize(..., ITEM_LOCAL_CHANGE, ...)`
+    /// after `copy_altdest_file()` for `COPY_DEST`.
+    ReferenceCopied,
     /// An existing destination file already matched the source.
     MetadataReused,
     /// A hard link was created pointing at a previously copied destination.

--- a/crates/engine/src/local_copy/tests/execute_copy_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_dest.rs
@@ -712,3 +712,145 @@ fn copy_dest_copies_zero_length_file() {
     assert_eq!(destination_file.metadata().expect("metadata").len(), 0);
     assert_eq!(summary.files_copied(), 1);
 }
+
+// upstream: generator.c:1033-1039 - a `--copy-dest` file that matches the
+// source is reconstructed locally and itemized with ITEM_LOCAL_CHANGE (`c`),
+// NOT ITEM_TRANSFER / ITEM_IS_NEW (`>f+++++++++`). The record must therefore be
+// `ReferenceCopied`, not created, with no attribute drift against the basis.
+#[test]
+fn copy_dest_identical_file_records_reference_copy_with_blank_attrs() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let copy_dest_dir = temp.path().join("copy_dest");
+    let destination_dir = temp.path().join("dest");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::create_dir_all(&copy_dest_dir).expect("create copy_dest dir");
+
+    let source_file = source_dir.join("file.txt");
+    let copy_dest_file = copy_dest_dir.join("file.txt");
+    fs::write(&source_file, b"identical content").expect("write source");
+    fs::write(&copy_dest_file, b"identical content").expect("write copy_dest");
+
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(&source_file, timestamp).expect("source mtime");
+    set_file_mtime(&copy_dest_file, timestamp).expect("copy_dest mtime");
+
+    let destination_file = destination_dir.join("file.txt");
+    let operands = vec![
+        source_file.into_os_string(),
+        destination_file.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .times(true)
+        .collect_events(true)
+        .extend_reference_directories([ReferenceDirectory::new(
+            ReferenceDirectoryKind::Copy,
+            &copy_dest_dir,
+        )]);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let file_record = report
+        .records()
+        .iter()
+        .find(|record| record.relative_path().ends_with("file.txt"))
+        .expect("file record present");
+    assert_eq!(file_record.action(), &LocalCopyAction::ReferenceCopied);
+    assert!(
+        !file_record.was_created(),
+        "copy-dest match must not be ITEM_IS_NEW"
+    );
+    assert_eq!(
+        file_record.change_set(),
+        LocalCopyChangeSet::new(),
+        "identical copy-dest basis leaves all attribute columns blank"
+    );
+}
+
+// upstream: generator.c:1469-1483 / 1117-1148 - a directory and symlink present
+// in a `--copy-dest` basis but absent from the destination itemize as local
+// changes (`cd`/`cL` + blank) against the basis, never `cd+++++++++`.
+#[cfg(unix)]
+#[test]
+fn copy_dest_directory_and_symlink_record_local_change_not_new() {
+    let temp = tempdir().expect("tempdir");
+    let source_dir = temp.path().join("source");
+    let copy_dest_dir = temp.path().join("copy_dest");
+    let destination_dir = temp.path().join("dest");
+    fs::create_dir_all(source_dir.join("sub")).expect("create source subdir");
+    fs::create_dir_all(copy_dest_dir.join("sub")).expect("create copy_dest subdir");
+
+    // Identical regular file inside the subdir plus a symlink to it.
+    fs::write(source_dir.join("sub/file.txt"), b"content").expect("write source file");
+    fs::write(copy_dest_dir.join("sub/file.txt"), b"content").expect("write basis file");
+    std::os::unix::fs::symlink("sub/file.txt", source_dir.join("link")).expect("source symlink");
+    std::os::unix::fs::symlink("sub/file.txt", copy_dest_dir.join("link")).expect("basis symlink");
+
+    let timestamp = FileTime::from_unix_time(1_700_000_000, 0);
+    set_file_mtime(source_dir.join("sub/file.txt"), timestamp).expect("src file mtime");
+    set_file_mtime(copy_dest_dir.join("sub/file.txt"), timestamp).expect("basis file mtime");
+    // The `sub` directory mtime must match the basis so the dir itemizes blank.
+    set_file_mtime(source_dir.join("sub"), timestamp).expect("src dir mtime");
+    set_file_mtime(copy_dest_dir.join("sub"), timestamp).expect("basis dir mtime");
+    // Symlink mtimes match the basis (symtimes preserved under `-t`).
+    filetime::set_symlink_file_times(source_dir.join("link"), timestamp, timestamp)
+        .expect("src link mtime");
+    filetime::set_symlink_file_times(copy_dest_dir.join("link"), timestamp, timestamp)
+        .expect("basis link mtime");
+
+    // Trailing-slash source so contents land directly under destination_dir.
+    let mut source_operand = source_dir.clone().into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, destination_dir.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .times(true)
+        .collect_events(true)
+        .extend_reference_directories([ReferenceDirectory::new(
+            ReferenceDirectoryKind::Copy,
+            &copy_dest_dir,
+        )]);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dir_record = report
+        .records()
+        .iter()
+        .find(|record| record.relative_path() == Path::new("sub"))
+        .expect("directory record present");
+    assert_eq!(dir_record.action(), &LocalCopyAction::DirectoryCreated);
+    assert!(
+        !dir_record.was_created(),
+        "copy-dest directory match must not be ITEM_IS_NEW"
+    );
+    assert_eq!(
+        dir_record.change_set(),
+        LocalCopyChangeSet::new(),
+        "identical copy-dest directory leaves attribute columns blank"
+    );
+
+    let link_record = report
+        .records()
+        .iter()
+        .find(|record| record.relative_path() == Path::new("link"))
+        .expect("symlink record present");
+    assert_eq!(link_record.action(), &LocalCopyAction::SymlinkCopied);
+    assert!(
+        !link_record.was_created(),
+        "copy-dest symlink match must not be ITEM_IS_NEW"
+    );
+    assert_eq!(
+        link_record.change_set(),
+        LocalCopyChangeSet::new(),
+        "identical copy-dest symlink leaves attribute columns blank"
+    );
+}


### PR DESCRIPTION
## Summary

Items reconstructed from an alternate-basis directory (`--copy-dest`, `--link-dest`, `--compare-dest`) that already match the source were itemized as fresh wire transfers (`>f+++++++++`, `cd+++++++++`, `cL+++++++++`) instead of upstream's local-change rows. This fixes the full alt-dest itemize behaviour to match upstream rsync 3.4.4 across regular files, directories, symlinks, and hard links, in both real and dry-run modes, at every verbosity tier.

## Root cause

When an item is satisfied from an alternate basis identical to the source, upstream itemizes it as a *local change* (update char `c`/`h`/`.`) with attribute columns compared against the **basis**, never setting `ITEM_IS_NEW`. oc-rsync was attributing these to `ITEM_TRANSFER`/`ITEM_IS_NEW` (a brand-new wire transfer), comparing attributes against the absent prior destination, and treating directory rows as unconditional creations.

## Changes

- New `ReferenceCopied` action so a `--copy-dest` reconstruction itemizes `cf` against the basis.
- Directories/symlinks reconstructed from any alt-basis look up the basis entry and record a non-creation change set (`cd`/`cL`/`.L` + blank).
- Hard-link aliases compute their change set against the group leader; `--link-dest` hardlinks report `is uptodate` under `-vv` and are suppressed at plain `-i`; a fresh `--copy-dest` cluster alias keeps its `=> leader` trailer.
- Hard-linked symlinks (`hL`) render `-> target`, not `=> leader`.
- Alt-dest bases are evaluated in `--dry-run` mode so dry-runs itemize identically to real runs.
- Relative alt-dest candidates are lexically normalized so they resolve even when the destination directory does not yet exist (dry-run).
- `created directory` is reported under `--dry-run` (upstream prints it before `dry_run++`).
- `--compare-dest` directories/files/symlinks itemize against the compare basis.

## Validation

Validated on a Linux host against the upstream 3.4.4 test suite:

- `itemize.test` — **PASS** (all `--copy-dest`/`--link-dest`/`--compare-dest` legs across `-i`, `-ivv`, `-vv`, and `--dry-run`).
- `hardlinks.test`, `daemon-gzip-download.test` — **PASS** (no itemize regression).
- `exclude.test`/`exclude-lsh.test` — still fail for a pre-existing, unrelated filter/exclusion reason (not touched by this change); not regressed.

New nextest regression tests cover alt-dest-matched files/dirs/symlinks/hardlinks itemizing as `c`/`h`/`.` + blank, plain-`-i` suppression vs `-vv` surfacing, and the fresh-vs-uptodate hardlink alias distinction. Full `engine`/`core`/`cli` nextest suite green (10,518 tests); fmt and clippy clean.
