### PR TITLE
feat(protocol,transfer): async wire read leaves (read_ndx/sum-head/stats, ASY, default-off)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -69,6 +69,13 @@ jobs:
             --features tokio-transfer,zstd,lz4 \
             -E 'test(recv_msg_parity) | test(token_parity)'
 
+      - name: Run sync vs async wire read-leaf parity tests
+        run: |
+          cargo nextest run --locked \
+            -p protocol \
+            --features tokio-transfer,zstd,lz4 \
+            -E 'test(read_leaf_parity)'
+
       - name: Run sync vs async MultiplexReader demux parity tests
         run: |
           cargo nextest run --locked \
@@ -89,6 +96,13 @@ jobs:
             -p transfer \
             --features tokio-transfer \
             -E 'test(asyncread_impl)'
+
+      - name: Run sync vs async sum-head and receive-stats parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer \
+            -E 'test(sum_head_read_async_matches_sync) | test(receive_stats_async_matches_sync)'
 
   async-equivalence:
     name: async-vs-default transfer equivalence (stable)

--- a/crates/protocol/src/codec/ndx/codec.rs
+++ b/crates/protocol/src/codec/ndx/codec.rs
@@ -8,6 +8,60 @@ use std::io::{self, Read, Write};
 
 use super::constants::NDX_DONE;
 
+/// Classification of the leading byte of a modern (protocol 30+) NDX value.
+///
+/// Shared by the sync and async modern-codec read leaves so the branch on the
+/// first byte can never diverge between them.
+enum NdxLead {
+    /// Leading `0x00`: `NDX_DONE` sentinel, no further bytes.
+    Done,
+    /// Leading `0xFF`: a negative index; the diff/tag byte follows.
+    Negative,
+    /// Any other leading byte: a positive index whose diff/tag is this byte.
+    Positive,
+}
+
+/// Classifies the leading byte of a modern NDX value.
+///
+/// Upstream `io.c:2290-2299` - `read_ndx()` first-byte dispatch.
+#[inline]
+fn classify_ndx_lead(lead: u8) -> NdxLead {
+    if lead == 0xFF {
+        NdxLead::Negative
+    } else if lead == 0 {
+        NdxLead::Done
+    } else {
+        NdxLead::Positive
+    }
+}
+
+/// Reconstructs the full 4-byte modern NDX value from the `0xFE`/high-bit form.
+///
+/// `tag` is the byte whose high bit was set; `b0`, `b1`, `b2` are the three
+/// following bytes. Upstream `io.c:2307-2311`.
+#[inline]
+fn decode_ndx_extended_full(tag: u8, b0: u8, b1: u8, b2: u8) -> i32 {
+    let high = (tag & !0x80) as i32;
+    (high << 24) | (b0 as i32) | ((b1 as i32) << 8) | ((b2 as i32) << 16)
+}
+
+/// Reconstructs a modern NDX value from the `0xFE` 2-byte diff form.
+///
+/// Upstream `io.c:2312-2314`.
+#[inline]
+fn decode_ndx_extended_diff(hi: u8, lo: u8, prev_val: i32) -> i32 {
+    let diff = ((hi as i32) << 8) | (lo as i32);
+    prev_val + diff
+}
+
+/// Reconstructs a modern NDX value from the single-byte short-diff form.
+///
+/// Upstream `io.c:2316`.
+#[inline]
+fn decode_ndx_short(diff_byte: u8, prev_val: i32) -> i32 {
+    prev_val + diff_byte as i32
+}
+
 /// Strategy trait for NDX encoding/decoding.
 ///
 /// Implementations provide protocol-version-specific wire formats for file
@@ -90,6 +144,19 @@ impl LegacyNdxCodec {
         );
         Self { protocol_version }
     }
+
+    /// Async twin of the legacy-codec `read_ndx` (a plain 4-byte LE integer).
+    #[cfg(feature = "tokio-transfer")]
+    async fn read_ndx_async<R>(&mut self, reader: &mut R) -> io::Result<i32>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use tokio::io::AsyncReadExt;
+
+        let mut buf = [0u8; 4];
+        reader.read_exact(&mut buf).await?;
+        Ok(i32::from_le_bytes(buf))
+    }
 }
 
 impl NdxCodec for LegacyNdxCodec {
@@ -154,6 +221,75 @@ impl ModernNdxCodec {
             prev_positive: -1,
             prev_negative: 1,
         }
+    }
+
+    /// Returns the delta base for the given sign, matching the sync/async reads.
+    #[inline]
+    fn prev_val(&self, is_negative: bool) -> i32 {
+        if is_negative {
+            self.prev_negative
+        } else {
+            self.prev_positive
+        }
+    }
+
+    /// Commits a freshly decoded magnitude, updating delta state and returning
+    /// the signed NDX. Shared by the sync and async modern-codec reads so the
+    /// state mutation can never diverge.
+    #[inline]
+    fn commit_ndx(&mut self, is_negative: bool, num: i32) -> i32 {
+        if is_negative {
+            self.prev_negative = num;
+            -num
+        } else {
+            self.prev_positive = num;
+            num
+        }
+    }
+
+    /// Async twin of the modern-codec `read_ndx`.
+    ///
+    /// Reads the identical byte sequence (`.await`-driven) and drives the same
+    /// shared decode helpers (`classify_ndx_lead`, `decode_ndx_*`,
+    /// [`commit_ndx`](Self::commit_ndx)) as the sync leaf, so it returns the
+    /// same value and consumes the same bytes for the same wire input.
+    #[cfg(feature = "tokio-transfer")]
+    async fn read_ndx_async<R>(&mut self, reader: &mut R) -> io::Result<i32>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use tokio::io::AsyncReadExt;
+
+        let mut b = [0u8; 4];
+        reader.read_exact(&mut b[..1]).await?;
+
+        let is_negative = match classify_ndx_lead(b[0]) {
+            NdxLead::Done => return Ok(NDX_DONE),
+            NdxLead::Negative => {
+                reader.read_exact(&mut b[..1]).await?;
+                true
+            }
+            NdxLead::Positive => false,
+        };
+
+        let prev_val = self.prev_val(is_negative);
+
+        let num = if b[0] == 0xFE {
+            reader.read_exact(&mut b[..1]).await?;
+            if b[0] & 0x80 != 0 {
+                let high = b[0];
+                reader.read_exact(&mut b[..3]).await?;
+                decode_ndx_extended_full(high, b[0], b[1], b[2])
+            } else {
+                let hi = b[0];
+                reader.read_exact(&mut b[1..2]).await?;
+                decode_ndx_extended_diff(hi, b[1], prev_val)
+            }
+        } else {
+            decode_ndx_short(b[0], prev_val)
+        };
+
+        Ok(self.commit_ndx(is_negative, num))
     }
 }
 
