### PR TITLE
ci: green up non-required checks (memmap2 advisory, lockfile cold-cache, bench timeout)

### DIFF
--- a/.github/workflows/bench-checksum-throughput.yml
+++ b/.github/workflows/bench-checksum-throughput.yml
@@ -43,10 +43,11 @@ jobs:
     continue-on-error: true
 
     env:
-      # 60-second measurement budget per benchmark group. Criterion will
-      # allocate samples within this window. The job-level timeout is the
-      # hard ceiling for the entire workflow run.
-      BENCH_MEASUREMENT_TIME: "10"
+      # Per-benchmark measurement budget. Criterion allocates samples within
+      # this window. The full checksums_benchmark suite has ~50 benches; at a
+      # larger budget the suite overruns the per-step `timeout` below. The
+      # job-level timeout is the hard ceiling for the entire workflow run.
+      BENCH_MEASUREMENT_TIME: "5"
 
     steps:
       - name: Checkout
@@ -83,13 +84,15 @@ jobs:
 
           # Run the main checksums_benchmark which covers rolling checksum,
           # MD4, MD5, SHA-1, SHA-256, SHA-512, XXH64, XXH3, and the
-          # algorithm_comparison group at 8 KiB block size.
-          timeout 600 \
+          # algorithm_comparison group at 8 KiB block size. This suite has the
+          # most benches, so it gets the larger per-step timeout below.
+          timeout 900 \
             cargo bench \
               -p checksums \
               --bench checksums_benchmark \
               -- \
               --output-format bencher \
+              --warm-up-time 1 \
               --measurement-time "$BENCH_MEASUREMENT_TIME" \
             | tee "$OUT"
 
@@ -107,6 +110,7 @@ jobs:
               --bench pipelined_benchmark \
               -- \
               --output-format bencher \
+              --warm-up-time 1 \
               --measurement-time "$BENCH_MEASUREMENT_TIME" \
             | tee "$OUT"
 

--- a/.github/workflows/cargo-lockfile-sync.yml
+++ b/.github/workflows/cargo-lockfile-sync.yml
@@ -90,6 +90,13 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
+      # Populate ~/.cargo/registry from the committed Cargo.lock so the offline
+      # resolvability check below has the crate index + sources to work from.
+      # Without this, a cold runner (no rust-cache restore) has an empty
+      # registry and `cargo update --offline` fails on the first crate.
+      - name: Warm cargo registry cache
+        run: cargo fetch
+
       - name: Validate lockfile resolves offline
         run: cargo update --workspace --offline
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,9 +2269,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Fixes three deterministic, repo-wide non-required CI failures that surface on every dependency-touching PR (observed red on #6076, but present on master).

## 1. cargo-deny (advisories FAILED)
`RUSTSEC-2026-0186` — unsound unchecked pointer offset in `memmap2` `advise_range`/`flush_range` (published 2026-06-20). The advisory marks `>= 0.9.11` as patched; we were pinned at 0.9.10 (reached transitively via the mmap path). Bumped to 0.9.11. Lockfile-only change.

## 2. Sync Cargo.lock (no matching package named `rayon` found … offline)
The "Validate lockfile resolves offline" step runs `cargo update --workspace --offline` on a cold runner with no warmed cargo cache (the job has no `rust-cache` restore; `dtolnay/rust-toolchain` only installs the compiler). With an empty `~/.cargo/registry`, `--offline` fails on the first crate. Added a `cargo fetch` step to populate the registry from the committed lockfile before the offline check, preserving the check's intent.

## 3. Checksum throughput regression (exit 124)
The full `checksums_benchmark` suite (~50 benches) overran the inner `timeout 600` at `--measurement-time 10` and was killed mid-run after sha512. Reduced the per-bench budget (measurement 5s, warm-up 1s) and widened the checksums_benchmark step timeout to 900s (within the 30-min job ceiling). Advisory `continue-on-error` cell; smoke-test fidelity is unaffected.

All three are infra/environment issues independent of any product code; none touch `crates/`.