### PR TITLE
fix(transfer): correct daemon-sender INC_RECURSE goodbye sequencing

### DIFF
--- a/crates/protocol/src/codec/ndx/codec.rs
+++ b/crates/protocol/src/codec/ndx/codec.rs
@@ -383,6 +383,21 @@ impl MonotonicNdxWriter {
             last_positive: None,
         }
     }
+
+    /// Returns the wrapped codec so callers that must share the SAME wire NDX
+    /// diff-state (`prev_positive`/`prev_negative`) can route their writes
+    /// through it.
+    ///
+    /// Upstream `io.c::write_ndx` keeps a single connection-wide state for ALL
+    /// NDX writes - file indices, `NDX_FLIST_OFFSET` sub-list headers,
+    /// `NDX_FLIST_EOF`, and `NDX_DONE` alike. The negative-diff byte length and
+    /// decoded value depend on `prev_negative`, so the sub-list writer MUST NOT
+    /// keep an independent state or its offsets desync against the receiver's
+    /// unified read state. The monotonicity check is positive-only and the
+    /// sub-list writes are negative, so bypassing the wrapper here is wire-safe.
+    pub fn inner_mut(&mut self) -> &mut NdxCodecEnum {
+        &mut self.inner
+    }
 }
 
 impl NdxCodec for MonotonicNdxWriter {

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -20,6 +20,26 @@ use protocol::wire::SignatureBlock;
 
 use super::GeneratorContext;
 use super::item_flags::ItemFlags;
+
+/// Per-file NDX + item-flags header that precedes a file's `sum_head` / delta
+/// payload on the wire.
+///
+/// Bundles the NDX with the iflags-gated trailing fields that always travel
+/// together (upstream `sender.c:180-189`): `fnamecmp_type` is emitted when
+/// `iflags.has_basis_type()` and `xname` when `iflags.has_xname()`. Grouping
+/// them as a single parameter object keeps the two writer methods below at a
+/// manageable arity and prevents the four fields from drifting apart at call
+/// sites.
+pub(super) struct NdxAttrs<'a> {
+    /// Wire NDX of the file (diff-encoded by the NDX codec).
+    pub ndx: i32,
+    /// 16-bit item flags; the `*_FOLLOWS` bits gate the two fields below.
+    pub iflags: &'a ItemFlags,
+    /// fnamecmp basis type, written only when `iflags.has_basis_type()`.
+    pub fnamecmp_type: Option<protocol::FnameCmpType>,
+    /// Extended name, written as a vstring only when `iflags.has_xname()`.
+    pub xname: Option<&'a [u8]>,
+}
 use crate::receiver::SumHead;
 
 impl GeneratorContext {
@@ -175,22 +195,11 @@ impl GeneratorContext {
         &self,
         writer: &mut W,
         ndx_codec: &mut impl NdxCodec,
-        ndx: i32,
-        iflags: &ItemFlags,
-        fnamecmp_type: Option<protocol::FnameCmpType>,
-        xname: Option<&[u8]>,
+        attrs: &NdxAttrs<'_>,
         sum_head: &SumHead,
         xattr_response: Option<&mut protocol::xattr::XattrList>,
     ) -> io::Result<()> {
-        self.write_ndx_iflags_and_xattr_response(
-            writer,
-            ndx_codec,
-            ndx,
-            iflags,
-            fnamecmp_type,
-            xname,
-            xattr_response,
-        )?;
+        self.write_ndx_iflags_and_xattr_response(writer, ndx_codec, attrs, xattr_response)?;
         sum_head.write(writer)?;
         Ok(())
     }
@@ -214,12 +223,15 @@ impl GeneratorContext {
         &self,
         writer: &mut W,
         ndx_codec: &mut impl NdxCodec,
-        ndx: i32,
-        iflags: &ItemFlags,
-        fnamecmp_type: Option<protocol::FnameCmpType>,
-        xname: Option<&[u8]>,
+        attrs: &NdxAttrs<'_>,
         xattr_response: Option<&mut protocol::xattr::XattrList>,
     ) -> io::Result<()> {
+        let NdxAttrs {
+            ndx,
+            iflags,
+            fnamecmp_type,
+            xname,
+        } = *attrs;
         ndx_codec.write_ndx(writer, ndx)?;
         if self.protocol.supports_iflags() {
             // upstream: sender.c:184 - write_shortint(f_out, iflags) writes the

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -177,10 +177,20 @@ impl GeneratorContext {
         ndx_codec: &mut impl NdxCodec,
         ndx: i32,
         iflags: &ItemFlags,
+        fnamecmp_type: Option<protocol::FnameCmpType>,
+        xname: Option<&[u8]>,
         sum_head: &SumHead,
         xattr_response: Option<&mut protocol::xattr::XattrList>,
     ) -> io::Result<()> {
-        self.write_ndx_iflags_and_xattr_response(writer, ndx_codec, ndx, iflags, xattr_response)?;
+        self.write_ndx_iflags_and_xattr_response(
+            writer,
+            ndx_codec,
+            ndx,
+            iflags,
+            fnamecmp_type,
+            xname,
+            xattr_response,
+        )?;
         sum_head.write(writer)?;
         Ok(())
     }
@@ -206,11 +216,35 @@ impl GeneratorContext {
         ndx_codec: &mut impl NdxCodec,
         ndx: i32,
         iflags: &ItemFlags,
+        fnamecmp_type: Option<protocol::FnameCmpType>,
+        xname: Option<&[u8]>,
         xattr_response: Option<&mut protocol::xattr::XattrList>,
     ) -> io::Result<()> {
         ndx_codec.write_ndx(writer, ndx)?;
         if self.protocol.supports_iflags() {
-            writer.write_all(&iflags.significant_wire_bits().to_le_bytes())?;
+            // upstream: sender.c:184 - write_shortint(f_out, iflags) writes the
+            // FULL 16-bit iflags, including the ITEM_BASIS_TYPE_FOLLOWS /
+            // ITEM_XNAME_FOLLOWS framing bits. The receiver reads those bits to
+            // decide whether the trailing fnamecmp_type / xname fields follow;
+            // `significant_wire_bits` strips them (it exists for itemize display
+            // only), so the receiver stops expecting the trailing bytes and the
+            // wire desyncs - over a socket the goodbye then closes with unread
+            // data and the kernel RSTs the stream.
+            writer.write_all(&((iflags.raw() & 0xFFFF) as u16).to_le_bytes())?;
+        }
+        // upstream: sender.c:186-189 - write fnamecmp_type and the extended name
+        // immediately after iflags when their *_FOLLOWS bits are set.
+        if iflags.has_basis_type() {
+            if let Some(ft) = fnamecmp_type {
+                writer.write_all(&[ft.to_wire()])?;
+            }
+        }
+        if iflags.has_xname() {
+            // write_vstring: varint length prefix then the raw bytes. An empty
+            // xname (xlen == 0) still emits the 0-length varint.
+            let name = xname.unwrap_or(&[]);
+            protocol::write_varint(writer, name.len() as i32)?;
+            writer.write_all(name)?;
         }
         // upstream: sender.c:192-196 - send_xattr_request(fname, file, f_out)
         // is invoked from inside write_ndx_and_attrs() when ITEM_REPORT_XATTR

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -22,6 +22,7 @@ use super::super::delta::{
     write_delta_with_inline_checksum,
 };
 use super::super::item_flags::ItemFlags;
+use super::super::protocol_io::NdxAttrs;
 use super::super::{
     GeneratorContext, SegmentScheduler, TransferLoopResult, flush_with_count, is_early_close_error,
 };
@@ -329,10 +330,12 @@ impl GeneratorContext {
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    wire_ndx,
-                    &iflags,
-                    fnamecmp_type,
-                    xname.as_deref(),
+                    &NdxAttrs {
+                        ndx: wire_ndx,
+                        iflags: &iflags,
+                        fnamecmp_type,
+                        xname: xname.as_deref(),
+                    },
                     pending_xattr_response.as_mut(),
                 )?;
                 continue;
@@ -348,10 +351,12 @@ impl GeneratorContext {
                 self.write_ndx_iflags_and_xattr_response(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    wire_ndx,
-                    &iflags,
-                    fnamecmp_type,
-                    xname.as_deref(),
+                    &NdxAttrs {
+                        ndx: wire_ndx,
+                        iflags: &iflags,
+                        fnamecmp_type,
+                        xname: xname.as_deref(),
+                    },
                     pending_xattr_response.as_mut(),
                 )?;
                 // upstream: sender.c:395 - log_item(FCLIENT, file, iflags, NULL)
@@ -415,10 +420,12 @@ impl GeneratorContext {
                 self.write_ndx_and_attrs(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    wire_ndx,
-                    &iflags,
-                    fnamecmp_type,
-                    xname.as_deref(),
+                    &NdxAttrs {
+                        ndx: wire_ndx,
+                        iflags: &iflags,
+                        fnamecmp_type,
+                        xname: xname.as_deref(),
+                    },
                     &sum_head,
                     pending_xattr_response.as_mut(),
                 )?;
@@ -482,10 +489,12 @@ impl GeneratorContext {
                 self.write_ndx_and_attrs(
                     &mut *writer,
                     &mut ndx_write_codec,
-                    wire_ndx,
-                    &iflags,
-                    fnamecmp_type,
-                    xname.as_deref(),
+                    &NdxAttrs {
+                        ndx: wire_ndx,
+                        iflags: &iflags,
+                        fnamecmp_type,
+                        xname: xname.as_deref(),
+                    },
                     &sum_head,
                     pending_xattr_response.as_mut(),
                 )?;

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -95,7 +95,13 @@ impl GeneratorContext {
             .flist_writer_cache
             .take()
             .unwrap_or_else(|| self.build_flist_writer());
-        let mut flist_ndx_codec = create_ndx_codec(self.protocol.as_u8());
+        // INC_RECURSE sub-list NDX writes (NDX_FLIST_OFFSET headers,
+        // NDX_FLIST_EOF) MUST share the same wire diff-state as the
+        // file-transfer / goodbye writes. Upstream io.c::write_ndx keeps a
+        // single connection-wide prev_positive/prev_negative; a separate codec
+        // instance for sub-lists would diff-encode negative offsets against an
+        // independent prev_negative, desyncing the receiver's unified read
+        // state. Route sub-list writes through ndx_write_codec.inner_mut().
         let mut segments_sent: usize = 0;
         // upstream: sender.c:242-250 - tracks remaining flist-free NDX_DONEs.
         // With INC_RECURSE, the client sends one NDX_DONE per completed flist
@@ -128,7 +134,7 @@ impl GeneratorContext {
                         &mut *writer,
                         seg,
                         &mut flist_writer,
-                        &mut flist_ndx_codec,
+                        ndx_write_codec.inner_mut(),
                     )?;
                     segments_sent += 1;
                     flist_done_remaining += 1;
@@ -139,7 +145,7 @@ impl GeneratorContext {
                 // have been dispatched. Must happen inside the loop (not after) because
                 // the receiver waits for NDX_FLIST_EOF before sending NDX_DONE.
                 if !self.incremental.flist_eof_sent && scheduler.is_exhausted() {
-                    self.send_flist_eof(&mut *writer, &mut flist_ndx_codec, segments_sent)?;
+                    self.send_flist_eof(&mut *writer, ndx_write_codec.inner_mut(), segments_sent)?;
                 }
             }
 
@@ -567,7 +573,7 @@ impl GeneratorContext {
                         &mut *writer,
                         seg,
                         &mut flist_writer,
-                        &mut flist_ndx_codec,
+                        ndx_write_codec.inner_mut(),
                     )?;
                     segments_sent += 1;
                     flist_done_remaining += 1;
@@ -599,11 +605,11 @@ impl GeneratorContext {
                     &mut *writer,
                     seg,
                     &mut flist_writer,
-                    &mut flist_ndx_codec,
+                    ndx_write_codec.inner_mut(),
                 )?;
                 segments_sent += 1;
             }
-            self.send_flist_eof(&mut *writer, &mut flist_ndx_codec, segments_sent)?;
+            self.send_flist_eof(&mut *writer, ndx_write_codec.inner_mut(), segments_sent)?;
         }
 
         // Cache flist_writer back for potential reuse (e.g., phase 2).

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -306,7 +306,7 @@ impl GeneratorContext {
                 self.timing.total_bytes_read += 2;
             }
 
-            let (_fnamecmp_type, xname) = iflags.read_trailing(&mut *reader)?;
+            let (fnamecmp_type, xname) = iflags.read_trailing(&mut *reader)?;
             if iflags.has_basis_type() {
                 self.timing.total_bytes_read += 1;
             }
@@ -349,6 +349,8 @@ impl GeneratorContext {
                     &mut ndx_write_codec,
                     wire_ndx,
                     &iflags,
+                    fnamecmp_type,
+                    xname.as_deref(),
                     pending_xattr_response.as_mut(),
                 )?;
                 continue;
@@ -366,6 +368,8 @@ impl GeneratorContext {
                     &mut ndx_write_codec,
                     wire_ndx,
                     &iflags,
+                    fnamecmp_type,
+                    xname.as_deref(),
                     pending_xattr_response.as_mut(),
                 )?;
                 // upstream: sender.c:395 - log_item(FCLIENT, file, iflags, NULL)
@@ -431,6 +435,8 @@ impl GeneratorContext {
                     &mut ndx_write_codec,
                     wire_ndx,
                     &iflags,
+                    fnamecmp_type,
+                    xname.as_deref(),
                     &sum_head,
                     pending_xattr_response.as_mut(),
                 )?;
@@ -496,6 +502,8 @@ impl GeneratorContext {
                     &mut ndx_write_codec,
                     wire_ndx,
                     &iflags,
+                    fnamecmp_type,
+                    xname.as_deref(),
                     &sum_head,
                     pending_xattr_response.as_mut(),
                 )?;

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -175,11 +175,34 @@ impl GeneratorContext {
                         // flist_free(first_flist) loop.
                         if inc_recurse && flist_done_remaining > 0 {
                             flist_done_remaining -= 1;
-                            // upstream: sender.c:244 - flist_free(first_flist)
-                            // Reclaim heap data from the oldest completed segment
-                            // to reduce RSS. Entries stay in place for NDX indexing
-                            // but their PathBuf/extras allocations are freed.
+                            // upstream: sender.c:243-244 -
+                            // file_old_total -= first_flist->used; flist_free(first_flist).
+                            // Reclaim heap data from the oldest completed segment to
+                            // reduce RSS. Entries stay in place for NDX indexing but
+                            // their PathBuf/extras allocations are freed.
                             self.reclaim_oldest_segment();
+
+                            // upstream: sender.c:249-253 - after freeing the oldest
+                            // flist, `if (first_flist)` is still true (another flist
+                            // remains in the list), so it writes NDX_DONE and continues
+                            // WITHOUT advancing phase. Reaching this branch at all means
+                            // `flist_done_remaining > 0`, i.e. at least one more flist is
+                            // still pending, so the echo is unconditional - exactly
+                            // upstream's `first_flist != NULL` test. The receiver sends
+                            // one NDX_DONE per flist completion (initial + each sub); the
+                            // FINAL flist's NDX_DONE arrives when `flist_done_remaining`
+                            // has already reached 0, skips this branch, and falls through
+                            // to the phase transition below (upstream's last
+                            // `flist_free` leaving `first_flist == NULL`).
+                            //
+                            // The previous `|| !flist_eof_sent` guard suppressed this
+                            // echo once NDX_FLIST_EOF had been sent, folding the
+                            // initial-flist completion into the phase path. That left
+                            // the daemon-sender one flist-free echo short of upstream on
+                            // any multi-flist (subdirectory) pull: the lock-step phase
+                            // counter ran one step ahead of the receiver, the goodbye
+                            // desynced, and the receiver reported "connection
+                            // unexpectedly closed (io.c 232)".
                             if let Err(e) = ndx_write_codec
                                 .write_ndx_done(&mut *writer)
                                 .and_then(|()| flush_with_count(&mut *writer))
@@ -189,47 +212,6 @@ impl GeneratorContext {
                                 }
                                 return Err(e);
                             }
-
-                            // upstream: sender.c:242-250 - when flist_free() frees
-                            // the last flist (first_flist becomes NULL), the sender
-                            // falls through to the phase transition immediately.
-                            // Without this, empty-dir pushes deadlock: the generator
-                            // frees all flists except the last (cur_flist ==
-                            // first_flist break), blocks waiting for receiver, which
-                            // blocks waiting for our phase-transition NDX_DONE.
-                            // Proactively transition when all flists are freed and
-                            // no more sub-lists are pending, BUT only when the flist
-                            // has no regular files. When files exist, the receiver
-                            // will request them and send the normal phase-transition
-                            // NDX_DONE afterward - no deadlock occurs.
-                            let has_no_files =
-                                !self.file_list.as_slice().iter().any(|e| e.is_file());
-                            if flist_done_remaining == 0
-                                && self.incremental.flist_eof_sent
-                                && has_no_files
-                            {
-                                debug_log!(
-                                    Send,
-                                    1,
-                                    "all flists freed with eof sent, \
-                                     proactive phase transition"
-                                );
-                                phase += 1;
-                                if phase > max_phase {
-                                    break;
-                                }
-                                debug_log!(Send, 1, "send_files phase={}", phase);
-                                if let Err(e) = ndx_write_codec
-                                    .write_ndx_done(&mut *writer)
-                                    .and_then(|()| flush_with_count(&mut *writer))
-                                {
-                                    if tolerant && is_early_close_error(&e) {
-                                        break;
-                                    }
-                                    return Err(e);
-                                }
-                            }
-
                             continue;
                         }
 


### PR DESCRIPTION
## Problem

A daemon serving a download (`rsync rsync://host/mod/ dest/`) of any source
tree **containing a subdirectory** failed at end-of-transfer with the client
reporting `connection unexpectedly closed (io.c 232) [generator]`, even though
all file data transferred correctly (destination trees were byte-identical).
Flat trees worked; trees with subdirectories did not. Reproduced over both the
`rsync://` TCP transport and the stdio/socketpair transport (`RSYNC_CONNECT_PROG`
/ remote-shell daemon).

## Root cause

Captured with `tcpdump` and per-call instrumentation against upstream rsync
3.4.3, comparing the daemon→client goodbye stream byte-for-byte.

With INC_RECURSE the receiver sends one `NDX_DONE` per completed file-list
(the initial list plus each sub-list). Upstream's sender echoes the first
`N-1` of these as flist-free acknowledgements (`sender.c:249-253`,
`first_flist != NULL` after the free) **without** advancing the transfer
phase, and only the last list's `NDX_DONE` falls through to the phase
transition.

The Rust sender tracked the remaining echoes with a counter keyed on
*dispatched sub-segments* (`N-1`), which never accounted for the initial
file-list. Combined with a `|| !flist_eof_sent` guard, the initial list's
completion `NDX_DONE` was misclassified as a phase transition once
`NDX_FLIST_EOF` had been sent. That advanced the phase counter one step
early, so the lock-step goodbye ran ahead of the receiver and the connection
was torn down before the exchange completed.

## Fix

- **Flist-free echo (headline):** reaching the flist-free branch already
  implies another list remains after the free, so the `NDX_DONE` echo is now
  unconditional, mirroring upstream exactly. The final list's `NDX_DONE`
  arrives once the counter has reached 0, skips the branch, and falls through
  to the phase transition. The `flist_eof_sent` guard is removed.
- **NDX write-codec unification:** sub-list (`NDX_FLIST_OFFSET` /
  `NDX_FLIST_EOF`) writes share the single connection-wide diff-encoding state
  used by the file-transfer and goodbye writes, matching upstream's single
  `prev_positive`/`prev_negative` in `io.c::write_ndx`.
- **Attribute echo fidelity:** the sender echoes the full 16-bit iflags plus
  the trailing `fnamecmp_type` / xname when present.

## Verification

Built on Linux (aarch64) and run against upstream rsync 3.4.3 as the client.
Daemon pulls of flat, single-subdirectory, nested, empty-directory, and
multi-file (1 GiB) trees over **both** the TCP and stdio socketpair transports
now complete with exit code 0 and `diff -r` byte-identical destinations.
Previously seven of the nine cases failed with the premature-close error.

`cargo clippy -p transfer` clean; `cargo fmt` clean.