### PR TITLE
feat(transfer): real AsyncRead impl for AsyncServerReader (ASY, default-off)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -83,6 +83,13 @@ jobs:
             --features tokio-transfer \
             -E 'test(reader_stack_parity)'
 
+      - name: Run sync vs async AsyncServerReader AsyncRead-impl parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer \
+            -E 'test(asyncread_impl)'
+
   async-equivalence:
     name: async-vs-default transfer equivalence (stable)
     runs-on: ubuntu-latest

--- a/crates/transfer/src/reader/multiplex_parity_tests.rs
+++ b/crates/transfer/src/reader/multiplex_parity_tests.rs
@@ -423,3 +423,114 @@ async fn demux_parity_chunked_delivery() {
         }
     }
 }
+
+/// Drives the multiplex-mode [`AsyncServerReader`] purely through its
+/// [`tokio::io::AsyncRead`] impl (`read().await`, never the inherent
+/// `read_async`), returning the demuxed bytes. This is the entry point the
+/// follow-up async read leaves will use: a uniform `R: AsyncRead` source.
+///
+/// `read_len` is the caller buffer size, exercised small so multi-frame data is
+/// split across `poll_read` calls exactly as the sync `ServerReader` splits it.
+async fn drive_asyncread_impl<R: AsyncRead + Unpin + Send + 'static>(
+    reader: R,
+    read_len: usize,
+) -> Vec<u8> {
+    use tokio::io::AsyncReadExt;
+    let mut server = AsyncServerReader::new_plain(reader)
+        .activate_multiplex()
+        .expect("activate multiplex");
+
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+    loop {
+        // `AsyncRead::read` returns Ok(0) on EOF; the demux surfaces a truncated
+        // trailing frame as UnexpectedEof, identical to the sync driver, so both
+        // terminators preserve parity.
+        match server.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => panic!("AsyncRead impl read failed: {err}"),
+        }
+    }
+    data
+}
+
+/// The new [`tokio::io::AsyncRead`] impl for [`AsyncServerReader`] must yield the
+/// exact same demuxed bytes the sync [`ServerReader`] yields for the same wire,
+/// across read-buffer sizes. This is the poll-driven half of the parity gate: it
+/// proves the `poll_read` core delivers the identical stream the inherent
+/// `read_async` and blocking `Read` paths do.
+#[tokio::test(flavor = "current_thread")]
+async fn asyncread_impl_parity_whole_stream() {
+    let (wire, expected) = data_only_wire();
+    for read_len in READ_LENS {
+        let (sync_data, _sync_count) = drive_sync_stack(&wire, read_len);
+        let async_data = drive_asyncread_impl(Cursor::new(wire.clone()), read_len).await;
+
+        assert_eq!(
+            sync_data, expected,
+            "sync stack delivered wrong bytes at read_len {read_len}"
+        );
+        assert_eq!(
+            async_data, sync_data,
+            "AsyncRead impl DATA diverged from sync at read_len {read_len}"
+        );
+    }
+}
+
+/// Same byte-identity guarantee for the `AsyncRead` impl, but the transport
+/// yields bytes in tiny chunks so frames reassemble across many `poll_read`
+/// calls - and, on a real socket, across `Poll::Pending` returns. This is the
+/// load-bearing test for the impl's Pending-safety: the in-flight demux future
+/// must survive fragmentation without dropping or reordering bytes.
+#[tokio::test(flavor = "current_thread")]
+async fn asyncread_impl_parity_chunked_delivery() {
+    let (wire, expected) = data_only_wire();
+    for read_len in READ_LENS {
+        let (sync_data, _sync_count) = drive_sync_stack(&wire, read_len);
+        for chunk in [1usize, 2, 3, 7, 13] {
+            let reader = ChunkedReader {
+                inner: Cursor::new(wire.clone()),
+                chunk,
+            };
+            let async_data = drive_asyncread_impl(reader, read_len).await;
+            assert_eq!(
+                async_data, expected,
+                "AsyncRead impl DATA diverged with chunk {chunk}, read_len {read_len}"
+            );
+            assert_eq!(
+                async_data, sync_data,
+                "AsyncRead impl DATA diverged from sync with chunk {chunk}, read_len {read_len}"
+            );
+        }
+    }
+}
+
+/// The `AsyncRead` impl in plain (non-multiplex) mode is a pure pass-through: it
+/// must deliver the raw transport bytes unchanged, matching the sync
+/// [`ServerReader`] plain path. Covers the `Plain` arm of `poll_read` alongside
+/// the multiplex arm exercised by the other tests.
+#[tokio::test(flavor = "current_thread")]
+async fn asyncread_impl_plain_passthrough() {
+    use tokio::io::AsyncReadExt;
+    let raw: Vec<u8> = (0..=255u8).cycle().take(1000).collect();
+    for read_len in READ_LENS {
+        let mut server = AsyncServerReader::new_plain(Cursor::new(raw.clone()));
+        assert!(!server.is_multiplexed(), "plain mode before activation");
+
+        let mut data = Vec::new();
+        let mut buf = vec![0u8; read_len];
+        loop {
+            match server.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => data.extend_from_slice(&buf[..n]),
+                Err(err) => panic!("plain AsyncRead read failed: {err}"),
+            }
+        }
+        assert_eq!(
+            data, raw,
+            "plain-mode AsyncRead pass-through diverged at read_len {read_len}"
+        );
+    }
+}

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -278,8 +278,53 @@ enum AsyncServerReaderInner<R> {
     /// Plain mode - await the inner transport directly, no demux.
     Plain(R),
     /// Multiplex mode - await MSG_DATA frames via the shared demux core.
-    Multiplex(MultiplexReader<R>),
+    ///
+    /// Wrapped in a [`MuxState`] so the [`tokio::io::AsyncRead`] impl can hold an
+    /// in-flight demux future across a `Poll::Pending` without losing frame
+    /// bytes already pulled off the transport (see the `poll_read` docs). The
+    /// inherent [`AsyncServerReader::read_async`] path, which `.await`s to
+    /// completion in one call, only ever sees the [`MuxState::Idle`] reader.
+    Multiplex(MuxState<R>),
 }
