### PR TITLE
feat(transfer): implied --list-only recursive listing for daemon source

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/server_config.rs
@@ -38,6 +38,12 @@ pub(crate) fn build_server_config_for_receiver(
     // client IS the receiver and --existing is a long-form-only flag absent from
     // the compact letter string, so carry it onto the local receiver config here.
     server_config.file_selection.existing_only = config.existing_only();
+    // upstream: options.c:2194 / generator.c:1249 - a single source operand with
+    // no destination implies --list-only. On a pull the local client IS the
+    // receiver and list_only is a long-form-only flag absent from the compact
+    // letter string, so carry it onto the local receiver config here. The
+    // receiver then renders the flist without issuing any per-file NDX request.
+    server_config.flags.list_only = config.list_only();
 
     flags::apply_common_server_flags(config, &mut server_config);
     Ok(server_config)

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use crate::client::summary::ClientSummary;
+use crate::client::summary::{ClientEntryMetadata, ClientEvent, ClientSummary};
 
 /// Converts server-side statistics to a client summary.
 ///
@@ -19,6 +19,28 @@ pub(super) fn convert_server_stats_to_summary(
     use crate::server::ServerStats;
     use engine::local_copy::LocalCopySummary;
     use transfer::io_error_flags;
+
+    // upstream: generator.c:1249 - in list-only mode the receiver captures every
+    // flist entry's metadata instead of requesting file data; convert those into
+    // metadata-bearing events so the client can render the listing.
+    let list_only_events: Vec<ClientEvent> = match stats {
+        ServerStats::Receiver(ref transfer_stats) => transfer_stats
+            .list_only_entries
+            .iter()
+            .map(|entry| {
+                let metadata = ClientEntryMetadata::from_list_only_entry(
+                    entry.mode,
+                    entry.size,
+                    entry.mtime,
+                    entry.mtime_nsec,
+                    entry.symlink_target.clone(),
+                    entry.is_symlink,
+                );
+                ClientEvent::from_list_only_entry(entry.path.clone(), metadata)
+            })
+            .collect(),
+        ServerStats::Generator(_) => Vec::new(),
+    };
 
     let (local_summary, io_error, error_count) = match stats {
         ServerStats::Receiver(ref transfer_stats) => {
@@ -58,6 +80,9 @@ pub(super) fn convert_server_stats_to_summary(
     };
 
     let mut summary = ClientSummary::from_summary(local_summary);
+    if !list_only_events.is_empty() {
+        summary = summary.with_events(list_only_events);
+    }
 
     // upstream: log.c - log_exit() converts io_error bitfield to RERR_* codes.
     let exit_code = io_error_flags::to_exit_code(io_error);

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -211,6 +211,44 @@ impl ClientEvent {
         }
     }
 
+    /// Builds an event for a `--list-only` flist entry.
+    ///
+    /// The renderer (`emit_list_only`) prints the line from `relative_path` plus
+    /// the metadata snapshot; `kind` only gates inclusion via `list_only_event`.
+    /// Directories map to `DirectoryCreated`, symlinks to `SymlinkCopied`, and
+    /// every other entry to `DataCopied` - all three pass the inclusion gate.
+    /// No destination write occurs in list-only mode, so the destination paths
+    /// are left empty.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1249` - `list_file_entry()` per-entry render
+    #[must_use]
+    pub fn from_list_only_entry(relative_path: PathBuf, metadata: ClientEntryMetadata) -> Self {
+        let kind = match metadata.kind() {
+            ClientEntryKind::Directory => ClientEventKind::DirectoryCreated,
+            ClientEntryKind::Symlink => ClientEventKind::SymlinkCopied,
+            _ => ClientEventKind::DataCopied,
+        };
+        let is_directory = metadata.kind().is_directory();
+        let total_bytes = Some(metadata.length());
+        let destination_root: Arc<Path> = Arc::from(Path::new(""));
+        Self {
+            relative_path,
+            kind,
+            bytes_transferred: 0,
+            total_bytes,
+            elapsed: Duration::ZERO,
+            metadata: Some(metadata),
+            created: false,
+            destination_root,
+            destination_path: PathBuf::new(),
+            change_set: LocalCopyChangeSet::new(),
+            hardlink_uptodate: false,
+            is_directory,
+        }
+    }
+
     /// Returns the relative path affected by this event.
     #[must_use]
     pub fn relative_path(&self) -> &Path {

--- a/crates/core/src/client/summary/metadata.rs
+++ b/crates/core/src/client/summary/metadata.rs
@@ -5,7 +5,7 @@
 //! are used by `ClientEvent` to report per-file details.
 
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use engine::local_copy::{LocalCopyFileKind, LocalCopyMetadata};
 
@@ -85,6 +85,60 @@ impl ClientEntryMetadata {
             uid,
             gid,
             nlink,
+            symlink_target,
+        }
+    }
+
+    /// Constructs metadata for a `--list-only` flist entry.
+    ///
+    /// The receiver captures each entry's raw mode/size/mtime/target while
+    /// rendering the file list (it never opens or stats the destination), so
+    /// this builds the snapshot directly from those fields. The `mtime` is in
+    /// whole seconds and `mtime_nsec` carries the sub-second component.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1249` - `list_file_entry()` renders mode/size/mtime/name
+    #[must_use]
+    pub fn from_list_only_entry(
+        mode: u32,
+        size: u64,
+        mtime: i64,
+        mtime_nsec: u32,
+        symlink_target: Option<PathBuf>,
+        is_symlink: bool,
+    ) -> Self {
+        let kind = if is_symlink {
+            ClientEntryKind::Symlink
+        } else {
+            // upstream: list_file_entry() derives the type char from the mode
+            // bits; mirror the POSIX S_IFMT classification here.
+            match mode & 0o170000 {
+                0o040000 => ClientEntryKind::Directory,
+                0o120000 => ClientEntryKind::Symlink,
+                0o010000 => ClientEntryKind::Fifo,
+                0o020000 => ClientEntryKind::CharDevice,
+                0o060000 => ClientEntryKind::BlockDevice,
+                0o140000 => ClientEntryKind::Socket,
+                0o100000 => ClientEntryKind::File,
+                _ => ClientEntryKind::Other,
+            }
+        };
+        let modified = if mtime > 0 || mtime_nsec > 0 {
+            u64::try_from(mtime)
+                .ok()
+                .map(|secs| SystemTime::UNIX_EPOCH + Duration::new(secs, mtime_nsec))
+        } else {
+            None
+        };
+        Self {
+            kind,
+            length: size,
+            modified,
+            mode: Some(mode),
+            uid: None,
+            gid: None,
+            nlink: None,
             symlink_target,
         }
     }

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -90,6 +90,17 @@ impl ClientSummary {
         }
     }
 
+    /// Replaces the recorded events with the supplied list.
+    ///
+    /// Used by the daemon-pull `--list-only` path, where the receiver returns
+    /// captured flist entries (not engine `LocalCopyRecord`s) that the caller
+    /// converts into metadata-bearing events for rendering.
+    #[must_use]
+    pub(crate) fn with_events(mut self, events: Vec<ClientEvent>) -> Self {
+        self.events = events;
+        self
+    }
+
     /// Returns the list of recorded transfer actions.
     #[must_use]
     pub fn events(&self) -> &[ClientEvent] {

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -64,6 +64,23 @@ pub struct ParsedServerFlags {
     pub delete: bool,
     /// Dry-run / no-transfer mode (`n` flag, upstream: `!do_xfers`).
     pub dry_run: bool,
+    /// List-only mode: render the received file list, suppress all destination
+    /// writes, and send no per-file NDX requests.
+    ///
+    /// Set when the client is invoked with a single source operand and no
+    /// destination (`rsync rsync://host/module`). Upstream derives this as the
+    /// implied `--list-only` and the generator iterates every flist entry
+    /// through `list_file_entry()` without requesting any file data.
+    ///
+    /// Not part of the compact flag string; set via long-form propagation. In
+    /// upstream `'n'` means dry-run, which (unlike list-only) still streams NDX
+    /// requests for every file.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2194` - `list_only` global / implied-list-only derivation
+    /// - `generator.c:1249` - `list_file_entry()` render gate
+    pub list_only: bool,
     /// Transfer directories without recursion (`d` flag, `--dirs`).
     pub dirs: bool,
     /// Whole file transfer, no delta (`W` flag, `--whole-file`).
@@ -180,6 +197,23 @@ pub struct InfoFlags {
 }
 
 impl ParsedServerFlags {
+    /// Returns whether the receiver must suppress all destination-side writes.
+    ///
+    /// True for both dry-run (`-n`) and list-only mode. Upstream gates every
+    /// filesystem mutation on `!dry_run` and additionally suppresses the
+    /// receiver entirely under `list_only` (the generator only renders the
+    /// flist). Both modes leave the destination untouched - no mkdir, no
+    /// metadata, no symlinks, no hardlinks, no data, no delayed updates.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2194` - `list_only` implies no transfers
+    /// - `generator.c:1249` - `list_file_entry()` without per-file requests
+    #[must_use]
+    pub const fn skip_dest_writes(&self) -> bool {
+        self.dry_run || self.list_only
+    }
+
     /// Clears feature-gated flags that are not supported in this build.
     ///
     /// When the remote peer requests ACL preservation (`-A`) or extended

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -174,7 +174,7 @@ pub use self::generator::{
     GeneratorContext, GeneratorStats, generate_delta_from_signature, io_error_flags,
 };
 pub use self::handshake::{HandshakeResult, perform_handshake, perform_legacy_handshake};
-pub use self::receiver::{ReceiverContext, SumHead, TransferStats};
+pub use self::receiver::{ListOnlyEntry, ReceiverContext, SumHead, TransferStats};
 pub use self::role::ServerRole;
 pub use self::shared::{ChecksumFactory, TransferDeadline};
 pub use self::temp_cleanup::cleanup_stale_temp_files;

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -46,8 +46,9 @@ impl ReceiverContext {
         writer: &mut W,
         #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> io::Result<Vec<(PathBuf, String)>> {
-        // upstream: receiver.c:693 - dry_run skips all filesystem modifications
-        if self.config.flags.dry_run {
+        // upstream: receiver.c:693 - dry_run skips all filesystem modifications;
+        // list-only suppresses the receiver entirely (generator.c:1249).
+        if self.config.flags.skip_dest_writes() {
             return Ok(Vec::new());
         }
 
@@ -306,7 +307,7 @@ impl ReceiverContext {
     /// - `generator.c:1472-1475` - retry `mkdir` after `make_path()` when
     ///   `relative_paths` and initial `mkdir` returns `ENOENT`
     pub(in crate::receiver) fn ensure_relative_parents(&self, dest_dir: &Path) {
-        if !self.config.flags.relative || self.config.flags.dry_run {
+        if !self.config.flags.relative || self.config.flags.skip_dest_writes() {
             return;
         }
 
@@ -559,7 +560,7 @@ impl ReceiverContext {
     pub(in crate::receiver) fn touch_up_dirs(&self, dest_dir: &Path) {
         // upstream: generator.c:2398 - need_retouch_dir_times =
         // preserve_mtimes && !omit_dir_times
-        if !self.config.flags.times || self.config.flags.dry_run {
+        if !self.config.flags.times || self.config.flags.skip_dest_writes() {
             return;
         }
 

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -38,7 +38,7 @@ impl ReceiverContext {
         sandbox: Option<&fast_io::DirSandbox>,
         writer: &mut W,
     ) -> std::io::Result<()> {
-        if !self.config.flags.links || self.config.flags.dry_run {
+        if !self.config.flags.links || self.config.flags.skip_dest_writes() {
             return Ok(());
         }
 
@@ -274,7 +274,7 @@ impl ReceiverContext {
         #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
         writer: &mut W,
     ) -> std::io::Result<()> {
-        if !self.config.flags.hard_links || self.config.flags.dry_run {
+        if !self.config.flags.hard_links || self.config.flags.skip_dest_writes() {
             return Ok(());
         }
 

--- a/crates/transfer/src/receiver/directory/missing_args.rs
+++ b/crates/transfer/src/receiver/directory/missing_args.rs
@@ -62,7 +62,7 @@ impl ReceiverContext {
         if !self.config.file_selection.delete_missing_args {
             return Ok(());
         }
-        if self.config.flags.dry_run {
+        if self.config.flags.skip_dest_writes() {
             return Ok(());
         }
 

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -65,7 +65,7 @@ use crate::transfer_state::TransferPipeline;
 
 pub use self::basis::{BasisFileConfig, BasisFileResult, find_basis_file_with_config};
 pub use self::file_list::IncrementalFileListReceiver;
-pub use self::stats::{SenderStats, TransferStats};
+pub use self::stats::{ListOnlyEntry, SenderStats, TransferStats};
 pub use self::wire::{
     SenderAttrs, SumHead, apply_xattr_abbreviation_values, write_signature_blocks,
     write_xattr_request,

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -7,6 +7,33 @@ use std::path::PathBuf;
 
 use protocol::stats::DeleteStats;
 
+/// A single file-list entry captured for `--list-only` rendering.
+///
+/// In list-only mode the receiver renders the file list without requesting any
+/// file data. Each active flist entry is snapshotted here so the client can
+/// format the upstream listing line (perms / size / date / name).
+///
+/// # Upstream Reference
+///
+/// - `generator.c:1249` - `list_file_entry()` renders one line per flist entry
+#[derive(Debug, Clone)]
+pub struct ListOnlyEntry {
+    /// Relative path of the entry within the transferred tree.
+    pub path: PathBuf,
+    /// Full Unix mode bits (file type + permissions).
+    pub mode: u32,
+    /// Logical size in bytes.
+    pub size: u64,
+    /// Modification time in whole seconds since the Unix epoch.
+    pub mtime: i64,
+    /// Sub-second component of the modification time, in nanoseconds.
+    pub mtime_nsec: u32,
+    /// Symlink target when the entry is a symbolic link.
+    pub symlink_target: Option<PathBuf>,
+    /// Whether the entry is a symbolic link.
+    pub is_symlink: bool,
+}
+
 /// Statistics from a receiver transfer operation.
 ///
 /// Returned inside [`crate::ServerStats::Receiver`] after a successful receive.
@@ -103,6 +130,16 @@ pub struct TransferStats {
     /// - `receiver.c:970-974` - `send_msg_int(MSG_REDO, ndx)` queues for redo
     /// - `generator.c:2160-2199` - generator processes redo queue in phase 2
     pub redo_count: usize,
+
+    /// File-list entries captured for `--list-only` rendering.
+    ///
+    /// Populated only in list-only mode; empty otherwise. The client converts
+    /// these into metadata-bearing summary events so the listing can be printed.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1249` - `list_file_entry()` per-entry render
+    pub list_only_entries: Vec<ListOnlyEntry>,
 }
 
 /// Statistics received from the remote sender after transfer completion.

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -172,6 +172,7 @@ fn transfer_stats_has_incremental_fields() {
         literal_data: 0,
         matched_data: 0,
         redo_count: 0,
+        list_only_entries: vec![],
     };
 
     assert_eq!(stats.entries_received, 100);

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -22,10 +22,43 @@ use crate::receiver::directory::FailedDirectories;
 use crate::receiver::quick_check::{
     dest_mtime_newer, is_hardlink_follower, quick_check_matches, try_reference_dest,
 };
-use crate::receiver::stats::TransferStats;
+use crate::receiver::stats::{ListOnlyEntry, TransferStats};
 use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
 
 impl ReceiverContext {
+    /// Snapshots every active file-list entry for `--list-only` rendering.
+    ///
+    /// In list-only mode the receiver issues no per-file NDX request; it simply
+    /// captures each entry's metadata so the client can print the upstream
+    /// listing line (perms / size / date / name). Every active entry is emitted:
+    /// directories (including the root `.`), symlinks, and regular/special files
+    /// alike.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1249` - `list_file_entry()` renders one line per entry
+    pub(in crate::receiver) fn collect_list_only_entries(&self) -> Vec<ListOnlyEntry> {
+        self.file_list
+            .iter()
+            .map(|entry| {
+                let is_symlink = entry.is_symlink();
+                ListOnlyEntry {
+                    path: entry.path().clone(),
+                    mode: entry.mode(),
+                    size: entry.size(),
+                    mtime: entry.mtime(),
+                    mtime_nsec: entry.mtime_nsec(),
+                    symlink_target: if is_symlink {
+                        entry.link_target().cloned()
+                    } else {
+                        None
+                    },
+                    is_symlink,
+                }
+            })
+            .collect()
+    }
+
     /// Builds the list of files that need transfer, applying quick-check to skip
     /// unchanged files and respecting size bounds and failed directory tracking.
     ///
@@ -123,8 +156,10 @@ impl ReceiverContext {
 
         // upstream: generator.c:1845 - dry_run (!do_xfers) skips stat and data
         // transfer but still builds the candidate list so NDX requests are sent
-        // to the sender, which logs each file name for verbose output.
-        if self.config.flags.dry_run {
+        // to the sender, which logs each file name for verbose output. List-only
+        // also skips the destination stat/quick-check; its caller never issues
+        // per-file NDX requests (the list_only branch in `run_pipelined`).
+        if self.config.flags.skip_dest_writes() {
             // upstream: generator.c:1925-1926 - dry-run still itemizes with
             // ITEM_TRANSFER; the dry-run loop writes the bare ITEM_TRANSFER
             // attrs over the wire and does not consume this precomputed value.

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -107,8 +107,15 @@ impl ReceiverContext {
         let mut redo_count: usize = 0;
         let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
 
-        // upstream: generator.c:1845 - dry_run sends NDX requests without data
-        if self.config.flags.dry_run {
+        // upstream: generator.c:1249 - list-only renders every flist entry via
+        // list_file_entry() and sends NO per-file NDX request. Only the existing
+        // post-loop phase markers (NDX_DONE) and the goodbye handshake cross the
+        // wire. This branch must precede the dry_run check: list-only is not
+        // dry-run (dry-run streams an NDX request per file).
+        if self.config.flags.list_only {
+            stats.list_only_entries = self.collect_list_only_entries();
+            writer.flush()?;
+        } else if self.config.flags.dry_run {
             self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
         } else {
             let total_files = files_to_transfer.len();

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -140,8 +140,13 @@ impl ReceiverContext {
         let mut redo_count: usize = 0;
         let mut all_delayed_updates: Vec<(PathBuf, PathBuf)> = Vec::new();
 
-        // upstream: generator.c:1845 - dry_run sends NDX requests without data
-        if self.config.flags.dry_run {
+        // upstream: generator.c:1249 - list-only renders every flist entry via
+        // list_file_entry() and sends NO per-file NDX request. This branch must
+        // precede the dry_run check: list-only is not dry-run.
+        if self.config.flags.list_only {
+            stats.list_only_entries = self.collect_list_only_entries();
+            writer.flush()?;
+        } else if self.config.flags.dry_run {
             self.run_dry_run_loop(reader, writer, &files_to_transfer)?;
         } else {
             let total_files = files_to_transfer.len();

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -288,7 +288,7 @@ impl ReceiverContext {
             &dest_dir,
             file_count,
             trailing_slash,
-            self.config.flags.dry_run,
+            self.config.flags.skip_dest_writes(),
         )
         .map_err(|e| {
             io::Error::new(
@@ -345,7 +345,7 @@ impl ReceiverContext {
         // symlink and let strict mode silently succeed against the resolved
         // target. Local-mode and non-daemon SSH transfers are the
         // upstream-parity case (issue #715 `symlink-dirlink-basis`).
-        let dest_dir = if !self.config.flags.dry_run
+        let dest_dir = if !self.config.flags.skip_dest_writes()
             && !self.config.connection.is_daemon_connection
             && dest_dir
                 .symlink_metadata()
@@ -480,9 +480,9 @@ impl ReceiverContext {
         if file_count != 1 || trailing_slash {
             return dest_dir;
         }
-        if self.config.flags.dry_run {
-            // Dry-run never touches disk, so the directory-vs-file ambiguity
-            // does not change observable output. Keep behaviour stable.
+        if self.config.flags.skip_dest_writes() {
+            // Dry-run and list-only never touch disk, so the directory-vs-file
+            // ambiguity does not change observable output. Keep behaviour stable.
             return dest_dir;
         }
         // An existing directory at the operand keeps the directory branch

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -106,7 +106,19 @@ impl ReceiverContext {
 
         let deadline = crate::shared::TransferDeadline::from_system_time(self.config.stop_at);
 
+        // upstream: generator.c:1249 - list-only renders the flist without
+        // requesting any file data. Capture the entries and skip the per-file
+        // NDX loop entirely so no per-file request crosses the wire.
+        let list_only_entries = if self.config.flags.list_only {
+            self.collect_list_only_entries()
+        } else {
+            Vec::new()
+        };
+
         for (file_idx, file_entry) in self.file_list.iter().enumerate() {
+            if self.config.flags.list_only {
+                break;
+            }
             if let Some(ref dl) = deadline {
                 if dl.is_reached() {
                     break;
@@ -471,6 +483,7 @@ impl ReceiverContext {
             literal_data: 0,
             matched_data: 0,
             redo_count: 0,
+            list_only_entries,
         })
     }
 }

--- a/crates/transfer/tests/incremental_transfer.rs
+++ b/crates/transfer/tests/incremental_transfer.rs
@@ -34,6 +34,7 @@ fn transfer_stats_incremental_fields_exist() {
         literal_data: 0,
         matched_data: 0,
         redo_count: 0,
+        list_only_entries: vec![],
     };
 
     assert_eq!(stats.files_listed, 10);


### PR DESCRIPTION
## Summary

A daemon source with no destination (e.g. `oc-rsync -r rsync://host/mod` or `oc-rsync host::mod`) is upstream's implied `--list-only`: it should print the recursive file listing of the module contents. oc correctly set `list_only` but the daemon-pull receiver ran a normal apply against a synthesized `.` destination and never rendered the received file list, so it printed nothing (exit 0, empty output).

This is leg-3 of the `daemon` entry in `tools/ci/upstream_testsuite_known_failures.conf`. (The bare `host::` module-*name* listing already worked; this is the module-*contents* recursive listing.)

## What it does

Mirrors upstream's list-only generator (`generator.c:1249` `list_file_entry`):

- The receiver iterates every active flist entry, captures its metadata, and sends **no per-file NDX request** — only the existing phase `NDX_DONE` markers + goodbye cross the wire (this is *not* dry-run, which streams an NDX per file).
- All destination writes are suppressed via a new `ParsedServerFlags::skip_dest_writes()` (`dry_run || list_only`) applied at the mkdir / metadata / hardlink / symlink / missing-args sites.
- Captured entries flow through `TransferStats::list_only_entries` into the daemon-pull `ClientSummary` as metadata-bearing `ClientEvent`s, which the existing `emit_list_only` renders as the upstream perms/size/date/name listing.

The render path, CLI `list_only` bool, and `-r` recursion were already correct; the gap was purely that the daemon-pull summary carried zero events.

## Verification

Built locally; `cargo fmt`/`clippy -p transfer -p core` clean. Smoke-tested against a local oc daemon and compared to **upstream rsync 3.4.4** — output is **byte-identical** for both `-r` (no symlink arrow) and `-rl` (with ` -> target`):

```
drwxr-xr-x            160 2026/06/28 06:01:15 .
-rw-r--r--              6 2026/06/28 06:01:15 file1.txt
lrwxrwxrwx              9 2026/06/28 06:01:15 link1
drwxr-xr-x             96 2026/06/28 06:01:15 sub
-rw-r--r--             11 2026/06/28 06:01:15 sub/file2.txt
```

Non-list_only paths are unchanged (the `list_only` branch precedes the `dry_run` check and only fires when no destination was supplied).