### PR TITLE
feat(transfer): async transport wrapper seam under tokio-transfer (ASY-4, default-off)

### DIFF
--- a/crates/transfer/src/pipeline/async_transport.rs
+++ b/crates/transfer/src/pipeline/async_transport.rs
@@ -1,0 +1,230 @@
+//! Async transport wrapper seam over the socket-backed transport (ASY-4).
+//!
+//! This module provides an internal `tokio::io::AsyncRead + AsyncWrite` adapter
+//! over the real transport socket. It is the prerequisite the coupled receiver
+//! conversion (re-chartered ASY-7, see `docs/design/asy-7-receiver-tokio-prototype.md`
+//! section 5) consumes: an async socket boundary that a future async-prefetch
+//! task can `.await`, feeding the sync demux stack under `spawn_blocking`.
+//!
+//! # Scope (ASY-4)
+//!
+//! This is the transport wrapper **only**. It is additive scaffolding and is
+//! **not** wired into the receiver read path, the multiplex demux, the SPSC
+//! disk bridge, or `core::session`. Wiring it into a transfer is the deferred
+//! coupled ASY-7-redo rung. Nothing here changes the default build: the module
+//! is compiled out entirely unless `tokio-transfer` is on.
+//!
+//! # Which transports it applies to
+//!
+//! Only transports backed by a real socket file descriptor. The daemon's
+//! `rsync://` connection carries a concrete `std::net::TcpStream`
+//! (`daemon::DaemonStream::Plain`, exposed via
+//! `DaemonStream::tcp_stream() -> Option<&TcpStream>`). SSH / stdio transports
+//! are pipe-backed (`DaemonStream::Stdio`, `Box<dyn Read>` / `Box<dyn Write>`)
+//! and have no async socket to adopt. Callers mirror the NSV-1 `Option<fd>`
+//! shape: they take the socket only when one exists and skip the wrapper
+//! otherwise. See [`from_std_tcp`](AsyncTransport::from_std_tcp) for the
+//! socket case; the pipe case has no constructor here by design.
+//!
+//! # Runtime-context requirement
+//!
+//! [`tokio::net::TcpStream::from_std`] must be called from within a tokio
+//! runtime context (a reactor must be registered for the socket). Within the
+//! ASY-3 current-thread runtime this holds: `core`'s session shim builds or
+//! adopts a runtime and `block_on`s the transfer future, so any code driven
+//! under that `block_on` (or a `Handle::enter()` guard) satisfies the
+//! requirement. Constructing an `AsyncTransport` outside any runtime context
+//! returns an `io::Error` from tokio rather than panicking; the unit tests
+//! exercise the in-context path.
+//!
+//! # No public tokio surface
+//!
+//! Per `docs/design/asy-2-tokio-runtime-feature.md` section 4, no tokio type
+//! appears in any public signature of `transfer` or `core`. This type is
+//! `pub(crate)` and never escapes into an exported signature; it is an
+//! implementation detail of the future tokio receiver.
+
+// ASY-4 is deliberately unwired scaffolding: the adapter is exercised by the
+// module's own tests but has no non-test caller yet (the coupled ASY-7-redo
+// receiver rung is deferred). Allow dead_code so the seam can land ahead of its
+// consumer without tripping `-D warnings`; the allow is removed when the
+// receiver rung wires it in.
+#![allow(dead_code)]
+
+use std::io;
+use std::net::TcpStream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream as TokioTcpStream;
+
+/// An `AsyncRead + AsyncWrite` adapter over a socket-backed transport.
+///
+/// Wraps a [`tokio::net::TcpStream`] adopted from a blocking
+/// [`std::net::TcpStream`]. All poll methods delegate to the inner tokio
+/// socket, so the adapter adds no buffering of its own (avoiding the
+/// double-buffering ASY-2 open-question 2 flags). It exists so the coupled
+/// ASY-7-redo receiver rung has a single async socket boundary to build on.
+pub(crate) struct AsyncTransport {
+    inner: TokioTcpStream,
+}
+
+impl AsyncTransport {
+    /// Adopts a blocking [`std::net::TcpStream`] as an async transport.
+    ///
+    /// The socket is switched to non-blocking mode inside this constructor
+    /// (`TcpStream::set_nonblocking(true)`), which is the precondition
+    /// [`tokio::net::TcpStream::from_std`] requires: tokio drives the socket
+    /// via its reactor and a blocking socket would stall the runtime. Callers
+    /// therefore need not pre-configure the socket.
+    ///
+    /// Only call this for a transport that owns a real socket fd (the daemon
+    /// `rsync://` path via `DaemonStream::Plain`). Pipe-backed transports
+    /// (SSH / stdio) have no socket and must not reach this constructor; there
+    /// is no equivalent for them by design (they stay on the sync path).
+    ///
+    /// # Runtime context
+    ///
+    /// Must be invoked from within a tokio runtime context so the socket can
+    /// register with the reactor. Under the ASY-3 model this is any code driven
+    /// by `core`'s session `block_on` / `Handle`. Outside a runtime context
+    /// tokio returns an `io::Error` (it does not panic).
+    ///
+    /// # Errors
+    ///
+    /// Returns any error from `set_nonblocking` or
+    /// [`tokio::net::TcpStream::from_std`] (including the no-reactor case).
+    pub(crate) fn from_std_tcp(stream: TcpStream) -> io::Result<Self> {
+        stream.set_nonblocking(true)?;
+        let inner = TokioTcpStream::from_std(stream)?;
+        Ok(Self { inner })
+    }
+}
+
+impl AsyncRead for AsyncTransport {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for AsyncTransport {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AsyncTransport;
+    use std::net::{TcpListener, TcpStream};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::runtime::Builder;
+
+    /// Builds a connected blocking `TcpStream` pair on loopback. Returns the
+    /// two ends of one connection so a byte written into one is read from the
+    /// other. Both ends are blocking; the wrapper flips them to non-blocking.
+    fn connected_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        (client, server)
+    }
+
+    /// `from_std_tcp` flips a blocking socket to non-blocking, which is the
+    /// precondition `tokio::net::TcpStream::from_std` requires. This proves the
+    /// constructor sets the mode the runtime relies on rather than leaving the
+    /// caller to do it.
+    #[test]
+    fn from_std_tcp_sets_nonblocking() {
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            let (client, _server) = connected_pair();
+            // Adopt the blocking client socket; the constructor must have
+            // set it non-blocking for the reactor to drive it.
+            let adopted = AsyncTransport::from_std_tcp(client).expect("adopt socket");
+            // Round-tripping the tokio socket back to std must observe the
+            // non-blocking mode set by the constructor: a std read on a
+            // non-blocking socket with no data returns WouldBlock rather than
+            // parking the thread.
+            let std_again = adopted.inner.into_std().expect("into_std");
+            let mut probe = std_again;
+            use std::io::Read;
+            let mut buf = [0u8; 1];
+            let err = probe.read(&mut buf).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::WouldBlock);
+        });
+    }
+
+    /// Bytes written into one end of a real loopback socket via the async
+    /// wrapper are read byte-exact from the other end, all from within the
+    /// ASY-3 current-thread runtime. This is the core round-trip contract the
+    /// coupled receiver rung will rely on, and proves no runtime-context panic
+    /// on construction or I/O.
+    #[test]
+    fn async_round_trip_over_loopback_socket() {
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            let (client, server) = connected_pair();
+            let mut writer = AsyncTransport::from_std_tcp(client).expect("adopt client");
+            let mut reader = AsyncTransport::from_std_tcp(server).expect("adopt server");
+
+            let payload: &[u8] = b"delta\x00token\x01frame\xffbytes";
+            writer.write_all(payload).await.expect("async write_all");
+            writer.flush().await.expect("async flush");
+
+            let mut got = vec![0u8; payload.len()];
+            reader.read_exact(&mut got).await.expect("async read_exact");
+            assert_eq!(got, payload, "async round-trip must be byte-exact");
+        });
+    }
+
+    /// The wrapper is usable within a current-thread runtime's `block_on`
+    /// without a runtime-context panic - the exact context ASY-3's driver runs
+    /// the server body in. Guards against a regression where construction or
+    /// I/O would require a multi-thread runtime.
+    #[test]
+    fn usable_from_current_thread_block_on() {
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        let echoed: Vec<u8> = rt.block_on(async {
+            let (client, server) = connected_pair();
+            let mut a = AsyncTransport::from_std_tcp(client).expect("adopt a");
+            let mut b = AsyncTransport::from_std_tcp(server).expect("adopt b");
+            a.write_all(b"ping").await.unwrap();
+            a.flush().await.unwrap();
+            let mut buf = [0u8; 4];
+            b.read_exact(&mut buf).await.unwrap();
+            buf.to_vec()
+        });
+        assert_eq!(echoed, b"ping");
+    }
+}

