### PR TITLE
feat(fast_io): re-arm TCP_QUICKACK across daemon handshake read loops

### DIFF
--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -278,9 +278,13 @@ pub fn run_module_list_with_password_and_options(
     let mut acknowledged = false;
     let mut pre_ack_messages = Vec::new();
 
+    // TCP_QUICKACK is one-shot; re-arm before each read so the client's ACKs
+    // to the daemon's module-listing lines stay immediate across the exchange.
+    fast_io::rearm_tcp_quickack(reader.get_ref().inner().as_tcp_stream());
     while let Some(line) = read_trimmed_line(&mut reader)
         .map_err(|error| socket_error("read from", addr.socket_addr_display(), error))?
     {
+        fast_io::rearm_tcp_quickack(reader.get_ref().inner().as_tcp_stream());
         if let Some(payload) = legacy_daemon_error_payload(&line) {
             return Err(daemon_error(payload, PARTIAL_TRANSFER_EXIT_CODE));
         }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -231,14 +231,22 @@ fn handle_legacy_session(
     // DIS-4.a R2: write the cached newest-protocol greeting bytes directly,
     // skipping the per-accept `format!`/`push_str` chain.
     // upstream: clientserver.c:455 output_daemon_greeting
-    write_limited(reader.get_mut(), &mut limiter, cached_legacy_daemon_greeting())?;
+    write_limited(
+        reader.get_mut(),
+        &mut limiter,
+        cached_legacy_daemon_greeting(),
+    )?;
 
     let mut request = None;
     let mut refused_options = Vec::new();
     let mut negotiated_protocol = None;
     let mut early_input_data: Option<Vec<u8>> = None;
 
+    // TCP_QUICKACK is one-shot; re-arm before each handshake read so every
+    // round's ACK stays immediate across the multi-line greeting exchange.
+    fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
     while let Some(line) = read_trimmed_line(&mut reader)? {
+        fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
         match parse_legacy_daemon_message(&line) {
             Ok(LegacyDaemonMessage::Version(version)) => {
                 // Record the negotiated protocol version but do NOT send @RSYNCD: OK here.
@@ -354,10 +362,7 @@ const EARLY_INPUT_MAX_SIZE: usize = 5120;
 ///
 /// upstream: clientserver.c:1357-1364 - `rsync_module()` reads early input data
 /// and stores it for later delivery to the pre-xfer exec script.
-fn read_early_input(
-    line: &str,
-    reader: &mut impl Read,
-) -> io::Result<Option<Vec<u8>>> {
+fn read_early_input(line: &str, reader: &mut impl Read) -> io::Result<Option<Vec<u8>>> {
     let len_str = match line.strip_prefix(EARLY_INPUT_CMD) {
         Some(rest) => rest,
         None => return Ok(None),
@@ -734,4 +739,3 @@ mod session_runtime_tests {
         assert!(io_err.to_string().contains("Transferring"));
     }
 }
-

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -337,9 +337,9 @@ pub use secure_dir::secure_open_dir;
 pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::{
     DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, enable_tcp_fastopen_listener,
-    enable_tcp_fastopen_raw, set_listener_int_option, set_socket_int_option, set_tcp_notsent_lowat,
-    set_tcp_quickack, tcp_fastopen_listener_supported, tcp_notsent_lowat_supported,
-    tcp_quickack_supported,
+    enable_tcp_fastopen_raw, rearm_tcp_quickack, set_listener_int_option, set_socket_int_option,
+    set_tcp_notsent_lowat, set_tcp_quickack, tcp_fastopen_listener_supported,
+    tcp_notsent_lowat_supported, tcp_quickack_supported,
 };
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -242,6 +242,19 @@ pub const fn tcp_quickack_supported() -> bool {
     cfg!(target_os = "linux")
 }
 
+/// Re-arms `TCP_QUICKACK` on a stream that may not be a TCP socket.
+///
+/// `TCP_QUICKACK` is one-shot on Linux: the kernel re-enables delayed ACKs
+/// after the next ACK. Call this before each blocking read in a multi-round
+/// handshake so every round's ACK stays immediate. `None` (TLS, connect
+/// program, or stdio transports) and non-Linux platforms are no-ops,
+/// matching the best-effort apply pattern of the other helpers here.
+pub fn rearm_tcp_quickack(stream: Option<&TcpStream>) {
+    if let Some(stream) = stream {
+        let _ = set_tcp_quickack(stream);
+    }
+}
+
 /// Returns `true` when the running platform implements server-side
 /// `TCP_FASTOPEN`.
 #[must_use]
@@ -468,6 +481,20 @@ mod tests {
             Ok(false) => assert!(!tcp_quickack_supported()),
             Err(error) => panic!("unexpected error from TCP_QUICKACK: {error}"),
         }
+
+        drop(stream);
+        handle.join().expect("accept thread completes");
+    }
+
+    #[test]
+    fn rearm_tcp_quickack_is_noop_on_none_and_some() {
+        // None (non-TCP transports) must be a silent no-op.
+        rearm_tcp_quickack(None);
+
+        // Some(&stream) re-arms best-effort and must not panic regardless of
+        // platform support.
+        let (stream, handle) = connected_stream();
+        rearm_tcp_quickack(Some(&stream));
 
         drop(stream);
         handle.join().expect("accept thread completes");


### PR DESCRIPTION
Re-arms `TCP_QUICKACK` before each blocking read in the `@RSYNCD:`
handshake loops so every round's ACK stays immediate.

(Re-lands the TCPK-3 change: the prior PR #6125 was merged into its base
branch `feat/tcp-quickack` *after* that branch had already squash-merged
to master as #6124, so the rearm commit was orphaned and never reached
master. This PR targets master directly.)

## Why

`TCP_QUICKACK` is one-shot on Linux: the kernel re-enables delayed ACKs
after the next ACK. #6124 set it once at connect/accept, which only covers
the first ACK. The daemon greeting exchange is multi-line (version, module
request, options), so without re-arming, rounds after the first fall back
to the 40ms delayed-ACK timer.

## What

- `fast_io::rearm_tcp_quickack(Option<&TcpStream>)` - best-effort re-arm
  that no-ops on `None` (TLS / connect-program / stdio transports) and on
  non-Linux platforms, matching the existing helper idiom.
- Daemon: re-arm before and inside the `handle_legacy_session` greeting
  read loop (`session_runtime.rs`), via `DaemonStream::tcp_stream()`.
- Client: re-arm before and inside the `#list` response read loop
  (`listing.rs`), via `NegotiatedStream::inner().as_tcp_stream()`.

Placing the re-arm at the top of each loop body covers every iteration
including `continue` paths; the pre-loop call covers the first read.

## Test

- `rearm_tcp_quickack_is_noop_on_none_and_some` asserts both the `None`
  no-op and the `Some(&stream)` best-effort path don't panic on any
  platform.

## Notes

Wire-compatible: touches only kernel socket behaviour, never the rsync
protocol stream.