### PR TITLE
chore(deps): bump zlib-rs to 0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,9 +5065,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
Repins the transitive `zlib-rs` dependency from 0.6.3 to 0.6.4 in `Cargo.lock`.

## What changed upstream (0.6.4)

- adler32 correctness fix for aarch64 NEON (off-by-one in the SIMD path) and an Intel Raptor Lake workaround.
- infback aliasing fix and input-validation hardening.
- MSRV unchanged (1.75); API is additive; this is a semver patch release.

## Impact on this workspace: none

- `zlib-rs` is **not** the active zlib backend here. The default backend is `zlib-ng` (C SIMD); `zlib-rs` is opt-in via the `zlib-rs` feature on the `compress`/`protocol` crates and is not enabled by default.
- All deflate access goes through the `flate2` API; there are no direct `zlib_rs::` calls in the tree.
- rsync's wire codec uses raw deflate (negative window bits, no zlib adler32 trailer) plus crc32, so the adler32 changes do not alter any compressed bytes oc-rsync emits.
- Golden/wire tests assert framing, not backend deflate bytes, so they are unaffected.

Lockfile-only change (2 lines). No source changes.