### PR TITLE
fix(engine): honor -R --no-implied-dirs in local-copy walk

### DIFF
--- a/crates/engine/src/local_copy/context_impl/options/dirs.rs
+++ b/crates/engine/src/local_copy/context_impl/options/dirs.rs
@@ -163,8 +163,13 @@ impl<'a> CopyContext<'a> {
                         self.replace_parent_entry_dry_run(parent, &existing, allow_creation)
                     }
                 }
+                // upstream: generator.c:1329-1333 - a missing leading parent
+                // is materialized on demand (make_path) when creation is
+                // allowed, or under `relative_paths && !implied_dirs`; in
+                // dry-run mode the real mkdir is elided, so mirror the real
+                // run's acceptance of the missing parent in both cases.
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                    if allow_creation {
+                    if allow_creation || self.relative_paths_enabled() {
                         Ok(())
                     } else {
                         Err(LocalCopyError::io(
@@ -225,6 +230,31 @@ impl<'a> CopyContext<'a> {
                         }
                     } else {
                         self.replace_parent_entry_forbidden(parent, &existing)
+                    }
+                }
+                // upstream: generator.c:1329-1333 - with `--no-implied-dirs`
+                // the implied parent dirs are absent from the flist, but under
+                // `relative_paths && !implied_dirs` recv_generator() still
+                // materializes a missing leading dir on demand via
+                // `make_path(fname, MKP_DROP_NAME | ...)`. The dir is created
+                // with default attributes (no source-attr mirroring); that
+                // suppression happens in retouch_relative_implied_dirs, which
+                // is already gated on implied_dirs_enabled(). Outside
+                // --relative mode there are no implied dirs, so a missing
+                // parent remains an error, matching upstream.
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    if self.relative_paths_enabled() {
+                        fs::create_dir_all(parent).map_err(|error| {
+                            LocalCopyError::io("create parent directory", parent, error)
+                        })?;
+                        self.register_progress();
+                        Ok(())
+                    } else {
+                        Err(LocalCopyError::io(
+                            "create parent directory",
+                            parent.to_path_buf(),
+                            error,
+                        ))
                     }
                 }
                 Err(error) => Err(LocalCopyError::io(

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -134,11 +134,9 @@ pub(crate) fn copy_file(
         return Ok(true);
     }
 
-    // Dry-run check must precede parent directory preparation. When
-    // --no-implied-dirs is active, prepare_parent_directory fails with NotFound
-    // for missing parents. That NotFound error is misclassified as "file has
-    // vanished" by the caller. In dry-run mode no filesystem mutations occur,
-    // so preparing the parent is unnecessary.
+    // Dry-run check must precede parent directory preparation: in dry-run mode
+    // no filesystem mutations occur, so materializing the parent is
+    // unnecessary and would create real directories.
     if mode.is_dry_run() {
         dry_run::handle_dry_run(
             context,

--- a/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_no_implied_dirs.rs
@@ -106,27 +106,22 @@ fn no_implied_dirs_works_with_relative_paths() {
     ];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    // With --relative and --no-implied-dirs, intermediate directories should not be created
+    // With --relative and --no-implied-dirs the implied leading dirs are still
+    // materialized on demand (upstream generator.c:1329-1333 make_path), but
+    // without the source's attributes. The deep file must transfer.
     let options = LocalCopyOptions::default()
         .relative_paths(true)
         .implied_dirs(false);
 
-    let error = plan
+    let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
-        .expect_err("should fail without parent directories in relative mode");
+        .expect("relative --no-implied-dirs creates leading dirs on demand");
 
-    match error.kind() {
-        LocalCopyErrorKind::Io { action, .. } => {
-            assert!(
-                *action == "create parent directory" || *action == "create directory",
-                "expected directory creation error, got: {action}"
-            );
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
-
-    // The deep structure should not have been created
-    assert!(!dest_root.join("dir1").join("dir2").exists());
+    assert!(dest_root.join("dir1").join("dir2").exists());
+    let copied = dest_root.join("dir1").join("dir2").join("file.txt");
+    assert!(copied.exists());
+    assert_eq!(fs::read(&copied).expect("read file"), b"content");
+    assert_eq!(summary.files_copied(), 1);
 }
 
 #[test]
@@ -234,20 +229,18 @@ fn no_implied_dirs_with_relative_and_deep_file() {
         .relative_paths(true)
         .implied_dirs(false);
 
-    let error = plan
+    // upstream generator.c:1329-1333: relative + --no-implied-dirs still
+    // make_path()s the missing leading dirs (a/b/c) with default attrs and
+    // transfers the deep file. This is exactly the relative-implied testsuite
+    // scenario that previously errored with "file has vanished".
+    let summary = plan
         .execute_with_options(LocalCopyExecution::Apply, options)
-        .expect_err("should fail without intermediate directories");
+        .expect("relative --no-implied-dirs materializes deep parents");
 
-    // Should fail trying to create parent directory
-    match error.kind() {
-        LocalCopyErrorKind::Io { action, .. } => {
-            assert!(
-                *action == "create parent directory" || *action == "create directory",
-                "expected directory creation error, got: {action}"
-            );
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
+    let copied = dest_root.join("a").join("b").join("c").join("file.txt");
+    assert!(copied.exists());
+    assert_eq!(fs::read(&copied).expect("read file"), b"content");
+    assert_eq!(summary.files_copied(), 1);
 }
 
 #[test]
@@ -485,6 +478,61 @@ fn no_implied_dirs_collection_reports_correct_events() {
         .any(|r| matches!(r.action(),
             LocalCopyAction::DataCopied |
             LocalCopyAction::MetadataReused)));
+}
+
+// Mirrors the upstream `relative-implied` testsuite `--no-implied-dirs` half:
+// `-aR --no-implied-dirs b/c/file dst/` must transfer dst/b/c/file, creating
+// the implied leading dirs with the default mode (umask-masked 0755) rather
+// than the source dir's distinctive 0750. Previously oc-rsync errored with
+// "file has vanished". upstream: generator.c:1329-1333 make_path().
+#[cfg(unix)]
+#[test]
+fn relative_no_implied_dirs_creates_leading_dirs_with_default_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let base = temp.path().join("rbase").join("a");
+    let deep = base.join("b").join("c");
+    fs::create_dir_all(&deep).expect("create deep source");
+    // Distinctive mode on the implied dir `b`, mirroring the testsuite.
+    fs::set_permissions(base.join("b"), fs::Permissions::from_mode(0o750))
+        .expect("chmod implied dir");
+    fs::write(deep.join("file"), b"data\n").expect("write file");
+
+    let dest_root = temp.path().join("to");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+
+    // Operand `b/c/file` relative to `rbase/a` via the `./` anchor.
+    let mut source_operand = base.into_os_string();
+    source_operand.push("/./b/c/file");
+
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .implied_dirs(false)
+        .permissions(true);
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("relative-implied --no-implied-dirs half succeeds");
+
+    let copied = dest_root.join("b").join("c").join("file");
+    assert!(copied.exists());
+    assert_eq!(fs::read(&copied).expect("read"), b"data\n");
+    assert_eq!(summary.files_copied(), 1);
+
+    // The implied dir `b` must carry the DEFAULT mode, not the source's 0750.
+    let b_mode = fs::metadata(dest_root.join("b"))
+        .expect("stat implied dir")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_ne!(
+        b_mode, 0o750,
+        "--no-implied-dirs must not mirror the source's 0750 onto the implied dir"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The `relative-implied` conformance test failed on master. Its `--no-implied-dirs` half is a **local** transfer:

```
run_rsync('-aR', '--no-implied-dirs', 'b/c/file', dst/)
```

oc-rsync aborted with:

```
oc-rsync error: file has vanished: ".../to/b/c" (code 24) at error.rs(269)
rsync exited 24
```

### Root cause

In the local-copy engine, `prepare_parent_directory` (`crates/engine/src/local_copy/context_impl/options/dirs.rs`) treated `--no-implied-dirs` as "never create a missing parent". When the leading dir `b/c` was absent it returned a `NotFound` IO error, which the caller reported as "file has vanished".

That is wrong. `--no-implied-dirs` does **not** mean "don't create leading dirs" - it means the implied dirs are absent from the flist and therefore do **not** get the source's attributes. Upstream `generator.c:1329-1333` still materializes the missing leading dir on demand:

```c
if (relative_paths && !implied_dirs && file->mode != 0
 && do_stat_at(dn, &sx.st) < 0) {
    if (dry_run)
        goto parent_is_dry_missing;
    if (make_path(fname, MKP_DROP_NAME | MKP_SKIP_SLASH) < 0) { ... }
}
```

### Fix

When `relative_paths && !implied_dirs` and the parent is missing, create it with `create_dir_all` (default attributes), matching `make_path`. The source-attribute stamping stays suppressed because `retouch_relative_implied_dirs` (`sources/orchestration.rs`) is already gated on `implied_dirs_enabled()`. Outside `--relative` mode a missing parent remains an error (no implied dirs exist there). The dry-run branch mirrors the same acceptance so dry-run does not diverge from the real run.

Stale tests in `execute_no_implied_dirs.rs` that pinned the old "file has vanished" error in relative mode were updated to assert the correct on-demand creation, and a focused `relative_no_implied_dirs_creates_leading_dirs_with_default_mode` regression was added.

## Validation on Linux host (aarch64, upstream rsync as oracle)

Before (master):

```
file has vanished: "b/c/file"
oc-rsync error: file has vanished: ".../to/b/c" (code 24)
rsync exited 24
FAIL    relative-implied
```

After (this branch, real testsuite via `runtests.py`):

```
PASS    relative-implied
PASS    dirs
PASS    itemize
```

`relative-implied` flips to PASS; the `dirs` and `itemize` sentinels do not regress.

## Local checks

- `cargo fmt --all` - clean
- `cargo clippy -p engine --all-targets --all-features --no-deps --locked` - No issues found

Upstream reference: `generator.c:1329-1333` (`make_path` under `relative_paths && !implied_dirs`).