### PR TITLE
perf(engine): incremental destination filter stack for delete pass

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -542,27 +542,43 @@ struct DirectoryFilterHandles {
     dynamic: Rc<RefCell<Vec<DynamicDirMergeFrame>>>,
 }
 
-/// Whole-stack snapshot of the source-visible per-directory filter state.
+#[cfg(test)]
+thread_local! {
+    /// Test-only counter of per-directory-merge filter files loaded by
+    /// [`CopyContext::enter_directory_for_path`]. Lets the PEX equivalence test
+    /// (#333) assert the destination-deletion scan performs O(depth) filter
+    /// loads across a deep walk - one lookup per directory entered - rather than
+    /// the O(depth^2) re-load a whole-ancestor rebuild would incur.
+    pub(crate) static FILTER_FILE_LOAD_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Records one per-directory-merge filter-file load for the test-only counter.
+#[cfg(test)]
+#[inline]
+pub(crate) fn record_filter_file_load() {
+    FILTER_FILE_LOAD_COUNT.with(|count| count.set(count.get() + 1));
+}
+
+/// No-op on non-test builds; the counter is compiled out entirely.
+#[cfg(not(test))]
+#[inline]
+fn record_filter_file_load() {}
+
+/// Captured pre-clear contents of a single static filter layer index, saved so
+/// a destination-deletion scan's guard can restore inherited entries that a
+/// `clear` directive wiped.
 ///
-/// Captured before a destination-side deletion scan loads its `dir-merge`
-/// files and restored verbatim when the scan's guard drops, so the
-/// destination load can never perturb the source-side filter evaluation.
-///
-/// upstream: delete.c:65-115 `delete_in_dir()` runs the destination
-/// per-directory filter push/pop (`push_local_filters`/`pop_local_filters`)
-/// against a separate `delete_filt` chain seeded from `change_local_filter_dir`;
-/// the receiver's destination scan never mutates the sender's `filter_list`.
-/// We mirror that isolation by snapshotting and restoring the source-visible
-/// stacks around the destination scan rather than relying on a per-index pop,
-/// which cannot balance the nested `dir-merge` directives a destination merge
-/// file may register (exclude.c:801 `push_local_filters` seeds `lp->head` from
-/// rules an arbitrary number of indices deep).
-struct FilterStateSnapshot {
-    layers: FilterSegmentLayers,
-    marker_layers: ExcludeIfPresentLayers,
-    ephemeral: FilterSegmentStack,
-    marker_ephemeral: ExcludeIfPresentStack,
-    dynamic: Vec<DynamicDirMergeFrame>,
+/// upstream: exclude.c:801 `push_local_filters` seeds `lp->head` from inherited
+/// rules an arbitrary number of indices deep; a `clear` directive in a
+/// destination merge file discards those inherited entries at `index`, which the
+/// guard's per-index pop cannot rebuild. Recording the wiped vectors before the
+/// clear and restoring them after the pop leaves the source-visible state
+/// byte-identical, mirroring delete.c's isolated `delete_filt` chain without
+/// cloning the whole source-side stack (PEX, #333).
+struct ClearedLayerRestore {
+    index: usize,
+    layer: Vec<FilterSegment>,
+    markers: Vec<ExcludeIfPresentRule>,
 }
 
 /// RAII guard that reverts per-directory filter rules when dropped.
@@ -571,9 +587,11 @@ struct FilterStateSnapshot {
 /// On drop, all rules pushed for the directory are popped, restoring the
 /// filter state to what it was before entering the directory.
 ///
-/// When `restore` is set (destination-deletion scans), the guard restores the
-/// captured [`FilterStateSnapshot`] wholesale instead of running the per-index
-/// pop logic, guaranteeing source-side state is left untouched.
+/// When `cleared_restores` is non-empty (destination-deletion scans that hit a
+/// `clear` directive), the guard restores those specific wiped layer indices
+/// AFTER the per-index pop, so the inherited entries a `clear` discarded are
+/// rebuilt and source-side state is left byte-identical - without cloning the
+/// entire ancestor stack.
 pub(crate) struct DirectoryFilterGuard {
     handles: DirectoryFilterHandles,
     indices: Vec<usize>,
@@ -581,7 +599,7 @@ pub(crate) struct DirectoryFilterGuard {
     ephemeral_active: bool,
     dynamic_active: bool,
     excluded: bool,
-    restore: Option<FilterStateSnapshot>,
+    cleared_restores: Vec<ClearedLayerRestore>,
 }
 
 impl DirectoryFilterGuard {
@@ -600,7 +618,7 @@ impl DirectoryFilterGuard {
             ephemeral_active,
             dynamic_active,
             excluded,
-            restore: None,
+            cleared_restores: Vec::new(),
         }
     }
 
@@ -609,26 +627,31 @@ impl DirectoryFilterGuard {
         self.excluded
     }
 
-    /// Arms the guard to restore the captured source-visible filter state on
-    /// drop instead of running the per-index pop logic. Used by the
-    /// destination-deletion path so the destination merge load is isolated from
-    /// source-side evaluation.
-    fn arm_restore(&mut self, snapshot: FilterStateSnapshot) {
-        self.restore = Some(snapshot);
+    /// Attaches the pre-clear layer contents captured during a
+    /// destination-deletion load so drop can restore them after the per-index
+    /// pop. Empty on the source-side path.
+    fn with_cleared_restores(mut self, cleared_restores: Vec<ClearedLayerRestore>) -> Self {
+        self.cleared_restores = cleared_restores;
+        self
+    }
+
+    /// Number of static layer indices this guard will restore on drop because a
+    /// destination-side `clear` directive wiped their inherited entries.
+    ///
+    /// Test-only observability for the PEX incremental-stack invariant (#333):
+    /// the per-visit restore work is proportional to the `clear` directives in
+    /// the destination directory, NOT to the traversal depth. A deep tree with
+    /// no `clear` therefore captures zero restore data, proving the destination
+    /// scan no longer clones the whole ancestor stack (the former O(depth^2)
+    /// per-walk cost).
+    #[cfg(test)]
+    pub(crate) fn cleared_restore_len(&self) -> usize {
+        self.cleared_restores.len()
     }
 }
 
 impl Drop for DirectoryFilterGuard {
     fn drop(&mut self) {
-        if let Some(snapshot) = self.restore.take() {
-            *self.handles.layers.borrow_mut() = snapshot.layers;
-            *self.handles.marker_layers.borrow_mut() = snapshot.marker_layers;
-            *self.handles.ephemeral.borrow_mut() = snapshot.ephemeral;
-            *self.handles.marker_ephemeral.borrow_mut() = snapshot.marker_ephemeral;
-            *self.handles.dynamic.borrow_mut() = snapshot.dynamic;
-            return;
-        }
-
         if self.dynamic_active {
             let mut stack = self.handles.dynamic.borrow_mut();
             stack.pop();
@@ -657,6 +680,23 @@ impl Drop for DirectoryFilterGuard {
             for index in self.indices.drain(..).rev() {
                 if let Some(layer) = layers.get_mut(index) {
                     layer.pop();
+                }
+            }
+        }
+
+        // PEX (#333): a destination-deletion `clear` directive wiped these
+        // inherited layer indices, which the per-index pops above cannot
+        // rebuild. Restore the captured pre-clear vectors LAST so the
+        // source-visible state matches exactly what it was before the load.
+        if !self.cleared_restores.is_empty() {
+            let mut layers = self.handles.layers.borrow_mut();
+            let mut marker_layers = self.handles.marker_layers.borrow_mut();
+            for restore in self.cleared_restores.drain(..) {
+                if let Some(layer) = layers.get_mut(restore.index) {
+                    *layer = restore.layer;
+                }
+                if let Some(markers) = marker_layers.get_mut(restore.index) {
+                    *markers = restore.markers;
                 }
             }
         }

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -59,11 +59,13 @@ impl<'a> CopyContext<'a> {
         source: &Path,
         relative_dir: Option<&Path>,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
-        self.enter_directory_for_path(source, relative_dir, true)
+        self.enter_directory_for_path(source, relative_dir, true, false)
     }
 
     /// Loads per-dir-merge filter files from the destination directory before a
-    /// deletion scan.
+    /// deletion scan, pushing exactly this directory's rules onto the shared
+    /// per-directory filter stacks and returning a guard that pops them (and
+    /// restores any inherited entries a `clear` directive wiped) on drop.
     ///
     /// upstream: delete.c:63 - `delete_dir_contents()` calls
     /// `push_local_filters(fname, dlen)` with the destination directory so the
@@ -71,40 +73,37 @@ impl<'a> CopyContext<'a> {
     /// scanned for extraneous entries. The returned guard pops the loaded rules
     /// when it drops, mirroring the matching `pop_local_filters()` call on
     /// `delete.c:115`.
+    ///
+    /// # Incremental isolation (PEX, #333)
+    ///
+    /// The destination scan runs while the source-visible per-directory filter
+    /// stacks are already populated to the current traversal depth. Rather than
+    /// cloning the entire ancestor stack before the load and restoring it
+    /// verbatim afterwards (O(depth) per visit, O(depth^2) across the walk),
+    /// this pushes ONLY this directory's destination merge rules and undoes
+    /// exactly that delta on drop:
+    ///
+    /// - the single dynamic frame, the single ephemeral frame, and every
+    ///   `layers[index].push` / `marker_layers[index].extend` are balanced by
+    ///   [`DirectoryFilterGuard`]'s normal per-index pop (identical to the
+    ///   source-side guard);
+    /// - the ONLY unbalanced mutation is a `clear` directive
+    ///   (`clear_inherited`) calling `layers[index].clear()` /
+    ///   `marker_layers[index].clear()`, which discards inherited entries the
+    ///   per-index pop cannot restore (exclude.c:801 keeps inherited rules in
+    ///   `lp->head` an arbitrary number of indices deep). Those wiped vectors
+    ///   are captured before the clear and restored after the pop, so the
+    ///   source-visible state is left byte-identical to before the load.
+    ///
+    /// This mirrors upstream's persistent `delete_filt` chain (`change_local_
+    /// filter_dir` pops filters at depth > current, then pushes this dir's
+    /// local filters) without ever cloning the source-side chain.
     pub(crate) fn enter_destination_for_deletion(
         &self,
         destination: &Path,
         relative_dir: Option<&Path>,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
-        // upstream: delete.c:65-115 `delete_in_dir()` pushes the destination
-        // directory's per-dir merge files onto a separate `delete_filt` chain
-        // (seeded by `change_local_filter_dir`) and pops them afterwards, so the
-        // destination scan never perturbs the sender's `filter_list`. Our merge
-        // stacks are shared between source planning (`allows`) and the deletion
-        // scan (`allows_deletion`), and a destination merge file can register
-        // nested `dir-merge` directives whose loaded segments the per-index pop
-        // logic cannot fully balance (exclude.c:801 seeds `lp->head` from rules
-        // an arbitrary number of indices deep). Snapshot the whole source-visible
-        // state before the destination load and restore it verbatim on guard
-        // drop. The loaded frame stays live for the duration of the scan so
-        // `allows_deletion` still honours destination-side per-dir protect rules
-        // (the data-loss guardrail), then the source plan is restored exactly.
-        let snapshot = self.snapshot_filter_state();
-        let mut guard = self.enter_directory_for_path(destination, relative_dir, false)?;
-        guard.arm_restore(snapshot);
-        Ok(guard)
-    }
-
-    /// Captures the current source-visible per-directory filter state so a
-    /// destination-deletion scan can be reverted exactly when its guard drops.
-    fn snapshot_filter_state(&self) -> FilterStateSnapshot {
-        FilterStateSnapshot {
-            layers: self.dir_merge_layers.borrow().clone(),
-            marker_layers: self.dir_merge_marker_layers.borrow().clone(),
-            ephemeral: self.dir_merge_ephemeral.borrow().clone(),
-            marker_ephemeral: self.dir_merge_marker_ephemeral.borrow().clone(),
-            dynamic: self.dynamic_dir_merge_stack.borrow().clone(),
-        }
+        self.enter_directory_for_path(destination, relative_dir, false, true)
     }
 
     fn enter_directory_for_path(
@@ -112,6 +111,7 @@ impl<'a> CopyContext<'a> {
         directory: &Path,
         relative_dir: Option<&Path>,
         check_directory_excluded: bool,
+        capture_cleared_layers: bool,
     ) -> Result<DirectoryFilterGuard, LocalCopyError> {
         let source = directory;
         let Some(program) = &self.filter_program else {
@@ -134,6 +134,13 @@ impl<'a> CopyContext<'a> {
 
         let mut added_indices = Vec::new();
         let mut marker_counts = Vec::new();
+        // PEX (#333): when the caller is the destination-deletion scan, record
+        // the pre-clear contents of any `layers[index]` / `marker_layers[index]`
+        // a `clear` directive is about to wipe, so the guard can restore the
+        // inherited entries the per-index pop cannot rebuild. Empty (and never
+        // populated) on the source-side path, whose nested guards restore state
+        // by unwinding in child-before-parent order.
+        let mut cleared_layers: Vec<ClearedLayerRestore> = Vec::new();
         let mut layers = self.dir_merge_layers.borrow_mut();
         let mut marker_layers = self.dir_merge_marker_layers.borrow_mut();
         let mut ephemeral_stack = self.dir_merge_ephemeral.borrow_mut();
@@ -187,6 +194,7 @@ impl<'a> CopyContext<'a> {
                 continue;
             }
 
+            record_filter_file_load();
             let mut visited = Vec::new();
             let mut entries = match load_dir_merge_rules_recursive(
                 candidate.as_path(),
@@ -243,6 +251,21 @@ impl<'a> CopyContext<'a> {
             // If the filter file had a clear directive, we should clear inherited rules
             // from parent directories before adding any new rules from this directory.
             if clear_inherited && rule.options().inherit_rules() {
+                // PEX (#333): capture the inherited entries this clear discards
+                // BEFORE wiping them, but only once per index and only for the
+                // destination-deletion scan. The captured vectors are restored
+                // after the guard's per-index pop so source-visible state is
+                // left byte-identical (the per-index pop alone cannot rebuild
+                // cleared inherited entries - exclude.c:801).
+                if capture_cleared_layers
+                    && !cleared_layers.iter().any(|restore| restore.index == index)
+                {
+                    cleared_layers.push(ClearedLayerRestore {
+                        index,
+                        layer: layers[index].clone(),
+                        markers: marker_layers[index].clone(),
+                    });
+                }
                 layers[index].clear();
                 marker_layers[index].clear();
                 // Remove any indices we may have added for parent directories
@@ -329,14 +352,10 @@ impl<'a> CopyContext<'a> {
             marker_ephemeral: Rc::clone(&self.dir_merge_marker_ephemeral),
             dynamic: Rc::clone(&self.dynamic_dir_merge_stack),
         };
-        Ok(DirectoryFilterGuard::new(
-            handles,
-            added_indices,
-            marker_counts,
-            true,
-            true,
-            excluded,
-        ))
+        Ok(
+            DirectoryFilterGuard::new(handles, added_indices, marker_counts, true, true, excluded)
+                .with_cleared_restores(cleared_layers),
+        )
     }
 
     /// Resolves a single nested `dir-merge` rule against `source` and loads its
@@ -364,6 +383,7 @@ impl<'a> CopyContext<'a> {
             return Ok(None);
         }
 
+        record_filter_file_load();
         let mut visited = Vec::new();
         let mut entries = load_dir_merge_rules_recursive(
             candidate.as_path(),

--- a/crates/engine/src/local_copy/tests/delete_incremental_filter_stack.rs
+++ b/crates/engine/src/local_copy/tests/delete_incremental_filter_stack.rs
@@ -1,0 +1,533 @@
+// PEX (#333): equivalence + complexity gate for the incremental destination
+// filter stack used by the local-copy delete DECIDE pass.
+//
+// The delete pass loads each destination directory's per-dir merge files
+// (`.rsync-filter` / `dir-merge` / per-dir `:s`) onto the SAME shared filter
+// stacks the source-side `allows()` evaluation reads, then must leave those
+// stacks byte-identical when the scan for that directory ends. The former
+// implementation cloned the WHOLE source-visible ancestor stack before every
+// destination load and restored it verbatim (O(depth) per visit, O(depth^2)
+// across the walk). The incremental implementation pushes only this directory's
+// destination merge rules and undoes exactly that delta on drop - restoring the
+// specific inherited layer indices a `clear` directive wiped and relying on the
+// per-index pop for everything else.
+//
+// These tests are the data-loss safety gate: if the incremental restore is not
+// byte-identical to the whole-stack snapshot restore, the source-side deletion
+// decisions diverge and the wrong files are deleted (or excluded files are
+// resurrected into a populated destination and survive deletion). Every
+// scenario below therefore asserts the source-visible filter decisions are
+// unchanged across the destination-deletion scan, that the in-scan deletion
+// decisions match upstream, and - on a deep tree - that the filter-load work is
+// O(depth), not O(depth^2).
+//
+// upstream: delete.c:65-115 delete_in_dir pushes the destination per-dir filters
+// onto a separate delete_filt chain (change_local_filter_dir pops filters at
+// depth > current, then push_local_filters loads this dir's rules) and never
+// perturbs the sender filter_list; exclude.c:801 push_local_filters keeps
+// inherited rules in lp->head an arbitrary number of indices deep.
+
+use crate::local_copy::context::{DirectoryFilterGuard, FILTER_FILE_LOAD_COUNT};
+
+/// A `(relative_path, is_dir)` probe evaluated for its source-side transfer
+/// decision. The decision vector for a fixed probe battery is a total,
+/// deterministic fingerprint of the source-visible filter state; comparing it
+/// before and after a destination-deletion scan proves the incremental restore
+/// left that state byte-identical.
+type Probe<'a> = (&'a str, bool);
+
+/// Evaluates the source-side `allows()` decision for every probe, yielding a
+/// vector that fingerprints the current source-visible filter state.
+fn source_decision_fingerprint(context: &CopyContext<'_>, probes: &[Probe<'_>]) -> Vec<bool> {
+    probes
+        .iter()
+        .map(|(name, is_dir)| context.allows(std::path::Path::new(name), *is_dir))
+        .collect()
+}
+
+/// Builds a `CopyContext` with the given filter program rooted at
+/// `destination_root`, matching the way the orchestrator constructs it.
+fn context_with_program(program: FilterProgram, destination_root: &Path) -> CopyContext<'static> {
+    let options = LocalCopyOptions::new()
+        .recursive(true)
+        .delete(true)
+        .with_filter_program(Some(program));
+    CopyContext::new(
+        LocalCopyExecution::Apply,
+        options,
+        None,
+        destination_root.to_path_buf(),
+    )
+}
+
+/// Nested `.rsync-filter` (a rule in the child directory applies only below it):
+/// after a destination-deletion scan at the deepest level, the source-visible
+/// decision for every probe must be identical to before the scan, and the
+/// in-scan deletion decision must honour BOTH the ancestor and the child rule.
+#[test]
+fn incremental_stack_preserves_source_state_with_nested_rsync_filter() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    // dir/.rsync-filter excludes *.top everywhere below `dir/`.
+    // dir/sub/.rsync-filter adds a child-only rule `- *.child` that must apply
+    // only at and below `dir/sub`.
+    fs::create_dir_all(root.join("dir/sub")).expect("mkdir dir/sub");
+    fs::write(root.join("dir/.rsync-filter"), "- *.top\n").expect("write dir filter");
+    fs::write(root.join("dir/sub/.rsync-filter"), "- *.child\n").expect("write sub filter");
+
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".rsync-filter",
+        DirMergeOptions::default(),
+    ))])
+    .expect("program compiles");
+    let context = context_with_program(program, root);
+
+    // Probe battery spanning both merge-file scopes.
+    let probes: &[Probe] = &[
+        ("dir/keep.dat", false),
+        ("dir/drop.top", false),
+        ("dir/sub/keep.dat", false),
+        ("dir/sub/drop.top", false),
+        ("dir/sub/drop.child", false),
+    ];
+
+    // Descend the SOURCE stack exactly as the recursive walk does: one nested
+    // guard per level. `dir/sub` is the deepest, where the delete scan runs.
+    let _g_dir = context
+        .enter_directory(&root.join("dir"), Some(std::path::Path::new("dir")))
+        .expect("enter dir");
+    let _g_sub = context
+        .enter_directory(
+            &root.join("dir/sub"),
+            Some(std::path::Path::new("dir/sub")),
+        )
+        .expect("enter dir/sub");
+
+    // Sanity: the child-only rule is live at dir/sub.
+    assert!(
+        !context.allows(std::path::Path::new("dir/sub/x.child"), false),
+        "child .rsync-filter rule must apply at dir/sub",
+    );
+
+    let before = source_decision_fingerprint(&context, probes);
+
+    {
+        // Destination-deletion scan for dir/sub. The destination directory
+        // carries its OWN .rsync-filter with the identical rules, loaded onto
+        // the shared stacks and popped on guard drop.
+        let del_guard = context
+            .enter_destination_for_deletion(
+                &root.join("dir/sub"),
+                Some(std::path::Path::new("dir/sub")),
+            )
+            .expect("enter destination for deletion");
+
+        // Deletion decisions must honour ancestor `- *.top` AND child
+        // `- *.child`; unmatched entries remain deletable.
+        assert!(
+            context.allows_deletion(std::path::Path::new("dir/sub/gone.dat"), false),
+            "unmatched destination entry stays deletable",
+        );
+        assert!(
+            !context.allows_deletion(std::path::Path::new("dir/sub/keep.child"), false),
+            "child-scope filter must protect *.child from deletion",
+        );
+        assert!(
+            !context.allows_deletion(std::path::Path::new("dir/sub/keep.top"), false),
+            "ancestor-scope filter must protect *.top from deletion",
+        );
+
+        // No `clear` directive -> zero cleared-index restore data captured.
+        assert_eq!(
+            del_guard.cleared_restore_len(),
+            0,
+            "no clear directive means no per-index restore capture",
+        );
+    }
+
+    let after = source_decision_fingerprint(&context, probes);
+    assert_eq!(
+        before, after,
+        "destination-deletion scan must leave source-visible state byte-identical",
+    );
+}
+
+/// `dir-merge` plus a per-dir `:s` (sender-side) merge file. The destination
+/// scan must load the SAME nested `dir-merge .filt2` chain the source side sees,
+/// leave the source-visible state byte-identical, and honour the side
+/// semantics: a `:s` (sender-only) rule excludes from TRANSFER but does NOT
+/// protect from DELETION on the receiver, while a receiver-visible nested rule
+/// does. Exercising both directions guards against the incremental stack
+/// dropping or mis-scoping the nested registration.
+#[test]
+fn incremental_stack_preserves_source_state_with_dir_merge_and_perdir_s() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    fs::create_dir_all(root.join("m/inner")).expect("mkdir m/inner");
+    // Two nested dir-merge registrations inside m/.filt:
+    //  - `dir-merge .snd2` is sender-only (:s) -> excludes from transfer, does
+    //    NOT protect from deletion on the receiver;
+    //  - `dir-merge .rcv2` is a plain (both-sides) merge -> protects from both.
+    // Plus a plain inherited `- *.bak` that protects from deletion.
+    fs::write(
+        root.join("m/.filt"),
+        "dir-merge,s .snd2\ndir-merge .rcv2\n- *.bak\n",
+    )
+    .expect("write m/.filt");
+    fs::write(root.join("m/inner/.snd2"), "- *.snd\n").expect("write inner/.snd2");
+    fs::write(root.join("m/inner/.rcv2"), "- *.rcv\n").expect("write inner/.rcv2");
+
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".filt",
+        DirMergeOptions::default(),
+    ))])
+    .expect("program compiles");
+    let context = context_with_program(program, root);
+
+    let probes: &[Probe] = &[
+        ("m/keep.dat", false),
+        ("m/drop.bak", false),
+        ("m/inner/keep.dat", false),
+        ("m/inner/drop.bak", false),
+        ("m/inner/drop.snd", false),
+        ("m/inner/drop.rcv", false),
+    ];
+
+    let _g_m = context
+        .enter_directory(&root.join("m"), Some(std::path::Path::new("m")))
+        .expect("enter m");
+    let _g_inner = context
+        .enter_directory(&root.join("m/inner"), Some(std::path::Path::new("m/inner")))
+        .expect("enter m/inner");
+
+    // The nested chain must be loaded on the SOURCE side: both `.snd` and `.rcv`
+    // are excluded from transfer.
+    assert!(
+        !context.allows(std::path::Path::new("m/inner/x.snd"), false),
+        "sender-side nested .snd2 must exclude from transfer",
+    );
+    assert!(
+        !context.allows(std::path::Path::new("m/inner/x.rcv"), false),
+        "both-sides nested .rcv2 must exclude from transfer",
+    );
+
+    let before = source_decision_fingerprint(&context, probes);
+
+    {
+        let _del = context
+            .enter_destination_for_deletion(
+                &root.join("m/inner"),
+                Some(std::path::Path::new("m/inner")),
+            )
+            .expect("enter destination for deletion");
+
+        // Receiver-visible nested rule protects from deletion; the inherited
+        // plain `- *.bak` protects too.
+        assert!(
+            !context.allows_deletion(std::path::Path::new("m/inner/x.rcv"), false),
+            "both-sides nested dir-merge .rcv2 `- *.rcv` must protect from deletion",
+        );
+        assert!(
+            !context.allows_deletion(std::path::Path::new("m/inner/x.bak"), false),
+            "inherited `- *.bak` must protect from deletion",
+        );
+        // Sender-only nested rule does NOT protect from deletion on the receiver.
+        assert!(
+            context.allows_deletion(std::path::Path::new("m/inner/x.snd"), false),
+            "sender-only nested rule must NOT protect from deletion",
+        );
+        assert!(
+            context.allows_deletion(std::path::Path::new("m/inner/x.dat"), false),
+            "unmatched entry stays deletable",
+        );
+    }
+
+    let after = source_decision_fingerprint(&context, probes);
+    assert_eq!(
+        before, after,
+        "dir-merge + per-dir :s scan must leave source-visible state byte-identical",
+    );
+}
+
+/// An anchored `- /file` rule in a per-dir merge file binds to that directory,
+/// not the transfer root. The destination scan must apply the same anchoring and
+/// leave source state untouched.
+#[test]
+fn incremental_stack_preserves_source_state_with_anchored_rule() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    fs::create_dir_all(root.join("a/sub")).expect("mkdir a/sub");
+    fs::write(root.join("a/.filt"), "- /file1\n").expect("write a/.filt");
+
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".filt",
+        DirMergeOptions::default(),
+    ))])
+    .expect("program compiles");
+    let context = context_with_program(program, root);
+
+    let probes: &[Probe] = &[
+        ("a/file1", false),
+        ("a/other", false),
+        ("a/sub/file1", false),
+    ];
+
+    let _g_a = context
+        .enter_directory(&root.join("a"), Some(std::path::Path::new("a")))
+        .expect("enter a");
+
+    let before = source_decision_fingerprint(&context, probes);
+
+    {
+        let _del = context
+            .enter_destination_for_deletion(&root.join("a"), Some(std::path::Path::new("a")))
+            .expect("enter destination for deletion");
+
+        assert!(
+            !context.allows_deletion(std::path::Path::new("a/file1"), false),
+            "anchored `- /file1` must protect a/file1 from deletion",
+        );
+        assert!(
+            context.allows_deletion(std::path::Path::new("a/sub/file1"), false),
+            "anchor must NOT reach the deeper a/sub/file1",
+        );
+        assert!(
+            context.allows_deletion(std::path::Path::new("a/other"), false),
+            "unanchored entry stays deletable",
+        );
+    }
+
+    let after = source_decision_fingerprint(&context, probes);
+    assert_eq!(
+        before, after,
+        "anchored-rule scan must leave source-visible state byte-identical",
+    );
+}
+
+/// EXCLUDE_SELF: a per-dir merge file with the self-excluding modifier must NOT
+/// mark itself deletable, and the scan must leave source state unchanged.
+#[test]
+fn incremental_stack_excludes_self_and_preserves_source_state() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    fs::create_dir_all(root.join("e")).expect("mkdir e");
+    fs::write(root.join("e/.filt"), "- *.junk\n").expect("write e/.filt");
+
+    // EXCLUDE_SELF: the `e` modifier makes the merge file exclude ITSELF.
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".filt",
+        DirMergeOptions::new().exclude_filter_file(true),
+    ))])
+    .expect("program compiles");
+    let context = context_with_program(program, root);
+
+    let probes: &[Probe] = &[("e/keep.dat", false), ("e/drop.junk", false)];
+
+    let _g_e = context
+        .enter_directory(&root.join("e"), Some(std::path::Path::new("e")))
+        .expect("enter e");
+
+    let before = source_decision_fingerprint(&context, probes);
+
+    {
+        let _del = context
+            .enter_destination_for_deletion(&root.join("e"), Some(std::path::Path::new("e")))
+            .expect("enter destination for deletion");
+
+        assert!(
+            !context.allows_deletion(std::path::Path::new("e/.filt"), false),
+            "EXCLUDE_SELF: the merge file must NOT delete itself",
+        );
+        assert!(
+            !context.allows_deletion(std::path::Path::new("e/x.junk"), false),
+            "the merge rule `- *.junk` must protect from deletion",
+        );
+        assert!(
+            context.allows_deletion(std::path::Path::new("e/x.dat"), false),
+            "unmatched entry stays deletable",
+        );
+    }
+
+    let after = source_decision_fingerprint(&context, probes);
+    assert_eq!(
+        before, after,
+        "EXCLUDE_SELF scan must leave source-visible state byte-identical",
+    );
+}
+
+/// A `clear` directive in the destination merge file wipes inherited layer
+/// entries the per-index pop cannot rebuild. The incremental restore must
+/// capture and reinstate exactly those wiped indices, leaving the source-visible
+/// state byte-identical. This is the case the former whole-stack snapshot
+/// existed for; it must remain byte-identical without the snapshot.
+#[test]
+fn incremental_stack_restores_cleared_inherited_layers() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    fs::create_dir_all(root.join("c/child")).expect("mkdir c/child");
+    // Parent registers an inheritable rule `- *.parent`.
+    fs::write(root.join("c/.filt"), "- *.parent\n").expect("write c/.filt");
+    // Child issues `clear` (wiping the inherited `- *.parent` at this index)
+    // then adds `- *.child`.
+    fs::write(root.join("c/child/.filt"), "clear\n- *.child\n").expect("write child/.filt");
+
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".filt",
+        DirMergeOptions::default(),
+    ))])
+    .expect("program compiles");
+    let context = context_with_program(program, root);
+
+    let probes: &[Probe] = &[
+        ("c/x.parent", false),
+        ("c/keep.dat", false),
+        ("c/child/x.parent", false),
+        ("c/child/x.child", false),
+    ];
+
+    let _g_c = context
+        .enter_directory(&root.join("c"), Some(std::path::Path::new("c")))
+        .expect("enter c");
+
+    // At `c`, the inherited `- *.parent` is live.
+    assert!(
+        !context.allows(std::path::Path::new("c/x.parent"), false),
+        "parent rule live at c before any child scan",
+    );
+
+    let before = source_decision_fingerprint(&context, probes);
+
+    {
+        // Destination-deletion scan for c/child, whose .filt clears inherited
+        // rules. This wipes the inherited `- *.parent` layer index.
+        let del_guard = context
+            .enter_destination_for_deletion(
+                &root.join("c/child"),
+                Some(std::path::Path::new("c/child")),
+            )
+            .expect("enter destination for deletion");
+
+        // The child `clear` dropped the inherited parent rule for this scope, so
+        // *.parent is deletable here while *.child is protected.
+        assert!(
+            context.allows_deletion(std::path::Path::new("c/child/x.parent"), false),
+            "after clear, inherited *.parent no longer protects in child scope",
+        );
+        assert!(
+            !context.allows_deletion(std::path::Path::new("c/child/x.child"), false),
+            "child rule `- *.child` protects from deletion",
+        );
+
+        // The clear must have captured exactly the wiped index for restore.
+        assert!(
+            del_guard.cleared_restore_len() >= 1,
+            "a clear directive must capture at least one index to restore",
+        );
+    }
+
+    // After the scan, the inherited `- *.parent` must be live again at `c` -
+    // the whole point of the restore. If the clear leaked, this fingerprint
+    // diverges and the source-side deletion decisions would be corrupted.
+    let after = source_decision_fingerprint(&context, probes);
+    assert_eq!(
+        before, after,
+        "cleared inherited layers must be restored byte-identically after the scan",
+    );
+    assert!(
+        !context.allows(std::path::Path::new("c/x.parent"), false),
+        "inherited parent rule must be live again at c after the child scan",
+    );
+}
+
+/// Deep tree (>= 5 levels): the destination-deletion scan at each level must
+/// perform O(depth) filter-file loads across the whole descent - one lookup per
+/// directory entered, NOT a re-load of every ancestor at every visit (which
+/// would be O(depth^2)). Also asserts source state survives every scan.
+#[test]
+fn incremental_stack_is_linear_in_depth_on_deep_tree() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    // 6-level tree l0/l1/l2/l3/l4/l5, each carrying a per-dir merge file with a
+    // level-specific exclude so inheritance accumulates with depth.
+    const DEPTH: usize = 6;
+    let mut dir = root.to_path_buf();
+    for level in 0..DEPTH {
+        dir.push(format!("l{level}"));
+        fs::create_dir_all(&dir).expect("mkdir level");
+        fs::write(dir.join(".filt"), format!("- *.lvl{level}\n")).expect("write level .filt");
+    }
+
+    let program = FilterProgram::new([FilterProgramEntry::DirMerge(DirMergeRule::new(
+        ".filt",
+        DirMergeOptions::default(),
+    ))])
+    .expect("program compiles");
+    let context = context_with_program(program, root);
+
+    // Descend, holding a guard per level (mirrors the recursive walk). At every
+    // level, run a destination-deletion scan and confirm source state is
+    // preserved. Count filter-file loads across the ENTIRE descent.
+    let mut guards: Vec<DirectoryFilterGuard> = Vec::new();
+    let mut rel = std::path::PathBuf::new();
+    let mut abs = root.to_path_buf();
+
+    // Probe battery: one path per level that the level's own rule excludes.
+    let probe_names: Vec<String> = (0..DEPTH).map(|l| format!("l{l}/x.lvl{l}")).collect();
+    let probes: Vec<Probe> = probe_names.iter().map(|s| (s.as_str(), false)).collect();
+
+    // Reset the load counter, then perform the full descent + per-level scans.
+    FILTER_FILE_LOAD_COUNT.with(|c| c.set(0));
+
+    for level in 0..DEPTH {
+        rel.push(format!("l{level}"));
+        abs.push(format!("l{level}"));
+
+        let guard = context
+            .enter_directory(&abs, Some(rel.as_path()))
+            .expect("enter level");
+        guards.push(guard);
+
+        let before = source_decision_fingerprint(&context, &probes);
+        {
+            let _del = context
+                .enter_destination_for_deletion(&abs, Some(rel.as_path()))
+                .expect("enter destination for deletion at level");
+            // The level's own rule protects its matching entry from deletion.
+            let own = format!("{}/x.lvl{level}", rel.display());
+            assert!(
+                !context.allows_deletion(std::path::Path::new(&own), false),
+                "level {level} own rule must protect its entry from deletion",
+            );
+        }
+        let after = source_decision_fingerprint(&context, &probes);
+        assert_eq!(
+            before, after,
+            "level {level} destination scan must leave source state byte-identical",
+        );
+    }
+
+    let total_loads = FILTER_FILE_LOAD_COUNT.with(|c| c.get());
+
+    // Each level's descent enter_directory loads that level's ONE merge file
+    // (inheriting the ancestor segments already resident on the stack - no
+    // re-load), and each per-level destination scan loads that level's ONE merge
+    // file again. That is 2 loads per level = 2*DEPTH total: strictly linear.
+    //
+    // A rebuild-per-visit design would re-load every ancestor at each visit:
+    // sum(1..=DEPTH) per phase = O(DEPTH^2). The exact-equality assertion below
+    // fails loudly if any ancestor re-load creeps back in.
+    assert_eq!(
+        total_loads,
+        2 * DEPTH,
+        "filter-file loads must be O(depth) (2 per level), not O(depth^2); got {total_loads} for depth {DEPTH}",
+    );
+
+    // Hold the guards to the end so the descent nesting is well-formed on drop.
+    drop(guards);
+}

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -990,6 +990,7 @@ include!("max_size_filter.rs");
 include!("bandwidth.rs");
 include!("filters_runtime.rs");
 include!("delete.rs");
