### PR TITLE
feat: meaningful local-copy --stats (file-list size in sent + I/O acceleration report)

### DIFF
--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -61,6 +61,8 @@ pub(crate) struct DerivedSettings {
     pub(crate) stats_level: u8,
     pub(crate) name_level: NameOutputLevel,
     pub(crate) name_overridden: bool,
+    /// `--info=copy`: opt-in to the oc-rsync `Copy method` stats line.
+    pub(crate) show_copy_method: bool,
     pub(crate) debug_flags_list: Vec<OsString>,
     pub(crate) bandwidth_limit: Option<BandwidthLimit>,
     pub(crate) max_delete_limit: Option<u64>,
@@ -93,6 +95,8 @@ struct InfoFlagsResult {
     stats_level: u8,
     name_level: NameOutputLevel,
     name_overridden: bool,
+    /// `--info=copy`: opt-in to the oc-rsync `Copy method` stats line.
+    show_copy_method: bool,
 }
 
 /// Parses --info flags and returns display settings.
@@ -120,6 +124,7 @@ where
             stats_level,
             name_level,
             name_overridden,
+            show_copy_method: false,
         });
     }
 
@@ -164,6 +169,7 @@ where
                 stats_level,
                 name_level,
                 name_overridden,
+                show_copy_method: settings.copy.is_some_and(|level| level > 0),
             })
         }
         Err(message) => Err(fail_with_message(message, stderr)),
@@ -581,6 +587,7 @@ where
         stats_level: info_result.stats_level,
         name_level: info_result.name_level,
         name_overridden: info_result.name_overridden,
+        show_copy_method: info_result.show_copy_method,
         debug_flags_list,
         bandwidth_limit: limits.bandwidth_limit,
         max_delete_limit: limits.max_delete_limit,

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -44,6 +44,9 @@ pub(crate) struct TransferExecutionInputs<'a> {
     pub(crate) verbosity: u8,
     pub(crate) list_only: bool,
     pub(crate) dry_run: bool,
+    /// `--info=copy`: opt-in to the oc-rsync `Copy method` line that reports
+    /// which local-copy I/O acceleration (clonefile/reflink/io_uring) ran.
+    pub(crate) show_copy_method: bool,
     pub(crate) out_format_template: Option<&'a crate::frontend::out_format::OutFormat>,
     pub(crate) name_level: NameOutputLevel,
     pub(crate) name_overridden: bool,
@@ -73,6 +76,7 @@ where
         verbosity,
         list_only,
         dry_run,
+        show_copy_method,
         out_format_template,
         name_level,
         name_overridden,
@@ -150,6 +154,7 @@ where
                     human_readable_mode,
                     suppress_updated_only_totals,
                     recursive,
+                    show_copy_method,
                     writer,
                 )
             }) {
@@ -258,6 +263,9 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         name_overridden,
         human_readable_mode,
         false,
+        false,
+        // The `Copy method` line is a stdout-only `--info=copy` nicety; keep it
+        // out of the log file.
         false,
         &mut log.file,
     )?;

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -390,6 +390,7 @@ where
         stats_level,
         name_level,
         name_overridden,
+        show_copy_method,
         debug_flags_list,
         bandwidth_limit,
         max_delete_limit,
@@ -948,6 +949,8 @@ where
             verbosity,
             list_only,
             dry_run,
+            // `--info=copy` opts into the oc-rsync `Copy method` stats line.
+            show_copy_method,
             out_format_template: out_format_template.as_ref(),
             name_level,
             name_overridden,

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -63,12 +63,25 @@ pub(crate) fn emit_transfer_summary(
             if wrote_listing {
                 writeln!(writer)?;
             }
-            emit_stats(summary, writer, human_readable_mode, dry_run, stats_level, show_copy_method)?;
+            emit_stats(
+                summary,
+                writer,
+                human_readable_mode,
+                dry_run,
+                stats_level,
+                show_copy_method,
+            )?;
         } else if verbosity > 0 {
             if wrote_listing {
                 writeln!(writer)?;
             }
-            emit_totals(summary, writer, human_readable_mode, dry_run, show_copy_method)?;
+            emit_totals(
+                summary,
+                writer,
+                human_readable_mode,
+                dry_run,
+                show_copy_method,
+            )?;
         }
 
         return Ok(());
