### PR TITLE
fix(transfer): drain delta stream on pipelined receiver temp-create failure

### DIFF
--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -42,7 +42,27 @@ pub(in crate::disk_commit) fn process_file(
     disk_batch: Option<&mut fast_io::IoUringDiskBatch>,
     iocp_batch: Option<&mut fast_io::IocpDiskBatch>,
 ) -> io::Result<CommitResult> {
-    let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
+    // upstream: receiver.c:999-1006 - when open_tmpfile() fails (e.g. EACCES
+    // from a read-only destination directory) the receiver does NOT abort the
+    // receive loop. It logs the error, calls discard_receive_data() to drain
+    // this file's delta, and continues to the next file. On the pipelined path
+    // the network thread has already lifted this file's entire delta off the
+    // wire into channel messages, so the wire itself cannot desync here - but
+    // the leftover Chunk/Commit messages for this file are still queued.
+    // Returning the open error immediately would leave those messages in the
+    // channel; the disk loop would then read the next Chunk and mis-parse it as
+    // a "message without Begin", corrupting the result stream. We instead drain
+    // this file's queued messages (the channel analog of discard_receive_data)
+    // and then surface the original open error. `drain_all_results` maps a
+    // permission failure to a per-file partial (IOERR_GENERAL -> RERR_PARTIAL,
+    // exit 23) with the upstream sender warning, exactly like the synchronous
+    // receiver (receiver/transfer/sync.rs via delta_apply::discard_delta_stream).
+    let (file, mut cleanup_guard, needs_rename) = match open_output_file(&begin, config) {
+        Ok(triple) => triple,
+        Err(open_err) => {
+            return discard_file_on_open_failure(file_rx, buf_return_tx, open_err);
+        }
+    };
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
     }
@@ -244,6 +264,11 @@ pub(in crate::disk_commit) fn process_whole_file(
     disk_batch: Option<&mut fast_io::IoUringDiskBatch>,
     iocp_batch: Option<&mut fast_io::IocpDiskBatch>,
 ) -> io::Result<CommitResult> {
+    // upstream: receiver.c:999-1006 - open failure is a benign per-file partial,
+    // not a fatal abort. The coalesced WholeFile carries its data inline, so
+    // there are no queued channel messages to drain (unlike process_file); the
+    // open error surfaces directly and drain_all_results maps a permission
+    // failure to RERR_PARTIAL (exit 23).
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
@@ -321,6 +346,64 @@ pub(in crate::disk_commit) fn process_whole_file(
         delayed_path: outcome.delayed_path,
         backup_notice: outcome.backup_notice,
     })
+}
+
+/// Drains a chunked file's queued channel messages after its output could not
+/// be opened, then surfaces the original open error.
+///
+/// The network thread has already lifted this file's entire delta off the wire
+/// and enqueued it as `Chunk` messages terminated by `Commit`. With no open
+/// output the disk thread cannot write them, so it recycles each chunk buffer
+/// and drops the bytes until the terminating message - the channel analog of
+/// upstream `discard_receive_data()`. This keeps the disk loop from reading the
+/// next queued `Chunk` and mis-parsing it as a "message without Begin".
+///
+/// Reaching `Commit` yields the original `open_err`, which the main-thread
+/// [`crate::pipeline::receiver::PipelinedReceiver`] maps to a per-file partial
+/// (permission failure -> IOERR_GENERAL -> RERR_PARTIAL, exit 23) with the
+/// upstream sender warning, matching the synchronous receiver
+/// (`receiver/transfer/sync.rs` via `delta_apply::discard_delta_stream`). If the
+/// channel instead delivers `Shutdown`/`Abort`/disconnect first, that terminal
+/// signal is propagated so the disk loop exits, exactly as the write path does.
+///
+/// upstream: receiver.c:999-1006 - discard this file's data and continue.
+fn discard_file_on_open_failure(
+    file_rx: &spsc::Receiver<FileMessage>,
+    buf_return_tx: &spsc::Sender<Vec<u8>>,
+    open_err: io::Error,
+) -> io::Result<CommitResult> {
+    loop {
+        match file_rx.recv() {
+            Ok(FileMessage::Chunk(data)) => {
+                // Recycle the buffer for the network thread; drop the bytes.
+                let _ = buf_return_tx.send(data);
+            }
+            Ok(FileMessage::Commit) => {
+                return Err(open_err);
+            }
+            Ok(FileMessage::Abort { reason }) => {
+                return Err(io::Error::other(reason));
+            }
+            Ok(FileMessage::Shutdown) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "disk thread: shutdown received while discarding file",
+                ));
+            }
+            Ok(FileMessage::Begin(_) | FileMessage::WholeFile { .. }) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "disk thread: received Begin while discarding another file",
+                ));
+            }
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "disk thread: channel disconnected while discarding file",
+                ));
+            }
+        }
+    }
 }
 
 /// Opens the output file using device write, inplace, or temp+rename strategy.

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -722,6 +722,123 @@ mod tests {
         drop(pr);
     }
 
