### PR TITLE
fix(delete): isolate destination deletion merge load from source filters

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -542,11 +542,38 @@ struct DirectoryFilterHandles {
     dynamic: Rc<RefCell<Vec<DynamicDirMergeFrame>>>,
 }
 
+/// Whole-stack snapshot of the source-visible per-directory filter state.
+///
+/// Captured before a destination-side deletion scan loads its `dir-merge`
+/// files and restored verbatim when the scan's guard drops, so the
+/// destination load can never perturb the source-side filter evaluation.
+///
+/// upstream: delete.c:65-115 `delete_in_dir()` runs the destination
+/// per-directory filter push/pop (`push_local_filters`/`pop_local_filters`)
+/// against a separate `delete_filt` chain seeded from `change_local_filter_dir`;
+/// the receiver's destination scan never mutates the sender's `filter_list`.
+/// We mirror that isolation by snapshotting and restoring the source-visible
+/// stacks around the destination scan rather than relying on a per-index pop,
+/// which cannot balance the nested `dir-merge` directives a destination merge
+/// file may register (exclude.c:801 `push_local_filters` seeds `lp->head` from
+/// rules an arbitrary number of indices deep).
+struct FilterStateSnapshot {
+    layers: FilterSegmentLayers,
+    marker_layers: ExcludeIfPresentLayers,
+    ephemeral: FilterSegmentStack,
+    marker_ephemeral: ExcludeIfPresentStack,
+    dynamic: Vec<DynamicDirMergeFrame>,
+}
+
 /// RAII guard that reverts per-directory filter rules when dropped.
 ///
 /// Pushing dir-merge rules into the layered filter stacks yields this guard.
 /// On drop, all rules pushed for the directory are popped, restoring the
 /// filter state to what it was before entering the directory.
