### PR TITLE
perf(fast_io): apply FILE_FLAG_SEQUENTIAL_SCAN to basis reads on Windows

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -361,7 +361,7 @@ pub use vmsplice_writer::{VMSPLICE_MIN_CHUNK, VmspliceFileWriter};
 
 pub use macos_io::{
     F_NOCACHE_THRESHOLD, MAX_IOV_COUNT, MacosWriter, apply_sequential_read_hint, is_nocache_set,
-    set_nocache, writev_buffers,
+    open_sequential_read, set_nocache, writev_buffers,
 };
 
 pub use kqueue::{KEvent, KEventFilter, KqueueLoop, TimerSleeper, is_kqueue_available};

--- a/crates/fast_io/src/macos_io.rs
+++ b/crates/fast_io/src/macos_io.rs
@@ -417,6 +417,42 @@ pub fn apply_sequential_read_hint(_file: &std::fs::File, _size_hint: u64) -> boo
     false
 }
 
+/// Opens `path` read-only for a sequential single-pass scan.
+///
+/// On Windows the sequential-access caching hint
+/// (`FILE_FLAG_SEQUENTIAL_SCAN`) is a `CreateFile`-time flag that cannot be
+/// set on an already-open handle, so it must be applied here at open time;
+/// it tells the cache manager to bias read-ahead for forward streaming and
+/// to evict pages eagerly behind the read point. On every other platform
+/// this is a plain [`std::fs::File::open`] - macOS applies its post-open
+/// `F_NOCACHE` hint separately via [`apply_sequential_read_hint`], and Linux
+/// has no equivalent open-time flag.
+///
+/// # Errors
+///
+/// Returns any error from opening the file.
+#[cfg(windows)]
+pub fn open_sequential_read(path: &Path) -> io::Result<std::fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_SEQUENTIAL_SCAN;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_SEQUENTIAL_SCAN)
+        .open(crate::win_path::to_extended_path(path))
+}
+
+/// Opens `path` read-only (non-Windows: a plain open; the read-ahead hint, if
+/// any, is applied post-open by [`apply_sequential_read_hint`]).
+///
+/// # Errors
+///
+/// Returns any error from opening the file.
+#[cfg(not(windows))]
+pub fn open_sequential_read(path: &Path) -> io::Result<std::fs::File> {
+    std::fs::File::open(path)
+}
+
 /// Queries whether `F_NOCACHE` is currently set on a file descriptor.
 ///
 /// macOS does not provide a direct query API for `F_NOCACHE` - the `fcntl`
@@ -926,5 +962,22 @@ mod tests {
         drop(writer);
         let content = std::fs::read(&path).unwrap();
         assert_eq!(&content, b"firstsecondthird");
+    }
+
+    #[test]
+    fn open_sequential_read_returns_readable_file() {
+        // The sequential-scan open must behave as a normal read-only open on
+        // every platform: the Windows variant only adds a caching hint, never
+        // changes the bytes returned. (The Windows flag path itself is
+        // exercised by the Windows CI matrix.)
+        use std::io::Read;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seq.bin");
+        std::fs::write(&path, b"sequential-scan-payload").unwrap();
+
+        let mut file = open_sequential_read(&path).expect("open_sequential_read");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).expect("read back");
+        assert_eq!(buf, b"sequential-scan-payload");
     }
 }

--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -48,13 +48,14 @@ impl BufferedMap {
     ///
     /// Returns an error if the file cannot be opened or its size determined.
     pub fn open_with_window<P: AsRef<Path>>(path: P, window_size: usize) -> io::Result<Self> {
-        let file = File::open(path)?;
+        // The buffered map streams the basis sequentially through a sliding
+        // window. On Windows the sequential-scan caching hint is a CreateFile
+        // open-time flag, so open through the helper to apply it; on other
+        // platforms this is a plain open. macOS then layers its post-open
+        // F_NOCACHE hint below (advisory, no-op elsewhere).
+        let file = fast_io::open_sequential_read(path.as_ref())?;
         let size = file.metadata()?.len();
 
-        // The buffered map streams the basis sequentially through a sliding
-        // window, so on macOS hint F_NOCACHE for large files to keep the
-        // single-pass read from evicting the page-cache working set. Advisory
-        // and a no-op on other platforms.
         let _ = fast_io::apply_sequential_read_hint(&file, size);
 
         Ok(Self {


### PR DESCRIPTION
## Summary

The buffered basis map streams the source file sequentially through a sliding window. On macOS this is hinted post-open via `F_NOCACHE`; on Linux there is no open-time equivalent. Windows had no hint at all, because `FILE_FLAG_SEQUENTIAL_SCAN` is a `CreateFile`-time flag that cannot be applied to an already-open handle.

This adds `fast_io::open_sequential_read(path)`:
- **Windows**: opens read-only with `FILE_FLAG_SEQUENTIAL_SCAN` via `OpenOptionsExt::custom_flags`, routed through `to_extended_path` for long-path correctness — telling the cache manager to bias read-ahead for forward streaming and evict behind the read point.
- **Everything else**: a plain `File::open` (macOS still layers its post-open `F_NOCACHE` hint below, unchanged).

`BufferedMap::open_with_window` now opens through the helper. Behaviour is preserved byte-for-byte on Linux/macOS; Windows gains the sequential-scan hint. The handle-based `from_file_with_window` path keeps the macOS post-open hint and is unchanged (the Windows flag can only be set by whoever opens the handle).

## Tests

`open_sequential_read_returns_readable_file` confirms the helper behaves as a normal read-only open and returns the exact bytes on every platform (the Windows flag path is additionally exercised by the Windows CI matrix).

Validated `clippy --all-targets -D warnings` (macOS) and the test on a Linux host.