### PR TITLE
fix(metadata): correct --fake-super %stat xattr encode/decode

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -710,6 +710,11 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .with_owner_override(config.owner_override())
             .group(config.preserve_group())
             .with_group_override(config.group_override())
+            // upstream: options.c set_fake_super() -> am_root = -1; the local-copy
+            // executor stores ownership/device/mode in the user.rsync.%stat xattr
+            // instead of chown/mknod. Without this the flag was a silent no-op on
+            // the local path and every fake-super round-trip lost its metadata.
+            .fake_super(config.fake_super())
             .with_copy_as(copy_as_ids)
             .with_chmod(config.chmod().cloned())
             .executability(config.preserve_executability())

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -20,6 +20,8 @@ use super::filter_program::{
     directory_has_marker,
 };
 
+#[cfg(all(unix, feature = "xattr"))]
+use super::store_effective_fake_super_if_requested;
 #[cfg(all(any(unix, windows), feature = "acl"))]
 use super::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -389,6 +389,15 @@ impl<'a> CopyContext<'a> {
         #[cfg(not(any(all(unix, feature = "xattr"), all(any(unix, windows), feature = "acl"))))]
         let _ = mode;
 
+        // upstream: xattrs.c:set_stat_xattr() reads the *source* stat via
+        // x_lstat() (get_stat_xattr layered over lstat), so a placeholder that
+        // already carries a `user.rsync.%stat` xattr forwards those recorded
+        // uid/gid/mode/rdev instead of the placeholder's own on-disk values.
+        // `set_owner_like` only saw the placeholder's `fs::Metadata`, so rewrite
+        // the destination xattr here from the effective source stat.
+        #[cfg(all(unix, feature = "xattr"))]
+        store_effective_fake_super_if_requested(&metadata_options, source, destination, metadata)?;
+
         self.record_hard_link(metadata, destination);
         remove_source_entry_if_requested(self, source, relative, file_type)?;
 

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -106,6 +106,52 @@ pub(crate) fn sync_nfsv4_acls_if_requested(
     Ok(())
 }
 
+/// Stores the effective fake-super `user.rsync.%stat` xattr on the destination.
+///
+/// Under `--fake-super` the source may be a placeholder whose real
+/// mode/uid/gid/rdev live in its own `user.rsync.%stat` xattr (written by an
+/// earlier fake-super receive). The metadata-apply step only saw the
+/// placeholder's raw `fs::Metadata`, so it stored the wrong ownership. Rewrite
+/// the destination xattr from [`::metadata::effective_source_stat`], which
+/// prefers the source's recorded stat and falls back to its `fs::Metadata`.
+///
+/// No-op unless `--fake-super` is active together with ownership preservation,
+/// matching `metadata::apply::ownership::set_owner_like`'s fake-super gate.
+// upstream: xattrs.c:set_stat_xattr() driven by x_lstat()/get_stat_xattr()
+#[cfg(all(unix, feature = "xattr"))]
+pub(crate) fn store_effective_fake_super_if_requested(
+    options: &::metadata::MetadataOptions,
+    source: &Path,
+    destination: &Path,
+    metadata: &std::fs::Metadata,
+) -> Result<(), LocalCopyError> {
+    let ownership_requested = options.owner()
+        || options.group()
+        || options.owner_override().is_some()
+        || options.group_override().is_some();
+    if !options.fake_super_enabled() || !ownership_requested {
+        return Ok(());
+    }
+
+    let stat = ::metadata::effective_source_stat(source, metadata);
+
+    // Skip the rewrite when the destination already carries the target stat,
+    // mirroring upstream's "no-op when the current xattr matches" fast path.
+    if let Ok(Some(existing)) = ::metadata::load_fake_super(destination) {
+        if existing == stat {
+            return Ok(());
+        }
+    }
+
+    ::metadata::store_fake_super(destination, &stat).map_err(|error| {
+        LocalCopyError::io(
+            "store fake-super metadata",
+            destination.to_path_buf(),
+            error,
+        )
+    })
+}
+
 /// Converts a [`MetadataError`] into a [`LocalCopyError`].
 pub(crate) fn map_metadata_error(error: MetadataError) -> LocalCopyError {
     let (context, path, source) = error.into_parts();

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -136,6 +136,9 @@ pub(crate) use metadata_sync::map_metadata_error;
 pub(crate) use metadata_sync::sync_acls_if_requested;
 
 #[cfg(all(unix, feature = "xattr"))]
+pub(crate) use metadata_sync::store_effective_fake_super_if_requested;
+
+#[cfg(all(unix, feature = "xattr"))]
 pub(crate) use metadata_sync::sync_xattrs_if_requested;
 
 #[cfg(all(unix, feature = "xattr"))]

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -223,6 +223,33 @@ pub fn remove_fake_super(path: &Path) -> io::Result<()> {
     }
 }
 
+/// Computes the *effective* fake-super stat for a source file.
+///
+/// Under `--fake-super`, a source placeholder file may already carry a
+/// `user.rsync.%stat` xattr recorded by an earlier fake-super receive. When
+/// present it holds the real mode/uid/gid/rdev the placeholder stands in for,
+/// so it - not the placeholder's own `fs::Metadata` - is the source of truth
+/// for what to preserve onto the destination. When absent (a first-time
+/// fake-super send of a real file), fall back to [`FakeSuperStat::from_metadata`].
+///
+/// This mirrors upstream rsync's `x_lstat()`, which layers `get_stat_xattr()`
+/// over the raw `lstat()` so the placeholder appears to have the recorded
+/// ownership/type on every subsequent read.
+// upstream: xattrs.c:get_stat_xattr() consumed via x_lstat()
+#[cfg(all(unix, feature = "xattr"))]
+pub fn effective_source_stat(source: &Path, metadata: &Metadata) -> FakeSuperStat {
+    match load_fake_super(source) {
+        Ok(Some(stat)) => stat,
+        _ => FakeSuperStat::from_metadata(metadata),
+    }
+}
+
+/// Non-xattr fallback: the effective stat is always derived from `fs::Metadata`.
+#[cfg(not(all(unix, feature = "xattr")))]
+pub fn effective_source_stat(_source: &Path, metadata: &Metadata) -> FakeSuperStat {
+    FakeSuperStat::from_metadata(metadata)
+}
+
 /// Checks if the file mode indicates a device file.
 #[cfg(unix)]
 const fn is_device_file(mode: u32) -> bool {
@@ -442,6 +469,55 @@ mod tests {
         assert!(!is_device_file(0o120777)); // Symlink
         assert!(is_device_file(0o60660)); // Block device
         assert!(is_device_file(0o20666)); // Char device
+    }
+
+    // Verifies the local-copy fake-super source read: a placeholder that
+    // already carries a `user.rsync.%stat` xattr must forward the RECORDED
+    // uid/gid/mode/rdev, not the placeholder's own on-disk stat. This is the
+    // exact round-trip a `--fake-super` local copy of a previously-received
+    // placeholder must preserve. upstream: xattrs.c:get_stat_xattr().
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn effective_source_stat_prefers_recorded_xattr() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("placeholder");
+        std::fs::write(&path, b"placeholder body").expect("write");
+
+        let recorded = FakeSuperStat {
+            mode: 0o60644,
+            uid: 5000,
+            gid: 5002,
+            rdev: Some((42, 69)),
+        };
+        // Skip when the FS can't hold user xattrs (e.g. tmpfs without support).
+        if store_fake_super(&path, &recorded).is_err() {
+            return;
+        }
+
+        let meta = std::fs::metadata(&path).expect("metadata");
+        let effective = effective_source_stat(&path, &meta);
+        assert_eq!(
+            effective, recorded,
+            "recorded %stat must win over the placeholder's real stat"
+        );
+    }
+
+    // Without a recorded xattr, the effective stat falls back to the file's
+    // real `fs::Metadata` (first-time fake-super send of a real file).
+    #[cfg(all(unix, feature = "xattr"))]
+    #[test]
+    fn effective_source_stat_falls_back_to_metadata() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("real");
+        std::fs::write(&path, b"real body").expect("write");
+
+        let meta = std::fs::metadata(&path).expect("metadata");
+        let effective = effective_source_stat(&path, &meta);
+        assert_eq!(effective, FakeSuperStat::from_metadata(&meta));
+        assert_eq!(effective.uid, meta.uid());
+        assert_eq!(effective.gid, meta.gid());
     }
 
     #[cfg(not(all(unix, feature = "xattr")))]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -261,7 +261,8 @@ pub use xattr_stub::{
 pub use copy_as::{CopyAsGuard, CopyAsIds, parse_copy_as_spec, switch_effective_ids};
 
 pub use fake_super::{
-    FAKE_SUPER_XATTR, FakeSuperStat, load_fake_super, remove_fake_super, store_fake_super,
+    FAKE_SUPER_XATTR, FakeSuperStat, effective_source_stat, load_fake_super, remove_fake_super,
+    store_fake_super,
 };
 
 pub use symlink_munge::{SYMLINK_MUNGE_PREFIX, munge_symlink, unmunge_symlink};


