### PR TITLE
perf(fast_io): version-gate the RWF_DONTCACHE writer selection

### DIFF
--- a/crates/fast_io/src/dontcache_writer.rs
+++ b/crates/fast_io/src/dontcache_writer.rs
@@ -169,6 +169,57 @@ fn dontcache_write(fd: RawFd, chunk: &[u8]) -> io::Result<usize> {
     Ok(ret as usize)
 }
 
+/// Returns whether the running kernel advertises `RWF_DONTCACHE` (Linux 6.14+).
+///
+/// The kernel release is read once via `uname(2)` and the verdict is cached for
+/// the lifetime of the process. A `true` result only means the version gate is
+/// met; per-file filesystem rejection is still handled by
+/// [`DontcacheFileWriter`]'s `dontcache_ok` fallback. Callers use this as a
+/// cheap up-front "is the flag worth attempting" check before selecting the
+/// writer, mirroring `is_io_uring_available`.
+#[cfg(all(target_os = "linux", feature = "dontcache"))]
+#[must_use]
+pub fn dontcache_supported() -> bool {
+    use crate::kernel_version::{DontcacheRequirement, VersionRequirement, parse_kernel_version};
+    use std::sync::OnceLock;
+
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(|| {
+        kernel_release()
+            .as_deref()
+            .and_then(parse_kernel_version)
+            .is_some_and(|kv| DontcacheRequirement.is_supported(&kv))
+    })
+}
+
+/// Reads the kernel release string via `uname(2)` (e.g. `"6.14.0-generic"`).
+#[cfg(all(target_os = "linux", feature = "dontcache"))]
+#[allow(unsafe_code)]
+fn kernel_release() -> Option<String> {
+    use std::ffi::CStr;
+    // SAFETY: `utsname` is zero-initialised then fully populated by `uname`,
+    // which is sound for the POD struct. On success `release` is a
+    // NUL-terminated byte array that stays valid for the `CStr` borrow below.
+    unsafe {
+        let mut utsname: libc::utsname = std::mem::zeroed();
+        if libc::uname(&mut utsname) != 0 {
+            return None;
+        }
+        CStr::from_ptr(utsname.release.as_ptr())
+            .to_str()
+            .ok()
+            .map(String::from)
+    }
+}
+
+/// Stub: `RWF_DONTCACHE` exists only on Linux 6.14+ with the `dontcache`
+/// feature, so every other configuration reports it unsupported.
+#[cfg(not(all(target_os = "linux", feature = "dontcache")))]
+#[must_use]
+pub fn dontcache_supported() -> bool {
+    false
+}
+
 /// Stub for non-Linux platforms or when the `dontcache` feature is disabled.
 ///
 /// Every constructor and write method returns
@@ -271,6 +322,24 @@ mod linux_tests {
         assert_eq!(writer.write_chunk(&[]).expect("empty"), 0);
         drop(writer);
         assert!(read_back(&path).is_empty());
+    }
+
+    #[test]
+    fn dontcache_supported_matches_live_kernel_and_is_cached() {
+        use crate::kernel_version::{
+            DontcacheRequirement, VersionRequirement, parse_kernel_version,
+        };
+
+        // The probe must agree with the version gate computed from this host's
+        // live `uname(2)` release, so the result is correct on both new and
+        // old kernels without hard-coding a version into the test.
+        let expected = super::kernel_release()
+            .as_deref()
+            .and_then(parse_kernel_version)
+            .is_some_and(|kv| DontcacheRequirement.is_supported(&kv));
+        assert_eq!(dontcache_supported(), expected);
+        // OnceLock caches the verdict: a repeat call returns the same value.
+        assert_eq!(dontcache_supported(), expected);
     }
 }
 

--- a/crates/fast_io/src/kernel_version.rs
+++ b/crates/fast_io/src/kernel_version.rs
@@ -184,6 +184,21 @@ impl VersionRequirement for SendZcRequirement {
     }
 }
 
+/// `RWF_DONTCACHE` uncached buffered I/O (Linux 6.14+).
+pub struct DontcacheRequirement;
+
+impl VersionRequirement for DontcacheRequirement {
+    fn min_version(&self) -> KernelVersion {
+        KernelVersion {
+            major: 6,
+            minor: 14,
+        }
+    }
+    fn feature_name(&self) -> &str {
+        "RWF_DONTCACHE"
+    }
+}
+
 /// Logs the io_uring probe result at debug level.
 ///
 /// On Linux with the `io_uring` feature enabled, this queries the kernel
