### PR TITLE
feat(transfer): capacity-source abstraction + bounded_dynamic constructor on WorkQueueSender (WQDB-1/2)

### DIFF
--- a/crates/engine/src/concurrent_delta/work_queue/bounded.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/bounded.rs
@@ -5,9 +5,13 @@
 //! consumption is implemented in [`super::drain`], iterator support in
 //! [`super::iter`], and capacity policy in [`super::capacity`].
 
+use std::sync::Arc;
+
 use crossbeam_channel::{self as channel, Receiver, Sender};
 
+use super::adaptive_semaphore::{AdaptiveSemaphore, ResizeError};
 use super::capacity::CAPACITY_MULTIPLIER;
+use super::capacity_source::CapacitySource;
 use crate::concurrent_delta::DeltaWork;
 
 /// Bounded work queue that limits in-flight delta computation items.
@@ -47,6 +51,12 @@ use crate::concurrent_delta::DeltaWork;
 /// ```
 pub struct WorkQueueSender {
     pub(super) tx: Sender<DeltaWork>,
+    /// Where admission capacity comes from.
+    ///
+    /// [`CapacitySource::Fixed`] preserves the original behaviour (the channel
+    /// bound is the only gate); [`CapacitySource::Dynamic`] gates admission
+    /// through a resizable [`AdaptiveSemaphore`].
+    pub(super) capacity: CapacitySource,
 }
 
 /// Receiving half of the bounded work queue.
@@ -75,8 +85,42 @@ impl WorkQueueSender {
     /// Sends a work item into the queue, blocking if at capacity.
     ///
     /// Returns `Err(SendError)` if the receiver has been dropped.
+    ///
+    /// For a [`CapacitySource::Fixed`] queue (the default), admission is gated
+    /// solely by the bounded channel, so this is identical to a plain channel
+    /// send. For a dynamic queue, admission is first gated by the backing
+    /// [`AdaptiveSemaphore`] before the item enters the (over-provisioned)
+    /// channel.
     pub fn send(&self, work: DeltaWork) -> Result<(), SendError> {
+        self.capacity.acquire();
         self.tx.send(work).map_err(|e| SendError(e.0))
+    }
+
+    /// Returns the current admission capacity ceiling.
+    ///
+    /// For a fixed-bound queue this is the channel capacity fixed at
+    /// construction. For a dynamic queue this is the semaphore's current
+    /// ceiling, which may sit anywhere in `[min, max]`.
+    #[must_use]
+    pub fn current_capacity(&self) -> usize {
+        match &self.capacity {
+            CapacitySource::Fixed => self.tx.capacity().unwrap_or(0),
+            CapacitySource::Dynamic { semaphore, .. } => semaphore.current_cap(),
+        }
+    }
+
+    /// Returns the configured `[min, max]` admission ceiling range.
+    ///
+    /// Returns `None` for a fixed-bound queue, whose capacity does not move. For
+    /// a dynamic queue it returns the `(min, max)` the ceiling may be resized
+    /// between, as set by [`bounded_dynamic`]. A controller reads these to clamp
+    /// any grow/shrink decision to the configured range.
+    #[must_use]
+    pub fn capacity_bounds(&self) -> Option<(usize, usize)> {
+        match &self.capacity {
+            CapacitySource::Fixed => None,
+            CapacitySource::Dynamic { min, max, .. } => Some((*min, *max)),
+        }
     }
 }
 
