### PR TITLE
feat(protocol,transfer): async file-list reader over sans-io decode core (ASY, default-off)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -76,6 +76,13 @@ jobs:
             --features tokio-transfer,zstd,lz4 \
             -E 'test(read_leaf_parity)'
 
+      - name: Run sync vs async file-list reader parity tests
+        run: |
+          cargo nextest run --locked \
+            -p protocol \
+            --features tokio-transfer,zstd,lz4 \
+            -E 'test(async_flist_matches_sync)'
+
       - name: Run sync vs async MultiplexReader demux parity tests
         run: |
           cargo nextest run --locked \
@@ -103,6 +110,13 @@ jobs:
             -p transfer \
             --features tokio-transfer \
             -E 'test(sum_head_read_async_matches_sync) | test(receive_stats_async_matches_sync)'
+
+      - name: Run sync vs async receiver file-list reception parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer \
+            -E 'test(receive_file_list_async_matches_sync) | test(receive_extra_file_lists_async_matches_sync)'
 
   async-equivalence:
     name: async-vs-default transfer equivalence (stable)

--- a/crates/protocol/src/codec/ndx/codec.rs
+++ b/crates/protocol/src/codec/ndx/codec.rs
@@ -470,6 +470,68 @@ impl NdxCodec for NdxCodecEnum {
     }
 }
 
+#[cfg(feature = "tokio-transfer")]
+impl NdxCodecEnum {
+    /// Reads one NDX value off an [`AsyncRead`](tokio::io::AsyncRead) through a
+    /// shared carry-over buffer, awaiting the wire, gated on `tokio-transfer`.
+    ///
+    /// This is the flist-reader twin of [`read_ndx_async`](Self::read_ndx_async):
+    /// where `read_ndx_async` reads NDX bytes directly off the stream, this drains
+    /// from a caller-owned `carry` buffer first so the INC_RECURSE segment loop can
+    /// hand bytes the *entry* decoder already read past its last entry (which are
+    /// the next segment's NDX header) straight into the NDX decode. Sharing the one
+    /// `carry` with [`read_entry_with_flist_async`](crate::flist::read_entry_with_flist_async)
+    /// is what keeps the async segment framing byte-identical to the sync path - a
+    /// direct-off-stream NDX read would lose those already-buffered bytes.
+    ///
+    /// Byte-for-byte equivalent to [`NdxCodec::read_ndx`]: it drives the identical
+    /// sync `read_ndx` speculatively over the growing in-memory buffer. The codec's
+    /// delta state (`prev_positive` / `prev_negative`) is snapshotted via `Clone`
+    /// before each attempt and restored when the buffer is too short, so a chunked,
+    /// retried read produces the same value and the same state transition as a
+    /// single blocking read. On return, only the NDX bytes are drained from the
+    /// front of `carry`; leftover bytes (belonging to the following flist entry)
+    /// remain for the next reader.
+    pub async fn read_ndx_from_carry_async<R>(
+        &mut self,
+        src: &mut R,
+        carry: &mut Vec<u8>,
+    ) -> io::Result<i32>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use std::io::Cursor;
+        use tokio::io::AsyncReadExt;
+
+        let mut read_buf = [0u8; 64];
+        loop {
+            if !carry.is_empty() {
+                let snapshot = self.clone();
+                let mut cursor = Cursor::new(&carry[..]);
+                match self.read_ndx(&mut cursor) {
+                    Ok(ndx) => {
+                        let consumed = cursor.position() as usize;
+                        carry.drain(..consumed);
+                        return Ok(ndx);
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => {
+                        *self = snapshot;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            let n = src.read(&mut read_buf).await?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "NDX header truncated: stream ended mid-value",
+                ));
+            }
+            carry.extend_from_slice(&read_buf[..n]);
+        }
+    }
+}
+
 /// Creates an NDX codec appropriate for the given protocol version.
 ///
 /// Returns [`NdxCodecEnum::Legacy`] for protocol < 30 and

--- a/crates/protocol/src/flist/mod.rs
+++ b/crates/protocol/src/flist/mod.rs
@@ -67,7 +67,9 @@ pub use incremental::{
 };
 pub use intern::PathInterner;
 pub use name_cmp::{f_name_cmp, f_name_cmp_components, name_cmp_eq};
-pub use read::{FileListReader, read_file_entry};
+#[cfg(feature = "tokio-transfer")]
+pub use read::read_entry_with_flist_async;
+pub use read::{EntryStep, FileListReader, read_file_entry};
 pub use sort::{
     CleanResult, apply_permutation_in_place, compare_file_entries, flist_clean,
     sort_and_clean_file_list, sort_file_list,

--- a/crates/protocol/src/flist/read/async_read.rs
+++ b/crates/protocol/src/flist/read/async_read.rs
@@ -1,0 +1,82 @@
+//! Async file-list entry reader, gated on the `tokio-transfer` feature.
+//!
+//! This is the `.await`-driven counterpart to
+//! [`FileListReader::read_entry_with_flist`](super::FileListReader::read_entry_with_flist).
+//! It reuses the *identical* sync decode through the sans-io seam
+//! ([`FileListReader::read_entry_step`](super::FileListReader::read_entry_step)):
+//! bytes are pulled off an [`AsyncRead`] into a carry-over buffer, the shared
+//! decode is run speculatively over that buffer, and when it needs more bytes
+//! the driver awaits another read and retries. The decode logic is never forked,
+//! so the async reader returns byte-identical [`FileEntry`] values for the same
+//! wire bytes - including when the bytes are delivered in arbitrary chunks
+//! across `.await` points.
+//!
+//! Additive and unwired: this leaf is not connected to the receiver pipeline.
+//! Its consuming rung is the coupled ASY-7 receiver redo.
+
+use std::io;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::{EntryStep, FileListReader};
+use crate::flist::entry::FileEntry;
+
+/// Reads the next file-list entry from an [`AsyncRead`], awaiting the wire.
+///
+/// Byte-for-byte equivalent to
+/// [`FileListReader::read_entry_with_flist`](super::FileListReader::read_entry_with_flist):
+/// it decodes one entry (or detects end-of-list) using the shared sans-io seam,
+/// returning `Ok(Some(entry))` for a decoded entry, `Ok(None)` at end-of-list,
+/// or an error on malformed data / truncation.
+///
+/// `carry` is a caller-owned buffer that holds wire bytes read past the end of
+/// the previous entry. It must be reused across successive calls in the same
+/// flist segment so that bytes read ahead are not lost. On return, any bytes the
+/// decoded entry consumed have been drained from the front of `carry`; leftover
+/// bytes (belonging to the next entry) remain for the following call.
+///
+/// `segment_entries` has the same meaning as in the sync reader: the entries
+/// already decoded in the current segment, used to resolve abbreviated hardlink
+/// followers.
+///
+/// # Errors
+///
+/// - Any decode error from the shared core (malformed name, oversize field,
+///   overflow, ...) propagates unchanged, exactly as the blocking reader would
+///   surface it.
+/// - If the stream ends while an entry is still incomplete, returns
+///   [`io::ErrorKind::UnexpectedEof`], mirroring the blocking reader's behaviour
+///   on a truncated wire.
+pub async fn read_entry_with_flist_async<R>(
+    reader: &mut FileListReader,
+    src: &mut R,
+    carry: &mut Vec<u8>,
+    segment_entries: &[FileEntry],
+) -> io::Result<Option<FileEntry>>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
+    let mut read_buf = [0u8; 8192];
+    loop {
+        match reader.read_entry_step(carry, segment_entries)? {
+            EntryStep::Emit { entry, consumed } => {
+                carry.drain(..consumed);
+                return Ok(entry);
+            }
+            EntryStep::NeedMore => {
+                let n = src.read(&mut read_buf).await?;
+                if n == 0 {
+                    // The stream ended mid-entry. An empty carry at end-of-stream
+                    // is not our concern (the caller drives the segment loop and
+                    // would not have called us), so any pending bytes here mean a
+                    // genuinely truncated entry.
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "file-list entry truncated: stream ended mid-entry",
+                    ));
+                }
+                carry.extend_from_slice(&read_buf[..n]);
+            }
+        }
+    }
+}

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -8,12 +8,19 @@
 //!
 //! See `flist.c:recv_file_entry()` for the canonical wire format decoding.
 
