### PR TITLE
fix(core): host::module with no dest enters implicit list-only

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -674,6 +674,13 @@ where
         return code;
     }
 
+    // upstream: options.c:2194-2195 - `if (argc < 2 && !read_batch && !am_server)
+    // list_only |= 1;`. A single remote source with no destination (e.g.
+    // `host::module` or `rsync://host/module`) implies list-only mode: list the
+    // module's contents instead of erroring "need source and destination".
+    let list_only =
+        list_only || (transfer_operands.len() == 1 && read_batch.is_none() && is_daemon_transfer);
+
     // upstream: options.c:2187-2188 - relative_paths defaults to 1 when files_from
     let effective_relative = if files_from_active && relative.is_none() {
         Some(true)

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -67,15 +67,26 @@ pub fn run_daemon_transfer(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    if args.len() < 2 {
+    // upstream: options.c:2194 - a single source with list_only set lists the
+    // module contents (`host::module` with no destination); only a genuinely
+    // empty operand list is an error.
+    if args.is_empty() || (args.len() < 2 && !config.list_only()) {
         return Err(invalid_argument_error(
             "need at least one source and one destination",
             1,
         ));
     }
 
-    let (sources, destination) = args.split_at(args.len() - 1);
-    let destination = &destination[0];
+    // For an implicit list-only transfer (single source, no dest) synthesize a
+    // dummy `.` destination; config.list_only() forces read-only/no-write so it
+    // is never materialized.
+    let dummy_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = if args.len() < 2 {
+        (args, &dummy_dest)
+    } else {
+        let (sources, destination) = args.split_at(args.len() - 1);
+        (sources, &destination[0])
+    };
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
     let role = transfer_spec.role();
@@ -258,15 +269,26 @@ pub fn run_daemon_over_remote_shell(
     batch_writer: Option<Arc<Mutex<BatchWriter>>>,
 ) -> Result<ClientSummary, ClientError> {
     let args = config.transfer_args();
-    if args.len() < 2 {
+    // upstream: options.c:2194 - a single source with list_only set lists the
+    // module contents (`host::module` with no destination); only a genuinely
+    // empty operand list is an error.
+    if args.is_empty() || (args.len() < 2 && !config.list_only()) {
         return Err(invalid_argument_error(
             "need at least one source and one destination",
             1,
         ));
     }
 
-    let (sources, destination) = args.split_at(args.len() - 1);
-    let destination = &destination[0];
+    // For an implicit list-only transfer (single source, no dest) synthesize a
+    // dummy `.` destination; config.list_only() forces read-only/no-write so it
+    // is never materialized.
+    let dummy_dest = std::ffi::OsString::from(".");
+    let (sources, destination) = if args.len() < 2 {
+        (args, &dummy_dest)
+    } else {
+        let (sources, destination) = args.split_at(args.len() - 1);
+        (sources, &destination[0])
+    };
 
     let transfer_spec = determine_transfer_role(sources, destination)?;
     let role = transfer_spec.role();


### PR DESCRIPTION
## Summary
`oc-rsync host::module` (single daemon source, no destination) errored with "need at least one source and one destination"; upstream (options.c:2194-2195) sets `list_only` when `argc < 2 && !read_batch && !am_server`, listing the module's contents. Fix:
- Apply the implicit list-only inference at operand assembly (`run.rs`) for a single remote source.
- The two daemon transfer entries (`daemon_transfer/mod.rs` TCP + over-rsh) now proceed with a synthesized `.` destination when `list_only && args.len()==1` (never materialized — `list_only` forces no-write), erroring only on a genuinely empty operand list.

e2e daemon-listing regression test tracked as a follow-up (#471); the inference + guard are verified, daemon module-listing is otherwise integration-covered.