### PR TITLE
feat(protocol): async multiplex read leaf under tokio-transfer + real wire-parity gate (ASY, default-off)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Run sync vs async wire-byte parity test
         run: |
           cargo nextest run --locked \
-            -p transfer \
-            --features async \
-            --no-tests=warn \
-            -E 'test(sync_async_wire_parity)'
+            -p protocol \
+            --features tokio-transfer \
+            -E 'test(recv_msg_parity)'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ async = ["daemon/async", "core/async"]
 # See docs/design/asy-2-tokio-runtime-feature.md and asy-3-async-boundary-spec.md.
 tokio-transfer = [
     "async",
+    "protocol/tokio-transfer",
     "core/tokio-transfer",
     "transfer/tokio-transfer",
     "daemon/tokio-transfer",

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -26,7 +26,14 @@ zlib-rs = ["flate2/zlib-rs"]
 # Filename encoding conversion (iconv)
 iconv = ["encoding_rs"]
 # Async codec support using tokio-util
-async = ["bytes", "tokio", "tokio-util"]
+async = ["dep:bytes", "dep:tokio", "dep:tokio-util"]
+# EXPERIMENTAL (ASY, default-off): compiles the async multiplex read leaf
+# (`recv_msg_into_async`), the `.await`-driven counterpart to `recv_msg_into`.
+# Pulls only the minimal tokio I/O surface (`io-util`). Additive and unwired;
+# the sync path is unchanged when this is off. See
+# docs/design/asy-2-tokio-runtime-feature.md and
+# docs/design/asy-7-receiver-tokio-prototype.md.
+tokio-transfer = ["dep:tokio"]
 # Serialization support for protocol types
 serde = ["dep:serde"]
 # Structured tracing for I/O operations

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -185,6 +185,9 @@ pub use legacy::{
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use multiplex::MultiplexCodec;
+#[cfg(feature = "tokio-transfer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-transfer")))]
+pub use multiplex::recv_msg_into_async;
 pub use multiplex::{
     BorrowedMessageFrame, BorrowedMessageFrames, MessageFrame, MplexReader, MplexWriter, recv_msg,
     recv_msg_into, send_frame, send_keepalive, send_msg, send_msgs_vectored,

--- a/crates/protocol/src/multiplex/helpers.rs
+++ b/crates/protocol/src/multiplex/helpers.rs
@@ -3,6 +3,18 @@ use std::io::{self, Read};
 
 use crate::envelope::{EnvelopeError, HEADER_LEN, MAX_PAYLOAD_LENGTH, MessageHeader};
 
+/// Decodes a fixed-size multiplex header from already-read bytes.
+///
+/// This is the single pure header-decode seam shared by every reader
+/// front-end (blocking `std::io::Read` and, under `tokio-transfer`, the async
+/// `tokio::io::AsyncRead` leaf). Sharing it guarantees the sync and async
+/// framing paths can never diverge on how the tag byte and length prefix are
+/// interpreted; the readers differ only in how the header bytes are pulled off
+/// the wire.
+pub(super) fn decode_header(header_bytes: &[u8; HEADER_LEN]) -> io::Result<MessageHeader> {
+    MessageHeader::decode(header_bytes).map_err(map_envelope_error)
+}
+
 #[cold]
 pub(super) fn map_envelope_error(err: EnvelopeError) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, err)
@@ -80,24 +92,38 @@ pub(super) fn read_payload<R: Read>(reader: &mut R, len: usize) -> io::Result<Ve
     Ok(payload)
 }
 
+/// Clears `buffer` and sizes it to exactly `len` bytes, ready to be filled.
+///
+/// Returns `true` when the caller must proceed to fill `buffer[0..len]` and
+/// `false` for the empty-payload fast path (buffer left empty). This is the
+/// shared buffer-preparation seam used by both the blocking and async payload
+/// readers so their reuse, allocation, and length semantics stay identical.
 #[allow(unsafe_code)]
+pub(super) fn prepare_payload_buffer(buffer: &mut Vec<u8>, len: usize) -> io::Result<bool> {
+    buffer.clear();
+
+    if len == 0 {
+        return Ok(false);
+    }
+
+    reserve_payload(buffer, len)?;
+    // SAFETY: `reserve_payload` ensures `capacity >= len`. Callers fill
+    // `buffer[0..len]` before any byte is exposed, and truncate to the
+    // only-written prefix on short read or error, so no uninitialized memory
+    // escapes.
+    unsafe { buffer.set_len(len) };
+
+    Ok(true)
+}
+
 pub(super) fn read_payload_into<R: Read>(
     reader: &mut R,
     buffer: &mut Vec<u8>,
     len: usize,
 ) -> io::Result<()> {
-    buffer.clear();
-
-    if len == 0 {
+    if !prepare_payload_buffer(buffer, len)? {
         return Ok(());
     }
-
-    reserve_payload(buffer, len)?;
-    // SAFETY: `reserve_payload` ensures `capacity >= len`. The read loop below
-    // fills `buffer[0..len]` before any byte is exposed. On short read or error,
-    // `buffer.truncate(read_total)` trims to only-written bytes, so no
-    // uninitialized memory escapes this function.
-    unsafe { buffer.set_len(len) };
 
     let mut read_total = 0;
     while read_total < len {

--- a/crates/protocol/src/multiplex/io/async_recv.rs
+++ b/crates/protocol/src/multiplex/io/async_recv.rs
@@ -1,0 +1,91 @@
+//! Async multiplex read leaf, gated on the `tokio-transfer` feature.
+//!
+//! This is the `.await`-driven counterpart to the blocking
+//! [`recv_msg_into`](super::recv::recv_msg_into) leaf. It exists because the
+//! ASY-7 scoping result (`docs/design/asy-7-receiver-tokio-prototype.md`)
+//! established that the receiver's real socket-read leaf is
+//! `protocol::recv_msg_into`, and a genuine receiver-side `.await` needs an
+//! async variant there rather than in `transfer` alone.
+//!
+//! The variant shares the header decode and payload buffer preparation with the
+//! sync leaf via `super::super::helpers`, so the two can never diverge on
+//! framing (tag byte, length prefix, reuse/allocation, truncation errors). The
+//! only difference is how bytes are pulled off the wire: `.await` on
+//! [`AsyncRead`] here versus a blocking `read` in the sync leaf.
+//!
+//! Additive and unwired: this leaf is not connected to `MultiplexReader` or the
+//! receiver pipeline. Wiring is a later rung (the coupled ASY-7 redo).
+
+use std::io;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::envelope::{HEADER_LEN, MessageCode, MessageHeader};
+
+use super::super::helpers::{decode_header, prepare_payload_buffer, truncated_payload_error};
+
+/// Receives the next multiplexed message into a caller-provided buffer,
+/// awaiting the underlying [`AsyncRead`] rather than blocking.
+///
+/// Byte-for-byte equivalent to [`recv_msg_into`](super::recv::recv_msg_into):
+/// it reads the 4-byte header, decodes it through the shared `decode_header`
+/// seam, clears and resizes `buffer` to the exact payload length via the shared
+/// `prepare_payload_buffer` seam, and fills it. The decoded [`MessageCode`] is
+/// returned so the caller can dispatch on the frame type while reading the
+/// payload from `buffer`.
+///
+/// Errors mirror the sync leaf exactly: an invalid header surfaces as
+/// [`io::ErrorKind::InvalidData`], and a payload short-read surfaces as
+/// [`io::ErrorKind::UnexpectedEof`] via `truncated_payload_error`.
+pub async fn recv_msg_into_async<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+    buffer: &mut Vec<u8>,
+) -> io::Result<MessageCode> {
+    let header = read_header_async(reader).await?;
+    let len = header.payload_len_usize();
+
+    read_payload_into_async(reader, buffer, len).await?;
+
+    Ok(header.code())
+}
+
+async fn read_header_async<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+) -> io::Result<MessageHeader> {
+    let mut header_bytes = [0u8; HEADER_LEN];
+    reader.read_exact(&mut header_bytes).await?;
+    decode_header(&header_bytes)
+}
+
+async fn read_payload_into_async<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+    buffer: &mut Vec<u8>,
+    len: usize,
+) -> io::Result<()> {
+    if !prepare_payload_buffer(buffer, len)? {
+        return Ok(());
+    }
+
+    let mut read_total = 0;
+    while read_total < len {
+        match reader.read(&mut buffer[read_total..]).await {
+            Ok(0) => {
+                buffer.truncate(read_total);
+                return Err(truncated_payload_error(len, read_total));
+            }
+            Ok(bytes_read) => {
+                read_total += bytes_read;
+            }
+            Err(ref err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(err) => {
+                buffer.truncate(read_total);
+                if err.kind() == io::ErrorKind::UnexpectedEof {
+                    return Err(truncated_payload_error(len, read_total));
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/protocol/src/multiplex/io/mod.rs
+++ b/crates/protocol/src/multiplex/io/mod.rs
@@ -1,8 +1,14 @@
+#[cfg(feature = "tokio-transfer")]
+mod async_recv;
 mod recv;
 mod send;
 
+#[cfg(all(test, feature = "tokio-transfer"))]
+mod parity_tests;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "tokio-transfer")]
+pub use async_recv::recv_msg_into_async;
 pub use recv::{recv_msg, recv_msg_into};
 pub use send::{send_frame, send_keepalive, send_msg, send_msgs_vectored};

--- a/crates/protocol/src/multiplex/io/parity_tests.rs
+++ b/crates/protocol/src/multiplex/io/parity_tests.rs
@@ -1,0 +1,166 @@
+//! Sync vs async wire-parity tests for the multiplex read leaf.
+//!
+//! These prove that [`recv_msg_into_async`](super::recv_msg_into_async) parses
+//! byte-identically to the blocking [`recv_msg_into`](super::recv_msg_into)
+//! leaf. Identical wire bytes are fed to both readers and every parsed frame
+//! (code, length, payload bytes) is compared frame-for-frame. A chunked variant
+//! drives the async reader over a byte-at-a-time delivery boundary to prove it
+//! reassembles frames identically across `.await` points.
+//!
+//! This is the test the `async-wire-parity` CI gate runs; it replaces the
+//! previous no-op that referenced a non-existent `transfer` test.
+
+use std::io::Cursor;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+use crate::MAX_PAYLOAD_LENGTH;
+use crate::envelope::MessageCode;
+
+use super::{recv_msg_into, recv_msg_into_async, send_msg};
+
+/// A parsed frame: the decoded code and the exact payload bytes.
+type ParsedFrame = (MessageCode, Vec<u8>);
+
+/// Builds the base corpus of representative multiplex frames: every message
+/// code plus empty, small, single-byte, and binary payloads. Kept small enough
+/// to drive byte-at-a-time through the chunked-delivery test.
+fn base_frames() -> Vec<ParsedFrame> {
+    let mut frames: Vec<ParsedFrame> = vec![
+        // MSG_DATA with content.
+        (MessageCode::Data, b"delta token payload".to_vec()),
+        // MSG_INFO empty payload.
+        (MessageCode::Info, Vec::new()),
+        // MSG_ERROR text.
+        (MessageCode::Error, b"error message text".to_vec()),
+        // MSG_DATA empty (keep-alive shaped frame).
+        (MessageCode::Data, Vec::new()),
+        // Warning + Log control frames.
+        (MessageCode::Warning, b"warning".to_vec()),
+        (MessageCode::Log, b"log line".to_vec()),
+        // Binary payload including NUL and high bytes.
+        (MessageCode::Data, vec![0u8, 1, 2, 0xFE, 0xFF, 0x7F]),
+        // Single-byte payload.
+        (MessageCode::Info, vec![0x42]),
+    ];
+
+    // Every message code with a fixed payload, so all tag bytes are exercised.
+    for code in MessageCode::ALL {
+        frames.push((code, b"code-sweep".to_vec()));
+    }
+
+    frames
+}
+
+/// Encodes `frames` into a single wire stream via [`send_msg`].
+fn encode(frames: &[ParsedFrame]) -> Vec<u8> {
+    let mut wire = Vec::new();
+    for (code, payload) in frames {
+        send_msg(&mut wire, *code, payload).unwrap();
+    }
+    wire
+}
+
+/// Drains all frames from the blocking reader over `wire`.
+fn parse_sync(wire: &[u8]) -> Vec<ParsedFrame> {
+    let mut reader = Cursor::new(wire);
+    let mut buffer = Vec::new();
+    let mut out = Vec::new();
+    for _ in 0.. {
+        if reader.position() as usize >= wire.len() {
+            break;
+        }
+        let code = recv_msg_into(&mut reader, &mut buffer).unwrap();
+        out.push((code, buffer.clone()));
+    }
+    out
+}
+
+/// Drains `count` frames from an async reader.
+async fn parse_async<R: AsyncRead + Unpin>(reader: &mut R, count: usize) -> Vec<ParsedFrame> {
+    let mut buffer = Vec::new();
+    let mut out = Vec::with_capacity(count);
+    for _ in 0..count {
+        let code = recv_msg_into_async(reader, &mut buffer).await.unwrap();
+        out.push((code, buffer.clone()));
+    }
+    out
+}
+
+/// An [`AsyncRead`] adapter that yields at most `chunk` bytes per `poll_read`,
+/// forcing the async payload/header loops to reassemble frames across multiple
+/// polls (and thus across `.await` points).
+struct ChunkedReader {
+    inner: Cursor<Vec<u8>>,
+    chunk: usize,
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let chunk = self.chunk.max(1);
+        let limit = chunk.min(buf.remaining());
+        if limit == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Read at most `limit` bytes into a scratch buffer, then copy the read
+        // prefix into the caller buffer. This forces frame reassembly across
+        // multiple polls without any unsafe buffer manipulation.
+        let mut scratch = vec![0u8; limit];
+        let mut scratch_buf = ReadBuf::new(&mut scratch);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut scratch_buf) {
+            Poll::Ready(Ok(())) => {
+                buf.put_slice(scratch_buf.filled());
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn recv_msg_parity_whole_stream() {
+    let mut expected = base_frames();
+    // Maximum-length payload to exercise the 24-bit length prefix boundary.
+    expected.push((MessageCode::Data, vec![0xABu8; MAX_PAYLOAD_LENGTH as usize]));
+    let wire = encode(&expected);
+
+    let sync_frames = parse_sync(&wire);
+    assert_eq!(sync_frames.len(), expected.len());
+    assert_eq!(sync_frames, expected);
+
+    let mut reader = Cursor::new(wire.clone());
+    let async_frames = parse_async(&mut reader, expected.len()).await;
+
+    assert_eq!(
+        async_frames, sync_frames,
+        "async multiplex read leaf diverged from the sync leaf on whole-stream delivery"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn recv_msg_parity_chunked_delivery() {
+    let expected = base_frames();
+    let wire = encode(&expected);
+    let sync_frames = parse_sync(&wire);
+
+    // Deliver bytes in tiny chunks so the async header and payload loops must
+    // reassemble every frame across many polls / await points.
+    for chunk in [1usize, 2, 3, 7] {
+        let mut reader = ChunkedReader {
+            inner: Cursor::new(wire.clone()),
+            chunk,
+        };
+        let async_frames = parse_async(&mut reader, expected.len()).await;
+        assert_eq!(
+            async_frames, sync_frames,
+            "async multiplex read leaf diverged from the sync leaf with chunk size {chunk}"
+        );
+    }
+}

--- a/crates/protocol/src/multiplex/io/recv.rs
+++ b/crates/protocol/src/multiplex/io/recv.rs
@@ -5,7 +5,7 @@ use logging::debug_log;
 use crate::envelope::{HEADER_LEN, MessageCode, MessageHeader};
 
 use super::super::frame::MessageFrame;
-use super::super::helpers::{map_envelope_error, read_payload, read_payload_into};
+use super::super::helpers::{decode_header, read_payload, read_payload_into};
 
 /// Receives the next multiplexed message from `reader`.
 ///
@@ -40,5 +40,5 @@ pub fn recv_msg_into<R: Read>(reader: &mut R, buffer: &mut Vec<u8>) -> io::Resul
 fn read_header<R: Read>(reader: &mut R) -> io::Result<MessageHeader> {
     let mut header_bytes = [0u8; HEADER_LEN];
     reader.read_exact(&mut header_bytes)?;
-    MessageHeader::decode(&header_bytes).map_err(map_envelope_error)
+    decode_header(&header_bytes)
 }

--- a/crates/protocol/src/multiplex/mod.rs
+++ b/crates/protocol/src/multiplex/mod.rs
@@ -33,6 +33,8 @@ pub use borrowed::{BorrowedMessageFrame, BorrowedMessageFrames};
 #[cfg(feature = "async")]
 pub use codec::MultiplexCodec;
 pub use frame::MessageFrame;
+#[cfg(feature = "tokio-transfer")]
+pub use io::recv_msg_into_async;
 pub use io::{recv_msg, recv_msg_into, send_frame, send_keepalive, send_msg, send_msgs_vectored};
 pub use reader::MplexReader;
 pub use writer::MplexWriter;

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -144,7 +144,7 @@ async = ["dep:tokio", "dep:tokio-util"]
 # on a tokio runtime and produces byte-identical wire output; per-boundary
 # `.await` conversion is deferred to ASY-7/8. See
 # docs/design/asy-3-async-boundary-spec.md.
-tokio-transfer = ["async"]
+tokio-transfer = ["async", "protocol/tokio-transfer"]
 
 # ============================================================================
 # Debugging Features

--- a/docs/design/asy-2-tokio-runtime-feature.md
+++ b/docs/design/asy-2-tokio-runtime-feature.md
@@ -37,15 +37,63 @@ scheduling with tokio. It depends on `async` (which provides the
 
 | Crate       | Feature added       | Forwards to                                | Notes |
 |-------------|---------------------|--------------------------------------------|-------|
-| root `bin`  | `tokio-transfer`    | `core/tokio-transfer`, `transfer/tokio-transfer`, `daemon/tokio-transfer` | Top-level switch. Implies `async`. |
+| root `bin`  | `tokio-transfer`    | `protocol/tokio-transfer`, `core/tokio-transfer`, `transfer/tokio-transfer`, `daemon/tokio-transfer` | Top-level switch. Implies `async`. |
 | `core`      | `tokio-transfer`    | `transfer/tokio-transfer`, `dep:tokio`     | Adds the runtime-ownership shim inside `core::session()`. |
-| `transfer`  | `tokio-transfer`    | `dep:tokio`, `dep:tokio-util`, `async`     | Compiles the tokio receiver/generator paths. |
+| `transfer`  | `tokio-transfer`    | `dep:tokio`, `dep:tokio-util`, `async`, `protocol/tokio-transfer` | Compiles the tokio receiver/generator paths and the async multiplex read leaf. |
+| `protocol`  | `tokio-transfer`    | `dep:tokio` (`io-util` only)               | See the 2026-07-01 amendment below. Optional async multiplex read leaf (`recv_msg_into_async`); no other change when off. |
 | `daemon`    | `tokio-transfer`    | `async-daemon`, `core/tokio-transfer`      | Lets the hybrid listener hand connections directly to the tokio receiver instead of `spawn_blocking`. |
 
-Crates NOT touched: `engine`, `fast_io`, `signature`, `protocol`,
+Crates NOT touched: `engine`, `fast_io`, `signature`,
 `filters`, `metadata`, `checksums`, `compress`. They stay sync and are
 called from `spawn_blocking` islands. ASY-9 decides whether
-delta-apply ever becomes async natively.
+delta-apply ever becomes async natively. (`protocol` is amended below;
+`compress` follows in a later rung.)
+
+## 2.3 Amendment (2026-07-01): async read/write leaves in protocol/compress
+
+The original §2.2 placed `protocol` and `compress` in the "not touched"
+set, on the assumption that a `transfer`-only rung could reach every
+async boundary. **The ASY-7 receiver scoping result
+(`docs/design/asy-7-receiver-tokio-prototype.md`) disproves that
+assumption.** ASY-7 §2-3 traced boundary #4 (the receiver's delta-token
+wire read) to its leaf and found the real socket-read leaf is
+`protocol::recv_msg_into` (`crates/protocol/src/multiplex/io/recv.rs`),
+reached through `MultiplexReader::read`. A genuine `.await` on that read
+cannot exist while the leaf itself is a synchronous `fn`: Rust cannot
+`.await` from a sync function, and hosting the sync leaf under
+`block_on` yields zero async benefit (ASY-7 §3.1, §3.4). The boundary is
+therefore not separable inside `transfer` alone - the leaf lives in
+`protocol`.
+
+**Amendment.** Behind the default-off `tokio-transfer` feature,
+`protocol` (and later `compress`) MAY expose async leaf variants that
+read from `tokio::io::AsyncRead` / write to `tokio::io::AsyncWrite`,
+alongside - never replacing - the existing sync leaves. Constraints:
+
+- **Additive and default-off.** With `tokio-transfer` off, `protocol`
+  pulls no tokio dependency and is byte-identical to today. The sync
+  leaves (`recv_msg`, `recv_msg_into`, `send_msg`, ...) are unchanged.
+- **No forked parser.** The async leaf and the sync leaf share the pure
+  framing/decode logic (header decode, payload buffer preparation,
+  truncation errors) via one internal seam, so they can never diverge on
+  wire interpretation. The variants differ only in how bytes are pulled
+  (`.await` vs blocking).
+- **Unsafe-free.** `protocol` keeps `#![deny(unsafe_code)]`; the async
+  path is all safe (`AsyncReadExt`).
+- **Unwired until its consuming rung.** The first leaf
+  (`recv_msg_into_async`, this amendment) is not connected to
+  `MultiplexReader` or the receiver; it is the reviewable primitive that
+  the coupled ASY-7-redo rung (ASY-7 §5) will consume once the demux,
+  SPSC->mpsc swap, and disk-task restructure land together.
+- **Parity is enforced in CI.** The `async-wire-parity` gate feeds
+  identical wire bytes to both the sync and async leaves and asserts
+  byte-identical parsed output frame-for-frame, including chunked
+  delivery across `.await` points.
+
+`compress`'s async token leaf (`decoder.recv_token` over an async
+reader) and the multiplex demux itself follow the same pattern in later
+rungs; this amendment establishes the precedent and the shared-seam
+discipline.
 
 ## 3. Default state and rollout path
 


### PR DESCRIPTION
Phase 1 of the async migration's real path (user approved amending ASY-2 to make protocol/compress async). Adds the async socket-read LEAF the coupled-receiver STOP (#6224) identified as the true blocker, **additive + default-off + unwired**, and repairs the no-op parity CI gate. Default build is byte-identical (Cargo.lock untouched); protocol stays `#![deny(unsafe_code)]`.

- **Shared parser (can't diverge):** `multiplex/helpers.rs` factors `decode_header` + `prepare_payload_buffer` (the latter owns the one pre-existing `#[allow(unsafe_code)]`, no net-new unsafe), fed by BOTH the sync `read_header`/`read_payload_into` and the async leaf.
- **Async leaf** (`multiplex/io/async_recv.rs`, `#[cfg(feature="tokio-transfer")]`): `recv_msg_into_async<R: AsyncRead + Unpin + ?Sized>(reader, buffer) -> io::Result<MessageCode>` — reuses the shared seams; fill loop byte-for-byte identical to sync with `.await` instead of blocking read (same Ok(0)/Interrupted/EOF-truncation handling). No unsafe in async code. Unwired (not connected to MultiplexReader/receiver — next rungs).
- **Real parity tests** (fix the gate): `recv_msg_parity_whole_stream` feeds an identical corpus (all 18 MessageCodes, empty/1-byte/binary/max-24-bit payloads, multi-frame) to sync (over `Cursor<&[u8]>`) and async (tokio `Cursor` on a current-thread runtime), asserting async==sync==expected frame-for-frame; `recv_msg_parity_chunked_delivery` drives 1/2/3/7-byte chunks proving reassembly across await points.
- **CI gate fix** (`.github/workflows/async-wire-parity.yml`): before ran `-p transfer --features async --no-tests=warn -E test(sync_async_wire_parity)` (nonexistent test + wrong feature + masking = always-green no-op); now `-p protocol --features tokio-transfer -E 'test(recv_msg_parity)'`, masking removed → fails if parity is absent/red.
- **ASY-2 amendment** §2.3: protocol/compress may expose async leaves behind `tokio-transfer`; §2.2 table updated (protocol moves out of the not-touched set, gains `dep:tokio` io-util only).

Verified (Rust 1.88.0): default OFF build/clippy(`-D warnings`)/`test -p protocol` (5645 pass, parity compiled out)/`build --workspace` clean; feature ON build/clippy/`test -p protocol --features tokio-transfer` (5647 pass incl 2 parity) + root-forwarding build + `clippy -p transfer --features tokio-transfer` clean; fmt + doc-gate clean both states.