### PR TITLE
perf(engine): parallelize local-copy delta basis-signature computation

### DIFF
--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -10,7 +10,10 @@ use checksums::strong::Xxh64;
 
 use crate::delta::{DeltaSignatureIndex, SignatureLayoutParams, calculate_signature_layout};
 use crate::local_copy::{COPY_BUFFER_SIZE, LocalCopyError};
-use crate::signature::{SignatureAlgorithm, SignatureError, generate_file_signature};
+use crate::signature::{
+    PARALLEL_THRESHOLD_BYTES, SignatureAlgorithm, SignatureError, generate_file_signature,
+    generate_file_signature_windowed,
+};
 
 use protocol::ProtocolVersion;
 
@@ -84,17 +87,27 @@ pub(crate) fn build_delta_signature(
         return Ok(None);
     };
 
-    let signature = match generate_file_signature(
-        fs::File::open(destination).map_err(|error| {
-            LocalCopyError::io(
-                "read existing destination",
-                destination.to_path_buf(),
-                error,
-            )
-        })?,
-        layout,
-        SignatureAlgorithm::Md4,
-    ) {
+    let basis = fs::File::open(destination).map_err(|error| {
+        LocalCopyError::io(
+            "read existing destination",
+            destination.to_path_buf(),
+            error,
+        )
+    })?;
+
+    // Computing the basis block checksums (the delta signature) is the
+    // single-threaded hot path of a delta transfer: perf shows md4::compress
+    // plus generate_file_signature pinning one core. For a large basis, fan
+    // the per-block rolling+strong checksums across the rayon pool with the
+    // bounded-memory windowed generator. Its output is byte-identical to the
+    // sequential path; below the threshold the rayon overhead would dominate,
+    // so stay sequential there.
+    let signature_result = if length >= PARALLEL_THRESHOLD_BYTES {
+        generate_file_signature_windowed(basis, layout, SignatureAlgorithm::Md4)
+    } else {
+        generate_file_signature(basis, layout, SignatureAlgorithm::Md4)
+    };
+    let signature = match signature_result {
         Ok(signature) => signature,
         Err(SignatureError::Io(error)) => {
             return Err(LocalCopyError::io(


### PR DESCRIPTION
## Summary

perf-profiled the delta path (`oc -a --no-whole-file --ignore-times src/ dst/`,
512 MiB basis) on a 4-core host: it runs on **1.0 of 4 cores**. The basis
block-checksum computation (`build_delta_signature` -> `generate_file_signature`,
MD4 over the whole basis) was using the **sequential** signature generator with no
parallel option, while the daemon receiver path (`basis.rs::compute_basis_signature`)
already had a parallel windowed path.

This routes the local-copy basis signature through the bounded-memory parallel
windowed generator (`generate_file_signature_windowed`) for basis files
>= `PARALLEL_THRESHOLD_BYTES` (256 KiB). The per-block rolling+strong checksums fan
across the rayon pool. Output is byte-identical to the sequential path (the windowed
generator is parity-tested in the `signature` crate), memory stays bounded (windowed,
not the whole-file-slurping `_parallel` variant), and below the threshold the
sequential path is kept to avoid rayon overhead.

## Profiling (thin-LTO, production-representative)

```
39.9%  CopyContext::copy_file_contents     (sender rolling scan + match verify - serial)
19.9%  accumulate_chunk_neon_impl          (rolling weak checksum)
16.7%  md4::compress + 9.7% md4 digest_x4  (strong checksum)
       of which basis signature gen = 10.9% (this PR parallelizes)
```

## Host benchmark (aarch64, 4 cores; 512 MiB basis, N=5 median; byte-verified)

| | median | CPUs utilized |
|---|---|---|
| before (sequential) | 3.674 s | 1.0 |
| after (parallel windowed) | 3.347 s | 1.1 |

~8.9% faster on local-copy delta. The gain is bounded by Amdahl: only the
signature-gen slice (~11%) parallelizes; the serial sender rolling scan dominates.
The larger win is on the **daemon/remote receiver**, whose checksum work is almost
entirely signature generation.

Follow-ups (not in this PR): the same sequential-signature gap exists at
`engine/src/concurrent_delta/strategy.rs:213`; and parallelizing the sender rolling
scan + match verification (the ~60% serial remainder) is the larger, separate effort.