### PR TITLE
fix(engine): correct local-copy fuzzy basis selection

### DIFF
--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -142,8 +142,11 @@ mod tests {
         assert!(stderr.is_empty());
     }
 
+    /// upstream: log.c:rwrite - a debug message (FINFO) renders verbatim on
+    /// the client's stdout, with no flag-category bracket. This is the stream
+    /// the fuzzy testsuite greps for "fuzzy basis selected ...".
     #[test]
-    fn test_debug_event_renders_to_stderr_with_flag() {
+    fn test_debug_event_renders_to_stdout_verbatim() {
         let events = vec![DiagnosticEvent::Debug {
             flag: DebugFlag::Filter,
             level: 1,
@@ -155,11 +158,11 @@ mod tests {
 
         render_diagnostic_events(&events, &mut stdout, &mut stderr, false).unwrap();
 
-        assert!(stdout.is_empty());
         assert_eq!(
-            String::from_utf8(stderr).unwrap(),
-            "[Filter] excluding file foo.txt\n"
+            String::from_utf8(stdout).unwrap(),
+            "excluding file foo.txt\n"
         );
+        assert!(stderr.is_empty());
     }
 
     #[test]

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -69,11 +69,17 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
                 }
             }
             DiagnosticEvent::Debug {
-                flag,
+                flag: _,
                 level: _,
                 message,
             } => {
-                writeln!(err, "[{flag:?}] {message}")?;
+                // upstream: log.c:rwrite() prints debug messages verbatim via
+                // rprintf(FINFO/FCLIENT, ...) with no flag-category bracket.
+                // The message already carries any role prefix (e.g. "[sender]")
+                // where upstream emits one, so rendering the DebugFlag name here
+                // would diverge from upstream byte-for-byte (breaks --debug=FUZZY
+                // parsers that grep the exact selection line).
+                writeln!(err, "{message}")?;
             }
         }
     }
@@ -206,8 +212,10 @@ mod tests {
         assert!(stdout_output.contains("first\n"));
         assert!(stdout_output.contains("third\n"));
 
+        // upstream: debug messages render verbatim, with no flag-category
+        // bracket prefix (log.c:rwrite via rprintf(FINFO, ...)).
         let stderr_output = String::from_utf8(stderr).unwrap();
-        assert_eq!(stderr_output, "[Io] second\n");
+        assert_eq!(stderr_output, "second\n");
     }
 
     #[test]
@@ -224,7 +232,8 @@ mod tests {
         assert!(stdout_output.contains("test info"));
 
         let stderr_output = String::from_utf8(stderr).unwrap();
-        assert!(stderr_output.contains("[Filter] test debug"));
+        assert!(stderr_output.contains("test debug"));
+        assert!(!stderr_output.contains("[Filter]"));
 
         let mut stdout2 = Vec::new();
         let mut stderr2 = Vec::new();

--- a/crates/cli/src/frontend/progress/diagnostic.rs
+++ b/crates/cli/src/frontend/progress/diagnostic.rs
@@ -74,12 +74,17 @@ pub fn render_diagnostic_events<O: Write, E: Write>(
                 message,
             } => {
                 // upstream: log.c:rwrite() prints debug messages verbatim via
-                // rprintf(FINFO/FCLIENT, ...) with no flag-category bracket.
-                // The message already carries any role prefix (e.g. "[sender]")
-                // where upstream emits one, so rendering the DebugFlag name here
-                // would diverge from upstream byte-for-byte (breaks --debug=FUZZY
-                // parsers that grep the exact selection line).
-                writeln!(err, "{message}")?;
+                // rprintf(FINFO, ...) with no flag-category bracket. FINFO
+                // routes to the client's stdout (the same stream as info
+                // events) unless msgs-to-stderr is in effect, so debug lines
+                // like "fuzzy basis selected ..." land on stdout where the
+                // fuzzy testsuite greps them. The message already carries any
+                // role prefix (e.g. "[sender]") where upstream emits one.
+                if msgs2stderr {
+                    writeln!(err, "{message}")?;
+                } else {
+                    writeln!(out, "{message}")?;
+                }
             }
         }
     }
@@ -178,9 +183,12 @@ mod tests {
         render_diagnostic_events(&events, &mut stdout, &mut stderr, true).unwrap();
 
         assert!(stdout.is_empty());
+        // With msgs-to-stderr, both info and debug route to stderr; debug
+        // renders verbatim with no flag-category bracket (upstream fidelity).
         let stderr_output = String::from_utf8(stderr).unwrap();
         assert!(stderr_output.contains("info message\n"));
-        assert!(stderr_output.contains("[Filter] debug message\n"));
+        assert!(stderr_output.contains("debug message\n"));
+        assert!(!stderr_output.contains("[Filter]"));
     }
 
     #[test]