@@ -174,9 +187,22 @@ pub(crate) fn emit_transfer_summary(
     }
 
     if stats_on {
-        emit_stats(summary, writer, human_readable_mode, dry_run, stats_level, show_copy_method)?;
+        emit_stats(
+            summary,
+            writer,
+            human_readable_mode,
+            dry_run,
+            stats_level,
+            show_copy_method,
+        )?;
     } else if emit_trailer_totals {
-        emit_totals(summary, writer, human_readable_mode, dry_run, show_copy_method)?;
+        emit_totals(
+            summary,
+            writer,
+            human_readable_mode,
+            dry_run,
+            show_copy_method,
+        )?;
     }
 
     Ok(())

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -46,6 +46,7 @@ pub(crate) fn emit_transfer_summary(
     human_readable_mode: HumanReadableMode,
     suppress_updated_only_totals: bool,
     emit_flist_banner: bool,
+    show_copy_method: bool,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
     let events = summary.events();
@@ -62,12 +63,12 @@ pub(crate) fn emit_transfer_summary(
             if wrote_listing {
                 writeln!(writer)?;
             }
-            emit_stats(summary, writer, human_readable_mode, dry_run, stats_level)?;
+            emit_stats(summary, writer, human_readable_mode, dry_run, stats_level, show_copy_method)?;
         } else if verbosity > 0 {
             if wrote_listing {
                 writeln!(writer)?;
             }
-            emit_totals(summary, writer, human_readable_mode, dry_run)?;
+            emit_totals(summary, writer, human_readable_mode, dry_run, show_copy_method)?;
         }
 
         return Ok(());
@@ -173,9 +174,9 @@ pub(crate) fn emit_transfer_summary(
     }
 
     if stats_on {
-        emit_stats(summary, writer, human_readable_mode, dry_run, stats_level)?;
+        emit_stats(summary, writer, human_readable_mode, dry_run, stats_level, show_copy_method)?;
     } else if emit_trailer_totals {
-        emit_totals(summary, writer, human_readable_mode, dry_run)?;
+        emit_totals(summary, writer, human_readable_mode, dry_run, show_copy_method)?;
     }
 
     Ok(())
@@ -306,6 +307,7 @@ pub(crate) fn emit_stats<W: Write + ?Sized>(
     human_readable: HumanReadableMode,
     dry_run: bool,
     level: u8,
+    show_copy_method: bool,
 ) -> io::Result<()> {
     if level == 0 {
         return Ok(());
@@ -316,7 +318,7 @@ pub(crate) fn emit_stats<W: Write + ?Sized>(
         writeln!(stdout)?;
     }
 
-    emit_totals(summary, stdout, human_readable, dry_run)
+    emit_totals(summary, stdout, human_readable, dry_run, show_copy_method)
 }
 
 /// Emits the level-2+ detail block: file counts, byte-breakdown, file-list
@@ -422,6 +424,7 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     stdout: &mut W,
     human_readable: HumanReadableMode,
     dry_run: bool,
+    show_copy_method: bool,
 ) -> io::Result<()> {
     let sent = summary.bytes_sent();
     let received = summary.bytes_received();
@@ -447,10 +450,10 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
 
     // oc-rsync extension: when a local copy used a kernel acceleration
     // (clonefile/reflink/io_uring), report which technology moved the data so
-    // the byte totals make sense (a CoW clone copies no bytes). Gated on an
-    // accelerated method actually running, so protocol transfers - which always
-    // reconstruct from the wire (standard) - keep upstream-identical output.
-    if summary.used_copy_acceleration() {
+    // the byte totals make sense (a CoW clone copies no bytes). Opt-in via
+    // `--info=copy`, and further gated on an accelerated method actually running
+    // so it never alters default or protocol-transfer output (upstream parity).
+    if show_copy_method && summary.used_copy_acceleration() {
         let methods = summary
             .copy_method_breakdown()
             .into_iter()

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -445,6 +445,21 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     let rate_display = format_summary_rate(rate, human_readable);
     let total_size_display = format_size(total_size, human_readable);
 
+    // oc-rsync extension: when a local copy used a kernel acceleration
+    // (clonefile/reflink/io_uring), report which technology moved the data so
+    // the byte totals make sense (a CoW clone copies no bytes). Gated on an
+    // accelerated method actually running, so protocol transfers - which always
+    // reconstruct from the wire (standard) - keep upstream-identical output.
+    if summary.used_copy_acceleration() {
+        let methods = summary
+            .copy_method_breakdown()
+            .into_iter()
+            .map(|(label, count)| format!("{label} x{count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(stdout, "Copy method: {methods}")?;
+    }
+
     writeln!(
         stdout,
         "sent {sent_display} bytes  received {received_display} bytes  {rate_display} bytes/sec"

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -239,6 +239,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         HumanReadableMode::Disabled,
         false,
         false, // emit_flist_banner
+        false, // show_copy_method
         &mut with_out_format,
     )
     .expect("render with out-format");
@@ -259,6 +260,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         HumanReadableMode::Disabled,
         false,
         false, // emit_flist_banner
+        false, // show_copy_method
         &mut without_out_format,
     )
     .expect("render without out-format");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -71,6 +71,7 @@ fn render_stats_at_level(
         human_readable,
         false,
         false, // emit_flist_banner
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render stats");
@@ -94,6 +95,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         HumanReadableMode::Disabled,
         false,
         true, // emit_flist_banner
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render verbose");
@@ -476,6 +478,7 @@ fn parity_totals_only_without_stats_flag() {
         HumanReadableMode::Disabled,
         false,
         true, // emit_flist_banner
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render");
@@ -717,6 +720,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         HumanReadableMode::Disabled,
         false,
         true, // emit_flist_banner
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -94,7 +94,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,
         HumanReadableMode::Disabled,
         false,
-        true, // emit_flist_banner
+        true,  // emit_flist_banner
         false, // show_copy_method
         &mut rendered,
     )
@@ -477,7 +477,7 @@ fn parity_totals_only_without_stats_flag() {
         false,
         HumanReadableMode::Disabled,
         false,
-        true, // emit_flist_banner
+        true,  // emit_flist_banner
         false, // show_copy_method
         &mut rendered,
     )
@@ -719,7 +719,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,
         HumanReadableMode::Disabled,
         false,
-        true, // emit_flist_banner
+        true,  // emit_flist_banner
         false, // show_copy_method
         &mut rendered,
     )

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -86,7 +86,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,
         HumanReadableMode::Enabled,
         false,
-        true, // emit_flist_banner
+        true,  // emit_flist_banner
         false, // show_copy_method
         &mut rendered,
     )

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -55,6 +55,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         HumanReadableMode::Enabled,
         false,
         false, // emit_flist_banner (list_only path)
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render summary");
@@ -86,6 +87,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         HumanReadableMode::Enabled,
         false,
         true, // emit_flist_banner
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render summary");
@@ -125,6 +127,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         HumanReadableMode::Disabled,
         false,
         false, // emit_flist_banner (out_format path: starts_with assertion)
+        false, // show_copy_method
         &mut rendered,
     )
     .expect("render summary");

--- a/crates/cli/src/frontend/tests/stats.rs
+++ b/crates/cli/src/frontend/tests/stats.rs
@@ -24,7 +24,11 @@ fn stats_human_readable_formats_totals() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
     assert!(rendered.contains("Total file size: 1,536 bytes"));
-    assert!(rendered.contains("Total bytes sent: 1,536"));
+    // `Total bytes sent` is data + the file-list size (like upstream, which
+    // always sends the flist), so it is not exactly the 1,536-byte payload. The
+    // human-readable formatter is verified deterministically by the `Total file
+    // size` assertions; here only confirm the totals line is present/formatted.
+    assert!(rendered.contains("Total bytes sent:"));
 
     let dest_human = tmp.path().join("human");
     let (code, stdout, stderr) = run_with_args([
@@ -39,7 +43,7 @@ fn stats_human_readable_formats_totals() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
     assert!(rendered.contains("Total file size: 1.54K bytes"));
-    assert!(rendered.contains("Total bytes sent: 1.54K"));
+    assert!(rendered.contains("Total bytes sent:"));
 }
 
 #[test]
@@ -66,7 +70,7 @@ fn stats_human_readable_combined_formats_totals() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
     assert!(rendered.contains("Total file size: 1.54K (1,536) bytes"));
-    assert!(rendered.contains("Total bytes sent: 1.54K (1,536)"));
+    assert!(rendered.contains("Total bytes sent:"));
 }
 
 // stats_transfer_renders_summary_block removed - end-to-end format expectations

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -246,9 +246,13 @@ fn verbose_human_readable_formats_sizes() {
     std::fs::write(&source, vec![0u8; 1_536]).expect("write source");
 
     let dest_default = tmp.path().join("default.bin");
+    // --stats so the deterministic `Total file size: 1,536 bytes` line is
+    // present: `Total bytes sent` now also includes the file-list size (like
+    // upstream), so it is no longer exactly the 1,536-byte payload.
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-vv"),
+        OsString::from("--stats"),
         source.clone().into_os_string(),
         dest_default.into_os_string(),
     ]);
@@ -262,6 +266,7 @@ fn verbose_human_readable_formats_sizes() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-vv"),
+        OsString::from("--stats"),
         OsString::from("--human-readable"),
         source.into_os_string(),
         dest_human.into_os_string(),
@@ -285,6 +290,7 @@ fn verbose_human_readable_combined_formats_sizes() {
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("-vv"),
+        OsString::from("--stats"),
         OsString::from("--human-readable=2"),
         source.into_os_string(),
         destination.into_os_string(),

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -84,8 +84,12 @@ fn verbose_transfer_emits_event_lines() {
     let rendered = String::from_utf8(stdout).expect("verbose output is UTF-8");
     assert!(rendered.contains("file.txt"));
     assert!(!rendered.contains("Total transferred"));
-    assert!(rendered.contains("sent 7 bytes  received 7 bytes"));
-    assert!(rendered.contains("total size is 7  speedup is 0.50"));
+    // `sent` is data + the file-list size (like upstream, which always sends
+    // the flist), so it is not exactly the 7-byte payload; only `total size`
+    // (the source size) is deterministic. Assert the trailer is present and
+    // reports the right total rather than pinning the flist-dependent bytes.
+    assert!(rendered.contains("sent ") && rendered.contains(" received "));
+    assert!(rendered.contains("total size is 7  speedup is"));
     assert_eq!(
         std::fs::read(destination).expect("read destination"),
         b"verbose"

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -355,7 +355,14 @@ fn run_client_internal(
                 .as_mut()
                 .map(ClientProgressForwarder::as_handler_mut),
         )
-        .map(ClientSummary::from_summary)
+        .map(|mut summary| {
+            // A local copy bypasses the wire protocol, so the executor only
+            // counts literal data in bytes_sent. Fold the file-list size in to
+            // report a comparable `sent` total (mirrors `from_report`). This
+            // no-events path covers `--stats` without `-v`/`-P`.
+            summary.fold_file_list_into_sent();
+            ClientSummary::from_summary(summary)
+        })
     };
 
     let summary = summary.map_err(map_local_copy_error)?;

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -61,7 +61,14 @@ pub struct ClientSummary {
 
 impl ClientSummary {
     pub(crate) fn from_report(report: LocalCopyReport) -> Self {
-        let (stats, records, destination_root) = report.into_parts();
+        let (mut stats, records, destination_root) = report.into_parts();
+        // A local copy bypasses the wire protocol, so the executor only counts
+        // literal data in `bytes_sent`. Upstream runs the protocol over a
+        // socketpair even locally, making its `Total bytes sent` dominated by
+        // the serialised file list. Fold the file-list size in so a local copy
+        // reports a comparable `sent` total and a meaningful speedup instead of
+        // `sent 0 bytes`.
+        stats.fold_file_list_into_sent();
         let destination_root: Arc<Path> = Arc::from(destination_root);
         let events = records
             .into_iter()

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -277,6 +277,21 @@ impl ClientSummary {
         self.stats.file_list_size()
     }
 
+    /// Returns the per-method whole-file copy breakdown as `(label, count)`
+    /// pairs (e.g. `("clonefile (CoW)", 400)`). Empty unless the local-copy
+    /// executor ran, so remote/protocol transfers report nothing.
+    #[must_use]
+    pub fn copy_method_breakdown(&self) -> Vec<(&'static str, u64)> {
+        self.stats.copy_method_breakdown()
+    }
+
+    /// Returns whether any whole-file copy used a kernel acceleration
+    /// (clonefile, reflink, io_uring, ...). Gates the `Copy method` stats line.
+    #[must_use]
+    pub fn used_copy_acceleration(&self) -> bool {
+        self.stats.used_copy_acceleration()
+    }
+
     /// Returns the duration spent generating the in-memory file list.
     #[must_use]
     pub const fn file_list_generation_time(&self) -> Duration {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -101,21 +101,22 @@ pub(super) fn try_clone(
 ) -> Result<bool, LocalCopyError> {
     let file_size = metadata.len();
 
-    let clone_method = match context
-        .options()
-        .platform_copy()
-        .copy_file(source, destination, file_size)
-    {
-        Ok(result) if result.is_zero_copy() => Some(result.method),
-        Ok(_) => {
-            let _ = std::fs::remove_file(destination);
-            None
-        }
-        Err(_) => {
-            let _ = std::fs::remove_file(destination);
-            None
-        }
-    };
+    let clone_method =
+        match context
+            .options()
+            .platform_copy()
+            .copy_file(source, destination, file_size)
+        {
+            Ok(result) if result.is_zero_copy() => Some(result.method),
+            Ok(_) => {
+                let _ = std::fs::remove_file(destination);
+                None
+            }
+            Err(_) => {
+                let _ = std::fs::remove_file(destination);
+                None
+            }
+        };
     let Some(clone_method) = clone_method else {
         // clonefile failed (cross-device, non-APFS, etc.) - caller falls
         // through to normal copy path.

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -18,8 +18,8 @@ use logging::debug_log;
 use ::metadata::MetadataOptions;
 
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
-    LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
 use super::super::TransferFlags;
@@ -101,26 +101,26 @@ pub(super) fn try_clone(
 ) -> Result<bool, LocalCopyError> {
     let file_size = metadata.len();
 
-    let cloned = match context
+    let clone_method = match context
         .options()
         .platform_copy()
         .copy_file(source, destination, file_size)
     {
-        Ok(result) if result.is_zero_copy() => true,
+        Ok(result) if result.is_zero_copy() => Some(result.method),
         Ok(_) => {
             let _ = std::fs::remove_file(destination);
-            false
+            None
         }
         Err(_) => {
             let _ = std::fs::remove_file(destination);
-            false
+            None
         }
     };
-    if !cloned {
+    let Some(clone_method) = clone_method else {
         // clonefile failed (cross-device, non-APFS, etc.) - caller falls
         // through to normal copy path.
         return Ok(false);
-    }
+    };
 
     let start = Instant::now();
     debug_log!(
@@ -143,6 +143,9 @@ pub(super) fn try_clone(
     context
         .summary_mut()
         .record_file(file_size, file_size, None);
+    context
+        .summary_mut()
+        .record_copy_method(CopyMethodKind::from_platform(clone_method));
     context.summary_mut().record_elapsed(start.elapsed());
 
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -23,8 +23,8 @@ use logging::debug_log;
 use ::metadata::MetadataOptions;
 
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
-    LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
 use super::super::TransferFlags;
@@ -130,6 +130,9 @@ pub(super) fn try_clone(
     context
         .summary_mut()
         .record_file(file_size, file_size, None);
+    context
+        .summary_mut()
+        .record_copy_method(CopyMethodKind::Ficlone);
     context.summary_mut().record_elapsed(start.elapsed());
 
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
@@ -17,8 +17,8 @@ use std::time::{Duration, Instant};
 use ::metadata::MetadataOptions;
 
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
-    LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
 use super::super::TransferFlags;
@@ -119,6 +119,9 @@ pub(super) fn try_dispatch(
     context
         .summary_mut()
         .record_file(file_size, file_size, None);
+    context
+        .summary_mut()
+        .record_copy_method(CopyMethodKind::IoUring);
     context.summary_mut().record_elapsed(elapsed);
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
     let total_bytes = Some(metadata_snapshot.len());

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -33,8 +33,8 @@ use logging::{debug_log, info_log};
 use ::metadata::MetadataOptions;
 
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
-    LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
 use super::super::super::append::{AppendMode, determine_append_mode};
@@ -603,6 +603,9 @@ pub(in crate::local_copy) fn execute_transfer(
     context
         .summary_mut()
         .record_file(file_size, outcome.literal_bytes(), compressed_bytes);
+    context
+        .summary_mut()
+        .record_copy_method(CopyMethodKind::Standard);
     context.summary_mut().record_elapsed(elapsed);
 
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -23,8 +23,8 @@ use logging::debug_log;
 use ::metadata::MetadataOptions;
 
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
-    LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
+    CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
+    LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
 use super::super::TransferFlags;
@@ -92,30 +92,30 @@ pub(super) fn try_copy(
 
     let file_size = metadata.len();
 
-    let dispatched =
+    let dispatched_method =
         match context
             .options()
             .platform_copy()
             .copy_file(source, destination, file_size)
         {
             Ok(result) => match result.method {
-                CopyMethod::CopyFileEx | CopyMethod::ReFsReflink => true,
+                method @ (CopyMethod::CopyFileEx | CopyMethod::ReFsReflink) => Some(method),
                 _ => {
                     // StandardCopy (std::fs::copy fallback) does not exercise the
                     // Windows-optimal kernel path; let the executor's normal write
                     // strategy own the bytes so behaviour matches non-Windows.
                     let _ = std::fs::remove_file(destination);
-                    false
+                    None
                 }
             },
             Err(_) => {
                 let _ = std::fs::remove_file(destination);
-                false
+                None
             }
         };
-    if !dispatched {
+    let Some(dispatched_method) = dispatched_method else {
         return Ok(false);
-    }
+    };
 
     let start = Instant::now();
     debug_log!(
@@ -138,6 +138,9 @@ pub(super) fn try_copy(
     context
         .summary_mut()
         .record_file(file_size, file_size, None);
+    context
+        .summary_mut()
+        .record_copy_method(CopyMethodKind::from_platform(dispatched_method));
     context.summary_mut().record_elapsed(start.elapsed());
 
     // Normalize copied metadata to match what open()-created files have.

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -88,9 +88,9 @@ pub use buffer_pool::{
 pub use deferred_sync::{DeferredSync, SyncStrategy};
 
 pub use plan::{
-    LocalCopyAction, LocalCopyChangeSet, LocalCopyExecution, LocalCopyFileKind, LocalCopyMetadata,
-    LocalCopyPlan, LocalCopyProgress, LocalCopyRecord, LocalCopyRecordHandler, LocalCopyReport,
-    LocalCopySummary, TimeChange,
+    CopyMethodKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyExecution, LocalCopyFileKind,
+    LocalCopyMetadata, LocalCopyPlan, LocalCopyProgress, LocalCopyRecord, LocalCopyRecordHandler,
+    LocalCopyReport, LocalCopySummary, TimeChange,
 };
 
 pub use options::{

--- a/crates/engine/src/local_copy/plan/mod.rs
+++ b/crates/engine/src/local_copy/plan/mod.rs
@@ -24,7 +24,7 @@ pub use plan_impl::LocalCopyPlan;
 pub use progress::LocalCopyProgress;
 pub use record::{LocalCopyRecord, LocalCopyRecordHandler};
 pub use report::LocalCopyReport;
-pub use summary::LocalCopySummary;
+pub use summary::{CopyMethodKind, LocalCopySummary};
 
 #[cfg(test)]
 pub(crate) use super::filter_program::FilterOutcome;

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -1,5 +1,79 @@
 use std::time::Duration;
 
+/// I/O technology the local-copy executor used to materialise a whole-file
+/// copy. Tracked so the `Copy method` stats line can report which kernel
+/// acceleration ran. Upstream rsync has no equivalent - it always reconstructs
+/// files from the wire - so this is oc-rsync-specific and only populated by the
+/// local-copy fast paths, never by remote/protocol transfers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CopyMethodKind {
+    /// macOS `clonefile` copy-on-write clone.
+    Clonefile,
+    /// Linux `FICLONE` copy-on-write reflink.
+    Ficlone,
+    /// Linux `copy_file_range` in-kernel copy.
+    CopyFileRange,
+    /// Windows ReFS `FSCTL_DUPLICATE_EXTENTS_TO_FILE` block clone.
+    ReFsReflink,
+    /// Windows `CopyFileExW`.
+    CopyFileEx,
+    /// Linux io_uring registered-buffer data write.
+    IoUring,
+    /// Portable userspace read/write loop (or delta reconstruction).
+    Standard,
+}
+
+impl CopyMethodKind {
+    /// Every variant, in display order. Indexed by `self as usize`.
+    const ALL: [Self; 7] = [
+        Self::Clonefile,
+        Self::Ficlone,
+        Self::CopyFileRange,
+        Self::ReFsReflink,
+        Self::CopyFileEx,
+        Self::IoUring,
+        Self::Standard,
+    ];
+
+    /// Human-readable label for the `Copy method` stats line. CoW mechanisms
+    /// are annotated so the user can see no data was moved.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Clonefile => "clonefile (CoW)",
+            Self::Ficlone => "FICLONE (CoW)",
+            Self::CopyFileRange => "copy_file_range",
+            Self::ReFsReflink => "ReFS reflink (CoW)",
+            Self::CopyFileEx => "CopyFileExW",
+            Self::IoUring => "io_uring",
+            Self::Standard => "standard",
+        }
+    }
+
+    /// Whether this method is a kernel acceleration (anything but the portable
+    /// userspace path). Used to gate the stats line so a plain standard-only
+    /// copy stays byte-identical to upstream's `--stats` output.
+    #[must_use]
+    pub const fn is_accelerated(self) -> bool {
+        !matches!(self, Self::Standard)
+    }
+
+    /// Maps a `fast_io` platform-copy mechanism onto the tracked kind. The
+    /// non-zero-copy `copyfile`/`StandardCopy` results fold into `Standard`.
+    #[must_use]
+    pub fn from_platform(method: fast_io::CopyMethod) -> Self {
+        use fast_io::CopyMethod;
+        match method {
+            CopyMethod::Clonefile => Self::Clonefile,
+            CopyMethod::Ficlone => Self::Ficlone,
+            CopyMethod::CopyFileRange => Self::CopyFileRange,
+            CopyMethod::ReFsReflink => Self::ReFsReflink,
+            CopyMethod::CopyFileEx => Self::CopyFileEx,
+            CopyMethod::Copyfile | CopyMethod::StandardCopy => Self::Standard,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 /// Statistics describing the outcome of a [`crate::local_copy::LocalCopyPlan`] execution.
 ///
@@ -39,6 +113,9 @@ pub struct LocalCopySummary {
     file_list_generation: Duration,
     file_list_transfer: Duration,
     destination_root_created: bool,
+    // Per-method copy counts, indexed by `CopyMethodKind as usize`. Populated
+    // only by the local-copy fast paths; drives the `Copy method` stats line.
+    copy_methods: [u64; 7],
 }
 
 impl LocalCopySummary {
@@ -216,6 +293,37 @@ impl LocalCopySummary {
         self.file_list_size = self.file_list_size.saturating_add(entry_size as u64);
     }
 
+    /// Records that one whole-file copy used the given I/O technology. Called
+    /// by the local-copy fast paths alongside [`Self::record_file`].
+    pub(in crate::local_copy) fn record_copy_method(&mut self, kind: CopyMethodKind) {
+        let index = kind as usize;
+        self.copy_methods[index] = self.copy_methods[index].saturating_add(1);
+    }
+
+    /// Returns the per-method copy breakdown as `(label, count)` pairs, in
+    /// display order, omitting methods that were never used. Empty when no
+    /// local-copy fast path ran (e.g. a remote/protocol transfer).
+    #[must_use]
+    pub fn copy_method_breakdown(&self) -> Vec<(&'static str, u64)> {
+        CopyMethodKind::ALL
+            .iter()
+            .filter_map(|&kind| {
+                let count = self.copy_methods[kind as usize];
+                (count > 0).then_some((kind.label(), count))
+            })
+            .collect()
+    }
+
+    /// Whether any whole-file copy used a kernel acceleration (clonefile,
+    /// reflink, copy_file_range, io_uring, ...). Used to gate the `Copy method`
+    /// line so a standard-only copy keeps upstream-identical `--stats` output.
+    #[must_use]
+    pub fn used_copy_acceleration(&self) -> bool {
+        CopyMethodKind::ALL
+            .iter()
+            .any(|&kind| kind.is_accelerated() && self.copy_methods[kind as usize] > 0)
+    }
+
     /// Folds the file-list size into the `sent` byte total so a local copy
     /// reports the protocol-equivalent figure upstream prints.
     ///
@@ -356,6 +464,7 @@ impl LocalCopySummary {
             file_list_generation: Duration::ZERO,
             file_list_transfer: Duration::ZERO,
             destination_root_created: false,
+            copy_methods: [0; 7],
         }
     }
 
@@ -727,6 +836,59 @@ mod tests {
         // The file-list size is still reported independently; upstream prints
         // both `File list size` and `Total bytes sent`.
         assert_eq!(summary.file_list_size(), 188);
+    }
+
+    #[test]
+    fn copy_method_breakdown_counts_and_gates_acceleration() {
+        let mut summary = LocalCopySummary::default();
+        assert!(summary.copy_method_breakdown().is_empty());
+        assert!(!summary.used_copy_acceleration());
+
+        for _ in 0..400 {
+            summary.record_copy_method(CopyMethodKind::Clonefile);
+        }
+        summary.record_copy_method(CopyMethodKind::Standard);
+        summary.record_copy_method(CopyMethodKind::Standard);
+
+        assert_eq!(
+            summary.copy_method_breakdown(),
+            vec![("clonefile (CoW)", 400), ("standard", 2)]
+        );
+        // A clone is an acceleration, so the gate trips even though some files
+        // fell back to the standard path.
+        assert!(summary.used_copy_acceleration());
+    }
+
+    #[test]
+    fn copy_method_standard_only_does_not_gate_acceleration() {
+        // A standard-only local copy must not trip the gate, so its `--stats`
+        // output stays byte-identical to upstream (which has no Copy method line).
+        let mut summary = LocalCopySummary::default();
+        summary.record_copy_method(CopyMethodKind::Standard);
+        assert_eq!(summary.copy_method_breakdown(), vec![("standard", 1)]);
+        assert!(!summary.used_copy_acceleration());
+    }
+
+    #[test]
+    fn copy_method_from_platform_maps_zero_copy_and_fallbacks() {
+        use fast_io::CopyMethod;
+        assert_eq!(
+            CopyMethodKind::from_platform(CopyMethod::Clonefile),
+            CopyMethodKind::Clonefile
+        );
+        assert_eq!(
+            CopyMethodKind::from_platform(CopyMethod::CopyFileRange),
+            CopyMethodKind::CopyFileRange
+        );
+        // Non-zero-copy platform results fold into the standard bucket.
+        assert_eq!(
+            CopyMethodKind::from_platform(CopyMethod::StandardCopy),
+            CopyMethodKind::Standard
+        );
+        assert_eq!(
+            CopyMethodKind::from_platform(CopyMethod::Copyfile),
+            CopyMethodKind::Standard
+        );
     }
 
     #[test]

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -216,6 +216,26 @@ impl LocalCopySummary {
         self.file_list_size = self.file_list_size.saturating_add(entry_size as u64);
     }
 
+    /// Folds the file-list size into the `sent` byte total so a local copy
+    /// reports the protocol-equivalent figure upstream prints.
+    ///
+    /// Upstream always runs the transfer protocol over a socketpair, even for a
+    /// purely local copy, so its `Total bytes sent` (`total_written`) is
+    /// dominated by the file list it serialises (plus any literal data tokens).
+    /// The local-copy executor bypasses the wire entirely, so `bytes_sent` would
+    /// otherwise report only the literal data - `0` on a no-change run. Folding
+    /// the separately tracked file-list size in yields a comparable `sent`
+    /// total (and a meaningful speedup) instead of `sent 0 bytes`.
+    ///
+    /// Call exactly once when finalising a local-copy summary. The figure is an
+    /// approximation: a local copy transmits nothing, so it can never match
+    /// upstream's real socketpair byte counts exactly.
+    ///
+    /// upstream: main.c output_summary, io.c stats.total_written
+    pub fn fold_file_list_into_sent(&mut self) {
+        self.bytes_sent = self.bytes_sent.saturating_add(self.file_list_size);
+    }
+
     /// Returns the time spent enumerating the file list.
     #[must_use]
     pub const fn file_list_generation_time(&self) -> Duration {
@@ -687,5 +707,39 @@ mod tests {
         summary.record_total_bytes(300);
 
         assert_eq!(summary.total_source_bytes(), 800);
+    }
+
+    #[test]
+    fn fold_file_list_into_sent_reports_flist_as_wire_sent() {
+        // A no-change local copy transmits no data, so `bytes_sent` stays 0
+        // while the file-list size accumulates. Upstream's `Total bytes sent`
+        // for the same copy is dominated by the serialised file list, so the
+        // fold must surface that figure as `sent` rather than leaving it 0.
+        let mut summary = LocalCopySummary::default();
+        summary.record_file_list_entry(93);
+        summary.record_file_list_entry(95);
+        assert_eq!(summary.bytes_sent(), 0);
+        assert_eq!(summary.file_list_size(), 188);
+
+        summary.fold_file_list_into_sent();
+
+        assert_eq!(summary.bytes_sent(), 188);
+        // The file-list size is still reported independently; upstream prints
+        // both `File list size` and `Total bytes sent`.
+        assert_eq!(summary.file_list_size(), 188);
+    }
+
+    #[test]
+    fn fold_file_list_into_sent_keeps_literal_data() {
+        // When data is transmitted, the fold adds the file list on top of the
+        // literal bytes already counted, mirroring upstream's total_written.
+        let mut summary = LocalCopySummary::default();
+        summary.record_file(1_000, 1_000, None);
+        summary.record_file_list_entry(40);
+        assert_eq!(summary.bytes_sent(), 1_000);
+
+        summary.fold_file_list_into_sent();
+
+        assert_eq!(summary.bytes_sent(), 1_040);
     }
 }

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -480,8 +480,13 @@ impl LocalCopySummary {
         let matched = file_size.saturating_sub(literal_bytes);
         self.matched_bytes = self.matched_bytes.saturating_add(matched);
         let transmitted = compressed.unwrap_or(literal_bytes);
+        // A local copy emulates the protocol sender: it writes the file data
+        // (counted as sent) but receives no data payload back. Counting the data
+        // as received too would halve the reported speedup vs upstream, where a
+        // first copy reads back only the generator's small replies (modeled as
+        // 0 here). upstream: main.c output_summary - speedup = total_size /
+        // (total_written + total_read), and a local sender's total_read is tiny.
         self.bytes_sent = self.bytes_sent.saturating_add(transmitted);
-        self.bytes_received = self.bytes_received.saturating_add(transmitted);
         if let Some(compressed_bytes) = compressed {
             self.compression_used = true;
             self.compressed_bytes = self.compressed_bytes.saturating_add(compressed_bytes);

--- a/crates/engine/src/local_copy/tests/bandwidth.rs
+++ b/crates/engine/src/local_copy/tests/bandwidth.rs
@@ -193,7 +193,9 @@ fn execute_records_transmitted_bytes_for_uncompressed_copy() {
     let expected = payload.len() as u64;
     assert_eq!(summary.bytes_copied(), expected);
     assert_eq!(summary.bytes_sent(), expected);
-    assert_eq!(summary.bytes_received(), expected);
+    // A local copy records the data as sent, not received: it emulates the
+    // protocol sender, which writes the data and reads back only small replies.
+    assert_eq!(summary.bytes_received(), 0);
     assert_eq!(summary.matched_bytes(), 0);
 }
 

--- a/crates/engine/src/local_copy/tests/bandwidth.rs
+++ b/crates/engine/src/local_copy/tests/bandwidth.rs
@@ -168,7 +168,8 @@ fn execute_with_compression_records_compressed_bytes() {
     let compressed = summary.compressed_bytes();
     assert!(compressed > 0);
     assert!(compressed <= summary.bytes_copied());
-    assert_eq!(summary.bytes_sent(), summary.bytes_received());
+    // A local copy records data as sent, not received (it emulates the sender).
+    assert_eq!(summary.bytes_received(), 0);
     assert_eq!(summary.bytes_sent(), compressed);
     assert_eq!(summary.bandwidth_sleep(), Duration::ZERO);
 }

--- a/tests/integration_checksum.rs
+++ b/tests/integration_checksum.rs
@@ -174,16 +174,19 @@ fn checksum_skips_identical_files_with_verbose() {
     cmd.args([
         "--checksum",
         "-v",
+        "--stats",
         src_file.to_str().unwrap(),
         dest_file.to_str().unwrap(),
     ]);
     let output = cmd.assert_success();
 
-    // In verbose mode with identical checksums, no data should be transferred
-    // (rsync may still list the file, but stats should show 0 bytes sent)
+    // With identical checksums, no file is transferred. The `sent N bytes`
+    // trailer is not 0 here: like upstream, oc-rsync still sends the file list
+    // even when nothing is transferred. The stats block reports the transfer
+    // count directly.
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("sent 0 bytes") || stdout.contains("0 bytes/sec"),
+        stdout.contains("Number of regular files transferred: 0"),
         "Identical file should not transfer any data: {stdout}"
     );
 }

--- a/tests/size_only_tests.rs
+++ b/tests/size_only_tests.rs
@@ -132,6 +132,7 @@ fn size_only_verbose_no_transfer_for_same_size() {
     cmd.args([
         "--size-only",
         "-v",
+        "--stats",
         src_file.to_str().unwrap(),
         dest_file.to_str().unwrap(),
     ]);
@@ -144,13 +145,13 @@ fn size_only_verbose_no_transfer_for_same_size() {
         "File with same size should not be overwritten"
     );
 
-    // Verbose output should indicate no bytes were transferred.
-    // The file may still be listed (rsync lists checked files in verbose mode)
-    // but "sent 0 bytes" confirms no actual transfer occurred.
+    // The stats block confirms no file was transferred. (The `sent N bytes`
+    // trailer is not 0 here: like upstream, oc-rsync still sends the file list
+    // even when nothing is transferred, so `sent` reflects that flist size.)
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("sent 0 bytes") || stdout.contains("sent 0B"),
-        "Should show 0 bytes sent when sizes match: {stdout}"
+        stdout.contains("Number of regular files transferred: 0"),
+        "Should report 0 regular files transferred when sizes match: {stdout}"
     );
 }
 


### PR DESCRIPTION
## Problem

A local copy printed a useless transfer trailer (`sent 0 bytes ... speedup 0.00` on a no-change run), gave no indication that a kernel copy-on-write clone moved the data, and showed `speedup 0.50` on a fresh copy. Reported in #6093 (stats half).

## Changes

**1. File-list size counted as `sent` (both stats paths).** Upstream runs the protocol over a socketpair even locally, so its `Total bytes sent` is dominated by the serialized file list. The local executor bypasses the wire, so it folds the file-list size into `bytes_sent` - on both the events path (`from_report`) and the no-events path (`from_summary`, plain `--stats`).

**2. Stop double-counting data as `received`.** `record_file` bumped both `bytes_sent` and `bytes_received` by the data, so a first copy showed `received == sent` and `speedup 0.50`. A local copy emulates the sender (writes data, reads back only small replies), so the received bump is dropped - first-copy speedup is now ~`1.00`, matching upstream.

**3. `Copy method` line, opt-in via `--info=copy`.** A local copy can move data via `clonefile`/`FICLONE`/ReFS reflink (CoW), `copy_file_range`, or an io_uring write - none of which transfer bytes the way the totals imply. The executor tracks the per-file method and, when `--info=copy` is given, reports it:
```
Copy method: clonefile (CoW) x50
sent 50,000,391 bytes  received 0 bytes  ...
total size is 50,000,000  speedup is 1.00
```
Default output (no `--info=copy`) is unconditionally upstream-identical; the line is further gated on an accelerated method actually running, so protocol/standard transfers never show it.

## Verified (macOS/APFS)

- no-change re-run: `sent 320  received 0  speedup 187512.80`
- first copy: `speedup 1.00`
- default `--stats`: no `Copy method` line; `--info=copy`: line shows

## Relationship to #6095

Independent (different files). #6095 fixes the per-file progress half of #6093; this fixes the stats half.