### PR TITLE
fix(core): daemon-over-rsh module listing (-e PROG host::)

### DIFF
--- a/crates/cli/src/frontend/execution/drive/module_listing.rs
+++ b/crates/cli/src/frontend/execution/drive/module_listing.rs
@@ -7,6 +7,7 @@ use core::client::{
 };
 use logging_sink::MessageSink;
 use protocol::ProtocolVersion;
+use rsync_io::ssh;
 
 use crate::frontend::{execution::render_module_list, write_message};
 
@@ -21,6 +22,8 @@ pub(super) struct ModuleListingInputs<'a> {
     pub address_mode: AddressMode,
     pub bind_address: Option<&'a BindAddress>,
     pub connect_program: Option<&'a OsString>,
+    pub remote_shell: Option<&'a OsString>,
+    pub rsync_path: Option<&'a OsString>,
     pub timeout_setting: TransferTimeout,
     pub connect_timeout_setting: TransferTimeout,
     pub sockopts: Option<&'a OsString>,
@@ -50,6 +53,8 @@ where
         address_mode,
         bind_address,
         connect_program,
+        remote_shell,
+        rsync_path,
         timeout_setting,
         connect_timeout_setting,
         sockopts,
@@ -79,11 +84,19 @@ where
         request
     };
 
+    // upstream: main.c - an explicit `-e`/`--rsh` makes `host::` listings reach
+    // the daemon over the remote shell (daemon-over-rsh) rather than TCP. Parse
+    // the shell spec the same way the transfer path does (config.rs). A
+    // malformed spec is ignored, matching the transfer path's lenient handling.
+    let remote_shell_args = remote_shell.and_then(|spec| ssh::parse_remote_shell(spec).ok());
+
     let list_options = ModuleListOptions::default()
         .suppress_motd(no_motd)
         .with_address_mode(address_mode)
         .with_bind_address(bind_address.map(|addr| addr.socket()))
         .with_connect_program(connect_program.cloned())
+        .with_remote_shell(remote_shell_args)
+        .with_rsync_path(rsync_path.cloned())
         .with_sockopts(sockopts.cloned())
         .with_tcp_fastopen(tcp_fastopen)
         .with_blocking_io(blocking_io);

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -481,6 +481,8 @@ where
             address_mode,
             bind_address: bind_address.as_ref(),
             connect_program: connect_program.as_ref(),
+            remote_shell: parsed.remote_shell.as_ref(),
+            rsync_path: parsed.rsync_path.as_ref(),
             timeout_setting,
             connect_timeout_setting,
             sockopts: sockopts.as_ref(),

--- a/crates/cli/src/frontend/execution/module_list.rs
+++ b/crates/cli/src/frontend/execution/module_list.rs
@@ -18,13 +18,15 @@ pub(crate) fn render_module_list<W: Write, E: Write>(
         }
     }
 
+    // upstream: clientserver.c:1254 - `io_printf(fd, "%-15s\t%s\n", name, comment)`
+    // always emits the name, a tab, then the (possibly empty) comment. The name
+    // already carries its `%-15s` padding (preserved by the `\t` split in
+    // ModuleListEntry::from_line), so a comment-less module renders as
+    // `name<pad>\t` - matching upstream rather than dropping the trailing tab.
     for entry in list.entries() {
         let name = entry.name();
-        if let Some(comment) = entry.comment() {
-            writeln!(stdout, "{name}\t{comment}")?;
-        } else {
-            writeln!(stdout, "{name}")?;
-        }
+        let comment = entry.comment().unwrap_or("");
+        writeln!(stdout, "{name}\t{comment}")?;
     }
     Ok(())
 }

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -1,6 +1,7 @@
 mod direct;
 mod program;
 mod proxy;
+mod rsh;
 #[cfg(feature = "client-tls")]
 pub(crate) mod tls;
 
