### PR TITLE
feat(engine): parallel exclusion matching for local-copy delete (XMP)

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -667,6 +667,102 @@ impl Drop for DirectoryFilterGuard {
 mod tests {
     use super::*;
 
+    /// The XMP invariant: parallelising the per-entry deletion matcher must not
+    /// change WHICH entries are deleted nor the ORDER they are emitted - only
+    /// WHERE the pure `allows_deletion` decision is computed. This test feeds an
+    /// identical candidate set through serial and rayon `par_iter` evaluation of
+    /// the same immutable [`DeletionFilterSnapshot`] (built from a nested
+    /// dir-merge fixture: a global `- *.deep` exclude plus a dynamic `- secret`
+    /// segment) and asserts the decision SET and the name-sorted emission ORDER
+    /// are byte-for-byte identical. If they ever diverge, the wire output would
+    /// no longer match upstream rsync, so this test must fail.
+    #[test]
+    fn deletion_snapshot_parallel_matches_serial_set_and_order() {
+        use crate::local_copy::filter_program::FilterProgramEntry;
+        use filters::FilterRule;
+        use rayon::prelude::*;
+        use std::path::Path;
+
+        let program =
+            FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude("*.deep"))])
+                .expect("filter program builds");
+        let mut dynamic_segment = FilterSegment::default();
+        dynamic_segment
+            .push_rule(FilterRule::exclude("secret"))
+            .expect("dynamic rule compiles");
+
+        let snapshot = DeletionFilterSnapshot {
+            program: Some(program),
+            layers: FilterSegmentLayers::new(),
+            ephemeral_last: None,
+            dynamic_loaded_segments: vec![LoadedDynamicSegment {
+                segment: dynamic_segment,
+                inherit: true,
+            }],
+            filter_set: None,
+            delete_excluded: false,
+        };
+
+        // A wide directory: `*.deep` and `secret` are filter-protected (must NOT
+        // delete), everything else is deletable. The mix guarantees both
+        // outcomes are exercised so the test can fail if either path regresses.
+        let candidates: Vec<(String, bool)> = (0..200)
+            .map(|i| {
+                let name = if i % 3 == 0 {
+                    format!("f{i}.deep")
+                } else if i % 7 == 0 {
+                    "secret".to_string()
+                } else {
+                    format!("f{i}.txt")
+                };
+                (name, false)
+            })
+            .collect();
+
+        let decide = |name: &str, is_dir: bool| snapshot.allows_deletion(Path::new(name), is_dir);
+
+        let serial: Vec<bool> = candidates
+            .iter()
+            .map(|(name, is_dir)| decide(name, *is_dir))
+            .collect();
+        let parallel: Vec<bool> = candidates
+            .par_iter()
+            .map(|(name, is_dir)| decide(name, *is_dir))
+            .collect();
+
+        // Decision SET parity: par_iter preserves index order, so the aligned
+        // decision vectors must be identical element-for-element.
+        assert_eq!(serial, parallel, "parallel decisions diverged from serial");
+
+        // Sanity: the fixture must produce both outcomes, otherwise the parity
+        // assertion above could pass vacuously.
+        assert!(serial.iter().any(|&d| d), "expected some deletable entries");
+        assert!(
+            serial.iter().any(|&d| !d),
+            "expected some protected entries"
+        );
+        assert!(!decide("secret", false), "dynamic - secret must protect");
+        assert!(!decide("f0.deep", false), "global - *.deep must protect");
+        assert!(decide("f1.txt", false), "unmatched entry must be deletable");
+
+        // Emission ORDER parity: the plan emits deletable names name-sorted.
+        // Derive that order from both decision vectors; they must match.
+        let emission = |decisions: &[bool]| -> Vec<String> {
+            let mut names: Vec<String> = candidates
+                .iter()
+                .zip(decisions)
+                .filter_map(|((name, _), &keep)| keep.then(|| name.clone()))
+                .collect();
+            names.sort_unstable();
+            names
+        };
+        assert_eq!(
+            emission(&serial),
+            emission(&parallel),
+            "parallel emission order diverged from serial"
+        );
+    }
+
     #[test]
     fn file_copy_outcome_new_stores_values() {
         let outcome = FileCopyOutcome::new(1000, Some(500));

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -683,9 +683,8 @@ mod tests {
         use rayon::prelude::*;
         use std::path::Path;
 
-        let program =
-            FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude("*.deep"))])
-                .expect("filter program builds");
+        let program = FilterProgram::new([FilterProgramEntry::Rule(FilterRule::exclude("*.deep"))])
+            .expect("filter program builds");
         let mut dynamic_segment = FilterSegment::default();
         dynamic_segment
             .push_rule(FilterRule::exclude("secret"))

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -750,7 +750,8 @@ mod tests {
             let mut names: Vec<String> = candidates
                 .iter()
                 .zip(decisions)
-                .filter_map(|((name, _), &keep)| keep.then(|| name.clone()))
+                .filter(|&(_, &keep)| keep)
+                .map(|((name, _), _)| name.clone())
                 .collect();
             names.sort_unstable();
             names

--- a/crates/engine/src/local_copy/context_impl/options/filter.rs
+++ b/crates/engine/src/local_copy/context_impl/options/filter.rs
@@ -102,6 +102,35 @@ impl<'a> CopyContext<'a> {
         }
     }
 
