### PR TITLE
fix(verbose): suppress plain deletion line under -i and slash itemized dir rows

### DIFF
--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -140,7 +140,11 @@ fn render_path(event: &ClientEvent, ensure_trailing_slash: bool) -> String {
     if ensure_trailing_slash
         && !rendered.ends_with('/')
         && event.metadata().map(ClientEntryMetadata::kind).map_or_else(
-            || matches!(event.kind(), ClientEventKind::DirectoryCreated),
+            // upstream: log.c:639-640 - %n appends `/` for any directory entry.
+            // `EntryDeleted` rows carry no metadata snapshot, so fall back to the
+            // record's directory bit (set by the engine cleanup pass) alongside
+            // the freshly-created-directory case.
+            || matches!(event.kind(), ClientEventKind::DirectoryCreated) || event.is_directory(),
             ClientEntryKind::is_directory,
         )
     {

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -640,6 +640,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
         config: &ClientConfig,
     ) -> LocalCopyOptions {
         options
+            .itemize_active(config.itemize_changes())
             .checksum(config.checksum())
             .with_checksum_algorithm(config.checksum_signature_algorithm())
             .enable_xxh64_dedup(config.xxh64_dedup())

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -82,6 +82,7 @@ pub struct ClientEvent {
     destination_path: PathBuf,
     change_set: LocalCopyChangeSet,
     hardlink_uptodate: bool,
+    is_directory: bool,
 }
 
 impl ClientEvent {
@@ -98,6 +99,7 @@ impl ClientEvent {
             was_created,
             change_set,
             hardlink_uptodate,
+            is_directory,
         ) = record.into_parts();
         let kind = match &action {
             LocalCopyAction::DataCopied => ClientEventKind::DataCopied,
@@ -170,6 +172,7 @@ impl ClientEvent {
             destination_path,
             change_set,
             hardlink_uptodate,
+            is_directory,
         }
     }
 
@@ -193,6 +196,7 @@ impl ClientEvent {
             destination_path,
             change_set: LocalCopyChangeSet::new(),
             hardlink_uptodate: false,
+            is_directory: false,
         }
     }
 
@@ -234,6 +238,16 @@ impl ClientEvent {
     #[must_use]
     pub const fn was_created(&self) -> bool {
         self.created
+    }
+
+    /// Returns whether the event describes a directory entry.
+    ///
+    /// Carried for `EntryDeleted` records, which lack a metadata snapshot, so
+    /// the renderer can still append the upstream `%n` trailing slash to a
+    /// deleted-directory row (e.g. `*deleting sub/`).
+    #[must_use]
+    pub const fn is_directory(&self) -> bool {
+        self.is_directory
     }
 
     /// Returns whether the event describes a hardlink whose destination
@@ -288,6 +302,7 @@ impl ClientEvent {
             destination_path,
             change_set,
             hardlink_uptodate: false,
+            is_directory: false,
         }
     }
 

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -326,23 +326,30 @@ fn apply_delete_side_effects(
         if !context.mode().is_dry_run() {
             context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
         }
-        if is_dir {
-            // upstream: log.c:log_delete emits "deleting %n"; f_name appends a
-            // trailing slash for directories and never inserts the word
-            // "directory".
-            info_log!(Del, 1, "deleting {}/", entry_relative.display());
-        } else {
-            info_log!(Del, 1, "deleting {}", entry_relative.display());
+        // upstream: log.c:log_delete emits exactly ONE line - the itemize
+        // format when stdout_format_has_o_or_i, otherwise "deleting %n".
+        // Suppress the plain line when itemize is active so only the
+        // `*deleting` record renders; f_name appends a trailing slash for
+        // directories and never inserts the word "directory".
+        if !context.options().is_itemize_active() {
+            if is_dir {
+                info_log!(Del, 1, "deleting {}/", entry_relative.display());
+            } else {
+                info_log!(Del, 1, "deleting {}", entry_relative.display());
+            }
         }
         context.summary_mut().record_deletion();
-        context.record(LocalCopyRecord::new(
-            entry_relative,
-            LocalCopyAction::EntryDeleted,
-            0,
-            None,
-            Duration::default(),
-            None,
-        ));
+        context.record(
+            LocalCopyRecord::new(
+                entry_relative,
+                LocalCopyAction::EntryDeleted,
+                0,
+                None,
+                Duration::default(),
+                None,
+            )
+            .with_directory(is_dir),
+        );
         context.register_progress();
     }
     Ok(())
@@ -386,23 +393,32 @@ fn record_directory_subtree(
                 error,
             )
         })?;
-        if file_type.is_dir() {
+        let is_dir = file_type.is_dir();
+        if is_dir {
             record_directory_subtree(context, path_buf, relative_buf)?;
-            // upstream: log.c:log_delete "deleting %n" - trailing slash for
-            // dirs, no "directory" word.
-            info_log!(Del, 1, "deleting {}/", relative_buf.display());
-        } else {
-            info_log!(Del, 1, "deleting {}", relative_buf.display());
+        }
+        // upstream: log.c:log_delete emits one line; suppress the plain
+        // "deleting %n" when itemize is active. f_name appends a trailing
+        // slash for dirs and never inserts the word "directory".
+        if !context.options().is_itemize_active() {
+            if is_dir {
+                info_log!(Del, 1, "deleting {}/", relative_buf.display());
+            } else {
+                info_log!(Del, 1, "deleting {}", relative_buf.display());
+            }
         }
         context.summary_mut().record_deletion();
-        context.record(LocalCopyRecord::new(
-            relative_buf.clone(),
-            LocalCopyAction::EntryDeleted,
-            0,
-            None,
-            Duration::default(),
-            None,
-        ));
+        context.record(
+            LocalCopyRecord::new(
+                relative_buf.clone(),
+                LocalCopyAction::EntryDeleted,
+                0,
+                None,
+                Duration::default(),
+                None,
+            )
+            .with_directory(is_dir),
+        );
         context.register_progress();
         relative_buf.pop();
         path_buf.pop();

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -45,6 +45,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) delete_timing: DeleteTiming,
     pub(super) delete_excluded: bool,
     pub(super) delete_missing_args: bool,
+    pub(super) itemize_active: bool,
     pub(super) max_deletions: Option<u64>,
 
     pub(super) min_file_size: Option<u64>,
@@ -182,6 +183,7 @@ impl LocalCopyOptionsBuilder {
             delete_timing: DeleteTiming::default(),
             delete_excluded: false,
             delete_missing_args: false,
+            itemize_active: false,
             max_deletions: None,
             min_file_size: None,
             max_file_size: None,

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -109,6 +109,7 @@ impl LocalCopyOptionsBuilder {
             delete_timing: self.delete_timing,
             delete_excluded: self.delete_excluded,
             delete_missing_args: self.delete_missing_args,
+            itemize_active: self.itemize_active,
             max_deletions: self.max_deletions,
             min_file_size: self.min_file_size,
             max_file_size: self.max_file_size,

--- a/crates/engine/src/local_copy/options/logging.rs
+++ b/crates/engine/src/local_copy/options/logging.rs
@@ -43,6 +43,27 @@ impl LocalCopyOptions {
             .as_deref()
             .unwrap_or(DEFAULT_LOG_FILE_FORMAT)
     }
+
+    /// Records whether `--itemize-changes`/`-i` is active for the transfer.
+    ///
+    /// upstream: log.c:log_delete - when `stdout_format_has_o_or_i` is set the
+    /// deletion line is emitted through the itemize format and the plain
+    /// `"deleting %n"` line is never produced. The engine mirrors that mutual
+    /// exclusion by suppressing its `info_log!(Del,1,..)` deletion line when
+    /// this flag is set, leaving the `*deleting` itemize record as the sole
+    /// emitter.
+    #[must_use]
+    #[doc(alias = "--itemize-changes")]
+    pub const fn itemize_active(mut self, active: bool) -> Self {
+        self.itemize_active = active;
+        self
+    }
+
+    /// Returns whether `--itemize-changes`/`-i` is active for the transfer.
+    #[must_use]
+    pub const fn is_itemize_active(&self) -> bool {
+        self.itemize_active
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -97,6 +97,12 @@ pub struct LocalCopyOptions {
     pub(super) delete_timing: DeleteTiming,
     pub(super) delete_excluded: bool,
     pub(super) delete_missing_args: bool,
+    /// Mirrors the client's `--itemize-changes`/`-i` state. When set, the
+    /// engine suppresses the plain `info_log!(Del,1,"deleting %n")` line so
+    /// only the `*deleting` itemize record reaches output, matching upstream
+    /// `log.c:log_delete` where `stdout_format_has_o_or_i` makes the itemize
+    /// format and the plain "deleting %n" line mutually exclusive.
+    pub(super) itemize_active: bool,
     pub(super) max_deletions: Option<u64>,
     pub(super) min_file_size: Option<u64>,
     pub(super) max_file_size: Option<u64>,
@@ -256,6 +262,7 @@ impl LocalCopyOptions {
             delete_timing: DeleteTiming::default(),
             delete_excluded: false,
             delete_missing_args: false,
+            itemize_active: false,
             max_deletions: None,
             min_file_size: None,
             max_file_size: None,

--- a/crates/engine/src/local_copy/plan/record.rs
+++ b/crates/engine/src/local_copy/plan/record.rs
@@ -15,6 +15,7 @@ pub struct LocalCopyRecord {
     created: bool,
     change_set: LocalCopyChangeSet,
     hardlink_uptodate: bool,
+    is_directory: bool,
 }
 
 impl LocalCopyRecord {
@@ -37,7 +38,19 @@ impl LocalCopyRecord {
             created: false,
             change_set: LocalCopyChangeSet::new(),
             hardlink_uptodate: false,
+            is_directory: false,
         }
+    }
+
+    /// Marks whether this record describes a directory entry.
+    ///
+    /// Carried so the CLI renderer can append the upstream `%n` trailing
+    /// slash for directory rows (e.g. `*deleting sub/`) even when no metadata
+    /// snapshot is attached, as is the case for `EntryDeleted` records.
+    #[must_use]
+    pub(in crate::local_copy) const fn with_directory(mut self, is_directory: bool) -> Self {
+        self.is_directory = is_directory;
+        self
     }
 
     /// Marks whether the record corresponds to the creation of a new destination entry.
@@ -97,6 +110,12 @@ impl LocalCopyRecord {
         self.created
     }
 
+    /// Returns whether this record describes a directory entry.
+    #[must_use]
+    pub const fn is_directory(&self) -> bool {
+        self.is_directory
+    }
+
     /// Returns whether this record describes a hardlink whose destination
     /// already shared the source group leader's inode (upstream:
     /// hlink.c:218-224).
@@ -139,6 +158,7 @@ impl LocalCopyRecord {
         bool,
         LocalCopyChangeSet,
         bool,
+        bool,
     ) {
         (
             self.relative_path,
@@ -150,6 +170,7 @@ impl LocalCopyRecord {
             self.created,
             self.change_set,
             self.hardlink_uptodate,
+            self.is_directory,
         )
     }
 }
@@ -339,8 +360,18 @@ mod tests {
     #[test]
     fn into_parts_moves_relative_path() {
         let record = test_record().with_creation(true);
-        let (path, action, bytes, total, elapsed, meta, created, change_set, hardlink_uptodate) =
-            record.into_parts();
+        let (
+            path,
+            action,
+            bytes,
+            total,
+            elapsed,
+            meta,
+            created,
+            change_set,
+            hardlink_uptodate,
+            is_directory,
+        ) = record.into_parts();
         assert_eq!(path, Path::new("test/file.txt"));
         assert_eq!(action, LocalCopyAction::DataCopied);
         assert_eq!(bytes, 1024);
@@ -349,6 +380,7 @@ mod tests {
         assert!(meta.is_none());
         assert!(created);
         assert!(!hardlink_uptodate);
+        assert!(!is_directory);
         assert_eq!(change_set, LocalCopyChangeSet::new());
     }
 


### PR DESCRIPTION
## Summary

Completes the P0 deletion-output fidelity work begun in #6056. Two remaining divergences from upstream rsync `log.c:log_delete`:

1. **`-iv` double-emit.** Upstream emits exactly one deletion line per entry — the itemize format when `stdout_format_has_o_or_i` is set, otherwise the plain `"deleting %n"` line. The two are mutually exclusive (`log.c:log_delete`). oc-rsync had two decoupled emission paths (the engine `info_log!(Del,1,..)` plain line and the `*deleting` itemize record) with no mutual-exclusion gate, so `-iv` printed both.

2. **Itemized deleted-directory rows missing the trailing slash.** Upstream `%n` (`log.c:639-640`) appends `/` for any directory entry. `EntryDeleted` records carry no metadata snapshot, so the renderer had no way to know the entry was a directory and rendered `*deleting sub` instead of `*deleting sub/`.

## Changes

- Plumb an `itemize_active` flag onto `LocalCopyOptions` (mirrors the `delete_excluded` 5-site pattern), wired from `ClientConfig::itemize_changes()`. The engine cleanup pass suppresses its plain `info_log!(Del,1,..)` line when `-i` is active, leaving the `*deleting` itemize record as the sole emitter.
- Carry an `is_directory` bit on `LocalCopyRecord` → `ClientEvent` so the CLI itemize renderer (`render_path`) appends the `%n` trailing slash to deleted-directory rows even without a metadata snapshot.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p engine -p core -p cli --all-features --no-deps -- -D warnings` clean.
- Full nextest runs in CI.