### PR TITLE
fix: symmetric --modify-window mtime comparison (upstream same_time parity)

### DIFF
--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -215,29 +215,34 @@ fn unix_seconds(time: SystemTime) -> i64 {
     }
 }
 
-/// Returns `true` when two timestamps differ by no more than `window`.
+/// Returns `true` when two timestamps are the "same" under `--modify-window`.
 ///
-/// With a zero window the comparison is at whole-second granularity: the
-/// sub-second component of each timestamp is discarded before comparing. This
-/// mirrors upstream, which stores the source `modtime` as a `time_t` and whose
-/// `same_time()` helper reduces to `f1_sec == f2_sec` when `modify_window == 0`,
-/// so a destination that only differs in the fractional second is still treated
-/// as up-to-date by the quick check.
+/// This is a direct port of upstream `util1.c:same_time()`, which the generator
+/// consults through `unchanged_file()` for the quick-check skip decision. Both
+/// timestamps are first truncated to whole seconds (mirroring the `time_t`
+/// storage of `st_mtime` / `file->modtime`), then:
 ///
-/// With a non-zero window the original full-resolution duration comparison is
-/// retained so sub-second `--modify-window` tolerances continue to apply.
+/// - `window == 0`: the seconds must be exactly equal (`f1_sec == f2_sec`), so a
+///   destination that only differs in the fractional second is still up-to-date.
+/// - `window > 0`: a SYMMETRIC whole-second tolerance applies, matching upstream
+///   `f2_sec > f1_sec ? f2_sec - f1_sec <= modify_window : f1_sec - f2_sec <=
+///   modify_window` -- i.e. `|a_sec - b_sec| <= window_secs`. Nanoseconds do not
+///   figure into the window check ("time windows don't care about that").
 ///
-/// upstream: generator.c:unchanged_file() -> same_time() - whole-second
-/// comparison when `modify_window == 0`.
+/// upstream: util1.c:1478 same_time() (via generator.c unchanged_file()).
 pub(crate) fn system_time_within_window(a: SystemTime, b: SystemTime, window: Duration) -> bool {
+    // Truncate to whole seconds, exactly as upstream compares `time_t` values.
+    let a_sec = unix_seconds(a);
+    let b_sec = unix_seconds(b);
+
     if window.is_zero() {
-        return unix_seconds(a) == unix_seconds(b);
+        // upstream: same_time() returns `f1_sec == f2_sec` when modify_window == 0.
+        return a_sec == b_sec;
     }
 
-    match a.duration_since(b) {
-        Ok(diff) => diff <= window,
-        Err(_) => matches!(b.duration_since(a), Ok(diff) if diff <= window),
-    }
+    // upstream: same_time() applies a symmetric window on whole seconds --
+    // nanoseconds are deliberately ignored (util1.c:1484).
+    a_sec.abs_diff(b_sec) <= window.as_secs()
 }
 
 enum LockstepCheck {
@@ -506,6 +511,61 @@ mod tests {
             next_second,
             Duration::ZERO
         ));
+    }
+
+    #[test]
+    fn system_time_window_is_symmetric_on_whole_seconds() {
+        // WHY: upstream util1.c:1478 same_time() treats two mtimes as equal when
+        // their whole-second delta is within `--modify-window`, and the window is
+        // SYMMETRIC (|a_sec - b_sec| <= window) regardless of which side is newer.
+        // A window of 2 must treat mtimes exactly 2s apart as the same file in
+        // BOTH directions, so the quick check does not needlessly re-transfer a
+        // content-identical file. This is the divergence being fixed: the previous
+        // implementation compared full-resolution durations, so a source at .0s and
+        // a destination at +2.9s (whole-second delta 2, within window) was wrongly
+        // seen as 2.9s apart and re-transferred.
+        let window = Duration::from_secs(2);
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let plus_two = base + Duration::from_secs(2);
+        let minus_two = base - Duration::from_secs(2);
+
+        assert!(system_time_within_window(base, plus_two, window));
+        assert!(system_time_within_window(plus_two, base, window));
+        assert!(system_time_within_window(base, minus_two, window));
+        assert!(system_time_within_window(minus_two, base, window));
+
+        // Sub-second parts must not tip a within-window pair over the edge:
+        // upstream ignores nanoseconds for the window check (util1.c:1484). Source
+        // at .0s vs destination at +2.9s is a whole-second delta of 2 -> same.
+        let base_frac = base + Duration::from_millis(0);
+        let plus_two_frac = base + Duration::new(2, 900_000_000);
+        assert!(system_time_within_window(base_frac, plus_two_frac, window));
+    }
+
+    #[test]
+    fn system_time_window_three_seconds_apart_differ_at_window_two() {
+        // WHY: with `--modify-window=2`, a whole-second delta of 3 exceeds the
+        // tolerance, so upstream same_time() returns 0 (different) and the file
+        // must be re-transferred. Guards against an off-by-one that would swallow
+        // a genuinely stale destination.
+        let window = Duration::from_secs(2);
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let plus_three = base + Duration::from_secs(3);
+
+        assert!(!system_time_within_window(base, plus_three, window));
+        assert!(!system_time_within_window(plus_three, base, window));
+    }
+
+    #[test]
+    fn system_time_zero_window_one_second_apart_differ() {
+        // WHY: `--modify-window=0` requires exact whole-second equality
+        // (same_time() reduces to `f1_sec == f2_sec`), so mtimes one second apart
+        // are different and the destination is re-transferred.
+        let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let plus_one = base + Duration::from_secs(1);
+
+        assert!(!system_time_within_window(base, plus_one, Duration::ZERO));
+        assert!(!system_time_within_window(plus_one, base, Duration::ZERO));
     }
 
     #[test]

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -665,8 +665,14 @@ fn modify_window_recursive_mixed_timestamps() {
     );
 }
 