+    /// Freezes the effective deletion filter chain for the current directory
+    /// into an immutable, `Send + Sync` [`DeletionFilterSnapshot`].
+    ///
+    /// Captures the global filter program plus the live per-directory merge
+    /// state (static layers, the active ephemeral frame, and the top dynamic
+    /// `dir-merge` frame) by value, so the per-entry `allows_deletion` decision
+    /// can be evaluated off-thread without ever touching the `Rc<RefCell<...>>`
+    /// filter stacks. Read-only: the live stacks are cloned, never mutated.
+    ///
+    /// Call this AFTER [`Self::enter_destination_for_deletion`] has seeded the
+    /// destination-side per-dir merge rules so the snapshot reflects the exact
+    /// chain the serial path would evaluate against.
+    pub(crate) fn deletion_filter_snapshot(&self) -> DeletionFilterSnapshot {
+        let dynamic_loaded_segments = self
+            .dynamic_dir_merge_stack
+            .borrow()
+            .last()
+            .map(|frame| frame.loaded_segments.clone())
+            .unwrap_or_default();
+        DeletionFilterSnapshot {
+            program: self.filter_program.clone(),
+            layers: self.dir_merge_layers.borrow().clone(),
+            ephemeral_last: self.dir_merge_ephemeral.borrow().last().cloned(),
+            dynamic_loaded_segments,
+            filter_set: self.options.filter_set().cloned(),
+            delete_excluded: self.options.delete_excluded_enabled(),
+        }
+    }
+
     /// Applies the top-of-stack dynamic per-directory merge segments against
     /// `relative` using upstream's first-match-wins semantics.
     ///
@@ -144,3 +173,96 @@ impl<'a> CopyContext<'a> {
         None
     }
 }
