### PR TITLE
refactor(protocol): sans-io compressed-token decoder + async token driver (byte-identical, default-off)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Run sync vs async wire-byte parity test
+      - name: Run sync vs async wire-byte parity tests
         run: |
           cargo nextest run --locked \
             -p protocol \
-            --features tokio-transfer \
-            -E 'test(recv_msg_parity)'
+            --features tokio-transfer,zstd,lz4 \
+            -E 'test(recv_msg_parity) | test(token_parity)'

--- a/crates/protocol/src/wire/compressed_token/decoder.rs
+++ b/crates/protocol/src/wire/compressed_token/decoder.rs
@@ -151,11 +151,31 @@ impl CompressedTokenDecoder {
     #[must_use]
     pub fn initialized(&self) -> bool {
         match &self.inner {
-            DecoderInner::Zlib(dec) => dec.initialized,
+            DecoderInner::Zlib(dec) => dec.initialized(),
             #[cfg(feature = "zstd")]
-            DecoderInner::Zstd(dec) => dec.initialized,
+            DecoderInner::Zstd(dec) => dec.initialized(),
             #[cfg(feature = "lz4")]
-            DecoderInner::Lz4(dec) => dec.initialized,
+            DecoderInner::Lz4(dec) => dec.initialized(),
+        }
+    }
+
+    /// Receives the next token from the stream, awaiting the underlying
+    /// [`AsyncRead`](tokio::io::AsyncRead) rather than blocking.
+    ///
+    /// Byte-for-byte equivalent to [`recv_token`](Self::recv_token): it drives
+    /// the same per-algorithm sans-io decode state machine, differing only in
+    /// how bytes are pulled off the wire (`.await` versus a blocking read).
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn recv_token_async<R>(&mut self, reader: &mut R) -> io::Result<CompressedToken>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        match &mut self.inner {
+            DecoderInner::Zlib(dec) => dec.recv_token_async(reader).await,
+            #[cfg(feature = "zstd")]
+            DecoderInner::Zstd(dec) => dec.recv_token_async(reader).await,
+            #[cfg(feature = "lz4")]
+            DecoderInner::Lz4(dec) => dec.recv_token_async(reader).await,
         }
     }
 }

--- a/crates/protocol/src/wire/compressed_token/lz4_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/lz4_codec.rs
@@ -27,9 +27,12 @@ use std::io::{self, Read, Write};
 
 use lz4_flex::block;
 
+#[cfg(feature = "tokio-transfer")]
+use super::step::drive_async;
+use super::step::{DeflateSink, TokenDecodeCore, drive_sync};
 use super::{
-    CHUNK_SIZE, CompressedToken, DEFLATED_DATA, END_FLAG, MAX_DATA_COUNT, TOKEN_LONG, TOKEN_REL,
-    TOKENRUN_LONG, TOKENRUN_REL, read_deflated_data_length, write_deflated_data_header,
+    CHUNK_SIZE, CompressedToken, END_FLAG, MAX_DATA_COUNT, TOKEN_LONG, TOKEN_REL, TOKENRUN_LONG,
+    TOKENRUN_REL, write_deflated_data_header,
 };
 
 /// LZ4 encoder state for sending compressed tokens.
@@ -238,146 +241,98 @@ impl Lz4TokenEncoder {
 ///
 /// Reference: upstream token.c:recv_compressed_token() (SUPPORT_LZ4)
 pub(super) struct Lz4TokenDecoder {
-    /// Buffer for decompressed output.
-    decompress_buf: Vec<u8>,
-    /// Current position in decompress buffer.
-    decompress_pos: usize,
+    /// Shared sans-io decode state machine (framing, run index, output).
+    core: TokenDecodeCore,
+    /// Algorithm-specific decompression half.
+    deflate: Lz4Deflate,
+}
+
+/// LZ4 decompression sink: the algorithm-specific half of the sans-io decoder.
+///
+/// Each DEFLATED_DATA block is decompressed independently via
+/// `LZ4_decompress_safe`; no persistent state between blocks.
+///
+/// upstream: token.c:recv_compressed_token() (SUPPORT_LZ4)
+struct Lz4Deflate {
+    /// Scratch buffer for decompressed output.
+    scratch: Vec<u8>,
     /// Reusable buffer for compressed input data read from the wire.
     compressed_input_buf: Vec<u8>,
-    /// Current token index.
-    rx_token: i32,
-    /// Remaining tokens in current run.
-    rx_run: i32,
-    pub(super) initialized: bool,
+}
+
+impl DeflateSink for Lz4Deflate {
+    fn accumulates(&self) -> bool {
+        false
+    }
+
+    fn begin_block(&mut self, payload: &[u8]) {
+        self.compressed_input_buf.clear();
+        self.compressed_input_buf.extend_from_slice(payload);
+    }
+
+    fn push_block(&mut self, payload: &[u8]) -> io::Result<()> {
+        // Never called: lz4 does not accumulate consecutive blocks.
+        self.compressed_input_buf.extend_from_slice(payload);
+        Ok(())
+    }
+
+    fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
+        // upstream: token.c line 1008 - LZ4_decompress_safe
+        let decompressed_len =
+            block::decompress_into(&self.compressed_input_buf, &mut self.scratch).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("LZ4 decompression failed: {e}"),
+                )
+            })?;
+        output.extend_from_slice(&self.scratch[..decompressed_len]);
+        Ok(())
+    }
 }
 
 impl Lz4TokenDecoder {
     pub(super) fn new() -> Self {
         let size = lz4_flex::block::get_maximum_output_size(CHUNK_SIZE).max(MAX_DATA_COUNT + 2);
         Self {
-            decompress_buf: vec![0u8; size],
-            decompress_pos: 0,
-            compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT),
-            rx_token: 0,
-            rx_run: 0,
-            initialized: false,
+            // LZ4 emits each decompressed block whole (not CHUNK_SIZE-chunked).
+            core: TokenDecodeCore::new(false),
+            deflate: Lz4Deflate {
+                scratch: vec![0u8; size],
+                compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT),
+            },
         }
     }
 
     pub(super) fn reset(&mut self) {
-        self.decompress_pos = 0;
-        self.compressed_input_buf.clear();
-        self.rx_token = 0;
-        self.rx_run = 0;
-        self.initialized = false;
+        self.core.reset();
+        self.core.initialized = false;
+        self.deflate.compressed_input_buf.clear();
+    }
+
+    pub(super) fn initialized(&self) -> bool {
+        self.core.initialized
     }
 
     /// Receives the next token from an LZ4-compressed stream.
     ///
-    /// Each DEFLATED_DATA block is decompressed independently via
-    /// `LZ4_decompress_safe`. No persistent state between blocks.
+    /// A thin blocking driver over the shared sans-io decode state machine.
     ///
     /// upstream: token.c:recv_compressed_token() lines 965-1026 (SUPPORT_LZ4)
     pub(super) fn recv_token<R: Read>(&mut self, reader: &mut R) -> io::Result<CompressedToken> {
-        if !self.initialized {
-            self.initialized = true;
-        }
+        drive_sync(&mut self.core, &mut self.deflate, reader)
+    }
 
