### PR TITLE
fix(engine): itemize --mkpath file dest in dry-run

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/dry_run.rs
@@ -168,6 +168,32 @@ pub(super) fn handle_dry_run(
     context
         .summary_mut()
         .record_file(file_size, bytes_transferred, None);
+
+    // upstream: generator.c:1942-1960 - a dry-run still itemizes the file
+    // against the existing destination via itemize()/report_flags, so an
+    // existing but differing dest reports the real attribute drift (e.g.
+    // `>f.st......`) rather than a blank `>f.........`. Mirror the real-run
+    // change set from execute/mod.rs so `-ni` matches `-i` byte-for-byte.
+    let wrote_data = bytes_transferred > 0;
+    #[cfg(all(unix, feature = "xattr"))]
+    let xattrs_enabled = context.xattrs_enabled();
+    #[cfg(not(all(unix, feature = "xattr")))]
+    let xattrs_enabled = false;
+    #[cfg(all(any(unix, windows), feature = "acl"))]
+    let acls_enabled = context.acls_enabled();
+    #[cfg(not(all(any(unix, windows), feature = "acl")))]
+    let acls_enabled = false;
+    let change_set = LocalCopyChangeSet::for_file_with_checksum(
+        metadata,
+        existing_metadata,
+        &context.metadata_options(),
+        destination_previously_existed,
+        wrote_data,
+        xattrs_enabled,
+        acls_enabled,
+        context.checksum_enabled(),
+        context.options().modify_window(),
+    );
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
     let total_bytes = Some(metadata_snapshot.len());
     context.record(
@@ -179,6 +205,7 @@ pub(super) fn handle_dry_run(
             Duration::default(),
             Some(metadata_snapshot),
         )
+        .with_change_set(change_set)
         .with_creation(!destination_previously_existed),
     );
     remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;

--- a/crates/engine/src/local_copy/tests/execute_dry_run.rs
+++ b/crates/engine/src/local_copy/tests/execute_dry_run.rs
@@ -1107,3 +1107,138 @@ fn dry_run_with_no_implied_dirs_and_missing_parent_succeeds() {
         "dry run must not create directories"
     );
 }
+
+/// Regression test for the file-to-file-mkpath-dry-run conformance test:
+/// a dry-run onto an existing but differing destination must itemize the same
+/// attribute change as the real run. Before the fix the dry-run DataCopied
+/// record carried an empty change set (rendering `>f.........`), while the real
+/// run reported the size/time drift (`>f.st......`).
+///
+/// upstream: generator.c:1942-1960 - the generator itemizes against the
+/// existing destination even under dry-run, so `-ni` matches `-i`.
+#[test]
+fn dry_run_existing_differing_dest_itemizes_size_and_time_change() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dry_dest = temp.path().join("dry_dst");
+    let real_dest = temp.path().join("real_dst");
+    // Source is larger than the destinations so the size column must change.
+    fs::write(&source, b"brand new content\n").expect("write source");
+    let epoch = FileTime::from_unix_time(0, 0);
+    for dest in [&dry_dest, &real_dest] {
+        fs::write(dest, b"old\n").expect("write dest");
+        set_file_mtime(dest, epoch).expect("backdate dest mtime");
+    }
+
+    let change_set_for = |dest: &std::path::Path, mode: LocalCopyExecution| {
+        let operands = vec![
+            source.clone().into_os_string(),
+            dest.to_path_buf().into_os_string(),
+        ];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        // `-a` implies preserved times, matching the conformance invocation.
+        let options = LocalCopyOptions::default().times(true).collect_events(true);
+        let report = plan
+            .execute_with_report(mode, options)
+            .expect("execution succeeds");
+        report
+            .records()
+            .iter()
+            .find(|record| matches!(record.action(), LocalCopyAction::DataCopied))
+            .expect("DataCopied record present")
+            .change_set()
+    };
+
+    let dry = change_set_for(&dry_dest, LocalCopyExecution::DryRun);
+    let real = change_set_for(&real_dest, LocalCopyExecution::Apply);
+
+    // The dry-run itemize must exactly match the real run.
+    assert_eq!(
+        dry, real,
+        "dry-run change set must match the real run for an existing differing destination"
+    );
+    // And it must report the actual size + time drift, not a blank change set.
+    assert!(dry.size_changed(), "size column must be reported (s)");
+    assert!(
+        dry.time_change().is_some(),
+        "time column must be reported (t)"
+    );
+    // Dry-run must not touch the destination.
+    assert_eq!(fs::read(&dry_dest).expect("read"), b"old\n");
+}
+
+/// Regression test for the `compare` conformance test: a dry-run must run the
+/// same quick-check as a real run, so an up-to-date destination (matching size
+/// and mtime, or an mtime difference absorbed by `--modify-window`) is skipped
+/// and reported as `MetadataReused` rather than a spurious `DataCopied`.
+///
+/// upstream: generator.c:unchanged_file() drives the quick-check regardless of
+/// dry_run; util1.c:same_time() applies the `--modify-window` tolerance.
+#[test]
+fn dry_run_skips_up_to_date_and_window_absorbed_destinations() {
+    let record_for = |mtime_offset: i64, window_secs: u64| {
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("src");
+        let destination = temp.path().join("dst");
+        let content = b"identical content\n";
+        fs::write(&source, content).expect("write source");
+        fs::write(&destination, content).expect("write dest");
+        let base = FileTime::from_unix_time(1_000_000_000, 0);
+        set_file_mtime(&destination, base).expect("set dest mtime");
+        set_file_mtime(
+            &source,
+            FileTime::from_unix_time(1_000_000_000 + mtime_offset, 0),
+        )
+        .expect("set source mtime");
+
+        let operands = vec![source.into_os_string(), destination.into_os_string()];
+        let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+        let mut options = LocalCopyOptions::default().times(true).collect_events(true);
+        if window_secs > 0 {
+            options = options.with_modify_window(Duration::from_secs(window_secs));
+        }
+        let report = plan
+            .execute_with_report(LocalCopyExecution::DryRun, options)
+            .expect("dry run succeeds");
+        let record = report
+            .records()
+            .iter()
+            .find(|record| {
+                matches!(
+                    record.action(),
+                    LocalCopyAction::MetadataReused | LocalCopyAction::DataCopied
+                )
+            })
+            .expect("file record present");
+        (record.action().clone(), record.change_set())
+    };
+
+    // Identical size + mtime: quick-check skips (no transfer, no `>f` line).
+    let (identical, _) = record_for(0, 0);
+    assert_eq!(
+        identical,
+        LocalCopyAction::MetadataReused,
+        "an up-to-date destination must be skipped in dry-run"
+    );
+    // 1s newer source, no window: quick-check transfers (itemized).
+    let (no_window, _) = record_for(1, 0);
+    assert_eq!(
+        no_window,
+        LocalCopyAction::DataCopied,
+        "a 1s mtime change must itemize a transfer without --modify-window"
+    );
+    // 1s newer source, --modify-window=2: the difference is absorbed, so the
+    // file is skipped AND the itemize reports no time change (no `t` glyph),
+    // matching upstream same_time(). A phantom `.f..t......` line would leak
+    // through the `compare` conformance test's `'f3' not in stdout` check.
+    let (windowed, windowed_change) = record_for(1, 2);
+    assert_eq!(
+        windowed,
+        LocalCopyAction::MetadataReused,
+        "--modify-window=2 must absorb a 1s mtime difference in dry-run"
+    );
+    assert!(
+        windowed_change.time_change().is_none(),
+        "a window-absorbed mtime difference must not report a time change"
+    );
+}


