### PR TITLE
fix(engine): exit 23/link_stat for a missing source, keep transferring

### DIFF
--- a/crates/cli/src/frontend/tests/error_recovery.rs
+++ b/crates/cli/src/frontend/tests/error_recovery.rs
@@ -11,11 +11,12 @@
 use super::common::*;
 use super::*;
 
-/// When one of several explicit source paths has been deleted, the transfer
-/// should still copy the remaining files and exit with code 24 (vanished).
+/// When one of several explicit source paths is missing, the transfer should
+/// still copy the remaining files and exit 23 (RERR_PARTIAL) via the failed
+/// link_stat. Verified against upstream rsync 3.4.3.
 #[cfg(unix)]
 #[test]
-fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
+fn missing_source_operand_yields_exit_23_and_remaining_files_transfer() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -64,8 +65,11 @@ fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
 
     std::fs::remove_file(&file_b).expect("remove bravo.txt");
 
-    // upstream: walk_path() sets IOERR_VANISHED for stat-ENOENT during the
-    // explicit-arg pass, surfacing as exit code 24.
+    // upstream: flist.c send_file_list() - a missing explicit source operand
+    // fails its link_stat, printing `link_stat "%s" failed` and setting
+    // IOERR_GENERAL (exit 23, RERR_PARTIAL); the remaining operands still
+    // transfer. Distinct from exit 24, which is reserved for a file that
+    // disappears mid-transfer after it was already in the file list.
     let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         file_a.clone().into_os_string(),
