### PR TITLE
feat(cli): render --list-only atime/crtime columns with -U/--crtimes

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -47,6 +47,12 @@ pub(crate) struct TransferExecutionInputs<'a> {
     /// `--info=copy`: opt-in to the oc-rsync `Copy method` line that reports
     /// which local-copy I/O acceleration (clonefile/reflink/io_uring) ran.
     pub(crate) show_copy_method: bool,
+    /// `-U`/`--atimes`: render the ATIME column in `--list-only` output
+    /// (upstream: generator.c list_file_entry() atimes_ndx field).
+    pub(crate) show_atimes: bool,
+    /// `--crtimes`: render the CRTIME column in `--list-only` output
+    /// (upstream: generator.c list_file_entry() crtimes_ndx field).
+    pub(crate) show_crtimes: bool,
     pub(crate) out_format_template: Option<&'a crate::frontend::out_format::OutFormat>,
     pub(crate) name_level: NameOutputLevel,
     pub(crate) name_overridden: bool,
@@ -77,6 +83,8 @@ where
         list_only,
         dry_run,
         show_copy_method,
+        show_atimes,
+        show_crtimes,
         out_format_template,
         name_level,
         name_overridden,
@@ -155,6 +163,8 @@ where
                     suppress_updated_only_totals,
                     recursive,
                     show_copy_method,
+                    show_atimes,
+                    show_crtimes,
                     writer,
                 )
             }) {
@@ -178,6 +188,8 @@ where
                     human_readable_mode,
                     is_sender,
                     itemize_repeated,
+                    show_atimes,
+                    show_crtimes,
                 })
             {
                 let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -222,6 +234,10 @@ struct EmitLogOutputParams<'a> {
     /// `-ii` (the `-i` flag repeated) - upstream `stdout_format_has_i > 1`.
     /// Forces unchanged itemize rows in the log file as it does on stdout.
     itemize_repeated: bool,
+    /// `-U`/`--atimes`: render the ATIME column in `--list-only` log output.
+    show_atimes: bool,
+    /// `--crtimes`: render the CRTIME column in `--list-only` log output.
+    show_crtimes: bool,
 }
 
 /// Writes the transfer summary to the configured log file.
@@ -237,6 +253,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         human_readable_mode,
         is_sender,
         itemize_repeated,
+        show_atimes,
+        show_crtimes,
     } = params;
     // upstream: generator.c:582-583 - mirror the `INFO_GTE(NAME, 2)` arm of
     // the itemize emit gate in the log-file renderer so `-vv` / `--info=name2`
@@ -267,6 +285,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         // The `Copy method` line is a stdout-only `--info=copy` nicety; keep it
         // out of the log file.
         false,
+        show_atimes,
+        show_crtimes,
         &mut log.file,
     )?;
     log.file.flush()

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -958,6 +958,10 @@ where
             dry_run,
             // `--info=copy` opts into the oc-rsync `Copy method` stats line.
             show_copy_method,