-        // Emit pending run tokens
-        // upstream: token.c defence-in-depth (3.4.3) - checked increment
-        // prevents rx_token from wrapping past i32::MAX during long runs.
-        if self.rx_run > 0 {
-            self.rx_run -= 1;
-            self.rx_token = self.rx_token.checked_add(1).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream run",
-                )
-            })?;
-            return Ok(CompressedToken::BlockMatch(self.rx_token as u32));
-        }
-
-        // Read next flag
-        let mut flag_buf = [0u8; 1];
-        reader.read_exact(&mut flag_buf)?;
-        let flag = flag_buf[0];
-
-        if (flag & 0xC0) == DEFLATED_DATA {
-            // upstream: token.c lines 979-984
-            let len = read_deflated_data_length(reader, flag)?;
-            self.compressed_input_buf.clear();
-            self.compressed_input_buf.resize(len, 0);
-            reader.read_exact(&mut self.compressed_input_buf)?;
-
-            // upstream: token.c line 1008 - LZ4_decompress_safe
-            let decompressed_len =
-                block::decompress_into(&self.compressed_input_buf, &mut self.decompress_buf)
-                    .map_err(|e| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("LZ4 decompression failed: {e}"),
-                        )
-                    })?;
-
-            if decompressed_len > 0 {
-                let data = self.decompress_buf[..decompressed_len].to_vec();
-                return Ok(CompressedToken::Literal(data));
-            }
-
-            // No output produced, try next token
-            return self.recv_token(reader);
-        }
-
-        if flag == END_FLAG {
-            return Ok(CompressedToken::End);
-        }
-
-        // Token parsing - identical to zlib/zstd
-        if flag & TOKEN_REL != 0 {
-            let rel = (flag & 0x3F) as i32;
-            // upstream: token.c defence-in-depth (3.4.3) - checked addition
-            // prevents rx_token from wrapping past i32::MAX via repeated
-            // TOKEN_REL accumulation from a malicious sender.
-            self.rx_token = self.rx_token.checked_add(rel).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream",
-                )
-            })?;
-
-            if (flag >> 6) & 1 != 0 {
-                let mut run_buf = [0u8; 2];
-                reader.read_exact(&mut run_buf)?;
-                self.rx_run = u16::from_le_bytes(run_buf) as i32;
-            }
-
-            Ok(CompressedToken::BlockMatch(self.rx_token as u32))
-        } else if flag & 0xE0 == TOKEN_LONG {
-            let mut buf = [0u8; 4];
-            reader.read_exact(&mut buf)?;
-            self.rx_token = i32::from_le_bytes(buf);
-            // upstream: token.c:844-847 (3.4.2) - reject negative absolute
-            // token to prevent block-index wrap into the valid range.
-            if self.rx_token < 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid token number in compressed stream",
-                ));
-            }
-
-            if flag & 1 != 0 {
-                let mut run_buf = [0u8; 2];
-                reader.read_exact(&mut run_buf)?;
-                self.rx_run = u16::from_le_bytes(run_buf) as i32;
-            }
-
-            Ok(CompressedToken::BlockMatch(self.rx_token as u32))
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid compressed token flag: 0x{flag:02X}"),
-            ))
-        }
+    /// Async counterpart to [`recv_token`](Self::recv_token), backed by the same
+    /// sans-io state machine.
+    #[cfg(feature = "tokio-transfer")]
+    pub(super) async fn recv_token_async<R>(
+        &mut self,
+        reader: &mut R,
+    ) -> io::Result<CompressedToken>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        drive_async(&mut self.core, &mut self.deflate, reader).await
     }
 
     /// Noop for LZ4 - no dictionary synchronization needed.