@@ -100,5 +144,94 @@ pub fn bounded() -> (WorkQueueSender, WorkQueueReceiver) {
 pub fn bounded_with_capacity(capacity: usize) -> (WorkQueueSender, WorkQueueReceiver) {
     assert!(capacity > 0, "work queue capacity must be non-zero");
     let (tx, rx) = channel::bounded(capacity);
-    (WorkQueueSender { tx }, WorkQueueReceiver { rx })
+    (
+        WorkQueueSender {
+            tx,
+            capacity: CapacitySource::Fixed,
+        },
+        WorkQueueReceiver { rx },
+    )
+}
+
+/// Handle to a dynamic work queue's resizable admission semaphore.
+///
+/// Bundles the [`WorkQueueSender`]/[`WorkQueueReceiver`] pair produced by
+/// [`bounded_dynamic`] with a shared reference to the backing
+/// [`AdaptiveSemaphore`]. A later change wires a controller to this handle to
+/// grow or shrink the queue's admission ceiling between `min` and `max` in
+/// response to observed backpressure; until then it is exercised only by tests.
+pub struct DynamicWorkQueue {
+    /// Producer half of the dynamic work queue.
+    pub sender: WorkQueueSender,
+    /// Consumer half of the dynamic work queue.
+    pub receiver: WorkQueueReceiver,
+    /// Shared admission semaphore whose ceiling may move within `[min, max]`.
+    pub semaphore: Arc<AdaptiveSemaphore>,
+}
+
+/// Creates a work queue whose admission capacity is a dynamic source.
+///
+/// Admission is gated by an [`AdaptiveSemaphore`] starting at `initial` permits
+/// and resizable at runtime between `min` and `max`. The underlying channel is
+/// opened at `max` capacity so the semaphore, not the channel, is always the
+/// binding constraint. Growing the semaphore ceiling immediately admits more
+/// in-flight work; shrinking it withholds future admissions without revoking
+/// permits already granted.
+///
+/// This is the additive foundation for dynamic work-queue capacity. It does not
+/// wire any controller to move the ceiling, nor does it release a permit when a
+/// consumed item drains - those are deliberately left to a later change. The
+/// returned [`DynamicWorkQueue`] exposes the semaphore so that later wiring, and
+/// current tests, can drive resizes directly. Fixed-bound queues built via
+/// [`bounded`] / [`bounded_with_capacity`] are entirely unaffected.
+///
+/// # Errors
+///
+/// Returns [`ResizeError`] if `initial`, `min`, or `max` falls outside the
+/// semaphore's permitted range, or if the range is inconsistent
+/// (`min > max`, or `initial` outside `[min, max]`).
+pub fn bounded_dynamic(
+    initial: usize,
+    min: usize,
+    max: usize,
+) -> Result<DynamicWorkQueue, ResizeError> {
+    // `AdaptiveSemaphore::new` validates each bound against the global
+    // [MIN_CAPACITY, MAX_CAPACITY] range; validate the relative ordering here so
+    // an inconsistent (initial, min, max) triple is rejected up front.
+    if min > max {
+        return Err(ResizeError::AboveMax {
+            requested: min,
+            max,
+        });
+    }
+    if initial < min {
+        return Err(ResizeError::BelowMin {
+            requested: initial,
+            min,
+        });
+    }
+    if initial > max {
+        return Err(ResizeError::AboveMax {
+            requested: initial,
+            max,
+        });
+    }
+
+    let semaphore = Arc::new(AdaptiveSemaphore::new(initial)?);
+    // Open the channel at `max` so it never gates admission below the
+    // semaphore's ceiling; the semaphore is the sole admission control.
+    let (tx, rx) = channel::bounded(max);
+    let sender = WorkQueueSender {
+        tx,
+        capacity: CapacitySource::Dynamic {
+            semaphore: Arc::clone(&semaphore),
+            min,
+            max,
+        },
+    };
+    Ok(DynamicWorkQueue {
+        sender,
+        receiver: WorkQueueReceiver { rx },
+        semaphore,
+    })
 }

--- a/crates/engine/src/concurrent_delta/work_queue/capacity_source.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/capacity_source.rs
@@ -1,0 +1,70 @@
+//! Admission-capacity source for the bounded work queue.
+//!
+//! [`WorkQueueSender`](super::WorkQueueSender) admits work items subject to a
+//! capacity limit. Historically that limit was a single fixed bound baked into
+//! the underlying [`crossbeam_channel::bounded`] channel. [`CapacitySource`]
+//! abstracts where that limit comes from so the queue can, in a later change,
+//! draw its admission capacity from a dynamic source instead:
+//!
+//! - [`CapacitySource::Fixed`] - the original behaviour. The crossbeam channel
+//!   bound is the sole admission gate; the sender adds no extra accounting, so
+//!   this path is byte-for-byte identical to the pre-abstraction sender.
+//! - [`CapacitySource::Dynamic`] - admission is gated by an
+//!   [`AdaptiveSemaphore`] whose ceiling may grow or shrink at runtime between a
+//!   configured `min` and `max`. The channel is opened at `max` so it never
+//!   becomes the binding constraint; the semaphore alone bounds in-flight work.
+//!
+//! # Scope
+//!
+//! This module introduces the abstraction and the semaphore-backed constructor
+//! only. Wiring a controller to actually grow/shrink the ceiling, and releasing
+//! a permit when a consumed item drains, are deliberately left to a later
+//! change. The dynamic path is therefore additive and opt-in; no existing caller
+//! is affected.
+
+use std::sync::Arc;
+
+use super::adaptive_semaphore::AdaptiveSemaphore;
+
+/// Where a [`WorkQueueSender`](super::WorkQueueSender) draws its admission
+/// capacity from.
+///
+/// See the [module documentation](self) for the two variants and their
+/// semantics.
+#[derive(Clone)]
+pub(super) enum CapacitySource {
+    /// A fixed admission bound enforced solely by the crossbeam channel.
+    ///
+    /// This is the original, default behaviour: the sender performs no extra
+    /// capacity accounting and backpressure comes entirely from the bounded
+    /// channel filling up.
+    Fixed,
+    /// A dynamic admission bound enforced by an [`AdaptiveSemaphore`].
+    ///
+    /// The semaphore ceiling may move between `min` and `max` at runtime. The
+    /// channel is opened at `max` so admission is governed by the semaphore
+    /// rather than the channel bound.
+    Dynamic {
+        /// The resizable semaphore that gates admission.
+        semaphore: Arc<AdaptiveSemaphore>,
+        /// The lowest ceiling the semaphore may be resized to.
+        min: usize,
+        /// The highest ceiling the semaphore may be resized to; also the fixed
+        /// capacity of the backing channel.
+        max: usize,
+    },
+}
+
+impl CapacitySource {
+    /// Acquires admission for one work item, blocking until capacity is free.
+    ///
+    /// For [`Fixed`](Self::Fixed) this is a no-op: the caller relies on the
+    /// bounded channel's own blocking send for backpressure. For
+    /// [`Dynamic`](Self::Dynamic) this blocks on the semaphore until a permit is
+    /// available, applying backpressure ahead of the (over-provisioned) channel.
+    pub(super) fn acquire(&self) {
+        if let CapacitySource::Dynamic { semaphore, .. } = self {
+            semaphore.acquire();
+        }
+    }
+}

--- a/crates/engine/src/concurrent_delta/work_queue/mod.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/mod.rs
@@ -100,6 +100,7 @@
 mod adaptive_semaphore;
 mod bounded;
 mod capacity;
+mod capacity_source;
 mod drain;
 mod iter;
 pub mod limiter;
@@ -109,7 +110,10 @@ mod multi_producer;
 pub use adaptive_semaphore::{
     AdaptiveSemaphore, MAX_CAPACITY, MIN_CAPACITY, ResizeError, SemStats,
 };
-pub use bounded::{SendError, WorkQueueReceiver, WorkQueueSender, bounded, bounded_with_capacity};
+pub use bounded::{
+    DynamicWorkQueue, SendError, WorkQueueReceiver, WorkQueueSender, bounded, bounded_dynamic,
+    bounded_with_capacity,
+};
 pub use capacity::{adaptive_queue_depth, default_capacity};
 pub use iter::WorkQueueIter;
 pub use limiter::{AimdLimiter, LimiterConfig, OverloadReason, Ticket};

--- a/crates/engine/src/concurrent_delta/work_queue/multi_producer.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/multi_producer.rs
@@ -18,6 +18,7 @@ impl Clone for WorkQueueSender {
     fn clone(&self) -> Self {
         Self {
             tx: self.tx.clone(),
+            capacity: self.capacity.clone(),
         }
     }
 }

--- a/crates/engine/src/concurrent_delta/work_queue/tests.rs
+++ b/crates/engine/src/concurrent_delta/work_queue/tests.rs
@@ -943,6 +943,140 @@ fn receiver_drop_unblocks_full_queue_producer() {
     );
 }
 
