### PR TITLE
feat(fast_io): add client-side TCP_FASTOPEN_CONNECT helper

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -336,11 +336,12 @@ pub use secure_dir::secure_open_dir;
 #[cfg(unix)]
 pub use sendfile::send_file_to_fd_with_policy;
 pub use socket_options::{
-    DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, enable_tcp_fastopen_listener,
-    enable_tcp_fastopen_raw, rearm_tcp_quickack, reuse_port_supported, set_listener_int_option,
-    set_so_max_pacing_rate, set_socket_int_option, set_tcp_cork, set_tcp_notsent_lowat,
-    set_tcp_quickack, so_max_pacing_rate_supported, tcp_cork_supported,
-    tcp_fastopen_listener_supported, tcp_notsent_lowat_supported, tcp_quickack_supported,
+    DEFAULT_TCP_FASTOPEN_QLEN, DEFAULT_TCP_NOTSENT_LOWAT, enable_tcp_fastopen_connect_raw,
+    enable_tcp_fastopen_listener, enable_tcp_fastopen_raw, rearm_tcp_quickack,
+    reuse_port_supported, set_listener_int_option, set_so_max_pacing_rate, set_socket_int_option,
+    set_tcp_cork, set_tcp_notsent_lowat, set_tcp_quickack, so_max_pacing_rate_supported,
+    tcp_cork_supported, tcp_fastopen_connect_supported, tcp_fastopen_listener_supported,
+    tcp_notsent_lowat_supported, tcp_quickack_supported,
 };
 #[cfg(target_os = "linux")]
 pub use splice::DEFAULT_PIPE_CAPACITY;

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -161,6 +161,56 @@ pub fn enable_tcp_fastopen_listener(listener: &TcpListener, qlen: i32) -> io::Re
     }
 }
 
+/// Enables the client-side `TCP_FASTOPEN_CONNECT` option on a socket file
+/// descriptor before `connect(2)`.
+///
+/// Unlike the server-side [`enable_tcp_fastopen_raw`], this is set on the
+/// connecting socket. The Linux kernel (4.11+) then defers the SYN until the
+/// first `write(2)`/`send(2)`, folding the request payload into the initial
+/// handshake so the connect saves one round trip. The regular
+/// `connect`/`write` flow works unchanged; no `sendto(MSG_FASTOPEN)` adapter
+/// is required.
+///
+/// Returns `Ok(false)` on non-Linux platforms (the option does not exist;
+/// macOS uses `connectx`, which is wired separately). Errors from
+/// `setsockopt(2)` propagate unchanged.
+///
+/// upstream: not implemented; this is an oc-rsync-specific perf improvement
+/// that is wire-compatible with upstream rsync. TFO only affects the initial
+/// SYN exchange, not the rsync protocol that follows.
+#[cfg(unix)]
+pub fn enable_tcp_fastopen_connect_raw(raw_fd: std::os::fd::RawFd) -> io::Result<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        setsockopt_int_raw(raw_fd, libc::IPPROTO_TCP, libc::TCP_FASTOPEN_CONNECT, 1)?;
+        Ok(true)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = raw_fd;
+        Ok(false)
+    }
+}
+
+/// Windows stub for [`enable_tcp_fastopen_connect_raw`].
+///
+/// Windows TFO is opt-in through a separate `WSAIoctl`/overlapped path, so the
+/// connect-side option is reported as unsupported and the client falls back to
+/// a standard `connect`.
+#[cfg(windows)]
+pub fn enable_tcp_fastopen_connect_raw(
+    _raw_socket: std::os::windows::io::RawSocket,
+) -> io::Result<bool> {
+    Ok(false)
+}
+
+/// Returns `true` when the running platform implements client-side
+/// `TCP_FASTOPEN_CONNECT`.
+#[must_use]
+pub const fn tcp_fastopen_connect_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
 /// Sets the `TCP_NOTSENT_LOWAT` watermark on a connected stream.
 ///
 /// Caps the unsent bytes the kernel buffers in the socket send buffer.
@@ -547,6 +597,37 @@ mod tests {
                 assert!(
                     tcp_fastopen_listener_supported(),
                     "unexpected TFO error on unsupported platform: {error}"
+                );
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn enable_tcp_fastopen_connect_reports_supported_platforms() {
+        use std::os::fd::{FromRawFd, OwnedFd};
+
+        // TCP_FASTOPEN_CONNECT must be set before connect(2), so exercise it on
+        // a fresh unconnected TCP socket rather than a connected stream.
+        // SAFETY: socket(2) returns a fresh owned fd; wrap it in OwnedFd so it
+        // is closed when the test ends.
+        let raw = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0) };
+        assert!(raw >= 0, "socket(2) failed: {}", io::Error::last_os_error());
+        let owned = unsafe { OwnedFd::from_raw_fd(raw) };
+        use std::os::fd::AsRawFd;
+
+        let result = enable_tcp_fastopen_connect_raw(owned.as_raw_fd());
+
+        match result {
+            Ok(true) => assert!(tcp_fastopen_connect_supported()),
+            Ok(false) => assert!(!tcp_fastopen_connect_supported()),
+            Err(error) => {
+                // A Linux kernel with client TFO disabled
+                // (`/proc/sys/net/ipv4/tcp_fastopen` bit 0 unset) may return
+                // EOPNOTSUPP; only Linux exposes the option at all.
+                assert!(
+                    tcp_fastopen_connect_supported(),
+                    "unexpected TFO connect error on unsupported platform: {error}"
                 );
             }
         }


### PR DESCRIPTION
Adds `enable_tcp_fastopen_connect_raw()` and `tcp_fastopen_connect_supported()` to the `fast_io` socket-options module, mirroring the existing server-side `enable_tcp_fastopen_raw`/`tcp_fastopen_listener_supported` and the `set_tcp_quickack`/`tcp_quickack_supported` pair.

On Linux this sets `TCP_FASTOPEN_CONNECT` on the connecting socket before `connect(2)`, so the kernel defers the SYN until the first `write(2)`, folding the request into the initial handshake and saving one round trip on connection setup. Non-Linux platforms report unsupported (`Ok(false)`); macOS uses `connectx` and is wired separately.

The helper takes a raw fd so the connect path can apply it to the pre-connect socket without coupling `fast_io` to `socket2`. Wiring the helper into the client connect chain and gating it on the `--tcp-fastopen` mode is a follow-up.

Wire-compatible: TFO only affects the SYN exchange, not the rsync protocol that follows. Upstream rsync has no client TFO; this is an oc-rsync-specific perf improvement.

Unit-tested with a unix-gated test that exercises the helper on a fresh unconnected socket and asserts consistency with the support predicate.