### PR TITLE
fix(cli): list-only size column width 15->14 to match upstream

### DIFF
--- a/crates/cli/src/frontend/progress/format/mod.rs
+++ b/crates/cli/src/frontend/progress/format/mod.rs
@@ -19,5 +19,6 @@ pub(crate) use self::rate::{
 };
 pub(crate) use self::remaining::RemainingTimeEstimator;
 pub(crate) use self::size::{
-    format_decimal_bytes, format_human_bytes, format_list_size, format_progress_bytes, format_size,
+    LIST_SIZE_WIDTH, format_decimal_bytes, format_human_bytes, format_list_size,
+    format_progress_bytes, format_size,
 };

--- a/crates/cli/src/frontend/progress/format/size.rs
+++ b/crates/cli/src/frontend/progress/format/size.rs
@@ -71,9 +71,18 @@ pub(crate) fn format_human_bytes(bytes: u64, base: f64) -> String {
     bytes.to_string()
 }
 
+/// Width of the size column in `--list-only` output.
+///
+/// upstream: generator.c:1159 `list_file_entry` - `size_width = human_readable
+/// ? 14 : 11`. `human_readable` defaults to 1 (options.c:111), so every oc
+/// rendering mode (all of which print thousands-separated values like upstream's
+/// default `human_num`) uses the 14-wide field; the 11-wide field only applies
+/// to upstream's `--no-human-readable`, which oc does not distinctly model.
+pub(crate) const LIST_SIZE_WIDTH: usize = 14;
+
 pub(crate) fn format_list_size(size: u64, human_readable: HumanReadableMode) -> String {
     let value = format_size(size, human_readable);
-    format!("{value:>15}")
+    format!("{value:>LIST_SIZE_WIDTH$}")
 }
 
 #[cfg(test)]
@@ -152,16 +161,17 @@ mod tests {
     }
 
     #[test]
-    fn format_list_size_pads_to_15() {
+    fn format_list_size_pads_to_14() {
+        // upstream: generator.c:1159 size_width = 14 (human_readable defaults to 1).
         let result = format_list_size(123, HumanReadableMode::Disabled);
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 14);
         assert!(result.trim_start().starts_with("123"));
     }
 
     #[test]
     fn format_list_size_zero_pads_correctly() {
         let result = format_list_size(0, HumanReadableMode::Disabled);
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 14);
         assert_eq!(result.trim(), "0");
         // Should be right-aligned: leading spaces then "0"
         assert!(result.ends_with('0'));
@@ -170,7 +180,7 @@ mod tests {
     #[test]
     fn format_list_size_large_value_with_separators() {
         let result = format_list_size(1_234_567, HumanReadableMode::Disabled);
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 14);
         assert!(
             result.contains("1,234,567"),
             "large value should have thousands separators: {result:?}"
@@ -190,14 +200,14 @@ mod tests {
     fn format_list_size_human_readable_small() {
         // Values under 1000 should show plain digits
         let result = format_list_size(500, HumanReadableMode::Enabled);
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 14);
         assert_eq!(result.trim(), "500");
     }
 
     #[test]
     fn format_list_size_human_readable_kilo() {
         let result = format_list_size(1_500, HumanReadableMode::Enabled);
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 14);
         assert!(
             result.contains("1.50K"),
             "1500 bytes should show as 1.50K in human-readable: {result:?}"
@@ -207,7 +217,7 @@ mod tests {
     #[test]
     fn format_list_size_human_readable_mega() {
         let result = format_list_size(2_500_000, HumanReadableMode::Enabled);
-        assert_eq!(result.len(), 15);
+        assert_eq!(result.len(), 14);
         assert!(
             result.contains("2.50M"),
             "2.5M bytes should show as 2.50M in human-readable: {result:?}"
@@ -219,8 +229,8 @@ mod tests {
         let small = format_list_size(1, HumanReadableMode::Disabled);
         let large = format_list_size(1_000_000, HumanReadableMode::Disabled);
 
-        assert_eq!(small.len(), 15);
-        assert_eq!(large.len(), 15);
+        assert_eq!(small.len(), 14);
+        assert_eq!(large.len(), 14);
 
         let small_spaces = small.len() - small.trim_start().len();
         let large_spaces = large.len() - large.trim_start().len();

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -26,9 +26,10 @@ use super::format::{
     event_matches_name_level, format_list_permissions, format_list_size, format_list_timestamp,
     format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
     format_size, format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
+    LIST_SIZE_WIDTH,
 };
 use super::mode::{NameOutputLevel, ProgressMode};
-use crate::{OutFormat, OutFormatContext, emit_out_format};
+use crate::{emit_out_format, OutFormat, OutFormatContext};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_transfer_summary(
@@ -235,9 +236,10 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
             let rendered = event.relative_path().to_string_lossy().into_owned();
             writeln!(
                 stdout,
-                "?????????? {:>15} {} {rendered}",
+                "?????????? {:>width$} {} {rendered}",
                 "?",
                 format_list_timestamp(None),
+                width = LIST_SIZE_WIDTH,
             )?;
         }
     }

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -23,13 +23,13 @@ fn display_without_trailing_separators(path: &Path) -> String {
 }
 
 use super::format::{
-    event_matches_name_level, format_list_permissions, format_list_size, format_list_timestamp,
-    format_progress_bytes, format_progress_elapsed, format_progress_percent, format_progress_rate,
-    format_size, format_stat_categories, format_summary_rate, is_progress_event, list_only_event,
-    LIST_SIZE_WIDTH,
+    LIST_SIZE_WIDTH, event_matches_name_level, format_list_permissions, format_list_size,
+    format_list_timestamp, format_progress_bytes, format_progress_elapsed, format_progress_percent,
+    format_progress_rate, format_size, format_stat_categories, format_summary_rate,
+    is_progress_event, list_only_event,
 };
 use super::mode::{NameOutputLevel, ProgressMode};
-use crate::{emit_out_format, OutFormat, OutFormatContext};
+use crate::{OutFormat, OutFormatContext, emit_out_format};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_transfer_summary(


### PR DESCRIPTION
## Summary

`--list-only` rendered the size column 15 chars wide; upstream's `list_file_entry` (generator.c:1159) uses `size_width = human_readable ? 14 : 11`, and `human_readable` defaults to 1 (options.c:111). Every rendering mode oc produces prints thousands-separated values like upstream's default `human_num`, so the correct width is **14** in all oc modes. Centralized into a single `LIST_SIZE_WIDTH` constant used by the active row and the `*missing` fallback row.

Unit tests updated 15->14; the `--list-only` integration tests derive expected size via `format_list_size` so they remain self-consistent.

Note: local clippy could not run (build env wedged); relying on CI fmt+clippy+nextest. The change is a width-constant + import only.