### PR TITLE
fix(engine): local-copy --fuzzy basis selection and --debug=NSTR summaries

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -697,6 +697,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .dirs(config.dirs())
             .implied_dirs(config.implied_dirs())
             .mkpath(config.mkpath())
+            .fuzzy_level(config.fuzzy_level())
             .prune_empty_dirs(config.prune_empty_dirs())
             .inplace(config.inplace())
             .append(config.append())

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -320,6 +320,14 @@ fn run_client_internal(
         filters::compile_filter_program(config.filter_rules(), config.delete_excluded())?;
     let mut options = build_local_copy_options(&config, filter_program);
 
+    // A local copy bypasses the wire, so the capability negotiator - the only
+    // place trace_checksum_summary/trace_compress_summary fire on the wire path
+    // - never runs. Upstream forks a real local_child server (main.c:649-654)
+    // whose parse_checksum_choice/parse_compress_choice still emit the NSTR
+    // summary lines, so reproduce them here from the resolved algorithms.
+    // upstream: checksum.c:206-211, compat.c:213-219 (DEBUG_GTE(NSTR, 1) client).
+    emit_local_copy_nstr_summaries(&config);
+
     let batch_writer_for_options = if let Some(ref writer) = batch_writer {
         batch::write_batch_header(writer, &config)?;
         Some(writer.clone())
@@ -436,6 +444,77 @@ fn apply_max_alloc(config: &ClientConfig) {
     // initialised the pool; their configuration wins to avoid silently
     // overriding their settings.
     let _ = init_global_buffer_pool(cfg);
+}
+
+/// Maps the engine's strong-checksum choice to the NSTR wire name upstream
+/// prints in the `parse_checksum_choice` summary. Names match
+/// `protocol::ChecksumAlgorithm::as_str` / upstream `valid_checksums_items[]`
+/// (checksum.c:49-64).
+const fn signature_checksum_nstr_name(
+    algorithm: engine::signature::SignatureAlgorithm,
+) -> &'static str {
+    use engine::signature::SignatureAlgorithm;
+    match algorithm {
+        SignatureAlgorithm::Md4 | SignatureAlgorithm::Md4Seeded { .. } => "md4",
+        SignatureAlgorithm::Md5 { .. } => "md5",
+        SignatureAlgorithm::Sha1 => "sha1",
+        SignatureAlgorithm::Xxh64 { .. } => "xxh64",
+        SignatureAlgorithm::Xxh3 { .. } => "xxh3",
+        SignatureAlgorithm::Xxh3_128 { .. } => "xxh128",
+    }
+}
+
+/// Emits the `--debug=NSTR` checksum and compress summary lines for a local
+/// copy, mirroring what upstream's forked `local_child` server prints via
+/// `parse_checksum_choice` / `parse_compress_choice`.
+///
+/// The local path performs no vstring negotiation, so the `" negotiated"`
+/// qualifier stays blank (upstream leaves `negotiated_nni` NULL when the
+/// algorithm is not chosen through `negotiate_the_strings()`). The trace
+/// helpers self-gate on the NSTR debug level, so this is a no-op unless
+/// `--debug=NSTR` is active.
+///
+/// upstream: checksum.c:206-211 (`"%s%s checksum: %s"`),
+/// compat.c:213-219 (`"%s%s compress: %s (level %d)"`), both at
+/// `DEBUG_GTE(NSTR, am_server ? 3 : 1)` - the client side is level 1.
+fn emit_local_copy_nstr_summaries(config: &ClientConfig) {
+    use protocol::nstr::{
+        CLVL_NOT_SPECIFIED, NstrSide, trace_checksum_summary, trace_compress_summary,
+    };
+
+    trace_checksum_summary(
+        NstrSide::Client,
+        false,
+        signature_checksum_nstr_name(config.checksum_signature_algorithm()),
+    );
+
+    // upstream: compat.c:214-215 - the compress summary only fires when
+    // `do_compression != CPRES_NONE || level != CLVL_NOT_SPECIFIED`.
+    let level = config
+        .compression_level()
+        .map_or(CLVL_NOT_SPECIFIED, compression_level_to_nstr);
+    if config.compress() || level != CLVL_NOT_SPECIFIED {
+        trace_compress_summary(
+            NstrSide::Client,
+            false,
+            config.compression_algorithm().name(),
+            level,
+        );
+    }
+}
+
+/// Maps a user-supplied `--compress-level` to the raw i32 upstream renders in
+/// the NSTR compress summary. upstream: token.c:init_compression_level() -
+/// zlib range 0..=9.
+fn compression_level_to_nstr(level: compress::zlib::CompressionLevel) -> i32 {
+    use compress::zlib::CompressionLevel;
+    match level {
+        CompressionLevel::None => 0,
+        CompressionLevel::Fast => 1,
+        CompressionLevel::Default => 6,
+        CompressionLevel::Best => 9,
+        CompressionLevel::Precise(n) => i32::from(n.get()),
+    }
 }
 
 /// Builder for [`LocalCopyOptions`] derived from a [`ClientConfig`] and

--- a/crates/core/tests/compression_integration.rs
+++ b/crates/core/tests/compression_integration.rs
@@ -242,3 +242,115 @@ fn test_large_file_with_compression() {
         assert_eq!(summary.bytes_copied() as usize, data.len());
     });
 }
