### PR TITLE
fix(cli): render listing/out-format dates in local time via localtime_r

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "logging",
  "logging-sink",
  "metadata",
+ "platform",
  "predicates",
  "protocol",
  "rayon",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,7 @@ logging-sink = { path = "../logging-sink" }
 protocol = { path = "../protocol" }
 compress = { path = "../compress", default-features = false }
 metadata = { path = "../metadata", default-features = false }
+platform = { path = "../platform" }
 rsync_io = { path = "../rsync_io", package = "rsync_io" }
 rayon = { workspace = true }
 time = { version = "0.3", default-features = false, features = ["formatting", "macros", "local-offset", "std"] }

--- a/crates/cli/src/frontend/local_time.rs
+++ b/crates/cli/src/frontend/local_time.rs
@@ -1,0 +1,22 @@
+//! Local-timezone conversion for rendered timestamps.
+//!
+//! Upstream rsync's `timestring()` renders file modtimes in local time via
+//! `localtime_r`, computing the offset per instant (so DST is correct for each
+//! file's modtime). We mirror that by asking [`platform::local_time`] for the
+//! offset in effect at the given instant - `localtime_r` is thread-safe, so
+//! unlike the `time` crate's `now_local()` it works in our multi-threaded
+//! process with no startup capture or global state.
+
+use std::time::SystemTime;
+
+use time::{OffsetDateTime, UtcOffset};
+
+/// Converts `time` to an [`OffsetDateTime`] in the local timezone in effect at
+/// that instant, mirroring upstream `timestring()`. Falls back to UTC when the
+/// offset is indeterminate (and on platforms without `localtime_r`).
+pub(crate) fn to_local(time: SystemTime) -> OffsetDateTime {
+    let datetime = OffsetDateTime::from(time);
+    // `::platform` is the workspace crate (cli also has a local `mod platform`).
+    let seconds = ::platform::local_time::local_utc_offset_seconds(datetime.unix_timestamp());
+    UtcOffset::from_whole_seconds(seconds).map_or(datetime, |offset| datetime.to_offset(offset))
+}

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -117,6 +117,7 @@ mod help;
 pub mod info_output;
 /// Upstream rsync `--itemize-changes` (`-i`) output format.
 pub mod itemize;
