### PR TITLE
fix(cli): thousands-separate speedup in summary line

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -496,9 +496,13 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
         "sent {sent_display} bytes  received {received_display} bytes  {rate_display} bytes/sec"
     )?;
     let dry_run_suffix = if dry_run { " (DRY RUN)" } else { "" };
+    // upstream: main.c:466-468 - speedup uses comma_dnum(_, 2), i.e. thousands
+    // grouping. Reuse the same helper the --stats path uses (stats_format.rs)
+    // so both summary paths group identically.
+    let speedup_display = crate::stats_format::format_speedup(speedup);
     writeln!(
         stdout,
-        "total size is {total_size_display}  speedup is {speedup:.2}{dry_run_suffix}"
+        "total size is {total_size_display}  speedup is {speedup_display}{dry_run_suffix}"
     )
 }
 


### PR DESCRIPTION
Part of #6108. The `emit_totals` summary printed `speedup is {speedup:.2}` (e.g. `250000.00`) while upstream `main.c:466-468` uses `comma_dnum(total_size/(written+read), 2)` — thousands-grouped (`250,000.00`). The `--stats` detail path already uses `format_speedup`; this aligns the summary trailer with it (DRY).

Verified with rebuilt binary: no-change re-copy of a 2 MB file now prints `total size is 2,000,000  speedup is 250,000.00`.

Stacked on #6117 (its two test-fix commits appear until it merges). Remaining #6108 parts (flist-size accounting, delta sum_head, rate timer) are separate follow-ups.