### PR TITLE
feat(cli): --checksum-threads to activate parallel signature hashing (bench-validated, 3.3x)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ name = "signature"
 version = "0.6.3"
 dependencies = [
  "checksums",
+ "criterion",
  "protocol",
  "rayon",
  "tempfile",

--- a/crates/cli/src/frontend/arguments/mod.rs
+++ b/crates/cli/src/frontend/arguments/mod.rs
@@ -19,6 +19,7 @@ mod tests;
 pub(crate) use bandwidth::BandwidthArgument;
 pub(crate) use env::env_protect_args_default;
 pub use parsed_args::ParsedArgs; // Changed to pub for test_utils
+pub(crate) use parser::ChecksumThreadsSetting;
 pub use parser::parse_args; // Changed to pub for test_utils
 pub(crate) use program_name::{ProgramName, detect_program_name};
 pub(crate) use stop::StopRequest;

--- a/crates/cli/src/frontend/arguments/parsed_args/mod.rs
+++ b/crates/cli/src/frontend/arguments/parsed_args/mod.rs
@@ -632,6 +632,13 @@ pub struct ParsedArgs {
     /// enabled at build time; otherwise the value is parsed and discarded.
     pub tokio_threads: Option<u32>,
 
+    /// `--checksum-threads` - control parallel basis-signature hashing.
+    ///
+    /// `None` leaves the bench-validated default (parallel above the size
+    /// threshold). Local-only performance knob; never forwarded to the remote
+    /// server and never changes wire bytes.
+    pub checksum_threads: Option<super::ChecksumThreadsSetting>,
+
     /// `--spill-dir` - override the reorder-buffer spill directory.
     ///
     /// Overrides the `OC_RSYNC_SPILL_DIR` environment variable and the

--- a/crates/cli/src/frontend/arguments/parser/coerce.rs
+++ b/crates/cli/src/frontend/arguments/parser/coerce.rs
@@ -46,6 +46,54 @@ pub(super) fn parse_thread_count(
     }
 }
 
+/// Resolved `--checksum-threads` request.
+///
+/// Local-only performance knob controlling parallel basis-signature hashing.
+/// Never forwarded to the remote server and never changes wire bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChecksumThreadsSetting {
+    /// `auto` / `0`: parallel above the size threshold using available cores.
+    Auto,
+    /// `1`: force sequential hashing.
+    Sequential,
+    /// `N > 1`: parallel, capping the rayon pool to `N` threads.
+    Capped(u32),
+}
+
+/// Parses the `--checksum-threads` value.
+///
+/// Accepts `auto` (case-insensitive), `0` (both meaning parallel-auto), `1`
+/// (force sequential), or `N` in `2..=1024` (parallel, cap the rayon pool to
+/// `N`). Returns `Ok(None)` when the flag was not supplied, leaving the
+/// bench-validated default (parallel-auto) in place.
+pub(super) fn parse_checksum_threads(
+    matches: &mut clap::ArgMatches,
+) -> Result<Option<ChecksumThreadsSetting>, clap::Error> {
+    let Some(value) = matches.remove_one::<OsString>("checksum-threads") else {
+        return Ok(None);
+    };
+    let raw = value.to_string_lossy();
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return Ok(Some(ChecksumThreadsSetting::Auto));
+    }
+    let invalid = || {
+        clap::Error::raw(
+            clap::error::ErrorKind::ValueValidation,
+            format!(
+                "invalid --checksum-threads value '{raw}': must be 'auto', 0 \
+                 (parallel), 1 (sequential), or 2-{MAX_THREAD_COUNT} (cap)\n"
+            ),
+        )
+    };
+    match trimmed.parse::<u32>() {
+        Ok(0) => Ok(Some(ChecksumThreadsSetting::Auto)),
+        Ok(1) => Ok(Some(ChecksumThreadsSetting::Sequential)),
+        Ok(n) if n <= MAX_THREAD_COUNT => Ok(Some(ChecksumThreadsSetting::Capped(n))),
+        _ => Err(invalid()),
+    }
+}
+
 /// Parses the `--spill-threshold-bytes` value into a positive byte count.
 ///
 /// Accepts a positive integer with an optional case-insensitive K/M/G/T/P/E

