### PR TITLE
fix(itemize): suppress server-side itemize emission to match upstream

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -267,10 +267,14 @@ impl GeneratorContext {
 
     /// Emits itemize output when conditions are met.
     ///
-    /// In server mode (daemon/SSH), sends the formatted itemize string
-    /// (`"%i %n%L\n"`) as a MSG_INFO multiplexed message to the client.
-    /// In client mode, writes directly to the process stdout via the
-    /// itemize callback, matching upstream's `rwrite()` `FCLIENT` path.
+    /// Emits the per-file itemize line, but ONLY in client mode. Upstream
+    /// `log.c:812 log_item()` gates the `FCLIENT` itemize emission on
+    /// `!am_server`: a server process (sender OR receiver) never prints its own
+    /// itemize row - the client always computes and prints it (the generator
+    /// ships the `iflags` over the wire, not the rendered text). Emitting from
+    /// the server duplicated the client's row, producing a spurious sender
+    /// `<f...` line alongside the receiver `>f...` line under `-ii` over a
+    /// remote shell (upstream `exclude-lsh.test` `-aiiO --update` leg).
     ///
     /// Upstream `generator.c:582-583` emits when ANY of four OR'd conditions
     /// hold: significant flags set, `INFO_GTE(NAME, 2)`, `stdout_format_has_i
@@ -280,21 +284,29 @@ impl GeneratorContext {
     ///
     /// # Upstream Reference
     ///
+    /// - `log.c:812-820` - `log_item()`: `code != FLOG && stdout_format &&
+    ///   !am_server` gates the `log_formatted(FCLIENT, ...)` itemize emission;
+    ///   the server's only itemize output is to its local `logfile`, never the
+    ///   client stream.
     /// - `generator.c:582-583` - emit gate: `(iflags & (SIGNIFICANT_ITEM_FLAGS
     ///   | ITEM_REPORT_XATTR)) || INFO_GTE(NAME, 2) || stdout_format_has_i > 1
     ///   || (xname && *xname)`
     /// - `sender.c:287` - `maybe_log_item()` for non-transfer items
     /// - `sender.c:430` - `log_item()` after file transfer
-    /// - `log.c:330-340` - `rwrite()`: when `am_server`, sends MSG_INFO;
-    ///   when `!am_server`, writes to stdout (FCLIENT)
     pub(super) fn maybe_emit_itemize<W: Write>(
         &self,
-        writer: &mut super::super::writer::ServerWriter<W>,
+        _writer: &mut super::super::writer::ServerWriter<W>,
         iflags: &super::item_flags::ItemFlags,
         ndx: usize,
         itemize_cb: &mut Option<&mut dyn super::super::ItemizeCallback>,
     ) -> io::Result<()> {
         if !self.config.flags.info_flags.itemize {
+            return Ok(());
+        }
+        // upstream: log.c:812 log_item() - only the client (`!am_server`) renders
+        // the itemize line; a server sender/receiver stays silent so it does not
+        // duplicate the client's row over MSG_INFO.
+        if !self.config.connection.client_mode {
             return Ok(());
         }
         // upstream: generator.c:582-583 - the gate is the OR of four
@@ -318,15 +330,12 @@ impl GeneratorContext {
         // Generator role is always the sender side
         let line = super::itemize::format_itemize_line(iflags, entry, true, &ctx);
 
-        if self.config.connection.client_mode {
-            // upstream: log.c:330-340 - when !am_server, rwrite() sends to FCLIENT (stdout)
-            if let Some(cb) = itemize_cb.as_mut() {
-                cb.on_itemize(&line);
-            }
-            Ok(())
-        } else {
-            writer.send_message(protocol::MessageCode::Info, line.as_bytes())
+        // upstream: log.c:818 - `log_formatted(FCLIENT, ...)` writes to stdout on
+        // the client. Reached only in client mode (server returned early above).
+        if let Some(cb) = itemize_cb.as_mut() {
+            cb.on_itemize(&line);
         }
+        Ok(())
     }
 
     /// Sends the file list to the receiver.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -4241,4 +4241,63 @@ mod itemize_emit_gate {
             "ITEM_XNAME_FOLLOWS must force an itemize line under upstream gate; got: {lines:?}"
         );
     }
+
+    /// upstream: log.c:812 `log_item()` gates `log_formatted(FCLIENT, ...)` on
+    /// `!am_server`. A server process (sender OR receiver) must NOT emit its own
+    /// itemize row - the client computes and prints it. Emitting from the server
+    /// produced a spurious sender `<f...` line that duplicated the client's
+    /// `>f...` row under `-ii` over a remote shell (`exclude-lsh.test`).
+    #[test]
+    fn server_mode_does_not_emit_itemize() {
+        init(VerbosityConfig::default());
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.connection.client_mode = false;
+        config.flags.info_flags.itemize = true;
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        ctx.file_list.push(protocol::flist::FileEntry::new_file(
+            "config1".into(),
+            42,
+            0o644,
+        ));
+
+        let captured: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let lines = Rc::clone(&captured);
+        let mut sink = move |line: &str| {
+            lines.borrow_mut().push(line.to_owned());
+        };
+        let mut callback: Option<&mut dyn crate::ItemizeCallback> = Some(&mut sink);
+
+        // Route the wire through a shared buffer so the test can prove no
+        // MSG_INFO itemize frame is multiplexed to the client.
+        struct SharedBuf(Rc<RefCell<Vec<u8>>>);
+        impl std::io::Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.borrow_mut().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let wire: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::new()));
+        let mut writer = crate::writer::ServerWriter::new_plain(SharedBuf(Rc::clone(&wire)));
+        // ITEM_XNAME_FOLLOWS would force emission in client mode; the server
+        // role must suppress it entirely.
+        let iflags = ItemFlags::from_raw(ItemFlags::ITEM_XNAME_FOLLOWS);
+        ctx.maybe_emit_itemize(&mut writer, &iflags, 0, &mut callback)
+            .expect("maybe_emit_itemize must not error in server mode");
+
+        assert!(
+            captured.borrow().is_empty(),
+            "server role must not emit an itemize line to the client callback; got: {:?}",
+            captured.borrow()
+        );
+        assert!(
+            wire.borrow().is_empty(),
+            "server role must not multiplex a MSG_INFO itemize frame to the client; got {} bytes",
+            wire.borrow().len()
+        );
+    }
 }


