### PR TITLE
ci: surface known-failure XFAIL log detail in upstream testsuite

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -208,6 +208,15 @@ run_one_test() {
             return 4
         fi
         echo "XFAIL   $testbase"
+        # Surface WHY the known failure still fails so a CI-only divergence
+        # (a test that passes on a dev host but fails on the runner) is
+        # diagnosable from the job log without re-running locally. Dump the
+        # tail of the captured test log, which holds the failing checkdiff.
+        if [[ -s "$log" ]]; then
+            echo "        --- last 40 lines of ${testbase}.log (XFAIL detail) ---"
+            tail -n 40 "$log" | sed 's/^/        /'
+            echo "        --- end ${testbase}.log ---"
+        fi
         return 3
     fi
 


### PR DESCRIPTION
## Summary

The upstream-testsuite harness prints only `XFAIL <name>` for a test listed in `known_failures.conf`, with no failure detail. This makes a **CI-vs-host divergence** undiagnosable: e.g. `daemon.test` now passes end-to-end on a real Linux host (verified after #6158/#6159/#6160) yet still XFAILs on the GitHub runner with identical code — and the job log gives no clue which leg fails on the runner.

This dumps the tail (40 lines) of the captured per-test log on XFAIL, so the failing `checkdiff` is visible directly in the CI job log.

## Why

- Known-failure XFAILs are the one path that produced **zero** diagnostic output.
- The captured `${log_root}/<name>.log` already exists (scratch is only cleaned on pass), so this just surfaces it.
- Self-validating: this workflow triggers on `tools/ci/run_upstream_testsuite.sh`, so this PR's own run will print the `daemon` XFAIL detail, exposing the runner-specific failing leg.

## Scope

Diagnostics only — no change to pass/fail accounting, exit codes, or the known-failures set. `bash -n` clean.