### PR TITLE
fix(transfer): handle receiver data-discard without panic

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -196,7 +196,12 @@ where
                     writeln!(writer, "warning: failed to append to log file: {error}")
                 });
             }
-            0
+            // upstream: log.c:log_exit() maps the accumulated io_error /
+            // got_xfer_error into RERR_* exit codes. A transfer can complete
+            // its summary yet still owe a non-zero code (e.g. a receiver that
+            // discarded a file because its output mkstemp() failed reports exit
+            // 23 via MSG_ERROR_XFER). Honour it here instead of forcing 0.
+            summary.io_error_exit_code().unwrap_or(0)
         }
         Err(error) => {
             if let Some(observer) = live_progress

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -287,6 +287,16 @@ impl GeneratorContext {
             .advance_to(TransferPhase::Complete)
             .map_err(crate::fsm_error)?;
 
+        // upstream: log.c:311 - each MSG_ERROR_XFER the peer sends sets
+        // got_xfer_error on receipt; main.c:1635 then _exit(RERR_PARTIAL).
+        // The receiver emits MSG_ERROR_XFER when it cannot open a file's output
+        // (e.g. mkstemp() denied by a read-only destination dir) and discards
+        // the delta. Fold that into io_error so this sender/generator reports
+        // exit 23 instead of a false success.
+        if reader.xfer_error_count() > 0 {
+            self.add_io_error(super::super::io_error_flags::IOERR_GENERAL);
+        }
+
         // upstream: handle_stats() reports stats.total_size, the sum of all
         // flist file sizes (main.c:351 write_varlong30(f, stats.total_size, 3)).
         let total_size = self.file_list.iter().map(|e| e.size()).sum();

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -17,6 +17,8 @@ use std::io;
 use std::path::PathBuf;
 use std::thread::JoinHandle;
 
+use protocol::MessageCode;
+
 use crate::pipeline::spsc::{self, TryRecvError};
 
 use crate::delta_apply::ChecksumVerifier;
@@ -69,8 +71,12 @@ pub struct PipelinedReceiver {
     /// permission failures. Collected here instead of using `eprintln!` to
     /// avoid deadlocking on the global stderr mutex in daemon handler threads.
     /// The caller retrieves these via [`Self::drain_warnings`] and routes
-    /// them through the multiplexed protocol writer.
-    warnings: Vec<String>,
+    /// them through the multiplexed protocol writer. Each entry carries the
+    /// upstream `rwrite()` message code so a fatal transfer error
+    /// (`MSG_ERROR_XFER`) is not downgraded to an informational message: the
+    /// peer sets `got_xfer_error` on `MSG_ERROR_XFER` receipt, yielding exit
+    /// 23 (`RERR_PARTIAL`).
+    warnings: Vec<(MessageCode, String)>,
     /// Files staged to `.~tmp~` partial dir when `--delay-updates` is active.
     /// Each entry is `(staging_path, final_path)`. The receiver performs a
     /// bulk rename sweep at the phase 2 boundary.
@@ -176,12 +182,18 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno,
-                        // "send_files failed to open %s", full_fname(...)); full_fname()
-                        // wraps the path in double quotes (util1.c:1228).
-                        self.warnings.push(format!(
-                            "rsync: [sender] send_files failed to open \"{}\": Permission denied (13)",
-                            path.display(),
+                        // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
+                        // "mkstemp %s failed", full_fname(fnametmp)); full_fname()
+                        // wraps the path in double quotes (util1.c:1228). Emitting
+                        // this as FERROR_XFER (not FINFO) makes the peer's rwrite()
+                        // set got_xfer_error, so the run exits 23 (RERR_PARTIAL)
+                        // instead of 0 when the output mkstemp() was denied.
+                        self.warnings.push((
+                            MessageCode::ErrorXfer,
+                            format!(
+                                "rsync: [receiver] mkstemp \"{}\" failed: Permission denied (13)",
+                                path.display(),
+                            ),
                         ));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
@@ -237,12 +249,18 @@ impl PipelinedReceiver {
                     let pending = self.expected_checksums.pop_front();
                     if is_permission_error(&e) {
                         let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        // upstream: sender.c:362 - rsyserr(FERROR_XFER, errno,
-                        // "send_files failed to open %s", full_fname(...)); full_fname()
-                        // wraps the path in double quotes (util1.c:1228).
-                        self.warnings.push(format!(
-                            "rsync: [sender] send_files failed to open \"{}\": Permission denied (13)",
-                            path.display(),
+                        // upstream: receiver.c:297 - rsyserr(FERROR_XFER, errno,
+                        // "mkstemp %s failed", full_fname(fnametmp)); full_fname()
+                        // wraps the path in double quotes (util1.c:1228). Emitting
+                        // this as FERROR_XFER (not FINFO) makes the peer's rwrite()
+                        // set got_xfer_error, so the run exits 23 (RERR_PARTIAL)
+                        // instead of 0 when the output mkstemp() was denied.
+                        self.warnings.push((
+                            MessageCode::ErrorXfer,
+                            format!(
+                                "rsync: [receiver] mkstemp \"{}\" failed: Permission denied (13)",
+                                path.display(),
+                            ),
                         ));
                         meta_errors.push((path, e.to_string()));
                         self.permission_error_count += 1;
@@ -296,18 +314,24 @@ impl PipelinedReceiver {
                     // upstream: receiver.c:965-968 -
                     // "WARNING: %s failed verification -- update %s%s.\n"
                     // with keptstr="discarded", redostr=" (will try again)".
-                    self.warnings.push(format!(
-                        "WARNING: {} failed verification -- update discarded (will try again).",
-                        pending.file_path.display(),
+                    self.warnings.push((
+                        MessageCode::Warning,
+                        format!(
+                            "WARNING: {} failed verification -- update discarded (will try again).",
+                            pending.file_path.display(),
+                        ),
                     ));
                     self.redo_indices.push(pending.file_index);
                     return Ok(());
                 }
                 // upstream: receiver.c:957-968 - phase-2 redo path (FERROR_XFER):
                 // "ERROR: %s failed verification -- update %s.\n" with keptstr="discarded".
-                self.warnings.push(format!(
-                    "ERROR: {} failed verification -- update discarded.",
-                    pending.file_path.display(),
+                self.warnings.push((
+                    MessageCode::ErrorXfer,
+                    format!(
+                        "ERROR: {} failed verification -- update discarded.",
+                        pending.file_path.display(),
+                    ),
                 ));
                 // In phase 2, upstream logs the error but continues the transfer.
                 return Ok(());
@@ -405,10 +429,12 @@ impl PipelinedReceiver {
     ///
     /// Implicitly drains remaining results. Returns the final accumulated
     /// (bytes_written, metadata_errors).
-    /// Drains accumulated warning messages from checksum verification and
-    /// permission failures. Returns them so the caller can route them through
-    /// the multiplexed protocol writer.
-    pub fn drain_warnings(&mut self) -> Vec<String> {
+    /// Drains accumulated warning/error messages from checksum verification and
+    /// permission failures. Each is paired with the upstream `rwrite()` message
+    /// code so the caller routes it through the matching multiplex frame:
+    /// `MSG_ERROR_XFER` for fatal transfer errors (setting the peer's
+    /// `got_xfer_error`), `MSG_INFO`/`MSG_WARNING` otherwise.
+    pub fn drain_warnings(&mut self) -> Vec<(MessageCode, String)> {
         std::mem::take(&mut self.warnings)
     }
 
@@ -843,6 +869,67 @@ mod tests {
     fn permission_error_count_starts_at_zero() {
         let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
         assert_eq!(pr.permission_error_count(), 0);
+        drop(pr);
+    }
+
+    /// A failed output `mkstemp()` must surface as a `MSG_ERROR_XFER` warning,
+    /// not `MSG_INFO`. The distinction is load-bearing: the peer's `rwrite()`
+    /// only sets `got_xfer_error` (yielding exit 23, `RERR_PARTIAL`) on
+    /// `FERROR_XFER` receipt (upstream log.c:311). Routing this as `MSG_INFO`
+    /// would let a client-sender push against a read-only destination exit 0,
+    /// silently masking that no file was transferred.
+    #[cfg(unix)]
+    #[test]
+    fn output_open_failure_drains_as_error_xfer_warning() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Root bypasses the read-only dir bit, so mkstemp would succeed.
+        if std::env::var("USER").is_ok_and(|u| u == "root") {
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let readonly_dir = dir.path().join("readonly");
+        std::fs::create_dir(&readonly_dir).unwrap();
+        std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o555)).unwrap();
+
+        let file_path = readonly_dir.join("denied.dat");
+        let mut pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+
+        pr.file_sender()
+            .send(FileMessage::WholeFile {
+                begin: Box::new(BeginMessage {
+                    file_path: file_path.clone(),
+                    target_size: 9,
+                    file_entry_index: 0,
+                    checksum_verifier: None,
+                    is_device_target: false,
+                    is_inplace: false,
+                    append_offset: 0,
+                    xattr_list: None,
+                }),
+                data: b"test data".to_vec(),
+            })
+            .unwrap();
+        pr.note_commit_sent([0u8; ChecksumVerifier::MAX_DIGEST_LEN], 0, file_path, 0);
+
+        let (_bytes, errors) = pr.drain_all_results().unwrap();
+        assert_eq!(errors.len(), 1, "one recoverable per-file error");
+
+        let warnings = pr.drain_warnings();
+        assert_eq!(warnings.len(), 1, "one warning queued for the failed open");
+        assert_eq!(
+            warnings[0].0,
+            MessageCode::ErrorXfer,
+            "output-open failure must be MSG_ERROR_XFER so the peer exits 23"
+        );
+        assert!(
+            warnings[0].1.contains("mkstemp"),
+            "message should mirror upstream receiver.c:297 \"mkstemp %s failed\": {}",
+            warnings[0].1
+        );
+
+        let _ = std::fs::set_permissions(&readonly_dir, PermissionsExt::from_mode(0o755));
         drop(pr);
     }
 

--- a/crates/transfer/src/reader/multiplex.rs
+++ b/crates/transfer/src/reader/multiplex.rs
@@ -141,6 +141,20 @@ impl<R> MultiplexReader<R> {
         std::mem::take(&mut self.io_error)
     }
 
+    /// Returns the count of `MSG_ERROR_XFER` frames received so far.
+    ///
+    /// A non-zero count is upstream's `got_xfer_error`: the peer reported a
+    /// per-file transfer error (e.g. a failed output `mkstemp()`), so the run
+    /// must terminate with `RERR_PARTIAL` (exit 23) rather than success.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:311`: receipt of `FERROR_XFER` sets `got_xfer_error = 1`
+    /// - `main.c:1635`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
+    pub(super) fn xfer_error_count(&self) -> u32 {
+        self.xfer_error_count
+    }
+
     /// Returns and drains the accumulated `MSG_NO_SEND` file indices.
     ///
     /// # Upstream Reference

--- a/crates/transfer/src/reader/server.rs
+++ b/crates/transfer/src/reader/server.rs
@@ -179,6 +179,25 @@ impl<R: Read> ServerReader<R> {
         }
     }
 
+    /// Returns the count of `MSG_ERROR_XFER` frames received from the peer.
+    ///
+    /// A non-zero count is upstream's `got_xfer_error`: the peer reported a
+    /// per-file transfer error (e.g. a failed output `mkstemp()` on the
+    /// receiver), so the run must exit with `RERR_PARTIAL` (23). Plain-mode
+    /// readers never carry multiplexed frames and return 0.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `log.c:311`: receipt of `FERROR_XFER` sets `got_xfer_error = 1`
+    /// - `main.c:1635`: `if (got_xfer_error) _exit(RERR_PARTIAL);`
+    pub fn xfer_error_count(&mut self) -> u32 {
+        match &mut self.inner {
+            ServerReaderInner::Multiplex(mux) => mux.xfer_error_count(),
+            ServerReaderInner::Compressed(compressed) => compressed.get_mut().xfer_error_count(),
+            ServerReaderInner::Plain(_) => 0,
+        }
+    }
+
     /// Returns and drains accumulated `MSG_NO_SEND` file indices from the sender.
     ///
     /// When the sender cannot open a file it was asked to transfer, it sends

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -82,6 +82,15 @@ impl ReceiverContext {
 
         let mut failed_dir_paths: std::collections::HashSet<PathBuf> =
             std::collections::HashSet::new();
+        // upstream: generator.c:1374-1378 - directories skipped under
+        // --existing (ignore_non_existing) are NOT errors: upstream sets
+        // skip_dir / FLAG_MISSING_DIR and never touches io_error. Track them
+        // apart from `failed_dir_paths` (real mkdir EACCES failures) so the
+        // itemize/metadata passes below skip them without folding a spurious
+        // "failed to create directory" into `dir_creation_errors` (which would
+        // wrongly set IOERR_GENERAL -> RERR_PARTIAL/exit 23).
+        let mut skipped_existing_dirs: std::collections::HashSet<PathBuf> =
+            std::collections::HashSet::new();
         // Track whether each directory was freshly created (true) or already
         // existed (false). Drives the iflags passed to `emit_itemize` so the
         // receiver matches upstream `generator.c:1480-1483`: a new dir emits
@@ -119,8 +128,9 @@ impl ReceiverContext {
             dir_was_new.push(is_new);
             if is_new && existing_only {
                 // upstream: generator.c:1374-1378 - "not creating new directory".
-                // Reuse the failed-dir set so the itemize and metadata passes
-                // below skip this directory (it was never created on disk).
+                // Record in the skip set (not `failed_dir_paths`) so the
+                // itemize and metadata passes below skip this directory without
+                // treating the benign --existing skip as a mkdir failure.
                 if self.config.flags.verbose && self.config.connection.client_mode {
                     info_log!(
                         Skip,
@@ -129,7 +139,7 @@ impl ReceiverContext {
                         dir_path.display()
                     );
                 }
-                failed_dir_paths.insert(dir_path.clone());
+                skipped_existing_dirs.insert(dir_path.clone());
                 continue;
             }
             if is_new {
@@ -208,7 +218,7 @@ impl ReceiverContext {
         // records instead of MSG_INFO frames).
         if self.should_emit_itemize() {
             for ((idx, _, dir_path), is_new) in dir_entries.iter().zip(dir_was_new.iter()) {
-                if failed_dir_paths.contains(dir_path) {
+                if failed_dir_paths.contains(dir_path) || skipped_existing_dirs.contains(dir_path) {
                     continue;
                 }
                 let entry = &self.file_list[*idx];
@@ -236,7 +246,9 @@ impl ReceiverContext {
         let metadata_opts_clone = metadata_opts.clone();
         let entry_snapshots: Vec<(PathBuf, FileEntry, Option<XattrList>)> = dir_entries
             .into_iter()
-            .filter(|(_, _, dir_path)| !failed_dir_paths.contains(dir_path))
+            .filter(|(_, _, dir_path)| {
+                !failed_dir_paths.contains(dir_path) && !skipped_existing_dirs.contains(dir_path)
+            })
             .map(|(idx, _, dir_path)| {
                 let entry = &self.file_list[idx];
                 let xattr_list = self.resolve_xattr_list(entry);
@@ -688,6 +700,53 @@ mod touch_up_dirs_tests {
             args: vec![OsString::from(".")],
             ..Default::default()
         }
+    }
+
+    /// A directory skipped under `--existing` (`ignore_non_existing`) must not
+    /// be reported as a "failed to create directory" error. Upstream sets
+    /// `skip_dir` / `FLAG_MISSING_DIR` and never touches `io_error`
+    /// (generator.c:1374-1378), so the non-incremental `create_directories`
+    /// pass on a remote pull must return an empty error vec for such a dir.
+    ///
+    /// This is the load-bearing regression: folding the benign skip into the
+    /// error set set `IOERR_GENERAL`, which surfaced as `RERR_PARTIAL` (exit
+    /// 23) once the client honoured the receiver's `io_error`. That broke a
+    /// plain `--existing --include='*/' --exclude='*'` pull, which must exit 0
+    /// exactly like upstream.
+    #[test]
+    fn create_directories_existing_only_missing_dir_is_not_an_error() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let mut config = config_with_times(false);
+        config.file_selection.existing_only = true;
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.file_list = vec![FileEntry::new_directory("missing".into(), 0o755)];
+
+        let opts = metadata::MetadataOptions::default();
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        let errors = ctx
+            .create_directories(
+                dest,
+                &opts,
+                None,
+                &mut writer,
+                #[cfg(unix)]
+                None,
+            )
+            .expect("create_directories succeeds");
+
+        assert!(
+            errors.is_empty(),
+            "--existing skip of a missing directory must not produce an error \
+             (would set IOERR_GENERAL -> exit 23): {errors:?}"
+        );
+        assert!(
+            !dest.join("missing").exists(),
+            "--existing must not create the missing directory"
+        );
     }
 
     /// After writing files into a directory, the OS clobbers the directory

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -342,8 +342,14 @@ impl ReceiverContext {
 
                 // Route accumulated warnings through the multiplexed writer
                 // instead of eprintln (which deadlocks in daemon handler threads).
-                for warning in pipelined_receiver.drain_warnings() {
-                    let _ = writer.send_msg_info(warning.as_bytes());
+                // Fatal transfer errors ride MSG_ERROR_XFER so the peer sets
+                // got_xfer_error (exit 23); everything else is MSG_INFO.
+                for (code, warning) in pipelined_receiver.drain_warnings() {
+                    let _ = if code == protocol::MessageCode::ErrorXfer {
+                        writer.send_msg_error_xfer(warning.as_bytes())
+                    } else {
+                        writer.send_msg_info(warning.as_bytes())
+                    };
                 }
 
                 // upstream: io.c:820 stats.total_read only counts bytes read
@@ -395,8 +401,14 @@ impl ReceiverContext {
             metadata_errors.extend(disk_meta_errors);
 
             // Route accumulated warnings through the multiplexed writer.
-            for warning in pipelined_receiver.drain_warnings() {
-                let _ = writer.send_msg_info(warning.as_bytes());
+            // Fatal transfer errors ride MSG_ERROR_XFER so the peer sets
+            // got_xfer_error (exit 23); everything else is MSG_INFO.
+            for (code, warning) in pipelined_receiver.drain_warnings() {
+                let _ = if code == protocol::MessageCode::ErrorXfer {
+                    writer.send_msg_error_xfer(warning.as_bytes())
+                } else {
+                    writer.send_msg_info(warning.as_bytes())
+                };
             }
 
             let redo_indices = pipelined_receiver.take_redo_indices();

--- a/crates/transfer/src/writer/msg_info.rs
+++ b/crates/transfer/src/writer/msg_info.rs
@@ -29,6 +29,24 @@ pub trait MsgInfoSender {
     fn send_msg_info(&mut self, _data: &[u8]) -> io::Result<()> {
         Ok(())
     }
+
+    /// Sends a `MSG_ERROR_XFER` frame through the multiplexed output stream.
+    ///
+    /// Mirrors upstream `rsyserr(FERROR_XFER, ...)`: the peer's `rwrite()`
+    /// sets `got_xfer_error = 1` on receipt, so the transfer terminates with
+    /// `RERR_PARTIAL` (exit 23) rather than success. Used by the receiver to
+    /// report per-file transfer errors (e.g. a failed output `mkstemp()`) that
+    /// force the incoming delta to be discarded.
+    ///
+    /// The default implementation is a no-op, matching [`Self::send_msg_info`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:297` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", ...)`
+    /// - `log.c:311` - receipt of `FERROR_XFER` sets `got_xfer_error = 1`
+    fn send_msg_error_xfer(&mut self, _data: &[u8]) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl<W: Write> MsgInfoSender for ServerWriter<W> {
@@ -41,16 +59,32 @@ impl<W: Write> MsgInfoSender for ServerWriter<W> {
             Ok(())
         }
     }
+
+    fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
+        if self.is_multiplexed() {
+            self.send_message(MessageCode::ErrorXfer, data)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<T: MsgInfoSender + ?Sized> MsgInfoSender for &mut T {
     fn send_msg_info(&mut self, data: &[u8]) -> io::Result<()> {
         (**self).send_msg_info(data)
     }
+
+    fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
+        (**self).send_msg_error_xfer(data)
+    }
 }
 
 impl<W: MsgInfoSender> MsgInfoSender for CountingWriter<W> {
     fn send_msg_info(&mut self, data: &[u8]) -> io::Result<()> {
         self.inner_ref_mut().send_msg_info(data)
+    }
+
+    fn send_msg_error_xfer(&mut self, data: &[u8]) -> io::Result<()> {
+        self.inner_ref_mut().send_msg_error_xfer(data)
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `recv-discard-nullderef` 3.5.0dev conformance test. In a daemon-pull
scenario (client sender to daemon receiver) where the receiver's output
`mkstemp()` fails - e.g. a read-only destination directory - the receiver must
discard the incoming delta and the run must exit 23 (`RERR_PARTIAL`), not 0.

oc-rsync already drained the delta cleanly (no null-deref / crash), but it
reported the failure through the wrong channel and dropped the exit code at two
points:

1. **Receiver side** (`crates/transfer/src/pipeline/receiver.rs`,
   `receiver/transfer/pipeline.rs`, `writer/msg_info.rs`): the failed-open
   error was emitted as `MSG_INFO`. Upstream emits it as `FERROR_XFER`
   (`receiver.c:297` - `rsyserr(FERROR_XFER, errno, "mkstemp %s failed", ...)`),
   which sets the peer's `got_xfer_error` on receipt (`log.c:311`). Warnings now
   carry their `MessageCode`, and fatal transfer errors ride `MSG_ERROR_XFER`.
   The message text now matches upstream (`[receiver] mkstemp "..." failed`)
   instead of the misattributed `[sender] send_files failed to open`.

2. **Sender/generator side** (`crates/transfer/src/generator/transfer/orchestrator.rs`,
   `reader/multiplex.rs`, `reader/server.rs`): the client sender now folds a
   received `MSG_ERROR_XFER` count into `io_error` (`IOERR_GENERAL`), mirroring
   upstream `got_xfer_error -> _exit(RERR_PARTIAL)` (`main.c:1635`).

3. **CLI exit code** (`crates/cli/src/frontend/execution/drive/summary.rs`): the
   completed-transfer branch of `execute_transfer` returned a hardcoded `0`,
   discarding `summary.io_error_exit_code()`. It now honours the summary's exit
   code (upstream `log.c:log_exit()` maps io_error to `RERR_*`).

## Transport / trigger

Daemon pull, pipelined receiver. Trigger: destination dir chmod 0555, so the
receiver's output `mkstemp()` returns EACCES and the delta (which contains a
block MATCH against the shared leading block) is discarded.

## Validation (Linux host, aarch64)

- `recv-discard-nullderef`: FAIL (exit 0) on master -> PASS after fix
  (client exits 23).
- `cargo nextest run --workspace`: see run summary below (only the known
  pre-existing xtask cross-compiler env artifacts fail identically on master).

## Test

Added `output_open_failure_drains_as_error_xfer_warning` in
`pipeline/receiver.rs`: asserts a denied output open surfaces a
`MessageCode::ErrorXfer` warning (not `MSG_INFO`), encoding why the code matters
(the peer only sets `got_xfer_error` on `FERROR_XFER`).

## lxhost run evidence

- Target test: `recv-discard-nullderef` -> `PASS` (client exits 23).
- `cargo nextest run --workspace --build-jobs 2 -j 2`:
  `29815 passed (5 slow), 1 failed, 161 skipped`. The single failure is the
  pre-existing xtask env artifact
  `xtask::commands::package::tests::cross_compiler_resolution_falls_back_to_zig`
  (no cross toolchain on the host); it is unrelated to this change and fails
  identically on master.