+
+/// Read state for the multiplex arm of [`AsyncServerReader`].
+///
+/// The blocking [`ServerReader`] holds a bare [`MultiplexReader`] because its
+/// `Read::read` runs to completion in one call. A `poll_read`, by contrast, can
+/// return [`Poll::Pending`](std::task::Poll::Pending) mid-frame, so the
+/// in-flight demux future - which owns the reader plus any bytes already pulled
+/// off the transport for the current frame header/payload - must persist across
+/// polls. Dropping and recreating it would silently discard those consumed bytes
+/// and corrupt the stream. This state enum keeps that future alive between polls
+/// and hands the reader back once the frame completes.
+///
+/// No demux logic is duplicated: the `Reading` future simply awaits the shared
+/// [`MultiplexReader::read_async`], the exact `.await` core the inherent
+/// [`AsyncServerReader::read_async`] uses.
+#[cfg(feature = "tokio-transfer")]
+enum MuxState<R> {
+    /// No read in flight - the demultiplexer is available to start one.
+    Idle(MultiplexReader<R>),
+    /// A read is in flight. The boxed future owns the [`MultiplexReader`] plus a
+    /// staging buffer and resolves to both (so the reader returns to `Idle`)
+    /// alongside the demuxed byte count. Boxing erases the future type so the
+    /// state can be stored in the struct across polls.
+    Reading(MuxReadFuture<R>),
+    /// Transient placeholder held only while ownership moves between `Idle` and
+    /// `Reading`. Never observed by a subsequent poll: every transition that
+    /// takes the state restores a real variant before `poll_read` returns.
+    Transitioning,
+}
+
+/// Boxed in-flight multiplex read future.
+///
+/// Resolves to the reclaimed [`MultiplexReader`], its staging buffer (returned
+/// so the allocation can be reused), and the demuxed byte count (or error). See
+/// [`MuxState::Reading`].
+#[cfg(feature = "tokio-transfer")]
+type MuxReadFuture<R> = std::pin::Pin<
+    Box<dyn std::future::Future<Output = (MultiplexReader<R>, Vec<u8>, io::Result<usize>)> + Send>,
+>;
 
 #[cfg(feature = "tokio-transfer")]
 impl<R: tokio::io::AsyncRead + Unpin> AsyncServerReader<R> {
@@ -299,7 +344,9 @@ impl<R: tokio::io::AsyncRead + Unpin> AsyncServerReader<R> {
     pub(crate) fn activate_multiplex(self) -> io::Result<Self> {
         match self.inner {
             AsyncServerReaderInner::Plain(reader) => Ok(Self {
-                inner: AsyncServerReaderInner::Multiplex(MultiplexReader::new(reader)),
+                inner: AsyncServerReaderInner::Multiplex(MuxState::Idle(MultiplexReader::new(
+                    reader,
+                ))),
             }),
             AsyncServerReaderInner::Multiplex(_) => Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
@@ -320,12 +367,137 @@ impl<R: tokio::io::AsyncRead + Unpin> AsyncServerReader<R> {
     /// plain and multiplex modes: plain mode delegates to the inner async
     /// transport's `read`, multiplex mode delegates to the shared
     /// [`MultiplexReader::read_async`]. No demux logic is duplicated here.
+    ///
+    /// This inherent path `.await`s to completion in a single call, so it only
+    /// ever observes the [`MuxState::Idle`] reader; a `Reading`/`Transitioning`
+    /// state can arise only inside a [`tokio::io::AsyncRead::poll_read`] cycle,
+    /// which never overlaps a `read_async` call.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn read_async(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         use tokio::io::AsyncReadExt;
         match &mut self.inner {
             AsyncServerReaderInner::Plain(r) => r.read(buf).await,
-            AsyncServerReaderInner::Multiplex(r) => r.read_async(buf).await,
+            AsyncServerReaderInner::Multiplex(MuxState::Idle(r)) => r.read_async(buf).await,
+            AsyncServerReaderInner::Multiplex(_) => Err(io::Error::other(
+                "read_async called while a poll_read demux future was in flight",
+            )),
+        }
+    }
+}
+
+/// Real [`tokio::io::AsyncRead`] for the async server reader, gated on the
+/// `tokio-transfer` feature.
+///
+/// This is the poll-based counterpart to the inherent
+/// [`AsyncServerReader::read_async`]: it yields the exact same demuxed byte
+/// stream (plain pass-through, or MSG_DATA payloads via the shared
+/// [`MultiplexReader`] demux core), so the follow-up async read leaves
+/// (flist / attrs / stats / NDX) can all read from one uniform
+/// `R: AsyncRead` source rather than reaching for the inherent method.
+///
+/// # Sharing the demux core - no duplication
+///
+/// The multiplex arm does not reimplement any framing, dispatch, buffering, or
+/// batch-tee logic. It drives the same [`MultiplexReader::read_async`] `.await`
+/// core the inherent `read_async` uses, which itself runs the shared,
+/// reader-free [`dispatch_message_with`](MultiplexReader) core. MSG_* side
+/// effects (stdout/stderr print + flush) therefore fire in the identical order
+/// relative to delivered data as the sync [`ServerReader`] and the inherent
+/// async path.
+///
+/// # `Poll::Pending` safety (the correctness crux)
+///
+/// A `poll_read` can suspend in the middle of a frame - after the demux future
+/// has already consumed part of a header or payload off the transport. Those
+/// bytes live inside the future's state, so the future must survive across
+/// polls. Recreating it on the next poll would re-read from the middle of the
+/// stream and corrupt it. The [`MuxState`] holds the in-flight future between
+/// polls (owning the reader) and reclaims the reader into `Idle` only once the
+/// frame completes, so a suspended read resumes exactly where it left off.
+///
+/// Because the future owns the reader, this impl requires `R: Send + 'static`,
+/// which the intended receiver transport stack (`tokio::io::BufReader` over the
+/// counting reader over the async transport) satisfies.
+///
+/// Additive and unwired: only the parity tests drive this impl.
+#[cfg(feature = "tokio-transfer")]
+impl<R> tokio::io::AsyncRead for AsyncServerReader<R>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        match &mut self.get_mut().inner {
+            // Plain mode: delegate straight to the inner transport. Byte-for-byte
+            // the `read_async` plain arm, just expressed in poll form.
+            AsyncServerReaderInner::Plain(r) => std::pin::Pin::new(r).poll_read(cx, buf),
+            AsyncServerReaderInner::Multiplex(state) => poll_read_multiplex(state, cx, buf),
+        }
+    }
+}
+
+/// Drives one multiplex demux step for [`AsyncServerReader::poll_read`].
+///
+/// Starts (or resumes) the in-flight [`MultiplexReader::read_async`] future held
+/// by `state`, copying its demuxed bytes into `buf` on completion. See the
+/// `AsyncRead` impl docs for the `Poll::Pending` safety argument.
+#[cfg(feature = "tokio-transfer")]
+fn poll_read_multiplex<R>(
+    state: &mut MuxState<R>,
+    cx: &mut std::task::Context<'_>,
+    buf: &mut tokio::io::ReadBuf<'_>,
+) -> std::task::Poll<io::Result<()>>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    use std::task::Poll;
+
+    // A zero-capacity target reads nothing and consumes no wire, matching the
+    // sync `Read::read` contract for an empty buffer.
+    if buf.remaining() == 0 {
+        return Poll::Ready(Ok(()));
+    }
+
+    // Begin a read if idle: move the reader into a future that owns it plus a
+    // staging buffer sized to the caller's free space, so the demux fills at
+    // most `buf.remaining()` bytes - the identical per-call chunking the sync
+    // and inherent-async drivers produce for the same buffer size.
+    let mut fut = match std::mem::replace(state, MuxState::Transitioning) {
+        MuxState::Idle(mut reader) => {
+            let cap = buf.remaining();
+            Box::pin(async move {
+                let mut scratch = vec![0u8; cap];
+                let result = reader.read_async(&mut scratch).await;
+                (reader, scratch, result)
+            }) as MuxReadFuture<R>
+        }
+        MuxState::Reading(fut) => fut,
+        MuxState::Transitioning => {
+            // Only reachable if a prior poll panicked mid-transition. The
+            // reader is gone, so the stream cannot continue safely.
+            return Poll::Ready(Err(io::Error::other(
+                "multiplex reader lost during a suspended poll_read",
+            )));
+        }
+    };
+
+    match fut.as_mut().poll(cx) {
+        Poll::Pending => {
+            *state = MuxState::Reading(fut);
+            Poll::Pending
+        }
+        Poll::Ready((reader, scratch, result)) => {
+            *state = MuxState::Idle(reader);
+            match result {
+                Ok(n) => {
+                    buf.put_slice(&scratch[..n]);
+                    Poll::Ready(Ok(()))
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a genuine `tokio::io::AsyncRead` impl for `AsyncServerReader<R>` (gated on `tokio-transfer`, default-off) so the receiver's async read leaves (flist / attrs / stats / NDX) can all read from one uniform demuxed `R: AsyncRead` source instead of reaching for the inherent `read_async` method.

## Sharing the demux core - no duplication

The multiplex arm does not reimplement any framing, dispatch, buffering, or batch-tee logic. `poll_read` drives the same `MultiplexReader::read_async` `.await` core the inherent `read_async` uses, which itself runs the shared, reader-free `dispatch_message_with` core through the `RealSink`/`MuxSink` seam. MSG_* side effects (stdout/stderr print + flush) therefore fire in the identical order relative to delivered data as the sync `ServerReader` and the inherent async path. The plain arm is a pure pass-through to the inner transport's `poll_read`.

## `Poll::Pending` safety (the correctness crux)

A `poll_read` can suspend mid-frame after the demux future has already consumed part of a header/payload off the transport. Those bytes live inside the future's state, so the future must survive across polls. A new `MuxState` enum holds the in-flight future (which owns the reader) between polls and reclaims the reader into `Idle` only once the frame completes; a suspended read resumes exactly where it left off. Recreating the future on the next poll would re-read from the middle of the stream and corrupt it. Because the future owns the reader, the impl requires `R: Send + 'static`, which the intended receiver transport stack satisfies.

## Invariants

- **Default build (no `tokio-transfer`): zero change.** The sync `ServerReader`, its `Read` impl, and all non-gated code are byte-for-byte untouched (the diff is confined to feature-gated code + tests).
- **Byte-identical**: reading via the `AsyncRead` impl yields exactly the bytes the sync `ServerReader` yields, across chunked poll boundaries, with MSG_* ordering preserved.
- No new unsafe, no wire/protocol change, no public sync-API break, no default-feature flip.
- Additive and **unwired** into the receiver hot path (that is the atomic fork later); exercised only by tests.

## Tests

New parity tests feed an identical mux stream to the sync `ServerReader` and to the new `AsyncRead` impl (driven in a current-thread runtime) and assert identical delivered bytes across read-buffer sizes {8, 64, 4096} and chunked delivery {1, 2, 3, 7, 13}, plus a plain-mode pass-through check. The `async-wire-parity` workflow gains a step running these.

## Verification (Rust 1.88.0)

- Feature OFF: `cargo build -p transfer`, `cargo clippy -p transfer --all-targets --no-deps -- -D warnings`, `cargo build --workspace` all clean.
- Feature ON: `cargo build/clippy -p transfer --features tokio-transfer -- -D warnings` clean; all 8 parity tests pass; `cargo fmt -p transfer -- --check` clean.