### PR TITLE
fix(core): forward --delete/ignore-missing-args to daemon server

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -331,6 +331,18 @@ pub(super) fn build_full_daemon_args(
         }
     }
 
+    // upstream: options.c:2866-2871 - --delete-missing-args needs the
+    // cooperation of both sides, so it is always forwarded to the server.
+    // --ignore-missing-args is forwarded only when the local side is the
+    // receiver (`!am_sender`); a sender handles ignore by itself. Here
+    // `we_are_sender == !is_sender` mirrors upstream `am_sender`, so the
+    // ignore branch fires when the daemon is the sender (`is_sender`).
+    if config.delete_missing_args() {
+        args.push("--delete-missing-args".to_owned());
+    } else if config.ignore_missing_args() && !we_are_sender {
+        args.push("--ignore-missing-args".to_owned());
+    }
+
     // upstream: options.c:2933-2942
     if config.append() {
         args.push("--append".to_owned());

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -238,6 +238,106 @@ mod protect_args_daemon_tests {
         );
     }
 
+    // upstream: options.c:2866-2869 - --delete-missing-args is always
+    // forwarded to the daemon because deleting a missing arg needs both
+    // sides to cooperate: the sender emits the mode-0 sentinel and the
+    // receiver must have missing_args==2 to accept it (flist.c:884) and
+    // run delete_item (generator.c:1360). Without this the daemon rejects
+    // the mode-0 entry with "invalid file mode 00" (upstream #910) or,
+    // against an oc daemon, silently keeps the stale destination path.
+    #[test]
+    fn build_full_args_forwards_delete_missing_args_on_push() {
+        let config = ClientConfig::builder().delete_missing_args(true).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        // is_sender=false => daemon is receiver (client push).
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(
+            args.iter().any(|a| a == "--delete-missing-args"),
+            "push must forward --delete-missing-args so the daemon accepts \
+             the mode-0 sentinel and deletes the missing arg: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_full_args_forwards_delete_missing_args_on_pull() {
+        let config = ClientConfig::builder().delete_missing_args(true).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        // is_sender=true => daemon is sender (client pull). Both sides still
+        // need the flag, so it is forwarded regardless of direction.
+        let args = build_full_daemon_args(&config, &request, protocol, true);
+
+        assert!(
+            args.iter().any(|a| a == "--delete-missing-args"),
+            "pull must also forward --delete-missing-args (both sides cooperate): {args:?}"
+        );
+    }
+
+    // upstream: options.c:2870-2871 - --ignore-missing-args is forwarded
+    // only when the local side is the receiver (`!am_sender`); a sender can
+    // honour ignore by itself and never tells the receiver. Here
+    // is_sender=true means the daemon is the sender, so the local side is
+    // the receiver and the flag must be forwarded.
+    #[test]
+    fn build_full_args_forwards_ignore_missing_args_only_on_pull() {
+        let config = ClientConfig::builder().ignore_missing_args(true).build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+
+        // Pull (daemon is sender, local side is receiver): forwarded.
+        let pull = build_full_daemon_args(&config, &request, protocol, true);
+        assert!(
+            pull.iter().any(|a| a == "--ignore-missing-args"),
+            "pull (local receiver) must forward --ignore-missing-args: {pull:?}"
+        );
+
+        // Push (daemon is receiver, local side is sender): NOT forwarded,
+        // the sender handles the missing arg locally.
+        let push = build_full_daemon_args(&config, &request, protocol, false);
+        assert!(
+            !push.iter().any(|a| a == "--ignore-missing-args"),
+            "push (local sender) must not forward --ignore-missing-args: {push:?}"
+        );
+    }
+
+    // Mutual exclusivity: with both flags set the builder emits only the
+    // delete form (upstream options.c:2867's `if/else if` gives
+    // --delete-missing-args precedence, matching options.c:2236-2237 where
+    // missing_args==3 is simplified to 2).
+    #[test]
+    fn build_full_args_delete_wins_over_ignore_missing_args() {
+        let config = ClientConfig::builder()
+            .delete_missing_args(true)
+            .ignore_missing_args(true)
+            .build();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(args.iter().any(|a| a == "--delete-missing-args"));
+        assert!(
+            !args.iter().any(|a| a == "--ignore-missing-args"),
+            "delete-missing-args must take precedence: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_full_args_omits_missing_args_by_default() {
+        let config = ClientConfig::default();
+        let request = test_daemon_request();
+        let protocol = ProtocolVersion::try_from(32u8).unwrap();
+        let args = build_full_daemon_args(&config, &request, protocol, false);
+
+        assert!(
+            !args
+                .iter()
+                .any(|a| a == "--delete-missing-args" || a == "--ignore-missing-args"),
+            "no missing-args flag by default: {args:?}"
+        );
+    }
+
     #[test]
     fn build_full_args_includes_multiple_reference_dirs() {
         let config = ClientConfig::builder()


### PR DESCRIPTION
The daemon-transport server-arg builder (`build_full_daemon_args`) never emitted `--delete-missing-args` or `--ignore-missing-args`, so a client pushing to a daemon with `--delete-missing-args` sent mode-0 delete sentinels the daemon-receiver rejected (its `missing_args` was 0). Upstream daemons abort with `invalid file mode 00 ... protocol incompatibility (code 2)`; an oc daemon silently keeps the stale destination path.

## Root cause

In a daemon push the client is the sender and the daemon is the receiver. The sender emits a mode-0 "missing" file-list entry for each missing `--files-from` arg (the delete signal). The receiver must have `missing_args == 2` to accept mode 0 (`flist.c:884`) and run `delete_item` (`generator.c:1360`). That requires the client to forward `--delete-missing-args` to the daemon, which `build_full_daemon_args` was not doing.

The local-copy path and the receiver-side sentinel handler already worked; only the daemon client-arg emission was missing.

## Fix

Mirror upstream `options.c:2866-2871`:
- always forward `--delete-missing-args` (both sides must cooperate);
- forward `--ignore-missing-args` only when the local side is the receiver (a sender handles ignore by itself).

`crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs`.

## Validation (Linux host, aarch64)

Target conformance test flips to PASS; regressions unaffected:

```
PASS    delete-missing-args-files-from
PASS    delete-deep
PASS    itemize
overall result is 0
```

Before the fix `delete-missing-args-files-from` FAILed ("missing-arg file ghost.txt was not deleted on the receiver"). A MITM capture of the pre-fix daemon arg stream confirmed the client sent `--delete-during` but not `--delete-missing-args`; an oc client against an upstream daemon reproduced `invalid file mode 00 for ghost.txt`.

Full workspace nextest:

```
Summary [350.488s] 29896 tests run: 29892 passed, 4 failed, 161 skipped
```

The 4 failures are pre-existing environment artifacts unrelated to this change (`commands::package::tests::cross_compiler_resolution_*`, `execute_reports_missing_cross_compiler`, `tarball_resolution_skips_targets_without_cross_tooling`) - they fail identically on master because the host lacks the cross-compiler tooling those tests assert on. The 5 new `build_full_args_*missing_args*` tests all pass.