### PR TITLE
fix(platform): infer time_t to avoid musl deprecation

### DIFF
--- a/crates/platform/src/local_time.rs
+++ b/crates/platform/src/local_time.rs
@@ -19,7 +19,12 @@
 #[allow(unsafe_code)]
 #[must_use]
 pub fn local_utc_offset_seconds(unix_secs: i64) -> i32 {
-    let t = unix_secs as libc::time_t;
+    // The target type is inferred from `localtime_r`'s `*const time_t`
+    // parameter below. Naming `libc::time_t` directly would trip the
+    // deprecation the libc crate attaches to that alias on musl (pending its
+    // 1.2.0 64-bit transition); inferring it keeps the correct per-target
+    // width (i32 or i64) without referencing the deprecated path.
+    let t = unix_secs as _;
     let mut tm: libc::tm = unsafe { std::mem::zeroed() };
     // SAFETY: `localtime_r` is POSIX-thread-safe; it writes the broken-down
     // local time into the caller-owned `tm` and returns its address (or NULL


### PR DESCRIPTION
## Problem

The **Linux musl** CI cell fails on master (deny-warnings): `error: use of deprecated type alias \`libc::time_t\` … could not compile \`platform\``. Introduced by the per-instant `localtime_r` local-time helper, which named `unix_secs as libc::time_t`. This blocks the musl cell on master and every open PR.

## Native safe fix (no lint suppression)

The deprecation fires only when the path `libc::time_t` is **named**. `localtime_r` takes a `*const time_t`, so the cast target is inferred from that FFI parameter — `let t = unix_secs as _;`. The correct per-target width (i32/i64) is still produced, the deprecated alias is never referenced, and **no `#[allow(deprecated)]` is used**.

`rustix` is not an option: it explicitly lists `localtime_r` as not-implemented (it is a libc timezone routine reading `/etc/localtime`, not a syscall).

## Verification

- `platform` builds clean for `aarch64-unknown-linux-musl` (no deprecation, no warnings).
- Host `cargo clippy --all-targets -D warnings` clean (no `unnecessary_cast`).