### PR TITLE
fix: strip #/; comment lines under --from0 (upstream read_line parity)

### DIFF
--- a/crates/cli/src/frontend/execution/file_list/loader.rs
+++ b/crates/cli/src/frontend/execution/file_list/loader.rs
@@ -90,6 +90,16 @@ pub(crate) fn read_file_list_from_reader<R: BufRead>(
                 buffer.pop();
             }
 
+            // upstream: flist.c:2249 sets RL_DUMP_COMMENTS independent of
+            // eol_nulls, and io.c:1276 read_line() strips leading '#'/';'
+            // comment lines even with NUL delimiters. Strip them here too.
+            if buffer
+                .first()
+                .is_some_and(|byte| matches!(byte, b'#' | b';'))
+            {
+                continue;
+            }
+
             push_file_list_entry(&buffer, entries);
         }
         return Ok(());

--- a/crates/cli/src/frontend/execution/file_list/tests.rs
+++ b/crates/cli/src/frontend/execution/file_list/tests.rs
@@ -144,17 +144,19 @@ fn read_file_list_zero_terminated_no_trailing_null() {
 }
 
 #[test]
-fn read_file_list_zero_terminated_allows_hash_and_semicolon() {
-    // upstream: --from0 disables comment handling, so `#` / `;` are literal.
-    let input = b"#not-a-comment\0;also-not-a-comment\0";
+fn read_file_list_zero_terminated_strips_hash_and_semicolon_comments() {
+    // upstream: flist.c:2249 sets RL_DUMP_COMMENTS independent of eol_nulls,
+    // and io.c:1276 read_line() strips leading '#'/';' comment lines even with
+    // NUL delimiters. Comment entries are dropped; normal entries are kept.
+    let input = b"#comment\0keep.txt\0;also-comment\0other.txt\0";
     let mut reader = Cursor::new(input);
     let mut entries = Vec::new();
 
     read_file_list_from_reader(&mut reader, true, &mut entries).unwrap();
 
     assert_eq!(entries.len(), 2);
-    assert_eq!(entries[0], "#not-a-comment");
-    assert_eq!(entries[1], ";also-not-a-comment");
+    assert_eq!(entries[0], "keep.txt");
+    assert_eq!(entries[1], "other.txt");
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/files_from.rs
+++ b/crates/cli/src/frontend/tests/files_from.rs
@@ -237,24 +237,26 @@ fn from0_reader_accepts_missing_trailing_separator() {
 }
 
 #[test]
-fn from0_disables_comment_handling() {
+fn from0_strips_comment_lines() {
     let tmp = test_support::create_tempdir();
     let list_path = tmp.path().join("from0_comments.list");
 
-    // With --from0, # and ; should not be treated as comments
+    // upstream: --from0 still strips leading #/; comment lines. RL_DUMP_COMMENTS
+    // is gated on reading_remotely, not eol_nulls (flist.c:2249); read_line drops
+    // #/; regardless of RL_EOL_NULLS (io.c:1276).
     let mut bytes = Vec::new();
-    bytes.extend_from_slice(b"#notacomment");
+    bytes.extend_from_slice(b"#comment");
     bytes.push(0);
-    bytes.extend_from_slice(b";alsonotacomment");
+    bytes.extend_from_slice(b";comment");
+    bytes.push(0);
+    bytes.extend_from_slice(b"realfile");
     bytes.push(0);
     std::fs::write(&list_path, bytes).expect("write list");
 
     let entries =
         load_file_list_operands(&[list_path.into_os_string()], true).expect("load entries");
 
-    assert_eq!(entries.len(), 2);
-    assert_eq!(entries[0], "#notacomment");
-    assert_eq!(entries[1], ";alsonotacomment");
+    assert_eq!(entries, vec!["realfile"]);
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/transfer_request_with_from0.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_from0.rs
@@ -41,7 +41,7 @@ fn transfer_request_with_from0_reads_null_separated_list() {
 }
 
 #[test]
-fn transfer_request_with_from0_preserves_comment_prefix_entries() {
+fn transfer_request_with_from0_strips_comment_prefix_entries() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -59,7 +59,7 @@ fn transfer_request_with_from0_preserves_comment_prefix_entries() {
     let dest_dir = tmp.path().join("files-from0-comments-dest");
     std::fs::create_dir(&dest_dir).expect("create dest");
 
-    let (code, stdout, stderr) = run_with_args([
+    let (code, _stdout, _stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--from0"),
         OsString::from(format!("--files-from={}", list_path.display())),
@@ -67,13 +67,9 @@ fn transfer_request_with_from0_preserves_comment_prefix_entries() {
         dest_dir.clone().into_os_string(),
     ]);
 
+    // upstream: a leading `#` marks a comment line in a --files-from list even
+    // under --from0 (read_line RL_DUMP_COMMENTS, io.c:1276), so the only entry
+    // is stripped and nothing is transferred.
     assert_eq!(code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
-
-    let copied = dest_dir.join("#commented.txt");
-    assert_eq!(
-        std::fs::read(&copied).expect("read copied"),
-        b"from0-comment"
-    );
+    assert!(!dest_dir.join("#commented.txt").exists());
 }

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -587,7 +587,14 @@ pub(super) fn read_files_from_local_path(path: &str, from0: bool) -> io::Result<
         // The local file is already in the server's local charset; upstream
         // reads it without RL_CONVERT (compat.c:799-806 only sets
         // filesfrom_convert when the file is being forwarded over the wire).
-        protocol::read_files_from_stream(&mut reader, None)
+        //
+        // upstream: flist.c:2249 sets RL_DUMP_COMMENTS independent of eol_nulls
+        // (it is gated only on reading_remotely), and io.c:1276 read_line()
+        // strips leading '#'/';' comment lines even with NUL delimiters. A
+        // local file open is not "reading remotely", so comments are stripped.
+        let mut filenames = protocol::read_files_from_stream(&mut reader, None)?;
+        filenames.retain(|name| !name.starts_with('#') && !name.starts_with(';'));
+        Ok(filenames)
     } else {
         // Line-delimited: read lines, skip comments and empty lines.
         let mut filenames = Vec::new();
@@ -602,8 +609,9 @@ pub(super) fn read_files_from_local_path(path: &str, from0: bool) -> io::Result<
             if trimmed.is_empty() {
                 continue;
             }
-            // upstream: flist.c:2266 - comments with '#' or ';' prefix
-            // only when not using --from0
+            // upstream: io.c:1276 - RL_DUMP_COMMENTS strips leading '#'/';'
+            // comment lines for local files (flist.c:2249, reading_remotely
+            // false), regardless of eol_nulls.
             if trimmed.starts_with('#') || trimmed.starts_with(';') {
                 continue;
             }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -3262,6 +3262,21 @@ mod files_from {
     }
 
     #[test]
+    fn read_files_from_local_path_nul_delimited_strips_comments() {
+        // upstream: flist.c:2249 sets RL_DUMP_COMMENTS for local files
+        // independent of eol_nulls; io.c:1276 strips leading '#'/';' comment
+        // lines even under --from0. Comment entries are dropped, normals kept.
+        let temp_dir = TempDir::new().unwrap();
+        let list_file = temp_dir.path().join("list0.txt");
+        std::fs::write(&list_file, b"#comment\0x.txt\0;skip\0y.txt\0\0").unwrap();
+
+        let result =
+            super::super::filters::read_files_from_local_path(&list_file.to_string_lossy(), true)
+                .unwrap();
+        assert_eq!(result, vec!["x.txt", "y.txt"]);
+    }
+
+    #[test]
     fn read_files_from_local_path_skips_empty_and_comments() {
         let temp_dir = TempDir::new().unwrap();
         let list_file = temp_dir.path().join("list.txt");


### PR DESCRIPTION
## Problem

Under `--from0` (NUL-delimited `--files-from`), oc-rsync did not strip `#`/`;` comment lines, treating them as literal filenames. This diverges from upstream and fails the 3.5.0dev files-from-depth conformance test.

## Upstream reference

Upstream strips comment lines regardless of NUL vs newline delimiters:

- `flist.c:2249` (rsync-3.4.4): `rl_flags = (reading_remotely ? 0 : RL_DUMP_COMMENTS) | ... | (eol_nulls || reading_remotely ? RL_EOL_NULLS : 0)`. `RL_DUMP_COMMENTS` is gated only on `reading_remotely`, independent of `eol_nulls`. A local file open is not "reading remotely", so comment dumping is enabled even under `--from0`.
- `io.c:1276` (`read_line`): `if (flags & RL_DUMP_COMMENTS && (*buf == '#' || *buf == ';')) goto start;` skips leading `#`/`;` comment lines even when `RL_EOL_NULLS` is set.

## Fix

Two loci, both local (non-remote) readers that upstream runs with `RL_DUMP_COMMENTS`:

1. `crates/cli/src/frontend/execution/file_list/loader.rs` - client-side `--files-from` reader: strip `#`/`;` entries in the NUL-delimited branch.
2. `crates/transfer/src/generator/filters.rs` - server local-file `--files-from` reader (`read_files_from_local_path`): filter comment entries after the NUL-delimited read.

The wire path (`protocol::read_files_from_stream` for a forwarded/remote list) is unchanged - upstream sets `RL_DUMP_COMMENTS` off when `reading_remotely`, so comment stripping there would be wrong.

Corrected the code comments that cited an incorrect rationale ("--from0 disables comment handling") to reference `flist.c:2249` / `io.c:1276`.

## Tests

- `read_file_list_zero_terminated_strips_hash_and_semicolon_comments` (was `..._allows_hash_and_semicolon`, which asserted the buggy behavior) - now asserts comment entries are dropped and normal entries kept.
- `read_files_from_local_path_nul_delimited_strips_comments` - new test for the server local-file path.

Verified end-to-end with the built binary over a loopback wire: `oc-rsync -r --from0 --files-from=-` fed a NUL list containing `#comment` and `;comment` lines produces a destination with only the real entries; no comment-named files are created.

Non-comment behavior (NUL termination, empty-entry skipping, non-UTF-8 preservation, embedded newlines) is preserved.

`cargo fmt --all` clean; `cargo clippy -p cli -p transfer --all-targets --all-features --no-deps --locked -- -D warnings` passes.