+    /// Pipelined-path mirror of #6249's synchronous discard test: a receiver
+    /// whose temp-file create fails mid-transfer on a MULTI-CHUNK delta must not
+    /// desync the disk-thread result stream. The network thread has already
+    /// lifted the whole delta off the wire and enqueued it as `Begin` + several
+    /// `Chunk`s + `Commit`; when `open_tmpfile()` fails, the disk thread must
+    /// drain those queued messages (the channel analog of upstream
+    /// `discard_receive_data`, receiver.c:999-1006) rather than returning
+    /// immediately and mis-parsing the next `Chunk` as a "message without
+    /// Begin". The file is marked failed and folded to a per-file partial
+    /// (IOERR_GENERAL -> RERR_PARTIAL, exit 23), never a fatal desync (exit 12).
+    ///
+    /// A MATCH-token delta on the wire becomes basis-copied `Chunk`s on this
+    /// channel, so multiple chunks reproduce the exact desync a MATCH delta
+    /// would trigger. Before the fix the orphaned `Chunk`/`Commit` messages
+    /// produced a spurious second error; a single clean recoverable error here
+    /// proves the drain works.
+    #[cfg(unix)]
+    #[test]
+    fn multi_chunk_temp_create_failure_drains_without_desync_exit_23() {
+        use crate::generator::io_error_flags::{IOERR_GENERAL, to_exit_code};
+        use std::os::unix::fs::PermissionsExt;
+
+        // Root bypasses the read-only dir bit, so the create would succeed.
+        if std::env::var("USER").is_ok_and(|u| u == "root") {
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let readonly_dir = dir.path().join("readonly");
+        std::fs::create_dir(&readonly_dir).unwrap();
+        std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o555)).unwrap();
+
+        let file_path = readonly_dir.join("multi.dat");
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+
+        // Drive the non-coalesced path: an explicit Begin followed by several
+        // Chunks and a Commit - exactly what the network thread emits for a
+        // delta that reduces to multiple (basis-copied) chunks.
+        pr.file_sender()
+            .send(FileMessage::Begin(Box::new(BeginMessage {
+                file_path: file_path.clone(),
+                target_size: 9,
+                file_entry_index: 0,
+                checksum_verifier: None,
+                is_device_target: false,
+                is_inplace: false,
+                append_offset: 0,
+                xattr_list: None,
+            })))
+            .unwrap();
+        pr.file_sender()
+            .send(FileMessage::Chunk(b"aaa".to_vec()))
+            .unwrap();
+        pr.file_sender()
+            .send(FileMessage::Chunk(b"bbb".to_vec()))
+            .unwrap();
+        pr.file_sender()
+            .send(FileMessage::Chunk(b"ccc".to_vec()))
+            .unwrap();
+        pr.file_sender().send(FileMessage::Commit).unwrap();
+
+        pr.note_commit_sent([0u8; ChecksumVerifier::MAX_DIGEST_LEN], 0, file_path, 0);
+
+        // Exactly ONE recoverable error - no spurious second error from
+        // orphaned Chunk/Commit messages, no propagated fatal Err (exit 12).
+        let (bytes, errors) = pr
+            .drain_all_results()
+            .expect("temp-create failure must be recoverable, not a fatal desync");
+        assert_eq!(bytes, 0, "no bytes written for the failed file");
+        assert_eq!(
+            errors.len(),
+            1,
+            "the drained multi-chunk file yields exactly one per-file error"
+        );
+        assert_eq!(pr.permission_error_count(), 1);
+
+        // The failed file sets IOERR_GENERAL, which maps to RERR_PARTIAL (23),
+        // matching upstream's FERROR_XFER -> got_xfer_error -> _exit(RERR_PARTIAL).
+        assert_eq!(
+            to_exit_code(IOERR_GENERAL),
+            23,
+            "temp-create failure must yield RERR_PARTIAL (exit 23), not fatal (12)"
+        );
+
+        // The disk thread survived the drain and processes the next file
+        // cleanly - proof the result stream is still aligned.
+        let ok_path = dir.path().join("after.dat");
+        pr.file_sender()
+            .send(FileMessage::WholeFile {
+                begin: Box::new(BeginMessage {
+                    file_path: ok_path.clone(),
+                    target_size: 4,
+                    file_entry_index: 1,
+                    checksum_verifier: None,
+                    is_device_target: false,
+                    is_inplace: false,
+                    append_offset: 0,
+                    xattr_list: None,
+                }),
+                data: b"next".to_vec(),
+            })
+            .unwrap();
+        pr.note_commit_sent(
+            [0u8; ChecksumVerifier::MAX_DIGEST_LEN],
+            0,
+            ok_path.clone(),
+            1,
+        );
+        let (bytes2, errors2) = pr.drain_all_results().unwrap();
+        assert_eq!(bytes2, 4, "the following file transfers normally");
+        assert!(errors2.is_empty());
+        assert_eq!(std::fs::read(&ok_path).unwrap(), b"next");
+
+        let _ = std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o755));
+        drop(pr);
+    }
+
     #[test]
     fn permission_error_count_starts_at_zero() {
         let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();


### PR DESCRIPTION
## Problem

PR #6249 taught the **synchronous** receiver (`receiver/transfer/sync.rs`) to drain a file's delta stream and exit 23 when its temp file cannot be created (EACCES on a read-only destination directory), instead of desyncing the protocol. The **pipelined** receiver lacked an equivalent guard.

In the pipelined path the network thread (`process_file_response_streaming`) lifts a file's entire delta off the wire and enqueues it as `Begin` + `Chunk`s + `Commit` on the disk SPSC channel, so the *wire* itself never desyncs. But the disk thread opens the temp file (`disk_commit/process/file_ops.rs::process_file` -> `open_output_file`). On a **multi-chunk** file whose temp-create failed, `process_file` returned the open error immediately via `?`, leaving the queued `Chunk`/`Commit` messages in the channel. The disk loop then read the next `Chunk` and mis-parsed it as a "message without Begin" -> spurious second error -> the recoverable per-file partial (exit 23) degraded into a fatal desync (exit 12).

The coalesced single-chunk path (`process_whole_file`, `FileMessage::WholeFile`) carries its data inline, so it never had queued messages to orphan; its EACCES behaviour (exit 23) was already correct and is unchanged.

## Fix

`process_file` no longer `?`-propagates a temp-create failure. It drains this file's queued channel messages first - recycling each chunk buffer, dropping the bytes, consuming up to the terminating `Commit` - then surfaces the original open error. This is the channel analog of upstream `discard_receive_data()`: the delta is already off the wire, so "draining the delta" here means draining the enqueued chunk messages. `drain_all_results`/`drain_ready_results` then classify the permission failure as a per-file partial (`IOERR_GENERAL` -> `RERR_PARTIAL`, exit 23) and emit the upstream sender warning, exactly as the synchronous receiver does.

Terminal signals encountered mid-drain (`Shutdown` / `Abort` / channel disconnect) are propagated so the disk loop still exits, matching the existing write-path behaviour.

## Upstream reference

`receiver.c:999-1006`: when `open_tmpfile()` returns `fd == -1`, upstream calls `discard_receive_data()` + `continue` rather than aborting the receive loop; the `FERROR_XFER` sets `got_xfer_error`, which `main.c` maps to `_exit(RERR_PARTIAL)` (exit 23). The block-match-with-no-basis absorb is `receiver.c:443-451`.

## Test

`multi_chunk_temp_create_failure_drains_without_desync_exit_23` (pipelined mirror of #6249's synchronous discard test): drives `Begin` + three `Chunk`s + `Commit` at a file inside a read-only directory, asserts exactly one recoverable per-file error (no spurious second error, no fatal `Err`), that `IOERR_GENERAL` maps to exit 23, and that the disk thread survives the drain and transfers the following file cleanly - proving the result stream stays aligned. A MATCH-token delta on the wire becomes basis-copied chunks on this channel, so multiple chunks reproduce the exact desync a MATCH delta triggers.

## Files touched

- `crates/transfer/src/disk_commit/process/file_ops.rs` - drain-then-surface on temp-create failure in `process_file`; new `discard_file_on_open_failure` helper; clarifying comment on `process_whole_file`.
- `crates/transfer/src/pipeline/receiver.rs` - regression test.

## Validation

- `cargo fmt --all`
- `cargo clippy -p transfer --all-targets --all-features --no-deps --locked -- -D warnings` - clean.
- Targeted `cargo nextest -p transfer` for the new test plus `permission_denied_on_output_is_recoverable` and `multi_chunk_file`: 3 passed.