### PR TITLE
fix(verbose): append trailing slash to local-copy dir listings

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -486,6 +486,28 @@ fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
             .is_some()
 }
 
+/// Renders an event's path for the verbose file listing, mirroring upstream
+/// `f_name()` (flist.c): directory names carry a trailing `/` and the transfer
+/// root (`.`) renders as `./`. Non-directory entries render verbatim. This
+/// matches the receiver-side verbose path (receiver/transfer/sync.rs) so a
+/// local-copy `-v`/`--info=name` listing agrees with upstream.
+///
+/// upstream: log.c:639-640 - the `%n` token strlcat()s a `/` for S_ISDIR
+/// entries; the transfer root is listed as `./`.
+fn verbose_listing_name(event: &ClientEvent) -> String {
+    let path = event.relative_path();
+    if matches!(
+        event.metadata().map(ClientEntryMetadata::kind),
+        Some(ClientEntryKind::Directory)
+    ) {
+        if path.as_os_str() == "." {
+            return String::from("./");
+        }
+        return format!("{}/", path.display());
+    }
+    path.to_string_lossy().into_owned()
+}
+
 /// Renders verbose listings for the provided transfer events.
 pub(crate) fn emit_verbose<W: Write + ?Sized>(
     events: &[ClientEvent],
@@ -547,7 +569,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
 
-            let mut rendered = event.relative_path().to_string_lossy().into_owned();
+            let mut rendered = verbose_listing_name(event);
             if matches!(kind, ClientEventKind::SymlinkCopied)
                 && let Some(metadata) = event.metadata()
                 && let Some(target) = metadata.symlink_target()
@@ -709,7 +731,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             _ => {}
         }
 
-        let mut rendered = event.relative_path().to_string_lossy().into_owned();
+        let mut rendered = verbose_listing_name(event);
         if matches!(kind, ClientEventKind::SymlinkCopied)
             && let Some(metadata) = event.metadata()
             && let Some(target) = metadata.symlink_target()

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -496,16 +496,25 @@ fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
 /// entries; the transfer root is listed as `./`.
 fn verbose_listing_name(event: &ClientEvent) -> String {
     let path = event.relative_path();
-    if matches!(
+    let is_dir = matches!(
         event.metadata().map(ClientEntryMetadata::kind),
         Some(ClientEntryKind::Directory)
-    ) {
-        if path.as_os_str() == "." {
-            return String::from("./");
-        }
-        return format!("{}/", path.display());
+    );
+    if is_dir && path.as_os_str() == "." {
+        return String::from("./");
     }
-    path.to_string_lossy().into_owned()
+    let mut rendered = path.to_string_lossy().into_owned();
+    // upstream: flist.c f_name() emits POSIX forward-slash separators
+    // regardless of host OS. Normalize Windows native backslashes at the
+    // rendering boundary; storage retains the platform-native form.
+    #[cfg(windows)]
+    {
+        rendered = rendered.replace('\\', "/");
+    }
+    if is_dir {
+        rendered.push('/');
+    }
+    rendered
 }
 
 /// Renders verbose listings for the provided transfer events.

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1476,15 +1476,15 @@ fn verbose_directory_listing_has_trailing_slash_and_root_row() {
     let rendered = String::from_utf8(stdout).expect("utf8");
     let lines: Vec<&str> = rendered.lines().collect();
     assert!(
-        lines.iter().any(|line| *line == "./"),
+        lines.contains(&"./"),
         "expected a `./` root row in the verbose listing, got: {rendered:?}"
     );
     assert!(
-        lines.iter().any(|line| *line == "sub/"),
+        lines.contains(&"sub/"),
         "expected directory `sub/` with a trailing slash, got: {rendered:?}"
     );
     assert!(
-        lines.iter().any(|line| *line == "sub/file.txt"),
+        lines.contains(&"sub/file.txt"),
         "expected the file row `sub/file.txt`, got: {rendered:?}"
     );
 }

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1445,3 +1445,46 @@ fn itemize_hardlink_already_linked_omits_arrow_suffix() {
         "already-linked hardlink row must omit `=> leader.bin` (upstream hlink.c:218-222 passes empty xname to itemize), got: {rendered:?}"
     );
 }
+
+/// Verifies that `-rv` lists directories with a trailing `/` and emits a `./`
+/// root row for the transfer root, matching upstream rsync's `f_name()`
+/// formatting (flist.c / log.c:639-640, where `%n` appends `/` for S_ISDIR and
+/// the root is shown as `./`). The destination is created fresh so every
+/// directory is freshly created and reaches the bare-name emission path.
+#[test]
+fn verbose_directory_listing_has_trailing_slash_and_root_row() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source = tmp.path().join("src");
+    let sub = source.join("sub");
+    std::fs::create_dir_all(&sub).expect("create source tree");
+    std::fs::write(sub.join("file.txt"), b"data").expect("write file");
+    let destination = tmp.path().join("dst");
+
+    let mut src_arg = source.into_os_string();
+    src_arg.push("/");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-rv"),
+        src_arg,
+        destination.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "stderr: {}", String::from_utf8_lossy(&stderr));
+    let rendered = String::from_utf8(stdout).expect("utf8");
+    let lines: Vec<&str> = rendered.lines().collect();
+    assert!(
+        lines.iter().any(|line| *line == "./"),
+        "expected a `./` root row in the verbose listing, got: {rendered:?}"
+    );
+    assert!(
+        lines.iter().any(|line| *line == "sub/"),
+        "expected directory `sub/` with a trailing slash, got: {rendered:?}"
+    );
+    assert!(
+        lines.iter().any(|line| *line == "sub/file.txt"),
+        "expected the file row `sub/file.txt`, got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
## Summary

The plain `-v` / `--info=name` file listing rendered freshly created directories with their bare path, and the transfer root as a bare `.`, diverging from upstream rsync.

Upstream's `f_name()` (the `%n` token in `log.c`) appends a trailing `/` to directory names, and lists the transfer root as `./`. The remote receiver path (`receiver/transfer/sync.rs`) already does this correctly; only the local-copy CLI renderer (`crates/cli/src/frontend/progress/render.rs`) diverged.

## Change

Add a `verbose_listing_name()` helper that mirrors upstream:
- directories render with a trailing `/`
- the transfer root renders as `./`
- non-directory entries render verbatim

Applied at both verbose-listing emission sites in `emit_verbose`. Itemize (`-i`) output is unaffected (it is gated separately and already emits `cd+++ ./` rows).

## Observable effect

```
$ oc-rsync -rv src/ dst/   # dst/ freshly created
./
sub/
sub/file.txt
```

Previously the root `./` row was absent and `sub` lacked its trailing slash.

## Tests

Adds `verbose_directory_listing_has_trailing_slash_and_root_row` (real-transfer harness) asserting the listing contains `./`, `sub/`, and `sub/file.txt`.

Mirrors upstream: `log.c:639-640`.