### PR TITLE
fix(daemon): keep macOS kqueue accept in lockstep with connection admission

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -292,7 +292,7 @@ impl AcceptEngine for MultiListenerEngine {
 }
 
 /// macOS `kqueue` accept engine: one `EVFILT_READ` registration per listener,
-/// readiness-driven `accept` with no per-iteration sleep.
+/// readiness-driven `accept` that yields exactly one connection per poll.
 ///
 /// Replaces the busy-wait shape of the portable engines (non-blocking `accept`
 /// plus a 50ms `WouldBlock` sleep) with a single `kevent(2)` wait over all
@@ -302,29 +302,48 @@ impl AcceptEngine for MultiListenerEngine {
 /// still bounding shutdown-flag inspection to the same 100ms cadence the
 /// dual-stack engine uses.
 ///
-/// The listeners are set non-blocking and registered `EVFILT_READ | EV_CLEAR`
-/// (edge-triggered). Because edge-triggered readiness fires once per readable
-/// transition, each ready listener is drained with repeated `accept` calls until
-/// `WouldBlock`, so a burst that queues several connections behind one
-/// notification is never dropped. Surplus accepted streams are buffered and
-/// handed out one per [`poll`](AcceptEngine::poll), preserving the "one
-/// connection per poll" contract the shared loop body relies on.
+/// # One connection per poll (admission correctness)
 ///
-/// Admission (`--max-connections`) and the N-listener fan-out are unchanged:
-/// this engine only sources accepted streams; the shared loop body still gates
-/// every returned connection through the process-global admission counter.
+/// The engine returns **exactly one** accepted connection per
+/// [`poll`](AcceptEngine::poll), matching the single-listener engine's
+/// one-at-a-time contract. This is load-bearing for `--max-connections`
+/// accounting: the shared accept loop reaps finished worker threads (dropping
+/// their [`ConnectionGuard`]s) only once per loop iteration, *before* it polls.
+/// An engine that drained and buffered several ready connections in one poll
+/// would hand them to the admission path back-to-back with no intervening reap,
+/// so guards from just-completed sequential transfers - still held while their
+/// worker threads finish teardown after the client has disconnected - would
+/// accumulate and spuriously trip the cap under rapid sequential load. Yielding
+/// one per poll routes every connection through the loop body's reap cadence,
+/// keeping the process-global counter in lockstep exactly as the portable
+/// engines do.
+///
+/// # Level-triggered readiness
+///
+/// Listeners are registered `EVFILT_READ` **without** `EV_CLEAR`
+/// (level-triggered) via [`submit_read_level`]. Because only one connection is
+/// taken per wake, a backlog that queues several connections must re-fire on the
+/// next `wait`; an edge-triggered (`EV_CLEAR`) registration would consume the
+/// edge after the first accept and strand the remainder until a *new* connection
+/// arrived. Level-triggered readiness re-surfaces the pending backlog on every
+/// poll, so no queued connection is ever lost.
+///
+/// Admission (`--max-connections`) and the N-listener fan-out are otherwise
+/// unchanged: this engine only sources accepted streams; the shared loop body
+/// still gates every returned connection through the process-global admission
+/// counter.
 ///
 /// Selected by [`build_accept_engine`] on macOS with a graceful fallback to the
 /// portable engines if `kqueue(2)` setup fails, so a kqueue error never breaks
 /// connection service.
+///
+/// [`submit_read_level`]: fast_io::KqueueLoop::submit_read_level
 #[cfg(target_os = "macos")]
 struct KqueueAcceptEngine {
     /// Registered listeners keyed by their `EVFILT_READ` user-data index.
     listeners: Vec<(TcpListener, SocketAddr)>,
     /// kqueue event surface; dropped (closing its fd) on [`Self::shutdown`].
     kq: fast_io::KqueueLoop,
-    /// Accepted streams drained from a readiness burst but not yet handed out.
-    pending: std::collections::VecDeque<(TcpStream, SocketAddr)>,
     log_sink: Option<SharedLogSink>,
 }
 
@@ -334,7 +353,8 @@ impl KqueueAcceptEngine {
     /// engine's `recv_timeout` interval so shutdown latency is identical.
     const WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 
-    /// Builds the engine, registering an `EVFILT_READ` event per listener.
+    /// Builds the engine, registering a level-triggered `EVFILT_READ` event per
+    /// listener.
     ///
     /// Returns an `io::Error` (not a [`DaemonError`]) so the caller can fall
     /// back to the portable engines on any kqueue setup failure without
@@ -353,30 +373,33 @@ impl KqueueAcceptEngine {
             .zip(bound_addresses.iter().copied())
             .enumerate()
         {
-            // Non-blocking so the drain-accept loop terminates on WouldBlock
-            // instead of blocking after the edge-triggered notification.
+            // Non-blocking so the single accept below returns WouldBlock (rather
+            // than blocking) if the readiness was spurious or already consumed.
             listener.set_nonblocking(true)?;
-            kq.submit_read(listener.as_raw_fd(), index as u64)?;
+            // Level-triggered: a pending backlog re-fires on the next wait, so
+            // taking one connection per poll never strands queued connections.
+            kq.submit_read_level(listener.as_raw_fd(), index as u64)?;
             registered.push((listener, local_addr));
         }
         Ok(Self {
             listeners: registered,
             kq,
-            pending: std::collections::VecDeque::new(),
             log_sink,
         })
     }
 
-    /// Drains all currently-pending connections from one ready listener.
+    /// Accepts exactly one connection from a ready listener.
     ///
-    /// Edge-triggered readiness fires once per readable transition, so a single
-    /// notification may cover several queued connections. Accept until
-    /// `WouldBlock` to avoid stranding a connection behind the edge until the
-    /// next transition. Accepted streams are reset to blocking (BSD kernels
-    /// propagate the listener's `O_NONBLOCK` to the accepted socket) and pushed
-    /// onto the pending queue. Returns the local address paired with a fatal
-    /// accept error, or `None` when the listener drained cleanly.
-    fn drain_listener(&mut self, index: usize) -> Option<(SocketAddr, io::Error)> {
+    /// Returns the accepted (blocking) stream on success, `Ok(None)` if the
+    /// readiness was spurious / already consumed (`WouldBlock`) or the accepted
+    /// socket could not be reset to blocking, or the fatal accept error paired
+    /// with the listener's local address. Accepted streams are reset to blocking
+    /// because BSD kernels propagate the listener's `O_NONBLOCK` to the accepted
+    /// socket, which would otherwise break the synchronous handshake reader.
+    fn accept_one(
+        &self,
+        index: usize,
+    ) -> Result<Option<(TcpStream, SocketAddr)>, (SocketAddr, io::Error)> {
         let (listener, local_addr) = &self.listeners[index];
         let local_addr = *local_addr;
         loop {
@@ -389,13 +412,13 @@ impl KqueueAcceptEngine {
                             let message = rsync_warning!(text).with_role(Role::Daemon);
                             log_message(log, &message);
                         }
-                        continue;
+                        return Ok(None);
                     }
-                    self.pending.push_back((stream, peer_addr));
+                    return Ok(Some((stream, peer_addr)));
                 }
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return None,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(None),
                 Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
-                Err(error) => return Some((local_addr, error)),
+                Err(error) => return Err((local_addr, error)),
             }
         }
     }
