### PR TITLE
fix(filters): carry dir-merge :s/:r side onto the wire for delete-pass parity

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -250,6 +250,19 @@ pub(crate) fn build_wire_format_rules(
             // default the empty pattern to `.cvsignore` nor activate
             // CVS-style whitespace parsing of the per-directory file.
             wire_rule.cvs_exclude = options.is_cvs_mode();
+            // upstream: exclude.c:1566-1572 get_rule_prefix() emits `s`/`r` for a
+            // side-restricted dir-merge. A `:s`/`:r` dir-merge's side lives in
+            // DirMergeOptions, NOT in the spec's applies_to_* booleans that
+            // wire_sender_side()/wire_receiver_side() read (FilterRuleSpec::dir_merge
+            // hardcodes both true). Without carrying it here, a `:s .filt`
+            // serializes with no side flag, so the receiver's --delete pass loads
+            // it (and any nested dir-merge) as two-sided and wrongly protects
+            // flist-absent files from deletion. Mirror the both-sides==no-flag
+            // convention exactly.
+            let dm_sender = options.applies_to_sender();
+            let dm_receiver = options.applies_to_receiver();
+            wire_rule.sender_side = dm_sender && !dm_receiver;
+            wire_rule.receiver_side = dm_receiver && !dm_sender;
         }
 
         wire_rules.push(wire_rule);


### PR DESCRIPTION
## Problem

`exclude-lsh` (upstream testsuite) fails on master: the remote-shell `--delete-before` leg with a side-restricted dir-merge (`-f :s_.filt -f .s_- -f P_nodel.deep`) leaves files that upstream deletes.

## Root cause

A per-directory merge declared `:s` (sender-side) or `:r` (receiver-side) stores its side in `DirMergeOptions`, not in the `FilterRuleSpec` `applies_to_sender/applies_to_receiver` booleans. `FilterRuleSpec::dir_merge()` hardcodes both booleans to `true`, and `wire_sender_side()/wire_receiver_side()` read those booleans — so a `:s .filt` serialized onto the wire with **no** side flag.

On a remote-shell pull the receiver builds its `--delete` filter chain from the wire rule list. With the side flag missing it loaded `:s .filt` (and any nested dir-merge it declares) as a both-sides rule, making its exclude rules receiver-applicable. The delete pass then protected files the sender had already excluded from the flist, leaving them undeleted where upstream removes them.

## Fix

Carry the dir-merge side from `DirMergeOptions` onto the wire rule, using the same both-sides == no-flag convention upstream uses in `exclude.c:1566-1572 get_rule_prefix()`. 13 lines, one file.

## Verification

Controlled experiment on a Linux host against upstream rsync 3.4.3:

- Master `5828f3f8c` -> `runtests.py exclude-lsh` **FAIL** (matches the latest master upstream-testsuite run).
- Master + only this 13-line change -> `runtests.py exclude-lsh` **PASS**, empty `diff -r chk to`.

The two binaries differ by exactly these lines, isolating them as the fix. `cargo fmt --all -- --check` clean.