### PR TITLE
feat(fast_io): mirror --bwlimit as SO_MAX_PACING_RATE kernel hint

### DIFF
--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -445,7 +445,8 @@ fn configure_daemon_stream(
             apply_socket_options(socket, values)?;
         }
 
-        super::tcp_perf::apply_client_tcp_perf_options(socket, options.tcp_fastopen());
+        // Module listing has no transfer, so no bwlimit pacing applies.
+        super::tcp_perf::apply_client_tcp_perf_options(socket, options.tcp_fastopen(), None);
 
         if let Some(blocking) = options.blocking_io() {
             socket.set_nonblocking(!blocking).map_err(|error| {

--- a/crates/core/src/client/module_list/tcp_perf.rs
+++ b/crates/core/src/client/module_list/tcp_perf.rs
@@ -13,8 +13,8 @@
 use std::net::TcpStream;
 
 use fast_io::{
-    DEFAULT_TCP_NOTSENT_LOWAT, set_tcp_notsent_lowat, set_tcp_quickack,
-    tcp_notsent_lowat_supported, tcp_quickack_supported,
+    DEFAULT_TCP_NOTSENT_LOWAT, set_so_max_pacing_rate, set_tcp_notsent_lowat, set_tcp_quickack,
+    so_max_pacing_rate_supported, tcp_notsent_lowat_supported, tcp_quickack_supported,
 };
 
 use crate::client::TcpFastOpenMode;
@@ -26,7 +26,16 @@ use crate::client::TcpFastOpenMode;
 /// which is incompatible with the standard `connect`/`write` flow used by
 /// the rsync client; client-side TFO is deferred to a follow-up that
 /// wires a `sendto` adapter.
-pub(crate) fn apply_client_tcp_perf_options(stream: &TcpStream, mode: TcpFastOpenMode) {
+///
+/// When `pacing_bytes_per_sec` is `Some` (the client `--bwlimit` rate),
+/// `SO_MAX_PACING_RATE` caps the kernel send pace to match. This is a
+/// complementary hint: the userspace token-bucket limiter remains
+/// authoritative for correctness while the kernel smooths bursts.
+pub(crate) fn apply_client_tcp_perf_options(
+    stream: &TcpStream,
+    mode: TcpFastOpenMode,
+    pacing_bytes_per_sec: Option<u32>,
+) {
     let _ = mode; // Reserved for future client-side TFO wiring.
     if tcp_notsent_lowat_supported() {
         // Errors are best-effort: `TCP_NOTSENT_LOWAT` is an optimisation
@@ -37,6 +46,12 @@ pub(crate) fn apply_client_tcp_perf_options(stream: &TcpStream, mode: TcpFastOpe
         // One-shot hint to skip the delayed-ACK timer on the first ACK;
         // best-effort, non-fatal.
         let _ = set_tcp_quickack(stream);
+    }
+    if let Some(rate) = pacing_bytes_per_sec {
+        if so_max_pacing_rate_supported() {
+            // Kernel pacing hint mirroring `--bwlimit`; best-effort, non-fatal.
+            let _ = set_so_max_pacing_rate(stream, rate);
+        }
     }
 }
 
@@ -61,7 +76,9 @@ mod tests {
             TcpFastOpenMode::On,
             TcpFastOpenMode::Off,
         ] {
-            apply_client_tcp_perf_options(&stream, mode);
+            // Exercise both the no-pacing and pacing-hint paths.
+            apply_client_tcp_perf_options(&stream, mode, None);
+            apply_client_tcp_perf_options(&stream, mode, Some(1_000_000));
         }
 
         drop(stream);

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -148,9 +148,16 @@ pub fn run_daemon_transfer(
     // client side; client-side TFO is deferred to a follow-up). These are
     // wire-compatible with upstream and only affect kernel socket state.
     if let Some(tcp) = stream.as_tcp_stream() {
+        // Mirror `--bwlimit` as a kernel pacing hint (saturating to the
+        // SO_MAX_PACING_RATE u32 field); the userspace limiter stays
+        // authoritative.
+        let pacing = config
+            .bandwidth_limit()
+            .map(|limit| u32::try_from(limit.bytes_per_second().get()).unwrap_or(u32::MAX));
         crate::client::module_list::tcp_perf::apply_client_tcp_perf_options(
             tcp,
             config.tcp_fastopen(),
+            pacing,
         );
     }
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -337,9 +337,9 @@ pub use secure_dir::secure_open_dir;
 pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::{
     DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, enable_tcp_fastopen_listener,
-    enable_tcp_fastopen_raw, rearm_tcp_quickack, set_listener_int_option, set_socket_int_option,
-    set_tcp_notsent_lowat, set_tcp_quickack, tcp_fastopen_listener_supported,
-    tcp_notsent_lowat_supported, tcp_quickack_supported,
+    enable_tcp_fastopen_raw, rearm_tcp_quickack, set_listener_int_option, set_so_max_pacing_rate,
+    set_socket_int_option, set_tcp_notsent_lowat, set_tcp_quickack, so_max_pacing_rate_supported,
+    tcp_fastopen_listener_supported, tcp_notsent_lowat_supported, tcp_quickack_supported,
 };
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -255,6 +255,44 @@ pub fn rearm_tcp_quickack(stream: Option<&TcpStream>) {
     }
 }
 
+/// Caps the kernel send pace for a connected stream to `bytes_per_sec`
+/// (`SO_MAX_PACING_RATE`).
+///
+/// A complementary kernel hint to the userspace token-bucket bandwidth
+/// limiter: the limiter stays authoritative for correctness, while the
+/// kernel smooths bursts at the NIC. On platforms without
+/// `SO_MAX_PACING_RATE` the call is a no-op and returns `Ok(false)`.
+///
+/// `SO_MAX_PACING_RATE` is a `u32` kernel field; the value is passed
+/// through the `int`-sized setsockopt path, which copies the same four
+/// bytes the kernel reads, so rates above `i32::MAX` are wire-correct.
+///
+/// upstream: not implemented; an oc-rsync-specific perf hint that is
+/// wire-compatible with upstream rsync.
+pub fn set_so_max_pacing_rate(stream: &TcpStream, bytes_per_sec: u32) -> io::Result<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        set_socket_int_option(
+            stream,
+            libc::SOL_SOCKET,
+            libc::SO_MAX_PACING_RATE,
+            bytes_per_sec as i32,
+        )?;
+        Ok(true)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (stream, bytes_per_sec);
+        Ok(false)
+    }
+}
+
+/// Returns `true` when the running platform implements `SO_MAX_PACING_RATE`.
+#[must_use]
+pub const fn so_max_pacing_rate_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
 /// Returns `true` when the running platform implements server-side
 /// `TCP_FASTOPEN`.
 #[must_use]
@@ -480,6 +518,20 @@ mod tests {
             Ok(true) => assert!(tcp_quickack_supported()),
             Ok(false) => assert!(!tcp_quickack_supported()),
             Err(error) => panic!("unexpected error from TCP_QUICKACK: {error}"),
+        }
+
+        drop(stream);
+        handle.join().expect("accept thread completes");
+    }
+
+    #[test]
+    fn set_so_max_pacing_rate_returns_supported_flag() {
+        let (stream, handle) = connected_stream();
+
+        match set_so_max_pacing_rate(&stream, 1_000_000) {
+            Ok(true) => assert!(so_max_pacing_rate_supported()),
+            Ok(false) => assert!(!so_max_pacing_rate_supported()),
+            Err(error) => panic!("unexpected error from SO_MAX_PACING_RATE: {error}"),
         }
 
         drop(stream);


### PR DESCRIPTION
Applies `SO_MAX_PACING_RATE` on the client daemon-transfer socket to match
the `--bwlimit` rate, so the kernel paces sends at the NIC instead of only
the userspace token-bucket limiter shaping bursts.

## What

- `fast_io::set_so_max_pacing_rate(stream, bytes_per_sec: u32)` +
  `so_max_pacing_rate_supported()` - Linux `setsockopt(SOL_SOCKET,
  SO_MAX_PACING_RATE)`; no-op `Ok(false)` elsewhere. Mirrors the
  `set_tcp_notsent_lowat` u32 helper (the u32 rate is passed through the
  int-sized setsockopt path, copying the same four bytes the kernel reads,
  so rates above `i32::MAX` are wire-correct).
- `apply_client_tcp_perf_options` gains a `pacing_bytes_per_sec: Option<u32>`
  param applied best-effort after the existing NOTSENT_LOWAT/QUICKACK hints.
- The daemon-transfer call site passes `config.bandwidth_limit()` saturated
  to `u32::MAX`; the module-listing call site passes `None` (no transfer).

## Why

The userspace limiter stays authoritative for correctness; `SO_MAX_PACING_RATE`
is a complementary kernel hint that smooths bursts and reduces queueing
latency under `--bwlimit`. Wire-compatible with upstream - it only affects
kernel socket scheduling, never the rsync protocol stream.

## Test

`set_so_max_pacing_rate_returns_supported_flag` asserts the return flag tracks
`so_max_pacing_rate_supported()`; the existing perf-options test now also
exercises the pacing path (`Some(1_000_000)`).

Independent of the in-flight ACL PR and the daemon-TLS work.