@@ -77,13 +81,13 @@ fn vanished_source_file_yields_exit_24_and_remaining_files_transfer() {
     let stderr_text = String::from_utf8_lossy(&stderr);
 
     assert_eq!(
-        code, 24,
-        "expected exit code 24 (vanished), got {code}: {stderr_text}"
+        code, 23,
+        "expected exit code 23 (partial/link_stat), got {code}: {stderr_text}"
     );
 
     assert!(
-        stderr_text.contains("vanished"),
-        "stderr should mention vanished file: {stderr_text}"
+        stderr_text.contains("link_stat"),
+        "stderr should mention the failed link_stat: {stderr_text}"
     );
 
     assert_eq!(
@@ -142,11 +146,12 @@ fn recursive_transfer_without_vanished_files_exits_zero() {
     );
 }
 
-/// When a single explicit source path does not exist, the transfer should
-/// still report exit code 24 (not 23 or 3) because the path vanished.
+/// When a single explicit source path does not exist, the transfer exits 23
+/// (RERR_PARTIAL) via the failed link_stat (not 24 or 3). Verified against
+/// upstream rsync 3.4.3.
 #[cfg(unix)]
 #[test]
-fn single_vanished_source_yields_exit_24() {
+fn single_missing_source_yields_exit_23() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -161,10 +166,10 @@ fn single_vanished_source_yields_exit_24() {
 
     let stderr_text = String::from_utf8_lossy(&stderr);
 
-    // upstream: a stat-ENOENT during file-list build yields "file has vanished"
-    // and exit 24; some build paths surface it as 23 (partial).
+    // upstream: flist.c send_file_list() - a missing source operand fails its
+    // link_stat and exits 23 (RERR_PARTIAL). Verified against upstream 3.4.3.
     assert!(
-        code == 24 || code == 23,
-        "expected exit code 24 (vanished) or 23 (partial), got {code}: {stderr_text}"
+        code == 23,
+        "expected exit code 23 (partial/link_stat), got {code}: {stderr_text}"
     );
 }

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -197,6 +197,17 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             path,
             source,
         } => io_error(action, &path, source),
+        LocalCopyErrorKind::LinkStatFailed { path, source } => {
+            // upstream: flist.c send_file_list() - a missing source argument is
+            // reported by the sender as `link_stat "%s" failed: %s` and exits
+            // RERR_PARTIAL (23). Deliberately not routed through io_error(),
+            // whose NotFound branch maps to RERR_VANISHED (24) for files that
+            // disappear mid-transfer.
+            let code = ExitCode::PartialTransfer;
+            let text = format!("link_stat \"{}\" failed: {source}", path.display());
+            let message = rsync_error!(code.as_i32(), text).with_role(Role::Sender);
+            ClientError::with_code(code, message)
+        }
         LocalCopyErrorKind::Timeout { duration } => {
             let code = ExitCode::Timeout;
             let text = format!(
@@ -569,6 +580,23 @@ mod tests {
             let msg = error.to_string();
             assert!(msg.contains("file has vanished"));
             assert!(msg.contains("/test/file.txt"));
+        }
+
+        /// upstream: flist.c send_file_list() - a missing source argument
+        /// (failed link_stat) exits RERR_PARTIAL (23) with `link_stat "%s"
+        /// failed`, NOT the RERR_VANISHED (24) "file has vanished" path used
+        /// for files that disappear mid-transfer.
+        #[test]
+        fn map_link_stat_failed_uses_partial_not_vanished() {
+            let io_err = io::Error::new(ErrorKind::NotFound, "No such file or directory");
+            let local_error =
+                LocalCopyError::link_stat_failed(Path::new("/tmp/nope").to_path_buf(), io_err);
+            let client_error = map_local_copy_error(local_error);
+
+            assert_eq!(client_error.code(), ExitCode::PartialTransfer);
+            let msg = client_error.to_string();
+            assert!(msg.contains("link_stat \"/tmp/nope\" failed"), "{msg}");
+            assert!(!msg.contains("file has vanished"), "{msg}");
         }
 
         #[test]

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -67,6 +67,26 @@ impl LocalCopyError {
         })
     }
 
+    /// Constructs an error for a source argument whose initial `link_stat`
+    /// failed because the path does not exist.
+    ///
+    /// Distinct from [`LocalCopyError::io`]'s NotFound mapping: a *source* (a
+    /// command-line operand or a `--files-from` entry) that is missing when the
+    /// sender stats it exits 23 (`RERR_PARTIAL`) with a `link_stat "%s" failed`
+    /// message, and the transfer continues with the remaining sources. Exit 24
+    /// (`RERR_VANISHED`, "file has vanished") is reserved for a file that
+    /// disappears mid-transfer after it was already in the file list.
+    ///
+    /// upstream: `flist.c send_file_list()` - a failed `link_stat` on an arg
+    /// sets `io_error |= IOERR_GENERAL`, yielding `exit_cleanup(RERR_PARTIAL)`.
+    #[must_use]
+    pub fn link_stat_failed(path: impl Into<PathBuf>, source: io::Error) -> Self {
+        Self::new(LocalCopyErrorKind::LinkStatFailed {
+            path: path.into(),
+            source,
+        })
+    }
+
     /// Constructs an error representing an inactivity timeout.
     #[must_use]
     pub const fn timeout(duration: Duration) -> Self {
@@ -101,6 +121,7 @@ impl LocalCopyError {
                     INVALID_OPERAND_EXIT_CODE
                 }
             }
+            LocalCopyErrorKind::LinkStatFailed { .. } => INVALID_OPERAND_EXIT_CODE,
             LocalCopyErrorKind::Timeout { .. } | LocalCopyErrorKind::StopAtReached { .. } => {
                 TIMEOUT_EXIT_CODE
             }
@@ -123,6 +144,7 @@ impl LocalCopyError {
                     "RERR_PARTIAL"
                 }
             }
+            LocalCopyErrorKind::LinkStatFailed { .. } => "RERR_PARTIAL",
             LocalCopyErrorKind::Timeout { .. } | LocalCopyErrorKind::StopAtReached { .. } => {
                 "RERR_TIMEOUT"
             }
@@ -155,6 +177,16 @@ impl LocalCopyError {
         )
     }
 
