### PR TITLE
fix: reject invalid --chmod specs to match upstream parse_chmod

### DIFF
--- a/crates/metadata/src/chmod/apply.rs
+++ b/crates/metadata/src/chmod/apply.rs
@@ -93,29 +93,6 @@ fn apply_symbolic_clause(mut mode: u32, clause: &SymbolicClause, is_dir: bool) -
             bits = 0;
         }
 
-        let mut copied = 0u32;
-        if clause.perms.copy_user {
-            copied |= copy_from(Dest::User, dest, before);
-        }
-        if clause.perms.copy_group {
-            copied |= copy_from(Dest::Group, dest, before);
-        }
-        if clause.perms.copy_other {
-            copied |= copy_from(Dest::Other, dest, before);
-        }
-
-        match clause.op {
-            Operation::Add => {
-                bits |= copied & mask;
-            }
-            Operation::Remove => {
-                bits &= !(copied & mask);
-            }
-            Operation::Assign => {
-                bits = copied & mask;
-            }
-        }
-
         let add_bits = permission_bits(&clause.perms, dest, is_dir, before) & umask_mask;
         match clause.op {
             Operation::Add | Operation::Assign => {
@@ -205,14 +182,6 @@ impl Dest {
         }
     }
 
-    const fn shift(self) -> u8 {
-        match self {
-            Self::User => 6,
-            Self::Group => 3,
-            Self::Other => 0,
-        }
-    }
-
     const fn read_mask(self) -> u32 {
         match self {
             Self::User => 0o400,
@@ -262,22 +231,6 @@ const fn permission_bits(spec: &PermSpec, dest: Dest, is_dir: bool, before: u32)
 }
 
 #[cfg(unix)]
-const fn copy_from(source: Dest, dest: Dest, before: u32) -> u32 {
-    let src_mask = source.permission_mask();
-    let src_bits = before & src_mask;
-    let shift = source.shift() as i8 - dest.shift() as i8;
-
-    let shifted = if shift == 0 {
-        src_bits
-    } else if shift > 0 {
-        src_bits >> shift as u32
-    } else {
-        src_bits << (-shift) as u32
-    };
-
-    shifted & dest.permission_mask()
-}
-
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
@@ -287,13 +240,6 @@ mod tests {
         assert_eq!(Dest::User.permission_mask(), 0o700);
         assert_eq!(Dest::Group.permission_mask(), 0o070);
         assert_eq!(Dest::Other.permission_mask(), 0o007);
-    }
-
-    #[test]
-    fn dest_shifts() {
-        assert_eq!(Dest::User.shift(), 6);
-        assert_eq!(Dest::Group.shift(), 3);
-        assert_eq!(Dest::Other.shift(), 0);
     }
 
     #[test]
@@ -315,34 +261,6 @@ mod tests {
         assert_eq!(Dest::User.exec_mask(), 0o100);
         assert_eq!(Dest::Group.exec_mask(), 0o010);
         assert_eq!(Dest::Other.exec_mask(), 0o001);
-    }
-
-    #[test]
-    fn copy_from_user_to_group() {
-        let mode = 0o750;
-        let result = copy_from(Dest::User, Dest::Group, mode);
-        assert_eq!(result, 0o070);
-    }
-
-    #[test]
-    fn copy_from_user_to_other() {
-        let mode = 0o700;
-        let result = copy_from(Dest::User, Dest::Other, mode);
-        assert_eq!(result, 0o007);
-    }
-
-    #[test]
-    fn copy_from_group_to_user() {
-        let mode = 0o070;
-        let result = copy_from(Dest::Group, Dest::User, mode);
-        assert_eq!(result, 0o700);
-    }
-
-    #[test]
-    fn copy_from_same_dest() {
-        let mode = 0o750;
-        let result = copy_from(Dest::User, Dest::User, mode);
-        assert_eq!(result, 0o700);
     }
 
     #[test]
@@ -385,9 +303,6 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
-            copy_user: false,
-            copy_group: false,
-            copy_other: false,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0), 0o400);
         assert_eq!(permission_bits(&spec, Dest::Group, false, 0), 0o040);
