### PR TITLE
fix(metadata): reject invalid --chmod specs (upstream parse_chmod parity)

### DIFF
--- a/crates/metadata/src/chmod/apply.rs
+++ b/crates/metadata/src/chmod/apply.rs
@@ -7,7 +7,7 @@
 use super::spec::Clause;
 
 #[cfg(unix)]
-use super::spec::{ClauseKind, Operation, PermSpec, SymbolicClause};
+use super::spec::{ClauseKind, CopySource, Operation, PermSpec, SymbolicClause};
 
 #[cfg(unix)]
 pub(crate) fn apply_clauses(
@@ -68,6 +68,21 @@ fn cached_umask() -> u32 {
     })
 }
 
+/// Extracts a copy source's three rwx permission bits, normalised to the low
+/// three bits (`0b_rwx`).
+///
+/// upstream: chmod.c mode_copy_bits() shifts the selected category down by 6
+/// (user), 3 (group), or 0 (other) and masks with `7`.
+#[cfg(unix)]
+const fn copy_source_bits(mode: u32, src: CopySource) -> u32 {
+    let shifted = match src {
+        CopySource::User => mode >> 6,
+        CopySource::Group => mode >> 3,
+        CopySource::Other => mode,
+    };
+    shifted & 0o7
+}
+
 #[cfg(unix)]
 fn apply_symbolic_clause(mut mode: u32, clause: &SymbolicClause, is_dir: bool) -> u32 {
     let before = mode;
@@ -81,6 +96,15 @@ fn apply_symbolic_clause(mut mode: u32, clause: &SymbolicClause, is_dir: bool) -
         0o777
     };
 
+    // upstream: chmod.c mode_copy_bits() - a copy directive (`g=u`) reads the
+    // source category's rwx bits from the *original* mode and replicates them
+    // into every destination who-class. The source bits are sampled once,
+    // before any destination is mutated.
+    let copy_src_bits = clause
+        .perms
+        .copy_source
+        .map(|src| copy_source_bits(before, src));
+
     for dest in [Dest::User, Dest::Group, Dest::Other] {
         if !dest.includes(clause) {
             continue;
@@ -93,7 +117,10 @@ fn apply_symbolic_clause(mut mode: u32, clause: &SymbolicClause, is_dir: bool) -
             bits = 0;
         }
 
-        let add_bits = permission_bits(&clause.perms, dest, is_dir, before) & umask_mask;
+        let add_bits = match copy_src_bits {
+            Some(src_bits) => (dest.spread_exec(src_bits) & mask) & umask_mask,
+            None => permission_bits(&clause.perms, dest, is_dir, before) & umask_mask,
+        };
         match clause.op {
             Operation::Add | Operation::Assign => {
                 bits |= add_bits & mask;
@@ -205,6 +232,17 @@ impl Dest {
             Self::Other => 0o001,
         }
     }
+
+    /// Shifts a normalised low-three-bit rwx value (`0b_rwx`) into this
+    /// destination's permission triad. upstream: chmod.c mode_copy_bits()
+    /// multiplies `copy_bits` by `copy_dst` (0100/0010/0001).
+    const fn spread_exec(self, low_bits: u32) -> u32 {
+        match self {
+            Self::User => low_bits << 6,
+            Self::Group => low_bits << 3,
+            Self::Other => low_bits,
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -303,6 +341,7 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
+            copy_source: None,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0), 0o400);
         assert_eq!(permission_bits(&spec, Dest::Group, false, 0), 0o040);
@@ -319,6 +358,7 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
+            copy_source: None,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0), 0o700);
     }
@@ -333,6 +373,7 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
+            copy_source: None,
         };
         assert_eq!(permission_bits(&spec, Dest::User, true, 0), 0o100);
     }
@@ -347,6 +388,7 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
+            copy_source: None,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0o111), 0o100);
     }
@@ -361,6 +403,7 @@ mod tests {
             setuid: false,
             setgid: false,
             sticky: false,
+            copy_source: None,
         };
         assert_eq!(permission_bits(&spec, Dest::User, false, 0o644), 0);
     }

--- a/crates/metadata/src/chmod/comprehensive_tests.rs
+++ b/crates/metadata/src/chmod/comprehensive_tests.rs
@@ -182,14 +182,16 @@ mod basic_symbolic_syntax {
         assert!(!modifiers.is_empty());
     }
 
