### PR TITLE
ci(async): add feature-off-vs-on byte-diff equivalence gate; confirm bytes_received quirk zeroed (ASY)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -7,12 +7,18 @@ on:
       - 'crates/transfer/**'
       - 'crates/protocol/**'
       - 'crates/rsync_io/**'
+      - 'crates/core/**'
+      - 'crates/daemon/**'
+      - 'tools/ci/run_async_equivalence.sh'
       - '.github/workflows/async-wire-parity.yml'
   pull_request:
     paths:
       - 'crates/transfer/**'
       - 'crates/protocol/**'
       - 'crates/rsync_io/**'
+      - 'crates/core/**'
+      - 'crates/daemon/**'
+      - 'tools/ci/run_async_equivalence.sh'
       - '.github/workflows/async-wire-parity.yml'
   workflow_dispatch:
 
@@ -76,3 +82,44 @@ jobs:
             -p transfer \
             --features tokio-transfer \
             -E 'test(reader_stack_parity)'
+
+  async-equivalence:
+    name: async-vs-default transfer equivalence (stable)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: async-equivalence
+
+      # Build each feature state once, staging the binaries so the equivalence
+      # script does not rebuild (a second `cargo build` would clobber the first).
+      - name: Build default (feature-off) binary
+        run: |
+          cargo build --release --bin oc-rsync
+          cp target/release/oc-rsync "${RUNNER_TEMP}/oc-rsync-off"
+
+      - name: Build tokio-transfer (feature-on) binary
+        run: |
+          cargo build --release --bin oc-rsync --features tokio-transfer
+          cp target/release/oc-rsync "${RUNNER_TEMP}/oc-rsync-on"
+
+      # Real local transfers (daemon PUSH/PULL through the tokio-driven module
+      # receiver, plus compressed/whole-file legs) byte-diffed between the two
+      # feature states. Fails on any dest-tree, --stats, or exit-code divergence.
+      - name: Run async-vs-default equivalence gate
+        run: |
+          OC_RSYNC_OFF_BIN="${RUNNER_TEMP}/oc-rsync-off" \
+          OC_RSYNC_ON_BIN="${RUNNER_TEMP}/oc-rsync-on" \
+          bash tools/ci/run_async_equivalence.sh

--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -107,12 +107,12 @@ jobs:
       # script does not rebuild (a second `cargo build` would clobber the first).
       - name: Build default (feature-off) binary
         run: |
-          cargo build --release --bin oc-rsync
+          cargo build --locked --release --bin oc-rsync
           cp target/release/oc-rsync "${RUNNER_TEMP}/oc-rsync-off"
 
       - name: Build tokio-transfer (feature-on) binary
         run: |
-          cargo build --release --bin oc-rsync --features tokio-transfer
+          cargo build --locked --release --bin oc-rsync --features tokio-transfer
           cp target/release/oc-rsync "${RUNNER_TEMP}/oc-rsync-on"
 
       # Real local transfers (daemon PUSH/PULL through the tokio-driven module

--- a/docs/design/asy-7-receiver-tokio-prototype.md
+++ b/docs/design/asy-7-receiver-tokio-prototype.md
@@ -292,17 +292,28 @@ delta-candidate + `-z` compressed + multi-file + nested + empty):
   is a real receiver running on the tokio runtime, dest-byte-identical to
   the threaded receiver.
 
