### PR TITLE
fix(engine): apply --modify-window in local-copy dry-run itemize

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -15,6 +15,7 @@ use crate::local_copy::{
 };
 
 use super::super::append::{AppendMode, determine_append_mode};
+use super::super::comparison::{CopyComparison, should_skip_copy};
 
 /// Aggregated parameters for simulating a file copy in dry-run mode.
 pub(super) struct DryRunRequest<'a> {
@@ -78,6 +79,36 @@ pub(super) fn handle_dry_run(
             Some(metadata_snapshot),
         ));
         return Ok(());
+    }
+
+    // upstream: generator.c:526,645 - the generator runs the quick check
+    // (unchanged_file()/itemize()) in dry-run exactly as in a real run: a
+    // destination whose size matches and whose mtime is within `--modify-window`
+    // of the source is up-to-date, so no transfer is itemized. Mirror the
+    // real-run `try_skip_up_to_date` path here; without it the dry-run always
+    // reports a `>f` transfer and `--modify-window` never absorbs a small mtime
+    // drift.
+    if let Some(existing) = existing_metadata {
+        let prefetched_match = if context.checksum_enabled() {
+            context.lookup_checksum(source)
+        } else {
+            None
+        };
+        if should_skip_copy(CopyComparison {
+            source_path: source,
+            source: metadata,
+            destination_path: destination,
+            destination: existing,
+            size_only: context.size_only_enabled(),
+            ignore_times: context.ignore_times_enabled(),
+            checksum: context.checksum_enabled(),
+            checksum_algorithm: context.options().checksum_algorithm(),
+            modify_window: context.options().modify_window(),
+            prefetched_match,
+        }) {
+            record_dry_run_skip(context, metadata, destination, record_path, existing);
+            return Ok(());
+        }
     }
 
     // upstream: generator.c:1469-1483 - in dry-run mode the generator still
@@ -152,6 +183,49 @@ pub(super) fn handle_dry_run(
     );
     remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
     Ok(())
+}
+
+/// Records a dry-run quick-check skip for an up-to-date destination.
+///
+/// Mirrors the real-run `record_metadata_only_skip` bookkeeping (hard-link
+/// registration, matched-file counter, `MetadataReused` event) but performs no
+/// filesystem mutation, since dry-run does no I/O. The change set is computed
+/// against the existing destination and honours `--modify-window`, so a file
+/// whose only drift is a sub-window mtime difference produces a blank itemize
+/// (suppressed at plain `-i`), matching upstream generator.c:526.
+fn record_dry_run_skip(
+    context: &mut CopyContext,
+    metadata: &fs::Metadata,
+    destination: &Path,
+    record_path: &Path,
+    existing: &fs::Metadata,
+) {
+    let metadata_options = context.metadata_options();
+    context.record_hard_link(metadata, destination);
+    context.summary_mut().record_regular_file_matched();
+    let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
+    let total_bytes = Some(metadata_snapshot.len());
+    let change_set = LocalCopyChangeSet::for_file(
+        metadata,
+        Some(existing),
+        &metadata_options,
+        true,
+        false,
+        false,
+        false,
+        context.options().modify_window(),
+    );
+    context.record(
+        LocalCopyRecord::new(
+            record_path.to_path_buf(),
+            LocalCopyAction::MetadataReused,
+            0,
+            total_bytes,
+            Duration::default(),
+            Some(metadata_snapshot),
+        )
+        .with_change_set(change_set),
+    );
 }
 
 /// Records the dry-run itemize for a regular file that would be satisfied by a
@@ -257,6 +331,7 @@ fn simulate_reference_match(
         false,
         false,
         false,
+        context.options().modify_window(),
     );
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
     context.record(

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -274,6 +274,7 @@ pub(super) fn process_links(
                         false
                     }
                 },
+                context.options().modify_window(),
             );
             // upstream: hlink.c:218-222 + generator.c:528-530 - the hardlink
             // leader-reuse path emits `itemize(..., ITEM_LOCAL_CHANGE, ...)`,
@@ -437,6 +438,7 @@ pub(super) fn process_links(
                     false
                 }
             },
+            context.options().modify_window(),
         );
         // upstream: generator.c:528-530 - ITEM_REPORT_TIME fires for the
         // hardlink-create path when the source mtime differs from the
@@ -537,6 +539,7 @@ pub(super) fn process_links(
                             false
                         }
                     },
