### PR TITLE
feat(transfer): async twin of sender-attrs read_ndx_and_attrs

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -118,6 +118,13 @@ jobs:
             --features tokio-transfer \
             -E 'test(receive_file_list_async_matches_sync) | test(receive_extra_file_lists_async_matches_sync)'
 
+      - name: Run sync vs async sender-attrs (read_ndx_and_attrs) parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer \
+            -E 'test(sender_attrs_read_async_matches_sync)'
+
   async-equivalence:
     name: async-vs-default transfer equivalence (stable)
     runs-on: ubuntu-latest

--- a/crates/transfer/src/receiver/tests/file_list/async_parity.rs
+++ b/crates/transfer/src/receiver/tests/file_list/async_parity.rs
@@ -169,3 +169,103 @@ async fn receive_extra_file_lists_async_matches_sync() {
         );
     }
 }
+
+/// Builds a sequence of per-file sender-response frames (NDX + iflags + optional
+/// basis-type / xname / xattr-abbreviation data), then drives both the sync
+/// [`SenderAttrs::read_with_codec_xattr`] and the async
+/// [`SenderAttrs::read_with_codec_xattr_async`] over the same wire bytes and
+/// asserts every decoded `(ndx, iflags, fnamecmp_type, xname, xattr_values)`
+/// tuple matches, including when the async source dribbles bytes across
+/// `.await` points. This is the read-leaf parity proof for the receiver's
+/// `read_ndx_and_attrs` twin (upstream rsync.c:read_ndx_and_attrs).
+#[tokio::test(flavor = "current_thread")]
+async fn sender_attrs_read_async_matches_sync() {
+    use protocol::codec::{NdxCodec, create_ndx_codec};
+    use protocol::write_varint;
+
+    use super::super::super::wire::SenderAttrs;
+
+    // Encode four sequential sender-response frames for protocol 31:
+    //   0: plain transfer (iflags only)
+    //   1: basis-type follows (fnamecmp_type byte)
+    //   2: xname follows (short vstring)
+    //   3: xattr report (abbreviation data: two entries + terminator)
+    let mut sender_codec = create_ndx_codec(31);
+    let mut wire = Vec::new();
+
+    // Frame 0: ndx=0, ITEM_TRANSFER only.
+    sender_codec.write_ndx(&mut wire, 0).unwrap();
+    wire.extend_from_slice(&SenderAttrs::ITEM_TRANSFER.to_le_bytes());
+
+    // Frame 1: ndx=1, ITEM_TRANSFER | ITEM_BASIS_TYPE_FOLLOWS, basis byte = 2 (Fuzzy).
+    sender_codec.write_ndx(&mut wire, 1).unwrap();
+    wire.extend_from_slice(
+        &(SenderAttrs::ITEM_TRANSFER | SenderAttrs::ITEM_BASIS_TYPE_FOLLOWS).to_le_bytes(),
+    );
+    wire.push(2u8);
+
+    // Frame 2: ndx=2, ITEM_TRANSFER | ITEM_XNAME_FOLLOWS, vstring "alt.bin".
+    sender_codec.write_ndx(&mut wire, 2).unwrap();
+    wire.extend_from_slice(
+        &(SenderAttrs::ITEM_TRANSFER | SenderAttrs::ITEM_XNAME_FOLLOWS).to_le_bytes(),
+    );
+    let xname = b"alt.bin";
+    wire.push(xname.len() as u8); // short vstring length prefix (< 0x80)
+    wire.extend_from_slice(xname);
+
+    // Frame 3: ndx=3, ITEM_TRANSFER | ITEM_REPORT_XATTR, two abbreviation entries.
+    sender_codec.write_ndx(&mut wire, 3).unwrap();
+    wire.extend_from_slice(
+        &(SenderAttrs::ITEM_TRANSFER | SenderAttrs::ITEM_REPORT_XATTR).to_le_bytes(),
+    );
+    // Entry A: rel_pos=1 (num=1), datum_len=3, value=b"abc".
+    write_varint(&mut wire, 1).unwrap();
+    write_varint(&mut wire, 3).unwrap();
+    wire.extend_from_slice(b"abc");
+    // Entry B: rel_pos=2 (num=3), datum_len=1, value=b"z".
+    write_varint(&mut wire, 2).unwrap();
+    write_varint(&mut wire, 1).unwrap();
+    wire.extend_from_slice(b"z");
+    // Terminator.
+    write_varint(&mut wire, 0).unwrap();
+
+    // Projected comparable tuple for one decoded frame.
+    type Frame = (i32, u16, Option<u8>, Option<Vec<u8>>, Vec<(i32, Vec<u8>)>);
+    fn project_attrs(ndx: i32, a: &SenderAttrs) -> Frame {
+        (
+            ndx,
+            a.iflags,
+            a.fnamecmp_type.map(|t| t.to_wire()),
+            a.xname.clone(),
+            a.xattr_values.clone(),
+        )
+    }
+
+    // Sync baseline: read all four frames with preserve_xattrs=true.
+    let mut sync_codec = create_ndx_codec(31);
+    let mut sync_cursor = Cursor::new(&wire[..]);
+    let mut sync_frames = Vec::new();
+    for _ in 0..4 {
+        let (ndx, attrs) =
+            SenderAttrs::read_with_codec_xattr(&mut sync_cursor, &mut sync_codec, true, false)
+                .unwrap();
+        sync_frames.push(project_attrs(ndx, &attrs));
+    }
+
+    for chunk in [1usize, 2, 3, 5, 9, wire.len()] {
+        let mut async_codec = create_ndx_codec(31);
+        let mut src = ChunkedReader::new(wire.clone(), chunk);
+        let mut async_frames = Vec::new();
+        for _ in 0..4 {
+            let (ndx, attrs) =
+                SenderAttrs::read_with_codec_xattr_async(&mut src, &mut async_codec, true, false)
+                    .await
+                    .unwrap();
+            async_frames.push(project_attrs(ndx, &attrs));
+        }
+        assert_eq!(
+            async_frames, sync_frames,
+            "sender-attrs frames diverged at chunk={chunk}"
+        );
+    }
+}

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -11,6 +11,74 @@ use protocol::codec::NdxCodec;
 use protocol::read_varint;
 use protocol::xattr::{MAX_WIRE_XATTR_VALUE_LEN, XattrList};
 