--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -19,7 +19,7 @@ use core::client::{
     AddressMode, DeleteMode, HumanReadableMode, StrongChecksumChoice, TcpFastOpenMode,
 };
 
-use super::coerce::{parse_spill_threshold_bytes, parse_thread_count};
+use super::coerce::{parse_checksum_threads, parse_spill_threshold_bytes, parse_thread_count};
 use super::cow::{last_occurrence, parse_reflink_mode, resolve_cow_policy};
 use super::flags::{tri_state_flag_negative_first, tri_state_flag_positive_first};
 use super::values::join_os_values;
@@ -207,6 +207,7 @@ where
 
     let rayon_threads = parse_thread_count(&mut matches, "rayon-threads")?;
     let tokio_threads = parse_thread_count(&mut matches, "tokio-threads")?;
+    let checksum_threads = parse_checksum_threads(&mut matches)?;
 
     let spill_dir = matches
         .remove_one::<OsString>("spill-dir")
@@ -957,6 +958,7 @@ where
         adaptive_concurrency,
         rayon_threads,
         tokio_threads,
+        checksum_threads,
         spill_dir,
         spill_threshold_bytes,
         no_spill,

--- a/crates/cli/src/frontend/arguments/parser/mod.rs
+++ b/crates/cli/src/frontend/arguments/parser/mod.rs
@@ -15,6 +15,7 @@ mod values;
 #[cfg(test)]
 mod tests;
 
+pub use coerce::ChecksumThreadsSetting;
 pub use entry::parse_args;
 
 use super::{BandwidthArgument, ParsedArgs, detect_program_name, env_protect_args_default};

--- a/crates/cli/src/frontend/arguments/parser/tests.rs
+++ b/crates/cli/src/frontend/arguments/parser/tests.rs
@@ -950,3 +950,33 @@ fn filter_short_arg_packed_inside_flag_cluster() {
     assert_eq!(parsed.filters, vec![std::ffi::OsString::from(":C")]);
     assert!(parsed.archive);
 }
+
+#[test]
+fn checksum_threads_defaults_to_none() {
+    let parsed = parse_test_args(["src/", "dst/"]).expect("parse without flag");
+    assert_eq!(parsed.checksum_threads, None);
+}
+
+#[test]
+fn checksum_threads_accepts_auto_zero_one_and_n() {
+    use crate::frontend::arguments::ChecksumThreadsSetting;
+    for (arg, expected) in [
+        ("auto", ChecksumThreadsSetting::Auto),
+        ("AUTO", ChecksumThreadsSetting::Auto),
+        ("0", ChecksumThreadsSetting::Auto),
+        ("1", ChecksumThreadsSetting::Sequential),
+        ("8", ChecksumThreadsSetting::Capped(8)),
+    ] {
+        let parsed = parse_test_args([&format!("--checksum-threads={arg}"), "src/", "dst/"])
+            .unwrap_or_else(|e| panic!("parse --checksum-threads={arg}: {e}"));
+        assert_eq!(parsed.checksum_threads, Some(expected), "value {arg}");
+    }
+}
+
+#[test]
+fn checksum_threads_rejects_invalid_and_out_of_range() {
+    for arg in ["nope", "-1", "2048", ""] {
+        let result = parse_test_args([&format!("--checksum-threads={arg}"), "src/", "dst/"]);
+        assert!(result.is_err(), "value {arg:?} must be rejected");
+    }
+}

