### PR TITLE
fix(metadata): accept empty source selector in usermap/groupmap

### DIFF
--- a/crates/metadata/src/mapping/parse.rs
+++ b/crates/metadata/src/mapping/parse.rs
@@ -18,9 +18,14 @@ use super::types::{MappingKind, MappingMatcher, MappingParseError, MappingTarget
 /// - Glob patterns containing `*`, `?`, or `[`
 /// - Otherwise, treated as an exact name string
 ///
-/// An empty source is rejected with a [`MappingParseError`].
+/// An empty source (e.g., `:1`) is accepted as an exact-empty-name matcher,
+/// which maps the nameless id (root, when the sender omits the id-0 name).
+/// upstream: uidlist.c:parse_name_map - an empty from-part is not numeric and
+/// not a wildcard, so it falls through to the `NFLAGS_NAME_MATCH` branch with
+/// `noiu.name = ""`, matching the nameless id (recv_add_id normalizes a missing
+/// name to "" before the strcmp).
 pub(crate) fn parse_matcher(
-    kind: MappingKind,
+    _kind: MappingKind,
     source: &str,
     _entry: &str,
 ) -> Result<MappingMatcher, MappingParseError> {
@@ -34,13 +39,6 @@ pub(crate) fn parse_matcher(
 
     if source.chars().any(|ch| matches!(ch, '*' | '?' | '[')) {
         return Ok(MappingMatcher::Pattern(source.to_owned()));
-    }
-
-    if source.is_empty() {
-        return Err(MappingParseError::new(
-            kind,
-            format!("{} entries must specify a source selector", kind.flag()),
-        ));
     }
 
     Ok(MappingMatcher::ExactName(source.to_owned()))

--- a/crates/metadata/src/mapping/tests.rs
+++ b/crates/metadata/src/mapping/tests.rs
@@ -172,9 +172,11 @@ fn parse_multiple_rules() {
 }
 
 #[test]
-fn parse_empty_source_fails() {
-    let error = NameMapping::parse(MappingKind::User, ":100").unwrap_err();
-    assert!(error.to_string().contains("must specify a source"));
+fn parse_empty_source_maps_nameless_id() {
+    // upstream uidlist.c:parse_name_map accepts an empty from-part as the
+    // empty-name (nameless id) matcher; ":100" maps the nameless user to 100.
+    let mapping = NameMapping::parse(MappingKind::User, ":100").expect("parse mapping");
+    assert_eq!(mapping.len(), 1);
 }
 
 #[test]

--- a/crates/metadata/src/mapping/tests.rs
+++ b/crates/metadata/src/mapping/tests.rs
@@ -582,9 +582,43 @@ fn parse_matcher_exact_name() {
 }
 
 #[test]
-fn parse_matcher_empty_fails() {
-    let error = parse_matcher(MappingKind::User, "", ":0").unwrap_err();
-    assert!(error.to_string().contains("must specify a source"));
+fn parse_matcher_empty_source_is_empty_exact_name() {
+    // upstream: uidlist.c:parse_name_map accepts an empty from-part (e.g. the
+    // `:1` in `--groupmap=:1`). It is neither numeric nor a wildcard, so it
+    // falls through to the `NFLAGS_NAME_MATCH` branch with `noiu.name = ""`,
+    // i.e. an exact-empty-name matcher. Rejecting it would diverge from
+    // upstream and break mapping of the nameless id.
+    let user = parse_matcher(MappingKind::User, "", ":1").unwrap();
+    assert_eq!(user, MappingMatcher::ExactName(String::new()));
+    let group = parse_matcher(MappingKind::Group, "", ":1").unwrap();
+    assert_eq!(group, MappingMatcher::ExactName(String::new()));
+}
+
+#[test]
+fn empty_source_matcher_maps_nameless_id() {
+    // upstream: uidlist.c:recv_add_id normalizes a missing name to "" before
+    // the strcmp, so the empty-name matcher matches the nameless id (root when
+    // the sender omits the id-0 name). The lookup returning `None` (no name)
+    // must therefore match `ExactName("")`, and any non-empty exact name must
+    // not.
+    let matcher = MappingMatcher::ExactName(String::new());
+    assert!(matcher.matches(0, || Ok(None)).unwrap());
+    assert!(matcher.matches(0, || Ok(Some(String::new()))).unwrap());
+    assert!(!matcher.matches(0, || Ok(Some("root".to_owned()))).unwrap());
+
+    // A non-empty exact name must not match the nameless id.
+    let named = MappingMatcher::ExactName("root".to_owned());
+    assert!(!named.matches(0, || Ok(None)).unwrap());
+}
+
+#[test]
+fn empty_source_groupmap_parses_and_targets_gid() {
+    // `--groupmap=:1` means "map the nameless (root) group to gid 1".
+    let mapping = NameMapping::parse(MappingKind::Group, ":1").unwrap();
+    assert_eq!(mapping.len(), 1);
+    let rule = &mapping.rules[0];
+    assert_eq!(rule.matcher, MappingMatcher::ExactName(String::new()));
+    assert_eq!(rule.target, MappingTarget::Id(1));
 }
 
 #[test]

--- a/crates/metadata/src/mapping/types.rs
+++ b/crates/metadata/src/mapping/types.rs
@@ -77,6 +77,11 @@ impl MappingMatcher {
     /// `name_lookup` is invoked lazily and only by name-based variants
     /// ([`Self::ExactName`], [`Self::Pattern`]). Numeric and wildcard-all
     /// variants never trigger a name resolution.
+    ///
+    /// A missing name (the nameless id, e.g. root when the sender omits the
+    /// id-0 name) is normalized to the empty string before comparison, so an
+    /// empty-name matcher matches it. upstream: uidlist.c:recv_add_id -
+    /// `if (!name) name = ""` before the strcmp/wildmatch.
     pub(crate) fn matches<F>(&self, identifier: u32, mut name_lookup: F) -> io::Result<bool>
     where
         F: FnMut() -> io::Result<Option<String>>,
@@ -84,19 +89,9 @@ impl MappingMatcher {
         Ok(match self {
             Self::Any => true,
             Self::IdRange { start, end } => (identifier >= *start) && (identifier <= *end),
-            Self::ExactName(expected) => {
-                if let Some(name) = name_lookup()? {
-                    name == *expected
-                } else {
-                    false
-                }
-            }
+            Self::ExactName(expected) => name_lookup()?.unwrap_or_default() == *expected,
             Self::Pattern(pattern) => {
-                if let Some(name) = name_lookup()? {
-                    wildcard_matches(pattern, &name)
-                } else {
-                    false
-                }
+                wildcard_matches(pattern, &name_lookup()?.unwrap_or_default())
             }
         })
     }


### PR DESCRIPTION
## Summary

`--usermap` / `--groupmap` rejected an empty source selector (e.g. `--groupmap=:1`, `--usermap=:UID`) with a parse error, diverging from upstream rsync.

Upstream 3.4.4 `uidlist.c:parse_name_map` accepts an empty from-part: it is neither numeric (`isDigit("")` is false) nor a wildcard (`strpbrk("", "*[?")` is NULL), so it falls through to the `NFLAGS_NAME_MATCH` branch with `noiu.name = ""` - an exact-empty-name matcher. Combined with `recv_add_id`'s `if (!name) name = ""` normalization, this matches the nameless id (root, when the sender omits the id-0 name). Identical in 3.5.0dev. So `:1` means "map the nameless/root group to gid 1".

## Changes

- `parse_matcher` no longer rejects an empty source; it parses to `ExactName("")`, mirroring upstream's fall-through to the empty-name matcher.
- `MappingMatcher::matches` normalizes a missing name (lookup returns `None`) to `""` before comparison, mirroring `recv_add_id`'s `if (!name) name = ""`, so the empty-name matcher matches the nameless id.
- Replaced the obsolete `parse_matcher_empty_fails` reject test with regression tests that assert an empty source parses to the empty-name matcher (for both `--usermap` and `--groupmap`) and maps the nameless/root id. Each test encodes the upstream rationale.

## Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p metadata --all-targets --all-features --no-deps --locked -- -D warnings`: no issues.

Upstream reference: `uidlist.c:parse_name_map` (empty from-part -> empty-name matcher) and `uidlist.c:recv_add_id` (missing name normalized to `""`).