+/// Upstream MAXPATHLEN ceiling for an xname vstring (io.c:1944-1960).
+const MAX_XNAME_LEN: usize = 4096;
+
+/// Validates and wraps a sender-echoed basis-type byte.
+///
+/// Shared by the sync [`SenderAttrs::read_with_codec_xattr`] and async
+/// [`SenderAttrs::read_with_codec_xattr_async`] leaves so the `fnamecmp_type`
+/// validation can never diverge between them. Upstream `rsync.c:read_ndx_and_attrs`
+/// reads a single byte and maps it through `FnameCmpType`.
+fn parse_fnamecmp_type(byte: u8) -> io::Result<protocol::FnameCmpType> {
+    protocol::FnameCmpType::from_wire(byte).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "invalid fnamecmp type: 0x{:02X} {}{}",
+                byte,
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            ),
+        )
+    })
+}
+
+/// Decodes an xname vstring length from its 1- or 2-byte prefix.
+///
+/// If the high bit of `len_byte` is set the length spans two bytes
+/// (`(len_byte & 0x7F) * 256 + second`); otherwise it is `len_byte`. Shared by
+/// the sync and async leaves so the vstring framing stays identical. Upstream
+/// `io.c:1944-1960` `read_vstring()`.
+#[inline]
+fn xname_len_from_bytes(len_byte: u8, second: Option<u8>) -> usize {
+    if len_byte & 0x80 != 0 {
+        ((len_byte & 0x7F) as usize) * 256 + second.unwrap_or(0) as usize
+    } else {
+        len_byte as usize
+    }
+}
+
+/// Rejects an oversized xname length with the same typed error on both leaves.
+#[inline]
+fn check_xname_len(xname_len: usize) -> io::Result<()> {
+    if xname_len > MAX_XNAME_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "xname length {xname_len} exceeds maximum {MAX_XNAME_LEN} {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Decides whether the sender-response frame carries xattr abbreviation data.
+///
+/// Mirrors upstream `receiver.c:609-611`: read when xattrs are preserved and
+/// `ITEM_REPORT_XATTR` is set, unless the xattr hardlink optimization elides it
+/// for a local-change rename. Shared by the sync and async leaves.
+#[inline]
+fn want_xattr_read(preserve_xattrs: bool, iflags: u16, want_xattr_optim: bool) -> bool {
+    preserve_xattrs
+        && (iflags & SenderAttrs::ITEM_REPORT_XATTR != 0)
+        && !(want_xattr_optim
+            && (iflags & SenderAttrs::ITEM_XNAME_FOLLOWS != 0)
+            && (iflags & SenderAttrs::ITEM_LOCAL_CHANGE != 0))
+}
+
 /// Signature header for delta transfer.
 ///
 /// Represents the `sum_head` structure from upstream rsync's rsync.h.
@@ -266,17 +334,7 @@ impl SenderAttrs {
         let fnamecmp_type = if iflags & Self::ITEM_BASIS_TYPE_FOLLOWS != 0 {
             let mut byte = [0u8; 1];
             reader.read_exact(&mut byte)?;
-            Some(protocol::FnameCmpType::from_wire(byte[0]).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "invalid fnamecmp type: 0x{:02X} {}{}",
-                        byte[0],
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver()
-                    ),
-                )
-            })?)
+            Some(parse_fnamecmp_type(byte[0])?)
         } else {
             None
         };
