### PR TITLE
fix(receiver): honor --existing for directory creation on remote pulls

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -33,6 +33,11 @@ pub(crate) fn build_server_config_for_receiver(
     // and -m is never sent over the wire (options.c gates it on am_sender), so the
     // flag must be carried onto the local receiver config here.
     server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
+    // upstream generator.c:1368-1383 never creates a directory absent at the
+    // destination under --existing (ignore_non_existing); on a pull the local
+    // client IS the receiver and --existing is a long-form-only flag absent from
+    // the compact letter string, so carry it onto the local receiver config here.
+    server_config.file_selection.existing_only = config.existing_only();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -492,6 +492,11 @@ fn build_server_config_for_receiver(
     // and -m is never sent over the wire (options.c gates it on am_sender), so the
     // flag must be carried onto the local receiver config here.
     server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
+    // upstream generator.c:1368-1383 never creates a directory absent at the
+    // destination under --existing (ignore_non_existing); on a pull the local
+    // client IS the receiver and --existing is a long-form-only flag absent from
+    // the compact letter string, so carry it onto the local receiver config here.
+    server_config.file_selection.existing_only = config.existing_only();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -693,6 +693,11 @@ pub(super) fn build_server_config_for_receiver(
     // and -m is never sent over the wire (options.c gates it on am_sender), so the
     // flag must be carried onto the local receiver config here.
     server_config.flags.prune_empty_dirs = config.prune_empty_dirs();
+    // upstream generator.c:1368-1383 never creates a directory absent at the
+    // destination under --existing (ignore_non_existing); on a pull the local
+    // client IS the receiver and --existing is a long-form-only flag absent from
+    // the compact letter string, so carry it onto the local receiver config here.
+    server_config.file_selection.existing_only = config.existing_only();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -103,12 +103,34 @@ impl ReceiverContext {
         ))]
         let mut probed_parents: std::collections::HashSet<PathBuf> =
             std::collections::HashSet::new();
+        // upstream: generator.c:1368-1383 - with --existing (ignore_non_existing),
+        // a directory that does not yet exist at the destination is never created;
+        // upstream sets skip_dir = file and FLAG_MISSING_DIR so the missing dir and
+        // its descendants are skipped. Because dir_entries are processed in
+        // parent-first sorted order and we never create the parent, each descendant
+        // path also fails the .exists() probe and is skipped the same way.
+        let existing_only = self.config.file_selection.existing_only;
         for (_, relative_path, dir_path) in &dir_entries {
             // `relative_path` is only read on Unix (mkdirat fast path).
             #[cfg(not(unix))]
             let _ = relative_path;
             let is_new = !dir_path.exists();
             dir_was_new.push(is_new);
+            if is_new && existing_only {
+                // upstream: generator.c:1374-1378 - "not creating new directory".
+                // Reuse the failed-dir set so the itemize and metadata passes
+                // below skip this directory (it was never created on disk).
+                if self.config.flags.verbose && self.config.connection.client_mode {
+                    info_log!(
+                        Skip,
+                        1,
+                        "not creating new directory \"{}\"",
+                        dir_path.display()
+                    );
+                }
+                failed_dir_paths.insert(dir_path.clone());
+                continue;
+            }
             if is_new {
                 #[cfg(all(
                     feature = "acl",
@@ -401,6 +423,23 @@ impl ReceiverContext {
         // `fs::create_dir_all`, which preserves the parent-walk for
         // `--relative` shapes.
         let is_new = !dir_path.exists();
+        // upstream: generator.c:1368-1383 - with --existing (ignore_non_existing),
+        // a directory missing at the destination is never created; the dir is
+        // marked skipped (FLAG_MISSING_DIR) so its descendants are skipped too.
+        // Marking it failed here drives the same descendant skip via the
+        // failed-ancestor check above on subsequent entries.
+        if is_new && self.config.file_selection.existing_only {
+            if self.config.flags.verbose && self.config.connection.client_mode {
+                info_log!(
+                    Skip,
+                    1,
+                    "not creating new directory \"{}\"",
+                    dir_path.display()
+                );
+            }
+            failed_dirs.mark_failed(entry.name());
+            return Ok(None);
+        }
         if is_new {
             #[cfg(unix)]
             let create_result = fast_io::mkdirat_via_sandbox_or_fallback(

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -225,6 +225,84 @@ mod create_directory_incremental_tests {
         assert_eq!(failed.count(), 0);
     }
 
+    /// Regression (exclude-lsh / upstream generator.c:1368-1383): with
+    /// `--existing` (`ignore_non_existing`), a directory that is missing at
+    /// the destination must NOT be created, and it must be marked failed so
+    /// its descendants are skipped too. Before the fix, the remote-pull
+    /// receiver created every directory from the file list unconditionally,
+    /// so `--existing --include='*/' --exclude='*'` re-materialised empty
+    /// directory skeletons that upstream leaves absent.
+    #[test]
+    fn existing_only_skips_missing_directory() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path();
+
+        let entry = FileEntry::new_directory("missing".into(), 0o755);
+        let opts = metadata::MetadataOptions::default();
+        let mut failed = FailedDirectories::new();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.file_selection.existing_only = true;
+        let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let result = ctx.create_directory_incremental(
+            dest,
+            &entry,
+            &opts,
+            &mut failed,
+            None,
+            #[cfg(unix)]
+            None,
+        );
+
+        assert!(result.is_ok());
+        // Returns None (skipped) and the directory is never created on disk.
+        assert_eq!(result.unwrap(), None);
+        assert!(
+            !dest.join("missing").exists(),
+            "--existing must not create a missing directory on a remote pull"
+        );
+        // The skipped dir is marked failed so descendants are skipped via the
+        // failed-ancestor check (mirrors upstream FLAG_MISSING_DIR).
+        assert_eq!(failed.count(), 1);
+    }
+
+    /// With `--existing`, a directory that already exists at the destination
+    /// is left in place (metadata still applies); only creation of *missing*
+    /// directories is suppressed.
+    #[test]
+    fn existing_only_keeps_present_directory() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path();
+        std::fs::create_dir(dest.join("present")).unwrap();
+
+        let entry = FileEntry::new_directory("present".into(), 0o755);
+        let opts = metadata::MetadataOptions::default();
+        let mut failed = FailedDirectories::new();
+
+        let handshake = test_handshake();
+        let mut config = test_config();
+        config.file_selection.existing_only = true;
+        let ctx = ReceiverContext::new_for_test(&handshake, config);
+
+        let result = ctx.create_directory_incremental(
+            dest,
+            &entry,
+            &opts,
+            &mut failed,
+            None,
+            #[cfg(unix)]
+            None,
+        );
+
+        assert!(result.is_ok());
+        // Returns Some(false): existing dir, not newly created.
+        assert_eq!(result.unwrap(), Some(false));
+        assert!(dest.join("present").exists());
+        assert_eq!(failed.count(), 0);
+    }
+
     #[test]
     fn skips_child_of_failed_parent() {
         let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

On a remote-shell (`RSYNC_RSH`/lsh.sh) or `rsync://` daemon **pull**, the local client is the receiver. Under `--existing` (`ignore_non_existing`), oc-rsync was unconditionally creating every directory from the file list, including ones absent at the destination — upstream `generator.c:1368-1383` never creates a directory missing at the destination under `--existing` (it sets `FLAG_MISSING_DIR` so descendants are skipped too).

### Root cause (two parts, same class as the prune-empty-dirs fix)
1. The receiver dir-creation path (`creation.rs`) did not gate on `existing_only`.
2. `--existing` is a long-form-only flag, absent from the compact server flag-letter string, so even after gating it read `false` on remote pulls — the flag was never carried onto the three remote receiver-config builders (ssh / embedded-ssh / daemon), exactly like the prune-empty-dirs gap.

### Fix
- Gate directory creation on `file_selection.existing_only` in the incremental + batch receiver paths; mark the skipped dir failed so descendants are skipped via the existing failed-ancestor check.
- Carry `config.existing_only()` onto all three remote receiver builders.

### Wire-neutral
The sender always transmits the full file list; `--existing` is applied client-receiver-side only. Confirmed by loopback tcpdump (oc vs upstream): identical server->client flist; the only divergence was receiver-local dir creation.

### Verification
Reproduced and fixed pure-oc on a Linux host. The directory-skeleton divergence (`foo/down`, `mid/for/foo/and`, `new/keep/this`, `new/lose`) that the `--existing --include='*/'` leg of `exclude.test` produced is eliminated.

Note: `exclude-lsh` has a **separate, independent** remaining cause (nested per-directory `dir-merge .filt2` deletion evaluation on the `--delete-during` leg) that this PR does not touch; this PR is a strict no-regression improvement that closes the `--existing` correctness bug.

Adds 2 receiver regression tests.

Closes the `--existing` remote-pull directory-creation bug.