### PR TITLE
test(nextest): retry flaky daemon tests under the default profile too

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,6 +22,14 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = "package(daemon) | test(execute_sparse) | binary_id(~integration_daemon)"
 retries = 2
 
+# Retry policies for tests with inherent race conditions (port binding TOCTOU,
+# slow CI runner timing, transient Windows %TEMP% "Access is denied" on
+# NamedTempFile creation). Mirrors profile.ci so the Windows nextest cells -
+# which run under the default profile, not profile.ci - also retry these.
+[[profile.default.overrides]]
+filter = "package(daemon) | test(execute_sparse) | binary_id(~integration_daemon)"
+retries = 2
+
 # SSH integration tests must run serially - parallel SSH sessions on the CI
 # runner cause pipe corruption (garbled data, zero-length filenames, broken
 # connections). Retries handle transient SSH pipe failures.


### PR DESCRIPTION
## Problem

The non-required **Windows ACL/xattr** cell failed on `runtime_options_loads_refuse_options_from_config` — but not on test logic:

```
NamedTempFile::new() -> PermissionDenied: "Access is denied."
  path: C:\Users\RUNNER~1\AppData\Local\Temp\.tmp...
```

`NamedTempFile::new()` couldn't create its temp file — a transient Windows `%TEMP%` access flake (AV scan / sharing violation / race), a known class of Windows CI flakiness. The panic appears once (immediate + final output = one attempt): **no retry happened.**

## Root cause

`profile.ci` already retries race-prone tests:

```toml
[[profile.ci.overrides]]
filter = "package(daemon) | test(execute_sparse) | binary_id(~integration_daemon)"
retries = 2
```

But the Windows nextest cells (`ci.yml`: Windows stable, transfer, ACL/xattr) run under the **default** profile, which had no such override. Switching them to `--profile ci` was rejected as a fix because `profile.ci` lacks the serial test-groups (`ssh-serial`, `global-pool-serial`, `spill-env-serial`) that live only in `profile.default` — doing so would trade one flake for another.

## Fix

Mirror the `package(daemon)` retry override into `profile.default`. The default-profile cells now retry the same race-prone daemon tests (transient `%TEMP%` flakes are absorbed; a real bug still fails all three attempts), and the default profile keeps its serial parallelism guards.