### PR DESCRIPTION
## Summary

Local copies dropped `--fake-super` entirely. Two defects compounded:

1. **The flag was never wired.** `config.fake_super()` was not passed into the local-copy `LocalCopyOptions` builder in `core::client::run`, so the executor always took the plain `chown`/`mknod` path and never wrote `user.rsync.%stat`. `--fake-super` was a silent no-op on local transfers.
2. **The source `%stat` was ignored.** Even with fake-super active, the destination xattr was derived from the placeholder's own `fs::Metadata`. A placeholder recorded by an earlier fake-super receive already carries the real uid/gid/mode/rdev in its own `%stat`; that must win, exactly as upstream's `x_lstat()` layers `get_stat_xattr()` over `lstat()`.

### Changes
- Wire `config.fake_super()` into the local-copy options builder.
- Add `metadata::effective_source_stat()` mirroring upstream `xattrs.c:get_stat_xattr()`: prefer the source's recorded `%stat`, else derive from `fs::Metadata`.
- Rewrite the destination `%stat` from the effective source stat at the local-copy finalize step (`apply_metadata_and_finalize`), the single chokepoint all copy-execute paths funnel through.

upstream: `xattrs.c` `get_stat_xattr()`/`set_stat_xattr()`; `options.c` `set_fake_super()` (`am_root = -1`).

