### PR TITLE
fix(core): match upstream errno suffix "(N)" in I/O error messages

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -204,7 +204,11 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             // whose NotFound branch maps to RERR_VANISHED (24) for files that
             // disappear mid-transfer.
             let code = ExitCode::PartialTransfer;
-            let text = format!("link_stat \"{}\" failed: {source}", path.display());
+            let text = format!(
+                "link_stat \"{}\" failed: {}",
+                path.display(),
+                upstream_io_error(&source)
+            );
             let message = rsync_error!(code.as_i32(), text).with_role(Role::Sender);
             ClientError::with_code(code, message)
         }
@@ -242,6 +246,23 @@ pub(crate) fn compile_filter_error(pattern: &str, error: &dyn fmt::Display) -> C
     ClientError::with_code(code, message)
 }
 
+/// Formats an [`io::Error`] the way upstream rsync's `rsyserr()` does:
+/// `"<strerror> (<errno>)"` (upstream `log.c:473` `": %s (%d)"`), rather than
+/// Rust's `std::io::Error` `Display`, which renders `" (os error <errno>)"`.
+/// Errors without an OS errno fall back to the `Display` string verbatim.
+fn upstream_io_error(error: &io::Error) -> String {
+    match error.raw_os_error() {
+        Some(code) => {
+            let full = error.to_string();
+            let strerror = full
+                .strip_suffix(&format!(" (os error {code})"))
+                .unwrap_or(full.as_str());
+            format!("{strerror} ({code})")
+        }
+        None => error.to_string(),
+    }
+}
+
 #[cold]
 pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientError {
     // upstream: main.c:1338-1345 - NotFound maps to RERR_VANISHED (24),
@@ -257,7 +278,10 @@ pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientErr
     let text = if error.kind() == io::ErrorKind::NotFound {
         format!("file has vanished: \"{path_display}\"")
     } else {
-        format!("failed to {action} '{path_display}': {error}")
+        format!(
+            "failed to {action} '{path_display}': {}",
+            upstream_io_error(&error)
+        )
     };
     let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
     ClientError::with_code(code, message)
@@ -269,7 +293,10 @@ pub(crate) fn destination_access_error(path: &Path, error: io::Error) -> ClientE
     // destination directory access errors.
     let code = ExitCode::FileSelect;
     let path_display = path.display();
-    let text = format!("failed to access destination directory '{path_display}': {error}");
+    let text = format!(
+        "failed to access destination directory '{path_display}': {}",
+        upstream_io_error(&error)
+    );
     let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
     ClientError::with_code(code, message)
 }
@@ -281,7 +308,7 @@ pub(crate) fn socket_error(
     error: io::Error,
 ) -> ClientError {
     let code = ExitCode::SocketIo;
-    let text = format!("failed to {action} {target}: {error}");
+    let text = format!("failed to {action} {target}: {}", upstream_io_error(&error));
     let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
     ClientError::with_code(code, message)
 }
