### PR TITLE
fix(filters): inherit dir-merge side + client deletion chain (exclude-lsh)

### DIFF
--- a/crates/filters/src/chain/config.rs
+++ b/crates/filters/src/chain/config.rs
@@ -202,6 +202,24 @@ impl DirMergeConfig {
         self.exclude_self
     }
 
+    /// Reports whether this config restricts its rules to the sender side.
+    ///
+    /// Used to propagate the `s` modifier of a side-restricted per-directory
+    /// merge into any `dir-merge` directives nested inside it, mirroring
+    /// upstream `exclude.c:1293-1303` (`rflags |= template->rflags & SIDES`).
+    #[must_use]
+    pub(super) const fn is_sender_only(&self) -> bool {
+        self.sender_only && !self.receiver_only
+    }
+
+    /// Reports whether this config restricts its rules to the receiver side.
+    ///
+    /// Mirror of [`Self::is_sender_only`] for the `r` modifier.
+    #[must_use]
+    pub(super) const fn is_receiver_only(&self) -> bool {
+        self.receiver_only && !self.sender_only
+    }
+
     /// Applies configured modifiers to a parsed rule.
     pub(super) fn apply_modifiers(&self, mut rule: FilterRule) -> FilterRule {
         if self.anchor_root {

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -136,6 +136,20 @@ impl FilterChain {
         self.merge_configs.push(config);
     }
 
+    /// Reports whether any per-directory merge file configurations are
+    /// registered on this chain.
+    ///
+    /// The receiver's delete pass consults this to decide whether it must
+    /// reload per-directory merge rules while scanning each destination
+    /// directory (mirroring upstream `delete.c`/`exclude.c`
+    /// `change_local_filter_dir` -> `push_local_filters`). When no merge
+    /// configs exist the shared global rule snapshot is sufficient and the
+    /// per-directory reload is skipped.
+    #[must_use]
+    pub fn has_per_dir_merge(&self) -> bool {
+        !self.merge_configs.is_empty()
+    }
+
     /// Marks this chain as operating under `--delete-excluded`.
     ///
     /// When enabled, rules expanded out of per-directory merge files acquire

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -364,7 +364,7 @@ impl FilterChain {
             // compilation drops DirMerge rules, so handle them here by
             // loading the named file from the current directory and folding
             // its tokens into this scope.
-            let (rules, dir_merge_descriptors) = split_dir_merge_rules(rules);
+            let (rules, mut dir_merge_descriptors) = split_dir_merge_rules(rules);
 
             if rules.is_empty() && dir_merge_descriptors.is_empty() && !config.excludes_self() {
                 continue;
@@ -372,6 +372,23 @@ impl FilterChain {
 
             let config = &self.merge_configs[config_index];
             let delete_excluded = self.delete_excluded;
+
+            // upstream: exclude.c:1293-1303 - a `dir-merge` directive parsed from
+            // inside a side-restricted per-directory merge (e.g. `:s .filt`)
+            // inherits the container's FILTRULES_SIDES, so the rules it later
+            // loads (and every descendant reload of the registered config) become
+            // side-restricted too. Without this, a nested `dir-merge .filt2`
+            // declared inside a `:s` merge stays two-sided and its `- *.deep`
+            // wrongly protects flist-absent files from receiver-side deletion.
+            if config.is_sender_only() {
+                for descriptor in &mut dir_merge_descriptors {
+                    descriptor.sender_only = true;
+                }
+            } else if config.is_receiver_only() {
+                for descriptor in &mut dir_merge_descriptors {
+                    descriptor.receiver_only = true;
+                }
+            }
 
             let mut modified_rules: Vec<FilterRule> = rules
                 .into_iter()
@@ -427,7 +444,9 @@ impl FilterChain {
                     self.merge_configs.push(
                         DirMergeConfig::new(descriptor.filename.clone())
                             .with_cvs_mode(descriptor.cvs_mode)
-                            .with_inherit(true),
+                            .with_inherit(true)
+                            .with_sender_only(descriptor.sender_only)
+                            .with_receiver_only(descriptor.receiver_only),
                     );
                 }
                 pushed_count += self.load_inline_dir_merge(directory, depth, &descriptor)?;
@@ -498,6 +517,7 @@ impl FilterChain {
         let delete_excluded = self.delete_excluded;
         let rules: Vec<FilterRule> = rules
             .into_iter()
+            .map(|rule| apply_dir_merge_inherited_side(rule, descriptor))
             .map(|rule| apply_merge_implicit_sender_side(rule, delete_excluded))
             .collect();
 
@@ -628,6 +648,31 @@ fn apply_merge_implicit_sender_side(rule: FilterRule, delete_excluded: bool) -> 
     rule.with_receiver(false)
 }
 
+/// Applies a nested dir-merge's inherited side modifier to a loaded rule.
+///
+/// When a `dir-merge` directive is side-restricted (its own `s`/`r` modifier,
+/// or inherited from a side-restricted container per-directory merge), the
+/// rules it loads default to that side unless they carry their own. Only
+/// two-sided include/exclude rules are adjusted, matching upstream's
+/// `FILTRULES_SIDES` inheritance (exclude.c:1293-1303); a rule that already
+/// specifies a side keeps it.
+fn apply_dir_merge_inherited_side(rule: FilterRule, descriptor: &InlineDirMerge) -> FilterRule {
+    if !descriptor.sender_only && !descriptor.receiver_only {
+        return rule;
+    }
+    if !matches!(rule.action(), FilterAction::Include | FilterAction::Exclude) {
+        return rule;
+    }
+    if !(rule.applies_to_sender() && rule.applies_to_receiver()) {
+        return rule;
+    }
+    if descriptor.sender_only {
+        rule.with_sides(true, false)
+    } else {
+        rule.with_sides(false, true)
+    }
+}
+
 /// Description of a dir-merge directive parsed from another merge file.
 ///
 /// Captures the pieces of the source [`FilterRule`] that drive how the
@@ -639,6 +684,15 @@ struct InlineDirMerge {
     filename: String,
     cvs_mode: bool,
     no_inherit: bool,
+    /// Restricts the rules loaded from this merge to the sender side.
+    ///
+    /// Set from the source `dir-merge` rule's own `s` modifier, then OR-ed
+    /// with the side of the containing per-directory merge so a `dir-merge`
+    /// nested inside a `:s` merge inherits sender-side. upstream:
+    /// `exclude.c:1293-1303` inherits `FILTRULES_SIDES` from the template.
+    sender_only: bool,
+    /// Receiver-side counterpart of [`Self::sender_only`] (`r` modifier).
+    receiver_only: bool,
 }
 
 /// Splits parsed rules into ordinary entries plus dir-merge descriptors.
@@ -693,6 +747,8 @@ fn split_dir_merge_rules(rules: Vec<FilterRule>) -> (Vec<FilterRule>, Vec<Inline
                 filename: rule.pattern().to_owned(),
                 cvs_mode: rule.is_cvs_mode(),
                 no_inherit: rule.is_no_inherit(),
+                sender_only: rule.applies_to_sender() && !rule.applies_to_receiver(),
+                receiver_only: rule.applies_to_receiver() && !rule.applies_to_sender(),
             });
         } else {
             keep.push(rule);

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -63,6 +63,14 @@ impl ReceiverContext {
 
         let max_delete = self.config.deletion.max_delete;
 
+        // Whether the deletion chain carries per-directory merge configs
+        // (`.rsync-filter`, dir-merge `.filt`/`.filt2`). Computed up front so it
+        // can gate both the scan-target expansion below and the per-worker
+        // reload further down. When there are no per-dir merge configs the
+        // deletion pass behaves exactly as before: dirs_to_scan is keyed off
+        // parents-with-a-visible-child and the flat global chain decides.
+        let needs_perdir_merge = self.deletion_filter_chain.has_per_dir_merge();
+
         // Build directory -> children map from the file list.
         // Use owned OsString keys so the map can be shared across threads.
         // On macOS, normalize filenames to NFC so that NFD names from read_dir
@@ -90,6 +98,26 @@ impl ReceiverContext {
                     .or_default()
                     .insert(normalize_filename_for_compare(name));
             }
+
+            // upstream: generator.c:delete_in_dir() runs for EVERY content
+            // directory in the file list. Each directory's deletion candidate
+            // list is built from a fresh readdir of the destination, regardless
+            // of whether any of that directory's source children are visible in
+            // the flist. A directory whose only source children are filter-
+            // hidden (e.g. `--filter='hide,! */'`) must still be scanned so
+            // extraneous destination entries inside it are removed. Keying
+            // dirs_to_scan solely off parents-with-a-visible-child skips such
+            // directories and leaves extraneous files undeleted, so register
+            // every directory entry as its own scan target with a (possibly
+            // empty) keep-set. Gated on `needs_perdir_merge`: the expanded
+            // scan set is only safe when the per-directory merge rules are
+            // reloaded per dir to protect dest-side merge files and their
+            // excludes; without them, scanning extra dirs against the flat
+            // chain would over-delete. Daemon/non-merge transfers keep the
+            // master scan set unchanged.
+            if needs_perdir_merge && entry.is_dir() {
+                dir_children.entry(relative.to_path_buf()).or_default();
+            }
         }
 
         let dirs_to_scan: Vec<PathBuf> = dir_children.keys().cloned().collect();
@@ -98,13 +126,29 @@ impl ReceiverContext {
         // upstream: main.c:1367 - deletion_count >= max_delete
         let deletions_performed = Arc::new(AtomicU64::new(0));
 
-        // Share directory children map and filter chain across workers.
-        // The filter chain clone captures the global rules snapshot for
-        // allows_deletion() checks. Per-directory merge files are not
-        // re-read during deletion (upstream also only evaluates the
-        // pre-loaded filter list in delete_in_dir).
+        // Share directory children map and filter chains across workers.
+        //
+        // Two chains are carried: `flat_chain` is the global rules snapshot
+        // used when no per-directory merge files are in play, and `merge_chain`
+        // is the deletion-pass chain that knows about per-directory merge
+        // configs (`.rsync-filter`, dir-merge `.filt`/`.filt2`).
+        //
+        // upstream: generator.c:308 delete_in_dir() ->
+        // change_local_filter_dir() -> exclude.c:push_local_filters() reloads
+        // each destination directory's per-directory merge file(s) (including
+        // nested merges) before is_excluded() tests a deletion candidate, so a
+        // merge file's own protect rule (and any merge-driven excludes) take
+        // effect during deletion. Carry the transfer root so leading-`/` rules
+        // in those merge files re-anchor correctly, and remember whether any
+        // per-directory merge configs exist so workers only pay the reload cost
+        // when the chain actually has per-dir merges.
         let dir_children = Arc::new(dir_children);
-        let filter_chain = Arc::new(self.filter_chain.clone());
+        let flat_chain = Arc::new(self.filter_chain.clone());
+        let merge_chain = Arc::new({
+            let mut chain = self.deletion_filter_chain.clone();
+            chain.set_transfer_root(dest_dir.to_path_buf());
+            chain
+        });
         let dest_dir_owned = dest_dir.to_path_buf();
         // SEC-1.q2: clone the sandbox `Arc` into the worker closure so
         // every per-directory job can route its scan and per-entry
@@ -178,6 +222,30 @@ impl ReceiverContext {
 
                     let mut stats = DeleteStats::new();
                     let mut deleted_paths = Vec::new();
+
+                    // upstream parity: reload this destination directory's
+                    // per-directory merge rules (and its inheriting ancestors')
+                    // so dir-merge self-exclusion and merge-driven excludes are
+                    // active while deciding deletions. Only entered when the
+                    // deletion chain has per-dir merge configs; otherwise the
+                    // flat global chain is consulted directly. enter_directory
+                    // takes `&mut self`, so each worker reloads onto its own
+                    // clone of the merge chain.
+                    let local_chain = if needs_perdir_merge {
+                        let mut chain = (*merge_chain).clone();
+                        let _ = chain.enter_directory(&dest_dir_owned);
+                        if dir_relative.as_os_str() != "." {
+                            let mut cur = dest_dir_owned.clone();
+                            for comp in dir_relative.iter() {
+                                cur.push(comp);
+                                let _ = chain.enter_directory(&cur);
+                            }
+                        }
+                        Some(chain)
+                    } else {
+                        None
+                    };
+
                     for entry in read_dir_iter {
                         #[cfg(unix)]
                         let (name, kind) = match entry {
@@ -223,7 +291,11 @@ impl ReceiverContext {
                         } else {
                             dir_relative.join(&name)
                         };
-                        if !filter_chain.allows_deletion(&rel_for_filter, is_dir) {
+                        let allows = match &local_chain {
+                            Some(chain) => chain.allows_deletion(&rel_for_filter, is_dir),
+                            None => flat_chain.allows_deletion(&rel_for_filter, is_dir),
+                        };
+                        if !allows {
                             continue;
                         }
 

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -345,6 +345,24 @@ pub struct ReceiverContext {
     ///
     /// - `generator.c:delete_in_dir()` - `is_excluded()` check before deletion
     filter_chain: FilterChain,
+    /// Per-directory merge rules consulted exclusively by the `--delete` pass.
+    ///
+    /// Held separately from `filter_chain` because `filter_chain` is also read
+    /// by the `--prune-empty-dirs` pass (`prune_empty_dirs_pass`); the deletion
+    /// pass needs the dir-merge configs (`.rsync-filter`, `.filt`/`.filt2`) so
+    /// it can reload each destination directory's per-directory merge files
+    /// while scanning, but those rules must not perturb prune-empty-dirs.
+    ///
+    /// On a local-client pull the wire filter list is never received
+    /// (`should_read_filter_list()` is false in client mode), so this is built
+    /// in `setup_transfer` from the local CLI filter rules. On a daemon/server
+    /// receiver it is cloned from the wire-populated `filter_chain`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:delete_in_dir()` -> `change_local_filter_dir()` ->
+    ///   `exclude.c:push_local_filters()` reloads dest-side per-dir merge files
+    deletion_filter_chain: FilterChain,
     /// Tracker for hardlink leader/follower relationships during file apply.
     ///
     /// Records committed leader paths so followers can be hard-linked to them.
@@ -459,6 +477,7 @@ impl ReceiverContext {
             gid_list: IdList::new(),
             daemon_filter_set,
             filter_chain: FilterChain::empty(),
+            deletion_filter_chain: FilterChain::empty(),
             hardlink_tracker,
             prior_hlinks: HashMap::new(),
             flist_io_error: 0,
@@ -790,6 +809,15 @@ impl ReceiverContext {
     #[must_use]
     pub fn filter_chain(&self) -> &FilterChain {
         &self.filter_chain
+    }
+
+    /// Sets the deletion-pass filter chain.
+    ///
+    /// Held separately from `filter_chain` so the `--delete` pass can reload
+    /// per-directory merge files without perturbing `--prune-empty-dirs`. In
+    /// production this is populated by `setup_transfer`; tests set it directly.
+    pub fn set_deletion_filter_chain(&mut self, chain: FilterChain) {
+        self.deletion_filter_chain = chain;
     }
 
     /// Returns the compiled daemon filter set, if any rules were configured.

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -108,6 +108,41 @@ impl ReceiverContext {
                 }
                 self.filter_chain = chain;
             }
+        } else if self.config.connection.client_mode
+            && !self.config.connection.filter_rules.is_empty()
+        {
+            // upstream: generator.c:delete_in_dir() -> change_local_filter_dir()
+            // reloads each DESTINATION directory's per-directory merge files
+            // before deciding deletions. On a local-client pull the wire filter
+            // list is never received (should_read_filter_list() is false in
+            // client mode), so the receiver's `--delete` pass would otherwise
+            // run against an empty filter chain and mis-handle dir-merge-governed
+            // trees (over-deleting self-protected `.filt`/`.filt2` merge files,
+            // under-deleting extraneous entries in filter-hidden dirs). Build a
+            // dedicated deletion chain from the same local CLI filter rules the
+            // generator consumes (generator/filters.rs), so the per-directory
+            // merge reload in `delete_extraneous_files` has the dir-merge
+            // configs. Held separately from `filter_chain` so `--prune-empty-dirs`
+            // is unaffected. Only the deletion pass consults this, so it is inert
+            // when `--delete` is not active.
+            let (filter_set, merge_configs) = parse_wire_filters_for_receiver(
+                &self.config.connection.filter_rules,
+            )
+            .map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "filter error: {e} {}{}",
+                        crate::role_trailer::error_location!(),
+                        crate::role_trailer::receiver()
+                    ),
+                )
+            })?;
+            let mut chain = FilterChain::new(filter_set);
+            for config in merge_configs {
+                chain.add_merge_config(config);
+            }
+            self.deletion_filter_chain = chain;
         }
 
         // FSM: filter list reading is complete. Advance to FileListTransfer.


### PR DESCRIPTION
Two complementary, independently-scoped filter/deletion fixes, each cited to upstream. Targets the upstream-testsuite `exclude` and `exclude-lsh` divergences (local + lsh.sh remote-shell).

## 1. Populate the deletion filter chain for local-client pulls

On a local-client pull the wire filter list is never received (`should_read_filter_list()` is false in client mode), so the receiver `--delete` pass ran against an empty filter chain. The per-directory merge rules that govern deletion (`dir-merge .filt`/`.filt2`, `.rsync-filter`) populated only the generator's chain, a separate evaluator.

A dedicated `deletion_filter_chain` (held separately from `filter_chain`, which `--prune-empty-dirs` also reads) is built in `setup_transfer` from the same local CLI filter rules the generator consumes. The delete pass reloads each destination directory's per-directory merge files while scanning, mirroring `generator.c:delete_in_dir()` -> `change_local_filter_dir()` -> `exclude.c:push_local_filters()`, and scans every content directory rather than only parents with a visible child. This closes the anchored `- /file1` case (`foo/file1`).

Scoped to client-mode-with-merges: daemon/server receivers and transfers without per-dir merges keep the existing scan set and flat chain unchanged.

## 2. Inherit the side modifier into nested dir-merge rules

A `dir-merge` directive parsed from inside a side-restricted per-directory merge (e.g. `:s .filt`) must inherit the container's sender/receiver side, so the rules it loads -- and every descendant reload of the registered config -- become side-restricted too (upstream `exclude.c:1293-1303`, `rflags |= template->rflags & FILTRULES_SIDES`).

`InlineDirMerge` now carries `sender_only`/`receiver_only` (from the dir-merge rule's own modifier, OR-ed with the container's side); it is threaded into the persistent `DirMergeConfig` registration and the inline-load rule pipeline. Scoped to descriptors that carry an explicit single side, so two-sided dir-merges are unchanged and ordinary receiver-side deletion still works.

## Validation status (host, Linux, full branch @ HEAD)

- `exclude`: PASS. `diff -r chk to` empty; `foo/file1` deleted; `.filt`/`.filt2`/`nodel.deep` kept (no data loss). Closed by fix #1.
- `exclude-lsh`: STILL FAILING. `diff -r chk to` has exactly one residual -- `bar/down/to/bar/baz/file5.deep` is kept by oc-rsync where upstream deletes it. All other entries match. Fix #2 did NOT change this delete decision; root cause is under active strace + `--debug=FILTER4` capture-vs-upstream investigation. **This PR does not yet close `exclude-lsh`.**
- fmt + clippy clean; targeted nextest (transfer deletion/filter_chain + filters dir-merge/merge) green.

Do not merge as an `exclude-lsh` closure until the `file5.deep` residual is resolved and the `upstream-testsuite` check (authoritative per-test gate) shows `exclude-lsh` PASS.