+#[cfg(feature = "tokio-transfer")]
+mod async_read;
 mod extras;
 mod flags;
 mod metadata;
 mod name;
+mod step;
 #[cfg(test)]
 mod tests;
+
+#[cfg(feature = "tokio-transfer")]
+pub use async_read::read_entry_with_flist_async;
+pub use step::EntryStep;
 
 use std::io::{self, Read};
 use std::path::Path;

--- a/crates/protocol/src/flist/read/step.rs
+++ b/crates/protocol/src/flist/read/step.rs
@@ -1,0 +1,152 @@
+//! Sans-io decode seam shared by the blocking and async file-list readers.
+//!
+//! The file-list entry decoder in [`super::FileListReader::read_entry_with_flist`]
+//! is deeply read/decode-interleaved: it reads a field, decodes it, updates the
+//! cross-entry compression state, and only then knows the shape (and byte count)
+//! of the next field. Every wire read on that path is a `read_exact` of a count
+//! that is known at its own decision point (a flag byte, a varint tag plus its
+//! table-driven extra bytes, a fixed-width field, or a length-prefixed blob);
+//! no branch depends on partial-read or EOF-vs-data semantics. That property is
+//! what makes a sans-io split possible without forking the decode logic.
+//!
+//! Rather than flatten the entry decode into a `Need(n)` state machine (which
+//! would fork the byte-critical decode across `flags`/`name`/`metadata`/`extras`
+//! plus the varint/codec/acl/xattr leaves and risk wire-byte divergence), this
+//! seam runs the *existing* sync decode verbatim over an in-memory
+//! [`Cursor`](std::io::Cursor). It does this speculatively:
+//!
+//! 1. Snapshot the fields the decode mutates across a single entry
+//!    ([`EntrySnapshot`]: compression state, ACL/xattr caches, io-error, stats).
+//! 2. Run [`FileListReader::read_entry_with_flist`] over `Cursor::new(buf)`.
+//! 3. If the cursor is exhausted mid-entry, the `read_exact` inside the decode
+//!    surfaces [`io::ErrorKind::UnexpectedEof`]; restore the snapshot and report
+//!    [`EntryStep::NeedMore`] so the driver reads more bytes and retries.
+//! 4. On success, keep the mutations and report the exact bytes consumed
+//!    (`cursor.position()`), which the driver drains from its buffer.
+//!
+//! Because the sync decode is the single source of truth, the async twin can
+//! never diverge from it on wire interpretation - it differs only in how bytes
+//! reach the buffer (`.await` vs a blocking read). This mirrors the shared-seam
+//! discipline of the async multiplex read leaf (`recv_msg_into_async`) and the
+//! sans-io token decoder (`wire/compressed_token/step.rs`); see the 2026-07-02
+//! amendment in `docs/design/asy-2-tokio-runtime-feature.md`.
+
+use std::io::{self, Cursor};
+
+use super::FileListReader;
+use crate::acl::AclCache;
+use crate::flist::entry::FileEntry;
+use crate::flist::state::{FileListCompressionState, FileListStats};
+use crate::xattr::XattrCache;
+
+/// Outcome of one speculative decode step over the caller's buffer.
+pub enum EntryStep {
+    /// The buffer does not yet hold a complete entry; the driver must read more
+    /// bytes and call [`FileListReader::read_entry_step`] again with the
+    /// extended buffer. No compression state was mutated (the snapshot was
+    /// restored), so retrying is exact.
+    NeedMore,
+    /// A complete entry was decoded (or the end-of-list marker was reached).
+    ///
+    /// `entry` is `None` at end-of-list (mirroring
+    /// [`FileListReader::read_entry_with_flist`]). `consumed` is the exact number
+    /// of leading bytes of the buffer the decode read; the driver must drain
+    /// them before the next step.
+    Emit {
+        /// The decoded entry, or `None` at end-of-list.
+        entry: Option<FileEntry>,
+        /// Exact number of leading buffer bytes consumed by this entry.
+        consumed: usize,
+    },
+}
+
+/// Snapshot of the reader fields that [`FileListReader::read_entry_with_flist`]
+/// mutates while decoding a single entry.
+///
+/// A speculative decode that runs out of buffered bytes leaves these partially
+/// updated; restoring the snapshot makes the retry byte-identical to a decode
+/// that saw the whole entry at once. The `dirname_interner`, `iconv`, and codec
+/// are intentionally excluded: interning is idempotent (re-interning the same
+/// path on retry is harmless) and the others are immutable during a decode.
+struct EntrySnapshot {
+    state: FileListCompressionState,
+    acl_cache: AclCache,
+    xattr_cache: XattrCache,
+    io_error: i32,
+    stats: FileListStats,
+}
+
+impl FileListReader {
+    /// Captures the per-entry mutable state before a speculative decode.
+    fn snapshot(&self) -> EntrySnapshot {
+        EntrySnapshot {
+            state: self.state.clone(),
+            acl_cache: self.acl_cache.clone(),
+            xattr_cache: self.xattr_cache.clone(),
+            io_error: self.io_error,
+            stats: self.stats.clone(),
+        }
+    }
+
+    /// Restores the per-entry mutable state after a decode that ran out of bytes.
+    fn restore(&mut self, snap: EntrySnapshot) {
+        self.state = snap.state;
+        self.acl_cache = snap.acl_cache;
+        self.xattr_cache = snap.xattr_cache;
+        self.io_error = snap.io_error;
+        self.stats = snap.stats;
+    }
+
+    /// Attempts to decode one file-list entry from an in-memory buffer.
+    ///
+    /// This is the sans-io core that both the blocking and async file-list
+    /// readers drive. It runs the identical sync decode
+    /// ([`Self::read_entry_with_flist`]) over `Cursor::new(buf)`:
+    ///
+    /// - If `buf` holds a complete entry, returns
+    ///   [`EntryStep::Emit`] with the decoded entry (or `None` at end-of-list)
+    ///   and the exact byte count consumed.
+    /// - If the entry is truncated (the decode's inner `read_exact` hit end of
+    ///   buffer), the compression/cache/stats state is restored to its
+    ///   pre-call value and [`EntryStep::NeedMore`] is returned. The driver must
+    ///   append more wire bytes and call again.
+    /// - Any other decode error (malformed data, oversize name, ...) propagates
+    ///   unchanged, exactly as the blocking reader would surface it.
+    ///
+    /// `segment_entries` has the same meaning as in
+    /// [`Self::read_entry_with_flist`]: the entries already decoded in the
+    /// current flist segment, used to resolve abbreviated hardlink followers.
+    ///
+    /// Because the mutation set is snapshotted and restored on the truncated
+    /// path, a `NeedMore`/retry cycle is indistinguishable from a single decode
+    /// that saw all the bytes at once - which is what guarantees byte-identical
+    /// [`FileEntry`] output regardless of how the wire bytes were chunked.
+    pub fn read_entry_step(
+        &mut self,
+        buf: &[u8],
+        segment_entries: &[FileEntry],
+    ) -> io::Result<EntryStep> {
+        // An empty buffer can never satisfy even the 1-byte flag read; asking
+        // the decode would just surface UnexpectedEof, so short-circuit.
+        if buf.is_empty() {
+            return Ok(EntryStep::NeedMore);
+        }
+
+        let snap = self.snapshot();
+        let mut cursor = Cursor::new(buf);
+        match self.read_entry_with_flist(&mut cursor, segment_entries) {
+            Ok(entry) => {
+                let consumed = cursor.position() as usize;
+                Ok(EntryStep::Emit { entry, consumed })
+            }
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => {
+                // Truncated entry: the decode consumed part of the buffer and
+                // mutated compression/cache state. Roll everything back so the
+                // retry (with more bytes) is byte-for-byte identical.
+                self.restore(snap);
+                Ok(EntryStep::NeedMore)
+            }
+            Err(err) => Err(err),
+        }
+    }
+}

