### PR TITLE
feat(transfer): async MultiplexReader demux over recv_msg_into_async (ASY, default-off, byte-identical)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -62,3 +62,10 @@ jobs:
             -p protocol \
             --features tokio-transfer,zstd,lz4 \
             -E 'test(recv_msg_parity) | test(token_parity)'
+
+      - name: Run sync vs async MultiplexReader demux parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer \
+            -E 'test(demux_parity) | test(read_async_delivers_data_via_real_sink)'

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -161,6 +161,11 @@ criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 crossbeam-channel = { workspace = true }
+# Drives the sync-vs-async MultiplexReader demux parity tests
+# (`reader::multiplex::parity_tests`) under `--features tokio-transfer`.
+# `macros` + `rt` supply `#[tokio::test]` and a current-thread runtime; unused
+# in the default build, so the default demux is unaffected.
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 filetime = { workspace = true }

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -1,6 +1,56 @@
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
 
+#[cfg(all(test, feature = "tokio-transfer"))]
+#[path = "multiplex_parity_tests.rs"]
+mod parity_tests;
+
+/// Sink for the inline, wire-visible side effects that frame dispatch performs.
+///
+/// Upstream rsync's `log.c:rwrite()` writes `MSG_INFO`/`MSG_CLIENT` to stdout
+/// (with a flush) and every `MSG_*ERROR*`/`MSG_WARNING` category to stderr, in
+/// line with the demultiplexed data stream. The ordering of these writes
+/// *relative to* delivered `MSG_DATA` payloads is observable on the wire/output,
+/// so it must be identical no matter which driver (blocking or `.await`) pulls
+/// the frame off the socket.
+///
+/// The dispatch core ([`MultiplexReader::dispatch_message_with`]) reads no wire
+/// and routes every side effect through this trait, so the sync and async
+/// drivers share one dispatch path and can never diverge on effect ordering.
+/// Production uses [`RealSink`], which reproduces the previous inline
+/// `print!`/`eprint!`/`stdout().flush()` byte-for-byte. Tests can substitute a
+/// capturing sink to assert the ordered effect sequence.
+pub(super) trait MuxSink {
+    /// Emits an `MSG_INFO`/`MSG_CLIENT` payload to stdout and flushes.
+    ///
+    /// upstream: `log.c:rwrite()` - FINFO and FCLIENT go to stdout.
+    fn info(&mut self, msg: &str);
+
+    /// Emits an `MSG_WARNING`/`MSG_LOG`/`MSG_*ERROR*` payload to stderr.
+    ///
+    /// upstream: `log.c:rwrite()` - FWARNING/FLOG/FERROR* go to stderr.
+    fn error(&mut self, msg: &str);
+}
+
+/// Production [`MuxSink`] that writes to the real stdout/stderr.
+///
+/// Byte-for-byte identical to the previous inline dispatch side effects:
+/// `print!("{msg}")` + `io::stdout().flush()` for info, `eprint!("{msg}")` for
+/// error. This is the only sink used outside tests, so the default build's
+/// demux output is unchanged.
+pub(super) struct RealSink;
+
+impl MuxSink for RealSink {
+    fn info(&mut self, msg: &str) {
+        print!("{msg}");
+        let _ = io::stdout().flush();
+    }
+
+    fn error(&mut self, msg: &str) {
+        eprint!("{msg}");
+    }
+}
+
 /// Reader that automatically demultiplexes incoming messages.
 ///
 /// Reads multiplex frames from the wire and extracts MSG_DATA payloads.
@@ -67,7 +117,7 @@ pub(super) const RERR_PARTIAL: i32 = 23;
 /// be up to 64KB - a smaller staging buffer forces extra reads per frame.
 const MULTIPLEX_READER_BUFFER_CAPACITY: usize = 64 * 1024;
 