+
+/// Collects `--debug=NSTR` messages emitted during `f`, initialising the
+/// thread-local logger at NSTR level 1 first. The local-copy path reads this
+/// same thread-local config, so the summary emitters fire on this thread.
+fn nstr_messages_during<F: FnOnce()>(f: F) -> Vec<String> {
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.nstr = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    f();
+
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Nstr,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A local `-z --debug=NSTR` copy must emit the upstream `checksum:` and
+/// `compress: <name> (level N)` NSTR summary lines even though the wire
+/// negotiator never runs for a local copy. upstream: checksum.c:206-211 and
+/// compat.c:213-219 - the forked local_child server prints these.
+#[test]
+fn local_copy_emits_nstr_summaries_under_debug_nstr() {
+    run_with_timeout(LOCAL_TIMEOUT, || {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        let dest_root = temp.path().join("dest");
+        fs::create_dir_all(&source_root).expect("source root");
+        fs::create_dir_all(&dest_root).expect("dest root");
+
+        touch(
+            &source_root.join("data.txt"),
+            &create_compressible_data(4096),
+        );
+        let mut source_arg = source_root.into_os_string();
+        source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+        let messages = nstr_messages_during(|| {
+            let config = ClientConfig::builder()
+                .transfer_args([source_arg, dest_root.into_os_string()])
+                .compress(true)
+                .build();
+            core::client::run_client(config).expect("run client");
+        });
+
+        // Checksum summary always fires. oc's default strong checksum choice
+        // (`Auto`) resolves locally to MD5, so that is the reported name -
+        // matching the algorithm the local delta path actually uses.
+        assert!(
+            messages.iter().any(|m| m == "Client checksum: md5"),
+            "expected NSTR checksum summary for local copy: {messages:?}"
+        );
+        // Compress fires because -z is active; no --compress-level means the
+        // upstream CLVL_NOT_SPECIFIED sentinel renders in the (level N) clause.
+        let expected = format!(
+            "Client compress: {} (level {})",
+            compress::algorithm::CompressionAlgorithm::default_algorithm().name(),
+            i32::MIN
+        );
+        assert!(
+            messages.contains(&expected),
+            "expected NSTR compress summary for local copy: {messages:?}"
+        );
+    });
+}
+
+/// `--compress-level=9` must render `(level 9)` in the local-copy NSTR compress
+/// summary, exercising the threaded level instead of the sentinel.
+#[test]
+fn local_copy_nstr_compress_summary_renders_explicit_level() {
+    run_with_timeout(LOCAL_TIMEOUT, || {
+        let temp = tempdir().expect("tempdir");
+        let source_root = temp.path().join("source");
+        let dest_root = temp.path().join("dest");
+        fs::create_dir_all(&source_root).expect("source root");
+        fs::create_dir_all(&dest_root).expect("dest root");
+
+        touch(
+            &source_root.join("data.txt"),
+            &create_compressible_data(4096),
+        );
+        let mut source_arg = source_root.into_os_string();
+        source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+        let level = compress::zlib::CompressionLevel::from_numeric(9).expect("level 9");
+        let messages = nstr_messages_during(|| {
+            let config = ClientConfig::builder()
+                .transfer_args([source_arg, dest_root.into_os_string()])
+                .compress(true)
+                .compression_level(Some(level))
+                .build();
+            core::client::run_client(config).expect("run client");
+        });
+
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.starts_with("Client compress: ") && m.ends_with("(level 9)")),
+            "expected compress summary to render level 9: {messages:?}"
+        );
+    });
+}

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -117,6 +117,10 @@ impl<'a> CopyContext<'a> {
         self.options.block_size_override()
     }
 
+    pub(super) const fn fuzzy_level_enabled(&self) -> u8 {
+        self.options.fuzzy_level_enabled()
+    }
+
     pub(super) const fn checksum_enabled(&self) -> bool {
         self.options.checksum_enabled()
     }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -32,6 +32,7 @@ use logging::{debug_log, info_log};
 
 use ::metadata::MetadataOptions;
 
+use crate::fuzzy::{FuzzyMatcher, trace_fuzzy_basis_selected};
 use crate::local_copy::{
     CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
     LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
@@ -116,6 +117,18 @@ pub(in crate::local_copy) fn execute_transfer(
         }
     }
 
+    // When the exact destination is absent and --fuzzy is active, look for a
+    // similarly-named file in the destination directory to serve as the delta
+    // basis. upstream: generator.c:1767-1795 - when `statret != 0 &&
+    // fuzzy_basis`, `find_fuzzy()` selects the closest-named candidate and the
+    // generator uses it as `fnamecmp` (the delta basis) instead of sending the
+    // whole file.
+    let fuzzy_basis = if !whole_file_enabled && existing_metadata.is_none() {
+        find_fuzzy_basis(context, destination, relative, file_type, file_size)
+    } else {
+        None
+    };
+
     // Build delta signature BEFORE backup renames the destination away.
     // upstream: receiver.c - the basis file must be read while it still exists
     // at the destination path. If backup runs first, the rename causes ENOENT
