### PR TITLE
fix(cli): thousands-group the bytes/sec rate in the summary trailer

### DIFF
--- a/crates/cli/src/frontend/progress/format/rate.rs
+++ b/crates/cli/src/frontend/progress/format/rate.rs
@@ -6,7 +6,11 @@ use core::client::HumanReadableMode;
 
 pub(crate) fn format_summary_rate(rate: f64, human_readable: HumanReadableMode) -> String {
     if !human_readable.is_enabled() {
-        return format!("{rate:.2}");
+        // upstream: main.c output_summary() prints the bytes/sec field with
+        // comma_dnum(rate, 2), i.e. thousands-grouped with 2 decimals. Reuse
+        // the same grouping helper the --stats renderer uses so the two
+        // summary paths agree (e.g. "1,234,567.89", not "1234567.89").
+        return crate::stats_format::format_speed(rate);
     }
 
     // upstream: main.c:464 formats the bytes/sec rate with human_num, the same
@@ -141,6 +145,21 @@ mod tests {
     #[test]
     fn format_human_rate_small() {
         assert_eq!(format_human_rate(500.0, 1000.0), "500.00");
+    }
+
+    #[test]
+    fn summary_rate_groups_thousands_without_human_readable() {
+        // upstream output_summary() uses comma_dnum for the bytes/sec field, so
+        // the default (non -h) summary trailer must be thousands-grouped, the
+        // same as oc-rsync's own --stats path.
+        assert_eq!(
+            format_summary_rate(1_234_567.89, HumanReadableMode::Disabled),
+            "1,234,567.89"
+        );
+        assert_eq!(
+            format_summary_rate(512.0, HumanReadableMode::Disabled),
+            "512.00"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The local-copy summary trailer `sent X bytes  received Y bytes  Z bytes/sec`
printed the `Z` bytes/sec rate as a plain `{:.2}` float with no thousands
separators, while the byte counts (and oc-rsync's own `--stats` renderer)
group them. Upstream `main.c` `output_summary()` prints the rate with
`comma_dnum(rate, 2)`, i.e. thousands-grouped.

Example (3 MB local copy): `... received 0 bytes  2870132504.19 bytes/sec`
-> `... received 0 bytes  2,870,132,504.19 bytes/sec`.

## Fix

`format_summary_rate` (non-human-readable branch) now reuses the existing
`stats_format::format_speed` helper - the same grouping the `--stats` path
already uses - so the two summary paths agree and match upstream. The
human-readable (`-h`) branch is unchanged (it correctly uses `human_num`).

## Test

`summary_rate_groups_thousands_without_human_readable` asserts
`1_234_567.89 -> "1,234,567.89"` and the small-value passthrough
`512.0 -> "512.00"`.

One-line behavior change in `crates/cli`; independent of the other open PRs.