### PR TITLE
feat(transfer): async AsyncRead receiver reader stack + byte-exact async counter (ASY, default-off)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -69,3 +69,10 @@ jobs:
             -p transfer \
             --features tokio-transfer \
             -E 'test(demux_parity) | test(read_async_delivers_data_via_real_sink)'
+
+      - name: Run sync vs async receiver reader-stack parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer \
+            -E 'test(reader_stack_parity)'

--- a/crates/transfer/src/reader/counting.rs
+++ b/crates/transfer/src/reader/counting.rs
@@ -50,3 +50,48 @@ impl<R: Read> Read for CountingReader<R> {
         Ok(n)
     }
 }
+
+/// Async counterpart to the blocking [`Read`] impl above, gated on the
+/// `tokio-transfer` feature.
+///
+/// This is the `.await`-driven twin of the counter: it wraps the same
+/// [`CountingReader`] type over an inner [`tokio::io::AsyncRead`] and updates the
+/// same shared `bytes_read` [`Arc<AtomicU64>`]. There is no forked type and no
+/// forked count logic - only the read primitive differs (a `poll_read` on the
+/// inner async transport versus a blocking `read`).
+///
+/// # Byte-exact accounting (the correctness crux)
+///
+/// The blocking impl increments by exactly the number of bytes the underlying
+/// `read` returned. The async impl increments by exactly the number of bytes the
+/// inner `poll_read` added to the [`tokio::io::ReadBuf`] on each poll: the
+/// difference between the filled length before and after the delegated
+/// `poll_read`. A `poll_read` may fill any amount `0..=remaining`, and every
+/// such byte came off the transport exactly once, so the running total counts
+/// each transport byte exactly once - identical to the blocking counter.
+///
+/// Placing the counter directly over the raw async transport (below any
+/// buffering layer, matching the sync stack's position below `BufReader`) means
+/// the total tracks bytes actually pulled from the wire. When the stream is
+/// drained to EOF the total equals the exact wire byte count with no buffering
+/// prefetch skew, so the async counter is byte-identical to the sync counter and
+/// carries none of the known feature-on prefetch quirk.
+#[cfg(feature = "tokio-transfer")]
+impl<R: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for CountingReader<R> {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let inner = std::pin::Pin::new(&mut self.inner);
+        match inner.poll_read(cx, buf) {
+            std::task::Poll::Ready(Ok(())) => {
+                let added = buf.filled().len() - before;
+                self.bytes_read.fetch_add(added as u64, Ordering::Relaxed);
+                std::task::Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}

--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -15,3 +15,7 @@ mod tests;
 pub(crate) use counting::CountingReader;
 pub(crate) use multiplex::MultiplexReader;
 pub use server::ServerReader;
+
+#[cfg(feature = "tokio-transfer")]
+#[cfg_attr(not(test), allow(unused_imports))]
+pub(crate) use server::AsyncServerReader;

--- a/crates/transfer/src/reader/multiplex_parity_tests.rs
+++ b/crates/transfer/src/reader/multiplex_parity_tests.rs
@@ -26,11 +26,13 @@
 
 use std::io::{Cursor, Read};
 use std::pin::Pin;
+use std::sync::atomic::Ordering;
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, ReadBuf};
 
 use super::{MultiplexReader, MuxSink};
+use crate::reader::{AsyncServerReader, CountingReader, ServerReader};
 
 /// A single observable event on the demux timeline.
 ///
@@ -241,6 +243,158 @@ async fn read_async_delivers_data_via_real_sink() {
     let mut buf = [0u8; 64];
     let n = mux.read_async(&mut buf).await.unwrap();
     assert_eq!(&buf[..n], b"payload-bytes");
+}
+
+/// A data-only wire stream: every frame is `MSG_DATA` so the demuxed output
+/// equals the concatenated payloads. Used by the full-stack counter-parity
+/// tests, where the assertion is on delivered bytes plus the raw wire byte
+/// count rather than side-effect ordering (covered by the demux-only tests).
+///
+/// The stream ends exactly at a frame boundary and the readers drain it to EOF,
+/// so both the sync `BufReader`-backed counter and the async counter observe the
+/// full wire length with no buffering prefetch skew.
+fn data_only_wire() -> (Vec<u8>, Vec<u8>) {
+    let payloads: [&[u8]; 5] = [
+        b"first-chunk",
+        b"",            // keep-alive empty frame - skipped, never data
+        &[0x5Au8; 200], // spans small read buffers
+        b"second",
+        &[0xC3u8; 40],
+    ];
+    let mut wire = Vec::new();
+    let mut expected = Vec::new();
+    for p in payloads {
+        protocol::send_msg(&mut wire, protocol::MessageCode::Data, p).unwrap();
+        expected.extend_from_slice(p);
+    }
+    (wire, expected)
+}
+
+/// Drives the full **sync** receiver reader stack over `wire`:
+/// `CountingReader` (raw byte counter, below buffering) -> `io::BufReader`
+/// -> `ServerReader` in multiplex mode. Returns the demuxed bytes and the final
+/// raw wire byte count from the counter.
+fn drive_sync_stack(wire: &[u8], read_len: usize) -> (Vec<u8>, u64) {
+    let counting = CountingReader::new(Cursor::new(wire.to_vec()));
+    let counter = counting.counter();
+    let buffered = std::io::BufReader::with_capacity(64 * 1024, counting);
+    let mut server = ServerReader::new_plain(buffered)
+        .activate_multiplex()
+        .expect("activate multiplex");
+
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+    loop {
+        match server.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => panic!("sync stack read failed: {err}"),
+        }
+    }
+    (data, counter.load(Ordering::Relaxed))
+}
+
+/// Drives the full **async** receiver reader stack over `reader`:
+/// `CountingReader` (AsyncRead, raw byte counter) -> `tokio::io::BufReader`
+/// -> `AsyncServerReader` in multiplex mode -> `MultiplexReader::read_async`.
+/// Returns the demuxed bytes and the final raw wire byte count from the counter.
+async fn drive_async_stack<R: AsyncRead + Unpin>(reader: R, read_len: usize) -> (Vec<u8>, u64) {
+    let counting = CountingReader::new(reader);
+    let counter = counting.counter();
+    let buffered = tokio::io::BufReader::with_capacity(64 * 1024, counting);
+    let mut server = AsyncServerReader::new_plain(buffered)
+        .activate_multiplex()
+        .expect("activate multiplex");
+    assert!(
+        server.is_multiplexed(),
+        "async stack must be in multiplex mode after activation"
+    );
+
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+    loop {
+        match server.read_async(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => panic!("async stack read failed: {err}"),
+        }
+    }
+    (data, counter.load(Ordering::Relaxed))
+}
+
+/// End-to-end sync-vs-async parity for the assembled receiver reader stack:
+/// identical delivered bytes AND identical final `bytes_received` counts, across
+/// read-buffer sizes. Proves the async twin stack
+/// (`CountingReader`/`AsyncServerReader`/`read_async`) is byte-identical to the
+/// sync stack and that the async counter is byte-exact.
+#[tokio::test(flavor = "current_thread")]
+async fn reader_stack_parity_whole_stream() {
+    let (wire, expected) = data_only_wire();
+    for read_len in READ_LENS {
+        let (sync_data, sync_count) = drive_sync_stack(&wire, read_len);
+        let (async_data, async_count) =
+            drive_async_stack(Cursor::new(wire.clone()), read_len).await;
+
+        assert_eq!(
+            sync_data, expected,
+            "sync stack delivered wrong bytes at read_len {read_len}"
+        );
+        assert_eq!(
+            async_data, sync_data,
+            "async stack DATA diverged from sync at read_len {read_len}"
+        );
+        assert_eq!(
+            async_count, sync_count,
+            "async byte counter diverged from sync at read_len {read_len} \
+             (sync={sync_count}, async={async_count})"
+        );
+        // Both drained the whole stream, so the counter equals the wire length
+        // exactly: no buffering prefetch skew, the known feature-on quirk absent.
+        assert_eq!(
+            async_count,
+            wire.len() as u64,
+            "async byte count must equal exact wire length at read_len {read_len}"
+        );
+    }
+}
+
+/// Same end-to-end stack parity, but the async transport yields bytes in tiny
+/// chunks so every frame is reassembled across many `.await` points. The counter
+/// must still land byte-exact regardless of how the transport fragments reads.
+#[tokio::test(flavor = "current_thread")]
+async fn reader_stack_parity_chunked_delivery() {
+    let (wire, expected) = data_only_wire();
+    for read_len in READ_LENS {
+        let (sync_data, sync_count) = drive_sync_stack(&wire, read_len);
+        for chunk in [1usize, 2, 3, 7, 13] {
+            let reader = ChunkedReader {
+                inner: Cursor::new(wire.clone()),
+                chunk,
+            };
+            let (async_data, async_count) = drive_async_stack(reader, read_len).await;
+
+            assert_eq!(
+                async_data, expected,
+                "async stack DATA diverged with chunk {chunk}, read_len {read_len}"
+            );
+            assert_eq!(
+                async_data, sync_data,
+                "async stack DATA diverged from sync with chunk {chunk}, read_len {read_len}"
+            );
+            assert_eq!(
+                async_count, sync_count,
+                "async byte counter diverged from sync with chunk {chunk}, read_len {read_len}"
+            );
+            assert_eq!(
+                async_count,
+                wire.len() as u64,
+                "async byte count must equal exact wire length with chunk {chunk}, \
+                 read_len {read_len}"
+            );
+        }
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -235,3 +235,97 @@ impl<R: Read> Read for ServerReader<R> {
         }
     }
 }
