### PR TITLE
fix(engine): first-match-wins for protect/risk filter rules

### DIFF
--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -122,6 +122,13 @@ impl FilterSegment {
         }
 
         for rule in &self.protect_risk {
+            // upstream check_filter() (exclude.c:1058-1061) returns on the first
+            // matching rule, so the first protect/risk decision wins. Stop once a
+            // protect/risk rule has applied rather than letting a later rule
+            // overwrite it (last-match-wins).
+            if outcome.protection_decided() {
+                break;
+            }
             if matches!(context, FilterContext::Deletion) && rule.perishable {
                 continue;
             }
@@ -217,6 +224,7 @@ pub(crate) struct FilterOutcome {
     transfer_allowed: bool,
     transfer_decided: bool,
     protected: bool,
+    protection_decided: bool,
     excluded_for_delete_excluded: bool,
 }
 
@@ -226,6 +234,7 @@ impl FilterOutcome {
             transfer_allowed: true,
             transfer_decided: false,
             protected: false,
+            protection_decided: false,
             excluded_for_delete_excluded: false,
         }
     }
@@ -246,6 +255,10 @@ impl FilterOutcome {
         self.transfer_decided
     }
 
+    const fn protection_decided(self) -> bool {
+        self.protection_decided
+    }
+
     const fn decide_transfer(&mut self) {
         self.transfer_decided = true;
     }
@@ -256,10 +269,12 @@ impl FilterOutcome {
 
     const fn protect(&mut self) {
         self.protected = true;
+        self.protection_decided = true;
     }
 
     const fn unprotect(&mut self) {
         self.protected = false;
+        self.protection_decided = true;
     }
 
     const fn set_delete_excluded(&mut self, excluded: bool) {

--- a/crates/engine/src/local_copy/filter_program_internal_tests.rs
+++ b/crates/engine/src/local_copy/filter_program_internal_tests.rs
@@ -68,12 +68,15 @@ fn filter_segment_apply_updates_transfer_and_deletion_outcomes() {
     segment
         .push_rule(FilterRule::include("keep.txt"))
         .expect("include rule added");
-    segment
-        .push_rule(FilterRule::protect("protected/**"))
-        .expect("protect rule added");
+    // Risk (more specific) precedes protect (broad): upstream check_filter()
+    // returns on the first matching rule (exclude.c:1058-1061), so the override
+    // sub-path is un-protected while the broad protect still guards its siblings.
     segment
         .push_rule(FilterRule::risk("protected/override/**"))
         .expect("risk rule added");
+    segment
+        .push_rule(FilterRule::protect("protected/**"))
+        .expect("protect rule added");
 
     let mut allowed = FilterOutcome::default();
     segment.apply(
@@ -102,13 +105,17 @@ fn filter_segment_apply_updates_transfer_and_deletion_outcomes() {
     );
     assert!(!deletion.allows_deletion());
 
+    // Each path is evaluated with a fresh outcome (program.rs builds one per
+    // path); the override sub-path matches the risk rule first and stays
+    // deletable, independent of the earlier protected/data.bin evaluation.
+    let mut override_outcome = FilterOutcome::default();
     segment.apply(
         Path::new("protected/override/data.bin"),
         false,
-        &mut deletion,
+        &mut override_outcome,
         FilterContext::Deletion,
     );
-    assert!(deletion.allows_deletion());
+    assert!(override_outcome.allows_deletion());
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_filter_program.rs
+++ b/crates/engine/src/local_copy/tests/execute_filter_program.rs
@@ -721,12 +721,14 @@ fn filter_segment_protect_blocks_deletion_but_allows_transfer() {
 #[test]
 fn filter_segment_risk_removes_protection() {
     let mut segment = FilterSegment::default();
-    segment
-        .push_rule(FilterRule::protect("data/**"))
-        .expect("protect data/**");
+    // Risk (specific) before protect (broad): upstream check_filter() first-match
+    // (exclude.c:1058-1061) un-protects data/temp/** while data/** stays guarded.
     segment
         .push_rule(FilterRule::risk("data/temp/**"))
         .expect("risk data/temp/**");
+    segment
+        .push_rule(FilterRule::protect("data/**"))
+        .expect("protect data/**");
 
     // data/important.db is protected.
     let mut protected_outcome = FilterOutcome::default();

--- a/crates/engine/tests/filter_modifiers_interop.rs
+++ b/crates/engine/tests/filter_modifiers_interop.rs
@@ -156,7 +156,6 @@ fn protect_keeps_extraneous_dest_file_from_delete() {
 /// evaluator is fixed to break on the first matching protect/risk rule. It must
 /// not be changed to assert oc's current (wrong) last-match behaviour.
 #[test]
-#[ignore = "oc protect/risk evaluator is last-match-wins; upstream is first-match-wins (segments.rs)"]
 fn risk_re_exposes_protected_dest_file_to_delete() {
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("src");


### PR DESCRIPTION
## What

The local-copy protect/risk evaluator iterated the whole rule chain and applied every match, so a later broad `P *.log` overwrote an earlier specific `R secret.log` — **last-match-wins**. Upstream `check_filter()` returns on the **first** matching rule (`exclude.c:1058-1061`), so a risk (include) matched before a protect (exclude) yields "may delete".

## Fix

Add a `protection_decided` latch to `FilterOutcome` (mirroring the existing `transfer_decided` guard the include/exclude loop already uses) and break the protect/risk loop once a rule applies — `segments.rs`. First-match-wins, matching upstream.

## Tests

- **Un-ignores** the `risk_re_exposes_protected_dest_file_to_delete` interop regression test (added by the filter-modifier interop work, previously `#[ignore]`d pending this fix). It verifies `R secret.log` before `P *.log` deletes `secret.log` while `keep.log` stays protected — identical to upstream rsync 3.4.4.
- Two internal protect/risk unit tests encoded the old last-match behavior (broad protect listed before specific risk, and one reused a single outcome across paths). Reordered to risk-before-protect and evaluate each path with a fresh outcome, matching upstream first-match and production per-path evaluation.

## Verification (lxhost, aarch64)

- `cargo nextest run -p engine --no-fail-fast`: **4736 passed, 26 skipped, 0 failed**.
- Upstream neighbors (over-deletion guard): `exclude`, `exclude-lsh`, `delete`, `delete-during` all PASS — no protected file is ever wrongly deleted.
- fmt + clippy (`-p engine`, `-D warnings`, `--locked`) clean.