### PR TITLE
fix(bandwidth): discard must-use LimiterSleep in kqueue pacing test

### DIFF
--- a/crates/bandwidth/tests/kqueue_sleep_backend.rs
+++ b/crates/bandwidth/tests/kqueue_sleep_backend.rs
@@ -48,7 +48,10 @@ fn bwlimit_1k_paces_within_tolerance() {
 
     let start = Instant::now();
     for _ in 0..4 {
-        limiter.register(512);
+        // `register` performs the pacing sleep internally; the returned
+        // `LimiterSleep` is only a timing record, so discard it explicitly
+        // (matching the priming call above) rather than tripping `must_use`.
+        let _ = limiter.register(512);
     }
     let elapsed = start.elapsed();
 


### PR DESCRIPTION
## What

The macOS-only `kqueue_sleep_backend` pacing test dropped the `#[must_use]` `LimiterSleep` returned by `register()` inside its measurement loop, tripping `-D warnings` under `--all-features`.

`register()` performs the pacing sleep **internally**; the returned `LimiterSleep` is only a timing *record*. So the fix is to discard it explicitly via `let _` — matching the existing priming call a few lines up — not a logic change (the sleep, and thus the pacing the test asserts on, still happens).

## Why CI didn't catch it

The `fmt + clippy` job compiles clippy on **Linux**, where this `#![cfg(target_os = "macos")]` test is excluded. The lint only surfaces in macOS all-features builds. Found while running the full-workspace clippy locally on macOS.

Validated: `cargo clippy -p bandwidth --all-targets --all-features --no-deps -- -D warnings` now passes. Pre-existing issue, unrelated to any other in-flight PR.