### PR TITLE
fix(flist): carry st_size for directory and symlink entries

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -59,7 +59,12 @@ fn build_protocol_file_entry(
         // upstream: flist.c:send_file_entry() - symlink target is read and
         // included in the flist entry so batch replay can recreate symlinks.
         let link_target = fs::read_link(source_path).unwrap_or_default();
-        protocol::flist::FileEntry::new_symlink(name, link_target)
+        // upstream: flist.c:1465 - symlinks carry stat.st_size (the target byte
+        // length), matching the directory case above; only devices/specials are
+        // zeroed.
+        let mut symlink_entry = protocol::flist::FileEntry::new_symlink(name, link_target);
+        symlink_entry.set_size(metadata.len());
+        symlink_entry
     } else {
         protocol::flist::FileEntry::new_file(name, metadata.len(), permissions)
     };
@@ -191,4 +196,40 @@ pub(crate) fn capture_batch_file_entry(
     context.increment_batch_flist_index();
 
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::build_protocol_file_entry;
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// upstream: flist.c:1465 - a symlink's `F_LENGTH` is its `st_size`, which
+    /// lstat reports as the target byte length. Batch capture must record the
+    /// same value the network flist would, otherwise `--list-only`/`%l` and the
+    /// `--stats` total computed from a replayed batch diverge from upstream.
+    #[test]
+    fn symlink_batch_entry_carries_target_length() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link = tmp.path().join("link");
+        let target = "some/relative/target";
+        symlink(target, &link).expect("create symlink");
+        let meta = std::fs::symlink_metadata(&link).expect("metadata");
+
+        let entry = build_protocol_file_entry(&link, &PathBuf::from("link"), &meta, false, true);
+
+        assert!(entry.is_symlink());
+        assert_eq!(
+            entry.size(),
+            target.len() as u64,
+            "batch symlink F_LENGTH must equal the target byte length, \
+             not the hardcoded 0 from FileEntry::new_symlink",
+        );
+        assert_eq!(
+            entry.size(),
+            meta.len(),
+            "F_LENGTH must mirror lstat st_size"
+        );
+    }
 }