@@ -18,6 +19,7 @@ pub(crate) use proxy::{
     ProxyConfig, ProxyCredentials, connect_via_proxy, establish_proxy_tunnel, load_daemon_proxy,
     parse_proxy_spec,
 };
+pub(crate) use rsh::{RshDaemonSpawn, spawn_rsh_daemon_stream};
 
 /// Read half of a [`DaemonStream`] after splitting.
 pub(crate) enum DaemonStreamReader {

--- a/crates/core/src/client/module_list/connect/rsh.rs
+++ b/crates/core/src/client/module_list/connect/rsh.rs
@@ -43,6 +43,17 @@ pub(crate) struct RshDaemonSpawn<'a> {
     pub connect_timeout: Option<Duration>,
 }
 
+/// Returns whether the remote-shell program is ssh (or an ssh-family binary
+/// such as `/usr/bin/ssh`), which understands the `-o`/`-J`/`-l` connection
+/// options. A custom `-e` program (`rsh`, the testsuite `lsh.sh`, etc.) does
+/// not, and upstream only injects those SSH flags when the rsh is ssh.
+fn is_ssh_like(program: &OsStr) -> bool {
+    let name = std::path::Path::new(program)
+        .file_name()
+        .map_or_else(|| program.to_string_lossy(), |n| n.to_string_lossy());
+    name == "ssh" || name.ends_with("ssh")
+}
+
 /// Spawns the remote shell and wraps its stdio as a [`DaemonStream`].
 ///
 /// Builds `PROG <pre-args> [ssh opts] <host> "<rsync-path> --server --daemon ."`
@@ -62,24 +73,43 @@ pub(crate) fn spawn_rsh_daemon_stream(
         cmd.arg(opt);
     }
 