@@ -404,9 +319,6 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
-            copy_user: false,
-            copy_group: false,
-            copy_other: false,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0), 0o700);
     }
@@ -421,9 +333,6 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
-            copy_user: false,
-            copy_group: false,
-            copy_other: false,
         };
         assert_eq!(permission_bits(&spec, Dest::User, true, 0), 0o100);
     }
@@ -438,9 +347,6 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
-            copy_user: false,
-            copy_group: false,
-            copy_other: false,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0o111), 0o100);
     }
@@ -455,9 +361,6 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
-            copy_user: false,
-            copy_group: false,
-            copy_other: false,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0o644), 0);
     }

--- a/crates/metadata/src/chmod/comprehensive_tests.rs
+++ b/crates/metadata/src/chmod/comprehensive_tests.rs
@@ -182,34 +182,22 @@ mod basic_symbolic_syntax {
         assert!(!modifiers.is_empty());
     }
 
+    // upstream: chmod.c:parse_chmod() has no GNU-style "copy permissions"
+    // form. A who-class letter in the RHS (STATE_2ND_HALF) is STATE_ERROR, so
+    // `g=u`, `o=g`, `o=u` are all rejected.
     #[test]
-    fn copy_user_to_group() {
-        let modifiers = ChmodModifiers::parse("g=u").expect("parse g=u");
-        assert!(!modifiers.is_empty());
+    fn who_letter_in_rhs_rejected() {
+        assert!(ChmodModifiers::parse("g=u").is_err());
+        assert!(ChmodModifiers::parse("o=g").is_err());
+        assert!(ChmodModifiers::parse("o=u").is_err());
     }
 
+    // upstream: who-class and permission letters are lowercase only (except
+    // `X`). Uppercase who/perm letters route to STATE_ERROR.
     #[test]
-    fn copy_group_to_other() {
-        let modifiers = ChmodModifiers::parse("o=g").expect("parse o=g");
-        assert!(!modifiers.is_empty());
-    }
-
-    #[test]
-    fn copy_user_to_other() {
-        let modifiers = ChmodModifiers::parse("o=u").expect("parse o=u");
-        assert!(!modifiers.is_empty());
-    }
-
-    #[test]
-    fn uppercase_who_specifiers() {
-        let modifiers = ChmodModifiers::parse("U+R").expect("parse U+R");
-        assert!(!modifiers.is_empty());
-    }
-
-    #[test]
-    fn mixed_case() {
-        let modifiers = ChmodModifiers::parse("Ug+Rw").expect("parse Ug+Rw");
-        assert!(!modifiers.is_empty());
+    fn uppercase_who_or_perm_rejected() {
+        assert!(ChmodModifiers::parse("U+R").is_err());
+        assert!(ChmodModifiers::parse("Ug+Rw").is_err());
     }
 }
 
@@ -647,29 +635,11 @@ mod apply_mode {
     }
 
     #[test]
-    fn copy_user_to_group_and_other() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let file_path = temp.path().join("test.txt");
-        std::fs::write(&file_path, b"content").expect("write file");
-
-        let file_type = get_file_type(&file_path);
-        let modifiers = ChmodModifiers::parse("g=u,o=u").expect("parse");
-
-        let result = modifiers.apply(0o700, file_type);
-        assert_eq!(result & 0o777, 0o777);
-    }
-
-    #[test]
-    fn copy_group_to_other() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let file_path = temp.path().join("test.txt");
-        std::fs::write(&file_path, b"content").expect("write file");
-
-        let file_type = get_file_type(&file_path);
-        let modifiers = ChmodModifiers::parse("o=g").expect("parse");
-
-        let result = modifiers.apply(0o750, file_type);
-        assert_eq!(result & 0o007, 0o005);
+    fn who_letter_copy_form_rejected_at_parse() {
+        // upstream: chmod.c:parse_chmod() rejects `g=u`/`o=u`/`o=g`; there is
+        // no runtime copy behaviour to exercise because parsing fails first.
+        assert!(ChmodModifiers::parse("g=u,o=u").is_err());
+        assert!(ChmodModifiers::parse("o=g").is_err());
     }
 
     #[test]

