### PR TITLE
test(engine): gate POSIX-absolute reference test to Unix

### DIFF
--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -316,6 +316,11 @@ mod tests {
         assert_eq!(result, PathBuf::from("/dest/backup"));
     }
 
+    // POSIX-absolute path: `/ref/../other` is only absolute on Unix. On Windows
+    // it lacks a drive letter, so `is_absolute()` is false and the relative
+    // branch lexically normalizes away the `..`. Gate to Unix where the absolute
+    // branch is exercised; real Windows paths (`C:\...`) hit the same branch.
+    #[cfg(unix)]
     #[test]
     fn resolve_dotdot_in_base() {
         let base = Path::new("/ref/../other");


### PR DESCRIPTION
## Problem

The entire master CI red set traces to a single Windows-only test failure: `engine::local_copy::executor::reference::tests::resolve_dotdot_in_base` panics on Windows (beta/nightly/stable), which cascades into the Windows feature-flag-combination and Windows interop cells.

## Root cause

The test asserts the absolute-path branch of `resolve_reference_candidate`:

```rust
let base = Path::new("/ref/../other");
// base is absolute, so just join
assert_eq!(result, PathBuf::from("/ref/../other/file.txt"));
```

`/ref/../other` is absolute on Unix, so the function takes the `base.join(relative)` branch and preserves the `..` literally. On Windows the same string is **not** absolute (it lacks a drive letter like `C:\`), so `is_absolute()` returns false, the function takes the relative branch, and `lexically_normalize` collapses `..` into `/other/file.txt` — diverging from the asserted value.

This is a test-portability bug only. The function itself is correct for real Windows paths (`C:\...`), which exercise the same absolute branch. The sibling tests in this module pass on Windows by coincidence (relative-branch inputs that reproduce identically).

## Fix

Gate the single divergent test with `#[cfg(unix)]`, where the absolute branch is actually exercised. Surgical, no production-code change.

Windows CI is the authoritative oracle here.