### PR TITLE
fix(protocol): checked arithmetic on wire-derived indices (EDG-PANIC.1)

### DIFF
--- a/crates/protocol/src/acl/wire/recv.rs
+++ b/crates/protocol/src/acl/wire/recv.rs
@@ -72,7 +72,14 @@ pub fn recv_ida_entries<R: Read + ?Sized>(reader: &mut R) -> io::Result<(IdaEntr
 /// Mirrors `recv_rsync_acl()` in `acls.c` lines 731-800.
 pub fn recv_rsync_acl<R: Read + ?Sized>(reader: &mut R) -> io::Result<RecvAclResult> {
     let ndx_plus_one = read_varint(reader)?;
-    let ndx = ndx_plus_one - 1;
+    // upstream: acls.c:736-740 reads `int ndx = read_varint(f)` and rejects
+    // out-of-range indices with an error. The wire value is an index + 1, so a
+    // malicious peer can send i32::MIN, making `ndx_plus_one - 1` underflow and
+    // panic under overflow-checks builds. Reject that edge with a protocol
+    // error rather than panicking, mirroring upstream's index validation.
+    let ndx = ndx_plus_one.checked_sub(1).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "invalid ACL cache index")
+    })?;
 
     if ndx >= 0 {
         return Ok(RecvAclResult::CacheHit(ndx as u32));
@@ -227,4 +234,23 @@ pub fn receive_acl_cached<R: Read + ?Sized>(
     };
 
     Ok((access_ndx, default_ndx))
+}
+
+#[cfg(test)]
+mod edg_panic_tests {
+    use super::recv_rsync_acl;
+    use std::io;
+
+    /// A malicious peer must not crash the parser by sending a cache index that
+    /// underflows the `wire_value - 1` remap. upstream: acls.c:736-740 reads the
+    /// index and rejects out-of-range values; the varint i32::MIN drives
+    /// `ndx_plus_one - 1` past i32::MIN, so the hardened decode must return a
+    /// clean InvalidData error rather than panicking under overflow-checks.
+    #[test]
+    fn recv_rsync_acl_rejects_underflowing_cache_index() {
+        // Varint of i32::MIN: leading tag 0xF0 (4 extra bytes) + LE 0x8000_0000.
+        let wire = [0xF0u8, 0x00, 0x00, 0x00, 0x80];
+        let err = recv_rsync_acl(&mut &wire[..]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
 }

--- a/crates/protocol/src/acl/wire/recv.rs
+++ b/crates/protocol/src/acl/wire/recv.rs
@@ -77,9 +77,9 @@ pub fn recv_rsync_acl<R: Read + ?Sized>(reader: &mut R) -> io::Result<RecvAclRes
     // malicious peer can send i32::MIN, making `ndx_plus_one - 1` underflow and
     // panic under overflow-checks builds. Reject that edge with a protocol
     // error rather than panicking, mirroring upstream's index validation.
-    let ndx = ndx_plus_one.checked_sub(1).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "invalid ACL cache index")
-    })?;
+    let ndx = ndx_plus_one
+        .checked_sub(1)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid ACL cache index"))?;
 
     if ndx >= 0 {
         return Ok(RecvAclResult::CacheHit(ndx as u32));

--- a/crates/protocol/src/flist/read/extras.rs
+++ b/crates/protocol/src/flist/read/extras.rs
@@ -217,8 +217,12 @@ impl FileListReader {
             self.state.prev_hardlink_dev()
         } else {
             let raw_dev = crate::read_longint(reader)?;
-            // Upstream stores dev + 1, so subtract 1
-            let dev = raw_dev - 1;
+            // Upstream stores dev + 1, so subtract 1. upstream: flist.c:1177
+            // `dev = read_longint(f)` then the +1 offset is undone with plain
+            // int64 arithmetic that wraps; a malicious sender can supply
+            // raw_dev == i64::MIN, so wrapping_sub matches upstream's wrap and
+            // avoids an overflow-checks panic (cargo-fuzz / debug builds).
+            let dev = raw_dev.wrapping_sub(1);
             self.state.update_hardlink_dev(dev);
             dev
         };
@@ -291,5 +295,41 @@ impl FileListReader {
         } else if entry.is_special() {
             self.stats.num_specials += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod edg_panic_tests {
+    use crate::flist::flags::{FileFlags, XMIT_HLINKED};
+    use crate::flist::read::FileListReader;
+    use crate::version::ProtocolVersion;
+
+    /// A malicious sender must not crash the protocol 28-29 hardlink decode by
+    /// sending dev == i64::MIN, which would underflow the `raw_dev - 1` offset
+    /// (upstream: flist.c:1177) and panic under overflow-checks (cargo-fuzz /
+    /// debug). The hardened decode mirrors upstream's int64 wraparound and must
+    /// return cleanly instead of panicking.
+    #[test]
+    fn read_hardlink_dev_ino_tolerates_min_dev_without_panic() {
+        let proto = ProtocolVersion::from_supported(28).expect("protocol 28 supported");
+        let mut reader = FileListReader::new(proto).with_preserve_hard_links(true);
+
+        // dev: read_longint sentinel 0xFFFFFFFF then i64::MIN little-endian.
+        // ino: a plain 4-byte longint (0).
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        wire.extend_from_slice(&i64::MIN.to_le_bytes());
+        wire.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+        // XMIT_HLINKED set, XMIT_SAME_DEV_PRE30 clear -> dev read from the wire.
+        let flags = FileFlags::new(0, XMIT_HLINKED);
+        let mode = 0o100_644; // regular file, not a directory
+
+        let (dev, ino) = reader
+            .read_hardlink_dev_ino(&mut &wire[..], flags, mode)
+            .expect("decode must not error")
+            .expect("hardlink dev/ino present");
+        assert_eq!(dev, i64::MAX); // i64::MIN.wrapping_sub(1)
+        assert_eq!(ino, 0);
     }
 }

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -141,7 +141,14 @@ pub fn read_xattr_definitions<R: Read>(reader: &mut R) -> io::Result<XattrSet> {
 /// on `ndx != 0` for cache hit vs literal data.
 pub fn recv_xattr<R: Read>(reader: &mut R) -> io::Result<RecvXattrResult> {
     let ndx_plus_one = read_varint(reader)?;
-    let ndx = ndx_plus_one - 1;
+    // upstream: xattrs.c:773-775 reads `int ndx = read_varint(f)` and rejects
+    // out-of-range indices with an error. The wire value is an index + 1, so a
+    // malicious peer can send i32::MIN, making `ndx_plus_one - 1` underflow and
+    // panic under overflow-checks builds. Reject that edge with a protocol
+    // error rather than panicking, mirroring upstream's index validation.
+    let ndx = ndx_plus_one.checked_sub(1).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "invalid xattr cache index")
+    })?;
 
     if ndx >= 0 {
         return Ok(RecvXattrResult::CacheHit(ndx as u32));
@@ -288,4 +295,23 @@ pub fn checksum_matches(checksum: &[u8], local_value: &[u8], checksum_seed: i32)
     }
     let local_checksum = compute_xattr_checksum(local_value, checksum_seed);
     checksum == local_checksum
+}
+
+#[cfg(test)]
+mod edg_panic_tests {
+    use super::recv_xattr;
+    use std::io;
+
+    /// A malicious peer must not crash the parser by sending a cache index that
+    /// underflows the `wire_value - 1` remap. upstream: xattrs.c:773-775 reads
+    /// the index and rejects out-of-range values; the varint i32::MIN drives
+    /// `ndx_plus_one - 1` past i32::MIN, so the hardened decode must return a
+    /// clean InvalidData error rather than panicking under overflow-checks.
+    #[test]
+    fn recv_xattr_rejects_underflowing_cache_index() {
+        // Varint of i32::MIN: leading tag 0xF0 (4 extra bytes) + LE 0x8000_0000.
+        let wire = [0xF0u8, 0x00, 0x00, 0x00, 0x80];
+        let err = recv_xattr(&mut &wire[..]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
 }

--- a/crates/protocol/src/xattr/wire/decode.rs
+++ b/crates/protocol/src/xattr/wire/decode.rs
@@ -146,9 +146,9 @@ pub fn recv_xattr<R: Read>(reader: &mut R) -> io::Result<RecvXattrResult> {
     // malicious peer can send i32::MIN, making `ndx_plus_one - 1` underflow and
     // panic under overflow-checks builds. Reject that edge with a protocol
     // error rather than panicking, mirroring upstream's index validation.
-    let ndx = ndx_plus_one.checked_sub(1).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "invalid xattr cache index")
-    })?;
+    let ndx = ndx_plus_one
+        .checked_sub(1)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid xattr cache index"))?;
 
     if ndx >= 0 {
         return Ok(RecvXattrResult::CacheHit(ndx as u32));


### PR DESCRIPTION
Eliminates three reachable wire-derived integer-underflow sites that panic under overflow-checks / cargo-fuzz (a malicious peer must not be able to crash the parser). The hot paths (varint, multiplex frame/reader, envelope, flist name/metadata) were already fully bounds-checked; these are the only remaining bare-arithmetic underflow sites:

- `recv_rsync_acl` (acl/wire/recv.rs): `ndx_plus_one - 1` on an `i32::MIN` wire cache index -> `checked_sub` -> `InvalidData` (upstream acls.c:736 rejects bad index).
- `recv_xattr` (xattr/wire/decode.rs): same pattern -> `checked_sub` -> `InvalidData` (xattrs.c:773).
- `read_hardlink_dev_ino` (flist/read/extras.rs): `raw_dev - 1` (i64 from read_longint) -> `wrapping_sub`, matching upstream flist.c:1177 int64 wrap (upstream does not validate dev).

One test per site feeds a malicious/edge input and asserts a clean Err / no panic. `cargo check -p protocol` + all 3 tests pass.