### PR TITLE
fix(cli): emit '<file> is newer' for --update skip under --info=skip

### DIFF
--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -12,6 +12,7 @@ mod tests;
 use std::io::{self, Write};
 
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
+use logging::{InfoFlag, info_gte};
 
 use super::tokens::{OutFormat, OutFormatContext, OutFormatToken};
 
@@ -146,6 +147,17 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
     writer: &mut W,
 ) -> io::Result<()> {
     for event in events {
+        // upstream: generator.c:1721-1724 - a file skipped by `--update`
+        // because the destination is newer never reaches the itemize call.
+        // The generator emits `"%s is newer"` only at INFO_GTE(SKIP, 1) and
+        // then `goto cleanup`, so the itemized row is suppressed regardless
+        // of `-i`/`-ii`.
+        if matches!(event.kind(), ClientEventKind::SkippedNewerDestination) {
+            if info_gte(InfoFlag::Skip, 1) {
+                writeln!(writer, "{} is newer", event.relative_path().display())?;
+            }
+            continue;
+        }
         if should_suppress_event(event, context) {
             continue;
         }

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -916,6 +916,55 @@ fn itemize_skipped_newer_destination_shows_dot() {
     );
 }
 
+// upstream: generator.c:1721-1724 - an `--update` skip (destination newer)
+// emits `"%s is newer"` only at INFO_GTE(SKIP, 1) and never itemizes the
+// entry. These two tests pin that orchestration behavior so the entry is not
+// rendered as an itemized `.f` row when `-ii` is also in effect.
+#[test]
+fn emit_out_format_update_skip_emits_is_newer_under_info_skip() {
+    logging::init(logging::VerbosityConfig::from_verbose_level(2));
+    let event = make_event(
+        ClientEventKind::SkippedNewerDestination,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    emit_out_format(
+        std::slice::from_ref(&event),
+        &format,
+        &OutFormatContext::default(),
+        &mut output,
+    )
+    .unwrap();
+    assert_eq!(String::from_utf8(output).unwrap(), "test.txt is newer\n");
+}
+
+#[test]
+fn emit_out_format_update_skip_silent_without_info_skip() {
+    logging::init(logging::VerbosityConfig::from_verbose_level(0));
+    let event = make_event(
+        ClientEventKind::SkippedNewerDestination,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    let format = parse_out_format(std::ffi::OsStr::new("%i %n")).unwrap();
+    let mut output = Vec::new();
+    emit_out_format(
+        std::slice::from_ref(&event),
+        &format,
+        &OutFormatContext::default(),
+        &mut output,
+    )
+    .unwrap();
+    assert!(
+        String::from_utf8(output).unwrap().is_empty(),
+        "update-skip must not itemize without --info=skip"
+    );
+}
+
 #[test]
 fn itemize_skipped_non_regular_shows_dot() {
     let event = make_event(


### PR DESCRIPTION
## What this fixes

The upstream-testsuite `exclude` test's final leg `-aiiO --update --info=skip up1/ up2/` had oc-rsync render an itemized `.f          dst-newness` row where upstream prints `dst-newness is newer`.

Upstream `generator.c:1721-1724`: an `--update` skip (destination newer) emits `"%s is newer"` **only** at `INFO_GTE(SKIP, 1)` and returns early without itemizing. oc-rsync recorded a `SkippedNewerDestination` client event the CLI rendered as a `.f` row and never emitted the skip message.

`emit_out_format` now special-cases `SkippedNewerDestination`: emit `<path> is newer` when `info_gte(InfoFlag::Skip, 1)`, always suppress the itemized row. Output-orchestration layer only; the itemize formatter is untouched. Two regression tests pin the behavior.

## Scope note

This closes the `dst-newness is newer` divergence (verified against the CI `exclude.log` artifact). One **separate, pre-existing** divergence remains on the same leg: oc-rsync does not itemize an equal-mtime *unchanged* file (`same-newness`) as `.f` under `-ii` in the local-copy path. That gap is independent of this change (it is not a `SkippedNewerDestination` event) and is tracked as a follow-up; the `exclude` upstream test stays red until it lands. No regression to existing behavior.