### PR TITLE
fix(cli): render per-type breakdown on deleted-files stats line

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -425,6 +425,16 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     let fifos = summary.fifos_created();
     let fifos_total = summary.fifos_total();
     let deleted = summary.items_deleted();
+    // upstream: main.c output_itemized_counts("Number of deleted files", ...)
+    // prints the total plus a per-type breakdown (reg/dir/link/dev/special),
+    // where reg = total - (dir + link + dev + special).
+    let deleted_breakdown = format_stat_categories(&[
+        ("reg", summary.deleted_regular_files()),
+        ("dir", summary.deleted_dirs()),
+        ("link", summary.deleted_symlinks()),
+        ("dev", summary.deleted_devices()),
+        ("special", summary.deleted_specials()),
+    ]);
     let literal_bytes = summary.bytes_copied();
     let transferred_size = summary.transferred_file_size();
     let bytes_sent = summary.bytes_sent();
@@ -486,7 +496,7 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
     )?;
     writeln!(
         stdout,
-        "Number of deleted files: {}",
+        "Number of deleted files: {}{deleted_breakdown}",
         format_decimal_bytes(deleted)
     )?;
     writeln!(

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/stats.rs
@@ -61,7 +61,7 @@ pub(super) fn convert_server_stats_to_summary(
                 elapsed,
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
-                u64::from(transfer_stats.delete_stats.total()),
+                transfer_stats.delete_stats,
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }
@@ -79,7 +79,7 @@ pub(super) fn convert_server_stats_to_summary(
                 elapsed,
                 generator_stats.literal_data,
                 generator_stats.matched_data,
-                u64::from(generator_stats.delete_stats.total()),
+                generator_stats.delete_stats,
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/core/src/client/remote/ssh_transfer/exit_status.rs
+++ b/crates/core/src/client/remote/ssh_transfer/exit_status.rs
@@ -38,7 +38,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 elapsed,
                 transfer_stats.literal_data,
                 transfer_stats.matched_data,
-                u64::from(transfer_stats.delete_stats.total()),
+                transfer_stats.delete_stats,
             );
             (s, transfer_stats.io_error, transfer_stats.error_count)
         }
@@ -54,7 +54,7 @@ pub(in crate::client::remote) fn convert_server_stats_to_summary(
                 elapsed,
                 generator_stats.literal_data,
                 generator_stats.matched_data,
-                u64::from(generator_stats.delete_stats.total()),
+                generator_stats.delete_stats,
             );
             (s, generator_stats.io_error, 0u32)
         }

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -369,7 +369,7 @@ fn replay_batch(
         std::time::Duration::ZERO,
         total_size,
         0,
-        0,
+        protocol::DeleteStats::new(),
     );
     Ok(ClientSummary::from_summary(summary))
 }

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -210,6 +210,36 @@ impl ClientSummary {
         self.stats.items_deleted()
     }
 