+
+/// Async twin of [`ServerReader`], gated on the `tokio-transfer` feature.
+///
+/// This is the `.await`-driven counterpart to the blocking [`ServerReader`]
+/// mode dispatch. It exists so the coupled receiver rung can assemble a genuine
+/// async reader chain up to [`MultiplexReader::read_async`]:
+///
+/// ```text
+/// AsyncTransport -> CountingReader (AsyncRead) -> tokio BufReader
+///                -> AsyncServerReader -> MultiplexReader::read_async
+/// ```
+///
+/// # Why a dedicated twin rather than generalising `ServerReader`
+///
+/// [`ServerReader`] is declared `ServerReader<R: Read>` and its `Compressed`
+/// variant is `CompressedReader<MultiplexReader<R>>`, which requires
+/// `R: Read`. An `AsyncRead` transport is not `Read`, so the same struct cannot
+/// hold both. This twin therefore carries only the two async-reachable modes -
+/// plain pass-through and multiplex demux - and drops no read logic: the demux
+/// itself lives in the shared, reader-free [`MultiplexReader`] core, and this
+/// type only selects the mode and awaits it.
+///
+/// The compression mode is intentionally absent: decompression runs through the
+/// synchronous decoder crates (`compress::zlib::CountingZlibDecoder` and
+/// friends), which have no `.await` variant, so a compressed async twin cannot
+/// be built byte-identically at this rung. It is deferred to the receiver-
+/// routing rung.
+///
+/// Additive and unwired: only the parity tests drive this type.
+#[cfg(feature = "tokio-transfer")]
+pub(crate) struct AsyncServerReader<R> {
+    inner: AsyncServerReaderInner<R>,
+}
+
+/// Async mode dispatch for [`AsyncServerReader`].
+///
+/// Mirrors the plain and multiplex arms of the blocking
+/// [`ServerReaderInner`]; the compressed arm is deferred (see the type docs).
+#[cfg(feature = "tokio-transfer")]
+enum AsyncServerReaderInner<R> {
+    /// Plain mode - await the inner transport directly, no demux.
+    Plain(R),
+    /// Multiplex mode - await MSG_DATA frames via the shared demux core.
+    Multiplex(MultiplexReader<R>),
+}
+
+#[cfg(feature = "tokio-transfer")]
+impl<R: tokio::io::AsyncRead + Unpin> AsyncServerReader<R> {
+    /// Creates a new plain-mode async reader.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new_plain(reader: R) -> Self {
+        Self {
+            inner: AsyncServerReaderInner::Plain(reader),
+        }
+    }
+
+    /// Activates multiplex mode, wrapping the reader in the demultiplexer.
+    ///
+    /// Mirrors [`ServerReader::activate_multiplex`]: a plain reader becomes a
+    /// [`MultiplexReader`]; calling it twice is an error.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn activate_multiplex(self) -> io::Result<Self> {
+        match self.inner {
+            AsyncServerReaderInner::Plain(reader) => Ok(Self {
+                inner: AsyncServerReaderInner::Multiplex(MultiplexReader::new(reader)),
+            }),
+            AsyncServerReaderInner::Multiplex(_) => Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "multiplex already active",
+            )),
+        }
+    }
+
+    /// Returns true if multiplex mode is active.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn is_multiplexed(&self) -> bool {
+        matches!(self.inner, AsyncServerReaderInner::Multiplex(_))
+    }
+
+    /// Reads demultiplexed (or plain) data into `buf`, awaiting the transport.
+    ///
+    /// Byte-for-byte equivalent to [`ServerReader::read`] restricted to the
+    /// plain and multiplex modes: plain mode delegates to the inner async
+    /// transport's `read`, multiplex mode delegates to the shared
+    /// [`MultiplexReader::read_async`]. No demux logic is duplicated here.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn read_async(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        use tokio::io::AsyncReadExt;
+        match &mut self.inner {
+            AsyncServerReaderInner::Plain(r) => r.read(buf).await,
+            AsyncServerReaderInner::Multiplex(r) => r.read_async(buf).await,
+        }
+    }
+}

