### PR TITLE
perf(fast_io): shared same-device helper; gate whole-file FICLONE on st_dev

### DIFF
--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -111,6 +111,8 @@ pub mod nofollow_open;
 pub mod page_aligned;
 /// Parallel file I/O operations using rayon.
 pub mod parallel;
+/// Same-filesystem (device) detection for reflink / copy-on-write gating.
+pub mod same_fs;
 /// Strict-resolution directory open for the SEC-1 dirfd sandbox.
 ///
 /// Unix-only: Windows callers use NTFS handle-based APIs which sidestep

--- a/crates/fast_io/src/platform_copy/dispatch.rs
+++ b/crates/fast_io/src/platform_copy/dispatch.rs
@@ -18,11 +18,25 @@ use super::types::{CopyMethod, CopyResult};
 pub(super) fn platform_copy_impl(src: &Path, dst: &Path, size_hint: u64) -> io::Result<CopyResult> {
     use std::fs::File;
 
+    // REFLINK-2: skip the FICLONE attempt when the source and the
+    // destination's parent directory are known to be on different filesystem
+    // devices - the ioctl would only fail with EXDEV after we created (and
+    // would then have to remove) the destination. An unknown result (`None`,
+    // e.g. a stat error) still attempts the clone, which records the outcome.
+    let cross_device = dst
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .is_some_and(|parent| {
+            matches!(crate::same_fs::paths_same_device(src, parent), Some(false))
+        });
+
     // upstream: does not use FICLONE; this is an oc-rsync optimization.
-    match try_ficlone_impl(src, dst) {
-        Ok(()) => return Ok(CopyResult::new(0, CopyMethod::Ficlone)),
-        Err(_) => {
-            let _ = std::fs::remove_file(dst);
+    if !cross_device {
+        match try_ficlone_impl(src, dst) {
+            Ok(()) => return Ok(CopyResult::new(0, CopyMethod::Ficlone)),
+            Err(_) => {
+                let _ = std::fs::remove_file(dst);
+            }
         }
     }
 

--- a/crates/fast_io/src/same_fs.rs
+++ b/crates/fast_io/src/same_fs.rs
@@ -1,0 +1,92 @@
+//! Same-filesystem (device) detection for reflink / copy-on-write gating.
+//!
+//! Block-cloning fast paths (`FICLONE`, `FICLONERANGE`, `clonefile`, ReFS
+//! `FSCTL_DUPLICATE_EXTENTS_TO_FILE`) only work when both operands reside on
+//! the same filesystem device. Comparing the POSIX `st_dev` up front lets the
+//! dispatch skip a doomed clone attempt (which would otherwise create the
+//! destination, fail with `EXDEV`, and have to be cleaned up) on a
+//! cross-device copy.
+//!
+//! Both helpers return `Option<bool>`:
+//! - `Some(true)`  - the two operands share a device.
+//! - `Some(false)` - the operands are on different devices.
+//! - `None`        - device identity is unavailable (a metadata error, or a
+//!   platform without a stable per-mount device id); the caller should treat
+//!   this as "unknown" and let the clone attempt decide.
+
+use std::fs::File;
+use std::path::Path;
+
+/// Returns whether two open files reside on the same filesystem device.
+///
+/// Compares the POSIX `st_dev` of each file. See the [module docs](self) for
+/// the meaning of the returned `Option`.
+#[cfg(unix)]
+#[must_use]
+pub fn files_same_device(a: &File, b: &File) -> Option<bool> {
+    use std::os::unix::fs::MetadataExt;
+    match (a.metadata(), b.metadata()) {
+        (Ok(x), Ok(y)) => Some(x.dev() == y.dev()),
+        _ => None,
+    }
+}
+
+/// Non-unix stub: device identity is not compared, so the result is `None`.
+#[cfg(not(unix))]
+#[must_use]
+pub fn files_same_device(_a: &File, _b: &File) -> Option<bool> {
+    None
+}
+
+/// Returns whether two paths reside on the same filesystem device.
+///
+/// Stats both paths and compares their POSIX `st_dev`. Use this when the
+/// destination file does not exist yet: pass the destination's parent
+/// directory, since the new file inherits its parent's device. See the
+/// [module docs](self) for the meaning of the returned `Option`.
+#[cfg(unix)]
+#[must_use]
+pub fn paths_same_device(a: &Path, b: &Path) -> Option<bool> {
+    use std::os::unix::fs::MetadataExt;
+    match (std::fs::metadata(a), std::fs::metadata(b)) {
+        (Ok(x), Ok(y)) => Some(x.dev() == y.dev()),
+        _ => None,
+    }
+}
+
+/// Non-unix stub: device identity is not compared, so the result is `None`.
+#[cfg(not(unix))]
+#[must_use]
+pub fn paths_same_device(_a: &Path, _b: &Path) -> Option<bool> {
+    None
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_files_in_one_dir_share_a_device() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::write(&a, b"a").expect("write a");
+        std::fs::write(&b, b"b").expect("write b");
+        let fa = File::open(&a).expect("open a");
+        let fb = File::open(&b).expect("open b");
+        assert_eq!(files_same_device(&fa, &fb), Some(true));
+        assert_eq!(paths_same_device(&a, &b), Some(true));
+        // The parent-directory form (used before the destination exists)
+        // agrees with the source file.
+        assert_eq!(paths_same_device(&a, dir.path()), Some(true));
+    }
+
+    #[test]
+    fn missing_path_yields_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let present = dir.path().join("present");
+        std::fs::write(&present, b"x").expect("write");
+        let missing = dir.path().join("missing");
+        assert_eq!(paths_same_device(&present, &missing), None);
+    }
+}

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -546,9 +546,10 @@ impl<'a> DeltaApplicator<'a> {
     fn resolve_same_fs(basis: &File, dest: &File) -> SameFsCache {
         #[cfg(target_os = "linux")]
         {
-            use std::os::unix::fs::MetadataExt;
-            match (basis.metadata(), dest.metadata()) {
-                (Ok(b), Ok(d)) if b.dev() == d.dev() => SameFsCache::SameFs,
+            // REFLINK-1: shared st_dev comparison so the delta-apply
+            // FICLONERANGE gate and the whole-file FICLONE gate agree.
+            match fast_io::same_fs::files_same_device(basis, dest) {
+                Some(true) => SameFsCache::SameFs,
                 _ => SameFsCache::DifferentFs,
             }
         }


### PR DESCRIPTION
## Summary

Part of the REFLINK series (#201).

**REFLINK-1** — extract the POSIX `st_dev` comparison into a shared `fast_io::same_fs` module (`files_same_device(&File,&File)` / `paths_same_device(&Path,&Path)`, each returning `Option<bool>`: `Some(true/false)` on unix, `None` when device identity is unavailable). The delta-apply `DeltaApplicator::resolve_same_fs` Linux branch is rewired onto it, so the FICLONERANGE gate (delta) and the FICLONE gate (whole-file) now share one implementation.

**REFLINK-2 (st_dev portion)** — gate the Linux whole-file `FICLONE` in `platform_copy` on the source vs the destination's parent-directory device. When they're known to be on different devices the ioctl can only fail with `EXDEV` *after* creating (and then having to remove) the destination, so the attempt is skipped; an unknown result (`None`) still tries the clone, which records the per-mount outcome via the existing `cow_detect` cache. The `--cow` `CowPolicy` gating already routes through `cow_detect` / `RequireCowPlatformCopy`, so this PR only adds the device check.

## Scope / safety

- No behavior change for same-device copies (the common case) — FICLONE still attempted.
- Cross-device whole-file copies skip a doomed create+EXDEV+remove round-trip and go straight to `copy_file_range` / `std::fs::copy`.
- New `same_fs` module is unit-tested (same-dir share device, parent-dir form, missing-path → `None`).

## Verification

Built `fast_io`+`transfer` (macOS); `cargo check` + `clippy` clean for the **Linux** target on `fast_io` (covers the cfg-gated dispatch) and host `clippy` clean on `transfer`. `cargo fmt` clean.