### PR TITLE
feat(core): apply TCP_NOTSENT_LOWAT on the client-TLS connection

### DIFF
--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -132,6 +132,14 @@ pub(super) fn open_daemon_stream_tls(
         )?,
     };
 
+    // Apply the NOTSENT_LOWAT send-buffer watermark on the raw TCP socket
+    // before wrapping it in TLS. The plain-TCP path sets this via
+    // apply_client_tcp_perf_options, but the TLS path bypassed it. rustls
+    // operates on the same fd transparently, so the kernel hint still governs
+    // the encrypted byte stream. Best-effort: a failure or an unsupported
+    // platform is a silent no-op (NBUF-3).
+    let _ = fast_io::set_tcp_notsent_lowat(&stream, fast_io::DEFAULT_TCP_NOTSENT_LOWAT);
+
     let tls_stream = connector
         .wrap(stream, addr.host())
         .map_err(|e| socket_error("TLS handshake with", addr.socket_addr_display(), e))?;

--- a/crates/core/src/client/module_list/connect/tls.rs
+++ b/crates/core/src/client/module_list/connect/tls.rs
@@ -258,6 +258,24 @@ mod tests {
     }
 
     #[test]
+    fn notsent_lowat_applies_to_pre_tls_stream() {
+        // NBUF-3: the raw TCP fd about to be wrapped in TLS must accept the
+        // NOTSENT_LOWAT watermark the plain path also sets, so the encrypted
+        // stream gets the same send-buffer flow control. This mirrors the
+        // pre-wrap operation open_daemon_stream_tls performs.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let stream = TcpStream::connect(addr).unwrap();
+        let (_server, _) = listener.accept().unwrap();
+
+        match fast_io::set_tcp_notsent_lowat(&stream, fast_io::DEFAULT_TCP_NOTSENT_LOWAT) {
+            Ok(true) => assert!(fast_io::tcp_notsent_lowat_supported()),
+            Ok(false) => assert!(!fast_io::tcp_notsent_lowat_supported()),
+            Err(error) => panic!("unexpected error applying NOTSENT_LOWAT pre-TLS: {error}"),
+        }
+    }
+
+    #[test]
     fn build_root_store_with_default_mozilla_roots() {
         let store = build_root_store(None).unwrap();
         // The Mozilla root bundle has > 100 CAs


### PR DESCRIPTION
The plain-TCP client path sets the `TCP_NOTSENT_LOWAT` send-buffer watermark via `apply_client_tcp_perf_options`, but the **client-TLS** path (`rsync-ssl`, `--ssl`) bypassed it: the raw `TcpStream` is moved into rustls in `open_daemon_stream_tls` before any perf hint is applied (NBUF-3).

## Change

Apply `fast_io::set_tcp_notsent_lowat(&stream, DEFAULT_TCP_NOTSENT_LOWAT)` on the bare `TcpStream` just before the rustls wrap. rustls operates on the same fd transparently, so the kernel watermark still governs the encrypted byte stream — matching the plain-TCP path and the daemon listener.

## Safety / scope

- **Best-effort, no behaviour change to the connect path:** the result is ignored (`let _ =`); a failure or an unsupported platform is a silent no-op, exactly like the existing daemon-side and plain-client applications of this helper.
- Uses the pre-existing `set_tcp_notsent_lowat` helper (no new fast_io surface); independent of any other in-flight PR.

## Verification

- `cargo clippy -p core --features client-tls --all-targets` clean; `cargo fmt --check` clean (local macOS).
- New unit test `notsent_lowat_applies_to_pre_tls_stream` in `connect/tls.rs` mirrors the pre-wrap operation on a loopback stream and asserts the helper's `Ok(true)`/`Ok(false)` result agrees with `tcp_notsent_lowat_supported()`. Runs in the Linux `nextest (stable)` cell (client-tls feature).