### PR TITLE
feat(engine): forward ReorderBuffer observability + opt-in adaptive capacity through SpillableReorderBuffer

### DIFF
--- a/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/lifecycle.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
-use super::super::super::reorder::ReorderBuffer;
+use super::super::super::adaptive::{AdaptiveCapacityPolicy, ReorderStats};
+use super::super::super::reorder::{Metrics, ReorderBuffer};
 use super::super::{
     DEFAULT_SPILL_THRESHOLD, SpillCodec, SpillCompression, SpillGranularity, SpillReclaim,
     SpillStats,
@@ -90,6 +91,46 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
             in_memory_only: false,
             spill_warned: false,
         })
+    }
+
+    /// Creates a spillable reorder buffer whose in-memory ring is governed by
+    /// an [`AdaptiveCapacityPolicy`] instead of a fixed capacity.
+    ///
+    /// This is strictly opt-in: the fixed-capacity [`new`](Self::new) path is
+    /// unchanged and remains the default everywhere. When selected, the inner
+    /// ring starts at `policy.min` slots and resizes between `policy.min` and
+    /// `policy.max` under the policy's grow / shrink rules while the spill
+    /// threshold continues to bound the on-disk overflow independently.
+    ///
+    /// Selecting concrete policy bounds (`min` / `max` / `growth_factor`) is a
+    /// tuning decision that depends on workload benchmarks; this constructor
+    /// only wires the mechanism and leaves those values to the caller.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `policy.min` is zero (validated by the policy constructor).
+    #[must_use]
+    pub fn with_adaptive_policy(policy: AdaptiveCapacityPolicy, threshold: usize) -> Self {
+        Self {
+            inner: ReorderBuffer::with_adaptive_policy(policy),
+            memory_used: 0,
+            threshold,
+            spill_index: BTreeMap::new(),
+            batch_members: BTreeMap::new(),
+            spill_file: None,
+            spill_dir: None,
+            spill_write_pos: 0,
+            granularity: SpillGranularity::default(),
+            spill_count: 0,
+            spill_activations: 0,
+            reload_count: 0,
+            dir_recreate_count: 0,
+            compression: SpillCompression::None,
+            reclaim: SpillReclaim::default(),
+            memory_pressure_bytes: None,
+            in_memory_only: false,
+            spill_warned: false,
+        }
     }
 
     /// Overrides the per-spill-event record granularity.
