### PR TITLE
fix(stats): comma-group the file counts in --stats like upstream

### DIFF
--- a/crates/cli/src/frontend/progress/format/progress.rs
+++ b/crates/cli/src/frontend/progress/format/progress.rs
@@ -26,10 +26,12 @@ pub(crate) fn format_progress_elapsed(elapsed: Duration) -> String {
 }
 
 pub(crate) fn format_stat_categories(categories: &[(&str, u64)]) -> String {
+    // upstream: main.c output_summary() comma_num()s each breakdown sub-count
+    // too, e.g. `(reg: 1,500, dir: 1)`.
     let parts: Vec<String> = categories
         .iter()
         .filter(|(_, count)| *count > 0)
-        .map(|(label, count)| format!("{label}: {count}"))
+        .map(|(label, count)| format!("{label}: {}", super::size::format_decimal_bytes(*count)))
         .collect();
     if parts.is_empty() {
         String::new()
@@ -106,5 +108,12 @@ mod tests {
             format_stat_categories(categories),
             " (files: 5, symlinks: 3)"
         );
+    }
+
+    #[test]
+    fn format_stat_categories_groups_thousands_like_upstream() {
+        // upstream comma_num()s each sub-count: `(reg: 1,500, dir: 1)`.
+        let categories: &[(&str, u64)] = &[("reg", 1500), ("dir", 1)];
+        assert_eq!(format_stat_categories(categories), " (reg: 1,500, dir: 1)");
     }
 }

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -23,10 +23,10 @@ fn display_without_trailing_separators(path: &Path) -> String {
 }
 
 use super::format::{
-    LIST_SIZE_WIDTH, event_matches_name_level, format_list_permissions, format_list_size,
-    format_list_timestamp, format_progress_bytes, format_progress_elapsed, format_progress_percent,
-    format_progress_rate, format_size, format_stat_categories, format_summary_rate,
-    is_progress_event, list_only_event,
+    LIST_SIZE_WIDTH, event_matches_name_level, format_decimal_bytes, format_list_permissions,
+    format_list_size, format_list_timestamp, format_progress_bytes, format_progress_elapsed,
+    format_progress_percent, format_progress_rate, format_size, format_stat_categories,
+    format_summary_rate, is_progress_event, list_only_event,
 };
 use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
@@ -413,13 +413,31 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     let bytes_sent_display = format_size(bytes_sent, human_readable);
     let bytes_received_display = format_size(bytes_received, human_readable);
 
-    writeln!(stdout, "Number of files: {total_entries}{files_breakdown}")?;
+    // upstream: main.c output_summary() - every count is wrapped in
+    // comma_num(), e.g. `rprintf(FINFO, "Number of files: %s%s\n",
+    // comma_num(stats.num_files), ...)`. comma_num inserts thousands
+    // separators unconditionally (independent of -h), so a count >= 1000
+    // renders as `1,500`, not `1500`.
     writeln!(
         stdout,
-        "Number of created files: {created_total}{created_breakdown}"
+        "Number of files: {}{files_breakdown}",
+        format_decimal_bytes(total_entries)
     )?;
-    writeln!(stdout, "Number of deleted files: {deleted}")?;
-    writeln!(stdout, "Number of regular files transferred: {files}")?;
+    writeln!(
+        stdout,
+        "Number of created files: {}{created_breakdown}",
+        format_decimal_bytes(created_total)
+    )?;
+    writeln!(
+        stdout,
+        "Number of deleted files: {}",
+        format_decimal_bytes(deleted)
+    )?;
+    writeln!(
+        stdout,
+        "Number of regular files transferred: {}",
+        format_decimal_bytes(files)
+    )?;
     writeln!(stdout, "Total file size: {total_size_display} bytes")?;
     writeln!(
         stdout,


### PR DESCRIPTION
Upstream wraps every `--stats` count in `comma_num()` — the four `Number of files/created/deleted/regular files transferred` lines and each `(reg/dir/link/special)` breakdown sub-count — so a count ≥ 1000 renders with thousands separators (`1,500`), independent of `-h`. oc printed them as bare integers (`1500`).

Route the count lines and `format_stat_categories` through the existing decimal grouping helper (the same one the byte lines already use — upstream likewise uses one `comma_num` for both). Byte lines were already grouped.

**Verified against the binary** — `-a --stats` over 1500 files:
```
Number of files: 1,501 (reg: 1,500, dir: 1)
Number of created files: 1,500 (reg: 1,500)
Number of deleted files: 0
Number of regular files transferred: 1,500
```
matching upstream 3.4.4 byte-for-byte. Added a `format_stat_categories` grouping test; built + clippy `--all-targets` clean.