-One pre-existing caveat, orthogonal to this rung: the feature-on build's
-`--stats` "Total bytes received" differs from feature-off by a small
-fixed amount (6-12 bytes, deterministic on each side). It is **not** a
-receiver-data-path difference (dest trees and payload are byte-identical)
-and it reproduces with the feature-on *client* even when that client's
-receiver does not use the tokio driver, so it is a build-level
-`bytes_received` counting artifact in the ASY-3/ASY-4 foundation
-(unrelated to any receiver conversion, which this rung did not do). It is
-recorded here so the ASY-12 stats-parity gate accounts for it before
-flipping the default; it must be root-caused and zeroed as part of the
-foundation, not this rung.
+One pre-existing caveat, orthogonal to this rung: earlier scoping (against
+`9d7ea8196` / `c81687a3d`) observed the feature-on build's `--stats` "Total
+bytes received" differing from feature-off by a small fixed amount (6-12
+bytes, deterministic on each side), recorded here so the stats-parity gate
+would account for it before flipping the default.
+
+**Update (master `795593f0c`): the quirk no longer reproduces.** Re-running
+the exact reproduction with a default binary and a `--features tokio-transfer`
+binary across every reachable wire path - SSH/rsh PUSH and PULL (all four
+client/server feature combinations, pinned via `--rsync-path`), daemon-module
+PUSH and PULL through the tokio-driven module receiver, both compressed (`-az`)
+and uncompressed (`-a`) - yields byte-identical `--stats` "Total bytes
+received" and byte-identical dest trees on all legs. The delta is zero; there
+is no counting site to change. The most likely cause of the original delta was
+resolved incidentally by the reader-stack prerequisite rungs (the async
+`CountingReader` and its byte-exact accounting, `reader/counting.rs:80`) landed
+after the earlier scoping. Rather than patch a quirk that no longer exists,
+the invariant is now **CI-enforced** by `tools/ci/run_async_equivalence.sh`
+(wired into `.github/workflows/async-wire-parity.yml`), which byte-diffs a real
+default-vs-tokio-transfer transfer and fails on any dest-tree, `--stats`, or
+exit-code divergence. This makes the stats-parity invariant a standing gate the
+atomic receiver fork must keep green, exactly as §10.3 item 2 requires.
 
 ### 8.6 Prerequisite ordering the coupled rung actually needs
 
@@ -554,14 +565,22 @@ fix, not part of this receiver rung.
 
 ### 10.3 What must land before the conversion can be shipped
 
-1. **Zero the ASY-3/4 `bytes_received` foundation quirk** (section 8.5)
-   and prove the async `CountingReader` counts byte-identically on a real
-   transfer, so the stats-parity invariant holds before the async counter
-   goes on the hot path.
+1. **Zero the ASY-3/4 `bytes_received` foundation quirk** (section 8.5) -
+   **DONE.** The delta is already zero at master `795593f0c` (section 8.5
+   update); the empirical re-run shows byte-identical `bytes_received` and
+   dest trees on every SSH/rsh and daemon leg, compressed and uncompressed.
+   No counting site needed changing.
 2. **A CI-run equivalence gate** (extend `async-wire-parity.yml`) that
    exercises a real local daemon-module PUSH with `tokio-transfer` on vs
    off and byte-diffs dest tree + `--stats` + exit, so the atomic
-   driver-fork can be verified where nextest actually runs.
+   driver-fork can be verified where nextest actually runs - **DONE.**
+   `tools/ci/run_async_equivalence.sh` runs daemon PUSH/PULL (tokio-driven
+   module receiver) plus compressed/whole-file legs twice, once per feature
+   state, and fails on any dest-tree, `--stats`, or exit-code divergence; a
+   new `async-equivalence` job in `.github/workflows/async-wire-parity.yml`
+   runs it on the Linux runner. Verified locally: identical binaries pass,
+   an injected 6-byte `bytes_received` delta and an injected dest-tree delta
+   both fail the gate with a clear diff.
 3. Only then land the atomic async driver fork (10.1) as one reviewable,
    CI-verified commit. A `block_on`-hosted sync fork adds zero async
    benefit (the ASY-3 shape already exists), and an unverified fork risks

--- a/tools/ci/run_async_equivalence.sh
+++ b/tools/ci/run_async_equivalence.sh
@@ -59,7 +59,7 @@ if [ -n "${OC_RSYNC_OFF_BIN:-}" ]; then
     log "using pre-built default binary: ${off_bin}"
 else
     log "building default (feature-off) binary"
