### PR TITLE
fix(engine): correct local-copy delete pass for --max-delete/backup

### DIFF
--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -392,7 +392,15 @@ fn apply_delete_side_effects(
             record_directory_subtree(context, &mut subtree_path, &mut subtree_relative)?;
         }
 
-        if !context.mode().is_dry_run() {
+        // upstream: delete.c:165 - back up an extraneous file before deletion
+        // only when `backup_dir || !is_backup_file(fbuf)`. A name that already
+        // ends in the backup suffix is unlinked directly (no re-backup to
+        // `<name><suffix><suffix>`); the emitter below performs that unlink.
+        if !context.mode().is_dry_run()
+            && context
+                .options()
+                .should_backup_before_delete(entry.name.as_os_str())
+        {
             context.backup_existing_entry(&path, Some(entry_relative.as_path()), file_type)?;
         }
         // upstream: log.c:log_delete emits exactly ONE line - the itemize

--- a/crates/engine/src/local_copy/options/backup.rs
+++ b/crates/engine/src/local_copy/options/backup.rs
@@ -68,6 +68,35 @@ impl LocalCopyOptions {
     pub fn backup_suffix(&self) -> &OsStr {
         &self.backup_suffix
     }
+
+    /// Reports whether `name` already ends with the backup suffix.
+    ///
+    /// Mirrors upstream `delete.c:37-41 is_backup_file()`: a non-empty suffix
+    /// that matches the trailing bytes of the name (with at least one byte
+    /// preceding it) marks the file as an existing backup.
+    #[must_use]
+    pub fn is_backup_file(&self, name: &OsStr) -> bool {
+        let suffix = self.backup_suffix.as_encoded_bytes();
+        if suffix.is_empty() {
+            return false;
+        }
+        let name = name.as_encoded_bytes();
+        // upstream: `k = strlen(fn) - backup_suffix_len; k > 0 && ...`
+        name.len() > suffix.len() && name.ends_with(suffix)
+    }
+
+    /// Reports whether an extraneous entry should be backed up before it is
+    /// deleted, rather than unlinked directly.
+    ///
+    /// Mirrors the guard on upstream `delete.c:165`:
+    /// `make_backups > 0 && (backup_dir || !is_backup_file(fbuf))`. A file
+    /// whose name already ends in the backup suffix is unlinked directly (no
+    /// re-backup to `<name><suffix><suffix>`) unless a `--backup-dir` is set,
+    /// in which case the backup always lands in the separate directory.
+    #[must_use]
+    pub fn should_backup_before_delete(&self, name: &OsStr) -> bool {
+        self.backup && (self.backup_dir.is_some() || !self.is_backup_file(name))
+    }
 }
 
 #[cfg(test)]
@@ -155,5 +184,49 @@ mod tests {
         let suffix = OsString::from(".backup");
         let opts = LocalCopyOptions::new().with_backup_suffix(Some(suffix));
         assert_eq!(opts.backup_suffix(), OsStr::new(".backup"));
+    }
+
+    #[test]
+    fn is_backup_file_matches_trailing_suffix() {
+        // upstream: delete.c:37-41 - k > 0 && strcmp(fn+k, backup_suffix) == 0.
+        let opts = LocalCopyOptions::new().backup(true); // default suffix "~"
+        assert!(opts.is_backup_file(OsStr::new("stale~")));
+        assert!(!opts.is_backup_file(OsStr::new("plain")));
+        // k > 0 requires at least one byte before the suffix: bare "~" is not a
+        // backup file (strlen("~") - 1 == 0).
+        assert!(!opts.is_backup_file(OsStr::new("~")));
+    }
+
+    #[test]
+    fn is_backup_file_false_when_suffix_empty() {
+        // A --backup-dir gives an empty suffix; nothing is ever "already a backup".
+        let opts = LocalCopyOptions::new()
+            .with_backup_directory(Some("/backups"))
+            .with_backup_suffix::<OsString>(None);
+        assert!(!opts.is_backup_file(OsStr::new("anything~")));
+    }
+
+    #[test]
+    fn should_backup_before_delete_skips_already_suffixed() {
+        // upstream: delete.c:165 - backup_dir || !is_backup_file(fbuf).
+        // With -b and no --backup-dir, a "~"-suffixed extraneous file is
+        // unlinked directly, not re-backed-up to "<name>~~".
+        let opts = LocalCopyOptions::new().backup(true);
+        assert!(opts.should_backup_before_delete(OsStr::new("plain")));
+        assert!(!opts.should_backup_before_delete(OsStr::new("stale~")));
+    }
+
+    #[test]
+    fn should_backup_before_delete_backup_dir_always_backs_up() {
+        // With --backup-dir the file lands in the separate directory, so even a
+        // suffixed name is backed up (backup_dir short-circuits the guard).
+        let opts = LocalCopyOptions::new().with_backup_directory(Some("/backups"));
+        assert!(opts.should_backup_before_delete(OsStr::new("stale~")));
+    }
+
+    #[test]
+    fn should_backup_before_delete_false_without_backup() {
+        let opts = LocalCopyOptions::new();
+        assert!(!opts.should_backup_before_delete(OsStr::new("plain")));
     }
 }

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -2220,3 +2220,55 @@ fn backup_dir_replaces_preexisting_directory_at_target() {
         "deleted file must not remain in destination"
     );
 }
