### PR TITLE
fix(daemon): allow non-root exec-hook modules by exempting them from worker capability-drop

### DIFF
--- a/crates/daemon/src/daemon/sections/capabilities.rs
+++ b/crates/daemon/src/daemon/sections/capabilities.rs
@@ -39,6 +39,30 @@ const CAP_FEATURE_AVAILABLE: bool = true;
 #[allow(dead_code)]
 const CAP_FEATURE_AVAILABLE: bool = false;
 
+/// Returns true when the operator configured this module with any exec hook
+/// (`early exec`, `pre-xfer exec`, or `post-xfer exec`).
+///
+/// Single source of truth for the "operator opted into running hooks"
+/// predicate. When true, the worker will `fork(2)`/`execve(2)` a helper
+/// script during the connection, so the hardening layers that would break
+/// that exec (worker capability drop, and - via the same condition -
+/// Landlock, which is inherited across `exec`) are relaxed for this module
+/// only. Modules without hooks keep the full defense-in-depth posture.
+///
+/// upstream: rsync 3.4.4 has no capability/seccomp/Landlock/prctl code at
+/// all - the exec hooks (`clientserver.c` `pre_exec_hook` / `post_exec_hook`
+/// / `early_exec`) run with the daemon's inherited privileges. This oc-only
+/// defense-in-depth must therefore exempt operator-configured hook modules to
+/// preserve upstream behavioural parity: a non-root daemon dropping worker
+/// capabilities would otherwise break the hook `execve`, which upstream never
+/// does. Mirrors the Landlock skip at `sandbox.rs` `engage_landlock_sandbox`,
+/// which reuses this same predicate.
+fn module_has_exec_hooks(module: &ModuleRuntime) -> bool {
+    module.early_exec.is_some()
+        || module.pre_xfer_exec.is_some()
+        || module.post_xfer_exec.is_some()
+}
+
 /// Pre-flight check: verify the daemon holds the capabilities its configuration
 /// requires.
 ///
