### PR TITLE
docs: scrub native daemon-tls references after feature removal

### DIFF
--- a/.github/RELEASE_NOTES_BETA.md
+++ b/.github/RELEASE_NOTES_BETA.md
@@ -475,8 +475,7 @@ chasing down `README.md` and individual closure docs.
   compression is not detected (audit #4674). Pick one layer.
 - **Daemon TLS.** Native TLS is not built into the daemon. Deploy
   `oc-rsync --daemon` behind `stunnel`, `ssh -L`, or a reverse proxy
-  that terminates TLS. See `docs/deployment/daemon-tls.md` and
-  `SECURITY.md`.
+  that terminates TLS. See `SECURITY.md`.
 - **`.rsync-filter` per-directory inheritance.** Matches upstream for
   the common cases tested in the interop suite; exhaustive parity
   against upstream's filter-tree corner cases (deeply nested merges,

--- a/.github/workflows/windows-nightly-daemon.yml
+++ b/.github/workflows/windows-nightly-daemon.yml
@@ -16,7 +16,7 @@
 #     for the daemon's Windows-service runtime-options path.
 #
 # Cross-OS feature rows in _test-features.yml (async, tracing,
-# concurrent-sessions, daemon-tls, iconv) compile -p daemon on
+# concurrent-sessions, iconv) compile -p daemon on
 # windows-latest but execute only the subset of tests enabled by the
 # named feature flag. The two default-features `#[cfg(windows)]` tests
 # above do not run under any required cell.
@@ -85,7 +85,7 @@ jobs:
       # Build the daemon crate first so the nextest step links against
       # an already-warm build artifact. Default features only; cross-OS
       # feature rows in _test-features.yml already cover async,
-      # tracing, concurrent-sessions, daemon-tls, and iconv variants.
+      # tracing, concurrent-sessions, and iconv variants.
       - name: Build daemon crate
         run: cargo build --locked -p daemon
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All transfer modes (local, SSH, daemon), delta algorithm, metadata preservation,
 | **Checksums** | MD4, MD5, XXH3/XXH128 with SIMD (AVX2, SSE2, NEON) |
 | **Incremental recursion** | Pull and push directions, enabled by default |
 | **Batch** | `--write-batch` / `--read-batch` roundtrip |
-| **Daemon** | Negotiation, auth, modules, chroot, syslog, pre/post-xfer exec, native TLS (rustls) |
+| **Daemon** | Negotiation, auth, modules, chroot, syslog, pre/post-xfer exec |
 | **Filtering** | `--filter`, `--exclude`, `--include`, `.rsync-filter`, `--files-from` |
 | **Reference dirs** | `--compare-dest`, `--link-dest`, `--copy-dest` |
 | **Options** | `--delay-updates`, `--inplace`, `--partial`, `--iconv`, fuzzy matching |

--- a/docs/architecture/dependency-map.md
+++ b/docs/architecture/dependency-map.md
@@ -184,11 +184,6 @@ bin[iocp] -> transfer/iocp -> fast_io/iocp
 bin[iocp] -> fast_io/iocp
 ```
 
-### daemon-tls (native TLS termination)
-```
-bin[daemon-tls] -> daemon/daemon-tls (dep:rustls, dep:rustls-pemfile)
-```
-
 ### client-tls (TLS for rsync:// connections)
 ```
 bin[client-tls] -> core/client-tls (dep:rustls, dep:rustls-pemfile, dep:webpki-roots)

--- a/docs/architecture/walkthrough.md
+++ b/docs/architecture/walkthrough.md
@@ -324,7 +324,7 @@ Start with `crates/transfer/src/lib.rs` for the overview, then:
 - Daemon entry: `crates/daemon/src/`
 - Config parsing (`oc-rsyncd.conf`): `crates/daemon/src/daemon/`
 - Authentication: `crates/core/src/auth/` and daemon auth module
-- TLS termination: behind `daemon-tls` feature flag
+- TLS termination: external (stunnel / reverse proxy); see `SECURITY.md`
 
 ### "I want to add platform-specific I/O optimizations"
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -241,8 +241,7 @@ The daemon manifest pairs the rootless `securityContext` with
 `--no-io-uring-sqpoll` so the io_uring fast path stays active without
 requesting `CAP_SYS_NICE`. Add a `NetworkPolicy` to restrict ingress to
 the client CIDR; external rsync over TLS belongs behind an stunnel
-sidecar (see [`daemon-tls.md`](daemon-tls.md) for native TLS or the
-external-terminator recipes).
+sidecar or another external TLS terminator.
 
 ## 5. Pod Security Standards / Pod Security Admission
 

--- a/docs/oc-rsync.1.md
+++ b/docs/oc-rsync.1.md
@@ -947,26 +947,6 @@ NEON) are used where available, with automatic scalar fallbacks.
     *oc-rsyncd.conf*). Releases prior to **v0.6.2** have no admission cap
     and accept connections until the operating system runs out of resources.
 
