### PR TITLE
fix(transfer): honor --modify-window in receiver quick-check

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -72,6 +72,13 @@ pub(super) struct ServerLongFlags {
     pub(super) from0: bool,
     pub(super) inplace: bool,
     pub(super) size_only: bool,
+    /// Modification-time window in whole seconds (upstream: `--modify-window=NUM`).
+    ///
+    /// upstream: options.c - `server_options()` emits `--modify-window=%d`
+    /// whenever the client set a non-default `modify_window`. The receiver's
+    /// quick-check consults this via `same_time()` so files within the window
+    /// are not needlessly re-transferred.
+    pub(super) modify_window: Option<String>,
     /// Numeric IDs only (upstream: `--numeric-ids`, long-form only).
     pub(super) numeric_ids: bool,
     /// Delete extraneous files (upstream: `--delete-*` variants, long-form only).
@@ -185,6 +192,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         from0: false,
         inplace: false,
         size_only: false,
+        modify_window: None,
         numeric_ids: false,
         delete: false,
         remove_source_files: false,
@@ -339,6 +347,9 @@ fn parse_value_bearing_flag(s: &str, flags: &mut ServerLongFlags) {
         flags.checksum_seed = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--checksum-choice=") {
         flags.checksum_choice = Some(value.to_owned());
+    } else if let Some(value) = s.strip_prefix("--modify-window=") {
+        // upstream: options.c - server_options() emits `--modify-window=%d`.
+        flags.modify_window = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--min-size=") {
         flags.min_size = Some(value.to_owned());
     } else if let Some(value) = s.strip_prefix("--max-size=") {
@@ -446,6 +457,7 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
         || arg.starts_with("--compare-dest=")
         || arg.starts_with("--copy-dest=")
         || arg.starts_with("--link-dest=")
+        || arg.starts_with("--modify-window=")
         || arg.starts_with("--min-size=")
         || arg.starts_with("--max-size=")
         || arg.starts_with("--max-alloc=")

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -402,6 +402,21 @@ fn apply_value_flags<Err: Write>(
         }
     }
 
+    // upstream: options.c - server_options() forwards `--modify-window=NUM`.
+    // The receiver's quick-check honours it via same_time() so files within
+    // the window are not needlessly re-transferred over the network.
+    if let Some(window_str) = &long_flags.modify_window {
+        match super::super::execution::parse_modify_window_argument(std::ffi::OsStr::new(
+            window_str,
+        )) {
+            Ok(window) => config.file_selection.modify_window = window,
+            Err(msg) => {
+                write_server_error(stderr, brand, msg.text().to_owned());
+                return Err(1);
+            }
+        }
+    }
+
     // upstream: options.c:1943-1950 - server-side `--max-alloc` is parsed and
     // applied to the local allocator. We forward it from the client and
     // enforce the cap on the server's buffer pool.

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -317,6 +317,12 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     server_config.partial_dir = config.partial_directory().map(std::path::Path::to_path_buf);
     server_config.file_selection.min_file_size = config.min_file_size();
     server_config.file_selection.max_file_size = config.max_file_size();
+    // upstream: generator.c:quick_check_ok() -> same_time() applies the
+    // `--modify-window` tolerance on the receiver. For a remote-shell pull the
+    // local client IS the receiver, so carry the window onto its config; the
+    // server-side receiver (push) picks it up from the forwarded
+    // `--modify-window=NUM` arg. `modify_window()` is None when unset (window 0).
+    server_config.file_selection.modify_window = config.modify_window().unwrap_or(0);
     // upstream: options.c:2046-2048 - do_stats sets INFO_STATS to level 2+
     server_config.do_stats = config.stats();
     // upstream: generator.c:124 - EARLY_DELETE_DONE_MSG = !(delete_during==2 || delete_after)

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -210,6 +210,13 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
                             config.deletion.max_delete = Some(n as u64);
                         }
                     }