@@ -221,20 +357,16 @@ impl NdxCodec for ModernNdxCodec {
         let mut b = [0u8; 4];
         reader.read_exact(&mut b[..1])?;
 
-        let is_negative = if b[0] == 0xFF {
-            reader.read_exact(&mut b[..1])?;
-            true
-        } else if b[0] == 0 {
-            return Ok(NDX_DONE);
-        } else {
-            false
+        let is_negative = match classify_ndx_lead(b[0]) {
+            NdxLead::Done => return Ok(NDX_DONE),
+            NdxLead::Negative => {
+                reader.read_exact(&mut b[..1])?;
+                true
+            }
+            NdxLead::Positive => false,
         };
 
-        let prev_val = if is_negative {
-            self.prev_negative
-        } else {
-            self.prev_positive
-        };
+        let prev_val = self.prev_val(is_negative);
 
         let num = if b[0] == 0xFE {
             // Extended encoding
@@ -243,26 +375,19 @@ impl NdxCodec for ModernNdxCodec {
             if b[0] & 0x80 != 0 {
                 // 4-byte full value
                 // Upstream io.c:2307-2311
-                let high = (b[0] & !0x80) as i32;
+                let high = b[0];
                 reader.read_exact(&mut b[..3])?;
-                (high << 24) | (b[0] as i32) | ((b[1] as i32) << 8) | ((b[2] as i32) << 16)
+                decode_ndx_extended_full(high, b[0], b[1], b[2])
             } else {
+                let hi = b[0];
                 reader.read_exact(&mut b[1..2])?;
-                let diff = ((b[0] as i32) << 8) | (b[1] as i32);
-                prev_val + diff
+                decode_ndx_extended_diff(hi, b[1], prev_val)
             }
         } else {
-            let diff = b[0] as i32;
-            prev_val + diff
+            decode_ndx_short(b[0], prev_val)
         };
 
-        if is_negative {
-            self.prev_negative = num;
-        } else {
-            self.prev_positive = num;
-        }
-
-        if is_negative { Ok(-num) } else { Ok(num) }
+        Ok(self.commit_ndx(is_negative, num))
     }
 
     fn protocol_version(&self) -> u8 {
@@ -295,6 +420,22 @@ impl NdxCodecEnum {
             Self::Legacy(LegacyNdxCodec::new(protocol_version))
         } else {
             Self::Modern(ModernNdxCodec::new(protocol_version))
+        }
+    }
+
+    /// Async twin of `read_ndx`, dispatching to the legacy or modern async leaf.
+    ///
+    /// Byte-identical to [`NdxCodec::read_ndx`] on this enum for the same wire
+    /// bytes: it forwards to the same variant's async read, which shares the
+    /// sync leaf's decode helpers.
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn read_ndx_async<R>(&mut self, reader: &mut R) -> io::Result<i32>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        match self {
+            Self::Legacy(codec) => codec.read_ndx_async(reader).await,
+            Self::Modern(codec) => codec.read_ndx_async(reader).await,
         }
     }
 }
@@ -397,6 +538,18 @@ impl MonotonicNdxWriter {
     /// sub-list writes are negative, so bypassing the wrapper here is wire-safe.
     pub fn inner_mut(&mut self) -> &mut NdxCodecEnum {
         &mut self.inner
+    }
+
+    /// Async twin of `read_ndx`, forwarding to the wrapped codec's async read.
+    ///
+    /// The monotonicity check is a write-side, debug-only guard, so the read
+    /// path is a straight delegate - byte-identical to the sync `read_ndx`.
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn read_ndx_async<R>(&mut self, reader: &mut R) -> io::Result<i32>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        self.inner.read_ndx_async(reader).await
     }
 }
 

--- a/crates/protocol/src/codec/protocol/dispatch.rs
+++ b/crates/protocol/src/codec/protocol/dispatch.rs
@@ -63,6 +63,30 @@ impl ProtocolCodec for ProtocolCodecEnum {
     delegate_codec!(read read_long_name_len -> io::Result<usize>);
 }
 
