### PR TITLE
feat(fast_io,engine): NTFS sparse files via FSCTL_SET_SPARSE (WIN-P-1)

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -37,6 +37,14 @@ impl<'a> CopyContext<'a> {
         // through the copy path by treating the run as non-inplace.
         let inplace_mode = self.inplace_enabled() && !basis_separate_from_writer;
 
+        // On NTFS the sparse zero-run seeks below only deallocate blocks once
+        // the handle is flagged sparse via FSCTL_SET_SPARSE. Elsewhere this is a
+        // no-op (holes are implicit). Best-effort: a non-NTFS volume or a
+        // refused control code falls back to a dense write, never an error.
+        if sparse {
+            let _ = fast_io::mark_file_sparse(writer);
+        }
+
         let mut destination_reader =
             Some(fs::File::open(destination).map_err(|error| {
                 LocalCopyError::io(

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -660,6 +660,11 @@ impl<'a> CopyContext<'a> {
     ) -> Result<FileCopyOutcome, LocalCopyError> {
         let mut total_bytes: u64 = 0;
         let mut literal_bytes: u64 = 0;
+        // On NTFS, seek-past-zero + set_len only yields a sparse file when the
+        // handle is first flagged sparse via FSCTL_SET_SPARSE. Elsewhere this
+        // is a no-op (holes are implicit). Best-effort: a non-NTFS volume or a
+        // refused control code falls back to a dense write, never an error.
+        let _ = fast_io::mark_file_sparse(writer);
         let mut sparse_writer = SparseWriter::new(&mut *writer);
         let mut compressor = self.start_compressor(compress, source)?;
         let mut compressed_progress: u64 = 0;

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -1879,3 +1879,72 @@ fn execute_sparse_large_trailing_zeros_uses_ftruncate() {
     }
 }
 
+/// Windows counterpart of `execute_with_sparse_enabled_creates_holes`.
+///
+/// On NTFS a hole is materialised only after the destination handle is flagged
+/// sparse via `FSCTL_SET_SPARSE` (wired through `fast_io::mark_file_sparse`).
+/// The observable proof is the `FILE_ATTRIBUTE_SPARSE_FILE` attribute on the
+/// destination plus byte-identical content; `st_blocks` has no Windows
+/// equivalent. The check is best-effort: if the scratch TempDir lives on a
+/// non-NTFS volume (FAT/exFAT), the sparse flag will not stick, so the test
+/// asserts only content correctness in that case rather than failing.
+#[cfg(windows)]
+#[test]
+fn execute_with_sparse_enabled_marks_ntfs_sparse() {
+    use std::os::windows::fs::MetadataExt;
+
+    // FILE_ATTRIBUTE_SPARSE_FILE (winnt.h) - set on a handle after a
+    // successful FSCTL_SET_SPARSE.
+    const FILE_ATTRIBUTE_SPARSE_FILE: u32 = 0x0000_0200;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("sparse.bin");
+    let mut source_file = fs::File::create(&source).expect("create source");
+    source_file.write_all(&[0xAA]).expect("write leading byte");
+    source_file
+        .seek(SeekFrom::Start(2 * 1024 * 1024))
+        .expect("seek to create hole");
+    source_file.write_all(&[0xBB]).expect("write trailing byte");
+    source_file.set_len(4 * 1024 * 1024).expect("extend source");
+    drop(source_file);
+
+    let sparse_dest = temp.path().join("sparse-copy.bin");
+    let plan = LocalCopyPlan::from_operands(&[
+        source.into_os_string(),
+        sparse_dest.clone().into_os_string(),
+    ])
+    .expect("plan sparse");
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().sparse(true),
+    )
+    .expect("sparse copy succeeds");
+
+    // Content must round-trip exactly regardless of sparse allocation.
+    let copied = fs::read(&sparse_dest).expect("read sparse copy");
+    assert_eq!(copied.len(), 4 * 1024 * 1024, "length preserved");
+    assert_eq!(copied[0], 0xAA, "leading byte preserved");
+    assert_eq!(copied[2 * 1024 * 1024], 0xBB, "trailing byte preserved");
+    assert!(
+        copied[1..2 * 1024 * 1024].iter().all(|&b| b == 0),
+        "hole region reads back as zeros"
+    );
+
+    let attrs = fs::metadata(&sparse_dest)
+        .expect("sparse metadata")
+        .file_attributes();
+    if attrs & FILE_ATTRIBUTE_SPARSE_FILE == 0 {
+        eprintln!(
+            "destination not flagged sparse (attrs={attrs:#x}); scratch volume likely \
+             non-NTFS, skipping strict sparse-attribute check"
+        );
+        return;
+    }
+
+    assert_ne!(
+        attrs & FILE_ATTRIBUTE_SPARSE_FILE,
+        0,
+        "sparse copy on NTFS must carry FILE_ATTRIBUTE_SPARSE_FILE"
+    );
+}
+

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -1891,6 +1891,7 @@ fn execute_sparse_large_trailing_zeros_uses_ftruncate() {
 #[cfg(windows)]
 #[test]
 fn execute_with_sparse_enabled_marks_ntfs_sparse() {
+    use std::io::{Seek, SeekFrom};
     use std::os::windows::fs::MetadataExt;
 
     // FILE_ATTRIBUTE_SPARSE_FILE (winnt.h) - set on a handle after a

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -195,7 +195,7 @@ block2 = ["dep:block2"]
 # Win32_Networking_WinSock added for WSARecv/WSASend in iocp::socket (#1928);
 # Win32_System_Pipes added for CreatePipe-based tests of anonymous-handle
 # rejection in writer_from_file (#1929).
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 
 [dev-dependencies]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -186,6 +186,8 @@ pub mod syscall_batch;
 pub mod vmsplice_writer;
 /// Windows extended-length path (`\\?\`) prefixing helper.
 pub mod win_path;
+/// NTFS sparse-file marking (`FSCTL_SET_SPARSE`) with a non-Windows no-op stub.
+pub mod win_sparse;
 /// Delete-on-close temporary file creation for Windows via `FileDispositionInfo`.
 pub mod win_tmpfile;
 
@@ -402,6 +404,7 @@ pub use temp_file_strategy::{
     DefaultTempFileStrategy, NamedTempFileStrategy, TempFileHandle, TempFileKind, TempFileStrategy,
 };
 pub use win_path::to_extended_path;
+pub use win_sparse::mark_file_sparse;
 pub use win_tmpfile::{
     WinDeleteOnCloseSupport, WinTempFileResult, WindowsTempFile, clear_delete_on_close,
     commit_delete_on_close, delete_on_close_available, open_delete_on_close_tmpfile,

--- a/crates/fast_io/src/win_sparse.rs
+++ b/crates/fast_io/src/win_sparse.rs
@@ -1,0 +1,112 @@
+//! NTFS sparse-file marking via `DeviceIoControl(FSCTL_SET_SPARSE)`.
+//!
+//! On Linux and macOS the sparse writer produces holes implicitly: seeking past
+//! a zero run and truncating with `set_len` leaves the skipped range
+//! unallocated. NTFS does not honour that pattern - a seek-past-EOF followed by
+//! `SetEndOfFile` zero-fills the gap and allocates blocks. To get the same
+//! sparse allocation on Windows the file handle must first be flagged sparse
+//! with `FSCTL_SET_SPARSE`; afterwards the identical seek + `set_len` logic the
+//! Linux path uses materialises real holes.
+//!
+//! [`mark_file_sparse`] performs that flagging. It is best-effort: on a volume
+//! that does not support sparse files (FAT/exFAT), or when the control code is
+//! rejected, it returns `Ok(false)` so the caller falls back to a dense write
+//! rather than failing the transfer. On non-Windows targets it is a zero-cost
+//! no-op returning `Ok(true)`, keeping call sites free of `#[cfg]` plumbing.
+
+use std::fs::File;
+use std::io;
+
+/// Marks an open file handle as sparse so subsequent seek-past-zero writes
+/// produce filesystem holes on NTFS.
+///
+/// Mirrors the implicit hole creation the Linux/macOS sparse path relies on.
+/// The Windows implementation issues `DeviceIoControl(FSCTL_SET_SPARSE)`.
+///
+/// # Best-effort semantics
+///
+/// A `false` return means the volume or filesystem does not support sparse
+/// files (for example FAT/exFAT) or rejected the control code. The caller
+/// should continue with a normal dense write; this is not an error. A `true`
+/// return means the handle is now sparse and later zero runs will be
+/// deallocated. On non-Windows platforms this always returns `Ok(true)` after
+/// doing nothing, because those filesystems create holes implicitly.
+///
+/// # Errors
+///
+/// The Windows implementation never surfaces the "unsupported / not applicable"
+/// class as an error (it maps those to `Ok(false)`); it is declared fallible so
+/// the signature stays stable if a future revision wants to distinguish other
+/// I/O failures. Callers treat any error as a signal to fall back to a dense
+/// write and never abort the transfer on it.
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code)]
+pub fn mark_file_sparse(file: &File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+    use windows_sys::Win32::System::Ioctl::FSCTL_SET_SPARSE;
+
+    let handle = file.as_raw_handle() as HANDLE;
+    let mut bytes_returned: u32 = 0;
+
+    // SAFETY: `handle` is a live handle owned by `file` for the duration of the
+    // call. `FSCTL_SET_SPARSE` takes no input buffer, so passing null pointers
+    // and zero sizes for both the in and out buffers is the documented calling
+    // convention. `lpBytesReturned` points at a valid `u32` and `lpOverlapped`
+    // is null (synchronous request), matching the handle's synchronous mode.
+    let ok = unsafe {
+        DeviceIoControl(
+            handle,
+            FSCTL_SET_SPARSE,
+            std::ptr::null(),
+            0,
+            std::ptr::null_mut(),
+            0,
+            &mut bytes_returned,
+            std::ptr::null_mut(),
+        )
+    };
+
+    if ok == 0 {
+        // Sparse files are unsupported on this volume (FAT/exFAT) or the
+        // control code was refused. Treat it as "no sparse available" rather
+        // than a hard failure so the caller writes densely instead.
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+/// Non-Windows no-op: Linux and macOS filesystems create holes implicitly when
+/// the sparse writer seeks past zero runs, so no handle flag is required.
+///
+/// # Errors
+///
+/// Never returns an error on these platforms.
+#[cfg(not(target_os = "windows"))]
+#[inline]
+pub fn mark_file_sparse(_file: &File) -> io::Result<bool> {
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mark_file_sparse;
+
+    #[test]
+    fn mark_file_sparse_reports_availability() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("sparse-probe.bin");
+        let file = std::fs::File::create(&path).expect("create");
+        // On non-Windows this is a no-op that returns Ok(true); on Windows it
+        // returns Ok(true) when the scratch volume is NTFS or Ok(false) on a
+        // FAT/exFAT temp mount. Either way it must not error.
+        let result = mark_file_sparse(&file);
+        assert!(
+            result.is_ok(),
+            "mark_file_sparse must never hard-fail: {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes the WIN-P-1 Windows correctness gap: `--sparse` transfers to NTFS now allocate real holes instead of materialising full-size dense files.

On Linux/macOS the sparse writer produces holes implicitly - seeking past a zero run and truncating with `set_len` leaves the range unallocated. NTFS does not honour that pattern: a seek-past-EOF followed by `SetEndOfFile` zero-fills the gap and allocates blocks. To get the same result the handle must first be flagged sparse via `FSCTL_SET_SPARSE`; afterwards the identical seek + `set_len` logic materialises real holes.

## Changes

- **`fast_io::mark_file_sparse`** (`crates/fast_io/src/win_sparse.rs`): Windows issues `DeviceIoControl(FSCTL_SET_SPARSE)` on the open file handle; non-Windows is a zero-cost no-op. Best-effort: a non-NTFS volume (FAT/exFAT) or a refused control code returns `Ok(false)` so the caller writes densely and never aborts the transfer - the same graceful-fallback discipline as the existing platform stubs.
- **Wiring**: called once before each sparse write loop - `copy_file_contents_sparse` (non-delta) and `copy_file_contents_with_delta` (delta path), gated on `--sparse`. All new code is `#[cfg(windows)]` or a no-op stub; the seek/`set_len` hole logic is unchanged.
- **Cargo**: added the `Win32_System_Ioctl` `windows-sys` feature to `fast_io` for the `FSCTL_SET_SPARSE` constant (`DeviceIoControl` was already available via `Win32_System_IO`).
- **Test**: Windows-gated integration test asserts the destination carries `FILE_ATTRIBUTE_SPARSE_FILE` plus byte-identical content (skips gracefully on a non-NTFS scratch volume); a `fast_io` unit test asserts the API never hard-fails.

## Invariants

- **Non-Windows builds unchanged** - all new logic is Windows-gated or a no-op stub. Host `cargo build` + `cargo clippy --all-targets -D warnings` for `fast_io`/`metadata`/`engine` are clean.
- **No wire/protocol impact** - receiver-side local file write behaviour only. Upstream is POSIX-focused (no NTFS sparse); the observable result matches the existing Linux/macOS sparse path (same content, sparse allocation).
- **`unsafe` only via `windows-sys` inside `fast_io`** (a permitted-unsafe crate) with SAFETY notes. No new unsafe in crates that deny it.

## Verification

- `cargo build -p fast_io -p metadata -p engine` - clean.
- `cargo clippy -p fast_io -p metadata -p engine --all-targets --no-deps -- -D warnings` - no issues.
- `cargo check --target x86_64-pc-windows-gnu -p fast_io` - clean (validates the `#[cfg(windows)]` `FSCTL_SET_SPARSE` code against the real `windows-sys` API).
- Full Windows link/`metadata`/`engine` cross-compile could not run on the dev host (mingw C toolchain for `zstd-sys`/`libz-ng-sys` build scripts is not installed); relying on the CI Windows cell for the end-to-end Windows test.
- `cargo fmt` clean.

Note: the sibling WIN-P-2 task (crtime preservation on Windows via `SetFileTime`) is already implemented on master (PR #6157), so this PR is WIN-P-1 only.