@@ -289,22 +347,11 @@ impl SenderAttrs {
             let xname_len = if len_byte[0] & 0x80 != 0 {
                 let mut second_byte = [0u8; 1];
                 reader.read_exact(&mut second_byte)?;
-                ((len_byte[0] & 0x7F) as usize) * 256 + second_byte[0] as usize
+                xname_len_from_bytes(len_byte[0], Some(second_byte[0]))
             } else {
-                len_byte[0] as usize
+                xname_len_from_bytes(len_byte[0], None)
             };
-            // Upstream MAXPATHLEN is typically 4096; reject excessively long names
-            const MAX_XNAME_LEN: usize = 4096;
-            if xname_len > MAX_XNAME_LEN {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "xname length {xname_len} exceeds maximum {MAX_XNAME_LEN} {}{}",
-                        crate::role_trailer::error_location!(),
-                        crate::role_trailer::receiver()
-                    ),
-                ));
-            }
+            check_xname_len(xname_len)?;
             if xname_len > 0 {
                 let mut xname_buf = vec![0u8; xname_len];
                 reader.read_exact(&mut xname_buf)?;
@@ -319,13 +366,99 @@ impl SenderAttrs {
         // upstream: receiver.c:609-611 - read xattr data when ITEM_REPORT_XATTR is set
         // Condition mirrors upstream: preserve_xattrs && iflags & ITEM_REPORT_XATTR && do_xfers
         // && !(want_xattr_optim && BITS_SET(iflags, ITEM_XNAME_FOLLOWS|ITEM_LOCAL_CHANGE))
-        let xattr_values = if preserve_xattrs
-            && (iflags & Self::ITEM_REPORT_XATTR != 0)
-            && !(want_xattr_optim
-                && (iflags & Self::ITEM_XNAME_FOLLOWS != 0)
-                && (iflags & Self::ITEM_LOCAL_CHANGE != 0))
-        {
+        let xattr_values = if want_xattr_read(preserve_xattrs, iflags, want_xattr_optim) {
             read_xattr_abbreviation_data(reader)?
+        } else {
+            Vec::new()
+        };
+
+        Ok((
+            ndx,
+            Self {
+                iflags,
+                fnamecmp_type,
+                xname,
+                xattr_values,
+            },
+        ))
+    }
+
+    /// Async twin of [`read_with_codec_xattr`](Self::read_with_codec_xattr).
+    ///
+    /// Reads the receiver's per-file sender-response header
+    /// (NDX + iflags + optional basis-type / xname / xattr-abbreviation data)
+    /// off an [`AsyncRead`](tokio::io::AsyncRead), driving the same
+    /// [`NdxCodecEnum::read_ndx_async`] and [`read_varint_async`] leaves plus
+    /// the shared sans-io decode helpers ([`parse_fnamecmp_type`],
+    /// [`xname_len_from_bytes`], [`check_xname_len`], [`want_xattr_read`]) as
+    /// the sync leaf. For the same wire bytes it yields the same
+    /// `(ndx, SenderAttrs)` and consumes the same bytes as the sync path,
+    /// including when the source delivers bytes one at a time across `.await`
+    /// points. Gated on `tokio-transfer`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:383` - `read_ndx_and_attrs()` (the sync twin mirrors this)
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn read_with_codec_xattr_async<R>(
+        reader: &mut R,
+        ndx_codec: &mut protocol::codec::NdxCodecEnum,
+        preserve_xattrs: bool,
+        want_xattr_optim: bool,
+    ) -> io::Result<(i32, Self)>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use tokio::io::AsyncReadExt;
+
+        // Read NDX using protocol-aware codec (handles delta encoding for protocol 30+)
+        let ndx = ndx_codec.read_ndx_async(reader).await?;
+
+        let protocol_version = ndx_codec.protocol_version();
+
+        // For protocol >= 29, read iflags (shortint = 2 bytes LE)
+        let iflags = if protocol_version >= 29 {
+            let mut iflags_buf = [0u8; 2];
+            reader.read_exact(&mut iflags_buf).await?;
+            u16::from_le_bytes(iflags_buf)
+        } else {
+            Self::ITEM_TRANSFER // Default for older protocols
+        };
+
+        // Read optional fields based on iflags
+        let fnamecmp_type = if iflags & Self::ITEM_BASIS_TYPE_FOLLOWS != 0 {
+            let mut byte = [0u8; 1];
+            reader.read_exact(&mut byte).await?;
+            Some(parse_fnamecmp_type(byte[0])?)
+        } else {
+            None
+        };
+
+        let xname = if iflags & Self::ITEM_XNAME_FOLLOWS != 0 {
+            // upstream io.c:1944-1960 read_vstring()
+            let mut len_byte = [0u8; 1];
+            reader.read_exact(&mut len_byte).await?;
+            let xname_len = if len_byte[0] & 0x80 != 0 {
+                let mut second_byte = [0u8; 1];
+                reader.read_exact(&mut second_byte).await?;
+                xname_len_from_bytes(len_byte[0], Some(second_byte[0]))
+            } else {
+                xname_len_from_bytes(len_byte[0], None)
+            };
+            check_xname_len(xname_len)?;
+            if xname_len > 0 {
+                let mut xname_buf = vec![0u8; xname_len];
+                reader.read_exact(&mut xname_buf).await?;
+                Some(xname_buf)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let xattr_values = if want_xattr_read(preserve_xattrs, iflags, want_xattr_optim) {
+            read_xattr_abbreviation_data_async(reader).await?
         } else {
             Vec::new()
         };
@@ -481,41 +614,91 @@ fn read_xattr_abbreviation_data<R: Read>(reader: &mut R) -> io::Result<Vec<(i32,
         if rel_pos == 0 {
             break;
         }
-        // upstream: xattrs.c:700-705 - reject signed overflow before
-        // num += rel_pos to stop a hostile peer wrapping num to an arbitrary
-        // value.
-        let num = prior_req.checked_add(rel_pos).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "xattr rel_pos accumulation overflow {}{}",
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver()
-                ),
-            )
-        })?;
+        let num = accumulate_xattr_num(prior_req, rel_pos)?;
         prior_req = num;
 
-        // upstream: xattrs.c:752 -
-        //   rxa->datum_len = read_varint_size(f_in, MAX_WIRE_XATTR_DATALEN, ...)
-        // We use the stricter oc-rsync ceiling (`MAX_WIRE_XATTR_VALUE_LEN`,
-        // 64 MiB) so a corrupt or hostile frame at this offset surfaces as a
-        // typed error instead of an unbounded allocation or a varint overflow
-        // panic.
         let raw_len = read_varint(reader)?;
-        if raw_len < 0 || raw_len as usize > MAX_WIRE_XATTR_VALUE_LEN {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "xattr datum_len {raw_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN} {}{}",
-                    crate::role_trailer::error_location!(),
-                    crate::role_trailer::receiver()
-                ),
-            ));
-        }
-        let datum_len = raw_len as usize;
+        let datum_len = check_xattr_datum_len(raw_len)?;
         let mut value = vec![0u8; datum_len];
         reader.read_exact(&mut value)?;
