### PR TITLE
fix(daemon): match upstream secrets-file permission mask (accept group-readable)

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -225,8 +225,8 @@ impl ChallengeGenerator {
 ///
 /// # Security
 ///
-/// On Unix systems, the secrets file must have mode 0600 (readable only by owner).
-/// This is enforced by [`SecretsFile::from_file`].
+/// On Unix systems, the secrets file must not be other-accessible (mode `& 06`);
+/// group access such as mode 0640 is allowed. Enforced by [`SecretsFile::from_file`].
 #[derive(Debug, Clone)]
 pub struct SecretsFile {
     entries: HashMap<String, String>,
@@ -293,9 +293,10 @@ impl SecretsFile {
     ///
     /// # Security
     ///
-    /// On Unix systems, this function checks that the file has mode 0600
-    /// (readable and writable only by owner). World-readable or group-readable
-    /// secrets files are rejected to prevent password disclosure.
+    /// On Unix systems, this function rejects a secrets file that is
+    /// accessible to others (mode `& 06`). Group access is permitted, so
+    /// mode 0640 is accepted. This prevents password disclosure to
+    /// unprivileged users while matching upstream rsync semantics.
     ///
     /// On Windows, permission checks are skipped (matching upstream rsync).
     ///
@@ -351,12 +352,12 @@ impl SecretsFile {
 
     /// Checks that the secrets file has correct permissions.
     ///
-    /// On Unix: File must be mode 0600 (owner read/write only)
-    /// On Windows: No checks performed
+    /// On Unix: File must not be accessible to others (no group requirement,
+    /// so mode 0640 is allowed). On Windows: No checks performed.
     ///
     /// # Errors
     ///
-    /// Returns an error if the file is world-readable or group-readable on Unix.
+    /// Returns an error if the file is other-readable or other-writable on Unix.
     #[cfg(unix)]
     pub fn check_permissions(path: &Path) -> io::Result<()> {
         use std::os::unix::fs::PermissionsExt;
@@ -365,12 +366,13 @@ impl SecretsFile {
         let permissions = metadata.permissions();
         let mode = permissions.mode();
 
-        // Check for world-readable (bit 2) or group-readable (bit 5)
-        if (mode & 0o044) != 0 {
+        // upstream: authenticate.c:120 check_secret() rejects only when OTHER
+        // has access ((st.st_mode & 06) != 0); group-readable (0640) is allowed.
+        if (mode & 0o6) != 0 {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 format!(
-                    "secrets file '{}' must not be readable by group or others (mode {:o})",
+                    "secrets file '{}' must not be other-accessible (mode {:o})",
                     path.display(),
                     mode & 0o777
                 ),

--- a/crates/daemon/src/daemon/sections/config_helpers/secrets_validation.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/secrets_validation.rs
@@ -58,7 +58,8 @@ fn validate_secrets_file_from_env(
 
 /// Ensures a file has proper secrets file permissions.
 ///
-/// Verifies the file is a regular file and (on Unix) has mode 0600.
+/// Verifies the file is a regular file and (on Unix) is not other-accessible.
+/// Group access (e.g. mode 0640) is allowed, matching upstream.
 fn ensure_secrets_file(path: &Path, metadata: &fs::Metadata) -> Result<(), String> {
     if !metadata.is_file() {
         return Err(format!(
@@ -70,9 +71,11 @@ fn ensure_secrets_file(path: &Path, metadata: &fs::Metadata) -> Result<(), Strin
     #[cfg(unix)]
     {
         let mode = metadata.permissions().mode();
-        if mode & 0o077 != 0 {
+        // upstream: authenticate.c:120 check_secret() rejects only when OTHER
+        // has access ((st.st_mode & 06) != 0); group-readable (0640) is allowed.
+        if mode & 0o6 != 0 {
             return Err(format!(
-                "secrets file '{}' must not be accessible to group or others (expected permissions 0600)",
+                "secrets file '{}' must not be other-accessible",
                 path.display()
             ));
         }

--- a/crates/daemon/src/tests/chunks/runtime_options_rejects_world_readable_secrets_file.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_rejects_world_readable_secrets_file.rs
@@ -29,7 +29,75 @@ fn runtime_options_rejects_world_readable_secrets_file() {
         error
             .message()
             .to_string()
-            .contains("must not be accessible to group or others")
+            .contains("must not be other-accessible")
+    );
+}
+
+/// A group-readable (0640) secrets file is accepted, matching upstream
+/// authenticate.c:120 check_secret() which rejects only OTHER access
+/// ((st.st_mode & 06) != 0). Group access is permitted.
+#[cfg(unix)]
+#[test]
+fn runtime_options_accepts_group_readable_secrets_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+    let secrets_path = dir.path().join("secrets.txt");
+    fs::write(&secrets_path, "alice:password\n").expect("write secrets");
+    fs::set_permissions(&secrets_path, PermissionsExt::from_mode(0o640)).expect("chmod secrets");
+
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[secure]\npath = {}\nauth users = alice\nsecrets file = {}\n",
+        module_dir.display(),
+        secrets_path.display()
+    )
+    .expect("write config");
+
+    RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        file.path().as_os_str().to_os_string(),
+    ])
+    .expect("group-readable secrets file should be accepted");
+}
+
+/// An other-writable (0602) secrets file is rejected: 0o6 catches OTHER
+/// write even without OTHER read, matching upstream's `& 06` mask.
+#[cfg(unix)]
+#[test]
+fn runtime_options_rejects_other_writable_secrets_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("config dir");
+    let module_dir = dir.path().join("module");
+    fs::create_dir_all(&module_dir).expect("module dir");
+    let secrets_path = dir.path().join("secrets.txt");
+    fs::write(&secrets_path, "alice:password\n").expect("write secrets");
+    fs::set_permissions(&secrets_path, PermissionsExt::from_mode(0o602)).expect("chmod secrets");
+
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[secure]\npath = {}\nauth users = alice\nsecrets file = {}\n",
+        module_dir.display(),
+        secrets_path.display()
+    )
+    .expect("write config");
+
+    let error = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        file.path().as_os_str().to_os_string(),
+    ])
+    .expect_err("other-writable secrets file should error");
+
+    assert!(
+        error
+            .message()
+            .to_string()
+            .contains("must not be other-accessible")
     );
 }
 


### PR DESCRIPTION
## Problem

The daemon's secrets-file permission check was stricter than upstream rsync and wrongly rejected a group-readable `0640` secrets file that upstream accepts.

Two daemon sites masked the file mode too broadly:
- `crates/daemon/src/daemon/sections/config_helpers/secrets_validation.rs` (config-load validation, the live path) used `& 0o077`.
- `crates/daemon/src/auth.rs` `SecretsFile::check_permissions` (public API) used `& 0o044`.

Both caught the group bits, so a `0640` file (group-read, no other access) was rejected.

## Upstream reference

`check_secret()` in `authenticate.c:120` rejects only when OTHER has access:

```c
if ((st.st_mode & 06) != 0) {
    rprintf(FLOG, "secrets file must not be other-accessible (see strict modes option)\n");
    ok = 0;
}
```

Mask `06` = OTHER read+write. Group bits are not checked. The check is gated behind strict modes and warns-and-refuses to use the file (does not hard-abort the process).

## Fix

Both sites now use the upstream `0o6` mask so a group-readable-but-not-other file is accepted, while other read/write is still rejected. Error text updated to "must not be other-accessible". Each site cites `authenticate.c:120`.

## Tests

- `runtime_options_accepts_group_readable_secrets_file`: `0640` is accepted.
- `runtime_options_rejects_world_readable_secrets_file`: `0644` is rejected (message updated).
- `runtime_options_rejects_other_writable_secrets_file`: `0602` is rejected (other-write with no other-read).

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p daemon --all-targets --all-features --no-deps --locked -- -D warnings`: 0 warnings.

Security note: this narrows the mask only to match upstream exactly; it does not loosen beyond upstream. Other read/write access remains rejected.