+#[test]
+fn bounded_dynamic_honors_initial_min_max() {
+    let dq = bounded_dynamic(4, 2, 16).expect("valid bounds");
+    // The semaphore starts at `initial`.
+    assert_eq!(dq.semaphore.current_cap(), 4);
+    // The sender reports the same current admission ceiling.
+    assert_eq!(dq.sender.current_capacity(), 4);
+    // The configured resize range is reported for later controller clamping.
+    assert_eq!(dq.sender.capacity_bounds(), Some((2, 16)));
+}
+
+#[test]
+fn fixed_bound_has_no_capacity_range() {
+    let (tx, _rx) = bounded_with_capacity(3);
+    assert_eq!(tx.capacity_bounds(), None);
+}
+
+#[test]
+fn bounded_dynamic_grow_shrink_reflects_in_permits() {
+    let dq = bounded_dynamic(2, 1, 8).expect("valid bounds");
+    // Exhaust the initial two permits.
+    assert!(dq.semaphore.try_acquire());
+    assert!(dq.semaphore.try_acquire());
+    assert!(!dq.semaphore.try_acquire(), "at initial capacity");
+
+    // Growing the ceiling admits more in-flight work immediately, and the
+    // sender observes the new ceiling.
+    dq.semaphore.resize(4).expect("grow within max");
+    assert_eq!(dq.sender.current_capacity(), 4);
+    assert!(dq.semaphore.try_acquire());
+    assert!(dq.semaphore.try_acquire());
+    assert!(!dq.semaphore.try_acquire(), "at grown capacity");
+
+    // Shrinking withholds future admissions without revoking held permits.
+    dq.semaphore.resize(1).expect("shrink within min");
+    assert_eq!(dq.sender.current_capacity(), 1);
+    assert_eq!(dq.semaphore.in_flight(), 4);
+    dq.semaphore.release();
+    dq.semaphore.release();
+    dq.semaphore.release();
+    // Still one over the shrunk ceiling of 1.
+    assert!(!dq.semaphore.try_acquire());
+    dq.semaphore.release();
+    assert_eq!(dq.semaphore.in_flight(), 0);
+    assert!(dq.semaphore.try_acquire());
+}
+
+#[test]
+fn bounded_dynamic_send_recv_round_trip() {
+    let dq = bounded_dynamic(4, 2, 8).expect("valid bounds");
+    let DynamicWorkQueue {
+        sender, receiver, ..
+    } = dq;
+    sender
+        .send(DeltaWork::whole_file(7, PathBuf::from("/dst"), 128))
+        .unwrap();
+    drop(sender);
+    let items: Vec<_> = receiver.into_iter().collect();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].ndx().get(), 7);
+}
+
+#[test]
+fn bounded_dynamic_semaphore_gates_admission() {
+    // Initial capacity 1: with the semaphore held, a send must block until a
+    // permit frees up. This exercises the dynamic admission path end to end.
+    let dq = bounded_dynamic(1, 1, 4).expect("valid bounds");
+    let DynamicWorkQueue {
+        sender,
+        receiver,
+        semaphore,
+    } = dq;
+
+    // Hold the only permit so the sender must block inside `send`.
+    semaphore.acquire();
+
+    let sent = Arc::new(AtomicUsize::new(0));
+    let sent_clone = Arc::clone(&sent);
+    let producer = thread::spawn(move || {
+        sender
+            .send(DeltaWork::whole_file(1, PathBuf::from("/dst"), 0))
+            .unwrap();
+        sent_clone.fetch_add(1, Ordering::Release);
+        sender
+    });
+
+    // The producer is blocked on the semaphore, not yet sent.
+    thread::sleep(Duration::from_millis(50));
+    assert_eq!(
+        sent.load(Ordering::Acquire),
+        0,
+        "send admitted without a permit"
+    );
+
+    // Free the permit; the send proceeds.
+    semaphore.release();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let sender = producer.join().expect("producer panicked");
+    assert!(Instant::now() < deadline, "send hung after permit release");
+    assert_eq!(sent.load(Ordering::Acquire), 1);
+
+    drop(sender);
+    let items: Vec<u32> = receiver.into_iter().map(|w| w.ndx().get()).collect();
+    assert_eq!(items, vec![1]);
+}
+
+#[test]
+fn bounded_dynamic_rejects_inconsistent_bounds() {
+    // min > max.
+    assert!(bounded_dynamic(4, 8, 4).is_err());
+    // initial below min.
+    assert!(bounded_dynamic(1, 2, 8).is_err());
+    // initial above max.
+    assert!(bounded_dynamic(9, 2, 8).is_err());
+    // Zero (below the semaphore's global floor) is rejected.
+    assert!(bounded_dynamic(0, 0, 8).is_err());
+}
+
+#[test]
+fn fixed_bound_send_is_unaffected() {
+    // The fixed-bound path performs no semaphore accounting: `current_capacity`
+    // reports the channel bound and admission blocks only when the channel is
+    // full, exactly as before the capacity-source abstraction.
+    let (tx, rx) = bounded_with_capacity(3);
+    assert_eq!(tx.current_capacity(), 3);
+    for i in 0..3u32 {
+        tx.send(DeltaWork::whole_file(i, PathBuf::from("/dst"), 0))
+            .unwrap();
+    }
+    drop(tx);
+    let items: Vec<u32> = rx.into_iter().map(|w| w.ndx().get()).collect();
+    assert_eq!(items, vec![0, 1, 2]);
+}
+
 proptest! {
     /// Property test: `drain_parallel` preserves input ordering under contention.
     ///


### PR DESCRIPTION
## Summary

Additive foundation for dynamic work-queue capacity with backpressure. Two pieces:

- **WQDB-1** — a `CapacitySource` abstraction on `WorkQueueSender` so the queue's admission capacity can come from either a fixed channel bound (today's behavior) or a dynamic source, without touching existing callers.
- **WQDB-2** — a `bounded_dynamic(initial, min, max)` constructor backed by the existing `AdaptiveSemaphore` primitive. It exposes a capacity that can grow/shrink between `min` and `max`, starting at `initial`.