### PR DESCRIPTION
## Problem

The upstream testsuite `exclude-lsh.test` fails on its `-aiiO --update` leg. With oc-rsync as the remote `--server --sender` (invoked via the test's `lsh.sh` remote shell) and upstream rsync as the local client-receiver, oc-rsync emits an extra sender-direction itemize line for every transferred file:

```
  >f+++++++++ extra-src
+ <f+++++++++ extra-src      # oc-rsync over-emits
  >f..t...... src-newness
+ <f..t...... src-newness    # oc-rsync over-emits
```

Upstream prints only the receiver `>f...` rows.

## Root cause

Upstream `log.c:812 log_item()` gates the per-file itemize emission to the client on `!am_server`:

```c
if (code != FLOG && stdout_format && !am_server)
    log_formatted(FCLIENT, stdout_format, s_or_r, file, NULL, iflags, hlink);
```

A server process (sender **or** receiver) never renders its own itemize row; the client always computes and prints it (the generator ships the `iflags` over the wire, not the rendered text). oc-rsync's `maybe_emit_itemize` instead multiplexed the line as a `MSG_INFO` frame whenever the process was not in client mode, so the server-sender's `<f...` lines leaked to the client and duplicated its `>f...` rows under `-ii`.

## Fix

`maybe_emit_itemize` now returns early when the process is a server (`!client_mode`, oc-rsync's equivalent of `am_server`), mirroring upstream's `!am_server` gate. The client-mode callback path that local transfers and the client-receiver/client-sender use is unchanged.

A regression test (`server_mode_does_not_emit_itemize`) asserts the server role emits to neither the itemize callback nor the wire.

## Verification (Linux host, upstream testsuite vs upstream rsync)

- `exclude-lsh` — now **PASS** (was FAIL)
- No regression: `exclude`, `itemize`, `dirs`, `output-options`, `00-hello`, `delete`, `daemon` all PASS
- `cargo nextest run -p transfer -E 'test(itemize_emit_gate)'` — 4 passed