### PR TITLE
feat(core,transfer,daemon): tokio-transfer feature foundation + runtime shim (ASY-3, default-off, experimental)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,19 @@ embedded-ssh = ["core/embedded-ssh"]
 # Async runtime support - enables tokio-based async I/O throughout the codebase
 async = ["daemon/async", "core/async"]
 
+# EXPERIMENTAL (ASY-3, default-off): hosts the transfer pipeline on a tokio
+# runtime instead of the threaded scheduler. Implies `async`. The threaded
+# production path is unchanged when this is off; when on, the tokio driver
+# runs the same sync pipeline body inside a runtime and MUST produce
+# byte-identical wire output. Not stabilized until the ASY-12 bench gate.
+# See docs/design/asy-2-tokio-runtime-feature.md and asy-3-async-boundary-spec.md.
+tokio-transfer = [
+    "async",
+    "core/tokio-transfer",
+    "transfer/tokio-transfer",
+    "daemon/tokio-transfer",
+]
+
 # systemd sd-notify integration for daemon
 sd-notify = ["daemon/sd-notify"]
 

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -25,7 +25,12 @@ where
     Out: Write,
     Err: Write,
 {
-    use core::server::{ServerConfig, ServerRole, run_server_stdio};
+    // Route through the session-level driver facade so the `tokio-transfer`
+    // feature can select the tokio-hosted driver. The signature and result are
+    // identical to `core::server::run_server_stdio`; only the driver changes.
+    // Default builds forward straight to the threaded path (ASY-3).
+    use core::server::{ServerConfig, ServerRole};
+    use core::session::run_server_stdio;
 
     let program_brand =
         super::super::detect_program_name(args.first().map(OsString::as_os_str)).brand();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -95,6 +95,14 @@ embedded-ssh = ["dep:tokio", "rsync_io/embedded-ssh"]
 # Async runtime support - enables tokio-based async I/O for core operations
 async = ["dep:tokio", "engine/async", "transfer/async"]
 
+# EXPERIMENTAL (ASY-3, default-off): adds the runtime-ownership shim in the
+# core client facade. Implies `async` and pulls tokio + the transfer-side
+# tokio driver. The shim probes `Handle::try_current()`, adopting an existing
+# runtime or building a session-scoped current-thread runtime and
+# `block_on`-ing the transfer future. No tokio type appears in any public
+# `core` signature. See docs/design/asy-2-tokio-runtime-feature.md section 5.
+tokio-transfer = ["async", "dep:tokio", "transfer/tokio-transfer"]
+
 
 # DEPRECATED (ISI.h): sender INC_RECURSE is now default-on. Marker
 # retained for one release until ISI.i.2 retires the feature flag.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,6 +29,15 @@ pub mod message;
 /// Implements the `--rsh`/`-e` option handling from upstream `options.c`
 /// and the shell execution logic from `main.c:do_cmd()`.
 pub mod remote_shell;
+/// Session-level transfer pipeline driver selection and tokio runtime
+/// ownership shim.
+///
+/// Exposes `session::run_server_stdio`, a driver-agnostic facade over the
+/// server entry point. When the `tokio-transfer` feature is off it forwards to
+/// the threaded `transfer::run_server_stdio` with zero tokio in the path;
+/// when on, it owns the tokio runtime and drives the transfer future. The
+/// public signature is identical in both cases.
+pub mod session;
 /// Server orchestration helpers consumed by CLI and embedding entry points.
 ///
 /// Re-exported from the [`transfer`] crate for backward compatibility.

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,0 +1,143 @@
+//! Session-level pipeline driver selection and tokio runtime ownership shim.
+//!
+//! `core` owns the choice of transfer pipeline driver. The public entry point
+//! (`run_server_stdio`) keeps the exact same signature and
+//! `Result<ServerStats, io::Error>` shape regardless of the `tokio-transfer`
+//! feature - the feature only swaps the *driver*, never the API
+//! (`docs/design/asy-2-tokio-runtime-feature.md` section 4).
+//!
+//! # Runtime ownership (ASY-3)
+//!
+//! Per section 5 of the design, `core` is the only crate permitted to build a
+//! tokio runtime for the transfer path. When `tokio-transfer` is on,
+//! `run_server_stdio` probes `tokio::runtime::Handle::try_current()`:
+//!
+//! - If an ambient runtime exists (e.g. the SSH transport's current-thread
+//!   runtime), its handle is **adopted** and the transfer future is driven on
+//!   it without building a second runtime.
+//! - Otherwise a session-scoped `Builder::new_current_thread()` runtime is
+//!   built and the future is driven with `block_on`.
+//!
+//! Crates below `core` (`transfer`, `engine`, `fast_io`) only ever receive a
+//! `tokio::runtime::Handle`; they never build a runtime. No tokio type
+//! appears in any public `core` signature.
+//!
+//! When `tokio-transfer` is off, `run_server_stdio` forwards directly to the
+//! threaded `transfer::run_server_stdio` with zero tokio in the path.
+
+use std::io::{Read, Write};
+
+use crate::server::{ServerConfig, ServerResult};
+use transfer::TransferProgressCallback;
+
+/// Executes the native server over standard I/O, selecting the pipeline driver
+/// according to the `tokio-transfer` feature.
+///
+/// This is the session-level facade the `--server` entry point calls. Its
+/// signature and result are identical whether or not `tokio-transfer` is
+/// enabled; only the driver behind it changes.
+///
+/// # Errors
+///
+/// Propagates every error from the underlying server body unchanged.
+#[cfg(not(feature = "tokio-transfer"))]
+pub fn run_server_stdio(
+    config: ServerConfig,
+    stdin: &mut dyn Read,
+    stdout: &mut dyn Write,
+    progress: Option<&mut dyn TransferProgressCallback>,
+) -> ServerResult {
+    // Threaded production path: byte-for-byte the pre-ASY-3 behaviour, no tokio.
+    transfer::run_server_stdio(config, stdin, stdout, progress)
+}
+
+/// Tokio-hosted variant. See the module docs for the runtime-ownership rules.
+///
+/// # Errors
+///
+/// Propagates every error from the underlying server body unchanged.
+#[cfg(feature = "tokio-transfer")]
+pub fn run_server_stdio(
+    config: ServerConfig,
+    stdin: &mut dyn Read,
+    stdout: &mut dyn Write,
+    progress: Option<&mut dyn TransferProgressCallback>,
+) -> ServerResult {
+    // The handshake is intrinsically part of the server body; perform it inside
+    // the same driver invocation so the tokio path is a drop-in for the
+    // threaded `transfer::run_server_stdio` (which does handshake + transfer).
+    let handshake = transfer::perform_handshake(stdin, stdout)?;
+    with_transfer_runtime(|handle| {
+        transfer::run_server_with_handshake_on(
+            handle, config, handshake, stdin, stdout, progress, None, None,
+        )
+    })
+}
+
+/// Runs `f` with a tokio runtime handle, adopting an ambient runtime when one
+/// exists and otherwise building a session-scoped current-thread runtime.
+///
+/// This is the single place in the workspace that constructs a runtime for the
+/// transfer pipeline. `f` receives a borrowed [`tokio::runtime::Handle`] and
+/// must not outlive it.
+#[cfg(feature = "tokio-transfer")]
+fn with_transfer_runtime<R>(f: impl FnOnce(&tokio::runtime::Handle) -> R) -> R {
+    match tokio::runtime::Handle::try_current() {
+        // Adopt an already-running runtime (e.g. the SSH transport's
+        // current-thread runtime). We must not build a nested runtime here.
+        Ok(handle) => f(&handle),
+        // No ambient runtime: build one scoped to this session. current_thread
+        // keeps the future on the calling thread so borrowed transports stay
+        // valid and wire ordering matches the threaded path. The multi-thread
+        // flavour is reserved for the daemon (design section 5).
+        Err(_) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build session-scoped tokio runtime");
+            f(runtime.handle())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "tokio-transfer"))]
+mod tests {
+    use super::with_transfer_runtime;
+
+    /// ASY-3 open-question 1: with no ambient runtime, the shim builds a
+    /// session-scoped current-thread runtime and runs the closure on it. The
+    /// closure can drive its own `block_on` on the supplied handle (the shape
+    /// the transfer driver uses).
+    #[test]
+    fn shim_builds_runtime_when_none_ambient() {
+        let out = with_transfer_runtime(|handle| {
+            // Driving a future on the built handle must succeed and run on this
+            // thread (current-thread runtime), mirroring the driver's use.
+            handle.block_on(async { 7u32 })
+        });
+        assert_eq!(out, 7);
+    }
+
+    /// With an ambient multi-thread runtime, the shim adopts its handle rather
+    /// than building a second runtime. `block_in_place` is used to prove the
+    /// adopted handle is the ambient one without a nested `block_on` (which
+    /// would panic on the current-thread flavour).
+    #[test]
+    fn shim_adopts_ambient_runtime() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let ambient_id = rt.handle().id();
+        let adopted_id = rt.block_on(async {
+            // Inside the runtime context, try_current() must resolve, so the
+            // shim adopts it. Capture the adopted handle's id to compare.
+            tokio::task::block_in_place(|| with_transfer_runtime(|handle| handle.id()))
+        });
+        assert_eq!(
+            adopted_id, ambient_id,
+            "shim must adopt the ambient runtime, not build a new one"
+        );
+    }
+}

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -25,6 +25,12 @@ async = ["dep:tokio", "core/async"]
 # `docs/design/daemon-async-accept-sync-workers.md` and the concrete
 # implementation steps in `docs/design/daemon-tokio-async-listener-impl.md`.
 async-daemon = ["dep:tokio"]
