### PR TITLE
fix(fast_io): resolve net_reader intra-doc links (fixes Pages docs build)

### DIFF
--- a/crates/fast_io/src/net_reader.rs
+++ b/crates/fast_io/src/net_reader.rs
@@ -6,7 +6,8 @@
 //! backend (io_uring `RECV` on Linux, IOCP `WSARecv` on Windows) can be
 //! selected without the caller naming the concrete reader.
 //!
-//! [`NetReader`] is the abstraction; [`for_socket`] is the factory. The
+//! [`NetReader`](crate::net_reader::NetReader) is the abstraction;
+//! [`for_socket`](crate::net_reader::for_socket) is the factory. The
 //! factory delegates to the already-tested [`crate::socket_reader_from_fd`],
 //! whose default arm is a behaviour-preserving standard blocking read, so
 //! wiring this seam in is a no-op until an accelerated policy is selected.


### PR DESCRIPTION
## Problem

The Pages docs workflow (`cargo doc --workspace --all-features --no-deps` with `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`) is **failing on master**:

```
error: unresolved link to `NetReader`
  --> crates/fast_io/src/lib.rs:107:1
error: unresolved link to `for_socket`
error: could not document `fast_io`
```

## Root cause

`net_reader.rs` has a module `//!` doc with intra-doc links `[`NetReader`]` and `[`for_socket`]`. Because `pub mod net_reader;` *also* carries an outer `///` doc (lib.rs:107), rustdoc concatenates the two and resolves the combined module doc at the **declaration (crate-root) scope** — where `NetReader`/`for_socket` are not in scope (they live in the `net_reader` submodule). Hence "no item named `NetReader` in scope."

Pre-existing; not introduced by recent refactors (none touched `fast_io`).

## Fix

Qualify the two links to absolute crate paths so they resolve regardless of the concatenated-doc scope:

```
[`NetReader`](crate::net_reader::NetReader)
[`for_socket`](crate::net_reader::for_socket)
```

Verified locally: `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p fast_io --no-deps` now finishes clean (reproduced the failure first, confirmed the fix clears it). Restores the master docs deploy to green.