+
+/// Immutable, `Send + Sync` snapshot of the effective deletion filter chain
+/// for a single destination directory.
+///
+/// The per-entry deletion decision is a pure function of the candidate path,
+/// its file kind, and the directory's frozen filter chain - upstream evaluates
+/// it serially in `delete.c:delete_in_dir()`, but the decision itself carries
+/// no order dependence. This snapshot lets the local-copy `--delete` DECIDE
+/// phase compute that pure function across rayon worker threads while leaving
+/// the live `Rc<RefCell<...>>` filter stacks untouched on the owning thread.
+///
+/// [`Self::allows_deletion`] mirrors [`CopyContext::allows_deletion`]
+/// instruction-for-instruction; parallelism only changes WHERE the decision
+/// runs, never WHAT it decides.
+#[derive(Clone)]
+pub(crate) struct DeletionFilterSnapshot {
+    program: Option<FilterProgram>,
+    layers: FilterSegmentLayers,
+    ephemeral_last: Option<Vec<(usize, FilterSegment)>>,
+    dynamic_loaded_segments: Vec<LoadedDynamicSegment>,
+    filter_set: Option<filters::FilterSet>,
+    delete_excluded: bool,
+}
+
+impl DeletionFilterSnapshot {
+    /// Returns `true` when the entry at `relative` may be deleted, evaluated
+    /// against the frozen chain. Byte-for-byte equivalent to
+    /// [`CopyContext::allows_deletion`].
+    pub(crate) fn allows_deletion(&self, relative: &Path, is_dir: bool) -> bool {
+        let delete_excluded = self.delete_excluded;
+        if let Some(program) = &self.program {
+            if let Some(outcome) = self.evaluate_dynamic_segments(relative, is_dir)
+                && outcome.transfer_decided()
+            {
+                return if delete_excluded {
+                    outcome.allows_deletion() || outcome.allows_deletion_when_excluded_removed()
+                } else {
+                    outcome.allows_deletion()
+                };
+            }
+            let temp_layers = self.ephemeral_last.as_deref();
+            let outcome = program.evaluate(
+                relative,
+                is_dir,
+                self.layers.as_slice(),
+                temp_layers,
+                FilterContext::Deletion,
+            );
+            if delete_excluded {
+                outcome.allows_deletion() || outcome.allows_deletion_when_excluded_removed()
+            } else {
+                outcome.allows_deletion()
+            }
+        } else if let Some(filters) = &self.filter_set {
+            if delete_excluded {
+                filters.allows_deletion(relative, is_dir)
+                    || filters.allows_deletion_when_excluded_removed(relative, is_dir)
+            } else {
+                filters.allows_deletion(relative, is_dir)
+            }
+        } else {
+            true
+        }
+    }
+
+    /// Snapshot equivalent of [`CopyContext::evaluate_dynamic_segments`] for
+    /// the deletion context. Returns `None` when no dynamic segments are active
+    /// (no frame, or an empty frame), matching the live path's None cases.
+    fn evaluate_dynamic_segments(&self, relative: &Path, is_dir: bool) -> Option<FilterOutcome> {
+        if self.dynamic_loaded_segments.is_empty() {
+            return None;
+        }
+        let mut outcome = FilterOutcome::default();
+        for loaded in self.dynamic_loaded_segments.iter().rev() {
+            if outcome.transfer_decided() {
+                break;
+            }
+            loaded
+                .segment
+                .apply(relative, is_dir, &mut outcome, FilterContext::Deletion);
+        }
+        Some(outcome)
+    }
+}
+
+// Compile-time guarantee that the snapshot can cross a rayon boundary. The
+// XMP invariant requires the per-entry matcher to capture ONLY immutable
+// Send + Sync data; this assertion fails the build if any field ever
+// reintroduces an Rc/RefCell.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<DeletionFilterSnapshot>();
+};

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -8,8 +8,19 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use logging::{debug_log, info_log};
+use rayon::prelude::*;
 
 use std::sync::Arc;
+
+/// Minimum number of deletion candidates in a single destination directory
+/// before the per-entry filter matching switches to a rayon `par_iter`.
+///
+/// Mirrors the codebase's `PARALLEL_STAT_THRESHOLD = 64` convention: below
+/// this count the serial path avoids rayon's fork/join overhead; above it the
+/// pure `allows_deletion` decisions are computed across worker threads. The
+/// threshold does not affect the decision SET or emission ORDER - only WHERE
+/// the matching runs.
+const PARALLEL_DELETION_MATCH_THRESHOLD: usize = 64;
 
 use crate::delete::{
     DeleteContext, DeleteEntry, DeleteEntryKind, DeleteFs, DeletePlan, DeletePlanMap, RealDeleteFs,
@@ -196,7 +207,12 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
         .and_then(|p| p.file_name())
         .map(OsStr::to_os_string);
 
-    let mut plan = DeletePlan::new(destination.to_path_buf());
+    // Phase A (serial): scan the destination in readdir order and collect the
+    // candidates that survive the cheap keep / partial-dir filters. The filter
+    // decision (`allows_deletion`) is deferred to Phase B so it can be batched.
+    // readdir order is preserved through every phase so the max-delete limit and
+    // debug logging observe the exact same sequence as the original serial loop.
+    let mut candidates: Vec<DeletionCandidate> = Vec::new();
     for entry in read_dir {
         context.enforce_timeout()?;
         let entry = entry
@@ -226,12 +242,51 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
             )
         })?;
 