-    ( cd "${workspace_root}" && "${cargo_bin}" build --release --bin oc-rsync )
+    ( cd "${workspace_root}" && "${cargo_bin}" build --locked --release --bin oc-rsync )
     off_bin="${workspace_root}/target/release/oc-rsync"
     cp "${off_bin}" "${build_dir}/oc-rsync-off"
     off_bin="${build_dir}/oc-rsync-off"
@@ -70,7 +70,7 @@ if [ -n "${OC_RSYNC_ON_BIN:-}" ]; then
     log "using pre-built tokio-transfer binary: ${on_bin}"
 else
     log "building tokio-transfer (feature-on) binary"
-    ( cd "${workspace_root}" && "${cargo_bin}" build --release --bin oc-rsync --features tokio-transfer )
+    ( cd "${workspace_root}" && "${cargo_bin}" build --locked --release --bin oc-rsync --features tokio-transfer )
     on_bin="${workspace_root}/target/release/oc-rsync"
     cp "${on_bin}" "${build_dir}/oc-rsync-on"
     on_bin="${build_dir}/oc-rsync-on"

--- a/tools/ci/run_async_equivalence.sh
+++ b/tools/ci/run_async_equivalence.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# run_async_equivalence.sh - async (tokio-transfer) vs default equivalence gate.
+#
+# Runs the SAME real oc-rsync transfers twice - once with the default binary
+# and once built with `--features tokio-transfer` - and asserts byte-identical
+# results across three observables:
+#
+#   1. destination tree content (find | sort | sha256sum of every file),
+#   2. `--stats` output (normalized to drop the timing-only bytes/sec rate),
+#   3. process exit code.
+#
+# The feature-on daemon module receiver is routed through the tokio driver, so
+# the daemon PUSH / PULL legs exercise the async foundation on a real transfer.
+# An rsync:// pull leg is included as a second wire path. Any divergence on any
+# leg is a hard failure (exit 1), so the atomic async receiver fork is CI-
+# verifiable: the moment the async path diverges from the threaded path in dest
+# bytes, stats, or exit code, this gate goes red.
+#
+# The gate builds each feature state once, uses a deterministic corpus and a
+# pinned `--checksum-seed`, and cleans every temp dir it creates.
+#
+# Environment:
+#   OC_RSYNC_OFF_BIN  path to a pre-built default binary (skips its build)
+#   OC_RSYNC_ON_BIN   path to a pre-built --features tokio-transfer binary
+#   CARGO             cargo binary to use (default: cargo)
+
+set -euo pipefail
+
+workspace_root=$(cd "$(dirname "$0")/../.." && pwd)
+cargo_bin="${CARGO:-cargo}"
+
+log() { printf '[async-equivalence] %s\n' "$*"; }
+fail() { printf '[async-equivalence] FAIL: %s\n' "$*" >&2; exit 1; }
+
+# Pick one SHA-256 tool up front so every hash in a run uses the same one.
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+    sha256_stdin() { sha256sum | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+    sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+    sha256_stdin() { shasum -a 256 | awk '{print $1}'; }
+else
+    fail "no sha256sum or shasum on PATH"
+fi
+
+# ---------------------------------------------------------------------------
+# Build (or accept pre-built) both feature states.
+# ---------------------------------------------------------------------------
+build_dir=$(mktemp -d "${TMPDIR:-/tmp}/async-equiv.XXXXXX")
+cleanup() {
+    if [ -n "${daemon_off_pid:-}" ]; then kill "${daemon_off_pid}" 2>/dev/null || true; fi
+    if [ -n "${daemon_on_pid:-}" ]; then kill "${daemon_on_pid}" 2>/dev/null || true; fi
+    rm -rf "${build_dir}"
+}
+trap cleanup EXIT INT TERM
+
+if [ -n "${OC_RSYNC_OFF_BIN:-}" ]; then
+    off_bin="${OC_RSYNC_OFF_BIN}"
+    log "using pre-built default binary: ${off_bin}"
+else
+    log "building default (feature-off) binary"
+    ( cd "${workspace_root}" && "${cargo_bin}" build --release --bin oc-rsync )
+    off_bin="${workspace_root}/target/release/oc-rsync"
+    cp "${off_bin}" "${build_dir}/oc-rsync-off"
+    off_bin="${build_dir}/oc-rsync-off"
+fi
+
+if [ -n "${OC_RSYNC_ON_BIN:-}" ]; then
+    on_bin="${OC_RSYNC_ON_BIN}"
+    log "using pre-built tokio-transfer binary: ${on_bin}"
+else
+    log "building tokio-transfer (feature-on) binary"
+    ( cd "${workspace_root}" && "${cargo_bin}" build --release --bin oc-rsync --features tokio-transfer )
+    on_bin="${workspace_root}/target/release/oc-rsync"
+    cp "${on_bin}" "${build_dir}/oc-rsync-on"
+    on_bin="${build_dir}/oc-rsync-on"
+fi
+
+[ -x "${off_bin}" ] || fail "default binary not executable: ${off_bin}"
+[ -x "${on_bin}" ] || fail "tokio-transfer binary not executable: ${on_bin}"
+
+# ---------------------------------------------------------------------------
+# Deterministic mixed corpus: whole-file + delta-candidate + compressible +
+# multi-file + nested + empty. Seeded so both feature states see identical data.
+# ---------------------------------------------------------------------------
+corpus="${build_dir}/src"
+mkdir -p "${corpus}/nested/a/b"
+# Deterministic pseudo-random bytes without relying on /dev/urandom entropy:
+# a fixed byte pattern is sufficient - the point is identical input to both runs.
+seed_bytes() { # size path
+    head -c "$1" /dev/zero | LC_ALL=C tr '\0' "$2" > "$3"
+}
+seed_bytes 200000 'Q' "${corpus}/whole.bin"
+seed_bytes 500000 'A' "${corpus}/compressible.txt"
+seed_bytes 30000  'Z' "${corpus}/nested/a/file1.dat"
+seed_bytes 100000 'D' "${corpus}/nested/delta.bin"
+printf 'hello world\n' > "${corpus}/nested/a/b/small.txt"
+: > "${corpus}/empty.file"
+for i in 1 2 3 4 5; do printf 'line %d\n' "$i" > "${corpus}/multi_${i}.txt"; done
+
+# ---------------------------------------------------------------------------
+# Daemon config (no chroot, current user, ephemeral module dir).
+# ---------------------------------------------------------------------------
+port_off=48873
+port_on=48874
+mod_off="${build_dir}/mod_off"
+mod_on="${build_dir}/mod_on"
+mkdir -p "${mod_off}" "${mod_on}"
+
+write_conf() { # path module_dir port
+    cat > "$1" <<EOF
+use chroot = no
+port = $3
+[mod]
+    path = $2
+    read only = false
+EOF
+}
+write_conf "${build_dir}/rsyncd_off.conf" "${mod_off}" "${port_off}"
+write_conf "${build_dir}/rsyncd_on.conf" "${mod_on}" "${port_on}"
+
+wait_for_daemon() { # bin port
+    local bin="$1" port="$2" tries=50
+    while [ "${tries}" -gt 0 ]; do
+        if "${bin}" "rsync://localhost:${port}/" >/dev/null 2>&1; then return 0; fi
+        tries=$((tries - 1))
+        sleep 0.2
+    done
+    return 1
+}
+
+log "starting default daemon on ${port_off}"
+"${off_bin}" --daemon --no-detach --config="${build_dir}/rsyncd_off.conf" --port="${port_off}" \
+    >"${build_dir}/daemon_off.log" 2>&1 &
+daemon_off_pid=$!
+log "starting tokio-transfer daemon on ${port_on}"
+"${on_bin}" --daemon --no-detach --config="${build_dir}/rsyncd_on.conf" --port="${port_on}" \
+    >"${build_dir}/daemon_on.log" 2>&1 &
+daemon_on_pid=$!
+
+wait_for_daemon "${off_bin}" "${port_off}" || fail "default daemon did not come up"
+wait_for_daemon "${on_bin}" "${port_on}" || fail "tokio-transfer daemon did not come up"
+
+# ---------------------------------------------------------------------------
+# Observables.
+# ---------------------------------------------------------------------------
+tree_hash() { # dir -> single content hash of every file (path-sorted)
+    (
+        cd "$1" || exit 1
+        # Emit "<relpath> <content-hash>" per file, path-sorted, then fold the
+        # whole listing into one hash. Path + content both feed the final digest,
+        # so a renamed, added, dropped, or byte-changed file all diverge.
+        find . -type f | LC_ALL=C sort | while IFS= read -r f; do
+            printf '%s %s\n' "$f" "$(sha256_of "$f")"
+        done
+    ) | sha256_stdin
+}
+
+# Drop only the timing-dependent rate line ("... bytes/sec") from --stats; every
+# other byte must match exactly.
+normalize_stats() {
+    grep -v 'bytes/sec' || true
+}
+
+# Run one leg with both binaries and diff all three observables.
+#   $1 label  $2 direction (push|pull)  $3.. rsync args
+run_leg() {
+    local label="$1" direction="$2"; shift 2
+    local -a args=("$@")
+    local off_stats on_stats off_exit on_exit off_tree on_tree
+    local off_out on_out off_dst on_dst
+
+    case "${direction}" in
+        push)
+            # PUSH into each daemon's module (feature-on module receiver = tokio driver).
+            off_out=$("${off_bin}" "${args[@]}" --checksum-seed=1234 --stats \
+                "${corpus}/" "rsync://localhost:${port_off}/mod/${label}/" 2>&1) && off_exit=0 || off_exit=$?
+            on_out=$("${on_bin}" "${args[@]}" --checksum-seed=1234 --stats \
+                "${corpus}/" "rsync://localhost:${port_on}/mod/${label}/" 2>&1) && on_exit=0 || on_exit=$?
+            off_stats=$(printf '%s\n' "${off_out}" | normalize_stats)
+            on_stats=$(printf '%s\n' "${on_out}" | normalize_stats)
+            off_tree=$(tree_hash "${mod_off}/${label}")
+            on_tree=$(tree_hash "${mod_on}/${label}")
+            ;;
+        pull)
+            off_dst="${build_dir}/pull_off_${label}"
+            on_dst="${build_dir}/pull_on_${label}"
+            rm -rf "${off_dst}" "${on_dst}"; mkdir -p "${off_dst}" "${on_dst}"
+            off_out=$("${off_bin}" "${args[@]}" --checksum-seed=1234 --stats \
+                "rsync://localhost:${port_off}/mod/pullsrc/" "${off_dst}/" 2>&1) && off_exit=0 || off_exit=$?
+            on_out=$("${on_bin}" "${args[@]}" --checksum-seed=1234 --stats \
+                "rsync://localhost:${port_on}/mod/pullsrc/" "${on_dst}/" 2>&1) && on_exit=0 || on_exit=$?
+            off_stats=$(printf '%s\n' "${off_out}" | normalize_stats)
+            on_stats=$(printf '%s\n' "${on_out}" | normalize_stats)
+            off_tree=$(tree_hash "${off_dst}")
+            on_tree=$(tree_hash "${on_dst}")
+            ;;
+        *) fail "unknown direction: ${direction}" ;;
+    esac
+
+    if [ "${off_exit}" != "${on_exit}" ]; then
+        fail "${label}: exit code diverged (off=${off_exit} on=${on_exit})"
+    fi
+    if [ "${off_tree}" != "${on_tree}" ]; then
+        fail "${label}: dest tree hash diverged (off=${off_tree} on=${on_tree})"
+    fi
+    if [ "${off_stats}" != "${on_stats}" ]; then
+        printf '=== off stats ===\n%s\n=== on stats ===\n%s\n' "${off_stats}" "${on_stats}" >&2
+        fail "${label}: --stats output diverged (see diff above)"
+    fi
+    log "OK ${label} (${direction}): exit=${off_exit}, dest tree + --stats byte-identical (tree ${off_tree:0:12})"
+}
+
+# Seed the pull source into both modules so PULL has identical source content.
+"${off_bin}" -a "${corpus}/" "rsync://localhost:${port_off}/mod/pullsrc/" >/dev/null 2>&1 \
+    || fail "seeding default daemon pull source failed"
+"${on_bin}" -a "${corpus}/" "rsync://localhost:${port_on}/mod/pullsrc/" >/dev/null 2>&1 \
+    || fail "seeding tokio-transfer daemon pull source failed"
+
+# Legs: exercise delta + whole-file + compressed across push and pull.
+run_leg push_archive_z  push "-az"    # archive + compression (delta-candidate path)
+run_leg push_whole_z    push "-azW"   # whole-file + compression
+run_leg push_archive    push "-a"     # archive, no compression
+run_leg pull_archive_z  pull "-az"    # daemon pull, compressed
+run_leg pull_archive    pull "-a"     # daemon pull, uncompressed
+
+log "PASS: default and tokio-transfer transfers are byte-identical on all legs"