+                    context.options().modify_window(),
                 );
                 context.record(
                     LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -166,6 +166,7 @@ pub(super) fn try_clone(
         true,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
+        context.options().modify_window(),
     );
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/ficlone.rs
@@ -165,6 +165,7 @@ pub(super) fn try_clone(
         true,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
+        context.options().modify_window(),
     );
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
@@ -133,6 +133,7 @@ pub(super) fn try_dispatch(
         true,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
+        context.options().modify_window(),
     );
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -667,6 +667,7 @@ pub(in crate::local_copy) fn execute_transfer(
         flags.xattrs_enabled(),
         flags.acls_enabled(),
         flags.checksum_enabled,
+        context.options().modify_window(),
     );
     let action = if is_reference_copy {
         LocalCopyAction::ReferenceCopied

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/skip.rs
@@ -170,6 +170,7 @@ pub(super) fn record_metadata_only_skip(
         false,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
+        context.options().modify_window(),
     );
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -162,6 +162,7 @@ pub(super) fn try_copy(
         true,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
+        context.options().modify_window(),
     );
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/special.rs
@@ -95,6 +95,7 @@ pub(in crate::local_copy) fn copy_special_as_regular_file(
         false,
         flags.xattrs_enabled(),
         flags.acls_enabled(),
+        context.options().modify_window(),
     );
     context.record(
         LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/file/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/mod.rs
@@ -20,7 +20,9 @@ pub use backup_trace::{
 };
 #[cfg(test)]
 pub(crate) use comparison::files_checksum_match;
-pub(crate) use comparison::{CopyComparison, DEFAULT_XXH64_DEDUP_SIZE_LIMIT, should_skip_copy};
+pub(crate) use comparison::{
+    CopyComparison, DEFAULT_XXH64_DEDUP_SIZE_LIMIT, should_skip_copy, system_time_within_window,
+};
 pub(crate) use copy::copy_file;
 #[cfg(test)]
 pub(crate) use copy::take_fsync_call_count;

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use directory::{
 pub(crate) use file::take_fsync_call_count;
 pub(crate) use file::{
     CopyComparison, DEFAULT_XXH64_DEDUP_SIZE_LIMIT, SparseWriteState, copy_entry_to_backup,
-    copy_file, should_skip_copy, write_sparse_chunk,
+    copy_file, should_skip_copy, system_time_within_window, write_sparse_chunk,
 };
 pub use file::{
     DestinationWriteGuard, PartialFileManager, PartialMode, SparseDetectStrategy, SparseDetector,

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -311,6 +311,7 @@ pub(crate) fn copy_symlink(
             false,
             false,
             false,
+            context.options().modify_window(),
         );
         context.summary_mut().record_symlink();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
@@ -379,6 +380,7 @@ pub(crate) fn copy_symlink(
                 false,
                 false,
                 false,
+                context.options().modify_window(),
             );
             context.record(
                 LocalCopyRecord::new(
@@ -630,6 +632,7 @@ pub(crate) fn copy_symlink(
                         false,
                         false,
                         false,
+                        context.options().modify_window(),
                     );
                     record = record.with_change_set(change_set);
                 }
@@ -743,6 +746,7 @@ pub(crate) fn copy_symlink(
                 false,
                 false,
                 false,
+                context.options().modify_window(),
             );
             record = record.with_change_set(change_set);
         }

--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -1,7 +1,9 @@
 use std::fs;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use ::metadata::MetadataOptions;
+
+use crate::local_copy::executor::system_time_within_window;
 
 use super::{LocalCopyChangeSet, TimeChange};
 
@@ -23,6 +25,7 @@ impl LocalCopyChangeSet {
         wrote_data: bool,
         xattrs_enabled: bool,
         acls_enabled: bool,
+        modify_window: Duration,
     ) -> Self {
         Self::for_file_with_checksum(
             metadata,
@@ -33,6 +36,7 @@ impl LocalCopyChangeSet {
             xattrs_enabled,
             acls_enabled,
             false,
+            modify_window,
         )
     }
 
@@ -54,6 +58,7 @@ impl LocalCopyChangeSet {
         xattrs_enabled: bool,
         acls_enabled: bool,
         checksum_enabled: bool,
+        modify_window: Duration,
     ) -> Self {
         let mut change_set = Self::new();
 
@@ -75,6 +80,7 @@ impl LocalCopyChangeSet {
             existing,
             destination_previously_existed,
             wrote_data,
+            modify_window,
         ));
 
         // upstream: generator.c:542-549 - `#ifndef CAN_CHMOD_SYMLINK` skips
@@ -238,6 +244,7 @@ fn determine_time_change(
     existing: Option<&fs::Metadata>,
     destination_previously_existed: bool,
     wrote_data: bool,
+    modify_window: Duration,
 ) -> Option<TimeChange> {
     if metadata_options.times() {
         if !destination_previously_existed {
@@ -247,8 +254,16 @@ fn determine_time_change(
         let new_mtime = metadata_modified_time(metadata);
         let old_mtime = existing.and_then(metadata_modified_time);
 
+        // upstream: generator.c:526 - the ITEM_REPORT_TIME bit is set via
+        // `!same_time(file->modtime, 0, &sxp->st)`. same_time() (util1.c:1478)
+        // treats two mtimes as equal when their whole-second delta is within
+        // `--modify-window`, so a sub-window drift must NOT light the `t` glyph.
         match (new_mtime, old_mtime) {
-            (Some(new_value), Some(old_value)) if new_value == old_value => None,
+            (Some(new_value), Some(old_value))
+                if system_time_within_window(new_value, old_value, modify_window) =>
+            {
+                None
+            }
             _ => Some(TimeChange::Modified),
         }
     } else if wrote_data || !destination_previously_existed {

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::time::Duration;
 
 use ::metadata::MetadataOptions;
 
@@ -252,9 +253,14 @@ fn for_file_new_destination_sets_size_changed() {
     let options = MetadataOptions::new();
 
     let change_set = LocalCopyChangeSet::for_file(
-        &metadata, None, // no existing
-        &options, false, // destination did not previously exist
-        false, false, false,
+        &metadata,
+        None, // no existing
+        &options,
+        false, // destination did not previously exist
+        false,
+        false,
+        false,
+        Duration::ZERO,
     );
 
     assert!(change_set.size_changed());
@@ -277,6 +283,7 @@ fn for_file_wrote_data_sets_checksum_changed() {
         false,
         false,
         true, // checksum mode active (gates position-2 `c` glyph per upstream generator.c:1942)
+        Duration::ZERO,
     );
 
     assert!(change_set.checksum_changed());
@@ -298,6 +305,7 @@ fn for_file_xattrs_enabled_sets_xattr_changed() {
         false,
         true, // xattrs enabled
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.xattr_changed());
@@ -319,6 +327,7 @@ fn for_file_acls_enabled_sets_acl_changed() {
         false,
         false,
         true, // acls enabled
+        Duration::ZERO,
     );
 
     assert!(change_set.acl_changed());
@@ -340,6 +349,7 @@ fn for_file_no_changes_same_metadata() {
         false, // no data written
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(!change_set.checksum_changed());
@@ -365,6 +375,7 @@ fn for_file_size_difference_detected() {
         false,
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.size_changed());
@@ -379,8 +390,14 @@ fn for_file_times_preserved_new_destination() {
     let options = MetadataOptions::new().preserve_times(true);
 
     let change_set = LocalCopyChangeSet::for_file(
-        &metadata, None, &options, false, // new destination
-        false, false, false,
+        &metadata,
+        None,
+        &options,
+        false, // new destination
+        false,
+        false,
+        false,
+        Duration::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::Modified));
@@ -402,6 +419,7 @@ fn for_file_times_not_preserved_wrote_data() {
         true, // wrote data
         false,
         false,
+        Duration::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::TransferTime));
@@ -416,8 +434,14 @@ fn for_file_times_not_preserved_new_destination() {
     let options = MetadataOptions::new().preserve_times(false);
 
     let change_set = LocalCopyChangeSet::for_file(
-        &metadata, None, &options, false, // new destination
-        false, false, false,
+        &metadata,
+        None,
+        &options,
+        false, // new destination
+        false,
+        false,
+        false,
+        Duration::ZERO,
     );
 
     assert_eq!(change_set.time_change(), Some(TimeChange::TransferTime));
@@ -439,9 +463,60 @@ fn for_file_times_not_changed_existing_no_write() {
         false, // no write
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.time_change().is_none());
+}
+
+/// upstream: generator.c:526 - the ITEM_REPORT_TIME (`t`) glyph is gated by
+/// `!same_time(...)`, which honours `--modify-window`. A same-size file whose
+/// mtime drifts by less than the window must therefore leave the time slot
+/// blank so the itemize line is suppressed. Guards the itemize path exercised
+/// by the upstream `compare` testsuite (`-ain --modify-window=2`).
+#[test]
+fn for_file_within_window_mtime_drift_reports_no_time_change() {
+    use filetime::{FileTime, set_file_mtime};
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let existing_path = temp.path().join("existing.txt");
+    fs::write(&existing_path, b"same size").expect("write existing");
+    set_file_mtime(&existing_path, FileTime::from_unix_time(1_700_000_001, 0))
+        .expect("set existing mtime");
+    let existing = fs::metadata(&existing_path).expect("metadata");
+
+    let new_path = temp.path().join("new.txt");
+    fs::write(&new_path, b"same size").expect("write new");
+    set_file_mtime(&new_path, FileTime::from_unix_time(1_700_000_000, 0)).expect("set new mtime");
+    let metadata = fs::metadata(&new_path).expect("metadata");
+
+    let options = MetadataOptions::new().preserve_times(true);
+    // 1s drift, 2s window -> within tolerance -> no `t` glyph.
+    let within = LocalCopyChangeSet::for_file(
+        &metadata,
+        Some(&existing),
+        &options,
+        true,
+        false,
+        false,
+        false,
+        Duration::from_secs(2),
+    );
+    assert!(within.time_change().is_none());
+    assert!(!within.has_any_change());
+
+    // Same drift with a zero window still lights the `t` glyph.
+    let exact = LocalCopyChangeSet::for_file(
+        &metadata,
+        Some(&existing),
+        &options,
+        true,
+        false,
+        false,
+        false,
+        Duration::ZERO,
+    );
+    assert_eq!(exact.time_change(), Some(TimeChange::Modified));
 }
 
 #[test]
@@ -469,6 +544,7 @@ fn change_set_detects_size_and_time_changes() {
         true,
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.size_changed());
@@ -514,6 +590,7 @@ fn change_set_detects_permission_changes_for_existing_destination() {
         false,
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.permissions_changed());
@@ -549,6 +626,7 @@ fn change_set_detects_owner_override_mismatch() {
         false,
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.owner_changed());
@@ -582,6 +660,7 @@ fn change_set_detects_group_override_mismatch() {
         false,
         false,
         false,
+        Duration::ZERO,
     );
 
     assert!(change_set.group_changed());

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -897,7 +897,7 @@ fn dry_run_large_file_reports_correct_byte_count() {
 
 
 #[test]
-fn dry_run_reports_matched_file_as_would_copy() {
+fn dry_run_reports_up_to_date_file_as_unchanged() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
@@ -924,10 +924,12 @@ fn dry_run_reports_matched_file_as_would_copy() {
         )
         .expect("dry run succeeds");
 
-    // In dry-run mode the engine reports the file as would-be-copied
-    // because the skip-comparison check is not performed in the dry-run
-    // path.  The destination file must remain unchanged.
-    assert_eq!(summary.files_copied(), 1);
+    // upstream: generator.c:526,645 - the generator runs the quick check in
+    // dry-run exactly as in a real run, so a same-size, same-mtime destination
+    // is up-to-date and NOT reported as a transfer (rsync -n prints nothing for
+    // it). The destination must remain unchanged.
+    assert_eq!(summary.files_copied(), 0);
+    assert_eq!(summary.regular_files_total(), 1);
     assert_eq!(
         fs::read(&destination).expect("read dest"),
         content,

--- a/crates/engine/src/local_copy/tests/execute_modify_window.rs
+++ b/crates/engine/src/local_copy/tests/execute_modify_window.rs
@@ -843,6 +843,87 @@ fn modify_window_dry_run_reports_correctly() {
     );
 }
 
+/// A dry-run itemize must apply `--modify-window` to the quick check exactly
+/// as a real run does. Upstream `generator.c:526,645` runs `same_time()` in
+/// both modes, so a destination whose only drift is a sub-window mtime
+/// difference is up-to-date and is NOT reported as a transfer. This is the
+/// exact scenario the upstream `compare` testsuite exercises with
+/// `run_rsync('-ain', '--modify-window=2', ...)`: a 1s-newer destination must
+/// be absorbed by a 2s window, leaving nothing itemized.
+///
+/// Regression guard: before the fix, `handle_dry_run` never ran the quick
+/// check, so it always recorded a transfer regardless of the window.
+#[test]
+fn modify_window_dry_run_absorbs_within_window_mtime_drift() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+
+    // Identical content and size; the only difference is a 1s mtime drift.
+    let content = b"identical content";
+    fs::write(&source, content).expect("write source");
+    fs::write(&destination, content).expect("write dest");
+
+    let base_time = FileTime::from_unix_time(1_700_000_000, 0);
+    let one_second_newer = FileTime::from_unix_time(1_700_000_001, 0);
+    set_file_times(&source, base_time, base_time).expect("set source times");
+    set_file_times(&destination, one_second_newer, one_second_newer).expect("set dest times");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::DryRun,
+            LocalCopyOptions::default().with_modify_window(Duration::from_secs(2)),
+        )
+        .expect("dry run succeeds");
+
+    // The 1s drift is within the 2s window, so the dry-run must NOT itemize a
+    // transfer: the file is counted as up-to-date, matching upstream `-ain`.
+    assert_eq!(summary.files_copied(), 0);
+    assert_eq!(summary.regular_files_total(), 1);
+}
+
+/// Contrast for the dry-run within-window case: with the DEFAULT zero window,
+/// the same 1s drift IS reported as a transfer, matching upstream `-ain`
+/// without `--modify-window`. This is the first leg of the upstream `compare`
+/// test (a 1s change must be itemized without a window).
+#[test]
+fn modify_window_dry_run_zero_window_itemizes_one_second_drift() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+
+    let content = b"identical content";
+    fs::write(&source, content).expect("write source");
+    fs::write(&destination, content).expect("write dest");
+
+    let base_time = FileTime::from_unix_time(1_700_000_000, 0);
+    let one_second_newer = FileTime::from_unix_time(1_700_000_001, 0);
+    set_file_times(&source, base_time, base_time).expect("set source times");
+    set_file_times(&destination, one_second_newer, one_second_newer).expect("set dest times");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::DryRun,
+            LocalCopyOptions::default(),
+        )
+        .expect("dry run succeeds");
+
+    // Zero window: a whole-second mtime difference is reported as a transfer.
+    assert_eq!(summary.files_copied(), 1);
+}
+
 /// This test documents the behavior of --modify-window matching upstream rsync.
 ///
 /// From rsync(1) man page:

--- a/crates/engine/src/local_copy/tests/execute_skip.rs
+++ b/crates/engine/src/local_copy/tests/execute_skip.rs
@@ -546,9 +546,13 @@ fn execute_skip_checksum_large_files_single_byte_difference() {
     );
 }
 
-/// Dry run with checksum reports all files as would-copy without modifying files.
-/// Note: dry run does not evaluate should_skip_copy (checksum/size_only/mtime),
-/// so all existing-dest files are reported as DataCopied rather than matched.
+/// Dry run with `--checksum` runs the same quick check as a real run, so a
+/// content-identical destination is reported as matched (not transferred) while
+/// a differing file is reported as a would-be-copy.
+///
+/// upstream: generator.c:645 - `unchanged_file()` (which honours `--checksum`)
+/// runs in dry-run just as in a real run, so `rsync -nc` itemizes only the file
+/// whose checksum differs.
 #[test]
 fn execute_skip_checksum_dry_run_reports_correctly() {
     let temp = create_tempdir();
@@ -577,10 +581,10 @@ fn execute_skip_checksum_dry_run_reports_correctly() {
         )
         .expect("dry run succeeds");
 
-    // Dry run does not perform should_skip_copy analysis; all files are
-    // reported as would-be-copied (DataCopied).
-    assert_eq!(summary.files_copied(), 2);
-    assert_eq!(summary.regular_files_matched(), 0);
+    // The checksum quick check runs in dry-run: only the differing file is a
+    // would-be-copy; the content-identical file is matched.
+    assert_eq!(summary.files_copied(), 1);
+    assert_eq!(summary.regular_files_matched(), 1);
     // Files unchanged in dry run
     assert_eq!(fs::read(dest_root.join("same.txt")).expect("read"), b"identical");
     assert_eq!(fs::read(dest_root.join("diff.txt")).expect("read"), b"dest_vvv");
@@ -990,15 +994,19 @@ fn execute_with_size_only_copies_smaller_file() {
     assert_eq!(fs::read(&destination).expect("read"), b"tiny");
 }
 
-/// Size-only in dry run mode reports would-copy without modifying files.
-/// Note: dry run does not evaluate should_skip_copy (checksum/size_only/mtime),
-/// so same-size files are still reported as DataCopied rather than matched.
+/// Size-only in dry run runs the same quick check as a real run: a same-size
+/// destination is matched (not transferred) even when its content differs.
+///
+/// upstream: generator.c:645 - `unchanged_file()` under `--size-only` compares
+/// only file sizes, and the generator runs it in dry-run just as in a real run,
+/// so `rsync -n --size-only` reports nothing for a same-size destination.
 #[test]
 fn execute_skip_size_only_dry_run() {
     let temp = create_tempdir();
     let source = temp.path().join("source.txt");
     let destination = temp.path().join("dest.txt");
 
+    // Same size (3 bytes), different content: --size-only treats them as equal.
     fs::write(&source, b"abc").expect("write source");
     fs::write(&destination, b"xyz").expect("write dest");
 
@@ -1015,10 +1023,10 @@ fn execute_skip_size_only_dry_run() {
         )
         .expect("dry run succeeds");
 
-    // Dry run does not perform should_skip_copy analysis; file is
-    // reported as would-be-copied (DataCopied).
-    assert_eq!(summary.files_copied(), 1);
-    assert_eq!(summary.regular_files_matched(), 0);
+    // The size-only quick check runs in dry-run: the same-size file is matched,
+    // not reported as a would-be-copy.
+    assert_eq!(summary.files_copied(), 0);
+    assert_eq!(summary.regular_files_matched(), 1);
     // Content unchanged in dry run
     assert_eq!(fs::read(&destination).expect("read"), b"xyz");
 }


### PR DESCRIPTION
## Problem

The upstream 3.5.0dev `compare` conformance test failed on oc-rsync: `--modify-window=2 did not absorb a 1s mtime difference`.

`compare_test.py` drives a purely LOCAL transfer, so it exercises the local-copy engine (`crates/engine/src/local_copy/`), not the wire path. Its final leg runs a dry-run itemize:

```
run_rsync('-ain', f'{src}/', f'{TODIR}/')                       # 1s-newer dest -> f3 itemized
run_rsync('-ain', '--modify-window=2', f'{src}/', f'{TODIR}/')  # 2s window -> f3 must NOT be itemized
```

Root cause: the local-copy dry-run path (`executor/file/copy/dry_run.rs::handle_dry_run`) never ran the quick check. It unconditionally recorded every existing-destination file as a would-be transfer, so `--modify-window` (and `--size-only`/`--checksum`/mtime) were ignored in dry-run. Separately, the itemize `t` (ITEM_REPORT_TIME) bit in `plan/change_set/detection.rs::determine_time_change` compared mtimes with exact equality instead of `same_time()`.

## Fix

- `handle_dry_run` now runs the same `should_skip_copy` quick check as the real-run `try_skip_up_to_date`, honouring `--modify-window`, `--size-only`, `--checksum`, and `--ignore-times`. Up-to-date files are recorded as matched (no itemize line, no I/O), matching a real `rsync -n`.
- `determine_time_change` now gates the `t` glyph on the symmetric whole-second `same_time()` window via `system_time_within_window`, so a sub-window mtime drift leaves the time slot blank. `--modify-window=0` still requires exact whole-second equality.

Upstream references: `generator.c:526` (itemize `!same_time()` for ITEM_REPORT_TIME), `generator.c:645` (`unchanged_file()` quick check, run in dry-run too), `util1.c:1478` (`same_time()`).

This supersedes #6259, which targeted the wire receiver/generator - the wrong engine for this test.

## Validation (Linux host, aarch64)

Before (master 28428423d): `FAIL compare` (`--modify-window=2 did not absorb a 1s mtime difference`).

After:

```
PASS    compare
PASS    itemize
PASS    update
overall result is 0
```

`cargo nextest run --workspace` (no-fail-fast): the only failures are the 5 pre-existing xtask `commands::package::tests::*cross_compiler*` / `tarball_resolution_skips_targets_without_cross_tooling` env artifacts (the host has a real `aarch64-linux-gnu-gcc`; they fail identically on master). The three stale dry-run tests that encoded the old "dry-run never checks skip" behaviour were updated to assert quick-check parity; targeted re-run: `149 tests run: 149 passed`.

`cargo fmt --all` and `cargo clippy -p engine --all-targets --all-features --no-deps --locked -D warnings` are clean.