### PR TITLE
fix(cli): silence per-file progress for up-to-date local-copy entries

### DIFF
--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -189,7 +189,15 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
         }
 
         let total = update.total().max(update.index());
-        let remaining = total.saturating_sub(update.index());
+        // Use the transfer-relative remaining computed by the forwarder rather
+        // than `total - index`: `total` counts every checked file-list entry
+        // (the to-chk denominator) while `index` is the transfer ordinal, so
+        // `total - index` never reaches 0 when up-to-date entries (which are
+        // counted in `total` but never transferred) trail the transfers. The
+        // forwarder's `remaining` counts down the transfers themselves, so
+        // to-chk reaches 0 on the last one. For remote transfers
+        // (`from_transfer_event`) this equals the old `total - index`.
+        let remaining = update.remaining().min(total);
 
         let write_result = match self.mode {
             ProgressMode::PerFile => (|| -> io::Result<()> {

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -224,18 +224,32 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
     stdout: &mut W,
     human_readable: HumanReadableMode,
 ) -> io::Result<bool> {
-    let progress_events: Vec<_> = events
+    // upstream: progress.c counts every checked file-list entry toward
+    // `to-chk=<remaining>/<total>`, but prints a per-file block and advances
+    // `xfr#` only for entries actually transferred. An up-to-date match
+    // (quick-check) is silent under `--progress`/`-P` (it surfaces only with
+    // `-vv`/`-i`), so a no-change run prints no per-file lines.
+    let flist_entries: Vec<_> = events
         .iter()
         .filter(|event| is_progress_event(event.kind()))
         .collect();
 
-    if progress_events.is_empty() {
+    let total = flist_entries.len();
+    if total == 0 {
         return Ok(false);
     }
 
-    let total = progress_events.len();
+    let mut xfr_index = 0usize;
+    let mut emitted_any = false;
+    for (position, event) in flist_entries.into_iter().enumerate() {
+        // Up-to-date entries advance the `to-chk` position but emit no line.
+        if is_uptodate_event(event) {
+            continue;
+        }
+        emitted_any = true;
+        xfr_index += 1;
+        let remaining = total - position - 1;
 
-    for (index, event) in progress_events.into_iter().enumerate() {
         writeln!(stdout, "{}", event.relative_path().display())?;
 
         let bytes = event.bytes_transferred();
@@ -254,8 +268,6 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
             format_progress_rate(bytes, event.elapsed(), human_readable)
         );
         let elapsed_field = format!("{:>10}", format_progress_elapsed(event.elapsed()));
-        let remaining = total - index - 1;
-        let xfr_index = index + 1;
 
         writeln!(
             stdout,
@@ -263,7 +275,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         )?;
     }
 
-    Ok(true)
+    Ok(emitted_any)
 }
 
 /// Emits a statistics summary mirroring the subset of counters supported by the local engine.
@@ -450,23 +462,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
 /// completes. The two processes pipeline so uptodate lines appear ahead of
 /// transferred-file lines in the observable client output.
 fn is_uptodate_event(event: &ClientEvent) -> bool {
-    if matches!(event.kind(), ClientEventKind::MetadataReused) || event.is_hardlink_uptodate() {
-        return true;
-    }
-    // upstream: generator.c:1019-1022 / 1145-1147 - a `--copy-dest` match emits
-    // its `"is uptodate"` notice from the generator, ahead of the receiver's
-    // bare-name lines. Regular files are `ReferenceCopied`; dirs and symlinks
-    // reconstructed from the basis carry a blank change set and no creation.
-    match event.kind() {
-        ClientEventKind::ReferenceCopied => true,
-        ClientEventKind::DirectoryCreated | ClientEventKind::SymlinkCopied => {
-            !event.was_created() && !event.change_set().has_any_change()
-        }
-        // A `--link-dest` symlink hard-linked from the basis is `hL` + blank and
-        // emits `"%s is uptodate"` like the other alt-dest matches.
-        ClientEventKind::HardLink => is_hardlinked_symlink_event(event),
-        _ => false,
-    }
+    event.is_uptodate()
 }
 
 /// Returns `true` for a HardLink event describing a hard-linked symlink (`hL`).

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -234,21 +234,25 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         .filter(|event| is_progress_event(event.kind()))
         .collect();
 
+    // Denominator counts every checked entry; the numerator counts down only the
+    // transfers, so to-chk reaches 0 on the last transferred file even when an
+    // up-to-date entry (e.g. an unchanged parent dir) trails it in the list.
     let total = flist_entries.len();
-    if total == 0 {
+    let transferred_total = flist_entries
+        .iter()
+        .filter(|event| !is_uptodate_event(event))
+        .count();
+    if transferred_total == 0 {
         return Ok(false);
     }
 
     let mut xfr_index = 0usize;
-    let mut emitted_any = false;
-    for (position, event) in flist_entries.into_iter().enumerate() {
-        // Up-to-date entries advance the `to-chk` position but emit no line.
+    for event in flist_entries.into_iter() {
         if is_uptodate_event(event) {
             continue;
         }
-        emitted_any = true;
         xfr_index += 1;
-        let remaining = total - position - 1;
+        let remaining = transferred_total - xfr_index;
 
         writeln!(stdout, "{}", event.relative_path().display())?;
 
@@ -275,7 +279,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         )?;
     }
 
-    Ok(emitted_any)
+    Ok(true)
 }
 
 /// Emits a statistics summary mirroring the subset of counters supported by the local engine.

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -202,13 +202,17 @@ where
 
 pub(crate) struct ClientProgressForwarder<'a> {
     observer: &'a mut dyn ClientProgressObserver,
+    // Total file-list entries (the `to-chk=<remaining>/<total>` denominator),
+    // including up-to-date ones the generator checks but never transfers.
     total: usize,
-    // Count of file-list entries processed so far, including up-to-date ones.
-    // Drives the `to-chk=<remaining>/<total>` numerator (remaining = total -
-    // emitted), so it must advance for every entry the generator checks.
-    emitted: usize,
-    // Count of entries actually transferred. Drives `xfr#`, which upstream only
-    // advances for transferred files, never for up-to-date matches.
+    // Number of entries that will actually be transferred. The `to-chk`
+    // remaining counts down from this, so the last transferred entry reaches 0
+    // even when up-to-date entries (e.g. an unchanged parent dir the local
+    // executor visits last) trail it in processing order.
+    transferred_total: usize,
+    // Running count of entries transferred. Drives `xfr#` and the remaining
+    // figure (transferred_total - transferred); only advances for real
+    // transfers, never for up-to-date matches.
     transferred: usize,
     overall_total_bytes: Option<u64>,
     overall_transferred: u64,
@@ -233,10 +237,17 @@ impl<'a> ClientProgressForwarder<'a> {
 
         let (summary, records, destination_root) = preview_report.into_parts();
         let destination_root: Arc<Path> = Arc::from(destination_root);
-        let total = records
+        let progress_events: Vec<_> = records
             .into_iter()
             .map(|record| ClientEvent::from_record_owned(record, Arc::clone(&destination_root)))
             .filter(|event| event.kind().is_progress())
+            .collect();
+        // Denominator counts every checked entry; the numerator base counts only
+        // those that will transfer, so to-chk reaches 0 on the last transfer.
+        let total = progress_events.len();
+        let transferred_total = progress_events
+            .iter()
+            .filter(|event| !event.is_uptodate())
             .count();
 
         let total_bytes = summary.total_source_bytes();
@@ -244,7 +255,7 @@ impl<'a> ClientProgressForwarder<'a> {
         Ok(Self {
             observer,
             total,
-            emitted: 0,
+            transferred_total,
             transferred: 0,
             overall_total_bytes: (total_bytes > 0).then_some(total_bytes),
             overall_transferred: 0,
@@ -266,11 +277,6 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             return;
         }
 
-        // Every checked file-list entry advances the `to-chk` position, even an
-        // up-to-date match the generator never transfers.
-        self.emitted = self.emitted.saturating_add(1);
-        let remaining = self.total.saturating_sub(self.emitted);
-
         // upstream: an up-to-date entry prints no per-file progress block and
         // does not advance `xfr#` - it is silent under `--progress`/`-P` (it
         // surfaces only with `-vv`/`-i`), so a no-change run emits nothing.
@@ -280,6 +286,7 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
 
         self.transferred = self.transferred.saturating_add(1);
         let index = self.transferred;
+        let remaining = self.transferred_total.saturating_sub(self.transferred);
 
         let total_bytes = if matches!(event.kind(), ClientEventKind::DataCopied) {
             event.total_bytes()
@@ -317,10 +324,10 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             return;
         }
 
-        // The in-flight file is the next transfer (`xfr#`), positioned one past
-        // the entries already checked (`to-chk`).
-        let index = (self.transferred + 1).min(self.total);
-        let remaining = self.total.saturating_sub(self.emitted + 1);
+        // The in-flight file is the next transfer (`xfr#`); to-chk counts the
+        // transfers still pending after it.
+        let index = (self.transferred + 1).min(self.transferred_total);
+        let remaining = self.transferred_total.saturating_sub(self.transferred + 1);
         let event = ClientEvent::from_progress(
             progress.relative_path(),
             progress.bytes_transferred(),

--- a/crates/core/src/client/progress.rs
+++ b/crates/core/src/client/progress.rs
@@ -203,7 +203,13 @@ where
 pub(crate) struct ClientProgressForwarder<'a> {
     observer: &'a mut dyn ClientProgressObserver,
     total: usize,
+    // Count of file-list entries processed so far, including up-to-date ones.
+    // Drives the `to-chk=<remaining>/<total>` numerator (remaining = total -
+    // emitted), so it must advance for every entry the generator checks.
     emitted: usize,
+    // Count of entries actually transferred. Drives `xfr#`, which upstream only
+    // advances for transferred files, never for up-to-date matches.
+    transferred: usize,
     overall_total_bytes: Option<u64>,
     overall_transferred: u64,
     overall_start: Instant,
@@ -239,6 +245,7 @@ impl<'a> ClientProgressForwarder<'a> {
             observer,
             total,
             emitted: 0,
+            transferred: 0,
             overall_total_bytes: (total_bytes > 0).then_some(total_bytes),
             overall_transferred: 0,
             overall_start: Instant::now(),
@@ -259,9 +266,20 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             return;
         }
 
+        // Every checked file-list entry advances the `to-chk` position, even an
+        // up-to-date match the generator never transfers.
         self.emitted = self.emitted.saturating_add(1);
-        let index = self.emitted;
-        let remaining = self.total.saturating_sub(index);
+        let remaining = self.total.saturating_sub(self.emitted);
+
+        // upstream: an up-to-date entry prints no per-file progress block and
+        // does not advance `xfr#` - it is silent under `--progress`/`-P` (it
+        // surfaces only with `-vv`/`-i`), so a no-change run emits nothing.
+        if event.is_uptodate() {
+            return;
+        }
+
+        self.transferred = self.transferred.saturating_add(1);
+        let index = self.transferred;
 
         let total_bytes = if matches!(event.kind(), ClientEventKind::DataCopied) {
             event.total_bytes()
@@ -299,8 +317,10 @@ impl<'a> LocalCopyRecordHandler for ClientProgressForwarder<'a> {
             return;
         }
 
-        let index = (self.emitted + 1).min(self.total);
-        let remaining = self.total.saturating_sub(index);
+        // The in-flight file is the next transfer (`xfr#`), positioned one past
+        // the entries already checked (`to-chk`).
+        let index = (self.transferred + 1).min(self.total);
+        let remaining = self.total.saturating_sub(self.emitted + 1);
         let event = ClientEvent::from_progress(
             progress.relative_path(),
             progress.bytes_transferred(),

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -53,7 +53,18 @@ pub enum ClientEventKind {
 }
 
 impl ClientEventKind {
-    /// Returns whether the event kind represents progress-worthy activity.
+    /// Returns whether the event kind is a file-list entry that counts toward
+    /// `--progress` accounting - i.e. whether it contributes to the
+    /// `to-chk=<remaining>/<total>` denominator.
+    ///
+    /// The generator walks every such entry, so `to-chk` counts down across all
+    /// of them regardless of whether each one is transferred. Whether a given
+    /// entry actually prints a per-file progress block and advances `xfr#` is
+    /// the narrower question answered by [`ClientEvent::is_uptodate`]: an
+    /// up-to-date (quick-check match) entry is still counted here but stays
+    /// silent under `--progress`/`-P`.
+    ///
+    /// upstream: progress.c rprint_progress
     pub const fn is_progress(&self) -> bool {
         matches!(
             self,
@@ -264,6 +275,40 @@ impl ClientEvent {
         self.change_set
     }
 
+    /// Returns whether this event describes an entry that is already up to date
+    /// at the destination: a quick-check metadata match, a `--copy-dest`
+    /// reconstruction, an already-correct hardlink alias, or an unchanged
+    /// directory/symlink reconstructed from a basis.
+    ///
+    /// Such entries count toward the `to-chk` file-list total but are never
+    /// transferred, so under `--progress`/`-P` they print no per-file block and
+    /// do not advance `xfr#` - matching upstream's silent second run. They
+    /// surface only with `-vv`/`-i`.
+    ///
+    /// upstream: hlink.c:218-224, generator.c:1010-1022/1145-1147,
+    /// rsync.c:672-676 - the generator records these as "is uptodate" without
+    /// opening a receiver progress block.
+    #[must_use]
+    pub fn is_uptodate(&self) -> bool {
+        if matches!(self.kind, ClientEventKind::MetadataReused) || self.hardlink_uptodate {
+            return true;
+        }
+        match self.kind {
+            ClientEventKind::ReferenceCopied => true,
+            ClientEventKind::DirectoryCreated | ClientEventKind::SymlinkCopied => {
+                !self.created && !self.change_set.has_any_change()
+            }
+            // A `--link-dest` symlink hard-linked from the basis is `hL` + blank
+            // and emits "%s is uptodate" like the other alt-dest matches.
+            ClientEventKind::HardLink => self
+                .metadata
+                .as_ref()
+                .map(ClientEntryMetadata::kind)
+                .is_some_and(|kind| matches!(kind, ClientEntryKind::Symlink)),
+            _ => false,
+        }
+    }
+
     /// Returns the root directory of the destination tree.
     #[must_use]
     pub fn destination_root(&self) -> &Path {
@@ -357,6 +402,9 @@ mod tests {
 
     #[test]
     fn client_event_kind_is_progress_returns_true_for_metadata_reused() {
+        // An up-to-date entry still counts toward the `to-chk` file-list total
+        // (it is a file the generator checked), so `is_progress` is true. Its
+        // per-file line/`xfr#` suppression is handled by `is_uptodate`, not here.
         assert!(ClientEventKind::MetadataReused.is_progress());
     }
 


### PR DESCRIPTION
## Problem

A no-change local copy run with `--progress`/`-P` printed a per-file progress block (and advanced `xfr#`) for every up-to-date file:

```
Music-test/opus/XXX/cd2/10.opus
              0  ??%    0.00kB/s    0:00:00 (xfr#1920, to-chk=0/1920)
sending incremental file list
...
```

Upstream rsync emits a per-file progress block only for entries the receiver actually transfers (`progress.c` `rprint_progress`), so its second run is silent:

```
sending incremental file list

sent 93,928 bytes  received 188 bytes  ...
```

Reported in #6093 (the per-file output half).

## Fix

Model upstream's two distinct counters explicitly (`progress.c:79-82`):

- `to-chk=<remaining>/<total>` denominator counts every file-list entry the generator checks, including up-to-date matches (`stats.num_files`).
- `xfr#` counts only transferred entries (`stats.xferred_files`).

Changes:

- Keep `ClientEventKind::is_progress()` as the file-list-entry set so the `to-chk` total stays the full count (a naive "drop `MetadataReused`" would collapse the denominator on mixed runs).
- Add `ClientEvent::is_uptodate()` as the single source of truth for "already correct" entries (quick-check match, `--copy-dest` reconstruction, already-correct hardlink alias, unchanged dir/symlink). `cli`'s `is_uptodate_event` now delegates to it.
- The live `ClientProgressForwarder` tracks the checked position (`emitted`, drives `to-chk`) and the transfer ordinal (`transferred`, drives `xfr#`) separately, suppressing the line and `xfr#` bump for up-to-date entries while still advancing the `to-chk` position.
- The `emit_progress` post-hoc fallback mirrors the same accounting.

Net effect: a no-change run prints no per-file lines (matching upstream); transfers still show progress with correct `xfr#`/`to-chk`.

## Scope

This PR covers the per-file progress half of #6093. The stats-line half (`sent`/`received`/`speedup` showing `0` for local copies) is a separate follow-up.