@@ -215,6 +256,46 @@ impl<T: SpillCodec> SpillableReorderBuffer<T> {
     #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
+    }
+
+    /// Returns the in-flight reorder window of the in-memory ring: how far
+    /// ahead of the delivery cursor the furthest buffered item currently
+    /// reaches.
+    ///
+    /// Forwarded from
+    /// [`ReorderBuffer::in_flight_window`](super::super::super::reorder::ReorderBuffer::in_flight_window).
+    /// This reflects only the in-memory ring window - the leading indicator of
+    /// spill pressure - and is distinct from [`buffered_count`](Self::buffered_count),
+    /// which also counts spilled items. A window approaching
+    /// [`capacity`](Self::capacity) is what forces the next spill event.
+    #[must_use]
+    pub fn in_flight_window(&self) -> usize {
+        self.inner.in_flight_window()
+    }
+
+    /// Returns a snapshot of the in-memory ring's diagnostic counters.
+    ///
+    /// Forwarded from
+    /// [`ReorderBuffer::metrics`](super::super::super::reorder::ReorderBuffer::metrics),
+    /// this exposes the ring's stall duration, instantaneous depth, and the
+    /// high-water mark of buffered items so operators can observe reorder
+    /// pressure on the spill path without instrumenting the hot path. Spilled
+    /// items are surfaced separately via [`spill_stats`](Self::spill_stats).
+    #[must_use]
+    pub fn metrics(&self) -> Metrics {
+        self.inner.metrics()
+    }
+
+    /// Returns the in-memory ring's adaptive capacity counters.
+    ///
+    /// Forwarded from
+    /// [`ReorderBuffer::stats`](super::super::super::reorder::ReorderBuffer::stats).
+    /// Grow / shrink event totals are zero unless the buffer was constructed
+    /// via [`with_adaptive_policy`](Self::with_adaptive_policy); `capacity`
+    /// always reflects the current ring capacity.
+    #[must_use]
+    pub fn reorder_stats(&self) -> ReorderStats {
+        self.inner.stats()
     }
 
     /// Returns a shared handle to the inner [`ReorderBuffer`]'s cumulative

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/adaptive.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/adaptive.rs
@@ -1,0 +1,165 @@
+//! Opt-in adaptive capacity wiring (ROB-3 / ROB-4) and in-flight window /
+//! metrics forwarding (ROB-1) on the [`SpillableReorderBuffer`] facade.
+//!
+//! These tests pin two invariants:
+//!
+//! * The adaptive constructor is strictly opt-in - the fixed-capacity
+//!   [`SpillableReorderBuffer::new`] path never grows or shrinks, and the
+//!   adaptive path grows under sustained head-of-line pressure while still
+//!   delivering every item in strict sequence order (no drop, no reorder).
+//! * The ROB-1 observability accessors (`in_flight_window`, `metrics`,
+//!   `reorder_stats`) forwarded from the inner ring track occupancy without
+//!   altering delivery behaviour, and the high-water mark is monotonic.
+
+use super::super::super::super::adaptive::AdaptiveCapacityPolicy;
+use super::super::super::SpillableReorderBuffer;
+use super::drain_all;
+
+/// Fixed-capacity buffers must report zero adaptive grow / shrink events no
+/// matter how much head-of-line pressure builds. A regression that flipped
+/// the default to adaptive would trip this immediately.
+#[test]
+fn default_fixed_capacity_never_grows_or_shrinks() {
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(16, 1 << 20);
+    let start_capacity = buf.capacity();
+
+    // Fill the ring right up against its fixed bound with a missing head.
+    for seq in (1..16).rev() {
+        buf.insert(seq, seq * 10).unwrap();
+    }
+
+    let stats = buf.reorder_stats();
+    assert_eq!(stats.grow_events, 0, "fixed path must not grow");
+    assert_eq!(stats.shrink_events, 0, "fixed path must not shrink");
+    assert_eq!(
+        stats.capacity, start_capacity,
+        "fixed capacity must stay constant"
+    );
+
+    // Deliver the head and confirm strict in-order drain with no loss.
+    buf.insert(0, 0).unwrap();
+    let items = drain_all(&mut buf);
+    assert_eq!(items.len(), 16);
+    for (i, &val) in items.iter().enumerate() {
+        assert_eq!(val, i as u64 * 10, "wrong value at index {i}");
+    }
+    assert!(buf.is_empty());
+}
+
+/// The opt-in adaptive path grows the inner ring beyond its `min` start when
+/// out-of-order arrivals stretch the gap window, and still delivers every
+/// item in sequence order. Growth is bounded by the policy `max`.
+#[test]
+fn adaptive_path_grows_under_pressure_and_preserves_order() {
+    // Start small (min=4), allow growth up to 64. A large byte threshold keeps
+    // everything resident so the ring - not the spill path - must absorb the
+    // out-of-order fan-out.
+    let policy = AdaptiveCapacityPolicy::new(4, 64, 2.0);
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_adaptive_policy(policy, 1 << 30);
+
+    assert_eq!(buf.capacity(), 4, "adaptive buffer starts at policy.min");
+
+    // Insert sequences 1..40 with the head (0) still missing. The gap window
+    // grows far past the initial capacity, forcing the ring to grow.
+    for seq in 1..40u64 {
+        buf.insert(seq, seq * 7).unwrap();
+    }
+
+    let stats = buf.reorder_stats();
+    assert!(
+        stats.grow_events > 0,
+        "adaptive path must record grow events under sustained pressure"
+    );
+    assert!(
+        buf.capacity() > 4 && buf.capacity() <= 64,
+        "capacity must grow within [min, max]; got {}",
+        buf.capacity()
+    );
+
+    // Now deliver the head and confirm strict in-order delivery of all 40
+    // items - no drop, no reorder.
+    buf.insert(0, 0).unwrap();
+    let items = drain_all(&mut buf);
+    assert_eq!(items.len(), 40, "every item must be delivered");
+    for (i, &val) in items.iter().enumerate() {
+        assert_eq!(val, i as u64 * 7, "out-of-order delivery at index {i}");
+    }
+    assert!(buf.is_empty());
+}
+
+/// The adaptive constructor honours the policy `max` bound: an arrival far
+/// beyond `max` still surfaces `CapacityExceeded` rather than growing without
+/// limit.
+#[test]
+fn adaptive_path_respects_max_bound() {
+    let policy = AdaptiveCapacityPolicy::new(2, 8, 2.0);
+    let mut buf: SpillableReorderBuffer<u64> =
+        SpillableReorderBuffer::with_adaptive_policy(policy, 1 << 30);
+
+    // Sequence 100 with head 0 missing needs a window of 101 slots, far past
+    // the policy max of 8, so the insert must be rejected.
+    let err = buf.insert(100, 1).unwrap_err();
+    assert!(
+        matches!(err, super::super::super::SpillError::Capacity(_)),
+        "beyond-max insert must surface a capacity error; got {err:?}"
+    );
+    assert!(buf.capacity() <= 8, "capacity must not exceed policy.max");
+}
+
+/// `in_flight_window` forwards the inner ring's gap window and tracks how far
+/// ahead of the delivery cursor buffered items reach - the leading indicator
+/// of spill pressure - independent of the buffered item count.
+#[test]
+fn in_flight_window_tracks_gap_not_count() {
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(16, 1 << 20);
+    assert_eq!(buf.in_flight_window(), 0, "empty buffer has zero window");
+
+    // A single far-ahead arrival stretches the window to its offset+1 while
+    // only one slot is occupied.
+    buf.insert(4, 40).unwrap();
+    assert_eq!(buf.in_flight_window(), 5, "window spans [0, 4]");
+    assert_eq!(buf.buffered_count(), 1, "only one slot occupied");
+
+    // Filling the gap does not widen the window further.
+    buf.insert(1, 10).unwrap();
+    buf.insert(2, 20).unwrap();
+    assert_eq!(buf.in_flight_window(), 5, "window unchanged by infill");
+
+    // Delivering the head shifts the window down toward the cursor.
+    buf.insert(0, 0).unwrap();
+    assert_eq!(buf.next_in_order().unwrap().unwrap(), 0);
+    assert_eq!(buf.in_flight_window(), 4, "window shifts down on delivery");
+}
+
+/// `metrics()` forwards the inner ring's diagnostic snapshot: instantaneous
+/// depth tracks occupancy and the high-water mark is monotonic across the
+/// insert / drain cycle. Forwarding must not perturb delivery order.
+#[test]
+fn metrics_forwarding_tracks_depth_and_monotonic_high_water() {
+    let mut buf: SpillableReorderBuffer<u64> = SpillableReorderBuffer::new(16, 1 << 20);
+    assert_eq!(buf.metrics().current_depth, 0);
+    assert_eq!(buf.metrics().max_depth, 0);
+
+    for seq in (1..6).rev() {
+        buf.insert(seq, seq).unwrap();
+    }
+    // Five out-of-order items are resident, head (0) still missing.
+    assert_eq!(buf.metrics().current_depth, 5);
+    let peak = buf.metrics().max_depth;
+    assert_eq!(peak, 5, "high-water mark records the peak occupancy");
+
+    // Delivering drops current_depth but must never lower the high-water mark.
+    buf.insert(0, 0).unwrap();
+    assert_eq!(buf.metrics().current_depth, 6);
+    assert_eq!(buf.metrics().max_depth, 6);
+
+    let drained = drain_all(&mut buf);
+    assert_eq!(drained.len(), 6);
+    assert_eq!(buf.metrics().current_depth, 0, "empty after drain");
+    assert!(
+        buf.metrics().max_depth >= peak,
+        "high-water mark must be monotonic across drains"
+    );
+    assert_eq!(buf.metrics().max_depth, 6);
+}

