### PR TITLE
ci: free disk space on linux jobs to fix recurring link-time ENOSPC flake

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -60,6 +60,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          df -h /
+
       - name: Install Rust (${{ inputs.rust_toolchain }})
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
@@ -160,6 +168,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          df -h /
 
       - name: Install Rust (${{ inputs.rust_toolchain }})
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          df -h /
+
       - name: Install Rust (${{ matrix.toolchain }})
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:


### PR DESCRIPTION
## Problem

CI jobs recurrently fail with `/usr/bin/ld: final link failed: No space left on device` — the documented disk-exhaustion flake. This week it hit `Feature flag combinations / default-features (linux)` (twice: #6197, #6199) and `Linux musl (beta)` (#6200), forcing repeated re-runs / admin-merges. The `nextest` job already had a disk-free step; the other Linux build/link jobs did not.

## Fix

Add a self-contained `Free disk space` step (no third-party action — inline `sudo rm -rf` of dotnet/android/ghc/CodeQL + docker prune + apt clean, ~20-30 GB freed) right after `actions/checkout`, guarded `if: runner.os == 'Linux'`, to the 3 disk-heavy Linux jobs that lacked it:

| File | Job | Covers status check |
|---|---|---|
| `ci.yml` | `linux-musl` | `Linux musl (beta)` |
| `_test-features.yml` | `feature-flags-linux` | `default-features (linux)` |
| `_test-features.yml` | `feature-flags-cross-os` | full-workspace Linux rows |

Note: the `default-features (linux)` job lives in the reusable `_test-features.yml` (called by ci.yml), so the step is added there. Pure additions — no existing step/trigger/matrix/status-check-name changed (verified, YAML-valid). The pre-existing `nextest` disk-free step is left untouched.