### PR TITLE
feat(transfer): hint sequential reads for the buffered basis map

### DIFF
--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -308,8 +308,8 @@ mod tests {
     /// UNCACHE-6: opening a file larger than the macOS `F_NOCACHE` threshold
     /// applies the advisory sequential-read hint in the constructor. The hint
     /// must not change the bytes the sliding window returns; this reads a
-    /// >1 MiB file end-to-end across multiple windows and asserts byte
-    /// equality. Runs on every platform (the hint is a no-op off macOS) so the
+    /// 2 MiB file end-to-end across multiple windows and asserts byte equality.
+    /// Runs on every platform (the hint is a no-op off macOS) so the
     /// constructor wiring stays covered everywhere.
     #[test]
     fn large_file_reads_correctly_after_sequential_read_hint() {

--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -51,6 +51,12 @@ impl BufferedMap {
         let file = File::open(path)?;
         let size = file.metadata()?.len();
 
+        // The buffered map streams the basis sequentially through a sliding
+        // window, so on macOS hint F_NOCACHE for large files to keep the
+        // single-pass read from evicting the page-cache working set. Advisory
+        // and a no-op on other platforms.
+        let _ = fast_io::apply_sequential_read_hint(&file, size);
+
         Ok(Self {
             file,
             size,
@@ -77,6 +83,10 @@ impl BufferedMap {
     /// Returns an error if the file size cannot be determined.
     pub fn from_file_with_window(file: File, window_size: usize) -> io::Result<Self> {
         let size = file.metadata()?.len();
+
+        // See `open_with_window`: hint sequential single-pass reads so the
+        // basis stream does not pollute the page cache on macOS.
+        let _ = fast_io::apply_sequential_read_hint(&file, size);
 
         Ok(Self {
             file,
@@ -293,6 +303,37 @@ mod tests {
             msg.contains("128..192") && msg.contains("32"),
             "error message missing bounds detail: {msg}"
         );
+    }
+
+    /// UNCACHE-6: opening a file larger than the macOS `F_NOCACHE` threshold
+    /// applies the advisory sequential-read hint in the constructor. The hint
+    /// must not change the bytes the sliding window returns; this reads a
+    /// >1 MiB file end-to-end across multiple windows and asserts byte
+    /// equality. Runs on every platform (the hint is a no-op off macOS) so the
+    /// constructor wiring stays covered everywhere.
+    #[test]
+    fn large_file_reads_correctly_after_sequential_read_hint() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // 2 MiB clears the 1 MiB F_NOCACHE threshold on macOS.
+        let len = 2 * 1024 * 1024usize;
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        let mut tmp = NamedTempFile::new().unwrap();
+        tmp.write_all(&data).unwrap();
+        tmp.flush().unwrap();
+
+        let mut map = BufferedMap::open(tmp.path()).unwrap();
+
+        // Read the whole file in 64 KiB slices, sliding the window forward.
+        let chunk = 64 * 1024;
+        let mut offset = 0usize;
+        while offset < len {
+            let this = chunk.min(len - offset);
+            let got = MapStrategy::map_ptr(&mut map, offset as u64, this).unwrap();
+            assert_eq!(got, &data[offset..offset + this], "mismatch at {offset}");
+            offset += this;
+        }
     }
 
     /// Drives the overlap-shrink branch of `load_window` directly: when the


### PR DESCRIPTION
Wires the already-present `fast_io::apply_sequential_read_hint` into `BufferedMap`s constructors (`open_with_window` and `from_file_with_window`). On macOS, basis files at or above the `F_NOCACHE` threshold (1 MiB) now read through the sliding window with `F_NOCACHE`, so the single-pass basis scan does not evict the page-cache working set during large delta transfers.

The hint is advisory (returns a bool, never errors) and a no-op on non-macOS platforms (the stub returns `false`), so the wiring is unconditional with no cfg gate at the call site. `BufferedMap` is only the read-fill path; large files that take the mmap strategy are unaffected, so the win lands on the forced-buffered route (e.g. io_uring destinations).

`apply_sequential_read_hint` was previously built and exported but had no production caller. Adds a cross-platform test that reads a >1 MiB file end-to-end across multiple windows and asserts byte equality, proving the hint does not change the bytes the window returns.

Verified: builds + clippy clean; the read-correctness test passes (run on Linux, where the hint is a no-op but the read path is exercised). The macOS `F_NOCACHE` behavior itself is already covered by `fast_io`s `apply_sequential_read_hint_large_file_matches_platform` test.

Wire-compatible: changes only page-cache residency of basis reads, never transfer bytes or semantics.