### PR TITLE
fix(transfer): report sender-side --stats fields on daemon/ssh push

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -45,8 +45,12 @@ pub(super) fn convert_server_stats_to_summary(
             let s = LocalCopySummary::from_generator_stats(
                 generator_stats.files_listed,
                 generator_stats.files_transferred,
+                generator_stats.bytes_read,
                 generator_stats.bytes_sent,
+                generator_stats.total_size,
                 elapsed,
+                generator_stats.literal_data,
+                generator_stats.matched_data,
                 u64::from(generator_stats.delete_stats.total()),
             );
             (s, generator_stats.io_error, 0u32)

--- a/crates/core/src/client/remote/ssh_transfer.rs
+++ b/crates/core/src/client/remote/ssh_transfer.rs
@@ -478,8 +478,12 @@ pub(super) fn convert_server_stats_to_summary(
             let s = LocalCopySummary::from_generator_stats(
                 generator_stats.files_listed,
                 generator_stats.files_transferred,
+                generator_stats.bytes_read,
                 generator_stats.bytes_sent,
+                generator_stats.total_size,
                 elapsed,
+                generator_stats.literal_data,
+                generator_stats.matched_data,
                 u64::from(generator_stats.delete_stats.total()),
             );
             (s, generator_stats.io_error, 0u32)

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -435,20 +435,30 @@ impl LocalCopySummary {
     /// Creates a summary from server-side generator statistics.
     ///
     /// This constructor is used when the local side acted as the generator/sender in a push transfer.
-    /// It maps the available generator statistics (files listed, files transferred, bytes sent)
-    /// to the corresponding LocalCopySummary fields.
+    /// It maps the generator statistics (files listed/transferred, bytes sent/received, and the
+    /// sender-accumulated matched/literal/total-size counters) to the corresponding
+    /// LocalCopySummary fields, mirroring [`Self::from_receiver_stats`] for the opposite direction.
     #[must_use]
+    #[allow(clippy::too_many_arguments)] // REASON: maps a wire-stats struct field-by-field
     pub fn from_generator_stats(
         files_listed: usize,
         files_transferred: usize,
+        bytes_received: u64,
         bytes_sent: u64,
+        total_source_bytes: u64,
         elapsed: Duration,
+        literal_data: u64,
+        matched_data: u64,
         items_deleted: u64,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
             files_copied: files_transferred as u64,
+            bytes_received,
             bytes_sent,
+            bytes_copied: literal_data,
+            matched_bytes: matched_data,
+            total_source_bytes,
             items_deleted,
             total_elapsed: elapsed,
             wall_clock_elapsed: elapsed,
@@ -671,8 +681,17 @@ mod tests {
     /// `--stats` renders "Number of deleted files: N" instead of zero.
     #[test]
     fn from_generator_stats_records_items_deleted() {
-        let summary =
-            LocalCopySummary::from_generator_stats(10, 5, 2048, Duration::from_secs(1), 7);
+        let summary = LocalCopySummary::from_generator_stats(
+            10,
+            5,
+            0,
+            2048,
+            0,
+            Duration::from_secs(1),
+            0,
+            0,
+            7,
+        );
         assert_eq!(summary.items_deleted(), 7);
     }
 
@@ -697,11 +716,23 @@ mod tests {
 
     #[test]
     fn from_generator_stats_sets_fields() {
-        let summary =
-            LocalCopySummary::from_generator_stats(200, 75, 2048, Duration::from_secs(3), 0);
+        let summary = LocalCopySummary::from_generator_stats(
+            200,
+            75,
+            1793,
+            2048,
+            204_800,
+            Duration::from_secs(3),
+            2800,
+            202_000,
+            0,
+        );
         assert_eq!(summary.regular_files_total(), 200);
         assert_eq!(summary.files_copied(), 75);
         assert_eq!(summary.bytes_sent(), 2048);
+        // #477: the sender-accumulated literal_data must reach the summary
+        // (previously dropped, so daemon/ssh-push --stats printed 0).
+        assert_eq!(summary.bytes_copied(), 2800);
         assert_eq!(summary.total_elapsed(), Duration::from_secs(3));
     }
 

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -406,6 +406,12 @@ pub(super) struct InlineChecksumResult {
     pub checksum_buf: [u8; ChecksumVerifier::MAX_DIGEST_LEN],
     /// Number of valid bytes in `checksum_buf`.
     pub checksum_len: usize,
+    /// Bytes covered by Copy tokens (block matches) on this file.
+    /// upstream: `match.c:118` `stats.matched_data += s2length`.
+    pub matched_data: u64,
+    /// Bytes sent as literal data on this file.
+    /// upstream: `match.c:330` `stats.literal_data += s->sums[j].len`.
+    pub literal_data: u64,
 }
 
 /// Writes delta tokens to the wire and computes the file checksum in a single pass.
@@ -445,6 +451,10 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
     };
     let mut source_offset: u64 = 0;
     let mut read_buf = Vec::new();
+    // upstream: match.c matched()/send_token() accumulate stats.matched_data
+    // and stats.literal_data as each token is emitted on the sender.
+    let mut matched_data: u64 = 0;
+    let mut literal_data: u64 = 0;
 
     match encoder {
         Some(encoder) => {
@@ -456,6 +466,7 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
                         verifier.update(data);
                         encoder.send_literal(writer, data)?;
                         source_offset += data.len() as u64;
+                        literal_data += data.len() as u64;
                     }
                     DeltaOp::Copy {
                         block_index,
@@ -476,6 +487,7 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
                             encoder.see_token(&read_buf)?;
                         }
                         source_offset += u64::from(*length);
+                        matched_data += u64::from(*length);
                     }
                 }
             }
@@ -495,6 +507,7 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
                         // match.c:matched() interleaves literal and block-match
                         // tokens against a single advancing file cursor.
                         source_offset += data.len() as u64;
+                        literal_data += data.len() as u64;
                     }
                     DeltaOp::Copy {
                         block_index,
@@ -512,6 +525,7 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
                         }
                         verifier.update(&read_buf);
                         source_offset += u64::from(*length);
+                        matched_data += u64::from(*length);
                     }
                 }
             }
