### PR TITLE
ci: make the upstream rsync testsuite a required check (real+skip reusable)

### DIFF
--- a/.github/workflows/_ci-skip-upstream-testsuite.yml
+++ b/.github/workflows/_ci-skip-upstream-testsuite.yml
@@ -1,0 +1,14 @@
+name: CI skip upstream testsuite
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  upstream-testsuite:
+    name: upstream testsuite
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped — no relevant changes"

--- a/.github/workflows/_upstream-testsuite.yml
+++ b/.github/workflows/_upstream-testsuite.yml
@@ -1,54 +1,33 @@
 name: Upstream Testsuite
 
 on:
-  push:
-    branches: [ master, main ]
-    paths:
-      - 'crates/**'
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'tools/ci/run_upstream_testsuite.sh'
-      - 'tools/ci/upstream_testsuite_known_failures.conf'
-      - '.github/workflows/upstream-testsuite.yml'
-  pull_request:
-    paths:
-      - 'crates/**'
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'tools/ci/run_upstream_testsuite.sh'
-      - 'tools/ci/upstream_testsuite_known_failures.conf'
-      - '.github/workflows/upstream-testsuite.yml'
-  workflow_dispatch:
-
-concurrency:
-  group: upstream-testsuite-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      cache_version:
+        description: 'Cache version for invalidation'
+        type: string
+        default: 'v1'
+      upstream_rsync_version:
+        description: 'Upstream rsync version for cache key'
+        type: string
+        default: '3.4.4'
 
 permissions:
   contents: read
-
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: "0"
-  RUSTFLAGS: "-D warnings"
-  RUST_BACKTRACE: "full"
-  CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
-  UPSTREAM_RSYNC_VERSION: "3.4.4"
 
 jobs:
   upstream-testsuite:
     name: upstream testsuite
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # Not a required check - there are known failures. The runner script
-    # exits non-zero only on UNEXPECTED failures (tests not in
-    # known_failures.conf) or UNEXPECTED passes (tests in known_failures.conf
-    # that start passing). Both conditions surface regressions worth
-    # investigating, but should not block PRs while the failure list
-    # stabilizes.
-    continue-on-error: true
+
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-D warnings"
+      RUST_BACKTRACE: "full"
+      CACHE_VERSION: ${{ inputs.cache_version }}
+      UPSTREAM_RSYNC_VERSION: ${{ inputs.upstream_rsync_version }}
 
     steps:
       - name: Checkout
@@ -95,9 +74,7 @@ jobs:
         # No step-level continue-on-error: a non-zero exit from the harness
         # (UNEXPECTED FAIL outside known_failures.conf or UPASS regression)
         # MUST surface to the job conclusion so PRs that claim to fix an
-        # upstream test can be validated against the per-test result. The
-        # job-level continue-on-error (above) keeps this from blocking
-        # branch protection while the failure list stabilizes.
+        # upstream test can be validated against the per-test result.
 
       - name: Generate job summary
         if: always()

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -72,3 +72,6 @@ jobs:
   interop-windows:
     name: interop (Windows, best-effort)
     uses: ./.github/workflows/_ci-skip-interop-windows.yml
+
+  upstream-testsuite:
+    uses: ./.github/workflows/_ci-skip-upstream-testsuite.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - '.github/workflows/_interop.yml'
       - '.github/workflows/_interop-macos.yml'
       - '.github/workflows/_interop-windows.yml'
+      - '.github/workflows/_upstream-testsuite.yml'
       - 'docker/**'
       - 'Cross.toml'
   pull_request:
@@ -34,6 +35,7 @@ on:
       - '.github/workflows/_interop.yml'
       - '.github/workflows/_interop-macos.yml'
       - '.github/workflows/_interop-windows.yml'
+      - '.github/workflows/_upstream-testsuite.yml'
       - 'docker/**'
       - 'Cross.toml'
   workflow_dispatch:
@@ -626,6 +628,24 @@ jobs:
     with:
       cache_version: ${{ vars.CACHE_VERSION || 'v1' }}
       timeout_minutes: 30
