### PR TITLE
fix(engine): delete :s-merge-hidden dest extras under --delete

### DIFF
--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -191,7 +191,19 @@ impl<'a> CopyContext<'a> {
 
             if rule.options().excludes_self() {
                 let pattern = rule.pattern().to_string_lossy().into_owned();
-                if let Err(error) = segment.push_rule(FilterRule::exclude(pattern)) {
+                // The merge file hides itself; that synthetic exclude must
+                // inherit the merge file's side (a `:s` merge -> sender-side)
+                // so on the delete pass it elides like every other rule loaded
+                // from that file instead of protecting the dest extra. Mirror
+                // apply_dir_merge_rule_defaults (dir_merge/load.rs).
+                let mut self_rule = FilterRule::exclude(pattern);
+                if let Some(sender) = rule.options().sender_side_override() {
+                    self_rule = self_rule.with_sender(sender);
+                }
+                if let Some(receiver) = rule.options().receiver_side_override() {
+                    self_rule = self_rule.with_receiver(receiver);
+                }
+                if let Err(error) = segment.push_rule(self_rule) {
                     ephemeral_stack.pop();
                     marker_ephemeral_stack.pop();
                     return Err(filter_program_local_error(&candidate, &error));

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -102,6 +102,39 @@ pub(crate) fn apply_dir_merge_rule_defaults(
     rule
 }
 
+/// Propagates the enclosing merge file's sender/receiver side onto a nested
+/// `dir-merge` directive that did not declare its own side.
+///
+/// # Upstream Reference
+///
+/// `exclude.c:1293-1303 parse_rule_tok`:
+///
+/// ```c
+/// if (template->rflags & FILTRULES_SIDES) {
+///     if (rule->rflags & FILTRULES_SIDES) { ... reject ... }
+///     rule->rflags |= template->rflags & FILTRULES_SIDES;
+/// }
+/// ```
+///
+/// Every rule read from a side-specified merge file (`:s`/`:r`) inherits that
+/// side, including a nested `dir-merge` directive. The nested merge then
+/// becomes the template for its own file, so the side propagates transitively.
+/// Without this, rules expanded from a `:s`-inherited `dir-merge` keep
+/// `applies_to_receiver = true` and wrongly protect destination extras from
+/// the receiver's deletion pass.
+fn inherit_enclosing_side(enclosing: &DirMergeOptions, child: DirMergeOptions) -> DirMergeOptions {
+    if child.sender_side_override().is_some() || child.receiver_side_override().is_some() {
+        return child;
+    }
+    match (
+        enclosing.sender_side_override(),
+        enclosing.receiver_side_override(),
+    ) {
+        (None, None) => child,
+        (sender, receiver) => child.with_side_overrides(sender, receiver),
+    }
+}
+
 /// Nested per-directory merge declaration encountered while loading another
 /// filter file.
 ///
@@ -323,9 +356,11 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         // upstream: exclude.c:1419-1428 - register the merge
                         // filename for lookup in each subdirectory; do NOT
                         // load anything from the enclosing file's directory.
+                        // exclude.c:1293-1303 - inherit the enclosing file's
+                        // side so a `:s`-loaded `dir-merge` carries sender-side.
                         entries.push_nested_dir_merge(NestedDirMerge {
                             pattern,
-                            options: merge_options,
+                            options: inherit_enclosing_side(options, merge_options),
                         });
                     }
                     Ok(None) => {}
@@ -419,9 +454,11 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         // upstream: exclude.c:1419-1428 - register the merge
                         // filename for lookup in each subdirectory; do NOT
                         // load anything from the enclosing file's directory.
+                        // exclude.c:1293-1303 - inherit the enclosing file's
+                        // side so a `:s`-loaded `dir-merge` carries sender-side.
                         entries.push_nested_dir_merge(NestedDirMerge {
                             pattern,
-                            options: merge_options,
+                            options: inherit_enclosing_side(options, merge_options),
                         });
                     }
                     Ok(Some(ParsedFilterDirective::Clear)) => {
@@ -488,6 +525,38 @@ mod tests {
         let pattern = Path::new(".");
         let result = resolve_dir_merge_path(base, pattern);
         assert_eq!(result, PathBuf::from("/base/."));
+    }
+
+    #[test]
+    fn nested_dir_merge_inherits_sender_side_from_enclosing() {
+        // upstream exclude.c:1293-1303 - a `dir-merge` directive read from a
+        // `:s` merge file inherits sender-side, so its rules elide at the
+        // receiver delete pass and the excluded dest files become extraneous.
+        let enclosing = DirMergeOptions::default().sender_modifier();
+        let child = DirMergeOptions::default();
+        let inherited = inherit_enclosing_side(&enclosing, child);
+        assert_eq!(inherited.sender_side_override(), Some(true));
+        assert_eq!(inherited.receiver_side_override(), Some(false));
+    }
+
+    #[test]
+    fn nested_dir_merge_keeps_its_own_side_over_enclosing() {
+        // A nested directive that declares its own side is not overridden by
+        // the enclosing merge file's side.
+        let enclosing = DirMergeOptions::default().sender_modifier();
+        let child = DirMergeOptions::default().receiver_modifier();
+        let inherited = inherit_enclosing_side(&enclosing, child);
+        assert_eq!(inherited.sender_side_override(), Some(false));
+        assert_eq!(inherited.receiver_side_override(), Some(true));
+    }
+
+    #[test]
+    fn nested_dir_merge_no_inheritance_when_enclosing_is_sideless() {
+        let enclosing = DirMergeOptions::default();
+        let child = DirMergeOptions::default();
+        let inherited = inherit_enclosing_side(&enclosing, child);
+        assert_eq!(inherited.sender_side_override(), None);
+        assert_eq!(inherited.receiver_side_override(), None);
     }
 
     #[test]

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -110,9 +110,18 @@ fn decide_entry_action(
             return Ok(EntryAction::CopyDirectory);
         }
 
-        if context.options().delete_excluded_enabled() {
-            *keep_name = false;
-        }
+        // A source-excluded entry is absent from upstream's file list
+        // (make_file returns NULL on a match, flist.c:1360), so it can never
+        // shield a same-named destination entry from deletion via the keep
+        // set. Drop it from the keep set unconditionally; whether the dest
+        // entry actually deletes is decided independently by allows_deletion
+        // (the receiver-active filter evaluated against the destination, i.e.
+        // delete_in_dir's flist-absence test, generator.c:340). This keeps the
+        // two upstream gates separate: flist presence vs receiver-side filter.
+        // A sender-side-only rule (e.g. `hide`) elides on the delete side, so
+        // such an entry becomes deletable; a sideless/receiver-active rule
+        // (e.g. `- *.deep`) still protects the dest entry through allows_deletion.
+        *keep_name = false;
         return Ok(EntryAction::SkipExcluded);
     }
 


### PR DESCRIPTION
Three stacked defects let a destination extra survive --delete when its source twin is hidden by a sender-side (:s) per-directory merge rule, diverging from upstream (which omits such names from the file list so they become deletable extras):

1. The keep set protected source-excluded names unconditionally unless --delete-excluded was set; that name then short-circuited deletion before the receiver-side filter ran. Drop source-excluded names from the keep set always and let allows_deletion (FilterContext::Deletion) decide, mirroring upstream's split between flist presence and the receiver-side filter (flist.c:1360, generator.c:340).
2. A nested dir-merge directive did not inherit the enclosing :s file's side, so its rules stayed receiver-active and wrongly protected the dest extra. Propagate the enclosing side onto side-less nested dir-merge directives (exclude.c:1293-1303).
3. The synthetic self-exclusion rule for a merge file was built as a both-sides exclude, so a :s merge's self-rule protected the file instead of eliding. Apply the merge file's side overrides to it.

A protect rule (P) or a sideless/receiver-active rule still shields the destination entry, so guarded names are unaffected.

<!--
Title format: <prefix>(<scope>): <imperative summary>
Conventional prefix is load-bearing - a labeler workflow categorizes release
notes from it. Keep titles under 70 characters; put detail in the body.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

- 1-3 bullets describing what changes and why.

## Test plan

- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.
- [ ] Add targeted local repro steps if applicable: `cargo nextest run -p <crate> -E 'test(<pattern>)'`.

## Coordination

- Related PRs / issues:
- Depends on:
- Blocked by:

## Conventional commit prefix

Pick one; PR title prefix must match the change category:

- `feat:` - new user-visible feature
- `fix:` - bug fix
- `perf:` - performance improvement
- `refactor:` - non-functional restructuring
- `docs:` - documentation only
- `test:` - tests only
- `style:` - formatting / lints, no behaviour change
- `chore:` - tooling, deps, housekeeping
- `ci:` - CI configuration

## Security considerations

Fill only if this PR touches `SECURITY.md`, daemon code, sandbox / `*at`
helpers, auth, or anything in the SEC-1 chain. Otherwise delete this section.

- Threat surface affected:
- Mitigations / tests added:
- Cross-references (`SECURITY.md`, design docs):

## Pre-merge checklist

- [ ] Conventional commit prefix on PR title matches the change category.
- [ ] `cargo fmt --all` run locally.
- [ ] `CHANGELOG.md` updated if user-visible.
- [ ] `SECURITY.md` updated if security-relevant.
- [ ] No references to internal tooling or non-human authoring aids; hyphens, not em-dashes.
