### PR TITLE
feat(transfer): wire DeltaApplicator into receiver delta-apply path

### DIFF
--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -127,6 +127,14 @@ pub struct DeltaApplyConfig {
     /// via `BufferedMap` to avoid handing `mmap`-backed pointers to the
     /// ring. See [`BasisWriterKind`] for the rationale.
     pub writer_kind: BasisWriterKind,
+    /// Copy-on-write policy for the `FICLONERANGE` partial-reflink fast path.
+    ///
+    /// Defaults to [`fast_io::CowPolicy::Auto`]. When set to
+    /// [`fast_io::CowPolicy::Disabled`] (the `--no-cow` flag) the applicator
+    /// skips `FICLONERANGE` entirely and falls through to `copy_file_range(2)`
+    /// or the read+write path, producing byte-identical output without
+    /// sharing extents.
+    pub cow_policy: fast_io::CowPolicy,
 }
 
 /// Result of applying a delta to a file.
@@ -194,6 +202,9 @@ pub struct DeltaApplicator<'a> {
     /// receiver does not pay one `ENOTSUP` ioctl per COPY token on
     /// non-reflink filesystems.
     reflink_range: ReflinkRangeCache,
+    /// Copy-on-write policy. When `Disabled`, the `FICLONERANGE` partial
+    /// clone path is skipped entirely (mirrors the `--no-cow` flag).
+    cow_policy: fast_io::CowPolicy,
     stats: DeltaApplyResult,
 }
 
@@ -253,6 +264,7 @@ impl<'a> DeltaApplicator<'a> {
             token_buffer: TokenBuffer::with_default_capacity(),
             same_fs: SameFsCache::Unresolved,
             reflink_range: ReflinkRangeCache::Unresolved,
+            cow_policy: config.cow_policy,
             stats: DeltaApplyResult::default(),
         })
     }
