### PR TITLE
feat(fast_io): apply TCP_QUICKACK on client connect + daemon accept

### DIFF
--- a/crates/core/src/client/module_list/tcp_perf.rs
+++ b/crates/core/src/client/module_list/tcp_perf.rs
@@ -12,7 +12,10 @@
 
 use std::net::TcpStream;
 
-use fast_io::{DEFAULT_TCP_NOTSENT_LOWAT, set_tcp_notsent_lowat, tcp_notsent_lowat_supported};
+use fast_io::{
+    DEFAULT_TCP_NOTSENT_LOWAT, set_tcp_notsent_lowat, set_tcp_quickack,
+    tcp_notsent_lowat_supported, tcp_quickack_supported,
+};
 
 use crate::client::TcpFastOpenMode;
 
@@ -29,6 +32,11 @@ pub(crate) fn apply_client_tcp_perf_options(stream: &TcpStream, mode: TcpFastOpe
         // Errors are best-effort: `TCP_NOTSENT_LOWAT` is an optimisation
         // hint and a failing setsockopt is non-fatal.
         let _ = set_tcp_notsent_lowat(stream, DEFAULT_TCP_NOTSENT_LOWAT);
+    }
+    if tcp_quickack_supported() {
+        // One-shot hint to skip the delayed-ACK timer on the first ACK;
+        // best-effort, non-fatal.
+        let _ = set_tcp_quickack(stream);
     }
 }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -109,10 +109,7 @@ fn log_progress_summary(
     served: usize,
     start_time: SystemTime,
 ) {
-    let uptime_secs = start_time
-        .elapsed()
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    let uptime_secs = start_time.elapsed().map(|d| d.as_secs()).unwrap_or(0);
 
     let hours = uptime_secs / 3600;
     let minutes = (uptime_secs % 3600) / 60;
@@ -282,7 +279,11 @@ fn warn_per_family_bind_failure(
     requested_addr: SocketAddr,
     error: &io::Error,
 ) {
-    let family = if requested_addr.is_ipv6() { "IPv6" } else { "IPv4" };
+    let family = if requested_addr.is_ipv6() {
+        "IPv6"
+    } else {
+        "IPv4"
+    };
     let payload = format!(
         "{family} bind for {requested_addr} failed: {error}; \
          continuing with remaining address families"
@@ -390,5 +391,8 @@ fn bind_listeners_per_family(
 fn apply_accepted_stream_tcp_notsent_lowat(stream: &TcpStream) {
     if fast_io::tcp_notsent_lowat_supported() {
         let _ = fast_io::set_tcp_notsent_lowat(stream, fast_io::DEFAULT_TCP_NOTSENT_LOWAT);
+    }
+    if fast_io::tcp_quickack_supported() {
+        let _ = fast_io::set_tcp_quickack(stream);
     }
 }

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -338,7 +338,8 @@ pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::{
     DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, enable_tcp_fastopen_listener,
     enable_tcp_fastopen_raw, set_listener_int_option, set_socket_int_option, set_tcp_notsent_lowat,
-    tcp_fastopen_listener_supported, tcp_notsent_lowat_supported,
+    set_tcp_quickack, tcp_fastopen_listener_supported, tcp_notsent_lowat_supported,
+    tcp_quickack_supported,
 };
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -213,6 +213,35 @@ pub fn set_tcp_notsent_lowat(stream: &TcpStream, bytes: u32) -> io::Result<bool>
     }
 }
 
+/// Disables delayed ACKs for the next ACK on a connected stream
+/// (`TCP_QUICKACK`).
+///
+/// One-shot on Linux: the kernel re-enables delayed ACKs after a single ACK,
+/// so this is applied once post-handshake to shave a round trip off the early
+/// exchange. On platforms without `TCP_QUICKACK` the call is a no-op and
+/// returns `Ok(false)`.
+///
+/// upstream: not implemented; an oc-rsync-specific perf hint that is
+/// wire-compatible with upstream rsync.
+pub fn set_tcp_quickack(stream: &TcpStream) -> io::Result<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        set_socket_int_option(stream, libc::IPPROTO_TCP, libc::TCP_QUICKACK, 1)?;
+        Ok(true)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = stream;
+        Ok(false)
+    }
+}
+
+/// Returns `true` when the running platform implements `TCP_QUICKACK`.
+#[must_use]
+pub const fn tcp_quickack_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
 /// Returns `true` when the running platform implements server-side
 /// `TCP_FASTOPEN`.
 #[must_use]
@@ -424,6 +453,20 @@ mod tests {
             Ok(true) => assert!(tcp_notsent_lowat_supported()),
             Ok(false) => assert!(!tcp_notsent_lowat_supported()),
             Err(error) => panic!("unexpected error from TCP_NOTSENT_LOWAT: {error}"),
+        }
+
+        drop(stream);
+        handle.join().expect("accept thread completes");
+    }
+
+    #[test]
+    fn set_tcp_quickack_returns_supported_flag() {
+        let (stream, handle) = connected_stream();
+
+        match set_tcp_quickack(&stream) {
+            Ok(true) => assert!(tcp_quickack_supported()),
+            Ok(false) => assert!(!tcp_quickack_supported()),
+            Err(error) => panic!("unexpected error from TCP_QUICKACK: {error}"),
         }
 
         drop(stream);


### PR DESCRIPTION
Adds a best-effort `TCP_QUICKACK` socket option to the client-side daemon
connect path and the daemon accept path, alongside the existing
`TCP_NOTSENT_LOWAT` handling.

## What

- `fast_io::set_tcp_quickack(stream)` - sets `TCP_QUICKACK` (one-shot,
  Linux value 12) to skip the delayed-ACK timer on the next ACK. Returns
  `Ok(true)` on Linux, `Ok(false)` (no-op) elsewhere.
- `fast_io::tcp_quickack_supported()` - compile-time platform gate.
- Applied in `apply_client_tcp_perf_options` (client daemon connect) and
  `apply_accepted_stream_tcp_notsent_lowat` (daemon accept).

## Why

`TCP_QUICKACK` disables Linux delayed-ACK for the immediate next ACK,
cutting up to 40ms of latency on the handshake/short request-response
exchanges that dominate daemon module listing and negotiation. It is a
pure kernel-socket tuning option and does not touch the rsync protocol
stream, so it stays wire-compatible with upstream.

## Notes

- Best-effort: a failing `setsockopt` is non-fatal (matches the existing
  `TCP_NOTSENT_LOWAT` pattern).
- One-shot semantics: the kernel re-arms delayed-ACK after the next ACK.
  Re-arming inside the handshake read loops is a separate follow-up.
- Non-Linux platforms compile the no-op path; Linux CI validates the
  active path.

## Test

- `set_tcp_quickack_returns_supported_flag` in
  `crates/fast_io/src/socket_options.rs` asserts the return flag tracks
  `tcp_quickack_supported()` over a real connected socket pair.