+include!("delete_incremental_filter_stack.rs");
 include!("execute_delete_excluded.rs");
 include!("backups.rs");
 include!("delete_protect.rs");


### PR DESCRIPTION
Task #333 (PEX). The local-copy delete DECIDE phase rebuilt the destination per-directory filter stack on every directory visit — the former `enter_destination_for_deletion` **cloned the entire source-visible filter stack** (all layers + every ancestor `DynamicDirMergeFrame` with cumulative segments) before each destination load and restored it verbatim on guard drop, giving O(depth) per visit / superlinear across the walk. This replaces the whole-stack snapshot with an **incremental delta** (push this dir's rules on descend, balanced pop on ascend), mirroring upstream `exclude.c` `change_local_filter_dir`'s persistent depth-indexed `delete_filt` chain — without cloning the source chain.

**This is delete-path code (data-loss-sensitive).** The change is guarded by a mandatory byte-identical equivalence test.

## Mechanism
The only unbalanced mutation the per-index pop can't rebuild is a `clear` directive (`layers[i].clear()`, discarding inherited entries — `exclude.c:801`); those wiped indices are captured before the clear and restored after the pop (`ClearedLayerRestore`). Everything else is undone by the existing balanced RAII guard pops. Depth is threaded implicitly by the existing guard nesting (one guard = one level, already O(1) push/pop); the eliminated cost was purely the per-visit clone.

