### PR TITLE
ci: verify iouring-send-zc via --io-uring-status, dedupe feature gates

### DIFF
--- a/.github/workflows/send-zc-5-15-lts.yml
+++ b/.github/workflows/send-zc-5-15-lts.yml
@@ -119,21 +119,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Build and run the binary with RUST_LOG to capture the io_uring probe.
-          # The --version output includes io_uring feature status.
-          VERSION_OUTPUT=$(cargo run --locked --features iouring-send-zc -- --version 2>&1 || true)
-          printf '%s\n' "$VERSION_OUTPUT"
+          # The `--io-uring-status` capability matrix is the canonical report
+          # of which io_uring cargo features the binary was built with (the
+          # plain `--version` banner only carries a one-line io_uring summary).
+          STATUS_OUTPUT=$(cargo run --locked --features iouring-send-zc -- --io-uring-status 2>&1 || true)
+          printf '%s\n' "$STATUS_OUTPUT"
 
           # Confirm the iouring-send-zc feature is compiled in.
-          if echo "$VERSION_OUTPUT" | grep -q "iouring-send-zc:.*on"; then
+          if echo "$STATUS_OUTPUT" | grep -q "iouring-send-zc:.*on"; then
             echo "iouring-send-zc feature: compiled in"
           else
-            echo "::error::iouring-send-zc feature not reported as 'on' in --version output"
+            echo "::error::iouring-send-zc feature not reported as 'on' in --io-uring-status output"
             exit 1
           fi
 
-          echo "version_output<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$VERSION_OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "status_output<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$STATUS_OUTPUT" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Run end-to-end local transfer with iouring-send-zc

--- a/crates/fast_io/src/status.rs
+++ b/crates/fast_io/src/status.rs
@@ -119,6 +119,22 @@ fn detect_io_uring_restriction_impl() -> IoUringRestriction {
     }
 }
 
+/// Compiled-in io_uring feature gates, as `(cargo-feature-name, enabled)`
+/// pairs.
+///
+/// `cfg!` expands to a boolean literal at compile time, so this is a genuine
+/// compile-time constant and the single source of truth for which io_uring
+/// features a binary was built with. The [`io_uring_capability_matrix`]
+/// renders it (and any external probe that needs the same answer reads from
+/// here), so the gate list can no longer drift across duplicated call sites.
+pub const IO_URING_FEATURE_GATES: &[(&str, bool)] = &[
+    ("io_uring", cfg!(feature = "io_uring")),
+    ("iouring-data-reads", cfg!(feature = "iouring-data-reads")),
+    ("iouring-data-writes", cfg!(feature = "iouring-data-writes")),
+    ("iouring-send-zc", cfg!(feature = "iouring-send-zc")),
+    ("sqpoll-mlock-basis", cfg!(feature = "sqpoll-mlock-basis")),
+];
+
 /// Prints a multi-line io_uring capability matrix to stdout.
 ///
 /// Designed for the `--io-uring-status` CLI flag. Reports:
@@ -202,49 +218,14 @@ pub fn io_uring_capability_matrix() -> String {
         ));
     }
 
-    // Feature gates
+    // Feature gates (rendered from the single IO_URING_FEATURE_GATES source).
     lines.push(String::new());
     lines.push("  feature gates:".to_string());
-    lines.push(format!(
-        "    io_uring:             {}",
-        if cfg!(feature = "io_uring") {
-            "on"
-        } else {
-            "off"
-        }
-    ));
-    lines.push(format!(
-        "    iouring-data-reads:   {}",
-        if cfg!(feature = "iouring-data-reads") {
-            "on"
-        } else {
-            "off"
-        }
-    ));
-    lines.push(format!(
-        "    iouring-data-writes:  {}",
-        if cfg!(feature = "iouring-data-writes") {
-            "on"
-        } else {
-            "off"
-        }
-    ));
-    lines.push(format!(
-        "    iouring-send-zc:      {}",
-        if cfg!(feature = "iouring-send-zc") {
-            "on"
-        } else {
-            "off"
-        }
-    ));
-    lines.push(format!(
-        "    sqpoll-mlock-basis:   {}",
-        if cfg!(feature = "sqpoll-mlock-basis") {
-            "on"
-        } else {
-            "off"
-        }
-    ));
+    for (name, enabled) in IO_URING_FEATURE_GATES {
+        let label = format!("{name}:");
+        let status = if *enabled { "on" } else { "off" };
+        lines.push(format!("    {label:<22}{status}"));
+    }
 
     // Fallback chain
     lines.push(String::new());
@@ -800,6 +781,30 @@ mod tests {
         assert!(matrix.contains("available:"));
         assert!(matrix.contains("feature gates:"));
         assert!(matrix.contains("active fallback chain:"));
+    }
+
+    #[test]
+    fn capability_matrix_renders_every_feature_gate() {
+        // The `--io-uring-status` output is the canonical place to confirm
+        // which io_uring features a binary was built with; every gate in the
+        // single source of truth must surface as a `name: on/off` line so
+        // external probes (e.g. the SEND_ZC CI check) can grep for it.
+        let matrix = io_uring_capability_matrix();
+        for (name, enabled) in IO_URING_FEATURE_GATES {
+            let expected = format!("{name}:");
+            assert!(
+                matrix.contains(&expected),
+                "matrix must list the {name} feature gate"
+            );
+            let status = if *enabled { "on" } else { "off" };
+            assert!(
+                matrix.lines().any(|line| {
+                    let line = line.trim_start();
+                    line.starts_with(&expected) && line.trim_end().ends_with(status)
+                }),
+                "{name} gate must render as `{name}: {status}`"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `SEND_ZC fallback (kernel ~5.15)` workflow confirms a build compiled the `iouring-send-zc` cargo feature in by grepping the binary's output for `iouring-send-zc: on`. It ran that grep against plain `--version`, but `--version` only carries a **one-line** io_uring summary (`io_uring: compiled in, available (...)`). The per-feature gate lines (`iouring-send-zc: on`) are rendered exclusively by the purpose-built `--io-uring-status` capability matrix.

As a result the check **always failed** whenever the workflow was triggered (it is path-filtered on `crates/fast_io/**`), surfacing as a red, non-required `SEND_ZC fallback` job on every fast_io PR.

## Fix

1. **Point the probe at the right command.** The workflow now runs `--io-uring-status` (the report designed to show which io_uring features are compiled in) and greps its capability matrix. Verified on a Linux host: a `--features iouring-send-zc` build prints `iouring-send-zc:      on` and the grep matches.

2. **Remove the duplication that let the gates drift (clean-up).** The capability matrix hand-maintained five copy-pasted `format!` blocks, one per gate. They are collapsed into a single `IO_URING_FEATURE_GATES` source of truth (`&[(name, enabled)]`, where `cfg!` is a compile-time literal) rendered by one loop. A new test asserts every gate in that list surfaces as a `name: on/off` line, so the exact string the CI check greps for is now regression-protected at the unit level.

No change to product behaviour or to the `--io-uring-status`/`--version` output format (the matrix columns are byte-identical; only the source of the strings changed).

Validated: `clippy --all-targets -D warnings` and the matrix tests on a Linux host (kernel 7.0.0); `--io-uring-status` grep check reproduced green.