### PR TITLE
fix(metadata): resolve ACL named-entry id/name instead of dropping to root

### DIFF
--- a/crates/metadata/src/acl_exacl/read.rs
+++ b/crates/metadata/src/acl_exacl/read.rs
@@ -9,6 +9,32 @@ use protocol::acl::{IdAccess, NO_ENTRY, RsyncAcl};
 
 use super::error::is_unsupported_error;
 use super::perms::exacl_perms_to_rsync;
+use crate::id_lookup::{lookup_group_by_name, lookup_user_by_name};
+
+/// Resolves an `exacl` named-entry string into a numeric id plus, when the OS
+/// supplied a real (non-numeric) name, the name bytes to ship on the wire.
+///
+/// `exacl` reports a named user/group entry either as a bare numeric id string
+/// (when the uid/gid has no passwd/group entry) or as a resolved name. A
+/// numeric string is used directly with no wire name. A real name is resolved
+/// to its local id via NSS (`getpwnam_r`/`getgrnam_r`) and preserved so the
+/// receiver can remap by name - mirroring upstream `add_uid`/`add_gid` at
+/// `acls.c:591-602`, which sends the name unless `--numeric-ids`.
+///
+/// The previous `name.parse().unwrap_or(0)` silently coerced every real name to
+/// id 0 (root) and dropped the name, so the receiver's name-based remap was
+/// starved and named ACL entries collapsed onto root.
+fn resolve_named_entry(name: &str, is_user: bool) -> (u32, Option<Vec<u8>>) {
+    if let Ok(id) = name.parse::<u32>() {
+        return (id, None);
+    }
+    let resolved = if is_user {
+        lookup_user_by_name(name.as_bytes()).ok().flatten()
+    } else {
+        lookup_group_by_name(name.as_bytes()).ok().flatten()
+    };
+    (resolved.unwrap_or(0), Some(name.as_bytes().to_vec()))
+}
 
 /// Reads the filesystem ACL for `path` and converts it to an [`RsyncAcl`].
 ///
@@ -98,14 +124,23 @@ pub fn get_rsync_acl(path: &Path, mode: u32, is_default: bool) -> RsyncAcl {
                 }
             }
             AclEntryKind::User => {
-                // upstream: acls.c:497-501 - named user ACE
-                let uid: u32 = entry.name.parse().unwrap_or(0);
-                acl.names.push(IdAccess::user(uid, u32::from(perms)));
+                // upstream: acls.c:497-501 - named user ACE. Resolve the name to
+                // a numeric id and keep it for the wire so the receiver remaps
+                // by name (upstream add_uid, acls.c:593).
+                let (uid, name) = resolve_named_entry(&entry.name, true);
+                acl.names.push(match name {
+                    Some(name) => IdAccess::user_with_name(uid, u32::from(perms), name),
+                    None => IdAccess::user(uid, u32::from(perms)),
+                });
             }
             AclEntryKind::Group => {
-                // upstream: acls.c:502-506 - named group ACE
-                let gid: u32 = entry.name.parse().unwrap_or(0);
-                acl.names.push(IdAccess::group(gid, u32::from(perms)));
+                // upstream: acls.c:502-506 - named group ACE. As above via
+                // upstream add_gid (acls.c:595).
+                let (gid, name) = resolve_named_entry(&entry.name, false);
+                acl.names.push(match name {
+                    Some(name) => IdAccess::group_with_name(gid, u32::from(perms), name),
+                    None => IdAccess::group(gid, u32::from(perms)),
+                });
             }
             _ => {}
         }