+# EXPERIMENTAL (ASY-3, default-off): lets the hybrid async listener hand
+# accepted connections to the tokio transfer driver. Implies `async-daemon`
+# (tokio accept loop) and forwards `core/tokio-transfer` so the per-connection
+# server body can run on the runtime. Default-off until the ASY-12 gate. See
+# docs/design/asy-2-tokio-runtime-feature.md section 5.
+tokio-transfer = ["async-daemon", "core/tokio-transfer"]
 # Concurrent session tracking - enables efficient shared state for multi-session daemons
 concurrent-sessions = ["dep:dashmap"]
 # Extended attributes (xattr) preservation during transfers

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -138,6 +138,14 @@ sender-inc-recurse = []
 # Async runtime support - enables tokio-based async pipeline for transfers
 async = ["dep:tokio", "dep:tokio-util"]
 
+# EXPERIMENTAL (ASY-3, default-off): compiles the tokio-hosted transfer
+# driver (`pipeline::tokio_driver`). Implies `async` (which pulls tokio +
+# tokio-util). For this rung the driver hosts the existing sync server body
+# on a tokio runtime and produces byte-identical wire output; per-boundary
+# `.await` conversion is deferred to ASY-7/8. See
+# docs/design/asy-3-async-boundary-spec.md.
+tokio-transfer = ["async"]
+
 # ============================================================================
 # Debugging Features
 # ============================================================================

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -198,6 +198,12 @@ pub use pipeline::{
 pub use progress::{ItemizeCallback, TransferProgressCallback, TransferProgressEvent};
 pub use transfer_state::{InvalidTransition, TransferPhase, TransferPipeline};
 
+// ASY-3: tokio-hosted server driver entry point. Re-exported so `core`'s
+// session shim can call it without reaching into the private `pipeline` module.
+// Default-off behind `tokio-transfer`; the threaded path never references it.
+#[cfg(feature = "tokio-transfer")]
+pub use pipeline::tokio_driver::run_server_with_handshake_on;
+
 /// Batch recording configuration for protocol stream teeing.
 ///
 /// When provided to `run_server_with_handshake`, enables post-demux (reader) or

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -72,6 +72,12 @@ pub mod async_dispatch;
 #[cfg(feature = "async")]
 pub mod async_pipeline;
 
+// ASY-3: tokio-hosted server driver. Gated on `tokio-transfer` (which implies
+// `async`), it hosts the sync server body on a tokio runtime and is wired into
+// the `core` session shim. Default-off; the threaded path is unchanged.
+#[cfg(feature = "tokio-transfer")]
+pub mod tokio_driver;
+
 pub use job::{FileJob, FileList, MAX_RETRY_COUNT, TransferFlags};
 pub use pending::PendingTransfer;
 pub use state::PipelineState;

--- a/crates/transfer/src/pipeline/tokio_driver.rs
+++ b/crates/transfer/src/pipeline/tokio_driver.rs
@@ -1,0 +1,124 @@
+//! Tokio-hosted driver for the server transfer pipeline (ASY-3 foundation).
+//!
+//! This module is the `tokio-transfer` counterpart to the threaded call into
+//! [`crate::run_server_with_handshake`]. For the ASY-3 rung it hosts the
+//! **existing synchronous** server body on a tokio runtime so the runtime
+//! ownership and wire-in scaffold can be proven end-to-end without converting
+//! any per-boundary blocking site to `.await`. Those conversions land in
+//! ASY-7/8 (see `docs/design/asy-3-async-boundary-spec.md`).
+//!
+//! # Byte-for-byte parity
+//!
+//! The driver runs the **same** [`crate::run_server_with_handshake`] code path
+//! as the threaded caller. The only difference is that the call is issued from
+//! inside a tokio `block_on` future rather than directly on the caller stack.
+//! The current-thread runtime executes the future on the calling thread, so the
+//! borrowed `stdin` / `stdout` transports stay valid and every wire byte, flush
+//! ordering, checksum, and goodbye handshake is identical to the threaded path.
+//! The hosting-primitive equivalence is asserted by the unit tests in this
+//! module; the full-transfer wire-byte parity is proven by a real oc-rsync
+//! self-transfer (client vs `--rsh` server) with a pinned `--checksum-seed`.
+//!
+//! # Runtime ownership
+//!
+//! Per `docs/design/asy-2-tokio-runtime-feature.md` section 5, no crate below
+//! `core` builds a runtime. The driver receives a [`tokio::runtime::Handle`]
+//! from `core`'s session shim and uses [`Handle::block_on`] to drive the
+//! future. `core` decides whether that handle was adopted from an ambient
+//! runtime or built as a session-scoped current-thread runtime.
+
+use std::io::{Read, Write};
+
+use tokio::runtime::Handle;
+
+use crate::{
+    BatchRecording, HandshakeResult, ItemizeCallback, ServerConfig, ServerResult,
+    TransferProgressCallback, run_server_with_handshake,
+};
+
+/// Drives [`run_server_with_handshake`] on the supplied tokio runtime handle.
+///
+/// This is the ASY-3 tokio entry point. It is signature-compatible with
+/// [`run_server_with_handshake`] except for the leading `handle` argument,
+/// which is the runtime the future is driven on. The synchronous server body
+/// runs inside the `block_on` future on the current thread, so borrowed
+/// transports remain valid and the wire output is byte-identical to the
+/// threaded path.
+///
+/// No tokio type appears in the return value: the caller in `core` sees the
+/// same [`ServerResult`] the threaded path returns. `handle` is an internal
+/// implementation detail passed down from the `core` session shim and never
+/// escapes into a public `core` signature.
+///
+/// # Errors
+///
+/// Propagates every error from [`run_server_with_handshake`] unchanged.
+pub fn run_server_with_handshake_on<W: Write>(
+    handle: &Handle,
+    config: ServerConfig,
+    handshake: HandshakeResult,
+    stdin: &mut dyn Read,
+    stdout: W,
+    progress: Option<&mut dyn TransferProgressCallback>,
+    batch: Option<BatchRecording>,
+    itemize: Option<&mut dyn ItemizeCallback>,
+) -> ServerResult {
+    // Run the synchronous server body inside the runtime. ASY-7/8 replace the
+    // inline sync call with per-boundary `.await` sites; ASY-3 only establishes
+    // the runtime-hosted scaffold.
+    host_sync_on(handle, move || {
+        run_server_with_handshake(config, handshake, stdin, stdout, progress, batch, itemize)
+    })
+}
+
+/// Runs a synchronous closure inside the runtime `handle` via `block_on`.
+///
+/// `block_on` on a current-thread runtime executes the future on the calling
+/// thread, so the closure may borrow non-`Send` / non-`'static` state (the
+/// borrowed `stdin` / `stdout` transports) and still run to completion. This is
+/// the single hosting primitive the ASY-3 driver uses; ASY-7/8 replace the body
+/// of the hosted closure with `.await` sites without changing this shape.
+fn host_sync_on<R>(handle: &Handle, f: impl FnOnce() -> R) -> R {
+    handle.block_on(async move { f() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_sync_on;
+    use std::io::Write;
+    use tokio::runtime::Builder;
+
+    /// The runtime-hosting primitive preserves borrowed-state access and returns
+    /// the closure's value unchanged. This is the ASY-3 invariant that lets the
+    /// driver host the sync server body without moving borrowed transports into
+    /// `spawn_blocking`.
+    #[test]
+    fn host_sync_on_runs_closure_with_borrows_and_returns_value() {
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        let mut out: Vec<u8> = Vec::new();
+        let ret = host_sync_on(rt.handle(), || {
+            out.write_all(b"wire-bytes").unwrap();
+            42u32
+        });
+        assert_eq!(ret, 42);
+        assert_eq!(out, b"wire-bytes");
+    }
+
+    /// Hosting a closure on the runtime yields byte-identical output to running
+    /// it directly. This is the mechanical core of the tokio-driver parity
+    /// claim: the runtime only changes *where* the sync body runs, not *what* it
+    /// writes.
+    #[test]
+    fn hosted_output_matches_direct_output() {
+        let payload: &[u8] = b"the quick brown fox\x00\x01\x02frame";
+
+        let mut direct = Vec::new();
+        direct.write_all(payload).unwrap();
+
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        let mut hosted = Vec::new();
+        host_sync_on(rt.handle(), || hosted.write_all(payload).unwrap());
+
+        assert_eq!(direct, hosted, "hosted wire output must be byte-identical");
+    }
+}


### PR DESCRIPTION
First rung of the async migration (ASY, greenlit). Establishes the `tokio-transfer` cargo feature + tokio runtime-ownership shim in `core::session()` + promotes the `async_pipeline` skeleton into a real feature-gated driver. **DEFAULT-OFF and experimental** — the threaded production path is byte-identical; this only compiles a tokio-hosted alternative when the flag is on. Per `docs/design/asy-2-tokio-runtime-feature.md`.

- **Feature forwarding** (§2.2): root `tokio-transfer` → core/transfer/daemon (implies `async`); transfer pulls tokio via async; core adds the runtime shim; daemon reaches the tokio path via `async-daemon`. engine/fast_io/protocol untouched (stay sync).
- **Runtime shim** (§5): new `core::session::run_server_stdio` facade with an **identical signature/result** both feature states (no tokio in any public core signature). OFF → threaded `transfer::run_server_stdio` unchanged. ON → sync handshake, then probe `Handle::try_current()` → adopt ambient runtime else build a session-scoped `new_current_thread()` + `block_on`. Only place a transfer-path runtime is built.
- **Driver wire-in** (§4/§6): new `transfer/pipeline/tokio_driver.rs` (`#[cfg(feature="tokio-transfer")]`) hosts the existing SYNC `run_server_with_handshake` body inside the runtime via `host_sync_on` (current-thread `block_on` runs the closure inline, so borrowed stdin/stdout stay valid). No per-boundary `.await` conversion — that's ASY-7/8.

**Proof — default unchanged:** `cargo build --workspace` green; CLI server suite 127/127; protocol golden wire 313/313. **Proof — feature-on byte-identical:** builds+clippy both states clean; new shim/hosting tests pass; **real self-transfer parity** (server side runs the tokio driver via `--rsh` peer, push+pull): identical dest trees/checksums/itemize/stats/exit, and byte-identical wire with pinned `--checksum-seed`.

Documented experimental in help/feature comments; NOT default-on (that's ASY-12, bench-gated). Next rungs (ASY-7 receiver, ASY-8 sender) build on this in sequence.

Note: a pre-existing `manual_ok_err` clippy lint in untouched `daemon module_directives.rs:59` (newer clippy) is out of scope (Rule 3).