@@ -207,6 +231,29 @@ fn drop_worker_capabilities(
 ) {
     use caps::{CapSet, Capability};
 
+    // Skip the per-worker drop when the operator configured an exec hook
+    // (`early exec` / `pre-xfer exec` / `post-xfer exec`) on this module.
+    // The worker will `fork`/`execve` a helper script, and stripping the
+    // capability set from a non-root worker breaks that exec (the observed
+    // failure: a non-root daemon serving a hook module drops the connection
+    // with code 12). This mirrors the Landlock skip at
+    // `engage_landlock_sandbox` (`sandbox.rs`) exactly: same predicate
+    // (`module_has_exec_hooks`), same rationale (the operator explicitly
+    // chose to run hooks). Non-hook modules keep the full capability drop.
+    // upstream: rsync 3.4.4 has no capability/prctl code; its hooks run with
+    // the daemon's inherited privileges, so this exemption preserves parity.
+    if module_has_exec_hooks(module) {
+        if let Some(log) = log_sink {
+            let text = format!(
+                "module '{}': skipping worker capability drop (pre/post/early-xfer exec configured - drop would break hook execve)",
+                module.name,
+            );
+            let message = rsync_info!(text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        return;
+    }
+
     // Skip the per-worker drop whenever the worker is still running as
     // root - either because the module is configured with `uid = 0`, or
     // because no per-module `uid` was set and the daemon-wide identity
@@ -344,6 +391,64 @@ mod capabilities_tests {
             ..Default::default()
         };
         ModuleRuntime::new(def, None)
+    }
+
+    /// Builds a non-root module (`uid = 1000`) carrying the requested hook so
+    /// the capability-drop exemption exercises the exact non-root path the
+    /// Linux daemon takes for an operator-configured hook module.
+    fn hook_module(field: &str) -> ModuleRuntime {
+        let mut def = ModuleDefinition {
+            name: "hookmod".to_owned(),
+            path: std::path::PathBuf::from("/tmp"),
+            uid: Some(1000),
+            ..Default::default()
+        };
+        match field {
+            "early" => def.early_exec = Some("/usr/local/bin/early.sh".to_owned()),
+            "pre" => def.pre_xfer_exec = Some("/usr/local/bin/pre.sh".to_owned()),
+            "post" => def.post_xfer_exec = Some("/usr/local/bin/post.sh".to_owned()),
+            other => panic!("unknown hook field {other}"),
+        }
+        ModuleRuntime::new(def, None)
+    }
+
+    /// A module without any exec hook must report `false` so it keeps the
+    /// full worker capability drop; a module with any of the three hook
+    /// directives must report `true` so the drop (and Landlock, and the
+    /// seccomp exec gate) are relaxed for it. This is the single predicate
+    /// all three hardening skips share.
+    #[test]
+    fn module_has_exec_hooks_matches_each_hook_directive() {
+        assert!(!module_has_exec_hooks(&module_with("plain", Some(1000))));
+        assert!(module_has_exec_hooks(&hook_module("early")));
+        assert!(module_has_exec_hooks(&hook_module("pre")));
+        assert!(module_has_exec_hooks(&hook_module("post")));
+    }
+
+    /// The worker capability drop must be skipped for a non-root hook module:
+    /// dropping the capability set would break the hook `fork`/`execve` and
+    /// crash the connection (code 12). The drop still runs for non-hook
+    /// modules. `drop_worker_capabilities` returns `()`, so this asserts the
+    /// predicate that gates the skip - the observable contract - and that the
+    /// call is panic-free on both paths in an unprivileged test process.
+    #[test]
+    fn capability_drop_skipped_only_for_hook_modules() {
+        let plain = module_with("plain", Some(1000));
+        assert!(
+            !module_has_exec_hooks(&plain),
+            "non-hook module must not be exempt from the capability drop",
+        );
+
+        for field in ["early", "pre", "post"] {
+            let module = hook_module(field);
+            assert!(
+                module_has_exec_hooks(&module),
+                "hook module ({field}) must be exempt from the capability drop",
+            );
+            // Both paths must be panic-free when called unprivileged.
+            drop_worker_capabilities(&module, None);
+        }
+        drop_worker_capabilities(&plain, None);
     }
 
     // CAP_FEATURE_AVAILABLE is a cfg-gated compile-time constant; the

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -279,7 +279,7 @@ fn process_approved_module(
     // process IS the worker (no parent to survive KillProcess). Failures
     // do not abort the connection - Landlock + SEC-1 `*at` remain the
     // primary defenses.
-    engage_seccomp_sandbox(ctx)?;
+    engage_seccomp_sandbox(ctx, module)?;
 
     let mut streams = match setup_transfer_streams(ctx)? {
         Some(s) => s,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -258,13 +258,15 @@ fn validate_client_paths_in_module(
 /// we treat that as a regression because the SEC-1.p design requires the
 /// sandbox to be live on supporting kernels.
 ///
-/// When `pre_xfer_exec` or `post_xfer_exec` is configured, the sandbox is
-/// skipped: Landlock rulesets are inherited by child processes, so engaging
-/// the allowlist would block `exec()` of hook scripts that live outside the
-/// module path (the common case - e.g. `/usr/local/bin/notify.sh`). Per-module
-/// opt-out via configuration matches the operator's intent (they explicitly
-/// chose to run hooks) and preserves SEC-1 *at* helpers as the primary
-/// defense for those modules.
+/// When any exec hook (`early exec` / `pre-xfer exec` / `post-xfer exec`) is
+/// configured, the sandbox is skipped: Landlock rulesets are inherited by
+/// child processes, so engaging the allowlist would block `exec()` of hook
+/// scripts that live outside the module path (the common case - e.g.
+/// `/usr/local/bin/notify.sh`). Per-module opt-out via configuration matches
+/// the operator's intent (they explicitly chose to run hooks) and preserves
+/// SEC-1 *at* helpers as the primary defense for those modules. The
+/// hook-detection predicate (`module_has_exec_hooks`) is shared with the
+/// worker capability-drop skip in `capabilities.rs`.
 fn engage_landlock_sandbox(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
@@ -272,10 +274,10 @@ fn engage_landlock_sandbox(
 ) -> io::Result<bool> {
     use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
 
-    if module.pre_xfer_exec.is_some() || module.post_xfer_exec.is_some() {
+    if module_has_exec_hooks(module) {
         if let Some(log) = ctx.log_sink {
             let text = format!(
-                "module '{}': landlock=skipped reason=pre-xfer-exec or post-xfer-exec configured (would block hook exec)",
+                "module '{}': landlock=skipped reason=early/pre/post-xfer-exec configured (would block hook exec)",
                 ctx.request,
             );
             let message = rsync_info!(text).with_role(Role::Daemon);
@@ -375,7 +377,14 @@ fn engage_landlock_sandbox(
 /// daemon workers are disposable threads inside a long-lived process, so
 /// the filter dies with the thread and does not affect the daemon or any
 /// other connection.
-fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> {
+///
+/// For modules with operator-configured exec hooks (`module_has_exec_hooks`)
+/// the filter is widened to permit `execve`/`execveat` so the worker can
+/// spawn the hook helper; non-hook modules keep the exec-free allowlist.
+fn engage_seccomp_sandbox(
+    ctx: &mut ModuleRequestContext<'_>,
+    module: &ModuleRuntime,
+) -> io::Result<()> {
     // Stdio sessions: the process IS the worker. Applying seccomp here
     // would restrict the entire process (including post-transfer cleanup,
     // exit handlers, and the parent shell). Skip - Landlock + SEC-1 *at*
@@ -392,7 +401,11 @@ fn engage_seccomp_sandbox(ctx: &mut ModuleRequestContext<'_>) -> io::Result<()> 
         return Ok(());
     }
 
-    match apply_worker_seccomp_filter() {
+    // Widen the allowlist to allow the hook `execve` only when the operator
+    // configured an exec hook on this module - same scope as the Landlock
+    // and capability-drop skips above.
+    let allow_exec = module_has_exec_hooks(module);
+    match apply_worker_seccomp_filter(allow_exec) {
         #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
         SeccompOutcome::Installed => {
             if let Some(log) = ctx.log_sink {

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -56,8 +56,15 @@ pub enum SeccompOutcome {
 /// process-scoped seccomp filter would restrict post-transfer cleanup
 /// and the exit path. The caller (`engage_seccomp_sandbox`) enforces
 /// this by checking `DaemonStream::is_stdio()` before calling here.
+///
+/// `allow_exec` widens the allowlist to include `execve`/`execveat` for
+/// modules the operator configured with exec hooks (`early exec` /
+/// `pre-xfer exec` / `post-xfer exec`); without it a hook `execve` would be
+/// `SIGSYS`-killed under an active filter. Non-hook modules pass `false` and
+/// keep the exec-free allowlist. The caller derives this from
+/// `module_has_exec_hooks`.
 #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
-pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
+pub fn apply_worker_seccomp_filter(allow_exec: bool) -> SeccompOutcome {
     // Default ON when the daemon-seccomp feature is compiled in.
     // Operators can opt out with `OC_RSYNC_NO_SECCOMP=1` if a workload
     // triggers a missing syscall (diagnosed via the SIGSYS crash with
@@ -79,7 +86,7 @@ pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
     };
 
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
-    for sysno in worker_seccomp_allowlist() {
+    for sysno in worker_seccomp_allowlist(allow_exec) {
         rules.insert(sysno, Vec::new());
     }
 
@@ -115,7 +122,7 @@ pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
 /// wire-in at `module_access/transfer.rs` does not need `#[cfg]`
 /// branches.
 #[cfg(not(all(target_os = "linux", feature = "daemon-seccomp")))]
-pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
+pub fn apply_worker_seccomp_filter(_allow_exec: bool) -> SeccompOutcome {
     SeccompOutcome::Unavailable
 }
 
@@ -129,8 +136,17 @@ pub fn apply_worker_seccomp_filter() -> SeccompOutcome {
 /// - B: network and IPC for the wire protocol
 /// - C: process / scheduling / runtime primitives
 /// - D: io_uring (additive; harmless when the runtime path is inert)
+///
+/// `allow_exec` adds bucket E (`execve`/`execveat`) only for modules the
+/// operator configured with exec hooks. Non-hook modules pass `false`, so
+/// the steady-state worker still cannot `exec`; a compromised worker on a
+/// normal module is `SIGSYS`-killed if it attempts to spawn a shell. The
+/// hook exemption is scoped exactly like the Landlock and capability-drop
+/// skips (`module_has_exec_hooks`) - the operator explicitly opted into
+/// running helper scripts. upstream: rsync 3.4.4 has no seccomp code, so
+/// this narrowing (and its per-hook-module relaxation) is oc-only.
 #[cfg(all(target_os = "linux", feature = "daemon-seccomp"))]
-pub fn worker_seccomp_allowlist() -> Vec<i64> {
+pub fn worker_seccomp_allowlist(allow_exec: bool) -> Vec<i64> {
     let mut s: Vec<i64> = Vec::new();
 
     // Bucket A - file I/O on the module tree.
@@ -291,6 +307,16 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
         libc::SYS_io_uring_register,
     ]);
 
+    // Bucket E - exec, added ONLY for modules with operator-configured exec
+    // hooks. The worker `fork`/`execve`s the hook helper (`early exec` /
+    // `pre-xfer exec` / `post-xfer exec`); without these entries an active
+    // filter would `SIGSYS`-kill the worker at the hook exec. Normal modules
+    // never reach this branch, so their allowlist stays exec-free.
+    if allow_exec {
+        s.push(libc::SYS_execve);
+        s.push(libc::SYS_execveat);
+    }
+
     s.sort_unstable();
     s.dedup();
     s
@@ -395,19 +421,48 @@ mod seccomp_tests {
 
     #[test]
     fn allowlist_is_non_empty_and_sorted() {
-        let list = worker_seccomp_allowlist();
-        assert!(!list.is_empty(), "allowlist must contain entries");
-        let mut sorted = list.clone();
-        sorted.sort_unstable();
-        assert_eq!(list, sorted, "allowlist must be sorted");
-        let mut dedup = list.clone();
-        dedup.dedup();
-        assert_eq!(list.len(), dedup.len(), "allowlist must be deduplicated");
+        for allow_exec in [false, true] {
+            let list = worker_seccomp_allowlist(allow_exec);
+            assert!(!list.is_empty(), "allowlist must contain entries");
+            let mut sorted = list.clone();
+            sorted.sort_unstable();
+            assert_eq!(list, sorted, "allowlist must be sorted");
+            let mut dedup = list.clone();
+            dedup.dedup();
+            assert_eq!(list.len(), dedup.len(), "allowlist must be deduplicated");
+        }
+    }
+
+    /// The exec syscalls are present in the allowlist only when a hook module
+    /// requests them (`allow_exec == true`); the steady-state worker allowlist
+    /// must never permit `execve`/`execveat`, so a compromised worker on a
+    /// normal module cannot spawn a shell.
+    #[test]
+    fn exec_syscalls_gated_on_hook_modules() {
+        let without = worker_seccomp_allowlist(false);
+        assert!(
+            without.binary_search(&libc::SYS_execve).is_err(),
+            "non-hook allowlist must not permit execve",
+        );
+        assert!(
+            without.binary_search(&libc::SYS_execveat).is_err(),
+            "non-hook allowlist must not permit execveat",
+        );
+
+        let with = worker_seccomp_allowlist(true);
+        assert!(
+            with.binary_search(&libc::SYS_execve).is_ok(),
+            "hook-module allowlist must permit execve",
+        );
+        assert!(
+            with.binary_search(&libc::SYS_execveat).is_ok(),
+            "hook-module allowlist must permit execveat",
+        );
     }
 
     #[test]
     fn allowlist_contains_steady_state_essentials() {
-        let list = worker_seccomp_allowlist();
+        let list = worker_seccomp_allowlist(false);
         for required in [
             libc::SYS_read,
             libc::SYS_write,
@@ -447,7 +502,7 @@ mod seccomp_tests {
             return;
         };
         let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
-        for sysno in worker_seccomp_allowlist() {
+        for sysno in worker_seccomp_allowlist(false) {
             rules.insert(sysno, Vec::new());
         }
         let filter = SeccompFilter::new(

--- a/crates/daemon/tests/seccomp_production_allowlist.rs
+++ b/crates/daemon/tests/seccomp_production_allowlist.rs
@@ -68,7 +68,8 @@ fn production_allowlist_covers_a_clean_transfer_slice() {
         // 1. Install the production filter. Identical to what
         //    `engage_seccomp_sandbox` does at the daemon's post-fork
         //    point.
-        match apply_worker_seccomp_filter() {
+        // Non-hook module: the steady-state exec-free allowlist.
+        match apply_worker_seccomp_filter(false) {
             SeccompOutcome::Installed => {}
             SeccompOutcome::Unavailable => return 77, // skip
             SeccompOutcome::Error(_) => return 78,
@@ -149,9 +150,12 @@ fn getrandom_via_libc(buf: &mut [u8]) -> std::io::Result<()> {
 fn allowlist_is_a_concrete_set() {
     // Sanity: the production allowlist must round-trip through the same
     // public accessor the integration child uses.
-    let list = worker_seccomp_allowlist();
+    let list = worker_seccomp_allowlist(false);
     assert!(!list.is_empty());
     assert!(list.binary_search(&libc::SYS_openat).is_ok());
     assert!(list.binary_search(&libc::SYS_close).is_ok());
     assert!(list.binary_search(&libc::SYS_futex).is_ok());
+    // The steady-state (non-hook) allowlist must never permit exec.
+    assert!(list.binary_search(&libc::SYS_execve).is_err());
+    assert!(list.binary_search(&libc::SYS_execveat).is_err());
 }


### PR DESCRIPTION
## Problem

A non-root daemon serving a module configured with `early exec` / `pre-xfer exec` / `post-xfer exec` hooks fails on **Linux** (connection closed, exit code 12, client sees "0 bytes received"). It passes as root, and passes on macOS non-root.

## Root cause

The only root-vs-non-root behavioral fork that runs for a hook module (no uid/gid/chroot configured) is `drop_worker_capabilities` in `capabilities.rs`. Root skips the capability drop; a non-root worker runs it, stripping the capability set the worker needs to `fork`/`execve` the hook helper. The worker thread's swallowed error then drops the socket.

`PR_SET_NO_NEW_PRIVS` (set globally at startup) is **not** the cause: it only blocks privilege *escalation* on `execve` (setuid/caps), never a plain hook `execve`, so no relaxation is needed there and it stays global.

## Fix

Mirrors the existing Landlock skip in `engage_landlock_sandbox` (`sandbox.rs`), which already exempts hook modules because Landlock rulesets are inherited across `exec`. A shared `module_has_exec_hooks` predicate is extracted and reused at all three hardening layers:

1. **`drop_worker_capabilities`** - skip the per-worker capability drop for hook modules (fixes the observed failure). Non-hook modules keep the full drop.
2. **`engage_landlock_sandbox`** - reuse the shared predicate (now also covers `early exec`, previously only `pre`/`post`).
3. **worker seccomp allowlist** - add `execve`/`execveat` **only** when the module has hooks (`allow_exec` threaded from `module_has_exec_hooks`), so hook modules work with seccomp ON without weakening the steady-state allowlist for normal modules.

Upstream rsync 3.4.4 has no capability/seccomp/Landlock/prctl code at all - its hooks run with the daemon's inherited privileges. These layers are oc-only defense-in-depth, so exempting operator-configured hook modules preserves upstream behavioural parity.

## Invariants preserved

- **Non-hook modules: security posture unchanged** - still capability-dropped, still seccomp-restricted (exec-free allowlist), still Landlock-sandboxed.
- **Non-Linux + root: zero behavior change** - all new logic is `#[cfg(target_os = "linux")]` and non-root-gated.
- The relaxation is tightly scoped to operator-configured hook modules, exactly the same trust model as the pre-existing Landlock skip.

## Tests

- `module_has_exec_hooks_matches_each_hook_directive` - predicate true for each of early/pre/post, false otherwise.
- `capability_drop_skipped_only_for_hook_modules` - drop gated by the predicate; panic-free on both paths.
- `exec_syscalls_gated_on_hook_modules` + `allowlist_is_a_concrete_set` - `execve`/`execveat` present **only** when `allow_exec == true`; steady-state allowlist never permits exec.

## Verification

- Local (macOS): `cargo build -p daemon --all-targets`, `cargo fmt -p daemon --check`, `cargo clippy` (no findings in changed files) all pass.
- The Linux-only hardening code path (`capabilities.rs`, seccomp allowlist internals) is `#[cfg(target_os = "linux")]` and cannot be compiled or the end-to-end non-root repro run on macOS. **The end-to-end non-root Linux repro must be verified on the Linux validation host and CI.**
