### PR TITLE
fix(output): emit upstream "<name> exists" for --ignore-existing skips

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -652,11 +652,10 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
 
         match kind {
             ClientEventKind::SkippedExisting => {
-                writeln!(
-                    stdout,
-                    "skipping existing file \"{}\"",
-                    event.relative_path().display()
-                )?;
+                // upstream: generator.c:1409 - `rprintf(FINFO, "%s exists\n",
+                // fname)` for an --ignore-existing skip: the bare relative name
+                // followed by " exists", no descriptor and no quotes.
+                writeln!(stdout, "{} exists", event.relative_path().display())?;
                 continue;
             }
             ClientEventKind::SkippedMissingDestination => {

--- a/crates/cli/src/frontend/tests/transfer_request_with_ignore.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_ignore.rs
@@ -28,6 +28,49 @@ fn transfer_request_with_ignore_existing_leaves_destination_unchanged() {
 }
 
 #[test]
+fn ignore_existing_verbose_reports_exists_in_upstream_format() {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src");
+    let dst_dir = tmp.path().join("dst");
+    std::fs::create_dir(&src_dir).expect("create src");
+    std::fs::create_dir(&dst_dir).expect("create dst");
+    std::fs::write(src_dir.join("keep.txt"), b"updated").expect("write src");
+    std::fs::write(dst_dir.join("keep.txt"), b"original").expect("write dst");
+
+    let (code, stdout, _stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-rvv"),
+        OsString::from("--ignore-existing"),
+        {
+            let mut p = src_dir.into_os_string();
+            p.push("/");
+            p
+        },
+        dst_dir.clone().into_os_string(),
+    ]);
+    let out = String::from_utf8_lossy(&stdout);
+
+    assert_eq!(code, 0, "transfer should succeed: {out}");
+    // upstream: generator.c:1409 - `rprintf(FINFO, "%s exists\n", fname)`.
+    assert!(
+        out.lines().any(|l| l == "keep.txt exists"),
+        "expected upstream `keep.txt exists` line: {out}"
+    );
+    // The oc-invented `skipping existing file "..."` wording must be gone.
+    assert!(
+        !out.contains("skipping existing file"),
+        "must not emit the non-upstream `skipping existing file` wording: {out}"
+    );
+    assert_eq!(
+        std::fs::read(dst_dir.join("keep.txt")).expect("read dst"),
+        b"original",
+        "ignored-existing file must keep its original content"
+    );
+}
+
+#[test]
 fn transfer_request_with_ignore_missing_args_skips_missing_sources() {
     use tempfile::tempdir;
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -190,6 +190,15 @@ impl ReceiverContext {
             let entry = &self.file_list[idx];
             if let Some(ref meta) = dest_meta {
                 if ignore_existing {
+                    // upstream: generator.c:1409 - `if (ignore_existing > 0 &&
+                    // statret == 0 && (!is_dir || stype != FT_DIR)) { if
+                    // (INFO_GTE(SKIP, 1) ...) rprintf(FINFO, "%s exists\n",
+                    // fname); }`. An already-present file is skipped with a
+                    // SKIP-gated notice; existing directories stay silent.
+                    if !entry.is_dir() && logging::info_gte(logging::InfoFlag::Skip, 1) {
+                        let name = entry.path().to_string_lossy();
+                        let _ = self.emit_info_line(writer, &format!("{name} exists\n"));
+                    }
                     continue;
                 }
                 if update_only && dest_mtime_newer(meta, entry) {


### PR DESCRIPTION
## Problem

An `--ignore-existing` skip diverged from upstream on both output paths:
- **local-copy** emitted the oc-invented `skipping existing file "X"`;
- **protocol-receiver** was silent.

Upstream rsync prints the bare relative name followed by ` exists` (`generator.c:1409`, `rprintf(FINFO, "%s exists\n", fname)`), gated on `INFO_GTE(SKIP, 1)`.

## Fix

Both paths now emit `<name> exists`:
- **receiver** (`candidates.rs`): a `SKIP`-gated info line, mirroring the adjacent `is newer` (`--update`) skip, and silent for an existing *directory* per upstream's `!is_dir || stype != FT_DIR` guard.
- **local copy** (`render.rs`): the `SkippedExisting` verbose row prints `<name> exists` instead of the invented `skipping existing file`.

## Verification

Against the built binary:
```
$ oc-rsync -rvv --ignore-existing src/ dst/
sending incremental file list
keep.txt exists
```
Default verbosity stays silent (existing test holds). New CLI test `ignore_existing_verbose_reports_exists_in_upstream_format` asserts the `keep.txt exists` line, the absence of `skipping existing file`, and that the file keeps its original content. Built + clippy `--all-targets` clean (transfer, cli).

> Note: a *separate*, pre-existing gating divergence remains for the whole skip-event family (oc emits at `-v`; upstream gates on `-vv`/`--info=skip`). Out of scope here — this PR only corrects the message wording.