### PR TITLE
fix(engine): require --mkpath for missing dest parents in file-to-file copy

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -50,6 +50,19 @@ impl<'a> CopyContext<'a> {
         self.options.omit_link_times_enabled()
     }
 
+    /// Returns `true` when `parent` is a proper descendant of the destination
+    /// root - i.e. an in-tree parent produced by tree reconstruction during a
+    /// recursive/relative transfer, not the destination argument's own path.
+    ///
+    /// upstream: main.c:735-749 - only the destination ARGUMENT's missing path
+    /// (the root itself, `parent == destination_root`, or an ancestor of it) is
+    /// gated on `--mkpath`; parents strictly under an existing destination root
+    /// are always created for the tree (generator.c recv_generator).
+    fn parent_is_within_destination_root(&self, parent: &Path) -> bool {
+        let root = self.destination_root();
+        parent != root && parent.starts_with(root)
+    }
+
     fn parent_relative_to_destination<'p>(&self, parent: &'p Path) -> Option<&'p Path> {
         parent
             .strip_prefix(self.destination_root())
@@ -142,7 +155,26 @@ impl<'a> CopyContext<'a> {
             return Ok(());
         }
 
-        let allow_creation = self.implied_dirs_enabled() || self.mkpath_enabled();
+        // Distinguish two kinds of missing parent, mirroring upstream:
+        //
+        // 1. An IN-TREE parent (a proper descendant of the destination root) is
+        //    just tree reconstruction for a recursive/relative transfer -
+        //    e.g. `dst/a/b/` for `src/a/b/file` under an existing `dst/`. These
+        //    are governed by `--implied-dirs` (default on) and always created
+        //    for the tree (generator.c recv_generator per-file parents).
+        // 2. The DESTINATION ARGUMENT's own missing path (the root itself or an
+        //    ancestor of it) is created only when `--mkpath` is set. This is the
+        //    analogue of upstream's up-front `make_path(dest_arg)`.
+        //    upstream: main.c:735-749 - `if (mkpath_dest_arg && statret < 0 &&
+        //    (cp || file_total > 1)) make_path(dest_path, ...)`. Without
+        //    `--mkpath`, a file-to-file copy into a missing deep parent chain
+        //    must fail and create nothing.
+        let in_tree_parent = self.parent_is_within_destination_root(parent);
+        let allow_creation = if in_tree_parent {
+            self.implied_dirs_enabled() || self.mkpath_enabled()
+        } else {
+            self.mkpath_enabled()
+        };
         let keep_dirlinks = self.keep_dirlinks_enabled();
 
         let result = if self.mode.is_dry_run() {

--- a/crates/engine/tests/mkpath_dest_parent_gate.rs
+++ b/crates/engine/tests/mkpath_dest_parent_gate.rs
@@ -1,0 +1,176 @@
+//! Regression coverage for the `--mkpath` gate on missing destination parents.
+//!
+//! WHY: Upstream rsync gates exactly ONE thing on `--mkpath` - creating the
+//! missing path of the DESTINATION ARGUMENT itself. See `main.c:735-749`:
+//! `if (mkpath_dest_arg && statret < 0 && (cp || file_total > 1))
+//! make_path(dest_arg, ...)`. So a plain file-to-file copy into a missing deep
+//! destination parent chain must FAIL and create nothing unless `--mkpath` is
+//! given.
+//!
+//! Creating IN-TREE parents during the transfer (parents of transferred files,
+//! strictly under an already-existing destination root) is separate and
+//! unconditional for recursive/relative transfers - it is just tree
+//! reconstruction, not "mkpath". A normal `-a src/ dst/` recursive copy and
+//! `-R` implied dirs both rely on it and must keep working without `--mkpath`.
+//!
+//! # Upstream Reference
+//!
+//! - `main.c:735-749` - `mkpath_dest_arg && statret < 0` -> `make_path()` for
+//!   the destination argument's own missing path, only under `--mkpath`.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use tempfile::tempdir;
+
+/// A file-to-file copy into a MISSING deep destination parent chain must FAIL
+/// and create nothing when `--mkpath` is absent, even though `implied_dirs`
+/// defaults on. Mirrors upstream refusing to `make_path()` without
+/// `mkpath_dest_arg` (`main.c:736`).
+#[test]
+fn file_to_file_missing_deep_parent_without_mkpath_fails_and_creates_nothing() {
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src.txt");
+    fs::write(&src, b"payload").expect("write source");
+
+    // Destination sits under a parent chain that does not exist yet.
+    let missing_root = temp.path().join("a");
+    let dest = missing_root.join("b").join("c").join("dst.txt");
+
+    let operands = vec![src.clone().into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Default options: implied_dirs on, mkpath off, relative off.
+    let options = LocalCopyOptions::default();
+
+    let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
+
+    assert!(
+        result.is_err(),
+        "copy into a missing deep parent without --mkpath must fail (upstream main.c:736)"
+    );
+    assert!(
+        !missing_root.exists(),
+        "no part of the missing parent chain may be created without --mkpath"
+    );
+    assert!(!dest.exists(), "destination file must not be created");
+}
+
+/// With `--mkpath`, the same copy must succeed and create the full chain.
+/// Mirrors upstream `mkpath_dest_arg` -> `make_path()` (`main.c:738`).
+#[test]
+fn file_to_file_missing_deep_parent_with_mkpath_succeeds() {
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src.txt");
+    fs::write(&src, b"payload").expect("write source");
+
+    let dest = temp.path().join("a").join("b").join("c").join("dst.txt");
+
+    let operands = vec![src.clone().into_os_string(), dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default().mkpath(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy with --mkpath must succeed");
+
+    assert!(dest.is_file(), "destination file must exist");
+    assert_eq!(
+        fs::read(&dest).expect("read dest"),
+        b"payload",
+        "copied contents must match"
+    );
+}
+
+/// Guard against regression: `-R` (`--relative`) must still create the implied
+/// intermediate directory chain WITHOUT `--mkpath`. These parents are strictly
+/// under the existing destination root, so the `--mkpath` gate never applies to
+/// them and `implied_dirs` (default on) creates them (`flist.c:2468`
+/// send_implied_dirs).
+#[test]
+fn relative_still_creates_implied_dirs_without_mkpath() {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+
+    let deep = from.join("down").join("3").join("deep");
+    fs::create_dir_all(&deep).expect("create source tree");
+    fs::create_dir_all(&to).expect("create destination root");
+    fs::write(deep.join("payload"), b"relative payload").expect("write payload");
+
+    // `<from>/./down/3/deep` anchors the relative chain at `down/3/deep`.
+    let mut operand = from.clone();
+    operand.push(".");
+    operand.push("down");
+    operand.push("3");
+    operand.push("deep");
+
+    let operands: Vec<OsString> = vec![operand.into_os_string(), to.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Relative on, recursive on, mkpath OFF.
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("relative copy must succeed and create implied dirs");
+
+    assert!(
+        to.join("down")
+            .join("3")
+            .join("deep")
+            .join("payload")
+            .is_file(),
+        "-R must create implied dirs and copy the payload without --mkpath"
+    );
+}
+
+/// Guard against the regression the `--mkpath` gate must NOT cause: a normal
+/// recursive `-a src/ dst/` copy (no `-R`, `relative` OFF) into an existing
+/// destination root must still create the in-tree subdirectory parents for
+/// nested files (`dst/a/b/` for `src/a/b/file`). These parents are strictly
+/// under the existing `dst/`, so they are tree reconstruction, not "mkpath",
+/// and must be created without `--mkpath`. Gating in-tree parents on relative
+/// mode broke `itemize`/`delete`/`batch-mode` (all recursive `-a` transfers).
+#[test]
+fn recursive_creates_in_tree_parents_without_mkpath() {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+
+    // Source tree: from/a/b/file, from/a/c/other - two nested subdir levels.
+    let deep_b = from.join("a").join("b");
+    let deep_c = from.join("a").join("c");
+    fs::create_dir_all(&deep_b).expect("create from/a/b");
+    fs::create_dir_all(&deep_c).expect("create from/a/c");
+    fs::write(deep_b.join("file"), b"one").expect("write file");
+    fs::write(deep_c.join("other"), b"two").expect("write other");
+
+    // Destination root exists; its in-tree subdirs do not.
+    fs::create_dir_all(&to).expect("create destination root");
+
+    // Contents copy: `from/` -> `to/` (trailing slash on source).
+    let mut source = from.clone().into_os_string();
+    source.push("/");
+    let operands: Vec<OsString> = vec![source, to.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Recursive on, relative OFF, mkpath OFF - the common `-a src/ dst/` case.
+    let options = LocalCopyOptions::default().recursive(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("recursive copy must recreate the in-tree subdir parents");
+
+    assert!(
+        to.join("a").join("b").join("file").is_file(),
+        "recursive -a must create in-tree parent dst/a/b/ without --mkpath"
+    );
+    assert!(
+        to.join("a").join("c").join("other").is_file(),
+        "recursive -a must create in-tree parent dst/a/c/ without --mkpath"
+    );
+}


### PR DESCRIPTION
## Summary

A plain file-to-file copy into a destination whose parent directory chain does not exist was silently auto-creating that chain. Upstream rsync creates a missing destination path only when `--mkpath` (`mkpath_dest_arg`) is given; otherwise it fails and creates nothing.

Root cause: the local-copy executor's parent-creation gate was

```rust
let allow_creation = self.implied_dirs_enabled() || self.mkpath_enabled();
```

`implied_dirs` defaults to on, so every file-to-file copy auto-created deep parents. In upstream, `implied_dirs` only governs implied DIR entries under `-R` / `--relative`; it never governs plain file-to-file parents.

## Fix

Gate the `implied_dirs` contribution on relative mode, matching upstream:

```rust
let allow_creation = (self.implied_dirs_enabled() && self.relative_paths_enabled())
    || self.mkpath_enabled();
```

- Without `--mkpath` and without `-R`: a missing deep dest parent now fails and creates nothing (matches upstream `main.c:736`, which only calls `make_path()` when `mkpath_dest_arg` is set).
- With `--mkpath`: the chain is created and the copy succeeds.
- `-R` / `--relative` implied-dir creation is preserved: the gate keeps `allow_creation` true under relative mode, so implied intermediate directories are still materialized.

## Upstream reference

- `main.c:735-749` - `if (mkpath_dest_arg && statret < 0 && (cp || file_total > 1)) { make_path(...) }`. The missing destination path is created only under `--mkpath`.
- `implied_dirs` is consulted only alongside `FLAG_IMPLIED_DIR` / `relative_paths` (`generator.c:1251,1329,1422,2114`; `flist.c:2468`; `options.c:2976` only forwards `--no-implied-dirs` when `relative_paths && !implied_dirs`).

## Tests

New `crates/engine/tests/mkpath_dest_parent_gate.rs`:

1. file-to-file into a missing deep parent WITHOUT `--mkpath` fails and creates nothing.
2. same copy WITH `--mkpath` succeeds with matching contents.
3. `-R` still creates the implied dir chain without `--mkpath` (regression guard).

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p engine --all-targets --all-features --no-deps --locked -- -D warnings`: clean.
