### PR TITLE
fix(core): propagate verbose flag to local SSH receiver/generator config

### DIFF
--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -349,6 +349,15 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // `--info=name2` make the generator emit itemize rows for unchanged
     // entries too; the local receiver-generator needs the same gate.
     server_config.flags.info_flags.itemize_unchanged = config.itemize_unchanged();
+    // upstream: the in-process local receiver/generator (SSH pull/push) needs
+    // the client's verbose level so per-file `info_log!(Name)` rows and the
+    // `receiving incremental file list` banner fire - both gated on
+    // `flags.verbose && client_mode` (receiver pipeline.rs / setup.rs).
+    // `build_server_flag_string` never sends 'v' to the remote and this local
+    // ServerConfig is built from that same string, so `verbose` stays false
+    // without this. Mirrors the daemon path (daemon_transfer server_config.rs).
+    server_config.flags.verbose = config.verbosity() > 0;
+    server_config.flags.verbose_level = config.verbosity();
     // upstream: flist.c::iconv_for_local and options.c::recv_iconv_settings -
     // when --iconv is configured, the local process must transcode file-list
     // entries between the local and remote charsets. Without this bridge the


### PR DESCRIPTION
Fixes #6103

## Problem

`oc-rsync -avP user@host:src/ dst` over SSH (and any remote-shell pull) printed only the file-list banner and the final summary — **no per-file `-v` names and no `--progress` output** — even though the data transferred correctly. `-i` (itemize) output worked, so the asymmetry was `-v`-specific.

## Root cause

A scp-style SSH transfer reuses the server receiver/generator infrastructure with `client_mode = true`. The per-file `info_log!(Name)` rows and the `receiving incremental file list` banner are gated on `flags.verbose && client_mode` (receiver `pipeline.rs` / `setup.rs`).

`client_mode` is set true, but `apply_common_server_flags` (`crates/core/src/client/remote/flags.rs`) only propagated `info_flags.itemize` onto the local `ServerConfig` — it **never set `flags.verbose`**. `build_server_flag_string` does not send `'v'` to the remote, and the local `ServerConfig` is built from that same string, so `verbose` stayed `false`. The `verbose && client_mode` gate therefore short-circuited and the names/banner were never emitted. `-i`/itemize was unaffected because it is gated on `info_flags.itemize` (which **was** propagated) and routes straight to stdout, bypassing the verbose gate — exactly the `-v`-vs-`-i` asymmetry in the report.

The daemon path already does this propagation (`daemon_transfer/orchestration/server_config.rs`); the SSH path was simply missing it.

## Fix

Propagate the client's verbose level onto the local `ServerConfig` in `apply_common_server_flags`, which is the common builder for both the pull receiver and the push generator:

```rust
server_config.flags.verbose = config.verbosity() > 0;
server_config.flags.verbose_level = config.verbosity();
```

The per-file emissions remain additionally gated on `client_mode`, so a real server/daemon receiver (`!client_mode`) still routes names via `MSG_INFO` rather than stdout — no double emission, and the itemize path is unchanged.

## Verification

Built on Linux; remote-shell pull (`-avP`) of a 5-file tree now prints the per-file names and the correct `receiving incremental file list` banner (previously absent / shown as `sending`):

```
receiving incremental file list
track1.bin
track2.bin
track3.bin
track4.bin
track5.bin
```

A follow-up (separate from this suppression fix): client-mode `info_log!(Name)` events are buffered and flushed at end of run, so the names currently print as a block rather than interleaved with progress; routing them through the immediate `emit_info_line` path would restore exact upstream interleaving.