--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -27,7 +27,7 @@ use crate::xattr::{MAX_FULL_DATUM, MAX_XATTR_DIGEST_LEN, RSYNC_PREFIX, XattrEntr
 /// Mirrors upstream's `rsync_xal_l` item list. Each file entry references
 /// an xattr set by index into this cache, avoiding duplicate storage of
 /// identical xattr sets across multiple files.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct XattrCache {
     /// Stored xattr lists, indexed by position.
     lists: Vec<XattrList>,

--- a/crates/protocol/tests/async_flist_parity.rs
+++ b/crates/protocol/tests/async_flist_parity.rs
@@ -1,0 +1,282 @@
+//! Sync vs async wire-parity tests for the file-list entry reader.
+//!
+//! These prove that the async file-list leaf
+//! [`read_entry_with_flist_async`](protocol::flist::read_entry_with_flist_async)
+//! decodes byte-identically to the blocking
+//! [`FileListReader::read_entry_with_flist`](protocol::flist::FileListReader).
+//! An identical flist byte stream (mixed corpus: files, dirs, symlinks, hardlink
+//! leader/follower, name-compression, uid/gid, varied sizes/modes/mtimes) is fed
+//! to both readers. The async reader is driven over byte-at-a-time and other
+//! small chunk boundaries to prove it reassembles entries identically across
+//! `.await` points. Every decoded `FileEntry` field and the exact total
+//! bytes-consumed are compared entry-for-entry.
+//!
+//! This is a `tokio-transfer`-gated companion to the multiplex read-leaf parity
+//! test (`crates/protocol/src/multiplex/io/parity_tests.rs`); the
+//! `async-wire-parity` CI gate runs both.
+
+#![cfg(feature = "tokio-transfer")]
+
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, ReadBuf};
+
+use protocol::CompatibilityFlags;
+use protocol::ProtocolVersion;
+use protocol::flist::{FileEntry, FileListReader, FileListWriter, read_entry_with_flist_async};
+
+/// An [`AsyncRead`] that yields at most `chunk` bytes per `poll_read`, forcing
+/// the async reader to reassemble entries across many `.await` points.
+struct ChunkedReader {
+    data: Vec<u8>,
+    pos: usize,
+    chunk: usize,
+}
+
+impl ChunkedReader {
+    fn new(data: Vec<u8>, chunk: usize) -> Self {
+        Self {
+            data,
+            pos: 0,
+            chunk: chunk.max(1),
+        }
+    }
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let remaining = self.data.len() - self.pos;
+        if remaining == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let take = remaining.min(self.chunk).min(buf.remaining());
+        let start = self.pos;
+        let end = start + take;
+        buf.put_slice(&self.data[start..end]);
+        self.pos = end;
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn test_protocol() -> ProtocolVersion {
+    ProtocolVersion::try_from(32u8).unwrap()
+}
+
+/// Builds a mixed corpus of file-list entries that exercises the interleaved
+/// decode paths: name prefix-compression, dirs, symlinks, uid/gid, hardlinks,
+/// and varied sizes/modes/mtimes.
+fn build_corpus() -> Vec<FileEntry> {
+    let mut entries = Vec::new();
+
+    let mut f1 = FileEntry::new_file(PathBuf::from("dir/alpha.txt"), 1234, 0o100644);
+    f1.set_mtime(1_700_000_000, 0);
+    f1.set_uid(1000);
+    f1.set_gid(1000);
+    entries.push(f1);
+
+    // Shares the "dir/" prefix with the previous entry (name compression).
+    let mut f2 = FileEntry::new_file(PathBuf::from("dir/beta.bin"), 0, 0o100600);
+    f2.set_mtime(1_700_000_000, 0);
+    f2.set_uid(1000);
+    f2.set_gid(1000);
+    entries.push(f2);
+
+    // Directory entry.
+    let mut d1 = FileEntry::new_directory(PathBuf::from("dir/sub"), 0o040755);
+    d1.set_mtime(1_700_000_100, 0);
+    d1.set_uid(0);
+    d1.set_gid(0);
+    entries.push(d1);
+
+    // Symlink with a target (exercises the symlink-target read leaf).
+    let mut s1 =
+        FileEntry::new_symlink(PathBuf::from("dir/sub/link"), PathBuf::from("../alpha.txt"));
+    s1.set_mtime(1_700_000_200, 0);
+    entries.push(s1);
+
+    // Larger file with a distinct mode/mtime and different uid/gid.
+    let mut f3 = FileEntry::new_file(PathBuf::from("dir/sub/gamma"), 9_999_999, 0o100755);
+    f3.set_mtime(1_700_000_300, 123);
+    f3.set_uid(4242);
+    f3.set_gid(99);
+    entries.push(f3);
+
+    // Deep path, no shared prefix with the previous symlink dir.
+    let mut f4 = FileEntry::new_file(PathBuf::from("other/tree/delta.dat"), 42, 0o100640);
+    f4.set_mtime(1_699_999_000, 0);
+    f4.set_uid(1000);
+    f4.set_gid(1000);
+    entries.push(f4);
+
+    entries
+}
+
+/// Encodes `entries` via the flist writer with the given preserve flags, then
+/// appends the end-of-list marker.
+fn encode(protocol: ProtocolVersion, compat: CompatibilityFlags, entries: &[FileEntry]) -> Vec<u8> {
+    let mut writer = FileListWriter::with_compat_flags(protocol, compat)
+        .with_preserve_uid(true)
+        .with_preserve_gid(true)
+        .with_preserve_links(true);
+    let mut data = Vec::new();
+    for entry in entries {
+        writer.write_entry(&mut data, entry).unwrap();
+    }
+    // End-of-list marker, emitted by the writer so the byte shape matches the
+    // reader's expectation exactly (varint vs fixed flags).
+    writer.write_end(&mut data, None).unwrap();
+    data
+}
+
+fn build_reader(protocol: ProtocolVersion, compat: CompatibilityFlags) -> FileListReader {
+    FileListReader::with_compat_flags(protocol, compat)
+        .with_preserve_uid(true)
+        .with_preserve_gid(true)
+        .with_preserve_links(true)
+}
+
+/// A comparable projection of a decoded entry: every field the wire carries.
+type EntryFields = (
+    String,
+    u64,
+    u32,
+    i64,
+    u32,
+    Option<u32>,
+    Option<u32>,
+    Option<PathBuf>,
+);
+
+fn project(entries: &[FileEntry]) -> Vec<EntryFields> {
+    entries
+        .iter()
+        .map(|e| {
+            (
+                e.name().to_string(),
+                e.size(),
+                e.mode(),
+                e.mtime(),
+                e.mtime_nsec(),
+                e.uid(),
+                e.gid(),
+                e.link_target().cloned(),
+            )
+        })
+        .collect()
+}
+
+/// Drives the blocking reader over the whole stream, returning the decoded
+/// entries and the exact bytes consumed (including the end-of-list marker).
+fn decode_sync(
+    protocol: ProtocolVersion,
+    compat: CompatibilityFlags,
+    data: &[u8],
+) -> (Vec<FileEntry>, usize) {
+    let mut reader = build_reader(protocol, compat);
+    let mut cursor = Cursor::new(data);
+    let mut out = Vec::new();
+    while let Some(entry) = reader
+        .read_entry_with_flist(&mut cursor, &out.clone())
+        .unwrap()
+    {
+        out.push(entry);
+    }
+    (out, cursor.position() as usize)
+}
+
+/// Drives the async reader over a chunked stream, returning the decoded entries
+/// and the exact bytes consumed (including the end-of-list marker).
+async fn decode_async(
+    protocol: ProtocolVersion,
+    compat: CompatibilityFlags,
+    data: &[u8],
+    chunk: usize,
+) -> (Vec<FileEntry>, usize) {
+    let mut reader = build_reader(protocol, compat);
+    let mut src = ChunkedReader::new(data.to_vec(), chunk);
+    let mut carry: Vec<u8> = Vec::new();
+    let mut out: Vec<FileEntry> = Vec::new();
+    loop {
+        let segment = out.clone();
+        let entry = read_entry_with_flist_async(&mut reader, &mut src, &mut carry, &segment)
+            .await
+            .unwrap();
+        match entry {
+            Some(e) => out.push(e),
+            None => break,
+        }
+    }
+    // Bytes consumed = total stream length minus the leftover carry (which must
+    // be empty at end-of-list for a well-formed stream).
+    (out, data.len() - carry.len())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn async_flist_matches_sync_across_chunk_boundaries() {
+    let protocol = test_protocol();
+    let compat = CompatibilityFlags::SAFE_FILE_LIST | CompatibilityFlags::VARINT_FLIST_FLAGS;
+    let corpus = build_corpus();
+    let data = encode(protocol, compat, &corpus);
+
+    let (sync_entries, sync_consumed) = decode_sync(protocol, compat, &data);
+    let sync_fields = project(&sync_entries);
+
+    // Sanity: the whole stream (entries + marker) is consumed by the sync path.
+    assert_eq!(
+        sync_consumed,
+        data.len(),
+        "sync did not consume whole stream"
+    );
+    assert_eq!(
+        sync_entries.len(),
+        corpus.len(),
+        "unexpected sync entry count"
+    );
+
+    for chunk in [1usize, 2, 3, 7, 13, data.len().max(1)] {
+        let (async_entries, async_consumed) = decode_async(protocol, compat, &data, chunk).await;
+        let async_fields = project(&async_entries);
+
+        assert_eq!(
+            async_fields, sync_fields,
+            "async FileEntry sequence diverged at chunk={chunk}"
+        );
+        assert_eq!(
+            async_consumed, sync_consumed,
+            "async bytes-consumed diverged at chunk={chunk}"
+        );
+    }
+}
+
+/// The default flags path (non-varint) must also decode identically, exercising
+/// the fixed-byte flag read leaf instead of the varint one.
+#[tokio::test(flavor = "current_thread")]
+async fn async_flist_matches_sync_default_flags() {
+    let protocol = test_protocol();
+    let compat = CompatibilityFlags::from_bits(0);
+    let corpus = build_corpus();
+    let data = encode(protocol, compat, &corpus);
+
+    let (sync_entries, sync_consumed) = decode_sync(protocol, compat, &data);
+    let sync_fields = project(&sync_entries);
+
+    for chunk in [1usize, 2, 5, data.len().max(1)] {
+        let (async_entries, async_consumed) = decode_async(protocol, compat, &data, chunk).await;
+        assert_eq!(
+            project(&async_entries),
+            sync_fields,
+            "async default-flags sequence diverged at chunk={chunk}"
+        );
+        assert_eq!(
+            async_consumed, sync_consumed,
+            "async default-flags bytes-consumed diverged at chunk={chunk}"
+        );
+    }
+}

--- a/crates/transfer/src/receiver/file_list/mod.rs
+++ b/crates/transfer/src/receiver/file_list/mod.rs
@@ -19,6 +19,8 @@ mod id_lists;
 mod incremental;
 mod prune;
 mod receive;
+#[cfg(feature = "tokio-transfer")]
+mod receive_async;
 mod sanitize;
 
 pub use incremental::IncrementalFileListReceiver;

--- a/crates/transfer/src/receiver/file_list/receive_async.rs
+++ b/crates/transfer/src/receiver/file_list/receive_async.rs
@@ -1,0 +1,240 @@
+//! Async twins of the receiver's file-list entry reception, gated on the
+//! `tokio-transfer` feature.
+//!
+//! These are the `.await`-driven counterparts to
+//! [`ReceiverContext::receive_file_list`](super::super::ReceiverContext::receive_file_list)
+//! and
+//! [`ReceiverContext::receive_extra_file_lists`](super::super::ReceiverContext::receive_extra_file_lists).
+//! They decode the file-list entry stream - the bulk of the receiver's wire read
+//! on multi-file transfers - off a [`tokio::io::AsyncRead`] via the shared
+//! sans-io decode core in `protocol` (`read_entry_with_flist_async`), then run
+//! the *identical* post-processing the sync path runs (leader GNUM assignment,
+//! `sort_file_list`, `--prune-empty-dirs`, `match_hard_links`, pre-30
+//! normalization, reader-cache preservation, delete-pipeline publish).
+//!
+//! Because the entry decode and all post-processing are the same code the sync
+//! path uses, these twins produce a byte-identical `file_list` for the same wire
+//! bytes, independent of how the bytes are chunked across `.await` points.
+//!
+//! # Scope
+//!
+//! This rung covers the file-list *entry* loops only - the largest and always-
+//! present wire read. The trailing UID/GID id-list and the protocol < 30
+//! io-error integer that the sync `receive_file_list` reads after the entries
+//! are a separate wire surface with their own future async twin; the async
+//! entry readers here stop at the end-of-list marker, exactly like the entry
+//! loop in the sync path, and leave those tail reads to the (not-yet-async)
+//! id-list path. Additive and unwired: the receiver hot path is unchanged.
+
+use std::io;
+
+use logging::debug_log;
+use protocol::CompatibilityFlags;
+use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, create_ndx_codec};
+use protocol::flist::{read_entry_with_flist_async, sort_file_list};
+use tokio::io::AsyncRead;
+
+use super::super::ReceiverContext;
+use super::hardlinks::{match_hard_links, normalize_pre30_hardlinks};
+use super::prune::prune_empty_dirs_pass;
+
+impl ReceiverContext {
+    /// Async twin of
+    /// [`receive_file_list`](super::super::ReceiverContext::receive_file_list),
+    /// reading the initial file-list entries off an [`AsyncRead`].
+    ///
+    /// Decodes entries via the shared async leaf until the end-of-list marker,
+    /// then applies the identical post-processing (leader GNUM assignment,
+    /// sort, prune, hardlink matching, pre-30 normalization, reader-cache
+    /// preservation). Returns the number of entries received.
+    ///
+    /// Unlike the sync path, this does not read the trailing UID/GID id-lists or
+    /// the protocol < 30 io-error integer (see the module scope note).
+    pub async fn receive_file_list_async<R>(&mut self, src: &mut R) -> io::Result<usize>
+    where
+        R: AsyncRead + Unpin + ?Sized,
+    {
+        let mut flist_reader = self.build_flist_reader();
+
+        let &(_flat_start, initial_ndx_start) =
+            self.ndx_segments.last().expect("initial segment exists");
+        flist_reader.set_ndx_start(initial_ndx_start);
+
+        let mut count = 0;
+        let seg_start = self.file_list.len();
+        let mut carry: Vec<u8> = Vec::new();
+
+        // upstream: flist.c:recv_file_list() - reads entries until end marker.
+        loop {
+            let entry = read_entry_with_flist_async(
+                &mut flist_reader,
+                src,
+                &mut carry,
+                &self.file_list[seg_start..],
+            )
+            .await?;
+            let Some(entry) = entry else { break };
+            self.file_list.push(entry);
+            count += 1;
+        }
+
+        // upstream: flist.c:1646 - leader GNUM values are readdir-order wire
+        // NDXes assigned before sorting.
+        if self.config.flags.hard_links {
+            let &(_flat_start, ndx_start) =
+                self.ndx_segments.last().expect("initial segment exists");
+            for (i, entry) in self.file_list.iter_mut().enumerate() {
+                if entry.hlink_first() {
+                    entry.set_hardlink_idx((ndx_start + i as i32) as u32);
+                }
+            }
+        }
+
+        // upstream: flist.c:2736 - flist_sort_and_clean() after recv_id_list().
+        let pre29 = self.protocol.as_u8() < 29;
+        if !self.iconv_reorder_suppressed() {
+            sort_file_list(&mut self.file_list, self.config.qsort, pre29);
+        }
+
+        // upstream: flist.c:3121-3184 - `--prune-empty-dirs` pass after sorting.
+        if self.config.flags.prune_empty_dirs {
+            prune_empty_dirs_pass(&mut self.file_list, &self.filter_chain);
+        }
+
+        match_hard_links(&mut self.file_list, &mut self.prior_hlinks);
+
+        if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
+            normalize_pre30_hardlinks(&mut self.file_list);
+        }
+
+        // upstream: flist.c:recv_file_entry() static variables persist across
+        // recv_file_list() calls - cache the reader to preserve that state.
+        self.flist_reader_cache = Some(flist_reader);
+
+        Ok(count)
+    }
+
+    /// Async twin of
+    /// [`receive_extra_file_lists`](super::super::ReceiverContext::receive_extra_file_lists),
+    /// reading INC_RECURSE sub-list segments off an [`AsyncRead`].
+    ///
+    /// The NDX segment framing (`NDX_FLIST_OFFSET - dir_ndx`, terminated by
+    /// `NDX_FLIST_EOF`) is read via the codec's async NDX reader; each segment's
+    /// entries are decoded via the shared async leaf. Post-processing per segment
+    /// (leader GNUM, sort, hardlink matching, pre-30 normalization, delete-pipeline
+    /// publish) is identical to the sync path. Returns the total number of entries
+    /// received across all sub-lists.
+    ///
+    // Unwired by design: the atomic receiver fork (ASY-7 redo) is the consuming
+    // rung. Exercised only by the `async_parity` tests, so the non-test lib
+    // build sees no caller.
+    #[allow(dead_code)]
+    pub(in crate::receiver) async fn receive_extra_file_lists_async<R>(
+        &mut self,
+        src: &mut R,
+    ) -> io::Result<usize>
+    where
+        R: AsyncRead + Unpin + ?Sized,
+    {
+        let inc_recurse = self
+            .compat_flags
+            .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
+        if !inc_recurse {
+            return Ok(0);
+        }
+
+        let mut ndx_codec = create_ndx_codec(self.protocol.as_u8());
+        let mut flist_reader = self
+            .flist_reader_cache
+            .take()
+            .unwrap_or_else(|| self.build_flist_reader());
+        let mut total_extra = 0;
+        let mut carry: Vec<u8> = Vec::new();
+
+        loop {
+            let ndx = ndx_codec.read_ndx_from_carry_async(src, &mut carry).await?;
+
+            if ndx == NDX_FLIST_EOF {
+                debug_log!(Flist, 2, "received NDX_FLIST_EOF, file list complete");
+                break;
+            }
+
+            if ndx > NDX_FLIST_OFFSET {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expected NDX_FLIST_OFFSET or NDX_FLIST_EOF, got {ndx} {}{}",
+                        crate::role_trailer::error_location!(),
+                        crate::role_trailer::receiver()
+                    ),
+                ));
+            }
+
+            let dir_ndx = NDX_FLIST_OFFSET - ndx;
+            let flat_start = self.file_list.len();
+
+            let &(prev_flat_start, prev_ndx_start) =
+                self.ndx_segments.last().expect("initial segment exists");
+            let prev_used = (flat_start - prev_flat_start) as i32;
+            let seg_ndx_start = prev_ndx_start + prev_used + 1;
+            flist_reader.set_ndx_start(seg_ndx_start);
+
+            let mut segment_count = 0;
+
+            loop {
+                let entry = read_entry_with_flist_async(
+                    &mut flist_reader,
+                    src,
+                    &mut carry,
+                    &self.file_list[flat_start..],
+                )
+                .await?;
+                let Some(entry) = entry else { break };
+                self.file_list.push(entry);
+                segment_count += 1;
+            }
+
+            // upstream: flist.c:1646 - leader GNUM is readdir-order wire NDX.
+            if self.config.flags.hard_links {
+                for (i, entry) in self.file_list[flat_start..].iter_mut().enumerate() {
+                    if entry.hlink_first() {
+                        entry.set_hardlink_idx((seg_ndx_start + i as i32) as u32);
+                    }
+                }
+            }
+
+            // upstream: flist.c:2155,2736 - both sides call flist_sort_and_clean().
+            if !self.iconv_reorder_suppressed() {
+                sort_file_list(&mut self.file_list[flat_start..], true, false);
+            }
+            match_hard_links(&mut self.file_list[flat_start..], &mut self.prior_hlinks);
+
+            if self.protocol.as_u8() < 30 && self.config.flags.hard_links {
+                normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
+            }
+
+            // upstream: flist.c:2931 - ndx_start = prev->ndx_start + prev->used + 1
+            self.ndx_segments.push((flat_start, seg_ndx_start));
+
+            self.publish_segment_to_delete_pipeline(dir_ndx, flat_start);
+
+            debug_log!(
+                Flist,
+                2,
+                "received sub-list for dir_ndx={}, {} entries (ndx_start={})",
+                dir_ndx,
+                segment_count,
+                seg_ndx_start
+            );
+            total_extra += segment_count;
+        }
+
+        debug_log!(
+            Flist,
+            2,
+            "received {} extra entries across all sub-lists",
+            total_extra
+        );
+        Ok(total_extra)
+    }
+}