-**--ssl-cert**=*FILE*
-:   Path to the PEM-encoded server certificate chain for the daemon's TLS
-    acceptor. The file must contain the server certificate followed by any
-    intermediate certificates (leaf-first). Overrides the **ssl cert**
-    directive in the daemon configuration file. Requires the **daemon-tls**
-    feature at build time.
-
-**--ssl-key**=*FILE*
-:   Path to the PEM-encoded private key for the daemon's TLS acceptor.
-    Accepts PKCS#8, PKCS#1 (RSA), and SEC1 (EC) key formats. Overrides the
-    **ssl key** directive in the daemon configuration file. Requires the
-    **daemon-tls** feature at build time.
-
-**--ssl-ca**=*FILE*
-:   Path to a PEM-encoded CA bundle for client certificate verification
-    (mutual TLS). When set, the daemon requires connecting clients to present
-    a valid certificate signed by one of the listed CAs. Overrides the
-    **ssl ca** directive in the daemon configuration file. Requires the
-    **daemon-tls** feature at build time.
-
 **--max-sessions**=*N*
 :   Cap the total number of sessions the daemon will serve before exiting.
     *N* must be a positive integer. After serving *N* sessions the daemon
@@ -1198,9 +1178,7 @@ and are not intended for direct use:
 
 **/etc/oc-rsyncd/oc-rsyncd.conf**
 :   Default daemon configuration file. Specifies modules, access control,
-    authentication, and other daemon parameters. When built with the
-    **daemon-tls** feature, the global directives **ssl cert**, **ssl key**,
-    and **ssl ca** configure native TLS termination.
+    authentication, and other daemon parameters.
 
 **oc-rsyncd.secrets**
 :   Daemon password file, referenced by the **secrets file** directive in
@@ -1270,25 +1248,19 @@ child, but it does not parse **~/.ssh/config** or **/etc/ssh/ssh_config**, so a
 **Compression yes** directive set there is invisible to the warning. If
 throughput looks CPU-bound on an SSH transfer, check those files as well.
 
-## Native TLS for daemon connections
+## TLS for daemon connections
 
-When built with the **daemon-tls** feature, the daemon accepts TLS connections
-directly via the **ssl cert**, **ssl key**, and optionally **ssl ca** directives
-in **oc-rsyncd.conf**. When **ssl cert** and **ssl key** are both configured,
-the daemon listens on port 874 (TLS) in addition to port 873 (cleartext).
+The daemon protocol is plaintext, matching upstream rsync: the daemon provides
+authentication (**auth users**) but not encryption. To encrypt daemon traffic,
+place the daemon behind an SSL proxy (**stunnel**, **HAProxy**, or **nginx**)
+that terminates TLS, binding the daemon to localhost so only the proxy reaches
+it - the same model as upstream **rsync-ssl**.
 
-When built with the **client-tls** feature, the **--ssl** flag connects to
-TLS-enabled daemons without external tooling. Default certificate verification
-uses the Mozilla root CA bundle; override with **--ssl-ca-cert**.
-
-Both features use rustls (pure Rust, no OpenSSL linking). Only TLS 1.2 and
-TLS 1.3 are supported. The TLS layer is transparent to the rsync wire protocol
-- daemon authentication (**auth users**), module access controls, and filter
-rules all function identically over TLS and cleartext.
-
-External TLS wrapping via **stunnel**, **HAProxy**, or **nginx** continues to
-work with any build. See **docs/user/daemon-tls-wrapping.md** for setup details
-covering both approaches.
+When built with the **client-tls** feature, the **--ssl** flag connects to such
+an SSL-proxied daemon without external client tooling. Default certificate
+verification uses the Mozilla root CA bundle; override with **--ssl-ca-cert**.
+client-tls uses rustls (pure Rust, no OpenSSL linking) and supports TLS 1.2 and
+TLS 1.3.
 
 ## SSH stderr socketpair channel
 


### PR DESCRIPTION
Follow-up to the daemon-tls feature removal (#6139). The daemon protocol is plaintext (matching upstream rsync); TLS is delegated to an external proxy (stunnel / reverse proxy) or the client-tls `rsync-ssl` connector. These docs still advertised a native daemon TLS acceptor that no longer exists, and two of them linked a deleted deployment guide.

## Changes

- **`docs/oc-rsync.1.md`**: drop the `--ssl-cert` / `--ssl-key` / `--ssl-ca` daemon flag entries and the "ssl cert/key/ca" config note; retitle the daemon-TLS section to describe the plaintext + external-proxy model (keeps the client `--ssl` / `--ssl-ca-cert` description).
- **`docs/architecture/dependency-map.md`**: remove the dead `daemon-tls` feature edge.
- **`docs/architecture/walkthrough.md`**: TLS termination is external now, not a feature flag.
- **`docs/deployment/kubernetes.md`**, **`.github/RELEASE_NOTES_BETA.md`**: drop dead links to the deleted `daemon-tls.md` guide.
- **`.github/workflows/windows-nightly-daemon.yml`**: drop `daemon-tls` from the feature-row comments (it was comment text only, never a `--features` flag, so no CI behavior changes).
- **`README.md`**: the daemon feature row no longer advertises native TLS.

## Verification

- `grep` sweep confirms no remaining user-facing `daemon-tls` / native-TLS references or dead `daemon-tls.md` links outside historical `docs/design/` research notes.
- The `RELEASE_NOTES_BETA.md` "Daemon TLS" entry and `feature_matrix.md` client-TLS row are kept verbatim — they already correctly state the daemon has no native TLS acceptor.
- Docs-only + CI-comment-only change; no code, no `--features` wiring touched.