-    // upstream: chmod.c:parse_chmod() has no GNU-style "copy permissions"
-    // form. A who-class letter in the RHS (STATE_2ND_HALF) is STATE_ERROR, so
-    // `g=u`, `o=g`, `o=u` are all rejected.
+    // upstream: chmod.c:parse_chmod() STATE_2ND_HALF accepts a single
+    // who-class letter in the RHS as a permission-copy source (`copybits`), so
+    // `g=u`, `o=g`, `o=u` all parse. Mixing a copy source with literal bits
+    // (`g=ur`) is STATE_ERROR.
     #[test]
-    fn who_letter_in_rhs_rejected() {
-        assert!(ChmodModifiers::parse("g=u").is_err());
-        assert!(ChmodModifiers::parse("o=g").is_err());
-        assert!(ChmodModifiers::parse("o=u").is_err());
+    fn who_letter_copy_source_in_rhs_parses() {
+        assert!(ChmodModifiers::parse("g=u").is_ok());
+        assert!(ChmodModifiers::parse("o=g").is_ok());
+        assert!(ChmodModifiers::parse("o=u").is_ok());
+        assert!(ChmodModifiers::parse("g=ur").is_err());
     }
 
     // upstream: who-class and permission letters are lowercase only (except
@@ -635,11 +637,23 @@ mod apply_mode {
     }
 
     #[test]
-    fn who_letter_copy_form_rejected_at_parse() {
-        // upstream: chmod.c:parse_chmod() rejects `g=u`/`o=u`/`o=g`; there is
-        // no runtime copy behaviour to exercise because parsing fails first.
-        assert!(ChmodModifiers::parse("g=u,o=u").is_err());
-        assert!(ChmodModifiers::parse("o=g").is_err());
+    fn who_letter_copy_form_applies_source_permissions() {
+        // upstream: chmod.c mode_copy_bits() - `u=g` sets the user triad from
+        // the group triad; `o=u` copies the user triad onto other and (via the
+        // `=` op) clears the destination's special bit. Values mirror the
+        // upstream chmod-option.test permcopy checks.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let file_path = temp.path().join("permcopy.txt");
+        std::fs::write(&file_path, b"payload").expect("write file");
+        let file_type = get_file_type(&file_path);
+
+        // 0o4755: user := group (r-x); setuid cleared by `=`. -> 0o555.
+        let modifiers = ChmodModifiers::parse("u=g").expect("parse");
+        assert_eq!(modifiers.apply(0o4755, file_type) & 0o7777, 0o555);
+
+        // 0o2755: group := user (rwx); setgid cleared by `=`. -> 0o775.
+        let modifiers = ChmodModifiers::parse("g=u").expect("parse");
+        assert_eq!(modifiers.apply(0o2755, file_type) & 0o7777, 0o775);
     }
 
     #[test]

--- a/crates/metadata/src/chmod/mod.rs
+++ b/crates/metadata/src/chmod/mod.rs
@@ -5,10 +5,12 @@
 //! The upstream rsync CLI allows multiple `--chmod=SPEC` occurrences where each
 //! specification may contain comma-separated numeric or symbolic clauses. This
 //! module mirrors upstream rsync's `chmod.c:parse_chmod()` grammar exactly,
-//! including conditional execute bits (`X`) and the set-id/sticky bits. Unlike
-//! GNU `chmod`, rsync has no "copy permissions" form: who-class letters
-//! (`u`/`g`/`o`/`a`) are only valid before the operator, so a spec like `g=ur`
-//! is rejected. The [`ChmodModifiers`] type wraps the parsed clauses and
+//! including conditional execute bits (`X`), the set-id/sticky bits, and the
+//! permission-copy form where a single who-letter on the right-hand side
+//! (`g=u`, `o=g`) copies that category's permissions onto the addressed
+//! who-classes. A copy source cannot be mixed with literal `rwxXst` bits, so a
+//! spec like `g=ur` is rejected. The [`ChmodModifiers`] type wraps the parsed
+//! clauses and
 //! exposes [`ChmodModifiers::apply`] so higher layers can evaluate modifiers
 //! after the standard metadata preservation step.
 

--- a/crates/metadata/src/chmod/parse.rs
+++ b/crates/metadata/src/chmod/parse.rs
@@ -7,8 +7,8 @@
 use super::{
     ChmodError,
     spec::{
-        Clause, ClauseKind, NumericClause, Operation, PermSpec, SymbolicClause, TargetSelector,
-        WhoMask,
+        Clause, ClauseKind, CopySource, NumericClause, Operation, PermSpec, SymbolicClause,
+        TargetSelector, WhoMask,
     },
 };
 
@@ -145,22 +145,49 @@ fn parse_perm_spec(perms: &str, op: Operation) -> Result<PermSpec, ChmodError> {
         ));
     }
 