@@ -388,6 +343,7 @@ impl Lz4TokenDecoder {
 
 #[cfg(test)]
 mod tests {
+    use super::super::{DEFLATED_DATA, read_deflated_data_length};
     use super::*;
     use std::io::Cursor;
 

--- a/crates/protocol/src/wire/compressed_token/mod.rs
+++ b/crates/protocol/src/wire/compressed_token/mod.rs
@@ -40,14 +40,19 @@ mod decoder;
 mod encoder;
 #[cfg(feature = "lz4")]
 mod lz4_codec;
+mod step;
 mod zlib_codec;
 #[cfg(feature = "zstd")]
 mod zstd_codec;
 
+#[cfg(all(test, feature = "tokio-transfer"))]
+mod parity_tests;
 #[cfg(test)]
 mod tests;
 
-use std::io::{self, Read, Write};
+#[cfg(test)]
+use std::io::Read;
+use std::io::{self, Write};
 
 pub use self::decoder::CompressedTokenDecoder;
 pub use self::encoder::CompressedTokenEncoder;
@@ -185,6 +190,10 @@ fn write_deflated_data_pieces<W: Write>(writer: &mut W, data: &[u8]) -> io::Resu
 ///
 /// * `reader` - The input stream to read the second byte from
 /// * `first_byte` - The first byte of the header (already read)
+///
+/// Retained for the codec test suites; the decoders now decode the length
+/// inline in the sans-io state machine (see `step.rs`).
+#[cfg(test)]
 #[inline]
 fn read_deflated_data_length<R: Read>(reader: &mut R, first_byte: u8) -> io::Result<usize> {
     let high = (first_byte & 0x3F) as usize;

--- a/crates/protocol/src/wire/compressed_token/parity_tests.rs
+++ b/crates/protocol/src/wire/compressed_token/parity_tests.rs
@@ -1,0 +1,247 @@
+//! Sync vs async parity tests for the sans-io compressed-token decoder.
+//!
+//! These prove that [`CompressedTokenDecoder::recv_token_async`] decodes
+//! byte-for-byte identically to the blocking
+//! [`CompressedTokenDecoder::recv_token`], across all three algorithms and
+//! every decode path the sans-io state machine exercises: multi-block deflated
+//! literals (the accumulation loop), dictionary carryover
+//! (CPRES_ZLIB `see_token`), zero-output continues, token runs, and absolute
+//! `TOKEN_LONG` tokens. Both whole-stream delivery and byte-at-a-time chunked
+//! delivery are checked so the async byte-fetch is driven across many
+//! `.await` points.
+//!
+//! Because both drivers advance the exact same [`TokenStepper`](super::step)
+//! state machine, any divergence here would be a driver bug, not a decode bug.
+//! This is the token half of the `async-wire-parity` CI gate.
+
+use std::io::Cursor;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use compress::zlib::CompressionLevel;
+use tokio::io::{AsyncRead, ReadBuf};
+
+use super::{CompressedToken, CompressedTokenDecoder, CompressedTokenEncoder};
+
+/// How to construct a fresh matching encoder/decoder pair for an algorithm.
+#[derive(Clone, Copy)]
+enum Algo {
+    Zlib,
+    Zlibx,
+    #[cfg(feature = "zstd")]
+    Zstd,
+    #[cfg(feature = "lz4")]
+    Lz4,
+}
+
+impl Algo {
+    fn encoder(self) -> CompressedTokenEncoder {
+        match self {
+            Algo::Zlib => CompressedTokenEncoder::new(CompressionLevel::Default, 31),
+            Algo::Zlibx => {
+                let mut enc = CompressedTokenEncoder::new(CompressionLevel::Default, 31);
+                enc.set_zlibx(true);
+                enc
+            }
+            #[cfg(feature = "zstd")]
+            Algo::Zstd => CompressedTokenEncoder::new_zstd(3, None).unwrap(),
+            #[cfg(feature = "lz4")]
+            Algo::Lz4 => CompressedTokenEncoder::new_lz4(),
+        }
+    }
+
+    fn decoder(self) -> CompressedTokenDecoder {
+        match self {
+            Algo::Zlib => CompressedTokenDecoder::new(),
+            Algo::Zlibx => {
+                let mut dec = CompressedTokenDecoder::new();
+                dec.set_zlibx(true);
+                dec
+            }
+            #[cfg(feature = "zstd")]
+            Algo::Zstd => CompressedTokenDecoder::new_zstd().unwrap(),
+            #[cfg(feature = "lz4")]
+            Algo::Lz4 => CompressedTokenDecoder::new_lz4(),
+        }
+    }
+
+    fn all() -> Vec<Algo> {
+        vec![
+            Algo::Zlib,
+            Algo::Zlibx,
+            #[cfg(feature = "zstd")]
+            Algo::Zstd,
+            #[cfg(feature = "lz4")]
+            Algo::Lz4,
+        ]
+    }
+}
+
+/// A scripted transfer operation used to build a representative wire corpus.
+enum Op {
+    Literal(Vec<u8>),
+    Block(u32),
+}
+
+/// Builds a corpus that exercises multi-block deflated literals, dictionary
+/// carryover, token runs, absolute tokens, and zero-output continues.
+fn corpus() -> Vec<Op> {
+    // A large incompressible literal forces multiple DEFLATED_DATA blocks and,
+    // for CPRES_ZLIB, output that spans several CHUNK_SIZE emissions.
+    let mut big = Vec::with_capacity(200_000);
+    for i in 0..200_000usize {
+        big.push((i.wrapping_mul(2654435761) >> 13) as u8);
+    }
+    // A highly compressible literal.
+    let repetitive = vec![0x5Au8; 100_000];
+
+    vec![
+        Op::Literal(b"first literal".to_vec()),
+        Op::Block(0),
+        Op::Block(1),
+        Op::Block(2),
+        Op::Literal(repetitive),
+        // Absolute token far from the last, forcing TOKEN_LONG encoding.
+        Op::Block(100_000),
+        Op::Block(100_001),
+        Op::Literal(big),
+        Op::Block(5),
+        Op::Literal(b"tail".to_vec()),
+    ]
+}
+
+/// Encodes `ops` to a single wire buffer with the given algorithm. Feeds block
+/// data to the encoder's dictionary (`see_token`) exactly as a real sender
+/// would, so CPRES_ZLIB dictionary carryover is exercised on the wire.
+fn encode(algo: Algo, ops: &[Op]) -> Vec<u8> {
+    let mut enc = algo.encoder();
+    let mut wire = Vec::new();
+    for op in ops {
+        match op {
+            Op::Literal(data) => enc.send_literal(&mut wire, data).unwrap(),
+            Op::Block(idx) => {
+                enc.send_block_match(&mut wire, *idx).unwrap();
+                // Feed synthetic basis-block bytes into the dictionary, matching
+                // the receiver's see_token below.
+                enc.see_token(&block_bytes(*idx)).unwrap();
+            }
+        }
+    }
+    enc.finish(&mut wire).unwrap();
+    wire
+}
+
+/// Deterministic synthetic basis-block bytes for a given block index.
+fn block_bytes(idx: u32) -> Vec<u8> {
+    let mut v = Vec::with_capacity(64);
+    for i in 0..64u32 {
+        v.push((idx.wrapping_add(i).wrapping_mul(31)) as u8);
+    }
+    v
+}
+
+/// Drains all tokens from the blocking decoder, feeding block data into the
+/// decoder dictionary via `see_token` on each block match.
+fn decode_sync(algo: Algo, wire: &[u8]) -> Vec<CompressedToken> {
+    let mut dec = algo.decoder();
+    let mut reader = Cursor::new(wire);
+    let mut out = Vec::new();
+    loop {
+        let tok = dec.recv_token(&mut reader).unwrap();
+        if let CompressedToken::BlockMatch(idx) = tok {
+            dec.see_token(&block_bytes(idx)).unwrap();
+        }
+        let end = matches!(tok, CompressedToken::End);
+        out.push(tok);
+        if end {
+            break;
+        }
+    }
+    out
+}
+
+/// Drains all tokens from the async decoder over `reader`.
+async fn decode_async<R: AsyncRead + Unpin>(algo: Algo, reader: &mut R) -> Vec<CompressedToken> {
+    let mut dec = algo.decoder();
+    let mut out = Vec::new();
+    loop {
+        let tok = dec.recv_token_async(reader).await.unwrap();
+        if let CompressedToken::BlockMatch(idx) = tok {
+            dec.see_token(&block_bytes(idx)).unwrap();
+        }
+        let end = matches!(tok, CompressedToken::End);
+        out.push(tok);
+        if end {
+            break;
+        }
+    }
+    out
+}
+
+/// An [`AsyncRead`] that yields at most `chunk` bytes per poll, forcing the
+/// async driver to reassemble every read across many `.await` points.
+struct ChunkedReader {
+    inner: Cursor<Vec<u8>>,
+    chunk: usize,
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let chunk = self.chunk.max(1);
+        let limit = chunk.min(buf.remaining());
+        if limit == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let mut scratch = vec![0u8; limit];
+        let mut scratch_buf = ReadBuf::new(&mut scratch);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut scratch_buf) {
+            Poll::Ready(Ok(())) => {
+                buf.put_slice(scratch_buf.filled());
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn token_parity_whole_stream() {
+    let ops = corpus();
+    for algo in Algo::all() {
+        let wire = encode(algo, &ops);
+        let sync_tokens = decode_sync(algo, &wire);
+
+        let mut reader = Cursor::new(wire.clone());
+        let async_tokens = decode_async(algo, &mut reader).await;
+
+        assert_eq!(
+            async_tokens, sync_tokens,
+            "async token decoder diverged from sync on whole-stream delivery"
+        );
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn token_parity_chunked_delivery() {
+    let ops = corpus();
+    for algo in Algo::all() {
+        let wire = encode(algo, &ops);
+        let sync_tokens = decode_sync(algo, &wire);
+
+        for chunk in [1usize, 2, 3, 7, 13] {
+            let mut reader = ChunkedReader {
+                inner: Cursor::new(wire.clone()),
+                chunk,
+            };
+            let async_tokens = decode_async(algo, &mut reader).await;
+            assert_eq!(
+                async_tokens, sync_tokens,
+                "async token decoder diverged from sync with chunk size {chunk}"
+            );
+        }
+    }
+}

--- a/crates/protocol/src/wire/compressed_token/step.rs
+++ b/crates/protocol/src/wire/compressed_token/step.rs
@@ -1,0 +1,450 @@
+//! Sans-io decode seam shared by the sync and async token decoder drivers.
+//!
+//! Each per-algorithm decoder exposes a resumable `step` function that owns ALL
+//! decode, decompression, dictionary, `saved_flag`, and run-index state
+//! internally and NEVER reads from the wire directly. The step consumes the
+//! bytes the previous step asked for and returns either [`TokenStep::Need`] (it
+//! needs exactly that many more bytes before it can make progress) or
+//! [`TokenStep::Emit`] (a fully decoded token, including end-of-stream).
+//!
+//! The reader lives entirely in a driver ([`drive_sync`] here, or the async
+//! driver behind `tokio-transfer`). Because every wire read in the original
+//! decoders was a `read_exact` of a statically known count at each decision
+//! point (1-byte flag, 1-byte deflated-length low byte, N-byte payload, 2-byte
+//! run count, 4-byte absolute token), the `Need(n)` / exact-`read_exact(n)`
+//! handshake reproduces the original read pattern byte-for-byte. The former
+//! Rust recursion for the zero-output DEFLATED_DATA case (`self.recv_token`)
+//! becomes an internal state-machine continue: the step simply loops back to
+//! its idle state and returns `Need(1)` for the next flag.
+
+use std::io::{self, Read};
+
+use super::{CHUNK_SIZE, CompressedToken, DEFLATED_DATA, END_FLAG, TOKEN_LONG, TOKEN_REL};
+
+/// The outcome of a single decoder step.
+///
+/// The state machine that produces these owns all decode state; the driver only
+/// pulls bytes. See the module docs for the byte-identical guarantee.
+pub(super) enum TokenStep {
+    /// The decoder needs exactly this many more bytes from the wire before it
+    /// can make progress. The driver must `read_exact` that many bytes and feed
+    /// them back into the next `step` call. A `Need(0)` is never produced.
+    Need(usize),
+    /// A fully decoded token (including [`CompressedToken::End`]).
+    Emit(CompressedToken),
+}
+
+/// Algorithm-specific hook for decoding a DEFLATED_DATA sequence.
+///
+/// The shared [`TokenDecodeCore`] state machine handles all common wire framing
+/// (idle flag read, run-token emission, TOKEN_REL / TOKEN_LONG parsing, output
+/// chunking, and the deflated-length header reads). It defers only the parts
+/// that differ per algorithm:
+///
+/// - whether consecutive DEFLATED_DATA blocks are accumulated before
+///   decompression (zlib) or decompressed one block at a time (zstd, lz4);
+/// - how a completed compressed buffer is turned into decompressed output.
+///
+/// Implementors own the persistent decompression context and the accumulation
+/// buffer; the core owns the run index, saved flag, and output buffer.
+pub(super) trait DeflateSink {
+    /// Whether this algorithm accumulates consecutive DEFLATED_DATA blocks into
+    /// one compressed buffer before decompressing (zlib does; zstd/lz4 do not).
+    fn accumulates(&self) -> bool;
+
+    /// Starts a new DEFLATED_DATA sequence with its first block payload.
+    ///
+    /// Resets the accumulation buffer and stores `payload`. The first block is
+    /// never subject to the accumulation cap (upstream applies the cap only to
+    /// the consecutive follow-on blocks).
+    fn begin_block(&mut self, payload: &[u8]);
+
+    /// Appends one consecutive follow-on DEFLATED_DATA payload (zlib only).
+    ///
+    /// Returns an error if the accumulation cap would be exceeded.
+    fn push_block(&mut self, payload: &[u8]) -> io::Result<()>;
+
+    /// Decompresses the accumulated compressed input into `output`, which the
+    /// caller has already cleared. Returns the produced bytes appended to
+    /// `output`.
+    fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()>;
+}
+
+/// Resumable, reader-free state of a common token decoder.
+///
+/// Owns the run index, saved flag, output buffer, and the phase of the wire
+/// read currently in flight. The algorithm-specific decompression is delegated
+/// to a [`DeflateSink`]. This is the single shared state machine that both the
+/// sync and async drivers advance one [`TokenStep`] at a time.
+pub(super) struct TokenDecodeCore {
+    /// Decompressed output awaiting emission in CHUNK_SIZE pieces.
+    decompress_buf: Vec<u8>,
+    /// Read position within `decompress_buf`.
+    decompress_pos: usize,
+    /// Current absolute token index.
+    rx_token: i32,
+    /// Remaining tokens in the current run.
+    rx_run: i32,
+    /// A flag byte peeked past the end of a DEFLATED_DATA accumulation (zlib).
+    saved_flag: Option<u8>,
+    /// Whether output is chunked in CHUNK_SIZE pieces (zlib/zstd) or emitted
+    /// whole (lz4).
+    chunk_output: bool,
+    /// The in-flight wire-read phase.
+    phase: Phase,
+    /// Whether the decoder has received its first token.
+    pub(super) initialized: bool,
+}
+
+/// The wire-read phase of [`TokenDecodeCore`]: encodes which `read_exact` is in
+/// flight so the state machine can resume after the driver supplies bytes.
+#[derive(Clone, Copy)]
+enum Phase {
+    /// At an idle boundary: needs a flag byte (unless one was saved).
+    Idle,
+    /// Read a DEFLATED_DATA flag; needs the low length byte. `flag` carries the
+    /// high length bits.
+    DeflatedLen { flag: u8 },
+    /// Have the full deflated length; needs the `len`-byte payload.
+    DeflatedPayload { len: usize },
+    /// (zlib accumulation) peeking the flag byte after a DEFLATED_DATA block.
+    AccumPeek,
+    /// (zlib accumulation) read a follow-on DEFLATED_DATA flag; needs its low
+    /// length byte.
+    AccumLen { flag: u8 },
+    /// (zlib accumulation) needs the follow-on `len`-byte payload.
+    AccumPayload { len: usize },
+    /// Parsed a TOKEN_REL/TOKEN_LONG flag that carries a 2-byte run count.
+    RunCount { token: i32 },
+    /// Parsed a TOKEN_LONG flag; needs the 4-byte absolute token, then possibly
+    /// a run count if `has_run`.
+    LongToken { has_run: bool },
+    /// Parsed a TOKEN_LONG absolute token that carries a 2-byte run count.
+    LongRunCount { token: i32 },
+}
+
+impl TokenDecodeCore {
+    pub(super) fn new(chunk_output: bool) -> Self {
+        Self {
+            decompress_buf: Vec::new(),
+            decompress_pos: 0,
+            rx_token: 0,
+            rx_run: 0,
+            saved_flag: None,
+            chunk_output,
+            phase: Phase::Idle,
+            initialized: false,
+        }
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.decompress_buf.clear();
+        self.decompress_pos = 0;
+        self.rx_token = 0;
+        self.rx_run = 0;
+        self.saved_flag = None;
+        self.phase = Phase::Idle;
+    }
+
+    /// Emits the next available output chunk, or `None` if the output buffer is
+    /// drained. Mirrors the entry-point drain in the original decoders.
+    fn emit_pending_output(&mut self) -> Option<CompressedToken> {
+        if self.decompress_pos < self.decompress_buf.len() {
+            let remaining = &self.decompress_buf[self.decompress_pos..];
+            let chunk_len = if self.chunk_output {
+                remaining.len().min(CHUNK_SIZE)
+            } else {
+                remaining.len()
+            };
+            let data = remaining[..chunk_len].to_vec();
+            self.decompress_pos += chunk_len;
+            return Some(CompressedToken::Literal(data));
+        }
+        None
+    }
+
+    /// After a decompression completes, sets up output emission. Returns the
+    /// first output chunk if any, otherwise `None` to continue the state
+    /// machine (the original zero-output recursive re-read).
+    fn take_first_output(&mut self) -> Option<CompressedToken> {
+        self.decompress_pos = 0;
+        if self.decompress_buf.is_empty() {
+            return None;
+        }
+        let chunk_len = if self.chunk_output {
+            self.decompress_buf.len().min(CHUNK_SIZE)
+        } else {
+            self.decompress_buf.len()
+        };
+        let data = self.decompress_buf[..chunk_len].to_vec();
+        self.decompress_pos = chunk_len;
+        Some(CompressedToken::Literal(data))
+    }
+
+    fn next_run_token(&mut self) -> io::Result<CompressedToken> {
+        self.rx_run -= 1;
+        self.rx_token = self.rx_token.checked_add(1).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "token index overflow in compressed stream run",
+            )
+        })?;
+        Ok(CompressedToken::BlockMatch(self.rx_token as u32))
+    }
+
+    /// Advances the shared decoder, delegating decompression to `sink`.
+    ///
+    /// `input` carries the bytes requested by the previous [`TokenStep::Need`]
+    /// (empty on the first step of a token).
+    pub(super) fn step<S: DeflateSink>(
+        &mut self,
+        sink: &mut S,
+        input: &[u8],
+    ) -> io::Result<TokenStep> {
+        if !self.initialized {
+            self.initialized = true;
+        }
+
+        // Each arm returns; the phase encodes exactly which read is resuming, so
+        // there is no need to iterate within a single step.
+        match self.phase {
+            Phase::Idle => {
+                // Drain any buffered decompressed output first.
+                if let Some(tok) = self.emit_pending_output() {
+                    return Ok(TokenStep::Emit(tok));
+                }
+                // Emit pending run tokens.
+                if self.rx_run > 0 {
+                    return Ok(TokenStep::Emit(self.next_run_token()?));
+                }
+                // Read the next flag byte, unless one was saved.
+                let flag = if let Some(f) = self.saved_flag.take() {
+                    f
+                } else if input.is_empty() {
+                    return Ok(TokenStep::Need(1));
+                } else {
+                    input[0]
+                };
+                self.dispatch_flag(flag)
+            }
+            Phase::DeflatedLen { flag } => {
+                // input holds the 1 low length byte.
+                let high = (flag & 0x3F) as usize;
+                let len = (high << 8) | (input[0] as usize);
+                if len == 0 {
+                    // Zero-length payload: no wire read needed. Process an
+                    // empty first block directly, matching the original
+                    // read_exact(&mut buf[..0]) no-op.
+                    sink.begin_block(&[]);
+                    if sink.accumulates() {
+                        self.phase = Phase::AccumPeek;
+                        return Ok(TokenStep::Need(1));
+                    }
+                    return self.finish_deflate(sink);
+                }
+                self.phase = Phase::DeflatedPayload { len };
+                Ok(TokenStep::Need(len))
+            }
+            Phase::DeflatedPayload { len } => {
+                debug_assert_eq!(input.len(), len);
+                sink.begin_block(input);
+                if sink.accumulates() {
+                    self.phase = Phase::AccumPeek;
+                    return Ok(TokenStep::Need(1));
+                }
+                self.finish_deflate(sink)
+            }
+            Phase::AccumPeek => {
+                let next_flag = input[0];
+                if (next_flag & 0xC0) == DEFLATED_DATA {
+                    self.phase = Phase::AccumLen { flag: next_flag };
+                    return Ok(TokenStep::Need(1));
+                }
+                self.saved_flag = Some(next_flag);
+                self.finish_deflate(sink)
+            }
+            Phase::AccumLen { flag } => {
+                let high = (flag & 0x3F) as usize;
+                let len = (high << 8) | (input[0] as usize);
+                if len == 0 {
+                    sink.push_block(&[])?;
+                    self.phase = Phase::AccumPeek;
+                    return Ok(TokenStep::Need(1));
+                }
+                self.phase = Phase::AccumPayload { len };
+                Ok(TokenStep::Need(len))
+            }
+            Phase::AccumPayload { len } => {
+                debug_assert_eq!(input.len(), len);
+                sink.push_block(input)?;
+                self.phase = Phase::AccumPeek;
+                Ok(TokenStep::Need(1))
+            }
+            Phase::RunCount { token } => {
+                self.rx_token = token;
+                self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
+                self.phase = Phase::Idle;
+                Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                    self.rx_token as u32,
+                )))
+            }
+            Phase::LongToken { has_run } => {
+                let token = i32::from_le_bytes([input[0], input[1], input[2], input[3]]);
+                if token < 0 {
+                    self.phase = Phase::Idle;
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid token number in compressed stream",
+                    ));
+                }
+                if has_run {
+                    self.phase = Phase::LongRunCount { token };
+                    return Ok(TokenStep::Need(2));
+                }
+                self.rx_token = token;
+                self.phase = Phase::Idle;
+                Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                    self.rx_token as u32,
+                )))
+            }
+            Phase::LongRunCount { token } => {
+                self.rx_token = token;
+                self.rx_run = u16::from_le_bytes([input[0], input[1]]) as i32;
+                self.phase = Phase::Idle;
+                Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                    self.rx_token as u32,
+                )))
+            }
+        }
+    }
+
+    /// Dispatches a freshly read flag byte to the appropriate phase.
+    fn dispatch_flag(&mut self, flag: u8) -> io::Result<TokenStep> {
+        if (flag & 0xC0) == DEFLATED_DATA {
+            self.phase = Phase::DeflatedLen { flag };
+            return Ok(TokenStep::Need(1));
+        }
+
+        if flag == END_FLAG {
+            self.phase = Phase::Idle;
+            return Ok(TokenStep::Emit(CompressedToken::End));
+        }
+
+        if flag & TOKEN_REL != 0 {
+            let rel = (flag & 0x3F) as i32;
+            self.rx_token = self.rx_token.checked_add(rel).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "token index overflow in compressed stream",
+                )
+            })?;
+            if (flag >> 6) & 1 != 0 {
+                self.phase = Phase::RunCount {
+                    token: self.rx_token,
+                };
+                return Ok(TokenStep::Need(2));
+            }
+            self.phase = Phase::Idle;
+            Ok(TokenStep::Emit(CompressedToken::BlockMatch(
+                self.rx_token as u32,
+            )))
+        } else if flag & 0xE0 == TOKEN_LONG {
+            self.phase = Phase::LongToken {
+                has_run: flag & 1 != 0,
+            };
+            Ok(TokenStep::Need(4))
+        } else {
+            self.phase = Phase::Idle;
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid compressed token flag: 0x{flag:02X}"),
+            ))
+        }
+    }
+
+    /// Runs decompression on the accumulated block(s) and sets up output.
+    ///
+    /// Returns the first output chunk, or resumes the idle state when the block
+    /// produced no output. This replaces the original zero-output recursive
+    /// re-read (`self.recv_token`) with an in-place state-machine transition:
+    /// when a flag was already saved during accumulation it is dispatched
+    /// without asking the driver for bytes, otherwise a fresh `Need(1)` is
+    /// returned - exactly the reads the recursion would have performed.
+    fn finish_deflate<S: DeflateSink>(&mut self, sink: &mut S) -> io::Result<TokenStep> {
+        self.decompress_buf.clear();
+        sink.decompress_into(&mut self.decompress_buf)?;
+        self.phase = Phase::Idle;
+        if let Some(tok) = self.take_first_output() {
+            return Ok(TokenStep::Emit(tok));
+        }
+        self.step_idle_after_zero_output()
+    }
+
+    /// Handles the idle re-entry after a zero-output DEFLATED_DATA block without
+    /// asking the driver for bytes when a saved flag is already buffered.
+    fn step_idle_after_zero_output(&mut self) -> io::Result<TokenStep> {
+        if let Some(tok) = self.emit_pending_output() {
+            return Ok(TokenStep::Emit(tok));
+        }
+        if self.rx_run > 0 {
+            return Ok(TokenStep::Emit(self.next_run_token()?));
+        }
+        if let Some(f) = self.saved_flag.take() {
+            return self.dispatch_flag(f);
+        }
+        Ok(TokenStep::Need(1))
+    }
+}
+
+/// Blocking driver over a [`TokenDecodeCore`] + [`DeflateSink`]: pulls the exact
+/// bytes each step requests via `read_exact` and returns the emitted token.
+///
+/// This reproduces the original blocking `recv_token` read pattern exactly: the
+/// first step is fed no bytes, and every subsequent step is fed precisely the
+/// `read_exact(n)` bytes it asked for.
+pub(super) fn drive_sync<S: DeflateSink, R: Read + ?Sized>(
+    core: &mut TokenDecodeCore,
+    sink: &mut S,
+    reader: &mut R,
+) -> io::Result<CompressedToken> {
+    let mut input: Vec<u8> = Vec::new();
+    loop {
+        match core.step(sink, &input)? {
+            TokenStep::Emit(token) => return Ok(token),
+            TokenStep::Need(n) => {
+                input.resize(n, 0);
+                reader.read_exact(&mut input)?;
+            }
+        }
+    }
+}
+
+/// Async driver over a [`TokenDecodeCore`] + [`DeflateSink`], gated on
+/// `tokio-transfer`.
+///
+/// Byte-for-byte equivalent to [`drive_sync`]: only the byte fetch differs
+/// (`.await` on an [`AsyncRead`](tokio::io::AsyncRead) versus a blocking
+/// `read_exact`). The same state machine backs both.
+#[cfg(feature = "tokio-transfer")]
+pub(super) async fn drive_async<S, R>(
+    core: &mut TokenDecodeCore,
+    sink: &mut S,
+    reader: &mut R,
+) -> io::Result<CompressedToken>
+where
+    S: DeflateSink,
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut input: Vec<u8> = Vec::new();
+    loop {
+        match core.step(sink, &input)? {
+            TokenStep::Emit(token) => return Ok(token),
+            TokenStep::Need(n) => {
+                input.resize(n, 0);
+                reader.read_exact(&mut input).await?;
+            }
+        }
+    }
+}

