### PR TITLE
fix(checksums): drop miscomputing asm hash backend on macOS

### DIFF
--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -49,10 +49,20 @@ logging = { path = "../logging" }
 # On unix, the `asm` feature on sha1/sha2 enables sha2-asm which provides assembly
 # fallbacks; the pure-Rust backend already auto-detects SHA-NI (x86_64) and
 # crypto extensions (aarch64) via `cpufeatures` regardless of this feature.
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 md-5 = { workspace = true, features = ["std", "asm"] }
 sha1 = { version = "0.10", default-features = false, features = ["std", "asm"] }
 sha2 = { version = "0.10", default-features = false, features = ["std", "asm"] }
+
+# The *-asm backends miscompute digests on macOS aarch64 (Apple Silicon,
+# macOS 26): sha1-asm returns the wrong SHA1 of empty input. Per the note
+# above, the pure-Rust RustCrypto backend already auto-detects SHA-NI (x86_64)
+# and crypto extensions (aarch64) via `cpufeatures`, so dropping `asm` on macOS
+# keeps hardware acceleration while restoring correct digests.
+[target.'cfg(target_os = "macos")'.dependencies]
+md-5 = { workspace = true, features = ["std"] }
+sha1 = { version = "0.10", default-features = false, features = ["std"] }
+sha2 = { version = "0.10", default-features = false, features = ["std"] }
 
 [target.'cfg(not(unix))'.dependencies]
 md-5 = { workspace = true, features = ["std"] }


### PR DESCRIPTION
## Problem

The `Feature flag combinations / iconv (macos-latest)` CI job fails on master with:

```
empty_file_checksum_verification_sha1 panicked at crates/transfer/tests/empty_file_handling.rs:93
  left:  ae8c02845f0793d3e33f1ac4a590a4da818d7cba   (sha1-asm output for empty input)
  right: da39a3ee5e6b4b0d3255bfef95601890afd80709   (correct SHA1 of empty string)
```

This is **not** iconv-related and **not flaky** — it reproduces with the identical wrong digest across multiple master commits. `sha1-asm` v0.5.3 miscomputes SHA1 on `macos-26-arm64` (Apple Silicon, macOS 26), which `macos-latest` now resolves to. A wrong SHA1 is a data-integrity bug for real users on that platform, not just a CI failure. The required `macOS (stable)` cell stays green only because it is crate-scoped (core/engine/cli) and never runs the `-p transfer` test that exercises SHA1.

## Fix

Scope the `asm` feature of `sha1`/`sha2`/`md-5` **off on macOS**, keeping it on Linux. As the existing comment in this manifest already notes, the pure-Rust RustCrypto backend auto-detects SHA-NI (x86_64) and ARM crypto extensions (aarch64) via `cpufeatures` regardless of the `asm` feature — so this keeps hardware acceleration on macOS while restoring correct digests. Linux is unchanged. No `Cargo.lock` change (same crate versions; only per-target feature activation differs).

## Verification

Linux paths are untouched, so all currently-green required checks stay green; the `macos-latest` feature-combination cell that exercises `-p transfer` will confirm the SHA1 digest is correct after this change.