### PR TITLE
test: port NXT-7 sender flist symlink-leak + NXT-8 daemon listing timeout

### DIFF
--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -195,6 +195,7 @@ include!("tests/chunks/run_daemon_config_flag_overrides_default_path.rs");
 include!("tests/chunks/run_daemon_loads_modules_from_config_file.rs");
 include!("tests/chunks/run_daemon_loads_modules_from_inline_config_flag.rs");
 include!("tests/chunks/run_daemon_lists_modules_with_motd_lines.rs");
+include!("tests/chunks/run_daemon_lists_modules_with_module_timeout.rs");
 include!("tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs");
 include!("tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs");
 include!("tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_lists_modules_with_module_timeout.rs
@@ -1,0 +1,61 @@
+/// NXT-8 regression test ported from the upstream `daemon` testsuite: a
+/// module-list request must complete - returning the listing and
+/// `@RSYNCD: EXIT` - even when the listed module carries a `timeout`
+/// directive.
+///
+/// # Why this matters
+///
+/// Upstream applies a module's timeout only *after* a module has been
+/// selected (`clientserver.c:1192` sets the io timeout against the chosen
+/// `module_id`). The module listing (`clientserver.c:1373`,
+/// `send_listing()`) runs *before* any module is selected, so a per-module
+/// timeout must neither gate nor block the pre-selection listing path. A
+/// naive implementation that armed the module read/write timeout before
+/// emitting the listing could stall or truncate `localhost::` listings; this
+/// test pins that the listing path stays independent of module timeouts.
+#[test]
+fn run_daemon_lists_modules_with_module_timeout() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let module_path = std::env::temp_dir().display().to_string().replace('\\', "/");
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            // A finite per-module timeout that must not interfere with the
+            // pre-selection listing path.
+            OsString::from("--module"),
+            OsString::from(format!("docs={module_path},Documentation;timeout=1")),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let expected_greeting = legacy_daemon_greeting();
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, expected_greeting);
+
+    // upstream: clientserver.c:1373 - an empty request lists modules.
+    stream.write_all(b"\n").expect("send empty request");
+    stream.flush().expect("flush empty request");
+
+    line.clear();
+    reader.read_line(&mut line).expect("module line");
+    assert_eq!(line, "docs           \tDocumentation\n");
+
+    line.clear();
+    reader.read_line(&mut line).expect("exit line");
+    assert_eq!(line, "@RSYNCD: EXIT\n");
+
+    drop(reader);
+    let result = handle.join().expect("daemon thread");
+    assert!(result.is_ok());
+}

--- a/crates/transfer/tests/nxt_7_sender_flist_symlink_leak.rs
+++ b/crates/transfer/tests/nxt_7_sender_flist_symlink_leak.rs
@@ -36,8 +36,8 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
-use protocol::flist::FileType;
 use protocol::ProtocolVersion;
+use protocol::flist::FileType;
 use transfer::{
     GeneratorContext, HandshakeResult, ServerConfig, ServerRole, TransferPhase, TransferPipeline,
 };

--- a/crates/transfer/tests/nxt_7_sender_flist_symlink_leak.rs
+++ b/crates/transfer/tests/nxt_7_sender_flist_symlink_leak.rs
@@ -15,9 +15,9 @@
 //! The invariant: during recursive file-list generation the sender records
 //! a symlink-to-directory as a single symlink entry and never descends into
 //! its target, so no path outside the transfer root ever reaches the wire.
-//! This holds because the default stat is an `lstat` (`fs::symlink_metadata`)
-//! - a symlink reports `is_dir() == false`, so `should_recurse` stays false
-//! in `walk.rs`.
+//! This holds because the default stat is an `lstat`
+//! (`fs::symlink_metadata`): a symlink reports `is_dir() == false`, so
+//! `should_recurse` stays false in `walk.rs`.
 //!
 //! # Upstream Reference
 //!

