### PR TITLE
test(test-support): add DirDiff tree-comparison harness primitive

### DIFF
--- a/crates/test-support/src/dir_diff.rs
+++ b/crates/test-support/src/dir_diff.rs
@@ -1,0 +1,541 @@
+//! Recursive directory-tree comparison for upstream-compat ports.
+//!
+//! `DirDiff` is the harness primitive that backs the runtests.py edge-case
+//! ports specified in `docs/design/uts-nextest-edge-b-test-harness.md`. It
+//! mirrors upstream's `rsync_ls_lR` + `diff -r` pair: after a transfer, a
+//! port asserts the destination tree equals a known-good tree under a chosen
+//! set of attributes (content, mode, owner, mtime, symlink target).
+//!
+//! The comparison is standard-library only and deterministic (entries are
+//! visited in sorted order), so a mismatch prints the same diff regardless
+//! of filesystem enumeration order. xattr and ACL comparison are declared in
+//! [`DirDiffOptions`] but not yet wired to a backend; requesting them returns
+//! an error rather than silently passing, so a test can never believe it
+//! checked an attribute the harness ignored.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+/// Streaming byte-compare threshold. Files at or below this size are read
+/// fully and compared with a slice equality; larger files stream in chunks
+/// so a multi-gigabyte basis file never forces a full in-memory copy.
+const STREAM_THRESHOLD: u64 = 1 << 20;
+
+/// Attributes to compare between two trees.
+///
+/// Defaults compare structure only (presence of every path). Enable
+/// individual checks or use the [`DirDiffOptions::structural`] /
+/// [`DirDiffOptions::archive`] presets that mirror upstream `checkit()` and
+/// `-a` semantics.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DirDiffOptions {
+    /// Compare regular-file byte content.
+    pub check_content: bool,
+    /// Compare the low 12 permission bits (`0o7777`).
+    pub check_mode: bool,
+    /// Compare modification time (whole seconds).
+    pub check_mtime: bool,
+    /// Compare `(uid, gid)` ownership. Unix only.
+    pub check_owner: bool,
+    /// Compare access time. Not yet implemented; requesting it errors.
+    pub check_atime: bool,
+    /// Compare extended attributes. Not yet implemented; requesting it errors.
+    pub check_xattr: bool,
+    /// Compare POSIX ACLs. Not yet implemented; requesting it errors.
+    pub check_acl: bool,
+}
+
+impl DirDiffOptions {
+    /// Upstream `checkit()` default: structure plus file content and mode.
+    ///
+    /// This is the "did every file arrive with the right bytes and bits"
+    /// check most non-archive ports need.
+    #[must_use]
+    pub fn structural() -> Self {
+        Self {
+            check_content: true,
+            check_mode: true,
+            ..Self::default()
+        }
+    }
+
+    /// Archive mode (`-a`): content, mode, owner, and mtime.
+    ///
+    /// Symlink targets are always compared literally (never dereferenced),
+    /// matching `rsync -a` which recreates the link rather than following it.
+    #[must_use]
+    pub fn archive() -> Self {
+        Self {
+            check_content: true,
+            check_mode: true,
+            check_mtime: true,
+            check_owner: true,
+            ..Self::default()
+        }
+    }
+
+    fn unsupported(self) -> Option<&'static str> {
+        if self.check_atime {
+            Some("check_atime")
+        } else if self.check_xattr {
+            Some("check_xattr")
+        } else if self.check_acl {
+            Some("check_acl")
+        } else {
+            None
+        }
+    }
+}
+
+/// Recursive tree comparator. See the module docs for semantics.
+pub struct DirDiff;
+
+impl DirDiff {
+    /// Compare `expected` against `actual` under `opts`.
+    ///
+    /// Returns `Ok(())` when the trees are equivalent. Returns a
+    /// [`DirDiffMismatch`] enumerating every difference otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DirDiffError::Unsupported`] if `opts` requests an attribute
+    /// the harness does not yet compare (atime, xattr, acl), and
+    /// [`DirDiffError::Io`] if either tree cannot be traversed. Both are
+    /// distinct from a content mismatch so a test never mistakes an
+    /// infrastructure failure for a clean tree.
+    pub fn compare(
+        expected: &Path,
+        actual: &Path,
+        opts: DirDiffOptions,
+    ) -> Result<Result<(), DirDiffMismatch>, DirDiffError> {
+        if let Some(attr) = opts.unsupported() {
+            return Err(DirDiffError::Unsupported(attr));
+        }
+
+        let mut differences = Vec::new();
+        compare_dir(expected, actual, Path::new(""), opts, &mut differences)?;
+
+        if differences.is_empty() {
+            Ok(Ok(()))
+        } else {
+            Ok(Err(DirDiffMismatch { differences }))
+        }
+    }
+}
+
+/// Infrastructure failure while comparing, distinct from a tree mismatch.
+#[derive(Debug)]
+pub enum DirDiffError {
+    /// An option requested an attribute the harness cannot yet compare.
+    Unsupported(&'static str),
+    /// A filesystem error occurred during traversal.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for DirDiffError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DirDiffError::Unsupported(attr) => {
+                write!(f, "DirDiff option {attr} is not yet implemented")
+            }
+            DirDiffError::Io(e) => write!(f, "DirDiff traversal failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DirDiffError {}
+
+impl From<io::Error> for DirDiffError {
+    fn from(e: io::Error) -> Self {
+        DirDiffError::Io(e)
+    }
+}
+
+/// A non-empty set of differences between two trees.
+#[derive(Debug)]
+pub struct DirDiffMismatch {
+    /// Every difference found, in sorted-path order.
+    pub differences: Vec<DirDiffEntry>,
+}
+
+impl DirDiffMismatch {
+    /// Render an upstream-`diff -r`-style message for a test panic.
+    #[must_use]
+    pub fn into_panic_message(self) -> String {
+        let mut out = format!(
+            "directory trees differ ({} differences):\n",
+            self.differences.len()
+        );
+        for entry in &self.differences {
+            let _ = writeln!(out, "  {entry}");
+        }
+        out
+    }
+}
+
+impl std::fmt::Display for DirDiffMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} differences", self.differences.len())
+    }
+}
+
+/// A single tree difference.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DirDiffEntry {
+    /// Present in `expected`, absent from `actual`.
+    OnlyInExpected(PathBuf),
+    /// Present in `actual`, absent from `expected`.
+    OnlyInActual(PathBuf),
+    /// Same path, different file type (e.g. file vs directory).
+    TypeMismatch {
+        /// Relative path.
+        path: PathBuf,
+        /// Type in the expected tree.
+        expected: &'static str,
+        /// Type in the actual tree.
+        actual: &'static str,
+    },
+    /// Regular-file byte content differs.
+    ContentMismatch {
+        /// Relative path.
+        path: PathBuf,
+        /// Byte length in the expected tree.
+        expected_len: u64,
+        /// Byte length in the actual tree.
+        actual_len: u64,
+    },
+    /// Permission bits differ.
+    ModeMismatch {
+        /// Relative path.
+        path: PathBuf,
+        /// Expected `0o7777` bits.
+        expected: u32,
+        /// Actual `0o7777` bits.
+        actual: u32,
+    },
+    /// `(uid, gid)` differ.
+    OwnerMismatch {
+        /// Relative path.
+        path: PathBuf,
+        /// Expected `(uid, gid)`.
+        expected: (u32, u32),
+        /// Actual `(uid, gid)`.
+        actual: (u32, u32),
+    },
+    /// Modification time (whole seconds) differs.
+    MtimeMismatch {
+        /// Relative path.
+        path: PathBuf,
+        /// Expected seconds since the Unix epoch.
+        expected: i64,
+        /// Actual seconds since the Unix epoch.
+        actual: i64,
+    },
+    /// Symlink target differs.
+    SymlinkMismatch {
+        /// Relative path.
+        path: PathBuf,
+        /// Expected link target.
+        expected: PathBuf,
+        /// Actual link target.
+        actual: PathBuf,
+    },
+}
+
+impl std::fmt::Display for DirDiffEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DirDiffEntry::OnlyInExpected(p) => write!(f, "only in expected: {}", p.display()),
+            DirDiffEntry::OnlyInActual(p) => write!(f, "only in actual: {}", p.display()),
+            DirDiffEntry::TypeMismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "type mismatch at {}: expected {expected}, actual {actual}",
+                path.display()
+            ),
+            DirDiffEntry::ContentMismatch {
+                path,
+                expected_len,
+                actual_len,
+            } => write!(
+                f,
+                "content mismatch at {}: expected {expected_len} bytes, actual {actual_len} bytes",
+                path.display()
+            ),
+            DirDiffEntry::ModeMismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "mode mismatch at {}: expected {expected:04o}, actual {actual:04o}",
+                path.display()
+            ),
+            DirDiffEntry::OwnerMismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "owner mismatch at {}: expected {}:{}, actual {}:{}",
+                path.display(),
+                expected.0,
+                expected.1,
+                actual.0,
+                actual.1
+            ),
+            DirDiffEntry::MtimeMismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "mtime mismatch at {}: expected {expected}, actual {actual}",
+                path.display()
+            ),
+            DirDiffEntry::SymlinkMismatch {
+                path,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "symlink target mismatch at {}: expected {}, actual {}",
+                path.display(),
+                expected.display(),
+                actual.display()
+            ),
+        }
+    }
+}
+
+fn compare_dir(
+    expected_root: &Path,
+    actual_root: &Path,
+    rel: &Path,
+    opts: DirDiffOptions,
+    out: &mut Vec<DirDiffEntry>,
+) -> Result<(), DirDiffError> {
+    let expected_names = sorted_entries(&expected_root.join(rel))?;
+    let actual_names = sorted_entries(&actual_root.join(rel))?;
+
+    let mut ei = 0;
+    let mut ai = 0;
+    while ei < expected_names.len() || ai < actual_names.len() {
+        match (expected_names.get(ei), actual_names.get(ai)) {
+            (Some(e), Some(a)) if e == a => {
+                let child = rel.join(e);
+                compare_entry(expected_root, actual_root, &child, opts, out)?;
+                ei += 1;
+                ai += 1;
+            }
+            (Some(e), Some(a)) if e < a => {
+                out.push(DirDiffEntry::OnlyInExpected(rel.join(e)));
+                ei += 1;
+            }
+            (Some(_), Some(a)) => {
+                out.push(DirDiffEntry::OnlyInActual(rel.join(a)));
+                ai += 1;
+            }
+            (Some(e), None) => {
+                out.push(DirDiffEntry::OnlyInExpected(rel.join(e)));
+                ei += 1;
+            }
+            (None, Some(a)) => {
+                out.push(DirDiffEntry::OnlyInActual(rel.join(a)));
+                ai += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    Ok(())
+}
+
+fn sorted_entries(dir: &Path) -> Result<Vec<PathBuf>, DirDiffError> {
+    let mut names = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        names.push(PathBuf::from(entry?.file_name()));
+    }
+    names.sort();
+    Ok(names)
+}
+
+fn compare_entry(
+    expected_root: &Path,
+    actual_root: &Path,
+    rel: &Path,
+    opts: DirDiffOptions,
+    out: &mut Vec<DirDiffEntry>,
+) -> Result<(), DirDiffError> {
+    let ep = expected_root.join(rel);
+    let ap = actual_root.join(rel);
+    let em = fs::symlink_metadata(&ep)?;
+    let am = fs::symlink_metadata(&ap)?;
+
+    let et = file_type_name(&em);
+    let at = file_type_name(&am);
+    if et != at {
+        out.push(DirDiffEntry::TypeMismatch {
+            path: rel.to_path_buf(),
+            expected: et,
+            actual: at,
+        });
+        return Ok(());
+    }
+
+    if em.file_type().is_symlink() {
+        let etarget = fs::read_link(&ep)?;
+        let atarget = fs::read_link(&ap)?;
+        if etarget != atarget {
+            out.push(DirDiffEntry::SymlinkMismatch {
+                path: rel.to_path_buf(),
+                expected: etarget,
+                actual: atarget,
+            });
+        }
+        // Symlink attributes (mode/owner) are not meaningfully portable to
+        // compare here; upstream checks the target string, which we did.
+        return Ok(());
+    }
+
+    if em.is_dir() {
+        compare_metadata(rel, &em, &am, opts, out);
+        return compare_dir(expected_root, actual_root, rel, opts, out);
+    }
+
+    // Regular file (or other non-dir, non-symlink node). A length mismatch
+    // short-circuits the byte compare; both cases report the same entry.
+    if opts.check_content && em.is_file() && am.is_file() {
+        let differs = em.len() != am.len() || !files_equal(&ep, &ap, em.len())?;
+        if differs {
+            out.push(DirDiffEntry::ContentMismatch {
+                path: rel.to_path_buf(),
+                expected_len: em.len(),
+                actual_len: am.len(),
+            });
+        }
+    }
+    compare_metadata(rel, &em, &am, opts, out);
+    Ok(())
+}
+
+fn compare_metadata(
+    rel: &Path,
+    em: &fs::Metadata,
+    am: &fs::Metadata,
+    opts: DirDiffOptions,
+    out: &mut Vec<DirDiffEntry>,
+) {
+    if opts.check_mode {
+        let (emode, amode) = (mode_bits(em), mode_bits(am));
+        if emode != amode {
+            out.push(DirDiffEntry::ModeMismatch {
+                path: rel.to_path_buf(),
+                expected: emode,
+                actual: amode,
+            });
+        }
+    }
+    if opts.check_owner {
+        if let (Some(eo), Some(ao)) = (owner(em), owner(am)) {
+            if eo != ao {
+                out.push(DirDiffEntry::OwnerMismatch {
+                    path: rel.to_path_buf(),
+                    expected: eo,
+                    actual: ao,
+                });
+            }
+        }
+    }
+    if opts.check_mtime {
+        if let (Some(et), Some(at)) = (mtime_secs(em), mtime_secs(am)) {
+            if et != at {
+                out.push(DirDiffEntry::MtimeMismatch {
+                    path: rel.to_path_buf(),
+                    expected: et,
+                    actual: at,
+                });
+            }
+        }
+    }
+}
+
+fn files_equal(a: &Path, b: &Path, len: u64) -> Result<bool, DirDiffError> {
+    if len <= STREAM_THRESHOLD {
+        return Ok(fs::read(a)? == fs::read(b)?);
+    }
+    let mut fa = fs::File::open(a)?;
+    let mut fb = fs::File::open(b)?;
+    let mut ba = [0u8; 64 * 1024];
+    let mut bb = [0u8; 64 * 1024];
+    loop {
+        let na = read_full(&mut fa, &mut ba)?;
+        let nb = read_full(&mut fb, &mut bb)?;
+        if na != nb || ba[..na] != bb[..nb] {
+            return Ok(false);
+        }
+        if na == 0 {
+            return Ok(true);
+        }
+    }
+}
+
+fn read_full(f: &mut fs::File, buf: &mut [u8]) -> io::Result<usize> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match f.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(filled)
+}
+
+fn file_type_name(m: &fs::Metadata) -> &'static str {
+    let t = m.file_type();
+    if t.is_dir() {
+        "dir"
+    } else if t.is_symlink() {
+        "symlink"
+    } else if t.is_file() {
+        "file"
+    } else {
+        "special"
+    }
+}
+
+#[cfg(unix)]
+fn mode_bits(m: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    m.mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn mode_bits(m: &fs::Metadata) -> u32 {
+    u32::from(m.permissions().readonly())
+}
+
+#[cfg(unix)]
+fn owner(m: &fs::Metadata) -> Option<(u32, u32)> {
+    use std::os::unix::fs::MetadataExt;
+    Some((m.uid(), m.gid()))
+}
+
+#[cfg(not(unix))]
+fn owner(_m: &fs::Metadata) -> Option<(u32, u32)> {
+    None
+}
+
+fn mtime_secs(m: &fs::Metadata) -> Option<i64> {
+    let modified = m.modified().ok()?;
+    match modified.duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => Some(d.as_secs() as i64),
+        Err(e) => Some(-(e.duration().as_secs() as i64)),
+    }
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -6,11 +6,13 @@
 //! duplicated retry logic and setup boilerplate across crates.
 
 pub mod cli;
+pub mod dir_diff;
 pub mod lsh;
 pub mod skip;
 pub mod upstream_compat;
 
 pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
+pub use dir_diff::{DirDiff, DirDiffEntry, DirDiffError, DirDiffMismatch, DirDiffOptions};
 pub use lsh::{LSH_STUB_BIN, LshError, LshRunnerStub};
 pub use skip::{
     locate_command_on_path, locate_workspace_binary, require_binary, require_command_on_path,

--- a/crates/test-support/tests/dir_diff.rs
+++ b/crates/test-support/tests/dir_diff.rs
@@ -1,0 +1,241 @@
+//! Behavioral tests for [`DirDiff`].
+//!
+//! Each test encodes *why* the primitive exists: an upstream-compat port
+//! transfers a tree and then asserts the destination matches a known-good
+//! tree. These tests prove `DirDiff` catches the exact regressions that
+//! would otherwise slip through a port silently passing - a dropped file,
+//! wrong bytes, wrong permission bits, a file/dir type flip, or a symlink
+//! whose target drifted. Equally, a clean tree must not report spurious
+//! differences, or every port would be a false positive.
+
+use std::fs;
+use std::path::Path;
+
+use test_support::{DirDiff, DirDiffEntry, DirDiffError, DirDiffOptions};
+
+fn write(root: &Path, rel: &str, bytes: &[u8]) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, bytes).unwrap();
+}
+
+fn seed(root: &Path) {
+    write(root, "top.txt", b"hello");
+    write(root, "sub/a.bin", b"\x00\x01\x02\x03");
+    write(root, "sub/deep/b.txt", b"nested");
+    fs::create_dir_all(root.join("empty_dir")).unwrap();
+}
+
+#[test]
+fn identical_trees_report_no_difference() {
+    // Why: if DirDiff flagged equal trees, every passing port would be a
+    // false positive. This is the base case every port depends on.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    seed(a.path());
+    seed(b.path());
+
+    let result = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural()).unwrap();
+    assert!(result.is_ok(), "expected no differences, got {result:?}");
+}
+
+#[test]
+fn dropped_file_is_reported_as_only_in_expected() {
+    // Why: the most common transfer regression is a file that never
+    // arrived. A port must fail loudly, not skip the missing path.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    seed(a.path());
+    seed(b.path());
+    fs::remove_file(b.path().join("sub/deep/b.txt")).unwrap();
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::OnlyInExpected(p) if p == Path::new("sub/deep/b.txt")
+    )));
+}
+
+#[test]
+fn extra_file_is_reported_as_only_in_actual() {
+    // Why: a stale file left in the destination (e.g. a --delete bug) must
+    // be caught symmetrically with a dropped file.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    seed(a.path());
+    seed(b.path());
+    write(b.path(), "sub/unexpected.txt", b"stale");
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::OnlyInActual(p) if p == Path::new("sub/unexpected.txt")
+    )));
+}
+
+#[test]
+fn content_mismatch_is_detected_when_length_matches() {
+    // Why: a same-length payload with different bytes is exactly what a
+    // broken delta or checksum bug produces. Length-only comparison would
+    // miss it, so content must be compared byte-for-byte.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    write(a.path(), "f", b"aaaaa");
+    write(b.path(), "f", b"aaaab");
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::ContentMismatch { path, .. } if path == Path::new("f")
+    )));
+}
+
+#[test]
+fn content_not_compared_when_check_content_disabled() {
+    // Why: structure-only comparison must ignore bytes, so a port that
+    // only cares about layout is not coupled to file content.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    write(a.path(), "f", b"aaaaa");
+    write(b.path(), "f", b"bbbbb");
+
+    let opts = DirDiffOptions::default();
+    let result = DirDiff::compare(a.path(), b.path(), opts).unwrap();
+    assert!(result.is_ok(), "structure-only compare must ignore bytes");
+}
+
+#[test]
+fn type_flip_file_to_dir_is_reported() {
+    // Why: a path that is a file in one tree and a directory in the other
+    // is a corruption a content-only check would mis-handle.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    write(a.path(), "x", b"file");
+    fs::create_dir_all(b.path().join("x")).unwrap();
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::TypeMismatch { path, expected: "file", actual: "dir" } if path == Path::new("x")
+    )));
+}
+
+#[test]
+fn unsupported_options_error_instead_of_passing_silently() {
+    // Why: Rule 12 - a port that asks for xattr comparison must never
+    // believe it checked xattrs when the harness silently ignored them.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+
+    let opts = DirDiffOptions {
+        check_xattr: true,
+        ..DirDiffOptions::default()
+    };
+    let err = DirDiff::compare(a.path(), b.path(), opts).unwrap_err();
+    assert!(matches!(err, DirDiffError::Unsupported("check_xattr")));
+}
+
+#[cfg(unix)]
+#[test]
+fn mode_mismatch_is_detected() {
+    // Why: rsync -p / -a must preserve permission bits; a mode regression
+    // is invisible to content comparison alone.
+    use std::os::unix::fs::PermissionsExt;
+
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    write(a.path(), "f", b"same");
+    write(b.path(), "f", b"same");
+    fs::set_permissions(a.path().join("f"), fs::Permissions::from_mode(0o644)).unwrap();
+    fs::set_permissions(b.path().join("f"), fs::Permissions::from_mode(0o600)).unwrap();
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::ModeMismatch { path, expected: 0o644, actual: 0o600 } if path == Path::new("f")
+    )));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_target_drift_is_detected_literally() {
+    // Why: rsync -l recreates the link target string; a broken symlink
+    // transfer points somewhere else. DirDiff compares the target
+    // literally rather than dereferencing, matching -a semantics.
+    use std::os::unix::fs::symlink;
+
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    symlink("target/one", a.path().join("link")).unwrap();
+    symlink("target/two", b.path().join("link")).unwrap();
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::archive())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::SymlinkMismatch { path, .. } if path == Path::new("link")
+    )));
+}
+
+#[cfg(unix)]
+#[test]
+fn matching_symlinks_are_equal_under_archive() {
+    // Why: a correctly transferred symlink must not be flagged, or every
+    // -a port with a symlink would be a false positive.
+    use std::os::unix::fs::symlink;
+
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    symlink("same/target", a.path().join("link")).unwrap();
+    symlink("same/target", b.path().join("link")).unwrap();
+
+    let result = DirDiff::compare(a.path(), b.path(), DirDiffOptions::archive()).unwrap();
+    assert!(
+        result.is_ok(),
+        "matching symlinks must compare equal: {result:?}"
+    );
+}
+
+#[test]
+fn large_file_streaming_compare_matches() {
+    // Why: the streaming path (> 1 MiB) must produce the same verdict as
+    // the small-file path, so a big basis file is not a blind spot.
+    let a = tempfile::tempdir().unwrap();
+    let b = tempfile::tempdir().unwrap();
+    let big: Vec<u8> = (0..(2 * 1024 * 1024u32)).map(|i| i as u8).collect();
+    write(a.path(), "big", &big);
+    write(b.path(), "big", &big);
+
+    assert!(
+        DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+            .unwrap()
+            .is_ok()
+    );
+
+    // Flip one byte deep in the file; the streaming compare must catch it.
+    let mut corrupted = big.clone();
+    let mid = corrupted.len() / 2;
+    corrupted[mid] ^= 0xff;
+    write(b.path(), "big", &corrupted);
+
+    let mismatch = DirDiff::compare(a.path(), b.path(), DirDiffOptions::structural())
+        .unwrap()
+        .unwrap_err();
+    assert!(mismatch.differences.iter().any(|d| matches!(
+        d,
+        DirDiffEntry::ContentMismatch { path, .. } if path == Path::new("big")
+    )));
+}

