### PR TITLE
fix(transfer): stop server-sender forwarding itemize to client

### DIFF
--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -319,13 +319,27 @@ impl GeneratorContext {
         let line = super::itemize::format_itemize_line(iflags, entry, true, &ctx);
 
         if self.config.connection.client_mode {
-            // upstream: log.c:330-340 - when !am_server, rwrite() sends to FCLIENT (stdout)
+            // upstream: log.c:822-823 - when !am_server, rwrite() sends FCLIENT
+            // to stdout. In a pull the local client is the receiver and this
+            // Generator(sender) callback path surfaces the client-side row.
             if let Some(cb) = itemize_cb.as_mut() {
                 cb.on_itemize(&line);
             }
             Ok(())
         } else {
-            writer.send_message(protocol::MessageCode::Info, line.as_bytes())
+            // upstream: sender.c:215 - `itemizing = am_server ?
+            // logfile_format_has_i : stdout_format_has_i`. On a server-sender
+            // (am_server) with no `--log-file-format`, logfile_format_has_i == 0,
+            // so the sender emits no client-visible itemize at all:
+            // maybe_log_item (log.c:828-843) only ever reaches
+            // log_item(FLOG, ...), a local `--log-file` artifact, never an
+            // MSG_INFO forward to the client. The client-visible itemize is
+            // owned by the receiver-side generator (receiver/mod.rs::emit_itemize).
+            // Forwarding a sender-direction row here duplicated every
+            // transferred file under `-ii`/`-vv` over a remote shell (the
+            // upstream `exclude-lsh` pull leg emitted both `>f` and `<f`).
+            let _ = writer;
+            Ok(())
         }
     }
 


### PR DESCRIPTION
## Problem

A `-aii` (or `-vv`) **pull** over a remote shell (`lsh.sh`/SSH) duplicates every transferred file's itemize line on the client: once `>f+++++++++ NAME` (correct, receiver direction) and once `<f+++++++++ NAME` (spurious, sender direction). Reproduced on the upstream testsuite `exclude-lsh` leg:

```
 dst-newness is newer
 >f+++++++++ extra-src
+<f+++++++++ extra-src      # oc-rsync emits a spurious second row
 .f          same-newness
 >f..t...... src-newness
+<f..t...... src-newness
```

The spurious `<f` is forwarded from the remote `--server --sender` process (oc-rsync's `ServerRole::Generator`) via `MSG_INFO`.

## Root cause

Upstream gates the **sender's** itemize on `am_server ? logfile_format_has_i : stdout_format_has_i` (`sender.c:215`). On a server-sender with no `--log-file-format`, `logfile_format_has_i == 0`, so it emits nothing to the client: `maybe_log_item` (`log.c:828-843`) only ever reaches `log_item(FLOG, ...)` — a local `--log-file` artifact, never an `MSG_INFO` forward. The client-visible itemize is owned by the receiver-side generator.

`maybe_emit_itemize` in `crates/transfer/src/generator/protocol_io.rs` gated only on the stdout-format equivalent (`info_flags.itemize`) and, in server mode, unconditionally forwarded a sender-direction (`<`) row.

## Fix

Suppress the server-mode (`!client_mode`) `MSG_INFO` forward, matching `sender.c:215`. The client-mode callback path and the receiver-side `emit_itemize` (`receiver/mod.rs`) are untouched, so the receiver side remains the sole source of client-visible itemize in both pull and push directions. Blast radius is confined to a process acting as **sender in server mode** (remote-shell pull and daemon pull); push is unaffected (its itemize is forwarded by the separate receiver path).

## Verification

- `cargo fmt` + `clippy -p transfer --all-targets --all-features` clean.
- No existing unit test asserts the suppressed server-mode forward (generator itemize tests exercise only the client-mode callback).
- Behavioral confirmation deferred to CI: full nextest across Linux/macOS/Windows guards against any itemize/daemon unit regression, and the upstream-testsuite cell exercises `exclude-lsh` directly.