+                // upstream: options.c - server_options() forwards `--modify-window=NUM`.
+                // The daemon receiver's quick-check honours it via same_time() so
+                // files within the window are not needlessly re-transferred.
+                } else if let Some(val) = arg.strip_prefix("--modify-window=") {
+                    if let Ok(n) = val.trim_start_matches('+').parse::<u64>() {
+                        config.file_selection.modify_window = n;
+                    }
                 // Fallback: =value format for reference directories and backup options.
                 // Handles both upstream (two-arg) and legacy (=value) formats.
                 } else if let Some(dir) = arg.strip_prefix("--backup-dir=") {

--- a/crates/transfer/src/config/builder.rs
+++ b/crates/transfer/src/config/builder.rs
@@ -428,6 +428,12 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Sets the `--modify-window` mtime comparison tolerance in whole seconds.
+    pub fn modify_window(&mut self, seconds: u64) -> &mut Self {
+        self.file_selection.modify_window = seconds;
+        self
+    }
+
     /// Sets the `--files-from` path for direct server-side reading.
     pub fn files_from_path(&mut self, path: Option<String>) -> &mut Self {
         self.file_selection.files_from_path = path;

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -197,6 +197,13 @@ pub struct FileSelectionConfig {
     pub existing_only: bool,
     /// Compare only file sizes, ignoring modification times (`--size-only`).
     pub size_only: bool,
+    /// Modification-time comparison tolerance in whole seconds (`--modify-window`).
+    ///
+    /// When zero (the default) the quick-check requires exact whole-second
+    /// mtime equality. When positive, two mtimes are treated as equal if their
+    /// whole-second delta does not exceed this value, matching upstream
+    /// `util1.c:same_time()` consulted via `generator.c:quick_check_ok()`.
+    pub modify_window: u64,
     /// Path for `--files-from` when the server reads the file list directly.
     pub files_from_path: Option<String>,
     /// Use NUL bytes as delimiters for `--files-from` input (`--from0`).

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -33,6 +33,26 @@ pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
     entry.hlinked() && !entry.hlink_first()
 }
 
+/// Returns `true` when two whole-second mtimes are the "same" under
+/// `--modify-window`, a direct port of upstream `util1.c:1478 same_time()`.
+///
+/// The receiver compares `time_t` seconds (`st_mtime` vs the file-list entry's
+/// `modtime`), so nanoseconds never enter this predicate - upstream likewise
+/// ignores them for the window check ("time windows don't care about that").
+///
+/// - `window == 0`: the seconds must be exactly equal (`f1_sec == f2_sec`).
+/// - `window > 0`: a SYMMETRIC whole-second tolerance applies, matching upstream
+///   `f2_sec > f1_sec ? f2_sec - f1_sec <= modify_window : f1_sec - f2_sec <=
+///   modify_window`, i.e. `|a_sec - b_sec| <= window`.
+///
+/// upstream: util1.c:1478 same_time() (via generator.c:quick_check_ok()).
+fn same_time(a_sec: i64, b_sec: i64, window: u64) -> bool {
+    if window == 0 {
+        return a_sec == b_sec;
+    }
+    a_sec.abs_diff(b_sec) <= window
+}
+
 /// Pure-function quick-check: compares destination stat against source entry.
 ///
 /// Returns `true` when the destination file matches the source entry (skip transfer).
@@ -42,7 +62,7 @@ pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
 /// 2. `always_checksum` - compute file checksum and compare (ignores mtime)
 /// 3. `size_only` - size matched, skip transfer
 /// 4. `!preserve_times` (implies `ignore_times`) - force transfer
-/// 5. mtime comparison
+/// 5. mtime comparison, tolerating `--modify-window` seconds of drift
 pub(super) fn quick_check_matches(
     entry: &FileEntry,
     dest_path: &Path,
@@ -50,6 +70,7 @@ pub(super) fn quick_check_matches(
     preserve_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
+    modify_window: u64,
 ) -> bool {
     // upstream: generator.c:621 - size check first
     if dest_meta.len() != entry.size() {
@@ -73,10 +94,12 @@ pub(super) fn quick_check_matches(
     if !preserve_times {
         return false;
     }
+    // upstream: generator.c:645 - `mtime_differs()` -> `same_time()` applies the
+    // `--modify-window` tolerance symmetrically on whole seconds.
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        dest_meta.mtime() == entry.mtime()
+        same_time(dest_meta.mtime(), entry.mtime(), modify_window)
     }
     #[cfg(not(unix))]
     {
@@ -84,7 +107,9 @@ pub(super) fn quick_check_matches(
             .modified()
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map_or(false, |d| d.as_secs() as i64 == entry.mtime())
+            .map_or(false, |d| {
+                same_time(d.as_secs() as i64, entry.mtime(), modify_window)
+            })
     }
 }
 
@@ -147,6 +172,7 @@ pub(super) fn try_reference_dest(
     preserve_times: bool,
     size_only: bool,
     always_checksum: Option<protocol::ChecksumAlgorithm>,
+    modify_window: u64,
     copy_links: bool,
     metadata_opts: &MetadataOptions,
     metadata_errors: &mut Vec<(PathBuf, String)>,
@@ -181,6 +207,7 @@ pub(super) fn try_reference_dest(
             preserve_times,
             size_only,
             always_checksum,
+            modify_window,
         ) {
             continue;
         }
@@ -442,6 +469,7 @@ mod info_copy_emission_tests {
             false,
             true,
             None,
+            0,
             false,
             &metadata_opts,
             &mut metadata_errors,
@@ -501,6 +529,7 @@ mod info_copy_emission_tests {
             false,
             true,
             None,
+            0,
             false,
             &metadata_opts,
             &mut metadata_errors,
@@ -591,6 +620,7 @@ mod symlink_basis_tests {
             false,
             true,
             None,
+            0,
             copy_links,
             &metadata_opts,
             &mut metadata_errors,
@@ -688,6 +718,104 @@ mod symlink_basis_tests {
         assert_eq!(
             fs::read(dest_dir.join("payload.bin")).expect("dest file"),
             b"basis payload"
+        );
+    }
+}
+
+/// Regression tests pinning `--modify-window` in the receiver quick-check.
+///
+/// upstream: generator.c:quick_check_ok() consults `mtime_differs()` ->
+/// `util1.c:1478 same_time()` for EVERY transfer, so a remote/daemon pull or
+/// push must tolerate `--modify-window` seconds of whole-second mtime drift
+/// exactly like the local-copy path. Without threading the window into the
+/// receiver, a content-identical file whose mtime differs by <= window is
+/// needlessly re-transferred.
+#[cfg(unix)]
+#[cfg(test)]
+mod modify_window_tests {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    use filetime::{FileTime, set_file_mtime};
+    use protocol::flist::FileEntry;
+
+    use super::quick_check_matches;
+
+    /// Builds a dest file at `dest_secs` and a source entry claiming `src_secs`,
+    /// both the same size, then runs the quick-check with `preserve_times=true`,
+    /// `size_only=false`, no checksum, at the given `window`.
+    fn run_window(src_secs: i64, dest_secs: i64, window: u64) -> bool {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest_path = dir.path().join("payload.bin");
+        let payload = b"identical content";
+        fs::write(&dest_path, payload).expect("write dest");
+        set_file_mtime(&dest_path, FileTime::from_unix_time(dest_secs, 0)).expect("set dest mtime");
+
+        // Read back the on-disk mtime so the assertion reflects what the
+        // filesystem actually stored (the quick-check reads dest_meta.mtime()).
+        let dest_meta = fs::metadata(&dest_path).expect("dest meta");
+        assert_eq!(
+            dest_meta.mtime(),
+            dest_secs,
+            "dest mtime not set as expected"
+        );
+
+        let mut entry = FileEntry::new_file("payload.bin".into(), payload.len() as u64, 0o644);
+        entry.set_mtime(src_secs, 0);
+
+        quick_check_matches(&entry, &dest_path, &dest_meta, true, false, None, window)
+    }
+
+    /// A destination whose mtime is within `--modify-window=2` of the source
+    /// (2s apart) is treated as up-to-date and SKIPPED, mirroring same_time()'s
+    /// symmetric whole-second tolerance. This is the network-receiver bug fix:
+    /// previously the exact `==` compare re-transferred it.
+    #[test]
+    fn within_window_two_is_skipped() {
+        let base = 1_700_000_000;
+        // Both directions of drift must skip (same_time is symmetric).
+        assert!(
+            run_window(base, base + 2, 2),
+            "dest +2s within window must skip"
+        );
+        assert!(
+            run_window(base, base - 2, 2),
+            "dest -2s within window must skip"
+        );
+        assert!(
+            run_window(base, base + 1, 2),
+            "dest +1s within window must skip"
+        );
+    }
+
+    /// A destination 3s away from the source exceeds `--modify-window=2`, so
+    /// same_time() reports the files as different and the receiver transfers.
+    #[test]
+    fn beyond_window_two_is_transferred() {
+        let base = 1_700_000_000;
+        assert!(
+            !run_window(base, base + 3, 2),
+            "dest +3s beyond window must transfer"
+        );
+        assert!(
+            !run_window(base, base - 3, 2),
+            "dest -3s beyond window must transfer"
+        );
+    }
+
+    /// With `--modify-window=0` the quick-check requires exact whole-second
+    /// equality (same_time() reduces to `f1_sec == f2_sec`): equal mtimes skip,
+    /// a one-second delta re-transfers.
+    #[test]
+    fn zero_window_requires_exact_seconds() {
+        let base = 1_700_000_000;
+        assert!(
+            run_window(base, base, 0),
+            "equal mtimes at window 0 must skip"
+        );
+        assert!(
+            !run_window(base, base + 1, 0),
+            "1s delta at window 0 must transfer"
         );
     }
 }

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -186,6 +186,9 @@ impl ReceiverContext {
 
         let preserve_times = self.config.flags.times && !self.config.flags.ignore_times;
         let size_only = self.config.file_selection.size_only;
+        // upstream: generator.c:quick_check_ok() -> same_time() honours the
+        // `--modify-window` tolerance for every transfer, not just local copies.
+        let modify_window = self.config.file_selection.modify_window;
         let ignore_existing = self.config.file_selection.ignore_existing;
         let existing_only = self.config.file_selection.existing_only;
         let update_only = self.config.flags.update;
@@ -261,6 +264,7 @@ impl ReceiverContext {
                     preserve_times,
                     size_only,
                     always_checksum,
+                    modify_window,
                 ) {
                     // upstream: generator.c:1816 - itemize() with iflags=0 for an
                     // up-to-date file; the attr-comparison may still surface a
@@ -295,6 +299,7 @@ impl ReceiverContext {
                         preserve_times,
                         size_only,
                         always_checksum,
+                        modify_window,
                         self.config.flags.copy_links,
                         metadata_opts,
                         metadata_errors,


### PR DESCRIPTION
## Summary

The network receiver quick-check compared mtimes with an exact `dest_meta.mtime() == entry.mtime()` and took no `--modify-window` parameter, so a remote/daemon pull or push with `--modify-window=N` re-transferred files whose mtimes fell within the window. Only the local-copy path honored the window.

This threads the whole-second `--modify-window` tolerance into the receiver quick-check and applies upstream `util1.c:1478 same_time()` exactly: symmetric `|a_sec - b_sec| <= window` for `window > 0`, and exact whole-second equality for `window == 0`. Size and checksum criteria are unchanged.

## Upstream reference

- `util1.c:1478 same_time()` - `modify_window == 0` reduces to `f1_sec == f2_sec`; `modify_window > 0` applies a symmetric whole-second window; nanoseconds are deliberately ignored for the window check.
- `generator.c:quick_check_ok()` -> `mtime_differs()` -> `same_time()` runs for every transfer, not just local copies.

## Plumbing

`--modify-window` (whole seconds) now flows into the receiver's `FileSelectionConfig.modify_window`:

- Client-side receiver (remote-shell/daemon pull): `apply_common_server_flags()` sets it from `config.modify_window()`.
- Server-side receiver (remote-shell push): `--modify-window=NUM` is parsed in the server long-flag scanner and applied in `apply_value_flags()`.
- Daemon receiver (push to daemon): parsed in the daemon client-args long-form scanner.

The value is consumed by `quick_check_matches()` (and `try_reference_dest()` for alt-dest basis checks) via a small `same_time()` helper.

## Tests

New receiver-side regression module asserts a dest mtime within `--modify-window=2` of the source is skipped (both drift directions and a 1s delta), 3s apart is transferred, and `window=0` requires exact whole-second equality.