### PR TITLE
fix(transfer): apply --modify-window in generator dry-run itemize (same_time parity)

### DIFF
--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -45,8 +45,9 @@ pub(super) fn is_hardlink_follower(entry: &FileEntry) -> bool {
 ///   `f2_sec > f1_sec ? f2_sec - f1_sec <= modify_window : f1_sec - f2_sec <=
 ///   modify_window`, i.e. `|a_sec - b_sec| <= window`.
 ///
-/// upstream: util1.c:1478 same_time() (via generator.c:quick_check_ok()).
-fn same_time(a_sec: i64, b_sec: i64, window: u64) -> bool {
+/// upstream: util1.c:1478 same_time() (via generator.c:quick_check_ok() and
+/// generator.c:526 itemize() -> mtime_differs()).
+pub(super) fn same_time(a_sec: i64, b_sec: i64, window: u64) -> bool {
     if window == 0 {
         return a_sec == b_sec;
     }
@@ -235,6 +236,9 @@ fn mode_from_metadata(meta: &fs::Metadata) -> u32 {
 /// - `generator.c:983` - match_level 3 with `COMPARE_DEST` returns -2 (skip)
 /// - `generator.c:991` - match_level 3 with `LINK_DEST` calls `hard_link_one()`
 /// - `generator.c:1021` - match_level >= 2 with `COPY_DEST` copies locally
+/// - `generator.c:1033` - `copy_altdest_file()` is gated on `!dry_run`; under
+///   `-n` the file still counts as handled (up-to-date) but no local copy or
+///   hard link is written to the destination.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn try_reference_dest(
     entry: &FileEntry,
@@ -245,6 +249,7 @@ pub(super) fn try_reference_dest(
     always_checksum: Option<protocol::ChecksumAlgorithm>,
     modify_window: u64,
     copy_links: bool,
+    dry_run: bool,
     metadata_opts: &MetadataOptions,
     metadata_errors: &mut Vec<(PathBuf, String)>,
     acl_cache: Option<&AclCache>,
@@ -290,6 +295,12 @@ pub(super) fn try_reference_dest(
                 return true;
             }
             ReferenceDirectoryKind::Link => {
+                // upstream: generator.c:1033 - the local copy/link is gated on
+                // `!dry_run`. Under `-n` the reference match still marks the
+                // file as handled (no transfer) without touching the dest.
+                if dry_run {
+                    return true;
+                }
                 // upstream: generator.c:991 - hard_link_one()
                 if let Some(parent) = dest_path.parent() {
                     let _ = fs::create_dir_all(parent);
@@ -316,6 +327,11 @@ pub(super) fn try_reference_dest(
                 }
             }
             ReferenceDirectoryKind::Copy => {
+                // upstream: generator.c:1033 - `copy_altdest_file()` runs only
+                // when `!dry_run`; `-n` marks the file handled without copying.
+                if dry_run {
+                    return true;
+                }
                 // upstream: generator.c:1021 - copy_altdest_file()
                 if let Some(parent) = dest_path.parent() {
                     let _ = fs::create_dir_all(parent);
@@ -542,6 +558,7 @@ mod info_copy_emission_tests {
             None,
             0,
             false,
+            false,
             &metadata_opts,
             &mut metadata_errors,
             None,
@@ -601,6 +618,7 @@ mod info_copy_emission_tests {
             true,
             None,
             0,
+            false,
             false,
             &metadata_opts,
             &mut metadata_errors,
@@ -693,6 +711,7 @@ mod symlink_basis_tests {
             None,
             0,
             copy_links,
+            false,
             &metadata_opts,
             &mut metadata_errors,
             None,

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -21,7 +21,7 @@ use protocol::flist::FileEntry;
 use crate::receiver::directory::FailedDirectories;
 use crate::receiver::quick_check::{
     dest_mtime_newer, dest_type_matches_source, is_hardlink_follower, quick_check_matches,
-    try_reference_dest,
+    same_time, try_reference_dest,
 };
 use crate::receiver::stats::{ListOnlyEntry, TransferStats};
 use crate::receiver::{ReceiverContext, apply_acls_from_receiver_cache};
@@ -163,15 +163,20 @@ impl ReceiverContext {
             })
             .collect();
 
-        // upstream: generator.c:1845 - dry_run (!do_xfers) skips stat and data
-        // transfer but still builds the candidate list so NDX requests are sent
-        // to the sender, which logs each file name for verbose output. List-only
-        // also skips the destination stat/quick-check; its caller never issues
-        // per-file NDX requests (the list_only branch in `run_pipelined`).
-        if self.config.flags.skip_dest_writes() {
-            // upstream: generator.c:1925-1926 - dry-run still itemizes with
-            // ITEM_TRANSFER; the dry-run loop writes the bare ITEM_TRANSFER
-            // attrs over the wire and does not consume this precomputed value.
+        // upstream: generator.c:1249 - list_only renders every flist entry via
+        // list_file_entry() and issues NO per-file NDX request or destination
+        // stat/quick-check. Only list-only takes this short-circuit; dry-run
+        // (`-n`) is NOT list-only. Upstream still stats the destination and
+        // runs quick_check_ok() for `-n` (generator.c:1818, gated only by
+        // `dry_run > 1` at generator.c:1290 when the parent dir is missing), so
+        // a within-`--modify-window` mtime is treated as unchanged and itemized
+        // with iflags=0 rather than `>f`. Falling through to the quick-check
+        // path below preserves that parity; `dry_run` merely suppresses the
+        // filesystem mutations (see the `dry_run` guards further down).
+        if self.config.flags.list_only {
+            // upstream: generator.c:1925-1926 - list-only itemizes with the bare
+            // ITEM_TRANSFER; the caller renders the flist and never consumes
+            // this precomputed value.
             return candidates
                 .into_iter()
                 .map(|(idx, entry)| {
@@ -203,12 +208,19 @@ impl ReceiverContext {
         // per-file method dispatch for the common no-itemize case.
         let emit_itemize = self.should_emit_itemize();
 
+        // upstream: generator.c:1814 - set_file_attrs() on a quick-check match
+        // is a no-op under dry_run (do_xfers == 0), so an up-to-date file's
+        // itemize row is still rendered but no ownership/permission/ACL/xattr
+        // change is written. Zeroing these gates keeps the no-change path
+        // itemize-only under `-n` while leaving the real-transfer path intact.
+        let dry_run = self.config.flags.dry_run;
+
         // Pre-compute whether ACLs and xattrs are enabled. When disabled
         // (the common case), the per-file function call overhead is avoided
         // entirely in the no-change path. At 100K files this eliminates
         // 100K-200K function calls that would each immediately return None/Ok.
-        let has_acls = acl_cache.is_some() && self.config.flags.acls;
-        let has_xattrs = self.config.flags.xattrs;
+        let has_acls = !dry_run && acl_cache.is_some() && self.config.flags.acls;
+        let has_xattrs = !dry_run && self.config.flags.xattrs;
         let has_reference_dirs = !self.config.reference_directories.is_empty();
 
         // Phase B: Parallel stat - preserve PathBufs for reuse in Phase C and
@@ -231,7 +243,9 @@ impl ReceiverContext {
 
         // Phase C: Sequential post-processing with stat results.
         // Pre-size for the expected minority that need transfer.
-        let needs_metadata_apply = metadata_opts.requires_apply();
+        // upstream: generator.c:1814 - dry_run suppresses set_file_attrs(), so
+        // the no-change path itemizes without mutating destination metadata.
+        let needs_metadata_apply = !dry_run && metadata_opts.requires_apply();
         let mut files_to_transfer = Vec::with_capacity(stat_results.len() / 4 + 1);
         for (idx, file_path, dest_meta) in stat_results {
             let entry = &self.file_list[idx];
@@ -311,6 +325,7 @@ impl ReceiverContext {
                         always_checksum,
                         modify_window,
                         self.config.flags.copy_links,
+                        dry_run,
                         metadata_opts,
                         metadata_errors,
                         acl_cache,
@@ -372,13 +387,19 @@ impl ReceiverContext {
         if entry.is_file() && entry.size() != dest_meta.len() {
             iflags |= ItemFlags::ITEM_REPORT_SIZE;
         }
-        // upstream: generator.c:519-523 - keep_time ? mtime_differs(&st, file).
+        // upstream: generator.c:526 - keep_time ? mtime_differs(&st, file).
         // For regular files keep_time == preserve_mtimes (`--times`).
+        // `mtime_differs()` is `!same_time()`, so an mtime within the
+        // `--modify-window` tolerance does NOT set the time-report bit - the
+        // itemize row shows `.` in the time column rather than `t`, matching
+        // the quick-check's up-to-date decision. Window 0 reduces to exact
+        // whole-second equality.
+        let modify_window = self.config.file_selection.modify_window;
         if self.config.flags.times {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::MetadataExt;
-                if dest_meta.mtime() != entry.mtime() {
+                if !same_time(dest_meta.mtime(), entry.mtime(), modify_window) {
                     iflags |= ItemFlags::ITEM_REPORT_TIME;
                 }
             }
@@ -389,7 +410,11 @@ impl ReceiverContext {
                     .ok()
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| d.as_secs() as i64);
-                if dest_secs != Some(entry.mtime()) {
+                let differs = match dest_secs {
+                    Some(secs) => !same_time(secs, entry.mtime(), modify_window),
+                    None => true,
+                };
+                if differs {
                     iflags |= ItemFlags::ITEM_REPORT_TIME;
                 }
             }

--- a/crates/transfer/tests/modify_window_dry_run_itemize.rs
+++ b/crates/transfer/tests/modify_window_dry_run_itemize.rs
@@ -1,0 +1,291 @@
+//! Regression coverage for `--modify-window` in a dry-run (`-n`) itemize.
+//!
+//! Upstream rsync applies its `same_time()` window tolerance
+//! (`util1.c:1478`) inside the generator's quick-check
+//! (`generator.c:645 mtime_differs()`) and itemize
+//! (`generator.c:526`) decisions, and that path runs for a dry-run too
+//! (only `dry_run > 1` at `generator.c:1290` short-circuits it, and that
+//! only happens when the destination parent directory is missing).
+//!
+//! The receiver's wire path previously short-circuited every dry-run
+//! candidate to a bare `ITEM_TRANSFER`, so a destination whose mtime was
+//! within `--modify-window` seconds of the source was wrongly itemized as
+//! `>f...` instead of being treated as up-to-date. This test drives the
+//! actual `oc-rsync` binary against an `oc-rsync --daemon` over a loopback
+//! socket - the only transport that exercises the wire generator - and
+//! pins the itemize decision at the whole-second window boundary:
+//!
+//! - a 1s destination drift under `--modify-window=2` is absorbed (no row);
+//! - a 3s drift exceeds the window and transfers (`>f`);
+//! - `--modify-window=0` keeps exact whole-second semantics (1s => `>f`).
+//!
+//! Verified byte-for-byte against upstream rsync 3.4.4 over the same
+//! loopback daemon during development.
+
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+use filetime::{FileTime, set_file_mtime};
+use tempfile::{TempDir, tempdir};
+
+/// Maximum time the daemon has to start accepting connections.
+const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A fixed base mtime for the source file, well clear of "now" so the
+/// quick-check never races the wall clock.
+const BASE_MTIME_SECS: i64 = 1_735_689_600; // 2025-01-01T00:00:00Z
+
+/// Locate the workspace `oc-rsync` binary the test runner built.
+fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(p) = env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let exe = env::current_exe().ok()?;
+    let mut dir = exe.parent()?;
+    let name = format!("oc-rsync{}", env::consts::EXE_SUFFIX);
+    while !dir.ends_with("target") {
+        let candidate = dir.join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+    for sub in ["debug", "release"] {
+        let candidate = dir.join(sub).join(&name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Allocate a free TCP port by binding to ephemeral port 0.
+fn allocate_test_port() -> Option<u16> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    drop(listener);
+    Some(port)
+}
+
+/// Wait until the daemon accepts a TCP connection on `port`.
+fn wait_for_daemon(port: u16) -> bool {
+    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let deadline = Instant::now() + DAEMON_BOOT_TIMEOUT;
+    let mut backoff = Duration::from_millis(20);
+    while Instant::now() < deadline {
+        if TcpStream::connect_timeout(&target, Duration::from_millis(200)).is_ok() {
+            return true;
+        }
+        thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_millis(200));
+    }
+    false
+}
+
+/// Guard that kills the daemon child on drop.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Write a minimal read-only `rsyncd.conf` exposing one module.
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_root: &Path,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [mod]\n\
+         path = {root}\n\
+         read only = true\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        root = module_root.display(),
+    );
+    fs::write(config_path, body)
+}
+
+/// Spawn `oc-rsync --daemon` on `port` and wait until it binds.
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path, port: u16) -> io::Result<DaemonGuard> {
+    let child = Command::new(oc_bin)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--config")
+        .arg(config_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    if !wait_for_daemon(port) {
+        let mut guard = DaemonGuard { child };
+        let _ = guard.child.kill();
+        return Err(io::Error::other(format!(
+            "oc-rsync --daemon did not accept connections on port {port} within {DAEMON_BOOT_TIMEOUT:?}",
+        )));
+    }
+    Ok(DaemonGuard { child })
+}
+
+/// Set an absolute whole-second mtime (nanoseconds zeroed) on `path`.
+fn set_mtime_secs(path: &Path, secs: i64) {
+    set_file_mtime(path, FileTime::from_unix_time(secs, 0)).expect("set mtime");
+}
+
+/// Run `oc-rsync -ain --modify-window=<window>` pulling the single module
+/// file into `dest_dir` and return the file's itemize row, or `None` if
+/// the file was treated as up-to-date (no row emitted).
+fn dry_run_itemize_row(
+    oc_bin: &Path,
+    port: u16,
+    window: u64,
+    dest_dir: &Path,
+) -> (Option<String>, String) {
+    let window_arg = format!("--modify-window={window}");
+    let source = format!("rsync://localhost:{port}/mod/file.txt");
+    let output = Command::new(oc_bin)
+        .arg("-ain")
+        .arg(&window_arg)
+        .arg(&source)
+        .arg(format!("{}/", dest_dir.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run oc-rsync dry-run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "dry-run exited non-zero: {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status,
+    );
+    let row = stdout
+        .lines()
+        .find(|line| line.contains("file.txt"))
+        .map(|line| line.to_string());
+    (row, format!("stdout:\n{stdout}\nstderr:\n{stderr}"))
+}
+
+/// Build a source module holding a single `file.txt` at [`BASE_MTIME_SECS`]
+/// plus a destination whose `file.txt` has identical bytes but an mtime
+/// offset by `dest_offset_secs` seconds. Returns the temp dir plus the
+/// module root so the daemon can serve it.
+fn seed(dest_offset_secs: i64) -> (TempDir, PathBuf, PathBuf) {
+    let temp = tempdir().expect("tempdir");
+    let module_root = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&module_root).expect("create src");
+    fs::create_dir_all(&dest).expect("create dst");
+
+    let payload = b"identical content payload";
+    fs::write(module_root.join("file.txt"), payload).expect("write src file");
+    fs::write(dest.join("file.txt"), payload).expect("write dst file");
+
+    set_mtime_secs(&module_root.join("file.txt"), BASE_MTIME_SECS);
+    set_mtime_secs(&dest.join("file.txt"), BASE_MTIME_SECS + dest_offset_secs);
+
+    (temp, module_root, dest)
+}
+
+/// End-to-end helper: spawn a daemon serving a freshly seeded module and
+/// return the itemize row (or `None`) for the dry-run pull.
+fn run_scenario(dest_offset_secs: i64, window: u64) -> (Option<String>, String) {
+    let Some(oc_bin) = locate_oc_rsync() else {
+        panic!("oc-rsync binary not found; build it before running this test");
+    };
+    let (temp, module_root, dest) = seed(dest_offset_secs);
+    let config_path = temp.path().join("rsyncd.conf");
+    let pid_path = temp.path().join("daemon.pid");
+    let log_path = temp.path().join("daemon.log");
+    write_daemon_config(&config_path, &pid_path, &log_path, &module_root)
+        .expect("write daemon config");
+    let port = allocate_test_port().expect("allocate port");
+    let _daemon = spawn_oc_daemon(&oc_bin, &config_path, port).expect("spawn daemon");
+
+    dry_run_itemize_row(&oc_bin, port, window, &dest)
+}
+
+/// A 1-second destination drift is inside `--modify-window=2`, so upstream
+/// `same_time()` reports the mtimes as equal: quick-check treats the file as
+/// up-to-date and itemize omits the time bit. The dry-run must emit NO row
+/// (no `>f`) rather than the pre-fix bare `ITEM_TRANSFER`.
+///
+/// Guards: `generator.c:645 mtime_differs()` and `generator.c:526`.
+#[test]
+fn within_modify_window_is_unchanged_in_dry_run() {
+    if SystemTime::UNIX_EPOCH.elapsed().is_err() {
+        return; // pre-epoch clock; skip rather than misfire
+    }
+    let (row, ctx) = run_scenario(1, 2);
+    assert!(
+        row.is_none(),
+        "1s drift within --modify-window=2 must be itemized as unchanged \
+         (no `>f` row); got {row:?}\n{ctx}",
+    );
+}
+
+/// A 3-second drift exceeds `--modify-window=2`, so the file must transfer:
+/// the dry-run itemizes it with the `>f` update indicator.
+#[test]
+fn beyond_modify_window_transfers_in_dry_run() {
+    let (row, ctx) = run_scenario(3, 2);
+    let row = row.unwrap_or_else(|| panic!("expected a `>f` transfer row for a 3s drift\n{ctx}"));
+    assert!(
+        row.starts_with(">f"),
+        "3s drift beyond --modify-window=2 must transfer (`>f`); got `{row}`\n{ctx}",
+    );
+}
+
+/// `--modify-window=0` keeps exact whole-second semantics, so even a 1s
+/// drift transfers. This pins the `window == 0` branch of the shared
+/// `same_time()` helper (exact equality, no tolerance).
+#[test]
+fn zero_window_preserves_exact_mtime_in_dry_run() {
+    let (row, ctx) = run_scenario(1, 0);
+    let row = row.unwrap_or_else(|| {
+        panic!("expected a `>f` transfer row for a 1s drift at window 0\n{ctx}")
+    });
+    assert!(
+        row.starts_with(">f"),
+        "1s drift at --modify-window=0 must transfer (`>f`); got `{row}`\n{ctx}",
+    );
+}
+
+/// Identical mtimes at `--modify-window=0` remain up-to-date: no row.
+/// Guards against an over-eager fix that would itemize matching files.
+#[test]
+fn identical_mtime_stays_unchanged_at_zero_window() {
+    let (row, ctx) = run_scenario(0, 0);
+    assert!(
+        row.is_none(),
+        "identical mtimes must stay unchanged (no row); got {row:?}\n{ctx}",
+    );
+}


### PR DESCRIPTION
## Problem

A `-ain --modify-window=2` dry-run (`-n`) did not absorb a 1s mtime difference: the file was itemized as `>f...` (transfer) instead of unchanged. PR #6252 added `--modify-window` to the receiver quick-check, but the dry-run wire path never reached it.

## Root cause

`build_files_to_transfer` short-circuited on `skip_dest_writes()` (`dry_run || list_only`), returning a bare `ITEM_TRANSFER` for **every** candidate and bypassing `quick_check_matches` (which honours `--modify-window`).

Upstream runs `quick_check_ok()` -> `mtime_differs()` -> `same_time()` (`util1.c:1478`) for a dry-run as well; only `dry_run > 1` (missing parent dir, `generator.c:1290`) short-circuits it. A within-window mtime is therefore treated as unchanged and itemized with `iflags=0`, not `>f`.

## Fix

- Restrict the receiver short-circuit to **list-only**; let `-n` fall through to the normal stat + quick-check path so within-window files are itemized as unchanged.
- Under `dry_run`, suppress only the filesystem mutations that upstream gates on `do_xfers`/`!dry_run`: metadata/ACL/xattr apply on a quick-check match (`generator.c:1814`) and alt-dest copy/link (`generator.c:1033`). The itemize stream is unchanged; the destination is never touched.
- Apply the same symmetric window compare to the itemize **time bit** (`generator.c:526 mtime_differs`) via the shared `same_time()` helper, so a within-window mtime no longer sets `ITEM_REPORT_TIME` (`t`). `window == 0` keeps exact whole-second equality.

## Verification

Byte-for-byte against upstream rsync 3.4.4 over a loopback daemon:

| case | oc-rsync | upstream 3.4.4 |
|---|---|---|
| 1s drift, `--modify-window=2` | *(unchanged, no row)* | *(unchanged, no row)* |
| 3s drift, `--modify-window=2` | `>f..t...... file.txt` | `>f..t...... file.txt` |
| 1s drift, `--modify-window=0` | `>f..t...... file.txt` | `>f..t...... file.txt` |
| identical, `--modify-window=0` | *(unchanged)* | *(unchanged)* |

New integration test `modify_window_dry_run_itemize` drives the real binary against an `oc-rsync --daemon` and pins the window boundary. The real (non-dry-run) transfer path is unaffected: a within-window file is still skipped and `-a` still normalises its mtime.

- `cargo fmt --all`: clean
- `cargo clippy -p transfer --all-targets --all-features --no-deps --locked -- -D warnings`: clean
- new + existing `--modify-window` and `itemize` unit/integration tests: pass