### PR TITLE
fix(engine): exit 23/link_stat for missing local source argument

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -197,6 +197,17 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             path,
             source,
         } => io_error(action, &path, source),
+        LocalCopyErrorKind::LinkStatFailed { path, source } => {
+            // upstream: flist.c send_file_list() - a source argument that fails
+            // its initial link_stat is reported by the sender as
+            // `link_stat "%s" failed: %s` and exits RERR_PARTIAL (23). This is
+            // deliberately not routed through io_error(), whose NotFound branch
+            // maps to RERR_VANISHED (24) for files that vanish mid-transfer.
+            let code = ExitCode::PartialTransfer;
+            let text = format!("link_stat \"{}\" failed: {source}", path.display());
+            let message = rsync_error!(code.as_i32(), text).with_role(Role::Sender);
+            ClientError::with_code(code, message)
+        }
         LocalCopyErrorKind::Timeout { duration } => {
             let code = ExitCode::Timeout;
             let text = format!(
@@ -569,6 +580,23 @@ mod tests {
             let msg = error.to_string();
             assert!(msg.contains("file has vanished"));
             assert!(msg.contains("/test/file.txt"));
+        }
+
+        /// upstream: flist.c send_file_list() - a missing source *argument*
+        /// (NotFound at the initial link_stat) exits RERR_PARTIAL (23) with a
+        /// `link_stat "%s" failed` message, NOT the RERR_VANISHED (24)
+        /// "file has vanished" path used for mid-transfer disappearances.
+        #[test]
+        fn map_link_stat_failed_uses_partial_not_vanished() {
+            let io_err = io::Error::new(ErrorKind::NotFound, "No such file or directory");
+            let local_error =
+                LocalCopyError::link_stat_failed(Path::new("/tmp/nope").to_path_buf(), io_err);
+            let client_error = map_local_copy_error(local_error);
+
+            assert_eq!(client_error.code(), ExitCode::PartialTransfer);
+            let msg = client_error.to_string();
+            assert!(msg.contains("link_stat \"/tmp/nope\" failed"), "{msg}");
+            assert!(!msg.contains("file has vanished"), "{msg}");
         }
 
         #[test]

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -67,6 +67,25 @@ impl LocalCopyError {
         })
     }
 
+    /// Constructs an error for an initial source `link_stat` that failed
+    /// because the source argument does not exist.
+    ///
+    /// This is deliberately distinct from [`LocalCopyError::io`]'s NotFound
+    /// mapping: a source argument that never existed fails at the initial stat
+    /// and exits 23 (`RERR_PARTIAL`) with a `link_stat "%s" failed` message,
+    /// whereas a file that vanishes mid-transfer exits 24 (`RERR_VANISHED`)
+    /// with "file has vanished".
+    ///
+    /// upstream: `flist.c send_file_list()` - a failed `link_stat` sets
+    /// `io_error |= IOERR_GENERAL`, yielding `exit_cleanup(RERR_PARTIAL)`.
+    #[must_use]
+    pub fn link_stat_failed(path: impl Into<PathBuf>, source: io::Error) -> Self {
+        Self::new(LocalCopyErrorKind::LinkStatFailed {
+            path: path.into(),
+            source,
+        })
+    }
+
     /// Constructs an error representing an inactivity timeout.
     #[must_use]
     pub const fn timeout(duration: Duration) -> Self {
@@ -101,6 +120,7 @@ impl LocalCopyError {
                     INVALID_OPERAND_EXIT_CODE
                 }
             }
+            LocalCopyErrorKind::LinkStatFailed { .. } => INVALID_OPERAND_EXIT_CODE,
             LocalCopyErrorKind::Timeout { .. } | LocalCopyErrorKind::StopAtReached { .. } => {
                 TIMEOUT_EXIT_CODE
             }
@@ -123,6 +143,7 @@ impl LocalCopyError {
                     "RERR_PARTIAL"
                 }
             }
+            LocalCopyErrorKind::LinkStatFailed { .. } => "RERR_PARTIAL",
             LocalCopyErrorKind::Timeout { .. } | LocalCopyErrorKind::StopAtReached { .. } => {
                 "RERR_TIMEOUT"
             }