--- a/crates/transfer/src/generator/file_list/entry.rs
+++ b/crates/transfer/src/generator/file_list/entry.rs
@@ -120,7 +120,13 @@ impl GeneratorContext {
             #[cfg(not(unix))]
             let mode = 0o755;
 
-            FileEntry::new_directory(relative_path, mode)
+            // upstream: flist.c:1465 - `file->len32 = (uint32)st.st_size` runs for
+            // every entry; only devices/specials are zeroed (flist.c:1452-1454).
+            // Directories therefore carry their on-disk inode size on the wire,
+            // which feeds `--list-only`, `%l`, and the `--stats` total.
+            let mut entry = FileEntry::new_directory(relative_path, mode);
+            entry.set_size(metadata.len());
+            entry
         } else if file_type.is_symlink() || {
             #[cfg(windows)]
             {
@@ -160,7 +166,13 @@ impl GeneratorContext {
             // re-applies the prefix when the link is materialized on disk.
             let target = strip_symlink_munge_prefix(self.config.munge_symlinks, raw_target);
 
-            FileEntry::new_symlink(relative_path, target)
+            // upstream: flist.c:1465 - symlinks carry `st_size`, which lstat
+            // reports as the byte length of the link target. The receiver gets
+            // the target separately, so this length is purely the size shown by
+            // `--list-only`/`%l` and summed into the `--stats` total.
+            let mut entry = FileEntry::new_symlink(relative_path, target);
+            entry.set_size(metadata.len());
+            entry
         } else {
             // Device and special file types (Unix only)
             #[cfg(unix)]
@@ -1147,6 +1159,106 @@ mod windows_reparse_tests {
         assert!(
             !link_target.as_os_str().is_empty(),
             "directory symlink target must be preserved, entry={entry:?}"
+        );
+    }
+}
+
+#[cfg(all(test, unix))]
+mod entry_length_tests {
+    //! `F_LENGTH` parity regression for directory and symlink entries.
+    //!
+    //! upstream: flist.c:1465 - `file->len32 = (uint32)st.st_size` runs for
+    //! every entry type; only devices and specials are zeroed at flist.c:1452
+    //! and flist.c:1454. Directories therefore carry their on-disk inode size
+    //! and symlinks carry `st_size` (the target byte length). That field is
+    //! summed into the `--stats` "Total file size" total at flist.c:679 and
+    //! rendered by `--list-only` and `%l`, so emitting 0 here would diverge
+    //! from upstream's observable output byte-for-byte.
+
+    use super::super::super::GeneratorContext;
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use protocol::ProtocolVersion;
+    use protocol::flist::FileType;
+    use std::ffi::OsString;
+    use std::os::unix::fs::symlink;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn generator() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let mut config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        config.flags.numeric_ids = true;
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    #[test]
+    fn directory_entry_carries_on_disk_size() {
+        let tmp = TempDir::new().expect("tempdir");
+        let dir = tmp.path().join("subdir");
+        std::fs::create_dir(&dir).expect("create dir");
+        let meta = std::fs::symlink_metadata(&dir).expect("metadata");
+
+        let ctx = generator();
+        let entry = ctx
+            .create_entry(&dir, PathBuf::from("subdir"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.file_type(), FileType::Directory);
+        assert!(
+            meta.len() > 0,
+            "directories report a non-zero on-disk st_size on Unix",
+        );
+        assert_eq!(
+            entry.size(),
+            meta.len(),
+            "directory F_LENGTH must mirror st_size (upstream flist.c:1465), \
+             not the hardcoded 0 from FileEntry::new_directory",
+        );
+    }
+
+    #[test]
+    fn symlink_entry_carries_target_length() {
+        let tmp = TempDir::new().expect("tempdir");
+        let link = tmp.path().join("link");
+        // lstat reports st_size == strlen(target) for symlinks.
+        let target = "some/relative/target";
+        symlink(target, &link).expect("create symlink");
+        let meta = std::fs::symlink_metadata(&link).expect("metadata");
+
+        let ctx = generator();
+        let entry = ctx
+            .create_entry(&link, PathBuf::from("link"), &meta)
+            .expect("create_entry");
+
+        assert_eq!(entry.file_type(), FileType::Symlink);
+        assert_eq!(
+            entry.size(),
+            target.len() as u64,
+            "symlink F_LENGTH must equal the target byte length \
+             (upstream flist.c:1465), not the hardcoded 0 from \
+             FileEntry::new_symlink",
+        );
+        assert_eq!(
+            entry.size(),
+            meta.len(),
+            "F_LENGTH must mirror lstat st_size"
         );
     }
 }


### PR DESCRIPTION
## Summary

Directory and symlink file-list entries were hardcoding `F_LENGTH` to `0`, diverging from upstream rsync. Upstream `flist.c:1465` runs `file->len32 = (uint32)st.st_size` for **every** entry type; only devices and specials are zeroed (`flist.c:1452-1454`).

As a result:
- Directories carry their on-disk inode `st_size`.
- Symlinks carry `st_size`, which `lstat` reports as the byte length of the link target.

That field feeds `--list-only`, the `%l` out-format escape, and the `--stats` "Total file size" total (summed at `flist.c:679`). Emitting `0` here produced observable output that diverged from upstream byte-for-byte.

## Changes

- `crates/transfer/src/generator/file_list/entry.rs` — set the size from on-disk metadata for both the directory and symlink branches of the generator flist builder (the network/daemon/SSH transfer path).
- `crates/engine/src/local_copy/executor/directory/recursive/batch.rs` — set the size for the symlink branch of the `--write-batch` capture path (the directory branch already did).

Device, special, FIFO, and socket entries are left untouched and continue to serialize size `0`, matching upstream.

## Validation

Validated against upstream rsync 3.4.1 in a Linux container:

- `--list-only` output is now byte-identical between oc-rsync and upstream for directories and symlinks.
- A `--stats` push with `--delete --exclude=*.tmp` reports the same `Total file size` as upstream, and the destination trees are identical (`diff -rq --no-dereference` → match), with the excluded `.tmp` absent and extraneous files deleted on both sides.

## Tests

- `entry_length_tests` (generator): assert directory and symlink entries carry their on-disk `st_size` rather than `0`.
- `tests::symlink_batch_entry_carries_target_length` (batch capture): assert the symlink `F_LENGTH` equals the target byte length.
