### PR TITLE
fix(verbose): match upstream "deleting %n" for dir deletions

### DIFF
--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -327,7 +327,10 @@ fn apply_delete_side_effects(
             context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
         }
         if is_dir {
-            info_log!(Del, 1, "deleting directory {}", entry_relative.display());
+            // upstream: log.c:log_delete emits "deleting %n"; f_name appends a
+            // trailing slash for directories and never inserts the word
+            // "directory".
+            info_log!(Del, 1, "deleting {}/", entry_relative.display());
         } else {
             info_log!(Del, 1, "deleting {}", entry_relative.display());
         }
@@ -385,7 +388,9 @@ fn record_directory_subtree(
         })?;
         if file_type.is_dir() {
             record_directory_subtree(context, path_buf, relative_buf)?;
-            info_log!(Del, 1, "deleting directory {}", relative_buf.display());
+            // upstream: log.c:log_delete "deleting %n" - trailing slash for
+            // dirs, no "directory" word.
+            info_log!(Del, 1, "deleting {}/", relative_buf.display());
         } else {
             info_log!(Del, 1, "deleting {}", relative_buf.display());
         }


### PR DESCRIPTION
## Summary

Match upstream rsync's `deleting %n` output for directory deletions in the
local-copy `--delete` verbose path.

Upstream `log.c:log_delete` emits a uniform `deleting %n` line for every
deleted entry. The `%n` token (`f_name`) appends a trailing slash for
directories and never inserts the word "directory". oc-rsync diverged on
both points for directory deletes in the engine local-copy executor:

- printed `deleting directory sub` instead of `deleting sub/`
- omitted the trailing slash on directory names

This change drops the literal "directory" word and appends `/` for
directory entries at the two `is_dir` branches in
`crates/engine/src/local_copy/executor/cleanup.rs`, so `-av --delete` now
emits `deleting sub/`, matching upstream byte-for-byte.

File and symlink deletion lines are unchanged. The relative path basis is
already transfer-root-relative at these sites.

## Verification

Verified against upstream rsync 3.4.3: a local-copy `-av --delete` run that
removes a directory now emits `deleting sub/` instead of
`deleting directory sub`.

- `cargo fmt --all -- --check` clean
- `cargo clippy -p engine --all-features --all-targets --no-deps -- -D warnings` clean
