### PR TITLE
fix(engine): retry inplace dest open without O_CREAT on EACCES

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -138,12 +138,24 @@ pub(in crate::local_copy) fn open_destination_writer(
             // Inplace + delta must NOT truncate: the existing blocks are the
             // basis the delta reads from.
             let should_truncate = delta_signature.is_none();
-            fs::OpenOptions::new()
+            let opened = fs::OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(should_truncate)
-                .open(destination)
-                .map_err(|error| LocalCopyError::io("copy file", destination, error))
+                .open(destination);
+            // upstream: receiver.c:978-986 - under the fs.protected_regular
+            // sysctl the kernel returns EACCES for an O_CREAT open of an
+            // existing file we do not own in a sticky, world-writable dir. The
+            // file already exists on the inplace path, so retry without O_CREAT.
+            #[cfg(target_os = "linux")]
+            let opened = match opened {
+                Err(error) if error.raw_os_error() == Some(libc::EACCES) => fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(should_truncate)
+                    .open(destination),
+                other => other,
+            };
+            opened.map_err(|error| LocalCopyError::io("copy file", destination, error))
         }
         WriteStrategy::Direct => {
             // upstream: receiver.c - direct write when no existing file to protect.

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -356,11 +356,24 @@ fn open_output_file(
         Ok((file, TempFileGuard::new(begin.file_path.clone()), false))
     } else if begin.is_inplace {
         // upstream: receiver.c:855 - do_open(fname, O_WRONLY|O_CREAT, 0600)
-        let mut file = fs::OpenOptions::new()
+        let opened = fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(false)
-            .open(&begin.file_path)?;
+            .open(&begin.file_path);
+        // upstream: receiver.c:978-986 - under the fs.protected_regular sysctl
+        // the kernel returns EACCES for an O_CREAT open of an existing file we
+        // do not own in a sticky, world-writable dir. The inplace target
+        // already exists, so retry without O_CREAT.
+        #[cfg(target_os = "linux")]
+        let opened = match opened {
+            Err(error) if error.raw_os_error() == Some(libc::EACCES) => fs::OpenOptions::new()
+                .write(true)
+                .truncate(false)
+                .open(&begin.file_path),
+            other => other,
+        };
+        let mut file = opened?;
         // upstream: receiver.c:307-308 - in append mode, seek past existing content
         if begin.append_offset > 0 {
             use std::io::Seek;


### PR DESCRIPTION
## Problem

Under the Linux `fs.protected_regular` sysctl, the kernel returns `EACCES` for an `O_CREAT` open (for write) of an existing file the caller does not own, located in a sticky, world-writable directory. oc-rsync's `--inplace` path opens the final destination directly with `O_CREAT`, so a local `rsync --inplace src dst` to such a file fails:

```
failed to copy file '.../files/dst': Permission denied (os error 13) (code 23)
```

Upstream rsync 3.4.4 passes the `protected-regular` test; oc-rsync failed it.

## Root cause

The inplace open uses `O_CREAT` and has no fallback. Upstream guards exactly this case in `receiver.c:978-986`: on `EACCES` it retries the open **without** `O_CREAT` (the inplace target already exists, so `O_CREAT` is unnecessary):

```c
fd2 = do_open(fnametmp, O_WRONLY|O_CREAT, 0600);
#ifdef linux
if (fd2 == -1 && errno == EACCES)
    fd2 = do_open(fname, O_WRONLY, 0600);  // retry without O_CREAT
#endif
```

## Fix

Mirror upstream: on the inplace open, if the create+write open fails with `EACCES`, retry without `O_CREAT` (Linux-gated, matching upstream's `#ifdef linux`). Applied at both inplace sites:

- `crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs` (engine local-copy inplace) - the path this test exercises.
- `crates/transfer/src/disk_commit/process.rs` (transfer receiver inplace commit) - same class of bug for the network/daemon inplace path.

Non-inplace transfers are unaffected (they use temp-file + atomic rename).

## Verification

Built on Linux and run against the upstream rsync 3.4.4 testsuite:

```
PASS    protected-regular
```

(Previously `FAIL` with the EACCES error above; upstream rsync 3.4.4 `PASS`.)