@@ -183,6 +204,17 @@ pub enum LocalCopyErrorKind {
         /// Action being performed.
         action: &'static str,
         /// Path involved in the failure.
+        path: PathBuf,
+        /// Underlying error.
+        #[source]
+        source: io::Error,
+    },
+    /// The initial `link_stat` (symlink_metadata) of a source argument failed
+    /// because the path does not exist. Distinct from a mid-transfer vanish:
+    /// this is a hard error exiting 23 (`RERR_PARTIAL`), not 24.
+    #[error("link_stat \"{}\" failed: {source}", path.display())]
+    LinkStatFailed {
+        /// The source path that could not be stat'd.
         path: PathBuf,
         /// Underlying error.
         #[source]
@@ -530,5 +562,25 @@ mod tests {
         let error = LocalCopyError::io("read", PathBuf::from("/denied"), io_err);
         assert_eq!(error.exit_code(), INVALID_OPERAND_EXIT_CODE);
         assert_eq!(error.exit_code(), 23);
+    }
+
+    #[test]
+    fn link_stat_failed_is_partial_not_vanished() {
+        // A source argument that never existed fails its initial link_stat and
+        // must exit 23 (RERR_PARTIAL), unlike a file that vanishes mid-transfer
+        // (which the Io NotFound path maps to 24). It must also not be
+        // classified as a vanish, so the mid-transfer skip logic ignores it.
+        let io_err = io::Error::new(ErrorKind::NotFound, "no such file");
+        let error = LocalCopyError::link_stat_failed(PathBuf::from("/tmp/nope"), io_err);
+        assert_eq!(error.exit_code(), INVALID_OPERAND_EXIT_CODE);
+        assert_eq!(error.exit_code(), 23);
+        assert_eq!(error.code_name(), "RERR_PARTIAL");
+        assert!(!error.is_vanished_error());
+        assert!(!error.is_io_error());
+        assert!(
+            error
+                .to_string()
+                .starts_with("link_stat \"/tmp/nope\" failed")
+        );
     }
 }

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -260,8 +260,11 @@ fn process_single_source(
         SourceMetadataResult::Found(m) => m,
         SourceMetadataResult::Handled => return Ok(()),
         SourceMetadataResult::NotFoundError(error) => {
-            return Err(LocalCopyError::io(
-                "access source",
+            // upstream: flist.c send_file_list() - a source argument that fails
+            // its initial link_stat is a hard error (exit 23, RERR_PARTIAL) with
+            // a `link_stat "%s" failed` message, distinct from a file that
+            // vanishes mid-transfer (exit 24, RERR_VANISHED, "file has vanished").
+            return Err(LocalCopyError::link_stat_failed(
                 source_path.to_path_buf(),
                 error,
             ));


### PR DESCRIPTION
## Problem

A local source argument that does not exist exits 24 (`RERR_VANISHED`) with `file has vanished: "..."`. Upstream rsync exits 23 (`RERR_PARTIAL`) with `link_stat "%s" failed: %s` for a source argument that fails its initial `link_stat`, reserving `RERR_VANISHED` for files that disappear *mid-transfer*.

```
# upstream:
$ rsync /tmp/nope dst/ ; echo $?
rsync: [sender] link_stat "/tmp/nope" failed: No such file or directory (2)
... (code 23) ...
23
```

The missing-source case was routed through the shared `io_error` helper, whose NotFound branch correctly maps to 24 for genuine mid-run vanishes (`generator`/recursive paths). Changing that helper globally would regress those.

## Fix

Add a dedicated `LocalCopyErrorKind::LinkStatFailed` used **only** at the initial source-stat site (the `NotFoundError` arm in the local-copy executor source orchestration). It maps to `PartialTransfer` (23) with the upstream `link_stat` wording and the `[sender]` role. The shared `io_error` NotFound->Vanished path is untouched, so mid-transfer vanishes still exit 24.

## Tests

- `engine`: `link_stat_failed_is_partial_not_vanished` - exit 23, `RERR_PARTIAL`, not classified as vanished/io.
- `core`: `map_link_stat_failed_uses_partial_not_vanished` - maps to `PartialTransfer` with `link_stat "..." failed` wording, not `file has vanished`.
- Existing `io_error_notfound_uses_vanished_code` stays valid (mid-run vanish unchanged).

Built + clippy clean (engine, core).