### PR TITLE
fix(cli): list directory entry for --list-only without -r/-d (upstream xfer_dirs parity)

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -195,10 +195,14 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         .dry_run(inputs.dry_run)
         .list_only(inputs.list_only)
         .recursive(inputs.recursive)
+        // upstream: options.c:2199-2203 - `else if (recurse) xfer_dirs = 1;
+        // else if (xfer_dirs < 0) xfer_dirs = list_only ? 1 : 0;`. When neither
+        // -r nor an explicit -d/--no-dirs is given, --list-only still transfers
+        // (lists) a bare directory operand's own entry.
         .dirs(if inputs.recursive {
             true
         } else {
-            inputs.dirs.unwrap_or(false)
+            inputs.dirs.unwrap_or(inputs.list_only)
         })
         .delete(
             inputs.delete_mode.is_enabled()

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -77,6 +77,41 @@ fn list_only_formats_directory_without_trailing_slash() {
     assert!(!directory_line.ends_with('/'));
 }
 
+/// `--list-only <dir>` with no `-r`/`-d` and no trailing slash must still list
+/// the directory operand's own entry, mirroring upstream's
+/// `xfer_dirs = list_only ? 1 : 0` default (options.c:2203). Without this,
+/// `xfer_dirs` stays 0 and `flist.c:2451` skips the bare directory, so the
+/// listing is empty - diverging from upstream which prints the `src` row.
+#[test]
+fn list_only_lists_bare_directory_without_recursion_or_slash() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let source_dir = tmp.path().join("src");
+    fs::create_dir(&source_dir).expect("create src dir");
+    fs::write(source_dir.join("file.txt"), b"contents").expect("write source file");
+
+    let (code, stdout, stderr) = run_with_args([
+        OsString::from(RSYNC),
+        OsString::from("--list-only"),
+        source_dir.into_os_string(),
+    ]);
+
+    assert_eq!(code, 0);
+    assert!(stderr.is_empty());
+    let rendered = String::from_utf8(stdout).expect("utf8 stdout");
+
+    let directory_line = rendered
+        .lines()
+        .find(|line| line.ends_with("src"))
+        .expect("bare directory operand entry present");
+    assert!(directory_line.starts_with('d'));
+    assert!(!directory_line.ends_with('/'));
+    // Without -r the directory's children must not be listed.
+    assert!(!rendered.contains("file.txt"));
+}
+
 #[cfg(unix)]
 #[test]
 fn list_only_matches_rsync_format_for_regular_file() {


### PR DESCRIPTION
## Bug (#502, broader than reported)

`oc-rsync --list-only <dir>` listed **nothing** for a bare directory — both the no-trailing-slash AND trailing-slash cases — where upstream rsync 3.4.4 lists the directory (or its contents):

```
oc --list-only src    → (empty)     | rsync → drwxr-xr-x ... src
oc --list-only src/   → (empty)     | rsync → ./, file1, file2, sub/
oc -d/-r --list-only  → correct (unchanged)
```

## Root cause

Upstream `options.c:2199-2203`:
```c
else if (recurse) xfer_dirs = 1;
else if (xfer_dirs < 0) xfer_dirs = list_only ? 1 : 0;
```
oc-rsync defaulted the dirs-transfer flag to `false` when neither `-r` nor `-d` was given, regardless of `--list-only`, so a bare directory hit the `!xfer_dirs` skip and was omitted.

## Fix (1 line)

`crates/cli/src/frontend/execution/drive/config.rs` — non-recursive dirs default changed from `inputs.dirs.unwrap_or(false)` to `inputs.dirs.unwrap_or(inputs.list_only)`, mirroring `xfer_dirs = list_only ? 1 : 0`. Explicit `--dirs`/`--no-dirs` still honored; `-r` still forces true; non-list-only real-copy behavior unchanged (still skips dirs without -r, no dest created).

Regression test `list_only_lists_bare_directory_without_recursion_or_slash` added. Verified: build, clippy (`-D warnings`), fmt, `cargo test -p cli --lib list_only` (41 pass incl. new) + `skips_directories_without_recursion` (4 pass, no regression).