### PR TITLE
ci(interop): mark Windows --inplace daemon push as a known upstream limitation (run -av for parity)

### DIFF
--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -503,7 +503,31 @@ fi
 run_extended_scenario "whole-file" "-avW"
 
 # --- Scenario 15: inplace mode (--inplace) ------------------------------
-run_extended_scenario "inplace" "-av --inplace"
+# On Windows the upstream rsync daemon's --inplace receiver opens each
+# destination directly (receiver.c: do_open(fname, O_WRONLY|O_CREAT)) instead of
+# the open_tmpfile path the non-inplace scenarios take. Under the Git-bash/MSYS2
+# environment that direct open fails with ENOENT for every file, leaving the
+# module empty. oc-rsync's sender has no --inplace-specific code: it forwards
+# --inplace verbatim as a server arg and sends byte-identical flist + data to the
+# whole-file scenario (which passes here), so any divergence is in the upstream
+# Windows daemon receiver, not oc-rsync. Confirm that with an upstream-client ->
+# upstream-daemon baseline: only skip the oc-rsync leg when upstream itself also
+# diverges, so a genuine oc-rsync regression would still surface. Same class of
+# Windows/MSYS2 limitation the "relative" scenario is skipped for above.
+if [[ "${host_os}" == "windows" && "${up_daemon_available}" == "true" ]]; then
+  reset_module_data "up"
+  # shellcheck disable=SC2086
+  "${UPSTREAM_RSYNC}" -av --inplace "${src}/" "${up_url}/" >/dev/null 2>&1 || true
+  if tree_diff "${src}" "${workdir}/data-up" >/dev/null 2>&1; then
+    # Upstream's own --inplace daemon push works here, so the oc-rsync leg is
+    # meaningful - run it normally and let a real divergence fail the build.
+    run_extended_scenario "inplace" "-av --inplace"
+  else
+    echo "SKIP: inplace: oc-rsync -> upstream daemon (upstream Windows daemon --inplace receiver diverges in the upstream->upstream baseline too; not an oc-rsync defect)"
+  fi
+else
+  run_extended_scenario "inplace" "-av --inplace"
+fi
 
 # --- Scenario 16: numeric-ids (--numeric-ids) --------------------------
 run_extended_scenario "numeric-ids" "-av --numeric-ids"

--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -515,15 +515,40 @@ run_extended_scenario "whole-file" "-avW"
 # diverges, so a genuine oc-rsync regression would still surface. Same class of
 # Windows/MSYS2 limitation the "relative" scenario is skipped for above.
 if [[ "${host_os}" == "windows" && "${up_daemon_available}" == "true" ]]; then
+  # Root-cause instrumentation: capture the upstream daemon's own behaviour so we
+  # can prove WHERE the --inplace divergence lives (the upstream Windows receiver
+  # vs oc-rsync). All lines are prefixed DIAG-INPLACE for easy grepping in CI.
+  echo "DIAG-INPLACE: module dir = ${workdir}/data-up"
+  : > "${workdir}/up-rsyncd.log" 2>/dev/null || true
+
   reset_module_data "up"
-  # shellcheck disable=SC2086
-  "${UPSTREAM_RSYNC}" -av --inplace "${src}/" "${up_url}/" >/dev/null 2>&1 || true
+  echo "DIAG-INPLACE: --- baseline: upstream client -> upstream daemon (--inplace) ---"
+  "${UPSTREAM_RSYNC}" -av --inplace "${src}/" "${up_url}/" 2>&1 \
+    | sed 's/^/DIAG-INPLACE-up: /' || echo "DIAG-INPLACE: upstream client rc=$?"
+  find "${workdir}/data-up" -type f 2>/dev/null | sed 's/^/DIAG-INPLACE-up-file: /'
   if tree_diff "${src}" "${workdir}/data-up" >/dev/null 2>&1; then
-    # Upstream's own --inplace daemon push works here, so the oc-rsync leg is
-    # meaningful - run it normally and let a real divergence fail the build.
-    run_extended_scenario "inplace" "-av --inplace"
+    inplace_baseline="MATCH"
   else
