### PR TITLE
ci: fix setpriv-reachable oc-rsync path in 3.5.0dev tracker

### DIFF
--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -35,10 +35,16 @@
 #      git-ref driver now publishes oc-rsync to a world-traversable path
 #      (/usr/local/bin, all components o+x) and points --rsync-bin there - see
 #      publish_oc_rsync_bin() in tools/ci/run_upstream_testsuite.sh.
-#   2. Root-owned scratch: root legs leave root-owned files; the git-ref driver
-#      runs the scratch tree under $log_root with a chmod -R u+rwX + rm -rf
-#      teardown before AND after each leg, so a mode-0 dir (xattrs/, recv-
-#      discard-nullderef/) can't wedge the next leg's cleanup.
+#   2. tmpfs-shadowed scratch (FIXED): the same root test unshares a mount
+#      namespace and mounts a fresh tmpfs OVER /home/runner (the first non-root,
+#      non-world-x parent of cwd), shadowing a scratch tree under target/interop
+#      so the from-dir vanishes and rsync fails link_stat with ENOENT. The
+#      git-ref driver now hosts the runtests.py scratch under a world-traversable
+#      base outside that parent (/tmp) - see world_traversable_scratch_base().
+#   3. Root-owned scratch: root legs leave root-owned files; the git-ref driver
+#      runs the scratch tree with a chmod -R u+rwX + rm -rf teardown before AND
+#      after each leg, so a mode-0 dir (xattrs/, recv-discard-nullderef/) can't
+#      wedge the next leg's cleanup.
 # Remaining raw FAILs that survive calibration and show a clear oc error (e.g.
 # ownership-depth `--groupmap=:1` rejected, mkpath auto-creating a path without
 # --mkpath, compress-options missing the --debug=NSTR line) are the genuine

--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -22,30 +22,27 @@
 # pin 3.4.4 -> 3.5.0, vendor the 3.5.0 testsuite as a release tarball, and
 # retire this git-ref tracker (or repoint it at the next dev branch).
 #
-# HARNESS-CALIBRATION FOLLOW-UP (not yet done; the raw leg counts are NOT yet
-# trustworthy as an oc-divergence number). The 3.5.0dev suite is the Python
-# *_test.py framework (rsyncfns.py + exitcodes.py), which drives rsync
-# differently from the 3.4.4 shell suite. A plain
-# `runtests.py --rsync-bin=oc-rsync` mis-drives a subset of it, so some FAILs
-# are harness gaps, NOT oc divergences. Known gaps to calibrate before the
-# tracker's number is authoritative:
-#   1. setpriv exec: fake-super/uid tests (e.g. partial_nowrite_test.py) run
-#      rsync via `setpriv`, which fails with "failed to execute .../oc-rsync:
-#      No such file or directory" (setpriv's dropped exec context can't resolve
-#      the binary/interp). The pre-transfer setup then never runs, cascading a
-#      Python FileNotFoundError that fails partial + partial_nowrite for a
-#      harness reason. Needs an rsync-on-PATH shim or a setpriv-visible binary.
-#   2. Per-test setup ordering in rsyncfns.py differs from the shell fns; some
-#      tests expect a FROMDIR the setpriv step was meant to populate.
-#   3. Root-owned scratch: root legs leave root-owned files; already chown'd
-#      back in the workflow, but the Python cleanup path (EACCES scandir on a
-#      mode-0 xattrs/to) still needs a permission-safe teardown inside the
-#      framework, not just around it.
-# Until these land, treat the tracker as a divergence *screen*: a test that
-# fails under BOTH pipe and tcp AND with a clear oc error (e.g. ownership-depth
-# `--groupmap=:1` rejected, mkpath auto-creating a path without --mkpath,
-# compress-options missing the --debug=NSTR line) is a real candidate; a test
-# failing via setpriv/FileNotFound/EACCES is a harness gap to fix here first.
+# HARNESS-CALIBRATION STATUS. The 3.5.0dev suite is the Python *_test.py
+# framework (rsyncfns.py + exitcodes.py), which drives rsync differently from
+# the 3.4.4 shell suite. A plain `runtests.py --rsync-bin=oc-rsync` mis-drives
+# a subset of it, so some raw FAILs were harness gaps, NOT oc divergences.
+# Calibrated so the leg counts approximate the real divergence set:
+#   1. setpriv exec (FIXED): fake-super/uid tests (e.g. partial_nowrite_test.py)
+#      run rsync via `setpriv` with CAP_DAC_OVERRIDE dropped. The default binary
+#      under /home/runner (mode 0750) is then un-traversable, so execve returned
+#      ENOENT ("setpriv: failed to execute .../oc-rsync: No such file or
+#      directory") and the Python harness cascaded a FileNotFoundError. The
+#      git-ref driver now publishes oc-rsync to a world-traversable path
+#      (/usr/local/bin, all components o+x) and points --rsync-bin there - see
+#      publish_oc_rsync_bin() in tools/ci/run_upstream_testsuite.sh.
+#   2. Root-owned scratch: root legs leave root-owned files; the git-ref driver
+#      runs the scratch tree under $log_root with a chmod -R u+rwX + rm -rf
+#      teardown before AND after each leg, so a mode-0 dir (xattrs/, recv-
+#      discard-nullderef/) can't wedge the next leg's cleanup.
+# Remaining raw FAILs that survive calibration and show a clear oc error (e.g.
+# ownership-depth `--groupmap=:1` rejected, mkpath auto-creating a path without
+# --mkpath, compress-options missing the --debug=NSTR line) are the genuine
+# pre-release divergence worklist, not harness noise.
 
 name: Track 3.5.0dev Testsuite
 

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -368,6 +368,24 @@ emit_gha_step_summary() {
     } >>"$summary_file"
 }
 