--- a/docs/design/uts-nextest-edge-b-test-harness.md
+++ b/docs/design/uts-nextest-edge-b-test-harness.md
@@ -313,6 +313,13 @@ Upstream `lsh.sh` is invoked by `oc-rsync` itself via `Command::new(env::var("RS
 
 ## 6. `DirDiff`
 
+Status: implemented in `crates/test-support/src/dir_diff.rs`. The landed
+surface uses standard-library traversal (deterministic sorted order) rather
+than `walkdir`, keeping `test-support` dependency-free. Content, mode, owner,
+mtime, and literal symlink-target comparison are wired; `check_atime`,
+`check_xattr`, and `check_acl` return `DirDiffError::Unsupported` instead of
+silently passing until a backend lands.
+
 ### 6.1 Responsibilities
 
 Recursively compare two directory trees with byte-equality + mode + owner + (optional) atime/mtime/xattr/acl. Mirrors upstream's `rsync_ls_lR` + `diff -r` pair.


### PR DESCRIPTION
## Summary

Implements the `DirDiff` primitive specified in `docs/design/uts-nextest-edge-b-test-harness.md` (section 6). It is the seam upstream-compat ports use to assert a destination tree matches a known-good tree after a transfer, mirroring upstream's `rsync_ls_lR` + `diff -r` pair.

## What it does

- Recursive, deterministic (sorted-order) comparison of two trees, standard-library only (no `walkdir` dependency, keeping `test-support` dependency-free).
- Compares presence, file type, byte content (streaming above 1 MiB), permission bits, `(uid,gid)`, mtime (whole seconds), and literal symlink targets.
- `DirDiffOptions::structural()` (content + mode, upstream `checkit()`) and `DirDiffOptions::archive()` (`-a`: content + mode + owner + mtime) presets.
- Enumerates every difference in a `DirDiffMismatch` with an upstream-`diff -r`-style panic message.
- Fails loud: `check_atime`/`check_xattr`/`check_acl` return `DirDiffError::Unsupported` rather than silently passing, and traversal I/O errors are distinct from content mismatches so infrastructure failure is never mistaken for a clean tree.

## Tests

11 behavioral tests (each encodes *why* the check matters): identical trees, dropped file, extra file, same-length content divergence, structure-only ignores bytes, file/dir type flip, unsupported-option error, mode mismatch, symlink drift, matching symlinks, and streaming large-file compare.

## Verification

- `cargo fmt -p test-support` clean
- `cargo clippy -p test-support --all-targets --all-features --no-deps --locked -D warnings` clean
- `cargo test -p test-support --all-features` -> 11 passed