### PR TITLE
fix(metadata): gate non-root chown by privilege to match upstream

### DIFF
--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -57,6 +57,55 @@ fn trace_chown_change(
     }
 }
 
+/// Returns `true` when the current process may set a file's group to `gid`
+/// without privilege: it is the effective gid or one of the supplementary
+/// groups. Mirrors upstream `is_in_group()` (uidlist.c:195-239), the test that
+/// gates `FLAG_SKIP_GROUP` for a non-root sender.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn process_in_group(gid: unix_fs::Gid) -> bool {
+    if rustix::process::getegid() == gid {
+        return true;
+    }
+    let target = gid.as_raw();
+    // SAFETY: the first call passes a NULL buffer with size 0 to learn the
+    // supplementary-group count; the second fills an exactly-sized buffer.
+    // Both are standard POSIX `getgroups` invocations with no aliasing.
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count <= 0 {
+        return false;
+    }
+    let mut groups = vec![0 as libc::gid_t; count as usize];
+    // SAFETY: `groups` is sized to `count`, matching the value just returned.
+    let filled = unsafe { libc::getgroups(count, groups.as_mut_ptr()) };
+    if filled < 0 {
+        return false;
+    }
+    groups[..filled as usize].contains(&target)
+}
+
+/// Gates an owner UID resolved from the *preserve* path (`-o`/`-a`, no explicit
+/// `--chown`/`--usermap`). Mirrors upstream `change_uid = am_root && ...`
+/// (rsync.c:526): a non-root process never sets a file's owner uid, so the
+/// chown is skipped rather than attempted and failed. Before this gate oc-rsync
+/// attempted it and surfaced the resulting `EPERM` as a fatal exit-code-23
+/// error, e.g. under `-aR` when an implied parent directory is owned by another
+/// user. Explicit overrides keep their fail-loud behaviour and are not routed here.
+#[cfg(unix)]
+pub(super) fn gate_preserved_owner(owner: Option<unix_fs::Uid>) -> Option<unix_fs::Uid> {
+    owner.filter(|_| rustix::process::geteuid().is_root())
+}
+
+/// Gates a group GID resolved from the *preserve* path (`-g`/`-a`, no explicit
+/// `--chown`/`--groupmap`). Mirrors upstream's `FLAG_SKIP_GROUP` gate
+/// (uidlist.c:284): a non-root process may only set a group it belongs to, so a
+/// non-member group is skipped rather than attempted and failed. Explicit
+/// overrides keep their fail-loud behaviour and are not routed here.
+#[cfg(unix)]
+pub(super) fn gate_preserved_group(group: Option<unix_fs::Gid>) -> Option<unix_fs::Gid> {
+    group.filter(|gid| rustix::process::geteuid().is_root() || process_in_group(*gid))
+}
+
 /// Resolves the target UID and GID after applying overrides, mappings, and
 /// numeric-id rules. Returns `(None, None)` when no ownership change is
 /// requested.
@@ -89,7 +138,7 @@ pub(super) fn resolve_ownership(
         {
             raw_uid = mapped;
         }
-        map_uid(raw_uid, options.numeric_ids_enabled())
+        gate_preserved_owner(map_uid(raw_uid, options.numeric_ids_enabled()))
     } else {
         None
     };
@@ -104,7 +153,7 @@ pub(super) fn resolve_ownership(
         {
             raw_gid = mapped;
         }
-        map_gid(raw_gid, options.numeric_ids_enabled())
+        gate_preserved_group(map_gid(raw_gid, options.numeric_ids_enabled()))
     } else {
         None
     };
