### PR TITLE
fix(core): gate remote --fake-super on receiver direction (upstream parity)

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -430,7 +430,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
             args.push(OsString::from("--no-implied-dirs"));
         }
 
-        if self.config.fake_super() {
+        // upstream: options.c:2825,2852-2853 server_options() - the super flag
+        // is forwarded only inside the `if (am_sender)` block (so to a remote
+        // receiver), never to a remote sender. `RemoteRole::Receiver` means the
+        // local process is the sender (PUSH), matching upstream's `am_sender`
+        // branch. Forwarding `--fake-super` to a remote sender (PULL) would make
+        // the remote stat source paths under fake-super semantics, which
+        // upstream never does.
+        if self.config.fake_super() && self.role == RemoteRole::Receiver {
             args.push(OsString::from("--fake-super"));
         }
 

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -803,14 +803,22 @@ fn includes_link_dest_via_reference_directories() {
 }
 
 #[test]
-fn includes_fake_super_long_arg() {
+fn forwards_fake_super_to_remote_receiver_only() {
+    // upstream: options.c:2825,2852-2853 - the super flag rides inside the
+    // `if (am_sender)` branch, so it is forwarded only to a remote receiver
+    // (local PUSH = RemoteRole::Receiver), never to a remote sender (PULL).
     let config = ClientConfig::builder().fake_super(true).build();
-    let builder = RemoteInvocationBuilder::new(&config, RemoteRole::Sender);
-    let args = builder.build("/path");
 
+    let to_receiver = RemoteInvocationBuilder::new(&config, RemoteRole::Receiver).build("/path");
     assert!(
-        args.iter().any(|a| a == "--fake-super"),
-        "expected --fake-super in args: {args:?}"
+        to_receiver.iter().any(|a| a == "--fake-super"),
+        "expected --fake-super forwarded to a remote receiver (push): {to_receiver:?}"
+    );
+
+    let to_sender = RemoteInvocationBuilder::new(&config, RemoteRole::Sender).build("/path");
+    assert!(
+        !to_sender.iter().any(|a| a == "--fake-super"),
+        "did not expect --fake-super forwarded to a remote sender (pull): {to_sender:?}"
     );
 }
 
@@ -2303,7 +2311,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--existing",
         "--remove-source-files",
         "--no-implied-dirs",
-        "--fake-super",
         "--delay-updates",
         "--copy-devices",
         "--write-devices",
@@ -2317,6 +2324,14 @@ fn all_flags_enabled_produces_valid_invocation() {
             "all-flags test: missing {expected} in args: {args:?}"
         );
     }
+
+    // upstream: options.c:2825,2852-2853 - the super flag is forwarded only in
+    // the am_sender branch (to a remote receiver), so a remote-sender (pull)
+    // invocation never carries --fake-super even with fake_super(true).
+    assert!(
+        !args.iter().any(|a| a == "--fake-super"),
+        "all-flags test: --fake-super must not be forwarded to a remote sender: {args:?}"
+    );
 
     // upstream: options.c:2802 - explicit zlib is sent as --old-compress
     assert!(


### PR DESCRIPTION
## Summary

oc-rsync forwarded `--fake-super` to the remote in **both** directions. Upstream rsync only forwards the super flag in the sender branch — i.e. when the *remote is the receiver* — because fake-super is a writer-side (receiver-side) concern.

## Upstream evidence (rsync-3.4.4)

- `options.c:2825` opens `if (am_sender) { ... }`, and only inside it (`options.c:2852-2853`) does upstream emit the super flag to the remote. It is never sent to a remote sender.
- `clientserver.c:1119-1120`: a remote that *receives* `--fake-super` from a client treats it as `--super` unless the daemon module sets `fake super = yes` — confirming fake-super is fundamentally receiver-side.

## Fix

`crates/core/src/client/remote/invocation/builder.rs` — gate the existing `--fake-super` emission on the remote being the receiver:

```rust
if self.config.fake_super() && self.role == RemoteRole::Receiver {
```

`RemoteRole::Receiver` (remote is receiver ⇒ local is sender ⇒ a PUSH) maps exactly to upstream's `am_sender` branch. Previously a PULL (remote sender) wrongly pushed `--fake-super` to the remote, which upstream never does.

## Tests

- `forwards_fake_super_to_remote_receiver_only`: asserts the flag is present for `RemoteRole::Receiver` and absent for `RemoteRole::Sender`.
- The all-flags (pull / `RemoteRole::Sender`) test now asserts `--fake-super` is **absent**.

Verified locally: `cargo build/clippy/test -p core --all-features` green (231 invocation-builder tests pass), fmt clean. Found via a verify-first audit (the audit's original line number was stale; the real site + upstream condition were confirmed against the C source).