### PR TITLE
fix(transfer): match upstream "deleting <dir>/" delete message

### DIFF
--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -420,7 +420,12 @@ impl ReceiverContext {
                                     dir_relative.join(&name)
                                 };
                                 if is_dir {
-                                    info_log!(Del, 1, "deleting directory {}", path.display());
+                                    // upstream: log.c:845 log_delete uses one
+                                    // "deleting %n" form; %n (log.c:633-641)
+                                    // appends a trailing slash for directories,
+                                    // so a dir prints "deleting sub/" - no word
+                                    // "directory".
+                                    info_log!(Del, 1, "deleting {}/", path.display());
                                     stats.dirs += 1;
                                 } else if is_symlink {
                                     info_log!(Del, 1, "deleting {}", path.display());

--- a/crates/transfer/src/receiver/directory/missing_args.rs
+++ b/crates/transfer/src/receiver/directory/missing_args.rs
@@ -136,7 +136,11 @@ impl ReceiverContext {
             match result {
                 Ok(()) => {
                     if is_dir {
-                        info_log!(Del, 1, "deleting directory {}", target.display());
+                        // upstream: log.c:845 log_delete uses one "deleting %n"
+                        // form; %n (log.c:633-641) appends a trailing slash for
+                        // directories, so a dir prints "deleting sub/" - no word
+                        // "directory".
+                        info_log!(Del, 1, "deleting {}/", target.display());
                     } else {
                         info_log!(Del, 1, "deleting {}", target.display());
                     }


### PR DESCRIPTION
## Problem

The verbose `--delete` message for a deleted **directory** printed an extra word:

```
deleting directory sub
```

Upstream rsync emits one `deleting %n` form for files and directories alike (`log.c:845`); the `%n` conversion (`log.c:633-641`) appends a trailing slash for directories, so a deleted directory prints:

```
deleting sub/
```

No word "directory", and a trailing slash.

## Fix

Both deletion emission sites now use upstream's form — drop "directory", append `/` for dirs:
- `crates/transfer/src/receiver/directory/deletion.rs` (delete pass)
- `crates/transfer/src/receiver/directory/missing_args.rs` (`--delete-missing-args`)

The file/symlink branches were already correct (`deleting <name>`).

## Tests

No test asserts the literal `deleting directory`; existing delete-message tests use file examples or the generic `deleting ` prefix and stay valid. This brings oc-rsync's delete output byte-for-byte in line with upstream's `delete.c`/`log.c` semantics, which should help the upstream-testsuite delete cases.