### PR TITLE
fix(cli): accept repeated -i/--itemize-changes like upstream

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -601,7 +601,7 @@ where
         } else {
             ProgressSetting::Unspecified
         };
-    let itemize_changes_flag = matches.get_flag("itemize-changes");
+    let itemize_changes_flag = matches.get_count("itemize-changes") > 0;
     let no_itemize_changes_flag = matches.get_flag("no-itemize-changes");
     let name_overridden = itemize_changes_flag || no_itemize_changes_flag;
     let mut verbosity = matches.get_count("verbose") as u8;

--- a/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
+++ b/crates/cli/src/frontend/command_builder/sections/build_base_command/output.rs
@@ -94,11 +94,15 @@ pub(super) fn add_output_args(command: ClapCommand) -> ClapCommand {
                 .value_parser(OsStringValueParser::new()),
         )
         .arg(
+            // upstream: options.c - `-i`/`--itemize-changes` is a repeatable
+            // counter (`-ii` raises itemize detail), so accept multiple
+            // occurrences via Count rather than SetTrue, which clap rejects on
+            // repeat with "cannot be used multiple times".
             Arg::new("itemize-changes")
                 .long("itemize-changes")
                 .short('i')
                 .help("Output a change summary for each updated entry.")
-                .action(ArgAction::SetTrue)
+                .action(ArgAction::Count)
                 .overrides_with("no-itemize-changes"),
         )
         .arg(

--- a/crates/cli/src/frontend/tests/parse_args_recognises_itemize.rs
+++ b/crates/cli/src/frontend/tests/parse_args_recognises_itemize.rs
@@ -29,6 +29,22 @@ fn parse_args_recognises_no_itemize_changes_flag() {
 }
 
 #[test]
+fn parse_args_accepts_repeated_itemize_changes() {
+    // upstream accepts repeated -i (`-ii` raises itemize detail); clap must not
+    // reject the second occurrence with "cannot be used multiple times".
+    let parsed = parse_args([
+        OsString::from(RSYNC),
+        OsString::from("-i"),
+        OsString::from("-i"),
+        OsString::from("source"),
+        OsString::from("dest"),
+    ])
+    .expect("parse");
+
+    assert!(parsed.itemize_changes);
+}
+
+#[test]
 fn parse_args_prefers_last_itemize_toggle() {
     let disabled = parse_args([
         OsString::from(RSYNC),


### PR DESCRIPTION
## Problem

Upstream rsync treats `-i`/`--itemize-changes` as a repeatable counter (`-ii` raises itemize detail). oc-rsync declared the arg with `ArgAction::SetTrue`, so clap rejected any repeated occurrence with `the argument '--itemize-changes' cannot be used multiple times`. Invocations like `-rii` or `-aii` exited 1 before performing any work — a drop-in incompatibility with upstream.

## Fix

- Switch `--itemize-changes` from `ArgAction::SetTrue` to `ArgAction::Count`.
- Read it via `get_count() > 0` instead of `get_flag()`.
- The mutual `overrides_with` between `itemize-changes` and `no-itemize-changes` is preserved, so last-wins toggling is unchanged.

## Tests

Adds `parse_args_accepts_repeated_itemize_changes` asserting repeated `-i` parses successfully. Existing override tests (`parse_args_prefers_last_itemize_toggle`) continue to validate last-wins semantics under the new action.