@@ -125,7 +138,12 @@ pub(in crate::local_copy) fn execute_transfer(
             Some(existing) if existing.is_file() => {
                 build_delta_signature(destination, existing, context.block_size_override())?
             }
-            _ => None,
+            _ => match fuzzy_basis {
+                Some((ref path, ref meta)) => {
+                    build_delta_signature(path, meta, context.block_size_override())?
+                }
+                None => None,
+            },
         }
     } else {
         None
@@ -137,7 +155,12 @@ pub(in crate::local_copy) fn execute_transfer(
     // upstream: receiver.c - the basis fd is opened before make_backup() runs;
     // here we track the new path because we cannot hold the fd across the
     // temp-file/inplace writer setup.
-    let mut delta_basis_override: Option<PathBuf> = None;
+    //
+    // A fuzzy basis is likewise a file separate from the (absent) destination:
+    // the writer creates a fresh destination while matched blocks are read from
+    // the fuzzy candidate, so seed the override with its path.
+    let mut delta_basis_override: Option<PathBuf> =
+        fuzzy_basis.as_ref().map(|(path, _)| path.clone());
     if let Some(existing) = existing_metadata {
         context.backup_existing_entry(destination, relative, existing.file_type())?;
         // When backup renamed the basis file and delta transfer will need it,
@@ -693,4 +716,46 @@ pub(in crate::local_copy) fn execute_transfer(
     )?;
 
     Ok(())
+}
+
+/// Finds a fuzzy delta basis for `destination` when the exact destination is
+/// absent and `--fuzzy` is active.
+///
+/// Scans the destination directory for the closest similarly-named regular
+/// file, reusing the shared [`FuzzyMatcher`] scorer. On a hit, emits the
+/// `--debug=FUZZY` selection line and returns the candidate's path and
+/// metadata so the caller can build a delta signature against it.
+///
+/// upstream: generator.c:1767-1795 - `find_fuzzy()` selects the basis and the
+/// generator announces `"fuzzy basis selected for %s: %s"` at
+/// `DEBUG_GTE(FUZZY, 1)` before using it as `fnamecmp`.
+fn find_fuzzy_basis(
+    context: &CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    file_type: fs::FileType,
+    file_size: u64,
+) -> Option<(PathBuf, fs::Metadata)> {
+    if context.fuzzy_level_enabled() == 0 || !file_type.is_file() {
+        return None;
+    }
+
+    let target_name = destination.file_name()?;
+    let dest_dir = destination.parent()?;
+
+    let matcher = FuzzyMatcher::with_level(context.fuzzy_level_enabled());
+    let candidate = matcher.find_fuzzy_basis(target_name, dest_dir, file_size)?;
+
+    let meta = fs::symlink_metadata(&candidate.path).ok()?;
+    if !meta.is_file() {
+        return None;
+    }
+
+    // upstream: generator.c:1787 - announce the selected basis at FUZZY,1. The
+    // target display mirrors upstream's `fname` (the relative transfer path)
+    // when available, falling back to the destination path.
+    let target_display = relative.unwrap_or(destination).display().to_string();
+    trace_fuzzy_basis_selected(&target_display, &candidate.path.display().to_string());
+
+    Some((candidate.path, meta))
 }

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -133,6 +133,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) force_replacements: bool,
     pub(super) implied_dirs: bool,
     pub(super) mkpath: bool,
+    pub(super) fuzzy_level: u8,
     pub(super) prune_empty_dirs: bool,
 
     pub(super) timeout: Option<Duration>,
@@ -260,6 +261,7 @@ impl LocalCopyOptionsBuilder {
             force_replacements: false,
             implied_dirs: true,
             mkpath: false,
+            fuzzy_level: 0,
             prune_empty_dirs: false,
             timeout: None,
             contimeout: None,

--- a/crates/engine/src/local_copy/options/builder/setters_path.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_path.rs
@@ -172,6 +172,13 @@ impl LocalCopyOptionsBuilder {
         self
     }
 
+    /// Sets the fuzzy basis matching level (0 = off, 1 = `--fuzzy`, 2 = `-yy`).
+    #[must_use]
+    pub fn fuzzy_level(mut self, level: u8) -> Self {
+        self.fuzzy_level = level;
+        self
+    }
+
     /// Enables prune-empty-dirs mode.
     #[must_use]
     pub fn prune_empty_dirs(mut self, enabled: bool) -> Self {

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -186,6 +186,7 @@ impl LocalCopyOptionsBuilder {
             force_replacements: self.force_replacements,
             implied_dirs: self.implied_dirs,
             mkpath: self.mkpath,
+            fuzzy_level: self.fuzzy_level,
             prune_empty_dirs: self.prune_empty_dirs,
             timeout: self.timeout,
             contimeout: self.contimeout,

--- a/crates/engine/src/local_copy/options/path_behavior.rs
+++ b/crates/engine/src/local_copy/options/path_behavior.rs
@@ -156,6 +156,18 @@ impl LocalCopyOptions {
         self
     }
 
+    /// Sets the fuzzy basis matching level (0 = off, 1 = `--fuzzy`, 2 = `-yy`).
+    ///
+    /// When non-zero and the exact destination file is absent, the executor
+    /// scans the destination directory for a similarly-named basis file to use
+    /// for delta transfer. Mirrors upstream `fuzzy_basis` in `options.c`.
+    #[must_use]
+    #[doc(alias = "--fuzzy")]
+    pub const fn fuzzy_level(mut self, level: u8) -> Self {
+        self.fuzzy_level = level;
+        self
+    }
+
     /// Prunes directories that would otherwise be empty after filtering.
     #[must_use]
     #[doc(alias = "--prune-empty-dirs")]
@@ -351,6 +363,14 @@ impl LocalCopyOptions {
     #[doc(alias = "--mkpath")]
     pub const fn mkpath_enabled(&self) -> bool {
         self.mkpath
+    }
+
+    /// Returns the fuzzy basis matching level (0 = off, 1 = `--fuzzy`,
+    /// 2 = `-yy`). Mirrors upstream `fuzzy_basis` in `options.c`.
+    #[must_use]
+    #[doc(alias = "--fuzzy")]
+    pub const fn fuzzy_level_enabled(&self) -> u8 {
+        self.fuzzy_level
     }
 
     /// Returns whether empty directories should be pruned after filtering.

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -210,6 +210,12 @@ pub struct LocalCopyOptions {
     pub(super) force_replacements: bool,
     pub(super) implied_dirs: bool,
     pub(super) mkpath: bool,
+    /// Fuzzy basis matching level (0 = off, 1 = `--fuzzy`, 2 = `-yy`).
+    ///
+    /// When non-zero and the exact destination file is absent, the local-copy
+    /// executor scans the destination directory for a similarly-named file to
+    /// use as the delta basis. Mirrors upstream `fuzzy_basis` in `options.c`.
+    pub(super) fuzzy_level: u8,
     pub(super) prune_empty_dirs: bool,
     pub(super) timeout: Option<Duration>,
     pub(super) contimeout: Option<Duration>,
@@ -339,6 +345,7 @@ impl LocalCopyOptions {
             force_replacements: false,
             implied_dirs: true,
             mkpath: false,
+            fuzzy_level: 0,
             prune_empty_dirs: false,
             timeout: None,
             contimeout: None,

--- a/crates/engine/tests/fuzzy_local_copy.rs
+++ b/crates/engine/tests/fuzzy_local_copy.rs
@@ -1,0 +1,187 @@
+//! Integration tests for `--fuzzy` basis selection in the local-copy executor.
+//!
+//! Upstream rsync's generator, when the exact destination file is absent and
+//! `fuzzy_basis` is set, calls `find_fuzzy()` to select the closest-named
+//! existing destination file as the delta basis and announces it at
+//! `DEBUG_GTE(FUZZY, 1)` before using it as `fnamecmp`
+//! (`generator.c:1767-1795`). These tests confirm the local-copy path mirrors
+//! that behaviour: a near-identical closest-named candidate is used as the
+//! delta basis (matched bytes > 0, not a full re-send) and the FUZZY,1
+//! selection line is emitted.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:831` `find_fuzzy()` - scores candidates and picks the basis.
+//! - `generator.c:1785-1794` - `fuzzy_file = find_fuzzy(...)`, sets
+//!   `fnamecmp = fnamecmpbuf` and prints "fuzzy basis selected for %s: %s".
+
+use std::fs;
+use std::path::Path;
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+use tempfile::tempdir;
+
+/// 256 KiB of deterministic bytes so the delta matcher has multiple full
+/// blocks to match (block size ~= sqrt(size), clamped to >= 700 bytes).
+fn deterministic_payload(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let chunk = state.to_le_bytes();
+        let take = chunk.len().min(len - out.len());
+        out.extend_from_slice(&chunk[..take]);
+    }
+    out
+}
+
+/// Enables FUZZY debug at the given level and clears any prior events so the
+/// assertion only sees this test's emissions.
+fn setup_fuzzy_capture(level: u8) {
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.fuzzy = level;
+    init(cfg);
+    let _ = drain_events();
+}
+
+/// Collects FUZZY debug messages emitted since the last drain.
+fn fuzzy_messages() -> Vec<String> {
+    drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Fuzzy,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+fn run_local_copy_with_trailing_slash(source: &Path, dest: &Path, options: LocalCopyOptions) {
+    let mut src_os = source.to_path_buf().into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest.to_path_buf().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+}
+
+/// With `--fuzzy`, when the exact destination file is absent, the executor
+/// selects the closest-named existing destination file as the delta basis and
+/// reuses its matching blocks. The near-identical basis must yield matched
+/// bytes (proving a delta transfer against the fuzzy basis rather than a full
+/// re-send), and the FUZZY,1 selection line must be emitted.
+#[test]
+fn fuzzy_selects_near_identical_basis_for_delta() {
+    setup_fuzzy_capture(1);
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    // Source: report_2024.csv. Dest already holds report_2023.csv whose first
+    // 224 KiB is byte-identical to the source (the delta basis), with a
+    // divergent tail so the two files are not identical.
+    let shared = deterministic_payload(0xF00D_CAFE, 224 * 1024);
+    let mut source_payload = shared.clone();
+    source_payload.extend_from_slice(&deterministic_payload(0xAAAA_1111, 32 * 1024));
+    let mut basis_payload = shared;
+    basis_payload.extend_from_slice(&deterministic_payload(0xBBBB_2222, 32 * 1024));
+
+    fs::write(source.join("report_2024.csv"), &source_payload).expect("write source file");
+    fs::write(dest.join("report_2023.csv"), &basis_payload).expect("write basis file");
+
+    let mut src_os = source.clone().into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    // Local copies default to whole-file; delta (and thus fuzzy-basis reuse)
+    // only engages with --no-whole-file. upstream: generator.c:1962 -
+    // `if (statret != 0 || whole_file) write_sum_head(NULL)` sends the whole
+    // file even when a fuzzy basis was selected.
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .whole_file(false)
+        .fuzzy_level(1);
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+
+    // A delta transfer against the fuzzy basis reuses the shared prefix: matched
+    // bytes must be non-zero. A full re-send (no basis) would report zero.
+    assert!(
+        summary.matched_bytes() > 0,
+        "expected fuzzy basis to drive a delta transfer (matched_bytes > 0), got {}",
+        summary.matched_bytes()
+    );
+
+    // The reconstructed destination must be byte-identical to the source.
+    let reconstructed = fs::read(dest.join("report_2024.csv")).expect("read dest");
+    assert_eq!(
+        reconstructed, source_payload,
+        "fuzzy delta must reconstruct the source exactly"
+    );
+
+    // upstream: generator.c:1787 - FUZZY,1 selection line naming target + basis.
+    let msgs = fuzzy_messages();
+    assert!(
+        msgs.iter().any(
+            |m| m.starts_with("fuzzy basis selected for report_2024.csv:")
+                && m.contains("report_2023.csv")
+        ),
+        "expected FUZZY,1 selection line for the chosen basis, got {msgs:?}"
+    );
+}
+
+/// Without `--fuzzy`, an absent exact destination forces a full whole-file
+/// transfer even when a similarly-named candidate exists: no basis is selected,
+/// matched bytes stay zero, and no FUZZY line is emitted.
+#[test]
+fn absent_fuzzy_flag_sends_whole_file() {
+    setup_fuzzy_capture(1);
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let shared = deterministic_payload(0xF00D_CAFE, 224 * 1024);
+    let mut source_payload = shared.clone();
+    source_payload.extend_from_slice(&deterministic_payload(0xAAAA_1111, 32 * 1024));
+    let mut basis_payload = shared;
+    basis_payload.extend_from_slice(&deterministic_payload(0xBBBB_2222, 32 * 1024));
+
+    fs::write(source.join("report_2024.csv"), &source_payload).expect("write source file");
+    fs::write(dest.join("report_2023.csv"), &basis_payload).expect("write basis file");
+
+    // Delta is enabled (--no-whole-file) but fuzzy_level defaults to 0 (off),
+    // so no fuzzy basis is consulted and no FUZZY line fires - isolating the
+    // fuzzy flag as the sole variable versus the delta-selecting test above.
+    run_local_copy_with_trailing_slash(
+        &source,
+        &dest,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .whole_file(false),
+    );
+
+    // Destination content is correct regardless of transfer strategy.
+    let reconstructed = fs::read(dest.join("report_2024.csv")).expect("read dest");
+    assert_eq!(reconstructed, source_payload);
+
+    // No fuzzy basis was consulted, so no FUZZY,1 line fired.
+    let msgs = fuzzy_messages();
+    assert!(
+        !msgs.iter().any(|m| m.starts_with("fuzzy basis selected")),
+        "no fuzzy basis should be selected without --fuzzy, got {msgs:?}"
+    );
+}

--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -40,6 +40,14 @@ pub struct NegotiationConfig {
     /// When set, the compression vstring exchange is skipped and this algorithm
     /// is used directly - matching upstream `compat.c:543`.
     pub compression_override: Option<CompressionAlgorithm>,
+    /// User-specified compression level (`--compress-level=N`), or
+    /// [`CLVL_NOT_SPECIFIED`] when the flag was not given.
+    ///
+    /// Rendered verbatim in the `parse_compress_choice` NSTR summary line
+    /// (`compat.c:214-219`), mirroring upstream's raw `do_compression_level`
+    /// value which stays `CLVL_NOT_SPECIFIED` (`INT_MIN`) unless
+    /// `--compress-level` was passed (`options.c:88,767`).
+    pub compression_level: i32,
 }
 
 /// Outcome of the protocol 30+ capability negotiation.
@@ -138,6 +146,7 @@ pub fn negotiate_capabilities(
             is_server,
             checksum_override: None,
             compression_override: None,
+            compression_level: CLVL_NOT_SPECIFIED,
         },
     )
 }
@@ -173,6 +182,7 @@ pub fn negotiate_capabilities_with_override(
         is_server,
         checksum_override,
         compression_override,
+        compression_level,
     } = *config;
     // Protocol < 30 doesn't support negotiation, use defaults
     if protocol.uses_fixed_encoding() {
@@ -341,9 +351,9 @@ pub fn negotiate_capabilities_with_override(
     // do_compression_level verbatim, which is CLVL_NOT_SPECIFIED
     // (INT_MIN) when the user did not pass --compress-level. The whole
     // emission is gated on `do_compression != CPRES_NONE || level !=
-    // CLVL_NOT_SPECIFIED`; the negotiator does not own a user-supplied
-    // level, so it always passes CLVL_NOT_SPECIFIED and only emits when
-    // compression is active.
+    // CLVL_NOT_SPECIFIED`; here compression is active so we render the
+    // user-supplied `compression_level` (CLVL_NOT_SPECIFIED when the flag
+    // was absent) exactly as upstream does.
     if compression != CompressionAlgorithm::None {
         let compression_negotiated =
             compression_override.is_none() && remote_compression_list.is_some();
@@ -351,7 +361,7 @@ pub fn negotiate_capabilities_with_override(
             side,
             compression_negotiated,
             compression.as_str(),
-            CLVL_NOT_SPECIFIED,
+            compression_level,
         );
     }
     Ok(NegotiationResult {

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -285,6 +285,61 @@ fn test_negotiate_nstr_summary_matches_upstream_wording_client() {
     );
 }
 
+/// Confirms an explicit `--compress-level=N` renders `(level N)` in the
+/// compress summary instead of the `CLVL_NOT_SPECIFIED` sentinel. Regression
+/// for the previously hardcoded level argument. upstream: compat.c:215-218 -
+/// `do_compression_level` is printed verbatim, so a user-supplied 9 must
+/// render as `(level 9)`.
+#[test]
+fn test_negotiate_nstr_compress_summary_renders_explicit_level() {
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    let mut cfg = VerbosityConfig::default();
+    cfg.debug.nstr = 1;
+    init(cfg);
+    let _ = drain_events();
+
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+    let client_response = b"\x03md5\x04zlib";
+    let mut stdin = &client_response[..];
+    let mut stdout = Vec::new();
+
+    let _ = negotiate_capabilities_with_override(
+        protocol,
+        &mut stdin,
+        &mut stdout,
+        &NegotiationConfig {
+            do_negotiation: true,
+            send_compression: true,
+            is_daemon_mode: false,
+            is_server: false,
+            checksum_override: None,
+            compression_override: None,
+            compression_level: 9,
+        },
+    )
+    .unwrap();
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Debug {
+                flag: DebugFlag::Nstr,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Client negotiated compress: zlib (level 9)"),
+        "compress summary must render the explicit level: {messages:?}"
+    );
+}
+
 /// Confirms `--checksum-choice` suppresses the `" negotiated"` qualifier
 /// in the per-side summary, mirroring upstream's
 /// `valid_checksums.negotiated_nni == NULL` branch (checksum.c:209).
@@ -314,6 +369,7 @@ fn test_negotiate_nstr_summary_omits_negotiated_when_forced() {
             is_server: false,
             checksum_override: Some(ChecksumAlgorithm::MD5),
             compression_override: None,
+            compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
         },
     )
     .unwrap();
@@ -2750,6 +2806,7 @@ fn compression_override_used_on_legacy_protocol() {
             is_server: true,
             checksum_override: None,
             compression_override: Some(CompressionAlgorithm::Zstd),
+            compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
         },
     )
     .unwrap();
@@ -2777,6 +2834,7 @@ fn compression_override_used_without_negotiation() {
             is_server: true,
             checksum_override: None,
             compression_override: Some(CompressionAlgorithm::LZ4),
+            compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
         },
     )
     .unwrap();
@@ -2804,6 +2862,7 @@ fn compression_override_none_falls_through_to_normal_negotiation() {
             is_server: true,
             checksum_override: None,
             compression_override: None,
+            compression_level: crate::nstr::CLVL_NOT_SPECIFIED,
         },
     )
     .unwrap();

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -248,6 +248,20 @@ pub enum ServerStats {
 /// On failure, contains the [`io::Error`] that caused the transfer to abort.
 pub type ServerResult = io::Result<ServerStats>;
 
+/// Maps a user-supplied [`compress::zlib::CompressionLevel`] to the raw i32
+/// upstream stores in `do_compression_level` and renders in the NSTR compress
+/// summary. upstream: token.c:init_compression_level() - zlib range 0..=9.
+fn compression_level_to_i32(level: compress::zlib::CompressionLevel) -> i32 {
+    use compress::zlib::CompressionLevel;
+    match level {
+        CompressionLevel::None => 0,
+        CompressionLevel::Fast => 1,
+        CompressionLevel::Default => 6,
+        CompressionLevel::Best => 9,
+        CompressionLevel::Precise(n) => i32::from(n.get()),
+    }
+}
+
 /// Determines whether the output stream should use multiplexed framing.
 ///
 /// Upstream rsync activates multiplex output differently depending on
@@ -449,6 +463,14 @@ pub fn run_server_with_handshake<W: Write>(
         None
     };
 
+    // upstream: options.c:88,767 - do_compression_level is CLVL_NOT_SPECIFIED
+    // unless the user passed --compress-level=N. The NSTR compress summary
+    // renders it verbatim, so map an absent override to CLVL_NOT_SPECIFIED.
+    let compression_level = config
+        .connection
+        .compression_level
+        .map_or(protocol::nstr::CLVL_NOT_SPECIFIED, compression_level_to_i32);
+
     let setup_config = setup::ProtocolSetupConfig {
         protocol: handshake.protocol,
         skip_compat_exchange: handshake.compat_exchanged,
@@ -458,6 +480,7 @@ pub fn run_server_with_handshake<W: Write>(
         is_daemon_mode,
         do_compression,
         compress_choice: compress_choice_algo,
+        compression_level,
         checksum_seed: config.checksum_seed,
         allow_inc_recurse,
     };

--- a/crates/transfer/src/setup/mod.rs
+++ b/crates/transfer/src/setup/mod.rs
@@ -150,6 +150,7 @@ pub fn setup_protocol_with<'a>(
                     is_server: config.is_server,
                     checksum_override: None,
                     compression_override: config.compress_choice,
+                    compression_level: config.compression_level,
                 },
             )?;
 

--- a/crates/transfer/src/setup/tests.rs
+++ b/crates/transfer/src/setup/tests.rs
@@ -75,6 +75,7 @@ fn ssh_server_flag_string_limits_compat_flags() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: true,
     };
@@ -110,6 +111,7 @@ fn ssh_server_flag_string_enables_advertised_caps() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: true,
     };
@@ -142,6 +144,7 @@ fn ssh_server_no_flag_string_uses_defaults() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
     };
@@ -276,6 +279,7 @@ fn setup_protocol_below_30_returns_none_for_algorithms_and_compat() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -315,6 +319,7 @@ fn setup_protocol_skip_compat_exchange_skips_flags() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -357,6 +362,7 @@ fn setup_protocol_server_writes_compat_flags_and_seed() {
         is_daemon_mode: true, // server advertises, client reads
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -412,6 +418,7 @@ fn setup_protocol_client_reads_compat_flags_from_server() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -455,6 +462,7 @@ fn setup_protocol_server_generates_deterministic_seeds() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -504,6 +512,7 @@ fn setup_protocol_ssh_mode_bidirectional_exchange() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -547,6 +556,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -578,6 +588,7 @@ fn setup_protocol_client_args_affects_compat_flags() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -621,6 +632,7 @@ fn setup_protocol_protocol_30_minimum_for_compat_exchange() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -1008,6 +1020,7 @@ fn setup_protocol_server_v_flag_uses_single_byte_encoding() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -1054,6 +1067,7 @@ fn setup_protocol_server_v_flag_enables_negotiation() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -1086,6 +1100,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
     };
@@ -1105,6 +1120,7 @@ fn setup_protocol_server_v_flag_with_both_v_and_uppercase_v() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
     };