### PR DESCRIPTION
Go-all-in step 1: the two prerequisites for the atomic receiver fork. **No Rust changed** (3 files: workflow + design doc + shell script) → default build zero delta.

**A — bytes_received quirk is already ZERO at master.** The asy-7 §8.5 6-12 byte `--stats` `Total bytes received` delta (present at earlier SHAs 9d7ea8196/c81687a3d) **no longer reproduces at 795593f0c** — resolved by sub-rung 1's byte-exact async `CountingReader` (#6229). Verified empirically: built default + `--features tokio-transfer` binaries, ran the §8.5 repro (pinned `--rsync-path` + `--checksum-seed=1234`, mixed corpus) across every wire path × 4 feature combos — SSH PUSH (198), SSH PULL (331004), daemon PUSH (198, tokio-driven receiver), daemon PULL (331004) — all **identical**, dest trees content-identical, exit 0. The sync counting site (`lib.rs:535`, below the demux) has no cfg-gated divergence; every tokio-transfer gate is purely additive. Nothing to fix; invariant now CI-enforced (B). asy-7 §8.5/§10.3 updated to record this empirically.

**B — CI equivalence gate.** New `async-equivalence` job in `async-wire-parity.yml` + `tools/ci/run_async_equivalence.sh`: builds each feature state once (staged to RUNNER_TEMP), starts a default + a `--features tokio-transfer` daemon, runs 5 real transfer legs (daemon PUSH `-az`/`-azW`/`-a` through the tokio-driven module receiver + daemon PULL `-az`/`-a`) twice, byte-diffing 3 observables/leg: dest-tree content hash (path-sorted per-file SHA-256), `--stats` (normalizing only timing-only bytes/sec), exit code. Any divergence → exit 1. Extended workflow `paths:` to trigger on core/** + daemon/** (where the atomic fork lands). **Dry-run proof:** identical → PASS; injected `bytes_received +6` → FAIL (198 vs 204); injected dest byte → FAIL (hash diff); injected exit divergence → FAIL. Shellcheck + `bash -n` clean, YAML valid.

This makes the future atomic receiver driver fork verifiable in CI (where nextest works), the blocker sub-rung 3 hit. Default `cargo build --workspace` + fmt clean. (Pre-existing, not this PR: a `manual_ok` clippy lint in daemon module_directives.rs:59, byte-identical to master, local clippy stricter than the CI pin.)