@@ -404,10 +427,6 @@ impl KqueueAcceptEngine {
 #[cfg(target_os = "macos")]
 impl AcceptEngine for KqueueAcceptEngine {
     fn poll(&mut self) -> Result<AcceptOutcome, DaemonError> {
-        if let Some((stream, peer_addr)) = self.pending.pop_front() {
-            return Ok(AcceptOutcome::Connection(stream, peer_addr));
-        }
-
         let events = match self.kq.wait(Some(Self::WAIT_TIMEOUT)) {
             Ok(events) => events,
             // EINTR is folded into an empty result by KqueueLoop::wait; any
@@ -421,20 +440,26 @@ impl AcceptEngine for KqueueAcceptEngine {
             return Ok(AcceptOutcome::Idle);
         }
 
+        // Take exactly one connection this poll so every admission is preceded
+        // by the loop body's worker-reap step. Level-triggered readiness re-
+        // fires the remaining backlog on the next poll, so nothing is stranded.
         let mut fatal: Option<(SocketAddr, io::Error)> = None;
         for event in events {
             let index = event.user_data as usize;
             if index >= self.listeners.len() {
                 continue;
             }
-            if let Some(err) = self.drain_listener(index) {
-                fatal.get_or_insert(err);
+            match self.accept_one(index) {
+                Ok(Some((stream, peer_addr))) => {
+                    return Ok(AcceptOutcome::Connection(stream, peer_addr));
+                }
+                Ok(None) => continue,
+                Err(err) => {
+                    fatal.get_or_insert(err);
+                }
             }
         }
 
-        if let Some((stream, peer_addr)) = self.pending.pop_front() {
-            return Ok(AcceptOutcome::Connection(stream, peer_addr));
-        }
         if let Some((local_addr, error)) = fatal {
             return Err(accept_error(local_addr, error));
         }
@@ -444,8 +469,7 @@ impl AcceptEngine for KqueueAcceptEngine {
     fn shutdown(&mut self) {
         // The KqueueLoop closes its fd on drop; there are no acceptor threads to
         // join. Clearing the listeners drops their fds too, matching the
-        // portable engines' teardown. Idempotent: a second call finds both empty.
-        self.pending.clear();
+        // portable engines' teardown. Idempotent: a second call finds it empty.
         self.listeners.clear();
     }
 }

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1436,11 +1436,12 @@ fn kqueue_engine_poll_returns_connection_with_blocking_reset() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn kqueue_engine_drains_burst_behind_one_notification() {
-    // Edge-triggered readiness (EV_CLEAR) fires once per readable transition, so
-    // several connections queued before a single kevent wake must all be
-    // drained rather than stranded. Connect three clients up front, then verify
-    // the engine hands back three distinct connections across successive polls.
+fn kqueue_engine_level_triggered_backlog_is_not_stranded() {
+    // Level-triggered readiness must re-surface a queued backlog on successive
+    // polls even though the engine takes only ONE connection per poll. Connect
+    // three clients up front, then verify the engine hands back all three
+    // distinct connections across successive polls (none stranded behind a
+    // consumed edge - the failure mode an EV_CLEAR registration would cause).
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let local = listener.local_addr().expect("local addr");
 
@@ -1468,7 +1469,63 @@ fn kqueue_engine_drains_burst_behind_one_notification() {
             AcceptOutcome::Closed => panic!("kqueue engine never reports Closed"),
         }
     }
-    assert_eq!(accepted, 3, "all queued connections must be drained, not dropped");
+    assert_eq!(accepted, 3, "all queued connections must be delivered, not stranded");
+
+    engine.shutdown();
+    drop(clients);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn kqueue_engine_needs_one_poll_per_queued_connection() {
+    // Admission-lockstep invariant: the engine must NOT drain and buffer a
+    // ready backlog inside a single poll. The shared accept loop reaps finished
+    // worker threads (dropping their connection guards) once per iteration,
+    // immediately before it polls; if one poll returned several connections
+    // their admissions would run back-to-back with no intervening reap. Yielding
+    // one connection per poll keeps the `max connections` accounting in lockstep
+    // with the loop's reap cadence, matching the single-listener engine.
+    //
+    // This is observable: with three clients queued up front, delivering all
+    // three requires (at least) three separate `poll()` calls that each return a
+    // `Connection`. A drain-and-buffer engine would satisfy the 2nd and 3rd from
+    // an internal queue without a fresh readiness wait; this test asserts the
+    // externally-visible contract that each connection costs its own poll.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+
+    let mut clients = Vec::new();
+    for _ in 0..3 {
+        clients.push(TcpStream::connect(local).expect("connect"));
+    }
+    thread::sleep(Duration::from_millis(50));
+
+    let mut engine =
+        KqueueAcceptEngine::new(vec![listener], &[local], None).expect("kqueue engine");
+
+    // Count how many polls returned a Connection. Each poll returns at most one
+    // (the engine returns on the first successful accept), so three queued
+    // clients require three connection-returning polls.
+    let mut connection_polls = 0;
+    for _ in 0..40 {
+        match engine.poll().expect("poll") {
+            AcceptOutcome::Connection(_, peer) => {
+                assert!(peer.ip().is_loopback());
+                connection_polls += 1;
+                if connection_polls == 3 {
+                    break;
+                }
+            }
+            AcceptOutcome::Idle => continue,
+            AcceptOutcome::Closed => panic!("kqueue engine never reports Closed"),
+        }
+    }
+
+    assert_eq!(
+        connection_polls, 3,
+        "each queued connection must be delivered by its own poll so admission \
+         stays in lockstep with per-iteration worker reaping"
+    );
 
     engine.shutdown();
     drop(clients);

--- a/crates/daemon/tests/connection_lifecycle_fsm.rs
+++ b/crates/daemon/tests/connection_lifecycle_fsm.rs
@@ -42,14 +42,28 @@ fn spawn_daemon(
     thread::JoinHandle<Result<(), daemon::DaemonError>>,
     SignalFlags,
 ) {
+    spawn_daemon_with_args(listener, port, &[])
+}
+
+/// Spawns a daemon with additional CLI arguments beyond `--no-detach --port`.
+fn spawn_daemon_with_args(
+    listener: TcpListener,
+    port: u16,
+    extra_args: &[&str],
+) -> (
+    thread::JoinHandle<Result<(), daemon::DaemonError>>,
+    SignalFlags,
+) {
     let flags = SignalFlags::new();
+    let mut args = vec![
+        "--no-detach".to_string(),
+        "--port".to_string(),
+        port.to_string(),
+    ];
+    args.extend(extra_args.iter().map(|a| (*a).to_string()));
     let config = DaemonConfig::builder()
         .disable_default_paths()
-        .arguments([
-            "--no-detach".to_string(),
-            "--port".to_string(),
-            port.to_string(),
-        ])
+        .arguments(args)
         .pre_bound_listener(listener)
         .signal_flags(flags.clone())
         .build();
@@ -293,6 +307,78 @@ fn lifecycle_multiple_sequential_connections() {
     assert!(
         result.is_ok(),
         "daemon should handle multiple sequential connections: {result:?}"
+    );
+}
+
+/// Rapid sequential connections under `--max-connections` must never be
+/// spuriously refused: the active count must return to zero between fully
+/// completed sessions.
+///
+/// Guards the macOS interop `max connections (N) reached` failure class,
+/// where connection-slot accounting drifts out of lockstep with the accept
+/// engine. The engine used on macOS is selected by `build_accept_engine`
+/// (the kqueue engine here); this exercises it end-to-end through the real
+/// `run_daemon` accept loop.
+///
+/// Drives 12 fully-completed sequential lifecycles against a daemon capped at
+/// 4 connections. Each session runs to `@RSYNCD: EXIT`, so no two are
+/// concurrent and the active count returns to zero between them. Every
+/// connection must therefore receive the `@RSYNCD:` greeting; a
+/// `@ERROR: max connections` first line would prove a leaked slot.
+#[test]
+fn lifecycle_max_connections_sequential_no_leak() {
+    const CAP: usize = 4;
+    const ITERATIONS: usize = CAP * 3; // Well past the cap: N+2 and then some.
+
+    let (port, listener) = allocate_listener();
+    let (handle, flags) = spawn_daemon_with_args(listener, port, &["--max-connections", "4"]);
+
+    for i in 0..ITERATIONS {
+        let stream = connect_with_timeout(port);
+        let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+        let mut writer = stream;
+
+        // First line MUST be the greeting. A `@ERROR: max connections ...`
+        // line here means a slot from an already-completed sequential session
+        // was never released - the exact regression under test.
+        let first = read_greeting(&mut reader);
+        assert!(
+            first.starts_with("@RSYNCD:") && !first.contains("max connections"),
+            "connection {i}: expected @RSYNCD greeting, got refusal/other: {first:?}"
+        );
+
+        // Drive the full lifecycle to completion so the worker finishes and
+        // drops its ConnectionGuard before the next iteration connects.
+        send_version(&mut writer);
+        let module = format!("no_such_module_{i}\n");
+        writer.write_all(module.as_bytes()).expect("send module");
+        writer.flush().expect("flush module");
+
+        let mut saw_exit = false;
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Err(_) => break,
+                Ok(_) => {}
+            }
+            if line.trim() == "@RSYNCD: EXIT" {
+                saw_exit = true;
+                break;
+            }
+        }
+        assert!(saw_exit, "connection {i}: daemon should send @RSYNCD: EXIT");
+
+        drop(writer);
+        drop(reader);
+    }
+
+    flags.shutdown.store(true, Ordering::Relaxed);
+    let result = handle.join().expect("daemon thread");
+    assert!(
+        result.is_ok(),
+        "daemon should serve all sequential connections without leaking a \
+         max-connections slot: {result:?}"
     );
 }
 

--- a/crates/fast_io/src/kqueue/mod.rs
+++ b/crates/fast_io/src/kqueue/mod.rs
@@ -158,6 +158,27 @@ impl KqueueLoop {
         self.submit_event(fd, KEventFilter::Read, user_data)
     }
 
+    /// Registers a **level-triggered** `EVFILT_READ` readiness event.
+    ///
+    /// Uses `EV_ADD` without `EV_CLEAR`, so the event keeps re-firing on
+    /// every [`wait`](Self::wait) while any readability remains (matching
+    /// the Linux non-`EPOLLET` shape). This is the correct mode for
+    /// consumers that intentionally handle **one** ready item per wake and
+    /// rely on the next `wait` to re-surface a still-pending backlog - for
+    /// example a listener fd where the accept loop takes a single
+    /// connection per poll and must not lose queued connections behind a
+    /// consumed edge.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if `kevent(2)` rejects the registration.
+    pub fn submit_read_level(&self, fd: RawFd, user_data: u64) -> io::Result<()> {
+        let change = make_kevent(fd, KEventFilter::Read.as_raw(), libc::EV_ADD, user_data);
+        let rc = self.kevent_call(Some(&change), None, None)?;
+        debug_assert_eq!(rc, 0, "registration kevent returns 0 with empty eventlist");
+        Ok(())
+    }
+
     /// Registers an `EVFILT_WRITE` readiness event for the given fd.
     ///
     /// See [`submit_read`](Self::submit_read) for semantics. This is

--- a/crates/fast_io/src/kqueue_stub.rs
+++ b/crates/fast_io/src/kqueue_stub.rs
@@ -108,6 +108,18 @@ impl KqueueLoop {
     /// # Errors
     ///
     /// Returns an `io::Error` with kind [`io::ErrorKind::Unsupported`].
+    pub fn submit_read_level(&self, _fd: RawFd, _user_data: u64) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "kqueue is only available on macOS",
+        ))
+    }
+
+    /// Stub - always returns `Unsupported`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` with kind [`io::ErrorKind::Unsupported`].
     pub fn submit_write(&self, _fd: RawFd, _user_data: u64) -> io::Result<()> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,


### PR DESCRIPTION
Follow-up fix for #6217 (merged as a93377f9b). The macOS `interop (macOS)` check on #6217 failed with `@ERROR: max connections (4) reached` — a real regression in the new kqueue accept engine.

**Root cause** (traced, not guessed): the drain-and-buffer engine (edge-triggered `EV_CLEAR`) accepted the *entire* ready backlog in one `poll()` and buffered the surplus. The shared accept loop reaps finished workers (releasing `ConnectionLimiter` lock-file slots via the `ConnectionLockGuard` RAII drop) **once per iteration, right before it polls**. When one poll returns several connections, their admissions run back-to-back with **no intervening reap**, so slots from just-completed sessions (whose worker threads are still tearing down) accumulate and trip the `max connections = 4` cap under rapid sequential load. The blocking `SingleListenerEngine` never does this — it returns exactly one connection per poll, so every admission is preceded by a reap.

**Fix** (the clean direction): replace drain-and-buffer with **level-triggered readiness that yields exactly one connection per poll**, restoring the one-accept-per-reap cadence the blocking engine has.
- New `KqueueLoop::submit_read_level` in `fast_io` (`EV_ADD` without `EV_CLEAR`) + stub counterpart.
- Engine registers listeners level-triggered; `poll()` returns on the first successful `accept` (no `pending` buffer, no `drain_listener`). A pending backlog re-fires on the next poll — nothing stranded behind a consumed edge.
- Fallback, shutdown, N-listener registration, blocking-reset of accepted sockets unchanged; Linux/blocking engines byte-identical.

**Verified (Rust 1.88.0):** `cargo build/clippy(-D warnings)/fmt/doc` clean for daemon + fast_io; `cargo test -p daemon --all-features` **1342 pass / 0 fail** (incl. new `kqueue_engine_needs_one_poll_per_queued_connection`, `lifecycle_max_connections_sequential_no_leak` asserting one-conn-per-poll + N+2 sequential admission with no slot leak through the real `run_daemon` loop); local interop smoke **29 PASS**, identical to the master blocking engine. This PR's `interop (macOS)` check is the true gate — will confirm green before merge.