### PR TITLE
feat(engine): gate FICLONERANGE on same-fs + wire --cow into delta reflink path

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -392,6 +392,21 @@ impl<'a> CopyContext<'a> {
 
         self.capture_batch_block_match(&matched, destination)?;
 
+        // REFLINK-3/4: attempt a same-filesystem FICLONERANGE reflink before
+        // falling back to the read+write copy loop. On a CoW filesystem this
+        // shares the basis extents into the destination with zero data copied.
+        // Skipped for sparse output (the reflink cannot reproduce the sparse
+        // writer's hole layout) and when `--no-cow` disables reflink. When the
+        // clone is unavailable (cross-fs, unaligned, unsupported fs) the helper
+        // reports `false` and we fall through to the byte copy. Byte-identical
+        // output either way - this is a local-only acceleration with no wire
+        // impact.
+        if !sparse.enabled
+            && self.try_reflink_matched_block(existing, writer, offset, block_length, destination)?
+        {
+            return Ok(());
+        }
+
         existing.seek(SeekFrom::Start(offset)).map_err(|error| {
             LocalCopyError::io(
                 "read existing destination",
@@ -436,5 +451,75 @@ impl<'a> CopyContext<'a> {
         }
 
         Ok(())
+    }
+
+    /// Attempts to reflink `existing[offset..offset+len]` into the writer at
+    /// its current position via Linux `FICLONERANGE`.
+    ///
+    /// Returns `Ok(true)` when the range clone succeeded and the writer's file
+    /// position has been advanced past the cloned range (so subsequent
+    /// sequential writes land correctly). Returns `Ok(false)` when the clone
+    /// was declined - `--no-cow` in effect, the operands are on different
+    /// filesystems (REFLINK-3), the range is below the worthwhile threshold,
+    /// or the ioctl reported that the filesystem / alignment cannot satisfy the
+    /// clone - so the caller falls back to the read+write copy.
+    ///
+    /// # Correctness
+    ///
+    /// The destination position is `writer.stream_position()`. On success the
+    /// clone copies no bytes but does not move the file offset, so we seek the
+    /// writer forward by `len` to match what an equivalent `write_all` would
+    /// have left behind. Cross-filesystem clones are never issued: `st_dev` of
+    /// the basis and destination are compared up front, and `FICLONERANGE`'s
+    /// own `EXDEV`/`EINVAL`/`EOPNOTSUPP` results are mapped to a graceful
+    /// fallback by the `fast_io` wrapper. The transfer never fails on a clone
+    /// error.
+    fn try_reflink_matched_block(
+        &self,
+        existing: &fs::File,
+        writer: &mut fs::File,
+        offset: u64,
+        len: usize,
+        destination: &Path,
+    ) -> Result<bool, LocalCopyError> {
+        // REFLINK-4: honour the `--cow` / `--no-cow` policy that also gates the
+        // whole-file FICLONE fast path.
+        if !self.reflink_enabled() {
+            return Ok(false);
+        }
+
+        let len = len as u64;
+        if len < fast_io::CLONE_FILE_RANGE_MIN_BYTES {
+            return Ok(false);
+        }
+
+        // REFLINK-3: never issue FICLONERANGE across filesystems. The ioctl
+        // returns EXDEV cross-mount; comparing st_dev up front avoids the
+        // wasted syscall. `None` (device id unavailable) falls through to let
+        // the ioctl decide rather than forcing the slow path.
+        if fast_io::same_fs::files_same_device(existing, writer) == Some(false) {
+            return Ok(false);
+        }
+
+        let dst_offset = writer.stream_position().map_err(|error| {
+            LocalCopyError::io("seek destination file", destination.to_path_buf(), error)
+        })?;
+
+        let cloned = fast_io::try_clone_file_range(existing, offset, writer, dst_offset, len)
+            .map_err(|error| LocalCopyError::io("clone basis range", destination, error))?;
+
+        if !cloned {
+            return Ok(false);
+        }
+
+        // FICLONERANGE leaves the writer's file offset unchanged; advance it so
+        // the next sequential write continues after the cloned range.
+        writer
+            .seek(SeekFrom::Start(dst_offset.saturating_add(len)))
+            .map_err(|error| {
+                LocalCopyError::io("seek destination file", destination.to_path_buf(), error)
+            })?;
+
+        Ok(true)
     }
 }

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -33,6 +33,19 @@ impl<'a> CopyContext<'a> {
         self.options.whole_file_enabled()
     }
 
+    /// Returns whether the active copy-on-write policy permits reflink
+    /// acceleration in the delta COPY-token path.
+    ///
+    /// REFLINK-4: `--no-cow` / `--reflink=never` installs a platform-copy
+    /// strategy whose `supports_reflink()` is `false`, and `--cow` /
+    /// `--reflink=always|auto` leaves a strategy that reports `true`. The
+    /// delta path consults this before attempting `FICLONERANGE`, so the same
+    /// flag that gates whole-file `FICLONE` (REFLINK-2) also gates range
+    /// clones.
+    pub(super) fn reflink_enabled(&self) -> bool {
+        self.options.platform_copy().supports_reflink()
+    }
+
     pub(super) const fn open_noatime_enabled(&self) -> bool {
         self.options.open_noatime_enabled()
     }

--- a/crates/engine/tests/reflink_clone_file_range_concurrent.rs
+++ b/crates/engine/tests/reflink_clone_file_range_concurrent.rs
@@ -1,0 +1,147 @@
+//! Linux FICLONERANGE concurrency stress test - drives many parallel
+//! `fast_io::try_clone_file_range` range clones on a single CoW filesystem to
+//! exercise the delta COPY-token reflink path under contention.
+//!
+//! This mirrors the whole-file `reflink_ficlone_concurrent` test (REFLINK-3.f)
+//! but targets the range ioctl the delta path uses (REFLINK-3/4/5): every
+//! basis and destination lives on the same filesystem, so no clone may return
+//! `EXDEV`, observe another file's bytes, or tear a partially-cloned range.
+//!
+//! Like its whole-file sibling, it self-skips when the backing filesystem is
+//! not range-reflink-capable (ext4, tmpfs, overlayfs in containers) by probing
+//! one aligned `try_clone_file_range` up front. A negative probe means the
+//! mount cannot satisfy the test, not that the wiring is broken - matching the
+//! repository's pre-check-and-degrade rule for tests that need external
+//! resources.
+
+#![cfg(target_os = "linux")]
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+use tempfile::tempdir;
+
+/// Block-aligned clone unit. FICLONERANGE requires the source offset,
+/// destination offset, and length to be multiples of the filesystem block
+/// size; 64 KiB is a safe multiple of every CoW block size in use (4/16/64
+/// KiB).
+const CLONE_LEN: u64 = 64 * 1024;
+
+fn make_basis(path: &Path, payload: &[u8]) -> File {
+    let mut f = File::create(path).expect("create basis");
+    f.write_all(payload).expect("write basis");
+    f.sync_all().ok();
+    File::open(path).expect("reopen basis for read")
+}
+
+fn make_dest(path: &Path, size: u64) -> File {
+    let f = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("create dest");
+    f.set_len(size).expect("size dest");
+    f
+}
+
+/// Probes whether the backing filesystem can satisfy an aligned range clone.
+fn detect_range_reflink_support(dir: &Path) -> bool {
+    let payload = vec![0xC3u8; CLONE_LEN as usize];
+    let basis = make_basis(&dir.join(".clonerange-probe-basis"), &payload);
+    let dest = make_dest(&dir.join(".clonerange-probe-dest"), CLONE_LEN);
+    let ok = matches!(
+        fast_io::try_clone_file_range(&basis, 0, &dest, 0, CLONE_LEN),
+        Ok(true)
+    );
+    let _ = std::fs::remove_file(dir.join(".clonerange-probe-basis"));
+    let _ = std::fs::remove_file(dir.join(".clonerange-probe-dest"));
+    ok
+}
+
+/// Distinct, recognisable payload for file `i` so a clone that returned another
+/// file's data (cross-contamination) is detectable byte-for-byte.
+fn payload_for(i: usize) -> Vec<u8> {
+    let seed = (i as u32).wrapping_mul(2_654_435_761);
+    (0..CLONE_LEN as u32)
+        .map(|j| (seed.wrapping_add(j) & 0xff) as u8)
+        .collect()
+}
+
+#[test]
+fn clone_file_range_concurrent_clones_are_independent_and_intact() {
+    let dir = tempdir().expect("tempdir");
+    if !detect_range_reflink_support(dir.path()) {
+        eprintln!(
+            "skipping concurrent FICLONERANGE stress - {:?} is not a range-reflink-capable filesystem",
+            dir.path()
+        );
+        return;
+    }
+
+    // All basis + destination files share one filesystem: every range clone is
+    // same-fs, so a returned EXDEV would be a real regression, not an
+    // environmental skip.
+    const FILE_COUNT: usize = 64;
+    let mut payloads = Vec::with_capacity(FILE_COUNT);
+    let mut basis_paths = Vec::with_capacity(FILE_COUNT);
+    let mut dest_paths = Vec::with_capacity(FILE_COUNT);
+    for i in 0..FILE_COUNT {
+        let payload = payload_for(i);
+        let basis_path = dir.path().join(format!("basis-{i:03}.bin"));
+        let dest_path = dir.path().join(format!("dest-{i:03}.bin"));
+        make_basis(&basis_path, &payload);
+        make_dest(&dest_path, CLONE_LEN);
+        payloads.push(payload);
+        basis_paths.push(basis_path);
+        dest_paths.push(dest_path);
+    }
+
+    // Fan out one aligned range clone per file across native threads. A torn
+    // clone, an fd mix-up, or a cross-filesystem EXDEV would surface as an Err
+    // or a mismatched payload below.
+    let results: Vec<Result<(), String>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..FILE_COUNT)
+            .map(|i| {
+                let basis_path = &basis_paths[i];
+                let dest_path = &dest_paths[i];
+                scope.spawn(move || {
+                    let basis =
+                        File::open(basis_path).map_err(|e| format!("open basis {i}: {e}"))?;
+                    let dest = OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .open(dest_path)
+                        .map_err(|e| format!("open dest {i}: {e}"))?;
+                    match fast_io::try_clone_file_range(&basis, 0, &dest, 0, CLONE_LEN) {
+                        Ok(true) => Ok(()),
+                        Ok(false) => Err(format!(
+                            "range clone {i} unexpectedly declined on a same-fs, aligned request"
+                        )),
+                        Err(e) => Err(format!("range clone {i} failed: {e}")),
+                    }
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("clone thread must not panic"))
+            .collect()
+    });
+
+    for result in &results {
+        assert!(result.is_ok(), "{}", result.as_ref().unwrap_err());
+    }
+
+    // Every destination must hold its own basis's bytes exactly - no clone may
+    // have observed another file's data or left a partially-written range.
+    for i in 0..FILE_COUNT {
+        let cloned = std::fs::read(&dest_paths[i]).expect("read clone");
+        assert_eq!(
+            cloned, payloads[i],
+            "concurrent range clone {i} must match its own basis byte-for-byte"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Completes copy-on-write (reflink) acceleration for same-filesystem transfers in the delta / local-copy path, building on the whole-file `FICLONE` gate.

- **REFLINK-3** — gate `FICLONERANGE` on same-filesystem (`st_dev`) equality **before** issuing the ioctl. Issuing a range clone across filesystems returns `EXDEV` and wastes a syscall; kernels require same-fs. Reuses the shared `fast_io::same_fs::files_same_device` helper.
- **REFLINK-4** — wire `--cow` / `--no-cow` / `--reflink` into the delta reflink path. The same policy that gates whole-file `FICLONE` (via the platform-copy strategy's `supports_reflink()`) now gates `FICLONERANGE` too, through a new `CopyContext::reflink_enabled()` accessor.
- **REFLINK-5** — concurrency stress test mirroring the whole-file `reflink_ficlone_concurrent` sibling: 64 parallel same-fs range clones asserting each destination holds its own basis bytes with no cross-contamination, tearing, or `EXDEV`.

## Where it plugs in

The gate lives in `CopyContext::copy_matched_block` (the non-inplace delta COPY-token path in `context_impl/delta_transfer.rs`). Before the read+write copy loop it attempts `fast_io::try_clone_file_range(basis, offset, writer, writer_pos, len)`, guarded by: `--cow` allows reflink, output is not sparse, `len >= CLONE_FILE_RANGE_MIN_BYTES`, and `st_dev(basis) == st_dev(dst)`. On success the writer offset is advanced by `len` so subsequent sequential writes land correctly; any decline (cross-fs, unaligned, unsupported fs, `--no-cow`) falls through to the existing byte copy.

## Invariants

- **Local-copy-only; zero wire/protocol impact.** Reflink only applies when both basis and destination are local files; the fallback path is byte-identical. Upstream rsync has no reflink primitive, so nothing changes on the wire.
- **Never crosses filesystems.** `st_dev` compared up front; the `fast_io` wrapper also maps `EXDEV`/`EINVAL`/`EOPNOTSUPP` to a graceful fallback. A clone error never fails the transfer.
- Linux-only ioctl; non-Linux keeps the existing `Ok(false)` stub.

## Verification

- `cargo build` + `cargo clippy --all-targets -D warnings` green for `fast_io` + `engine` on macOS and on Linux (aarch64).
- `cargo fmt --check` clean on the touched crates.
- On a loopback **btrfs** mount (Linux aarch64): the new FICLONERANGE concurrency test executes all 64 real range clones and passes; the 32 `delta_reconstruction` + `delta_transfer_strategy` tests pass (confirming byte-identical output whether the reflink fires or falls back). On ext4/tmpfs the test self-skips (pre-check-and-degrade), matching the whole-file sibling.
- Note: a pre-existing whole-file test (`ficlone_idempotent_second_clone_replaces_destination`) fails on btrfs on the untouched base commit as well; it is unrelated to this change (whole-file `FICLONE`, not the delta path).