--- a/crates/metadata/src/chmod/mod.rs
+++ b/crates/metadata/src/chmod/mod.rs
@@ -4,11 +4,13 @@
 //!
 //! The upstream rsync CLI allows multiple `--chmod=SPEC` occurrences where each
 //! specification may contain comma-separated numeric or symbolic clauses. This
-//! module mirrors the clause grammar and applies modifiers to permission modes
-//! with behaviour identical to GNU `chmod`, including conditional execute bits
-//! and copy directives (for example `g=u`). The [`ChmodModifiers`] type wraps
-//! the parsed clauses and exposes [`ChmodModifiers::apply`] so higher layers can
-//! evaluate modifiers after the standard metadata preservation step.
+//! module mirrors upstream rsync's `chmod.c:parse_chmod()` grammar exactly,
+//! including conditional execute bits (`X`) and the set-id/sticky bits. Unlike
+//! GNU `chmod`, rsync has no "copy permissions" form: who-class letters
+//! (`u`/`g`/`o`/`a`) are only valid before the operator, so a spec like `g=ur`
+//! is rejected. The [`ChmodModifiers`] type wraps the parsed clauses and
+//! exposes [`ChmodModifiers::apply`] so higher layers can evaluate modifiers
+//! after the standard metadata preservation step.
 
 mod apply;
 mod parse;

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -32,13 +32,16 @@ fn parse_clause(text: &str) -> Result<Clause, ChmodError> {
     let mut chars = text.chars().peekable();
     let mut target = TargetSelector::All;
 
+    // upstream: chmod.c:parse_chmod() STATE_1ST_HALF - only uppercase `D`
+    // (dirs-only) and `F` (files-only) are target flags. Lowercase `d`/`f`
+    // are not accepted; upstream routes them to STATE_ERROR.
     loop {
         match chars.peek().copied() {
-            Some('D') | Some('d') => {
+            Some('D') => {
                 target = TargetSelector::Directories;
                 chars.next();
             }
-            Some('F') | Some('f') => {
+            Some('F') => {
                 target = TargetSelector::Files;
                 chars.next();
             }
@@ -60,24 +63,27 @@ fn parse_clause(text: &str) -> Result<Clause, ChmodError> {
     let mut who = WhoMask::new(false, false, false);
     let mut consumed_who = false;
 
+    // upstream: chmod.c:parse_chmod() STATE_1ST_HALF - the who-class letters
+    // are lowercase only (`u`, `g`, `o`, `a`). Uppercase variants are not
+    // accepted and fall through to STATE_ERROR.
     loop {
         match chars.peek().copied() {
-            Some('u') | Some('U') => {
+            Some('u') => {
                 who.user = true;
                 consumed_who = true;
                 chars.next();
             }
-            Some('g') | Some('G') => {
+            Some('g') => {
                 who.group = true;
                 consumed_who = true;
                 chars.next();
             }
-            Some('o') | Some('O') => {
+            Some('o') => {
                 who.other = true;
                 consumed_who = true;
                 chars.next();
             }
-            Some('a') | Some('A') => {
+            Some('a') => {
                 who = WhoMask::new(true, true, true);
                 consumed_who = true;
                 chars.next();
@@ -139,20 +145,22 @@ fn parse_perm_spec(perms: &str, op: Operation) -> Result<PermSpec, ChmodError> {
         ));
     }
 
+    // upstream: chmod.c:parse_chmod() STATE_2ND_HALF - the permission letters
+    // are exactly `r`, `w`, `x`, `X`, `s`, `t`. Anything else (including the
+    // who-class letters `u`/`g`/`o`/`a` and uppercase `R`/`W`/`S`/`T`) is
+    // rejected via STATE_ERROR. rsync has no GNU-style "copy permissions"
+    // form, so `g=ur` must be an error rather than a copy directive.
     for ch in perms.chars() {
         match ch {
-            'r' | 'R' => spec.read = true,
-            'w' | 'W' => spec.write = true,
+            'r' => spec.read = true,
+            'w' => spec.write = true,
             'x' => spec.exec = true,
             'X' => spec.exec_if_conditional = true,
-            's' | 'S' => {
+            's' => {
                 spec.setuid = true;
                 spec.setgid = true;
             }
-            't' | 'T' => spec.sticky = true,
-            'u' | 'U' => spec.copy_user = true,
-            'g' | 'G' => spec.copy_group = true,
-            'o' | 'O' => spec.copy_other = true,
+            't' => spec.sticky = true,
             _ => return Err(ChmodError::new(format!("unsupported chmod token '{ch}'"))),
         }
     }
@@ -451,21 +459,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_perm_spec_copy_user() {
-        let spec = parse_perm_spec("u", Operation::Add).unwrap();
-        assert!(spec.copy_user);
-    }
-
-    #[test]
-    fn parse_perm_spec_copy_group() {
-        let spec = parse_perm_spec("g", Operation::Add).unwrap();
-        assert!(spec.copy_group);
-    }
-
-    #[test]
-    fn parse_perm_spec_copy_other() {
-        let spec = parse_perm_spec("o", Operation::Add).unwrap();
-        assert!(spec.copy_other);
+    fn parse_perm_spec_who_letters_rejected() {
+        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF rejects the who-class
+        // letters u/g/o/a as permission bits. rsync has no GNU "copy" form.
+        assert!(parse_perm_spec("u", Operation::Add).is_err());
+        assert!(parse_perm_spec("g", Operation::Add).is_err());
+        assert!(parse_perm_spec("o", Operation::Add).is_err());
+        assert!(parse_perm_spec("a", Operation::Add).is_err());
     }
 
     #[test]
@@ -477,11 +477,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_perm_spec_uppercase() {
-        let spec = parse_perm_spec("RWX", Operation::Add).unwrap();
-        assert!(spec.read);
-        assert!(spec.write);
-        // Upstream maps capital X to "conditional exec", never plain exec.
+    fn parse_perm_spec_uppercase_rwst_rejected() {
+        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF only accepts uppercase
+        // `X`; uppercase R/W/S/T are not permission letters and error out.
+        assert!(parse_perm_spec("R", Operation::Add).is_err());
+        assert!(parse_perm_spec("W", Operation::Add).is_err());
+        assert!(parse_perm_spec("S", Operation::Add).is_err());
+        assert!(parse_perm_spec("T", Operation::Add).is_err());
+        // `X` remains valid (conditional exec).
+        let spec = parse_perm_spec("X", Operation::Add).unwrap();
         assert!(spec.exec_if_conditional);
     }
 
@@ -692,5 +696,34 @@ mod tests {
             }
             _ => panic!("expected symbolic clause"),
         }
+    }
+
+    #[test]
+    fn upstream_g_eq_ur_is_rejected() {
+        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF sees `u` after `g=`
+        // and transitions to STATE_ERROR, so parse_chmod returns NULL. rsync
+        // rejects `g=ur`; oc-rsync must not silently accept it as a copy form.
+        assert!(parse_spec("g=ur").is_err());
+        // Equivalent who-letter-in-RHS mixes are likewise rejected.
+        assert!(parse_spec("u+g").is_err());
+        assert!(parse_spec("o=g").is_err());
+        assert!(parse_spec("a=u").is_err());
+    }
+
+    #[test]
+    fn upstream_valid_symbolic_forms_still_parse() {
+        // Guard against over-rejection: the canonical valid specs from
+        // chmod-option.test must continue to parse cleanly.
+        for spec in ["Fugo=rwx", "g-w", "Dg+s", "u+rwx", "Fo-x", "ug-s", "a+rX"] {
+            parse_spec(spec).unwrap_or_else(|_| panic!("`{spec}` must parse"));
+        }
+    }
+
+    #[test]
+    fn upstream_lowercase_target_flags_rejected() {
+        // upstream: only uppercase `D`/`F` are target flags; lowercase `d`/`f`
+        // are not who-class letters, digits, or operators -> STATE_ERROR.
+        assert!(parse_spec("d755").is_err());
+        assert!(parse_spec("fu+x").is_err());
     }
 }

--- a/crates/metadata/src/chmod/spec.rs
+++ b/crates/metadata/src/chmod/spec.rs
@@ -77,9 +77,6 @@ pub(crate) struct PermSpec {
     pub(crate) setuid: bool,
     pub(crate) setgid: bool,
     pub(crate) sticky: bool,
-    pub(crate) copy_user: bool,
-    pub(crate) copy_group: bool,
-    pub(crate) copy_other: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -211,9 +208,6 @@ mod tests {
         assert!(!spec.setuid);
         assert!(!spec.setgid);
         assert!(!spec.sticky);
-        assert!(!spec.copy_user);
-        assert!(!spec.copy_group);
-        assert!(!spec.copy_other);
     }
 
     #[test]

--- a/crates/metadata/src/chmod/tests.rs
+++ b/crates/metadata/src/chmod/tests.rs
@@ -61,19 +61,12 @@ fn conditional_execute_bit_behaviour_matches_rsync() {
     assert_eq!(dir_mode & 0o777, 0o711);
 }
 
-#[cfg(unix)]
+/// upstream: chmod.c:parse_chmod() rejects who-class letters (u/g/o/a) in the
+/// permission RHS (STATE_2ND_HALF -> STATE_ERROR). rsync has no GNU-style
+/// "copy permissions" form, so `g=u,o=g` must fail to parse.
 #[test]
-fn user_group_copy_clauses_are_respected() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let file_path = temp.path().join("data.bin");
-    std::fs::write(&file_path, b"payload").expect("write file");
-    let file_type = std::fs::metadata(&file_path)
-        .expect("file metadata")
-        .file_type();
-
-    let modifiers = ChmodModifiers::parse("g=u,o=g").expect("parse");
-    let mode = modifiers.apply(0o640, file_type);
-    assert_eq!(mode & 0o777, 0o666);
+fn user_group_copy_clauses_are_rejected() {
+    assert!(ChmodModifiers::parse("g=u,o=g").is_err());
 }
 
 /// Verifies that `D+w` (no explicit who) applies umask masking.


### PR DESCRIPTION
## Problem

3.5.0dev conformance run flagged that `--chmod=g=ur` was not rejected: oc-rsync accepted an invalid chmod spec that upstream rsync rejects.

Upstream `chmod.c:parse_chmod()` is a small state machine. In `STATE_2ND_HALF` (the permission RHS after `+`/`-`/`=`) the only accepted letters are `r w x X s t`; anything else - including the who-class letters `u`/`g`/`o`/`a` - hits `default: state = STATE_ERROR`, so `parse_chmod` returns NULL and rsync rejects the spec. rsync has no GNU-style "copy permissions" form, so `g=ur` (a `u` copy-letter mixed with an `r` perm-letter) is invalid.

oc-rsync instead treated `u`/`g`/`o` in the RHS as GNU "copy from user/group/other" directives and silently accepted them.

## Fix

Align the parser in `crates/metadata/src/chmod/` with `parse_chmod` exactly:

- Permission RHS letters restricted to `r w x X s t` (matches `STATE_2ND_HALF`). Who-class letters and uppercase `R`/`W`/`S`/`T` now error.
- Who-class letters accepted only as lowercase `u`/`g`/`o`/`a` before the operator (matches `STATE_1ST_HALF`); uppercase variants error.
- Target flags accepted only as uppercase `D`/`F`; lowercase `d`/`f` error.
- Removed the non-upstream `copy_user`/`copy_group`/`copy_other` field and the associated `copy_from`/`shift` apply paths (dead once the copy form is rejected).

## Verification

Valid specs still parse: `Fugo=rwx`, `g-w`, `Dg+s`, `u+rwx`, `Fo-x`, `ug-s`, `a+rX`. Invalid specs now error: `g=ur`, `o=g`, `o=u`, `U+R`, `d755`, `fu+x`.

`cargo fmt --all --check` clean; `cargo clippy -p metadata --all-targets --all-features --no-deps --locked -- -D warnings` clean.

Reference: `chmod.c:parse_chmod()`.