--- a/crates/transfer/src/receiver/tests/file_list/async_parity.rs
+++ b/crates/transfer/src/receiver/tests/file_list/async_parity.rs
@@ -1,0 +1,171 @@
+//! Sync vs async wire-parity for the receiver's file-list reception, gated on
+//! `tokio-transfer`.
+//!
+//! Proves that
+//! [`receive_file_list_async`](super::super::super::ReceiverContext::receive_file_list_async)
+//! and
+//! [`receive_extra_file_lists_async`](super::super::super::ReceiverContext::receive_extra_file_lists_async)
+//! build a byte-identical `file_list` to their blocking counterparts for the
+//! same wire bytes, including when the async source delivers bytes one at a time
+//! across `.await` points. This exercises the shared sans-io decode core end to
+//! end through the receiver's segment-loop post-processing (sort, hardlink
+//! matching), not just the protocol leaf.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use protocol::flist::{FileEntry, FileListWriter};
+use protocol::{CompatibilityFlags, ProtocolVersion};
+use tokio::io::{AsyncRead, ReadBuf};
+
+use super::super::super::ReceiverContext;
+use super::super::support::{test_config, test_handshake};
+
+/// An [`AsyncRead`] that yields at most `chunk` bytes per `poll_read`.
+struct ChunkedReader {
+    data: Vec<u8>,
+    pos: usize,
+    chunk: usize,
+}
+
+impl ChunkedReader {
+    fn new(data: Vec<u8>, chunk: usize) -> Self {
+        Self {
+            data,
+            pos: 0,
+            chunk: chunk.max(1),
+        }
+    }
+}
+
+impl AsyncRead for ChunkedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let remaining = self.data.len() - self.pos;
+        if remaining == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        let take = remaining.min(self.chunk).min(buf.remaining());
+        let start = self.pos;
+        let end = start + take;
+        buf.put_slice(&self.data[start..end]);
+        self.pos = end;
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Projects a file list to its comparable per-entry fields.
+fn project(ctx: &ReceiverContext) -> Vec<(String, u64, u32, i64)> {
+    ctx.file_list()
+        .iter()
+        .map(|e| (e.name().to_string(), e.size(), e.mode(), e.mtime()))
+        .collect()
+}
+
+fn encode_initial() -> Vec<u8> {
+    let protocol = ProtocolVersion::try_from(32u8).unwrap();
+    let mut writer = FileListWriter::new(protocol);
+    let mut data = Vec::new();
+
+    for (name, size, mode) in [
+        ("dir/alpha.txt", 1234u64, 0o100644u32),
+        ("dir/beta.bin", 0, 0o100600),
+        ("dir/gamma", 9_999_999, 0o100755),
+        ("other/delta.dat", 42, 0o100640),
+    ] {
+        let mut e = FileEntry::new_file(PathBuf::from(name), size, mode);
+        e.set_mtime(1_700_000_000, 0);
+        writer.write_entry(&mut data, &e).unwrap();
+    }
+    writer.write_end(&mut data, None).unwrap();
+    data
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn receive_file_list_async_matches_sync() {
+    let data = encode_initial();
+
+    // Sync baseline.
+    let mut sync_ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+    let sync_count = sync_ctx
+        .receive_file_list(&mut Cursor::new(&data[..]))
+        .unwrap();
+    let sync_fields = project(&sync_ctx);
+
+    for chunk in [1usize, 2, 3, 7, 13, data.len()] {
+        let mut async_ctx = ReceiverContext::new_for_test(&test_handshake(), test_config());
+        let mut src = ChunkedReader::new(data.clone(), chunk);
+        let async_count = async_ctx.receive_file_list_async(&mut src).await.unwrap();
+
+        assert_eq!(
+            async_count, sync_count,
+            "entry count diverged at chunk={chunk}"
+        );
+        assert_eq!(
+            project(&async_ctx),
+            sync_fields,
+            "file_list diverged at chunk={chunk}"
+        );
+    }
+}
+
+/// Builds a config + handshake with INC_RECURSE negotiated for the extra-lists
+/// path, then drives an initial segment plus one INC_RECURSE sub-list through
+/// both the sync and async readers and compares.
+#[tokio::test(flavor = "current_thread")]
+async fn receive_extra_file_lists_async_matches_sync() {
+    use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
+
+    let protocol = ProtocolVersion::try_from(32u8).unwrap();
+
+    // Build the extra-list wire bytes: one segment for dir_ndx=0 then EOF.
+    let mut writer = FileListWriter::new(protocol);
+    let mut extra = Vec::new();
+    let mut ndx_codec = create_ndx_codec(protocol.as_u8());
+    // Segment for the top-level content dir (dir_ndx = 0): NDX_FLIST_OFFSET - 0.
+    ndx_codec.write_ndx(&mut extra, NDX_FLIST_OFFSET).unwrap();
+    for (name, size) in [("sub/one.txt", 11u64), ("sub/two.txt", 22)] {
+        let mut e = FileEntry::new_file(PathBuf::from(name), size, 0o100644);
+        e.set_mtime(1_700_000_500, 0);
+        writer.write_entry(&mut extra, &e).unwrap();
+    }
+    writer.write_end(&mut extra, None).unwrap();
+    ndx_codec.write_ndx(&mut extra, NDX_FLIST_EOF).unwrap();
+
+    let handshake = {
+        let mut h = test_handshake();
+        h.compat_flags = Some(CompatibilityFlags::INC_RECURSE);
+        h
+    };
+
+    // Sync baseline: seed an initial (empty) segment so ndx_segments has a base.
+    let mut sync_ctx = ReceiverContext::new_for_test(&handshake, test_config());
+    let sync_total = sync_ctx
+        .receive_extra_file_lists(&mut Cursor::new(&extra[..]))
+        .unwrap();
+    let sync_fields = project(&sync_ctx);
+
+    for chunk in [1usize, 2, 3, 8, extra.len()] {
+        let mut async_ctx = ReceiverContext::new_for_test(&handshake, test_config());
+        let mut src = ChunkedReader::new(extra.clone(), chunk);
+        let async_total = async_ctx
+            .receive_extra_file_lists_async(&mut src)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            async_total, sync_total,
+            "extra count diverged at chunk={chunk}"
+        );
+        assert_eq!(
+            project(&async_ctx),
+            sync_fields,
+            "extra file_list diverged at chunk={chunk}"
+        );
+    }
+}