--- a/crates/transfer/src/pipeline/mod.rs
+++ b/crates/transfer/src/pipeline/mod.rs
@@ -78,6 +78,13 @@ pub mod async_pipeline;
 #[cfg(feature = "tokio-transfer")]
 pub mod tokio_driver;
 
+// ASY-4: async transport wrapper seam. Gated on `tokio-transfer`. An additive,
+// unwired `AsyncRead + AsyncWrite` adapter over the socket-backed transport
+// that the coupled ASY-7-redo receiver rung consumes. Not wired into the
+// receiver read path, demux, SPSC bridge, or `core::session`; default-off.
+#[cfg(feature = "tokio-transfer")]
+pub(crate) mod async_transport;
+
 pub use job::{FileJob, FileList, MAX_RETRY_COUNT, TransferFlags};
 pub use pending::PendingTransfer;
 pub use state::PipelineState;

--- a/docs/design/asy-7-receiver-tokio-prototype.md
+++ b/docs/design/asy-7-receiver-tokio-prototype.md
@@ -1,0 +1,187 @@
+# ASY-7: Receiver network-read boundary - scoping result (STOP)
+
+Status: Scoping outcome. ASY-7 was chartered to convert the receiver's
+network-read boundary (ASY-1 boundary #4) to run natively on tokio
+(`.await`) under the `tokio-transfer` feature, replacing the
+`block_on`-hosted sync pipeline that ASY-3 scaffolded, while keeping the
+default threaded path byte-identical.
+
+This document records the scoping outcome: **the boundary is not
+cleanly separable at one rung.** A byte-identical single-boundary
+conversion of the receiver socket read is not achievable without a
+larger cross-boundary change than one rung, so no tokio-receiver code
+was shipped. Per the ASY-7 charter's stop clause, we stop and report
+the exact coupling rather than ship a tokio receiver that diverges from
+the threaded wire output.
+
+No `.rs` changed. The `tokio-transfer` foundation (ASY-3) is unaffected
+and remains default-off.
+
+## 1. What ASY-3 built (the starting point)
+
+ASY-3 (master `5473901d5`) hosts the **entire synchronous**
+`transfer::run_server_with_handshake` body inside a single tokio future:
+
+```rust
+// crates/transfer/src/pipeline/tokio_driver.rs
+fn host_sync_on<R>(handle: &Handle, f: impl FnOnce() -> R) -> R {
+    handle.block_on(async move { f() })   // f() is the whole sync server
+}
+```
+
+`core::session::with_transfer_runtime` (crates/core/src/session.rs)
+adopts an ambient runtime or builds a `current_thread` one, then
+`block_on`s the sync closure on the calling thread. The sync body still
+does blocking `read` on `stdin: &mut dyn Read`; ASY-3 changed only
+*where* the sync body runs, not *how* it reads. It is a runtime-hosting
+scaffold, not a boundary conversion.
+
+## 2. The boundary and the leaf read
+
+ASY-1 boundary #4 is the receiver's delta-token wire read. Its call
+chain (verified on this branch's tree; note the ASY-3 spec's file path
+`transfer_ops/response.rs` moved to `transfer_ops/streaming.rs` and the
+loop to `receiver/transfer/pipeline.rs` after the #6210 receiver split):
+
+```
+run_server_with_handshake                 crates/transfer/src/lib.rs:339
+  reader = ServerReader<BufReader<CountingReader<Box<dyn Read>>>>  lib.rs:535-538
+  ReceiverContext::run<R: Read>           receiver/transfer.rs:43
+    run_pipelined<R: Read>                receiver/transfer/pipelined.rs:33
+      setup_transfer<R: Read>             receiver/transfer/setup/context.rs:41
+        reader.activate_multiplex()       setup/context.rs:71
+      run_pipeline_loop_decoupled<R: Read>  receiver/transfer/pipeline.rs:43
+        process_file_response_streaming<R: Read>  transfer_ops/streaming.rs:74
+          TokenReader::read_token<R: Read>  token_reader.rs:142
+            reader.read_exact(..)         token_reader.rs:146  (plain)
+            decoder.recv_token(reader)                          (compressed)
+              ServerReader::read          reader/server.rs:229
+                MultiplexReader::read     reader/multiplex.rs:339
+                  protocol::recv_msg_into(&mut self.inner, ..)  multiplex.rs:368
+                    inner BufReader/CountingReader -> OS read
+```
+
+## 3. Why the boundary is not separable at one rung
+
+Three independent couplings each force a larger change than "make one
+socket read `.await`". Any one of them is sufficient to stop; all three
+hold.
+
+### 3.1 The reader is a monomorphized `R: Read`, not a trait object
+
+`R: Read` is threaded as a generic type parameter through **seven**
+functions from `ReceiverContext::run` down to `TokenReader::read_token`
+(section 2). To swap the leaf read to `AsyncRead`/`.await`, every one of
+those seven signatures must become `async fn` simultaneously, because
+Rust cannot `.await` from a synchronous `fn`. There is no intermediate
+seam where a single `fn` can be converted while its callers stay sync
+without wrapping in `block_on` - which reintroduces exactly the
+`block_on`-hosted sync shape ASY-3 already has and yields zero async
+benefit. This is a whole-call-tree conversion, not one boundary.
+
+### 3.2 The demux read is a stateful sync state machine, not a raw read
+
+`MultiplexReader::read` (reader/multiplex.rs:339) is not a passthrough
+socket read. Each call:
+
+- loops calling `protocol::recv_msg_into` until a `MSG_DATA` frame
+  arrives, **dispatching control frames as side effects** in between
+  (`dispatch_message`, `check_error_exit` at multiplex.rs:370,392):
+  MSG_INFO / MSG_ERROR / MSG_LOG emission, keep-alive handling, and
+  error-exit propagation;
+- carries an internal `buffer`/`pos` cursor spanning multiple `read`
+  calls (multiplex.rs:341-361);
+- tees post-demux bytes to the batch recorder (multiplex.rs:352-358,
+  382-388);
+- skips length-0 activation frames (multiplex.rs:375).
+
+This state machine, the compression layer above it
+(`CompressedReader`), and the token decoder (`TokenReader`) are all
+written against `std::io::Read`. Converting only the leaf OS read to
+`.await` while leaving this stack sync is impossible: the stack owns the
+framing, the control-message side effects, and the buffer cursor.
+Making the read async means rewriting the demux + decompress + token
+decode as an async state machine - ASY-4's transport wrapper does not
+exist yet, and even it would not cover the control-frame dispatch that
+lives above the transport.
+
+### 3.3 The read is fused to the SPSC disk bridge inside one sync frame
+
+`process_file_response_streaming` (transfer_ops/streaming.rs:74) does
+not just read - it reads a delta token **and** hands it to the
+disk-commit thread over `spsc::Sender<FileMessage>` within the same
+synchronous call (streaming.rs: `read_token` then `file_tx.send(..)`),
+recycling buffers back over `spsc::Receiver<Vec<u8>>`. ASY-3's spec
+(section 2, boundaries 6/7) requires swapping SPSC -> tokio `mpsc` in
+lockstep with the read conversion, and boundary 9 requires the disk
+commit to become a long-lived `spawn_blocking` task driven by
+`block_on`. So converting the read `.await` drags in the channel swap
+(#6/#7) and the disk-task restructure (#9) - three ASY-1 boundaries move
+together, not one. Splitting them would put an async reader and a sync
+SPSC producer in the same stack frame with no valid bridge.
+
+### 3.4 ASY-3's runtime-hosting model blocks an async prefetch shim
+
+The one shape that could isolate the read - an async task that `.await`s
+the socket and feeds a buffer that a **sync** demux stack drains under
+`spawn_blocking` (the `rsync_io::channel_adapter::ChannelReader`
+pattern) - is incompatible with ASY-3's model. ASY-3 runs the *entire*
+sync server on the runtime's current thread via `block_on`, not in
+`spawn_blocking`. Introducing an async prefetch task feeding a
+`spawn_blocking` demux is a restructure of the ASY-3 runtime-ownership
+scaffold itself (who owns the thread, how the server body is split
+across an async half and a blocking half), plus the flush-before-block
+invariant (ASY-1 "Preserved"; ASY-3 spec section 3 row 7) must be
+re-established across the new task boundary. That is a larger change
+than one rung and belongs to ASY-4 (transport wrapper) landing first.
+
+## 4. Invariants that a partial conversion would break
+
+- **Wire-byte parity** (ASY-1 "Preserved" #1): the demux control-frame
+  dispatch (#3.2) is where MSG_INFO/MSG_ERROR ordering is produced.
+  Splitting the read from the demux risks reordering or dropping those
+  frames.
+- **Flush-before-block** (ASY-1 "Preserved" #7): an async reader task
+  separated from the sync writer would need the flush-before-read
+  ordering re-encoded across the task boundary (ASY-3 spec's
+  `WriterGuard`), which does not exist yet.
+- **In-order disk commit** (ASY-1 "Preserved" #3): the read is fused to
+  the SPSC `send` (#3.3); converting one without the other has no valid
+  in-order bridge.
+
+## 5. What the next rung must do first
+
+ASY-7 cannot be a single receiver-read rung. The dependency order is:
+
+1. **ASY-4 transport wrapper (prerequisite).** Build the
+   `tokio::io::AsyncRead`/`AsyncWrite` shim over the receiver transport
+   (design doc referenced by ASY-2 open-question 2, not yet written),
+   including how the multiplex demux, decompression, and control-frame
+   dispatch move onto async - or a prefetch-into-buffer adapter with a
+   documented flush-before-block guard.
+2. **Re-charter ASY-7 as a coupled rung**, converting boundaries 4
+   (read), 6+7 (SPSC -> mpsc), and the async half of 9 (disk task)
+   together, because section 3.3 shows they share a stack frame. The
+   monomorphized `R: Read` chain (section 3.1) becomes async across all
+   seven functions in one change, gated on `tokio-transfer`, with the
+   threaded path kept via `#[cfg]`-split sync/async bodies.
+3. Only then can the equivalence test (threaded vs tokio-receiver
+   byte-diff) be written meaningfully; there is no partial tokio
+   receiver to test at this rung.
+
+## 6. Result
+
+No code changed. Default build and the ASY-3 `tokio-transfer`
+foundation are untouched and remain byte-identical / default-off. The
+receiver network-read boundary is deferred pending ASY-4 and a
+re-chartered coupled ASY-7 per section 5.
+
+## 7. Cross-references
+
+- `docs/audits/asy-1-threading-model.md` - boundary #4, "Preserved"
+  invariants #1/#3/#7.
+- `docs/design/asy-2-tokio-runtime-feature.md` - feature flag, runtime
+  ownership (section 5), spawn_blocking policy (section 6), open
+  question 2 (the ASY-4 transport wrapper this rung depends on).
+- `docs/design/asy-3-async-boundary-spec.md` - per-boundary contracts;
+  boundaries 4, 6, 7, 9 and section 3 rows 5/7.

--- a/docs/design/asy-7-receiver-tokio-prototype.md
+++ b/docs/design/asy-7-receiver-tokio-prototype.md
@@ -153,12 +153,23 @@ than one rung and belongs to ASY-4 (transport wrapper) landing first.
 
 ASY-7 cannot be a single receiver-read rung. The dependency order is:
 
-1. **ASY-4 transport wrapper (prerequisite).** Build the
-   `tokio::io::AsyncRead`/`AsyncWrite` shim over the receiver transport
-   (design doc referenced by ASY-2 open-question 2, not yet written),
-   including how the multiplex demux, decompression, and control-frame
-   dispatch move onto async - or a prefetch-into-buffer adapter with a
-   documented flush-before-block guard.
+1. **ASY-4 transport wrapper (prerequisite - BUILT).** The
+   `tokio::io::AsyncRead`/`AsyncWrite` shim over the socket-backed
+   transport now exists as
+   `crates/transfer/src/pipeline/async_transport.rs`
+   (`pub(crate) AsyncTransport`, gated on `tokio-transfer`, default-off).
+   It wraps a `std::net::TcpStream` via `TcpStream::from_std` after
+   flipping the socket non-blocking in `from_std_tcp`, and applies only
+   to socket-backed transports (daemon `rsync://` /
+   `DaemonStream::Plain`); pipe-backed SSH / stdio transports
+   (`DaemonStream::Stdio`) have no socket and stay on the sync path,
+   mirroring the NSV-1 `Option<fd>` shape. The adapter is additive and
+   **unwired**: it is not connected to the receiver read path, the
+   multiplex demux, the SPSC bridge, or `core::session`. The remaining
+   ASY-4 work that this rung still needs - moving the multiplex demux,
+   decompression, and control-frame dispatch onto async, or a
+   prefetch-into-buffer adapter with a documented flush-before-block
+   guard - is deferred to the coupled ASY-7-redo rung below.
 2. **Re-charter ASY-7 as a coupled rung**, converting boundaries 4
    (read), 6+7 (SPSC -> mpsc), and the async half of 9 (disk task)
    together, because section 3.3 shows they share a stack frame. The


### PR DESCRIPTION
Next rung of the async migration (ASY greenlit; ASY-3 foundation merged). Adds the async `AsyncRead`/`AsyncWrite` transport seam that ASY-7 scoping identified as the missing prerequisite, and carries the ASY-7 design finding. **Additive + default-off + unwired** — not connected to the receiver read path, demux, SPSC bridge, or `core::session`; exercised only by its own tests until the coupled receiver rung consumes it.

- `transfer/src/pipeline/async_transport.rs` (`#[cfg(feature="tokio-transfer")]`, `pub(crate)`): `AsyncTransport` implements `tokio::io::AsyncRead + AsyncWrite` by delegating each poll to an inner `tokio::net::TcpStream` (no added buffering — avoids ASY-2 open-question-2 double-buffering). Constructor `from_std_tcp(std::net::TcpStream) -> io::Result<Self>` sets the socket non-blocking (tokio's precondition) then `TcpStream::from_std`. No tokio type in any public `core`/`transfer` signature.
- **Runtime-context requirement documented:** `from_std` needs a tokio runtime context (reactor registration) — holds under the ASY-3 session `block_on`/`Handle` model; outside a context it's an `io::Error`, not a panic.
- **Fallback:** the concrete socket lives at `daemon::DaemonStream::Plain(TcpStream)`; SSH/stdio (`Stdio`, boxed dyn) has no socket constructor by design and stays on the sync path (NSV-1 `Option<fd>` shape).
- Also lands `docs/design/asy-7-receiver-tokio-prototype.md` (the ASY-7 scoping outcome: the receiver read is coupled to the monomorphized R:Read chain + stateful MultiplexReader demux + SPSC bridge; §5 updated to note this wrapper is now built).

Verified: default (feature-off) build/clippy(`-D warnings`) unchanged, module compiled out; feature-on build/clippy clean; `cargo test -p transfer --features tokio-transfer --lib async_transport` **3 passed** (non-blocking set, byte-exact async round-trip over a real 127.0.0.1 pair, usable-from-current-thread-block_on no panic); fmt + doc-gate clean both feature states.