### PR TITLE
fix(progress): normalize path separators to / on Windows

### DIFF
--- a/crates/cli/src/frontend/progress/live.rs
+++ b/crates/cli/src/frontend/progress/live.rs
@@ -210,7 +210,13 @@ impl<'a> ClientProgressObserver for LiveProgress<'a> {
                         writeln!(self.writer)?;
                         self.line_active = false;
                     }
-                    writeln!(self.writer, "{}", relative.display())?;
+                    // upstream: flist.c f_name() emits POSIX forward-slash
+                    // separators regardless of host OS. Normalize Windows
+                    // native backslashes at the rendering boundary.
+                    let name = relative.display().to_string();
+                    #[cfg(windows)]
+                    let name = name.replace('\\', "/");
+                    writeln!(self.writer, "{name}")?;
                     self.active_path = Some(relative.to_path_buf());
                 }
 

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -289,7 +289,12 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
         xfr_index += 1;
         let remaining = transferred_total - xfr_index;
 
-        writeln!(stdout, "{}", event.relative_path().display())?;
+        // upstream: flist.c f_name() emits POSIX forward-slash separators
+        // regardless of host OS. Normalize Windows native backslashes here.
+        let name = event.relative_path().display().to_string();
+        #[cfg(windows)]
+        let name = name.replace('\\', "/");
+        writeln!(stdout, "{name}")?;
 
         let bytes = event.bytes_transferred();
         // Field widths mirror upstream rsync's `rprint_progress` format string


### PR DESCRIPTION
## Summary
The two `--progress` per-file render sites (`progress/live.rs`, `progress/render.rs`) print `relative_path().display()`, which emits the **native backslash** separator on Windows (e.g. `sub\f.txt`). Upstream rsync always displays POSIX forward slashes regardless of host OS; itemize (`render_path`) and verbose-listing (`verbose_listing_name`) already normalize at the render boundary, but these two progress sites did not.

## Fix
Apply the same `#[cfg(windows)]` `\\` -> `/` normalization to both progress name lines.

## Impact
Fixes the Windows failure in `cli ... progress_implies_name_shows_directory_names` (the asserted `sub/` is the file path's parent component, which renders with a backslash on Windows) and the underlying output-fidelity bug. Required Windows check unblocks for master.

Verified: `cargo fmt` + `cargo clippy -p cli -- -D warnings` clean.