-impl<R: Read> MultiplexReader<R> {
+impl<R> MultiplexReader<R> {
     pub(super) fn new(inner: R) -> Self {
         Self {
             inner,
@@ -208,24 +258,47 @@ impl<R: Read> MultiplexReader<R> {
         }
     }
 
-    /// Dispatches a non-data message code to the appropriate handler.
+    /// Dispatches a non-data message code using the production [`RealSink`].
+    ///
+    /// Byte-identical to the previous inline dispatch: routes `MSG_INFO`/
+    /// `MSG_CLIENT` to stdout+flush and every error/warning category to stderr.
+    /// This is the entry point for the blocking `Read` driver.
     ///
     /// Returns `true` for `MSG_DATA` (caller should break the read loop),
     /// `false` for all other message types (caller should continue reading).
     fn dispatch_message(&mut self, code: protocol::MessageCode) -> bool {
+        self.dispatch_message_with(code, &mut RealSink)
+    }
+
+    /// Dispatches a non-data message code to the appropriate handler, routing
+    /// every wire-visible side effect through `sink`.
+    ///
+    /// This is the shared, reader-free dispatch core. It mutates only in-memory
+    /// state (`buffer`, the `io_error`/`no_send`/`redo`/`xfer_error`/exit
+    /// accumulators) and emits side effects exclusively via `sink`, in exactly
+    /// the same order relative to the caller's data delivery. The blocking and
+    /// `.await` drivers both call it at the identical point (immediately after a
+    /// frame read), so they can never diverge on effect ordering.
+    ///
+    /// Returns `true` for `MSG_DATA` (caller should break the read loop),
+    /// `false` for all other message types (caller should continue reading).
+    fn dispatch_message_with<S: MuxSink>(
+        &mut self,
+        code: protocol::MessageCode,
+        sink: &mut S,
+    ) -> bool {
         match code {
             protocol::MessageCode::Data => return true,
             protocol::MessageCode::Info | protocol::MessageCode::Client => {
                 // upstream: log.c:rwrite() - FINFO and FCLIENT go to stdout
                 if let Ok(msg) = std::str::from_utf8(&self.buffer) {
-                    print!("{msg}");
-                    let _ = io::stdout().flush();
+                    sink.info(msg);
                 }
             }
             protocol::MessageCode::Warning | protocol::MessageCode::Log => {
                 // upstream: log.c:rwrite() - FWARNING to stderr, FLOG to daemon log
                 if let Ok(msg) = std::str::from_utf8(&self.buffer) {
-                    eprint!("{msg}");
+                    sink.error(msg);
                 }
             }
             protocol::MessageCode::Error
@@ -233,7 +306,7 @@ impl<R: Read> MultiplexReader<R> {
             | protocol::MessageCode::ErrorUtf8 => {
                 // upstream: log.c:rwrite() - FERROR* to stderr
                 if let Ok(msg) = std::str::from_utf8(&self.buffer) {
-                    eprint!("{msg}");
+                    sink.error(msg);
                 }
             }
             protocol::MessageCode::ErrorXfer => {
@@ -242,7 +315,7 @@ impl<R: Read> MultiplexReader<R> {
                 // can distinguish daemon filter refusals from real errors.
                 self.xfer_error_count += 1;
                 if let Ok(msg) = std::str::from_utf8(&self.buffer) {
-                    eprint!("{msg}");
+                    sink.error(msg);
                 }
             }
             protocol::MessageCode::ErrorExit => {
@@ -336,28 +409,63 @@ impl<R: Read> MultiplexReader<R> {
     }
 }
 
+impl<R> MultiplexReader<R> {
+    /// Tees `bytes` to the batch recorder when one is attached.
+    ///
+    /// upstream: io.c:read_buf() - post-demux data is teed to batch_fd
+    /// unconditionally. Shared by every read path so the blocking and `.await`
+    /// drivers record identical batch output.
+    fn tee_batch(&self, bytes: &[u8]) -> io::Result<()> {
+        if let Some(ref recorder) = self.batch_recorder {
+            let mut rec = recorder
+                .lock()
+                .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
+            rec.write_all(bytes)?;
+        }
+        Ok(())
+    }
+
+    /// Drains bytes already buffered from a prior frame into `buf`.
+    ///
+    /// Reader-free: copies from the internal frame buffer starting at `pos`,
+    /// advances `pos`, resets the buffer when drained, and tees the copied
+    /// bytes to the batch recorder. Returns the number of bytes copied. Both
+    /// the blocking and `.await` drivers call this first, so buffered-data
+    /// delivery is byte-identical.
+    fn drain_buffered(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let available = self.buffer.len() - self.pos;
+        let to_copy = available.min(buf.len());
+        buf[..to_copy].copy_from_slice(&self.buffer[self.pos..self.pos + to_copy]);
+        self.pos += to_copy;
+
+        if self.pos >= self.buffer.len() {
+            self.buffer.clear();
+            self.pos = 0;
+        }
+
+        self.tee_batch(&buf[..to_copy])?;
+        Ok(to_copy)
+    }
+
+    /// Places a freshly demuxed `MSG_DATA` frame into `buf`.
+    ///
+    /// Reader-free: copies the head of the frame buffer into `buf`, records the
+    /// consumed length in `pos` (leaving any overflow for the next `read`), and
+    /// tees the copied bytes to the batch recorder. Returns the number of bytes
+    /// copied. Shared by both drivers so newly-read data delivery is identical.
+    fn place_frame(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let to_copy = self.buffer.len().min(buf.len());
+        buf[..to_copy].copy_from_slice(&self.buffer[..to_copy]);
+        self.pos = to_copy;
+        self.tee_batch(&buf[..to_copy])?;
+        Ok(to_copy)
+    }
+}
+
 impl<R: Read> Read for MultiplexReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.pos < self.buffer.len() {
-            let available = self.buffer.len() - self.pos;
-            let to_copy = available.min(buf.len());
-            buf[..to_copy].copy_from_slice(&self.buffer[self.pos..self.pos + to_copy]);
-            self.pos += to_copy;
-
-            if self.pos >= self.buffer.len() {
-                self.buffer.clear();
-                self.pos = 0;
-            }
-
-            // upstream: io.c:read_buf() - tee post-demux data to batch_fd
-            if let Some(ref recorder) = self.batch_recorder {
-                let mut rec = recorder
-                    .lock()
-                    .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
-                rec.write_all(&buf[..to_copy])?;
-            }
-
-            return Ok(to_copy);
+            return self.drain_buffered(buf);
         }
 
         // Loop until we get a MSG_DATA message
@@ -375,19 +483,82 @@ impl<R: Read> Read for MultiplexReader<R> {
                 if self.buffer.is_empty() {
                     continue;
                 }
-                let to_copy = self.buffer.len().min(buf.len());
-                buf[..to_copy].copy_from_slice(&self.buffer[..to_copy]);
-                self.pos = to_copy;
+                return self.place_frame(buf);
+            }
+            self.check_error_exit()?;
+        }
+    }
+}
 
-                // upstream: io.c:read_buf() - tee post-demux data to batch_fd
-                if let Some(ref recorder) = self.batch_recorder {
-                    let mut rec = recorder
-                        .lock()
-                        .map_err(|_| io::Error::other("batch recorder lock poisoned"))?;
-                    rec.write_all(&buf[..to_copy])?;
+/// Async `.await`-driven demux, gated on the `tokio-transfer` feature.
+///
+/// This is the `.await` counterpart to the blocking [`Read`] impl above. It
+/// exists so a genuine receiver-side `.await` can pull multiplex frames off a
+/// [`tokio::io::AsyncRead`] socket without a blocking read, per the ASY-7
+/// receiver-prototype scoping (`docs/design/asy-7-receiver-tokio-prototype.md`).
+///
+/// The only difference from the sync driver is the frame read: it awaits
+/// [`protocol::recv_msg_into_async`] instead of blocking on
+/// [`protocol::recv_msg_into`]. Every non-read step - the demux loop shape, the
+/// empty-frame skip, the buffer-drain/place copies, the batch tee, the
+/// `check_error_exit` abort, and (crucially) the inline print/flush side effects
+/// via [`MultiplexReader::dispatch_message_with`] - is the exact same shared,
+/// reader-free code the sync driver runs. Because the dispatch core fires each
+/// side effect at the identical point relative to data delivery, the async
+/// output is byte-identical to the sync output, effect ordering included.
+///
+/// Additive and unwired: this driver is not connected to the receiver hot path
+/// yet (that routing is the next rung). It is exercised only by the sync-vs-
+/// async parity tests.
+#[cfg(feature = "tokio-transfer")]
+impl<R: tokio::io::AsyncRead + Unpin> MultiplexReader<R> {
+    /// Reads demultiplexed data into `buf`, awaiting the underlying socket.
+    ///
+    /// Byte-for-byte equivalent to [`Read::read`] with the production
+    /// [`RealSink`] side effects. See the impl-level docs for the parity
+    /// guarantee.
+    ///
+    /// Unwired pending the receiver-routing rung; only tests drive it, so it is
+    /// dead code in non-test builds.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(super) async fn read_async(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read_async_with(buf, &mut RealSink).await
+    }
+
+    /// Reads demultiplexed data into `buf`, routing side effects through `sink`.
+    ///
+    /// Identical demux logic to [`Read::read`]; only the frame read is awaited
+    /// and the side-effect sink is injectable so parity tests can capture the
+    /// ordered effect sequence. Production callers use [`read_async`], which
+    /// supplies [`RealSink`].
+    ///
+    /// [`read_async`]: MultiplexReader::read_async
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(super) async fn read_async_with<S: MuxSink>(
+        &mut self,
+        buf: &mut [u8],
+        sink: &mut S,
+    ) -> io::Result<usize> {
+        if self.pos < self.buffer.len() {
+            return self.drain_buffered(buf);
+        }
+
+        // Loop until we get a MSG_DATA message
+        loop {
+            self.buffer.clear();
+            self.pos = 0;
+
+            let code = protocol::recv_msg_into_async(&mut self.inner, &mut self.buffer).await?;
+
+            if self.dispatch_message_with(code, sink) {
+                // upstream: io.c io_start_multiplex_out() sends a length-0
+                // MSG_DATA frame as a multiplex activation marker. Returning
+                // Ok(0) signals EOF, so we must skip empty data frames and
+                // continue to the next message - matching the sync driver.
+                if self.buffer.is_empty() {
+                    continue;
                 }
-
-                return Ok(to_copy);
+                return self.place_frame(buf);
             }
             self.check_error_exit()?;
         }

--- a/crates/transfer/src/reader/multiplex_parity_tests.rs
+++ b/crates/transfer/src/reader/multiplex_parity_tests.rs
@@ -1,0 +1,271 @@
+//! Sync vs async wire-parity tests for the `MultiplexReader` demux.
+//!
+//! These prove that the `.await`-driven demux
+//! ([`MultiplexReader::read_async_with`]) produces byte-identical output to the
+//! blocking demux ([`Read::read`]) - both the demultiplexed `MSG_DATA` payload
+//! bytes AND the ordered, wire-visible side effects that
+//! [`dispatch_message_with`](MultiplexReader::dispatch_message_with) fires for
+//! `MSG_INFO`/`MSG_CLIENT` (stdout) and every `MSG_*ERROR*`/`MSG_WARNING`
+//! category (stderr).
+//!
+//! Side-effect ordering is the load-bearing property (see
+//! `docs/design/asy-7-receiver-tokio-prototype.md` §8): the inline print/flush
+//! for a control frame must fire at the same point *relative to* delivered data
+//! as it does in the sync driver. To assert this, both drivers run through a
+//! capturing [`MuxSink`] that appends `Info`/`Error` events to a shared event
+//! log, and the harness appends a `Data` event after each demuxed read. The
+//! resulting interleaved timeline is compared frame-for-frame.
+//!
+//! A chunked-delivery variant feeds the async driver bytes in tiny pieces so
+//! frames are reassembled across many `.await` points, proving the await
+//! boundary never reorders or drops an effect.
+//!
+//! Because both drivers advance the exact same reader-free dispatch core, any
+//! divergence here is a driver bug, not a demux bug. This is the demux half of
+//! the `async-wire-parity` CI gate.
+
+use std::io::{Cursor, Read};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+use super::{MultiplexReader, MuxSink};
+
+/// A single observable event on the demux timeline.
+///
+/// `Info`/`Error` come from the dispatch side-effect sink (in the exact order
+/// dispatch fires them); `Data` is appended by the harness after each demuxed
+/// read returns payload bytes. Comparing the full ordered sequence proves both
+/// the data stream and the effect ordering match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    /// An `MSG_INFO`/`MSG_CLIENT` payload routed to stdout by the sink.
+    Info(Vec<u8>),
+    /// An `MSG_WARNING`/`MSG_LOG`/`MSG_*ERROR*` payload routed to stderr.
+    Error(Vec<u8>),
+    /// Demuxed `MSG_DATA` bytes delivered by a `read` call.
+    Data(Vec<u8>),
+}
+
+/// Capturing [`MuxSink`] that records effects into an ordered log instead of
+/// touching the real stdout/stderr, so tests can assert effect ordering.
+struct CapturingSink {
+    events: Vec<Event>,
+}
+
+impl MuxSink for CapturingSink {
+    fn info(&mut self, msg: &str) {
+        self.events.push(Event::Info(msg.as_bytes().to_vec()));
+    }
+
+    fn error(&mut self, msg: &str) {
+        self.events.push(Event::Error(msg.as_bytes().to_vec()));
+    }
+}
+
+/// Builds a representative wire stream that interleaves MSG_DATA, MSG_INFO,
+/// MSG_ERROR, keep-alive (empty MSG_DATA), warnings, and a multi-frame data
+/// payload that must span two `read` calls.
+fn corpus() -> Vec<u8> {
+    let mut wire = Vec::new();
+    let push = |wire: &mut Vec<u8>, code, payload: &[u8]| {
+        protocol::send_msg(wire, code, payload).unwrap();
+    };
+
+    // Control frame before any data: effect must fire before the first Data.
+    push(&mut wire, protocol::MessageCode::Info, b"connecting\n");
+    // First data frame.
+    push(&mut wire, protocol::MessageCode::Data, b"hello ");
+    // Interleaved control frames between data.
+    push(&mut wire, protocol::MessageCode::Warning, b"slow link\n");
+    push(&mut wire, protocol::MessageCode::Error, b"a soft error\n");
+    // Keep-alive: empty MSG_DATA frame - must be skipped, never delivered as EOF.
+    push(&mut wire, protocol::MessageCode::Data, b"");
+    // More data after the keep-alive.
+    push(&mut wire, protocol::MessageCode::Data, b"world");
+    // A larger data frame that will be split across small read buffers.
+    push(&mut wire, protocol::MessageCode::Data, &vec![0xABu8; 300]);
+    // Trailing control frames after the last data.
+    push(&mut wire, protocol::MessageCode::Client, b"done\n");
+    push(
+        &mut wire,
+        protocol::MessageCode::ErrorXfer,
+        b"one skipped\n",
+    );
+    wire
+}
+
+/// Reads the entire demuxed stream via the blocking driver, recording the
+/// interleaved data + side-effect timeline.
+///
+/// `read_len` is the caller buffer size, exercised small so multi-frame data is
+/// split across reads exactly as the async driver would split it.
+fn drive_sync(wire: &[u8], read_len: usize) -> (Vec<u8>, Vec<Event>) {
+    let mut mux = MultiplexReader::new(Cursor::new(wire.to_vec()));
+    let mut sink = CapturingSink { events: Vec::new() };
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+
+    loop {
+        // Mirror the async driver's dispatch-through-sink by pre-draining any
+        // buffered bytes, then reading a fresh frame through the shared core.
+        // The demux never emits an explicit Ok(0) EOF frame, so end-of-stream
+        // surfaces as UnexpectedEof from the underlying reader - identical for
+        // both drivers, so terminating on it preserves parity.
+        match read_sync_with(&mut mux, &mut buf, &mut sink) {
+            Ok(0) => break,
+            Ok(n) => {
+                sink.events.push(Event::Data(buf[..n].to_vec()));
+                data.extend_from_slice(&buf[..n]);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => panic!("sync demux read failed: {err}"),
+        }
+    }
+    (data, sink.events)
+}
+
+/// Blocking read that routes dispatch side effects through `sink`, mirroring
+/// [`MultiplexReader::read_async_with`] exactly so the two timelines are
+/// directly comparable. This is the sync counterpart used only by the parity
+/// harness; production uses the `RealSink`-backed [`Read::read`].
+fn read_sync_with<R: Read, S: MuxSink>(
+    mux: &mut MultiplexReader<R>,
+    buf: &mut [u8],
+    sink: &mut S,
+) -> std::io::Result<usize> {
+    if mux.pos < mux.buffer.len() {
+        return mux.drain_buffered(buf);
+    }
+    loop {
+        mux.buffer.clear();
+        mux.pos = 0;
+        let code = protocol::recv_msg_into(&mut mux.inner, &mut mux.buffer)?;
+        if mux.dispatch_message_with(code, sink) {
+            if mux.buffer.is_empty() {
+                continue;
+            }
+            return mux.place_frame(buf);
+        }
+        mux.check_error_exit()?;
+    }
+}
+
+/// Reads the entire demuxed stream via the async driver over `reader`,
+/// recording the interleaved data + side-effect timeline.
+async fn drive_async<R: AsyncRead + Unpin>(reader: R, read_len: usize) -> (Vec<u8>, Vec<Event>) {
+    let mut mux = MultiplexReader::new(reader);
+    let mut sink = CapturingSink { events: Vec::new() };
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+
+    loop {
+        match mux.read_async_with(&mut buf, &mut sink).await {
+            Ok(0) => break,
+            Ok(n) => {
+                sink.events.push(Event::Data(buf[..n].to_vec()));
+                data.extend_from_slice(&buf[..n]);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => panic!("async demux read failed: {err}"),
+        }
+    }
+    (data, sink.events)
+}
+
+/// An [`AsyncRead`] adapter that yields at most `chunk` bytes per `poll_read`,
+/// forcing the async demux to reassemble frames across many `.await` points.
+struct ChunkedReader {
+    inner: Cursor<Vec<u8>>,
+    chunk: usize,
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let limit = self.chunk.max(1).min(buf.remaining());
+        if limit == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let mut scratch = vec![0u8; limit];
+        let mut scratch_buf = ReadBuf::new(&mut scratch);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut scratch_buf) {
+            Poll::Ready(Ok(())) => {
+                buf.put_slice(scratch_buf.filled());
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+/// The read-buffer sizes checked: 8 splits the 300-byte frame across many
+/// reads; 4096 delivers each frame whole. The async and sync drivers must
+/// agree at every size.
+const READ_LENS: [usize; 3] = [8, 64, 4096];
+
+#[tokio::test(flavor = "current_thread")]
+async fn demux_parity_whole_stream() {
+    let wire = corpus();
+    for read_len in READ_LENS {
+        let (sync_data, sync_events) = drive_sync(&wire, read_len);
+        let (async_data, async_events) = drive_async(Cursor::new(wire.clone()), read_len).await;
+
+        assert_eq!(
+            async_data, sync_data,
+            "async demux DATA diverged from sync at read_len {read_len}"
+        );
+        assert_eq!(
+            async_events, sync_events,
+            "async demux side-effect ordering diverged from sync at read_len {read_len}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_async_delivers_data_via_real_sink() {
+    // Exercises the production-facing `read_async` (which routes side effects
+    // through `RealSink` to the real stdout/stderr) end to end, proving the
+    // default async entry point demuxes the same DATA bytes the sync `Read`
+    // impl would. Control-frame effects go to the real streams here; ordered-
+    // effect parity is asserted separately via the capturing-sink tests.
+    let mut wire = Vec::new();
+    protocol::send_msg(&mut wire, protocol::MessageCode::Info, b"info\n").unwrap();
+    protocol::send_msg(&mut wire, protocol::MessageCode::Data, b"payload-bytes").unwrap();
+
+    let mut mux = MultiplexReader::new(Cursor::new(wire));
+    let mut buf = [0u8; 64];
+    let n = mux.read_async(&mut buf).await.unwrap();
+    assert_eq!(&buf[..n], b"payload-bytes");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn demux_parity_chunked_delivery() {
+    let wire = corpus();
+    // The sync reference: whole-stream delivery at each read length.
+    for read_len in READ_LENS {
+        let (sync_data, sync_events) = drive_sync(&wire, read_len);
+
+        // Deliver wire bytes in tiny chunks so every frame is reassembled
+        // across many polls / await points.
+        for chunk in [1usize, 2, 3, 7, 13] {
+            let reader = ChunkedReader {
+                inner: Cursor::new(wire.clone()),
+                chunk,
+            };
+            let (async_data, async_events) = drive_async(reader, read_len).await;
+            assert_eq!(
+                async_data, sync_data,
+                "async demux DATA diverged with chunk {chunk}, read_len {read_len}"
+            );
+            assert_eq!(
+                async_events, sync_events,
+                "async demux side-effect ordering diverged with chunk {chunk}, read_len {read_len}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Next async-migration rung: makes the `MultiplexReader` demux async, consuming the merged async multiplex read leaf (`protocol::recv_msg_into_async`). Behind default-off `tokio-transfer`, **byte-identical to the sync demux including inline side-effect ordering**, no fork. Unwired into the receiver hot path (receiver routing is the next rung).

The coupled-receiver STOP (#6224) flagged `dispatch_message`'s inline MSG_INFO/MSG_ERROR `print!`/`eprint!`/`stdout().flush()` between frames as the correctness-sensitive part. Resolved by making the side-effect surface explicit + shared:
- **`MuxSink` trait** (`info`/`error`) — `RealSink` reproduces the previous inline `print!("{msg}")+stdout().flush()` / `eprint!("{msg}")` byte-for-byte (default build unchanged).
- **Reader-free shared core:** `dispatch_message` delegates to `dispatch_message_with<S: MuxSink>` (moved to an unbounded `impl<R>` block — no `R: Read`); the buffer copy+tee factored into `drain_buffered`/`place_frame`/`tee_batch`. Both drivers call it at the IDENTICAL point (right after each frame read, before delivering data), so every info/error effect fires at the same position relative to MSG_DATA.
- **Async driver** `read_async`/`read_async_with<S>` (`#[cfg(feature="tokio-transfer")] impl<R: AsyncRead+Unpin>`): same loop as `Read::read`, awaiting `recv_msg_into_async`.

**Parity test** (`multiplex_parity_tests.rs`): identical wire stream (interleaved MSG_INFO/DATA/WARNING/ERROR + empty-DATA keep-alive + 300-byte multi-frame + MSG_CLIENT + MSG_ERROR_XFER) → both drivers via a capturing `MuxSink` → asserts identical demuxed DATA bytes AND identical ordered Info/Error/Data event timeline, across read-buffer sizes {8,64,4096} + chunked delivery {1,2,3,7,13}-byte across await points. CI `async-wire-parity.yml` extended.

Verified: default OFF build/clippy(`-D warnings`)/`test -p transfer -p protocol` (75 reader + 259 protocol multiplex green) + workspace build; feature ON build/clippy/3 parity tests + protocol recv_msg_parity green; fmt + doc-gate clean both states. No fork, no wire/protocol change, no public sync-API break, no default-feature flip, unsafe-free. One test-only tokio dev-dep added to transfer (mirrors protocol).