## Validation (Linux host, aarch64)

Conformance testsuite (`runtests.py`, upstream rsync 3.4.x harness):

| test | before | after |
|------|--------|-------|
| chown-fake | FAIL | **PASS** |
| itemize | PASS | PASS (not regressed) |
| xattrs | FAIL (pre-existing on master) | FAIL (unchanged mode: `preserve timestamps '../to': Is a directory` on the `--chmod=a=` leg) |
| xattrs-hlink | FAIL (pre-existing) | FAIL ("Too many hard links on file1" - distinct `-H` hardlink bug) |
| devices-fake | FAIL | FAIL (itemize only) |

For **devices-fake** the destination `%stat` is now **byte-identical to upstream** (`60644 42,69 0:0`); the only remaining difference is the itemize letter (`>f` vs `cD`), which requires masquerading a placeholder regular file as a device in the local-copy classifier - a larger refactor tracked separately (the executor dispatches on the opaque `std::fs::FileType`, which cannot be synthesized from an xattr).

`cargo nextest run --workspace`: **29891 tests run: 29887 passed, 4 failed, 161 skipped**. The 4 failures are the known pre-existing xtask cross-compiler environment artifacts (`commands::package::tests::cross_compiler_resolution_*`, `execute_reports_missing_cross_compiler`, `tarball_resolution_skips_targets_without_cross_tooling`) that fail identically on master. Zero product-test failures.

`cargo fmt --all --check` and `cargo clippy -p metadata -p engine -p core --all-targets --all-features --no-deps --locked -- -D warnings` both clean.