### PR TITLE
fix(transfer): gate receiver dest-path creation on --mkpath (keep in-tree subdirs)

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -162,6 +162,13 @@ pub(super) struct ServerLongFlags {
     /// upstream: options.c:2891-2892 - `server_options()` emits
     /// `--delay-updates` alongside `--partial-dir` when both are active.
     pub(super) delay_updates: bool,
+    /// Whether `--mkpath` was forwarded by the client (upstream: `--mkpath`).
+    ///
+    /// upstream: options.c:2996-2997 - `if (mkpath_dest_arg && am_sender)
+    /// args[ac++] = "--mkpath"`. Long-form only. Gates the receiver's
+    /// dest-arg path creation (`main.c:736` `make_path` vs `main.c:788`
+    /// single `do_mkdir`).
+    pub(super) mkpath: bool,
 }
 
 /// Parses all long-form flags from the server argument list.
@@ -208,6 +215,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         log_format: None,
         partial_dir: None,
         delay_updates: false,
+        mkpath: false,
     };
 
     let mut idx = 0;
@@ -266,6 +274,11 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             }
             // upstream: options.c:2891-2892 - emitted alongside --partial-dir.
             "--delay-updates" => flags.delay_updates = true,
+            // upstream: options.c:2996-2997 - --mkpath forwarded to the server
+            // receiver when the client is the sender (push). --no-mkpath is the
+            // negation (options.c:834). Gates dest-arg path creation below.
+            "--mkpath" => flags.mkpath = true,
+            "--no-mkpath" | "--old-dirs" => flags.mkpath = false,
             _ => {
                 // upstream: options.c::server_options() emits a handful of
                 // path-bearing long flags (`--copy-dest`, `--link-dest`,
@@ -447,6 +460,9 @@ pub(super) fn is_known_server_long_flag(arg: &str) -> bool {
             | "--delay-updates"
             | "--partial-dir"
             | "--backup"
+            | "--mkpath"
+            | "--no-mkpath"
+            | "--old-dirs"
     ) || arg == "-s"
         || arg == "--new-compress"
         || arg == "--old-compress"

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -185,6 +185,12 @@ where
     // consumed by the sender's `successful_send()` after each transferred
     // file is acknowledged.
     config.flags.remove_source_files = long_flags.remove_source_files;
+    // upstream: options.c:2996-2997 - `--mkpath` is forwarded long-form to the
+    // server receiver on a push. The receiver gates dest-arg path creation on
+    // this flag: without it, a missing ancestor chain is an error
+    // (`main.c:788` single `do_mkdir`); with it, the whole chain is created
+    // (`main.c:736` `make_path`).
+    config.flags.mkpath = long_flags.mkpath;
     // upstream: options.c:2046-2048 - do_stats sets info_levels[INFO_STATS] >= 2.
     // The server-side flag must be set so the generator emits NDX_DEL_STATS
     // during the goodbye phase (generator.c:2377,2422).

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -359,6 +359,14 @@ pub(super) fn build_full_daemon_args(
         args.push("--remove-source-files".to_owned());
     }
 
+    // upstream: options.c:2996-2997 - `if (mkpath_dest_arg && am_sender)`.
+    // The dest-arg path creation is receiver-side, so forward `--mkpath` only
+    // on a push (local client is the sender). `!is_sender` mirrors upstream's
+    // `am_sender` here (see the module note above).
+    if config.mkpath() && !is_sender {
+        args.push("--mkpath".to_owned());
+    }
+
     // upstream: options.c:2944-2962 - server_options() forwards the
     // files-from arg only when the remote peer reads the list. `is_sender`
     // here means the daemon is the sender (PULL), so the local side pushes

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -448,6 +448,17 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // `--omit-dir-times` to a remote sender (pull), which then stats it as a
         // source path.
 
+        // upstream: options.c:2996-2997 - `if (mkpath_dest_arg && am_sender)
+        // args[ac++] = "--mkpath"`. The dest-arg path creation is a
+        // receiver-side concern, so the option is forwarded only when the
+        // local process is the sender (a PUSH to a remote receiver).
+        // `RemoteRole::Sender` here means the remote peer acts as the
+        // receiver (this builder pushes `--sender` for the opposite role),
+        // matching upstream's `am_sender` branch (see `am_sender` above).
+        if self.config.mkpath() && self.role == RemoteRole::Sender {
+            args.push(OsString::from("--mkpath"));
+        }
+
         if self.config.delay_updates() {
             args.push(OsString::from("--delay-updates"));
         }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -110,6 +110,15 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--fsync" => {
                 config.write.fsync = true;
             }
