### PR TITLE
fix(engine): correct per-directory merge traversal semantics

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -448,6 +448,59 @@ include!("context_impl/transfer.rs");
 include!("context_impl/delta_transfer.rs");
 include!("context_impl/reporting.rs");
 
+/// Outcome of loading one nested `dir-merge` file in a directory: the compiled
+/// rule segment (absent when the file had no concrete rules), any
+/// `exclude-if-present` markers, and any further nested dir-merge rules it
+/// registered.
+struct LoadedNestedDirMerge {
+    segment: Option<FilterSegment>,
+    markers: Vec<ExcludeIfPresentRule>,
+    nested: Vec<NestedDirMerge>,
+}
+
+/// Rewrites an anchored per-dir merge rule so its leading `/` anchor binds to
+/// the merge file's directory (`relative_dir`) rather than the transfer root.
+///
+/// upstream: exclude.c:200-207 `add_rule` - for a rule loaded via
+/// `parse_filter_file` with `XFLG_ANCHORED2ABS`, a leading-`/` pattern gets the
+/// directory prefix `dirbuf + module_dirlen` (length `dirbuf_len - module_dirlen
+/// - 1`) prepended, so `- /file1` in `foo/.filt` matches `foo/file1`. Unanchored
+/// patterns and rules with no directory context are returned unchanged.
+fn anchor_dir_merge_rule(rule: FilterRule, relative_dir: Option<&Path>) -> FilterRule {
+    let Some(dir) = relative_dir else {
+        return rule;
+    };
+    if dir.as_os_str().is_empty() {
+        return rule;
+    }
+    let pattern = rule.pattern();
+    let Some(rest) = pattern.strip_prefix('/') else {
+        return rule;
+    };
+    // `dir` is the transfer-root-relative directory of the merge file; build the
+    // anchored pattern `/<dir>/<rest>` using forward slashes (filter patterns are
+    // always `/`-delimited regardless of platform separator).
+    let dir_str = dir.to_string_lossy().replace('\\', "/");
+    let dir_str = dir_str.trim_matches('/');
+    let new_pattern = if rest.is_empty() {
+        format!("/{dir_str}")
+    } else {
+        format!("/{dir_str}/{rest}")
+    };
+    rule.with_pattern(new_pattern)
+}
+
+/// A filter segment loaded from a runtime-registered `dir-merge` file, paired
+/// with whether the originating rule inherits into subdirectories.
+#[derive(Clone, Debug)]
+pub(crate) struct LoadedDynamicSegment {
+    /// Compiled rules loaded from the merge file in this directory.
+    pub(crate) segment: FilterSegment,
+    /// `true` unless the dir-merge rule carried the `n` modifier
+    /// (`FILTRULE_NO_INHERIT`); inheritable segments propagate to child frames.
+    pub(crate) inherit: bool,
+}
+
 /// Per-directory frame for runtime-registered `dir-merge` rules.
 ///
 /// upstream: exclude.c:1419-1428 - tracks the cumulative set of nested
