### PR TITLE
feat(engine): take clonefile fast path for plain -a, strip cloned xattrs

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -56,16 +56,23 @@ pub(super) fn eligible(
         && !context.delay_updates_enabled()
         && context.temp_directory_path().is_none();
 
-    // Extended attributes: clonefile copies all xattrs verbatim, so skip
-    // when (a) xattr filters need selective copy, or (b) xattrs are disabled
-    // entirely (source xattrs would leak to destination).
+    // Extended attributes: clonefile copies all xattrs verbatim. We can still
+    // take the fast path when xattrs are disabled (`-a` without `-X`) by
+    // stripping the source-originated attributes from the clone afterwards
+    // (see try_clone). The one case we cannot reproduce with a blanket strip
+    // is a selective xattr `--filter`, so keep the slow path there.
+    //
+    // The ACL dimension (`-A`) is intentionally unchanged here: clonefile
+    // already copies source ACLs on the existing `-X`-on fast path regardless
+    // of `-A`, so relaxing `-X` does not introduce a new ACL behavior. The
+    // pre-existing ACL-leak-when-`-A`-off is tracked separately.
     let xattr_ok = {
         #[cfg(all(unix, feature = "xattr"))]
         {
             let has_filter_rules = context
                 .filter_program()
                 .is_some_and(|p| p.has_xattr_rules());
-            flags.xattrs_enabled() && !has_filter_rules
+            !has_filter_rules
         }
         #[cfg(not(all(unix, feature = "xattr")))]
         {
@@ -181,6 +188,19 @@ pub(super) fn try_clone(
     // upstream: rsync creates files via open() then applies metadata -
     // clonefile must produce identical results.
     normalize_cloned_metadata(destination, metadata, &metadata_options)?;
+
+    // clonefile() copies the source's extended attributes verbatim. When the
+    // user did not request xattr preservation (`-a` without `-X`), upstream
+    // rsync writes a fresh destination that carries none of them, so strip the
+    // source-originated attributes the clone introduced. finalize's sync_xattrs
+    // only runs when preservation is on, so this is the off-case correction.
+    // upstream: rsync's receiver open()s a new file and never copies xattrs
+    // without --xattrs.
+    #[cfg(all(unix, feature = "xattr"))]
+    if !flags.preserve_xattrs {
+        ::metadata::strip_source_xattrs(source, destination, false)
+            .map_err(crate::local_copy::metadata_sync::map_metadata_error)?;
+    }
 
     finalize_guard_and_metadata(
         context,

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -251,10 +251,12 @@ pub use special::{
 };
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]
-pub use xattr::{apply_xattrs_from_list, read_xattrs_for_wire, sync_xattrs};
+pub use xattr::{apply_xattrs_from_list, read_xattrs_for_wire, strip_source_xattrs, sync_xattrs};
 
 #[cfg(not(all(feature = "xattr", any(unix, windows))))]
-pub use xattr_stub::{apply_xattrs_from_list, read_xattrs_for_wire, sync_xattrs};
+pub use xattr_stub::{
+    apply_xattrs_from_list, read_xattrs_for_wire, strip_source_xattrs, sync_xattrs,
+};
 
 pub use copy_as::{CopyAsGuard, CopyAsIds, parse_copy_as_spec, switch_effective_ids};
 

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -156,6 +156,37 @@ pub fn read_xattrs_for_wire(
     Ok(XattrList::with_entries(entries))
 }
 
+/// Removes from `destination` every extended attribute that also exists on
+/// `source`, mirroring upstream `-a` without `-X`: a freshly written
+/// destination carries none of the source's xattrs.
+///
+/// This is the post-clone correction for the macOS `clonefile` fast path,
+/// which copies all of the source's xattrs verbatim. When xattr preservation
+/// is disabled the destination must look as if it had been `open()`ed and
+/// written fresh, so the source-originated attributes are stripped. Only
+/// names present on `source` are removed, so attributes the filesystem
+/// applied to the new inode on its own (e.g. `com.apple.provenance`) are
+/// left untouched. Removing only names confirmed present on `destination`
+/// avoids spurious `ENOATTR` churn.
+pub fn strip_source_xattrs(
+    source: &Path,
+    destination: &Path,
+    follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    let source_attrs = list_attributes(source, follow_symlinks)?;
+    if source_attrs.is_empty() {
+        return Ok(());
+    }
+    let source_names: HashSet<Vec<u8>> = source_attrs.into_iter().collect();
+
+    for name in list_attributes(destination, follow_symlinks)? {
+        if source_names.contains(&name) {
+            remove_attribute(destination, &name, follow_symlinks)?;
+        }
+    }
+    Ok(())
+}
+
 /// Synchronises the extended attributes from `source` to `destination`.
 pub fn sync_xattrs(
     source: &Path,
@@ -382,6 +413,69 @@ mod tests {
         let attr_name = test_xattr_name("nonexistent");
         let result = read_attribute(&file, &attr_name, false).expect("read attr");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn strip_source_xattrs_removes_shared_keeps_dest_only() {
+        let dir = tempdir().expect("create temp dir");
+        let source = dir.path().join("source.txt");
+        let dest = dir.path().join("dest.txt");
+        fs::write(&source, "src").expect("write source");
+        fs::write(&dest, "dst").expect("write dest");
+
+        if !xattrs_supported(&source) || !xattrs_supported(&dest) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        // Model the clonefile scenario: the destination carries the source's
+        // attribute (the clone copied it) plus one the filesystem applied on
+        // its own (modeled by a dest-only name, e.g. com.apple.provenance).
+        let shared = test_xattr_name("clone_leaked");
+        let dest_only = test_xattr_name("fs_applied");
+        write_attribute(&source, &shared, b"from-source", false).expect("write source attr");
+        write_attribute(&dest, &shared, b"from-source", false).expect("write dest shared");
+        write_attribute(&dest, &dest_only, b"fs", false).expect("write dest-only attr");
+
+        strip_source_xattrs(&source, &dest, false).expect("strip");
+
+        let dest_attrs = list_attributes(&dest, false).expect("list dest");
+        assert!(
+            !dest_attrs.contains(&shared),
+            "source-originated attribute must be stripped from the destination"
+        );
+        assert!(
+            dest_attrs.contains(&dest_only),
+            "filesystem-applied (dest-only) attribute must be preserved"
+        );
+        // The source is read-only input to the strip and must be untouched.
+        let source_attrs = list_attributes(&source, false).expect("list source");
+        assert!(source_attrs.contains(&shared), "source must be untouched");
+    }
+
+    #[test]
+    fn strip_source_xattrs_with_no_source_attrs_is_noop() {
+        let dir = tempdir().expect("create temp dir");
+        let source = dir.path().join("source.txt");
+        let dest = dir.path().join("dest.txt");
+        fs::write(&source, "src").expect("write source");
+        fs::write(&dest, "dst").expect("write dest");
+
+        if !xattrs_supported(&dest) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let dest_only = test_xattr_name("keep_me");
+        write_attribute(&dest, &dest_only, b"v", false).expect("write dest attr");
+
+        strip_source_xattrs(&source, &dest, false).expect("strip with empty source");
+
+        let dest_attrs = list_attributes(&dest, false).expect("list dest");
+        assert!(
+            dest_attrs.contains(&dest_only),
+            "with no source attributes the destination is left untouched"
+        );
     }
 
     #[test]

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -34,6 +34,19 @@ pub fn sync_xattrs(
     Ok(())
 }
 
+/// Removes from `destination` every extended attribute that also exists on
+/// `source`.
+///
+/// On platforms without xattr support there are no attributes to strip, so
+/// this returns `Ok(())` without warning (no preservation was promised).
+pub fn strip_source_xattrs(
+    _source: &Path,
+    _destination: &Path,
+    _follow_symlinks: bool,
+) -> Result<(), MetadataError> {
+    Ok(())
+}
+
 /// Reads xattr data from a file and returns it as a wire-format `XattrList`.
 ///
 /// On platforms without xattr support, returns an empty list.


### PR DESCRIPTION
## Summary

macOS `clonefile(2)` is a metadata-preserving CoW clone that copies the source's extended attributes verbatim. The clonefile fast path was therefore gated behind `-X` (xattr preservation): a plain `-a` copy without `--xattrs` fell back to a slow byte copy to avoid leaking source xattrs to the destination.

This relaxes the gate so clonefile runs for `-a` without `-X`, and strips the source-originated attributes from the clone afterwards, recovering the CoW speedup for the most common archive invocation while keeping the destination byte-identical to upstream.

## Changes

- **`metadata::strip_source_xattrs(source, dest, follow)`** (new): removes from the destination only the xattr names present on *both* source and destination. Attributes the filesystem applied to the new inode on its own (e.g. `com.apple.provenance`) are absent from the source set and left untouched, so the result matches upstream's fresh-write `-a` destination (which carries no source xattrs). A no-op stub is provided for non-xattr builds.
- **`clonefile.rs` gate**: `xattr_ok` no longer requires `xattrs_enabled()`; only a selective xattr `--filter` keeps the slow path (a blanket strip cannot reproduce selective filtering).
- **`clonefile.rs` strip hook**: after a successful clone, when `-X` is off, call `strip_source_xattrs`. With `-X` on, finalize's `sync_xattrs` handles preservation as before.

## Scope

The ACL dimension (`-A`) is intentionally unchanged. clonefile already copies source ACLs on the existing `-X`-on fast path regardless of `-A`, so relaxing `-X` introduces no new ACL behavior; the pre-existing ACL-leak-when-`-A`-off is tracked as a separate follow-up.

## Upstream reference

rsync's receiver `open()`s a fresh destination and never copies xattrs without `--xattrs` (`receiver.c`), so a no-`-X` destination carries none of the source's attributes.

## Testing

- New `metadata` unit tests: `strip_source_xattrs_removes_shared_keeps_dest_only`, `strip_source_xattrs_with_no_source_attrs_is_noop` (cross-platform via the `user.` prefix; run on Linux and macOS).
- The existing `execute_without_xattrs_flag_does_not_copy_xattrs` test now exercises the clone+strip path end-to-end on macOS APFS (a leak would flip it red).
- `cargo check/fmt/clippy -p metadata -p engine --all-features --tests` — clean.