+///
+/// When `restore` is set (destination-deletion scans), the guard restores the
+/// captured [`FilterStateSnapshot`] wholesale instead of running the per-index
+/// pop logic, guaranteeing source-side state is left untouched.
 pub(crate) struct DirectoryFilterGuard {
     handles: DirectoryFilterHandles,
     indices: Vec<usize>,
@@ -554,6 +581,7 @@ pub(crate) struct DirectoryFilterGuard {
     ephemeral_active: bool,
     dynamic_active: bool,
     excluded: bool,
+    restore: Option<FilterStateSnapshot>,
 }
 
 impl DirectoryFilterGuard {
@@ -572,6 +600,7 @@ impl DirectoryFilterGuard {
             ephemeral_active,
             dynamic_active,
             excluded,
+            restore: None,
         }
     }
 
@@ -579,10 +608,27 @@ impl DirectoryFilterGuard {
     pub(crate) const fn is_excluded(&self) -> bool {
         self.excluded
     }
+
+    /// Arms the guard to restore the captured source-visible filter state on
+    /// drop instead of running the per-index pop logic. Used by the
+    /// destination-deletion path so the destination merge load is isolated from
+    /// source-side evaluation.
+    fn arm_restore(&mut self, snapshot: FilterStateSnapshot) {
+        self.restore = Some(snapshot);
+    }
 }
 
 impl Drop for DirectoryFilterGuard {
     fn drop(&mut self) {
+        if let Some(snapshot) = self.restore.take() {
+            *self.handles.layers.borrow_mut() = snapshot.layers;
+            *self.handles.marker_layers.borrow_mut() = snapshot.marker_layers;
+            *self.handles.ephemeral.borrow_mut() = snapshot.ephemeral;
+            *self.handles.marker_ephemeral.borrow_mut() = snapshot.marker_ephemeral;
+            *self.handles.dynamic.borrow_mut() = snapshot.dynamic;
+            return;
+        }
+
         if self.dynamic_active {
             let mut stack = self.handles.dynamic.borrow_mut();
             stack.pop();

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -76,7 +76,35 @@ impl<'a> CopyContext<'a> {
         destination: &Path,
         relative_dir: Option<&Path>,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
-        self.enter_directory_for_path(destination, relative_dir, false)
+        // upstream: delete.c:65-115 `delete_in_dir()` pushes the destination
+        // directory's per-dir merge files onto a separate `delete_filt` chain
+        // (seeded by `change_local_filter_dir`) and pops them afterwards, so the
+        // destination scan never perturbs the sender's `filter_list`. Our merge
+        // stacks are shared between source planning (`allows`) and the deletion
+        // scan (`allows_deletion`), and a destination merge file can register
+        // nested `dir-merge` directives whose loaded segments the per-index pop
+        // logic cannot fully balance (exclude.c:801 seeds `lp->head` from rules
+        // an arbitrary number of indices deep). Snapshot the whole source-visible
+        // state before the destination load and restore it verbatim on guard
+        // drop. The loaded frame stays live for the duration of the scan so
+        // `allows_deletion` still honours destination-side per-dir protect rules
+        // (the data-loss guardrail), then the source plan is restored exactly.
+        let snapshot = self.snapshot_filter_state();
+        let mut guard = self.enter_directory_for_path(destination, relative_dir, false)?;
+        guard.arm_restore(snapshot);
+        Ok(guard)
+    }
+
+    /// Captures the current source-visible per-directory filter state so a
+    /// destination-deletion scan can be reverted exactly when its guard drops.
+    fn snapshot_filter_state(&self) -> FilterStateSnapshot {
+        FilterStateSnapshot {
+            layers: self.dir_merge_layers.borrow().clone(),
+            marker_layers: self.dir_merge_marker_layers.borrow().clone(),
+            ephemeral: self.dir_merge_ephemeral.borrow().clone(),
+            marker_ephemeral: self.dir_merge_marker_ephemeral.borrow().clone(),
+            dynamic: self.dynamic_dir_merge_stack.borrow().clone(),
+        }
     }
 
     fn enter_directory_for_path(

--- a/crates/engine/tests/per_dir_merge_traversal.rs
+++ b/crates/engine/tests/per_dir_merge_traversal.rs
@@ -2,10 +2,10 @@
 //! engine local-copy path, mirroring the LOCAL legs of upstream's
 //! `testsuite/exclude.test`.
 //!
-//! These exercise three behaviours that upstream `exclude.c` defines for
-//! per-directory merge files and that must hold during the copy walk - not the
-//! deletion pass. The files under test enter the transfer purely on the merge
-//! rules; no `--delete` is involved.
+//! Most cases exercise behaviours that upstream `exclude.c` defines for
+//! per-directory merge files during the copy walk; the final case covers the
+//! `--delete-before` deletion pass, where the destination-side merge load must
+//! stay isolated from the source-side filter evaluation.
 //!
 //! # Upstream Reference
 //!
@@ -16,14 +16,18 @@
 //! - `exclude.c:787-789 push_local_filters` - the push loop walks the GROWING
 //!   `mergelist_cnt`, so a `dir-merge` directive registered while loading a
 //!   directory's merge file is itself loaded against that same directory.
+//! - `delete.c:65-115 delete_in_dir` - the destination deletion scan pushes the
+//!   destination's per-dir filters onto a separate chain and pops them
+//!   afterwards, never perturbing the sender's filter list.
 
 use std::fs;
 use std::path::Path;
 
 use engine::local_copy::{
-    DirMergeOptions, DirMergeRule, FilterProgram, FilterProgramEntry, LocalCopyExecution,
-    LocalCopyOptions, LocalCopyPlan,
+    DeleteTiming, DirMergeOptions, DirMergeRule, FilterProgram, FilterProgramEntry,
+    LocalCopyExecution, LocalCopyOptions, LocalCopyPlan,
 };
+use filters::FilterRule;
 use tempfile::tempdir;
 
 /// Runs a recursive local copy from `source` to `dest` using a filter program
@@ -146,4 +150,133 @@ fn same_dir_nested_dir_merge_applies_to_current_dir_and_descendants() {
         dest.join("bar/baz/keep.txt").exists(),
         "non-matching descendants must still transfer",
     );
+}
+
+/// Regression: a populated destination plus a sender-side per-directory
+/// `dir-merge .filt` under `--delete-before` must NOT resurrect files that the
+/// merge rules exclude from the sender flist.
+///
+/// The destination is a full copy of the source, so every excluded file
+/// pre-exists. With a sender-side merge, `bar/.filt`, `foo/file2.old`, and the
+/// nested `bar/down/to/foo/file1.bak` are absent from the sender flist and must
+/// be removed by `--delete-before`, exactly as upstream does and exactly as the
+/// `--delete-during` timing already did. A `protect nodel.deep` rule must keep
+/// `nodel.deep` in every cell (the data-loss guardrail).
+///
+/// Before the fix, the destination-deletion scan loaded the destination's own
+/// `.filt` files onto the shared dynamic merge stack; under `--delete-before`
+/// (deletion runs ahead of the child source plans) that leaked frame corrupted
+/// the source-side `allows()` evaluation, so the `- .filt`/`- *.old`/`- *.bak`
+/// rules stopped matching and the excluded files were copied back and survived.
+///
+/// upstream: delete.c:65-115 delete_in_dir runs the destination per-dir filter
+/// push/pop against a separate delete_filt chain, isolating it from the sender
+/// filter_list; exclude.c:801 push_local_filters keeps inherited rules in
+/// lp->head, so a destination merge file may register nested directives an
+/// arbitrary depth deep that a per-index pop cannot balance.
+#[test]
+fn delete_before_does_not_resurrect_sender_excluded_files_into_populated_dest() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+
+    // Source tree mirrors the contested legs of upstream exclude.test.
+    fs::create_dir_all(source.join("foo/sub")).expect("mkdir foo/sub");
+    fs::create_dir_all(source.join("bar/down/to/foo")).expect("mkdir bar/down/to/foo");
+    fs::create_dir_all(source.join("bar/down/to/bar/baz")).expect("mkdir bar/.../baz");
+
+    // Root .filt mirrors upstream exclude.test: it registers a nested
+    // `: .filt-temp` dir-merge directive BEFORE the static excludes. That nested
+    // directive is what makes the leak observable - when the destination scan
+    // loads the destination's own root .filt, the nested registration lands an
+    // extra index deep that the per-index pop cannot balance, corrupting the
+    // source-side allows() for the child directories under --delete-before.
+    fs::write(
+        source.join(".filt"),
+        ": .filt-temp\nclear\n- .filt\n- *.bak\n- *.old\n",
+    )
+    .expect("write .filt");
+    // bar/.filt registers a nested dir-merge .filt2 (a second growing-list
+    // directive whose loaded segments deepen the imbalance).
+    fs::write(source.join("bar/.filt"), "dir-merge .filt2\n").expect("write bar/.filt");
+    fs::write(source.join("bar/down/to/bar/.filt2"), "- *.deep\n").expect("write .filt2");
+
+    // Files that the merge rules exclude from the SENDER flist; each must be
+    // deleted from the populated destination by --delete-before.
+    fs::write(source.join("foo/file1"), b"kept").expect("write foo/file1");
+    fs::write(source.join("foo/file2.old"), b"excluded-old").expect("write file2.old");
+    fs::write(source.join("bar/down/to/foo/file1"), b"kept").expect("write keeper");
+    fs::write(source.join("bar/down/to/foo/file1.bak"), b"excluded-bak").expect("write .bak");
+    // *.deep is excluded from transfer but protected from deletion via `P`.
+    fs::write(source.join("bar/down/to/bar/baz/file5.deep"), b"deep").expect("write deep");
+
+    // Full copy: every file (including the to-be-excluded ones) pre-exists.
+    copy_tree(&source, &dest);
+    // nodel.deep exists ONLY in the destination and is protected by `protect`.
+    fs::write(dest.join("bar/down/to/bar/baz/nodel.deep"), b"retained").expect("write nodel");
+
+    let program = FilterProgram::new([
+        FilterProgramEntry::DirMerge(DirMergeRule::new(
+            ".filt",
+            DirMergeOptions::new().sender_modifier(),
+        )),
+        FilterProgramEntry::Rule(FilterRule::protect("nodel.deep")),
+    ])
+    .expect("filter program compiles");
+
+    // Trailing slash on the source: copy its CONTENTS into dest (rsync
+    // `src/ dst/`), so the merge rules and populated destination line up at the
+    // same relative roots, exactly as the upstream exclude.test leg does.
+    let mut source_contents = source.clone().into_os_string();
+    source_contents.push("/");
+    let operands = vec![source_contents, dest.to_path_buf().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::new()
+        .recursive(true)
+        .delete(true)
+        .delete_before(true)
+        .with_filter_program(Some(program));
+    assert_eq!(options.delete_timing(), Some(DeleteTiming::Before));
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    // The sender-excluded files must be deleted, never resurrected.
+    for resurrected in ["bar/.filt", "foo/file2.old", "bar/down/to/foo/file1.bak"] {
+        assert!(
+            !dest.join(resurrected).exists(),
+            "{resurrected} is excluded from the sender flist and must be deleted \
+             by --delete-before, not resurrected from the populated destination",
+        );
+    }
+
+    // The data-loss guardrail: protected and non-excluded files survive.
+    assert!(
+        dest.join("bar/down/to/bar/baz/nodel.deep").exists(),
+        "`protect nodel.deep` must keep nodel.deep in the delete-before cell",
+    );
+    assert!(
+        dest.join("foo/file1").exists(),
+        "non-excluded foo/file1 must remain",
+    );
+    assert!(
+        dest.join("bar/down/to/foo/file1").exists(),
+        "non-excluded bar/down/to/foo/file1 must remain",
+    );
+}
+
+/// Recursively copies a directory tree, mirroring `cp -a` for the populated
+/// destination used by the deletion regression test.
+fn copy_tree(source: &Path, dest: &Path) {
+    fs::create_dir_all(dest).expect("create dest dir");
+    for entry in fs::read_dir(source).expect("read source dir") {
+        let entry = entry.expect("dir entry");
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        if entry.file_type().expect("file type").is_dir() {
+            copy_tree(&from, &to);
+        } else {
+            fs::copy(&from, &to).expect("copy file");
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Under `--delete-before` with a sender-side per-directory `dir-merge` filter (`:s .filt`), a local copy into a *populated* destination resurrects files that should be excluded and deleted. With the upstream `exclude.test` `:s` leg, `bar/.filt`, `mid/.filt`, `foo/file2.old`, and `bar/down/to/foo/file1.bak` survive where upstream rsync 3.4.4 removes them. The same transfer into an *empty* destination behaves correctly, and `--delete-during` is correct regardless of destination content — the bug is specific to `--delete-before` + a destination that already contains the per-dir merge files.

## Root cause

The source-side plan evaluation (`context.allows()` in `decide_entry_action`) and the destination-side deletion scan share one set of per-directory filter stacks (`dynamic_dir_merge_stack` and the layered segment/marker stacks). `enter_destination_for_deletion` loads the destination directory's `dir-merge` files (`.filt`/`.filt2`) onto those shared stacks. A destination merge file can register nested `dir-merge` directives whose loaded segments sit an arbitrary number of indices deep, which the guard's per-index pop cannot fully balance. Because `--delete-before` runs the deletion scan ahead of the child source plans, the unbalanced residue corrupts the subsequent source-side evaluation, so `- .filt` / `- *.bak` / `- *.old` stop matching and the excluded files are copied back into the destination and survive deletion. `--delete-during` avoids the leak purely by timing (destination frames are pushed and popped around each child).

This mirrors a real upstream invariant: `delete.c:65-115` `delete_in_dir()` runs the destination per-directory filter push/pop against a separate `delete_filt` chain seeded by `change_local_filter_dir`, so the receiver's destination scan never mutates the sender's `filter_list`.

## Fix

Snapshot the source-visible per-directory filter state before the destination-deletion load and restore it verbatim when the scan's guard drops, instead of relying on a per-index pop that cannot balance nested destination `dir-merge` directives. The loaded frame stays live for the duration of the scan, so `allows_deletion` still honors destination-side per-dir protect rules (the data-loss guardrail), and the source plan is restored exactly afterward.

## Validation (vs upstream rsync 3.4.4)

2×2 matrix into a fully populated destination — all cells match upstream exactly, with no over-deletion and `nodel.deep` preserved in every cell:

| cell | result |
|---|---|
| both-sides `dir-merge` / `--delete-during` | keep all (match) |
| both-sides `dir-merge` / `--delete-before` | keep all (match) — data-loss guard |
| `:s` sender-side / `--delete-during` | delete contested set (match) |
| `:s` sender-side / `--delete-before` | delete contested set (match) — was over-keeping 4 files |

- Upstream `exclude.test`: PASS.
- New engine regression test `delete_before_does_not_resurrect_sender_excluded_files_into_populated_dest` fails without the fix, passes with it.
- `cargo fmt --all --check` clean; `cargo clippy -p engine --all-features --no-deps -D warnings` clean; engine deletion/per-dir-merge/timing nextest suites green.

`exclude-lsh.test` remains red, but identically on master: its failure is an unrelated `-aiiO --update` itemize leg, not the deletion path this change touches.