### PR TITLE
fix(client): prune empty dirs on the remote-shell/daemon pull receiver

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -28,6 +28,11 @@ pub(crate) fn build_server_config_for_receiver(
 
     apply_common_daemon_config(config, &mut server_config, filter_rules);
     server_config.reference_directories = config.reference_directories().to_vec();
+    // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
+    // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
+    // and -m is never sent over the wire (options.c gates it on am_sender), so the
+    // flag must be carried onto the local receiver config here.
+    server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -487,6 +487,11 @@ fn build_server_config_for_receiver(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
+    // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
+    // and -m is never sent over the wire (options.c gates it on am_sender), so the
+    // flag must be carried onto the local receiver config here.
+    server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -688,6 +688,11 @@ pub(super) fn build_server_config_for_receiver(
     server_config.flags.numeric_ids = config.numeric_ids();
     server_config.flags.delete = config.delete_mode().is_enabled() || config.delete_excluded();
     server_config.file_selection.size_only = config.size_only();
+    // upstream flist.c:flist_sort_and_clean prunes empty dirs on the receiver
+    // (prune_empty_dirs && !am_sender); on a pull the local client IS the receiver,
+    // and -m is never sent over the wire (options.c gates it on am_sender), so the
+    // flag must be carried onto the local receiver config here.
+    server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)
@@ -813,6 +818,31 @@ mod tests {
         assert_eq!(server_config.role, ServerRole::Receiver);
         assert_eq!(server_config.args.len(), 1);
         assert_eq!(server_config.args[0], "dest/");
+    }
+
+    #[test]
+    fn receiver_server_config_propagates_prune_empty_dirs() {
+        // upstream prunes empty dirs on the receiver (flist.c: prune_empty_dirs &&
+        // !am_sender); on a pull the local client IS the receiver and -m is never
+        // sent over the wire, so the flag must be carried onto the receiver config
+        // here or prune_empty_dirs_pass never runs. Regression guard for the
+        // remote-shell pull prune gap.
+        let config = ClientConfig::builder()
+            .recursive(true)
+            .times(true)
+            .prune_empty_dirs(true)
+            .build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest/".to_owned()]).unwrap();
+        assert!(server_config.flags.prune_empty_dirs);
+    }
+
+    #[test]
+    fn receiver_server_config_prune_empty_dirs_default_false() {
+        let config = ClientConfig::builder().recursive(true).times(true).build();
+        let server_config =
+            build_server_config_for_receiver(&config, &["dest/".to_owned()]).unwrap();
+        assert!(!server_config.flags.prune_empty_dirs);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`--prune-empty-dirs` (`-m`) is a receiver-side operation. On a pull the local client is the receiver, so upstream gates the empty-dir-chain drop on `prune_empty_dirs && !am_sender` (`flist.c:flist_sort_and_clean`) and **never ships `-m` over the wire** (`options.c:server_options` only adds `m` when `am_sender`). The sender always sends every directory, including empty ones; the receiver prunes them locally after receiving the file list.

oc-rsync already does the prune in `transfer/src/receiver/file_list/receive.rs` (gated on `config.flags.prune_empty_dirs`), but the **remote-shell** and **rsync:// daemon** receiver-config builders never carried the flag onto the local receiver `ServerConfig`. As a result `prune_empty_dirs_pass` never ran on pulls over a custom remote shell (`RSYNC_RSH`) or the daemon transport, leaving empty directory chains on disk that upstream removes.

This carries `config.prune_empty_dirs()` onto all three receiver builders:

- `ssh_transfer.rs` (subprocess SSH; also used by the async SSH transport)
- `embedded_ssh_transfer.rs` (embedded/russh)
- `daemon_transfer/orchestration/server_config.rs` (rsync:// daemon)

## Why this is the right layer

The flag must NOT go through `apply_common_server_flags` (shared with the generator/sender path) — that would incorrectly enable sender-side pruning. It belongs only on the receiver builders, matching upstream's `!am_sender` gate.

## Wire-neutrality (verified)

A loopback tcpdump comparison of an oc vs upstream `--prune-empty-dirs` daemon pull confirms:

- Neither client sends `-m`/`--prune-empty-dirs` to the server.
- The server→client file list is **byte-identical** (all directories, including empty ones, shipped).
- The only divergence is receiver-local: the unfixed binary keeps the empty dirs where upstream removes them.

So the fix changes no bytes on the wire — it only runs the existing receiver-local prune pass on the transports that were missing it.

## Tests

Two regression guards in `ssh_transfer.rs`:

- `receiver_server_config_propagates_prune_empty_dirs` — `-m` set → receiver config has `prune_empty_dirs`.
- `receiver_server_config_prune_empty_dirs_default_false` — default off.

`cargo fmt` and `cargo clippy -p core --all-targets --all-features` both clean locally.