+
+        values.push((num, value));
+    }
+
+    Ok(values)
+}
+
+/// Accumulates the 1-based xattr entry number, rejecting signed overflow.
+///
+/// Shared by the sync and async xattr readers. Upstream `xattrs.c:700-705`
+/// rejects overflow before `num += rel_pos` to stop a hostile peer wrapping
+/// `num` to an arbitrary value.
+#[inline]
+fn accumulate_xattr_num(prior_req: i32, rel_pos: i32) -> io::Result<i32> {
+    prior_req.checked_add(rel_pos).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "xattr rel_pos accumulation overflow {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            ),
+        )
+    })
+}
+
+/// Validates a raw xattr datum length against the receiver-side ceiling.
+///
+/// Shared by the sync and async xattr readers. Upstream `xattrs.c:752` reads
+/// `datum_len` via `read_varint_size(..., MAX_WIRE_XATTR_DATALEN, ...)`; we use
+/// the stricter oc-rsync ceiling (`MAX_WIRE_XATTR_VALUE_LEN`, 64 MiB) so a
+/// corrupt or hostile frame surfaces as a typed error instead of an unbounded
+/// allocation or a varint overflow panic.
+#[inline]
+fn check_xattr_datum_len(raw_len: i32) -> io::Result<usize> {
+    if raw_len < 0 || raw_len as usize > MAX_WIRE_XATTR_VALUE_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "xattr datum_len {raw_len} exceeds maximum {MAX_WIRE_XATTR_VALUE_LEN} {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            ),
+        ));
+    }
+    Ok(raw_len as usize)
+}
+
+/// Async twin of [`read_xattr_abbreviation_data`].
+///
+/// Reads the identical `(rel_pos, datum_len, value)` sequence (`.await`-driven)
+/// through the same shared bounds helpers ([`accumulate_xattr_num`],
+/// [`check_xattr_datum_len`]) and [`read_varint_async`], so it returns the same
+/// `(num, value)` pairs and consumes the same bytes as the sync leaf. Gated on
+/// `tokio-transfer`.
+#[cfg(feature = "tokio-transfer")]
+async fn read_xattr_abbreviation_data_async<R>(reader: &mut R) -> io::Result<Vec<(i32, Vec<u8>)>>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    use protocol::read_varint_async;
+    use tokio::io::AsyncReadExt;
+
+    let mut values = Vec::new();
+    let mut prior_req = 0i32;
+
+    loop {
+        let rel_pos = read_varint_async(reader).await?;
+        if rel_pos == 0 {
+            break;
+        }
+        let num = accumulate_xattr_num(prior_req, rel_pos)?;
+        prior_req = num;
+
+        let raw_len = read_varint_async(reader).await?;
+        let datum_len = check_xattr_datum_len(raw_len)?;
+        let mut value = vec![0u8; datum_len];
+        reader.read_exact(&mut value).await?;
 
         values.push((num, value));
     }