@@ -389,6 +401,7 @@ impl<'a> DeltaApplicator<'a> {
                     &self.output,
                     dest_off,
                     bytes_to_copy,
+                    self.cow_policy,
                     &mut self.reflink_range,
                     &mut self.same_fs,
                 )? {
@@ -495,6 +508,9 @@ impl<'a> DeltaApplicator<'a> {
     ///
     /// The gating rules are conservative:
     ///
+    /// - The [`fast_io::CowPolicy`] must not be `Disabled`. `--no-cow`
+    ///   suppresses every reflink attempt and falls straight through to
+    ///   `copy_file_range(2)`.
     /// - The cache must not be in the `Declined` state. After one negative
     ///   result we assume the filesystem does not support reflinks and stop
     ///   retrying.
@@ -515,9 +531,16 @@ impl<'a> DeltaApplicator<'a> {
         dest_file: &File,
         dest_off: u64,
         bytes_to_copy: usize,
+        cow_policy: fast_io::CowPolicy,
         cache: &mut ReflinkRangeCache,
         same_fs: &mut SameFsCache,
     ) -> io::Result<bool> {
+        // `--no-cow`: never attempt a reflink. Fall through to
+        // copy_file_range(2); leave the cache untouched so toggling the
+        // policy back on within the same applicator can still clone.
+        if cow_policy == fast_io::CowPolicy::Disabled {
+            return Ok(false);
+        }
         if *cache == ReflinkRangeCache::Declined {
             return Ok(false);
         }
@@ -743,11 +766,16 @@ impl<'a> DeltaApplicator<'a> {
     /// post-finish size check (`receiver/transfer/sync.rs:276-289`). The
     /// sparse final position is recorded in
     /// [`DeltaApplyResult::final_pos`] regardless.
+    ///
+    /// Returns the reconstructed output [`File`] alongside the result so the
+    /// caller can fsync and commit the very handle that received the data -
+    /// the live receiver path requires this handle for `--fsync` before the
+    /// temp-file rename.
     pub fn finish<R: Read>(
         mut self,
         reader: &mut R,
         expected_size: Option<u64>,
-    ) -> io::Result<DeltaApplyResult> {
+    ) -> io::Result<(File, DeltaApplyResult)> {
         if let Some(ref mut sparse) = self.sparse_state {
             let final_pos = sparse.finish(&mut self.output)?;
             self.stats.final_pos = Some(final_pos);
@@ -805,7 +833,7 @@ impl<'a> DeltaApplicator<'a> {
             self.stats.matched_bytes
         );
 
-        Ok(self.stats)
+        Ok((self.output, self.stats))
     }
 }
 
@@ -853,6 +881,7 @@ mod tests {
         let config = DeltaApplyConfig {
             sparse: true,
             writer_kind: BasisWriterKind::Standard,
+            cow_policy: fast_io::CowPolicy::Auto,
         };
         assert!(config.sparse);
     }
@@ -888,6 +917,7 @@ mod tests {
         let config = DeltaApplyConfig {
             sparse: false,
             writer_kind: BasisWriterKind::Standard,
+            cow_policy: fast_io::CowPolicy::Auto,
         };
         let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
         let applicator =
@@ -913,6 +943,7 @@ mod tests {
         let config = DeltaApplyConfig {
             sparse: false,
             writer_kind: BasisWriterKind::IoUring,
+            cow_policy: fast_io::CowPolicy::Auto,
         };
         let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
         let applicator =
@@ -937,6 +968,7 @@ mod tests {
         let config = DeltaApplyConfig {
             sparse: false,
             writer_kind: BasisWriterKind::IoUring,
+            cow_policy: fast_io::CowPolicy::Auto,
         };
         let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::MD5);
         let applicator =
@@ -1016,6 +1048,7 @@ mod tests {
             &dest,
             0,
             (fast_io::CLONE_FILE_RANGE_MIN_BYTES - 1) as usize,
+            fast_io::CowPolicy::Auto,
             &mut cache,
             &mut same_fs,
         )
@@ -1045,6 +1078,7 @@ mod tests {
             &dest,
             0,
             REFLINK_BLOCK_ALIGNMENT as usize * 8,
+            fast_io::CowPolicy::Auto,
             &mut cache,
             &mut same_fs,
         )
@@ -1068,6 +1102,7 @@ mod tests {
             &dest,
             1024,
             REFLINK_BLOCK_ALIGNMENT as usize * 8,
+            fast_io::CowPolicy::Auto,
             &mut cache,
             &mut same_fs,
         )
@@ -1094,6 +1129,7 @@ mod tests {
             &dest,
             0,
             REFLINK_BLOCK_ALIGNMENT as usize * 16,
+            fast_io::CowPolicy::Auto,
             &mut cache,
             &mut same_fs,
         )
@@ -1121,6 +1157,7 @@ mod tests {
             &dest,
             0,
             REFLINK_BLOCK_ALIGNMENT as usize * 16,
+            fast_io::CowPolicy::Auto,
             &mut cache,
             &mut same_fs,
         )

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -16,9 +16,7 @@ use metadata::apply_metadata_with_cached_stat;
 
 use engine::CleanupManager;
 
-use crate::adaptive_buffer::adaptive_writer_capacity;
-use crate::delta_apply::{ChecksumVerifier, SparseWriteState};
-use crate::map_file::MapFile;
+use crate::delta_apply::ChecksumVerifier;
 use crate::receiver::basis::find_basis_file_with_config;
 use crate::receiver::quick_check::is_hardlink_follower;
 use crate::receiver::stats::TransferStats;
@@ -28,8 +26,7 @@ use crate::receiver::{PipelineSetup, ReceiverContext, apply_acls_from_receiver_c
 use crate::temp_guard::open_tmpfile;
 #[cfg(unix)]
 use crate::temp_guard::open_tmpfile_sandboxed;
-use crate::token_buffer::TokenBuffer;
-use crate::token_reader::{DeltaToken as TokenReaderDeltaToken, LiteralData, TokenReader};
+use crate::token_reader::TokenReader;
 
 impl ReceiverContext {
     /// Runs the receiver with synchronous (non-pipelined) transfer.
@@ -89,14 +86,6 @@ impl ReceiverContext {
 
         let mut ndx_write_codec = MonotonicNdxWriter::new(self.protocol.as_u8());
         let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
-
-        let mut checksum_verifier = ChecksumVerifier::new(
-            self.negotiated_algorithms.as_ref(),
-            self.protocol,
-            self.checksum_seed,
-            self.compat_flags.as_ref(),
-        );
-        let mut token_buffer = TokenBuffer::with_default_capacity();
 
         // upstream: token.c uses a single compression context across all files.
         // For zstd the DCtx must persist across file boundaries (continuous
@@ -228,53 +217,69 @@ impl ReceiverContext {
             #[cfg(not(unix))]
             let (file, mut temp_guard) = open_tmpfile(&file_path, self.config.temp_dir.as_deref())?;
             CleanupManager::global().register_temp_file(temp_guard.path().to_path_buf());
-            let target_size = file_entry.size();
-            let writer_capacity = adaptive_writer_capacity(target_size);
-            let mut output = std::io::BufWriter::with_capacity(writer_capacity, file);
-            let mut total_bytes: u64 = 0;
-            let mut literal_bytes: u64 = 0;
 
             let use_sparse = self.config.flags.sparse;
-            let mut sparse_state = if use_sparse {
-                Some(SparseWriteState::default())
-            } else {
-                None
-            };
 
-            let mut basis_map = if let Some(ref path) = basis_path_opt {
-                Some(MapFile::open(path).map_err(|e| {
-                    io::Error::new(
-                        e.kind(),
-                        format!(
-                            "failed to open basis file {path:?}: {e} {}{}",
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver()
-                        ),
-                    )
-                })?)
-            } else {
-                None
+            // Drive the per-file reconstruction through `DeltaApplicator`. It
+            // owns its basis handle (opened from the path), its own sparse
+            // state, token buffer, and per-file checksum verifier - the same
+            // mechanism the pipelined receiver uses. Behaviour is identical to
+            // the previous in-module `apply_delta_tokens` loop:
+            //   - literal/block-ref dispatch with `see_token` after every
+            //     block match keeps the `-z` inflate dictionary synced
+            //     (token.c:631);
+            //   - sparse mode runs the same `SparseWriteState`; the post-write
+            //     size check against `file_entry.size()` is performed below on
+            //     `result.final_pos`, byte-identical to the old standalone loop;
+            //   - `finish` reads + verifies the wire checksum exactly like the
+            //     old `End` branch, raising `InvalidData` on mismatch.
+            // The verifier MUST be a fresh per-file instance built the same way
+            // the session-shared one is (and the same way the old `End` branch
+            // reset it via `for_algorithm_seeded`): seed prepended only for
+            // legacy MD4, no seed for MD5/XXH*.
+            let file_verifier = ChecksumVerifier::new(
+                self.negotiated_algorithms.as_ref(),
+                self.protocol,
+                self.checksum_seed,
+                self.compat_flags.as_ref(),
+            );
+
+            // REFLINK: the receiver's `ServerConfig` does not carry a CoW
+            // policy - `--cow`/`--no-cow` is plumbed only through the
+            // local-copy client config (core::client), never to this
+            // wire-receive scope. Default to `Auto`; threading the flag here
+            // would require new ServerConfig plumbing across the daemon/server
+            // boundary, out of scope for this cutover.
+            let config = crate::delta_apply::DeltaApplyConfig {
+                sparse: use_sparse,
+                writer_kind: crate::delta_apply::BasisWriterKind::Standard,
+                cow_policy: fast_io::CowPolicy::Auto,
             };
 
             token_reader.reset();
 
-            apply_delta_tokens(
-                reader,
-                &mut output,
-                &mut sparse_state,
-                &mut basis_map,
+            let mut applicator = crate::delta_apply::DeltaApplicator::new(
+                file,
+                &config,
+                file_verifier,
                 signature_opt.as_ref(),
-                &mut token_reader,
-                &mut token_buffer,
-                &mut checksum_verifier,
-                self.checksum_seed,
-                &file_path,
-                &mut total_bytes,
-                &mut literal_bytes,
+                basis_path_opt.as_deref(),
             )?;
 
-            if let Some(ref mut sparse) = sparse_state {
-                let final_pos = sparse.finish(&mut output)?;
+            crate::delta_apply::apply_delta_stream(reader, &mut applicator, &mut token_reader)?;
+
+            // Pass `None` so `finish` records the sparse `final_pos` without
+            // emitting its own generic size-mismatch error; the receiver
+            // re-checks below to preserve the exact pre-change message text
+            // (file path + role trailer). `finish` still reads and verifies
+            // the wire checksum identically to the old `End` branch.
+            let (file, result) = applicator.finish(reader, None)?;
+
+            // Sparse mode: verify the materialized file length against the
+            // file-list entry size. Mirrors the original sync.rs:276-289 check
+            // byte-for-byte (same ErrorKind, same message). `final_pos` is the
+            // position `SparseWriteState::finish` returned inside `finish`.
+            if let Some(final_pos) = result.final_pos {
                 let expected_size = file_entry.size();
                 if final_pos != expected_size {
                     return Err(io::Error::new(
@@ -289,13 +294,11 @@ impl ReceiverContext {
                 }
             }
 
-            let file = output.into_inner().map_err(|e| {
-                io::Error::other(format!(
-                    "failed to flush output buffer for {file_path:?}: {e} {}{}",
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver(),
-                ))
-            })?;
+            // upstream: io.c:820 - only literal bytes traverse the read fd;
+            // matched-from-basis bytes never do. Preserve the exact stat
+            // mapping the old loop used (`literal_bytes` -> `bytes_received`).
+            let literal_bytes = result.literal_bytes;
+
             if self.config.write.fsync {
                 file.sync_all().map_err(|e| {
                     io::Error::new(
@@ -485,166 +488,5 @@ impl ReceiverContext {
             redo_count: 0,
             list_only_entries,
         })
-    }
-}
-
-/// Applies the stream of delta tokens for a single file.
-///
-/// Drives the token reader until `End`, dispatching `Literal` writes through
-/// the optional sparse-write path and resolving `BlockRef` tokens against the
-/// (optional) basis map. On `End` the receiver-side checksum is compared
-/// against the sender's; mismatch is a hard `InvalidData` error.
-///
-/// # Upstream Reference
-///
-/// - `match.c:hash_search()` - sender emits literal/block-ref tokens
-/// - `receiver.c:recv_token()` - receiver-side token consumption
-/// - `checksum.c:sum_init()` - per-file MD4 seed reset
-#[allow(clippy::too_many_arguments)]
-fn apply_delta_tokens<R: Read>(
-    reader: &mut crate::reader::ServerReader<R>,
-    output: &mut std::io::BufWriter<std::fs::File>,
-    sparse_state: &mut Option<SparseWriteState>,
-    basis_map: &mut Option<MapFile>,
-    signature_opt: Option<&engine::signature::FileSignature>,
-    token_reader: &mut TokenReader,
-    token_buffer: &mut TokenBuffer,
-    checksum_verifier: &mut ChecksumVerifier,
-    checksum_seed: i32,
-    file_path: &std::path::Path,
-    total_bytes: &mut u64,
-    literal_bytes: &mut u64,
-) -> io::Result<()> {
-    loop {
-        match token_reader.read_token(reader)? {
-            TokenReaderDeltaToken::End => {
-                let checksum_len = checksum_verifier.digest_len();
-                let mut expected_buf = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
-                reader.read_exact(&mut expected_buf[..checksum_len])?;
-
-                let algo = checksum_verifier.algorithm();
-                // upstream: checksum.c:sum_init() prepends seed for legacy MD4.
-                let old_verifier = std::mem::replace(
-                    checksum_verifier,
-                    ChecksumVerifier::for_algorithm_seeded(algo, checksum_seed),
-                );
-                let mut computed = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
-                let computed_len = old_verifier.finalize_into(&mut computed);
-                if computed_len != checksum_len {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "checksum length mismatch for {file_path:?}: expected {checksum_len} bytes, got {computed_len} bytes {}{}",
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver(),
-                        ),
-                    ));
-                }
-                if computed[..computed_len] != expected_buf[..checksum_len] {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "checksum verification failed for {file_path:?}: expected {:02x?}, got {:02x?} {}{}",
-                            &expected_buf[..checksum_len],
-                            &computed[..computed_len],
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver(),
-                        ),
-                    ));
-                }
-                return Ok(());
-            }
-            TokenReaderDeltaToken::Literal(literal) => match literal {
-                LiteralData::Ready(data) => {
-                    let len = data.len();
-                    write_chunk(output, sparse_state, &data)?;
-                    checksum_verifier.update(&data);
-                    *total_bytes += len as u64;
-                    *literal_bytes += len as u64;
-                }
-                LiteralData::Pending(len) => {
-                    if let Some(data) = reader.try_borrow_exact(len)? {
-                        write_chunk(output, sparse_state, data)?;
-                        checksum_verifier.update(data);
-                    } else {
-                        token_buffer.resize_for(len);
-                        reader.read_exact(token_buffer.as_mut_slice())?;
-                        let data = token_buffer.as_slice();
-                        write_chunk(output, sparse_state, data)?;
-                        checksum_verifier.update(data);
-                    }
-                    *total_bytes += len as u64;
-                    *literal_bytes += len as u64;
-                }
-            },
-            TokenReaderDeltaToken::BlockRef(block_idx) => {
-                let (sig, map) = match (signature_opt, basis_map.as_mut()) {
-                    (Some(sig), Some(map)) => (sig, map),
-                    _ => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!(
-                                "block reference {block_idx} without basis file {}{}",
-                                crate::role_trailer::error_location!(),
-                                crate::role_trailer::receiver()
-                            ),
-                        ));
-                    }
-                };
-
-                let layout = sig.layout();
-                let block_count = layout.block_count() as usize;
-
-                if block_idx >= block_count {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "block index {block_idx} out of bounds (file has {block_count} blocks) {}{}",
-                            crate::role_trailer::error_location!(),
-                            crate::role_trailer::receiver(),
-                        ),
-                    ));
-                }
-
-                let block_len = layout.block_length().get() as u64;
-                let offset = block_idx as u64 * block_len;
-
-                let bytes_to_copy = if block_idx == block_count.saturating_sub(1) {
-                    let remainder = layout.remainder();
-                    if remainder > 0 {
-                        remainder as usize
-                    } else {
-                        block_len as usize
-                    }
-                } else {
-                    block_len as usize
-                };
-
-                let block_data = map.map_ptr(offset, bytes_to_copy)?;
-
-                write_chunk(output, sparse_state, block_data)?;
-                checksum_verifier.update(block_data);
-
-                // upstream: token.c:631 - see_deflate_token()
-                token_reader.see_token(block_data)?;
-
-                *total_bytes += bytes_to_copy as u64;
-            }
-        }
-    }
-}
-
-/// Writes a chunk either through the sparse-aware writer or straight to the
-/// underlying buffered output.
-fn write_chunk(
-    output: &mut std::io::BufWriter<std::fs::File>,
-    sparse_state: &mut Option<SparseWriteState>,
-    data: &[u8],
-) -> io::Result<()> {
-    if let Some(sparse) = sparse_state.as_mut() {
-        sparse.write(output, data)?;
-        Ok(())
-    } else {
-        output.write_all(data)
     }
 }

--- a/crates/transfer/tests/delta_applicator_equivalence.rs
+++ b/crates/transfer/tests/delta_applicator_equivalence.rs
@@ -321,7 +321,10 @@ fn applicator_apply(
     let mut applicator = DeltaApplicator::new(out, &config, verifier, signature, basis_path)?;
     let mut cursor = Cursor::new(wire.to_vec());
     apply_delta_stream(&mut cursor, &mut applicator, token_reader)?;
-    applicator.finish(&mut cursor, expected_size)
+    // The output File is committed by re-opening the path below; the
+    // reconstructed handle is dropped (flushed) here.
+    let (_out, result) = applicator.finish(&mut cursor, expected_size)?;
+    Ok(result)
 }
 
 /// Core equivalence check for a plain (uncompressed) stream.

--- a/crates/transfer/tests/reflink_range_delta_apply.rs
+++ b/crates/transfer/tests/reflink_range_delta_apply.rs
@@ -110,6 +110,7 @@ fn aligned_copy_token_at_offset_zero_matches_basis_block() {
     let config = DeltaApplyConfig {
         sparse: false,
         writer_kind: BasisWriterKind::Standard,
+        cow_policy: fast_io::CowPolicy::Auto,
     };
     let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::None);
     let mut applicator = DeltaApplicator::new(
@@ -158,6 +159,7 @@ fn sequential_aligned_copy_tokens_reconstruct_full_basis() {
     let config = DeltaApplyConfig {
         sparse: false,
         writer_kind: BasisWriterKind::Standard,
+        cow_policy: fast_io::CowPolicy::Auto,
     };
     let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::None);
     let mut applicator = DeltaApplicator::new(
@@ -201,6 +203,7 @@ fn literal_then_copy_falls_through_alignment_guard() {
     let config = DeltaApplyConfig {
         sparse: false,
         writer_kind: BasisWriterKind::Standard,
+        cow_policy: fast_io::CowPolicy::Auto,
     };
     let verifier = ChecksumVerifier::for_algorithm(protocol::ChecksumAlgorithm::None);
     let mut applicator = DeltaApplicator::new(


### PR DESCRIPTION
Phase 2 of #486/#201 — makes the delta-range reflink (FICLONERANGE) + `copy_file_range` fast paths **live** by routing the receiver's delta reconstruction through `DeltaApplicator` (Phase 1, #6211, made it a proven byte-identical superset of the old `apply_delta_tokens`).

**This is a correctness-critical hot path — it reconstructs every delta-transferred file.** Reviewer/merge gate: I am treating **Interop Validation** + **Upstream Testsuite** (the `-z`/delta/daemon end-to-end workflows) as required for this PR, on top of the normal required checks, because the equivalence is unit-proven but the full wire `-z` session can only be validated by those.

## What changed (4 files, all in `crates/transfer`)
**Cutover (`sync.rs`):** replaced `apply_delta_tokens` with `DeltaApplicator::new` + `apply_delta_stream` + `finish`. Every observable semantic preserved and verified against the old code:
- **Stats:** `result.literal_bytes → bytes_received` identically (old `total_bytes` was computed-but-unused).
- **Checksum:** fresh per-file `ChecksumVerifier::new(...)` is provably identical to the old session-verifier build + `End`-branch reset for every algorithm/proto/seed path; `finish` reads+verifies the wire digest with the same order and same `InvalidData` on mismatch.
- **Sparse:** `finish(reader, None)` + the receiver re-does the size check on `result.final_pos`, emitting the **byte-identical** old error message + role trailer.
- **fsync/rename:** `finish` now returns `(File, DeltaApplyResult)` so the receiver fsyncs the exact handle that received the data; the temp-guard rename commit is unchanged.
- **Compression:** the same session `TokenReader` (persistent zstd DCtx) is threaded through; `see_token` after each block match keeps `-z` dictionary-synced (Phase 1).
- Removed now-dead `apply_delta_tokens` + `write_chunk` + unused imports.

**`--cow` gate (`applicator.rs`):** `DeltaApplyConfig.cow_policy` + a first guard in `try_clone_basis_range` (`Disabled → Ok(false)`, falls through to `copy_file_range`). Currently defaults to `Auto` in the receiver (the receiver `ServerConfig` has no cow field yet — threading `--no-cow` across the daemon/server boundary is a tracked follow-up; the whole-file FICLONE path already honors `--cow`).

## Verification
build, clippy (`-D warnings`), fmt, doc gate — all clean. `cargo test -p transfer --all-features`: **1807 passed, 3 failed** — the 3 are the known pre-existing `disk_commit::tests::cleanup_manager_*` `cargo test`-only flakes (process-global `CleanupManager` singleton; confirmed identical on master with this change stashed; pass in isolation and under nextest's process-per-test, which is CI's runner). Phase-1 equivalence (7) + reflink-range (3) tests green.

Tracks #486 / #201.