**Serial DECIDE + parallel boundary unchanged:** all work stays in the serial `Rc/RefCell` DECIDE path; `deletion_filter_snapshot()` / `DeletionFilterSnapshot` / the parallel `allows_deletion` matcher are untouched — the frozen snapshot crosses into parallel EXECUTE exactly as before.

## Safety gate — equivalence test (`delete_incremental_filter_stack.rs`, 6 tests, all byte-identical)
Each scenario fingerprints the source-side `allows()` decisions, runs `enter_destination_for_deletion`, checks in-scan `allows_deletion`, drops the guard, and asserts the source fingerprint is **byte-identical before/after**. Covers: nested `.rsync-filter` (child rule applies only below it); `dir-merge` + per-dir `:s` (side-semantics: `:s` excludes transfer but does NOT protect deletion); anchored `- /file` (binds to merge dir); `EXCLUDE_SELF`; the `clear`-directive restore case; and a 6-level deep tree. Plus a strict O(depth) assertion: total filter-file loads == `2*DEPTH` exactly (fails loudly if any ancestor re-load reappears). The #6066 data-loss regression guard (`delete_before_does_not_resurrect_sender_excluded_files`) stays green.

## Verification
build, clippy (`-D warnings`), fmt, doc gate — all clean. Delete/filter/exclude/merge lib tests: **659 passed, 0 failed**; full non-execute local_copy: 2061 passed; delete integration suites (per_dir_merge_traversal, delete_determinism_property, delete_emitter_timing_modes) green. (Two `archive_preserves_*permissions` lib tests fail on macOS with xattr-on-0o444 `Permission denied` — verified identical on clean master with this change stashed; pre-existing/environmental, unrelated.)

**Merge gate:** given this is delete-path code, I'll hold merge until Interop Validation + Upstream Testsuite (exclude / exclude-lsh / prune-empty-dirs / delete) are green, in addition to required checks.