@@ -208,14 +216,12 @@ mod tests {
 
         render_diagnostic_events(&events, &mut stdout, &mut stderr, false).unwrap();
 
+        // upstream: FINFO info AND debug messages both route to the client's
+        // stdout, verbatim, with no flag-category bracket prefix
+        // (log.c:rwrite via rprintf(FINFO, ...)). Order is preserved.
         let stdout_output = String::from_utf8(stdout).unwrap();
-        assert!(stdout_output.contains("first\n"));
-        assert!(stdout_output.contains("third\n"));
-
-        // upstream: debug messages render verbatim, with no flag-category
-        // bracket prefix (log.c:rwrite via rprintf(FINFO, ...)).
-        let stderr_output = String::from_utf8(stderr).unwrap();
-        assert_eq!(stderr_output, "second\n");
+        assert_eq!(stdout_output, "first\nsecond\nthird\n");
+        assert!(stderr.is_empty());
     }
 
     #[test]
@@ -228,12 +234,13 @@ mod tests {
 
         flush_diagnostics(&mut stdout, &mut stderr, false).unwrap();
 
+        // Without msgs-to-stderr, both info and debug land on stdout; debug
+        // renders verbatim with no flag-category bracket (upstream fidelity).
         let stdout_output = String::from_utf8(stdout).unwrap();
         assert!(stdout_output.contains("test info"));
-
-        let stderr_output = String::from_utf8(stderr).unwrap();
-        assert!(stderr_output.contains("test debug"));
-        assert!(!stderr_output.contains("[Filter]"));
+        assert!(stdout_output.contains("test debug"));
+        assert!(!stdout_output.contains("[Filter]"));
+        assert!(stderr.is_empty());
 
         let mut stdout2 = Vec::new();
         let mut stderr2 = Vec::new();

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -751,11 +751,22 @@ fn find_fuzzy_basis(
         return None;
     }
 
-    // upstream: generator.c:1787 - announce the selected basis at FUZZY,1. The
-    // target display mirrors upstream's `fname` (the relative transfer path)
-    // when available, falling back to the destination path.
-    let target_display = relative.unwrap_or(destination).display().to_string();
-    trace_fuzzy_basis_selected(&target_display, &candidate.path.display().to_string());
+    // upstream: generator.c:1787-1793 - announce the selected basis at FUZZY,1
+    // as `"fuzzy basis selected for %s: %s"`, where the target is `fname` (the
+    // relative transfer path) and the basis is `f_name(fuzzy_file)` - the
+    // basis's relative flist name, not an absolute filesystem path. The basis
+    // shares the target's directory, so its relative name is the target's
+    // parent joined with the candidate basename.
+    let target_rel = relative.unwrap_or(destination);
+    let target_display = target_rel.display().to_string();
+    let basis_display = match (target_rel.parent(), candidate.path.file_name()) {
+        (Some(parent), Some(basis_name)) if !parent.as_os_str().is_empty() => {
+            parent.join(basis_name).display().to_string()
+        }
+        (_, Some(basis_name)) => Path::new(basis_name).display().to_string(),
+        (_, None) => candidate.path.display().to_string(),
+    };
+    trace_fuzzy_basis_selected(&target_display, &basis_display);
 
     Some((candidate.path, meta))
 }

--- a/crates/engine/tests/fuzzy_local_copy.rs
+++ b/crates/engine/tests/fuzzy_local_copy.rs
@@ -130,14 +130,16 @@ fn fuzzy_selects_near_identical_basis_for_delta() {
         "fuzzy delta must reconstruct the source exactly"
     );
 
-    // upstream: generator.c:1787 - FUZZY,1 selection line naming target + basis.
+    // upstream: generator.c:1787-1793 - the FUZZY,1 line names the target and
+    // basis by their relative flist names (basenames here), byte-for-byte:
+    // "fuzzy basis selected for %s: %s". The fuzzy testsuite greps this exact
+    // string, so the basis must be the basename `report_2023.csv`, not an
+    // absolute destination path.
     let msgs = fuzzy_messages();
     assert!(
-        msgs.iter().any(
-            |m| m.starts_with("fuzzy basis selected for report_2024.csv:")
-                && m.contains("report_2023.csv")
-        ),
-        "expected FUZZY,1 selection line for the chosen basis, got {msgs:?}"
+        msgs.iter()
+            .any(|m| m == "fuzzy basis selected for report_2024.csv: report_2023.csv"),
+        "expected exact FUZZY,1 selection line for the chosen basis, got {msgs:?}"
     );
 }
 