-    if let Some(bind_addr) = spec.bind_address {
-        cmd.arg("-o").arg(format!("BindAddress={bind_addr}"));
+    // upstream: main.c - the `-o`/`-J`/`-l` connection options are SSH-specific
+    // and are only injected when the remote-shell program is ssh. A custom
+    // `-e PROG` (e.g. the testsuite `lsh.sh`, or `rsh`) is spawned verbatim as
+    // `PROG <pre-args> <host> "<cmd>"`; passing it `-o ConnectTimeout=...`
+    // breaks programs that do not understand SSH flags (lsh.sh reads the next
+    // token as the host and fails with "unable to connect to host
+    // ConnectTimeout=10").
+    let ssh_like = is_ssh_like(ssh_program);
+    if ssh_like {
+        if let Some(bind_addr) = spec.bind_address {
+            cmd.arg("-o").arg(format!("BindAddress={bind_addr}"));
+        }
+
+        if let Some(jump) = spec.jump_hosts {
+            cmd.arg("-J").arg(jump);
+        }
+
+        if let Some(timeout) = spec.connect_timeout {
+            cmd.arg("-o")
+                .arg(format!("ConnectTimeout={}", timeout.as_secs()));
+        }
+
+        if let Some(user) = spec.username {
+            cmd.arg("-l").arg(user);
+        }
     }
 
-    if let Some(jump) = spec.jump_hosts {
-        cmd.arg("-J").arg(jump);
+    // ssh takes the login via `-l user` above and the bare host here; a custom
+    // rsh program receives `user@host` (upstream do_cmd handling).
+    match (ssh_like, spec.username) {
+        (false, Some(user)) => {
+            cmd.arg(format!("{user}@{}", spec.host));
+        }
+        _ => {
+            cmd.arg(spec.host);
+        }
     }
-
-    if let Some(timeout) = spec.connect_timeout {
-        cmd.arg("-o")
-            .arg(format!("ConnectTimeout={}", timeout.as_secs()));
-    }
-
-    if let Some(user) = spec.username {
-        cmd.arg("-l").arg(user);
-    }
-
-    cmd.arg(spec.host);
 
     // upstream: main.c:594-604 - the remote command is
     // `rsync_path --server --daemon .` with no server_options().

--- a/crates/core/src/client/module_list/connect/rsh.rs
+++ b/crates/core/src/client/module_list/connect/rsh.rs
@@ -1,0 +1,154 @@
+//! Daemon-connection-over-remote-shell transport.
+//!
+//! Spawns the `-e`/`--rsh` program with `rsync --server --daemon .` as the
+//! remote command and wraps its stdio pipes as a [`DaemonStream`], so the
+//! client speaks the `@RSYNCD:` daemon protocol over the shell instead of
+//! opening a TCP socket to the daemon port.
+//!
+//! Shared by the transfer path (`remote::run_daemon_over_remote_shell`) and
+//! the module-listing path so both honour `-e PROG host::` identically.
+//!
+//! upstream: `main.c:594-604` + `main.c:1571-1586` - the daemon-over-rsh path
+//! in `start_client()` runs `rsync_path --server --daemon .` with no
+//! `server_options()`, exports `RSYNC_PORT` into the shell environment, and
+//! then speaks the daemon protocol over the spawned process's stdin/stdout.
+
+use std::ffi::{OsStr, OsString};
+use std::net::IpAddr;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use super::DaemonStream;
+use crate::client::IPC_EXIT_CODE;
+use crate::client::error::{ClientError, invalid_argument_error};
+
+/// Parameters for spawning a daemon-connection-over-remote-shell stream.
+pub(crate) struct RshDaemonSpawn<'a> {
+    /// `-e`/`--rsh` program and its pre-host arguments. `shell_args[0]` is the
+    /// program; the remaining entries precede the host on the command line.
+    pub shell_args: &'a [OsString],
+    /// Daemon host passed to the remote shell.
+    pub host: &'a str,
+    /// Optional `-l <user>` login name parsed from `user@host::`.
+    pub username: Option<&'a str>,
+    /// Daemon port, exported as `RSYNC_PORT` for the remote shell.
+    pub port: u16,
+    /// `--rsync-path` override for the remote command (defaults to `rsync`).
+    pub rsync_path: Option<&'a OsStr>,
+    /// Optional `-o BindAddress=` applied to the spawned shell.
+    pub bind_address: Option<IpAddr>,
+    /// Optional `-J` jump-host specification.
+    pub jump_hosts: Option<&'a OsStr>,
+    /// Optional `-o ConnectTimeout=` in whole seconds.
+    pub connect_timeout: Option<Duration>,
+}
+
+/// Spawns the remote shell and wraps its stdio as a [`DaemonStream`].
+///
+/// Builds `PROG <pre-args> [ssh opts] <host> "<rsync-path> --server --daemon ."`
+/// matching upstream `main.c`'s daemon-over-rsh invocation, then returns a
+/// stream carrying the `@RSYNCD:` protocol over the child's pipes.
+pub(crate) fn spawn_rsh_daemon_stream(
+    spec: RshDaemonSpawn<'_>,
+) -> Result<DaemonStream, ClientError> {
+    let ssh_program = if spec.shell_args.is_empty() {
+        OsStr::new("ssh")
+    } else {
+        spec.shell_args[0].as_os_str()
+    };
+    let mut cmd = Command::new(ssh_program);
+
+    for opt in spec.shell_args.iter().skip(1) {
+        cmd.arg(opt);
+    }
+
+    if let Some(bind_addr) = spec.bind_address {
+        cmd.arg("-o").arg(format!("BindAddress={bind_addr}"));
+    }
+
+    if let Some(jump) = spec.jump_hosts {
+        cmd.arg("-J").arg(jump);
+    }
+
+    if let Some(timeout) = spec.connect_timeout {
+        cmd.arg("-o")
+            .arg(format!("ConnectTimeout={}", timeout.as_secs()));
+    }
+
+    if let Some(user) = spec.username {
+        cmd.arg("-l").arg(user);
+    }
+
+    cmd.arg(spec.host);
+
+    // upstream: main.c:594-604 - the remote command is
+    // `rsync_path --server --daemon .` with no server_options().
+    let rsync_path = spec.rsync_path.unwrap_or_else(|| OsStr::new("rsync"));
+    cmd.arg(rsync_path).arg("--server").arg("--daemon").arg(".");
+
+    // upstream: main.c:1571-1572 - set_env_num("RSYNC_PORT", env_port)
+    cmd.env("RSYNC_PORT", spec.port.to_string());
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::inherit());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        invalid_argument_error(
+            &format!("failed to spawn remote shell for daemon-over-rsh: {e}"),
+            IPC_EXIT_CODE,
+        )
+    })?;
+
+    let stdin = child.stdin.take().ok_or_else(|| {
+        invalid_argument_error("remote shell process did not expose stdin", IPC_EXIT_CODE)
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        invalid_argument_error("remote shell process did not expose stdout", IPC_EXIT_CODE)
+    })?;
+
+    Ok(DaemonStream::from_child_process(child, stdin, stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Documents the precedence wiring: when a remote shell is configured, the
+    /// listing/transfer paths must build a daemon-over-rsh invocation that runs
+    /// `PROG ... <host> "<rsync-path> --server --daemon ."` instead of opening
+    /// a TCP socket. A bogus shell program lets us assert the spawn attempt
+    /// targets the program (not the daemon port) without a live daemon.
+    ///
+    /// WHY: upstream `rsync -e PROG host::` reaches the daemon through the
+    /// spawned shell; regressing to TCP yields `connect()` -> ECONNREFUSED
+    /// (exit 10), the exact failure this path fixes.
+    #[test]
+    fn spawn_rsh_daemon_stream_runs_program_not_tcp() {
+        let shell_args = vec![OsString::from("/nonexistent/oc-rsync-rsh-daemon-probe-bin")];
+        let spec = RshDaemonSpawn {
+            shell_args: &shell_args,
+            host: "localhost",
+            username: None,
+            port: 873,
+            rsync_path: None,
+            bind_address: None,
+            jump_hosts: None,
+            connect_timeout: None,
+        };
+
+        // `DaemonStream` is not `Debug`, so match instead of `expect_err`.
+        let err = match spawn_rsh_daemon_stream(spec) {
+            Ok(_) => panic!("spawning a nonexistent shell program must fail"),
+            Err(e) => e,
+        };
+
+        // The failure must come from attempting to exec the remote-shell
+        // program, proving the path did not silently fall back to a TCP
+        // connect against the daemon port.
+        assert_eq!(err.exit_code(), IPC_EXIT_CODE);
+        assert!(
+            err.to_string().contains("daemon-over-rsh"),
+            "error should reference the daemon-over-rsh spawn, got: {err}"
+        );
+    }
+}

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -31,7 +31,9 @@ use super::auth::{
 };
 #[cfg(feature = "client-tls")]
 use super::connect::open_daemon_stream_tls;
-use super::connect::{open_daemon_stream, resolve_connect_timeout};
+use super::connect::{
+    RshDaemonSpawn, open_daemon_stream, resolve_connect_timeout, spawn_rsh_daemon_stream,
+};
 use super::errors::{legacy_daemon_error_payload, map_daemon_handshake_error, read_trimmed_line};
 use super::request::ModuleListOptions;
 use super::request::ModuleListRequest;
@@ -221,14 +223,34 @@ pub fn run_module_list_with_password_and_options(
         ));
     }
 