@@ -463,8 +516,16 @@ pub(crate) struct DynamicDirMergeFrame {
     /// directory's merge files.
     pub(crate) active_rules: Vec<NestedDirMerge>,
     /// Filter segments loaded by resolving `active_rules` against the
-    /// current directory's filesystem entries.
-    pub(crate) loaded_segments: Vec<FilterSegment>,
+    /// current directory's filesystem entries, each tagged with whether the
+    /// originating dir-merge rule inherits into subdirectories.
+    ///
+    /// upstream: exclude.c:801 `push_local_filters` sets `lp->tail = NULL` so
+    /// rules loaded at an ancestor depth stay in `lp->head` and continue to
+    /// match descendants. The frame's loaded segments therefore accumulate the
+    /// inheritable segments of every ancestor; segments whose rule carried the
+    /// `n` modifier (`FILTRULE_NO_INHERIT`) are flagged non-inheritable and are
+    /// dropped from child frames.
+    pub(crate) loaded_segments: Vec<LoadedDynamicSegment>,
     /// `exclude-if-present` markers loaded from the same files.
     pub(crate) loaded_markers: Vec<ExcludeIfPresentRule>,
 }

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -463,9 +463,10 @@ struct LoadedNestedDirMerge {
 ///
 /// upstream: exclude.c:200-207 `add_rule` - for a rule loaded via
 /// `parse_filter_file` with `XFLG_ANCHORED2ABS`, a leading-`/` pattern gets the
-/// directory prefix `dirbuf + module_dirlen` (length `dirbuf_len - module_dirlen
-/// - 1`) prepended, so `- /file1` in `foo/.filt` matches `foo/file1`. Unanchored
-/// patterns and rules with no directory context are returned unchanged.
+/// directory prefix `dirbuf + module_dirlen` (length
+/// `dirbuf_len - module_dirlen - 1`) prepended, so `- /file1` in `foo/.filt`
+/// matches `foo/file1`. Unanchored patterns and rules with no directory context
+/// are returned unchanged.
 fn anchor_dir_merge_rule(rule: FilterRule, relative_dir: Option<&Path>) -> FilterRule {
     let Some(dir) = relative_dir else {
         return rule;

--- a/crates/engine/src/local_copy/context_impl/options/filter.rs
+++ b/crates/engine/src/local_copy/context_impl/options/filter.rs
@@ -122,11 +122,13 @@ impl<'a> CopyContext<'a> {
             return None;
         }
         let mut outcome = FilterOutcome::default();
-        for segment in frame.loaded_segments.iter().rev() {
+        for loaded in frame.loaded_segments.iter().rev() {
             if outcome.transfer_decided() {
                 break;
             }
-            segment.apply(relative, is_dir, &mut outcome, context);
+            loaded
+                .segment
+                .apply(relative, is_dir, &mut outcome, context);
         }
         Some(outcome)
     }
@@ -134,8 +136,8 @@ impl<'a> CopyContext<'a> {
     fn dynamic_excluded_dir_by_non_dir_rule(&self, relative: &Path) -> Option<bool> {
         let stack = self.dynamic_dir_merge_stack.borrow();
         let frame = stack.last()?;
-        for segment in frame.loaded_segments.iter().rev() {
-            if let Some(result) = segment.excluded_dir_by_non_dir_rule(relative) {
+        for loaded in frame.loaded_segments.iter().rev() {
+            if let Some(result) = loaded.segment.excluded_dir_by_non_dir_rule(relative) {
                 return Some(result);
             }
         }

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -57,8 +57,9 @@ impl<'a> CopyContext<'a> {
     pub(super) fn enter_directory(
         &self,
         source: &Path,
+        relative_dir: Option<&Path>,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
-        self.enter_directory_for_path(source, true)
+        self.enter_directory_for_path(source, relative_dir, true)
     }
 
     /// Loads per-dir-merge filter files from the destination directory before a
@@ -73,13 +74,15 @@ impl<'a> CopyContext<'a> {
     pub(crate) fn enter_destination_for_deletion(
         &self,
         destination: &Path,
+        relative_dir: Option<&Path>,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
-        self.enter_directory_for_path(destination, false)
+        self.enter_directory_for_path(destination, relative_dir, false)
     }
 
     fn enter_directory_for_path(
         &self,
         directory: &Path,
+        relative_dir: Option<&Path>,
         check_directory_excluded: bool,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
         let source = directory;
@@ -110,87 +113,30 @@ impl<'a> CopyContext<'a> {
         ephemeral_stack.push(Vec::new());
         marker_ephemeral_stack.push(Vec::new());
 
-        // upstream: exclude.c:1419-1428 - inherit the parent frame's active
-        // nested dir-merge rules and look each one up in the current directory.
-        // Newly-registered rules (encountered while loading the files below)
-        // become active for subdirectories but are NOT looked up against the
-        // current directory.
-        let inherited_active: Vec<NestedDirMerge> = self
-            .dynamic_dir_merge_stack
-            .borrow()
-            .last()
-            .map(|frame| frame.active_rules.clone())
-            .unwrap_or_default();
+        // upstream: exclude.c:801 `push_local_filters` sets `lp->tail = NULL`,
+        // keeping `lp->head` so rules loaded at an ancestor depth keep matching
+        // descendants. Seed the new frame's active rules AND inheritable loaded
+        // segments from the parent frame, then look each active rule up in this
+        // directory. Non-inheritable (`n`-modifier) segments are dropped.
+        let (inherited_active, inherited_segments): (Vec<NestedDirMerge>, Vec<LoadedDynamicSegment>) =
+            self.dynamic_dir_merge_stack
+                .borrow()
+                .last()
+                .map(|frame| {
+                    let segments = frame
+                        .loaded_segments
+                        .iter()
+                        .filter(|loaded| loaded.inherit)
+                        .cloned()
+                        .collect();
+                    (frame.active_rules.clone(), segments)
+                })
+                .unwrap_or_default();
         let mut new_frame = DynamicDirMergeFrame {
-            active_rules: inherited_active.clone(),
-            loaded_segments: Vec::new(),
+            active_rules: inherited_active,
+            loaded_segments: inherited_segments,
             loaded_markers: Vec::new(),
         };
-
-        for rule in &inherited_active {
-            let candidate = resolve_dir_merge_path(source, &rule.pattern);
-            let metadata = match fs::metadata(&candidate) {
-                Ok(metadata) => metadata,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-                Err(error) => {
-                    ephemeral_stack.pop();
-                    marker_ephemeral_stack.pop();
-                    return Err(LocalCopyError::io(
-                        "inspect filter file",
-                        candidate,
-                        error,
-                    ));
-                }
-            };
-            if !metadata.is_file() {
-                continue;
-            }
-
-            let mut visited = Vec::new();
-            let mut entries = match load_dir_merge_rules_recursive(
-                candidate.as_path(),
-                &rule.options,
-                self.options.delete_excluded_enabled(),
-                &mut visited,
-            ) {
-                Ok(entries) => entries,
-                Err(error) => {
-                    ephemeral_stack.pop();
-                    marker_ephemeral_stack.pop();
-                    return Err(error);
-                }
-            };
-
-            let mut segment = FilterSegment::default();
-            for compiled in entries.rules.drain(..) {
-                if let Err(error) = segment.push_rule(compiled) {
-                    ephemeral_stack.pop();
-                    marker_ephemeral_stack.pop();
-                    return Err(filter_program_local_error(&candidate, &error));
-                }
-            }
-
-            if rule.options.excludes_self() {
-                let pattern = rule.pattern.to_string_lossy().into_owned();
-                if let Err(error) = segment.push_rule(FilterRule::exclude(pattern)) {
-                    ephemeral_stack.pop();
-                    marker_ephemeral_stack.pop();
-                    return Err(filter_program_local_error(&candidate, &error));
-                }
-            }
-
-            if !segment.is_empty() {
-                new_frame.loaded_segments.push(segment);
-            }
-            if !entries.exclude_if_present.is_empty() {
-                new_frame
-                    .loaded_markers
-                    .append(&mut entries.exclude_if_present);
-            }
-            new_frame
-                .active_rules
-                .append(&mut entries.nested_dir_merges);
-        }
 
         for (index, rule) in program.dir_merge_rules().iter().enumerate() {
             let candidate = resolve_dir_merge_path(source, rule.pattern());
@@ -230,6 +176,12 @@ impl<'a> CopyContext<'a> {
 
             let mut segment = FilterSegment::default();
             for compiled in entries.rules.drain(..) {
+                // upstream: exclude.c:200-207 add_rule - an anchored pattern in a
+                // per-dir merge file is rooted at the merge file's directory, not
+                // the transfer root: `pre_len = dirbuf_len - module_dirlen - 1`
+                // prepends the dir prefix. Mirror that so `- /file1` in `foo/.filt`
+                // matches `foo/file1`, not a top-level `file1`.
+                let compiled = anchor_dir_merge_rule(compiled, relative_dir);
                 if let Err(error) = segment.push_rule(compiled) {
                     ephemeral_stack.pop();
                     marker_ephemeral_stack.pop();
@@ -250,9 +202,12 @@ impl<'a> CopyContext<'a> {
             let markers = entries.exclude_if_present;
             let clear_inherited = entries.clear_inherited;
 
-            // upstream: exclude.c:1419-1428 - any `dir-merge`/`:` directives
-            // inside the loaded file register new per-directory rules that
-            // apply to subdirectories of `source`, not to `source` itself.
+            // upstream: exclude.c:787-789 - dir-merge directives found in a
+            // top-level merge file register per-directory rules that the growing
+            // push loop then loads against this same directory (and descendants).
+            // Append them to the dynamic frame's active set; the growing while
+            // loop below picks them up so `dir-merge .filt2` in `bar/.filt` loads
+            // `bar/.filt2` here as well as in descendants.
             new_frame
                 .active_rules
                 .append(&mut entries.nested_dir_merges);
@@ -298,6 +253,36 @@ impl<'a> CopyContext<'a> {
 
         drop(layers);
         drop(marker_layers);
+
+        // upstream: exclude.c:787-789 - walk the GROWING active-rule list so a
+        // dir-merge directive registered while loading an inherited file (or a
+        // top-level merge file above) is itself loaded against THIS directory.
+        // Loading a rule may append further nested rules; the re-read bound then
+        // picks them up. This makes `:C` load `.cvsignore` for the current dir
+        // and a same-directory nested `dir-merge` apply to the current dir.
+        let mut next_index = 0usize;
+        while next_index < new_frame.active_rules.len() {
+            let rule = new_frame.active_rules[next_index].clone();
+            next_index += 1;
+            let loaded = match self.load_nested_dir_merge(source, relative_dir, &rule) {
+                Ok(loaded) => loaded,
+                Err(error) => {
+                    ephemeral_stack.pop();
+                    marker_ephemeral_stack.pop();
+                    return Err(error);
+                }
+            };
+            let Some(mut loaded) = loaded else { continue };
+            if let Some(segment) = loaded.segment.take() {
+                new_frame.loaded_segments.push(LoadedDynamicSegment {
+                    segment,
+                    inherit: rule.options.inherit_rules(),
+                });
+            }
+            new_frame.loaded_markers.append(&mut loaded.markers);
+            new_frame.active_rules.append(&mut loaded.nested);
+        }
+
         drop(ephemeral_stack);
         drop(marker_ephemeral_stack);
 
@@ -324,6 +309,61 @@ impl<'a> CopyContext<'a> {
             true,
             excluded,
         ))
+    }
+
+    /// Resolves a single nested `dir-merge` rule against `source` and loads its
+    /// filter file (if present), returning the compiled segment, any
+    /// `exclude-if-present` markers, and any further nested dir-merge rules the
+    /// file registered.
+    ///
+    /// Anchored patterns are rewritten relative to `relative_dir` to mirror
+    /// upstream `exclude.c:200-207 add_rule`.
+    fn load_nested_dir_merge(
+        &self,
+        source: &Path,
+        relative_dir: Option<&Path>,
+        rule: &NestedDirMerge,
+    ) -> Result<Option<LoadedNestedDirMerge>, LocalCopyError> {
+        let candidate = resolve_dir_merge_path(source, &rule.pattern);
+        let metadata = match fs::metadata(&candidate) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(LocalCopyError::io("inspect filter file", candidate, error));
+            }
+        };
+        if !metadata.is_file() {
+            return Ok(None);
+        }
+
+        let mut visited = Vec::new();
+        let mut entries = load_dir_merge_rules_recursive(
+            candidate.as_path(),
+            &rule.options,
+            self.options.delete_excluded_enabled(),
+            &mut visited,
+        )?;
+
+        let mut segment = FilterSegment::default();
+        for compiled in entries.rules.drain(..) {
+            let compiled = anchor_dir_merge_rule(compiled, relative_dir);
+            segment
+                .push_rule(compiled)
+                .map_err(|error| filter_program_local_error(&candidate, &error))?;
+        }
+
+        if rule.options.excludes_self() {
+            let pattern = rule.pattern.to_string_lossy().into_owned();
+            segment
+                .push_rule(FilterRule::exclude(pattern))
+                .map_err(|error| filter_program_local_error(&candidate, &error))?;
+        }
+
+        Ok(Some(LoadedNestedDirMerge {
+            segment: (!segment.is_empty()).then_some(segment),
+            markers: entries.exclude_if_present,
+            nested: entries.nested_dir_merges,
+        }))
     }
 
     pub(super) fn directory_excluded(

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -170,7 +170,8 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
     // receiver applies any `: filter` rules found in the directory being
     // scanned. The guard pops the loaded rules at end of scope, mirroring
     // upstream's matching `pop_local_filters()` on delete.c:115.
-    let _destination_dir_merge_guard = context.enter_destination_for_deletion(destination)?;
+    let _destination_dir_merge_guard =
+        context.enter_destination_for_deletion(destination, relative)?;
 
     let keep: HashSet<OsString> = source_entries
         .iter()

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -199,7 +199,7 @@ fn copy_directory_recursive_inner(
     context.reserve_event_capacity(entries.len());
     context.register_progress();
 
-    let dir_merge_guard = context.enter_directory(source)?;
+    let dir_merge_guard = context.enter_directory(source, relative)?;
     if dir_merge_guard.is_excluded() {
         return Ok(false);
     }

--- a/crates/engine/tests/per_dir_merge_traversal.rs
+++ b/crates/engine/tests/per_dir_merge_traversal.rs
@@ -1,0 +1,149 @@
+//! Integration tests for per-directory merge (`dir-merge`) traversal in the
+//! engine local-copy path, mirroring the LOCAL legs of upstream's
+//! `testsuite/exclude.test`.
+//!
+//! These exercise three behaviours that upstream `exclude.c` defines for
+//! per-directory merge files and that must hold during the copy walk - not the
+//! deletion pass. The files under test enter the transfer purely on the merge
+//! rules; no `--delete` is involved.
+//!
+//! # Upstream Reference
+//!
+//! - `exclude.c:200-207 add_rule` - an anchored pattern loaded from a per-dir
+//!   merge file is rooted at the merge file's directory, not the transfer root.
+//! - `exclude.c:1248-1255 parse_rule_tok` - the `:C` modifier registers a
+//!   `.cvsignore` per-directory merge.
+//! - `exclude.c:787-789 push_local_filters` - the push loop walks the GROWING
+//!   `mergelist_cnt`, so a `dir-merge` directive registered while loading a
+//!   directory's merge file is itself loaded against that same directory.
+
+use std::fs;
+use std::path::Path;
+
+use engine::local_copy::{
+    DirMergeOptions, DirMergeRule, FilterProgram, FilterProgramEntry, LocalCopyExecution,
+    LocalCopyOptions, LocalCopyPlan,
+};
+use tempfile::tempdir;
+
+/// Runs a recursive local copy from `source` to `dest` using a filter program
+/// that registers `dir-merge .filt` (the per-directory merge filename used
+/// throughout upstream `exclude.test`).
+fn copy_with_dir_merge(source: &Path, dest: &Path) {
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".filt",
+        DirMergeOptions::default(),
+    ))])
+    .expect("filter program compiles");
+
+    let operands = vec![
+        source.to_path_buf().into_os_string(),
+        dest.to_path_buf().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::new()
+        .recursive(true)
+        .with_filter_program(Some(program));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+}
+
+/// `- /file1` inside `foo/.filt` is anchored to the merge file's directory, so
+/// it must exclude `foo/file1` while leaving `foo/sub/file1` (a deeper path
+/// that the anchor does not reach) transferred.
+///
+/// upstream: exclude.c:200-207 add_rule prepends `dirbuf + module_dirlen` to a
+/// leading-`/` pattern, turning `- /file1` in `foo/.filt` into an anchored
+/// `foo/file1` rule. Without that prefix the anchor would (wrongly) bind to the
+/// transfer root and match nothing, leaking `foo/file1` into the destination.
+#[test]
+fn anchored_rule_in_per_dir_merge_anchors_at_merge_file_directory() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(source.join("foo/sub")).expect("mkdir");
+
+    fs::write(source.join("foo/.filt"), "- /file1\n").expect("write .filt");
+    fs::write(source.join("foo/file1"), b"excluded").expect("write file1");
+    fs::write(source.join("foo/sub/file1"), b"kept").expect("write sub/file1");
+
+    copy_with_dir_merge(&source, &dest);
+
+    assert!(
+        !dest.join("foo/file1").exists(),
+        "`- /file1` in foo/.filt must exclude the anchored foo/file1",
+    );
+    assert!(
+        dest.join("foo/sub/file1").exists(),
+        "the anchor must not reach the deeper foo/sub/file1",
+    );
+}
+
+/// `:C` inside `mid/.filt` registers `.cvsignore` as a per-directory CVS-ignore
+/// source that applies to the directory containing the merge file. The
+/// `mid/.cvsignore` listing `one-in-one-out` must therefore exclude
+/// `mid/one-in-one-out`.
+///
+/// upstream: exclude.c:1248-1255 - the `C` modifier on a `:` (dir-merge) rule
+/// sets `FILTRULE_CVS_IGNORE` with the `.cvsignore` default; exclude.c:787-789
+/// then loads that registration against the current directory (not only
+/// subdirectories) because the push loop walks the growing mergelist count.
+#[test]
+fn cvs_modifier_in_per_dir_merge_loads_cvsignore_for_current_dir() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(source.join("mid")).expect("mkdir");
+
+    fs::write(source.join("mid/.filt"), ":C\n").expect("write .filt");
+    fs::write(source.join("mid/.cvsignore"), "one-in-one-out\n").expect("write .cvsignore");
+    fs::write(source.join("mid/one-in-one-out"), b"excluded").expect("write target");
+    fs::write(source.join("mid/one-for-all"), b"kept").expect("write keeper");
+
+    copy_with_dir_merge(&source, &dest);
+
+    assert!(
+        !dest.join("mid/one-in-one-out").exists(),
+        ":C in mid/.filt must load mid/.cvsignore and exclude one-in-one-out",
+    );
+    assert!(
+        dest.join("mid/one-for-all").exists(),
+        "files not listed in .cvsignore must still transfer",
+    );
+}
+
+/// A `dir-merge .filt2` registered inside `bar/.filt` must take effect in the
+/// directory that holds the registering file and all of its descendants. The
+/// `bar/.filt2` rule `- *.deep` must therefore exclude `bar/baz/file5.deep`,
+/// which lives in a sub-subdirectory below the registration point.
+///
+/// upstream: exclude.c:787-789 push_local_filters - registering a per-dir merge
+/// while loading `bar/.filt` grows `mergelist_cnt`, so `bar/.filt2` is loaded
+/// for `bar/` itself; exclude.c:801 sets `lp->tail = NULL`, keeping the loaded
+/// rule in `lp->head` so it continues matching descendants like
+/// `bar/baz/file5.deep`.
+#[test]
+fn same_dir_nested_dir_merge_applies_to_current_dir_and_descendants() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(source.join("bar/baz")).expect("mkdir");
+
+    fs::write(source.join("bar/.filt"), "dir-merge .filt2\n").expect("write .filt");
+    fs::write(source.join("bar/.filt2"), "- *.deep\n").expect("write .filt2");
+    fs::write(source.join("bar/baz/file5.deep"), b"excluded").expect("write deep");
+    fs::write(source.join("bar/baz/keep.txt"), b"kept").expect("write keep");
+
+    copy_with_dir_merge(&source, &dest);
+
+    assert!(
+        !dest.join("bar/baz/file5.deep").exists(),
+        "bar/.filt2's `- *.deep` (registered by bar/.filt) must exclude the \
+         descendant bar/baz/file5.deep",
+    );
+    assert!(
+        dest.join("bar/baz/keep.txt").exists(),
+        "non-matching descendants must still transfer",
+    );
+}

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -484,6 +484,17 @@ impl FilterRule {
         }
         self
     }
+
+    /// Returns the rule with its pattern text replaced, preserving every other
+    /// attribute (action, side flags, perishability, negation, modifiers).
+    ///
+    /// Used to re-anchor a per-directory merge rule against the merge file's
+    /// directory without rebuilding the rule from scratch.
+    #[must_use]
+    pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.pattern = pattern.into();
+        self
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes three per-directory merge (`dir-merge`) behaviours in the engine local-copy traversal so that the LOCAL legs of the upstream `exclude` testsuite pass. This is the local-copy path only; the receiver/network path is untouched. The bugs cause files that upstream excludes (`foo/file1`, `mid/one-in-one-out`, `bar/down/to/bar/baz/file5.deep`) to be wrongly kept and transferred during a plain copy.

## Root causes and fixes

1. **Anchored pattern in a per-dir merge anchors at transfer root, not the merge file's directory.** A leading-`/` rule loaded from `foo/.filt` (e.g. `- /file1`) is now rewritten to `/foo/file1`, mirroring `add_rule` prepending `dirbuf + module_dirlen` (`exclude.c:200-207`). Adds `FilterRule::with_pattern` and threads the directory's transfer-root-relative path into the merge loader.

2. **A `dir-merge`/`:C` directive registered while loading a directory's own merge file is only applied to subdirectories.** A growing active-rule loop now re-scans newly registered nested rules against the current directory, mirroring `push_local_filters` walking the growing `mergelist_cnt` (`exclude.c:787-789`). This makes `:C` in `mid/.filt` load `mid/.cvsignore` for `mid/` itself, and a same-directory `dir-merge .filt2` apply to that directory.

3. **Loaded nested dir-merge segments do not inherit into subdirectories.** Inheritable loaded segments now accumulate into child frames so a rule loaded at an ancestor depth keeps matching descendants, mirroring `push_local_filters` setting `lp->tail = NULL` while keeping `lp->head` (`exclude.c:801`). Non-inheritable (`n`/`C` modifier) segments are dropped from child frames.

## Code sites changed

- `crates/filters/src/rule.rs` — add `FilterRule::with_pattern` builder (preserves all other attributes).
- `crates/engine/src/local_copy/context.rs` — `LoadedDynamicSegment` (segment + inherit flag), `LoadedNestedDirMerge`, and `anchor_dir_merge_rule` (re-anchors a leading-`/` pattern at the merge file's directory).
- `crates/engine/src/local_copy/context_impl/transfer.rs` — thread `relative_dir` into `enter_directory*`; seed child frames with inheritable parent segments; growing active-rule loop loads same-directory nested dir-merges; `load_nested_dir_merge` helper.
- `crates/engine/src/local_copy/context_impl/options/filter.rs` — read the new tagged loaded-segment shape.
- `crates/engine/src/local_copy/executor/directory/recursive/mod.rs`, `crates/engine/src/local_copy/executor/cleanup.rs` — pass the directory's relative path to the merge loader.

## Tests

New engine integration test `crates/engine/tests/per_dir_merge_traversal.rs`:
- `anchored_rule_in_per_dir_merge_anchors_at_merge_file_directory` — `- /file1` in `foo/.filt` excludes `foo/file1` but not `foo/sub/file1`.
- `cvs_modifier_in_per_dir_merge_loads_cvsignore_for_current_dir` — `:C` in `mid/.filt` loads `mid/.cvsignore` and excludes `one-in-one-out`.
- `same_dir_nested_dir_merge_applies_to_current_dir_and_descendants` — `dir-merge .filt2` in `bar/.filt` applies `bar/.filt2` (`- *.deep`) to `bar/baz/file5.deep`.

Each test encodes the upstream parity rationale in its rustdoc.