## Design

`CapacitySource` (private enum) has two variants:

- `Fixed` — the original behavior. `send()` gates solely on the bounded `crossbeam_channel`; the sender adds no accounting, so this path is behavior-identical to the pre-abstraction sender. `WorkQueueSender::send` calls `capacity.acquire()`, which is a no-op for `Fixed`.
- `Dynamic { semaphore, min, max }` — admission gated by an `Arc<AdaptiveSemaphore>`. The channel is opened at `max` so the semaphore (not the channel) is always the binding constraint. `send()` acquires a permit before enqueuing.

`bounded_dynamic` returns a `DynamicWorkQueue { sender, receiver, semaphore }`, validates the `(initial, min, max)` ordering up front, and delegates per-bound range checks to `AdaptiveSemaphore::new`. New sender accessors: `current_capacity()` and `capacity_bounds()`.

## Scope / invariants

- **Fixed-bound path unchanged.** No default flip. All existing `bounded()` / `bounded_with_capacity()` callers keep identical admission/backpressure semantics.
- **Dynamic path is opt-in and unwired into production** — exercised only by unit tests in this change. The grow/shrink controller and release-on-drain are deliberately left to a follow-up (the `min`/`max` plumbing and `semaphore` handle are exposed so that later work can activate them).
- Thread-safe; the semaphore is `Send + Sync` and shared via `Arc`.

## Tests

New unit tests: initial/min/max honored; grow/shrink of the semaphore reflected in available permits and `current_capacity()`; dynamic `send`/recv round-trip; the dynamic `send` path blocks on the semaphore until a permit frees; inconsistent-bound rejection; and explicit checks that the fixed-bound path (`send`, `current_capacity`, `capacity_bounds` → `None`) is unaffected.

Local verification (Rust 1.88.0): `cargo build -p engine`, `cargo clippy -p engine --all-targets --no-deps -- -D warnings` (also with `--features multi-producer`), `cargo fmt -p engine --check`, and `cargo test -p engine --lib concurrent_delta::work_queue` (86 passed, 0 failed) all green.