--- a/crates/engine/src/concurrent_delta/spill/buffer/tests/mod.rs
+++ b/crates/engine/src/concurrent_delta/spill/buffer/tests/mod.rs
@@ -10,6 +10,7 @@ use std::io::{self, Read, Write};
 
 use super::super::{SpillCodec, SpillableReorderBuffer};
 
+mod adaptive;
 mod basic;
 mod compression;
 mod enospc_degradation;


### PR DESCRIPTION
ROB family (#77 / #482-484). Most of ROB was already on master (in-flight observability #6175, `AdaptiveCapacityPolicy` + `ReorderBuffer::with_adaptive_policy`, and comprehensive spill FS-error hardening with the `MockEnoSpcWriter`/`FaultPlan` ENOSPC/temp-vanish harness). The one remaining gap: those were on the bare ring but **not forwarded through the `SpillableReorderBuffer` facade**. This closes it (additive only):

- **ROB-1** — `SpillableReorderBuffer::in_flight_window()`, `metrics() -> Metrics` (current/max depth), `reorder_stats()`.
- **ROB-3/4** — opt-in `SpillableReorderBuffer::with_adaptive_policy(policy, threshold)`; the default `new`/`with_spill_dir` (fixed capacity) paths are untouched. Policy tuning (min/max/growth) is caller-supplied + bench-gated — only the mechanism is wired.
- **ROB-6** — audited; already complete (every spill FS op returns `io::Result`, items re-inserted on failure, no `unwrap`/`panic` on FS ops). No gap; nothing invented.
- ROB-2/ROB-5 (bench-gated default flips) out of scope.

**Invariants:** no default flipped (`default_fixed_capacity_never_grows_or_shrinks` asserts zero grow/shrink on the default path); in-order contract preserved (`adaptive_path_grows_under_pressure_and_preserves_order` inserts 40 out-of-order, forces growth, asserts strict-order delivery, no drop/reorder; `adaptive_path_respects_max_bound` → `SpillError::Capacity` beyond max).

Verified: build, clippy `-D warnings`, fmt, `cargo doc` gate — clean; engine lib nextest 202 passed + 5 new adaptive + 85 in the adaptive/window/metrics filter, 0 failures.