--- a/docs/design/asy-7-receiver-tokio-prototype.md
+++ b/docs/design/asy-7-receiver-tokio-prototype.md
@@ -334,3 +334,126 @@ real converted async receiver. Until then, shipping a tokio receiver
 means shipping either a `block_on`-hosted sync read (zero async benefit,
 the ASY-3 shape) or a divergent one (blocker D) - both worse than none.
 Per the ASY-7 charter stop clause, we stop.
+
+## 9. Third scoping (blockers A/D resolved) - STILL STOP
+
+Status: Re-scoped against master `9d7ea8196`, after the two hardest
+prerequisites landed:
+
+- **Prerequisite 1 / blocker A RESOLVED.** The async read leaves now
+  exist inside `protocol` (ASY-2 section 2.2 was amended to permit async
+  variants): `protocol::recv_msg_into_async`
+  (`crates/protocol/src/multiplex/io/async_recv.rs:40`,
+  `R: AsyncRead + Unpin`) and `CompressedTokenDecoder::recv_token_async`
+  (`crates/protocol/src/wire/compressed_token/decoder.rs:169`).
+- **Blocker D RESOLVED.** The async demux
+  `MultiplexReader::read_async_with<S: MuxSink>`
+  (`crates/transfer/src/reader/multiplex.rs:537`) reproduces the sync
+  demux's control-frame side effects in the same order via an injectable
+  `MuxSink`/`RealSink`, with a parity test
+  (`reader/multiplex_parity_tests.rs`).
+
+Outcome: **still STOP.** A byte-identical tokio receiver that genuinely
+`.await`s the socket is not shippable in a reviewable slice. No receiver
+`.rs` was converted. Default build and the ASY-3/ASY-4/demux foundation
+are untouched and remain byte-identical / default-off. Two blockers that
+resolving A/D did not remove hold; each is independently sufficient.
+
+### 9.1 Blocker B' - the async reader stack above the leaf does not exist
+
+`read_async` is only defined for `MultiplexReader<R>` where
+`R: AsyncRead + Unpin` (multiplex.rs:514). In production the multiplex
+inner `R` is `BufReader<CountingReader<Box<dyn Read>>>` - a
+`std::io::Read` stack, not `AsyncRead` - so `read_async` is uncallable on
+the real chain: there is no `AsyncRead`-typed reader to instantiate it
+over. The entire reader stack the receiver builds (lib.rs:535-538) is
+`std::io::Read`-typed and has **no async twin**:
+
+- `CountingReader` (`reader/counting.rs`) - counts raw wire bytes for the
+  `bytes_received` stat (lib.rs:535-536); no `AsyncRead` impl.
+- `std::io::BufReader` (64 KB, matches upstream `iobuf.in`) - a sync-only
+  type; the async path needs `tokio::io::BufReader` or none.
+- `ServerReader<R: Read>` (`reader/server.rs:15`) - the
+  Plain/Multiplex/Compressed state machine; no async read.
+- `CompressedReader` (the `ServerReaderInner::Compressed` layer) - no
+  async twin.
+
+Building the async path requires an end-to-end `AsyncRead`-typed reader
+chain (async CountingReader for byte-identical `bytes_received`, async
+ServerReader state machine, async CompressedReader) so `read_async` has a
+concrete socket-backed `R` to run over. That is a net-new reader stack,
+not a single-boundary swap. Grep confirms the only async-capable reader
+in `transfer` today is `MultiplexReader::read_async` plus a test-only
+`ChunkedReader`; every other layer is sync.
+
+### 9.2 Blocker C' - neither reachable receiver is a socket-backed tokio receiver
+
+Two receivers exist; neither is simultaneously (a) reachable through the
+tokio driver and (b) backed by a concrete async socket:
+
+- **CLI `--server` receiver** - the only caller of the tokio driver
+  (`core::session::run_server_stdio` ->
+  `transfer::run_server_with_handshake_on`,
+  `crates/core/src/session.rs:71`). But its transport is
+  `io::stdin().lock()` (`crates/cli/src/frontend/server/run.rs:57`) - a
+  **pipe**, which `AsyncTransport` structurally cannot wrap (ASY-4:
+  socket-backed only). Tokio-driven but no socket.
+- **Daemon module receiver** - runs in-process with a concrete
+  `TcpStream` clone available
+  (`daemon/.../transfer/streams.rs:50`, `tcp.try_clone()`), but it calls
+  the **sync** `run_server_with_handshake` directly (streams.rs:132),
+  never the tokio driver / `with_transfer_runtime`. The clone is boxed to
+  `Box<dyn Read + Send>` at streams.rs:69 before it reaches the server
+  body. Socket-backed but not tokio-driven, and type-erased at the
+  boundary.
+
+Routing the daemon receiver through the tokio driver AND threading the
+pre-erasure `TcpStream` (as `Option<TcpStream>`, NSV-1 shape) down to the
+receiver so `AsyncTransport::from_std_tcp` can adopt it is a `daemon` +
+`core` plumbing change, not a `transfer`-internal receiver rung. It also
+forks the daemon transfer entry (sync vs tokio) under `#[cfg]`.
+
+### 9.3 Blocker E - the fused read->SPSC frame and the 7-fn cfg-split
+
+Even with 9.1/9.2 solved, the coupled conversion still requires, in one
+change: async twins of the seven `R: Read` receiver functions
+(`ReceiverContext::run` -> `run_pipelined` -> `setup_transfer` ->
+`run_pipeline_loop_decoupled` -> `process_file_response_streaming` ->
+`TokenReader::read_token`, plus `ServerReader`/`MultiplexReader` reads),
+each `#[cfg]`-split sync/async; and a bridge for the fused read->send
+frame. `process_file_response_streaming`
+(`transfer_ops/streaming.rs:74`) reads a token (streaming.rs:138) and
+`file_tx.send(..)`s it to the disk-commit `std::thread` (streaming.rs:156)
+in the same synchronous frame, over a bounded spin-wait
+`spsc::channel` (`pipeline/spsc.rs`). The async twin must `.await` the
+read then hand the SPSC producer to a `spawn_blocking` island without
+reordering the in-order disk commits or the goodbye/flush sequence - a
+task boundary inside the previously-fused frame, re-establishing the
+flush-before-block invariant across it.
+
+### 9.4 Reviewable-slice verdict
+
+A byte-identical async daemon receiver is now *architecturally reachable*
+(A and D are resolved and the socket exists in-process), but not in a
+reviewable slice: it requires (1) a net-new end-to-end `AsyncRead` reader
+stack incl. a byte-exact async `bytes_received` counter (9.1), (2) a
+`daemon`+`core` re-route + `Option<TcpStream>` plumbing forking the
+daemon transfer entry (9.2), and (3) a 7-function sync/async `#[cfg]`
+fan-out plus an async-read -> `spawn_blocking`-SPSC bridge preserving
+in-order commit and flush-before-block (9.3). Landing that atomically is
+the only way to keep it byte-identical - a partial split leaves an async
+reader feeding a sync SPSC producer in one frame with no valid bridge
+(section 3.3), or an async `read_async` with no `AsyncRead` stack to run
+on (9.1). The known ASY-3/4 `bytes_received` 6-12 byte foundation quirk
+(section 8.5) would also be reproduced-and-amplified by an async
+`CountingReader` unless it counts byte-identically, so the stats-parity
+gate must be green on the new counter before the default can flip.
+
+Per the ASY-7 charter stop clause, we stop and report rather than ship
+either a `block_on`-hosted sync receiver (zero async benefit, the ASY-3
+shape already in place) or a receiver split across a boundary that
+diverges. The prerequisite ordering for the next rung is the three items
+in 9.4, landed as separate reviewable rungs (async reader stack; daemon
+tokio re-route + socket plumbing; the fused 7-fn conversion + SPSC
+bridge), in that dependency order, before an equivalence test can be
+written against a real converted async receiver.


