### PR TITLE
fix(fast_io): correct COPY_FILE_NO_BUFFERING flag value (0x8 -> 0x1000)

### DIFF
--- a/crates/fast_io/src/copy_file_ex.rs
+++ b/crates/fast_io/src/copy_file_ex.rs
@@ -97,14 +97,14 @@ pub fn try_copy_file_ex(src: &Path, dst: &Path) -> io::Result<u64> {
 /// - `src_wide` and `dst_wide` are null-terminated UTF-16 slices produced by
 ///   `OsStrExt::encode_wide` chained with `once(0)`.
 /// - Progress callback, user data, and cancel pointers are null (unused).
-/// - The `flags` parameter is either 0 or `COPY_FILE_NO_BUFFERING` (0x8).
+/// - The `flags` parameter is either 0 or `COPY_FILE_NO_BUFFERING` (0x1000).
 #[cfg(windows)]
 #[allow(unsafe_code)]
 mod ffi {
     use std::io;
 
-    /// Windows `COPY_FILE_NO_BUFFERING` flag value.
-    pub const COPY_FILE_NO_BUFFERING: u32 = 0x0000_0008;
+    /// Windows `COPY_FILE_NO_BUFFERING` flag value (winbase.h).
+    pub const COPY_FILE_NO_BUFFERING: u32 = 0x0000_1000;
 
     /// Call `CopyFileExW` with the given null-terminated wide-string paths.
     pub fn copy_file_ex_w(src_wide: &[u16], dst_wide: &[u16], flags: u32) -> io::Result<()> {

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -230,7 +230,7 @@ pub(super) fn try_copy_file_ex(src: &Path, dst: &Path, use_no_buffering: bool) -
 
     /// `COPY_FILE_NO_BUFFERING` flag for `CopyFileExW` - bypasses system cache
     /// for large file copies, reducing memory pressure.
-    const COPY_FILE_NO_BUFFERING: u32 = 0x0000_0008;
+    const COPY_FILE_NO_BUFFERING: u32 = 0x0000_1000;
 
     let flags: u32 = if use_no_buffering {
         COPY_FILE_NO_BUFFERING


### PR DESCRIPTION
`COPY_FILE_NO_BUFFERING` was defined as `0x0000_0008` in two places, but the Win32 value (winbase.h / [CopyFileExW docs](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfileexw)) is **`0x00001000`**. `0x8` is `COPY_FILE_ALLOW_DECRYPTED_DESTINATION`.

## Impact
For Windows local copies of files > 4 MB (the `NO_BUFFERING_THRESHOLD` gate), oc-rsync:
- never actually applied unbuffered I/O (the intended large-file optimization), and
- silently passed `ALLOW_DECRYPTED_DESTINATION`, which permits copying an EFS-encrypted source to a **decrypted** destination — an unintended data-at-rest weakening.

## Fix
Corrected the constant to `0x0000_1000` in `copy_file_ex.rs:107` and `platform_copy/dispatch.rs:233` (+ a stale `(0x8)` doc comment). Value-only change — same type, same call sites, compiles unchanged on all platforms. The constants live in `#[cfg(windows)]` code; behavior is exercised by the Windows CI cells. No test pinned the old value.

Found while re-verifying the wincopy ADS path (#339).