### PR DESCRIPTION
## Summary

Advances the async migration (`tokio-transfer`, default-off) by one landable rung: an async twin of the receiver's per-file sender-response header read (`read_ndx_and_attrs`).

Before this change the async receiver foundation had feature-gated `.await`-driven leaves for the NDX codec (`read_ndx_async`), sum-head (`SumHead::read_async`), varints (`read_varint_async`), and file-list reception, but the per-file **NDX + iflags + optional basis-type / xname / xattr-abbreviation** frame the delta-transfer loop reads after each file request (`SenderAttrs::read_with_codec_xattr`) had no async equivalent. That frame was the remaining sync-only boundary in the async per-file path.

## What changed

- Added `SenderAttrs::read_with_codec_xattr_async` (feature-gated on `tokio-transfer`), the `.await`-driven twin of `read_with_codec_xattr`. It drives the existing `NdxCodecEnum::read_ndx_async` and `read_varint_async` leaves.
- Extracted the sans-io decode logic into shared helpers used by **both** the sync and async leaves, so field decode can never diverge:
  - `parse_fnamecmp_type` (basis-type byte validation)
  - `xname_len_from_bytes` / `check_xname_len` (vstring framing + MAXPATHLEN bound)
  - `want_xattr_read` (the `receiver.c:609-611` xattr-read predicate)
  - `accumulate_xattr_num` / `check_xattr_datum_len` (the `xattrs.c:700-705` overflow + `xattrs.c:752` datum-length bound), plus `read_xattr_abbreviation_data_async`.
- The default (feature-off) build is untouched: the sync path now calls the same shared helpers and is byte-for-byte identical in behaviour.

## Parity test

`sender_attrs_read_async_matches_sync` (in the receiver async-parity set) builds four sequential sender-response frames exercising the plain, basis-type-follows, xname-follows, and xattr-report branches, then decodes them with both the sync and async readers and asserts every `(ndx, iflags, fnamecmp_type, xname, xattr_values)` tuple matches - including when the async source dribbles bytes one at a time across `.await` points (chunk sizes 1,2,3,5,9,full). Wired into `.github/workflows/async-wire-parity.yml`.

## Verification

```
cargo fmt --all                                   # clean
cargo clippy -p transfer --features tokio-transfer --all-targets --no-deps --locked -- -D warnings   # clean
cargo clippy -p transfer --all-targets --no-deps --locked -- -D warnings                             # default build clean
cargo nextest run -p transfer --features tokio-transfer \
  -E 'test(sender_attrs_read_async_matches_sync) | test(receive_file_list_async_matches_sync) | test(receive_extra_file_lists_async_matches_sync)'
  => 3 tests run: 3 passed
```

Wire output is byte-identical; the threaded production path is unchanged.