### PR DESCRIPTION
Sub-rung 1 of 3 for the ASY coupled receiver (per docs/design/asy-7 §9.4). Builds a net-new end-to-end `tokio::io::AsyncRead` reader stack so `MultiplexReader::read_async` becomes callable on a real chain — the layer that was missing above the merged async leaves. **Additive, default-off, unwired, byte-identical.**

- **Async `CountingReader`** (`reader/counting.rs`): `AsyncRead` impl on the SAME type; `poll_read` delegates to the inner async transport and increments the same shared `bytes_read: Arc<AtomicU64>` by the fill delta — BYTE-EXACT. Placed identically to the sync counter (below `BufReader`, counting raw transport reads), so the known feature-on `bytes_received` prefetch quirk is ABSENT in the async counter (prevented by construction).
- **Async `AsyncServerReader`** (`reader/server.rs`): async twin of the mode dispatch — `Plain` (awaits transport) + `Multiplex` (delegates to shared `MultiplexReader::read_async`). No demux logic duplicated.
- **Assembled chain** (callable, test-exercised): `AsyncTransport → CountingReader(AsyncRead) → tokio BufReader → AsyncServerReader → read_async`.
- **Deferred (reported for sub-rung 2/3):** the `Compressed` mode (`CompressedReader` wraps sync zlib/lz4/zstd decoders with no `.await`) — decompression is CPU-bound with no await point, so it runs above the async demux under `spawn_blocking` when wired. Intentionally absent from `AsyncServerReader`.

**Parity tests** (`multiplex_parity_tests.rs`, CI-gated): identical wire stream → sync stack vs async stack → assert identical delivered bytes AND identical final `bytes_received` (== exact wire length), across read-buffer sizes {8,64,4096} + chunked delivery {1,2,3,7,13} across await points. `async-wire-parity.yml` extended.

Verified: default OFF build/clippy(`-D warnings`)/workspace build clean; feature ON build/clippy/parity+demux tests pass; fmt clean. (Pre-existing on master, NOT this PR: `disk_commit cleanup_manager` parallelism flake — passes single-threaded; 4 broken intra-doc links in `writer/mod.rs`+`writer/server.rs` — verified identical on clean origin/master; my reader/ files produce zero doc errors.) Also carries the asy-7 §9.4 roadmap doc.