-    let mut stream = open_daemon_stream(
-        addr,
-        connect_duration,
-        effective_timeout,
-        address_mode,
-        options.connect_program(),
-        options.bind_address(),
-    )?;
+    // Precedence mirrors upstream `main.c`: an explicit `-e`/`--rsh` for a
+    // `host::` listing reaches the daemon through the remote shell
+    // (daemon-over-rsh); otherwise RSYNC_CONNECT_PROG, otherwise plain TCP.
+    let mut stream = if let Some(shell_args) = options.remote_shell() {
+        // upstream: main.c:594-604 + main.c:1571-1586 - spawn the remote shell
+        // with `rsync --server --daemon .` and speak the `@RSYNCD:` listing
+        // handshake over its pipes instead of opening a TCP socket. Matches
+        // `clientserver.c:start_inband_exchange` carried over the shell.
+        spawn_rsh_daemon_stream(RshDaemonSpawn {
+            shell_args,
+            host: addr.host(),
+            username: username.as_deref(),
+            port: addr.port(),
+            rsync_path: options.rsync_path(),
+            bind_address: options.bind_address().map(|addr| addr.ip()),
+            jump_hosts: None,
+            connect_timeout: connect_duration,
+        })?
+    } else {
+        open_daemon_stream(
+            addr,
+            connect_duration,
+            effective_timeout,
+            address_mode,
+            options.connect_program(),
+            options.bind_address(),
+        )?
+    };
 
     configure_daemon_stream(&mut stream, &options, addr)?;
 