--- a/crates/protocol/src/wire/compressed_token/zlib_codec.rs
+++ b/crates/protocol/src/wire/compressed_token/zlib_codec.rs
@@ -11,9 +11,12 @@ use std::io::{self, Read, Write};
 use compress::zlib::CompressionLevel;
 use flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress};
 
+#[cfg(feature = "tokio-transfer")]
+use super::step::drive_async;
+use super::step::{DeflateSink, TokenDecodeCore, drive_sync};
 use super::{
-    CHUNK_SIZE, CompressedToken, DEFLATED_DATA, END_FLAG, MAX_DATA_COUNT, TOKEN_LONG, TOKEN_REL,
-    TOKENRUN_LONG, TOKENRUN_REL, read_deflated_data_length, write_deflated_data_pieces,
+    CHUNK_SIZE, CompressedToken, END_FLAG, MAX_DATA_COUNT, TOKEN_LONG, TOKEN_REL, TOKENRUN_LONG,
+    TOKENRUN_REL, write_deflated_data_pieces,
 };
 
 /// Maximum aggregate size of accumulated compressed data in a single
@@ -295,23 +298,107 @@ impl ZlibTokenEncoder {
     }
 }
 
+/// Zlib decompression sink: the algorithm-specific half of the sans-io decoder.
+///
+/// Owns the persistent inflate stream, the reusable output scratch, and the
+/// consecutive-DEFLATED_DATA accumulation buffer. The shared
+/// [`TokenDecodeCore`] drives all wire framing and delegates only block
+/// accumulation and decompression here.
+///
+/// Reference: upstream token.c:recv_deflated_token()
+struct ZlibDeflate {
+    decompressor: Decompress,
+    output_buf: Vec<u8>,
+    compressed_input_buf: Vec<u8>,
+}
+
+impl ZlibDeflate {
+    fn new() -> Self {
+        Self {
+            decompressor: Decompress::new(false),
+            output_buf: vec![0u8; CHUNK_SIZE * 2],
+            compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT + 4),
+        }
+    }
+}
+
+impl DeflateSink for ZlibDeflate {
+    fn accumulates(&self) -> bool {
+        true
+    }
+
+    fn begin_block(&mut self, payload: &[u8]) {
+        self.compressed_input_buf.clear();
+        self.compressed_input_buf.extend_from_slice(payload);
+    }
+
+    fn push_block(&mut self, payload: &[u8]) -> io::Result<()> {
+        // upstream: token.c defence-in-depth - bound accumulated compressed
+        // data (3.4.3). The cap guards the consecutive follow-on blocks; the
+        // first block (begin_block) is not capped, matching upstream.
+        if self.compressed_input_buf.len() + payload.len() > MAX_ACCUMULATED_COMPRESSED_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "accumulated compressed data exceeds {MAX_ACCUMULATED_COMPRESSED_BYTES} byte cap",
+                ),
+            ));
+        }
+        self.compressed_input_buf.extend_from_slice(payload);
+        Ok(())
+    }
+
+    fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
+        // Restore sync marker stripped by encoder.
+        self.compressed_input_buf
+            .extend_from_slice(&[0x00, 0x00, 0xFF, 0xFF]);
+
+        let mut input = &self.compressed_input_buf[..];
+
+        loop {
+            let before_in = self.decompressor.total_in();
+            let before_out = self.decompressor.total_out();
+
+            self.decompressor
+                .decompress(input, &mut self.output_buf, FlushDecompress::Sync)
+                .map_err(|e| io::Error::other(e.to_string()))?;
+
+            let consumed = (self.decompressor.total_in() - before_in) as usize;
+            let produced = (self.decompressor.total_out() - before_out) as usize;
+
+            if produced > 0 {
+                output.extend_from_slice(&self.output_buf[..produced]);
+            }
+
+            if consumed > 0 {
+                input = &input[consumed..];
+            }
+
+            if input.is_empty() || (consumed == 0 && produced == 0) {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Zlib decoder state for receiving compressed tokens.
 ///
 /// Manages a persistent inflate stream for decompressing literal data.
 /// Restores the sync marker stripped by the encoder.
 ///
+/// The decode/decompress logic lives in a sans-io state machine
+/// ([`TokenDecodeCore`] + [`ZlibDeflate`]); [`recv_token`](Self::recv_token) is
+/// a thin blocking driver over it, and [`recv_token_async`](Self::recv_token_async)
+/// is the `.await` counterpart. Both share the exact same state machine, so
+/// they stay byte-identical.
+///
 /// Reference: upstream token.c:recv_deflated_token()
 pub(super) struct ZlibTokenDecoder {
-    decompress_buf: Vec<u8>,
-    decompress_pos: usize,
-    decompressor: Decompress,
-    output_buf: Vec<u8>,
-    compressed_input_buf: Vec<u8>,
-    rx_token: i32,
-    rx_run: i32,
-    pub(super) initialized: bool,
+    core: TokenDecodeCore,
+    deflate: ZlibDeflate,
     is_zlibx: bool,
-    saved_flag: Option<u8>,
 }
 
 impl Default for ZlibTokenDecoder {
@@ -323,195 +410,38 @@ impl Default for ZlibTokenDecoder {
 impl ZlibTokenDecoder {
     pub(super) fn new() -> Self {
         Self {
-            decompress_buf: Vec::new(),
-            decompress_pos: 0,
-            decompressor: Decompress::new(false),
-            output_buf: vec![0u8; CHUNK_SIZE * 2],
-            compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT + 4),
-            rx_token: 0,
-            rx_run: 0,
-            initialized: false,
+            core: TokenDecodeCore::new(true),
+            deflate: ZlibDeflate::new(),
             is_zlibx: false,
-            saved_flag: None,
         }
     }
 
     pub(super) fn reset(&mut self) {
-        self.decompress_buf.clear();
-        self.decompress_pos = 0;
-        self.decompressor.reset(false);
-        self.compressed_input_buf.clear();
-        self.rx_token = 0;
-        self.rx_run = 0;
-        self.initialized = false;
-        self.saved_flag = None;
+        self.core.reset();
+        self.core.initialized = false;
+        self.deflate.decompressor.reset(false);
+        self.deflate.compressed_input_buf.clear();
     }
 
     pub(super) fn recv_token<R: Read>(&mut self, reader: &mut R) -> io::Result<CompressedToken> {
-        if !self.initialized {
-            self.initialized = true;
-        }
+        drive_sync(&mut self.core, &mut self.deflate, reader)
+    }
 
-        if self.decompress_pos < self.decompress_buf.len() {
-            let remaining = &self.decompress_buf[self.decompress_pos..];
-            let chunk_len = remaining.len().min(CHUNK_SIZE);
-            let data = remaining[..chunk_len].to_vec();
-            self.decompress_pos += chunk_len;
-            return Ok(CompressedToken::Literal(data));
-        }
+    /// Async counterpart to [`recv_token`](Self::recv_token), backed by the same
+    /// sans-io state machine. Only the byte fetch differs (`.await` vs blocking).
+    #[cfg(feature = "tokio-transfer")]
+    pub(super) async fn recv_token_async<R>(
+        &mut self,
+        reader: &mut R,
+    ) -> io::Result<CompressedToken>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        drive_async(&mut self.core, &mut self.deflate, reader).await
+    }
 
-        // Emit pending run tokens
-        // upstream: token.c defence-in-depth (3.4.3) - checked increment
-        // prevents rx_token from wrapping past i32::MAX during long runs.
-        if self.rx_run > 0 {
-            self.rx_run -= 1;
-            self.rx_token = self.rx_token.checked_add(1).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream run",
-                )
-            })?;
-            return Ok(CompressedToken::BlockMatch(self.rx_token as u32));
-        }
-
-        let flag = if let Some(f) = self.saved_flag.take() {
-            f
-        } else {
-            let mut buf = [0u8; 1];
-            reader.read_exact(&mut buf)?;
-            buf[0]
-        };
-
-        if (flag & 0xC0) == DEFLATED_DATA {
-            self.compressed_input_buf.clear();
-            let len = read_deflated_data_length(reader, flag)?;
-            let start = self.compressed_input_buf.len();
-            self.compressed_input_buf.resize(start + len, 0);
-            reader.read_exact(&mut self.compressed_input_buf[start..start + len])?;
-
-            // Accumulate consecutive DEFLATED_DATA blocks
-            // upstream: token.c defence-in-depth - bound accumulated compressed data (3.4.3)
-            loop {
-                let mut peek = [0u8; 1];
-                reader.read_exact(&mut peek)?;
-                let next_flag = peek[0];
-
-                if (next_flag & 0xC0) == DEFLATED_DATA {
-                    let next_len = read_deflated_data_length(reader, next_flag)?;
-                    if self.compressed_input_buf.len() + next_len > MAX_ACCUMULATED_COMPRESSED_BYTES
-                    {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!(
-                                "accumulated compressed data exceeds {MAX_ACCUMULATED_COMPRESSED_BYTES} byte cap",
-                            ),
-                        ));
-                    }
-                    let s = self.compressed_input_buf.len();
-                    self.compressed_input_buf.resize(s + next_len, 0);
-                    reader.read_exact(&mut self.compressed_input_buf[s..s + next_len])?;
-                } else {
-                    self.saved_flag = Some(next_flag);
-                    break;
-                }
-            }
-
-            // Restore sync marker stripped by encoder
-            self.compressed_input_buf
-                .extend_from_slice(&[0x00, 0x00, 0xFF, 0xFF]);
-
-            self.decompress_buf.clear();
-            let mut input = &self.compressed_input_buf[..];
-
-            loop {
-                let before_in = self.decompressor.total_in();
-                let before_out = self.decompressor.total_out();
-
-                let decompress_result = self.decompressor.decompress(
-                    input,
-                    &mut self.output_buf,
-                    FlushDecompress::Sync,
-                );
-                decompress_result.map_err(|e| io::Error::other(e.to_string()))?;
-
-                let consumed = (self.decompressor.total_in() - before_in) as usize;
-                let produced = (self.decompressor.total_out() - before_out) as usize;
-
-                if produced > 0 {
-                    self.decompress_buf
-                        .extend_from_slice(&self.output_buf[..produced]);
-                }
-
-                if consumed > 0 {
-                    input = &input[consumed..];
-                }
-
-                if input.is_empty() || (consumed == 0 && produced == 0) {
-                    break;
-                }
-            }
-
-            self.decompress_pos = 0;
-
-            if !self.decompress_buf.is_empty() {
-                let chunk_len = self.decompress_buf.len().min(CHUNK_SIZE);
-                let data = self.decompress_buf[..chunk_len].to_vec();
-                self.decompress_pos = chunk_len;
-                return Ok(CompressedToken::Literal(data));
-            }
-
-            return self.recv_token(reader);
-        }
-
-        if flag == END_FLAG {
-            return Ok(CompressedToken::End);
-        }
-
-        if flag & TOKEN_REL != 0 {
-            let rel = (flag & 0x3F) as i32;
-            // upstream: token.c defence-in-depth (3.4.3) - checked addition
-            // prevents rx_token from wrapping past i32::MAX via repeated
-            // TOKEN_REL accumulation from a malicious sender.
-            self.rx_token = self.rx_token.checked_add(rel).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream",
-                )
-            })?;
-
-            if (flag >> 6) & 1 != 0 {
-                let mut run_buf = [0u8; 2];
-                reader.read_exact(&mut run_buf)?;
-                self.rx_run = u16::from_le_bytes(run_buf) as i32;
-            }
-
-            Ok(CompressedToken::BlockMatch(self.rx_token as u32))
-        } else if flag & 0xE0 == TOKEN_LONG {
-            let mut buf = [0u8; 4];
-            reader.read_exact(&mut buf)?;
-            self.rx_token = i32::from_le_bytes(buf);
-            // upstream: token.c:595-598 (3.4.2) - reject negative absolute
-            // token to prevent block-index wrap into the valid range.
-            if self.rx_token < 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid token number in compressed stream",
-                ));
-            }
-
-            if flag & 1 != 0 {
-                let mut run_buf = [0u8; 2];
-                reader.read_exact(&mut run_buf)?;
-                self.rx_run = u16::from_le_bytes(run_buf) as i32;
-            }
-
-            Ok(CompressedToken::BlockMatch(self.rx_token as u32))
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid compressed token flag: 0x{flag:02X}"),
-            ))
-        }
+    pub(super) fn initialized(&self) -> bool {
+        self.core.initialized
     }
 
     /// Feeds block data into the decompressor's dictionary.