+# True (0) iff every component of the absolute path $1 has its o+x bit set, so
+# a CAP_DAC_OVERRIDE-dropped root or a dropped uid can traverse it. Unknown
+# (stat unavailable) counts as not-traversable - we only claim traversable when
+# we can prove it.
+path_world_traversable() {
+    local target=$1 p="" comp mode
+    local -a parts
+    IFS='/' read -r -a parts <<<"${target#/}"
+    for comp in "${parts[@]}"; do
+        [[ -z "$comp" ]] && continue
+        p="${p}/${comp}"
+        mode=$(stat -c '%a' "$p" 2>/dev/null || stat -f '%Lp' "$p" 2>/dev/null || echo "")
+        [[ -n "$mode" ]] || return 1
+        (( (0"$mode" & 1) != 0 )) || return 1
+    done
+    return 0
+}
+
 # Publish the oc-rsync binary to a world-traversable path and echo that path.
 #
 # WHY (root leg, setpriv): the 3.5.0dev fake-super/uid tests run rsync via
@@ -392,23 +410,7 @@ publish_oc_rsync_bin() {
     local dir
     for dir in /usr/local/bin /usr/bin; do
         [[ -d "$dir" && -w "$dir" ]] || continue
-        # Every path component of $dir must be o+x for a cap-dropped/dropped-uid
-        # exec to traverse it. Standard FHS dirs are 0755, but verify rather
-        # than assume - a hardened runner could differ.
-        local p="" comp mode ok=1
-        local -a parts
-        IFS='/' read -r -a parts <<<"${dir#/}"
-        for comp in "${parts[@]}"; do
-            p="${p}/${comp}"
-            mode=$(stat -c '%a' "$p" 2>/dev/null || stat -f '%Lp' "$p" 2>/dev/null || echo "")
-            # Require the "other execute" bit (0o1) on every component. If stat
-            # is unavailable we cannot prove traversability, so treat as not-ok.
-            if [[ -z "$mode" ]] || (( (0"$mode" & 1) == 0 )); then
-                ok=0
-                break
-            fi
-        done
-        [[ "$ok" -eq 1 ]] || continue
+        path_world_traversable "$dir" || continue
         local dst="${dir}/oc-rsync"
         if cp -f "$src" "$dst" 2>/dev/null && chmod 0755 "$dst" 2>/dev/null; then
             echo "$dst"
@@ -417,6 +419,31 @@ publish_oc_rsync_bin() {
     done
     # No writable world-traversable dir: keep the original path.
     echo "$src"
+    return 0
+}
+
+# Echo a world-traversable base dir to host the runtests.py scratch tree, or
+# the given fallback when none is usable.
+#
+# WHY (root leg, mount namespace): partial_nowrite_test.py, when running as
+# root on Linux, unshares a mount namespace and mounts a fresh tmpfs OVER the
+# first non-root, non-world-x parent of cwd (chown_target). On the runner that
+# parent is /home/runner, so the tmpfs SHADOWS everything beneath it - including
+# a scratch tree under target/interop (which lives under /home/runner). The
+# test's from-dir then vanishes inside the namespace and rsync fails link_stat
+# with ENOENT, a pure harness artifact. Hosting the scratch OUTSIDE the shadowed
+# parent (e.g. /tmp, mode 1777, all components world-x, never chown_target since
+# it is world-x) keeps the from/to/chk dirs visible after the tmpfs mount.
+world_traversable_scratch_base() {
+    local fallback=$1
+    local base
+    for base in "${TMPDIR:-}" /tmp; do
+        [[ -n "$base" && -d "$base" && -w "$base" ]] || continue
+        path_world_traversable "$base" || continue
+        echo "$base"
+        return 0
+    done
+    echo "$fallback"
     return 0
 }
 
@@ -497,10 +524,19 @@ run_git_ref_mode() {
         --srcdir="$upstream_src_dir"
         --timeout="$testrun_timeout"
     )
-    local scratch_home="${log_root}/scratch-${mode_tag}-${transport_tag}"
+    # Host the scratch tree under a world-traversable base OUTSIDE the parent
+    # that partial_nowrite_test.py shadows with a tmpfs (see
+    # world_traversable_scratch_base). Falls back to $log_root off-CI, so local
+    # runs (no root leg, no mount namespace) are unchanged.
+    local scratch_base
+    scratch_base=$(world_traversable_scratch_base "$log_root")
+    local scratch_home="${scratch_base}/oc-rsync-uts-scratch-${mode_tag}-${transport_tag}"
     chmod -R u+rwX "$scratch_home" 2>/dev/null || true
     rm -rf "$scratch_home"
     mkdir -p "$scratch_home"
+    if [[ "$scratch_base" != "$log_root" ]]; then
+        echo "==> Scratch tree under ${scratch_home} (outside the tmpfs-shadowed HOME)" >&2
+    fi
 
     local rc=0
     (

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -368,6 +368,58 @@ emit_gha_step_summary() {
     } >>"$summary_file"
 }
 
+# Publish the oc-rsync binary to a world-traversable path and echo that path.
+#
+# WHY (root leg, setpriv): the 3.5.0dev fake-super/uid tests run rsync via
+# setpriv with CAP_DAC_OVERRIDE dropped (partial_nowrite_test.py:65
+# "setpriv --inh-caps -all --bounding-set -all"). The default binary lives at
+# $GITHUB_WORKSPACE/target/release/oc-rsync, i.e. under /home/runner, which is
+# mode 0750 and owned by the runner user. Without CAP_DAC_OVERRIDE even root
+# cannot TRAVERSE /home/runner, so execve() of that path returns ENOENT and
+# setpriv prints "failed to execute .../oc-rsync: No such file or directory".
+# The Python harness then throws FileNotFoundError on the test's from-dir and
+# the failure cascades. The test's own mount-namespace remount only covers the
+# cwd (the upstream source tree), not target/release, so the binary stays
+# unreachable. Copying it to a path whose every component is o+x (e.g.
+# /usr/local/bin, all 0755 on the runner) removes the traversal barrier for
+# both the cap-dropped root leg and any dropped-uid exec. Prefer copying the
+# binary OUT of the runner HOME over chmod'ing HOME itself.
+#
+# Falls back to the original path when no world-traversable install dir is
+# writable (local dev), so non-CI runs are unchanged.
+publish_oc_rsync_bin() {
+    local src=$1
+    local dir
+    for dir in /usr/local/bin /usr/bin; do
+        [[ -d "$dir" && -w "$dir" ]] || continue
+        # Every path component of $dir must be o+x for a cap-dropped/dropped-uid
+        # exec to traverse it. Standard FHS dirs are 0755, but verify rather
+        # than assume - a hardened runner could differ.
+        local p="" comp mode ok=1
+        local -a parts
+        IFS='/' read -r -a parts <<<"${dir#/}"
+        for comp in "${parts[@]}"; do
+            p="${p}/${comp}"
+            mode=$(stat -c '%a' "$p" 2>/dev/null || stat -f '%Lp' "$p" 2>/dev/null || echo "")
+            # Require the "other execute" bit (0o1) on every component. If stat
+            # is unavailable we cannot prove traversability, so treat as not-ok.
+            if [[ -z "$mode" ]] || (( (0"$mode" & 1) == 0 )); then
+                ok=0
+                break
+            fi
+        done
+        [[ "$ok" -eq 1 ]] || continue
+        local dst="${dir}/oc-rsync"
+        if cp -f "$src" "$dst" 2>/dev/null && chmod 0755 "$dst" 2>/dev/null; then
+            echo "$dst"
+            return 0
+        fi
+    done
+    # No writable world-traversable dir: keep the original path.
+    echo "$src"
+    return 0
+}
+
 # Git-ref mode driver: delegate to upstream's own runtests.py.
 #
 # The 3.5.0dev testsuite is Python (runtests.py + testsuite/*_test.py), so we
@@ -403,6 +455,16 @@ run_git_ref_mode() {
     mkdir -p "$log_root"
     local output_log="${log_root}/runtests-output.log"
 
+    # Point --rsync-bin at a world-traversable copy of the binary so the root
+    # leg's setpriv (CAP_DAC_OVERRIDE-dropped) exec can reach it - see
+    # publish_oc_rsync_bin(). Non-CI runs where no such dir is writable fall
+    # back to the original path, so behaviour there is unchanged.
+    local rsync_bin_published
+    rsync_bin_published=$(publish_oc_rsync_bin "$oc_rsync_bin")
+    if [[ "$rsync_bin_published" != "$oc_rsync_bin" ]]; then
+        echo "==> Published oc-rsync to ${rsync_bin_published} (setpriv-reachable)" >&2
+    fi
+
     # Permission-safe scratch cleanup. A test that leaves a mode-0 directory
     # behind (e.g. xattrs/, recv-discard-nullderef/) makes a plain `rm -rf`
     # throw for the non-root runner, and runtests.py's per-test prep_scratch
@@ -430,7 +492,7 @@ run_git_ref_mode() {
         runtests_argv+=(--use-tcp)
     fi
     runtests_argv+=(
-        --rsync-bin="$oc_rsync_bin"
+        --rsync-bin="$rsync_bin_published"
         --tooldir="$upstream_src_dir"
         --srcdir="$upstream_src_dir"
         --timeout="$testrun_timeout"


### PR DESCRIPTION
## Problem

The nightly 3.5.0dev testsuite tracker's raw leg counts include harness
artifacts, not just oc-rsync divergences. The root legs hit a two-layer
harness failure originating in `partial_nowrite_test.py`.

### Layer 1 - setpriv exec (confirmed from run 28566295381, root-pipe)

```
setpriv: failed to execute /home/runner/work/rsync/rsync/target/release/oc-rsync: No such file or directory
...
FileNotFoundError: [Errno 2] No such file or directory: '.../scratch-root-pipe/testtmp/partial_nowrite/from'
```

`partial_nowrite_test.py:65` sets `RSYNC = "setpriv --inh-caps -all
--bounding-set -all " + RSYNC`, dropping `CAP_DAC_OVERRIDE`. The binary at
`/home/runner/.../target/release/oc-rsync` is behind `/home/runner`
(mode 0750, runner-owned); without `CAP_DAC_OVERRIDE` even root can't
traverse it, so `execve` returns ENOENT.

### Layer 2 - tmpfs-shadowed scratch (surfaced after Layer 1 fix, run 28599847003)

With the binary reachable, `setpriv` execs fine, but a second artifact
appears:

```
link_stat ".../partial_nowrite/from/" failed: No such file or directory (2)
```

The same root test unshares a mount namespace and mounts a fresh tmpfs
**over** `/home/runner` (the first non-root, non-world-x parent of cwd),
shadowing a scratch tree under `target/interop` so the from-dir vanishes
inside the namespace.

## Fix (both confined to `run_git_ref_mode()`)

1. `publish_oc_rsync_bin()` - copies oc-rsync to `/usr/local/bin/oc-rsync`
   (every path component verified `o+x`) and points `--rsync-bin` there.
2. `world_traversable_scratch_base()` - hosts the runtests.py scratch under
   a world-traversable base outside the shadowed parent (`/tmp`, mode 1777).
   The shared `path_world_traversable()` proof also rejects a `TMPDIR` that
   itself sits under the shadowed HOME.

Both fall back to the original paths off-CI, so local runs are unchanged.
The required 3.4.4 tarball gate runs `main()` (git_ref_mode=no) and is
untouched.

## Validation

- `bash -n` + `shellcheck` clean; workflow YAML `safe_load`-valid.
- All `cargo` invocations keep `--locked`; action SHAs unchanged; no AI refs.
- Dispatched runs confirm the setpriv/FileNotFound cascade is removed; the
  corrected per-leg divergence counts + genuine failing-test worklist are in
  the PR discussion.

Non-required / informational tracker (`continue-on-error`); does not gate PRs.