@@ -1299,6 +1315,7 @@ fn setup_protocol_with_mock_negotiator_server_mode() {
         is_daemon_mode: true,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -1344,6 +1361,7 @@ fn setup_protocol_with_mock_negotiator_client_mode() {
         is_daemon_mode: false,
         do_compression: false,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: None,
         allow_inc_recurse: false,
     };
@@ -1638,6 +1656,7 @@ fn compress_choice_override_skips_vstring_and_uses_algorithm() {
         is_daemon_mode: true,
         do_compression: true,
         compress_choice: Some(protocol::CompressionAlgorithm::Zstd),
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
     };
@@ -1672,6 +1691,7 @@ fn compress_choice_none_allows_normal_negotiation() {
         is_daemon_mode: true,
         do_compression: true,
         compress_choice: None,
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
     };
@@ -1706,6 +1726,7 @@ fn compress_choice_zlib_override_on_legacy_protocol() {
         is_daemon_mode: false,
         do_compression: true,
         compress_choice: Some(protocol::CompressionAlgorithm::ZlibX),
+        compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
         checksum_seed: Some(42),
         allow_inc_recurse: false,
     };

--- a/crates/transfer/src/setup/types.rs
+++ b/crates/transfer/src/setup/types.rs
@@ -88,6 +88,15 @@ pub struct ProtocolSetupConfig<'a> {
     /// compression vstrings when `do_compression && !compress_choice`.
     pub compress_choice: Option<CompressionAlgorithm>,
 
+    /// User-specified compression level (`--compress-level=N`), or
+    /// [`protocol::nstr::CLVL_NOT_SPECIFIED`] when the flag was not given.
+    ///
+    /// Threaded into the capability negotiator so the `parse_compress_choice`
+    /// NSTR summary renders the real level. Mirrors upstream's raw
+    /// `do_compression_level` (`options.c:88`), which stays `CLVL_NOT_SPECIFIED`
+    /// unless `--compress-level` was passed.
+    pub compression_level: i32,
+
     /// Optional user-specified checksum seed from `--checksum-seed=NUM`.
     ///
     /// When `Some(seed)`, the server uses this fixed seed instead of generating
@@ -139,6 +148,7 @@ impl<'a> ProtocolSetupConfig<'a> {
             is_daemon_mode: false,
             do_compression: false,
             compress_choice: None,
+            compression_level: protocol::nstr::CLVL_NOT_SPECIFIED,
             checksum_seed: None,
             allow_inc_recurse: false,
         }
@@ -176,6 +186,13 @@ impl<'a> ProtocolSetupConfig<'a> {
     #[must_use]
     pub const fn with_compression(mut self, compress: bool) -> Self {
         self.do_compression = compress;
+        self
+    }
+
+    /// Sets [`Self::compression_level`].
+    #[must_use]
+    pub const fn with_compression_level(mut self, level: i32) -> Self {
+        self.compression_level = level;
         self
     }
 


### PR DESCRIPTION
Two verified oc-vs-upstream divergences in the local-copy path, both fixed
here as they share the local-copy engine.

## Commit 1 - `--fuzzy` basis selection (local copy)

The local-copy executor never consulted `--fuzzy`: the flag was not plumbed
into `LocalCopyOptions`, and fuzzy-basis selection existed only on the
wire-receiver path that local copies never enter. `oc-rsync -a --fuzzy
--no-whole-file src/ dst/` therefore never scored candidates, never selected a
fuzzy basis, and never emitted the `FUZZY,1` trace.

- Plumb `fuzzy_level` through `LocalCopyOptions` (setter, accessor, engine
  builder, and the core config bridge in `apply_behavioral_flags`).
- In the file executor, when delta is active (`!whole_file`) and the exact
  destination is absent, scan the destination directory for the closest
  similarly-named file via the shared `matching::fuzzy::FuzzyMatcher` scorer,
  use it as the delta basis, and emit the existing
  `trace_fuzzy_basis_selected` line.

Gated on `!whole_file_enabled`, mirroring upstream `generator.c:1962`
(`if (statret != 0 || whole_file) write_sum_head(NULL)`) so default
whole-file local copies are unchanged. Selection mirrors
`generator.c:1767-1795 find_fuzzy()`.

Regression test `crates/engine/tests/fuzzy_local_copy.rs`: a near-identical
closest-named candidate yields a delta transfer (`matched_bytes > 0`, not a
full re-send) and emits the `FUZZY,1` line; without `--fuzzy` no basis is
selected and no line fires.

## Commit 2 - `--debug=NSTR` summaries (local copy) + compress-level fix

A local copy bypasses the wire, so the capability negotiator - the only
caller of `trace_compress_summary`/`trace_checksum_summary` - never runs.
The NSTR `compress: <algo> (level N)` and `checksum: <algo>` lines therefore
never appeared for a local `-az --debug=NSTR` copy, even though upstream forks
a real `local_child` server (`main.c:649-654`) whose
`parse_compress_choice`/`parse_checksum_choice` emit them (`compat.c:213-219`,
`checksum.c:206-211`).

- Emit the client-side (level 1) NSTR summaries from the local-copy path,
  rendering the resolved checksum and compression algorithm plus the real
  compression level.
- Fix the latent wire-path defect where the compress-summary level was
  hardcoded to `CLVL_NOT_SPECIFIED`: thread the user-supplied
  `--compress-level` through `NegotiationConfig` and `ProtocolSetupConfig`.
  Absent `--compress-level` it defaults to `CLVL_NOT_SPECIFIED`, keeping
  default wire output byte-identical.

Regression tests: local `-az --debug=NSTR` emits both summary lines
(`crates/core/tests/compression_integration.rs`); `--compress-level=9` renders
`(level 9)` on both the wire path
(`crates/protocol/.../negotiate` test) and the local path.

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p {engine,protocol,transfer,core} --all-targets
  --all-features --no-deps --locked -- -D warnings`: clean on all four.
- New tests pass; existing negotiate/setup/compression suites unchanged.
- Default (non-fuzzy, no `--compress-level`, NSTR-off) path is unchanged:
  fuzzy is gated behind `--fuzzy` + `!whole_file`; the NSTR emitters self-gate
  on debug level; the wire compress level defaults to `CLVL_NOT_SPECIFIED`.