### PR TITLE
ci: nightly 3.5.0dev testsuite tracker (non-required, RsyncProject master)

### DIFF
--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -1,0 +1,106 @@
+# Nightly tracker for the upstream rsync 3.5.0dev target (RsyncProject master).
+#
+# WHY: oc-rsync shadows the latest upstream rsync. rsync 3.5.0 releases
+# 2026-07-15. Until then, master (version.h == "3.5.0dev") is a moving target
+# whose testsuite migrated from shell *.test scripts to Python (runtests.py +
+# testsuite/*_test.py). This workflow runs that evolving suite against oc-rsync
+# every night so the full, growing divergence set is visible BEFORE release -
+# without gating any PR.
+#
+# NON-REQUIRED / INFORMATIONAL:
+#   - Triggers: nightly schedule + manual dispatch only (never on push/PR).
+#   - Not referenced by ci.yml / ci-skip.yml and not in branch protection.
+#   - A 3.5.0dev build break or test failure here MUST NOT affect any PR: the
+#     job surfaces the divergence (step-summary table + non-zero run status)
+#     but is best-effort tracking, not a gate.
+#
+# The REQUIRED gate stays on the pinned 3.4.4 release tarball
+# (.github/workflows/_upstream-testsuite.yml, context
+# "upstream-testsuite / upstream testsuite"). This workflow does not touch it.
+#
+# RELEASE-DAY PLAN (2026-07-15): once 3.5.0 ships, bump the REQUIRED gate's
+# pin 3.4.4 -> 3.5.0, vendor the 3.5.0 testsuite as a release tarball, and
+# retire this git-ref tracker (or repoint it at the next dev branch).
+
+name: Track 3.5.0dev Testsuite
+
+on:
+  schedule:
+    # 06:00 UTC nightly - off-peak, after the day's PR activity settles.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: 'RsyncProject ref to track (branch, tag, or sha)'
+        type: string
+        default: 'master'
+
+permissions:
+  contents: read
+
+jobs:
+  track-3-5-0dev:
+    name: 3.5.0dev testsuite (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Best-effort tracker: never let a 3.5.0dev break look like a repo failure
+    # that someone must firefight. The step summary + run status carry the
+    # signal; this flag keeps the job green so it stays purely informational.
+    continue-on-error: true
+
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      RUST_BACKTRACE: "full"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: track-3-5-0dev-cargo
+          key: track-3-5-0dev-testsuite
+          cache-on-failure: true
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        with:
+          # Same autotools/dev set as the 3.4.4 gate, plus python3 for
+          # runtests.py (the git-ref suite is Python) and git for the clone.
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev python3 git
+          version: v1
+
+      - name: Build oc-rsync (release)
+        run: cargo build --locked --release --bin oc-rsync
+
+      - name: Run 3.5.0dev testsuite (git-ref mode)
+        id: testsuite
+        env:
+          OC_RSYNC_BIN: target/release/oc-rsync
+          UPSTREAM_REF: ${{ github.event.inputs.upstream_ref || 'master' }}
+        run: |
+          set -uo pipefail
+          mkdir -p target/interop
+          # Best-effort: capture the driver's exit but do not fail the step -
+          # continue-on-error at the job level already keeps this informational,
+          # and we still want the artifact + summary to publish on divergence.
+          bash tools/ci/run_upstream_testsuite.sh 2>&1 \
+            | tee target/interop/track-3.5.0dev-output.log || true
+
+      - name: Upload testsuite logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: track-3.5.0dev-testsuite-logs
+          path: |
+            target/interop/upstream-testsuite/
+            target/interop/track-3.5.0dev-output.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -18,13 +18,42 @@
 #   WHICHTESTS=00-hello.test tools/ci/...sh           # run a single test
 #   UPSTREAM_VERSION=3.4.4 tools/ci/...sh             # pin upstream version
 #   PRESERVE_SCRATCH=yes tools/ci/...sh               # keep per-test scratch dirs
+#
+# Git-ref mode (tracks the moving 3.5.0dev target - RsyncProject master):
+#   UPSTREAM_VERSION=master tools/ci/...sh            # git-clone + build master
+#   UPSTREAM_REF=<sha-or-tag> tools/ci/...sh          # any RsyncProject ref
+#   UPSTREAM_GIT_URL=<url> UPSTREAM_REF=... tools/ci/...sh
+#
+# Git-ref mode is additive and OFF by default: the release-tarball path above
+# is 100% unchanged unless UPSTREAM_REF is set or UPSTREAM_VERSION=master. In
+# git-ref mode the upstream source is a git checkout, not a release tarball,
+# and (since the 3.4.x -> 3.5.0dev migration) upstream's testsuite is Python
+# (runtests.py + testsuite/*_test.py), not the shell *.test scripts of 3.4.x.
+# We therefore delegate to upstream's own runtests.py with --rsync-bin set to
+# oc-rsync - the master analog of pointing $RSYNC at oc-rsync in the tarball
+# path - rather than driving *.test scripts ourselves. See run_git_ref_mode().
 
 set -euo pipefail
 
 workspace_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 upstream_version="${UPSTREAM_VERSION:-3.4.4}"
+# Git-ref mode is selected by an explicit UPSTREAM_REF, or by the sentinel
+# UPSTREAM_VERSION=master. Default (empty UPSTREAM_REF, numeric version) keeps
+# the release-tarball path untouched.
+upstream_git_url="${UPSTREAM_GIT_URL:-https://github.com/RsyncProject/rsync}"
+upstream_ref="${UPSTREAM_REF:-}"
+if [[ -z "$upstream_ref" && "$upstream_version" == "master" ]]; then
+    upstream_ref="master"
+fi
+git_ref_mode="no"
+[[ -n "$upstream_ref" ]] && git_ref_mode="yes"
 upstream_src_root="${workspace_root}/target/interop/upstream-src"
-upstream_src_dir="${upstream_src_root}/rsync-${upstream_version}"
+if [[ "$git_ref_mode" == "yes" ]]; then
+    # A ref may be a sha/tag/branch; sanitize it into a safe directory name.
+    upstream_src_dir="${upstream_src_root}/rsync-git-${upstream_ref//[^A-Za-z0-9._-]/_}"
+else
+    upstream_src_dir="${upstream_src_root}/rsync-${upstream_version}"
+fi
 oc_rsync_bin="${OC_RSYNC_BIN:-${workspace_root}/target/release/oc-rsync}"
 # Resolve to absolute path - test scripts cd into the upstream source tree,
 # so a relative OC_RSYNC_BIN would break.
@@ -78,6 +107,24 @@ ensure_oc_rsync() {
 
 ensure_upstream_src() {
     if [[ -d "$upstream_src_dir" && -f "${upstream_src_dir}/configure" ]]; then
+        return
+    fi
+    if [[ "$git_ref_mode" == "yes" ]]; then
+        # Git-ref mode: clone a RsyncProject ref instead of a release tarball.
+        # A fresh checkout ships a stub ./configure that bootstraps
+        # configure.sh via prepare-source (needs autoconf/autoheader), so the
+        # downstream build_upstream_helpers() path is unchanged.
+        echo "==> Cloning ${upstream_git_url} @ ${upstream_ref} ..." >&2
+        mkdir -p "$upstream_src_root"
+        rm -rf "$upstream_src_dir"
+        if git ls-remote --exit-code "$upstream_git_url" "$upstream_ref" >/dev/null 2>&1; then
+            git clone --depth 1 --branch "$upstream_ref" \
+                "$upstream_git_url" "$upstream_src_dir"
+        else
+            # Ref is a commit sha (not a branch/tag): clone then fetch it.
+            git clone "$upstream_git_url" "$upstream_src_dir"
+            (cd "$upstream_src_dir" && git checkout --detach "$upstream_ref")
+        fi
         return
     fi
     echo "==> Fetching upstream rsync ${upstream_version} source..." >&2
@@ -298,7 +345,114 @@ emit_gha_step_summary() {
     } >>"$summary_file"
 }
 
+# Git-ref mode driver: delegate to upstream's own runtests.py.
+#
+# The 3.5.0dev testsuite is Python (runtests.py + testsuite/*_test.py), so we
+# do NOT iterate *.test scripts as the tarball path does. Instead we build the
+# upstream helper programs the suite needs (`make check-progs` == the `all`
+# target plus CHECK_PROGS/CHECK_SYMLINKS, per upstream Makefile.in:381) and
+# then invoke upstream's runtests.py with --rsync-bin pointed at oc-rsync. That
+# flag is the master analog of exporting $RSYNC=oc-rsync in the tarball path.
+#
+# runtests.py prints one "PASS/FAIL/SKIP/XFAIL <testbase>" line per test and a
+# trailing "overall result is N" (N = failure count). This is informational
+# tracking of a moving target, so there is no known-failures gate: we surface
+# every divergence (the FAIL/XFAIL set) and propagate runtests.py's own exit
+# code, which the nightly workflow reports without blocking any PR.
+run_git_ref_mode() {
+    ensure_oc_rsync
+    ensure_upstream_src
+
+    echo "==> Building upstream (git ${upstream_ref}) + testsuite helpers..." >&2
+    (
+        cd "$upstream_src_dir"
+        if [[ ! -f configure.sh ]]; then
+            ./configure --disable-debug --disable-md2man --disable-iconv \
+                --disable-zstd --disable-lz4 >configure.log 2>&1 \
+                || { tail -80 configure.log; exit 1; }
+        fi
+        # check-progs builds `all` + CHECK_PROGS + CHECK_SYMLINKS: exactly the
+        # tools runtests.py needs (upstream Makefile.in:381).
+        make check-progs >make.log 2>&1 || { tail -120 make.log; exit 1; }
+    )
+
+    rm -rf "$log_root"
+    mkdir -p "$log_root"
+    local output_log="${log_root}/runtests-output.log"
+
+    local rc=0
+    (
+        cd "$upstream_src_dir"
+        python3 ./runtests.py \
+            --rsync-bin="$oc_rsync_bin" \
+            --tooldir="$upstream_src_dir" \
+            --srcdir="$upstream_src_dir" \
+            --timeout="$testrun_timeout"
+    ) 2>&1 | tee "$output_log"
+    rc=${PIPESTATUS[0]}
+
+    emit_git_ref_step_summary "$output_log" "$rc"
+    return "$rc"
+}
+
+# Write a $GITHUB_STEP_SUMMARY table for a git-ref (runtests.py) run: PASS/FAIL/
+# SKIP/XFAIL counts plus the FAIL/XFAIL test names. GHA-only; no-op locally.
+emit_git_ref_step_summary() {
+    local output_log=$1 rc=$2
+    local summary_file=${GITHUB_STEP_SUMMARY:-}
+    [[ -z "$summary_file" ]] && return 0
+    [[ -f "$output_log" ]] || return 0
+
+    local p f s x
+    p=$(grep -c '^PASS ' "$output_log" || true)
+    f=$(grep -c '^FAIL ' "$output_log" || true)
+    s=$(grep -c '^SKIP ' "$output_log" || true)
+    x=$(grep -c '^XFAIL ' "$output_log" || true)
+
+    {
+        echo "## 3.5.0dev testsuite (RsyncProject ${upstream_ref})"
+        echo
+        echo "Informational tracker of the moving upstream target."
+        echo "runtests.py overall exit code: \`${rc}\`"
+        echo
+        echo "| Result | Count |"
+        echo "|--------|------:|"
+        echo "| PASS   | $p |"
+        echo "| FAIL   | $f |"
+        echo "| XFAIL  | $x |"
+        echo "| SKIP   | $s |"
+        echo
+        local fails
+        fails=$(grep -E '^FAIL ' "$output_log" | awk '{print $2}' || true)
+        if [[ -n "$fails" ]]; then
+            echo "### Failures (divergence set)"
+            echo
+            local t
+            while IFS= read -r t; do
+                [[ -n "$t" ]] && echo "- \`$t\`"
+            done <<<"$fails"
+            echo
+        fi
+        local xfails
+        xfails=$(grep -E '^XFAIL ' "$output_log" | awk '{print $2}' || true)
+        if [[ -n "$xfails" ]]; then
+            echo "### Expected failures (XFAIL)"
+            echo
+            local t
+            while IFS= read -r t; do
+                [[ -n "$t" ]] && echo "- \`$t\`"
+            done <<<"$xfails"
+            echo
+        fi
+    } >>"$summary_file"
+}
+
 main() {
+    if [[ "$git_ref_mode" == "yes" ]]; then
+        run_git_ref_mode
+        exit $?
+    fi
+
     ensure_oc_rsync
     ensure_upstream_src
     build_upstream_helpers


### PR DESCRIPTION
## Summary

Stand up a 3.5.0-readiness tracking CI cell. rsync 3.5.0 releases 2026-07-15; oc-rsync shadows the latest upstream. This adds a **non-required, nightly** workflow that runs the RsyncProject **master** (3.5.0dev) testsuite against oc-rsync so the full, evolving divergence set is visible before release **without blocking any PR**.

## Changes

### `tools/ci/run_upstream_testsuite.sh` - additive git-ref mode
- Selected by `UPSTREAM_REF=<ref>` or the sentinel `UPSTREAM_VERSION=master`. Default (numeric version, empty ref) leaves the **3.4.4 release-tarball path byte-unchanged** (diff is additions-only; no existing line altered).
- In git-ref mode: `git clone --depth 1` the ref instead of downloading a tarball, then `./configure && make check-progs`.
- The 3.4.x -> 3.5.0dev migration replaced shell `*.test` scripts + `runtests.sh` with **Python** `testsuite/*_test.py` + `runtests.py`. So git-ref mode delegates to upstream's own `runtests.py --rsync-bin=<oc-rsync>` (the master analog of exporting `$RSYNC=oc-rsync` in the tarball path) rather than driving `*.test` scripts. It parses the `PASS/FAIL/SKIP/XFAIL` lines + `overall result is N` and emits a `$GITHUB_STEP_SUMMARY` table with the FAIL/XFAIL divergence set.
- Every `cargo` invocation keeps `--locked`.

### `.github/workflows/track-3.5.0dev-testsuite.yml` - new nightly tracker
- `on: schedule` (`0 6 * * *`) + `workflow_dispatch` (with an `upstream_ref` input). Never runs on push/PR.
- Builds oc-rsync `--locked --release`, runs the driver in git-ref mode, uploads the full log as an artifact (14-day retention), and publishes the PASS/FAIL/SKIP/XFAIL summary.
- **Non-required / informational**: `continue-on-error: true` at job level; not referenced by `ci.yml`/`ci-skip.yml`; not in branch protection. A 3.5.0dev build break or test fail cannot affect any PR.
- Action SHAs copied verbatim from the sibling `_upstream-testsuite.yml`.

## Invariants held
- Required 3.4.4 gate (`_upstream-testsuite.yml`) and `ci.yml`/`ci-skip.yml` **untouched**; branch-protection ruleset not modified.
- Default tarball path unchanged; git-ref branching is fully gated behind the new env var.

## Release-day plan (documented in the workflow header)
On 2026-07-15, bump the REQUIRED gate's pin 3.4.4 -> 3.5.0, vendor the 3.5.0 testsuite tarball, and retire this git-ref tracker.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` valid; `bash -n` clean; `shellcheck` clean.
- Dry-ran the clone locally: `RsyncProject/rsync@master` resolves and clones; `version.h == 3.5.0dev`; master ships `runtests.py` (no `*.test` files). Full autoconf/make build could not be exercised on the macOS dev host (its `make`-driven `aclocal` bootstrap needs the Linux autotools set) - the scheduled CI runner installs `autoconf automake libtool` and completes it.