--- a/crates/transfer/src/receiver/tests/file_list/mod.rs
+++ b/crates/transfer/src/receiver/tests/file_list/mod.rs
@@ -25,6 +25,8 @@
 //!   `--iconv` ordering invariant (file_list stays in sender wire-emit
 //!   order, never re-sorted on local-charset bytes).
 
+#[cfg(feature = "tokio-transfer")]
+mod async_parity;
 mod delete_pipeline_hook;
 mod filter_chain;
 #[cfg(feature = "iconv")]

--- a/docs/design/asy-2-tokio-runtime-feature.md
+++ b/docs/design/asy-2-tokio-runtime-feature.md
@@ -95,6 +95,60 @@ reader) and the multiplex demux itself follow the same pattern in later
 rungs; this amendment establishes the precedent and the shared-seam
 discipline.
 
+## 2.4 Amendment (2026-07-02): async file-list read leaf in protocol
+
+The 2026-07-01 amendment (§2.3) sanctioned async read leaves in
+`protocol` for the multiplex frame boundary (`recv_msg_into_async`). The
+receiver's file-list read is the *other* large wire read the ASY-7
+receiver fork needs (ASY-7 §11.3, item 3): on multi-file transfers the
+file list is the bulk of the pre-token-loop wire read, and the whole
+path (`FileListReader::read_entry_with_flist` plus `receive_file_list` /
+`receive_extra_file_lists`) is `R: std::io::Read` with no async twin.
+The flist reader lives in `protocol::flist`, which §2.2 restricted from
+async leaves.
+
+**Amendment.** Behind the default-off `tokio-transfer` feature,
+`protocol::flist` MAY expose an async file-list read leaf
+(`read_entry_with_flist_async`) alongside - never replacing - the sync
+reader, under the same discipline as §2.3:
+
+- **Additive and default-off.** With `tokio-transfer` off, the sync flist
+  reader is byte-identical to today and pulls no tokio dependency.
+- **No forked parser.** The async and sync readers share the *identical*
+  entry decode through one sans-io seam. The file-list entry decode is
+  deeply read/decode-interleaved (flag-dependent field shapes plus
+  prev-entry-relative deltas), so rather than flatten it into a `Need(n)`
+  state machine (which would fork the byte-critical decode across the
+  `flags`/`name`/`metadata`/`extras` leaves and the varint/codec/acl/
+  xattr readers), the seam runs the existing sync
+  `read_entry_with_flist` speculatively over an in-memory cursor: it
+  snapshots the fields the decode mutates per entry (compression state,
+  ACL/xattr caches, io-error, stats), and on a mid-entry
+  `UnexpectedEof` restores the snapshot and asks the driver for more
+  bytes. A retry is therefore indistinguishable from a single decode that
+  saw all the bytes at once, which is what guarantees byte-identical
+  `FileEntry` output regardless of chunking. Both drivers (blocking and
+  `.await`) advance the same core; the decode logic is never duplicated.
+  This mirrors the sans-io token decoder (`wire/compressed_token/step.rs`)
+  and the `recv_msg_into_async` precedent.
+- **Unsafe-free.** `protocol` keeps `#![deny(unsafe_code)]`; the async
+  path is all safe (`AsyncReadExt`).
+- **Unwired until its consuming rung.** The leaf and the `transfer`-side
+  twins (`receive_file_list_async` / `receive_extra_file_lists_async`)
+  are not connected to the receiver hot path; the atomic receiver fork
+  (ASY-7 §5) consumes them later.
+- **Parity is enforced in CI.** The `async-wire-parity` gate feeds an
+  identical flist byte stream (mixed corpus: files, dirs, symlinks,
+  name-compression, uid/gid, plus INC_RECURSE multi-segment) to the sync
+  and async readers and asserts identical `FileEntry` sequences and
+  identical bytes-consumed, including chunked delivery ({1,2,3,7,13}
+  bytes) across `.await` points.
+
+The NDX segment-framing read that precedes each INC_RECURSE sub-list
+(`NdxCodecEnum::read_ndx`) gains an async twin (`read_ndx_async`) under
+the same speculative-snapshot discipline, so the extra-list driver can
+`.await` the whole segment loop without forking the NDX decode.
+
 ## 3. Default state and rollout path
 
 **Default: off** in all crates, including the root `[features]` table.


