### PR TITLE
docs: verify upstream-testsuite skip-path (probe)

### DIFF
--- a/docs/design/asy-7-receiver-tokio-prototype.md
+++ b/docs/design/asy-7-receiver-tokio-prototype.md
@@ -585,3 +585,5 @@ fix, not part of this receiver rung.
    CI-verified commit. A `block_on`-hosted sync fork adds zero async
    benefit (the ASY-3 shape already exists), and an unverified fork risks
    a wire/stats divergence - both worse than none per the stop clause.
+
+<!-- CI skip-path verification probe for required upstream-testsuite check. -->


### PR DESCRIPTION
Docs-only probe to confirm the new required-capable context `upstream-testsuite / upstream testsuite` reports **green (skipped)** on a docs-only PR — proving the real+skip reusable (#6233) does not deadlock non-code PRs. Will close/merge after the check reports.