### PR TITLE
chore(fast_io): remove orphaned set_tcp_congestion helper

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -338,9 +338,8 @@ pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::{
     DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, enable_tcp_fastopen_listener,
     enable_tcp_fastopen_raw, rearm_tcp_quickack, reuse_port_supported, set_listener_int_option,
-    set_so_max_pacing_rate, set_socket_int_option, set_tcp_congestion, set_tcp_cork,
-    set_tcp_notsent_lowat, set_tcp_quickack, so_max_pacing_rate_supported,
-    tcp_available_congestion_control, tcp_congestion_supported, tcp_cork_supported,
+    set_so_max_pacing_rate, set_socket_int_option, set_tcp_cork, set_tcp_notsent_lowat,
+    set_tcp_quickack, so_max_pacing_rate_supported, tcp_cork_supported,
     tcp_fastopen_listener_supported, tcp_notsent_lowat_supported, tcp_quickack_supported,
 };
 #[cfg(target_os = "linux")]

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -332,62 +332,6 @@ pub const fn tcp_cork_supported() -> bool {
     ))
 }
 
-/// Selects the TCP congestion-control algorithm for a connected stream
-/// (`TCP_CONGESTION`).
-///
-/// `algorithm` is a kernel CC name such as `"bbr"`, `"cubic"`, or `"reno"`;
-/// the value must appear in [`tcp_available_congestion_control`] or the
-/// kernel rejects it. Unlike the other helpers here, `TCP_CONGESTION` takes a
-/// string option value, not an `int`. On platforms without `TCP_CONGESTION`
-/// the call is a no-op and returns `Ok(false)`.
-///
-/// upstream: not implemented; an oc-rsync-specific perf hint that is
-/// wire-compatible with upstream rsync.
-pub fn set_tcp_congestion(stream: &TcpStream, algorithm: &str) -> io::Result<bool> {
-    #[cfg(target_os = "linux")]
-    {
-        use std::os::fd::AsRawFd;
-        setsockopt_bytes_raw(
-            stream.as_raw_fd(),
-            libc::IPPROTO_TCP,
-            libc::TCP_CONGESTION,
-            algorithm.as_bytes(),
-        )?;
-        Ok(true)
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (stream, algorithm);
-        Ok(false)
-    }
-}
-
-/// Returns the kernel's list of available TCP congestion-control algorithms.
-///
-/// Reads `/proc/sys/net/ipv4/tcp_available_congestion_control` on Linux (a
-/// space-separated list such as `reno cubic bbr`). Returns an empty vector on
-/// non-Linux platforms or if the sysctl is unreadable, so callers can fall
-/// back without distinguishing "unsupported" from "unavailable".
-#[must_use]
-pub fn tcp_available_congestion_control() -> Vec<String> {
-    #[cfg(target_os = "linux")]
-    {
-        std::fs::read_to_string("/proc/sys/net/ipv4/tcp_available_congestion_control")
-            .map(|list| list.split_whitespace().map(str::to_owned).collect())
-            .unwrap_or_default()
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        Vec::new()
-    }
-}
-
-/// Returns `true` when the running platform supports setting `TCP_CONGESTION`.
-#[must_use]
-pub const fn tcp_congestion_supported() -> bool {
-    cfg!(target_os = "linux")
-}
-
 /// Returns `true` when the running platform implements `SO_REUSEPORT`.
 ///
 /// `SO_REUSEPORT` lets multiple listener sockets bind the same address and
@@ -439,40 +383,6 @@ fn setsockopt_int_raw(raw_fd: libc::c_int, level: i32, option: i32, value: i32) 
             option,
             std::ptr::from_ref(&value).cast::<libc::c_void>(),
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        )
-    };
-
-    if ret == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
-
-// Sets a byte-string socket option (e.g. `TCP_CONGESTION`, which takes a CC
-// algorithm name rather than an `int`). Linux-only: the sole caller
-// `set_tcp_congestion` is gated to Linux, so guarding this here avoids an
-// unused-function warning on other platforms.
-#[cfg(target_os = "linux")]
-#[allow(unsafe_code)]
-fn setsockopt_bytes_raw(
-    raw_fd: libc::c_int,
-    level: i32,
-    option: i32,
-    value: &[u8],
-) -> io::Result<()> {
-    // SAFETY: `raw_fd` is a valid file descriptor borrowed from a live
-    // `TcpStream` for the duration of this synchronous call. `value` is a
-    // byte slice that outlives the syscall; `setsockopt` only reads
-    // `value.len()` bytes from `optval` and performs no aliasing or
-    // allocation.
-    let ret = unsafe {
-        libc::setsockopt(
-            raw_fd,
-            level,
-            option,
-            value.as_ptr().cast::<libc::c_void>(),
-            value.len() as libc::socklen_t,
         )
     };
 
@@ -702,40 +612,6 @@ mod tests {
 
         drop(stream);
         handle.join().expect("accept thread completes");
-    }
-
-    #[test]
-    fn set_tcp_congestion_returns_supported_flag() {
-        let (stream, handle) = connected_stream();
-
-        // Use an algorithm the kernel reports as available so the set cannot
-        // fail with ENOENT; "reno" is always built in on Linux. On non-Linux
-        // the call is a no-op regardless of the name.
-        let available = tcp_available_congestion_control();
-        let algorithm = available.first().map_or("reno", String::as_str);
-
-        match set_tcp_congestion(&stream, algorithm) {
-            Ok(true) => assert!(tcp_congestion_supported()),
-            Ok(false) => assert!(!tcp_congestion_supported()),
-            Err(error) => panic!("unexpected error from TCP_CONGESTION ({algorithm}): {error}"),
-        }
-
-        drop(stream);
-        handle.join().expect("accept thread completes");
-    }
-
-    #[test]
-    fn tcp_available_congestion_control_matches_platform() {
-        let available = tcp_available_congestion_control();
-
-        if !tcp_congestion_supported() {
-            assert!(
-                available.is_empty(),
-                "non-Linux platforms must report no congestion-control algorithms"
-            );
-        }
-        // Entries read from /proc are always non-empty names.
-        assert!(available.iter().all(|algorithm| !algorithm.is_empty()));
     }
 
     #[test]


### PR DESCRIPTION
`set_tcp_congestion` / `tcp_available_congestion_control` (added in #6141) have **no production consumer**. Their only intended caller was a `--congestion=<algo>` CLI flag — an oc-specific extension with no upstream rsync equivalent, which diverges from the project's CLI/wire-fidelity goal and has been dropped (NPACE-4/5 closed as won't-do). Unlike pacing (`SO_MAX_PACING_RATE`, applied transparently via `--bwlimit`), congestion control can't be applied without an explicit, upstream-diverging flag.

## Removed
- `set_tcp_congestion`, `tcp_available_congestion_control`, `tcp_congestion_supported`
- the Linux-only `setsockopt_bytes_raw` byte-string `setsockopt` helper that backed them
- their two unit tests + the `lib.rs` re-exports

## Kept (from the same #6141)
- `set_tcp_cork` / `tcp_cork_supported` — a transparent write-coalescing hint
- `reuse_port_supported` + `SO_REUSEPORT` — wired into the daemon listener bind

Net: -124 lines in `socket_options.rs`. `cargo clippy -p fast_io --all-targets` + `cargo fmt --check` clean locally.