### PR TITLE
ci: correct daemon known-failure rationale (source-only operand, not IPv6)

### DIFF
--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -15,18 +15,23 @@
 
 KNOWN_FAILURES=(
 
-  # "daemon" - CI-environment-only failure on GitHub Actions hosted runners.
-  #   The upstream daemon.test exits with code 10 (daemon startup) because
-  #   GitHub Actions runners disable IPv6 on the loopback interface; the
-  #   default dual-stack IPv6-first bind path the daemon takes when handed
-  #   port=0 cannot acquire `::1`, surfaces only as an IPv4 listener, and
-  #   trips a per-family bind error that the harness reads as exit 10.
-  #   The same binary passes the test on every developer host (Linux,
-  #   macOS) and inside the rsync-profile podman container, where IPv6
-  #   loopback is available. Documented in UTS-DD-daemon-exit10 deep dive.
-  #   Track real fixes under UTS-DD-daemon-exit10.1 (IPv4-only default)
-  #   and UTS-DD-daemon-exit10.2 (surface per-family bind errors as
-  #   warnings) before removing this entry.
+  # "daemon" - source-only daemon operand is not treated as implied
+  #   --list-only. The upstream daemon.test runs several legs under `bash
+  #   -e`, so the first failing leg aborts the whole script. Legs 1-2
+  #   (module listing over rsh, trailing-tab) now pass; leg 3
+  #   (`rsync -r localhost::test-hidden`, a source with no destination)
+  #   fails. Upstream implies a listing for a missing destination via
+  #   options.c:2194-2195 (`if (argc < 2 && !read_batch && !am_server)
+  #   list_only |= 1;`), but oc-rsync's daemon transfer rejects the lone
+  #   operand at crates/core/src/client/remote/daemon_transfer/mod.rs:71-76
+  #   ("need at least one source and one destination", exit 1), so the
+  #   leg-3 `checkdiff` returns non-zero and `set -e` aborts the test.
+  #   The harness classifies known failures by test NAME, not exit code
+  #   (tools/ci/run_upstream_testsuite.sh:44-51,202-211), so this entry
+  #   correctly marks the test XFAIL regardless of the exit value.
+  #   Real fix: imply --list-only for a single remote/daemon source
+  #   operand (mirror options.c:2194) so leg 3 produces a recursive
+  #   listing; remove this entry once that lands.
 
   "daemon"
 


### PR DESCRIPTION
## Summary

Corrects a stale rationale comment in `tools/ci/upstream_testsuite_known_failures.conf` for the `daemon` test. The comment claimed the failure was an exit-10 IPv6-loopback bind issue on GitHub Actions runners. That is no longer accurate.

## Actual cause (verified)
The upstream `daemon.test` runs several legs under `bash -e`, so the first failing leg aborts the script. Legs 1-2 (module listing over rsh, trailing-tab) now pass. Leg 3 (`rsync -r localhost::test-hidden` - a source with no destination) fails: oc-rsync does not treat a single source-only daemon operand as implied `--list-only`. Upstream implies it via `options.c:2194-2195` (`if (argc < 2 && !read_batch && !am_server) list_only |= 1;`), but oc-rsync rejects the lone operand at `crates/core/src/client/remote/daemon_transfer/mod.rs:71-76` ("need at least one source and one destination", exit 1).

The harness classifies known failures by test **name**, not exit code, so the entry already marks the test XFAIL correctly - only the comment was wrong.

## Scope
Comment-only change. The `"daemon"` known-failure entry itself is unchanged. The real fix (imply `--list-only` for a single remote/daemon source operand) is tracked separately.