### PR TITLE
fix(filters): inherit parent dir-merge side flags in nested merges

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -102,6 +102,28 @@ pub(crate) fn apply_dir_merge_rule_defaults(
     rule
 }
 
+/// Propagates a parent dir-merge's SIDE flags onto a nested `dir-merge`
+/// directive that specified none of its own.
+///
+/// upstream: exclude.c:1293-1303 - a nested per-dir merge inherits the
+/// enclosing template's FILTRULES_SIDES when it carries no side modifier of its
+/// own. Without this, a `:s .filt` whose body declares `dir-merge .filt2` would
+/// load `.filt2` as both-sides, wrongly protecting a sender-side-hidden file
+/// from `--delete`.
+fn inherit_dir_merge_side(nested: DirMergeOptions, parent: &DirMergeOptions) -> DirMergeOptions {
+    if nested.sender_side_override().is_some() || nested.receiver_side_override().is_some() {
+        return nested;
+    }
+    let mut nested = nested;
+    if parent.sender_side_override() == Some(true) {
+        nested = nested.sender_modifier();
+    }
+    if parent.receiver_side_override() == Some(true) {
+        nested = nested.receiver_modifier();
+    }
+    nested
+}
+
 /// Nested per-directory merge declaration encountered while loading another
 /// filter file.
 ///
@@ -323,6 +345,13 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         // upstream: exclude.c:1419-1428 - register the merge
                         // filename for lookup in each subdirectory; do NOT
                         // load anything from the enclosing file's directory.
+                        // upstream: exclude.c:1293-1303 - a nested dir-merge
+                        // inherits the enclosing per-dir merge's SIDE flags
+                        // (FILTRULES_SIDES) when it specifies none of its own,
+                        // so `:s`/`.s` per-dir merges keep sender-side semantics
+                        // through nesting (the delete pass must not protect a
+                        // sender-side-hidden file).
+                        let merge_options = inherit_dir_merge_side(merge_options, options);
                         entries.push_nested_dir_merge(NestedDirMerge {
                             pattern,
                             options: merge_options,
@@ -419,6 +448,13 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         // upstream: exclude.c:1419-1428 - register the merge
                         // filename for lookup in each subdirectory; do NOT
                         // load anything from the enclosing file's directory.
+                        // upstream: exclude.c:1293-1303 - a nested dir-merge
+                        // inherits the enclosing per-dir merge's SIDE flags
+                        // (FILTRULES_SIDES) when it specifies none of its own,
+                        // so `:s`/`.s` per-dir merges keep sender-side semantics
+                        // through nesting (the delete pass must not protect a
+                        // sender-side-hidden file).
+                        let merge_options = inherit_dir_merge_side(merge_options, options);
                         entries.push_nested_dir_merge(NestedDirMerge {
                             pattern,
                             options: merge_options,
@@ -599,5 +635,45 @@ mod tests {
 
         assert_eq!(parent_entries.rules.len(), 2);
         assert!(!parent_entries.clear_inherited);
+    }
+
+    #[test]
+    fn inherit_dir_merge_side_propagates_parent_sender_flag() {
+        // upstream: exclude.c:1293-1303 - a `:s` per-dir merge whose body declares
+        // a bare `dir-merge .filt2` must load `.filt2` with the parent's
+        // sender-side semantics, otherwise the delete pass would treat a
+        // sender-hidden file as both-sides-protected and refuse to delete it.
+        let parent = DirMergeOptions::default().sender_modifier();
+        let nested = DirMergeOptions::default();
+
+        let inherited = inherit_dir_merge_side(nested, &parent);
+
+        assert_eq!(inherited.sender_side_override(), Some(true));
+        assert_eq!(inherited.receiver_side_override(), Some(false));
+    }
+
+    #[test]
+    fn inherit_dir_merge_side_preserves_explicit_nested_side() {
+        // A nested merge that names its own side modifier keeps it; the parent's
+        // flags must not override an explicit choice.
+        let parent = DirMergeOptions::default().sender_modifier();
+        let nested = DirMergeOptions::default().receiver_modifier();
+
+        let inherited = inherit_dir_merge_side(nested, &parent);
+
+        assert_eq!(inherited.sender_side_override(), Some(false));
+        assert_eq!(inherited.receiver_side_override(), Some(true));
+    }
+
+    #[test]
+    fn inherit_dir_merge_side_is_noop_for_unspecified_parent() {
+        // A parent with no side modifier leaves a bare nested merge unspecified.
+        let parent = DirMergeOptions::default();
+        let nested = DirMergeOptions::default();
+
+        let inherited = inherit_dir_merge_side(nested, &parent);
+
+        assert_eq!(inherited.sender_side_override(), None);
+        assert_eq!(inherited.receiver_side_override(), None);
     }
 }


### PR DESCRIPTION
## Summary

A nested `dir-merge` directive that declares no side modifier of its own must inherit the enclosing per-directory merge's `FILTRULES_SIDES`, mirroring upstream `exclude.c:1293-1303`. Without this, a `:s .filt` whose body declares `dir-merge .filt2` loaded `.filt2` as a both-sides rule, which wrongly protected a sender-side-hidden file from `--delete` during the local-copy delete pass.

## Root cause

The two `DirMerge` arms in `load_dir_merge_rules_recursive` (whitespace and line parser branches) registered the nested merge using only the directive's own `DirMergeOptions`. The `Rule`/`Merge` arms already apply the parent's side override via `apply_dir_merge_rule_defaults`, but the `DirMerge` arm dropped it — so a sender-side `:s` parent did not propagate its sender-side semantics through a bare nested `dir-merge`.

## Fix

Add `inherit_dir_merge_side`, which propagates the parent's sender/receiver side flags onto a nested merge that specified none of its own (an explicit nested modifier is preserved unchanged). Call it from both parser branches before pushing the `NestedDirMerge`.

This makes the `:s` per-dir-merge `--delete-during` leg of upstream `exclude.test` delete the same 8/10 destination entries upstream does, keeping only the un-hidden merge files. The data-loss guardrail holds: protective both-sides `dir-merge` rules still keep their files (their side flags stay both-sides, so the delete pass continues to protect them).

## Validation

- `cargo fmt` + `cargo clippy --all-features -D warnings` clean on the `engine` crate.
- New unit tests for `inherit_dir_merge_side` cover: sender-flag propagation onto a bare nested merge, preservation of an explicit nested side modifier, and the no-op case for an unspecified parent.
- Empirically validated on a Linux host: with the fix, the `:s --delete-during` leg becomes byte-identical to upstream, and the both-sides `dir-merge` cells are unchanged (no over-deletion).