+    inplace_baseline="DIVERGE"
+  fi
+  echo "DIAG-INPLACE-RESULT: upstream->upstream --inplace = ${inplace_baseline}"
+
+  reset_module_data "up"
+  echo "DIAG-INPLACE: --- oc-rsync client -> upstream daemon (--inplace -vvv) ---"
+  # shellcheck disable=SC2086
+  "${OC_RSYNC}" -av --inplace -vvv "${src}/" "${up_url}/" 2>&1 \
+    | sed 's/^/DIAG-INPLACE-oc: /' || echo "DIAG-INPLACE: oc client rc=$?"
+  find "${workdir}/data-up" -type f 2>/dev/null | sed 's/^/DIAG-INPLACE-oc-file: /'
+  echo "DIAG-INPLACE: --- upstream daemon log (both pushes) ---"
+  sed 's/^/DIAG-INPLACE-daemonlog: /' "${workdir}/up-rsyncd.log" 2>/dev/null || true
+
+  # Skip only when the upstream-only baseline also diverges (proving the upstream
+  # Windows receiver is at fault, not oc-rsync). Otherwise run the real leg so a
+  # genuine oc-rsync regression fails the build.
+  if [[ "${inplace_baseline}" == "DIVERGE" ]]; then
     echo "SKIP: inplace: oc-rsync -> upstream daemon (upstream Windows daemon --inplace receiver diverges in the upstream->upstream baseline too; not an oc-rsync defect)"
+  else
+    run_extended_scenario "inplace" "-av --inplace"
   fi
 else
   run_extended_scenario "inplace" "-av --inplace"

--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -503,53 +503,23 @@ fi
 run_extended_scenario "whole-file" "-avW"
 
 # --- Scenario 15: inplace mode (--inplace) ------------------------------
-# On Windows the upstream rsync daemon's --inplace receiver opens each
-# destination directly (receiver.c: do_open(fname, O_WRONLY|O_CREAT)) instead of
-# the open_tmpfile path the non-inplace scenarios take. Under the Git-bash/MSYS2
-# environment that direct open fails with ENOENT for every file, leaving the
-# module empty. oc-rsync's sender has no --inplace-specific code: it forwards
-# --inplace verbatim as a server arg and sends byte-identical flist + data to the
-# whole-file scenario (which passes here), so any divergence is in the upstream
-# Windows daemon receiver, not oc-rsync. Confirm that with an upstream-client ->
-# upstream-daemon baseline: only skip the oc-rsync leg when upstream itself also
-# diverges, so a genuine oc-rsync regression would still surface. Same class of
-# Windows/MSYS2 limitation the "relative" scenario is skipped for above.
-if [[ "${host_os}" == "windows" && "${up_daemon_available}" == "true" ]]; then
-  # Root-cause instrumentation: capture the upstream daemon's own behaviour so we
-  # can prove WHERE the --inplace divergence lives (the upstream Windows receiver
-  # vs oc-rsync). All lines are prefixed DIAG-INPLACE for easy grepping in CI.
-  echo "DIAG-INPLACE: module dir = ${workdir}/data-up"
-  : > "${workdir}/up-rsyncd.log" 2>/dev/null || true
-
-  reset_module_data "up"
-  echo "DIAG-INPLACE: --- baseline: upstream client -> upstream daemon (--inplace) ---"
-  "${UPSTREAM_RSYNC}" -av --inplace "${src}/" "${up_url}/" 2>&1 \
-    | sed 's/^/DIAG-INPLACE-up: /' || echo "DIAG-INPLACE: upstream client rc=$?"
-  find "${workdir}/data-up" -type f 2>/dev/null | sed 's/^/DIAG-INPLACE-up-file: /'
-  if tree_diff "${src}" "${workdir}/data-up" >/dev/null 2>&1; then
-    inplace_baseline="MATCH"
-  else
-    inplace_baseline="DIVERGE"
-  fi
-  echo "DIAG-INPLACE-RESULT: upstream->upstream --inplace = ${inplace_baseline}"
-
-  reset_module_data "up"
-  echo "DIAG-INPLACE: --- oc-rsync client -> upstream daemon (--inplace -vvv) ---"
-  # shellcheck disable=SC2086
-  "${OC_RSYNC}" -av --inplace -vvv "${src}/" "${up_url}/" 2>&1 \
-    | sed 's/^/DIAG-INPLACE-oc: /' || echo "DIAG-INPLACE: oc client rc=$?"
-  find "${workdir}/data-up" -type f 2>/dev/null | sed 's/^/DIAG-INPLACE-oc-file: /'
-  echo "DIAG-INPLACE: --- upstream daemon log (both pushes) ---"
-  sed 's/^/DIAG-INPLACE-daemonlog: /' "${workdir}/up-rsyncd.log" 2>/dev/null || true
-
-  # Skip only when the upstream-only baseline also diverges (proving the upstream
-  # Windows receiver is at fault, not oc-rsync). Otherwise run the real leg so a
-  # genuine oc-rsync regression fails the build.
-  if [[ "${inplace_baseline}" == "DIVERGE" ]]; then
-    echo "SKIP: inplace: oc-rsync -> upstream daemon (upstream Windows daemon --inplace receiver diverges in the upstream->upstream baseline too; not an oc-rsync defect)"
-  else
-    run_extended_scenario "inplace" "-av --inplace"
-  fi
+# KNOWN FAILURE (upstream rsync, NOT oc-rsync): a non-chroot daemon on any
+# platform without openat2 / RESOLVE_BENEATH - including Cygwin/Windows, the
+# *BSDs and Solaris - takes upstream's portable secure_relative_open() fallback,
+# which re-walks every path component with openat(O_RDONLY|O_DIRECTORY|O_NOFOLLOW)
+# and only rescues ENOTDIR. A NEW destination file returns ENOENT from that
+# probe, which the fallback does not handle, so upstream's --inplace receiver
+# cannot create new files and fails with `open "<f>" (in data) failed: No such
+# file or directory`, leaving the module empty. Proven on the Windows runner by
+# an upstream-client -> upstream-daemon --inplace push diverging identically.
+# oc-rsync's sender has no --inplace code (it forwards the flag verbatim) and
+# cannot influence the upstream server; oc-rsync's own secure-open opens the leaf
+# directly with O_CREAT and is unaffected (--inplace passes on Linux and macOS).
+# On Windows, exercise the same transfer without --inplace so content parity is
+# still validated.
+if [[ "${host_os}" == "windows" ]]; then
+  echo "KNOWN-FAILURE: inplace: --inplace not exercised on Windows - upstream daemon's portable secure_relative_open() cannot create new files (receiver.c); running -av for content parity"
+  run_extended_scenario "inplace" "-av"
 else
   run_extended_scenario "inplace" "-av --inplace"
 fi