@@ -551,18 +481,19 @@ impl ZlibTokenDecoder {
             // header + payload together without intermediate flush boundaries.
             let mut input = &combined[..];
             loop {
-                let before_in = self.decompressor.total_in();
-                let before_out = self.decompressor.total_out();
+                let before_in = self.deflate.decompressor.total_in();
+                let before_out = self.deflate.decompressor.total_out();
 
-                self.decompressor
-                    .decompress(input, &mut self.output_buf, FlushDecompress::Sync)
+                self.deflate
+                    .decompressor
+                    .decompress(input, &mut self.deflate.output_buf, FlushDecompress::Sync)
                     .map_err(|e| io::Error::other(e.to_string()))?;
 
-                let consumed = (self.decompressor.total_in() - before_in) as usize;
+                let consumed = (self.deflate.decompressor.total_in() - before_in) as usize;
                 if consumed > 0 {
                     input = &input[consumed..];
                 }
-                let produced = (self.decompressor.total_out() - before_out) as usize;
+                let produced = (self.deflate.decompressor.total_out() - before_out) as usize;
 
                 if input.is_empty() || (consumed == 0 && produced == 0) {
                     break;

--- a/crates/protocol/src/wire/compressed_token/zstd_codec/decoder.rs
+++ b/crates/protocol/src/wire/compressed_token/zstd_codec/decoder.rs
@@ -10,10 +10,10 @@ use std::io::{self, Read};
 
 use zstd::stream::raw::{Decoder as ZstdRawDecoder, Operation};
 
-use super::super::{
-    CHUNK_SIZE, CompressedToken, DEFLATED_DATA, END_FLAG, MAX_DATA_COUNT, TOKEN_LONG, TOKEN_REL,
-    read_deflated_data_length,
-};
+#[cfg(feature = "tokio-transfer")]
+use super::super::step::drive_async;
+use super::super::step::{DeflateSink, TokenDecodeCore, drive_sync};
+use super::super::{CompressedToken, MAX_DATA_COUNT};
 
 /// Zstd decoder state for receiving compressed tokens.
 ///
@@ -32,22 +32,92 @@ use super::super::{
 /// upstream: token.c:recv_zstd_token() - DCtx created once (line 789),
 /// never reset between files (line 807-810 only resets rx_token)
 pub(in crate::wire::compressed_token) struct ZstdTokenDecoder {
+    /// Shared sans-io decode state machine (framing, run index, output chunking).
+    core: TokenDecodeCore,
+    /// Algorithm-specific decompression half.
+    deflate: ZstdDeflate,
+}
+
+/// Zstd decompression sink: the algorithm-specific half of the sans-io decoder.
+///
+/// Owns the persistent `ZSTD_DCtx` (never reset between files), the scratch
+/// output buffer, and the single-block compressed input. The shared
+/// [`TokenDecodeCore`] drives all wire framing and delegates one DEFLATED_DATA
+/// block at a time here.
+///
+/// upstream: token.c:recv_zstd_token() - DCtx created once (line 789),
+/// never reset between files (line 807-810 only resets rx_token)
+struct ZstdDeflate {
     /// Persistent zstd decompression context.
     decoder: ZstdRawDecoder<'static>,
-    /// Buffer for decompressed output.
-    decompress_buf: Vec<u8>,
-    /// Current position in decompress buffer.
-    decompress_pos: usize,
     /// Scratch buffer for decompression output.
     /// upstream: out_buffer_size = ZSTD_DStreamOutSize() * 2
     output_buf: Vec<u8>,
     /// Reusable buffer for compressed input data read from the wire.
     compressed_input_buf: Vec<u8>,
-    /// Current token index.
-    rx_token: i32,
-    /// Remaining tokens in current run.
-    rx_run: i32,
-    pub(in crate::wire::compressed_token) initialized: bool,
+}
+
+impl DeflateSink for ZstdDeflate {
+    fn accumulates(&self) -> bool {
+        false
+    }
+
+    fn begin_block(&mut self, payload: &[u8]) {
+        self.compressed_input_buf.clear();
+        self.compressed_input_buf.extend_from_slice(payload);
+    }
+
+    fn push_block(&mut self, payload: &[u8]) -> io::Result<()> {
+        // Never called: zstd does not accumulate consecutive blocks.
+        self.compressed_input_buf.extend_from_slice(payload);
+        Ok(())
+    }
+
+    fn decompress_into(&mut self, output: &mut Vec<u8>) -> io::Result<()> {
+        // Decompress the block.
+        // upstream: token.c lines 846-863 (r_inflating state)
+        let mut input_pos = 0;
+
+        while input_pos < self.compressed_input_buf.len() {
+            let mut in_buf =
+                zstd::stream::raw::InBuffer::around(&self.compressed_input_buf[input_pos..]);
+            let mut out_buf = zstd::stream::raw::OutBuffer::around(&mut self.output_buf);
+
+            self.decoder.run(&mut in_buf, &mut out_buf)?;
+            input_pos += in_buf.pos();
+            let produced = out_buf.pos();
+
+            if produced > 0 {
+                output.extend_from_slice(&self.output_buf[..produced]);
+            }
+
+            // upstream: token.c lines 862-863
+            // If input is fully consumed and output buffer not full,
+            // transition back to idle (read next flag).
+            if input_pos >= self.compressed_input_buf.len() && produced < self.output_buf.len() {
+                break;
+            }
+        }
+
+        // Drain any remaining buffered output from the zstd decoder.
+        // After all compressed input is consumed, the decoder may still
+        // hold decompressed data internally when the output buffer was
+        // full on the last iteration. Flush by feeding empty input.
+        // upstream: token.c lines 846-863 - inflate loop continues until
+        // output buffer is not full, indicating decoder is drained.
+        loop {
+            let mut in_buf = zstd::stream::raw::InBuffer::around(&[]);
+            let mut out_buf = zstd::stream::raw::OutBuffer::around(&mut self.output_buf);
+            self.decoder.run(&mut in_buf, &mut out_buf)?;
+            let produced = out_buf.pos();
+            if produced == 0 {
+                break;
+            }
+            output.extend_from_slice(&self.output_buf[..produced]);
+        }
+
+        Ok(())
+    }
 }
 
 impl ZstdTokenDecoder {
@@ -56,15 +126,17 @@ impl ZstdTokenDecoder {
         // upstream: token.c line 795 - out_buffer_size = ZSTD_DStreamOutSize() * 2
         let out_size = zstd::zstd_safe::DCtx::out_size() * 2;
         Ok(Self {
-            decoder,
-            decompress_buf: Vec::new(),
-            decompress_pos: 0,
-            output_buf: vec![0u8; out_size],
-            compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT),
-            rx_token: 0,
-            rx_run: 0,
-            initialized: false,
+            core: TokenDecodeCore::new(true),
+            deflate: ZstdDeflate {
+                decoder,
+                output_buf: vec![0u8; out_size],
+                compressed_input_buf: Vec::with_capacity(MAX_DATA_COUNT),
+            },
         })
+    }
+
+    pub(in crate::wire::compressed_token) fn initialized(&self) -> bool {
+        self.core.initialized
     }
 
     /// Resets decoder state for a new file.
@@ -75,178 +147,34 @@ impl ZstdTokenDecoder {
     ///
     /// upstream: token.c:807-810 - r_init only resets rx_token to 0
     pub(in crate::wire::compressed_token) fn reset(&mut self) {
-        self.decompress_buf.clear();
-        self.decompress_pos = 0;
-        self.compressed_input_buf.clear();
-        self.rx_token = 0;
-        self.rx_run = 0;
+        self.core.reset();
+        self.deflate.compressed_input_buf.clear();
         // Keep initialized=true - the DCtx is still valid from the same stream
     }
 
     /// Receives the next token from a zstd-compressed stream.
     ///
-    /// Mirrors upstream's state machine in recv_zstd_token() (token.c lines
-    /// 805-877). Processes one DEFLATED_DATA block at a time: reads compressed
-    /// data, decompresses via `ZSTD_decompressStream`, and returns available
-    /// output. If all input is consumed and the output buffer is not full,
-    /// transitions back to idle to read the next wire flag.
+    /// A thin blocking driver over the shared sans-io decode state machine.
     ///
     /// upstream: token.c:recv_zstd_token() lines 805-877
     pub(in crate::wire::compressed_token) fn recv_token<R: Read>(
         &mut self,
         reader: &mut R,
     ) -> io::Result<CompressedToken> {
-        if !self.initialized {
-            self.initialized = true;
-        }
+        drive_sync(&mut self.core, &mut self.deflate, reader)
+    }
 
-        if self.decompress_pos < self.decompress_buf.len() {
-            let remaining = &self.decompress_buf[self.decompress_pos..];
-            let chunk_len = remaining.len().min(CHUNK_SIZE);
-            let data = remaining[..chunk_len].to_vec();
-            self.decompress_pos += chunk_len;
-            return Ok(CompressedToken::Literal(data));
-        }
-
-        // Emit pending run tokens
-        // upstream: token.c lines 871-876 (r_running state)
-        // upstream: token.c defence-in-depth (3.4.3) - checked increment
-        // prevents rx_token from wrapping past i32::MAX during long runs.
-        if self.rx_run > 0 {
-            self.rx_run -= 1;
-            self.rx_token = self.rx_token.checked_add(1).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream run",
-                )
-            })?;
-            return Ok(CompressedToken::BlockMatch(self.rx_token as u32));
-        }
-
-        // Read next flag byte
-        // upstream: token.c lines 812-813 (r_idle state)
-        let mut flag_buf = [0u8; 1];
-        reader.read_exact(&mut flag_buf)?;
-        let flag = flag_buf[0];
-
-        if (flag & 0xC0) == DEFLATED_DATA {
-            // upstream: token.c lines 814-822
-            let len = read_deflated_data_length(reader, flag)?;
-            self.compressed_input_buf.clear();
-            self.compressed_input_buf.resize(len, 0);
-            reader.read_exact(&mut self.compressed_input_buf)?;
-
-            // Decompress the block
-            // upstream: token.c lines 846-863 (r_inflating state)
-            self.decompress_buf.clear();
-            let mut input_pos = 0;
-
-            while input_pos < self.compressed_input_buf.len() {
-                let mut in_buf =
-                    zstd::stream::raw::InBuffer::around(&self.compressed_input_buf[input_pos..]);
-                let mut out_buf = zstd::stream::raw::OutBuffer::around(&mut self.output_buf);
-
-                self.decoder.run(&mut in_buf, &mut out_buf)?;
-                input_pos += in_buf.pos();
-                let produced = out_buf.pos();
-
-                if produced > 0 {
-                    self.decompress_buf
-                        .extend_from_slice(&self.output_buf[..produced]);
-                }
-
-                // upstream: token.c lines 862-863
-                // If input is fully consumed and output buffer not full,
-                // transition back to idle (read next flag).
-                if input_pos >= self.compressed_input_buf.len() && produced < self.output_buf.len()
-                {
-                    break;
-                }
-            }
-
-            // Drain any remaining buffered output from the zstd decoder.
-            // After all compressed input is consumed, the decoder may still
-            // hold decompressed data internally when the output buffer was
-            // full on the last iteration. Flush by feeding empty input.
-            // upstream: token.c lines 846-863 - inflate loop continues until
-            // output buffer is not full, indicating decoder is drained.
-            loop {
-                let mut in_buf = zstd::stream::raw::InBuffer::around(&[]);
-                let mut out_buf = zstd::stream::raw::OutBuffer::around(&mut self.output_buf);
-                self.decoder.run(&mut in_buf, &mut out_buf)?;
-                let produced = out_buf.pos();
-                if produced == 0 {
-                    break;
-                }
-                self.decompress_buf
-                    .extend_from_slice(&self.output_buf[..produced]);
-            }
-
-            self.decompress_pos = 0;
-
-            if !self.decompress_buf.is_empty() {
-                let chunk_len = self.decompress_buf.len().min(CHUNK_SIZE);
-                let data = self.decompress_buf[..chunk_len].to_vec();
-                self.decompress_pos = chunk_len;
-                return Ok(CompressedToken::Literal(data));
-            }
-
-            // No output produced - read next flag
-            return self.recv_token(reader);
-        }
-
-        if flag == END_FLAG {
-            // upstream: token.c lines 825-828
-            return Ok(CompressedToken::End);
-        }
-
-        // Token parsing - same encoding for all algorithms
-        // upstream: token.c lines 831-841
-        if flag & TOKEN_REL != 0 {
-            let rel = (flag & 0x3F) as i32;
-            // upstream: token.c defence-in-depth (3.4.3) - checked addition
-            // prevents rx_token from wrapping past i32::MAX via repeated
-            // TOKEN_REL accumulation from a malicious sender.
-            self.rx_token = self.rx_token.checked_add(rel).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "token index overflow in compressed stream",
-                )
-            })?;
-
-            if (flag >> 6) & 1 != 0 {
-                let mut run_buf = [0u8; 2];
-                reader.read_exact(&mut run_buf)?;
-                self.rx_run = u16::from_le_bytes(run_buf) as i32;
-            }
-
-            Ok(CompressedToken::BlockMatch(self.rx_token as u32))
-        } else if flag & 0xE0 == TOKEN_LONG {
-            let mut buf = [0u8; 4];
-            reader.read_exact(&mut buf)?;
-            self.rx_token = i32::from_le_bytes(buf);
-            // upstream: token.c:1013-1016 (3.4.2) - reject negative absolute
-            // token to prevent block-index wrap into the valid range.
-            if self.rx_token < 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "invalid token number in compressed stream",
-                ));
-            }
-
-            if flag & 1 != 0 {
-                let mut run_buf = [0u8; 2];
-                reader.read_exact(&mut run_buf)?;
-                self.rx_run = u16::from_le_bytes(run_buf) as i32;
-            }
-
-            Ok(CompressedToken::BlockMatch(self.rx_token as u32))
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid compressed token flag: 0x{flag:02X}"),
-            ))
-        }
+    /// Async counterpart to [`recv_token`](Self::recv_token), backed by the same
+    /// sans-io state machine.
+    #[cfg(feature = "tokio-transfer")]
+    pub(in crate::wire::compressed_token) async fn recv_token_async<R>(
+        &mut self,
+        reader: &mut R,
+    ) -> io::Result<CompressedToken>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        drive_async(&mut self.core, &mut self.deflate, reader).await
     }
 
     /// Noop for zstd - no dictionary synchronization needed.