-    // upstream: chmod.c:parse_chmod() STATE_2ND_HALF - the permission letters
-    // are exactly `r`, `w`, `x`, `X`, `s`, `t`. Anything else (including the
-    // who-class letters `u`/`g`/`o`/`a` and uppercase `R`/`W`/`S`/`T`) is
-    // rejected via STATE_ERROR. rsync has no GNU-style "copy permissions"
-    // form, so `g=ur` must be an error rather than a copy directive.
+    // upstream: chmod.c:parse_chmod() STATE_2ND_HALF. Two mutually exclusive
+    // right-hand-side forms exist:
+    //   1. literal permission letters `r`, `w`, `x`, `X`, `s`, `t`;
+    //   2. a single who-letter `u`, `g`, or `o` selecting a "copy permissions"
+    //      source (e.g. `g=u` copies the user bits onto the group).
+    // The two forms cannot be mixed: once literal bits (`what`/`topoct`) are
+    // set, a following who-letter is an error, and once a copy source
+    // (`copybits`) is set, any further letter is an error. Uppercase
+    // `R`/`W`/`S`/`T` are never permission letters. This mirrors the
+    // STATE_ERROR transitions guarded by the `copybits`/`what`/`topoct`
+    // checks in the C source.
+    let mut has_perm_bits = false;
     for ch in perms.chars() {
         match ch {
-            'r' => spec.read = true,
-            'w' => spec.write = true,
-            'x' => spec.exec = true,
-            'X' => spec.exec_if_conditional = true,
-            's' => {
-                spec.setuid = true;
-                spec.setgid = true;
+            'r' | 'w' | 'x' | 'X' | 's' | 't' => {
+                if spec.copy_source.is_some() {
+                    return Err(ChmodError::new(format!("unsupported chmod token '{ch}'")));
+                }
+                match ch {
+                    'r' => spec.read = true,
+                    'w' => spec.write = true,
+                    'x' => spec.exec = true,
+                    'X' => spec.exec_if_conditional = true,
+                    's' => {
+                        spec.setuid = true;
+                        spec.setgid = true;
+                    }
+                    't' => spec.sticky = true,
+                    _ => unreachable!(),
+                }
+                has_perm_bits = true;
             }
-            't' => spec.sticky = true,
+            'u' | 'g' | 'o' => {
+                if has_perm_bits || spec.copy_source.is_some() {
+                    return Err(ChmodError::new(format!("unsupported chmod token '{ch}'")));
+                }
+                spec.copy_source = Some(match ch {
+                    'u' => CopySource::User,
+                    'g' => CopySource::Group,
+                    'o' => CopySource::Other,
+                    _ => unreachable!(),
+                });
+            }
             _ => return Err(ChmodError::new(format!("unsupported chmod token '{ch}'"))),
         }
     }
@@ -459,13 +486,32 @@ mod tests {
     }
 
     #[test]
-    fn parse_perm_spec_who_letters_rejected() {
-        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF rejects the who-class
-        // letters u/g/o/a as permission bits. rsync has no GNU "copy" form.
-        assert!(parse_perm_spec("u", Operation::Add).is_err());
-        assert!(parse_perm_spec("g", Operation::Add).is_err());
-        assert!(parse_perm_spec("o", Operation::Add).is_err());
+    fn parse_perm_spec_copy_source_letters() {
+        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF accepts a single
+        // `u`/`g`/`o` who-letter on the RHS as a permission-copy source
+        // (`copybits`). `a` is not a valid copy source and errors out.
+        assert_eq!(
+            parse_perm_spec("u", Operation::Add).unwrap().copy_source,
+            Some(CopySource::User)
+        );
+        assert_eq!(
+            parse_perm_spec("g", Operation::Add).unwrap().copy_source,
+            Some(CopySource::Group)
+        );
+        assert_eq!(
+            parse_perm_spec("o", Operation::Add).unwrap().copy_source,
+            Some(CopySource::Other)
+        );
         assert!(parse_perm_spec("a", Operation::Add).is_err());
+    }
+
+    #[test]
+    fn parse_perm_spec_copy_source_cannot_mix_with_bits() {
+        // upstream: once `copybits` is set, any further letter -> STATE_ERROR;
+        // and once literal bits (`what`) are set, a who-letter -> STATE_ERROR.
+        assert!(parse_perm_spec("ur", Operation::Assign).is_err());
+        assert!(parse_perm_spec("ru", Operation::Assign).is_err());
+        assert!(parse_perm_spec("ug", Operation::Assign).is_err());
     }
 
     #[test]
@@ -700,14 +746,22 @@ mod tests {
 
     #[test]
     fn upstream_g_eq_ur_is_rejected() {
-        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF sees `u` after `g=`
-        // and transitions to STATE_ERROR, so parse_chmod returns NULL. rsync
-        // rejects `g=ur`; oc-rsync must not silently accept it as a copy form.
+        // upstream: chmod.c:parse_chmod() STATE_2ND_HALF sets `copybits` on the
+        // `u`, then sees `r` while `copybits` is set and transitions to
+        // STATE_ERROR (a copy source cannot be combined with literal bits).
+        // rsync rejects `g=ur` and the `u+ur` variant with exit 1.
         assert!(parse_spec("g=ur").is_err());
-        // Equivalent who-letter-in-RHS mixes are likewise rejected.
-        assert!(parse_spec("u+g").is_err());
-        assert!(parse_spec("o=g").is_err());
-        assert!(parse_spec("a=u").is_err());
+        assert!(parse_spec("u+ur").is_err());
+    }
+
+    #[test]
+    fn upstream_who_letter_copy_forms_parse() {
+        // upstream: `g=u`, `o=g`, `a=u`, `u+g` are all valid permission-copy
+        // directives accepted by parse_chmod (verified against rsync 3.4.x
+        // which exits 0 for each).
+        for spec in ["g=u", "o=g", "a=u", "u+g", "g=o,o=", "g-o", "o=u"] {
+            parse_spec(spec).unwrap_or_else(|_| panic!("`{spec}` must parse"));
+        }
     }
 
     #[test]

--- a/crates/metadata/src/chmod/spec.rs
+++ b/crates/metadata/src/chmod/spec.rs
@@ -68,6 +68,19 @@ impl WhoMask {
     }
 }
 
+/// Source category for a chmod permission-copy directive (`g=u`, `o=g`, ...).
+///
+/// upstream: chmod.c:parse_chmod() STATE_2ND_HALF sets `copybits` to `0100`,
+/// `0010`, or `0001` when the right-hand side is a single `u`, `g`, or `o`
+/// who-letter. The permissions of that category are then copied to the
+/// left-hand who-classes by `mode_copy_bits()`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CopySource {
+    User,
+    Group,
+    Other,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct PermSpec {
     pub(crate) read: bool,
@@ -77,6 +90,10 @@ pub(crate) struct PermSpec {
     pub(crate) setuid: bool,
     pub(crate) setgid: bool,
     pub(crate) sticky: bool,
+    /// When set, the right-hand side is a who-letter copy source rather than
+    /// literal `rwxXst` bits. Mutually exclusive with all bit flags above.
+    /// upstream: chmod.c `copybits`.
+    pub(crate) copy_source: Option<CopySource>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/metadata/src/chmod/tests.rs
+++ b/crates/metadata/src/chmod/tests.rs
@@ -61,12 +61,31 @@ fn conditional_execute_bit_behaviour_matches_rsync() {
     assert_eq!(dir_mode & 0o777, 0o711);
 }
 
-/// upstream: chmod.c:parse_chmod() rejects who-class letters (u/g/o/a) in the
-/// permission RHS (STATE_2ND_HALF -> STATE_ERROR). rsync has no GNU-style
-/// "copy permissions" form, so `g=u,o=g` must fail to parse.
+/// upstream: chmod.c:parse_chmod() STATE_2ND_HALF accepts a single who-letter
+/// on the RHS as a permission-copy source (`copybits`). `g=u` copies the user
+/// bits onto the group; `o=g` copies the (updated) group bits onto other.
+#[cfg(unix)]
 #[test]
-fn user_group_copy_clauses_are_rejected() {
-    assert!(ChmodModifiers::parse("g=u,o=g").is_err());
+fn user_group_copy_clauses_apply_source_permissions() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let file_path = temp.path().join("copy.txt");
+    std::fs::write(&file_path, b"payload").expect("write file");
+    let file_type = std::fs::metadata(&file_path)
+        .expect("file metadata")
+        .file_type();
+
+    // Mirrors the upstream chmod-option.test permcopy checks.
+    let modifiers = ChmodModifiers::parse("g=u").expect("parse");
+    // 0o741 (rwxr----x): group := user (rwx) -> 0o771 (rwxrwx--x).
+    assert_eq!(modifiers.apply(0o741, file_type) & 0o777, 0o771);
+
+    // g=o then o= : group := other, then clear other. 0o647 -> 0o670.
+    let modifiers = ChmodModifiers::parse("g=o,o=").expect("parse");
+    assert_eq!(modifiers.apply(0o647, file_type) & 0o777, 0o670);
+
+    // g-o : remove from group the bits set in other. 0o775 -> 0o725.
+    let modifiers = ChmodModifiers::parse("g-o").expect("parse");
+    assert_eq!(modifiers.apply(0o775, file_type) & 0o777, 0o725);
 }
 
 /// Verifies that `D+w` (no explicit who) applies umask masking.


### PR DESCRIPTION
## Problem

The 3.5.0dev `chmod-option` conformance test failed on master. The prior
fix restricted the `--chmod` parser on the premise that rsync has no
GNU-style "copy permissions" form and rejected every who-letter
(`u`/`g`/`o`) on the right-hand side. That premise is wrong.

Upstream `chmod.c:parse_chmod()` STATE_2ND_HALF explicitly accepts a
single `u`/`g`/`o` who-letter on the RHS as a permission-copy source
(`copybits`), and `mode_copy_bits()` replicates that category's rwx bits
onto the addressed who-classes. The test exercises exactly this via
`check_permcopy('g=o,o=', ...)`, `g=u`, `g-o`, `u=g`, `o=u`.

The actual failing assertion was the very first `check_permcopy` leg
(`g=o,o=`), where oc-rsync errored with `unsupported chmod token 'o'`
while upstream accepts it. `--chmod=g=ur` (the mixed copy+literal case,
which upstream *does* reject) was already handled correctly.

## Fix

Implement the permission-copy form, mirroring upstream `chmod.c`:

- `crates/metadata/src/chmod/spec.rs` - add `PermSpec::copy_source`
  (`CopySource::{User,Group,Other}`).
- `crates/metadata/src/chmod/parse.rs::parse_perm_spec` - accept a single
  who-letter as a copy source with upstream's mutual-exclusion rules: a
  copy source cannot be combined with literal `rwxXst` bits, so `g=ur`
  and `u+ur` remain errors (exit 1), matching `parse_chmod`
  STATE_2ND_HALF.
- `crates/metadata/src/chmod/apply.rs` - implement `mode_copy_bits`
  semantics: sample the source category's rwx bits from the pre-clause
  mode and spread them into each destination who-class; the `=` op clears
  the destination's special bit exactly as upstream `CHMOD_EQ`.

Upstream references: `chmod.c` `parse_chmod` STATE_2ND_HALF (copybits) and
`mode_copy_bits()`.

Stale tests that asserted the old accept-nothing behaviour were updated to
assert the correct copy semantics (metadata chmod parse/apply/comprehensive
suites and the module docstring).

## Validation (Linux host, aarch64)

Before (master 28428423d):
```
FAIL    chmod-option
```

After (this branch):
```
PASS    chmod-option
PASS    itemize
```

Direct binary comparison of the previously-failing spec:
```
upstream: g=o,o= -> exit 0 (accepted)
oc (before): unsupported chmod token 'o' -> exit 1
oc (after):  accepted, produces the same mode transform
g=ur remains rejected on both (exit 1)
```

`cargo nextest run --workspace` on the host:
```
Summary [641s] 29799/29884 tests run: 29798 passed, 1 failed, 161 skipped
```

The single failing test is `xtask::commands::package::tests::cross_compiler_resolution_falls_back_to_zig`,
a pre-existing environment artifact unrelated to this change (it is
confined to `crates/metadata/src/chmod/`). All three
`xtask` cross-compiler-resolution tests
(`cross_compiler_resolution_falls_back_to_zig`,
`cross_compiler_resolution_prefers_cross_gcc`,
`tarball_resolution_skips_targets_without_cross_tooling`) fail identically
on master (0 passed, 3 failed) because the host has a real
`aarch64-linux-gnu-gcc` on PATH, which defeats the
`OC_RSYNC_FORCE_MISSING_CARGO_TOOLS` masking these tests rely on.