### PR TITLE
fix(progress): do not re-list file names under --progress

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -138,12 +138,18 @@ pub(crate) fn emit_transfer_summary(
     };
 
     let name_enabled = !matches!(name_level, NameOutputLevel::Disabled);
+    // upstream: with --progress each name is printed exactly once, inline
+    // before its progress line (progress.c / rprintf name1 path). When the
+    // per-file progress block already rendered the names, suppress the verbose
+    // name listing so `--progress` (info=name1, verbosity 0) does not re-print
+    // the whole list - mirroring the `!progress_rendered` guard already applied
+    // to the verbosity>0 branch above.
     let emit_verbose_listing = out_format.is_none()
         && !events.is_empty()
         && ((verbosity > 0
             && (!name_overridden || name_enabled)
             && (!progress_rendered || verbosity > 1))
-            || (verbosity == 0 && name_enabled));
+            || (verbosity == 0 && name_enabled && !progress_rendered));
 
     if formatted_rendered && (emit_verbose_listing || stats_on || verbosity > 0) {
         writeln!(writer)?;

--- a/crates/cli/src/frontend/tests/progress.rs
+++ b/crates/cli/src/frontend/tests/progress.rs
@@ -31,6 +31,40 @@ fn progress_transfer_renders_progress_lines() {
 }
 
 #[test]
+fn progress_does_not_relist_names() {
+    // upstream prints each name exactly once, inline before its progress line.
+    // `--progress` (info=name1, verbosity 0) must NOT re-emit the whole name
+    // listing after the per-file progress block.
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).expect("mkdir src");
+    std::fs::write(src.join("alpha.txt"), b"a").expect("write alpha");
+    std::fs::write(src.join("bravo.txt"), b"b").expect("write bravo");
+
+    let mut src_arg = src.into_os_string();
+    src_arg.push("/");
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("-a"),
+        OsString::from("--progress"),
+        src_arg,
+        dst.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0, "{}", String::from_utf8_lossy(&stderr));
+    let out = String::from_utf8(stdout).expect("progress output is UTF-8");
+    assert_eq!(
+        out.matches("alpha.txt").count(),
+        1,
+        "each name must be printed once, not re-listed:\n{out}"
+    );
+    assert_eq!(out.matches("bravo.txt").count(), 1, "{out}");
+}
+
+#[test]
 fn progress_human_readable_formats_sizes() {
     use tempfile::tempdir;
 


### PR DESCRIPTION
With `--progress` (info=name1, verbosity 0) the per-file progress block already prints each name inline before its progress line, but the verbose name listing then re-emitted the entire list — every name appeared **twice**, plus a spurious blank separator. Upstream prints each name exactly once.

The `verbosity > 0` branch of the `emit_verbose_listing` gate already carries a `!progress_rendered` guard; the `verbosity == 0 && name_enabled` branch was missing it.

**Verified on the binary:** `-a --progress` over two files now prints each name once (was twice); `-av --progress` unchanged. Added a regression test asserting each name appears once; clippy `--all-targets` clean.