@@ -510,5 +532,45 @@ mod tests {
         let custom = NonZeroU64::new(60).unwrap();
         let result = effective_timeout(TransferTimeout::Seconds(custom), default);
         assert_eq!(result, Some(Duration::from_secs(60)));
+    }
+
+    /// When `-e`/remote_shell is configured (and no connect program), a
+    /// `host::` listing must reach the daemon by spawning the remote shell -
+    /// not by opening TCP to the daemon port.
+    ///
+    /// WHY: upstream `rsync -e PROG host::` lists modules over the spawned
+    /// shell (`main.c` daemon-over-rsh). Regressing to TCP yields
+    /// `connect()` -> ECONNREFUSED (exit 10) against port 873, the exact
+    /// daemon.test failure this path fixes. Pointing remote_shell at a
+    /// nonexistent program makes the rsh branch fail at spawn time with an
+    /// IPC error mentioning "daemon-over-rsh", proving the listing took the
+    /// remote-shell branch rather than the TCP branch.
+    #[test]
+    fn listing_with_remote_shell_uses_rsh_not_tcp() {
+        use std::ffi::OsString;
+
+        let operands = vec![OsString::from("localhost::")];
+        let request = ModuleListRequest::from_operands(&operands)
+            .expect("valid operands")
+            .expect("daemon listing request");
+
+        let options = ModuleListOptions::default().with_remote_shell(Some(vec![OsString::from(
+            "/nonexistent/oc-rsync-rsh-daemon-probe-bin",
+        )]));
+
+        let err = run_module_list_with_password_and_options(
+            request,
+            options,
+            None,
+            TransferTimeout::Default,
+            TransferTimeout::Default,
+        )
+        .expect_err("spawning a nonexistent remote shell must fail");
+
+        assert_eq!(err.exit_code(), crate::client::IPC_EXIT_CODE);
+        assert!(
+            err.to_string().contains("daemon-over-rsh"),
+            "listing should fail in the daemon-over-rsh spawn, got: {err}"
+        );
     }
 }

--- a/crates/core/src/client/module_list/mod.rs
+++ b/crates/core/src/client/module_list/mod.rs
@@ -52,8 +52,9 @@ pub(super) use connect::tls::{TlsClientConfig, TlsConnector, TlsStream};
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use connect::{
     ConnectProgramConfig, DaemonStream, DaemonStreamGuard, DaemonStreamReader, DaemonStreamWriter,
-    ProxyConfig, ProxyCredentials, connect_direct, connect_via_proxy, establish_proxy_tunnel,
-    open_daemon_stream, parse_proxy_spec, resolve_connect_timeout, resolve_daemon_addresses,
+    ProxyConfig, ProxyCredentials, RshDaemonSpawn, connect_direct, connect_via_proxy,
+    establish_proxy_tunnel, open_daemon_stream, parse_proxy_spec, resolve_connect_timeout,
+    resolve_daemon_addresses, spawn_rsh_daemon_stream,
 };
 #[allow(unused_imports)] // REASON: convenience re-export for sibling modules
 pub(super) use errors::map_daemon_handshake_error;

