### PR TITLE
fix(core): escape leading tilde in remote filename args on pull

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -214,10 +214,27 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // the remote shell's eval naturally splits space-separated paths.
         let old_args_active = self.config.old_args().unwrap_or(false);
 
+        // upstream: options.c:2553-2558 escape_leading_tilde is set only when
+        // local is NOT the sender (a pull, so the remote paths are the source)
+        // and the sender's args are not trusted. The per-path shape test is
+        // applied below.
+        let am_sender = self.role == RemoteRole::Sender;
+        let escape_tilde_role = !am_sender && !self.config.trust_sender();
+
         for path in remote_paths {
             if escape_for_shell && !old_args_active {
                 // upstream: main.c:613 safe_arg(NULL, *remote_argv++)
-                args.push(OsString::from(shell_safe_filename_arg(path)));
+                // upstream: options.c:2555-2557 - escape a leading ~ for a
+                // relative path without a `/./` pivot, or a path with no `/`.
+                let escape_tilde = escape_tilde_role
+                    && ((self.config.relative_paths() && !path.contains("/./"))
+                        || !path.contains('/'));
+                let escaped = if escape_tilde {
+                    shell_safe_filename_arg_with_tilde(path, true)
+                } else {
+                    shell_safe_filename_arg(path)
+                };
+                args.push(OsString::from(escaped));
             } else {
                 args.push(OsString::from(*path));
             }
@@ -754,8 +771,24 @@ const WILD_CHARS: &str = "*?[]";
 /// This escaping is applied when `protect_args` is not active, matching the
 /// upstream condition `!protect_args && old_style_args < 2`.
 pub(super) fn shell_safe_filename_arg(arg: &str) -> String {
+    shell_safe_filename_arg_with_tilde(arg, false)
+}
+
+/// Backslash-escapes shell metacharacters in a filename argument, optionally
+/// escaping a leading `~`.
+///
+/// Behaves like [`shell_safe_filename_arg`]; when `escape_leading_tilde` is
+/// set and `arg` begins with `~`, a single backslash is prepended (`~foo` ->
+/// `\~foo`) so the remote shell does not tilde-expand a path literally named
+/// `~foo`. Mirrors upstream `options.c:2553-2558` / `:2581`, where the
+/// `escape_leading_tilde` flag is set only on a pull (`!am_sender`) for an
+/// untrusted sender and a relative/no-slash path; the caller computes that
+/// gate and passes the result here.
+pub(super) fn shell_safe_filename_arg_with_tilde(arg: &str, escape_leading_tilde: bool) -> String {
     let leading_dash = arg.starts_with('-');
-    let needs_escaping = leading_dash || arg.chars().any(|c| SHELL_CHARS.contains(c));
+    let leading_tilde = escape_leading_tilde && arg.starts_with('~');
+    let needs_escaping =
+        leading_dash || leading_tilde || arg.chars().any(|c| SHELL_CHARS.contains(c));
     if !needs_escaping {
         return arg.to_owned();
     }
@@ -764,6 +797,9 @@ pub(super) fn shell_safe_filename_arg(arg: &str) -> String {
 
     if leading_dash {
         out.push_str("./");
+    } else if leading_tilde {
+        // upstream: options.c:2581 - a single backslash before a leading ~.
+        out.push('\\');
     }
 
     let chars: Vec<char> = arg.chars().collect();

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -2678,7 +2678,7 @@ fn iconv_explicit_single_forwards_whole_spec() {
 // filename args when protect_args is off. These tests verify that oc-rsync
 // produces the same escaping, matching the lsh.sh `eval "$@"` contract.
 
-use super::builder::shell_safe_filename_arg;
+use super::builder::{shell_safe_filename_arg, shell_safe_filename_arg_with_tilde};
 
 #[test]
 fn shell_safe_simple_path_unchanged() {
@@ -2727,6 +2727,30 @@ fn shell_safe_escapes_tab() {
 fn shell_safe_leading_dash_gets_dot_slash() {
     // upstream: safe_arg prepends "./" to prevent option interpretation
     assert_eq!(shell_safe_filename_arg("-file"), "./-file");
+}
+
+#[test]
+fn shell_safe_leading_tilde_unescaped_when_not_requested() {
+    // The plain wrapper - and a push, where escape_leading_tilde is false -
+    // leaves a leading ~ untouched, matching upstream which lets the remote
+    // expand ~ on the destination.
+    assert_eq!(shell_safe_filename_arg("~foo"), "~foo");
+    assert_eq!(shell_safe_filename_arg_with_tilde("~foo", false), "~foo");
+}
+
+#[test]
+fn shell_safe_leading_tilde_escaped_when_requested() {
+    // upstream: options.c:2553-2558 / :2581 - on a pull the leading ~ of a
+    // bare-name source path is backslash-escaped to \~foo so the remote shell
+    // does not tilde-expand a path literally named ~foo.
+    assert_eq!(shell_safe_filename_arg_with_tilde("~foo", true), "\\~foo");
+}
+
+#[test]
+fn shell_safe_tilde_escape_only_affects_leading_tilde() {
+    // A ~ that is not the first character is ordinary (not a SHELL_CHARS
+    // member) and is left as-is even when tilde escaping is requested.
+    assert_eq!(shell_safe_filename_arg_with_tilde("a~b", true), "a~b");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Mirrors upstream `options.c:2553-2558` / `:2581` (`escape_leading_tilde`). On a **pull**, the remote paths are the source; a filename argument beginning with `~` must be backslash-escaped (`~foo` -> `\~foo`) so the remote shell does not tilde-expand a path literally named `~foo`. oc-rsync previously left a leading `~` unescaped (it is not a `SHELL_CHARS` member), diverging from upstream on this case.

## Gate (matches upstream)

`escape_leading_tilde` fires only when:
- local is **not** the sender (a pull, so the remote path is the source), and
- sender args are not trusted (`!trust_sender()`), and
- the path is relative-mode without a `/./` pivot, **or** has no `/` at all.

On a **push**, the remote paths are the destination, where upstream lets the remote expand `~` - so this change does not affect push behavior (already correct).

## Changes

- `shell_safe_filename_arg_with_tilde(arg, escape_leading_tilde)`: new variant prepending a single `\` before a leading `~` when the gate is set (the `~` itself then passes through unescaped, yielding `\~foo`). The existing `shell_safe_filename_arg(arg)` is retained as the no-escape form (used on the push/no-escape path and by existing tests), so no existing call sites or tests change.
- Call site (`build_args_without_program`) computes the per-path gate from `role`, `trust_sender()`, and `relative_paths()`.

## Testing

- New unit tests: `~foo` -> `~foo` (push / not requested), `~foo` -> `\~foo` (pull / requested), and a non-leading `~` left untouched.
- `cargo fmt -p core -- --check`, `cargo clippy -p core --all-features --tests --no-deps -- -D warnings` - both clean.