### PR TITLE
feat(daemon): acceptor threads = N for SO_REUSEPORT listener replication

### DIFF
--- a/crates/daemon/src/daemon/runtime_options/accessors.rs
+++ b/crates/daemon/src/daemon/runtime_options/accessors.rs
@@ -15,6 +15,12 @@ impl RuntimeOptions {
         self.listen_backlog
     }
 
+    /// Returns the number of SO_REUSEPORT listener replicas to bind per
+    /// address family. Defaults to 1 (single listener) when unset.
+    pub(crate) fn acceptor_threads(&self) -> u32 {
+        self.acceptor_threads.map_or(1, NonZeroU32::get)
+    }
+
     /// Returns the configured socket options string.
     ///
     /// Upstream: `daemon-parm.txt` - `socket options` STRING. Comma-separated

--- a/crates/daemon/src/daemon/runtime_options/config.rs
+++ b/crates/daemon/src/daemon/runtime_options/config.rs
@@ -81,6 +81,12 @@ impl RuntimeOptions {
             self.set_listen_backlog_from_config(backlog, &origin)?;
         }
 
+        // Config-only option (no CLI flag); duplicate detection already happened
+        // during directive parsing, so a direct assignment is sufficient.
+        if let Some((threads, _origin)) = parsed.acceptor_threads {
+            self.acceptor_threads = Some(threads);
+        }
+
         // upstream: clientserver.c - config `port` overrides the default
         // listening port unless CLI `--port` was already given.
         if let Some((port, _origin)) = parsed.rsync_port {

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -63,6 +63,17 @@ pub(crate) struct RuntimeOptions {
     daemon_gid: Option<u32>,
     listen_backlog: Option<u32>,
     listen_backlog_from_config: bool,
+    /// Number of SO_REUSEPORT listener replicas to bind per address family.
+    ///
+    /// When set above 1, the daemon binds N kernel-load-balanced listener
+    /// sockets per family (each with its own acceptor thread) instead of one,
+    /// distributing inbound connection load across CPUs on platforms that
+    /// support SO_REUSEPORT. `None` preserves the single-listener default.
+    ///
+    /// This is an oc-rsync perf extension with no upstream equivalent
+    /// (upstream forks one child per accepted connection from a single
+    /// listener); it changes only kernel socket behaviour, never the wire.
+    acceptor_threads: Option<NonZeroU32>,
     /// TCP port from the `port` / `rsync port` global config parameter.
     ///
     /// upstream: daemon-parm.txt - `port` INTEGER, P_GLOBAL, default 0.
@@ -143,6 +154,7 @@ impl Default for RuntimeOptions {
             daemon_gid: None,
             listen_backlog: None,
             listen_backlog_from_config: false,
+            acceptor_threads: None,
             rsync_port: None,
             socket_options: None,
             socket_options_from_config: false,

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives.rs
@@ -67,6 +67,7 @@ struct GlobalParseState {
     daemon_uid: Option<(String, ConfigDirectiveOrigin)>,
     daemon_gid: Option<(String, ConfigDirectiveOrigin)>,
     listen_backlog: Option<(u32, ConfigDirectiveOrigin)>,
+    acceptor_threads: Option<(NonZeroU32, ConfigDirectiveOrigin)>,
     socket_options: Option<(String, ConfigDirectiveOrigin)>,
     proxy_protocol: Option<(bool, ConfigDirectiveOrigin)>,
     rsync_port: Option<(u16, ConfigDirectiveOrigin)>,
@@ -109,6 +110,7 @@ impl GlobalParseState {
             daemon_uid: None,
             daemon_gid: None,
             listen_backlog: None,
+            acceptor_threads: None,
             socket_options: None,
             proxy_protocol: None,
             rsync_port: None,
@@ -182,6 +184,7 @@ impl GlobalParseState {
             daemon_uid: self.daemon_uid,
             daemon_gid: self.daemon_gid,
             listen_backlog: self.listen_backlog,
+            acceptor_threads: self.acceptor_threads,
             socket_options: self.socket_options,
             proxy_protocol: self.proxy_protocol,
             rsync_port: self.rsync_port,
@@ -722,6 +725,45 @@ fn apply_global_directive(
                 }
             } else {
                 state.listen_backlog = Some((parsed, origin));
+            }
+        }
+        // oc-rsync extension - number of SO_REUSEPORT listener replicas to bind
+        // per address family (default 1). Has no upstream equivalent; changes
+        // only kernel socket behaviour, never the wire.
+        "acceptor threads" => {
+            let parsed: u32 = value.parse().map_err(|_| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    format!("invalid integer value '{value}' for 'acceptor threads'"),
+                )
+            })?;
+            let threads = NonZeroU32::new(parsed).ok_or_else(|| {
+                config_parse_error(
+                    path,
+                    line_number,
+                    "'acceptor threads' must be at least 1".to_string(),
+                )
+            })?;
+
+            let origin = ConfigDirectiveOrigin {
+                path: canonical.to_path_buf(),
+                line: line_number,
+            };
+
+            if let Some((existing, existing_origin)) = &state.acceptor_threads {
+                if *existing != threads {
+                    let existing_line = existing_origin.line;
+                    return Err(config_parse_error(
+                        path,
+                        line_number,
+                        format!(
+                            "duplicate 'acceptor threads' directive in global section (previously defined on line {existing_line})"
+                        ),
+                    ));
+                }
+            } else {
+                state.acceptor_threads = Some((threads, origin));
             }
         }
         // upstream: daemon-parm.txt - port INTEGER, P_GLOBAL, default 0.

--- a/crates/daemon/src/daemon/sections/config_parsing/types.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/types.rs
@@ -44,6 +44,9 @@ pub(crate) struct ParsedConfigModules {
     /// The value is a groupname string or numeric gid that gets resolved at runtime.
     daemon_gid: Option<(String, ConfigDirectiveOrigin)>,
     listen_backlog: Option<(u32, ConfigDirectiveOrigin)>,
+    /// Number of SO_REUSEPORT listener replicas per family from the
+    /// `acceptor threads` directive (oc-rsync extension, default 1).
+    acceptor_threads: Option<(NonZeroU32, ConfigDirectiveOrigin)>,
     /// Global socket options from the `socket options` directive.
     ///
     /// upstream: daemon-parm.txt - `socket options` STRING. Comma-separated list

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -35,6 +35,7 @@ fn serve_connections(
     let version = manifest.rust_version();
     let detach = options.detach();
     let listen_backlog = options.listen_backlog();
+    let acceptor_threads = options.acceptor_threads();
     let socket_options_str = options.socket_options().map(str::to_string);
     let tcp_fastopen_mode = options.tcp_fastopen();
     let RuntimeOptions {
@@ -204,6 +205,7 @@ fn serve_connections(
             port,
             backlog,
             tcp_fastopen_mode,
+            acceptor_threads,
             log_sink.as_ref(),
         ) {
             Ok((bound_listeners, bound_local_addrs)) => {

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -357,29 +357,58 @@ fn bind_listeners_per_family(
     port: u16,
     backlog: i32,
     tcp_fastopen: TcpFastOpenMode,
+    acceptor_threads: u32,
     log_sink: Option<&SharedLogSink>,
 ) -> Result<(Vec<TcpListener>, Vec<SocketAddr>), io::Error> {
-    let mut listeners = Vec::with_capacity(bind_addresses.len());
-    let mut bound_addresses = Vec::with_capacity(bind_addresses.len());
+    let replicas = acceptor_threads.max(1) as usize;
+    let mut listeners = Vec::with_capacity(bind_addresses.len() * replicas);
+    let mut bound_addresses = Vec::with_capacity(bind_addresses.len() * replicas);
     let dual_stack = bind_addresses.len() > 1;
     let mut last_error: Option<io::Error> = None;
 
     for addr in bind_addresses {
         let requested_addr = SocketAddr::new(*addr, port);
-        match bind_with_backlog(requested_addr, backlog, tcp_fastopen) {
-            Ok(listener) => {
-                let local_addr = listener.local_addr().unwrap_or(requested_addr);
-                bound_addresses.push(local_addr);
-                listeners.push(listener);
-            }
-            Err(error) => {
-                if dual_stack {
-                    warn_per_family_bind_failure(log_sink, requested_addr, &error);
-                    last_error = Some(error);
-                    continue;
+
+        // Bind up to `replicas` SO_REUSEPORT sockets for this family. The kernel
+        // load-balances accepted connections across them, each driven by its own
+        // acceptor thread. With replicas == 1 this is the historical
+        // single-listener-per-family behaviour.
+        let mut family_bound = 0usize;
+        let mut family_error: Option<io::Error> = None;
+        for _ in 0..replicas {
+            match bind_with_backlog(requested_addr, backlog, tcp_fastopen) {
+                Ok(listener) => {
+                    let local_addr = listener.local_addr().unwrap_or(requested_addr);
+                    bound_addresses.push(local_addr);
+                    listeners.push(listener);
+                    family_bound += 1;
                 }
-                return Err(error);
+                Err(error) => {
+                    family_error = Some(error);
+                    break;
+                }
             }
+        }
+
+        if family_bound == 0 {
+            // Whole family failed to bind even once - apply the existing
+            // per-family tolerance: warn and continue in dual-stack mode so a
+            // surviving family keeps the daemon up, else propagate.
+            let error = family_error.expect("a bind failure was recorded");
+            if dual_stack {
+                warn_per_family_bind_failure(log_sink, requested_addr, &error);
+                last_error = Some(error);
+                continue;
+            }
+            return Err(error);
+        }
+
+        // The family is serving with at least one replica. If a later replica
+        // failed, surface it as a warning but keep the bound replicas.
+        if family_bound < replicas
+            && let Some(error) = family_error
+        {
+            warn_per_family_bind_failure(log_sink, requested_addr, &error);
         }
     }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1015,6 +1015,7 @@ fn bind_listeners_per_family_falls_back_when_first_family_unreachable() {
         0,
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
+        1,
         None,
     )
     .expect("at least one family must bind");
@@ -1030,6 +1031,46 @@ fn bind_listeners_per_family_falls_back_when_first_family_unreachable() {
         bound_addresses[0].port() != 0,
         "kernel must assign an ephemeral port for the bound listener"
     );
+}
+
+#[test]
+fn bind_listeners_per_family_replicates_acceptor_threads() {
+    // acceptor_threads = N must bind N listener sockets for a reachable
+    // family. With port 0 each replica gets its own ephemeral port, which
+    // deterministically exercises the replication loop on every platform
+    // regardless of SO_REUSEPORT same-port semantics (the load-balancing
+    // benefit of binding to a fixed shared port is a kernel feature covered
+    // by the per-socket set_reuse_port call, not this counting test).
+    let reachable = IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+    let bind_addresses = vec![reachable];
+
+    let (listeners, bound_addresses) = bind_listeners_per_family(
+        &bind_addresses,
+        0,
+        DEFAULT_LISTEN_BACKLOG,
+        TcpFastOpenMode::Off,
+        3,
+        None,
+    )
+    .expect("the reachable family must bind all replicas");
+
+    assert_eq!(
+        listeners.len(),
+        3,
+        "acceptor_threads=3 must bind three listener replicas"
+    );
+    assert_eq!(bound_addresses.len(), 3);
+    for addr in &bound_addresses {
+        assert_eq!(addr.ip(), reachable, "every replica binds the same family");
+        assert!(addr.port() != 0, "each replica must get a real ephemeral port");
+    }
+}
+
+#[test]
+fn default_acceptor_threads_is_one() {
+    // Absent an `acceptor threads` directive the daemon binds a single
+    // listener per family, preserving the historical pre-NACC-2 behaviour.
+    assert_eq!(RuntimeOptions::default().acceptor_threads(), 1);
 }
 
 #[test]
@@ -1051,6 +1092,7 @@ fn bind_listeners_per_family_fails_only_when_all_families_unreachable() {
         0,
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
+        1,
         None,
     )
     .expect_err("no family should bind");
@@ -1093,6 +1135,7 @@ fn bind_listeners_per_family_falls_back_from_ipv6_to_ipv4() {
         0,
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
+        1,
         None,
     )
     .expect("IPv4 fallback must bind when IPv6 is unreachable");
@@ -1129,6 +1172,7 @@ fn bind_listeners_per_family_single_family_propagates_error() {
         0,
         DEFAULT_LISTEN_BACKLOG,
         TcpFastOpenMode::Off,
+        1,
         None,
     )
     .expect_err("the single configured address must fail to bind");

--- a/docs/user/daemon-concurrency-limits.md
+++ b/docs/user/daemon-concurrency-limits.md
@@ -140,6 +140,39 @@ Pair `--max-connections` with the OS limits the daemon actually consumes:
   backlog headroom or new connections see `ECONNREFUSED` before the
   accept loop runs.
 
+## Spreading accept load: acceptor threads
+
+By default the daemon binds one listener socket per address family and runs
+a single accept loop over it. On a host fielding a high rate of short-lived
+connections, that one accept loop can become the bottleneck before any
+worker thread saturates.
+
+The `acceptor threads` global directive binds N `SO_REUSEPORT` listener
+replicas per family instead of one:
+
+```
+# /etc/oc-rsyncd.conf
+acceptor threads = 4
+```
+
+Each replica gets its own acceptor thread, and the kernel load-balances
+inbound connections across them. This is an oc-rsync extension with no
+upstream equivalent (upstream forks one child per accepted connection from
+a single listener) and changes only kernel socket behaviour, never the
+wire. The default of 1 preserves the historical single-listener model.
+
+Notes:
+
+- `SO_REUSEPORT` is a Linux/BSD feature. On platforms without it the
+  replicas still bind, but the kernel does not load-balance across them, so
+  values above 1 provide no benefit there.
+- Size N to the number of CPUs you want fielding accepts, not to
+  `--max-connections`. A handful (2-8) is typically enough; the accept path
+  is cheap once a connection lands on a worker thread.
+- The per-daemon `--max-connections` cap and its admission counter are
+  global across all acceptor threads, so adding replicas never loosens the
+  concurrency ceiling.
+
 ## Why not async
 
 A `tokio`-based runtime would lift the per-connection ceiling by an order


### PR DESCRIPTION
## Summary

Adds the global `acceptor threads = N` config directive, which binds **N SO_REUSEPORT listener replicas per address family** instead of one. Each replica gets its own acceptor thread and the kernel load-balances inbound connections across them, spreading accept load across CPUs when the daemon fields a high rate of short-lived connections (NACC-2).

Builds directly on the `AcceptEngine` seam from #6165: the multi-listener engine already consumes a `Vec<TcpListener>`, so this change is purely (a) plumbing the numeric value end-to-end and (b) wrapping the per-family bind in a `0..N` replication loop.

## What changed

- **`acceptor threads` directive** parsed in `global_directives.rs` (rejects 0 and duplicate definitions, mirroring `listen backlog`), threaded through the parse-state -> `ParsedConfigModules` -> `RuntimeOptions.acceptor_threads: Option<NonZeroU32>` with an `acceptor_threads()` accessor (effective default 1).
- **`bind_listeners_per_family`** gains an `acceptor_threads` parameter and binds up to N replicas per family. The existing per-family failure tolerance is preserved: a family that fails to bind even once still warns-and-continues in dual-stack mode (or propagates otherwise); a partial-replica failure keeps the bound replicas and warns.
- **Config-only**, matching `listen backlog` (the closest socket-tuning option, which also has no CLI flag). No upstream equivalent; changes only kernel socket behaviour, never the wire.
- User docs: a new section in `docs/user/daemon-concurrency-limits.md`.

## Behaviour preservation

With the default `acceptor threads = 1` the replication loop runs exactly once per family, reproducing the historical single-listener-per-family bind including dual-stack tolerance. The process-global `--max-connections` counter spans all acceptor threads, so replicas never loosen the concurrency cap.

## Test plan

- New unit tests: `bind_listeners_per_family_replicates_acceptor_threads` (asserts N=3 yields 3 listeners, deterministic on all platforms via port-0 ephemeral binding) and `default_acceptor_threads_is_one`.
- Existing `bind_listeners_per_family_*` tests updated for the new parameter.
- `cargo build -p daemon`, `cargo clippy -p daemon --all-targets --all-features --no-deps -- -D warnings`, `cargo fmt -p daemon -- --check` all clean.
- Full daemon nextest + interop run in CI.