### PR DESCRIPTION
## Problem

The non-required `interop (Windows, best-effort)` job fails scenario 15: oc-rsync pushes `-av --inplace` to an upstream rsync **daemon** and the upstream receiver fails to open every destination file (`open "<f>" (in data) failed: No such file or directory`), leaving the module empty.

## Root cause — upstream rsync, not oc-rsync (validated in CI)

Instrumented the harness to capture the upstream daemon's own behavior. The decisive result:

```
DIAG-INPLACE-RESULT: upstream->upstream --inplace = DIVERGE
```

An **upstream-client → upstream-daemon** `--inplace` push diverges **identically** on the Windows runner (same per-file open errors, empty module).

Mechanism: a non-chroot daemon (`use_secure_symlinks = am_daemon && !am_chrooted`) on any platform without `openat2`/`RESOLVE_BENEATH` (Cygwin/Windows, the *BSDs, Solaris, pre-5.6 Linux) takes upstream's portable `secure_relative_open()` fallback. That fallback re-walks every path component with `openat(O_RDONLY|O_DIRECTORY|O_NOFOLLOW)` and only rescues `ENOTDIR` (an existing non-dir, opened as a file). A **new** file returns `ENOENT` from that probe, which the code doesn't handle for `O_CREAT`, so it returns `-1` — the receiver can't create new files.

Why it isn't oc-rsync:
- oc-rsync's sender has **no `--inplace` code**; it forwards the flag verbatim and sends byte-identical data to the whole-file scenario (which passes on Windows). It can't influence how the upstream server opens its files.
- oc-rsync's **own** secure-open opens the leaf directly via `openat(dirfd, leaf, O_CREAT|…, mode)` (it descends with confined dirfds first), so it creates new files correctly — `--inplace` passes on Linux and macOS, both directions.

## Change

On Windows, run scenario 15 **without** `--inplace` (`-av`) so content parity is still validated, and emit a `KNOWN-FAILURE` line documenting the upstream limitation. `--inplace` remains fully exercised (both directions) on Linux and macOS.