@@ -396,6 +423,20 @@ impl From<LocalCopyError> for ClientError {
 mod tests {
     use super::*;
     use std::io::ErrorKind;
+
+    #[test]
+    fn upstream_io_error_uses_bare_errno_suffix() {
+        // upstream rsync renders "<strerror> (<errno>)" (log.c:473), not Rust's
+        // "<strerror> (os error <errno>)".
+        let err = io::Error::from_raw_os_error(2);
+        let text = upstream_io_error(&err);
+        assert!(text.ends_with(" (2)"), "got: {text}");
+        assert!(!text.contains("os error"), "got: {text}");
+
+        // Errors without an OS errno fall back to the Display string verbatim.
+        let custom = io::Error::new(ErrorKind::Other, "boom");
+        assert_eq!(upstream_io_error(&custom), "boom");
+    }
 
     mod exit_codes_tests {
         use super::*;

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use crate::exit_code::{ErrorCodification, ExitCode, HasExitCode};
 use crate::message::{Message, Role};
 use crate::rsync_error;
-use engine::local_copy::{LocalCopyError, LocalCopyErrorKind};
+use engine::local_copy::{LocalCopyError, LocalCopyErrorKind, upstream_io_error};
 
 // upstream: errcode.h - Exit code definitions
 
@@ -244,23 +244,6 @@ pub(crate) fn compile_filter_error(pattern: &str, error: &dyn fmt::Display) -> C
     let text = format!("failed to compile filter pattern '{pattern}': {error}");
     let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
     ClientError::with_code(code, message)
-}
-
-/// Formats an [`io::Error`] the way upstream rsync's `rsyserr()` does:
-/// `"<strerror> (<errno>)"` (upstream `log.c:473` `": %s (%d)"`), rather than
-/// Rust's `std::io::Error` `Display`, which renders `" (os error <errno>)"`.
-/// Errors without an OS errno fall back to the `Display` string verbatim.
-fn upstream_io_error(error: &io::Error) -> String {
-    match error.raw_os_error() {
-        Some(code) => {
-            let full = error.to_string();
-            let strerror = full
-                .strip_suffix(&format!(" (os error {code})"))
-                .unwrap_or(full.as_str());
-            format!("{strerror} ({code})")
-        }
-        None => error.to_string(),
-    }
 }
 
 #[cold]

--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -417,7 +417,7 @@ mod tests {
         assert!(!text.contains("os error"), "got: {text}");
 
         // Errors without an OS errno fall back to the Display string verbatim.
-        let custom = io::Error::new(ErrorKind::Other, "boom");
+        let custom = io::Error::other("boom");
         assert_eq!(upstream_io_error(&custom), "boom");
     }
 

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -9,6 +9,24 @@ use super::filter_program::{
     VANISHED_EXIT_CODE,
 };
 
+/// Formats an [`io::Error`] the way upstream rsync's `rsyserr()` does:
+/// `"<strerror> (<errno>)"` (upstream `log.c:473` `": %s (%d)"`), rather than
+/// Rust's `std::io::Error` `Display`, which renders `" (os error <errno>)"`.
+/// Errors without an OS errno fall back to the `Display` string verbatim.
+#[must_use]
+pub fn upstream_io_error(error: &io::Error) -> String {
+    match error.raw_os_error() {
+        Some(code) => {
+            let full = error.to_string();
+            let strerror = full
+                .strip_suffix(&format!(" (os error {code})"))
+                .unwrap_or(full.as_str());
+            format!("{strerror} ({code})")
+        }
+        None => error.to_string(),
+    }
+}
+
 /// Error produced when planning or executing a local copy fails.
 ///
 /// # Exit Code Integration
@@ -224,7 +242,7 @@ pub enum LocalCopyErrorKind {
     /// does not exist. A hard error exiting 23 (`RERR_PARTIAL`), distinct from
     /// a mid-transfer vanish (exit 24); the caller continues with the remaining
     /// sources.
-    #[error("link_stat \"{}\" failed: {source}", path.display())]
+    #[error("link_stat \"{}\" failed: {}", path.display(), upstream_io_error(source))]
     LinkStatFailed {
         /// The source path that could not be stat'd.
         path: PathBuf,

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -98,7 +98,7 @@ pub use options::{
     ReferenceDirectoryKind,
 };
 
-pub use error::{LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind};
+pub use error::{LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, upstream_io_error};
 
 #[cfg(test)]
 pub(crate) use plan::FilterOutcome;

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -118,10 +118,9 @@ impl GeneratorContext {
                         // FFV-4: emit the correct error message and error flag
                         // for a source that never existed at flist build time.
                         eprintln!(
-                            "rsync: [sender] link_stat \"{}\" failed: {} ({})",
+                            "rsync: [sender] link_stat \"{}\" failed: {}",
                             path.display(),
-                            e,
-                            e.raw_os_error().unwrap_or(0),
+                            engine::local_copy::upstream_io_error(&e),
                         );
                         self.add_io_error(io_error_flags::IOERR_GENERAL);
                         Ok(false)
@@ -260,10 +259,9 @@ impl GeneratorContext {
             Err(e) => {
                 // upstream: flist.c - rsyserr for make_file() failures
                 eprintln!(
-                    "rsync: [sender] make_file failed for \"{}\": {} ({})",
+                    "rsync: [sender] make_file failed for \"{}\": {}",
                     path.display(),
-                    e,
-                    e.raw_os_error().unwrap_or(0),
+                    engine::local_copy::upstream_io_error(&e),
                 );
                 self.add_io_error(io_error_flags::IOERR_GENERAL);
                 return Ok(());
@@ -286,10 +284,9 @@ impl GeneratorContext {
                 Err(e) => {
                     // upstream: flist.c:1842 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     eprintln!(
-                        "rsync: [sender] opendir \"{}\" failed: {} ({})",
+                        "rsync: [sender] opendir \"{}\" failed: {}",
                         path.display(),
-                        e,
-                        e.raw_os_error().unwrap_or(0),
+                        engine::local_copy::upstream_io_error(&e),
                     );
                     self.record_io_error(&e);
                     None
@@ -386,10 +383,9 @@ impl GeneratorContext {
             Err(e) => {
                 // upstream: flist.c:1842 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                 eprintln!(
-                    "rsync: [sender] opendir \"{}\" failed: {} ({})",
+                    "rsync: [sender] opendir \"{}\" failed: {}",
                     dir_path.display(),
-                    e,
-                    e.raw_os_error().unwrap_or(0),
+                    engine::local_copy::upstream_io_error(&e),
                 );
                 self.record_io_error(&e);
                 Ok(())
@@ -415,10 +411,9 @@ impl GeneratorContext {
                 Err(e) => {
                     // upstream: flist.c:1888 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     eprintln!(
-                        "rsync: [sender] readdir(\"{}\"): {} ({})",
+                        "rsync: [sender] readdir(\"{}\"): {}",
                         dir_path.display(),
-                        e,
-                        e.raw_os_error().unwrap_or(0),
+                        engine::local_copy::upstream_io_error(&e),
                     );
                     self.record_io_error(&e);
                 }
@@ -498,10 +493,9 @@ impl GeneratorContext {
         } else {
             // upstream: flist.c:1810 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
             eprintln!(
-                "rsync: [sender] link_stat \"{}\" failed: {} ({})",
+                "rsync: [sender] link_stat \"{}\" failed: {}",
                 path.display(),
-                e,
-                e.raw_os_error().unwrap_or(0),
+                engine::local_copy::upstream_io_error(e),
             );
         }
     }

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -254,9 +254,8 @@ impl GeneratorContext {
             self.io_error |= super::io_error_flags::IOERR_GENERAL;
             // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno, "send_files failed to open %s", ...)
             eprintln!(
-                "rsync: [sender] send_files failed to open \"{path_display}\": {} ({})",
-                error,
-                error.raw_os_error().unwrap_or(0),
+                "rsync: [sender] send_files failed to open \"{path_display}\": {}",
+                engine::local_copy::upstream_io_error(error),
             );
         }
         if self.protocol.supports_generator_messages() {


### PR DESCRIPTION
oc-rsync interpolated a raw `std::io::Error` into client error messages, whose `Display` renders `<strerror> (os error N)`. Upstream rsync's `rsyserr()` prints `<strerror> (N)` (log.c:473 `": %s (%d)"`).

Example — a missing local source argument (`oc-rsync /nonexistent /tmp/dst`):
- oc (before): `link_stat "/nonexistent" failed: No such file or directory (os error 2)`
- upstream: `link_stat "/nonexistent" failed: No such file or directory (2)`

(Exit code 23 and the `"..."` path quoting were already upstream-correct; only the errno-paren text diverged.)

## Fix
- Add `upstream_io_error(&io::Error) -> String` that strips Rust's ` (os error N)` tail and appends ` (N)`, matching `rsyserr()`. Non-OS errors fall back to `Display` verbatim.
- Route the four `io::Error` interpolation sites — `link_stat`, `io_error`, `destination_access_error`, `socket_error` — through it.
- Unit test `upstream_io_error_uses_bare_errno_suffix`.

## Verification
- `clippy -p core` + `fmt --check` clean locally; zero existing tests/goldens asserted the old `(os error N)` text.
- Host repro: `oc-rsync /nonexistent /tmp/dst` now prints `... (2)` matching `rsync`. *(host-verified)*