+
+  # ===========================================================================
+  # Upstream Testsuite - Drive upstream rsync's own testsuite/*.test corpus
+  # against oc-rsync (reusable workflow)
+  # ---------------------------------------------------------------------------
+  # Required check. The harness exits non-zero only on UNEXPECTED failures
+  # (tests not in tools/ci/upstream_testsuite_known_failures.conf) or
+  # UNEXPECTED passes (known-failure tests that start passing); both surface
+  # regressions worth blocking on. The ci-skip umbrella emits the matching
+  # `upstream-testsuite / upstream testsuite` context on doc-only PRs so this
+  # required check never deadlocks.
+  # ===========================================================================
+  upstream-testsuite:
+    needs: lint
+    uses: ./.github/workflows/_upstream-testsuite.yml
+    with:
+      cache_version: ${{ vars.CACHE_VERSION || 'v1' }}
+      upstream_rsync_version: ${{ vars.UPSTREAM_RSYNC_VERSION || '3.4.4' }}
 
   # ===========================================================================
   # DG-3.e: concurrent_register_and_dispatch stress (#2694)


### PR DESCRIPTION
## Problem: required-check + path-filter deadlock

`.github/workflows/upstream-testsuite.yml` was a standalone, path-filtered workflow (runs only when `crates/**`, `src/**`, `Cargo.*`, or the testsuite files change) explicitly commented "Not a required check". A required check must report a status on **every** PR. A path-filtered standalone workflow does not fire on doc-only PRs, so promoting it to required as-is would hang those PRs forever waiting for a status that never arrives.

## Solution: mirror the existing interop real+skip reusable convention

The repo already solves exactly this for interop with two disjoint umbrellas that trigger on curated, non-overlapping path-lists, so exactly one runs per PR and the shared context always reports once:

- `ci.yml` (code path-set) has `interop-upstream` → `uses: ./.github/workflows/_interop.yml` (real, job name `interop with upstream rsync`).
- `ci-skip.yml` (docs/packaging path-set) has `interop` → `uses: ./.github/workflows/_ci-skip-interop.yml` (stub, identical job name, echoes "Skipped").

This PR folds the upstream testsuite into the same model:

- **`_upstream-testsuite.yml`** — new `workflow_call` reusable containing the current standalone job body verbatim (checkout, install rust, caches, build oc-rsync `--locked --release`, cache/build upstream 3.4.4, run `tools/ci/run_upstream_testsuite.sh`, the UNEXPECTED-FAIL/UPASS gate, step summary, log artifact). Adds `cache_version` + `upstream_rsync_version` inputs mirroring `_interop.yml`. Job name pinned to `upstream testsuite`. The job-level `continue-on-error: true` is **removed** so the gate becomes blocking.
- **`_ci-skip-upstream-testsuite.yml`** — stub reusable with an identically named job (`upstream testsuite`), single step echoing "Skipped — no relevant changes".
- **`ci.yml`** — new `upstream-testsuite` job `uses: ./.github/workflows/_upstream-testsuite.yml`; added `_upstream-testsuite.yml` to both `push`/`pull_request` `paths:` lists (as with `_interop.yml`).
- **`ci-skip.yml`** — new `upstream-testsuite` job `uses: ./.github/workflows/_ci-skip-upstream-testsuite.yml`.
- **Deleted** the standalone `upstream-testsuite.yml` (its code path-set + `workflow_dispatch` are covered by `ci.yml`). Nothing else references it.

`ci.yml` and `ci-skip.yml` remain mutually exclusive by path (verified: zero path overlap), so exactly one umbrella runs per PR and the required context reports exactly once.

## Gate semantics preserved

The known-failures contract is unchanged: `tools/ci/run_upstream_testsuite.sh` exits non-zero **only** on UNEXPECTED failures (tests not in `tools/ci/upstream_testsuite_known_failures.conf`) or UPASS regressions (known-failure tests that start passing). Removing the job-level `continue-on-error` simply lets those surface as a failing required check. The harness invocation, `known_failures.conf` sourcing, UPASS/FAIL summary, and log artifact are byte-identical to the old standalone. Every `cargo` invocation keeps `--locked`.

## New required-check context

```
upstream-testsuite / upstream testsuite
```

(caller-job-id `upstream-testsuite` / reusable-job-name `upstream testsuite`), analogous to `interop / interop with upstream rsync`.

## Follow-up (manual, after merge)

The branch-protection ruleset must be updated to require **`upstream-testsuite / upstream testsuite`** *after* this merges. This PR intentionally does **not** touch the ruleset — that is a separate manual step.
