### PR TITLE
feat(transfer): plumb source fd to stream_whole_file_transfer (NSV-1 groundwork)

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -26,6 +26,17 @@ use crate::config::ServerConfig;
 use crate::handshake::HandshakeResult;
 use crate::transfer_state::TransferPipeline;
 
+/// Concrete source-file descriptor surfaced by `open_source_unbuffered`.
+///
+/// NSV-1: `RawFd` on Unix so the daemon SERVE path can later engage a zero-copy
+/// file->socket sender. `!()` collapses to unit on non-unix where no fd exists;
+/// the value is always `None` there.
+#[cfg(unix)]
+pub(crate) type SourceFd = std::os::fd::RawFd;
+/// Non-unix placeholder for the source descriptor (never populated).
+#[cfg(not(unix))]
+pub(crate) type SourceFd = ();
+
 /// Context for the generator role during a transfer.
 ///
 /// Holds protocol state, configuration, file list, and filter rules needed
@@ -487,11 +498,19 @@ impl GeneratorContext {
     ///
     /// The io_uring fast path is unchanged - it already returns a reader with
     /// its own internal buffering strategy.
+    ///
+    /// # NSV-1
+    ///
+    /// Returns the reader together with the concrete source `RawFd` when the
+    /// fallback path opens a plain `File` (Unix only). The io_uring fast path
+    /// yields `None` for the fd because its reader owns the descriptor behind an
+    /// abstraction; a later zero-copy SERVE gate applies only to the plain-file
+    /// case. The fd is purely informational here - the byte stream is identical.
     pub(crate) fn open_source_unbuffered(
         &self,
         path: &std::path::Path,
         file_size: u64,
-    ) -> std::io::Result<Box<dyn std::io::Read>> {
+    ) -> std::io::Result<(Box<dyn std::io::Read>, Option<SourceFd>)> {
         // 1 MB threshold: io_uring ring creation has fixed overhead that only
         // pays off for larger reads where batched syscalls reduce total cost.
         const IO_URING_READ_THRESHOLD: u64 = 1024 * 1024;
@@ -507,7 +526,7 @@ impl GeneratorContext {
                 self.config.write.io_uring_policy,
                 self.config.write.io_uring_depth,
             ) {
-                Ok(r) => return Ok(Box::new(r)),
+                Ok(r) => return Ok((Box::new(r), None)),
                 Err(_) => {
                     // Fall through to raw File on io_uring failure
                 }
@@ -515,7 +534,11 @@ impl GeneratorContext {
         }
 
         let f = open_source::open_source_with_noatime(path, use_noatime)?;
-        Ok(Box::new(f))
+        #[cfg(unix)]
+        let src_fd = Some(std::os::fd::AsRawFd::as_raw_fd(&f));
+        #[cfg(not(unix))]
+        let src_fd = None;
+        Ok((Box::new(f), src_fd))
     }
 
     /// Returns the upstream `missing_args` mode for ENOENT handling.

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -75,6 +75,39 @@ pub(super) fn create_token_encoder(
 /// with a basis file are strongly preferred to reduce bandwidth.
 pub(super) const LARGE_FILE_WARNING_THRESHOLD: u64 = 8 * 1024 * 1024 * 1024; // 8 GB
 
+/// Concrete source-file and destination-socket descriptors for the SERVE path.
+///
+/// NSV-1 plumbing: threads the raw source `File` descriptor and, when available,
+/// the raw destination socket descriptor down to [`stream_whole_file_transfer`]
+/// so a later applicability gate (NSV-3) and platform sender (NSV-6..10) can
+/// engage a zero-copy file->socket path (sendfile / TransmitFile / splice).
+///
+/// Passed as `Option<ServeFds>`: `None` for transports without a usable fd pair
+/// (SSH pipe, stdio, TLS) or callers that never touch a socket (tests). When the
+/// source is a plain `File` but the socket fd is not reachable through the writer
+/// abstraction, `dst_fd` is `None` and the source fd is still surfaced so the
+/// future gate can decide.
+///
+/// This struct is purely additive: the current transfer never reads these fds,
+/// so wire bytes, stats, and output are byte-for-byte unchanged. The fields are
+/// intentionally unread until the NSV-3 zero-copy gate consumes them.
+#[allow(dead_code)]
+pub(super) struct ServeFds {
+    /// Raw descriptor of the concrete source `File`, when the source is a plain
+    /// file (not an io_uring reader or a `BufReader`).
+    #[cfg(unix)]
+    pub src_fd: std::os::fd::RawFd,
+    /// Raw descriptor of the destination socket, when the writer wraps a
+    /// concrete `TcpStream`. `None` for pipe/stdio/TLS writers or any writer
+    /// that erases its fd behind `dyn Write`.
+    #[cfg(unix)]
+    pub dst_fd: Option<std::os::fd::RawFd>,
+    /// Windows placeholder so the struct stays constructible on all platforms
+    /// while zero-copy remains Unix-only for now (NSV-6..10 add TransmitFile).
+    #[cfg(not(unix))]
+    pub _unsupported: (),
+}
+
 /// Result of streaming a whole file to the wire.
 ///
 /// Returned by [`stream_whole_file_transfer`] with the whole-file checksum that
@@ -215,7 +248,18 @@ pub(super) fn stream_whole_file_transfer<R: Read, W: Write>(
     checksum_algorithm: ChecksumAlgorithm,
     encoder: Option<&mut CompressedTokenEncoder>,
     buf: &mut Vec<u8>,
+    serve_fds: Option<ServeFds>,
 ) -> io::Result<StreamResult> {
+    // NSV-1: `serve_fds` carries the concrete source-file and destination-socket
+    // descriptors for the daemon SERVE path. It is plumbed but unused here. A
+    // future zero-copy gate (NSV-3) will branch at this point: when `serve_fds`
+    // yields both a source fd and a socket fd, no compression/checksum-only
+    // constraints apply, and the platform supports it, dispatch to a
+    // sendfile/TransmitFile/splice sender (NSV-6..10) instead of the read->hash->
+    // write loop below. Until then the bytes flow through the existing path
+    // unchanged, so wire output and stats are byte-for-byte identical.
+    let _ = &serve_fds;
+
     if file_size > LARGE_FILE_WARNING_THRESHOLD {
         debug_log!(
             Send,

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -785,6 +785,7 @@ fn stream_whole_file_produces_correct_wire_format() {
         ChecksumAlgorithm::MD5,
         None,
         &mut buf,
+        None,
     )
     .unwrap();
 
@@ -811,6 +812,7 @@ fn stream_whole_file_handles_empty_file() {
         ChecksumAlgorithm::MD5,
         None,
         &mut buf,
+        None,
     )
     .unwrap();
 
@@ -840,6 +842,7 @@ fn stream_whole_file_computes_correct_checksum() {
         ChecksumAlgorithm::MD5,
         None,
         &mut buf,
+        None,
     )
     .unwrap();
 
@@ -877,6 +880,7 @@ fn stream_whole_file_reuses_buffer() {
         ChecksumAlgorithm::None,
         None,
         &mut buf,
+        None,
     )
     .unwrap();
 
@@ -894,6 +898,7 @@ fn stream_whole_file_reuses_buffer() {
         ChecksumAlgorithm::None,
         None,
         &mut buf,
+        None,
     )
     .unwrap();
 
@@ -922,6 +927,7 @@ fn stream_whole_file_none_checksum() {
         ChecksumAlgorithm::None,
         None,
         &mut buf,
+        None,
     )
     .unwrap();
 

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -476,10 +476,10 @@ impl GeneratorContext {
                 // Use unbuffered reader: stream_whole_file_transfer manages its
                 // own 256 KB staging buffer with read_exact, so a BufReader would
                 // only add an extra memcpy per byte through its internal buffer.
-                let source: Box<dyn Read> = match self
+                let (source, src_fd): (Box<dyn Read>, Option<_>) = match self
                     .open_source_unbuffered(source_path, file_size)
                 {
-                    Ok(r) => r,
+                    Ok(pair) => pair,
                     Err(e) => {
                         self.record_open_failure(&mut *writer, wire_ndx, &e, &source_path_display)?;
                         continue;
@@ -509,6 +509,23 @@ impl GeneratorContext {
                 // size would over-report by the compression ratio under -z/-zz
                 // and trip the daemon-gzip "did -zz engage?" assertion on
                 // whole-file pushes.
+                // NSV-1: build the SERVE fd pair. The concrete source `File` fd
+                // is surfaced by `open_source_unbuffered`; the destination socket
+                // fd is not yet reachable because the daemon erases its
+                // `TcpStream` to `dyn Write` before it reaches this crate, so
+                // `dst_fd` is `None` for now (wired by a later rung). The pair is
+                // plumbed but unused, so the transfer stays byte-for-byte
+                // identical.
+                #[cfg(unix)]
+                let serve_fds = src_fd.map(|fd| super::super::delta::ServeFds {
+                    src_fd: fd,
+                    dst_fd: None,
+                });
+                #[cfg(not(unix))]
+                let serve_fds = {
+                    let _ = src_fd;
+                    None::<super::super::delta::ServeFds>
+                };
                 let wire_bytes = {
                     let mut cw = crate::writer::CountingWriter::new(&mut *writer);
                     let result = stream_whole_file_transfer(
@@ -522,6 +539,7 @@ impl GeneratorContext {
                             None
                         },
                         &mut stream_buf,
+                        serve_fds,
                     )?;
                     cw.write_all(&result.checksum_buf[..result.checksum_len])?;
                     cw.bytes_written()


### PR DESCRIPTION
NSV-1 (#415): prerequisite plumbing for the future zero-copy file->socket serve path. Adds a `ServeFds { src_fd, dst_fd }` parameter to `stream_whole_file_transfer` (generator send path, `generator/delta.rs`) so a later applicability gate (NSV-3) + platform sender (NSV-6..10) can use concrete fds. **Additive + byte-identical — no zero-copy/sendfile added, fds are plumbed-but-unread this rung.**

- `open_source_unbuffered` now also returns the concrete source `File` fd (via `AsRawFd`) on the plain-file path; io_uring fast-path + non-unix yield `None`.
- 1 production caller (`transfer_loop.rs`) passes `Some(ServeFds { src_fd, dst_fd: None })`; 6 test callers pass `None`.
- `// NSV-1` markers at the gate branch point + the ServeFds construction.

**Scope note (documented, not a silent gap):** the SOURCE fd is genuinely wired; the SOCKET (dst) fd is `None` because reaching it needs a larger cross-crate refactor — the daemon boxes its `TcpStream` to `dyn Write` (`streams.rs:70`), erasing the fd before it reaches the transfer crate, across 6 `run_server_with_handshake` callers + `ServerWriter` (which carries no fd accessor). That writer-stack refactor is the NSV follow-up; the `ServeFds` seam + NSV-3 gate can observe `dst_fd = None` until it lands.

Verified: build + clippy (`-D warnings`, transfer & daemon) + fmt + `cargo doc` gate clean; `cargo test -p transfer` 1808 passed incl. the byte-for-byte golden `wire_output == expected` whole-file tests (the 2 `disk_commit cleanup_manager` failures are the known pre-existing parallel-harness flake, pass single-threaded).