### PR TITLE
fix(daemon): enforce refuse options against client requests

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/refuse_options.rs
@@ -213,6 +213,23 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
         return None;
     }
 
+    // upstream: options.c:2215-2241 - a `refuse options = delete` rule matches
+    // the single `delete` popt entry, but the enforcement at options.c:2238 is
+    // semantic: `if (refused_delete && (delete_mode || missing_args == 2))`.
+    // Every delete-timing variant (`--delete-before/during/after/delay`),
+    // `--delete-excluded`, `--del`, and `--delete-missing-args` sets
+    // `delete_mode` (options.c:2215-2229), so refusing `delete` refuses them
+    // all. The lexical per-arg scan below only matches e.g. `delete-during`
+    // against a `delete*` glob, never the bare `delete` rule, so this semantic
+    // pass catches the timing variants the client actually sends on the wire
+    // (oc emits `--delete-during` for a plain `-a --delete`). The reported
+    // option is always `--delete`, matching `create_refuse_error(refused_delete)`.
+    if is_option_refused(&module.refuse_options, "delete", None)
+        && client_args.iter().any(|arg| enables_delete_mode(arg))
+    {
+        return Some("--delete".to_owned());
+    }
+
     for arg in client_args {
         let trimmed = arg.trim_start();
         if let Some(rest) = trimmed.strip_prefix("--") {
@@ -252,6 +269,31 @@ fn refused_client_arg(module: &ModuleDefinition, client_args: &[String]) -> Opti
         }
     }
     None
+}
+
+/// Reports whether a client argument turns on the delete machinery, so a
+/// `refuse options = delete` rule can reject it regardless of which timing
+/// variant the client sent.
+///
+/// upstream: options.c:2215-2229 - `--delete`, `--del`, every
+/// `--delete-WHEN` variant, and `--delete-excluded` all set `delete_mode`;
+/// `--delete-missing-args` sets `missing_args = 2`. options.c:2238 then
+/// refuses the transfer whenever `refused_delete` is set and any of those is
+/// active. `--delete-missing-args` also needs the `missing_args == 2` guard
+/// there, which matches this option once it has been requested.
+fn enables_delete_mode(arg: &str) -> bool {
+    let canonical = canonical_option(arg);
+    matches!(
+        canonical.as_str(),
+        "del"
+            | "delete"
+            | "delete-before"
+            | "delete-during"
+            | "delete-delay"
+            | "delete-after"
+            | "delete-excluded"
+            | "delete-missing-args"
+    )
 }
 
 /// Evaluates a canonical option (long name + optional short letter) against an

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -453,6 +453,66 @@ fn refused_client_arg_pure_negation_allowlist_passes_av() {
 }
 
 #[test]
