### PR TITLE
fix(cli): local-copy transfer rate uses wall-clock span (no absurd bytes/sec)

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -457,13 +457,11 @@ pub(crate) fn emit_totals<W: Write + ?Sized>(
     let sent = summary.bytes_sent();
     let received = summary.bytes_received();
     let total_size = summary.total_source_bytes();
-    let elapsed = summary.total_elapsed();
-    let seconds = elapsed.as_secs_f64();
-    let rate = if seconds > 0.0 {
-        (sent + received) as f64 / seconds
-    } else {
-        0.0
-    };
+    // upstream main.c:418-423: rate = (written+read) / (0.5 + (endtime-starttime)),
+    // a single wall-clock span with a 0.5s floor - never the summed per-file copy
+    // durations (which are ~0 for CoW/clonefile and explode the rate).
+    let wall_seconds = summary.wall_clock_elapsed().as_secs_f64();
+    let rate = (sent + received) as f64 / (0.5 + wall_seconds);
     let transmitted = sent.saturating_add(received);
     let speedup = if transmitted > 0 {
         total_size as f64 / transmitted as f64

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -264,6 +264,12 @@ impl ClientSummary {
         self.stats.total_elapsed()
     }
 
+    /// Returns the whole-transfer wall-clock span (for the transfer rate).
+    #[must_use]
+    pub const fn wall_clock_elapsed(&self) -> Duration {
+        self.stats.wall_clock_elapsed()
+    }
+
     /// Returns the cumulative duration spent sleeping due to bandwidth throttling.
     #[must_use]
     #[doc(alias = "--bwlimit")]

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -47,6 +47,7 @@ pub(crate) fn copy_sources(
             )
         })?;
 
+    let run_start = Instant::now();
     let destination_root = plan.destination_spec().path().to_path_buf();
     let mut context = CopyContext::new(mode, options, handler, destination_root);
     context.set_multi_source(plan.sources().len() > 1);
@@ -211,7 +212,14 @@ pub(crate) fn copy_sources(
     };
 
     match result {
-        Ok(()) => Ok(context.into_outcome()),
+        Ok(()) => {
+            // upstream main.c:418: the transfer rate uses a single wall-clock
+            // span, not the sum of per-file copy durations (which is ~0 for CoW).
+            context
+                .summary_mut()
+                .record_wall_clock_elapsed(run_start.elapsed());
+            Ok(context.into_outcome())
+        }
         Err(error) => {
             context.rollback_on_error(&error);
             Err(error)

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -108,6 +108,9 @@ pub struct LocalCopySummary {
     compression_used: bool,
     total_source_bytes: u64,
     total_elapsed: Duration,
+    /// Wall-clock span of the whole transfer (not the sum of per-file copy
+    /// durations in `total_elapsed`). Used for the upstream-style transfer rate.
+    wall_clock_elapsed: Duration,
     bandwidth_sleep: Duration,
     file_list_size: u64,
     file_list_generation: Duration,
@@ -276,6 +279,21 @@ impl LocalCopySummary {
         self.total_elapsed
     }
 
+    /// Returns the wall-clock span of the whole transfer.
+    ///
+    /// Unlike [`Self::total_elapsed`] (the sum of per-file copy durations, which
+    /// is ~0 for CoW/clonefile), this is a single span suitable for computing a
+    /// transfer rate that mirrors upstream `main.c:418` `bytes_per_sec_human_dnum`.
+    #[must_use]
+    pub const fn wall_clock_elapsed(&self) -> Duration {
+        self.wall_clock_elapsed
+    }
+
+    /// Records the whole-transfer wall-clock span. Call once at finalize.
+    pub(in crate::local_copy) const fn record_wall_clock_elapsed(&mut self, elapsed: Duration) {
+        self.wall_clock_elapsed = elapsed;
+    }
+
     /// Returns the cumulative duration spent sleeping due to `--bwlimit` pacing.
     #[must_use]
     #[doc(alias = "--bwlimit")]
@@ -409,6 +427,7 @@ impl LocalCopySummary {
             total_source_bytes,
             items_deleted,
             total_elapsed: elapsed,
+            wall_clock_elapsed: elapsed,
             ..Default::default()
         }
     }
@@ -432,6 +451,7 @@ impl LocalCopySummary {
             bytes_sent,
             items_deleted,
             total_elapsed: elapsed,
+            wall_clock_elapsed: elapsed,
             ..Default::default()
         }
     }
@@ -469,6 +489,7 @@ impl LocalCopySummary {
             compression_used: false,
             total_source_bytes: 0,
             total_elapsed: Duration::ZERO,
+            wall_clock_elapsed: Duration::ZERO,
             bandwidth_sleep: Duration::ZERO,
             file_list_size: 0,
             file_list_generation: Duration::ZERO,


### PR DESCRIPTION
## Issue #6108 (rate)
`oc-rsync -a --stats` on a fast local copy printed an absurd `bytes/sec` (e.g. `546,988,523,735.00`) because the rate divided by `total_elapsed` = the **sum of per-file copy durations**, which is ~0 for CoW/clonefile.

## Fix (upstream main.c:418-423)
Upstream computes `rate = (written+read) / (0.5 + (endtime-starttime))` - a single wall-clock span with a 0.5s floor. Added a `wall_clock_elapsed` field to `LocalCopySummary` (captured via `Instant` at executor start, recorded at finalize), delegated through `ClientSummary`, and changed `emit_totals` to divide by `0.5 + wall_seconds`.

- Remote path already supplies a real wall-clock `elapsed` (`ssh_transfer.rs`), so `wall_clock_elapsed` returns the same value there; the `0.5` floor is applied universally (upstream main.c:422), making remote output *more* upstream-faithful (it previously omitted the floor). No invented bytes.
- `total_elapsed` retained for per-file `--stats` timing.

## Verified (rebuilt binary)
Fresh 1 MiB copy: `2,078,618.41 bytes/sec` (= bytes/(0.5+~0)), not `5.4e11`.

No test pins a numeric `bytes/sec` on this path (substring/format checks only). Stacked on master.