+mod local_time;
 mod lsm_status;
 mod out_format;
 pub(crate) mod password;

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -9,7 +9,6 @@ use std::time::SystemTime;
 
 use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions, platform};
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
-use time::OffsetDateTime;
 
 use crate::frontend::out_format::tokens::{
     OutFormatContext, OutFormatPlaceholder, PlaceholderToken,
@@ -163,7 +162,7 @@ fn format_out_format_mtime(metadata: Option<&ClientEntryMetadata>) -> String {
     metadata
         .and_then(|meta| meta.modified())
         .and_then(|time| {
-            OffsetDateTime::from(time)
+            crate::frontend::local_time::to_local(time)
                 .format(LIST_TIMESTAMP_FORMAT)
                 .ok()
         })
@@ -210,7 +209,7 @@ fn resolve_group_name(gid: u32) -> String {
 
 /// Formats the current wall-clock time using the list timestamp format.
 fn format_current_timestamp() -> String {
-    let now = OffsetDateTime::from(SystemTime::now());
+    let now = crate::frontend::local_time::to_local(SystemTime::now());
     now.format(LIST_TIMESTAMP_FORMAT).map_or_else(
         |_| "1970/01/01-00:00:00".to_owned(),
         |text| text.replace(' ', "-"),

--- a/crates/cli/src/frontend/progress/format/list.rs
+++ b/crates/cli/src/frontend/progress/format/list.rs
@@ -3,7 +3,6 @@
 use std::time::SystemTime;
 
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEventKind};
-use time::OffsetDateTime;
 
 use crate::LIST_TIMESTAMP_FORMAT;
 
@@ -85,7 +84,8 @@ pub(crate) fn format_list_permissions(metadata: &ClientEntryMetadata) -> String 
 
 pub(crate) fn format_list_timestamp(modified: Option<SystemTime>) -> String {
     if let Some(time) = modified
-        && let Ok(datetime) = OffsetDateTime::from(time).format(LIST_TIMESTAMP_FORMAT)
+        && let Ok(datetime) =
+            crate::frontend::local_time::to_local(time).format(LIST_TIMESTAMP_FORMAT)
     {
         return datetime;
     }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -33,6 +33,9 @@ pub mod env;
 pub mod error;
 /// System group membership lookups.
 pub mod group;
+/// Per-instant local timezone offset (mirrors upstream `timestring()`'s
+/// `localtime_r`), used to render file modtimes in local time.
+pub mod local_time;
 /// Windows account name to RID resolution.
 pub mod name_resolution;
 /// Process privilege operations - chroot and uid/gid dropping.

--- a/crates/platform/src/local_time.rs
+++ b/crates/platform/src/local_time.rs
@@ -1,0 +1,68 @@
+//! Local timezone offset for a specific instant.
+//!
+//! Mirrors upstream rsync's `timestring()` (`util1.c`), which renders file
+//! modtimes through `localtime_r`. The offset is computed *per instant*, so
+//! daylight-saving time is correct for each file's modtime - a file modified
+//! in July and one modified in January render with their own offsets.
+//!
+//! `localtime_r` is POSIX-thread-safe (it writes into a caller-owned `tm`),
+//! so this works in oc-rsync's multi-threaded process. That is the crucial
+//! difference from the `time` crate's `OffsetDateTime::now_local()`, which
+//! refuses to read the local offset once any other thread exists.
+
+/// Returns the local UTC offset, in seconds east of UTC, in effect at
+/// `unix_secs` - accounting for DST at that instant, matching upstream
+/// `localtime_r`-based `timestring()`.
+///
+/// Returns `0` (UTC) when the offset cannot be determined.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+#[must_use]
+pub fn local_utc_offset_seconds(unix_secs: i64) -> i32 {
+    let t = unix_secs as libc::time_t;
+    let mut tm: libc::tm = unsafe { std::mem::zeroed() };
+    // SAFETY: `localtime_r` is POSIX-thread-safe; it writes the broken-down
+    // local time into the caller-owned `tm` and returns its address (or NULL
+    // on failure). We pass a valid `time_t` and an owned, zeroed `tm`.
+    let result = unsafe { libc::localtime_r(&t, &mut tm) };
+    if result.is_null() {
+        return 0;
+    }
+    tm.tm_gmtoff as i32
+}
+
+/// Windows lacks `localtime_r`/`tm_gmtoff`; rendering the listing column in
+/// the local timezone there is a follow-up. Returns `0` (UTC) for now.
+#[cfg(not(unix))]
+#[must_use]
+pub fn local_utc_offset_seconds(_unix_secs: i64) -> i32 {
+    0
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::local_utc_offset_seconds;
+
+    #[test]
+    fn offset_is_a_valid_utc_offset() {
+        // Whatever the test host's timezone, the offset must be a real one:
+        // within [-12h, +14h] and a whole number of minutes.
+        let offset = local_utc_offset_seconds(1_700_000_000);
+        assert!(
+            (-12 * 3600..=14 * 3600).contains(&offset),
+            "offset {offset} out of range"
+        );
+        assert_eq!(offset % 60, 0, "offset {offset} is not minute-aligned");
+    }
+
+    #[test]
+    fn offset_matches_localtime_r_per_instant() {
+        // Summer and winter timestamps in a DST zone differ by an hour; in a
+        // non-DST zone they are equal. Either way both must be valid offsets,
+        // and their difference is 0 or +-3600 - never anything else.
+        let summer = local_utc_offset_seconds(1_690_000_000); // 2023-07-22
+        let winter = local_utc_offset_seconds(1_704_000_000); // 2023-12-31
+        let delta = (summer - winter).abs();
+        assert!(delta == 0 || delta == 3600, "unexpected DST delta {delta}");
+    }
+}


### PR DESCRIPTION
oc-rsync rendered file modtimes in the `--list-only` date column and the
`--out-format` `%M`/`%t` placeholders in **UTC**, while upstream rsync's
`timestring()` (`util1.c`) renders them in **local time** via `localtime_r`.

## Design

Rather than capture a single offset at startup (which would be wrong across a
DST boundary and fragile re: thread-startup timing), this computes the offset
**per instant** - exactly what upstream does:

- New `platform::local_time::local_utc_offset_seconds(unix_secs) -> i32` uses
  `libc::localtime_r` and returns `tm.tm_gmtoff` for that specific instant, so
  DST is correct per file (a July modtime and a January one get their own
  offsets). `localtime_r` is POSIX-thread-safe, so unlike the `time` crate's
  `now_local()` it works in oc's multi-threaded process - no global state, no
  startup capture. The unsafe FFI lives in `platform` (next to the existing
  `tzset` call); cli stays `#![deny(unsafe_code)]`.
- A small cli `to_local()` maps that to `time::UtcOffset` and applies it.
- Windows (no `localtime_r`/`tm_gmtoff`) falls back to UTC for now (follow-up).

## Verified on the binary

```
file mtime = 2024-07-01 12:00 IDT  (= 09:00 UTC)
oc-rsync --out-format='%M %n' (TZ=IDT+3): 2024/07/01-12:00:00   # local
oc-rsync --out-format='%M %n' (TZ=UTC):   2024/07/01-09:00:00   # honors $TZ
```

Matches upstream. Plus `platform` unit tests for the offset helper (valid
range, minute-aligned, per-instant DST delta of 0 or +-3600).

Closes the LISTDATE-TZ divergence. Independent of the other open PRs.