### PR TITLE
fix(cli): --progress implies --info=name so directory names print

### DIFF
--- a/crates/cli/src/frontend/execution/drive/options.rs
+++ b/crates/cli/src/frontend/execution/drive/options.rs
@@ -99,6 +99,35 @@ struct InfoFlagsResult {
     show_copy_method: bool,
 }
 
+/// Applies upstream's `--progress` ⇒ `--info=name` implication.
+///
+/// upstream: options.c:2351-2355 - when the `--progress`/`-P` flag set
+/// `do_progress` (and the run is not a server), an unset NAME level is bumped to
+/// 1 via `parse_output_words("name", DEFAULT_PRIORITY)`. That `DEFAULT_PRIORITY`
+/// assignment cannot override a USER_PRIORITY one, so an explicit `--info=name0`
+/// / `--info=none` (tracked here by `name_overridden`) blocks the bump.
+///
+/// `initial_progress` is the faithful `do_progress` proxy: it reflects the
+/// `--progress`/`-P` flag only, NOT `--info=progress2` (Overall), which sets the
+/// progress info level without setting `do_progress` - upstream prints no names
+/// for `--info=progress2`.
+fn imply_name_from_progress(
+    initial_progress: ProgressSetting,
+    name_level: NameOutputLevel,
+    name_overridden: bool,
+) -> NameOutputLevel {
+    if !matches!(
+        initial_progress,
+        ProgressSetting::Disabled | ProgressSetting::Unspecified
+    ) && matches!(name_level, NameOutputLevel::Disabled)
+        && !name_overridden
+    {
+        NameOutputLevel::UpdatedOnly
+    } else {
+        name_level
+    }
+}
+
 /// Parses --info flags and returns display settings.
 fn parse_info_settings<Out, Err>(
     stdout: &mut Out,
@@ -119,6 +148,7 @@ where
     let mut name_overridden = initial_name_overridden;
 
     if info_args.is_empty() {
+        let name_level = imply_name_from_progress(initial_progress, name_level, name_overridden);
         return Ok(InfoFlagsResult {
             progress_setting,
             stats_level,
@@ -164,6 +194,8 @@ where
             // upstream: options.c set_output_verbosity / parse_output_words
             settings.apply_to_thread_local();
 
+            let name_level =
+                imply_name_from_progress(initial_progress, name_level, name_overridden);
             Ok(InfoFlagsResult {
                 progress_setting,
                 stats_level,

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -56,6 +56,40 @@ fn info_none_disables_progress_output() {
 }
 
 #[test]
+fn progress_implies_name_shows_directory_names() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let src = tmp.path().join("src");
+    std::fs::create_dir_all(src.join("sub")).expect("mkdir");
+    std::fs::write(src.join("sub/f.txt"), b"hi").expect("write source");
+    let dst = tmp.path().join("dst");
+
+    let mut src_arg = src.into_os_string();
+    src_arg.push("/");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--progress"),
+        OsString::from("-r"),
+        src_arg,
+        dst.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let rendered = String::from_utf8(stdout).expect("stdout utf8");
+    // upstream options.c:2351-2355: the `--progress`/`-P` flag sets do_progress,
+    // which bumps NAME to 1, so created directories print their name line even
+    // without `-v`. `--info=progress2` (Overall) does NOT set do_progress and
+    // stays name-free (info_progress2_enables_progress_output).
+    assert!(
+        rendered.contains("sub/"),
+        "bare --progress should print directory name line: {rendered:?}"
+    );
+}
+
+#[test]
 fn info_help_lists_supported_flags() {
     let (code, stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--info=help")]);
 


### PR DESCRIPTION
## Issue #6105
Local-copy `--progress` (without `-v`) dropped directory names from the output. Upstream prints them.

## Root cause
oc-rsync omitted the upstream `--progress` ⇒ `--info=name` implication (`options.c:2351-2355`): when the `--progress`/`-P` flag sets `do_progress`, an unset NAME level is bumped to 1, so created directories print their name line. Without it, `name_level` stayed `Disabled` and the directory NAME path early-returned.

## Fix
`parse_info_settings` now applies the implication on both return paths via `imply_name_from_progress`. Gated on:
- **`initial_progress`** (the faithful `do_progress` proxy — the `--progress`/`-P` flag), NOT the post-`--info` merged value. Verified against upstream: `--info=progress2` (Overall) sets the progress info level *without* `do_progress` and prints **no** names, while bare `--progress` does.
- **`name_level == Disabled && !name_overridden`** — an explicit `--info=name0`/`--info=none` (USER_PRIORITY) blocks the bump, matching upstream's priority semantics.

## Verification (rebuilt binary vs upstream rsync 3.4.4)
| command | upstream | oc (this PR) |
|---|---|---|
| `--progress -r` | `./`, `top.txt`, `sub/`, `sub/f.txt` | same ✓ |
| `--info=progress2 -r` | no names | no names ✓ |
| `--progress --info=none` | empty | empty ✓ |

Added `progress_implies_name_shows_directory_names`. Existing `info_progress2_enables_progress_output` (no names) and `info_none_disables_progress_output` (empty) remain valid and lock in the gate.

Stacked on #6117 (its two test-fix commits appear here until it merges).