--- a/crates/transfer/tests/nxt_7_sender_flist_symlink_leak.rs
+++ b/crates/transfer/tests/nxt_7_sender_flist_symlink_leak.rs
@@ -1,0 +1,159 @@
+//! NXT-7 regression test for the sender-side file-list symlink leak,
+//! ported from the upstream `sender-flist-symlink-leak.test`.
+//!
+//! # Why this matters
+//!
+//! When a daemon module runs with `use chroot = no`, a local attacker can
+//! plant a symlink inside the module that points outside the module root
+//! (e.g. `module/cd -> /outside`). A client that pulls the symlinked
+//! subdir must not be able to learn anything about `/outside`: the sender
+//! enumerates the file list before any content transfer, so if the flist
+//! generator followed the symlink it would ship the names, sizes, modes and
+//! mtimes of every file under `/outside` to the client - a metadata leak -
+//! even though the eventual content copy fails with EXDEV.
+//!
+//! The invariant: during recursive file-list generation the sender records
+//! a symlink-to-directory as a single symlink entry and never descends into
+//! its target, so no path outside the transfer root ever reaches the wire.
+//! This holds because the default stat is an `lstat` (`fs::symlink_metadata`)
+//! - a symlink reports `is_dir() == false`, so `should_recurse` stays false
+//! in `walk.rs`.
+//!
+//! # Upstream Reference
+//!
+//! - `testsuite/sender-flist-symlink-leak.test` - the end-to-end daemon
+//!   regression this test encodes as a fast in-process check.
+//! - `flist.c:send_file_list()` / `readlink_stat()` - default lstat keeps
+//!   symlinks unfollowed during enumeration.
+//! - `util1.c:change_dir()` - the secure branch the upstream test exercises
+//!   to reject a chdir that follows an attacker-controlled symlink.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use protocol::flist::FileType;
+use protocol::ProtocolVersion;
+use transfer::{
+    GeneratorContext, HandshakeResult, ServerConfig, ServerRole, TransferPhase, TransferPipeline,
+};
+
+/// Builds a recursive sender (generator) config, the shape produced once a
+/// daemon has accepted a pull request and is enumerating a module.
+fn recursive_generator_config(source_root: &Path) -> ServerConfig {
+    let flag_string = "-r.iLsfxCIvu".to_owned();
+    let mut config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        flag_string,
+        vec![source_root.to_path_buf().into_os_string()],
+    )
+    .expect("server config");
+    config.connection.client_mode = true;
+    config
+}
+
+fn test_handshake() -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: true,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+fn test_pipeline() -> TransferPipeline {
+    let mut pipeline = TransferPipeline::new(ServerRole::Generator);
+    pipeline
+        .advance_to(TransferPhase::FilterExchange)
+        .expect("advance to FilterExchange");
+    pipeline
+        .advance_to(TransferPhase::FileListTransfer)
+        .expect("advance to FileListTransfer");
+    pipeline
+}
+
+/// A symlink-to-directory escaping the transfer root must be enumerated as
+/// a symlink entry only - never followed into the outside tree - so the
+/// metadata of files under the symlink target never reaches the client.
+#[test]
+fn sender_flist_does_not_leak_symlink_target_outside_root() {
+    let scratch = TempDir::new().expect("tempdir");
+
+    // The transfer root the client is allowed to see.
+    let module = scratch.path().join("module");
+    let sub = module.join("sub");
+    fs::create_dir_all(&sub).expect("mkdir module/sub");
+    fs::write(module.join("real.txt"), b"in-module payload").expect("write real.txt");
+    fs::write(sub.join("nested.txt"), b"nested payload").expect("write nested.txt");
+
+    // The outside tree the attacker wants the daemon to enumerate. The
+    // distinctive marker name makes a leak trivial to detect.
+    let outside = scratch.path().join("outside");
+    fs::create_dir_all(&outside).expect("mkdir outside");
+    fs::write(
+        outside.join("leak_marker.txt"),
+        b"OUTSIDE_PROTECTED_FILE_USED_AS_LEAK_DETECTOR",
+    )
+    .expect("write leak_marker.txt");
+
+    // The trap: a symlink inside the module pointing at the outside tree.
+    symlink(&outside, module.join("cd")).expect("plant cd symlink");
+
+    let config = recursive_generator_config(&module);
+    let handshake = test_handshake();
+    let pipeline = test_pipeline();
+    let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+
+    ctx.build_file_list(&[module.clone()])
+        .expect("build_file_list");
+
+    let file_list = ctx.file_list();
+    let names: Vec<&str> = file_list.iter().map(|e| e.name()).collect();
+
+    // Core invariant: nothing under the symlink target was enumerated.
+    assert!(
+        names.iter().all(|n| !n.contains("leak_marker")),
+        "sender flist leaked an outside file into the wire list: {names:?}"
+    );
+    assert!(
+        names.iter().all(|n| !n.contains("outside")),
+        "sender flist leaked an outside path into the wire list: {names:?}"
+    );
+
+    // The legitimate in-module files must still be present.
+    assert!(
+        names.iter().any(|n| n.ends_with("real.txt")),
+        "expected in-module real.txt to be enumerated: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n.ends_with("nested.txt")),
+        "expected in-module sub/nested.txt to be enumerated: {names:?}"
+    );
+
+    // The trap itself must appear as a symlink entry (recorded, not
+    // descended), carrying its literal target rather than the target's
+    // contents - exactly upstream's unfollowed-symlink behaviour.
+    let cd = file_list
+        .iter()
+        .find(|e| e.name().ends_with("cd"))
+        .expect("the cd symlink entry must be present in the file list");
+    assert_eq!(
+        cd.file_type(),
+        FileType::Symlink,
+        "cd must be recorded as a symlink, not a followed directory"
+    );
+    assert_eq!(
+        cd.link_target().map(|t| t.as_path()),
+        Some(outside.as_path()),
+        "the symlink entry must carry its literal target, proving the \
+         sender stored the link instead of walking into it"
+    );
+}


### PR DESCRIPTION
Two fast nextest ports of upstream-testsuite edge cases so they run on every PR.

NXT-7 (transfer): in-process flist-walk test asserting a planted out-of-root symlink target never leaks into the sender's file list (default lstat keeps symlinks unfollowed during enumeration). Ported from upstream testsuite/sender-flist-symlink-leak.test.

NXT-8 (daemon): a `#list` module listing still succeeds when a module `timeout` is configured - upstream arms a module's timeout only after module selection (clientserver.c:1192), so it must not gate the pre-selection send_listing() path.

NXT-7 passes; NXT-8 runs the listing+EXIT handshake and joins cleanly.