+fn refused_client_arg_delete_rule_refuses_timing_variant() {
+    // Regression for the upstream `daemon-refuse` testsuite: a module with
+    // `refuse options = delete` must reject a client `-a --delete` even though
+    // the client encodes it on the wire as `--delete-during`.
+    //
+    // upstream: options.c:2238 - `if (refused_delete && (delete_mode || ...))`
+    // refuses the transfer whenever any delete-timing variant is active, and
+    // reports the canonical `--delete` regardless of which variant arrived.
+    let module = ModuleDefinition {
+        refuse_options: vec!["delete".to_owned()],
+        ..Default::default()
+    };
+    for variant in [
+        "--delete",
+        "--delete-during",
+        "--delete-before",
+        "--delete-after",
+        "--delete-delay",
+        "--delete-excluded",
+        "--del",
+        "--delete-missing-args",
+    ] {
+        let args = vec!["--server".to_owned(), variant.to_owned()];
+        assert_eq!(
+            refused_client_arg(&module, &args),
+            Some("--delete".to_owned()),
+            "expected {variant} to be refused as --delete",
+        );
+    }
+}
+
+#[test]
+fn refused_client_arg_delete_rule_allows_non_delete_transfer() {
+    // A `refuse options = delete` module must still accept a plain push that
+    // carries no delete flag. upstream: options.c:2238 only fires when
+    // `delete_mode` (or `missing_args == 2`) is set.
+    let module = ModuleDefinition {
+        refuse_options: vec!["delete".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["--server".to_owned(), "-vlogDtpr".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
+fn refused_client_arg_delete_negation_clears_semantic_refusal() {
+    // `refuse options = !delete` un-refuses the `delete` entry, so the
+    // semantic delete-mode pass must not fire. With no other refuse rule a
+    // bare `--delete` transfer is allowed. upstream: options.c:977-991 - the
+    // negated rule flips the `delete` descrip back to accepted, clearing
+    // `refused_delete`, so options.c:2238 never triggers.
+    let module = ModuleDefinition {
+        refuse_options: vec!["!delete".to_owned()],
+        ..Default::default()
+    };
+    let args = vec!["--server".to_owned(), "--delete".to_owned()];
+    assert_eq!(refused_client_arg(&module, &args), None);
+}
+
+#[test]
 fn refused_client_arg_archive_rule_refuses_implied_short_letters() {
     // upstream: options.c:904-906 - the `archive` rule rewrites itself to the
     // character class `[ardlptgoD]`. A module configured with


### PR DESCRIPTION
## Summary

The upstream `fuzzy` conformance test (a local-copy transfer:
`-avvi --no-whole-file --fuzzy --delete-delay --debug=FUZZY`) failed because
oc-rsync never emitted the generator's `fuzzy basis selected for X: Y` line on
stdout, even though the local-copy engine already selected and used the fuzzy
basis correctly (delta matched bytes were byte-identical to upstream).

Root cause was a chain of three output-fidelity gaps between the local-copy
engine and upstream's `--debug=FUZZY` output:

1. **Case-sensitive flag matching.** `apply_debug_flag`/`apply_info_flag`
   matched flag names case-sensitively against lower-case arms, so the
   user-typed token `FUZZY` returned an ignored `Err` and left `debug.fuzzy = 0`.
   Upstream `options.c:parse_output_words()` compares names with `strncasecmp`
   (case-insensitive). Fixed to lower-case the parsed name before matching.

2. **Absolute basis path.** The local-copy fuzzy trace emitted the basis as an
   absolute filesystem path; upstream `generator.c:1787` prints
   `f_name(fuzzy_file)` - the basis's relative flist name (the basename for a
   top-level file). Now built from the target's relative parent + candidate
   basename.

3. **Debug on stderr with a category bracket.** `render_diagnostic_events`
   prefixed debug lines with the flag category (`[Fuzzy] ...`) and routed them
   to stderr. Upstream `log.c:rwrite` prints debug (`FINFO`) messages verbatim
   on the client's stdout with no bracket. Fixed to render verbatim and honour
   `msgs-to-stderr` exactly like info events.

## Upstream references

- `generator.c:830` `find_fuzzy()`, `generator.c:1787-1793` selection line.
- `options.c:437` `parse_output_words()` - `strncasecmp` case-insensitive names.
- `log.c:rwrite()` - `FINFO` debug output to client stdout, no category prefix.

## Before / after (lxhost, upstream testsuite + full nextest)

Before (master 28428423d):
```
FAIL    fuzzy   (--fuzzy did not print "fuzzy basis selected for rsync.c: rsync2.c")
```

After (this branch):
```
PASS    fuzzy
PASS    itemize      (not regressed)
FAIL    compare      (pre-existing, fails identically on master)
```

`cargo nextest run --workspace` on lxhost: all tests pass except two
`xtask::commands::package` tests
(`cross_compiler_resolution_prefers_cross_gcc`,
`tarball_resolution_skips_targets_without_cross_tooling`) - both confirmed to
fail identically on master. They are a host environment artifact: lxhost has a
real `/usr/bin/aarch64-linux-gnu-gcc`, so the "force missing cross tooling"
override does not suppress detection. No product regressions.

## Tests

- `logging::config` case-insensitive `apply_debug_flag`/`apply_info_flag`.
- `logging` flag-parsing tests flipped from case-sensitive to case-insensitive.
- `engine` local-copy fuzzy test asserts the exact upstream selection string.
- `cli` diagnostic render tests updated for verbatim stdout debug output.
