### PR TITLE
fix(matching): reset consumed bitset before chunked parallel delta scan

### DIFF
--- a/crates/matching/Cargo.toml
+++ b/crates/matching/Cargo.toml
@@ -82,3 +82,7 @@ harness = false
 [[bench]]
 name = "zsync_optimizations"
 harness = false
+
+[[bench]]
+name = "parallel_delta_scan"
+harness = false

--- a/crates/matching/benches/parallel_delta_scan.rs
+++ b/crates/matching/benches/parallel_delta_scan.rs
@@ -66,18 +66,23 @@ fn scattered_edits(size: usize, seed: u64, change_count: usize) -> Vec<u8> {
 }
 
 fn bench_parallel_delta_scan(c: &mut Criterion) {
-    const SIZE: usize = 128 * 1024 * 1024; // 128 MiB
+    const SIZE: usize = 256 * 1024 * 1024; // 256 MiB
+
     let basis = pseudo_random(SIZE, 0x1234_5678);
     let index = build_index(&basis);
 
-    // 1% scattered edits: realistic delta, dominated by copy matches.
-    let source = scattered_edits(SIZE, 0x1234_5678, SIZE / 100);
+    // 64 scattered single-byte edits across 256 MiB: ~99.6% of basis blocks
+    // still match, so the scan is dominated by per-block rolling+MD4 work (the
+    // real sender cost) rather than a pathological all-literal byte walk. The
+    // edits must be far sparser than the block length, or every block is
+    // dirtied and nothing matches.
+    let source = scattered_edits(SIZE, 0x1234_5678, 64);
     let generator = DeltaGenerator::new();
 
-    let mut group = c.benchmark_group("parallel_delta_scan_128MiB_1pct");
+    let mut group = c.benchmark_group("parallel_delta_scan_256MiB_mostly_copy");
     group.throughput(Throughput::Bytes(SIZE as u64));
     group.sample_size(10);
-    group.measurement_time(std::time::Duration::from_secs(15));
+    group.measurement_time(std::time::Duration::from_secs(10));
 
     group.bench_function("sequential", |b| {
         b.iter(|| {

--- a/crates/matching/benches/parallel_delta_scan.rs
+++ b/crates/matching/benches/parallel_delta_scan.rs
@@ -1,0 +1,112 @@
+//! Scaling benchmark for the parallel sender-scan delta generator.
+//!
+//! Compares the sequential [`DeltaGenerator::generate`] against the parallel
+//! [`DeltaGenerator::generate_chunked`] at increasing range counts, on a
+//! large delta workload (mostly-copy, the common rsync case). The parallel
+//! path's wall-clock speedup saturates at the rayon pool size; pin it with
+//! `RAYON_NUM_THREADS=N` across runs to trace the per-core scaling curve:
+//!
+//! ```sh
+//! for n in 1 2 4 8; do
+//!   RAYON_NUM_THREADS=$n cargo bench -p matching --bench parallel_delta_scan
+//! done
+//! ```
+
+use std::hint::black_box;
+use std::io::Cursor;
+use std::num::NonZeroU8;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use matching::{DeltaGenerator, DeltaSignatureIndex};
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+/// Deterministic pseudo-random fill (xorshift64) so basis blocks are distinct,
+/// exercising the real hash-probe + MD4-verify path rather than a degenerate
+/// all-duplicate index.
+fn pseudo_random(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.push((state & 0xff) as u8);
+    }
+    out
+}
+
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+/// Basis with `change_count` scattered single-byte edits - a mostly-copy delta.
+fn scattered_edits(size: usize, seed: u64, change_count: usize) -> Vec<u8> {
+    let mut data = pseudo_random(size, seed);
+    if change_count > 0 {
+        let spacing = size / change_count;
+        for i in 0..change_count {
+            let pos = (i * spacing).min(size - 1);
+            data[pos] ^= 0xff;
+        }
+    }
+    data
+}
+
+fn bench_parallel_delta_scan(c: &mut Criterion) {
+    const SIZE: usize = 128 * 1024 * 1024; // 128 MiB
+    let basis = pseudo_random(SIZE, 0x1234_5678);
+    let index = build_index(&basis);
+
+    // 1% scattered edits: realistic delta, dominated by copy matches.
+    let source = scattered_edits(SIZE, 0x1234_5678, SIZE / 100);
+    let generator = DeltaGenerator::new();
+
+    let mut group = c.benchmark_group("parallel_delta_scan_128MiB_1pct");
+    group.throughput(Throughput::Bytes(SIZE as u64));
+    group.sample_size(10);
+    group.measurement_time(std::time::Duration::from_secs(15));
+
+    group.bench_function("sequential", |b| {
+        b.iter(|| {
+            let script = generator.generate(Cursor::new(black_box(source.as_slice())), &index);
+            black_box(script)
+        });
+    });
+
+    for max_chunks in [2usize, 4, 8, 16] {
+        group.bench_with_input(
+            BenchmarkId::new("chunked", max_chunks),
+            &max_chunks,
+            |b, &max_chunks| {
+                b.iter(|| {
+                    let script =
+                        generator.generate_chunked(black_box(source.as_slice()), &index, max_chunks);
+                    black_box(script)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = bench_parallel_delta_scan
+);
+
+criterion_main!(benches);

--- a/crates/matching/benches/parallel_delta_scan.rs
+++ b/crates/matching/benches/parallel_delta_scan.rs
@@ -97,8 +97,11 @@ fn bench_parallel_delta_scan(c: &mut Criterion) {
             &max_chunks,
             |b, &max_chunks| {
                 b.iter(|| {
-                    let script =
-                        generator.generate_chunked(black_box(source.as_slice()), &index, max_chunks);
+                    let script = generator.generate_chunked(
+                        black_box(source.as_slice()),
+                        &index,
+                        max_chunks,
+                    );
                     black_box(script)
                 });
             },

--- a/crates/matching/examples/parallel_delta_timing.rs
+++ b/crates/matching/examples/parallel_delta_timing.rs
@@ -1,0 +1,112 @@
+//! Direct wall-clock timing for the parallel sender-scan delta generator.
+//!
+//! Bypasses criterion's adaptive iteration estimate (which explodes when one
+//! variant is anomalously slow) and times single `generate` / `generate_chunked`
+//! calls. Prints throughput plus token/literal counts so a chunk that stops
+//! matching (literal blow-up) is immediately visible.
+//!
+//! Run with `RAYON_NUM_THREADS=N cargo run -p matching --release --example parallel_delta_timing`.
+
+use std::hint::black_box;
+use std::io::Cursor;
+use std::num::NonZeroU8;
+use std::time::Instant;
+
+use matching::{DeltaGenerator, DeltaSignatureIndex};
+use protocol::ProtocolVersion;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+fn pseudo_random(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.push((state & 0xff) as u8);
+    }
+    out
+}
+
+fn build_index(data: &[u8]) -> DeltaSignatureIndex {
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        None,
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature =
+        generate_file_signature(data, layout, SignatureAlgorithm::Md4).expect("signature");
+    DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index")
+}
+
+fn scattered_edits(size: usize, seed: u64, change_count: usize) -> Vec<u8> {
+    let mut data = pseudo_random(size, seed);
+    if change_count > 0 {
+        let spacing = size / change_count;
+        for i in 0..change_count {
+            data[(i * spacing).min(size - 1)] ^= 0xff;
+        }
+    }
+    data
+}
+
+/// Returns (best_seconds, tokens, literal_bytes) over 3 reps.
+fn time_it(label: &str, size: usize, mut f: impl FnMut() -> (usize, u64)) {
+    let mut best = f64::INFINITY;
+    let mut tokens = 0usize;
+    let mut literal = 0u64;
+    for _ in 0..3 {
+        let start = Instant::now();
+        let (t, l) = black_box(f());
+        let secs = start.elapsed().as_secs_f64();
+        if secs < best {
+            best = secs;
+            tokens = t;
+            literal = l;
+        }
+    }
+    let mibs = (size as f64 / (1024.0 * 1024.0)) / best;
+    println!(
+        "  {label:<12} {best:8.3}s  {mibs:8.1} MiB/s  tokens={tokens:>8} literal_bytes={literal}",
+    );
+}
+
+fn main() {
+    const SIZE: usize = 128 * 1024 * 1024; // 128 MiB
+    let basis = pseudo_random(SIZE, 0x1234_5678);
+    let index = build_index(&basis);
+    let source = scattered_edits(SIZE, 0x1234_5678, 32);
+    let generator = DeltaGenerator::new();
+
+    println!(
+        "threads={}  size={} MiB  block_len={}",
+        rayon::current_num_threads(),
+        SIZE / (1024 * 1024),
+        index.block_length(),
+    );
+
+    // Warm the page cache / allocator.
+    let _ = generator
+        .generate(Cursor::new(source.as_slice()), &index)
+        .expect("warm");
+
+    time_it("sequential", SIZE, || {
+        let s = generator
+            .generate(Cursor::new(source.as_slice()), &index)
+            .expect("seq");
+        (s.tokens().len(), s.literal_bytes())
+    });
+
+    for n in [2usize, 4, 8] {
+        time_it(&format!("chunked/{n}"), SIZE, || {
+            let s = generator
+                .generate_chunked(source.as_slice(), &index, n)
+                .expect("chunked");
+            (s.tokens().len(), s.literal_bytes())
+        });
+    }
+}

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -492,12 +492,16 @@ impl DeltaGenerator {
     ///
     /// The sender-side rolling scan is inherently sequential per byte, so the
     /// only way to engage multiple cores is to split the source into disjoint
-    /// ranges and scan each against the shared, read-only signature `index`.
-    /// Each range scans with pruning disabled, which keeps the index purely
-    /// read-only (`AtomicU64` consumed-bitset is never touched), so the shared
-    /// `&index` is safe to scan from every rayon worker with no locking. Every
-    /// worker keeps its own window, rolling checksum, and token vector; there
-    /// is no shared mutable state and therefore no mutex on the hot path.
+    /// ranges and scan each against the shared signature `index`. Each range
+    /// scans with pruning disabled, so no worker ever *writes* the index's
+    /// `consumed` bitset. We clear that bitset once up front (the matcher
+    /// consults it unconditionally, and a prior pruned [`Self::generate`] would
+    /// otherwise leave every block marked consumed, defeating all matching);
+    /// after that single reset it is immutable for the duration of the scan, so
+    /// the shared `&index` is safe to read from every rayon worker with no
+    /// locking. Every worker keeps its own window, rolling checksum, and token
+    /// vector; there is no shared mutable state and therefore no mutex on the
+    /// hot path.
     ///
     /// # Correctness
     ///
@@ -538,6 +542,13 @@ impl DeltaGenerator {
             // Too small to split usefully - keep the pruned sequential path.
             return self.generate(Cursor::new(source), index);
         }
+
+        // The matcher consults the shared `consumed` bitset on every probe,
+        // even though these chunks pass no per-chunk prune filter. A prior
+        // pruned generate() leaves blocks marked consumed; clear the bitset
+        // once so every chunk can match. Pruning is off per chunk, so no worker
+        // writes it back - it stays immutable across the concurrent scan.
+        index.reset_consumed();
 
         // Partition into `chunks` contiguous, non-overlapping ranges.
         let base = n / chunks;
@@ -944,5 +955,39 @@ mod tests {
         assert_eq!(sequential.tokens().len(), single.tokens().len());
         assert_eq!(sequential.total_bytes(), single.total_bytes());
         assert_eq!(sequential.literal_bytes(), single.literal_bytes());
+    }
+
+    #[test]
+    fn generate_chunked_matches_after_prior_pruned_generate() {
+        // Regression: the matcher consults the shared `consumed` bitset on
+        // every probe. A pruned generate() leaves blocks marked consumed; if
+        // generate_chunked does not reset the bitset, every block looks taken
+        // and the scan degrades to all-literal (correct output, but zero delta
+        // compression and pathologically slow). Reconstruction parity alone
+        // cannot catch this - assert effectiveness (most bytes are copied).
+        let data = pseudo_random(4 * 1024 * 1024, 0x0bad_f00d);
+        let index = build_index(&data);
+        let generator = DeltaGenerator::new();
+
+        // Prime the shared consumed-bitset with a pruned sequential generate.
+        let seq = generator
+            .generate(Cursor::new(&data[..]), &index)
+            .expect("seq");
+        assert!(
+            seq.literal_bytes() < data.len() as u64 / 4,
+            "sequential should mostly match identical data"
+        );
+
+        let chunked = generator
+            .generate_chunked(&data, &index, 4)
+            .expect("chunked");
+        assert_eq!(reconstruct(&data, &index, &chunked), data);
+        assert!(
+            chunked.literal_bytes() < data.len() as u64 / 4,
+            "chunked must still produce copies after a prior pruned generate; \
+             got literal_bytes={} of {}",
+            chunked.literal_bytes(),
+            data.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

`DeltaGenerator::generate_chunked` (merged in #6183) scans each range with pruning **off**, but the matcher consults the shared `consumed` bitset on *every* probe regardless of the per-chunk filter. A prior pruned `generate()` leaves every basis block marked consumed, so without a reset the chunked scan matched **nothing** and degraded to all-literal output — correct reconstruction, but zero delta compression and ~200× slower.

This was found empirically while benchmarking: `sequential` produced 376 KB of literals on a 128 MiB mostly-copy workload, while `chunked/2` produced the full 128 MiB as literals (every byte a literal token).

## Fix

Clear the bitset **once** before the rayon fan-out. Pruning is off per chunk, so no worker writes it back — it stays immutable across the concurrent scan, keeping the path lock-free.

## Test gap closed

The existing reconstruction-parity tests could not catch this: all-literal output still reconstructs the source byte-for-byte. Added `generate_chunked_matches_after_prior_pruned_generate`, which primes the index with a pruned `generate()` and then asserts the chunked path still produces copies (low `literal_bytes`).

## Scope

`generate_chunked` remains **library-only and unwired** from the production sender; the parallel sender-scan effort is deferred. This PR lands the correctness fix for the already-merged method plus the bench harness + timing example used to find it (non-production; useful when the work is revisited). All 6 chunked tests pass; fmt + clippy clean.