### PR TITLE
feat(engine): take FICLONE fast path for plain -a (no -X)

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -64,13 +64,20 @@ pub(super) fn eligible(
         && !context.delay_updates_enabled()
         && context.temp_directory_path().is_none();
 
+    // Unlike macOS clonefile, FICLONE clones data extents only into a fresh
+    // File::create() inode - it never copies the source's xattrs, so plain
+    // `-a` (no -X) is safe with no post-clone strip: the destination simply
+    // starts with none. When -X is set, finalize applies the source xattrs
+    // (it runs for this path with flags.preserve_xattrs). The one case a
+    // blanket clone cannot reproduce is a selective xattr `--filter`, which
+    // still takes the slow path so the filter can be honoured per-attribute.
     let xattr_ok = {
         #[cfg(all(unix, feature = "xattr"))]
         {
             let has_filter_rules = context
                 .filter_program()
                 .is_some_and(|p| p.has_xattr_rules());
-            flags.xattrs_enabled() && !has_filter_rules
+            !has_filter_rules
         }
         #[cfg(not(all(unix, feature = "xattr")))]
         {

--- a/crates/engine/tests/reflink_ficlone_executor.rs
+++ b/crates/engine/tests/reflink_ficlone_executor.rs
@@ -14,6 +14,7 @@
 use std::fs;
 use std::io::Write;
 
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
 use tempfile::tempdir;
 
 fn detect_reflink_support(dir: &std::path::Path) -> bool {
@@ -118,4 +119,40 @@ fn ficlone_idempotent_second_clone_replaces_destination() {
     fs::write(&src, b"second").expect("rewrite source");
     fast_io::try_ficlone(&src, &dst).expect("second FICLONE");
     assert_eq!(fs::read(&dst).expect("read2"), b"second");
+}
+
+#[test]
+fn executor_uses_ficlone_for_plain_archive_without_xattrs() {
+    let dir = tempdir().expect("tempdir");
+    if !detect_reflink_support(dir.path()) {
+        eprintln!(
+            "skipping plain-archive ficlone gate test - {:?} is not a reflink-capable filesystem",
+            dir.path()
+        );
+        return;
+    }
+
+    let src = dir.path().join("src.bin");
+    let dst = dir.path().join("dst.bin");
+    let payload: Vec<u8> = (0..256u32 * 1024).map(|i| (i & 0xff) as u8).collect();
+    fs::write(&src, &payload).expect("write source");
+
+    let operands = vec![src.into_os_string(), dst.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Plain `-a` semantics: no .xattrs(true). Before the gate relaxation this
+    // fell back to a slow read/write copy because the gate required -X; now it
+    // must take the FICLONE fast path. The fresh-inode clone copies data only
+    // and never leaks source xattrs, so -X is not needed for correctness.
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .expect("copy succeeds");
+
+    assert_eq!(summary.files_copied(), 1);
+    assert_eq!(fs::read(&dst).expect("read dst"), payload);
+    assert!(
+        summary.used_copy_acceleration(),
+        "plain -a copy on a reflink-capable fs must engage FICLONE, got methods {:?}",
+        summary.copy_method_breakdown()
+    );
 }


### PR DESCRIPTION
## Summary

The Linux FICLONE reflink fast path was gated behind `-X` (xattr preservation), so a plain `-a` copy without `--xattrs` fell back to a slow read/write copy. This relaxes the gate so plain `-a` gets the O(1) reflink.

This is the Linux counterpart to the macOS clonefile relaxation (#6099), but **simpler**: unlike macOS `clonefile(2)` (a metadata-preserving clone that copies xattrs and needs a post-clone strip), the Linux `ioctl(FICLONE)` clones **data extents only** into a fresh `File::create()` inode. It never copies the source's xattrs, so there is no leak to strip - the destination simply starts with none.

## Changes

- **`ficlone.rs` gate**: `xattr_ok` no longer requires `xattrs_enabled()`; only a selective xattr `--filter` keeps the slow path (a blanket clone cannot honour per-attribute filtering).
- Updated the gate comment to describe FICLONE's data-only semantics (vs the macOS clonefile comment it was copied from).

## Correctness

FICLONE already ran for `-aX` before this change (the gate required `-X`), and `finalize_guard_and_metadata` receives `flags.preserve_xattrs` (ficlone.rs:185), so finalize is what applies source xattrs when `-X` is set - not the clone. Relaxing to also allow `-a` is therefore safe: `-aX` is unchanged (finalize still applies xattrs), and `-a` gets a fresh inode with no xattrs, matching upstream's fresh-write destination.

## Testing

- New `executor_uses_ficlone_for_plain_archive_without_xattrs` (in `reflink_ficlone_executor.rs`): a plain `-a` copy on a reflink-capable fs must report copy acceleration (FICLONE engaged) with byte-identical content. Self-skips on non-reflink filesystems, like the sibling tests.
- Test body type-checked on the host; `cargo fmt -p engine` clean.

## Upstream reference

rsync creates the destination via `open()` then applies metadata; reflinks must produce identical observable results.