### PR TITLE
fix(client): apply --prune-empty-dirs over remote shell

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -302,6 +302,14 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // as --log-format=%i, but the local ServerConfig also needs the flag set so
     // the generator's maybe_emit_itemize() produces client-side output via callback.
     server_config.flags.info_flags.itemize = config.itemize_changes();
+    // upstream: flist.c::flist_sort_and_clean - prune_empty_dirs is a global the
+    // RECEIVER acts on (clean_flist drops empty-dir chains) regardless of
+    // transport. It is deliberately not part of build_server_flag_string because
+    // that compact string is parsed by the remote SENDER, which must ship all
+    // dirs. Propagate it here so the local receiver's flist prune pass
+    // (receiver::file_list::prune::prune_empty_dirs_pass) runs on remote-shell
+    // pulls; otherwise empty directories survive that upstream would have pruned.
+    server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
     // upstream: flist.c::iconv_for_local and options.c::recv_iconv_settings -
     // when --iconv is configured, the local process must transcode file-list
     // entries between the local and remote charsets. Without this bridge the
@@ -399,6 +407,25 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
         assert!(!server_config.flags.info_flags.itemize);
+    }
+
+    #[test]
+    fn apply_common_server_flags_sets_prune_empty_dirs() {
+        // upstream: flist.c::flist_sort_and_clean honours prune_empty_dirs on the
+        // receiver for every transport; the remote-shell receiver ServerConfig
+        // must carry the flag so the local prune pass runs.
+        let config = ClientConfig::builder().prune_empty_dirs(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.flags.prune_empty_dirs);
+    }
+
+    #[test]
+    fn apply_common_server_flags_prune_empty_dirs_default_false() {
+        let config = ClientConfig::default();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(!server_config.flags.prune_empty_dirs);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`--prune-empty-dirs` (`-m`) was silently ignored for remote-shell (SSH) pulls. Empty directories whose contents are all excluded survived in the destination, where upstream rsync prunes them.

## Root cause

Upstream treats `prune_empty_dirs` as a receiver-side global: `flist.c::flist_sort_and_clean` (`clean_flist`) drops empty-directory chains from the file list on the receiver, for every transport. It is deliberately NOT part of the compact server flag-letter string, because that string is parsed by the remote *sender*, which must ship all directories.

On the remote-shell pull path the local process is the receiver, and its prune pass (`receiver::file_list::prune::prune_empty_dirs_pass`, gated on `config.flags.prune_empty_dirs`) only ran when the flag was set on its `ServerConfig`. `apply_common_server_flags` propagated itemize and several other receiver-local flags but never `prune_empty_dirs`, so the gate was always false for SSH pulls. Local transfers set the flag through a different path and were unaffected.

## Fix

Propagate `config.prune_empty_dirs()` into the receiver `ServerConfig` in `apply_common_server_flags`, alongside the existing itemize propagation. This makes the local receiver's prune pass run on remote-shell pulls, matching upstream `clean_flist` semantics. The flag is receiver-local; nothing changes on the wire.

## Tests

- `apply_common_server_flags_sets_prune_empty_dirs` - flag propagates when `-m` is set.
- `apply_common_server_flags_prune_empty_dirs_default_false` - default stays off.

Covers the upstream `exclude-lsh.test` `--prune-empty-dirs` leg that fails over remote shell.