### PR TITLE
fix(core): local-copy File list size 0; sent = flist file size (no path-length inflation)

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -356,11 +356,12 @@ fn run_client_internal(
                 .map(ClientProgressForwarder::as_handler_mut),
         )
         .map(|mut summary| {
-            // A local copy bypasses the wire protocol, so the executor only
-            // counts literal data in bytes_sent. Fold the file-list size in to
-            // report a comparable `sent` total (mirrors `from_report`). This
-            // no-events path covers `--stats` without `-v`/`-P`.
-            summary.fold_file_list_into_sent();
+            // A local copy bypasses the wire protocol; `bytes_sent` holds only
+            // the literal file data. Match upstream's `File list size: 0` for
+            // local copies (mirrors `from_report`) instead of folding the
+            // enumerated path lengths into `sent`. Covers `--stats` without
+            // `-v`/`-P`.
+            summary.clear_file_list_size();
             ClientSummary::from_summary(summary)
         })
     };

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -62,13 +62,13 @@ pub struct ClientSummary {
 impl ClientSummary {
     pub(crate) fn from_report(report: LocalCopyReport) -> Self {
         let (mut stats, records, destination_root) = report.into_parts();
-        // A local copy bypasses the wire protocol, so the executor only counts
-        // literal data in `bytes_sent`. Upstream runs the protocol over a
-        // socketpair even locally, making its `Total bytes sent` dominated by
-        // the serialised file list. Fold the file-list size in so a local copy
-        // reports a comparable `sent` total and a meaningful speedup instead of
-        // `sent 0 bytes`.
-        stats.fold_file_list_into_sent();
+        // A local copy bypasses the wire protocol, so `bytes_sent` holds only
+        // the literal file data the executor counted. Upstream reports
+        // `File list size: 0` for local copies and a `Total bytes sent`
+        // dominated by that file data (not the path lengths), so zero the
+        // enumerated flist size to match - folding it into `sent` inflated the
+        // figure ~2x.
+        stats.clear_file_list_size();
         let destination_root: Arc<Path> = Arc::from(destination_root);
         let events = records
             .into_iter()

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -335,13 +335,23 @@ impl LocalCopySummary {
     /// the separately tracked file-list size in yields a comparable `sent`
     /// total (and a meaningful speedup) instead of `sent 0 bytes`.
     ///
-    /// Call exactly once when finalising a local-copy summary. The figure is an
-    /// approximation: a local copy transmits nothing, so it can never match
-    /// upstream's real socketpair byte counts exactly.
+    /// Resets the enumerated file-list size to zero for a local-copy summary.
     ///
-    /// upstream: main.c output_summary, io.c stats.total_written
-    pub fn fold_file_list_into_sent(&mut self) {
-        self.bytes_sent = self.bytes_sent.saturating_add(self.file_list_size);
+    /// Call exactly once when finalising a local copy. Upstream rsync reports
+    /// `File list size: 0` for local transfers, and its `Total bytes sent` is
+    /// dominated by the file *data*, not the file list (verified against
+    /// rsync 3.4.4: a 1 MiB local copy reports `sent 1,049,017` ~= the file
+    /// size, not the path lengths). oc-rsync already counts the literal data in
+    /// `bytes_sent` via `record_file`, so it must NOT fold the enumerated path
+    /// lengths on top - doing so inflated `sent` ~2x. Zeroing here matches
+    /// upstream's `File list size: 0` and leaves `bytes_sent` as the data-only
+    /// figure. A local copy transmits nothing over a wire, so the residual gap
+    /// versus upstream's socketpair framing bytes is irreducible and not
+    /// synthesised.
+    ///
+    /// upstream: main.c output_summary (`File list size: 0` for local copies)
+    pub fn clear_file_list_size(&mut self) {
+        self.file_list_size = 0;
     }
 
     /// Returns the time spent enumerating the file list.
@@ -824,23 +834,20 @@ mod tests {
     }
 
     #[test]
-    fn fold_file_list_into_sent_reports_flist_as_wire_sent() {
-        // A no-change local copy transmits no data, so `bytes_sent` stays 0
-        // while the file-list size accumulates. Upstream's `Total bytes sent`
-        // for the same copy is dominated by the serialised file list, so the
-        // fold must surface that figure as `sent` rather than leaving it 0.
+    fn clear_file_list_size_zeroes_flist_and_keeps_sent() {
+        // A local copy reports `File list size: 0` (upstream parity) and never
+        // folds enumerated path lengths into `sent`. A no-change copy transmits
+        // no data, so `bytes_sent` stays 0.
         let mut summary = LocalCopySummary::default();
         summary.record_file_list_entry(93);
         summary.record_file_list_entry(95);
         assert_eq!(summary.bytes_sent(), 0);
         assert_eq!(summary.file_list_size(), 188);
 
-        summary.fold_file_list_into_sent();
+        summary.clear_file_list_size();
 
-        assert_eq!(summary.bytes_sent(), 188);
-        // The file-list size is still reported independently; upstream prints
-        // both `File list size` and `Total bytes sent`.
-        assert_eq!(summary.file_list_size(), 188);
+        assert_eq!(summary.bytes_sent(), 0);
+        assert_eq!(summary.file_list_size(), 0);
     }
 
     #[test]
@@ -897,16 +904,18 @@ mod tests {
     }
 
     #[test]
-    fn fold_file_list_into_sent_keeps_literal_data() {
-        // When data is transmitted, the fold adds the file list on top of the
-        // literal bytes already counted, mirroring upstream's total_written.
+    fn clear_file_list_size_keeps_literal_data() {
+        // Clearing the flist size must leave already-counted literal data in
+        // `bytes_sent` untouched - that data-only figure is what upstream's
+        // `Total bytes sent` is built on for a local copy.
         let mut summary = LocalCopySummary::default();
         summary.record_file(1_000, 1_000, None);
         summary.record_file_list_entry(40);
         assert_eq!(summary.bytes_sent(), 1_000);
 
-        summary.fold_file_list_into_sent();
+        summary.clear_file_list_size();
 
-        assert_eq!(summary.bytes_sent(), 1_040);
+        assert_eq!(summary.bytes_sent(), 1_000);
+        assert_eq!(summary.file_list_size(), 0);
     }
 }


### PR DESCRIPTION
## Issue #6108 (sent accounting)
Local-copy `--stats` reported `Total bytes sent` ~2x too high and a non-zero `File list size`, diverging from upstream.

## Root cause
`from_report`/the no-events path folded the *enumerated file-list size* (summed from raw `encoded_path_len` = full path lengths + NUL) into `bytes_sent`. The old comment justified it as "upstream's sent is dominated by the serialised file list" — but that premise is wrong.

## Upstream ground truth (rsync 3.4.4, local copy, captured)
| | sent | File list size | total size |
|---|---|---|---|
| fresh 1 MiB copy | 1,049,017 | **0** | 1,048,582 |
| no-change re-copy | 94 | **0** | 1,048,582 |

Upstream reports **`File list size: 0`** for local transfers, and `sent` is dominated by the **file data** (≈ file size), not path lengths. The ~435-byte excess over the file size is socketpair framing.

## Fix
Replaced `fold_file_list_into_sent` with `clear_file_list_size` at the two local-copy summary boundaries (`from_report`, no-events `--stats`):
- **`File list size: 0`** — byte-exact to upstream.
- **`sent` = the file data already counted via `record_file`** (= the flist `F_LENGTH` for a whole-file local copy), so `sent` = `total size` = exact file size. No path-length inflation.

A local copy transmits nothing over a wire, so the residual vs upstream's framing-inclusive `sent` is irreducible and **not synthesised** (no invented bytes). `speedup` is a derived figure computed from `sent`/`received`.

## Verified (rebuilt binary)
`oc-rsync -a --stats`: `File list size: 0`; fresh-copy `sent 1,048,577` = exact file size, `speedup 1.00`.

Two engine unit tests updated (fold→clear). Stacked on master.