--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -444,6 +444,20 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .value_parser(OsStringValueParser::new()),
             )
             .arg(
+                Arg::new("checksum-threads")
+                    .long("checksum-threads")
+                    .value_name("N")
+                    .help(
+                        "Parallelise basis-signature checksum hashing. \
+                         auto/0 = use available cores above the size threshold \
+                         (default); 1 = force sequential; N = parallel, capping \
+                         the rayon pool to N (1-1024). Local-only; never sent to \
+                         the remote and never changes wire bytes.",
+                    )
+                    .num_args(1)
+                    .value_parser(OsStringValueParser::new()),
+            )
+            .arg(
                 Arg::new("tokio-threads")
                     .long("tokio-threads")
                     .value_name("N")

--- a/crates/cli/src/frontend/defaults.rs
+++ b/crates/cli/src/frontend/defaults.rs
@@ -29,7 +29,7 @@ pub(super) const SUPPORTED_OPTIONS_LIST: &str = concat!(
     "--chown, --usermap, --groupmap, --chmod, --executability/-E, --perms/-p, --no-perms, --times/-t, --no-times, ",
     "--atimes/-U, --no-atimes, --crtimes/-N, --no-crtimes, --omit-dir-times, --no-omit-dir-times, --omit-link-times, --no-omit-link-times, ",
     "--acls/-A, --no-acls, --xattrs/-X, --no-xattrs, ",
-    "--numeric-ids, --no-numeric-ids, --rayon-threads, --tokio-threads"
+    "--numeric-ids, --no-numeric-ids, --rayon-threads, --checksum-threads, --tokio-threads"
 );
 
 /// Format string used for `--itemize-changes` output.

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -14,7 +14,7 @@ use crate::frontend::execution::drive::{config, filters, metadata, options, summ
 use crate::frontend::outbuf::parse_outbuf_mode;
 use crate::frontend::progress::{ProgressOutputConfig, StderrMode};
 use crate::frontend::{
-    arguments::{ParsedArgs, StopRequest},
+    arguments::{ChecksumThreadsSetting, ParsedArgs, StopRequest},
     execution::{
         chown::ParsedChown, extract_operands, load_file_list_operands, operand_is_remote,
         parse_chown_argument, resolve_file_list_entries, resolve_files_from_source,
@@ -228,6 +228,7 @@ where
         jump_host,
         rayon_threads,
         tokio_threads,
+        checksum_threads,
         spill_dir,
         spill_threshold_bytes,
         no_spill,
@@ -275,7 +276,37 @@ where
 
     let rayon_thread_count = rayon_threads.and_then(|n| NonZeroUsize::new(n as usize));
     let tokio_thread_count = tokio_threads.and_then(|n| NonZeroUsize::new(n as usize));
-    if let Some(threads) = rayon_thread_count {
+
+    // Resolve `--checksum-threads` into the receiver's basis-signature policy
+    // and, for the capped form, an implied rayon pool size. This is an
+    // oc-only local performance knob: it is never forwarded to the remote
+    // server and never changes wire bytes (the signature is byte-identical
+    // regardless of thread count).
+    let checksum_rayon_cap = match checksum_threads {
+        Some(ChecksumThreadsSetting::Auto) => {
+            core::server::receiver::set_checksum_threads_policy(
+                core::server::receiver::ChecksumThreadsPolicy::Auto,
+            );
+            None
+        }
+        Some(ChecksumThreadsSetting::Sequential) => {
+            core::server::receiver::set_checksum_threads_policy(
+                core::server::receiver::ChecksumThreadsPolicy::Sequential,
+            );
+            None
+        }
+        Some(ChecksumThreadsSetting::Capped(n)) => {
+            core::server::receiver::set_checksum_threads_policy(
+                core::server::receiver::ChecksumThreadsPolicy::Auto,
+            );
+            NonZeroUsize::new(n as usize)
+        }
+        None => None,
+    };
+
+    // `--rayon-threads` takes precedence over the `--checksum-threads=N` cap
+    // when both are supplied; either way the global pool is installed once.
+    if let Some(threads) = rayon_thread_count.or(checksum_rayon_cap) {
         super::super::thread_tunables::install_rayon_thread_count(threads, stderr);
     }
 

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -48,6 +48,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --max-alloc=SIZE  Cap memory allocation at SIZE bytes (K=1024, M=1024^2, G=1024^3, T=1024^4, P=1024^5, E=1024^6; KB/MB/GB use powers of 1000; KiB/MiB/GiB are explicit binary; default 1G; 0 is rejected).\n",
             "      --block-size=SIZE  Force the delta-transfer block size to SIZE bytes.\n",
             "      --rayon-threads=N  Cap the rayon worker pool to N threads (1-1024).\n",
+            "      --checksum-threads=N  Parallelise basis-signature hashing (auto/0=parallel, 1=sequential, N=cap); local-only, no wire change.\n",
             "      --tokio-threads=N  Cap the async (tokio) runtime to N threads (1-1024); requires async features.\n",
             "  -b, --backup    Create backups before overwriting or deleting existing entries.\n",
             "      --backup-dir=DIR  Store backups inside DIR instead of alongside the destination.\n",

--- a/crates/signature/Cargo.toml
+++ b/crates/signature/Cargo.toml
@@ -36,3 +36,8 @@ parallel = []
 
 [dev-dependencies]
 tempfile = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "signature_parallel"
+harness = false

--- a/crates/signature/benches/signature_parallel.rs
+++ b/crates/signature/benches/signature_parallel.rs
@@ -1,0 +1,87 @@
+//! Parallel vs sequential file-signature generation benchmark.
+//!
+//! Validates the SMP Adler32 + strong-checksum signature path that the
+//! network-receiver basis-signature step gates behind `--checksum-threads`.
+//! The windowed generator ([`generate_file_signature_windowed`]) fans the
+//! per-block rolling+strong checksums across the rayon pool; the sequential
+//! generator ([`generate_file_signature`]) hashes them on one core. Both emit
+//! byte-identical [`FileSignature`] output - this bench measures only the
+//! wall-clock/throughput difference on multi-core hardware.
+//!
+//! # Sizes
+//!
+//! - **64 KiB** - below `PARALLEL_THRESHOLD_BYTES` (256 KiB). The production
+//!   path stays sequential here, so the windowed generator must NOT regress
+//!   meaningfully relative to sequential at this size.
+//! - **256 MiB** - many blocks, well above threshold. This is where SMP-across
+//!   -blocks should show a real multi-core speedup.
+//!
+//! Run with `cargo bench -p signature`.
+
+use std::hint::black_box;
+use std::io::Cursor;
+use std::num::NonZeroU8;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use protocol::ProtocolVersion;
+use signature::parallel::generate_file_signature_windowed;
+use signature::{
+    SignatureAlgorithm, SignatureLayoutParams, calculate_signature_layout, generate_file_signature,
+};
+
+/// Deterministic, non-trivial bytes so each block hashes distinctly.
+fn build_buffer(size: usize) -> Vec<u8> {
+    (0..size).map(|i| (i % 251) as u8).collect()
+}
+
+/// The two representative sizes: a below-threshold small file that must not
+/// regress, and a large many-block file where SMP should pay off.
+const SIZES: &[(&str, usize)] = &[("64KiB", 64 * 1024), ("256MiB", 256 * 1024 * 1024)];
+
+fn bench_signature(c: &mut Criterion) {
+    // MD5 is a representative CPU-intensive strong checksum. XXH3 is much
+    // cheaper per block; MD5 better reflects the single-core hot path the
+    // parallelization targets.
+    let algorithm = SignatureAlgorithm::Md5 {
+        seed_config: checksums::strong::Md5Seed::none(),
+    };
+
+    let mut group = c.benchmark_group("file_signature");
+    for &(label, size) in SIZES {
+        let data = build_buffer(size);
+        let layout = calculate_signature_layout(SignatureLayoutParams::new(
+            size as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).expect("16 is non-zero"),
+        ))
+        .expect("layout");
+
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", label), &data, |b, data| {
+            b.iter(|| {
+                let sig = generate_file_signature(Cursor::new(data.as_slice()), layout, algorithm)
+                    .expect("sequential signature");
+                black_box(sig);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("windowed", label), &data, |b, data| {
+            b.iter(|| {
+                let sig = generate_file_signature_windowed(
+                    Cursor::new(data.as_slice()),
+                    layout,
+                    algorithm,
+                )
+                .expect("windowed signature");
+                black_box(sig);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_signature);
+criterion_main!(benches);

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -240,20 +240,67 @@ fn generate_basis_signature(
     }
 }
 
-/// Process-wide opt-in gate for parallel basis-signature generation.
+/// Process-wide policy set by the `--checksum-threads` CLI flag, overriding the
+/// bench-validated default (parallel-on above the threshold).
 ///
-/// Read once from `OC_RSYNC_PARALLEL_CHECKSUM` (truthy = `1` / `true` / `yes`,
-/// case-insensitive) via a [`OnceLock`], matching the other `OC_RSYNC_*`
-/// runtime probes. Default off: signature generation stays sequential and the
-/// wire output is byte-identical either way. This is the interim opt-in until a
-/// `--checksum-threads` flag plus adaptive backpressure land; gating keeps the
-/// parallel path out of default builds until it is bench-validated.
+/// Installed once at CLI startup via [`set_checksum_threads_policy`]. Because
+/// the basis signature is wire-visible and byte-identical regardless of thread
+/// count, this is a pure local performance knob - it is never forwarded to the
+/// upstream server as an argument, exactly like `--rayon-threads`.
+static CHECKSUM_THREADS_POLICY: OnceLock<ChecksumThreadsPolicy> = OnceLock::new();
+
+/// Resolved `--checksum-threads` behaviour for basis-signature hashing.
+///
+/// `auto`/`0` fans per-block checksums across the rayon pool for baseses at or
+/// above [`PARALLEL_THRESHOLD_BYTES`]; `1` forces the sequential path; `N > 1`
+/// is parallel with the rayon pool capped to `N` (the cap is applied by the CLI
+/// via the shared `--rayon-threads` mechanism, so this variant only records the
+/// parallel intent here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChecksumThreadsPolicy {
+    /// Parallel above the threshold using the available rayon pool.
+    Auto,
+    /// Force sequential hashing regardless of basis size.
+    Sequential,
+}
+
+impl ChecksumThreadsPolicy {
+    /// Whether this policy selects the parallel windowed generator.
+    #[must_use]
+    const fn is_parallel(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}
+
+/// Installs the process-wide `--checksum-threads` policy.
+///
+/// Called once from CLI startup before any transfer begins. Later calls are
+/// ignored (the first policy wins), matching the write-once semantics of the
+/// other startup thread tunables.
+pub fn set_checksum_threads_policy(policy: ChecksumThreadsPolicy) {
+    let _ = CHECKSUM_THREADS_POLICY.set(policy);
+}
+
+/// Resolves whether the parallel windowed generator should be used.
+///
+/// Precedence: an explicit `--checksum-threads` policy wins; otherwise the
+/// `OC_RSYNC_PARALLEL_CHECKSUM` env var is consulted as a documented override
+/// (`0`/`false`/`no` forces sequential); absent both, the bench-validated
+/// default is parallel-on. The wire output is byte-identical either way.
 fn parallel_checksum_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
+    if let Some(policy) = CHECKSUM_THREADS_POLICY.get() {
+        return policy.is_parallel();
+    }
+    static ENV_DEFAULT: OnceLock<bool> = OnceLock::new();
+    *ENV_DEFAULT.get_or_init(|| {
         std::env::var("OC_RSYNC_PARALLEL_CHECKSUM")
-            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-            .unwrap_or(false)
+            .map(|v| {
+                !matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "0" | "false" | "no" | "off"
+                )
+            })
+            .unwrap_or(true)
     })
 }
 
@@ -361,6 +408,57 @@ mod tests {
         assert_eq!(
             sequential, parallel,
             "parallel basis signature diverged from sequential",
+        );
+    }
+
+    #[test]
+    fn checksum_threads_policy_maps_to_parallel_flag() {
+        // The `--checksum-threads` policy must map to exactly the parallel
+        // gate: auto -> parallel, sequential -> sequential. A regression here
+        // would silently (dis)engage the parallel windowed generator.
+        assert!(ChecksumThreadsPolicy::Auto.is_parallel());
+        assert!(!ChecksumThreadsPolicy::Sequential.is_parallel());
+    }
+
+    #[test]
+    fn checksum_threads_policy_paths_are_byte_identical() {
+        // The `--checksum-threads` flag selects between the parallel windowed
+        // generator (Auto) and the sequential generator (Sequential). Because
+        // the basis signature is wire-visible, both policies MUST yield a
+        // byte-identical FileSignature - otherwise the flag would corrupt
+        // delta reconstruction depending on thread count. Size exceeds the
+        // threshold so Auto actually engages the parallel branch.
+        use std::io::Cursor;
+        let size = (PARALLEL_THRESHOLD_BYTES * 4 + 4096) as usize;
+        let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        let layout = calculate_signature_layout(SignatureLayoutParams::new(
+            size as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        ))
+        .expect("layout");
+
+        let auto = compute_basis_signature(
+            Cursor::new(data.clone()),
+            size as u64,
+            layout,
+            SignatureAlgorithm::Md4,
+            ChecksumThreadsPolicy::Auto.is_parallel(),
+        )
+        .expect("auto signature");
+        let sequential = compute_basis_signature(
+            Cursor::new(data),
+            size as u64,
+            layout,
+            SignatureAlgorithm::Md4,
+            ChecksumThreadsPolicy::Sequential.is_parallel(),
+        )
+        .expect("sequential signature");
+
+        assert_eq!(
+            auto, sequential,
+            "--checksum-threads parallel and sequential paths must be byte-identical",
         );
     }
 

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -50,7 +50,10 @@ pub(crate) use crate::parallel_io::ParallelThresholds;
 
 use signature;
 
-pub use self::basis::{BasisFileConfig, BasisFileResult, find_basis_file_with_config};
+pub use self::basis::{
+    BasisFileConfig, BasisFileResult, ChecksumThreadsPolicy, find_basis_file_with_config,
+    set_checksum_threads_policy,
+};
 pub use self::context::ReceiverContext;
 pub(in crate::receiver) use self::dest_root::dest_arg_has_trailing_slash;
 pub use self::dest_root::ensure_dest_root_exists;


### PR DESCRIPTION
Activates the already-built, byte-identical SMP block-checksum (Adler32 weak + strong) parallelization in the NETWORK-RECEIVER basis-signature path, which was gated off pending bench validation. The parallel generator (`signature/parallel.rs`, rayon `par_chunks`, 256 KiB threshold, SMP-across-blocks + SIMD-within-block) already existed and was live in local-copy; this bench-validates it and turns it on by default for network transfers, controllable via a new flag. **No new parallelization code; no wire change.**

**Bench (10-core aarch64, MD5, criterion `signature/benches/signature_parallel.rs`):** 256 MiB basis = **3.30x** (windowed 2.86 GiB/s vs sequential 889 MiB/s). 64 KiB (below threshold) is slower but never reaches production — the `PARALLEL_THRESHOLD_BYTES = 256 KiB` gate keeps small baseses sequential (no regression).

- **Flag** `--checksum-threads=<auto|0|1|N>`: auto/0 = parallel above threshold using available cores (**new default**); 1 = force sequential; N = cap the checksum rayon workers (N also caps the pool; `--rayon-threads` wins if both given). Parsed to `ChecksumThreadsSetting`, plumbed cli→run.rs→`ChecksumThreadsPolicy` (process-wide `OnceLock`, mirrors `--rayon-threads`/`--tokio-threads`)→`receiver/basis.rs`.
- **Default flip → parallel-on**, justified by the 3.30x win + threshold guard. `parallel_checksum_enabled()`: explicit `--checksum-threads` wins → else `OC_RSYNC_PARALLEL_CHECKSUM` env (now a documented override; only falsey forces sequential) → else default parallel.
- **Oc-only local knob, NOT a wire/server arg:** grepped both remote arg builders (`remote/invocation/builder.rs`, `daemon_transfer/.../arguments.rs`) — zero `checksum`/`rayon`/`tokio` matches; follows the `--rayon-threads`/`--spill` pattern. Byte-identical output regardless of thread count.

**Byte-identical proof:** new `checksum_threads_policy_paths_are_byte_identical` (Auto==Sequential FileSignature) + existing `windowed_matches_sequential_across_sizes_and_algorithms` + real delta transfer `--checksum-threads=1` vs `auto` (`cmp`-identical, both == source) + protocol golden/wire **5863 pass** (no wire change). Verified: build/clippy(`-D warnings`)/fmt clean; `signature` 247, `transfer basis` 50, `cli` 3105 (TZ=UTC), `protocol` 5863 pass.

Note: two PRE-EXISTING broken intra-doc links on master (`writer/server.rs:266`, `signature/parallel.rs:231`) are untouched by this PR.