+    /// Reports whether this is a failed initial `link_stat` of a source
+    /// argument (a missing command-line operand or `--files-from` entry).
+    ///
+    /// Like a vanished file, the transfer continues with the remaining
+    /// sources, but the exit code is 23 (`RERR_PARTIAL`), not 24.
+    #[must_use]
+    pub const fn is_link_stat_failed(&self) -> bool {
+        matches!(self.kind, LocalCopyErrorKind::LinkStatFailed { .. })
+    }
+
     /// Provides access to the underlying error kind.
     #[must_use]
     pub const fn kind(&self) -> &LocalCopyErrorKind {
@@ -183,6 +215,18 @@ pub enum LocalCopyErrorKind {
         /// Action being performed.
         action: &'static str,
         /// Path involved in the failure.
+        path: PathBuf,
+        /// Underlying error.
+        #[source]
+        source: io::Error,
+    },
+    /// The initial `link_stat` of a source argument failed because the path
+    /// does not exist. A hard error exiting 23 (`RERR_PARTIAL`), distinct from
+    /// a mid-transfer vanish (exit 24); the caller continues with the remaining
+    /// sources.
+    #[error("link_stat \"{}\" failed: {source}", path.display())]
+    LinkStatFailed {
+        /// The source path that could not be stat'd.
         path: PathBuf,
         /// Underlying error.
         #[source]
@@ -530,5 +574,25 @@ mod tests {
         let error = LocalCopyError::io("read", PathBuf::from("/denied"), io_err);
         assert_eq!(error.exit_code(), INVALID_OPERAND_EXIT_CODE);
         assert_eq!(error.exit_code(), 23);
+    }
+
+    #[test]
+    fn link_stat_failed_is_partial_and_continues() {
+        // A missing source argument (command-line operand or --files-from
+        // entry) is a failed link_stat: exit 23 (RERR_PARTIAL), classified for
+        // continue-with-remaining but NOT as a mid-transfer vanish (24).
+        let io_err = io::Error::new(ErrorKind::NotFound, "no such file");
+        let error = LocalCopyError::link_stat_failed(PathBuf::from("/tmp/nope"), io_err);
+        assert_eq!(error.exit_code(), INVALID_OPERAND_EXIT_CODE);
+        assert_eq!(error.exit_code(), 23);
+        assert_eq!(error.code_name(), "RERR_PARTIAL");
+        assert!(error.is_link_stat_failed());
+        assert!(!error.is_vanished_error());
+        assert!(!error.is_io_error());
+        assert!(
+            error
+                .to_string()
+                .starts_with("link_stat \"/tmp/nope\" failed")
+        );
     }
 }

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -158,6 +158,16 @@ pub(crate) fn copy_sources(
                         if first_io_error.is_none() {
                             first_io_error = Some(error);
                         }
+                    } else if error.is_link_stat_failed() {
+                        // upstream: flist.c send_file_list() - a missing source
+                        // argument prints `link_stat "%s" failed: %s` to stderr,
+                        // sets IOERR_GENERAL (exit 23), and the transfer
+                        // continues with the remaining sources.
+                        eprintln!("{error}");
+                        context.record_io_error();
+                        if first_io_error.is_none() {
+                            first_io_error = Some(error);
+                        }
                     } else if error.is_io_error() {
                         // upstream: rsync continues transferring remaining sources
                         // when individual entries fail with I/O errors, regardless
@@ -260,8 +270,13 @@ fn process_single_source(
         SourceMetadataResult::Found(m) => m,
         SourceMetadataResult::Handled => return Ok(()),
         SourceMetadataResult::NotFoundError(error) => {
-            return Err(LocalCopyError::io(
-                "access source",
+            // upstream: flist.c send_file_list() - a source argument (operand or
+            // --files-from entry) whose link_stat fails is reported as
+            // `link_stat "%s" failed`, sets IOERR_GENERAL (exit 23,
+            // RERR_PARTIAL), and the transfer continues with the remaining
+            // sources. Distinct from a file that vanishes mid-transfer (exit
+            // 24, "file has vanished").
+            return Err(LocalCopyError::link_stat_failed(
                 source_path.to_path_buf(),
                 error,
             ));

--- a/crates/engine/src/local_copy/tests/files_from_vanished.rs
+++ b/crates/engine/src/local_copy/tests/files_from_vanished.rs
@@ -4,18 +4,19 @@
 // transfer, the engine produces the correct exit codes and behavior
 // for --ignore-missing-args and --delete-missing-args.
 
-// FFV-5: Vanished source file produces exit code 24 and warning.
+// FFV-5: Missing source operand produces exit code 23 (link_stat failed).
 //
-// When a source file disappears between plan creation and execution,
-// upstream rsync emits "file has vanished" and exits with
-// RERR_VANISHED (24). The remaining files in the transfer must still
-// be copied.
+// When a source file is absent at scan time, upstream rsync emits
+// `link_stat "%s" failed: ...`, sets IOERR_GENERAL and exits RERR_PARTIAL
+// (23) - NOT RERR_VANISHED (24), which is reserved for a file that vanishes
+// mid-transfer after it was already in the file list. The remaining source
+// files must still be copied. Verified against upstream rsync 3.4.3.
 //
 // Each source file is passed as an individual operand so the plan
 // records them explicitly. Directory operands defer enumeration to
 // execute() time, which would silently skip removed files.
 #[test]
-fn vanished_source_exits_with_vanished_code_and_copies_remaining() {
+fn missing_source_exits_with_partial_code_and_copies_remaining() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
@@ -43,17 +44,18 @@ fn vanished_source_exits_with_vanished_code_and_copies_remaining() {
 
     let result = plan.execute();
 
-    // Must fail with exit code 24 (RERR_VANISHED).
-    let err = result.expect_err("vanished file should produce an error");
+    // upstream: a missing source operand exits 23 (RERR_PARTIAL) via the
+    // failed link_stat, and the remaining sources still transfer.
+    let err = result.expect_err("missing source should produce an error");
     assert_eq!(
         err.exit_code(),
-        24,
-        "expected RERR_VANISHED (24), got {}",
+        23,
+        "expected RERR_PARTIAL (23), got {}",
         err.exit_code()
     );
     assert!(
-        err.is_vanished_error(),
-        "error should be classified as vanished"
+        err.is_link_stat_failed(),
+        "error should be classified as a failed link_stat"
     );
 
     // Surviving files must still be copied.
@@ -71,10 +73,10 @@ fn vanished_source_exits_with_vanished_code_and_copies_remaining() {
     );
 }
 
-// FFV-5 (single file variant): When the sole source file vanishes,
-// the error should still be RERR_VANISHED (24).
+// FFV-5 (single file variant): When the sole source file is missing at scan
+// time, upstream exits 23 (RERR_PARTIAL) via the failed link_stat, not 24.
 #[test]
-fn sole_vanished_source_exits_with_vanished_code() {
+fn sole_missing_source_exits_with_partial_code() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source");
@@ -93,8 +95,9 @@ fn sole_vanished_source_exits_with_vanished_code() {
 
     fs::remove_file(&source_file).expect("delete source");
 
-    let err = plan.execute().expect_err("vanished source should fail");
-    assert_eq!(err.exit_code(), 24, "sole vanished file: expected 24");
+    let err = plan.execute().expect_err("missing source should fail");
+    assert_eq!(err.exit_code(), 23, "sole missing source: expected 23");
+    assert!(err.is_link_stat_failed());
 }
 
 // FFV-6: --ignore-missing-args suppresses warning and exits 0.


### PR DESCRIPTION
## Problem

A missing local source — a command-line operand **or** a `--files-from` entry that fails its initial `link_stat` — exits 24 (`RERR_VANISHED`) with `file has vanished`. Verified against upstream rsync 3.4.3, **both** cases exit **23** (`RERR_PARTIAL`) with `link_stat "%s" failed: %s`, and the transfer **continues** with the remaining sources:

```
$ rsync a /nonexistent b dst/ ; echo $?
rsync: [sender] link_stat "/nonexistent" failed: No such file or directory (2)
23                       # a and b still copied
```

Exit 24 is reserved for a file that vanishes **mid-transfer**, after it was already in the file list (the mid-recursion path), which is unchanged.

## Why the earlier attempt (#6131) failed

#6131 changed the exit code but routed the new error to the *fatal* branch, so a missing `--files-from` entry aborted the transfer instead of skipping — breaking `run_interop.sh:test_file_vanished` and the `files_from_vanished` tests. This version fixes the control flow too.

## Fix

- New `LocalCopyErrorKind::LinkStatFailed` (exit 23, `link_stat "%s" failed` message, `[sender]` role) + `is_link_stat_failed()` predicate.
- `copy_sources` now treats it as **skip-and-continue** (record the error, print the link_stat line, keep transferring), mirroring upstream's `IOERR_GENERAL` accumulation — not a fatal abort.
- The shared `io_error` NotFound→Vanished mapping and the mid-recursion vanish path are untouched, so genuine mid-transfer vanishes still exit 24.

## Tests

- `engine`: `link_stat_failed_is_partial_and_continues`; FFV-4/FFV-5 corrected to 23/link_stat/continue (they encoded the old 24 behaviour).
- `core`: `map_link_stat_failed_uses_partial_not_vanished`.
- `cli`: `error_recovery` ×2 corrected to 23/link_stat; `single_*` tightened to `==23`.
- Lenient tests (`23||24`) and the `ExitCode::Vanished`==24 enum tests stay valid.

Built + clippy `--all-targets` clean (engine, core, cli). Closes the divergence in #473.