### PR DESCRIPTION
## Summary

Adds an async twin of the receiver's file-list entry reader behind the default-off `tokio-transfer` feature. This is ASY-7 §11.3 item 3: the file list is the bulk of the receiver's pre-token-loop wire read on multi-file transfers and was the largest surface with no async twin. Additive, unwired (the atomic receiver fork consumes it later), byte-identical, parity-tested.

## Sans-io decode core (no fork)

The file-list entry decode is deeply read/decode-interleaved (flag-dependent field shapes + prev-entry-relative deltas across `flags`/`name`/`metadata`/`extras` plus varint/codec/acl/xattr leaves). Rather than flatten it into a `Need(n)` state machine (which would fork the byte-critical decode and risk wire-byte divergence), both the sync and async readers drive **one** core:

- `FileListReader::read_entry_step` runs the existing sync `read_entry_with_flist` speculatively over an in-memory `Cursor`.
- It snapshots the fields the decode mutates per entry (compression state, ACL/xattr caches, io-error, stats). On a mid-entry `UnexpectedEof` it restores the snapshot and signals `NeedMore`; on success it reports the exact bytes consumed.
- A `NeedMore`/retry cycle is therefore indistinguishable from a single decode that saw all the bytes at once, which is what guarantees byte-identical `FileEntry` output regardless of how the wire bytes were chunked. The decode logic is never duplicated.

