### PR TITLE
ci: root+non-root testsuite legs for 3.4.4 gate and 3.5.0dev tracker

### DIFF
--- a/.github/workflows/_upstream-testsuite.yml
+++ b/.github/workflows/_upstream-testsuite.yml
@@ -146,3 +146,96 @@ jobs:
             target/interop/upstream-testsuite-output.log
           if-no-files-found: ignore
           retention-days: 14
+
+  # ===========================================================================
+  # Root leg (informational). The non-root job above is the REQUIRED gate; it
+  # stays untouched so its `upstream testsuite` check context and green status
+  # are preserved. This job re-runs the SAME 3.4.4 shell suite under sudo so
+  # the root-only tests (chown/devices/xattrs/dir-sgid/protected-regular) that
+  # self-skip as the runner user actually RUN. It is `continue-on-error` so a
+  # root-only divergence surfaces here (job summary + non-green leg) without
+  # wedging the required gate. Promote to required only after a CI run proves
+  # it green. The 3.4.4 shell suite has no --use-tcp support (that is a
+  # runtests.py flag added on master), so this gate is privilege-only; the
+  # transport dimension applies solely to the 3.5.0dev tracker.
+  # ===========================================================================
+  upstream-testsuite-root:
+    name: upstream testsuite (root, informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-D warnings"
+      RUST_BACKTRACE: "full"
+      CACHE_VERSION: ${{ inputs.cache_version }}
+      UPSTREAM_RSYNC_VERSION: ${{ inputs.upstream_rsync_version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: ci-${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: upstream-testsuite-root
+          cache-on-failure: true
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        with:
+          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+          version: ${{ env.CACHE_VERSION }}
+
+      - name: Cache upstream rsync source
+        id: cache-upstream
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target/interop/upstream-src/rsync-${{ env.UPSTREAM_RSYNC_VERSION }}
+          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh') }}-${{ runner.os }}
+
+      - name: Build oc-rsync (release)
+        uses: ./.github/actions/build-oc-rsync
+
+      - name: Run upstream testsuite (root)
+        id: testsuite
+        env:
+          OC_RSYNC_BIN: target/release/oc-rsync
+          UPSTREAM_VERSION: ${{ env.UPSTREAM_RSYNC_VERSION }}
+        run: |
+          set -uo pipefail
+          mkdir -p target/interop
+          # Passwordless sudo re-exec so root-only tests RUN. Forward the env
+          # the harness reads (a bare `sudo` scrubs it) plus the GHA summary
+          # sink. Informational: never fail the step - the job status carries
+          # the signal and continue-on-error keeps the leg green.
+          sudo env \
+            "PATH=$PATH" \
+            "OC_RSYNC_BIN=$OC_RSYNC_BIN" \
+            "UPSTREAM_VERSION=$UPSTREAM_VERSION" \
+            "GITHUB_ACTIONS=${GITHUB_ACTIONS:-}" \
+            "GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}" \
+            bash tools/ci/run_upstream_testsuite.sh 2>&1 \
+            | tee target/interop/upstream-testsuite-root-output.log || true
+          # Reclaim root-owned scratch/logs for the upload + post-job cache.
+          sudo chown -R "$(id -u):$(id -g)" target/interop 2>/dev/null || true
+
+      - name: Upload testsuite logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: upstream-testsuite-root-logs
+          path: |
+            target/interop/upstream-testsuite/
+            target/interop/upstream-testsuite-root-output.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -21,6 +21,31 @@
 # RELEASE-DAY PLAN (2026-07-15): once 3.5.0 ships, bump the REQUIRED gate's
 # pin 3.4.4 -> 3.5.0, vendor the 3.5.0 testsuite as a release tarball, and
 # retire this git-ref tracker (or repoint it at the next dev branch).
+#
+# HARNESS-CALIBRATION FOLLOW-UP (not yet done; the raw leg counts are NOT yet
+# trustworthy as an oc-divergence number). The 3.5.0dev suite is the Python
+# *_test.py framework (rsyncfns.py + exitcodes.py), which drives rsync
+# differently from the 3.4.4 shell suite. A plain
+# `runtests.py --rsync-bin=oc-rsync` mis-drives a subset of it, so some FAILs
+# are harness gaps, NOT oc divergences. Known gaps to calibrate before the
+# tracker's number is authoritative:
+#   1. setpriv exec: fake-super/uid tests (e.g. partial_nowrite_test.py) run
+#      rsync via `setpriv`, which fails with "failed to execute .../oc-rsync:
+#      No such file or directory" (setpriv's dropped exec context can't resolve
+#      the binary/interp). The pre-transfer setup then never runs, cascading a
+#      Python FileNotFoundError that fails partial + partial_nowrite for a
+#      harness reason. Needs an rsync-on-PATH shim or a setpriv-visible binary.
+#   2. Per-test setup ordering in rsyncfns.py differs from the shell fns; some
+#      tests expect a FROMDIR the setpriv step was meant to populate.
+#   3. Root-owned scratch: root legs leave root-owned files; already chown'd
+#      back in the workflow, but the Python cleanup path (EACCES scandir on a
+#      mode-0 xattrs/to) still needs a permission-safe teardown inside the
+#      framework, not just around it.
+# Until these land, treat the tracker as a divergence *screen*: a test that
+# fails under BOTH pipe and tcp AND with a clear oc error (e.g. ownership-depth
+# `--groupmap=:1` rejected, mkpath auto-creating a path without --mkpath,
+# compress-options missing the --debug=NSTR line) is a real candidate; a test
+# failing via setpriv/FileNotFound/EACCES is a harness gap to fix here first.
 
 name: Track 3.5.0dev Testsuite
 

--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -40,13 +40,27 @@ permissions:
 
 jobs:
   track-3-5-0dev:
-    name: 3.5.0dev testsuite (informational)
+    # Full coverage of the 3.5.0dev suite is a privilege x transport matrix:
+    #   privilege=nonroot  - runs as the runner user; root-only tests SKIP.
+    #   privilege=root     - runs under sudo; chown/devices/xattrs/dir-sgid/
+    #                        protected-regular RUN (upstream passwordless sudo).
+    #   transport=pipe     - daemon tests use the secure stdio-pipe default.
+    #   transport=tcp      - --use-tcp: real loopback rsyncd, un-skips
+    #                        daemon-chroot-acl + proxy-response-line-too-long.
+    # All four legs are surfaced independently so a divergence is attributable
+    # to a specific (privilege, transport) cell.
+    name: 3.5.0dev testsuite (${{ matrix.privilege }}/${{ matrix.transport }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # Best-effort tracker: never let a 3.5.0dev break look like a repo failure
     # that someone must firefight. The step summary + run status carry the
-    # signal; this flag keeps the job green so it stays purely informational.
+    # signal; this flag keeps every leg green so it stays purely informational.
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        privilege: [nonroot, root]
+        transport: [pipe, tcp]
 
     env:
       CARGO_TERM_COLOR: always
@@ -65,6 +79,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
+          # Share the compiled oc-rsync across all four legs (identical build).
           shared-key: track-3-5-0dev-cargo
           key: track-3-5-0dev-testsuite
           cache-on-failure: true
@@ -85,20 +100,43 @@ jobs:
         env:
           OC_RSYNC_BIN: target/release/oc-rsync
           UPSTREAM_REF: ${{ github.event.inputs.upstream_ref || 'master' }}
+          # transport=tcp -> --use-tcp (real loopback rsyncd); pipe -> default.
+          USE_TCP: ${{ matrix.transport == 'tcp' && 'yes' || 'no' }}
         run: |
           set -uo pipefail
           mkdir -p target/interop
+          # Root leg: re-exec the harness under sudo (the runner has
+          # passwordless sudo) so chown/devices/xattrs/dir-sgid/protected-
+          # regular actually RUN instead of self-skipping. Forward the env the
+          # harness reads - a bare `sudo` scrubs it. Non-root leg runs plainly.
+          runner=(bash tools/ci/run_upstream_testsuite.sh)
+          if [[ "${{ matrix.privilege }}" == "root" ]]; then
+            runner=(sudo env
+              "PATH=$PATH"
+              "OC_RSYNC_BIN=$OC_RSYNC_BIN"
+              "UPSTREAM_REF=$UPSTREAM_REF"
+              "USE_TCP=$USE_TCP"
+              "GITHUB_ACTIONS=${GITHUB_ACTIONS:-}"
+              "GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}"
+              bash tools/ci/run_upstream_testsuite.sh)
+          fi
           # Best-effort: capture the driver's exit but do not fail the step -
           # continue-on-error at the job level already keeps this informational,
           # and we still want the artifact + summary to publish on divergence.
-          bash tools/ci/run_upstream_testsuite.sh 2>&1 \
+          "${runner[@]}" 2>&1 \
             | tee target/interop/track-3.5.0dev-output.log || true
+          # The root leg leaves root-owned files under target/interop (the
+          # runtests.py scratch + logs). Hand them back to the runner user so
+          # the upload-artifact step and post-job cache can read/clean them.
+          if [[ "${{ matrix.privilege }}" == "root" ]]; then
+            sudo chown -R "$(id -u):$(id -g)" target/interop 2>/dev/null || true
+          fi
 
       - name: Upload testsuite logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: track-3.5.0dev-testsuite-logs
+          name: track-3.5.0dev-testsuite-logs-${{ matrix.privilege }}-${{ matrix.transport }}
           path: |
             target/interop/upstream-testsuite/
             target/interop/track-3.5.0dev-output.log

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -403,16 +403,56 @@ run_git_ref_mode() {
     mkdir -p "$log_root"
     local output_log="${log_root}/runtests-output.log"
 
+    # Permission-safe scratch cleanup. A test that leaves a mode-0 directory
+    # behind (e.g. xattrs/, recv-discard-nullderef/) makes a plain `rm -rf`
+    # throw for the non-root runner, and runtests.py's per-test prep_scratch
+    # PermissionErrors then cascade into every later test - inflating the FAIL
+    # count with pure environment noise. Drive the scratch tree from a
+    # dedicated, mode-tagged directory under $log_root (never a bind mount) and
+    # force-clear it so a poisoned tree from a prior leg can never wedge this
+    # one. `chmod -R u+rwX` restores owner traversal on any 0-mode dir before
+    # the delete; both run under the current euid (root in the sudo leg, the
+    # runner user otherwise), so the owner always holds the bit.
+    local mode_tag="nonroot"
+    [[ "${EUID:-$(id -u)}" -eq 0 ]] && mode_tag="root"
+    # Build the runtests.py argv. Include the base program so the array is
+    # never empty - portable across bash 3.2 (macOS), which errors on an
+    # empty "${arr[@]}" expansion under `set -u`.
+    local transport_tag="pipe"
+    local -a runtests_argv
+    runtests_argv=(python3 ./runtests.py)
+    if [[ "${USE_TCP:-no}" == "yes" ]]; then
+        # --use-tcp runs daemon/proxy tests against a real loopback rsyncd
+        # (RSYNC_TEST_USE_TCP=1) instead of degrading/SKIPping under the secure
+        # stdio-pipe default. Un-skips daemon-chroot-acl + proxy-response-line-
+        # too-long. Binds 127.0.0.1:<high-port>, needs no privilege.
+        transport_tag="tcp"
+        runtests_argv+=(--use-tcp)
+    fi
+    runtests_argv+=(
+        --rsync-bin="$oc_rsync_bin"
+        --tooldir="$upstream_src_dir"
+        --srcdir="$upstream_src_dir"
+        --timeout="$testrun_timeout"
+    )
+    local scratch_home="${log_root}/scratch-${mode_tag}-${transport_tag}"
+    chmod -R u+rwX "$scratch_home" 2>/dev/null || true
+    rm -rf "$scratch_home"
+    mkdir -p "$scratch_home"
+
     local rc=0
     (
         cd "$upstream_src_dir"
-        python3 ./runtests.py \
-            --rsync-bin="$oc_rsync_bin" \
-            --tooldir="$upstream_src_dir" \
-            --srcdir="$upstream_src_dir" \
-            --timeout="$testrun_timeout"
+        # scratchbase -> runtests.py places $scratchbase/testtmp here, off the
+        # source tree, so the cleanup above owns the whole scratch lifecycle.
+        scratchbase="$scratch_home" "${runtests_argv[@]}"
     ) 2>&1 | tee "$output_log"
     rc=${PIPESTATUS[0]}
+
+    # Force-clear the scratch tree again so the NEXT leg (or a re-run on the
+    # same self-hosted runner) never inherits a mode-0 dir from this leg.
+    chmod -R u+rwX "$scratch_home" 2>/dev/null || true
+    rm -rf "$scratch_home" 2>/dev/null || true
 
     emit_git_ref_step_summary "$output_log" "$rc"
     return "$rc"


### PR DESCRIPTION
## Summary

Runs the upstream rsync testsuite in **both root and non-root modes** for the
pinned 3.4.4 required gate and the 3.5.0dev nightly tracker. Previously neither
suite ran root, and the 3.5.0dev non-root run reported ~25 FAILs whose count was
dominated by environment noise (a mode-0-dir PermissionError cascade + daemon
tests degrading to SKIP without a TCP socket).

## Env fixes (`tools/ci/run_upstream_testsuite.sh`, git-ref mode)

- **`--use-tcp`** (gated on `USE_TCP=yes`): daemon/proxy tests run against a
  real loopback rsyncd (`RSYNC_TEST_USE_TCP=1`) instead of SKIPping under the
  secure stdio-pipe default.
- **Permission-safe scratch cleanup**: the scratch tree is driven from a
  dedicated, mode+transport-tagged dir under the log root (never a bind mount),
  force-cleared with `chmod -R u+rwX` before `rm -rf`, before and after the run.
  Kills the cross-run cascade a mode-0 leftover dir triggers.

## Matrix wiring

- **3.5.0dev tracker** (`track-3.5.0dev-testsuite.yml`, informational):
  `privilege {nonroot,root} x transport {pipe,tcp}` = 4 legs, `fail-fast:
  false`, `continue-on-error`. Root legs re-exec under passwordless `sudo`
  (env + GHA summary sink forwarded) and `chown` scratch/logs back afterward.
- **Required 3.4.4 gate** (`_upstream-testsuite.yml`): existing non-root job
  (context `upstream testsuite`) untouched -> required gate stays green. New
  `upstream-testsuite-root` job runs the same 3.4.4 shell suite under `sudo`,
  **informational** (`continue-on-error`). The 3.4.4 shell suite has no
  `--use-tcp` (a runtests.py/master flag), so this gate is privilege-only.

## Validation

### Required 3.4.4 gate (PR CI, run 28566291156) - stays green in BOTH modes

- **`upstream testsuite` (required, non-root): 52 / 0 / 5 - GREEN** (unchanged).
- **`upstream testsuite (root, informational)`: 53 / 1 / 3** - root-only tests
  (chown, dir-sgid, protected-regular) now RUN and PASS. The single fail is
  `devices`: containerized GitHub-runner root lacks `CAP_MKNOD`, so `mknod` is
  denied even as root - an environment limit, not an oc bug.
  **Kept informational (NOT promoted to required)**: a required root leg would
  fail every PR on the mknod limit, wedging the gate. Per the "confirmed green
  before required" invariant it stays informational until the mknod-capable
  runner question is settled.

### 3.5.0dev tracker (dispatch run 28566295381) - the number is not yet
authoritative

| Leg | passed / failed / skipped |
|-----|---------------------------|
| nonroot / pipe | 82 / 25 / 5 |
| nonroot / tcp  | 83 / 26 / 3 |
| root / pipe    | 83 / 24 / 5 |
| root / tcp     | 85 / 25 / 2 |

`--use-tcp` works: `proxy-response-line-too-long`, `daemon-chroot-acl`, and
`daemon-access-ip` (SKIP under pipe with "run with --use-tcp") PASS under
tcp+root; tcp uniquely surfaces `daemon-auth` (only reachable over a socket).

**The env fixes removed the cross-run PermissionError cascade, but the leg
counts are NOT yet a trustworthy oc-divergence number.** The 3.5.0dev suite is
the Python `*_test.py` framework (rsyncfns.py); a plain
`runtests.py --rsync-bin=oc-rsync` mis-drives a subset of it. So the FAILs split
into two classes:

**(A) Harness-calibration gaps (fix in the tracker first; NOT oc divergences):**
- `partial` / `partial_nowrite`: run oc via `setpriv`, which fails
  `setpriv: failed to execute .../oc-rsync: No such file or directory` (dropped
  exec context can't resolve the binary/interp). The pre-transfer setup then
  never runs, cascading a Python `FileNotFoundError` (missing `FROMDIR`).
- Any FAIL whose log shows setpriv / FileNotFoundError / EACCES-scandir is a
  framework gap, not oc. (Documented in the tracker workflow header as
  follow-up: setpriv exec shim, per-test setup ordering, in-framework
  permission-safe teardown.)

**(B) Real oc <-> 3.5.0dev divergences (clear oc error, fail under pipe AND tcp;
for the July-15 worklist - not fixed in this CI-config PR):**
- `ownership-depth`: oc rejects `--groupmap=:1` ("--groupmap entries must
  specify a source selector"); upstream accepts an empty source selector.
- `mkpath` / `file-to-file-mkpath-dry-run`: oc creates the missing intermediate
  path WITHOUT `--mkpath`.
- `compress-options`: oc emits no `compress: <algo> (level N)` line for
  `--debug=NSTR` (upstream compat.c:216).
- `fuzzy` / `fuzzy-basis`: `--fuzzy` does not select the basis file.
- `compare`: `--modify-window=2` does not absorb a 1s mtime diff.
- `daemon-refuse`: `refuse=delete` module does not refuse `--delete`.
- `daemon-auth` (tcp-only): daemon auth divergence, only over a real socket.
- `recv-discard-nullderef` (non-root only): sender opens the mode-0 dest dir and
  dies "Permission denied (13)" instead of the discard path (exit 23); SKIPs
  under root. This test's mode-0 dir also seeded the old non-root cascade.
- Plus `chmod-option`, `devices`/`devices-fake` itemize, `xattrs`/`xattrs-hlink`
  perms, `chown`/`chown-fake`, `delete-deep`, `delete-missing-args-files-from`,
  `files-from-depth`, `filter-depth`, `relative-implied`, `update`,
  `preallocate` (each needs per-test triage to confirm real vs harness).

## Follow-up (separate PR)

Calibrate the 3.5.0dev Python harness (setpriv exec path, `*_test.py` setup
ordering, in-framework root-owned cleanup) so its leg count becomes an
authoritative oc-divergence figure, then triage class (B) into the divergence
worklist.

## Invariants

`--locked` preserved on every cargo call; new action SHAs pinned to sibling
values; `yaml.safe_load` + `bash -n` + `shellcheck` clean.