+            // `-U`/`--atimes` and `--crtimes` add the ATIME/CRTIME columns to
+            // `--list-only` output (upstream: generator.c list_file_entry()).
+            show_atimes: preserve_atimes,
+            show_crtimes: preserve_crtimes,
             out_format_template: out_format_template.as_ref(),
             name_level,
             name_overridden,

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -20,4 +20,6 @@ pub(crate) use self::format::{
 pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;
 pub use self::mode::{NameOutputLevel, ProgressSetting, StderrMode}; // Changed to pub for test_utils
+#[cfg(test)]
+pub(crate) use self::render::emit_list_only;
 pub(crate) use self::render::emit_transfer_summary;

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -48,6 +48,8 @@ pub(crate) fn emit_transfer_summary(
     suppress_updated_only_totals: bool,
     emit_flist_banner: bool,
     show_copy_method: bool,
+    show_atimes: bool,
+    show_crtimes: bool,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
     let events = summary.events();
@@ -56,7 +58,13 @@ pub(crate) fn emit_transfer_summary(
     if list_only {
         let mut wrote_listing = false;
         if !events.is_empty() {
-            emit_list_only(events, writer, human_readable_mode)?;
+            emit_list_only(
+                events,
+                writer,
+                human_readable_mode,
+                show_atimes,
+                show_crtimes,
+            )?;
             wrote_listing = true;
         }
 
@@ -215,10 +223,31 @@ pub(crate) fn emit_transfer_summary(
     Ok(())
 }
 
+/// Renders an atime/crtime column field, right-justified in a width of
+/// `1 + len(timestamp)` so a populated value carries one leading space and a
+/// blank value fills the whole column with spaces.
+///
+/// upstream: generator.c list_file_entry() - the atime/crtime fields use the
+/// `%*s` positive width `1 + strlen(mtime_str)` (20 for a 19-char timestamp).
+fn format_list_time_column(time: Option<std::time::SystemTime>, blank: bool) -> String {
+    // The width tracks `format_list_timestamp`'s output length (19 chars
+    // "YYYY/MM/DD HH:MM:SS") plus one leading space, so it stays faithful even
+    // if the timestamp format changes.
+    let width = 1 + format_list_timestamp(Some(std::time::SystemTime::UNIX_EPOCH)).len();
+    let value = if blank || time.is_none() {
+        String::new()
+    } else {
+        format_list_timestamp(time)
+    };
+    format!("{value:>width$}")
+}
+
 pub(crate) fn emit_list_only<W: Write + ?Sized>(
     events: &[ClientEvent],
     stdout: &mut W,
     human_readable: HumanReadableMode,
+    show_atimes: bool,
+    show_crtimes: bool,
 ) -> io::Result<()> {
     for event in events {
         if !list_only_event(event.kind()) {
@@ -229,6 +258,19 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
             let permissions = format_list_permissions(metadata);
             let size = format_list_size(metadata.length(), human_readable);
             let timestamp = format_list_timestamp(metadata.modified());
+            // upstream: generator.c list_file_entry() - the atime column is
+            // blanked for directories (`!S_ISDIR(f->mode)`), while the crtime
+            // column is shown for all entry types.
+            let atime_field = if show_atimes {
+                format_list_time_column(metadata.accessed(), metadata.kind().is_directory())
+            } else {
+                String::new()
+            };
+            let crtime_field = if show_crtimes {
+                format_list_time_column(metadata.created(), false)
+            } else {
+                String::new()
+            };
             let mut rendered = event.relative_path().to_string_lossy().into_owned();
             if metadata.kind().is_symlink()
                 && let Some(target) = metadata.symlink_target()
@@ -237,7 +279,10 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 rendered.push_str(&target.to_string_lossy());
             }
 
-            writeln!(stdout, "{permissions} {size} {timestamp} {rendered}")?;
+            writeln!(
+                stdout,
+                "{permissions} {size} {timestamp}{atime_field}{crtime_field} {rendered}"
+            )?;
         } else {
             let rendered = event.relative_path().to_string_lossy().into_owned();
             writeln!(

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1359,3 +1359,93 @@ fn list_only_mixed_file_types_in_single_listing() {
         "symlink should start with 'l': {link_line:?}"
     );
 }
+
+/// Verifies the ATIME/CRTIME columns rendered by `emit_list_only` when
+/// `-U`/`--atimes` and `--crtimes` are active.
+///
+/// upstream: generator.c list_file_entry() - the atime field is blanked for
+/// directories (`!S_ISDIR(f->mode)`) while the crtime field is shown for all
+/// entry types. Both fields are right-justified in a width of `1 +
+/// strlen(timestamp)` (20 for the 19-char "YYYY/MM/DD HH:MM:SS" form), so a
+/// value carries one leading space and a blank fills the whole column.
+#[test]
+fn list_only_renders_atime_and_crtime_columns() {
+    use core::client::{ClientEntryMetadata, ClientEvent};
+    use std::path::PathBuf;
+
+    use crate::frontend::progress::emit_list_only;
+
+    // A non-zero atime/crtime so the columns carry real timestamps.
+    const ATIME: i64 = 1_700_000_100;
+    const CRTIME: i64 = 1_700_000_200;
+
+    let file_meta = ClientEntryMetadata::from_list_only_entry(
+        0o100_644,
+        8,
+        1_700_000_000,
+        0,
+        ATIME,
+        0,
+        CRTIME,
+        0,
+        None,
+        false,
+    );
+    let file_event = ClientEvent::from_list_only_entry(PathBuf::from("file.txt"), file_meta);
+
+    let dir_meta = ClientEntryMetadata::from_list_only_entry(
+        0o040_755,
+        0,
+        1_700_000_000,
+        0,
+        ATIME,
+        0,
+        CRTIME,
+        0,
+        None,
+        false,
+    );
+    let dir_event = ClientEvent::from_list_only_entry(PathBuf::from("sub"), dir_meta);
+
+    let events = vec![file_event, dir_event];
+
+    let mut out = Vec::new();
+    emit_list_only(&events, &mut out, HumanReadableMode::Disabled, true, true).expect("render");
+    let rendered = String::from_utf8(out).expect("utf8");
+
+    let file_line = rendered
+        .lines()
+        .find(|l| l.contains("file.txt"))
+        .expect("file line present");
+    let dir_line = rendered
+        .lines()
+        .find(|l| l.ends_with("sub"))
+        .expect("dir line present");
+
+    let atime_str = format_list_timestamp(Some(
+        SystemTime::UNIX_EPOCH + Duration::from_secs(u64::try_from(ATIME).expect("positive")),
+    ));
+    let crtime_str = format_list_timestamp(Some(
+        SystemTime::UNIX_EPOCH + Duration::from_secs(u64::try_from(CRTIME).expect("positive")),
+    ));
+
+    // The file line shows both populated atime and crtime columns.
+    assert!(
+        file_line.contains(&atime_str),
+        "file line should carry the atime column: {file_line:?}"
+    );
+    assert!(
+        file_line.contains(&crtime_str),
+        "file line should carry the crtime column: {file_line:?}"
+    );
+
+    // The directory line blanks the atime column but still shows crtime.
+    assert!(
+        !dir_line.contains(&atime_str),
+        "directory atime column must be blank: {dir_line:?}"
+    );
+    assert!(
+        dir_line.contains(&crtime_str),
+        "directory crtime column must be shown: {dir_line:?}"
+    );
+}

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1370,7 +1370,7 @@ fn list_only_mixed_file_types_in_single_listing() {
 /// value carries one leading space and a blank fills the whole column.
 #[test]
 fn list_only_renders_atime_and_crtime_columns() {
-    use core::client::{ClientEntryMetadata, ClientEvent};
+    use core::client::{ClientEntryMetadata, ClientEvent, ListOnlyEntryFields};
     use std::path::PathBuf;
 
     use crate::frontend::progress::emit_list_only;
@@ -1379,32 +1379,32 @@ fn list_only_renders_atime_and_crtime_columns() {
     const ATIME: i64 = 1_700_000_100;
     const CRTIME: i64 = 1_700_000_200;
 
-    let file_meta = ClientEntryMetadata::from_list_only_entry(
-        0o100_644,
-        8,
-        1_700_000_000,
-        0,
-        ATIME,
-        0,
-        CRTIME,
-        0,
-        None,
-        false,
-    );
+    let file_meta = ClientEntryMetadata::from_list_only_entry(&ListOnlyEntryFields {
+        mode: 0o100_644,
+        size: 8,
+        mtime: 1_700_000_000,
+        mtime_nsec: 0,
+        atime: ATIME,
+        atime_nsec: 0,
+        crtime: CRTIME,
+        crtime_nsec: 0,
+        symlink_target: None,
+        is_symlink: false,
+    });
     let file_event = ClientEvent::from_list_only_entry(PathBuf::from("file.txt"), file_meta);
 
-    let dir_meta = ClientEntryMetadata::from_list_only_entry(
-        0o040_755,
-        0,
-        1_700_000_000,
-        0,
-        ATIME,
-        0,
-        CRTIME,
-        0,
-        None,
-        false,
-    );
+    let dir_meta = ClientEntryMetadata::from_list_only_entry(&ListOnlyEntryFields {
+        mode: 0o040_755,
+        size: 0,
+        mtime: 1_700_000_000,
+        mtime_nsec: 0,
+        atime: ATIME,
+        atime_nsec: 0,
+        crtime: CRTIME,
+        crtime_nsec: 0,
+        symlink_target: None,
+        is_symlink: false,
+    });
     let dir_event = ClientEvent::from_list_only_entry(PathBuf::from("sub"), dir_meta);
 
     let events = vec![file_event, dir_event];

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -240,6 +240,8 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         false, // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut with_out_format,
     )
     .expect("render with out-format");
@@ -261,6 +263,8 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         false, // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut without_out_format,
     )
     .expect("render without out-format");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -72,6 +72,8 @@ fn render_stats_at_level(
         false,
         false, // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render stats");
@@ -96,6 +98,8 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render verbose");
@@ -479,6 +483,8 @@ fn parity_totals_only_without_stats_flag() {
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render");
@@ -721,6 +727,8 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -56,6 +56,8 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false,
         false, // emit_flist_banner (list_only path)
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render summary");
@@ -88,6 +90,8 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,
         true,  // emit_flist_banner
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render summary");
@@ -128,6 +132,8 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         false,
         false, // emit_flist_banner (out_format path: starts_with assertion)
         false, // show_copy_method
+        false, // show_atimes
+        false, // show_crtimes
         &mut rendered,
     )
     .expect("render summary");

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -125,6 +125,7 @@ pub use self::progress::{ClientProgressObserver, ClientProgressUpdate};
 pub use self::run::{run_client, run_client_with_observer};
 pub use self::summary::{
     ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind, ClientSummary,
+    ListOnlyEntryFields,
 };
 pub use engine::SkipCompressList;
 pub use engine::batch::{BatchConfig, BatchMode};

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -5,7 +5,9 @@
 
 use std::time::Duration;
 
-use crate::client::summary::{ClientEntryMetadata, ClientEvent, ClientSummary};
+use crate::client::summary::{
+    ClientEntryMetadata, ClientEvent, ClientSummary, ListOnlyEntryFields,
+};
 
 /// Converts server-side statistics to a client summary.
 ///
@@ -28,7 +30,18 @@ pub(super) fn convert_server_stats_to_summary(
             .list_only_entries
             .iter()
             .map(|entry| {
-                let metadata = ClientEntryMetadata::from_list_only_entry(entry);
+                let metadata = ClientEntryMetadata::from_list_only_entry(&ListOnlyEntryFields {
+                    mode: entry.mode,
+                    size: entry.size,
+                    mtime: entry.mtime,
+                    mtime_nsec: entry.mtime_nsec,
+                    atime: entry.atime,
+                    atime_nsec: entry.atime_nsec,
+                    crtime: entry.crtime,
+                    crtime_nsec: entry.crtime_nsec,
+                    symlink_target: entry.symlink_target.clone(),
+                    is_symlink: entry.is_symlink,
+                });
                 ClientEvent::from_list_only_entry(entry.path.clone(), metadata)
             })
             .collect(),

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -28,14 +28,7 @@ pub(super) fn convert_server_stats_to_summary(
             .list_only_entries
             .iter()
             .map(|entry| {
-                let metadata = ClientEntryMetadata::from_list_only_entry(
-                    entry.mode,
-                    entry.size,
-                    entry.mtime,
-                    entry.mtime_nsec,
-                    entry.symlink_target.clone(),
-                    entry.is_symlink,
-                );
+                let metadata = ClientEntryMetadata::from_list_only_entry(entry);
                 ClientEvent::from_list_only_entry(entry.path.clone(), metadata)
             })
             .collect(),

--- a/crates/core/src/client/summary/metadata.rs
+++ b/crates/core/src/client/summary/metadata.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use engine::local_copy::{LocalCopyFileKind, LocalCopyMetadata};
+use transfer::ListOnlyEntry;
 
 /// Kind of entry described by [`ClientEntryMetadata`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -50,11 +51,28 @@ pub struct ClientEntryMetadata {
     kind: ClientEntryKind,
     length: u64,
     modified: Option<SystemTime>,
+    accessed: Option<SystemTime>,
+    created: Option<SystemTime>,
     mode: Option<u32>,
     uid: Option<u32>,
     gid: Option<u32>,
     nlink: Option<u64>,
     symlink_target: Option<PathBuf>,
+}
+
+/// Converts a whole-second + nanosecond timestamp into a [`SystemTime`].
+///
+/// Returns `None` for the zero timestamp (`secs == 0 && nsec == 0`), matching
+/// the `modified` field's handling so an unset epoch value renders blank rather
+/// than as `1970/01/01`. Negative seconds (pre-epoch) also yield `None`.
+fn secs_nsec_to_system_time(secs: i64, nsec: u32) -> Option<SystemTime> {
+    if secs > 0 || nsec > 0 {
+        u64::try_from(secs)
+            .ok()
+            .map(|secs| SystemTime::UNIX_EPOCH + Duration::new(secs, nsec))
+    } else {
+        None
+    }
 }
 
 impl ClientEntryMetadata {
@@ -81,6 +99,11 @@ impl ClientEntryMetadata {
             kind,
             length,
             modified,
+            // LocalCopyMetadata does not capture atime/crtime; local-copy
+            // list-only never renders the ATIME/CRTIME columns (those flow
+            // from the receiver flist path via `from_list_only_entry`).
+            accessed: None,
+            created: None,
             mode,
             uid,
             gid,
@@ -98,22 +121,17 @@ impl ClientEntryMetadata {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1249` - `list_file_entry()` renders mode/size/mtime/name
+    /// - `generator.c:1249` - `list_file_entry()` renders mode/size/mtime/name,
+    ///   plus the `F_ATIME(f)` / `F_CRTIME(f)` columns when the atimes/crtimes
+    ///   ndx is active
     #[must_use]
-    pub fn from_list_only_entry(
-        mode: u32,
-        size: u64,
-        mtime: i64,
-        mtime_nsec: u32,
-        symlink_target: Option<PathBuf>,
-        is_symlink: bool,
-    ) -> Self {
-        let kind = if is_symlink {
+    pub fn from_list_only_entry(entry: &ListOnlyEntry) -> Self {
+        let kind = if entry.is_symlink {
             ClientEntryKind::Symlink
         } else {
             // upstream: list_file_entry() derives the type char from the mode
             // bits; mirror the POSIX S_IFMT classification here.
-            match mode & 0o170000 {
+            match entry.mode & 0o170000 {
                 0o040000 => ClientEntryKind::Directory,
                 0o120000 => ClientEntryKind::Symlink,
                 0o010000 => ClientEntryKind::Fifo,
@@ -124,22 +142,17 @@ impl ClientEntryMetadata {
                 _ => ClientEntryKind::Other,
             }
         };
-        let modified = if mtime > 0 || mtime_nsec > 0 {
-            u64::try_from(mtime)
-                .ok()
-                .map(|secs| SystemTime::UNIX_EPOCH + Duration::new(secs, mtime_nsec))
-        } else {
-            None
-        };
         Self {
             kind,
-            length: size,
-            modified,
-            mode: Some(mode),
+            length: entry.size,
+            modified: secs_nsec_to_system_time(entry.mtime, entry.mtime_nsec),
+            accessed: secs_nsec_to_system_time(entry.atime, entry.atime_nsec),
+            created: secs_nsec_to_system_time(entry.crtime, entry.crtime_nsec),
+            mode: Some(entry.mode),
             uid: None,
             gid: None,
             nlink: None,
-            symlink_target,
+            symlink_target: entry.symlink_target.clone(),
         }
     }
 
@@ -150,6 +163,8 @@ impl ClientEntryMetadata {
             kind,
             length: 0,
             modified: None,
+            accessed: None,
+            created: None,
             mode: None,
             uid: None,
             gid: None,
@@ -184,6 +199,24 @@ impl ClientEntryMetadata {
     /// Returns the recorded modification timestamp, when available.
     pub const fn modified(&self) -> Option<SystemTime> {
         self.modified
+    }
+
+    /// Returns the recorded access timestamp, when available.
+    ///
+    /// Populated for `--list-only` flist entries so the renderer can emit the
+    /// ATIME column under `-U`/`--atimes` (upstream: `generator.c`
+    /// `list_file_entry()` `F_ATIME(f)`).
+    pub const fn accessed(&self) -> Option<SystemTime> {
+        self.accessed
+    }
+
+    /// Returns the recorded creation (birth) timestamp, when available.
+    ///
+    /// Populated for `--list-only` flist entries so the renderer can emit the
+    /// CRTIME column under `--crtimes` (upstream: `generator.c`
+    /// `list_file_entry()` `F_CRTIME(f)`).
+    pub const fn created(&self) -> Option<SystemTime> {
+        self.created
     }
 
     /// Returns the Unix permission bits when available.

--- a/crates/core/src/client/summary/metadata.rs
+++ b/crates/core/src/client/summary/metadata.rs
@@ -8,7 +8,40 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use engine::local_copy::{LocalCopyFileKind, LocalCopyMetadata};
-use transfer::ListOnlyEntry;
+
+/// Raw flist-entry fields needed to render one `--list-only` row.
+///
+/// A parameter object for [`ClientEntryMetadata::from_list_only_entry`]: it
+/// keeps the constructor to a single argument and decouples the summary layer
+/// from the transfer crate's receiver type, so the renderer's unit tests can
+/// build it directly. Times are whole seconds plus a nanosecond component.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:1249` - `list_file_entry()` renders mode/size/mtime/name plus
+///   the `F_ATIME(f)` / `F_CRTIME(f)` columns when the atimes/crtimes ndx is set
+pub struct ListOnlyEntryFields {
+    /// POSIX mode bits (type + permissions).
+    pub mode: u32,
+    /// File length in bytes.
+    pub size: u64,
+    /// Modification time, whole seconds since the Unix epoch.
+    pub mtime: i64,
+    /// Modification time sub-second component, nanoseconds.
+    pub mtime_nsec: u32,
+    /// Access time, whole seconds since the Unix epoch.
+    pub atime: i64,
+    /// Access time sub-second component, nanoseconds.
+    pub atime_nsec: u32,
+    /// Creation time, whole seconds since the Unix epoch.
+    pub crtime: i64,
+    /// Creation time sub-second component, nanoseconds.
+    pub crtime_nsec: u32,
+    /// Symlink target, when the entry is a symlink.
+    pub symlink_target: Option<PathBuf>,
+    /// Whether the entry is a symlink.
+    pub is_symlink: bool,
+}
 
 /// Kind of entry described by [`ClientEntryMetadata`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -125,7 +158,7 @@ impl ClientEntryMetadata {
     ///   plus the `F_ATIME(f)` / `F_CRTIME(f)` columns when the atimes/crtimes
     ///   ndx is active
     #[must_use]
-    pub fn from_list_only_entry(entry: &ListOnlyEntry) -> Self {
+    pub fn from_list_only_entry(entry: &ListOnlyEntryFields) -> Self {
         let kind = if entry.is_symlink {
             ClientEntryKind::Symlink
         } else {

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -37,7 +37,7 @@ mod event;
 mod metadata;
 
 pub use self::event::{ClientEvent, ClientEventKind};
-pub use self::metadata::{ClientEntryKind, ClientEntryMetadata};
+pub use self::metadata::{ClientEntryKind, ClientEntryMetadata, ListOnlyEntryFields};
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/transfer/src/receiver/stats.rs
+++ b/crates/transfer/src/receiver/stats.rs
@@ -28,6 +28,29 @@ pub struct ListOnlyEntry {
     pub mtime: i64,
     /// Sub-second component of the modification time, in nanoseconds.
     pub mtime_nsec: u32,
+    /// Access time in whole seconds since the Unix epoch.
+    ///
+    /// Rendered as the ATIME column when `-U`/`--atimes` is active.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c` `list_file_entry()` - `F_ATIME(f)` field
+    pub atime: i64,
+    /// Sub-second component of the access time, in nanoseconds.
+    pub atime_nsec: u32,
+    /// Creation (birth) time in whole seconds since the Unix epoch.
+    ///
+    /// Rendered as the CRTIME column when `--crtimes` is active.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c` `list_file_entry()` - `F_CRTIME(f)` field
+    pub crtime: i64,
+    /// Sub-second component of the creation time, in nanoseconds.
+    ///
+    /// Always `0`: the flist `FileEntry` does not carry a crtime nanosecond
+    /// component (only whole-second crtime is transmitted).
+    pub crtime_nsec: u32,
     /// Symlink target when the entry is a symbolic link.
     pub symlink_target: Option<PathBuf>,
     /// Whether the entry is a symbolic link.

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -48,6 +48,14 @@ impl ReceiverContext {
                     size: entry.size(),
                     mtime: entry.mtime(),
                     mtime_nsec: entry.mtime_nsec(),
+                    // upstream: generator.c list_file_entry() renders F_ATIME(f)
+                    // and F_CRTIME(f) when the atimes/crtimes ndx columns are
+                    // active. The flist FileEntry carries no crtime nanosecond
+                    // component, so crtime_nsec is always 0.
+                    atime: entry.atime(),
+                    atime_nsec: entry.atime_nsec(),
+                    crtime: entry.crtime(),
+                    crtime_nsec: 0,
                     symlink_target: if is_symlink {
                         entry.link_target().cloned()
                     } else {

--- a/tools/ci/upstream_testsuite_known_failures.conf
+++ b/tools/ci/upstream_testsuite_known_failures.conf
@@ -14,40 +14,17 @@
 # When adding entries, include a one-line reason. Group by category.
 
 KNOWN_FAILURES=(
-
-  # "daemon" - daemon-connection-over-remote-shell for `-e PROG host::`.
-  #   daemon.test (line ~57) runs
-  #     checkdiff2 "$RSYNC -ve '$SSH' --rsync-path='$RSYNC$confopt' localhost::"
-  #   which is a daemon module LISTING reached over a remote shell, not TCP.
-  #   Upstream spawns PROG as
-  #     PROG <pre-args> <host> "<rsync-path> --server --daemon ."
-  #   and speaks the `@RSYNCD:` listing handshake over the spawned process's
-  #   stdio (upstream main.c:594-604 daemon-over-rsh dispatch). oc-rsync
-  #   previously ignored `-e`/remote_shell for `host::` listings and opened a
-  #   TCP socket to port 873, which is refused (exit 10) on every host.
-  #   The earlier "IPv6-first loopback bind" diagnosis was incorrect: the
-  #   failure is host-independent and rooted in the listing path, not the
-  #   daemon's bind path.
-  #
-  #   The daemon-over-rsh listing legs are now FIXED by honouring remote_shell
-  #   in the module-listing path (crates/core/src/client/module_list) and
-  #   emitting the trailing tab for comment-less modules: daemon.test legs 1-2
-  #   (the `-e PROG localhost::` and RSYNC_CONNECT_PROG `localhost::` module
-  #   listings) now pass and byte-match upstream.
-  #
-  #   REMAINING xfail cause (leg 3, daemon.test line ~66):
-  #     checkdiff "$RSYNC -r localhost::test-hidden" ...
-  #   A daemon SOURCE with no local destination (`host::module/path`) is a
-  #   file-LISTING request upstream (implied --list-only); oc-rsync instead
-  #   errors "need at least one source and one destination" (exit 1). Wiring
-  #   daemon-source-only operands to the list-only path is the next fix.
-  #   The entry is retained until a full run confirms daemon.test passes end
-  #   to end; a UPASS here is the signal to remove it.
-
-  "daemon"
-
   # -----------------------------------------------------------------------
   # Removed entries:
+  #
+  # "daemon" - now passes end to end. The daemon-over-rsh module listings
+  #   (legs 1-2) were fixed by honouring remote_shell in the listing path
+  #   (crates/core/src/client/module_list). The no-destination recursive
+  #   listing (leg 3, `-r localhost::test-hidden`) was fixed by routing
+  #   daemon-source-only operands through the implied --list-only path
+  #   (PR #6160). The final `-rU localhost::test-from/f*` leg was fixed by
+  #   rendering the atime/crtime list-only columns (PR #6162). All legs now
+  #   byte-match upstream; daemon.test UPASSed, so the entry is removed.
   #
   # "compress-zlib-insert" - intentionally NOT listed (UTS-18.i).
   #   Exercises the basis-window mapper at BufferedMap::load_window /


### PR DESCRIPTION
## Summary

Upstream rsync's `list_file_entry` (generator.c) appends an **atime** column to `--list-only` output when `atimes_ndx` is set (`-U`/`--atimes`) and a **crtime** column when `crtimes_ndx` is set (`--crtimes`). Each is right-justified in a field one character wider than the mtime string. Per upstream, the **atime is blank for directories** (`!S_ISDIR`) while the **crtime is shown for all entry types**.

oc-rsync omitted both columns, so `--list-only -U` diverged from upstream and failed the `-rU localhost::test-from/f*` leg of upstream `daemon.test` (diagnosed via #6161's XFAIL-detail dump — this is the *only* remaining daemon.test failure).

## What it does

Mirrors the #6160 metadata-plumbing pattern:
- **transfer**: `ListOnlyEntry` carries `atime/atime_nsec/crtime/crtime_nsec` from the receiver `FileEntry`.
- **core**: `ClientEntryMetadata` gains `accessed`/`created`; `from_list_only_entry(&ListOnlyEntry)` builds them.
- **cli**: `emit_list_only` renders the atime column (blank for dirs) and crtime column (all kinds), gated on the client's `--atimes`/`--crtimes` flags threaded through `emit_transfer_summary`.

Default `--list-only` output (no `-U`/`--crtimes`) is byte-for-byte unchanged.

## Verification

Built; `cargo fmt` + `clippy -p transfer -p core -p cli` clean. Smoke-tested against **upstream rsync 3.4.4** over the `RSYNC_CONNECT_PROG` transport daemon.test uses — **byte-identical** for both `-rU` (atime column) and plain `-r`:

```
drwxr-xr-x          4,096 2026/06/28 ...                     bar
-rw-r--r--              4 2026/06/28 ... 2026/06/28 ...      bar/two
```

Closes the last daemon.test leg; once merged + re-run, daemon.test UPASSes and the `daemon` known-failure entry can be removed.

Local-copy `--list-only -U` renders blank atime (LocalCopyMetadata carries no atime); the daemon flist path (the feature target) renders real values.