### PR TITLE
feat(core): wire client-side TCP Fast Open at connect

### DIFF
--- a/crates/core/src/client/module_list/connect/direct.rs
+++ b/crates/core/src/client/module_list/connect/direct.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
 use super::super::DaemonAddress;
-use crate::client::{AddressMode, ClientError, SOCKET_IO_EXIT_CODE, daemon_error, socket_error};
+use crate::client::{
+    AddressMode, ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, daemon_error, socket_error,
+};
 
 /// Establishes a direct TCP connection to an rsync daemon.
 ///
@@ -18,12 +20,13 @@ pub(crate) fn connect_direct(
     io_timeout: Option<Duration>,
     address_mode: AddressMode,
     bind_address: Option<SocketAddr>,
+    tfo: TcpFastOpenMode,
 ) -> Result<TcpStream, ClientError> {
     let addresses = resolve_daemon_addresses(addr, address_mode)?;
     let mut last_error: Option<(SocketAddr, io::Error)> = None;
 
     for candidate in addresses {
-        match connect_with_optional_bind(candidate, bind_address, connect_timeout) {
+        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo) {
             Ok(stream) => {
                 if let Some(duration) = io_timeout {
                     stream.set_read_timeout(Some(duration)).map_err(|error| {
@@ -111,12 +114,22 @@ pub(crate) fn resolve_daemon_addresses(
 ///
 /// When `bind_address` is provided its port is forced to `0` so the OS picks
 /// an ephemeral port. A `connect_timeout`, when given, is forwarded to the
-/// underlying socket.
+/// underlying socket. The connection is always built through a `socket2`
+/// socket so a `TCP_FASTOPEN_CONNECT` option can be set before `connect(2)`
+/// when `tfo` requests it.
 pub(crate) fn connect_with_optional_bind(
     target: SocketAddr,
     bind_address: Option<SocketAddr>,
     timeout: Option<Duration>,
+    tfo: TcpFastOpenMode,
 ) -> io::Result<TcpStream> {
+    let domain = if target.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+
     if let Some(bind) = bind_address {
         if target.is_ipv4() != bind.is_ipv4() {
             return Err(io::Error::new(
@@ -125,31 +138,44 @@ pub(crate) fn connect_with_optional_bind(
             ));
         }
 
-        let domain = if target.is_ipv4() {
-            Domain::IPV4
-        } else {
-            Domain::IPV6
-        };
-
-        let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
         let mut bind_addr = bind;
         match &mut bind_addr {
             SocketAddr::V4(addr) => addr.set_port(0),
             SocketAddr::V6(addr) => addr.set_port(0),
         }
         socket.bind(&SockAddr::from(bind_addr))?;
-
-        let target_addr = SockAddr::from(target);
-        if let Some(duration) = timeout {
-            socket.connect_timeout(&target_addr, duration)?;
-        } else {
-            socket.connect(&target_addr)?;
-        }
-
-        Ok(socket.into())
-    } else if let Some(duration) = timeout {
-        TcpStream::connect_timeout(&target, duration)
-    } else {
-        TcpStream::connect(target)
     }
+
+    // Request client-side TCP Fast Open before connect. On Linux this sets
+    // TCP_FASTOPEN_CONNECT so the kernel defers the SYN until the first write,
+    // folding the request into the handshake and saving a round trip. This
+    // supersedes the older MSG_FASTOPEN-on-sendto mechanism, which is why the
+    // standard connect/write flow below works unchanged. Best-effort: an
+    // unsupported or failing setsockopt leaves the connect to proceed normally.
+    apply_tcp_fastopen_connect(&socket, tfo);
+
+    let target_addr = SockAddr::from(target);
+    if let Some(duration) = timeout {
+        socket.connect_timeout(&target_addr, duration)?;
+    } else {
+        socket.connect(&target_addr)?;
+    }
+
+    Ok(socket.into())
+}
+
+/// Sets `TCP_FASTOPEN_CONNECT` on `socket` before connect when `tfo` enables
+/// it and the platform supports it. A no-op on platforms without client-side
+/// TFO (the strict-mode unsupported warning is surfaced at config time).
+fn apply_tcp_fastopen_connect(socket: &Socket, tfo: TcpFastOpenMode) {
+    if !tfo.is_enabled() || !fast_io::tcp_fastopen_connect_supported() {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        let _ = fast_io::enable_tcp_fastopen_connect_raw(socket.as_raw_fd());
+    }
+    #[cfg(not(unix))]
+    let _ = socket;
 }

--- a/crates/core/src/client/module_list/connect/mod.rs
+++ b/crates/core/src/client/module_list/connect/mod.rs
@@ -10,7 +10,7 @@ use std::io::{self, Read, Write};
 use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
-use super::super::{AddressMode, ClientError, TransferTimeout};
+use super::super::{AddressMode, ClientError, TcpFastOpenMode, TransferTimeout};
 use super::DaemonAddress;
 pub(crate) use direct::{connect_direct, resolve_daemon_addresses};
 pub(crate) use program::ConnectProgramConfig;
@@ -82,6 +82,7 @@ pub(crate) fn open_daemon_stream(
     address_mode: AddressMode,
     connect_program: Option<&OsStr>,
     bind_address: Option<SocketAddr>,
+    tfo: TcpFastOpenMode,
 ) -> Result<DaemonStream, ClientError> {
     if let Some(program) = program::load_daemon_connect_program(connect_program)? {
         return program::connect_via_program(addr, &program);
@@ -89,7 +90,7 @@ pub(crate) fn open_daemon_stream(
 
     let stream = match load_daemon_proxy()? {
         Some(proxy) => {
-            proxy::connect_via_proxy(addr, &proxy, connect_timeout, io_timeout, bind_address)?
+            proxy::connect_via_proxy(addr, &proxy, connect_timeout, io_timeout, bind_address, tfo)?
         }
         None => connect_direct(
             addr,
@@ -97,6 +98,7 @@ pub(crate) fn open_daemon_stream(
             io_timeout,
             address_mode,
             bind_address,
+            tfo,
         )?,
     };
 
@@ -115,13 +117,14 @@ pub(super) fn open_daemon_stream_tls(
     io_timeout: Option<Duration>,
     address_mode: AddressMode,
     bind_address: Option<SocketAddr>,
+    tfo: TcpFastOpenMode,
     connector: &tls::TlsConnector,
 ) -> Result<DaemonStream, ClientError> {
     use crate::client::socket_error;
 
     let stream = match load_daemon_proxy()? {
         Some(proxy) => {
-            proxy::connect_via_proxy(addr, &proxy, connect_timeout, io_timeout, bind_address)?
+            proxy::connect_via_proxy(addr, &proxy, connect_timeout, io_timeout, bind_address, tfo)?
         }
         None => connect_direct(
             addr,
@@ -129,6 +132,7 @@ pub(super) fn open_daemon_stream_tls(
             io_timeout,
             address_mode,
             bind_address,
+            tfo,
         )?,
     };
 

--- a/crates/core/src/client/module_list/connect/proxy.rs
+++ b/crates/core/src/client/module_list/connect/proxy.rs
@@ -9,7 +9,7 @@ use base64::engine::general_purpose::STANDARD;
 use super::direct::connect_with_optional_bind;
 use crate::client::module_list::parsing::{decode_host_component, hex_value, parse_bracketed_host};
 use crate::client::module_list::{DaemonAddress, types::SocketAddrDisplay};
-use crate::client::{ClientError, SOCKET_IO_EXIT_CODE, socket_error};
+use crate::client::{ClientError, SOCKET_IO_EXIT_CODE, TcpFastOpenMode, socket_error};
 use crate::message::Role;
 use crate::rsync_error;
 
@@ -19,6 +19,7 @@ pub(crate) fn connect_via_proxy(
     connect_timeout: Option<Duration>,
     io_timeout: Option<Duration>,
     bind_address: Option<SocketAddr>,
+    tfo: TcpFastOpenMode,
 ) -> Result<TcpStream, ClientError> {
     let target = (proxy.host.as_str(), proxy.port);
     let addrs = target
@@ -29,7 +30,7 @@ pub(crate) fn connect_via_proxy(
     let mut stream_result: Option<TcpStream> = None;
 
     for candidate in addrs {
-        match connect_with_optional_bind(candidate, bind_address, connect_timeout) {
+        match connect_with_optional_bind(candidate, bind_address, connect_timeout, tfo) {
             Ok(stream) => {
                 stream_result = Some(stream);
                 break;

--- a/crates/core/src/client/module_list/listing.rs
+++ b/crates/core/src/client/module_list/listing.rs
@@ -215,6 +215,7 @@ pub fn run_module_list_with_password_and_options(
             effective_timeout,
             address_mode,
             options.bind_address(),
+            options.tcp_fastopen(),
             &connector,
         )?;
         return Err(daemon_error(
@@ -249,6 +250,7 @@ pub fn run_module_list_with_password_and_options(
             address_mode,
             options.connect_program(),
             options.bind_address(),
+            options.tcp_fastopen(),
         )?
     };
 

--- a/crates/core/src/client/module_list/tcp_perf.rs
+++ b/crates/core/src/client/module_list/tcp_perf.rs
@@ -21,11 +21,11 @@ use crate::client::TcpFastOpenMode;
 
 /// Apply client-side perf options to a connected stream.
 ///
-/// Sets `TCP_NOTSENT_LOWAT` when the platform supports it. The Linux
-/// client-side TFO path requires `MSG_FASTOPEN` on the first `sendto(2)`,
-/// which is incompatible with the standard `connect`/`write` flow used by
-/// the rsync client; client-side TFO is deferred to a follow-up that
-/// wires a `sendto` adapter.
+/// Sets `TCP_NOTSENT_LOWAT` when the platform supports it. Client-side TFO is
+/// requested earlier, before `connect(2)`, via `TCP_FASTOPEN_CONNECT` in
+/// `connect_with_optional_bind`; that mechanism is compatible with the
+/// standard `connect`/`write` flow, so this post-connect helper does not act
+/// on `mode`.
 ///
 /// When `pacing_bytes_per_sec` is `Some` (the client `--bwlimit` rate),
 /// `SO_MAX_PACING_RATE` caps the kernel send pace to match. This is a
@@ -36,7 +36,7 @@ pub(crate) fn apply_client_tcp_perf_options(
     mode: TcpFastOpenMode,
     pacing_bytes_per_sec: Option<u32>,
 ) {
-    let _ = mode; // Reserved for future client-side TFO wiring.
+    let _ = mode; // TFO is applied pre-connect; this helper is post-connect.
     if tcp_notsent_lowat_supported() {
         // Errors are best-effort: `TCP_NOTSENT_LOWAT` is an optimisation
         // hint and a failing setsockopt is non-fatal.

--- a/crates/core/src/client/remote/daemon_transfer/mod.rs
+++ b/crates/core/src/client/remote/daemon_transfer/mod.rs
@@ -133,6 +133,7 @@ pub fn run_daemon_transfer(
         config.address_mode(),
         config.connect_program(),
         config.bind_address().map(|b| b.socket()),
+        config.tcp_fastopen(),
     )?;
 
     // upstream: clientserver.c - start_daemon_client() calls set_socket_options()

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -499,6 +499,7 @@ fn connect_direct_applies_io_timeout() {
         timeout,
         AddressMode::Default,
         None,
+        crate::client::TcpFastOpenMode::Auto,
     )
     .expect("connect directly");
 
@@ -543,8 +544,15 @@ fn connect_via_proxy_applies_io_timeout() {
     });
 
     let timeout = Some(Duration::from_secs(6));
-    let stream = connect_via_proxy(&target, &proxy, Some(Duration::from_secs(9)), timeout, None)
-        .expect("proxy connect");
+    let stream = connect_via_proxy(
+        &target,
+        &proxy,
+        Some(Duration::from_secs(9)),
+        timeout,
+        None,
+        crate::client::TcpFastOpenMode::Auto,
+    )
+    .expect("proxy connect");
 
     assert_eq!(stream.read_timeout().expect("read timeout"), timeout);
     assert_eq!(stream.write_timeout().expect("write timeout"), timeout);


### PR DESCRIPTION
Wires the parsed `--tcp-fastopen` mode (default `auto`) into the daemon-connect path so the client requests TCP Fast Open. The merged `fast_io::enable_tcp_fastopen_connect_raw` (TCPK-4) sets `TCP_FASTOPEN_CONNECT` on the connecting socket before `connect(2)`; on Linux the kernel then defers the SYN until the first write, folding the request into the handshake and saving a round trip on connection setup.

`connect_with_optional_bind` now always builds a `socket2::Socket` (previously the no-bind branch used `std::net::TcpStream::connect`, leaving no pre-connect fd) so the option can be applied in both the bound and unbound paths. The mode is threaded from the two call sites (`listing.rs`, `daemon_transfer/mod.rs`) through `open_daemon_stream{,_tls}` -> `connect_direct`/`connect_via_proxy` -> `connect_with_optional_bind`.

`TCP_FASTOPEN_CONNECT` (kernel 4.11+) supersedes the older `MSG_FASTOPEN`-on-`sendto` mechanism, so the standard connect/write flow works unchanged - this is exactly why the previous code deferred client TFO. That now-stale comment in `apply_client_tcp_perf_options` is corrected.

Behavior:
- `Auto` (default) / `On`: set the option best-effort; an unsupported or failing `setsockopt` leaves connect to proceed normally.
- `Off`: never set.
- Non-Linux (`tcp_fastopen_connect_supported()` is false): skipped, no-op.

Wire-compatible: TFO only affects the SYN exchange, not the rsync protocol stream.

Verified on Linux kernel 7.0.0 (`/proc/sys/net/ipv4/tcp_fastopen=1`, client TFO enabled): `cargo build -p core --all-features` clean; `cargo clippy -p core --all-features --all-targets` clean; `cargo nextest -p core` connect suite - 162 passed (the connect tests open real TCP connections via `connect_direct`/`connect_via_proxy` with TFO Auto, so the socket2 refactor and the option are exercised live).