@@ -123,4 +158,49 @@ pub fn get_rsync_acl(path: &Path, mode: u32, is_default: bool) -> RsyncAcl {
     }
 
     acl
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_named_entry;
+    use crate::id_lookup::lookup_user_by_name;
+
+    #[test]
+    fn numeric_name_passes_through_without_wire_name() {
+        // A bare numeric id (no passwd/group entry) is used as-is and carries
+        // no wire name.
+        assert_eq!(resolve_named_entry("4242", true), (4242, None));
+        assert_eq!(resolve_named_entry("0", false), (0, None));
+    }
+
+    #[test]
+    fn real_username_resolves_via_nss_and_keeps_name() {
+        // "daemon" is uid 1 on both Linux and macOS. The old
+        // `parse().unwrap_or(0)` collapsed it to root and dropped the name;
+        // the fix must resolve the real uid via NSS and preserve the name so
+        // the receiver can remap by name.
+        let Some(daemon_uid) = lookup_user_by_name(b"daemon").ok().flatten() else {
+            return; // environment without a "daemon" account: skip
+        };
+        let (id, name) = resolve_named_entry("daemon", true);
+        assert_eq!(
+            id, daemon_uid,
+            "named entry must resolve via NSS, not coerce to 0"
+        );
+        assert_ne!(id, 0, "regression: a real username silently became root");
+        assert_eq!(name.as_deref(), Some(&b"daemon"[..]));
+    }
+
+    #[test]
+    fn unknown_name_still_ships_so_receiver_can_remap() {
+        // An unmappable name must still travel on the wire (id falls back to 0)
+        // so the receiver's name-based remap gets a chance, rather than being
+        // silently replaced by a nameless root entry.
+        let (id, name) = resolve_named_entry("oc_rsync_nonexistent_principal_zzz", true);
+        assert_eq!(id, 0);
+        assert_eq!(
+            name.as_deref(),
+            Some(&b"oc_rsync_nonexistent_principal_zzz"[..])
+        );
+    }
 }


### PR DESCRIPTION
Mirrors upstream rsync's cross-platform ACL identity handling (the Gap #1
fix from the upstream-ACL-model analysis).

## Problem

When reading a named user/group ACL entry, `exacl` reports the entry's
principal as a resolved **name** string (e.g. `alice`). The read path did:

```rust
let uid: u32 = entry.name.parse().unwrap_or(0);
acl.names.push(IdAccess::user(uid, perms)); // name: None
```

So any real username failed `parse::<u32>()` and silently became **uid 0
(root)**, *and* the name was never put on the entry - so it never reached the
wire. The receiver's name-based remap (already implemented correctly in
`reconstruct.rs::resolve_ida_id`) was therefore starved, and every named ACL
entry collapsed onto root on the destination.

## Upstream behavior (the thing we mirror)

`acls.c:588-602`: a named entry is sent as `write_varint(id)` **plus the
user/group name** via `add_uid`/`add_gid`, unless `--numeric-ids`. The
receiver remaps the name to a local id. There is no SID/UUID translation -
cross-platform ACL identity is purely this name-based uid/gid mapping, shared
with `-o`/`-g`.

## Fix

`resolve_named_entry()` in `acl_exacl/read.rs`:
- numeric exacl string -> use directly, no wire name (no passwd/group entry
  exists to name);
- real name -> resolve to a local id via NSS (`getpwnam_r`/`getgrnam_r`) and
  **preserve the name bytes** on the entry via `IdAccess::user_with_name` /
  `group_with_name`, so `send_ida_entries` ships it when `include_names`
  (i.e. not `--numeric-ids`).

The send path already gates the name on `include_names`, and the receiver
already remaps by name, so this completes the loop. Under `--numeric-ids`
the NSS-resolved numeric id is sent as before.

## Tests

`read.rs` unit tests for `resolve_named_entry`: numeric passthrough; a real
account (`daemon`, uid 1 on Linux+macOS) resolving via NSS to its real uid
with the name preserved (regression guard - old code gave uid 0, name None);
and an unmappable name still shipping its name so the receiver can remap.

## Scope

Source/read side only, `crates/metadata` - no wire-format structural change
(the optional-name field already exists). Wire-compatible with upstream and
improves Linux/macOS->any ACL fidelity. Independent of the other open PRs.