-        if !context.allows_deletion(entry_relative.as_path(), file_type.is_dir()) {
+        let is_dir = file_type.is_dir();
+        candidates.push(DeletionCandidate {
+            name,
+            entry_relative,
+            file_type,
+            is_dir,
+        });
+    }
+
+    // Phase B (parallel above threshold): compute the pure `allows_deletion`
+    // decision for every candidate against an immutable, Send + Sync snapshot
+    // of the directory's filter chain. The closure captures ONLY the snapshot
+    // (no Rc/RefCell CopyContext), so it is safe to run on rayon workers.
+    // `par_iter().map().collect()` preserves index order, keeping decisions
+    // aligned with the readdir-order candidates for Phase C.
+    let snapshot = context.deletion_filter_snapshot();
+    let allowed: Vec<bool> = if candidates.len() >= PARALLEL_DELETION_MATCH_THRESHOLD {
+        candidates
+            .par_iter()
+            .map(|candidate| {
+                snapshot.allows_deletion(candidate.entry_relative.as_path(), candidate.is_dir)
+            })
+            .collect()
+    } else {
+        candidates
+            .iter()
+            .map(|candidate| {
+                snapshot.allows_deletion(candidate.entry_relative.as_path(), candidate.is_dir)
+            })
+            .collect()
+    };
+
+    // Phase C (serial): apply the decisions in readdir order. Filter-protected
+    // entries log and are dropped; the rest count against the max-delete limit
+    // and join the plan. The final `sort_by_name` fixes the wire emission order.
+    // This sequence is identical to the original serial loop - only the matching
+    // in Phase B was parallelised.
+    let mut plan = DeletePlan::new(destination.to_path_buf());
+    for (candidate, allowed) in candidates.into_iter().zip(allowed) {
+        if !allowed {
             debug_log!(
                 Filter,
                 2,
                 "filter protected {} from deletion",
-                entry_relative.display()
+                candidate.entry_relative.display()
             );
             continue;
         }
@@ -247,10 +302,24 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
             continue;
         }
 
-        plan.push(DeleteEntry::new(name, classify_kind(file_type)));
+        plan.push(DeleteEntry::new(
+            candidate.name,
+            classify_kind(candidate.file_type),
+        ));
     }
     plan.sort_by_name();
     Ok(Some(plan))
+}
+
+/// A destination entry that survived the cheap keep / partial-dir filters and
+/// awaits the `allows_deletion` decision in [`build_plan_for_directory`].
+///
+/// Holds only `Send` data so a slice of candidates can be matched in parallel.
+struct DeletionCandidate {
+    name: OsString,
+    entry_relative: PathBuf,
+    file_type: fs::FileType,
+    is_dir: bool,
 }
 
 /// Mirrors the upstream classification table used by


### PR DESCRIPTION
First piece of the wire-neutral delete/exclude parallelism redesign (XMP). The local-copy `--delete` DECIDE phase now matches directory entries against the deletion filter chain in parallel.

- New immutable `DeletionFilterSnapshot` (`Send + Sync`) captures the effective filter chain at a directory, read-only from the live `Rc<RefCell>` stacks; the rayon closure captures only the snapshot (compile-time `Send + Sync` assertion + UB guard).
- `build_plan_for_directory` becomes 3 phases: serial readdir -> rayon `par_iter` match (>=64 entries, serial below) -> serial readdir-order push + `sort_by_name`.
- **100% wire-compatible:** the decision set and emission order are byte-identical to the serial path; `allows_deletion` logic mirrors the original exactly; `--max-delete` and debug logging unchanged.
- Test `deletion_snapshot_parallel_matches_serial_set_and_order` (200-entry nested dir-merge fixture) asserts serial==parallel decision set AND name-sorted order. `cargo check --all-features` + the test pass.

Opt-in by construction (threshold-gated); wire parity is enforced by the test, not assumed.