+            // upstream: options.c:2996-2997 - --mkpath forwarded to the daemon
+            // receiver on a push. Gates dest-arg path creation (main.c:736
+            // make_path vs main.c:788 single do_mkdir).
+            "--mkpath" => {
+                config.flags.mkpath = true;
+            }
+            "--no-mkpath" | "--old-dirs" => {
+                config.flags.mkpath = false;
+            }
             // upstream: options.c:2849 - backup
             "--backup" => {
                 config.flags.backup = true;

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -167,6 +167,16 @@ pub struct ParsedServerFlags {
     /// - `options.c:765` - `remove_source_files` global definition
     pub remove_source_files: bool,
 
+    /// Create missing destination path components (long-form `--mkpath`).
+    ///
+    /// Not part of the compact flag string; forwarded by the sending client
+    /// only (upstream `options.c:2996-2997` - `if (mkpath_dest_arg &&
+    /// am_sender) args[ac++] = "--mkpath"`). Gates the receiver's dest-arg
+    /// path creation: without it, upstream `main.c:788` does a single
+    /// `do_mkdir(dest_path)` (which fails when an ancestor is missing); with
+    /// it, `main.c:736` calls `make_path()` to create the whole chain.
+    pub mkpath: bool,
+
     /// Info flags after the first `.` separator.
     pub info_flags: InfoFlags,
 }

--- a/crates/transfer/src/receiver/dest_root.rs
+++ b/crates/transfer/src/receiver/dest_root.rs
@@ -56,11 +56,22 @@ pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
 /// proceeds when `S_ISDIR(st.st_mode)` is true. A symlinked dest root is
 /// the upstream `symlink-dirlink-basis` interop scenario (issue #715).
 ///
-/// A dangling symlink resolves to `ENOENT`, and the helper would then call
-/// `create_dir_all`, which would materialize the directory at the symlink
-/// target. To avoid that footgun we lstat first when the stat reports
-/// `NotFound`: if the path is actually a dangling symlink we propagate the
-/// stat-side `NotFound` instead of auto-creating through the link.
+/// A dangling symlink resolves to `ENOENT`, and the helper would then create
+/// the directory, which would materialize it at the symlink target. To avoid
+/// that footgun we lstat first when the stat reports `NotFound`: if the path
+/// is actually a dangling symlink we propagate the stat-side `NotFound`
+/// instead of auto-creating through the link.
+///
+/// # `--mkpath` gating
+///
+/// Upstream creates the destination root with a *single* `do_mkdir(dest_path)`
+/// (`main.c:788-792`), which fails with `ENOENT` when an ancestor directory is
+/// missing. The whole missing chain is created only under `--mkpath`, via
+/// `make_path(dest_path)` (`main.c:736`). This helper mirrors that: with
+/// `mkpath == false` it uses [`std::fs::create_dir`] (single level), with
+/// `mkpath == true` it uses [`std::fs::create_dir_all`] (full chain). Passing
+/// `create_dir_all` unconditionally would auto-create deep destination paths
+/// without `--mkpath`, diverging from upstream.
 ///
 /// # Security model
 ///
@@ -86,7 +97,10 @@ pub(in crate::receiver) fn dest_arg_has_trailing_slash(arg: &OsStr) -> bool {
 /// - `main.c:745-754` - `get_local_name()` `S_ISDIR(st.st_mode)` branch:
 ///   `do_stat()` follows symlinks, `change_dir()` resolves the link and
 ///   enters the target.
+/// - `main.c:736` - `get_local_name()` `--mkpath` branch:
+///   `make_path(dest_path, ...)` creates the whole missing chain.
 /// - `main.c:778-792` - `get_local_name()` pre-flight `do_mkdir(dest_path, ACCESSPERMS)`
+///   (single level, no ancestor creation) when `--mkpath` was not requested.
 /// - `main.c:794-796` - sets `FLAG_DIR_CREATED` on the first flist entry when
 ///   its basename is `.` (deferred follow-up; oc-rsync's delete path does
 ///   not currently consume that flag).
@@ -95,11 +109,23 @@ pub fn ensure_dest_root_exists(
     file_total: usize,
     trailing_slash: bool,
     dry_run: bool,
+    mkpath: bool,
 ) -> io::Result<bool> {
     if dry_run {
         return Ok(false);
     }
-    if file_total <= 1 && !trailing_slash {
+    // upstream: main.c:788 - the non-mkpath dir branch only fires for a
+    // multi-file transfer or a trailing-slash operand. A single-file
+    // no-slash operand names the destination file itself (the operand
+    // basename was already split off by `apply_single_file_rename`), so
+    // without `--mkpath` there is no root to pre-create here.
+    //
+    // upstream: main.c:736 - under `--mkpath`, `make_path(dest_path, ...)`
+    // also creates the parent chain of a single-file operand (the
+    // `MKP_DROP_NAME` case), so the early no-op must not swallow the mkpath
+    // path. `dest_root` here is already the parent directory for the
+    // single-file rename, so creating it materializes the missing chain.
+    if file_total <= 1 && !trailing_slash && !mkpath {
         return Ok(false);
     }
     // stat (follows symlinks) so a symlinked dest pointing at a real
@@ -133,7 +159,14 @@ pub fn ensure_dest_root_exists(
                     ),
                 ));
             }
-            std::fs::create_dir_all(dest_root).map(|()| true)
+            // upstream: main.c:736 make_path (full chain) only under --mkpath;
+            // otherwise main.c:788 do_mkdir creates a single level and fails
+            // with ENOENT when an ancestor is missing.
+            if mkpath {
+                std::fs::create_dir_all(dest_root).map(|()| true)
+            } else {
+                std::fs::create_dir(dest_root).map(|()| true)
+            }
         }
         Err(err) => Err(err),
     }

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -293,6 +293,7 @@ impl ReceiverContext {
             file_count,
             trailing_slash,
             self.config.flags.skip_dest_writes(),
+            self.config.flags.mkpath,
         )
         .map_err(|e| {
             io::Error::new(

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -182,27 +182,17 @@ fn open_tmpfile_inner(
             }
             Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                // upstream: receiver.c:766 - mkdir_defmode(dn) before do_mkstemp().
-                // SEC-1.r accepted residual: multi-component parent recovery
-                // cannot anchor on a single dirfd without an `mkpath_via_sandbox`
-                // helper; fall back to the path-based create_dir_all walk.
-                if let Some(parent) = concrete_path.parent() {
-                    fs::create_dir_all(parent)?;
-                    if let Ok(file) = try_create_new(
-                        &concrete_path,
-                        #[cfg(unix)]
-                        sandbox,
-                        #[cfg(unix)]
-                        dest_dir,
-                    ) {
-                        #[cfg(unix)]
-                        let guard =
-                            TempFileGuard::with_anchor(concrete_path.clone(), sandbox, dest_dir);
-                        #[cfg(not(unix))]
-                        let guard = TempFileGuard::new(concrete_path);
-                        return Ok((file, guard));
-                    }
-                }
+                // upstream: receiver.c:283-293 - the ENOENT-recovery that
+                // called `make_path(fnametmp, ...)` before re-`do_mkstemp()`
+                // is compiled out (`#if 0`). Upstream never creates a missing
+                // parent chain at temp-file open time; a missing destination
+                // ancestor is a hard error (`mkstemp %s failed`). In-tree
+                // subdirectories are created up-front by the receiver's
+                // directory pass (generator.c:1317-1326 / create_directories),
+                // and the dest-arg path is created only under `--mkpath` in
+                // `ensure_dest_root_exists` (upstream main.c:736). Auto-creating
+                // here would resurrect the no-`--mkpath` deep-path bug, so we
+                // surface the ENOENT verbatim to match upstream.
                 return Err(io::Error::new(e.kind(), e.to_string()));
             }
             Err(e) => return Err(e),

--- a/crates/transfer/tests/uts_12_reopen_altdest_server_mkdir.rs
+++ b/crates/transfer/tests/uts_12_reopen_altdest_server_mkdir.rs
@@ -56,7 +56,12 @@ use transfer::receiver::ensure_dest_root_exists;
 fn alt_dest_server_chain_creates_missing_dest_root() {
     let tmp = tempdir().expect("tempdir");
     let alt_basis = tmp.path().join("alt3");
-    let dest_root = tmp.path().join("missing/dest/root");
+    // Single missing leaf whose parent already exists: upstream `main.c:788`
+    // does a single `do_mkdir(dest_path)`, which creates one level. A deeper
+    // chain (`missing/dest/root`) would fail without `--mkpath` (verified
+    // against upstream 3.4.4: `mkdir ... failed: No such file or directory`),
+    // so the pre-flight only owns the final component here.
+    let dest_root = tmp.path().join("to");
 
     // Operator-seeded alt-dest basis: upstream's main.c:798-806 only
     // checks that the basis path resolves. The pre-flight owns the
@@ -81,8 +86,9 @@ fn alt_dest_server_chain_creates_missing_dest_root() {
     let file_total = 5; // multi-file alt-dest source tree
     let trailing_slash = true; // upstream argv carries `/tmp/to/`
     let dry_run = false;
+    let mkpath = false; // upstream forwards --mkpath only on client request
 
-    let created = ensure_dest_root_exists(&dest_root, file_total, trailing_slash, dry_run)
+    let created = ensure_dest_root_exists(&dest_root, file_total, trailing_slash, dry_run, mkpath)
         .expect("alt-dest --copy-dest pre-flight must auto-create the dest");
 
     assert!(
@@ -92,8 +98,8 @@ fn alt_dest_server_chain_creates_missing_dest_root() {
     );
     assert!(
         dest_root.is_dir(),
-        "the dest root (multiple directory components deep) must exist \
-         as a directory after the pre-flight (create_dir_all semantics)"
+        "the single missing dest-root level must exist as a directory \
+         after the pre-flight (do_mkdir semantics)"
     );
     assert!(
         alt_basis.join("seed.txt").exists(),
@@ -116,7 +122,7 @@ fn single_file_without_trailing_slash_does_not_mkdir_destroot() {
     let dest_root = tmp.path().join("would-be-file");
 
     let created =
-        ensure_dest_root_exists(&dest_root, 1, false, false).expect("helper must succeed");
+        ensure_dest_root_exists(&dest_root, 1, false, false, false).expect("helper must succeed");
 
     assert!(
         !created,
@@ -142,7 +148,7 @@ fn dest_existing_as_file_returns_typed_error() {
     let dest_file = tmp.path().join("not-a-directory");
     fs::write(&dest_file, b"existing file").expect("seed dest as a file");
 
-    let err = ensure_dest_root_exists(&dest_file, 3, true, false)
+    let err = ensure_dest_root_exists(&dest_file, 3, true, false, false)
         .expect_err("dest existing as a regular file must be rejected");
 
     assert_eq!(

--- a/crates/transfer/tests/uts_2_dest_root_mkdir.rs
+++ b/crates/transfer/tests/uts_2_dest_root_mkdir.rs
@@ -28,7 +28,7 @@ fn creates_dest_root_for_multi_file_transfer() {
     let dest = tmp.path().join("new_dest");
     assert!(!dest.exists());
 
-    let created = ensure_dest_root_exists(&dest, 4, false, false).expect("ensure ok");
+    let created = ensure_dest_root_exists(&dest, 4, false, false, false).expect("ensure ok");
 
     assert!(created, "should report newly created");
     assert!(dest.is_dir(), "destination root must exist as a directory");
@@ -42,7 +42,7 @@ fn creates_dest_root_for_trailing_slash_single_file() {
     let dest = tmp.path().join("with_slash");
     assert!(!dest.exists());
 
-    let created = ensure_dest_root_exists(&dest, 1, true, false).expect("ensure ok");
+    let created = ensure_dest_root_exists(&dest, 1, true, false, false).expect("ensure ok");
 
     assert!(created, "trailing slash forces creation");
     assert!(dest.is_dir());
@@ -57,8 +57,8 @@ fn skips_create_for_single_file_without_trailing_slash() {
     let dest = tmp.path().join("single_file_dest");
     assert!(!dest.exists());
 
-    let created =
-        ensure_dest_root_exists(&dest, 1, false, false).expect("single-file path must not error");
+    let created = ensure_dest_root_exists(&dest, 1, false, false, false)
+        .expect("single-file path must not error");
 
     assert!(!created, "single-file transfer must not create the root");
     assert!(
@@ -75,7 +75,7 @@ fn pre_existing_directory_is_noop() {
     let dest = tmp.path().join("already_there");
     fs::create_dir(&dest).expect("seed dest");
 
-    let created = ensure_dest_root_exists(&dest, 7, false, false).expect("ensure ok");
+    let created = ensure_dest_root_exists(&dest, 7, false, false, false).expect("ensure ok");
 
     assert!(!created, "no creation when dest already exists");
     assert!(dest.is_dir());
@@ -89,23 +89,61 @@ fn dry_run_never_creates_dest_root() {
     let dest = tmp.path().join("dry_run_dest");
     assert!(!dest.exists());
 
-    let created = ensure_dest_root_exists(&dest, 100, true, true).expect("dry_run ok");
+    let created = ensure_dest_root_exists(&dest, 100, true, true, false).expect("dry_run ok");
 
     assert!(!created);
     assert!(!dest.exists(), "dry-run must not create the destination");
 }
 
-/// Walks a multi-component path that lives several levels below an existing
-/// directory: `--server` invocations from the upstream alt-dest harness pass
-/// destinations like `out/sub/leaf/` whose ancestors do not yet exist. The
-/// helper relies on `create_dir_all` so the entire chain materializes.
+/// A multi-component destination whose ancestors do not exist must fail
+/// WITHOUT `--mkpath`: upstream `main.c:788` does a single
+/// `do_mkdir(dest_path)` that returns `ENOENT` when the parent chain is
+/// missing. Auto-creating the whole chain here (the old `create_dir_all`
+/// behavior) diverged from upstream by materializing a deep destination path
+/// that the user never asked for. Regression guard for the wire-receiver
+/// no-`--mkpath` deep-path bug.
 #[test]
-fn creates_nested_dest_root() {
+fn deep_missing_dest_root_without_mkpath_errors() {
     let tmp = tempdir().expect("tempdir");
     let dest = tmp.path().join("a/b/c/d");
     assert!(!dest.exists());
 
-    let created = ensure_dest_root_exists(&dest, 3, false, false).expect("ensure ok");
+    let err = ensure_dest_root_exists(&dest, 3, false, false, false)
+        .expect_err("missing ancestor chain must error without --mkpath");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    assert!(
+        !tmp.path().join("a").exists(),
+        "no part of the missing chain may be created without --mkpath"
+    );
+}
+
+/// WITH `--mkpath`, the same multi-component destination materializes the
+/// whole missing chain, mirroring upstream `main.c:736`
+/// `make_path(dest_path, ...)`.
+#[test]
+fn deep_missing_dest_root_with_mkpath_creates_chain() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("a/b/c/d");
+    assert!(!dest.exists());
+
+    let created = ensure_dest_root_exists(&dest, 3, false, false, true).expect("mkpath ensure ok");
+
+    assert!(created);
+    assert!(dest.is_dir());
+}
+
+/// A single-level destination whose parent already exists is created even
+/// without `--mkpath`: upstream `main.c:788` `do_mkdir(dest_path)` succeeds
+/// when only the final component is missing. This is the common recursive
+/// `rsync -a src/ newdst/` shape and must never regress.
+#[test]
+fn single_level_dest_root_without_mkpath_creates() {
+    let tmp = tempdir().expect("tempdir");
+    let dest = tmp.path().join("newdst");
+    assert!(!dest.exists());
+
+    let created = ensure_dest_root_exists(&dest, 3, false, false, false).expect("ensure ok");
 
     assert!(created);
     assert!(dest.is_dir());
@@ -143,7 +181,7 @@ fn rejects_broken_symlink_dest_root() {
     );
     assert!(!outside_target.exists(), "target must remain dangling");
 
-    let err = ensure_dest_root_exists(&dest, 3, false, false)
+    let err = ensure_dest_root_exists(&dest, 3, false, false, false)
         .expect_err("dangling-symlink dest root must surface NotFound");
 
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
@@ -175,7 +213,7 @@ fn accepts_symlink_to_existing_directory() {
     let dest = tmp.path().join("dest_root");
     symlink(&real_dir, &dest).expect("symlink dest -> real_dir");
 
-    let created = ensure_dest_root_exists(&dest, 5, false, false)
+    let created = ensure_dest_root_exists(&dest, 5, false, false, false)
         .expect("symlink-to-dir dest must be accepted");
 
     assert!(
@@ -215,7 +253,7 @@ fn accepts_symlink_to_existing_directory_outside_parent() {
     let dest = module_root.path().join("dest_root");
     symlink(&outside_dir, &dest).expect("dest -> outside dir");
 
-    let created = ensure_dest_root_exists(&dest, 8, true, false)
+    let created = ensure_dest_root_exists(&dest, 8, true, false, false)
         .expect("symlink-to-dir-outside-parent dest must be accepted");
 
     assert!(!created, "no creation when dest resolves to existing dir");
@@ -231,7 +269,7 @@ fn rejects_existing_non_directory_at_dest_root() {
     let dest = tmp.path().join("existing_file");
     fs::write(&dest, b"x").expect("seed file");
 
-    let err = ensure_dest_root_exists(&dest, 5, true, false)
+    let err = ensure_dest_root_exists(&dest, 5, true, false, false)
         .expect_err("non-directory dest root must error");
 
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
@@ -254,7 +292,7 @@ fn rejects_chained_dangling_symlink_dest_root() {
     // link_a -> link_b (which does not exist)
     symlink(&intermediate, &dangling_link).expect("symlink link_a -> link_b");
 
-    let err = ensure_dest_root_exists(&dangling_link, 3, false, false)
+    let err = ensure_dest_root_exists(&dangling_link, 3, false, false, false)
         .expect_err("dangling-chain symlink dest must error");
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     assert!(

--- a/crates/transfer/tests/uts_2_efg_ssh_alt_dest_verification.rs
+++ b/crates/transfer/tests/uts_2_efg_ssh_alt_dest_verification.rs
@@ -88,7 +88,7 @@ fn uts_2_e_pre_flight_runs_under_server_dispatch() {
     // file_total > 1 emulates the alt-dest interop scenario (push of a
     // multi-file source tree). trailing_slash=false matches the upstream
     // test argv shape (`/dest_root` without a trailing slash).
-    let created = ensure_dest_root_exists(&dest_root, 3, false, false)
+    let created = ensure_dest_root_exists(&dest_root, 3, false, false, false)
         .expect("--server receiver pre-flight must succeed");
 
     assert!(
@@ -122,7 +122,10 @@ fn uts_2_e_pre_flight_runs_under_server_dispatch() {
 #[test]
 fn uts_2_f_ssh_alt_dest_auto_creates_missing_dest_root() {
     let tmp = tempdir().expect("tempdir");
-    let dest_root = tmp.path().join("missing/dest/root");
+    // Single missing leaf whose parent (tmp) already exists: upstream
+    // `main.c:788` `do_mkdir(dest_path)` creates exactly one level and fails
+    // with ENOENT on a deeper missing chain unless `--mkpath` was forwarded.
+    let dest_root = tmp.path().join("missing_dest_root");
     let copy_dest_basis = tmp.path().join("basis_for_copy_dest");
 
     // The copy-dest basis is materialized by the operator separately;
@@ -139,8 +142,9 @@ fn uts_2_f_ssh_alt_dest_auto_creates_missing_dest_root() {
     );
 
     // Multi-file transfer (file_total > 1) tripping the pre-flight, no
-    // trailing slash, not dry-run. This is the alt-dest interop argv shape.
-    let created = ensure_dest_root_exists(&dest_root, 5, false, false)
+    // trailing slash, not dry-run, no --mkpath. This is the alt-dest interop
+    // argv shape.
+    let created = ensure_dest_root_exists(&dest_root, 5, false, false, false)
         .expect("alt-dest --copy-dest pre-flight must auto-create the dest");
 
     assert!(
@@ -149,8 +153,8 @@ fn uts_2_f_ssh_alt_dest_auto_creates_missing_dest_root() {
     );
     assert!(
         dest_root.is_dir(),
-        "the deeply nested dest path must exist as a directory \
-         after the pre-flight (create_dir_all semantics)"
+        "the single missing dest-root level must exist as a directory \
+         after the pre-flight (do_mkdir semantics)"
     );
     // The alt-dest basis is untouched - the pre-flight only owns the
     // dest, mirroring upstream's separation between get_local_name and
@@ -195,7 +199,7 @@ fn uts_2_g_wire_byte_parity_mkdir_is_receiver_local() {
     let wire_capture: Cursor<Vec<u8>> = Cursor::new(Vec::new());
     let captured_len_before = wire_capture.get_ref().len();
 
-    let created = ensure_dest_root_exists(&dest_root, 4, false, false)
+    let created = ensure_dest_root_exists(&dest_root, 4, false, false, false)
         .expect("helper must succeed without touching any wire writer");
 
     let captured_len_after = wire_capture.get_ref().len();


### PR DESCRIPTION
## Problem

The wire receiver auto-created a missing deep destination path **without** `--mkpath`, diverging from upstream. Upstream only creates the whole missing chain under `--mkpath` (`main.c:736` `make_path`); without it, `main.c:788` does a single `do_mkdir(dest_path)` that fails with `ENOENT` when an ancestor is missing.

An earlier attempt (#6248, closed) fixed this in the local-copy engine and regressed twice - that was the wrong path. The 3.5.0dev tracker runs oc as a forked server child, i.e. the **wire receiver**, which is fixed here.

Verified empirically against upstream rsync 3.4.4 over a remote-shell push:

| Scenario (no `--mkpath`) | before | upstream 3.4.4 | after |
|---|---|---|---|
| single file -> deep missing | creates path | fails, nothing | fails, nothing |
| trailing-slash -> deep missing | creates chain | fails, nothing | fails, nothing |
| multi-file -> deep missing | creates chain | fails, nothing | fails, nothing |

With `--mkpath`, all three now create the chain, matching upstream byte-for-byte on the created entry counts.

## Root cause (three receiver auto-create sites)

1. `ensure_dest_root_exists` (`dest_root.rs`) used `create_dir_all` unconditionally for the `file_total > 1 || trailing_slash` branch.
2. The temp-file `ENOENT` recovery (`temp_guard.rs`) ran `create_dir_all(parent)` for the single-file case. Upstream's equivalent recovery is compiled out (`receiver.c:283-293`, `#if 0`).
3. `--mkpath` was never plumbed to the receiver at all - so even the *positive* `--mkpath` case failed.

## Fix

- Plumb `--mkpath` end to end:
  - forward `--mkpath` to the server on a push only (`options.c:2996` `if (mkpath_dest_arg && am_sender)`) in the remote-shell and daemon arg builders;
  - parse `--mkpath` / `--no-mkpath` / `--old-dirs` in the server long-flag parser (and daemon client-arg parser) and add it to the known-long-flag allowlist so it is not misread as a positional dest;
  - store it on `ParsedServerFlags::mkpath`.
- `ensure_dest_root_exists`: use `create_dir` (single level, upstream `main.c:788`) without `--mkpath`, `create_dir_all` (upstream `main.c:736`) with it; allow the single-file/no-slash early return to proceed under `--mkpath` so the `MKP_DROP_NAME` parent chain is created.
- `temp_guard.rs`: drop the `create_dir_all` `ENOENT` recovery to match upstream's `#if 0`. In-tree subdirectories are still created up front by the receiver directory pass, and the dest-arg chain is created by `ensure_dest_root_exists` under `--mkpath`.

## In-tree recursion preserved

A recursive `-a src/ dst/` where `dst` exists still creates `dst/a/b/` for `src/a/b/file`: those single-level in-tree dirs are made by the directory pass before files, not by the gated dest-arg path. Verified identical trees vs upstream for existing-dest, new-single-level-dest, and dir-operand cases. All 7 upstream `mkpath.test` scenarios pass both locally and over the wire.

## Tests

- New `dest_root.rs` coverage: deep-missing-without-mkpath errors and creates nothing; deep-missing-with-mkpath creates the chain; single-level-without-mkpath creates.
- Updated the alt-dest server pre-flight integration tests that previously encoded the deep-chain-without-mkpath behavior (verified against upstream that a deep missing alt-dest dest fails without `--mkpath`).

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p transfer --all-targets --all-features --no-deps --locked -- -D warnings`: clean (also clean for cli/core/daemon).