### PR DESCRIPTION
Async-migration rung: the phase-2 STOP found `recv_token` can't be an async leaf — reads interleave with decode/decompress state (flag-dependent read shape, unbounded deflated-block accumulation, mid-call Decompress/DCtx advance, recursive re-read). Fix = make the decoder **sans-io**, then sync+async are thin drivers over ONE shared state machine (no fork). **Byte-identical sync path** (unconditional refactor of shipping wire code, gated by golden-wire + interop); async driver is default-off.

- New `wire/compressed_token/step.rs`: `TokenStep::Need(n)/Emit` + `TokenDecodeCore` (owns run index/`saved_flag`/output-chunk state + a `Phase` enum for the exact in-flight `read_exact`; never touches a reader) + `DeflateSink` trait (the only per-algo hook: accumulate/begin_block/push_block/decompress_into). `drive_sync`/`drive_async` differ ONLY in blocking `read_exact` vs `.await`.
- zlib/zstd/lz4 decoders collapse into the shared core (**net -156 lines**); the unbounded DEFLATED_DATA accumulation loop → `AccumPeek/AccumLen/AccumPayload` phase cycle with `saved_flag` in the core + `MAX_ACCUMULATED_COMPRESSED_BYTES` cap only on follow-on blocks (first uncapped, matching upstream); zero-output recursion → `finish_deflate`/`step_idle_after_zero_output` continue (identical reads); `see_token` dictionary feed + persistent DCtx (never reset between files) unchanged.
- **Async driver** `recv_token_async<R: AsyncRead+Unpin+?Sized>` (`#[cfg(feature="tokio-transfer")]`) over the same core. New `parity_tests.rs`: sync==async across zlib/zlibx/zstd/lz4 exercising multi-block deflated literals, CPRES_ZLIB dictionary carryover, TOKEN_LONG, runs, zero-output continues — whole-stream + chunked (1,2,3,7,13-byte). CI `async-wire-parity.yml` extended to `test(recv_msg_parity)|test(token_parity)` with `tokio-transfer,zstd,lz4`.

**Byte-identical proof:** `cargo test -p protocol` default 110/0, `zstd,lz4` **5787/0** (golden-wire, all codec, EOF-error-mapping, negative-token/overflow, accumulation-cap tests unchanged); `tokio-transfer,zstd,lz4` 5791/0 (+parity). Public sync API + `engine` callers unaffected; protocol stays `#![deny(unsafe_code)]`; default build + Cargo.lock unchanged. clippy `-D warnings` + fmt + doc-gate clean both feature states.

Interop-with-upstream checks are the final byte-identical gate for this unconditional refactor.