### PR TITLE
fix(cli): match upstream -hh base 1024 and drop exact-value parens

### DIFF
--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -5,35 +5,31 @@ use std::time::Duration;
 use core::client::HumanReadableMode;
 
 pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) -> String {
-    let decimal = format!("{rate:.2}");
     if !human_readable.is_enabled() {
-        return decimal;
-    }
-
-    let human = format_human_rate(rate);
-    if human_readable.includes_exact() && human != decimal {
-        format!("{human} ({decimal})")
-    } else {
-        human
-    }
-}
-
-pub(crate) fn format_human_rate(rate: f64) -> String {
-    if rate < 1_000.0 {
         return format!("{rate:.2}");
     }
 
-    const UNITS: &[(&str, f64)] = &[
-        ("P", 1_000_000_000_000_000.0),
-        ("T", 1_000_000_000_000.0),
-        ("G", 1_000_000_000.0),
-        ("M", 1_000_000.0),
-        ("K", 1_000.0),
+    // upstream: main.c:464 formats the bytes/sec rate with human_num, the same
+    // do_big_num path as the byte counters, so the rate honours the level's base.
+    format_human_rate(rate, human_readable.unit_base())
+}
+
+pub(crate) fn format_human_rate(rate: f64, base: f64) -> String {
+    if rate < base {
+        return format!("{rate:.2}");
+    }
+
+    let units = [
+        ("P", base.powi(5)),
+        ("T", base.powi(4)),
+        ("G", base.powi(3)),
+        ("M", base.powi(2)),
+        ("K", base),
     ];
 
-    for (suffix, threshold) in UNITS {
-        if rate >= *threshold {
-            let value = rate / *threshold;
+    for (suffix, threshold) in units {
+        if rate >= threshold {
+            let value = rate / threshold;
             return format!("{value:.2}{suffix}");
         }
     }
@@ -84,17 +80,11 @@ pub(crate) fn format_progress_rate(
     }
 
     let rate = bytes as f64 / seconds;
-    let decimal = format_progress_rate_decimal(rate);
     if !human_readable.is_enabled() {
-        return decimal;
+        return format_progress_rate_decimal(rate);
     }
 
-    let human = format_progress_rate_human(rate);
-    if human_readable.includes_exact() && human != decimal {
-        format!("{human} ({decimal})")
-    } else {
-        human
-    }
+    format_progress_rate_human(rate)
 }
 
 pub(crate) fn format_progress_rate_decimal(rate: f64) -> String {
@@ -137,17 +127,11 @@ pub(crate) fn format_progress_rate_from_value(
         };
     }
 
-    let decimal = format_progress_rate_decimal(rate);
     if !human_readable.is_enabled() {
-        return decimal;
+        return format_progress_rate_decimal(rate);
     }
 
-    let human = format_progress_rate_human(rate);
-    if human_readable.includes_exact() && human != decimal {
-        format!("{human} ({decimal})")
-    } else {
-        human
-    }
+    format_progress_rate_human(rate)
 }
 
 #[cfg(test)]
@@ -156,17 +140,23 @@ mod tests {
 
     #[test]
     fn format_human_rate_small() {
-        assert_eq!(format_human_rate(500.0), "500.00");
+        assert_eq!(format_human_rate(500.0, 1000.0), "500.00");
     }
 
     #[test]
     fn format_human_rate_kilo() {
-        assert_eq!(format_human_rate(1_500.0), "1.50K");
+        assert_eq!(format_human_rate(1_500.0, 1000.0), "1.50K");
     }
 
     #[test]
     fn format_human_rate_mega() {
-        assert_eq!(format_human_rate(2_500_000.0), "2.50M");
+        assert_eq!(format_human_rate(2_500_000.0, 1000.0), "2.50M");
+    }
+
+    #[test]
+    fn format_human_rate_base_1024() {
+        // -hh divides the rate by 1024, matching upstream human_num.
+        assert_eq!(format_human_rate(1_048_576.0, 1024.0), "1.00M");
     }
 
     #[test]

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -3,25 +3,18 @@
 use core::client::HumanReadableMode;
 
 /// Formats a byte count using thousands separators when human-readable formatting is disabled. When
-/// enabled, the output uses decimal unit suffixes such as `K`, `M`, or `G` with two fractional
-/// digits. Combined mode includes the exact decimal value in parentheses when the two representations
-/// differ.
+/// enabled, the output uses unit suffixes such as `K`, `M`, or `G` with two fractional digits.
+/// `-h` (Enabled) divides by 1000; `-hh` (Combined) divides by 1024, mirroring upstream `do_big_num`.
 pub(crate) fn format_progress_bytes(bytes: u64, human_readable: HumanReadableMode) -> String {
     format_size(bytes, human_readable)
 }
 
 pub(crate) fn format_size(bytes: u64, human_readable: HumanReadableMode) -> String {
-    let decimal = format_decimal_bytes(bytes);
     if !human_readable.is_enabled() {
-        return decimal;
+        return format_decimal_bytes(bytes);
     }
 
-    let human = format_human_bytes(bytes);
-    if human_readable.includes_exact() && human != decimal {
-        format!("{human} ({decimal})")
-    } else {
-        human
-    }
+    format_human_bytes(bytes, human_readable.unit_base())
 }
 
 pub(crate) fn format_decimal_bytes(bytes: u64) -> String {
@@ -51,23 +44,26 @@ pub(crate) fn format_decimal_bytes(bytes: u64) -> String {
     String::from(std::str::from_utf8(&buf[pos..]).expect("ASCII-only content"))
 }
 
-pub(crate) fn format_human_bytes(bytes: u64) -> String {
-    if bytes < 1_000 {
+pub(crate) fn format_human_bytes(bytes: u64, base: f64) -> String {
+    // upstream: lib/compat.c:do_big_num - values below the multiplier are
+    // printed without a unit suffix; otherwise K/M/G/T/P with two fractional
+    // digits. `base` is 1000 for `-h` and 1024 for `-hh` (compat.c:183).
+    let bytes_f64 = bytes as f64;
+    if bytes_f64 < base {
         return bytes.to_string();
     }
 
-    const UNITS: &[(&str, f64)] = &[
-        ("P", 1_000_000_000_000_000.0),
-        ("T", 1_000_000_000_000.0),
-        ("G", 1_000_000_000.0),
-        ("M", 1_000_000.0),
-        ("K", 1_000.0),
+    let units = [
+        ("P", base.powi(5)),
+        ("T", base.powi(4)),
+        ("G", base.powi(3)),
+        ("M", base.powi(2)),
+        ("K", base),
     ];
 
-    let bytes_f64 = bytes as f64;
-    for (suffix, threshold) in UNITS {
-        if bytes_f64 >= *threshold {
-            let value = bytes_f64 / *threshold;
+    for (suffix, threshold) in units {
+        if bytes_f64 >= threshold {
+            let value = bytes_f64 / threshold;
             return format!("{value:.2}{suffix}");
         }
     }
@@ -114,32 +110,45 @@ mod tests {
         assert_eq!(format_decimal_bytes(u64::MAX), "18,446,744,073,709,551,615");
     }
 
+    // upstream: lib/compat.c:183 - `-h` (level 2) uses base 1000.
+    const BASE_1000: f64 = 1000.0;
+    // upstream: lib/compat.c:183 - `-hh` (level 3) uses base 1024.
+    const BASE_1024: f64 = 1024.0;
+
     #[test]
     fn format_human_bytes_small() {
-        assert_eq!(format_human_bytes(0), "0");
-        assert_eq!(format_human_bytes(999), "999");
+        assert_eq!(format_human_bytes(0, BASE_1000), "0");
+        assert_eq!(format_human_bytes(999, BASE_1000), "999");
     }
 
     #[test]
     fn format_human_bytes_kilo() {
-        assert_eq!(format_human_bytes(1_000), "1.00K");
-        assert_eq!(format_human_bytes(1_500), "1.50K");
+        assert_eq!(format_human_bytes(1_000, BASE_1000), "1.00K");
+        assert_eq!(format_human_bytes(1_500, BASE_1000), "1.50K");
     }
 
     #[test]
     fn format_human_bytes_mega() {
-        assert_eq!(format_human_bytes(1_000_000), "1.00M");
-        assert_eq!(format_human_bytes(2_500_000), "2.50M");
+        assert_eq!(format_human_bytes(1_000_000, BASE_1000), "1.00M");
+        assert_eq!(format_human_bytes(2_500_000, BASE_1000), "2.50M");
     }
 
     #[test]
     fn format_human_bytes_giga() {
-        assert_eq!(format_human_bytes(1_000_000_000), "1.00G");
+        assert_eq!(format_human_bytes(1_000_000_000, BASE_1000), "1.00G");
     }
 
     #[test]
     fn format_human_bytes_tera() {
-        assert_eq!(format_human_bytes(1_000_000_000_000), "1.00T");
+        assert_eq!(format_human_bytes(1_000_000_000_000, BASE_1000), "1.00T");
+    }
+
+    #[test]
+    fn format_human_bytes_base_1024() {
+        // -hh divides by 1024: 2,201,503 bytes -> 2.10M (not 2.20M at base 1000).
+        assert_eq!(format_human_bytes(2_201_503, BASE_1024), "2.10M");
+        assert_eq!(format_human_bytes(1_024, BASE_1024), "1.00K");
+        assert_eq!(format_human_bytes(1_048_576, BASE_1024), "1.00M");
     }
 
     #[test]

--- a/crates/cli/src/frontend/tests/format.rs
+++ b/crates/cli/src/frontend/tests/format.rs
@@ -2,11 +2,10 @@ use super::common::*;
 use super::*;
 
 #[test]
-fn format_size_combined_includes_exact_component() {
-    assert_eq!(
-        format_size(1_536, HumanReadableMode::Combined),
-        "1.54K (1,536)"
-    );
+fn format_size_combined_uses_base_1024_no_exact() {
+    // upstream: lib/compat.c:183 - `-hh` (Combined) divides by 1024 and never
+    // appends an exact-value component: 1536 / 1024 = 1.50K.
+    assert_eq!(format_size(1_536, HumanReadableMode::Combined), "1.50K");
 }
 
 #[test]
@@ -26,11 +25,12 @@ fn format_progress_rate_zero_bytes_matches_mode() {
 }
 
 #[test]
-fn format_progress_rate_combined_includes_decimal_component() {
+fn format_progress_rate_combined_no_exact_component() {
+    // upstream never appends an exact-value component to the progress rate.
     let rendered = format_progress_rate(
         1_048_576,
         Duration::from_secs(1),
         HumanReadableMode::Combined,
     );
-    assert_eq!(rendered, "1.05MB/s (1.00MB/s)");
+    assert_eq!(rendered, "1.05MB/s");
 }

--- a/crates/cli/src/frontend/tests/human_readable_format.rs
+++ b/crates/cli/src/frontend/tests/human_readable_format.rs
@@ -149,7 +149,7 @@ fn three_h_flags_remain_combined_mode() {
 }
 
 #[test]
-fn combined_mode_includes_exact_values() {
+fn combined_mode_uses_base_1024_no_exact() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -169,14 +169,16 @@ fn combined_mode_includes_exact_values() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
+    // upstream: lib/compat.c:183 - `-hh` divides by 1024 (2048 / 1024 = 2.00K)
+    // and never appends an exact-value component.
     assert!(
-        rendered.contains("2.05K (2,048)"),
-        "expected combined format, got: {rendered}"
+        rendered.contains("2.00K") && !rendered.contains("(2,048)"),
+        "expected base-1024 format without exact component, got: {rendered}"
     );
 }
 
 #[test]
-fn combined_mode_shows_both_human_and_decimal() {
+fn combined_mode_long_form_uses_base_1024() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -195,7 +197,12 @@ fn combined_mode_shows_both_human_and_decimal() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
-    assert!(rendered.contains("1.54K (1,536)"));
+    // upstream: lib/compat.c:183 - `-hh` divides by 1024 (1536 / 1024 = 1.50K)
+    // and never appends an exact-value component.
+    assert!(
+        rendered.contains("1.50K") && !rendered.contains("(1,536)"),
+        "expected base-1024 format without exact component, got: {rendered}"
+    );
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/progress.rs
+++ b/crates/cli/src/frontend/tests/progress.rs
@@ -89,7 +89,8 @@ fn progress_human_readable_combined_formats_sizes() {
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("progress output utf8");
     let normalized = rendered.replace('\r', "\n");
-    assert!(normalized.contains("1.54K (1,536)"));
+    // upstream: `-hh` divides by 1024 (1536/1024 = 1.50K), no exact component.
+    assert!(normalized.contains("1.50K") && !normalized.contains("(1,536)"));
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/progress_format_upstream.rs
+++ b/crates/cli/src/frontend/tests/progress_format_upstream.rs
@@ -486,38 +486,44 @@ fn format_decimal_bytes_u64_max() {
     assert!(!result.is_empty());
 }
 
+// upstream: lib/compat.c:183 - `-h` (the default human level) divides by 1000.
+const BASE_1000: f64 = 1000.0;
+
 #[test]
 fn format_human_bytes_under_threshold() {
-    assert_eq!(format_human_bytes(0), "0");
-    assert_eq!(format_human_bytes(999), "999");
+    assert_eq!(format_human_bytes(0, BASE_1000), "0");
+    assert_eq!(format_human_bytes(999, BASE_1000), "999");
 }
 
 #[test]
 fn format_human_bytes_kilo_range() {
-    assert_eq!(format_human_bytes(1_000), "1.00K");
-    assert_eq!(format_human_bytes(1_500), "1.50K");
-    assert_eq!(format_human_bytes(999_999), "1000.00K");
+    assert_eq!(format_human_bytes(1_000, BASE_1000), "1.00K");
+    assert_eq!(format_human_bytes(1_500, BASE_1000), "1.50K");
+    assert_eq!(format_human_bytes(999_999, BASE_1000), "1000.00K");
 }
 
 #[test]
 fn format_human_bytes_mega_range() {
-    assert_eq!(format_human_bytes(1_000_000), "1.00M");
-    assert_eq!(format_human_bytes(2_500_000), "2.50M");
+    assert_eq!(format_human_bytes(1_000_000, BASE_1000), "1.00M");
+    assert_eq!(format_human_bytes(2_500_000, BASE_1000), "2.50M");
 }
 
 #[test]
 fn format_human_bytes_giga_range() {
-    assert_eq!(format_human_bytes(1_000_000_000), "1.00G");
+    assert_eq!(format_human_bytes(1_000_000_000, BASE_1000), "1.00G");
 }
 
 #[test]
 fn format_human_bytes_tera_range() {
-    assert_eq!(format_human_bytes(1_000_000_000_000), "1.00T");
+    assert_eq!(format_human_bytes(1_000_000_000_000, BASE_1000), "1.00T");
 }
 
 #[test]
 fn format_human_bytes_peta_range() {
-    assert_eq!(format_human_bytes(1_000_000_000_000_000), "1.00P");
+    assert_eq!(
+        format_human_bytes(1_000_000_000_000_000, BASE_1000),
+        "1.00P"
+    );
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/stats.rs
+++ b/crates/cli/src/frontend/tests/stats.rs
@@ -69,7 +69,8 @@ fn stats_human_readable_combined_formats_totals() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("stats output utf8");
-    assert!(rendered.contains("Total file size: 1.54K (1,536) bytes"));
+    // upstream: `-hh` divides by 1024 (1536/1024 = 1.50K), no exact component.
+    assert!(rendered.contains("Total file size: 1.50K bytes"));
     assert!(rendered.contains("Total bytes sent:"));
 }
 

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -299,7 +299,9 @@ fn verbose_human_readable_combined_formats_sizes() {
     assert_eq!(code, 0);
     assert!(stderr.is_empty());
     let rendered = String::from_utf8(stdout).expect("verbose output utf8");
-    assert!(rendered.contains("1.54K (1,536) bytes"));
+    // upstream: `-hh` (--human-readable=2) divides by 1024 (1536/1024 = 1.50K)
+    // and never appends an exact-value component.
+    assert!(rendered.contains("1.50K bytes") && !rendered.contains("(1,536)"));
 }
 
 /// Verifies that -vv lists files using upstream's bare `%n%L` format

--- a/crates/core/src/client/config/enums/human_readable.rs
+++ b/crates/core/src/client/config/enums/human_readable.rs
@@ -5,18 +5,18 @@ use thiserror::Error;
 /// Controls how byte counters are rendered for user-facing output.
 ///
 /// Upstream `rsync` accepts optional levels for `--human-readable` that either
-/// disable humanisation entirely, enable suffix-based formatting, or emit both
-/// the humanised and exact decimal value.  The enum mirrors those levels so the
-/// CLI can propagate the caller's preference to both the local renderer and any
-/// fallback `rsync` invocations.
+/// disable humanisation entirely, enable base-1000 suffix formatting (`-h`), or
+/// switch to base-1024 suffix formatting (`-hh`). The enum mirrors those levels
+/// so the CLI can propagate the caller's preference to both the local renderer
+/// and any fallback `rsync` invocations. See [`Self::unit_base`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[doc(alias = "--human-readable")]
 pub enum HumanReadableMode {
     /// Disable human-readable formatting and display exact decimal values.
     Disabled,
-    /// Enable suffix-based formatting (e.g. `1.23K`, `4.56M`).
+    /// Enable base-1000 suffix formatting (e.g. `1.23K`, `4.56M`) for `-h`.
     Enabled,
-    /// Display both the human-readable value and the exact decimal value.
+    /// Enable base-1024 suffix formatting for `-hh`.
     Combined,
 }
 
@@ -49,11 +49,17 @@ impl HumanReadableMode {
         !matches!(self, Self::Disabled)
     }
 
-    /// Reports whether the exact decimal value should be included alongside the
-    /// human-readable representation.
+    /// The unit multiplier upstream `do_big_num` applies for K/M/G/T units.
+    ///
+    /// Mirrors `lib/compat.c:183`: `mult = human_flag == 2 ? 1000 : 1024`.
+    /// A single `-h` (level 2, [`Self::Enabled`]) uses base 1000; `-hh`
+    /// (level 3, [`Self::Combined`]) uses base 1024.
     #[must_use]
-    pub const fn includes_exact(self) -> bool {
-        matches!(self, Self::Combined)
+    pub const fn unit_base(self) -> f64 {
+        match self {
+            Self::Combined => 1024.0,
+            _ => 1000.0,
+        }
     }
 }
 
@@ -165,18 +171,11 @@ mod tests {
     }
 
     #[test]
-    fn includes_exact_disabled() {
-        assert!(!HumanReadableMode::Disabled.includes_exact());
-    }
-
-    #[test]
-    fn includes_exact_enabled() {
-        assert!(!HumanReadableMode::Enabled.includes_exact());
-    }
-
-    #[test]
-    fn includes_exact_combined() {
-        assert!(HumanReadableMode::Combined.includes_exact());
+    fn unit_base_levels() {
+        // upstream: lib/compat.c:183 - mult = human_flag == 2 ? 1000 : 1024.
+        assert_eq!(HumanReadableMode::Disabled.unit_base(), 1000.0);
+        assert_eq!(HumanReadableMode::Enabled.unit_base(), 1000.0);
+        assert_eq!(HumanReadableMode::Combined.unit_base(), 1024.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Aligns `--human-readable` output with upstream rsync's `do_big_num` (`lib/compat.c:183`):

- `-h` (level 2) divides byte/rate values by **1000** (unchanged).
- `-hh` (level 3) divides by **1024** instead of 1000. Before this change `-hh` showed e.g. `2.20M`; upstream shows `2.10M`.
- Removes the non-upstream exact-value component (`2.20M (2,201,503)`) that oc-rsync appended in `-hh`/Combined mode. Upstream never emits it.

## Approach (DRY, mirrors upstream)

Upstream uses a single `do_big_num`/`human_num` path with one base for both byte counters and the bytes/sec rate. This change introduces `HumanReadableMode::unit_base()` as the single source of the per-level base and routes both the size formatter and the summary-rate formatter through it. The dead `includes_exact()` predicate and the three branches that consumed it are removed.

The live `--progress` per-file rate keeps its fixed base-1024 unit selection (upstream `progress.c` rprint_progress), unchanged.

## Tests

Updated the size/rate/stats/verbose/progress unit + integration tests to assert the base-1024 `-hh` output with no exact-value parens, and added base-1024 coverage for both the byte and rate formatters. `cargo fmt` + `clippy --all-targets` clean.