### PR TITLE
refactor(transfer): split generator file_list entry into submodules

### DIFF
--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -1,21 +1,23 @@
-//! File entry construction and metadata collection for the generator role.
+//! `FileEntry` construction from filesystem metadata for the generator role.
 //!
-//! Builds `FileEntry` values from filesystem metadata, handling platform-specific
-//! fields (mode, uid/gid, devices, symlinks, hardlink dev/ino).
-//!
-//! # Upstream Reference
-//!
-//! - `flist.c:make_file()` - determines file type and populates `file_struct`
-//! - `flist.c:readlink_stat()` - symlink target resolution
-//! - `xattrs.c:get_stat_xattr()` - fake-super override applied via
-//!   `x_lstat()` before `make_file()` consumes the stat values
+//! Implements `create_entry`, which classifies the on-disk file type and
+//! populates mode, mtime, uid/gid, atime/crtime, symlink targets, device
+//! numbers, xattrs, ACLs, and hardlink dev/ino fields based on the active
+//! preservation flags. Also implements the fake-super stat override lookup
+//! consumed during construction.
 
 use std::io;
 use std::path::{Path, PathBuf};
 
 use protocol::flist::FileEntry;
 
-use super::super::GeneratorContext;
+use super::super::super::GeneratorContext;
+
+#[cfg(unix)]
+use super::device::rdev_to_major_minor;
+#[cfg(unix)]
+use super::fake_super::build_entry_from_fake_super;
+use super::munge::strip_symlink_munge_prefix;
 
 impl GeneratorContext {
     /// Creates a `FileEntry` from filesystem metadata for wire transmission.
@@ -395,288 +397,14 @@ impl GeneratorContext {
     // call site later should reintroduce a stub here.
 }
 
-/// Builds the wire `FileEntry` for a regular placeholder file whose
-/// `user.rsync.%stat` xattr decoded successfully.
-///
-/// The xattr's mode encodes the *effective* file type (regular, device,
-/// symlink, fifo, socket) plus permission bits. For devices, the decoded
-/// `rdev` major/minor populate the wire fields. When the xattr's mode does
-/// not encode a recognised type, fall back to a regular file with the
-/// decoded permission bits.
-///
-/// # Upstream Reference
-///
-/// - `xattrs.c:1172 from_wire_mode()` - the xattr's mode replaces st_mode
-/// - `flist.c:make_file()` - downstream branches pick the wire encoding
-///   from the (now overridden) mode
-#[cfg(unix)]
-fn build_entry_from_fake_super(
-    relative_path: PathBuf,
-    size: u64,
-    stat: &metadata::FakeSuperStat,
-) -> FileEntry {
-    use protocol::flist::FileType;
-
-    let perm_bits = stat.mode & 0o7777;
-    let (rdev_major, rdev_minor) = stat.rdev.unwrap_or((0, 0));
-
-    match FileType::from_mode(stat.mode) {
-        Some(FileType::Regular) | None => FileEntry::new_file(relative_path, size, perm_bits),
-        Some(FileType::Directory) => FileEntry::new_directory(relative_path, perm_bits),
-        Some(FileType::Symlink) => {
-            // upstream: fake-super symlinks stash the target separately;
-            // when the xattr alone is the source of truth, we emit an empty
-            // target to match the placeholder content.
-            FileEntry::new_symlink(relative_path, PathBuf::new())
-        }
-        Some(FileType::BlockDevice) => {
-            FileEntry::new_block_device(relative_path, perm_bits, rdev_major, rdev_minor)
-        }
-        Some(FileType::CharDevice) => {
-            FileEntry::new_char_device(relative_path, perm_bits, rdev_major, rdev_minor)
-        }
-        Some(FileType::Fifo) => FileEntry::new_fifo(relative_path, perm_bits),
-        Some(FileType::Socket) => FileEntry::new_socket(relative_path, perm_bits),
-    }
-}
-
-/// Extracts major and minor device numbers from a raw `rdev` value.
-///
-/// The layout differs by platform:
-/// - **Linux**: Split encoding where major/minor span non-contiguous bits.
-/// - **macOS/BSD**: Major in high byte, minor in low 24 bits.
-///
-/// # Upstream Reference
-///
-/// Mirrors glibc `major()`/`minor()` macros used by upstream rsync to populate
-/// `rdev_major`/`rdev_minor` in `file_struct`.
-#[cfg(all(unix, target_os = "linux"))]
-pub(in crate::generator) fn rdev_to_major_minor(rdev: u64) -> (u32, u32) {
-    let major = ((rdev >> 8) & 0xfff) as u32 | (((rdev >> 32) & !0xfff) as u32);
-    let minor = (rdev & 0xff) as u32 | (((rdev >> 12) & !0xff) as u32);
-    (major, minor)
-}
-
-/// Extracts major and minor device numbers from a raw `rdev` value (BSD/macOS).
-///
-/// BSD layout: major in bits 31-24, minor in bits 23-0.
-#[cfg(all(unix, not(target_os = "linux")))]
-pub(in crate::generator) fn rdev_to_major_minor(rdev: u64) -> (u32, u32) {
-    let major = (rdev >> 24) as u32;
-    let minor = (rdev & 0xffffff) as u32;
-    (major, minor)
-}
-
-/// Strips the `/rsyncd-munged/` prefix from a symlink target when munging is active.
-///
-/// Mirrors upstream `flist.c:222-226`: when the daemon module has
-/// `munge symlinks = yes`, the sender restores the original target before it
-/// is encoded onto the wire so the receiver can reapply the prefix on its
-/// side. The receiver-side write path uses the matching
-/// [`crate::receiver::directory::apply_symlink_munge_prefix`] helper.
-///
-/// Targets that lack the prefix pass through unchanged; this is the
-/// `llen > SYMLINK_PREFIX_LEN && strncmp(...) == 0` branch in upstream's
-/// `readlink_stat()`.
-fn strip_symlink_munge_prefix(munge_symlinks: bool, target: PathBuf) -> PathBuf {
-    if !munge_symlinks {
-        return target;
-    }
-    let prefix_len = ::metadata::SYMLINK_MUNGE_PREFIX.len();
-    // upstream: flist.c:222 - the strncmp guard requires `llen > SYMLINK_PREFIX_LEN`,
-    // so a target consisting of exactly the prefix is left untouched.
-    #[cfg(unix)]
-    {
-        use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
-
-        let bytes = target.as_os_str().as_bytes();
-        let prefix = ::metadata::SYMLINK_MUNGE_PREFIX.as_bytes();
-        if bytes.len() > prefix_len && bytes.starts_with(prefix) {
-            let tail = OsStr::from_bytes(&bytes[prefix_len..]);
-            return PathBuf::from(tail);
-        }
-        target
-    }
-    #[cfg(not(unix))]
-    {
-        match target.to_str() {
-            Some(text)
-                if text.len() > prefix_len
-                    && text.starts_with(::metadata::SYMLINK_MUNGE_PREFIX) =>
-            {
-                PathBuf::from(&text[prefix_len..])
-            }
-            _ => target,
-        }
-    }
-}
-
-#[cfg(test)]
-mod munge_strip_tests {
-    use super::*;
-
-    #[test]
-    fn passes_through_when_disabled() {
-        let original = PathBuf::from("/rsyncd-munged/etc/passwd");
-        let returned = strip_symlink_munge_prefix(false, original.clone());
-        assert_eq!(returned, original);
-    }
-
-    #[test]
-    fn strips_prefix_when_enabled() {
-        let original = PathBuf::from("/rsyncd-munged/etc/passwd");
-        let returned = strip_symlink_munge_prefix(true, original);
-        assert_eq!(returned, PathBuf::from("etc/passwd"));
-    }
-
-    #[test]
-    fn passes_through_unprefixed_target_when_enabled() {
-        let original = PathBuf::from("../sibling");
-        let returned = strip_symlink_munge_prefix(true, original.clone());
-        assert_eq!(returned, original);
-    }
-
-    #[test]
-    fn does_not_strip_exact_prefix_match() {
-        // upstream: flist.c:222 - `llen > SYMLINK_PREFIX_LEN` is strict, so a
-        // target whose entire content is the prefix is left untouched. Without
-        // the strict check we would emit an empty target onto the wire and
-        // diverge from upstream byte-for-byte.
-        let original = PathBuf::from("/rsyncd-munged/");
-        let returned = strip_symlink_munge_prefix(true, original.clone());
-        assert_eq!(returned, original);
-    }
-}
-
-#[cfg(all(test, unix))]
-mod fake_super_tests {
-    //! Sender-side `user.rsync.%stat` consumption tests.
-    //!
-    //! Verifies that under `--fake-super` the source-stored xattr overrides
-    //! the on-disk stat values when populating the wire file-list entry,
-    //! matching upstream rsync 3.4.1 `xattrs.c:get_stat_xattr()` semantics.
-
-    use super::*;
-    use ::metadata::FakeSuperStat;
-    use protocol::flist::FileType;
-
-    #[test]
-    fn build_from_fake_super_emits_regular_file_for_regular_mode() {
-        let stat = FakeSuperStat {
-            mode: 0o100644,
-            uid: 1234,
-            gid: 5678,
-            rdev: None,
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("a"), 42, &stat);
-        assert_eq!(entry.file_type(), FileType::Regular);
-        assert_eq!(entry.permissions() & 0o7777, 0o644);
-        assert_eq!(entry.size(), 42);
-    }
-
-    #[test]
-    fn build_from_fake_super_emits_block_device_from_mode_bits() {
-        // 0o60660 = S_IFBLK | 0660
-        let stat = FakeSuperStat {
-            mode: 0o60660,
-            uid: 0,
-            gid: 6,
-            rdev: Some((8, 0)),
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("sda"), 0, &stat);
-        assert_eq!(entry.file_type(), FileType::BlockDevice);
-        assert_eq!(entry.permissions() & 0o7777, 0o660);
-        assert_eq!(entry.rdev_major(), Some(8));
-        assert_eq!(entry.rdev_minor(), Some(0));
-    }
-
-    #[test]
-    fn build_from_fake_super_emits_char_device_from_mode_bits() {
-        // 0o20666 = S_IFCHR | 0666
-        let stat = FakeSuperStat {
-            mode: 0o20666,
-            uid: 0,
-            gid: 0,
-            rdev: Some((1, 3)),
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("null"), 0, &stat);
-        assert_eq!(entry.file_type(), FileType::CharDevice);
-        assert_eq!(entry.rdev_major(), Some(1));
-        assert_eq!(entry.rdev_minor(), Some(3));
-    }
-
-    #[test]
-    fn build_from_fake_super_emits_fifo_from_mode_bits() {
-        let stat = FakeSuperStat {
-            mode: 0o10644,
-            uid: 0,
-            gid: 0,
-            rdev: None,
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("pipe"), 0, &stat);
-        assert_eq!(entry.file_type(), FileType::Fifo);
-    }
-
-    #[test]
-    fn build_from_fake_super_emits_socket_from_mode_bits() {
-        let stat = FakeSuperStat {
-            mode: 0o140755,
-            uid: 0,
-            gid: 0,
-            rdev: None,
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("sock"), 0, &stat);
-        assert_eq!(entry.file_type(), FileType::Socket);
-    }
-
-    #[test]
-    fn build_from_fake_super_emits_directory_from_mode_bits() {
-        let stat = FakeSuperStat {
-            mode: 0o40755,
-            uid: 0,
-            gid: 0,
-            rdev: None,
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("d"), 0, &stat);
-        assert_eq!(entry.file_type(), FileType::Directory);
-    }
-
-    #[test]
-    fn build_from_fake_super_emits_symlink_with_empty_target() {
-        let stat = FakeSuperStat {
-            mode: 0o120777,
-            uid: 1000,
-            gid: 1000,
-            rdev: None,
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("link"), 0, &stat);
-        assert_eq!(entry.file_type(), FileType::Symlink);
-    }
-
-    #[test]
-    fn build_from_fake_super_unknown_mode_falls_back_to_regular() {
-        // No file-type bits set: treat as regular with the given perms.
-        let stat = FakeSuperStat {
-            mode: 0o0644,
-            uid: 1,
-            gid: 2,
-            rdev: None,
-        };
-        let entry = build_entry_from_fake_super(PathBuf::from("f"), 7, &stat);
-        assert_eq!(entry.file_type(), FileType::Regular);
-        assert_eq!(entry.size(), 7);
-    }
-}
-
 #[cfg(all(test, unix, feature = "xattr"))]
 mod fake_super_round_trip_tests {
     //! End-to-end sender override: place a fake-super xattr on a regular
     //! placeholder file, then verify `create_entry` consumes it and emits
     //! the decoded mode/uid/gid/rdev instead of the on-disk stat values.
 
-    use super::super::super::GeneratorContext;
     use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
     use crate::handshake::HandshakeResult;
     use crate::role::ServerRole;
     use ::metadata::{FAKE_SUPER_XATTR, FakeSuperStat};
@@ -830,8 +558,8 @@ mod daemon_outgoing_chmod_tests {
     //! `clientserver.c:rsync_module()` arming `daemon_chmod_modes` and
     //! `flist.c:make_file()` applying them as file_struct values are built.
 
-    use super::super::super::GeneratorContext;
     use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
     use crate::handshake::HandshakeResult;
     use crate::role::ServerRole;
     use ::metadata::ChmodModifiers;
@@ -917,8 +645,8 @@ mod munge_symlinks_tests {
     //! the wire format carries the original target. The matching prepend on
     //! the receive side lives in `crate::receiver::directory::links`.
 
-    use super::super::super::GeneratorContext;
     use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
     use crate::handshake::HandshakeResult;
     use crate::role::ServerRole;
     use protocol::ProtocolVersion;
@@ -1018,8 +746,8 @@ mod windows_reparse_tests {
     //! in the symlink branch", which the junction case already verifies
     //! end-to-end.
 
-    use super::super::super::GeneratorContext;
     use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
     use crate::handshake::HandshakeResult;
     use crate::role::ServerRole;
     use protocol::ProtocolVersion;
@@ -1175,8 +903,8 @@ mod entry_length_tests {
     //! rendered by `--list-only` and `%l`, so emitting 0 here would diverge
     //! from upstream's observable output byte-for-byte.
 
-    use super::super::super::GeneratorContext;
     use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
     use crate::handshake::HandshakeResult;
     use crate::role::ServerRole;
     use protocol::ProtocolVersion;

--- a/crates/transfer/src/generator/file_list/entry/device.rs
+++ b/crates/transfer/src/generator/file_list/entry/device.rs
@@ -1,0 +1,31 @@
+//! Device number extraction for `FileEntry` rdev fields.
+//!
+//! Splits a raw `rdev` value into major/minor components using the
+//! platform-specific bit layout (Linux split encoding vs BSD/macOS).
+
+/// Extracts major and minor device numbers from a raw `rdev` value.
+///
+/// The layout differs by platform:
+/// - **Linux**: Split encoding where major/minor span non-contiguous bits.
+/// - **macOS/BSD**: Major in high byte, minor in low 24 bits.
+///
+/// # Upstream Reference
+///
+/// Mirrors glibc `major()`/`minor()` macros used by upstream rsync to populate
+/// `rdev_major`/`rdev_minor` in `file_struct`.
+#[cfg(all(unix, target_os = "linux"))]
+pub(in crate::generator) fn rdev_to_major_minor(rdev: u64) -> (u32, u32) {
+    let major = ((rdev >> 8) & 0xfff) as u32 | (((rdev >> 32) & !0xfff) as u32);
+    let minor = (rdev & 0xff) as u32 | (((rdev >> 12) & !0xff) as u32);
+    (major, minor)
+}
+
+/// Extracts major and minor device numbers from a raw `rdev` value (BSD/macOS).
+///
+/// BSD layout: major in bits 31-24, minor in bits 23-0.
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(in crate::generator) fn rdev_to_major_minor(rdev: u64) -> (u32, u32) {
+    let major = (rdev >> 24) as u32;
+    let minor = (rdev & 0xffffff) as u32;
+    (major, minor)
+}

--- a/crates/transfer/src/generator/file_list/entry/fake_super.rs
+++ b/crates/transfer/src/generator/file_list/entry/fake_super.rs
@@ -1,0 +1,176 @@
+//! Fake-super `user.rsync.%stat` xattr override for the generator role.
+//!
+//! Builds the wire `FileEntry` for a regular placeholder file whose
+//! `user.rsync.%stat` xattr decoded successfully, mapping the decoded mode
+//! bits back to the effective file type.
+
+#[cfg(unix)]
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use protocol::flist::FileEntry;
+
+/// Builds the wire `FileEntry` for a regular placeholder file whose
+/// `user.rsync.%stat` xattr decoded successfully.
+///
+/// The xattr's mode encodes the *effective* file type (regular, device,
+/// symlink, fifo, socket) plus permission bits. For devices, the decoded
+/// `rdev` major/minor populate the wire fields. When the xattr's mode does
+/// not encode a recognised type, fall back to a regular file with the
+/// decoded permission bits.
+///
+/// # Upstream Reference
+///
+/// - `xattrs.c:1172 from_wire_mode()` - the xattr's mode replaces st_mode
+/// - `flist.c:make_file()` - downstream branches pick the wire encoding
+///   from the (now overridden) mode
+#[cfg(unix)]
+pub(super) fn build_entry_from_fake_super(
+    relative_path: PathBuf,
+    size: u64,
+    stat: &metadata::FakeSuperStat,
+) -> FileEntry {
+    use protocol::flist::FileType;
+
+    let perm_bits = stat.mode & 0o7777;
+    let (rdev_major, rdev_minor) = stat.rdev.unwrap_or((0, 0));
+
+    match FileType::from_mode(stat.mode) {
+        Some(FileType::Regular) | None => FileEntry::new_file(relative_path, size, perm_bits),
+        Some(FileType::Directory) => FileEntry::new_directory(relative_path, perm_bits),
+        Some(FileType::Symlink) => {
+            // upstream: fake-super symlinks stash the target separately;
+            // when the xattr alone is the source of truth, we emit an empty
+            // target to match the placeholder content.
+            FileEntry::new_symlink(relative_path, PathBuf::new())
+        }
+        Some(FileType::BlockDevice) => {
+            FileEntry::new_block_device(relative_path, perm_bits, rdev_major, rdev_minor)
+        }
+        Some(FileType::CharDevice) => {
+            FileEntry::new_char_device(relative_path, perm_bits, rdev_major, rdev_minor)
+        }
+        Some(FileType::Fifo) => FileEntry::new_fifo(relative_path, perm_bits),
+        Some(FileType::Socket) => FileEntry::new_socket(relative_path, perm_bits),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod fake_super_tests {
+    //! Sender-side `user.rsync.%stat` consumption tests.
+    //!
+    //! Verifies that under `--fake-super` the source-stored xattr overrides
+    //! the on-disk stat values when populating the wire file-list entry,
+    //! matching upstream rsync 3.4.1 `xattrs.c:get_stat_xattr()` semantics.
+
+    use super::*;
+    use ::metadata::FakeSuperStat;
+    use protocol::flist::FileType;
+
+    #[test]
+    fn build_from_fake_super_emits_regular_file_for_regular_mode() {
+        let stat = FakeSuperStat {
+            mode: 0o100644,
+            uid: 1234,
+            gid: 5678,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("a"), 42, &stat);
+        assert_eq!(entry.file_type(), FileType::Regular);
+        assert_eq!(entry.permissions() & 0o7777, 0o644);
+        assert_eq!(entry.size(), 42);
+    }
+
+    #[test]
+    fn build_from_fake_super_emits_block_device_from_mode_bits() {
+        // 0o60660 = S_IFBLK | 0660
+        let stat = FakeSuperStat {
+            mode: 0o60660,
+            uid: 0,
+            gid: 6,
+            rdev: Some((8, 0)),
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("sda"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::BlockDevice);
+        assert_eq!(entry.permissions() & 0o7777, 0o660);
+        assert_eq!(entry.rdev_major(), Some(8));
+        assert_eq!(entry.rdev_minor(), Some(0));
+    }
+
+    #[test]
+    fn build_from_fake_super_emits_char_device_from_mode_bits() {
+        // 0o20666 = S_IFCHR | 0666
+        let stat = FakeSuperStat {
+            mode: 0o20666,
+            uid: 0,
+            gid: 0,
+            rdev: Some((1, 3)),
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("null"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::CharDevice);
+        assert_eq!(entry.rdev_major(), Some(1));
+        assert_eq!(entry.rdev_minor(), Some(3));
+    }
+
+    #[test]
+    fn build_from_fake_super_emits_fifo_from_mode_bits() {
+        let stat = FakeSuperStat {
+            mode: 0o10644,
+            uid: 0,
+            gid: 0,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("pipe"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::Fifo);
+    }
+
+    #[test]
+    fn build_from_fake_super_emits_socket_from_mode_bits() {
+        let stat = FakeSuperStat {
+            mode: 0o140755,
+            uid: 0,
+            gid: 0,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("sock"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::Socket);
+    }
+
+    #[test]
+    fn build_from_fake_super_emits_directory_from_mode_bits() {
+        let stat = FakeSuperStat {
+            mode: 0o40755,
+            uid: 0,
+            gid: 0,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("d"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::Directory);
+    }
+
+    #[test]
+    fn build_from_fake_super_emits_symlink_with_empty_target() {
+        let stat = FakeSuperStat {
+            mode: 0o120777,
+            uid: 1000,
+            gid: 1000,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("link"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::Symlink);
+    }
+
+    #[test]
+    fn build_from_fake_super_unknown_mode_falls_back_to_regular() {
+        // No file-type bits set: treat as regular with the given perms.
+        let stat = FakeSuperStat {
+            mode: 0o0644,
+            uid: 1,
+            gid: 2,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("f"), 7, &stat);
+        assert_eq!(entry.file_type(), FileType::Regular);
+        assert_eq!(entry.size(), 7);
+    }
+}

--- a/crates/transfer/src/generator/file_list/entry/mod.rs
+++ b/crates/transfer/src/generator/file_list/entry/mod.rs
@@ -1,0 +1,26 @@
+//! File entry construction and metadata collection for the generator role.
+//!
+//! Builds `FileEntry` values from filesystem metadata, handling platform-specific
+//! fields (mode, uid/gid, devices, symlinks, hardlink dev/ino).
+//!
+//! # Submodules
+//!
+//! - `create` - `create_entry` classification and metadata population
+//! - `fake_super` - `user.rsync.%stat` xattr override mapping
+//! - `device` - rdev major/minor extraction
+//! - `munge` - symlink-target munge prefix stripping
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:make_file()` - determines file type and populates `file_struct`
+//! - `flist.c:readlink_stat()` - symlink target resolution
+//! - `xattrs.c:get_stat_xattr()` - fake-super override applied via
+//!   `x_lstat()` before `make_file()` consumes the stat values
+
+mod create;
+mod device;
+mod fake_super;
+mod munge;
+
+#[cfg(all(unix, test))]
+pub(in crate::generator) use self::device::rdev_to_major_minor;

--- a/crates/transfer/src/generator/file_list/entry/munge.rs
+++ b/crates/transfer/src/generator/file_list/entry/munge.rs
@@ -1,0 +1,89 @@
+//! Symlink-target munge prefix handling for the generator role.
+//!
+//! Strips the `/rsyncd-munged/` prefix from symlink targets when the daemon
+//! module has `munge symlinks = yes`, restoring the original target before it
+//! is encoded onto the wire.
+
+use std::path::PathBuf;
+
+/// Strips the `/rsyncd-munged/` prefix from a symlink target when munging is active.
+///
+/// Mirrors upstream `flist.c:222-226`: when the daemon module has
+/// `munge symlinks = yes`, the sender restores the original target before it
+/// is encoded onto the wire so the receiver can reapply the prefix on its
+/// side. The receiver-side write path uses the matching
+/// [`crate::receiver::directory::apply_symlink_munge_prefix`] helper.
+///
+/// Targets that lack the prefix pass through unchanged; this is the
+/// `llen > SYMLINK_PREFIX_LEN && strncmp(...) == 0` branch in upstream's
+/// `readlink_stat()`.
+pub(super) fn strip_symlink_munge_prefix(munge_symlinks: bool, target: PathBuf) -> PathBuf {
+    if !munge_symlinks {
+        return target;
+    }
+    let prefix_len = ::metadata::SYMLINK_MUNGE_PREFIX.len();
+    // upstream: flist.c:222 - the strncmp guard requires `llen > SYMLINK_PREFIX_LEN`,
+    // so a target consisting of exactly the prefix is left untouched.
+    #[cfg(unix)]
+    {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = target.as_os_str().as_bytes();
+        let prefix = ::metadata::SYMLINK_MUNGE_PREFIX.as_bytes();
+        if bytes.len() > prefix_len && bytes.starts_with(prefix) {
+            let tail = OsStr::from_bytes(&bytes[prefix_len..]);
+            return PathBuf::from(tail);
+        }
+        target
+    }
+    #[cfg(not(unix))]
+    {
+        match target.to_str() {
+            Some(text)
+                if text.len() > prefix_len
+                    && text.starts_with(::metadata::SYMLINK_MUNGE_PREFIX) =>
+            {
+                PathBuf::from(&text[prefix_len..])
+            }
+            _ => target,
+        }
+    }
+}
+
+#[cfg(test)]
+mod munge_strip_tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_when_disabled() {
+        let original = PathBuf::from("/rsyncd-munged/etc/passwd");
+        let returned = strip_symlink_munge_prefix(false, original.clone());
+        assert_eq!(returned, original);
+    }
+
+    #[test]
+    fn strips_prefix_when_enabled() {
+        let original = PathBuf::from("/rsyncd-munged/etc/passwd");
+        let returned = strip_symlink_munge_prefix(true, original);
+        assert_eq!(returned, PathBuf::from("etc/passwd"));
+    }
+
+    #[test]
+    fn passes_through_unprefixed_target_when_enabled() {
+        let original = PathBuf::from("../sibling");
+        let returned = strip_symlink_munge_prefix(true, original.clone());
+        assert_eq!(returned, original);
+    }
+
+    #[test]
+    fn does_not_strip_exact_prefix_match() {
+        // upstream: flist.c:222 - `llen > SYMLINK_PREFIX_LEN` is strict, so a
+        // target whose entire content is the prefix is left untouched. Without
+        // the strict check we would emit an empty target onto the wire and
+        // diverge from upstream byte-for-byte.
+        let original = PathBuf::from("/rsyncd-munged/");
+        let returned = strip_symlink_munge_prefix(true, original.clone());
+        assert_eq!(returned, original);
+    }
+}


### PR DESCRIPTION
Pure mechanical decomposition of `crates/transfer/src/generator/file_list/entry.rs` (1264 lines) into a submodule directory. **No behavior change** — only relocation.

| File | Lines | Contents |
|---|---|---|
| `entry/mod.rs` | 26 | doc, submodule decls, gated `rdev_to_major_minor` re-export |
| `entry/create.rs` | ~770 | `create_entry` + `fake_super_override`; create-entry tests |
| `entry/fake_super.rs` | 176 | `build_entry_from_fake_super` + tests |
| `entry/munge.rs` | 89 | `strip_symlink_munge_prefix` + tests |
| `entry/device.rs` | 31 | `rdev_to_major_minor` (both cfg variants) |

Wiring preserved: parent uses `mod entry;` (converted `entry.rs` → `entry/mod.rs`); the `#[cfg(all(unix, test))] pub(super) use self::entry::rdev_to_major_minor` re-export still resolves. Two private free fns became `pub(super)` only so the `create` submodule can call them across the new boundary — no signature/behavior/cfg/doc changes. Verified: build, clippy (`-D warnings`), `cargo test generator::file_list::entry` (23 pass, original count), fmt — all green.