### PR TITLE
fix(core): exit 0 for successful local --list-only (upstream parity)

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -277,7 +277,23 @@ fn run_client_internal(
         return Ok(summary);
     }
 
-    let plan = match LocalCopyPlan::from_operands(config.transfer_args()) {
+    // upstream: main.c:708 `get_local_name()` returns NULL when `list_only` is
+    // set, so a local listing needs no destination operand. oc-rsync's local
+    // plan always requires source+destination, so for `--list-only` with a
+    // single source we synthesize a placeholder destination. List-only output
+    // is rendered from the source flist in DryRun mode and never touches the
+    // destination, so the placeholder is inert.
+    let mut synthesized_operands: Option<Vec<std::ffi::OsString>> = None;
+    if config.list_only() && config.transfer_args().len() == 1 {
+        let mut operands = config.transfer_args().to_vec();
+        operands.push(std::ffi::OsString::from("."));
+        synthesized_operands = Some(operands);
+    }
+    let plan_operands = synthesized_operands
+        .as_deref()
+        .unwrap_or_else(|| config.transfer_args());
+
+    let plan = match LocalCopyPlan::from_operands(plan_operands) {
         Ok(plan) => plan,
         Err(error) => return Err(map_local_copy_error(error)),
     };

--- a/crates/core/tests/client_integration.rs
+++ b/crates/core/tests/client_integration.rs
@@ -376,3 +376,60 @@ fn test_crtimes_preservation() {
         );
     });
 }
+
+// upstream: main.c:708 `get_local_name()` returns NULL when `list_only` is set,
+// so a local `--list-only` run needs no destination operand and exits 0 on
+// success. oc-rsync's local plan always requires source+destination, so a single
+// source operand previously errored with RERR_PARTIAL (23). A successful
+// `--list-only` with no errors must exit 0.
+#[test]
+fn list_only_single_source_succeeds_without_destination() {
+    run_with_timeout(LOCAL_TIMEOUT, || {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        touch(&source_root.join("a.txt"), b"hello");
+        touch(&source_root.join("nested/c.txt"), b"nested");
+
+        let source_a = source_root.join("a.txt");
+
+        let mut source_arg = source_root.into_os_string();
+        source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+        let config = ClientConfig::builder()
+            .transfer_args([source_arg])
+            .recursive(true)
+            .list_only(true)
+            .build();
+
+        // Success (Ok) maps to exit code 0; the missing-operands error would be
+        // RERR_PARTIAL (23). Asserting Ok pins the upstream-parity exit code:
+        // a clean `--list-only` with no destination must exit 0, not 23.
+        run_client(config).expect("list-only succeeds without a destination");
+
+        // List-only runs in dry-run mode; the source tree is only enumerated.
+        assert_eq!(fs::read(&source_a).unwrap(), b"hello", "source untouched");
+    });
+}
+
+// Guard the error path: a single source operand WITHOUT `--list-only` is still a
+// missing-destination error (RERR_PARTIAL, exit 23), exactly as before. The
+// list-only fix must not mask this.
+#[test]
+fn single_source_without_list_only_still_errors() {
+    run_with_timeout(LOCAL_TIMEOUT, || {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        touch(&source_root.join("a.txt"), b"hello");
+
+        let mut source_arg = source_root.into_os_string();
+        source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+        let config = ClientConfig::builder()
+            .transfer_args([source_arg])
+            .recursive(true)
+            .build();
+
+        let error = run_client(config).expect_err("missing destination must still error");
+        assert_eq!(error.exit_code(), 23, "missing operands stays RERR_PARTIAL");
+    });
+}


### PR DESCRIPTION
## Bug

`oc-rsync --list-only <localdir>/` returned exit **23 (RERR_PARTIAL)** where upstream rsync 3.4.4 returns **0**.

```
$ oc-rsync -r --list-only /tmp/src/   → error: missing source operands (code 23)
$ rsync    -r --list-only /tmp/src/   → lists flist, exit 0
```

## Root cause

The local-copy plan (`local_copy/plan/plan_impl.rs`) requires **two** operands (source + destination). With `--list-only` and a single source operand, `LocalCopyPlan::from_operands` returned `MissingSourceOperands`, mapped to `ExitCode::PartialTransfer` (23). Upstream needs no destination in list-only mode: `main.c:708` `get_local_name()` returns NULL immediately when `list_only` is set, and `options.c:2194` (`argc < 2 → list_only |= 1`) makes a single operand a listing.

With a destination supplied, oc-rsync's `--list-only` output already matched upstream byte-for-byte and exited 0 — output renders from the source flist in DryRun mode and ignores destination contents. So the only defect was the operand-count requirement.

## Fix

In `crates/core/src/client/run/mod.rs`, when `config.list_only()` is set and exactly one operand is present, synthesize an inert placeholder destination (`.`). List-only runs in DryRun mode and never writes, so the placeholder is harmless. The error path is untouched: a single operand **without** `--list-only` still returns exit 23.

## Tests (`crates/core/tests/client_integration.rs`)

- `list_only_single_source_succeeds_without_destination` — pins exit 0
- `single_source_without_list_only_still_errors` — guards the RERR_PARTIAL error path is not masked

Verified: build, clippy (`-D warnings`), `cargo test -p core` (2119 lib + 141 exit-code/recovery + 6 integration), fmt — all green. Binary e2e: `-r --list-only src/` → exit 0; bare `-r src/` → exit 23.