### PR DESCRIPTION
## Summary

A file-to-file local-copy dry-run onto an existing destination misreported the itemize output, and the local-copy dry-run path never ran the quick-check skip decision. This fixes the `file-to-file-mkpath-dry-run` conformance test and, as a bonus, the `compare` conformance test, both against the upstream 3.5.0dev testsuite.

Three related fixes:

1. **Itemize existing-differing dest in dry-run.** The dry-run data-copy branch recorded a `DataCopied` event with no change set, so `-ni` rendered a blank `>f.........` instead of the real drift `>f.st......`. It now computes the change set against the existing destination, mirroring the real transfer path (`executor/file/copy/transfer/execute/mod.rs`).

2. **Run the quick-check in dry-run.** The local-copy dry-run never ran `should_skip_copy`, so an up-to-date destination (matching size + mtime, or a `--size-only`/`--checksum` match) was reported as a spurious transfer. It now runs the same quick-check as a real run and records `MetadataReused` when the file is up-to-date.

3. **Honor `--modify-window` in the skip itemize.** The change-set time comparison used exact whole-second equality, so a within-window mtime difference lit a phantom `t` glyph (`.f..t......`). Ported upstream `same_time()` into the change-set detection and routed both the dry-run and real skip paths through a modify-window-aware constructor.

## Upstream references

- `generator.c:unchanged_file()` drives the quick-check regardless of `dry_run`.
- `util1.c:same_time()` applies the symmetric whole-second `--modify-window` tolerance via `itemize()`.

## Validation (Linux, aarch64)

Testsuite (upstream 3.5.0dev), before vs after:

- `file-to-file-mkpath-dry-run`: FAIL -> **PASS**
- `compare`: FAIL (pre-existing, `--modify-window=2 did not absorb a 1s mtime difference`) -> **PASS**
- `mkpath`: PASS (no regression)
- `itemize`: PASS (no regression)

`cargo nextest run --workspace`: **29880 passed, 0 failed, 169 skipped** (excluding the pre-existing, environment-dependent `xtask::commands::package::tests` cross-compiler-tooling artifacts, which fail identically on master).

## Stale tests updated

The change surfaced three tests that encoded the old no-quick-check behavior (all rewritten to assert the upstream-correct skip):

- `execute_dry_run.rs::dry_run_reports_matched_file_as_would_copy` -> `dry_run_skips_up_to_date_file`
- `execute_skip.rs::execute_skip_checksum_dry_run_reports_correctly`
- `execute_skip.rs::execute_skip_size_only_dry_run`

New focused tests added in `execute_dry_run.rs`:

- `dry_run_existing_differing_dest_itemizes_size_and_time_change`
- `dry_run_skips_up_to_date_and_window_absorbed_destinations`