--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -202,7 +202,11 @@ impl VerbosityConfig {
     pub fn apply_info_flag(&mut self, token: &str) -> Result<(), String> {
         let (name, level) = parse_flag_token(token)?;
 
-        let flag = match name {
+        // upstream: options.c:parse_output_words() matches names with
+        // strncasecmp, so `--info=NAME` is case-insensitive (users and the
+        // testsuite pass upper-case tokens like `--debug=FUZZY`).
+        let name = name.to_ascii_lowercase();
+        let flag = match name.as_str() {
             "backup" => InfoFlag::Backup,
             "copy" => InfoFlag::Copy,
             "del" => InfoFlag::Del,
@@ -232,7 +236,11 @@ impl VerbosityConfig {
     pub fn apply_debug_flag(&mut self, token: &str) -> Result<(), String> {
         let (name, level) = parse_flag_token(token)?;
 
-        let flag = match name {
+        // upstream: options.c:parse_output_words() matches names with
+        // strncasecmp, so `--debug=NAME` is case-insensitive (users and the
+        // testsuite pass upper-case tokens like `--debug=FUZZY`).
+        let name = name.to_ascii_lowercase();
+        let flag = match name.as_str() {
             "acl" => DebugFlag::Acl,
             "backup" => DebugFlag::Backup,
             "bind" => DebugFlag::Bind,
@@ -546,6 +554,38 @@ mod tests {
 
         config.apply_debug_flag("time").unwrap();
         assert_eq!(config.debug.time, 1);
+    }
+
+    /// upstream: options.c:parse_output_words() matches flag names with
+    /// strncasecmp, so `--debug=FUZZY` (as typed by users and the fuzzy
+    /// testsuite) must enable the flag exactly like `--debug=fuzzy`. A
+    /// case-sensitive matcher silently dropped upper-case tokens, leaving
+    /// `debug.fuzzy = 0` and suppressing the "fuzzy basis selected" line.
+    #[test]
+    fn apply_debug_flag_is_case_insensitive() {
+        let mut config = VerbosityConfig::default();
+
+        config.apply_debug_flag("FUZZY").unwrap();
+        assert_eq!(config.debug.fuzzy, 1);
+
+        // Level suffixes still parse against an upper-case name.
+        config.apply_debug_flag("Fuzzy2").unwrap();
+        assert_eq!(config.debug.fuzzy, 2);
+
+        config.apply_debug_flag("DELTASUM").unwrap();
+        assert_eq!(config.debug.deltasum, 1);
+    }
+
+    /// Info flags share the same case-insensitive matching contract.
+    #[test]
+    fn apply_info_flag_is_case_insensitive() {
+        let mut config = VerbosityConfig::default();
+
+        config.apply_info_flag("COPY").unwrap();
+        assert_eq!(config.info.copy, 1);
+
+        config.apply_info_flag("Progress").unwrap();
+        assert_eq!(config.info.progress, 1);
     }
 
     #[test]

--- a/crates/logging/tests/debug_flag_parsing.rs
+++ b/crates/logging/tests/debug_flag_parsing.rs
@@ -333,18 +333,27 @@ fn empty_flag_rejected() {
     assert!(result.is_err());
 }
 
-/// Verifies flag names are case-sensitive (lowercase required).
+/// Verifies flag names match case-insensitively.
+///
+/// upstream: options.c:parse_output_words() compares names with strncasecmp,
+/// so `--debug=RECV`, `--debug=Recv`, and `--debug=recv` are equivalent.
+/// Users and the fuzzy testsuite pass upper-case tokens like `--debug=FUZZY`.
 #[test]
-fn flag_names_case_sensitive() {
+fn flag_names_case_insensitive() {
     init(VerbosityConfig::default());
 
-    // Lowercase should work
     apply_debug_flag("recv").unwrap();
     assert!(debug_gte(DebugFlag::Recv, 1));
 
-    // Uppercase should fail (config.rs expects lowercase)
-    let result = apply_debug_flag("RECV");
-    assert!(result.is_err());
+    // Upper-case names resolve to the same flag.
+    init(VerbosityConfig::default());
+    apply_debug_flag("RECV").unwrap();
+    assert!(debug_gte(DebugFlag::Recv, 1));
+
+    // Mixed case with a level suffix also works.
+    init(VerbosityConfig::default());
+    apply_debug_flag("Fuzzy2").unwrap();
+    assert!(debug_gte(DebugFlag::Fuzzy, 2));
 }
 
 /// Verifies level 0 disables a flag.

--- a/crates/logging/tests/info_flag_parsing.rs
+++ b/crates/logging/tests/info_flag_parsing.rs
@@ -491,15 +491,15 @@ fn zero_level_explicit() {
     assert_eq!(config.info.copy, 0);
 }
 
-/// Verifies flag names are case-sensitive (should fail).
+/// Verifies flag names match case-insensitively.
+///
+/// upstream: options.c:parse_output_words() uses strncasecmp, so `--info=COPY`
+/// resolves to the same flag as `--info=copy`.
 #[test]
-fn flag_name_case_sensitive() {
+fn flag_name_case_insensitive() {
     let mut config = VerbosityConfig::default();
-    let result = parse_info_flags(&mut config, "COPY");
-
-    // Flag names are case-sensitive, so "COPY" should be unknown
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("unknown info flag"));
+    parse_info_flags(&mut config, "COPY").unwrap();
+    assert!(info_gte(InfoFlag::Copy, 1));
 }
 
 /// Verifies proper case works.

--- a/crates/logging/tests/info_flag_parsing.rs
+++ b/crates/logging/tests/info_flag_parsing.rs
@@ -499,7 +499,7 @@ fn zero_level_explicit() {
 fn flag_name_case_insensitive() {
     let mut config = VerbosityConfig::default();
     parse_info_flags(&mut config, "COPY").unwrap();
-    assert!(info_gte(InfoFlag::Copy, 1));
+    assert_eq!(config.info.copy, 1);
 }
 
 /// Verifies proper case works.


### PR DESCRIPTION
## Summary

The upstream `fuzzy` conformance test (a local-copy transfer:
`-avvi --no-whole-file --fuzzy --delete-delay --debug=FUZZY`) failed because
oc-rsync never emitted the generator's `fuzzy basis selected for X: Y` line on
stdout, even though the local-copy engine already selected and used the fuzzy
basis correctly (delta matched bytes were byte-identical to upstream).

Root cause was a chain of three output-fidelity gaps between the local-copy
engine and upstream's `--debug=FUZZY` output:

1. **Case-sensitive flag matching.** `apply_debug_flag`/`apply_info_flag`
   matched flag names case-sensitively against lower-case arms, so the
   user-typed token `FUZZY` returned an ignored `Err` and left `debug.fuzzy = 0`.
   Upstream `options.c:parse_output_words()` compares names with `strncasecmp`
   (case-insensitive). Fixed to lower-case the parsed name before matching.

2. **Absolute basis path.** The local-copy fuzzy trace emitted the basis as an
   absolute filesystem path; upstream `generator.c:1787` prints
   `f_name(fuzzy_file)` - the basis's relative flist name (the basename for a
   top-level file). Now built from the target's relative parent + candidate
   basename.

3. **Debug on stderr with a category bracket.** `render_diagnostic_events`
   prefixed debug lines with the flag category (`[Fuzzy] ...`) and routed them
   to stderr. Upstream `log.c:rwrite` prints debug (`FINFO`) messages verbatim
   on the client's stdout with no bracket. Fixed to render verbatim and honour
   `msgs-to-stderr` exactly like info events.

## Upstream references

- `generator.c:830` `find_fuzzy()`, `generator.c:1787-1793` selection line.
- `options.c:437` `parse_output_words()` - `strncasecmp` case-insensitive names.
- `log.c:rwrite()` - `FINFO` debug output to client stdout, no category prefix.

## Before / after (lxhost, upstream testsuite + full nextest)

Before (master 28428423d):
```
FAIL    fuzzy   (--fuzzy did not print "fuzzy basis selected for rsync.c: rsync2.c")
```

After (this branch):
```
PASS    fuzzy
PASS    itemize      (not regressed)
FAIL    compare      (pre-existing, fails identically on master)
```

`cargo nextest run --workspace` on lxhost: all tests pass except two
`xtask::commands::package` tests
(`cross_compiler_resolution_prefers_cross_gcc`,
`tarball_resolution_skips_targets_without_cross_tooling`) - both confirmed to
fail identically on master. They are a host environment artifact: lxhost has a
real `/usr/bin/aarch64-linux-gnu-gcc`, so the "force missing cross tooling"
override does not suppress detection. No product regressions.

## Tests

- `logging::config` case-insensitive `apply_debug_flag`/`apply_info_flag`.
- `logging` flag-parsing tests flipped from case-sensitive to case-insensitive.
- `engine` local-copy fuzzy test asserts the exact upstream selection string.
- `cli` diagnostic render tests updated for verbatim stdout debug output.
