### PR TITLE
perf(engine): skip FICLONE ioctl on cross-filesystem local copies

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -22,6 +22,7 @@ use logging::debug_log;
 
 use ::metadata::MetadataOptions;
 
+use crate::local_copy::overrides::same_filesystem;
 use crate::local_copy::{
     CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
     LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
@@ -110,6 +111,18 @@ pub(super) fn try_clone(
     flags: TransferFlags,
 ) -> Result<bool, LocalCopyError> {
     let file_size = metadata.len();
+
+    // REFLINK-2: skip the FICLONE ioctl when source and destination live on
+    // different filesystems. ioctl(FICLONE) only reflinks within one
+    // filesystem and fails with EXDEV across mounts - but not before
+    // File::create() has already materialised an empty destination inode that
+    // we then have to unlink. Comparing st_dev up front avoids that wasted
+    // create/ioctl/unlink round-trip on cross-filesystem copies. When the
+    // device ids cannot be determined the helper returns None and we fall
+    // through to let try_ficlone decide.
+    if same_filesystem(source, metadata, destination) == Some(false) {
+        return Ok(false);
+    }
 
     if fast_io::try_ficlone(source, destination).is_err() {
         let _ = std::fs::remove_file(destination);

--- a/crates/engine/src/local_copy/overrides.rs
+++ b/crates/engine/src/local_copy/overrides.rs
@@ -158,3 +158,92 @@ pub(super) fn device_identifier(path: &Path, metadata: &fs::Metadata) -> Option<
         None
     }
 }
+
+/// Returns whether `source` and `destination` reside on the same filesystem.
+///
+/// Compares the device id of `source` against the device id of
+/// `destination`'s parent directory - the destination file itself may not
+/// exist yet, so its filesystem is the parent's. Returns `None` when either
+/// device id cannot be determined (e.g. the parent cannot be stat'd), letting
+/// callers fall back to attempting the operation. Used to gate reflink fast
+/// paths (`ioctl(FICLONE)`/`FICLONERANGE`) that only clone within a single
+/// filesystem and otherwise fail with `EXDEV`.
+#[cfg(target_os = "linux")]
+pub(super) fn same_filesystem(
+    source: &Path,
+    source_metadata: &fs::Metadata,
+    destination: &Path,
+) -> Option<bool> {
+    let source_dev = device_identifier(source, source_metadata)?;
+    let parent = destination.parent()?;
+    let parent_metadata = fs::symlink_metadata(parent).ok()?;
+    let dest_dev = device_identifier(parent, &parent_metadata)?;
+    Some(source_dev == dest_dev)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod same_filesystem_tests {
+    use super::{same_filesystem, with_device_id_override};
+    use tempfile::tempdir;
+
+    #[test]
+    fn reports_same_device_when_ids_match() {
+        // Source and destination parent both resolve to device 1: the helper
+        // must report Some(true) so the FICLONE fast path proceeds.
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("src");
+        let dest = temp.path().join("dst");
+        std::fs::write(&source, b"data").expect("write source");
+        let source_meta = std::fs::symlink_metadata(&source).expect("source metadata");
+
+        let verdict = with_device_id_override(
+            |_path, _meta| Some(1),
+            || same_filesystem(&source, &source_meta, &dest),
+        );
+        assert_eq!(verdict, Some(true));
+    }
+
+    #[test]
+    fn reports_cross_device_when_ids_differ() {
+        // Source resolves to device 1, the destination's parent to device 2:
+        // the helper must report Some(false) so the caller skips the doomed
+        // cross-filesystem FICLONE ioctl entirely.
+        let source_dir = tempdir().expect("source tempdir");
+        let dest_dir = tempdir().expect("dest tempdir");
+        let source = source_dir.path().join("src");
+        let dest = dest_dir.path().join("dst");
+        std::fs::write(&source, b"data").expect("write source");
+        let source_meta = std::fs::symlink_metadata(&source).expect("source metadata");
+
+        let dest_parent = dest_dir.path().to_path_buf();
+        let verdict = with_device_id_override(
+            move |path, _meta| {
+                if path == dest_parent.as_path() {
+                    Some(2)
+                } else {
+                    Some(1)
+                }
+            },
+            || same_filesystem(&source, &source_meta, &dest),
+        );
+        assert_eq!(verdict, Some(false));
+    }
+
+    #[test]
+    fn reports_none_when_destination_parent_missing() {
+        // A destination whose parent directory does not exist cannot be
+        // stat'd, so the helper returns None and the caller falls through to
+        // try_ficlone rather than wrongly skipping it.
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("src");
+        std::fs::write(&source, b"data").expect("write source");
+        let source_meta = std::fs::symlink_metadata(&source).expect("source metadata");
+        let dest = temp.path().join("missing").join("dst");
+
+        let verdict = with_device_id_override(
+            |_path, _meta| Some(1),
+            || same_filesystem(&source, &source_meta, &dest),
+        );
+        assert_eq!(verdict, None);
+    }
+}


### PR DESCRIPTION
## Summary

Whole-file local copies attempt `ioctl(FICLONE)` unconditionally. FICLONE only creates a reflink within a single filesystem and fails with `EXDEV` across mount boundaries - but not before `File::create()` has already materialised an empty destination inode that then has to be unlinked.

This adds a `same_filesystem` helper that compares the source `st_dev` against the destination parent's `st_dev` and skips the doomed `ioctl`/`create`/`unlink` round-trip when they differ.

## Behaviour

- **Same filesystem** (the common path): unchanged - the gate passes and `try_ficlone` proceeds.
- **Cross filesystem**: returns early to the generic copy path, identical end result without the wasted syscalls + temp inode.
- **Device id unavailable** (helper returns `None`): falls through to `try_ficlone` exactly as before - no behaviour change.

The `same_filesystem` helper lives next to `device_identifier` so the upcoming `FICLONERANGE` same-fs gate can reuse it. Both the helper and the FICLONE fast path are Linux-only.

## Tests

New `same_filesystem` unit tests (Linux) using the existing `with_device_id_override` harness cover same-device, cross-device, and missing-parent cases.

Verified `clippy --all-targets --all-features` and the new tests on a Linux host (kernel 7.0.0).