+/// upstream `util1.c:same_time()` compares `time_t` (whole-second) values and
+/// deliberately ignores nanoseconds for the window check ("time windows don't
+/// care about that"). `--modify-window` is parsed as whole seconds upstream
+/// (`int modify_window`), so two mtimes in the same second are always treated
+/// as equal regardless of their fractional part. A +100ms sub-second delta
+/// therefore reduces to the same second and the file is skipped.
 #[test]
-fn modify_window_subsecond_precision_within_window() {
+fn modify_window_subsecond_same_second_skips() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
@@ -674,7 +680,7 @@ fn modify_window_subsecond_precision_within_window() {
     fs::write(&source, b"content").expect("write source");
     fs::write(&destination, b"content").expect("write dest");
 
-    // Differ by 100 milliseconds
+    // Differ by 100 milliseconds within the same whole second.
     let base_time = FileTime::from_unix_time(1_700_000_000, 0);
     let subsec_diff = FileTime::from_unix_time(1_700_000_000, 100_000_000); // +100ms
     set_file_times(&source, base_time, base_time).expect("set source times");
@@ -686,51 +692,14 @@ fn modify_window_subsecond_precision_within_window() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // 1-second window should tolerate 100ms difference
     let summary = plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_millis(500)),
+            LocalCopyOptions::default().with_modify_window(Duration::from_secs(1)),
         )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 0);
-}
-
-#[test]
-fn modify_window_subsecond_precision_outside_window() {
-    let temp = tempdir().expect("tempdir");
-    let source = temp.path().join("source.txt");
-    let destination = temp.path().join("dest.txt");
-
-    fs::write(&source, b"new content").expect("write source");
-    fs::write(&destination, b"old content").expect("write dest");
-
-    // Differ by 600 milliseconds
-    let base_time = FileTime::from_unix_time(1_700_000_000, 0);
-    let subsec_diff = FileTime::from_unix_time(1_700_000_000, 600_000_000); // +600ms
-    set_file_times(&source, subsec_diff, subsec_diff).expect("set source times");
-    set_file_times(&destination, base_time, base_time).expect("set dest times");
-
-    let operands = vec![
-        source.into_os_string(),
-        destination.clone().into_os_string(),
-    ];
-    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
-
-    // 500ms window should NOT tolerate 600ms difference
-    let summary = plan
-        .execute_with_options(
-            LocalCopyExecution::Apply,
-            LocalCopyOptions::default().with_modify_window(Duration::from_millis(500)),
-        )
-        .expect("copy succeeds");
-
-    assert_eq!(summary.files_copied(), 1);
-    assert_eq!(
-        fs::read(&destination).expect("read dest"),
-        b"new content"
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

With `--modify-window=N`, two mtimes that differ by exactly `N` whole seconds must compare EQUAL so the quick check skips the transfer. The local-copy skip predicate `system_time_within_window` compared full-resolution `Duration`s instead of truncating to whole seconds first, diverging from upstream `same_time`.

Concretely, a source at second `T.0` and a destination at `T+N.9` have a whole-second delta of `N` (within the window), but the old code measured them as `N.9s` apart and re-transmitted a content-identical file.

## Upstream reference

`target/interop/upstream-src/rsync-3.4.4/util1.c:1478` `same_time()`:

```c
int same_time(time_t f1_sec, unsigned long f1_nsec, time_t f2_sec, unsigned long f2_nsec)
{
    if (modify_window == 0)
        return f1_sec == f2_sec;
    if (modify_window < 0)
        return f1_sec == f2_sec && f1_nsec == f2_nsec;
    /* The nanoseconds do not figure into these checks -- time windows don't care about that. */
    if (f2_sec > f1_sec)
        return f2_sec - f1_sec <= modify_window;
    return f1_sec - f2_sec <= modify_window;
}
```

The window check is symmetric on whole seconds (`|f1_sec - f2_sec| <= modify_window`) and deliberately ignores nanoseconds. `--modify-window` is a whole-second `int` upstream and is parsed as whole `u64` seconds here, so sub-second windows never occur in practice.

## Change

`crates/engine/src/local_copy/executor/file/comparison.rs`: `system_time_within_window` now floors both timestamps to whole seconds (reusing the existing `unix_seconds` helper) and applies a symmetric `|a_sec - b_sec| <= window_secs` bound. Zero-window still requires exact whole-second equality, matching `f1_sec == f2_sec`.

## Tests

New unit tests on `system_time_within_window` encode the WHY:
- window=2 -> mtimes exactly 2s apart are the "same" in both directions (skip); sub-second parts do not tip a within-window pair over the edge.
- window=2 -> 3s apart differ (re-transfer).
- window=0 -> 1s apart differ.

The sub-second window integration test was replaced with a whole-second-truncation test, since upstream has no sub-second window semantics.