### PR TITLE
refactor(fast_io): retire dead send_zc from_shared_ring constructor (IUC-4)

### DIFF
--- a/crates/fast_io/src/io_uring/send_zc.rs
+++ b/crates/fast_io/src/io_uring/send_zc.rs
@@ -328,45 +328,6 @@ impl ZeroCopySender {
         })
     }
 
-    /// Wraps an existing socket `fd` against a caller-supplied
-    /// `Arc<Mutex<IoUring>>` so multiple senders can share a single ring
-    /// (e.g., a session-wide [`SessionRingPool`](super::session_pool::SessionRingPool)
-    /// slot). The shared ring's submission queue is serialised on the
-    /// mutex; concurrent senders will block briefly.
-    ///
-    /// Registration of the per-sender buffer pool against the shared ring
-    /// is best-effort; failure leaves the sender on the unregistered
-    /// SEND_ZC path (still zero-copy at the socket layer).
-    ///
-    /// # Errors
-    ///
-    /// [`io::ErrorKind::Unsupported`] when `IORING_OP_SEND_ZC` is not
-    /// advertised by the running kernel.
-    pub fn from_shared_ring(fd: RawFd, ring: Arc<Mutex<RawIoUring>>) -> io::Result<Self> {
-        if !is_supported() {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "IORING_OP_SEND_ZC is not supported on this kernel",
-            ));
-        }
-        let buffers = {
-            let guard = ring
-                .lock()
-                .map_err(|_| io::Error::other("ZeroCopySender ring mutex poisoned"))?;
-            RegisteredBufferGroup::try_new(&guard, ZERO_COPY_SLOT_BYTES, ZERO_COPY_SLOT_COUNT)
-        };
-        let slot_bytes = buffers
-            .as_ref()
-            .map(RegisteredBufferGroup::buffer_size)
-            .unwrap_or(ZERO_COPY_SLOT_BYTES);
-        Ok(Self {
-            ring,
-            fd,
-            buffers,
-            slot_bytes,
-        })
-    }
-
     /// Submits `buf` via `IORING_OP_SEND_ZC` and waits for both the
     /// transfer and notification CQEs before returning.
     ///


### PR DESCRIPTION
Dead-code removal: `ZeroCopySender::from_shared_ring` (the `Arc<Mutex<RawIoUring>>` shared-ring SEND_ZC constructor) has **zero callers** — a repo-wide `grep` finds only its own definition. IUC-3 migrated the writer/reader/socket factories onto `per_thread_ring::with_ring`, and the active `ZeroCopySender::new()` builds its own ring; the `send_zc` tests exercise `try_send_zc` directly. Removing −39 lines prunes the opt-in (`iouring-send-zc`) SEND_ZC path — the network-io_uring area found to give lower-than-expected benefit and since deprioritized.

No orphaned imports: `RawIoUring`/`Arc`/`Mutex` are still used by `new()` and the struct field. Nothing else touched.

**Verified on Linux** (lxhost, aarch64, kernel 7.0 — this file is `io_uring`-gated and cannot compile on macOS): `cargo build/clippy -p fast_io --features iouring-send-zc` clean (`-D warnings`), `cargo test -p fast_io --features iouring-send-zc --lib` 818 pass; default + `--all-features` builds clean. CI re-verifies on its Linux matrix.