+impl ProtocolCodecEnum {
+    /// Async twin of [`ProtocolCodec::read_stat`] for this enum.
+    ///
+    /// `read_stat` delegates to `read_file_size`, whose two variants are exact
+    /// aliases of shared varint primitives: the legacy codec's fixed longint is
+    /// [`read_longint`](crate::read_longint), and the modern codec's
+    /// `varlong(min_bytes=3)` is [`read_varlong`](crate::read_varlong). This
+    /// async twin dispatches to the `.await` versions of those same primitives,
+    /// so it yields the same value and consumes the same bytes as the sync
+    /// `read_stat`. Gated on `tokio-transfer`.
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn read_stat_async<R>(&self, reader: &mut R) -> io::Result<i64>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use crate::varint::{read_longint_async, read_varlong_async};
+
+        match self {
+            Self::Legacy(_) => read_longint_async(reader).await,
+            Self::Modern(_) => read_varlong_async(reader, 3).await,
+        }
+    }
+}
+
 /// Creates the appropriate protocol codec for the given version.
 ///
 /// - Protocol 28-29: Returns [`LegacyProtocolCodec`] wrapped in [`ProtocolCodecEnum::Legacy`]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -206,6 +206,8 @@ pub use varint::{
     read_varlong, read_varlong30, write_int, write_longint, write_varint, write_varint30_int,
     write_varlong, write_varlong30,
 };
+#[cfg(feature = "tokio-transfer")]
+pub use varint::{read_int_async, read_longint_async, read_varint_async, read_varlong_async};
 pub use version::{
     ParseProtocolVersionError, ParseProtocolVersionErrorKind, ProtocolCapabilities,
     ProtocolVersion, ProtocolVersionAdvertisement, SUPPORTED_PROTOCOL_BITMAP,

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -119,6 +119,39 @@ impl DeleteStats {
             specials,
         })
     }
+
+    /// Async twin of [`read_from`](Self::read_from).
+    ///
+    /// Reads the same five varints (`.await`-driven) in the same order and
+    /// applies the identical [`read_capped_del_stat`] validation, so it yields
+    /// the same `DeleteStats` and consumes the same bytes for the same wire
+    /// input. Gated on `tokio-transfer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading from the stream fails or if any field
+    /// exceeds `MAX_WIRE_DEL_STAT`.
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn read_from_async<R>(reader: &mut R) -> io::Result<Self>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use crate::varint::read_varint_async;
+
+        let files = read_capped_del_stat(read_varint_async(reader).await?, "files")?;
+        let dirs = read_capped_del_stat(read_varint_async(reader).await?, "dirs")?;
+        let symlinks = read_capped_del_stat(read_varint_async(reader).await?, "symlinks")?;
+        let devices = read_capped_del_stat(read_varint_async(reader).await?, "devices")?;
+        let specials = read_capped_del_stat(read_varint_async(reader).await?, "specials")?;
+
+        Ok(Self {
+            files,
+            dirs,
+            symlinks,
+            devices,
+            specials,
+        })
+    }
 }
 
 /// Validates and converts a varint-decoded delete-stat field.

--- a/crates/protocol/src/varint/decode_async.rs
+++ b/crates/protocol/src/varint/decode_async.rs
@@ -1,0 +1,116 @@
+//! Async twins of the variable-length integer read leaves.
+//!
+//! Gated on the `tokio-transfer` feature. Each function is the `.await`-driven
+//! counterpart of its blocking sibling in [`super::decode`]. The only
+//! difference is how the tag byte and continuation bytes are pulled off the
+//! wire (`.await` on [`AsyncRead`] versus a blocking `read_exact`); the decode
+//! math (the `INT_BYTE_EXTRA` table lookup, the little-endian reconstruction,
+//! the overflow guards) is byte-for-byte identical to the sync leaves, so the
+//! two can never diverge on the value produced or the number of bytes consumed.
+//!
+//! Additive and unwired: these leaves are exercised only by the parity tests.
+
+use std::io;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::table::{INT_BYTE_EXTRA, MAX_EXTRA_BYTES, invalid_data};
+
+/// Async twin of [`read_varint`](super::read_varint).
+///
+/// Reads the leading tag byte, derives the continuation-byte count from
+/// `INT_BYTE_EXTRA`, reads exactly that many extra bytes, and reconstructs the
+/// value with the identical bit math the sync leaf uses.
+#[inline]
+pub async fn read_varint_async<R: AsyncRead + Unpin + ?Sized>(reader: &mut R) -> io::Result<i32> {
+    let mut first = [0u8; 1];
+    reader.read_exact(&mut first).await?;
+
+    let extra = INT_BYTE_EXTRA[(first[0] / 4) as usize] as usize;
+    if extra > MAX_EXTRA_BYTES {
+        return Err(invalid_data("overflow in read_varint"));
+    }
+
+    let mut buf = [0u8; 5];
+    if extra > 0 {
+        reader.read_exact(&mut buf[..extra]).await?;
+        let bit = 1u8 << (8 - extra as u32);
+        buf[extra] = first[0] & (bit - 1);
+    } else {
+        buf[0] = first[0];
+    }
+
+    let value = i32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+    Ok(value)
+}
+
+/// Async twin of [`read_varlong`](super::read_varlong).
+///
+/// Reads `min_bytes` (leading tag plus `min_bytes - 1` initial data bytes),
+/// derives the continuation count, reads the extra bytes, and reconstructs the
+/// 64-bit value with the identical guards and masking the sync leaf uses.
+#[inline]
+pub async fn read_varlong_async<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+    min_bytes: u8,
+) -> io::Result<i64> {
+    if min_bytes == 0 || min_bytes > 8 {
+        return Err(invalid_data("invalid min_bytes in read_varlong"));
+    }
+    let min = min_bytes as usize;
+
+    let mut initial = [0u8; 8];
+    reader.read_exact(&mut initial[..min]).await?;
+
+    let leading = initial[0];
+
+    let mut result = [0u8; 9];
+    result[..min - 1].copy_from_slice(&initial[1..min]);
+
+    let extra = INT_BYTE_EXTRA[(leading / 4) as usize] as usize;
+
+    if extra > 0 {
+        if min + extra > 9 {
+            return Err(invalid_data("overflow in read_varlong"));
+        }
+        let bit = 1u8 << (8 - extra as u32);
+        reader
+            .read_exact(&mut result[min - 1..min - 1 + extra])
+            .await?;
+        result[min + extra - 1] = leading & (bit - 1);
+    } else {
+        result[min - 1] = leading;
+    }
+
+    Ok(i64::from_le_bytes([
+        result[0], result[1], result[2], result[3], result[4], result[5], result[6], result[7],
+    ]))
+}
+
+/// Async twin of [`read_longint`](super::read_longint).
+///
+/// Reads the 4-byte prefix; if it is the `0xFFFFFFFF` marker, reads the full
+/// 8-byte value, exactly as the sync leaf does.
+pub async fn read_longint_async<R: AsyncRead + Unpin + ?Sized>(reader: &mut R) -> io::Result<i64> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf).await?;
+    let first = i32::from_le_bytes(buf);
+
+    if first == -1 {
+        let mut buf64 = [0u8; 8];
+        reader.read_exact(&mut buf64).await?;
+        Ok(i64::from_le_bytes(buf64))
+    } else {
+        Ok(first as i64)
+    }
+}
+
+/// Async twin of [`read_int`](super::read_int).
+///
+/// Reads the fixed 4-byte little-endian integer.
+#[inline]
+pub async fn read_int_async<R: AsyncRead + Unpin + ?Sized>(reader: &mut R) -> io::Result<i32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf).await?;
+    Ok(i32::from_le_bytes(buf))
+}

