### PR TITLE
fix(ci): de-flake interop smoke delta-update scenario

### DIFF
--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -99,6 +99,17 @@ printf 'deep\n'  > "${src}/subdir/nested/deep.txt"
 # 256 KiB is enough to push past a single block without being slow.
 dd if=/dev/urandom of="${src}/random.bin" bs=1024 count=256 \
    >/dev/null 2>&1
+# Backdate the random file to a fixed old timestamp so its basis on the
+# receiver has a clearly-old mtime. Scenario 7 modifies a same-size copy in
+# place; without this, the modification and the basis can land in the same
+# wall-clock second on a fast machine, and rsync's quick-check (equal size +
+# same second-resolution mtime) skips the file - so the delta is never sent
+# and the receiver keeps the stale content. This is standard rsync behaviour:
+# upstream rsync 3.4.4 -> upstream 3.4.4 diverges identically in that case.
+# Backdating makes the later in-place edit land in a strictly newer second,
+# so the change is detected deterministically while still exercising the
+# default mtime quick-check + delta path.
+touch -t 202001010000 "${src}/random.bin"
 # Empty file edge case.
 : > "${src}/empty.txt"
 


### PR DESCRIPTION
## Summary

Root-causes and fixes the recurring **"delta update push (oc-rsync -> upstream) diverged"** macOS interop flake. It is **not an oc-rsync bug** — it's a racy test fixture hitting standard rsync quick-check semantics.

## Root cause (reproduced + verified locally on macOS with rsync 3.4.4)

Scenario 7 builds a 256 KiB random file, `cp -R` to `modified/`, flips one byte **in place** (same size), and pushes, asserting convergence. On a fast machine the in-place edit and the basis mtime fall in the **same wall-clock second**, so rsync's quick-check (equal size + same second-resolution mtime) **skips the file** and the receiver keeps the stale content.

This is standard rsync behaviour, confirmed by a head-to-head:

| Sender | same-second result |
|---|---|
| oc-rsync | 14/15 diverge (`got == basis` exactly — full skip, no transfer) |
| **upstream rsync 3.4.4 -> upstream 3.4.4** | **6/6 diverge — identical** |

So neither implementation detects a same-size, same-second change without an mtime separation — the fixture was racy by design.

## Fix

Backdate the random file to a fixed old timestamp so its **basis** mtime is distinctly old. The later in-place edit then lands in a strictly newer second and is detected deterministically — while still exercising the **default** mtime quick-check + delta path (not `--checksum`, which would mask the realistic path). Mirrors rsync's own testsuite idiom.

## Verification

- Before: ~93% fail on a fast host.
- After: **0 failures across 6 full smoke-test runs** (`backdate 0/15`, `--checksum 0/15` in the isolated delta loop).
- The `oc-rsync re-run is a no-op (quick-check)` and reverse-direction scenarios still pass — backdating doesn't break them.

## Notes

CI-script only; no product code change. Unblocks the macOS interop check for all PRs. A separate latent finding in the delta matcher (final partial-block `remainder` length) was filed for its own reproduction; it is **not** this failure (the file was skipped, so the matcher never ran).