### PR TITLE
fix(delete): drop excluded entries from keep-set when deletable

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -110,7 +110,13 @@ fn decide_entry_action(
             return Ok(EntryAction::CopyDirectory);
         }
 
-        if context.options().delete_excluded_enabled() {
+        // upstream: a file absent from the sender flist (sender-side hide, or any
+        // exclude under --delete-excluded) is extraneous at the receiver and is
+        // removed by --del/--delete-during. Drop it from the keep-set exactly when
+        // the delete-side filter permits deletion. Protective both-sides excludes
+        // keep allows_deletion() == false, so they stay in the keep-set and are
+        // never deleted (e.g. a per-dir `- *.deep` still protects nodel.deep).
+        if context.allows_deletion(relative_path, effective_type.is_dir()) {
             *keep_name = false;
         }
         return Ok(EntryAction::SkipExcluded);


### PR DESCRIPTION
## Problem

In the local-copy delete pass, an excluded source entry was dropped from the
keep-set (making it a deletion candidate) only under `--delete-excluded`. As a
result, files that upstream rsync omits from the sender flist - and therefore
deletes from the destination via `--del`/`--delete-during` - were retained by
oc-rsync.

Reproduced against upstream's `exclude.test` (run locally with oc-rsync as the
rsync binary): the `-f 'dir-merge .filt' -f 'merge -' --delete-during` leg left
two files in the destination (`foo/file1`, `bar/down/to/bar/baz/file5.deep`)
that upstream removes.

## Fix

Gate the keep-set drop on the delete-side filter (`allows_deletion`) instead of
only `--delete-excluded`. An excluded source entry now leaves the keep-set
exactly when the delete-side filter permits its deletion - true for sender-side
hidden entries and for `--delete-excluded`, and false for protective both-sides
excludes. Protective per-directory rules keep `allows_deletion() == false`, so
files like `nodel.deep` (protected by a per-dir `- *.deep`) remain in the
keep-set and are never deleted (verified - no data loss).

## Validation

A/B against upstream's `exclude.test` on Linux (oc-rsync built before/after,
upstream-as-both passes):

- Before: `--delete-during` dir-merge leg fails, retaining `foo/file1` +
  `file5.deep`.
- After: that leg passes (both deleted, `nodel.deep` survives) and the test
  advances to a later `--delete-before` leg.

A separate `--delete-before` sender-side per-dir-merge leg remains, tracked
independently; this change closes the `--delete-during` keep-set divergence.

Scope: one branch in `decide_entry_action`; no public API change.