--- a/crates/protocol/src/varint/mod.rs
+++ b/crates/protocol/src/varint/mod.rs
@@ -34,6 +34,8 @@
 //!   bitfield that relies on this codec.
 
 mod decode;
+#[cfg(feature = "tokio-transfer")]
+mod decode_async;
 mod encode;
 mod table;
 
@@ -44,6 +46,8 @@ pub use decode::{
     decode_varint, read_int, read_longint, read_varint, read_varint30_int, read_varlong,
     read_varlong30,
 };
+#[cfg(feature = "tokio-transfer")]
+pub use decode_async::{read_int_async, read_longint_async, read_varint_async, read_varlong_async};
 pub use encode::{
     encode_varint_to_vec, write_int, write_longint, write_varint, write_varint30_int,
     write_varlong, write_varlong30,

--- a/crates/protocol/tests/async_wire_read_leaves_parity.rs
+++ b/crates/protocol/tests/async_wire_read_leaves_parity.rs
@@ -1,0 +1,336 @@
+//! Sync vs async wire-byte parity for the small protocol read leaves.
+//!
+//! Proves the `..._async` twins of `read_varint`, `read_varlong`,
+//! `read_longint`, `read_int`, the NDX codec `read_ndx`, `DeleteStats::read_from`,
+//! and the protocol codec `read_stat` parse byte-identically to their blocking
+//! siblings: for the same wire bytes they return the same value and consume the
+//! same number of bytes, including when the bytes are delivered in tiny chunks
+//! across `.await` points.
+//!
+//! Gated on `tokio-transfer` - compiles to nothing in the default build.
+#![cfg(feature = "tokio-transfer")]
+
+use std::io::Cursor;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+use protocol::codec::{create_ndx_codec, create_protocol_codec};
+use protocol::{
+    DeleteStats, read_int, read_int_async, read_longint, read_longint_async, read_varint,
+    read_varint_async, read_varlong, read_varlong_async, write_int, write_longint, write_varint,
+    write_varlong,
+};
+
+/// An [`AsyncRead`] that yields at most `chunk` bytes per `poll_read`, forcing
+/// each async read leaf to reassemble its value across multiple polls / awaits.
+struct ChunkedReader {
+    inner: Cursor<Vec<u8>>,
+    chunk: usize,
+}
+
+impl ChunkedReader {
+    fn new(bytes: Vec<u8>, chunk: usize) -> Self {
+        Self {
+            inner: Cursor::new(bytes),
+            chunk: chunk.max(1),
+        }
+    }
+
+    /// Bytes consumed so far - used to assert the async leaf reads exactly as
+    /// many bytes as the sync leaf.
+    fn consumed(&self) -> u64 {
+        self.inner.position()
+    }
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let limit = self.chunk.min(buf.remaining());
+        if limit == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let mut scratch = vec![0u8; limit];
+        let mut scratch_buf = ReadBuf::new(&mut scratch);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut scratch_buf) {
+            Poll::Ready(Ok(())) => {
+                buf.put_slice(scratch_buf.filled());
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+/// Bytes consumed by the sync reader given a `Cursor`.
+fn sync_consumed(cursor: &Cursor<Vec<u8>>) -> u64 {
+    cursor.position()
+}
+
+/// Chunk sizes exercised for every leaf, per the ASY task spec.
+const CHUNKS: [usize; 5] = [1, 2, 3, 7, 13];
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_varint() {
+    let cases: [i32; 12] = [
+        0,
+        1,
+        63,
+        64,
+        127,
+        128,
+        255,
+        0x3FFF,
+        0x0001_0000,
+        i32::MAX,
+        -1,
+        i32::MIN,
+    ];
+    for value in cases {
+        let mut wire = Vec::new();
+        write_varint(&mut wire, value).unwrap();
+
+        let mut sync_cur = Cursor::new(wire.clone());
+        let sync_val = read_varint(&mut sync_cur).unwrap();
+        assert_eq!(sync_val, value, "sync varint decode mismatch for {value}");
+
+        for chunk in CHUNKS {
+            let mut reader = ChunkedReader::new(wire.clone(), chunk);
+            let async_val = read_varint_async(&mut reader).await.unwrap();
+            assert_eq!(
+                async_val, sync_val,
+                "async varint diverged from sync for {value} at chunk {chunk}"
+            );
+            assert_eq!(
+                reader.consumed(),
+                sync_consumed(&sync_cur),
+                "async varint consumed a different byte count for {value} at chunk {chunk}"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_varlong() {
+    let cases: [i64; 10] = [
+        0,
+        1,
+        255,
+        0x1_0000,
+        0x00FF_FFFF,
+        0x0001_0000_0000,
+        i64::MAX,
+        -1,
+        -0x1_0000_0000,
+        i64::MIN,
+    ];
+    for &min_bytes in &[3u8, 4] {
+        for value in cases {
+            let mut wire = Vec::new();
+            write_varlong(&mut wire, value, min_bytes).unwrap();
+
+            let mut sync_cur = Cursor::new(wire.clone());
+            let sync_val = read_varlong(&mut sync_cur, min_bytes).unwrap();
+            assert_eq!(sync_val, value, "sync varlong mismatch for {value}");
+
+            for chunk in CHUNKS {
+                let mut reader = ChunkedReader::new(wire.clone(), chunk);
+                let async_val = read_varlong_async(&mut reader, min_bytes).await.unwrap();
+                assert_eq!(
+                    async_val, sync_val,
+                    "async varlong diverged for {value} min_bytes {min_bytes} chunk {chunk}"
+                );
+                assert_eq!(
+                    reader.consumed(),
+                    sync_consumed(&sync_cur),
+                    "async varlong byte count mismatch for {value} min_bytes {min_bytes} chunk {chunk}"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_longint() {
+    let cases: [i64; 8] = [
+        0,
+        1,
+        i32::MAX as i64,
+        i32::MIN as i64,
+        -2,
+        0x1_0000_0000,
+        i64::MAX,
+        i64::MIN,
+    ];
+    for value in cases {
+        let mut wire = Vec::new();
+        write_longint(&mut wire, value).unwrap();
+
+        let mut sync_cur = Cursor::new(wire.clone());
+        let sync_val = read_longint(&mut sync_cur).unwrap();
+        assert_eq!(sync_val, value, "sync longint mismatch for {value}");
+
+        for chunk in CHUNKS {
+            let mut reader = ChunkedReader::new(wire.clone(), chunk);
+            let async_val = read_longint_async(&mut reader).await.unwrap();
+            assert_eq!(
+                async_val, sync_val,
+                "async longint diverged for {value} chunk {chunk}"
+            );
+            assert_eq!(
+                reader.consumed(),
+                sync_consumed(&sync_cur),
+                "async longint byte count mismatch for {value} chunk {chunk}"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_int() {
+    let cases: [i32; 6] = [0, 1, -1, i32::MAX, i32::MIN, 0x1234_5678];
+    for value in cases {
+        let mut wire = Vec::new();
+        write_int(&mut wire, value).unwrap();
+
+        let mut sync_cur = Cursor::new(wire.clone());
+        let sync_val = read_int(&mut sync_cur).unwrap();
+        assert_eq!(sync_val, value);
+
+        for chunk in CHUNKS {
+            let mut reader = ChunkedReader::new(wire.clone(), chunk);
+            let async_val = read_int_async(&mut reader).await.unwrap();
+            assert_eq!(async_val, sync_val, "async int diverged for {value}");
+            assert_eq!(reader.consumed(), sync_consumed(&sync_cur));
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_ndx() {
+    // Drive a stream of NDX values through both a sync codec and an async codec
+    // for each protocol, proving the delta state stays in lockstep and every
+    // value decodes identically. Legacy (29) uses 4-byte LE; modern (32) uses
+    // the delta byte-reduction form.
+    let ndx_stream: [i32; 9] = [0, 1, 5, 4, 300, -1, -2, 0x10_0000, 7];
+
+    for protocol in [29u8, 32] {
+        // Encode the stream once with a writer codec.
+        let mut writer_codec = create_ndx_codec(protocol);
+        let mut wire = Vec::new();
+        for &ndx in &ndx_stream {
+            use protocol::codec::NdxCodec;
+            writer_codec.write_ndx(&mut wire, ndx).unwrap();
+        }
+
+        // Sync decode of the whole stream.
+        let mut sync_cur = Cursor::new(wire.clone());
+        let mut sync_codec = create_ndx_codec(protocol);
+        let mut sync_vals = Vec::new();
+        {
+            use protocol::codec::NdxCodec;
+            for _ in 0..ndx_stream.len() {
+                sync_vals.push(sync_codec.read_ndx(&mut sync_cur).unwrap());
+            }
+        }
+
+        for chunk in CHUNKS {
+            let mut reader = ChunkedReader::new(wire.clone(), chunk);
+            let mut async_codec = create_ndx_codec(protocol);
+            let mut async_vals = Vec::new();
+            for _ in 0..ndx_stream.len() {
+                async_vals.push(async_codec.read_ndx_async(&mut reader).await.unwrap());
+            }
+            assert_eq!(
+                async_vals, sync_vals,
+                "async read_ndx diverged from sync (protocol {protocol}, chunk {chunk})"
+            );
+            assert_eq!(
+                reader.consumed(),
+                sync_consumed(&sync_cur),
+                "async read_ndx byte count mismatch (protocol {protocol}, chunk {chunk})"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_delete_stats() {
+    let cases = [
+        DeleteStats::new(),
+        DeleteStats {
+            files: 10,
+            dirs: 3,
+            symlinks: 2,
+            devices: 1,
+            specials: 4,
+        },
+        DeleteStats {
+            files: 0x3FFF_FFFF,
+            dirs: 0,
+            symlinks: 1,
+            devices: 0x1234,
+            specials: 0x0010_0000,
+        },
+    ];
+
+    for stats in cases {
+        let mut wire = Vec::new();
+        stats.write_to(&mut wire).unwrap();
+
+        let mut sync_cur = Cursor::new(wire.clone());
+        let sync_stats = DeleteStats::read_from(&mut sync_cur).unwrap();
+        assert_eq!(sync_stats, stats);
+
+        for chunk in CHUNKS {
+            let mut reader = ChunkedReader::new(wire.clone(), chunk);
+            let async_stats = DeleteStats::read_from_async(&mut reader).await.unwrap();
+            assert_eq!(
+                async_stats, sync_stats,
+                "async DeleteStats diverged from sync at chunk {chunk}"
+            );
+            assert_eq!(
+                reader.consumed(),
+                sync_consumed(&sync_cur),
+                "async DeleteStats byte count mismatch at chunk {chunk}"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_leaf_parity_stat() {
+    use protocol::codec::ProtocolCodec;
+
+    let values: [i64; 7] = [0, 1, 1000, i32::MAX as i64, 0x1_0000_0000, -1, i64::MAX];
+
+    for protocol in [29u8, 32] {
+        for value in values {
+            let codec = create_protocol_codec(protocol);
+            let mut wire = Vec::new();
+            codec.write_stat(&mut wire, value).unwrap();
+
+            let mut sync_cur = Cursor::new(wire.clone());
+            let sync_val = codec.read_stat(&mut sync_cur).unwrap();
+
+            for chunk in CHUNKS {
+                let mut reader = ChunkedReader::new(wire.clone(), chunk);
+                let async_val = codec.read_stat_async(&mut reader).await.unwrap();
+                assert_eq!(
+                    async_val, sync_val,
+                    "async read_stat diverged (protocol {protocol}, value {value}, chunk {chunk})"
+                );
+                assert_eq!(
+                    reader.consumed(),
+                    sync_consumed(&sync_cur),
+                    "async read_stat byte count mismatch (protocol {protocol}, value {value}, chunk {chunk})"
+                );
+            }
+        }
+    }
+}

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -232,6 +232,48 @@ impl ReceiverContext {
         })
     }
 
+    /// Async twin of [`receive_stats`](Self::receive_stats).
+    ///
+    /// Reads the same three (or five, for protocol >= 31) stat values via the
+    /// protocol codec's async `read_stat_async` - the `.await` counterpart of
+    /// the sync `read_stat` used above, sharing the same longint/varlong
+    /// primitives. It yields the same `SenderStats` and consumes the same bytes
+    /// as the sync leaf. Gated on `tokio-transfer`; additive and unwired.
+    ///
+    /// Unwired: the atomic receiver fork (the coupled ASY-7 redo) consumes this
+    /// leaf later; until then it is exercised only by the parity tests.
+    #[cfg(feature = "tokio-transfer")]
+    #[allow(dead_code)]
+    pub(in crate::receiver) async fn receive_stats_async<R>(
+        &self,
+        reader: &mut R,
+    ) -> io::Result<SenderStats>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        let stats_codec = create_protocol_codec(self.protocol.as_u8());
+
+        let total_read = stats_codec.read_stat_async(reader).await? as u64;
+        let total_written = stats_codec.read_stat_async(reader).await? as u64;
+        let total_size = stats_codec.read_stat_async(reader).await? as u64;
+
+        let (flist_buildtime_ms, flist_xfertime_ms) = if self.protocol.supports_flist_times() {
+            let buildtime = stats_codec.read_stat_async(reader).await? as u64;
+            let xfertime = stats_codec.read_stat_async(reader).await? as u64;
+            (Some(buildtime), Some(xfertime))
+        } else {
+            (None, None)
+        };
+
+        Ok(SenderStats {
+            total_read,
+            total_written,
+            total_size,
+            flist_buildtime_ms,
+            flist_xfertime_ms,
+        })
+    }
+
     /// Exchanges phase transitions, receives stats, and handles goodbye handshake.
     ///
     /// This is the common finalization sequence shared by all transfer modes.
@@ -482,5 +524,144 @@ mod genr_debug_emission_tests {
             msgs.is_empty(),
             "Flist debug emissions must be gated; got: {msgs:?}"
         );
+    }
+}
+
+#[cfg(all(test, feature = "tokio-transfer"))]
+mod receive_stats_parity_tests {
+    //! Sync vs async wire-byte parity for [`receive_stats`] /
+    //! [`receive_stats_async`].
+    //!
+    //! Encodes the sender-stats fields with the protocol codec, then decodes
+    //! the identical bytes with the blocking [`receive_stats`] and the
+    //! `.await`-driven [`receive_stats_async`], asserting every field matches
+    //! and that both consume the same number of bytes - including when the
+    //! wire is delivered one byte at a time across await points.
+
+    use std::ffi::OsString;
+    use std::io::Cursor;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use protocol::ProtocolVersion;
+    use protocol::codec::{ProtocolCodec, create_protocol_codec};
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::role::ServerRole;
+
+    struct ChunkedReader {
+        inner: Cursor<Vec<u8>>,
+        chunk: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(bytes: Vec<u8>, chunk: usize) -> Self {
+            Self {
+                inner: Cursor::new(bytes),
+                chunk: chunk.max(1),
+            }
+        }
+
+        fn consumed(&self) -> u64 {
+            self.inner.position()
+        }
+    }
+
+    impl AsyncRead for ChunkedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let limit = self.chunk.min(buf.remaining());
+            if limit == 0 {
+                return Poll::Ready(Ok(()));
+            }
+            let mut scratch = vec![0u8; limit];
+            let mut scratch_buf = ReadBuf::new(&mut scratch);
+            match Pin::new(&mut self.inner).poll_read(cx, &mut scratch_buf) {
+                Poll::Ready(Ok(())) => {
+                    buf.put_slice(scratch_buf.filled());
+                    Poll::Ready(Ok(()))
+                }
+                other => other,
+            }
+        }
+    }
+
+    fn handshake_for(protocol_version: u8) -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    fn receiver_for(protocol_version: u8) -> ReceiverContext {
+        let handshake = handshake_for(protocol_version);
+        let config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        ReceiverContext::new_for_test(&handshake, config)
+    }
+
+    /// Encodes the sender-stats fields the way upstream `handle_stats` does:
+    /// total_read, total_written, total_size, then (protocol >= 29) the two
+    /// flist times, each via the protocol codec's `write_stat`.
+    fn encode_stats(protocol_version: u8, values: &[i64]) -> Vec<u8> {
+        let codec = create_protocol_codec(protocol_version);
+        let mut wire = Vec::new();
+        for &v in values {
+            codec.write_stat(&mut wire, v).unwrap();
+        }
+        wire
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn receive_stats_async_matches_sync() {
+        // Protocol 32 sends 5 stat fields (>= 29 adds the two flist times);
+        // protocol 28 sends only the first 3.
+        for (protocol, fields) in [
+            (28u8, vec![10_000i64, 512, 1_048_576]),
+            (32u8, vec![10_000i64, 512, 1_048_576, 7, 3]),
+        ] {
+            let wire = encode_stats(protocol, &fields);
+            let receiver = receiver_for(protocol);
+
+            let mut sync_cur = Cursor::new(wire.clone());
+            let sync_stats = receiver.receive_stats(&mut sync_cur).unwrap();
+            let sync_consumed = sync_cur.position();
+
+            for chunk in [1usize, 2, 3, 7, 13] {
+                let mut reader = ChunkedReader::new(wire.clone(), chunk);
+                let async_stats = receiver.receive_stats_async(&mut reader).await.unwrap();
+
+                assert_eq!(async_stats.total_read, sync_stats.total_read);
+                assert_eq!(async_stats.total_written, sync_stats.total_written);
+                assert_eq!(async_stats.total_size, sync_stats.total_size);
+                assert_eq!(
+                    async_stats.flist_buildtime_ms,
+                    sync_stats.flist_buildtime_ms
+                );
+                assert_eq!(async_stats.flist_xfertime_ms, sync_stats.flist_xfertime_ms);
+                assert_eq!(
+                    reader.consumed(),
+                    sync_consumed,
+                    "async receive_stats consumed a different byte count (protocol {protocol}, chunk {chunk})"
+                );
+            }
+        }
     }
 }

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -116,16 +116,44 @@ impl SumHead {
         Ok(())
     }
 
-    /// Reads a sum_head from the wire in rsync format.
-    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
-        let mut buf = [0u8; 16];
-        reader.read_exact(&mut buf)?;
-        Ok(Self {
+    /// Decodes a sum_head from its 16-byte little-endian wire representation.
+    ///
+    /// Shared by the sync [`read`](Self::read) and async
+    /// [`read_async`](Self::read_async) leaves so the field decode can never
+    /// diverge between them.
+    #[must_use]
+    fn from_wire_bytes(buf: &[u8; 16]) -> Self {
+        Self {
             count: i32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as u32,
             blength: i32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]) as u32,
             s2length: i32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]) as u32,
             remainder: i32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]) as u32,
-        })
+        }
+    }
+
+    /// Reads a sum_head from the wire in rsync format.
+    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let mut buf = [0u8; 16];
+        reader.read_exact(&mut buf)?;
+        Ok(Self::from_wire_bytes(&buf))
+    }
+
+    /// Async twin of [`read`](Self::read).
+    ///
+    /// Reads the same 16 bytes (`.await`-driven) and decodes them through the
+    /// shared [`from_wire_bytes`](Self::from_wire_bytes) core, so it yields the
+    /// same `SumHead` and consumes the same bytes as the sync leaf. Gated on
+    /// `tokio-transfer`.
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn read_async<R>(reader: &mut R) -> io::Result<Self>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use tokio::io::AsyncReadExt;
+
+        let mut buf = [0u8; 16];
+        reader.read_exact(&mut buf).await?;
+        Ok(Self::from_wire_bytes(&buf))
     }
 }
 

--- a/crates/transfer/tests/sum_head_async_parity.rs
+++ b/crates/transfer/tests/sum_head_async_parity.rs
@@ -1,0 +1,93 @@
+//! Sync vs async wire-byte parity for `SumHead::read` / `SumHead::read_async`.
+//!
+//! The sum_head is the 16-byte (four 32-bit LE fields) signature header the
+//! receiver reads before the block sums. This proves the `.await`-driven
+//! `read_async` decodes byte-identically to the blocking `read`, including when
+//! the 16 bytes are delivered one at a time across await points.
+//!
+//! Gated on `tokio-transfer` - compiles to nothing in the default build.
+#![cfg(feature = "tokio-transfer")]
+
+use std::io::Cursor;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+use transfer::SumHead;
+
+struct ChunkedReader {
+    inner: Cursor<Vec<u8>>,
+    chunk: usize,
+}
+
+impl ChunkedReader {
+    fn new(bytes: Vec<u8>, chunk: usize) -> Self {
+        Self {
+            inner: Cursor::new(bytes),
+            chunk: chunk.max(1),
+        }
+    }
+
+    fn consumed(&self) -> u64 {
+        self.inner.position()
+    }
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let limit = self.chunk.min(buf.remaining());
+        if limit == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let mut scratch = vec![0u8; limit];
+        let mut scratch_buf = ReadBuf::new(&mut scratch);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut scratch_buf) {
+            Poll::Ready(Ok(())) => {
+                buf.put_slice(scratch_buf.filled());
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sum_head_read_async_matches_sync() {
+    let cases = [
+        SumHead::empty(),
+        SumHead::new(1, 700, 16, 0),
+        SumHead::new(1234, 65536, 2, 511),
+        SumHead::new(u32::MAX, u32::MAX, u32::MAX, u32::MAX),
+        SumHead::new(0, 0, 0, 1),
+    ];
+
+    for head in cases {
+        let mut wire = Vec::new();
+        head.write(&mut wire).unwrap();
+        assert_eq!(wire.len(), 16, "sum_head wire form must be 16 bytes");
+
+        let mut sync_cur = Cursor::new(wire.clone());
+        let sync_head = SumHead::read(&mut sync_cur).unwrap();
+        assert_eq!(sync_head, head, "sync sum_head round-trip mismatch");
+        let sync_consumed = sync_cur.position();
+
+        for chunk in [1usize, 2, 3, 7, 13] {
+            let mut reader = ChunkedReader::new(wire.clone(), chunk);
+            let async_head = SumHead::read_async(&mut reader).await.unwrap();
+            assert_eq!(
+                async_head, sync_head,
+                "async sum_head diverged from sync at chunk {chunk}"
+            );
+            assert_eq!(
+                reader.consumed(),
+                sync_consumed,
+                "async sum_head consumed a different byte count at chunk {chunk}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `.await`-driven twins of the receiver's small protocol/wire read leaves, byte-identical to their blocking siblings. Additive, default-off behind `tokio-transfer`, and unwired (the atomic receiver fork consumes them later). This is the missing async read surface for the small leaves; the flist reader is a separate piece.

## Async leaves added (all `#[cfg(feature = "tokio-transfer")]`)

- `protocol::read_varint_async`, `read_varlong_async`, `read_longint_async`, `read_int_async` - varint primitives in `varint/decode_async.rs`. These mirror the sync decode math (`INT_BYTE_EXTRA` table, LE reconstruction, overflow guards) exactly; only the byte pull differs (`.await` vs blocking `read_exact`).
- `NdxCodecEnum::read_ndx_async` (plus per-variant `LegacyNdxCodec`/`ModernNdxCodec` and `MonotonicNdxWriter` twins). The modern-codec first-byte dispatch and value reconstruction were extracted into shared sans-io helpers (`classify_ndx_lead`, `decode_ndx_extended_full`/`_diff`/`_short`, `prev_val`/`commit_ndx`) that the sync `read_ndx` now also calls, so the two share one parse core.
- `SumHead::read_async` - the 16-byte signature header. Sync and async both decode via a shared `from_wire_bytes([u8; 16])` core.
- `DeleteStats::read_from_async` - the five `NDX_DEL_STATS` varints, reusing the existing `read_capped_del_stat` validator.
- `ProtocolCodecEnum::read_stat_async` and `ReceiverContext::receive_stats_async` - the sender-stats fields. `read_stat` delegates to `read_file_size`, whose two variants are exact aliases of `read_longint` (legacy) and `read_varlong(3)` (modern); the async twin dispatches to the `.await` versions of those same primitives.

## Sharing the parse core (no fork)

Every twin shares the decode logic with its sync sibling rather than duplicating it:
- Varint leaves reuse the `INT_BYTE_EXTRA` table and identical bit math.
- NDX modern-codec read now routes both sync and async through the same extracted decode helpers and `commit_ndx` state mutation.
- `SumHead` shares `from_wire_bytes`.
- `DeleteStats` shares `read_capped_del_stat`.
- `receive_stats_async` shares the longint/varlong primitives via `read_stat_async`.

The NDX and varint leaves interleave read and parse (the number of bytes read depends on earlier bytes), so the shared core is the per-step decode helpers and the state-commit tail, not a single pre-read buffer.

## Invariants

- Default build unchanged: sync leaves untouched behaviourally, all 66 existing NDX comprehensive tests and 199 varint lib tests pass, full workspace builds default-off.
- Byte-identical: parity tests feed the same wire bytes to sync and async, asserting identical value and identical bytes-consumed, including chunked delivery `{1,2,3,7,13}` across await points.
- No wire/protocol change, no unsafe, no default flip.

## Parity tests + CI

- `crates/protocol/tests/async_wire_read_leaves_parity.rs` - `read_leaf_parity_*` for varint/varlong/longint/int/ndx/delete_stats/stat (7 tests).
- `crates/transfer/tests/sum_head_async_parity.rs` - sum-head parity.
- Inline `receive_stats_parity_tests` in `phases.rs` - `receive_stats_async` parity (client-mode `ReceiverContext`, protocol 28 and 32).
- `async-wire-parity.yml` extended with two steps selecting `read_leaf_parity`, `sum_head_read_async_matches_sync`, and `receive_stats_async_matches_sync`.

## Verify

- Default OFF: `cargo build -p protocol -p transfer`, `cargo build --workspace`, clippy `-D warnings` - all clean.
- Feature ON: `cargo build -p protocol -p transfer --features tokio-transfer` (`-D warnings`), clippy `--features tokio-transfer -- -D warnings`, all parity tests pass.
- `cargo fmt` clean on both crates.