--- a/crates/core/src/client/module_list/request.rs
+++ b/crates/core/src/client/module_list/request.rs
@@ -135,6 +135,8 @@ pub struct ModuleListOptions {
     sockopts: Option<OsString>,
     tcp_fastopen: TcpFastOpenMode,
     blocking_io: Option<bool>,
+    remote_shell: Option<Vec<OsString>>,
+    rsync_path: Option<OsString>,
 }
 
 impl ModuleListOptions {
@@ -149,6 +151,8 @@ impl ModuleListOptions {
             sockopts: None,
             tcp_fastopen: TcpFastOpenMode::Auto,
             blocking_io: None,
+            remote_shell: None,
+            rsync_path: None,
         }
     }
 
@@ -191,6 +195,36 @@ impl ModuleListOptions {
     /// Returns the configured connect program command, if any.
     pub fn connect_program(&self) -> Option<&std::ffi::OsStr> {
         self.connect_program.as_deref()
+    }
+
+    /// Supplies the `-e`/`--rsh` remote-shell argv for daemon-over-rsh listings.
+    ///
+    /// When present, `host::` listings reach the daemon by spawning this
+    /// program with `rsync --server --daemon .` instead of opening TCP,
+    /// mirroring upstream `main.c`'s daemon-over-rsh dispatch.
+    #[must_use]
+    #[doc(alias = "--rsh")]
+    pub fn with_remote_shell(mut self, shell: Option<Vec<OsString>>) -> Self {
+        self.remote_shell = shell;
+        self
+    }
+
+    /// Returns the configured remote-shell argv, if any.
+    pub fn remote_shell(&self) -> Option<&[OsString]> {
+        self.remote_shell.as_deref()
+    }
+
+    /// Supplies the `--rsync-path` override for daemon-over-rsh listings.
+    #[must_use]
+    #[doc(alias = "--rsync-path")]
+    pub fn with_rsync_path(mut self, rsync_path: Option<OsString>) -> Self {
+        self.rsync_path = rsync_path;
+        self
+    }
+
+    /// Returns the configured remote `--rsync-path`, if any.
+    pub fn rsync_path(&self) -> Option<&OsStr> {
+        self.rsync_path.as_deref()
     }
 
     /// Configures additional socket options that should be applied to daemon connections.

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -23,22 +23,21 @@ mod orchestration;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-use std::ffi::OsStr;
 use std::io::BufReader;
-use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use engine::batch::BatchWriter;
 
+use super::super::DAEMON_SOCKET_TIMEOUT;
 use super::super::config::ClientConfig;
 use super::super::error::{ClientError, invalid_argument_error, socket_error};
 use super::super::module_list::{
-    DaemonStream, apply_socket_options, open_daemon_stream, resolve_connect_timeout,
+    RshDaemonSpawn, apply_socket_options, open_daemon_stream, resolve_connect_timeout,
+    spawn_rsh_daemon_stream,
 };
 use super::super::progress::ClientProgressObserver;
 use super::super::summary::ClientSummary;
-use super::super::{DAEMON_SOCKET_TIMEOUT, IPC_EXIT_CODE};
 use super::batch_support::build_batch_context;
 use super::invocation::{RemoteRole, TransferSpec, determine_transfer_role};
 
@@ -296,61 +295,18 @@ pub fn run_daemon_over_remote_shell(
         .remote_shell()
         .ok_or_else(|| invalid_argument_error("daemon-over-remote-shell requires -e/--rsh", 1))?;
 
-    let ssh_program = if shell_args.is_empty() {
-        OsStr::new("ssh")
-    } else {
-        &shell_args[0]
-    };
-    let mut cmd = Command::new(ssh_program);
-
-    for opt in shell_args.iter().skip(1) {
-        cmd.arg(opt);
-    }
-
-    if let Some(bind_addr) = config.bind_address() {
-        cmd.arg("-o")
-            .arg(format!("BindAddress={}", bind_addr.socket().ip()));
-    }
-
-    if let Some(jump) = config.jump_hosts() {
-        cmd.arg("-J").arg(jump);
-    }
-
-    if let Some(timeout) = config.connect_timeout().effective(Duration::from_secs(30)) {
-        cmd.arg("-o")
-            .arg(format!("ConnectTimeout={}", timeout.as_secs()));
-    }
-
-    if let Some(user) = &request.username {
-        cmd.arg("-l").arg(user);
-    }
-
-    cmd.arg(request.address.host());
-
-    let rsync_path = config.rsync_path().unwrap_or(OsStr::new("rsync"));
-    cmd.arg(rsync_path).arg("--server").arg("--daemon").arg(".");
-
-    // upstream: main.c:1571-1572 - set_env_num("RSYNC_PORT", env_port)
-    cmd.env("RSYNC_PORT", request.address.port().to_string());
-    cmd.stdin(Stdio::piped());
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::inherit());
-
-    let mut child = cmd.spawn().map_err(|e| {
-        invalid_argument_error(
-            &format!("failed to spawn remote shell for daemon-over-rsh: {e}"),
-            IPC_EXIT_CODE,
-        )
+    // Shared with the module-listing path so `-e PROG host::` behaves
+    // identically whether listing modules or transferring files.
+    let stream = spawn_rsh_daemon_stream(RshDaemonSpawn {
+        shell_args,
+        host: request.address.host(),
+        username: request.username.as_deref(),
+        port: request.address.port(),
+        rsync_path: config.rsync_path(),
+        bind_address: config.bind_address().map(|addr| addr.socket().ip()),
+        jump_hosts: config.jump_hosts(),
+        connect_timeout: config.connect_timeout().effective(Duration::from_secs(30)),
     })?;
-
-    let stdin = child.stdin.take().ok_or_else(|| {
-        invalid_argument_error("remote shell process did not expose stdin", IPC_EXIT_CODE)
-    })?;
-    let stdout = child.stdout.take().ok_or_else(|| {
-        invalid_argument_error("remote shell process did not expose stdout", IPC_EXIT_CODE)
-    })?;
-
-    let stream = DaemonStream::from_child_process(child, stdin, stdout);
 
     let transfer_timeout = config
         .timeout()

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -29,11 +29,20 @@ KNOWN_FAILURES=(
   #   failure is host-independent and rooted in the listing path, not the
   #   daemon's bind path.
   #
-  #   Fixed by honouring remote_shell in the module-listing path
-  #   (crates/core/src/client/module_list). The entry is retained until a
-  #   full Upstream Testsuite run confirms daemon.test passes end to end (it
-  #   exercises several further sub-transfers); a UPASS here is the signal to
-  #   remove it.
+  #   The daemon-over-rsh listing legs are now FIXED by honouring remote_shell
+  #   in the module-listing path (crates/core/src/client/module_list) and
+  #   emitting the trailing tab for comment-less modules: daemon.test legs 1-2
+  #   (the `-e PROG localhost::` and RSYNC_CONNECT_PROG `localhost::` module
+  #   listings) now pass and byte-match upstream.
+  #
+  #   REMAINING xfail cause (leg 3, daemon.test line ~66):
+  #     checkdiff "$RSYNC -r localhost::test-hidden" ...
+  #   A daemon SOURCE with no local destination (`host::module/path`) is a
+  #   file-LISTING request upstream (implied --list-only); oc-rsync instead
+  #   errors "need at least one source and one destination" (exit 1). Wiring
+  #   daemon-source-only operands to the list-only path is the next fix.
+  #   The entry is retained until a full run confirms daemon.test passes end
+  #   to end; a UPASS here is the signal to remove it.
 
   "daemon"
 

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -15,18 +15,25 @@
 
 KNOWN_FAILURES=(
 
-  # "daemon" - CI-environment-only failure on GitHub Actions hosted runners.
-  #   The upstream daemon.test exits with code 10 (daemon startup) because
-  #   GitHub Actions runners disable IPv6 on the loopback interface; the
-  #   default dual-stack IPv6-first bind path the daemon takes when handed
-  #   port=0 cannot acquire `::1`, surfaces only as an IPv4 listener, and
-  #   trips a per-family bind error that the harness reads as exit 10.
-  #   The same binary passes the test on every developer host (Linux,
-  #   macOS) and inside the rsync-profile podman container, where IPv6
-  #   loopback is available. Documented in UTS-DD-daemon-exit10 deep dive.
-  #   Track real fixes under UTS-DD-daemon-exit10.1 (IPv4-only default)
-  #   and UTS-DD-daemon-exit10.2 (surface per-family bind errors as
-  #   warnings) before removing this entry.
+  # "daemon" - daemon-connection-over-remote-shell for `-e PROG host::`.
+  #   daemon.test (line ~57) runs
+  #     checkdiff2 "$RSYNC -ve '$SSH' --rsync-path='$RSYNC$confopt' localhost::"
+  #   which is a daemon module LISTING reached over a remote shell, not TCP.
+  #   Upstream spawns PROG as
+  #     PROG <pre-args> <host> "<rsync-path> --server --daemon ."
+  #   and speaks the `@RSYNCD:` listing handshake over the spawned process's
+  #   stdio (upstream main.c:594-604 daemon-over-rsh dispatch). oc-rsync
+  #   previously ignored `-e`/remote_shell for `host::` listings and opened a
+  #   TCP socket to port 873, which is refused (exit 10) on every host.
+  #   The earlier "IPv6-first loopback bind" diagnosis was incorrect: the
+  #   failure is host-independent and rooted in the listing path, not the
+  #   daemon's bind path.
+  #
+  #   Fixed by honouring remote_shell in the module-listing path
+  #   (crates/core/src/client/module_list). The entry is retained until a
+  #   full Upstream Testsuite run confirms daemon.test passes end to end (it
+  #   exercises several further sub-transfers); a UPASS here is the signal to
+  #   remove it.
 
   "daemon"
 


### PR DESCRIPTION
Root-caused with strace on the Linux host (the known-failures comment blaming IPv6 bind was wrong). oc-rsync ignored `-e`/`--rsh` for daemon-mode `host::` module listings and opened a direct TCP socket to port 873 (`connect() -> ECONNREFUSED`, exit 10) on every host. Upstream instead spawns the rsh program with `rsync --server --daemon .` and speaks `@RSYNCD:` over its stdio (main.c:594-604 daemon-over-rsh).

Fixes, each validated on the host via strace + daemon.test:
1. Route `host::` listings through daemon-over-rsh when remote_shell is set (new `module_list/connect/rsh.rs`, shared with the transfer path).
2. Only pass SSH options (`-o ConnectTimeout`/`-o BindAddress`/`-J`/`-l`) to ssh; a custom `-e` program (lsh.sh, rsh) is spawned verbatim with `user@host` (lsh.sh otherwise read `ConnectTimeout=10` as the host).
3. Emit the trailing tab for comment-less modules (upstream clientserver.c:1254 `%-15s\t%s`).

Result: daemon.test legs 1-2 (both module-listing forms) now pass and byte-match upstream (`oc exit=0`, lists `mod`). The test still xfails further in at leg 3 (a daemon source with no destination = implied --list-only, a separate gap documented in the known-failures conf), so `daemon` stays in the known-failures list with an updated, accurate reason.