@@ -492,6 +507,26 @@ mod tests {
             minor: 19
         }));
         assert!(req.is_supported(&KernelVersion { major: 6, minor: 0 }));
+    }
+
+    #[test]
+    fn dontcache_requirement_needs_6_14() {
+        let req = DontcacheRequirement;
+        assert_eq!(
+            req.min_version(),
+            KernelVersion {
+                major: 6,
+                minor: 14
+            }
+        );
+        assert!(!req.is_supported(&KernelVersion {
+            major: 6,
+            minor: 13
+        }));
+        assert!(req.is_supported(&KernelVersion {
+            major: 6,
+            minor: 14
+        }));
     }
 
     #[test]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -354,7 +354,7 @@ pub use stdio_blocking::force_blocking_stdio;
 pub use stdio_shutdown::shutdown_stdio_write;
 // Non-unix `recv_fd_to_file` stub returns `Unsupported`; gate the public
 // re-export on unix to remove the dead surface area (see WIN-S.LAND.1.a).
-pub use dontcache_writer::DontcacheFileWriter;
+pub use dontcache_writer::{DontcacheFileWriter, dontcache_supported};
 #[cfg(unix)]
 pub use splice::recv_fd_to_file;
 pub use vmsplice_writer::{VMSPLICE_MIN_CHUNK, VmspliceFileWriter};

--- a/crates/transfer/src/disk_commit/process.rs
+++ b/crates/transfer/src/disk_commit/process.rs
@@ -462,11 +462,14 @@ fn make_writer<'a>(
     // dontcache path: preferred over vmsplice when both are enabled. Lands
     // chunks via pwritev2(RWF_DONTCACHE) so bulk transfers do not evict the
     // page-cache working set, falling back per-chunk to a buffered write when
-    // the kernel/filesystem rejects the flag. Sparse and append require Seek,
-    // so they keep using Buffered.
+    // the filesystem rejects the flag. `dontcache_supported()` version-gates
+    // the selection up front (RWF_DONTCACHE needs Linux 6.14+) so older
+    // kernels skip straight to vmsplice/Buffered instead of burning a failed
+    // syscall per file. Sparse and append require Seek, so they keep using
+    // Buffered.
     #[cfg(all(target_os = "linux", feature = "dontcache"))]
     {
-        if !use_sparse && append_offset == 0 {
+        if !use_sparse && append_offset == 0 && fast_io::dontcache_supported() {
             return Ok(Writer::Dontcache(fast_io::DontcacheFileWriter::new(file)?));
         }
     }


### PR DESCRIPTION
## Summary

The `dontcache` disk-commit path selected `DontcacheFileWriter` whenever the feature was compiled in, relying on the per-chunk `EINVAL`/`ENOSYS` fallback to cope with kernels older than 6.14 — which cost one failed `pwritev2` per file on every unsupported kernel.

This adds a process-wide `dontcache_supported()` probe that:
- reads the kernel release once via `uname(2)` and caches the verdict in a `OnceLock`,
- gates on a new `DontcacheRequirement` (>= 6.14) built on the existing `VersionRequirement` machinery (alongside `IoUringRequirement`, `SendZcRequirement`, etc.).

`make_writer` now consults the probe, so an old kernel skips straight to vmsplice/Buffered instead of constructing a Dontcache writer that would fail its first syscall. The per-file `dontcache_ok` flag remains as the second-line fallback for filesystem-level rejection (a 6.14+ kernel on a filesystem that rejects the flag).

## Tests

- `kernel_version.rs`: `dontcache_requirement_needs_6_14` asserts the 6.14 gate.
- `dontcache_writer.rs`: `dontcache_supported_matches_live_kernel_and_is_cached` cross-checks the probe against the version gate computed from the host's live `uname(2)` (correct on both new and old kernels, no hard-coded version) and confirms the `OnceLock` caches the verdict.

All paths are `#[cfg(all(target_os = "linux", feature = "dontcache"))]`; the non-Linux/no-feature build gets a `dontcache_supported() -> false` stub. Verified `clippy --all-targets --features dontcache -D warnings` and the tests on a Linux host (kernel 7.0.0).