### PR TITLE
refactor(daemon): AcceptEngine trait abstracts accept-loop polling

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -16,6 +16,8 @@ include!("server_runtime/reload.rs");
 
 include!("server_runtime/connection.rs");
 
+include!("server_runtime/accept_engine.rs");
+
 include!("server_runtime/accept_loop.rs");
 
 #[cfg(test)]

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -1,0 +1,289 @@
+/// Strategy for sourcing accepted client connections in the daemon accept loop.
+///
+/// Selected once at accept-loop entry from the bound listener topology
+/// (single-family vs dual-stack). Each implementation hides *how* the next
+/// connection becomes ready - non-blocking `accept` on one listener, or an
+/// acceptor-thread-per-listener fan-in for many - behind a uniform [`poll`]
+/// interface. The accept loop body (signal handling, capacity refusal, worker
+/// spawn) is therefore identical regardless of listener count or platform.
+///
+/// This is the seam the per-platform readiness engines (io_uring multishot
+/// `IORING_OP_ACCEPT`, kqueue `EVFILT_READ`, IOCP `AcceptEx`) plug into without
+/// touching the shared loop body.
+///
+/// upstream: socket.c `start_accept_loop()` runs a single `select(2)` over all
+/// listener descriptors; the engine abstraction preserves that "one loop over
+/// N listeners" shape while letting the readiness mechanism vary.
+///
+/// [`poll`]: AcceptEngine::poll
+trait AcceptEngine {
+    /// Polls for the next accepted connection.
+    ///
+    /// Blocks for at most one internal poll interval (bounding signal-flag
+    /// inspection latency) before yielding control. The returned [`TcpStream`]
+    /// is always in blocking mode, matching upstream's synchronous per-session
+    /// I/O model.
+    fn poll(&mut self) -> Result<AcceptOutcome, DaemonError>;
+
+    /// Stops the engine, joining any acceptor threads. Idempotent.
+    fn shutdown(&mut self);
+}
+
+/// Result of polling an [`AcceptEngine`].
+enum AcceptOutcome {
+    /// A client connection was accepted (stream already set to blocking).
+    Connection(TcpStream, SocketAddr),
+    /// No connection was ready within the poll interval. The engine has
+    /// already waited the appropriate amount, so the caller must re-check
+    /// signal flags and poll again without adding its own sleep.
+    Idle,
+    /// Every listener has shut down; the accept loop terminates.
+    Closed,
+}
+
+/// Single-listener accept engine: non-blocking `accept` with a 50ms idle sleep.
+///
+/// Used when exactly one address family is bound (IPv4-only or IPv6-only). The
+/// 50ms WouldBlock interval bounds first-connection latency on a quiet daemon
+/// while still letting the loop body re-check signal flags promptly.
+struct SingleListenerEngine {
+    listener: TcpListener,
+    local_addr: SocketAddr,
+    log_sink: Option<SharedLogSink>,
+}
+
+impl SingleListenerEngine {
+    fn new(
+        listener: TcpListener,
+        local_addr: SocketAddr,
+        log_sink: Option<SharedLogSink>,
+    ) -> Result<Self, DaemonError> {
+        listener
+            .set_nonblocking(true)
+            .map_err(|error| bind_error(local_addr, error))?;
+        Ok(Self {
+            listener,
+            local_addr,
+            log_sink,
+        })
+    }
+}
+
+impl AcceptEngine for SingleListenerEngine {
+    fn poll(&mut self) -> Result<AcceptOutcome, DaemonError> {
+        match self.listener.accept() {
+            Ok((tcp_stream, raw_peer_addr)) => {
+                if let Err(error) = tcp_stream.set_nonblocking(false) {
+                    if let Some(log) = self.log_sink.as_ref() {
+                        let text =
+                            format!("failed to set accepted socket to blocking: {error}");
+                        let message = rsync_warning!(text).with_role(Role::Daemon);
+                        log_message(log, &message);
+                    }
+                    return Ok(AcceptOutcome::Idle);
+                }
+                Ok(AcceptOutcome::Connection(tcp_stream, raw_peer_addr))
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                // No pending connection - sleep briefly then let the caller
+                // re-check signal flags. The 50ms interval matches the
+                // dual-stack engine so first-connection latency on a quiet
+                // daemon is bounded by half the sleep interval.
+                thread::sleep(Duration::from_millis(50));
+                Ok(AcceptOutcome::Idle)
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => Ok(AcceptOutcome::Idle),
+            Err(error) => Err(accept_error(self.local_addr, error)),
+        }
+    }
+
+    fn shutdown(&mut self) {}
+}
+
+/// Dual-stack accept engine: one acceptor thread per listener, fanned into an
+/// MPSC channel.
+///
+/// Used when multiple address families are bound. Each acceptor thread runs a
+/// non-blocking accept loop so it can observe the shutdown flag, and forwards
+/// accepted (blocking) streams through the channel. A single family failing
+/// does not tear down the daemon: the engine tracks live acceptors and only
+/// escalates an accept error to a fatal exit once every family has dropped out.
+///
+/// upstream: socket.c `start_accept_loop()` - one busted descriptor does not
+/// collapse the `select(2)` over the others.
+struct MultiListenerEngine {
+    rx: std::sync::mpsc::Receiver<Result<(TcpStream, SocketAddr), (SocketAddr, io::Error)>>,
+    acceptor_handles: Vec<thread::JoinHandle<()>>,
+    shutdown: Arc<AtomicBool>,
+    alive_acceptors: usize,
+    log_sink: Option<SharedLogSink>,
+    joined: bool,
+}
+
+impl MultiListenerEngine {
+    fn new(
+        listeners: Vec<TcpListener>,
+        bound_addresses: &[SocketAddr],
+        state: &AcceptLoopState<'_>,
+    ) -> Result<Self, DaemonError> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let shutdown = Arc::clone(&state.signal_flags.shutdown);
+        let graceful_exit = Arc::clone(&state.signal_flags.graceful_exit);
+        let total_acceptors = listeners.len();
+        let mut acceptor_handles: Vec<thread::JoinHandle<()>> =
+            Vec::with_capacity(total_acceptors);
+
+        for (listener, local_addr) in listeners.into_iter().zip(bound_addresses.iter().copied()) {
+            let tx = tx.clone();
+            let shutdown = Arc::clone(&shutdown);
+            let graceful_exit = Arc::clone(&graceful_exit);
+
+            // Set non-blocking so acceptor threads can check the shutdown flag
+            // without getting stuck in a blocking accept() call.
+            if let Err(error) = listener.set_nonblocking(true) {
+                return Err(bind_error(local_addr, error));
+            }
+
+            let handle = thread::spawn(move || {
+                while !shutdown.load(Ordering::Relaxed)
+                    && !graceful_exit.load(Ordering::Relaxed)
+                {
+                    match listener.accept() {
+                        Ok((stream, peer_addr)) => {
+                            // BSD-derived kernels (macOS, FreeBSD) propagate the
+                            // listener's O_NONBLOCK flag to the accepted socket,
+                            // which would cause the legacy handshake reader to
+                            // fail with EAGAIN before the client writes its
+                            // greeting. Reset to blocking so the worker thread
+                            // sees the upstream-compatible synchronous I/O model.
+                            if let Err(error) = stream.set_nonblocking(false) {
+                                let _ = tx.send(Err((local_addr, error)));
+                                break;
+                            }
+                            if tx.send(Ok((stream, peer_addr))).is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(50));
+                            continue;
+                        }
+                        Err(error) if error.kind() == io::ErrorKind::Interrupted => {
+                            continue;
+                        }
+                        Err(error) => {
+                            let _ = tx.send(Err((local_addr, error)));
+                            break;
+                        }
+                    }
+                }
+            });
+            acceptor_handles.push(handle);
+        }
+
+        // Drop our copy of the sender so the channel closes when acceptors exit.
+        drop(tx);
+
+        Ok(Self {
+            rx,
+            acceptor_handles,
+            shutdown,
+            alive_acceptors: total_acceptors,
+            log_sink: state.log_sink.clone(),
+            joined: false,
+        })
+    }
+
+    fn join_acceptors(&mut self) {
+        for handle in self.acceptor_handles.drain(..) {
+            let _ = handle.join();
+        }
+        self.joined = true;
+    }
+}
+
+impl AcceptEngine for MultiListenerEngine {
+    fn poll(&mut self) -> Result<AcceptOutcome, DaemonError> {
+        // recv_timeout allows periodic worker reaping and signal checks in the
+        // shared loop body between accepted connections.
+        match self.rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Ok((tcp_stream, raw_peer_addr))) => {
+                Ok(AcceptOutcome::Connection(tcp_stream, raw_peer_addr))
+            }
+            Ok(Err((local_addr, error))) => {
+                // The dual-stack loop only escalates an accept error to a fatal
+                // daemon exit when every family has dropped out - a single
+                // family failing logs a warning and the survivors keep serving.
+                self.alive_acceptors = self.alive_acceptors.saturating_sub(1);
+                if self.alive_acceptors == 0 {
+                    self.shutdown.store(true, Ordering::Relaxed);
+                    self.join_acceptors();
+                    return Err(accept_error(local_addr, error));
+                }
+                warn_per_family_accept_failure(self.log_sink.as_ref(), local_addr, &error);
+                Ok(AcceptOutcome::Idle)
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Ok(AcceptOutcome::Idle),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Ok(AcceptOutcome::Closed),
+        }
+    }
+
+    fn shutdown(&mut self) {
+        if self.joined {
+            return;
+        }
+        self.shutdown.store(true, Ordering::Relaxed);
+        self.join_acceptors();
+    }
+}
+
+/// Builds the accept engine for the bound listener topology.
+///
+/// A single bound listener uses [`SingleListenerEngine`]; multiple listeners
+/// (dual-stack) use [`MultiListenerEngine`]. The choice is made once here and
+/// never re-evaluated inside the loop.
+fn build_accept_engine(
+    mut listeners: Vec<TcpListener>,
+    bound_addresses: &[SocketAddr],
+    state: &AcceptLoopState<'_>,
+) -> Result<Box<dyn AcceptEngine>, DaemonError> {
+    if listeners.len() == 1 {
+        let listener = listeners.remove(0);
+        let engine =
+            SingleListenerEngine::new(listener, bound_addresses[0], state.log_sink.clone())?;
+        Ok(Box::new(engine))
+    } else {
+        let engine = MultiListenerEngine::new(listeners, bound_addresses, state)?;
+        Ok(Box::new(engine))
+    }
+}
+
+/// Drives the daemon accept loop over an [`AcceptEngine`].
+///
+/// The loop body is identical regardless of engine: check signal flags, poll
+/// for the next connection, and dispatch it through the shared admission and
+/// worker-spawn path. Polling cadence and readiness mechanism are entirely the
+/// engine's concern.
+fn run_accept_loop(
+    engine: &mut dyn AcceptEngine,
+    state: &mut AcceptLoopState<'_>,
+) -> Result<(), DaemonError> {
+    loop {
+        if let Some(true) = check_signals_and_maintain(state)? {
+            break;
+        }
+
+        match engine.poll()? {
+            AcceptOutcome::Connection(tcp_stream, raw_peer_addr) => {
+                if handle_accepted_connection(tcp_stream, raw_peer_addr, state) {
+                    break;
+                }
+            }
+            AcceptOutcome::Idle => continue,
+            AcceptOutcome::Closed => break,
+        }
+    }
+
+    engine.shutdown();
+    Ok(())
+}

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -177,9 +177,9 @@ fn serve_connections(
 
     // When a pre-bound listener is injected (test infrastructure), use it
     // directly - skipping the bind step eliminates the TOCTOU race between
-    // port allocation and daemon bind. `listeners` is later drained via
-    // `listeners.remove(0)`; `bound_addresses` is only read by index.
-    let mut listeners: Vec<TcpListener>;
+    // port allocation and daemon bind. `listeners` is later moved into the
+    // accept engine; `bound_addresses` is only read by index.
+    let listeners: Vec<TcpListener>;
     let bound_addresses: Vec<SocketAddr>;
 
     if let Some(listener) = pre_bound_listener {
@@ -368,13 +368,11 @@ fn serve_connections(
         proxy_protocol,
     };
 
-    if listeners.len() == 1 {
-        let listener = listeners.remove(0);
-        let local_addr = bound_addresses[0];
-        run_single_listener_loop(listener, local_addr, &mut state)?;
-    } else {
-        run_dual_stack_loop(listeners, &bound_addresses, &mut state)?;
-    }
+    // Select the accept engine once from the bound listener topology, then run
+    // the shared accept loop. The engine hides the readiness mechanism
+    // (non-blocking accept vs acceptor-thread fan-in) behind a uniform poll.
+    let mut engine = build_accept_engine(listeners, &bound_addresses, &state)?;
+    run_accept_loop(engine.as_mut(), &mut state)?;
 
     let result = drain_workers(&mut state.workers);
 

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -299,233 +299,45 @@ fn update_connection_status_after_accept(state: &mut AcceptLoopState<'_>) {
     }
 }
 
-/// Runs the accept loop for a single TCP listener.
+/// Admits one accepted connection: applies socket options, enforces the
+/// concurrent-connection cap, and spawns a session worker.
 ///
-/// Uses non-blocking accept with periodic signal flag checks. This is the
-/// simpler path used when only one address family is bound (e.g., IPv4-only
-/// or IPv6-only).
-fn run_single_listener_loop(
-    listener: TcpListener,
-    local_addr: SocketAddr,
+/// Shared by every [`AcceptEngine`] so admission semantics (capacity refusal,
+/// worker spawn, session accounting) are identical regardless of how the
+/// connection was sourced. Returns `true` when the `--max-sessions` limit has
+/// been reached and the accept loop should stop.
+fn handle_accepted_connection(
+    tcp_stream: TcpStream,
+    raw_peer_addr: SocketAddr,
     state: &mut AcceptLoopState<'_>,
-) -> Result<(), DaemonError> {
-    listener
-        .set_nonblocking(true)
-        .map_err(|error| bind_error(local_addr, error))?;
+) -> bool {
+    apply_accepted_stream_tcp_notsent_lowat(&tcp_stream);
 
-    loop {
-        if let Some(true) = check_signals_and_maintain(state)? {
-            break;
-        }
+    let Some(mut stream) = wrap_accepted_stream(tcp_stream, state) else {
+        return false;
+    };
 
-        match listener.accept() {
-            Ok((tcp_stream, raw_peer_addr)) => {
-                if let Err(error) = tcp_stream.set_nonblocking(false) {
-                    if let Some(log) = state.log_sink.as_ref() {
-                        let text = format!(
-                            "failed to set accepted socket to blocking: {error}"
-                        );
-                        let message = rsync_warning!(text).with_role(Role::Daemon);
-                        log_message(log, &message);
-                    }
-                    continue;
-                }
+    apply_client_options(&stream, &state.client_socket_options, state.log_sink.as_ref());
 
-                apply_accepted_stream_tcp_notsent_lowat(&tcp_stream);
-
-                let Some(mut stream) = wrap_accepted_stream(tcp_stream, state) else {
-                    continue;
-                };
-
-                apply_client_options(&stream, &state.client_socket_options, state.log_sink.as_ref());
-
-                if refuse_if_at_capacity(&mut stream, raw_peer_addr, state) {
-                    drop(stream);
-                    continue;
-                }
-
-                let handle = spawn_connection_worker(stream, raw_peer_addr, state);
-                state.workers.push(handle);
-                state.served = state.served.saturating_add(1);
-
-                update_connection_status_after_accept(state);
-            }
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                // No pending connection - sleep briefly then re-check flags.
-                // The 50ms interval matches `run_dual_stack_loop` so first-
-                // connection latency on a quiet daemon is bounded by half the
-                // sleep interval rather than the (much coarser) 500ms signal
-                // poll. The longer SIGNAL_CHECK_INTERVAL is still honoured for
-                // the signal-flag inspection at the top of the loop body via
-                // `check_signals_and_maintain`, which is the only consumer
-                // that needs that resolution.
-                thread::sleep(Duration::from_millis(50));
-                continue;
-            }
-            Err(error) if error.kind() == io::ErrorKind::Interrupted => {
-                continue;
-            }
-            Err(error) => {
-                return Err(accept_error(local_addr, error));
-            }
-        }
-
-        if let Some(limit) = state.max_sessions
-            && state.served >= limit {
-                if let Err(error) = state.notifier.status("Draining worker threads") {
-                    log_sd_notify_failure(state.log_sink.as_ref(), "connection status update", &error);
-                }
-                break;
-            }
+    if refuse_if_at_capacity(&mut stream, raw_peer_addr, state) {
+        drop(stream);
+        return false;
     }
 
-    Ok(())
-}
+    let handle = spawn_connection_worker(stream, raw_peer_addr, state);
+    state.workers.push(handle);
+    state.served = state.served.saturating_add(1);
 
-/// Runs the accept loop for multiple TCP listeners (dual-stack mode).
-///
-/// Spawns an acceptor thread per listener and multiplexes accepted connections
-/// through an MPSC channel. Signal flags are shared with acceptor threads so
-/// shutdown propagates promptly.
-fn run_dual_stack_loop(
-    listeners: Vec<TcpListener>,
-    bound_addresses: &[SocketAddr],
-    state: &mut AcceptLoopState<'_>,
-) -> Result<(), DaemonError> {
-    use std::sync::mpsc;
+    update_connection_status_after_accept(state);
 
-    let (tx, rx) = mpsc::channel::<Result<(TcpStream, SocketAddr), (SocketAddr, io::Error)>>();
-    let shutdown = Arc::clone(&state.signal_flags.shutdown);
-    let graceful_exit = Arc::clone(&state.signal_flags.graceful_exit);
-
-    let mut acceptor_handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity(listeners.len());
-    let total_acceptors = listeners.len();
-
-    for (listener, local_addr) in listeners.into_iter().zip(bound_addresses.iter().copied()) {
-        let tx = tx.clone();
-        let shutdown = Arc::clone(&shutdown);
-        let graceful_exit = Arc::clone(&graceful_exit);
-
-        // Set non-blocking so acceptor threads can check the shutdown flag
-        // without getting stuck in a blocking accept() call.
-        if let Err(error) = listener.set_nonblocking(true) {
-            return Err(bind_error(local_addr, error));
+    if let Some(limit) = state.max_sessions
+        && state.served >= limit
+    {
+        if let Err(error) = state.notifier.status("Draining worker threads") {
+            log_sd_notify_failure(state.log_sink.as_ref(), "connection status update", &error);
         }
-
-        let handle = thread::spawn(move || {
-            while !shutdown.load(Ordering::Relaxed)
-                && !graceful_exit.load(Ordering::Relaxed)
-            {
-                match listener.accept() {
-                    Ok((stream, peer_addr)) => {
-                        // BSD-derived kernels (macOS, FreeBSD) propagate the
-                        // listener's O_NONBLOCK flag to the accepted socket,
-                        // which would cause the legacy handshake reader to
-                        // fail with EAGAIN before the client writes its
-                        // greeting. Reset to blocking so the worker thread
-                        // sees the upstream-compatible synchronous I/O model.
-                        if let Err(error) = stream.set_nonblocking(false) {
-                            let _ = tx.send(Err((local_addr, error)));
-                            break;
-                        }
-                        if tx.send(Ok((stream, peer_addr))).is_err() {
-                            break;
-                        }
-                    }
-                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(50));
-                        continue;
-                    }
-                    Err(error) if error.kind() == io::ErrorKind::Interrupted => {
-                        continue;
-                    }
-                    Err(error) => {
-                        let _ = tx.send(Err((local_addr, error)));
-                        break;
-                    }
-                }
-            }
-        });
-        acceptor_handles.push(handle);
+        return true;
     }
 
-    // Drop our copy of the sender so the channel closes when acceptors exit
-    drop(tx);
-
-    // Track how many per-family acceptors have failed. The dual-stack loop
-    // only escalates an accept error to a fatal daemon exit when every
-    // family has dropped out - a single family failing (the GitHub Actions
-    // exit-10 pattern: IPv6 `bind(2)` succeeds but `accept(2)` then
-    // returns a non-routable family) used to tear down the whole daemon
-    // and surface as `error in socket I/O (code 10)`. With this fix the
-    // surviving family keeps serving traffic and the failed family logs
-    // a warning, mirroring upstream `socket.c::start_accept_loop`
-    // semantics where one busted descriptor does not collapse the
-    // `select(2)` over the others.
-    let mut alive_acceptors = total_acceptors;
-
-    // Main loop: receive connections from any listener
-    loop {
-        if let Some(true) = check_signals_and_maintain(state)? {
-            break;
-        }
-
-        // Use recv_timeout to allow periodic worker reaping and signal checks
-        match rx.recv_timeout(Duration::from_millis(100)) {
-            Ok(Ok((tcp_stream, raw_peer_addr))) => {
-                apply_accepted_stream_tcp_notsent_lowat(&tcp_stream);
-
-                let Some(mut stream) = wrap_accepted_stream(tcp_stream, state) else {
-                    continue;
-                };
-
-                apply_client_options(&stream, &state.client_socket_options, state.log_sink.as_ref());
-
-                if refuse_if_at_capacity(&mut stream, raw_peer_addr, state) {
-                    drop(stream);
-                    continue;
-                }
-
-                let handle = spawn_connection_worker(stream, raw_peer_addr, state);
-                state.workers.push(handle);
-                state.served = state.served.saturating_add(1);
-
-                update_connection_status_after_accept(state);
-
-                if let Some(limit) = state.max_sessions
-                    && state.served >= limit {
-                        if let Err(error) = state.notifier.status("Draining worker threads") {
-                            log_sd_notify_failure(state.log_sink.as_ref(), "connection status update", &error);
-                        }
-                        shutdown.store(true, Ordering::Relaxed);
-                        break;
-                    }
-            }
-            Ok(Err((local_addr, error))) => {
-                alive_acceptors = alive_acceptors.saturating_sub(1);
-                if alive_acceptors == 0 {
-                    shutdown.store(true, Ordering::Relaxed);
-                    for handle in acceptor_handles {
-                        let _ = handle.join();
-                    }
-                    return Err(accept_error(local_addr, error));
-                }
-                warn_per_family_accept_failure(state.log_sink.as_ref(), local_addr, &error);
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                continue;
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                break;
-            }
-        }
-    }
-
-    // Signal acceptors to stop and wait for them
-    shutdown.store(true, Ordering::Relaxed);
-    for handle in acceptor_handles {
-        let _ = handle.join();
-    }
-
-    Ok(())
+    false
 }


### PR DESCRIPTION
## Summary

Replaces the two duplicated daemon accept loops (single-listener and dual-stack) with a single `AcceptEngine` trait selected once at accept-loop entry. The trait hides *how* the next connection becomes ready - non-blocking `accept` on one listener, or an acceptor-thread-per-listener fan-in for many - behind a uniform `poll` interface, so the shared loop body (signal handling, capacity refusal, worker spawn) is identical regardless of listener topology.

## What changed

- **New `accept_engine.rs`**: `AcceptEngine` trait + `AcceptOutcome` enum; `SingleListenerEngine` (non-blocking accept + 50ms idle poll) and `MultiListenerEngine` (acceptor-thread fan-in with per-family error tolerance); `build_accept_engine` (topology-based selection) and `run_accept_loop` (unified loop body).
- **`connection.rs`**: the two loop functions collapse into one shared `handle_accepted_connection` helper (socket options -> capacity refusal -> worker spawn -> session accounting -> max-sessions check). Net -227/+43 lines in this file.
- **`accept_loop.rs`**: the `if listeners.len() == 1` branch becomes `build_accept_engine(...)` + `run_accept_loop(...)`.

## Behaviour preservation

This is a pure behaviour-preserving extraction:
- Single-listener path keeps the 50ms `WouldBlock` sleep and the same signal-check cadence.
- Dual-stack path keeps the acceptor-thread-per-listener model, the 100ms `recv_timeout`, the per-family accept-failure tolerance (one family failing logs a warning; the daemon only exits once every family drops out), and the shutdown/join semantics.
- The process-global `--max-connections` counter, capacity-refusal wire bytes, and accepted-socket blocking-mode reset are unchanged.

## Why

Establishes the seam the per-platform readiness engines (io_uring multishot `IORING_OP_ACCEPT`, kqueue `EVFILT_READ`, IOCP `AcceptEx`) plug into without touching the shared loop body. Mirrors upstream `socket.c::start_accept_loop`'s single-loop-over-N-listeners shape.

## Test plan

- `cargo build -p daemon` clean.
- `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings` clean.
- `cargo fmt -p daemon -- --check` clean.
- Existing daemon accept-loop integration tests (single-family, dual-stack, max-connections, max-sessions) exercise the new path via `serve_connections` and run in CI nextest + the interop harness.