### PR TITLE
perf(fast_io): RWF_DONTCACHE basis-window reads (UNCACHE-5)

### DIFF
--- a/crates/fast_io/src/dontcache_writer.rs
+++ b/crates/fast_io/src/dontcache_writer.rs
@@ -169,6 +169,67 @@ fn dontcache_write(fd: RawFd, chunk: &[u8]) -> io::Result<usize> {
     Ok(ret as usize)
 }
 
+/// Fills `dst` from `offset` using positioned `preadv2(RWF_DONTCACHE)` reads so
+/// the bytes are dropped from the page cache after the read.
+///
+/// Returns `Ok(true)` once `dst` is fully filled, `Ok(false)` if the very first
+/// read is rejected because the kernel or filesystem does not support
+/// `RWF_DONTCACHE` (the caller then falls back to a buffered read), and `Err`
+/// for a genuine I/O error or an unexpected short read after some bytes landed.
+/// Uses positioned reads, so the file's seek offset is left untouched.
+///
+/// Mirrors [`dontcache_write`] on the read side.
+#[cfg(all(target_os = "linux", feature = "dontcache"))]
+#[allow(unsafe_code)]
+pub fn dontcache_read_exact(file: &File, offset: u64, dst: &mut [u8]) -> io::Result<bool> {
+    use std::os::fd::AsRawFd;
+
+    let fd = file.as_raw_fd();
+    let mut filled = 0usize;
+    while filled < dst.len() {
+        let iov = libc::iovec {
+            iov_base: dst[filled..].as_mut_ptr() as *mut libc::c_void,
+            iov_len: dst.len() - filled,
+        };
+        // SAFETY: `fd` is a valid open descriptor owned by `file` for the call.
+        // `iov` points to `dst[filled..]`, a unique mutable slice of exactly
+        // `iov_len` bytes that preadv2 only writes into; iovcnt 1 matches the
+        // single iovec. The positioned offset leaves the file cursor untouched.
+        let ret = unsafe {
+            libc::preadv2(
+                fd,
+                &iov as *const libc::iovec,
+                1,
+                (offset + filled as u64) as libc::off_t,
+                libc::RWF_DONTCACHE,
+            )
+        };
+        if ret < 0 {
+            let e = io::Error::last_os_error();
+            // A first-read rejection means the flag is unsupported on this
+            // mount; signal a clean fallback. Once bytes have landed (a flag
+            // accepted then a later genuine error), surface the error.
+            if filled == 0
+                && matches!(
+                    e.raw_os_error(),
+                    Some(libc::EINVAL) | Some(libc::ENOTSUP) | Some(libc::ENOSYS)
+                )
+            {
+                return Ok(false);
+            }
+            return Err(e);
+        }
+        if ret == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "preadv2 returned 0 before the basis window was filled",
+            ));
+        }
+        filled += ret as usize;
+    }
+    Ok(true)
+}
+
 /// Returns whether the running kernel advertises `RWF_DONTCACHE` (Linux 6.14+).
 ///
 /// The kernel release is read once via `uname(2)` and the verdict is cached for
@@ -218,6 +279,13 @@ fn kernel_release() -> Option<String> {
 #[must_use]
 pub fn dontcache_supported() -> bool {
     false
+}
+
+/// Stub for non-Linux or when the `dontcache` feature is off: always reports
+/// that the caller should fall back to a buffered read.
+#[cfg(not(all(target_os = "linux", feature = "dontcache")))]
+pub fn dontcache_read_exact(_file: &File, _offset: u64, _dst: &mut [u8]) -> io::Result<bool> {
+    Ok(false)
 }
 
 /// Stub for non-Linux platforms or when the `dontcache` feature is disabled.

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -356,7 +356,7 @@ pub use stdio_blocking::force_blocking_stdio;
 pub use stdio_shutdown::shutdown_stdio_write;
 // Non-unix `recv_fd_to_file` stub returns `Unsupported`; gate the public
 // re-export on unix to remove the dead surface area (see WIN-S.LAND.1.a).
-pub use dontcache_writer::{DontcacheFileWriter, dontcache_supported};
+pub use dontcache_writer::{DontcacheFileWriter, dontcache_read_exact, dontcache_supported};
 #[cfg(unix)]
 pub use splice::recv_fd_to_file;
 pub use vmsplice_writer::{VMSPLICE_MIN_CHUNK, VmspliceFileWriter};

--- a/crates/transfer/src/map_file/buffered.rs
+++ b/crates/transfer/src/map_file/buffered.rs
@@ -194,9 +194,23 @@ impl BufferedMap {
 
         let read_size = window_size - read_offset;
         if read_size > 0 {
-            self.file.seek(SeekFrom::Start(read_start))?;
-            self.file
-                .read_exact(&mut self.buffer[read_offset..window_size])?;
+            let dst = &mut self.buffer[read_offset..window_size];
+            // UNCACHE-5: on a kernel that advertises RWF_DONTCACHE (Linux 6.14+
+            // with the `dontcache` feature), read the basis window via
+            // positioned preadv2(RWF_DONTCACHE) so streaming a large basis file
+            // does not evict the resident working set from the page cache. The
+            // helper uses a positioned read (the file cursor is untouched) and
+            // returns false - falling through to the buffered seek+read - when
+            // the feature is off, the kernel is too old, or the filesystem
+            // rejects the flag.
+            let mut filled = false;
+            if fast_io::dontcache_supported() {
+                filled = fast_io::dontcache_read_exact(&self.file, read_start, dst)?;
+            }
+            if !filled {
+                self.file.seek(SeekFrom::Start(read_start))?;
+                self.file.read_exact(dst)?;
+            }
         }
 
         self.window_start = aligned_start;


### PR DESCRIPTION
Part of UNCACHE (#347).

## Problem
`BufferedMap::load_window` (the delta-apply basis-window read) fills via buffered `seek` + `read_exact`. Streaming a large basis file pollutes the page cache and can evict the resident working set.

## Fix
- New `fast_io::dontcache_read_exact(&File, offset, &mut [u8]) -> io::Result<bool>` — positioned `preadv2(.., RWF_DONTCACHE)` reads (mirroring the existing `pwritev2` write side in `dontcache_writer.rs`), in the unsafe-permitted `fast_io` crate.
- `BufferedMap::load_window` calls it when `fast_io::dontcache_supported()` reports the kernel advertises the flag (Linux 6.14+, the `dontcache` cargo feature); otherwise it falls through to the existing buffered read.

## Safety / scope
- The `transfer` crate stays `#![deny(unsafe_code)]`-clean — the raw syscall lives in `fast_io`.
- Positioned reads leave the file cursor untouched.
- Graceful per-mount fallback: a first-read `EINVAL`/`ENOTSUP`/`ENOSYS` returns `false` and the buffered path re-reads cleanly.
- mmap-backed basis serves via page faults and never enters `load_window`, so no extra skip-guard is needed (UNCACHE-7 concern is structurally satisfied).
- Default builds are unaffected (the `dontcache` feature is opt-in; the non-feature/non-Linux stub returns `Ok(false)`).

## Verification
Built host `transfer`; `cargo check` + `clippy` clean for the **Linux** target with `--features dontcache` (the real `preadv2` path) on `fast_io`; host `clippy` clean on `transfer`; `fmt` clean.