@@ -300,7 +349,7 @@ pub(super) fn apply_ownership_from_entry(
     let owner = if let Some(uid_override) = options.owner_override() {
         Some(ownership::uid_from_raw(uid_override as RawUid))
     } else if options.owner() {
-        entry.uid().and_then(|uid| {
+        gate_preserved_owner(entry.uid().and_then(|uid| {
             let mut mapped_uid = uid as RawUid;
             if let Some(mapping) = options.user_mapping()
                 && let Ok(Some(mapped)) = mapping.map_uid(mapped_uid)
@@ -308,7 +357,7 @@ pub(super) fn apply_ownership_from_entry(
                 mapped_uid = mapped;
             }
             map_uid(mapped_uid, options.numeric_ids_enabled())
-        })
+        }))
     } else {
         None
     };
@@ -316,7 +365,7 @@ pub(super) fn apply_ownership_from_entry(
     let group = if let Some(gid_override) = options.group_override() {
         Some(ownership::gid_from_raw(gid_override as RawGid))
     } else if options.group() {
-        entry.gid().and_then(|gid| {
+        gate_preserved_group(entry.gid().and_then(|gid| {
             let mut mapped_gid = gid as RawGid;
             if let Some(mapping) = options.group_mapping()
                 && let Ok(Some(mapped)) = mapping.map_gid(mapped_gid)
@@ -324,7 +373,7 @@ pub(super) fn apply_ownership_from_entry(
                 mapped_gid = mapped;
             }
             map_gid(mapped_gid, options.numeric_ids_enabled())
-        })
+        }))
     } else {
         None
     };
@@ -389,7 +438,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     let owner = if let Some(uid_override) = options.owner_override() {
         Some(ownership::uid_from_raw(uid_override as RawUid))
     } else if options.owner() {
-        entry.uid().and_then(|uid| {
+        gate_preserved_owner(entry.uid().and_then(|uid| {
             let mut mapped_uid = uid as RawUid;
             if let Some(mapping) = options.user_mapping()
                 && let Ok(Some(mapped)) = mapping.map_uid(mapped_uid)
@@ -397,7 +446,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
                 mapped_uid = mapped;
             }
             map_uid(mapped_uid, options.numeric_ids_enabled())
-        })
+        }))
     } else {
         None
     };
@@ -405,7 +454,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
     let group = if let Some(gid_override) = options.group_override() {
         Some(ownership::gid_from_raw(gid_override as RawGid))
     } else if options.group() {
-        entry.gid().and_then(|gid| {
+        gate_preserved_group(entry.gid().and_then(|gid| {
             let mut mapped_gid = gid as RawGid;
             if let Some(mapping) = options.group_mapping()
                 && let Ok(Some(mapped)) = mapping.map_gid(mapped_gid)
@@ -413,7 +462,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
                 mapped_gid = mapped;
             }
             map_gid(mapped_gid, options.numeric_ids_enabled())
-        })
+        }))
     } else {
         None
     };

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1628,3 +1628,34 @@ fn keep_dirlinks_bypass_is_cross_platform_safe() {
         );
     }
 }
+
+// Mirrors upstream rsync's `change_uid`/`change_gid` privilege gates
+// (rsync.c:526-528): a non-root process must not attempt to set a file's owner
+// uid, and may only set its group to one it belongs to. Before this gate,
+// oc-rsync attempted the chown unconditionally and surfaced the resulting
+// EPERM as a fatal exit-code-23 error (e.g. under `-aR` when an implied parent
+// directory is owned by root).
+#[cfg(unix)]
+#[test]
+fn non_root_ownership_gate_drops_owner_keeps_member_group() {
+    if rustix::process::geteuid().is_root() {
+        // As root the gate is a no-op; root behaviour is exercised by the
+        // geteuid()==0 chown tests above.
+        return;
+    }
+
+    let owner = Some(ownership::uid_from_raw(0));
+    let group = Some(ownership::gid_from_raw(rustix::process::getegid().as_raw()));
+
+    let gated_owner = super::ownership::gate_preserved_owner(owner);
+    let gated_group = super::ownership::gate_preserved_group(group);
+
+    assert!(
+        gated_owner.is_none(),
+        "non-root must not attempt to set the owner uid"
+    );
+    assert!(
+        gated_group.is_some(),
+        "non-root may set the group to its own effective gid"
+    );
+}


### PR DESCRIPTION
## Problem

A non-root transfer with `-o`/`-g` (typically via `-a`) that must apply ownership to a destination owned by another user - for example `-aR` where an implied `--relative` parent directory like `/home` is root-owned - attempted `fchownat` to the source owner uid, got `EPERM`, and treated it as a **fatal error (exit code 23)**.

Upstream rsync never issues the chown without privilege. In `rsync.c:set_file_attrs()` (lines 526-528):

```c
change_uid = am_root && uid_ndx && sxp->st.st_uid != (uid_t)F_OWNER(file);
change_gid = gid_ndx && !(file->flags & FLAG_SKIP_GROUP) && ...
```

`change_uid` is gated on `am_root`; `FLAG_SKIP_GROUP` is set at id-map time (`uidlist.c:284`) unless `is_in_group()` (`uidlist.c:195`, a `getgroups()` membership test). A non-root process therefore attempts neither the owner chown nor a chgrp to a non-member group, so no EPERM ever arises.

This reproduces standalone on any `oc-rsync` build (not a regression) and is what blocks the upstream `exclude` testsuite test from passing after the `--delete-before` leg was fixed.

## Fix

Resolved ownership is now passed through `restrict_ownership_to_privilege` before the `chownat`/`fchown` call in all three apply sites (`resolve_ownership`, `apply_ownership_from_entry`, `apply_symlink_ownership_from_entry`):

- non-root resolves the **owner uid to `None`** (mirrors `change_uid = am_root && ...`)
- non-root resolves the **group gid only when it is a member** of that group, via `getegid` + `getgroups` (mirrors `FLAG_SKIP_GROUP`/`is_in_group`)
- **root behaviour is unchanged** (the gate short-circuits)

The fake-super path already diverts to xattr storage before chown, so it is unaffected.

## Tests

Adds `non_root_ownership_gate_drops_owner_keeps_member_group` asserting that, run non-root, the owner uid is dropped and the effective-gid group is kept. Existing chown integration tests are `geteuid()==0`-gated (root-only) and are unaffected.

Local `cargo fmt` + `cargo clippy -p metadata --all-features` clean; targeted nextest green.