### PR TITLE
fix(engine): gate local-copy dest-parent creation on --mkpath

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -142,7 +142,18 @@ impl<'a> CopyContext<'a> {
             return Ok(());
         }
 
-        let allow_creation = self.implied_dirs_enabled() || self.mkpath_enabled();
+        // upstream: main.c:736 get_local_name() - the destination argument's own
+        // missing leading directories are only materialised when --mkpath is set
+        // (`make_path(dest_path, ...)`); without it a missing parent prefix makes
+        // the transfer fail (ENOENT) rather than being auto-created. Source-relative
+        // subdirs created UNDER an existing destination root during recursion are a
+        // separate concern governed by --implied-dirs (main.c:794 do_mkdir of the
+        // dest root + generator.c dir creation). Distinguish the two by whether the
+        // parent lies at/below the destination root: a parent strictly above the
+        // root is the destination arg's leading prefix and needs --mkpath.
+        let parent_within_root = parent.starts_with(self.destination_root());
+        let allow_creation =
+            self.mkpath_enabled() || (self.implied_dirs_enabled() && parent_within_root);
         let keep_dirlinks = self.keep_dirlinks_enabled();
 
         let result = if self.mode.is_dry_run() {

--- a/crates/engine/src/local_copy/tests/execute_basic.rs
+++ b/crates/engine/src/local_copy/tests/execute_basic.rs
@@ -784,8 +784,12 @@ fn execute_copies_file_to_nonexistent_destination() {
     assert_eq!(fs::read(&destination).expect("read dest"), b"content");
 }
 
+// upstream: main.c:738 make_path(dest_path, MKP_DROP_NAME) - creating a missing
+// intermediate prefix of the destination ARGUMENT requires --mkpath. Under
+// default options the transfer fails (see the negative control in
+// execute_no_implied_dirs.rs); with --mkpath the leading dirs are materialised.
 #[test]
-fn execute_creates_intermediate_directories_when_needed() {
+fn execute_creates_intermediate_directories_with_mkpath() {
     let temp = create_tempdir();
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("nested").join("path").join("dest.txt");
@@ -799,7 +803,10 @@ fn execute_creates_intermediate_directories_when_needed() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     let summary = plan
-        .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().mkpath(true),
+        )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);

--- a/crates/engine/src/local_copy/tests/execute_copy_dest.rs
+++ b/crates/engine/src/local_copy/tests/execute_copy_dest.rs
@@ -725,6 +725,7 @@ fn copy_dest_identical_file_records_reference_copy_with_blank_attrs() {
     let destination_dir = temp.path().join("dest");
     fs::create_dir_all(&source_dir).expect("create source dir");
     fs::create_dir_all(&copy_dest_dir).expect("create copy_dest dir");
+    fs::create_dir_all(&destination_dir).expect("create dest dir");
 
     let source_file = source_dir.join("file.txt");
     let copy_dest_file = copy_dest_dir.join("file.txt");

--- a/crates/engine/src/local_copy/tests/execute_directories.rs
+++ b/crates/engine/src/local_copy/tests/execute_directories.rs
@@ -446,8 +446,13 @@ fn execute_dry_run_without_implied_dirs_skips_parent_check() {
     assert!(!destination.exists());
 }
 
+// upstream: main.c:736 get_local_name() - --implied-dirs (archive default) does
+// NOT auto-create the destination arg's own missing leading prefix; only
+// --mkpath does. A single-file transfer to `.../missing/dest.txt` where
+// `missing/` is absent must fail with ENOENT and create nothing, exactly like
+// --no-implied-dirs (the prefix is strictly above the destination root).
 #[test]
-fn execute_with_implied_dirs_creates_missing_parents() {
+fn execute_with_implied_dirs_still_requires_dest_arg_parent() {
     let temp = create_tempdir();
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("missing").join("dest.txt");
@@ -459,10 +464,19 @@ fn execute_with_implied_dirs_creates_missing_parents() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    plan.execute().expect("copy succeeds");
+    let error = plan
+        .execute()
+        .expect_err("missing dest-arg parent should error without --mkpath");
 
-    assert!(destination.exists());
-    assert_eq!(fs::read(&destination).expect("read dest"), b"data");
+    match error.kind() {
+        LocalCopyErrorKind::Io { action, source, .. } => {
+            assert_eq!(*action, "create parent directory");
+            assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+    assert!(!destination.parent().expect("parent").exists());
+    assert!(!destination.exists());
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -535,8 +535,53 @@ fn relative_no_implied_dirs_creates_leading_dirs_with_default_mode() {
     );
 }
 
+// upstream: main.c:736 get_local_name() - without --mkpath a missing leading
+// prefix of the destination ARGUMENT is never auto-created; the transfer fails
+// with ENOENT. Archive defaults enable --implied-dirs, which only governs
+// source-relative subdirs created UNDER an existing destination root, NOT the
+// destination arg's own missing parent. This is the negative control the
+// upstream `mkpath` conformance test relies on: a transfer WITHOUT --mkpath
+// must NOT create the missing intermediate path.
 #[test]
-fn implied_dirs_default_creates_parents_automatically() {
+fn default_does_not_create_missing_dest_arg_parent() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("file.txt");
+    fs::write(&source, b"content").expect("write source");
+
+    // `a` is the top of the destination arg's own missing leading prefix
+    // (strictly above the destination root `.../a/b/c/file.txt`).
+    let missing_prefix = temp.path().join("a");
+    let destination = temp.path().join("a").join("b").join("c").join("file.txt");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    // Default options (archive-like: implied_dirs enabled, mkpath disabled).
+    let error = plan
+        .execute()
+        .expect_err("transfer must fail without --mkpath when parent is missing");
+
+    match error.kind() {
+        LocalCopyErrorKind::Io { action, source, .. } => {
+            assert_eq!(*action, "create parent directory");
+            assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+
+    // Nothing may be created along the missing prefix.
+    assert!(!missing_prefix.exists());
+    assert!(!destination.exists());
+}
+
+// upstream: main.c:738 make_path(dest_path, MKP_DROP_NAME) - --mkpath creates
+// the destination arg's leading directories (dropping the final name) and the
+// transfer then proceeds. Mirrors the `mkpath` conformance test's positive leg.
+#[test]
+fn mkpath_creates_missing_dest_arg_parent() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("file.txt");
     fs::write(&source, b"content").expect("write source");
@@ -549,8 +594,12 @@ fn implied_dirs_default_creates_parents_automatically() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Default should have implied_dirs enabled
-    let summary = plan.execute().expect("copy succeeds with default options");
+    // Default implied_dirs stays enabled; --mkpath is what unlocks dest-arg
+    // prefix creation.
+    let options = LocalCopyOptions::default().mkpath(true);
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds with mkpath");
 
     assert!(destination.exists());
     assert_eq!(fs::read(&destination).expect("read"), b"content");

--- a/crates/engine/src/local_copy/tests/execute_remove_source.rs
+++ b/crates/engine/src/local_copy/tests/execute_remove_source.rs
@@ -5,6 +5,7 @@
 fn remove_source_files_removes_successfully_transferred_file() {
     let ctx = test_helpers::setup_copy_test();
     fs::write(ctx.source.join("file.txt"), b"content").expect("write file");
+    fs::create_dir_all(&ctx.dest).expect("create dest");
 
     let operands = vec![
         ctx.source.join("file.txt").into_os_string(),

--- a/crates/engine/src/local_copy/tests/execute_zero_length.rs
+++ b/crates/engine/src/local_copy/tests/execute_zero_length.rs
@@ -646,8 +646,12 @@ fn execute_empty_file_to_empty_file_skipped_with_times() {
     assert_eq!(summary.regular_files_matched(), 1);
 }
 
+// upstream: main.c:736 get_local_name() - a single empty-file transfer to
+// `.../newdir/dest.txt` where `newdir/` is absent must fail with ENOENT and
+// create nothing without --mkpath, exactly like a non-empty file. Empty files
+// bypass the delta path but not the dest-parent gate.
 #[test]
-fn execute_creates_empty_file_in_nonexistent_directory() {
+fn execute_empty_file_in_nonexistent_directory_errors_without_mkpath() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("empty.txt");
     let destination = temp.path().join("newdir/dest.txt");
@@ -660,10 +664,42 @@ fn execute_creates_empty_file_in_nonexistent_directory() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // Should fail without --create-directories equivalent
-    // (Default behavior should create parent directories for single file copy)
-    let summary = plan
+    let error = plan
         .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .expect_err("missing dest-arg parent should error without --mkpath");
+
+    match error.kind() {
+        LocalCopyErrorKind::Io { action, source, .. } => {
+            assert_eq!(*action, "create parent directory");
+            assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+        }
+        other => panic!("unexpected error kind: {other:?}"),
+    }
+    assert!(!destination.parent().expect("parent").exists());
+    assert!(!destination.exists());
+}
+
+// upstream: --mkpath materialises the missing dest-arg parent even for an empty
+// source file.
+#[test]
+fn execute_empty_file_in_nonexistent_directory_with_mkpath() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("empty.txt");
+    let destination = temp.path().join("newdir/dest.txt");
+
+    fs::write(&source, b"").expect("write empty source");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().mkpath(true),
+        )
         .expect("copy succeeds");
 
     assert_eq!(summary.files_copied(), 1);

--- a/tests/integration_basic.rs
+++ b/tests/integration_basic.rs
@@ -410,14 +410,40 @@ fn error_on_nonexistent_source() {
     cmd.assert_failure();
 }
 
+// upstream: main.c:736 get_local_name() - without --mkpath a missing leading
+// prefix of the destination argument is never auto-created; the transfer fails
+// (change_dir ENOENT, exit 3) and nothing is written. Verified against upstream
+// rsync 3.4.x: `rsync source.txt newdir/dest.txt` with newdir absent exits 3.
 #[test]
-fn create_missing_destination_directory() {
+fn missing_destination_parent_without_mkpath_fails() {
     let test_dir = TestDir::new().expect("create test dir");
     let src_file = test_dir.write_file("source.txt", b"content").unwrap();
     let dest_file = test_dir.path().join("newdir/dest.txt");
 
     let mut cmd = RsyncCommand::new();
     cmd.args([src_file.to_str().unwrap(), dest_file.to_str().unwrap()]);
+    cmd.assert_failure();
+
+    assert!(
+        !test_dir.path().join("newdir").exists(),
+        "missing destination parent must not be auto-created without --mkpath"
+    );
+}
+
+// upstream: main.c:736 - with --mkpath the destination argument's missing
+// leading directories are materialized via make_path() before the transfer.
+#[test]
+fn create_missing_destination_directory_with_mkpath() {
+    let test_dir = TestDir::new().expect("create test dir");
+    let src_file = test_dir.write_file("source.txt", b"content").unwrap();
+    let dest_file = test_dir.path().join("newdir/dest.txt");
+
+    let mut cmd = RsyncCommand::new();
+    cmd.args([
+        "--mkpath",
+        src_file.to_str().unwrap(),
+        dest_file.to_str().unwrap(),
+    ]);
     cmd.assert_success();
 
     assert_eq!(fs::read(&dest_file).unwrap(), b"content");


### PR DESCRIPTION
## Problem

In local-copy mode, a transfer whose destination argument has a missing intermediate parent prefix (e.g. `oc-rsync -ai from/text to/foo/bar/baz/down/deep/new` where `to/` exists but the rest of the prefix does not) auto-created the missing parent even without `--mkpath`. Upstream only creates the destination argument's leading directories when `--mkpath` is given; otherwise the transfer fails with `ENOENT`.

This made the upstream `mkpath` conformance test fail: its negative control (a transfer WITHOUT `--mkpath` to a missing intermediate path must fail and create nothing) was violated because the local-copy engine created the parent.

## Fix

The site is `CopyContext::prepare_parent_directory` (`crates/engine/src/local_copy/context_impl/options/dirs.rs`). It computed `allow_creation = implied_dirs_enabled() || mkpath_enabled()`. Because archive mode enables `--implied-dirs`, the missing destination-arg prefix was created without `--mkpath`.

The gate is now narrow:

```
allow_creation = mkpath_enabled() || (implied_dirs_enabled() && parent.starts_with(destination_root))
```

`--implied-dirs` still creates source-relative subdirs **under** an existing destination root during recursion (those paths lie at/below the destination root). Only the destination argument's own missing leading prefix (strictly above the root) now requires `--mkpath`. Without it the pre-existing `ENOENT` path returns the upstream-matching error, and nothing is created.

This avoids the prior over-broad regression (broke recursive `src/ dst/` subdir creation): the recursion path that creates subdirs under an existing dest root is untouched.

## Upstream reference

`target/interop/upstream-src/rsync-3.4.4/main.c:736` `get_local_name()`:
- With `--mkpath`: `make_path(dest_path, MKP_DROP_NAME)` creates the leading dirs (dropping the final name component).
- Without it: a single-file transfer whose parent dir is absent fails when it tries to `change_dir` into the missing parent (`ENOENT`).

## lxhost testsuite validation (real upstream testsuite, oc vs rsync 3.4.3)

Sentinels `dirs` and `itemize` are recursion/dir-creation regression controls.

Master baseline (`f3dd0ba74`):
```
FAIL    mkpath
PASS    dirs
PASS    itemize
FAIL    chmod-option
```

This branch (`61e07568b`):
```
PASS    mkpath
PASS    dirs
PASS    itemize
FAIL    chmod-option
```

`mkpath` goes FAIL -> PASS. `dirs` and `itemize` stay PASS (no regression). `chmod-option` is a pre-existing failure unrelated to this change (unchanged on both).

## Tests

- New negative control + positive `--mkpath` unit tests in `execute_no_implied_dirs.rs` and updates to `execute_directories.rs` / `execute_basic.rs` (the three tests that previously encoded the incorrect auto-create behavior now assert the upstream-faithful `ENOENT`/`--mkpath` semantics).
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p engine --all-targets --all-features --no-deps --locked -- -D warnings`: no issues.