+
+/// upstream: delete.c:165 - under `--backup` with no `--backup-dir`, an
+/// extraneous file is backed up to `<name>~` before removal, but a name that
+/// already ends in the backup suffix is unlinked directly (no re-backup to
+/// `<name>~~`). Mirrors the `is_backup_file` leg of the upstream `delete-deep`
+/// testsuite case.
+#[test]
+fn backup_delete_skips_already_suffixed_extraneous_file() {
+    let ctx = test_helpers::setup_copy_test();
+    fs::create_dir_all(&ctx.dest).expect("create dest");
+
+    // Source keeps one file so the destination directory is not empty.
+    fs::write(ctx.source.join("keep.txt"), b"keep").expect("write keep");
+
+    let dest_root = ctx.dest.join("source");
+    fs::create_dir_all(&dest_root).expect("create dest root");
+    fs::write(dest_root.join("keep.txt"), b"keep").expect("write dest keep");
+    // Plain extraneous file -> backed up to plain~.
+    fs::write(dest_root.join("plain"), b"extraneous").expect("write plain");
+    // Already-suffixed extraneous file -> unlinked directly, never re-backed-up.
+    fs::write(dest_root.join("stale~"), b"already a backup").expect("write stale~");
+
+    let operands = vec![
+        ctx.source.clone().into_os_string(),
+        ctx.dest.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default().delete(true).backup(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy with --delete --backup succeeds");
+
+    // Plain file removed and backed up.
+    assert!(
+        !dest_root.join("plain").exists(),
+        "extraneous plain file must be removed"
+    );
+    assert!(
+        dest_root.join("plain~").exists(),
+        "extraneous plain file must be backed up to plain~"
+    );
+
+    // Suffixed file removed, with no double-suffix backup created.
+    assert!(
+        !dest_root.join("stale~").exists(),
+        "already-suffixed extraneous file must be removed"
+    );
+    assert!(
+        !dest_root.join("stale~~").exists(),
+        "already-suffixed file must be unlinked, not re-backed-up to stale~~"
+    );
+}


### PR DESCRIPTION
## Problem

The `delete-deep` conformance test failed on the local-copy engine. The
failing assertion:

```
is_backup_file: already-suffixed file unlinked, not re-backed-up:
  .../to/d1/d2/stale~~ exists but should not
```

Under `--backup` with no `--backup-dir`, the delete pass backed up an
extraneous file whose name already ended in the backup suffix (`stale~`) to
`stale~~`, instead of unlinking it directly.

## Fix

Mirror upstream `delete.c:165`, which backs up an extraneous file before
deletion only when `backup_dir || !is_backup_file(fbuf)`. A name that already
ends in the backup suffix is unlinked directly (the emitter then performs the
unlink).

- Added `LocalCopyOptions::is_backup_file` mirroring `delete.c:37-41`.
- Added `LocalCopyOptions::should_backup_before_delete` mirroring the
  `delete.c:165` guard.
- Gated the delete-pass backup call in the cleanup emitter on that guard.

The existing `--backup-dir` delete-backup tests are unaffected: with a backup
directory set the guard short-circuits to true, so those files are still
backed up.

## Validation (Linux host, aarch64)

`cargo nextest run -p engine`:

```
Summary [8.649s] 4722 tests run: 4722 passed, 26 skipped
```

`runtests.py delete-deep delete itemize`:

```
PASS    delete-deep
PASS    delete
PASS    itemize
```

`delete-deep` flipped FAIL -> PASS; `delete` and `itemize` sentinels remain
PASS. Added a focused unit test covering the already-suffixed skip.