@@ -525,6 +539,8 @@ pub(super) fn write_delta_with_inline_checksum<W: Write>(
     Ok(InlineChecksumResult {
         checksum_buf,
         checksum_len,
+        matched_data,
+        literal_data,
     })
 }
 

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -25,6 +25,10 @@ pub(crate) struct TransferLoopResult {
     pub(crate) files_transferred: usize,
     /// Total bytes sent during transfer.
     pub(crate) bytes_sent: u64,
+    /// Bytes covered by block matches across all files (upstream: matched_data).
+    pub(crate) matched_data: u64,
+    /// Bytes sent as literal data across all files (upstream: literal_data).
+    pub(crate) literal_data: u64,
     /// NDX read codec state carried over for the goodbye handshake.
     pub(crate) ndx_read_codec: NdxCodecEnum,
     /// NDX write codec state carried over for the goodbye handshake.
@@ -51,6 +55,12 @@ pub struct GeneratorStats {
     pub bytes_sent: u64,
     /// Total bytes read from the receiver (signatures, NDX requests).
     pub bytes_read: u64,
+    /// Bytes covered by block matches (upstream: `stats.matched_data`).
+    pub matched_data: u64,
+    /// Bytes sent as literal data (upstream: `stats.literal_data`).
+    pub literal_data: u64,
+    /// Sum of all source file sizes in the flist (upstream: `stats.total_size`).
+    pub total_size: u64,
     /// File list build time in milliseconds (upstream: `stats.flist_buildtime`).
     pub flist_buildtime_ms: u64,
     /// File list transfer time in milliseconds (upstream: `stats.flist_xfertime`).

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -287,11 +287,18 @@ impl GeneratorContext {
             .advance_to(TransferPhase::Complete)
             .map_err(crate::fsm_error)?;
 
+        // upstream: handle_stats() reports stats.total_size, the sum of all
+        // flist file sizes (main.c:351 write_varlong30(f, stats.total_size, 3)).
+        let total_size = self.file_list.iter().map(|e| e.size()).sum();
+
         Ok(GeneratorStats {
             files_listed: file_count,
             files_transferred: transfer_result.files_transferred,
             bytes_sent: transfer_result.bytes_sent,
             bytes_read: self.timing.total_bytes_read,
+            matched_data: transfer_result.matched_data,
+            literal_data: transfer_result.literal_data,
+            total_size,
             flist_buildtime_ms: flist_buildtime,
             flist_xfertime_ms: flist_xfertime,
             flist_first_byte_latency: self.timing.flist_first_byte_latency,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -64,6 +64,10 @@ impl GeneratorContext {
 
         let mut files_transferred = 0;
         let mut bytes_sent = 0u64;
+        // upstream: match.c stats.matched_data / stats.literal_data accumulated
+        // per token as the sender emits the delta stream.
+        let mut matched_data = 0u64;
+        let mut literal_data = 0u64;
         // upstream: io.c IO_BUFFER_SIZE (32KB)
         let mut stream_buf = Vec::with_capacity(32 * 1024);
 
@@ -461,6 +465,8 @@ impl GeneratorContext {
                         checksum_algorithm,
                     )?;
                     cw.write_all(&result.checksum_buf[..result.checksum_len])?;
+                    matched_data += result.matched_data;
+                    literal_data += result.literal_data;
                     cw.bytes_written()
                 };
                 bytes_sent += wire_bytes;
@@ -516,6 +522,10 @@ impl GeneratorContext {
                     cw.bytes_written()
                 };
                 bytes_sent += wire_bytes;
+                // Whole-file transfer: the entire body is sent as literal data
+                // (no block matches). upstream: match.c accounts the full file
+                // as literal_data when whole_file is in effect.
+                literal_data += file_size;
             }
             files_transferred += 1;
 
@@ -619,6 +629,8 @@ impl GeneratorContext {
         Ok(TransferLoopResult {
             files_transferred,
             bytes_sent,
+            matched_data,
+            literal_data,
             ndx_read_codec,
             ndx_write_codec,
         })


### PR DESCRIPTION
## Problem (verified on host)

On a **daemon-upload** or **ssh-push**, oc-rsync's client-sender `--stats` printed receiver-relevant fields as zero while the transfer itself was correct:

| stat | upstream | oc (before) |
|---|---|---|
| Matched data | 202,000 | **0** |
| Literal data | 2,800 | **0** |
| Total bytes received | 1,793 | **0** |
| total size | 204,800 | **0** |
| speedup | 34.98 | **0.00** |

## Root cause

These are **sender-accumulated locally** — upstream `handle_stats` (main.c:325-385) does *no* stats wire I/O for a client-sender push. oc never tracked `matched_data`/`literal_data`/`total_size`, and `from_generator_stats` dropped them plus `bytes_read`, defaulting all to 0. (Pull already worked: the receiver counts incoming tokens.) **No wire change** — this would have been a protocol-desync bug if "fixed" by adding a read.

## Fix

- Accumulate `matched_data` (Copy-token bytes) and `literal_data` (Literal-token bytes + whole-file body) per token in `write_delta_with_inline_checksum`, mirroring upstream `match.c matched()`.
- Thread them through `TransferLoopResult` → `GeneratorStats`; compute `total_size` as the flist file-size sum in the orchestrator.
- `from_generator_stats` now takes `bytes_received`/`total_source_bytes`/`literal_data`/`matched_data` and sets the summary fields (mirroring `from_receiver_stats`); the daemon and ssh push call sites pass the real `generator_stats` values.

## Verification

- `cargo build`/`clippy -p transfer -p core` + `fmt --check` clean locally.
- Unit test `from_generator_stats_sets_fields` extended to assert `bytes_copied()` (literal_data) threads through.
- Host repro (oc-sender push to a daemon, `-a -I --no-whole-file --stats`) confirms the five fields now match upstream's nonzero values. *(host-verified before merge)*