+    /// Returns the number of regular files removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_regular_files(&self) -> u64 {
+        self.stats.deleted_regular_files()
+    }
+
+    /// Returns the number of directories removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_dirs(&self) -> u64 {
+        self.stats.deleted_dirs()
+    }
+
+    /// Returns the number of symlinks removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_symlinks(&self) -> u64 {
+        self.stats.deleted_symlinks()
+    }
+
+    /// Returns the number of device nodes removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_devices(&self) -> u64 {
+        self.stats.deleted_devices()
+    }
+
+    /// Returns the number of special files removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_specials(&self) -> u64 {
+        self.stats.deleted_specials()
+    }
+
     /// Returns the aggregate number of bytes copied.
     #[must_use]
     pub const fn bytes_copied(&self) -> u64 {

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -794,7 +794,7 @@ impl<'a> CopyContext<'a> {
         let file_type = metadata.file_type();
 
         if self.mode.is_dry_run() {
-            self.summary_mut().record_deletion();
+            self.summary_mut().record_deletion(file_type);
             if let Some(path) = relative {
                 self.record(LocalCopyRecord::new(
                     path.to_path_buf(),
@@ -835,7 +835,7 @@ impl<'a> CopyContext<'a> {
             }
         }
 
-        self.summary_mut().record_deletion();
+        self.summary_mut().record_deletion(file_type);
         if let Some(path) = relative {
             self.record(LocalCopyRecord::new(
                 path.to_path_buf(),

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -415,7 +415,7 @@ fn apply_delete_side_effects(
                 info_log!(Del, 1, "deleting {}", entry_relative.display());
             }
         }
-        context.summary_mut().record_deletion();
+        context.summary_mut().record_deletion(file_type);
         context.record(
             LocalCopyRecord::new(
                 entry_relative,
@@ -484,7 +484,7 @@ fn record_directory_subtree(
                 info_log!(Del, 1, "deleting {}", relative_buf.display());
             }
         }
-        context.summary_mut().record_deletion();
+        context.summary_mut().record_deletion(file_type);
         context.record(
             LocalCopyRecord::new(
                 relative_buf.clone(),

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -610,7 +610,7 @@ pub(super) fn delete_missing_source_entry(
     let record_path = non_empty_path(relative.as_path());
 
     if context.mode().is_dry_run() {
-        context.summary_mut().record_deletion();
+        context.summary_mut().record_deletion(file_type);
         if let Some(path) = record_path {
             context.record(LocalCopyRecord::new(
                 path.to_path_buf(),
@@ -634,7 +634,7 @@ pub(super) fn delete_missing_source_entry(
 
     match removal {
         Ok(()) => {
-            context.summary_mut().record_deletion();
+            context.summary_mut().record_deletion(file_type);
             if let Some(path) = record_path {
                 context.record(LocalCopyRecord::new(
                     path.to_path_buf(),

--- a/crates/engine/src/local_copy/plan/summary.rs
+++ b/crates/engine/src/local_copy/plan/summary.rs
@@ -98,6 +98,14 @@ pub struct LocalCopySummary {
     devices_created: u64,
     fifos_created: u64,
     items_deleted: u64,
+    // Per-type deletion counts, mirroring upstream's `stats.deleted_*` fields
+    // (main.c write_del_stats/read_del_stats). `items_deleted` is the total;
+    // these break it down for the `Number of deleted files: N (reg: .., dir: ..)`
+    // line rendered by `output_itemized_counts`.
+    deleted_dirs: u64,
+    deleted_symlinks: u64,
+    deleted_devices: u64,
+    deleted_specials: u64,
     sources_removed: u64,
     transferred_file_size: u64,
     bytes_copied: u64,
@@ -216,6 +224,43 @@ impl LocalCopySummary {
     #[must_use]
     pub const fn items_deleted(&self) -> u64 {
         self.items_deleted
+    }
+
+    /// Returns the number of directories removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_dirs(&self) -> u64 {
+        self.deleted_dirs
+    }
+
+    /// Returns the number of symlinks removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_symlinks(&self) -> u64 {
+        self.deleted_symlinks
+    }
+
+    /// Returns the number of device nodes removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_devices(&self) -> u64 {
+        self.deleted_devices
+    }
+
+    /// Returns the number of special files (FIFOs, sockets) removed because of `--delete`.
+    #[must_use]
+    pub const fn deleted_specials(&self) -> u64 {
+        self.deleted_specials
+    }
+
+    /// Returns the number of regular files removed because of `--delete`.
+    ///
+    /// Derived as the total minus the typed sub-counts, mirroring upstream's
+    /// `output_itemized_counts` which computes `counts[0] -= counts[1..]`.
+    #[must_use]
+    pub const fn deleted_regular_files(&self) -> u64 {
+        self.items_deleted
+            .saturating_sub(self.deleted_dirs)
+            .saturating_sub(self.deleted_symlinks)
+            .saturating_sub(self.deleted_devices)
+            .saturating_sub(self.deleted_specials)
     }
 
     /// Returns the number of source entries removed due to `--remove-source-files`.
@@ -415,7 +460,7 @@ impl LocalCopySummary {
         elapsed: Duration,
         literal_data: u64,
         matched_data: u64,
-        items_deleted: u64,
+        delete_stats: protocol::DeleteStats,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
@@ -425,7 +470,11 @@ impl LocalCopySummary {
             bytes_copied: literal_data,
             matched_bytes: matched_data,
             total_source_bytes,
-            items_deleted,
+            items_deleted: u64::from(delete_stats.total()),
+            deleted_dirs: u64::from(delete_stats.dirs),
+            deleted_symlinks: u64::from(delete_stats.symlinks),
+            deleted_devices: u64::from(delete_stats.devices),
+            deleted_specials: u64::from(delete_stats.specials),
             total_elapsed: elapsed,
             wall_clock_elapsed: elapsed,
             ..Default::default()
@@ -449,7 +498,7 @@ impl LocalCopySummary {
         elapsed: Duration,
         literal_data: u64,
         matched_data: u64,
-        items_deleted: u64,
+        delete_stats: protocol::DeleteStats,
     ) -> Self {
         Self {
             regular_files_total: files_listed as u64,
@@ -459,7 +508,11 @@ impl LocalCopySummary {
             bytes_copied: literal_data,
             matched_bytes: matched_data,
             total_source_bytes,
-            items_deleted,
+            items_deleted: u64::from(delete_stats.total()),
+            deleted_dirs: u64::from(delete_stats.dirs),
+            deleted_symlinks: u64::from(delete_stats.symlinks),
+            deleted_devices: u64::from(delete_stats.devices),
+            deleted_specials: u64::from(delete_stats.specials),
             total_elapsed: elapsed,
             wall_clock_elapsed: elapsed,
             ..Default::default()
@@ -491,6 +544,10 @@ impl LocalCopySummary {
             devices_created: 0,
             fifos_created: 0,
             items_deleted: 0,
+            deleted_dirs: 0,
+            deleted_symlinks: 0,
+            deleted_devices: 0,
+            deleted_specials: 0,
             sources_removed: 0,
             transferred_file_size: 0,
             bytes_copied: 0,
@@ -611,8 +668,26 @@ impl LocalCopySummary {
         self.fifos_total = self.fifos_total.saturating_add(1);
     }
 
-    pub(in crate::local_copy) const fn record_deletion(&mut self) {
+    /// Records one `--delete` removal, bumping the total and the per-type
+    /// sub-count for the entry's kind. Mirrors upstream's `stats.deleted_*`
+    /// counters (main.c write_del_stats) so `Number of deleted files` renders
+    /// the `(reg: .., dir: ..)` breakdown via `output_itemized_counts`.
+    pub(in crate::local_copy) fn record_deletion(&mut self, file_type: std::fs::FileType) {
         self.items_deleted = self.items_deleted.saturating_add(1);
+        if file_type.is_dir() {
+            self.deleted_dirs = self.deleted_dirs.saturating_add(1);
+        } else if file_type.is_symlink() {
+            self.deleted_symlinks = self.deleted_symlinks.saturating_add(1);
+        } else if !file_type.is_file() {
+            // Block/char devices vs FIFOs/sockets: upstream splits these into
+            // `dev` and `special` (main.c write_del_stats). Reuse the shared
+            // platform-specific classifier used elsewhere in the executor.
+            if super::super::is_device(file_type) {
+                self.deleted_devices = self.deleted_devices.saturating_add(1);
+            } else {
+                self.deleted_specials = self.deleted_specials.saturating_add(1);
+            }
+        }
     }
 
     pub(in crate::local_copy) const fn record_source_removed(&mut self) {
@@ -646,7 +721,7 @@ mod tests {
             Duration::from_secs(5),
             0,
             0,
-            0,
+            protocol::DeleteStats::new(),
         );
         assert_eq!(summary.regular_files_total(), 100);
         assert_eq!(summary.files_copied(), 50);
@@ -667,7 +742,7 @@ mod tests {
             Duration::from_secs(2),
             800,
             1200,
-            0,
+            protocol::DeleteStats::new(),
         );
         assert_eq!(summary.bytes_copied(), 800);
         assert_eq!(summary.matched_bytes(), 1200);
@@ -677,10 +752,18 @@ mod tests {
 
     /// Mirrors the daemon-upload + `--delete` path: the daemon receiver
     /// sweeps the destination and sends `NDX_DEL_STATS` back to the client
-    /// sender. The client's `LocalCopySummary` must surface the count so
-    /// `--stats` renders "Number of deleted files: N" instead of zero.
+    /// sender. The client's `LocalCopySummary` must surface both the total
+    /// and the per-type breakdown so `--stats` renders the upstream
+    /// "Number of deleted files: N (reg: .., dir: ..)" line, not just `N`.
     #[test]
     fn from_generator_stats_records_items_deleted() {
+        let delete_stats = protocol::DeleteStats {
+            files: 4,
+            dirs: 2,
+            symlinks: 1,
+            devices: 0,
+            specials: 0,
+        };
         let summary = LocalCopySummary::from_generator_stats(
             10,
             5,
@@ -690,16 +773,28 @@ mod tests {
             Duration::from_secs(1),
             0,
             0,
-            7,
+            delete_stats,
         );
         assert_eq!(summary.items_deleted(), 7);
+        // reg is derived as total - (dir+link+dev+special), mirroring upstream
+        // output_itemized_counts (main.c) - a stale flat count would break this.
+        assert_eq!(summary.deleted_regular_files(), 4);
+        assert_eq!(summary.deleted_dirs(), 2);
+        assert_eq!(summary.deleted_symlinks(), 1);
     }
 
     /// Mirrors the daemon-pull + `--delete` path: the local receiver
     /// performs the delete sweep and records the count locally; the
-    /// summary must surface the same counter.
+    /// summary must surface the same total plus per-type breakdown.
     #[test]
     fn from_receiver_stats_records_items_deleted() {
+        let delete_stats = protocol::DeleteStats {
+            files: 2,
+            dirs: 1,
+            symlinks: 0,
+            devices: 0,
+            specials: 0,
+        };
         let summary = LocalCopySummary::from_receiver_stats(
             10,
             5,
@@ -709,9 +804,11 @@ mod tests {
             Duration::from_secs(2),
             0,
             0,
-            3,
+            delete_stats,
         );
         assert_eq!(summary.items_deleted(), 3);
+        assert_eq!(summary.deleted_regular_files(), 2);
+        assert_eq!(summary.deleted_dirs(), 1);
     }
 
     #[test]
@@ -725,7 +822,7 @@ mod tests {
             Duration::from_secs(3),
             2800,
             202_000,
-            0,
+            protocol::DeleteStats::new(),
         );
         assert_eq!(summary.regular_files_total(), 200);
         assert_eq!(summary.files_copied(), 75);
@@ -840,12 +937,22 @@ mod tests {
 
     #[test]
     fn record_deletion_and_source_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("f");
+        std::fs::write(&file_path, b"x").unwrap();
+        let file_type = std::fs::symlink_metadata(&file_path).unwrap().file_type();
+        let dir_type = std::fs::symlink_metadata(dir.path()).unwrap().file_type();
+
         let mut summary = LocalCopySummary::default();
-        summary.record_deletion();
-        summary.record_deletion();
+        summary.record_deletion(file_type);
+        summary.record_deletion(dir_type);
         summary.record_source_removed();
 
         assert_eq!(summary.items_deleted(), 2);
+        // Per-type classification must split the two deletions so the
+        // rendered breakdown mirrors upstream's `(reg: 1, dir: 1)`.
+        assert_eq!(summary.deleted_regular_files(), 1);
+        assert_eq!(summary.deleted_dirs(), 1);
         assert_eq!(summary.sources_removed(), 1);
     }
 

--- a/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
@@ -298,19 +298,20 @@ fn assert_destination_pruned(dest: &Path) {
     );
 }
 
-/// Assert that `stdout` contains exactly `Number of deleted files: 1`.
+/// Assert that `stdout` reports `Number of deleted files: N (reg: N)`.
 ///
-/// The `--stats` formatter (`crates/cli/src/frontend/stats_format.rs`)
-/// renders the counter with thousands separators - at N=1 there is no
-/// separator so the literal "1" is the exact byte we expect. This is
-/// the user-visible surface of the `NDX_DEL_STATS` wire frame: a
-/// regression that dropped the frame or zeroed the counters would
-/// print "Number of deleted files: 0" here.
+/// Both scenarios delete a single extraneous *regular* file, so upstream's
+/// `output_itemized_counts` (main.c) prints the total plus the per-type
+/// breakdown `(reg: N)`. This is the user-visible surface of the
+/// `NDX_DEL_STATS` wire frame (5 per-type varints): a regression that dropped
+/// the frame or zeroed the counters would print "Number of deleted files: 0",
+/// and one that collapsed the per-type counts to a bare total would drop the
+/// `(reg: N)` suffix.
 fn assert_delete_count(stdout: &str, stderr: &str, expected: u32) {
-    let needle = format!("Number of deleted files: {expected}");
+    let needle = format!("Number of deleted files: {expected} (reg: {expected})");
     assert!(
         stdout.contains(&needle),
-        "missing `{needle}` line in --stats output (NDX_DEL_STATS goodbye-phase frame missing or zeroed)\n\
+        "missing `{needle}` line in --stats output (NDX_DEL_STATS goodbye-phase frame missing, zeroed, or per-type breakdown dropped)\n\
          stdout:\n{stdout}\nstderr:\n{stderr}",
     );
 }


### PR DESCRIPTION
## Problem

On a daemon transfer with `--delete --stats`, oc-rsync printed a bare total on the deleted-files line:

```
Number of deleted files: 1
```

while upstream rsync prints the per-type breakdown from `output_itemized_counts` (main.c):

```
Number of deleted files: 1 (reg: 1)
```

This failed the `daemon-delete-stats` conformance test, whose final assertion requires `Number of deleted files: 1 (reg: 1)`.

## Root cause

The per-type deletion counts already travel the wire in the `NDX_DEL_STATS` goodbye frame (five varints: files/dirs/symlinks/devices/specials, `protocol::DeleteStats`). But when the client built its summary, the counts were collapsed to a single total via `delete_stats.total()` at the summary conversion layer, so the renderer had no breakdown to print.

## Fix

Mirror upstream `main.c` `output_itemized_counts` / `write_del_stats`:

- Thread the full `protocol::DeleteStats` (not just the total) through `LocalCopySummary::from_generator_stats` / `from_receiver_stats`, storing per-type sub-counts (`deleted_dirs`/`deleted_symlinks`/`deleted_devices`/`deleted_specials`) alongside the total. Applied on the daemon, SSH, and batch paths.
- For local-copy deletions, classify each removal by `FileType` in `record_deletion` (using the existing shared `is_device` helper), so local `--stats --delete` output gains the same breakdown.
- The renderer now builds the deleted breakdown with the shared `format_stat_categories`, deriving `reg = total - (dir + link + dev + special)` exactly as upstream does.

## Verification (Linux host, aarch64)

Before (master f4061d609): `daemon-delete-stats` = FAIL (`Number of deleted files: 1`, missing `(reg: 1)`).

After:

```
PASS    daemon-delete-stats
```

Neighbor delete-family spot-check (no regressions):

```
PASS    delete
PASS    delete-deep
PASS    delete-missing-args-files-from
```

Full workspace `cargo nextest run --workspace --no-fail-fast`:

```
Summary [645.362s] 29907 tests run: 29903 passed, 4 failed, 162 skipped
```

The 4 failures are the pre-existing xtask cross-compiler env artifacts (`cross_compiler_resolution_*`, `execute_reports_missing_cross_compiler`, `tarball_resolution_skips_targets_without_cross_tooling`) unrelated to this change; no product-crate test fails.

## Tests

- Strengthened `crates/transfer/tests/uts_nextest_daemon_delete_stats.rs` to assert the full `Number of deleted files: 1 (reg: 1)` line for both push and pull directions.
- Extended `LocalCopySummary` unit tests to assert the per-type breakdown (`deleted_regular_files`/`deleted_dirs`/`deleted_symlinks`) and to classify a real regular file vs directory deletion via `record_deletion`.