### PR TITLE
ci: make delay-updates upstream-testsuite test deterministic

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -169,6 +169,29 @@ setup_test_env() {
         ECHO_N ECHO_C ECHO_T
 }
 
+# Backdate the mtime of the upstream source root so tests that reference the
+# cwd's parent directory ("..") get a stable, old timestamp.
+#
+# The tests run with cwd = $upstream_src_dir, so ".." resolves to
+# $upstream_src_root. delay-updates.test does
+#   touch -r .. "$todir/foo"
+# to age the destination file, then writes a fresh source file and expects the
+# two mtimes to differ so the quick-check (same size + same mtime => skip)
+# forces a transfer. On a cold CI run the tarball is extracted moments before
+# the tests execute, so $upstream_src_root's mtime lands in the same wall-clock
+# second as the freshly written source file. The mtimes then collide, the
+# quick-check skips the transfer, the stale destination is left in place, and
+# the test's dir/file diff fails. Warm-cache runs use an already-old source
+# root and pass, which is exactly the observed intermittency. Pinning the mtime
+# to a fixed epoch makes ".." deterministically old. Nothing writes directly
+# into $upstream_src_root during a run (scratch lives under $log_root), so the
+# stamp survives the whole test loop. Both oc-rsync and upstream rsync 3.4.4
+# skip under the collision, so this is a harness-timing fix, not a behavioural
+# divergence.
+stabilize_srcroot_mtime() {
+    touch -t 200001010000 "$upstream_src_root" 2>/dev/null || true
+}
+
 prep_scratch() {
     local sd=$1
     [[ -d "$sd" ]] && chmod -R u+rwX "$sd" 2>/dev/null && rm -rf "$sd"
@@ -303,6 +326,7 @@ main() {
     ensure_upstream_src
     build_upstream_helpers
     setup_test_env
+    stabilize_srcroot_mtime
 
     rm -rf "$log_root"
     mkdir -p "$log_root"


### PR DESCRIPTION
## Problem

`upstream-testsuite / upstream testsuite` intermittently reports `FAIL delay-updates (exit 1)` and passes on rerun (master stays green). Now that this check is required (#6233), the flake blocks PRs.

## Root cause (a timing race, not an oc-rsync bug)

`testsuite/delay-updates.test` ages the destination file with:

```sh
touch -r .. "$todir/.~tmp~/foo" "$todir/foo"
echo 3 > "$fromdir/foo"
```

then runs `rsync -a --delay-updates` and expects the transfer to happen because the destination mtime (`..`) differs from the freshly written source mtime.

The tests run with `cwd = upstream source dir`, so `..` resolves to the **upstream source root** (`target/interop/upstream-src`). On a **cold CI run** the tarball is extracted moments before the tests execute, so the source root's mtime lands in the **same wall-clock second** as `echo 3 > from/foo`. rsync's quick-check (same size + same mtime => skip) then skips the transfer, the stale destination is left in place, and `checkit`'s dir/file diff fails. Warm-cache runs use an already-old root and pass — exactly the observed intermittency.

Verified locally by replaying the two-run sequence: with the parent (`..`) mtime fresh, the transfer is skipped (`.f..t`, stale content); with it old, the transfer runs (`>f..t`, correct content). **Upstream rsync 3.4.4 behaves identically** — it also skips under the collision — confirming this is harness timing, not a behavioural divergence.

## Fix

Pin the upstream source root mtime to a fixed old epoch before the test loop, so `..` is deterministically old and the quick-check always sees differing mtimes. Nothing writes directly into the source root during a run (scratch lives under the log root), so the stamp survives.

Harness-only change; no product code touched. `delay-updates` is **not** added to the known-failures list. `bash -n` and `shellcheck -S warning` clean.