### PR TITLE
feat(transfer): wire DontcacheFileWriter into receiver make_writer

### DIFF
--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -105,6 +105,13 @@ iocp = ["fast_io/iocp"]
 # docs/design/splice-vmsplice-zero-copy.md.
 vmsplice = ["fast_io/vmsplice"]
 
+# dontcache uncached bulk disk writer (Linux 6.14+). Selected by the
+# disk-commit thread when io_uring/IOCP are not in play and the write is
+# non-sparse/non-append; lands chunks via pwritev2(RWF_DONTCACHE) so large
+# transfers do not evict the page-cache working set, with a per-file buffered
+# fallback. Default off until eviction/throughput benchmarks justify promotion.
+dontcache = ["fast_io/dontcache"]
+
 
 # Per-thread slab pool for buffer returns - forwards to the engine crate.
 # Forwarded so `--all-features` enables it transitively on engine *and* exposes

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -459,6 +459,17 @@ fn make_writer<'a>(
             )));
         }
     }
+    // dontcache path: preferred over vmsplice when both are enabled. Lands
+    // chunks via pwritev2(RWF_DONTCACHE) so bulk transfers do not evict the
+    // page-cache working set, falling back per-chunk to a buffered write when
+    // the kernel/filesystem rejects the flag. Sparse and append require Seek,
+    // so they keep using Buffered.
+    #[cfg(all(target_os = "linux", feature = "dontcache"))]
+    {
+        if !use_sparse && append_offset == 0 {
+            return Ok(Writer::Dontcache(fast_io::DontcacheFileWriter::new(file)?));
+        }
+    }
     // vmsplice path: only when neither io_uring nor IOCP claimed the file. It
     // gates per-chunk inside VmspliceFileWriter, falling back to plain write
     // for chunks below 64 KiB or with unaligned pointers - the design doc's

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -160,6 +160,13 @@ pub(super) enum Writer<'a> {
     /// `docs/design/splice-vmsplice-zero-copy.md`.
     #[cfg(all(target_os = "linux", feature = "vmsplice"))]
     Vmsplice(fast_io::VmspliceFileWriter),
+    /// Uncached bulk writer that lands literal chunks via
+    /// `pwritev2(RWF_DONTCACHE)` (Linux + `dontcache` feature, non-sparse,
+    /// non-append) so large transfers do not evict the page-cache working set.
+    /// Per-chunk it falls back to a buffered write when the kernel or
+    /// filesystem rejects the flag. See `fast_io::DontcacheFileWriter`.
+    #[cfg(all(target_os = "linux", feature = "dontcache"))]
+    Dontcache(fast_io::DontcacheFileWriter),
 }
 
 impl<'a> Writer<'a> {
@@ -192,6 +199,11 @@ impl<'a> Writer<'a> {
                 debug_assert!(false, "sparse mode must select buffered writer");
                 unreachable!("sparse mode must select buffered writer")
             }
+            #[cfg(all(target_os = "linux", feature = "dontcache"))]
+            Writer::Dontcache(_) => {
+                debug_assert!(false, "sparse mode must select buffered writer");
+                unreachable!("sparse mode must select buffered writer")
+            }
         }
     }
 
@@ -207,6 +219,8 @@ impl<'a> Writer<'a> {
             Writer::Macos(w) => w.write_all(data),
             #[cfg(all(target_os = "linux", feature = "vmsplice"))]
             Writer::Vmsplice(w) => w.write_chunk(data).map(|_| ()),
+            #[cfg(all(target_os = "linux", feature = "dontcache"))]
+            Writer::Dontcache(w) => w.write_chunk(data).map(|_| ()),
         }
     }
 
@@ -257,6 +271,19 @@ impl<'a> Writer<'a> {
                     Ok(())
                 }
             }
+            #[cfg(all(target_os = "linux", feature = "dontcache"))]
+            Writer::Dontcache(w) => {
+                // pwritev2 writes go straight to the file fd, so there is no
+                // userspace buffer to flush. The fsync, when requested, syncs
+                // the file the writer owns.
+                if do_fsync {
+                    w.file().sync_all().map_err(|e| {
+                        io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}"))
+                    })
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 
@@ -295,6 +322,8 @@ impl<'a> Writer<'a> {
             Writer::Macos(_) => Ok(()),
             #[cfg(all(target_os = "linux", feature = "vmsplice"))]
             Writer::Vmsplice(_) => Ok(()),
+            #[cfg(all(target_os = "linux", feature = "dontcache"))]
+            Writer::Dontcache(_) => Ok(()),
         }
     }
 }


### PR DESCRIPTION
Wires the `fast_io::DontcacheFileWriter` added in #6148 into the receiver disk-commit dispatch, so receiver writes can land via `pwritev2(RWF_DONTCACHE)` and large transfers do not evict the page-cache working set.

Changes (mirroring the existing `vmsplice` wiring exactly):
- New `Writer::Dontcache(fast_io::DontcacheFileWriter)` variant in `disk_commit/writer.rs`, gated `cfg(all(target_os = "linux", feature = "dontcache"))`, with arms in `buffered_for_sparse` (unreachable - sparse uses Buffered), `write_chunk`, `flush_and_sync` (fsync via `file().sync_all()`), and `finish` (no-op).
- Dispatch block in `make_writer` (`disk_commit/process.rs`) immediately **before** the vmsplice path, with the same `!use_sparse && append_offset == 0` guard, so dontcache wins when both features are enabled.
- `dontcache = ["fast_io/dontcache"]` passthrough in `crates/transfer/Cargo.toml`.

Default-off (the `dontcache` feature is not in `transfer`s default set), pending the eviction/throughput bench on the `>RAM` workload. With the feature off, the variant cfg-compiles out and the receiver path is byte-identical to today.

Host-verified on Linux 6.14+ (kernel 7.0.0), since CI does not build `feature=dontcache`:
- `cargo build -p transfer` (default, variant cfg-out) - clean
- `cargo build -p transfer --features dontcache` (real arm) - clean
- `cargo clippy -p transfer --features dontcache --all-targets` - clean
- `cargo nextest run -p transfer --features dontcache -E test(disk_commit)` - 97 passed (the wired path runs end-to-end through make_writer)

Wire-compatible: changes only page-cache residency of receiver writes, never the bytes landed.