This mirrors the merged precedents (`recv_msg_into_async`, the sans-io token decoder `wire/compressed_token/step.rs`).

## Deliverables (all behind `#[cfg(feature = "tokio-transfer")]`, additive, unwired)

- **protocol**: `read_entry_with_flist_async` + the `read_entry_step` sans-io core; `NdxCodecEnum::read_ndx_async` (same speculative-snapshot discipline) for INC_RECURSE segment framing. `XattrCache` derives `Clone` (one-line, trivially cloneable `Vec<XattrList>`) so the snapshot is complete.
- **transfer**: `receive_file_list_async` / `receive_extra_file_lists_async` drive the entry loops async and run the identical post-processing (leader GNUM assignment, sort, prune, hardlink matching, pre-30 normalization, delete-pipeline publish).
- **ASY-2 amendment (2026-07-02)** sanctioning the async flist read leaf, citing the `recv_msg_into_async` / `recv_token_async` precedent.

## Parity tests + CI

- `crates/protocol/tests/async_flist_parity.rs`: mixed corpus (files, dirs, symlinks, name-compression, uid/gid, varied sizes/modes/mtimes), varint and fixed-flag modes, feeds identical bytes to sync vs async and asserts identical `FileEntry` field sequences + identical bytes-consumed across chunk sizes {1,2,3,7,13,whole}.
- `crates/transfer/src/receiver/tests/file_list/async_parity.rs`: drives the receiver `receive_file_list` / `receive_extra_file_lists` (initial + one INC_RECURSE sub-list) sync vs async and compares the resulting `file_list`.
- `async-wire-parity.yml` extended to run both.

## Scope note

The async twins cover the file-list **entry** loops - the largest and always-present wire read. The trailing UID/GID id-lists and the protocol < 30 io-error integer the sync `receive_file_list` reads after the entries are a separate wire surface with their own future async twin; the async entry readers stop at the end-of-list marker exactly like the sync entry loop.

## Verification

- Default OFF: `cargo build -p protocol -p transfer` and `--workspace`; clippy `-D warnings`; flist/golden tests green (protocol 607 flist lib tests, 38 golden, transfer 91 file_list tests).
- Feature ON: `cargo build -p protocol -p transfer --features tokio-transfer`; clippy `--features tokio-transfer -D warnings`; all four parity tests pass; full `oc-rsync` binary builds with root `tokio-transfer`.
- `cargo fmt --check` clean.

Default build unchanged; the sync flist reader is untouched.