### PR TITLE
fix(fast_io): drain in-flight IOCP writes before returning a mid-batch submit error

### DIFF
--- a/crates/fast_io/src/iocp/disk_batch/completion.rs
+++ b/crates/fast_io/src/iocp/disk_batch/completion.rs
@@ -161,6 +161,81 @@ pub(super) fn drain_completions(
     }
 }
 
+/// Reaps exactly `outstanding` completion packets from the port, tolerating
+/// faulted completions, and returns the total bytes transferred across every
+/// reaped op.
+///
+/// Used only on the submission-error cleanup path: once one submission has
+/// failed synchronously the batch is doomed, but every op still in flight has
+/// already been accepted by the kernel and will post exactly one completion
+/// packet. Those packets must be reaped before the pinned `OverlappedOp`
+/// boxes are dropped, otherwise the kernel may still be writing into a freed
+/// buffer (use-after-free). Unlike [`drain_completions`], a faulted NTSTATUS
+/// on a completion is not propagated - it merely marks that op as done so the
+/// loop keeps waiting for the remaining outstanding ops. The caller returns
+/// the original submission error, so swallowing per-completion faults here
+/// does not hide the failure; it only guarantees the buffers outlive the
+/// kernel's writes. The returned byte count preserves partial progress the
+/// same way the success path does.
+pub(super) fn drain_all_ignoring_completion_errors(
+    port: &CompletionPort,
+    mut outstanding: usize,
+) -> usize {
+    let mut bytes = 0usize;
+    while outstanding > 0 {
+        let batch = outstanding.min(COMPLETION_DRAIN_BATCH);
+        let mut entries: Vec<OVERLAPPED_ENTRY> = vec![zeroed_entry(); batch];
+        let mut removed: u32 = 0;
+        // SAFETY: `port.handle()` is owned by `port` and lives for the
+        // duration of the call; `entries` backs `batch` slots.
+        #[allow(unsafe_code)]
+        let ok = unsafe {
+            GetQueuedCompletionStatusEx(
+                port.handle(),
+                entries.as_mut_ptr(),
+                batch as u32,
+                &mut removed,
+                DRAIN_TIMEOUT_MS,
+                FALSE,
+            )
+        };
+
+        if ok == FALSE {
+            let err = io::Error::last_os_error();
+            // Spurious wake without entries: retry until the outstanding ops
+            // report. Any other failure means the port itself is unusable, so
+            // there is no way left to observe the remaining completions; stop
+            // to avoid spinning forever. This matches the pre-existing posture
+            // of the success path, where `drain_completions` also returns on
+            // such an error and the caller drops the in-flight queue.
+            if matches!(err.raw_os_error(), Some(c) if c as u32 == WAIT_TIMEOUT) {
+                continue;
+            }
+            break;
+        }
+
+        let reaped = removed as usize;
+        if reaped == 0 {
+            continue;
+        }
+        for entry in entries.iter().take(reaped) {
+            if entry.lpOverlapped.is_null() {
+                continue;
+            }
+            // SAFETY: entry.lpOverlapped points at an OVERLAPPED we submitted;
+            // its pinned op is still alive in the caller's in-flight queue.
+            #[allow(unsafe_code)]
+            let internal = unsafe { (*entry.lpOverlapped).Internal };
+            // Only credit bytes for completions that landed without a fault.
+            if internal == 0 {
+                bytes += entry.dwNumberOfBytesTransferred as usize;
+            }
+        }
+        outstanding = outstanding.saturating_sub(reaped);
+    }
+    bytes
+}
+
 /// Translates the small set of NTSTATUS codes that overlapped file I/O can
 /// produce into Win32 DOS error codes.
 fn ntstatus_to_dos_error(status: u32) -> u32 {

--- a/crates/fast_io/src/iocp/disk_batch/writer.rs
+++ b/crates/fast_io/src/iocp/disk_batch/writer.rs
@@ -22,7 +22,9 @@ use crate::iocp::config::IocpConfig;
 use crate::iocp::overlapped::OverlappedOp;
 
 use super::buffer::BOUNCE_COPIES_AVOIDED;
-use super::completion::{drain_completions, take_injected_write_error};
+use super::completion::{
+    drain_all_ignoring_completion_errors, drain_completions, take_injected_write_error,
+};
 
 /// Reopens an existing file handle with `FILE_FLAG_OVERLAPPED` so it can be
 /// associated with a completion port.
@@ -113,18 +115,27 @@ pub(super) fn submit_write_batch(
     let mut in_flight: Vec<Pin<Box<OverlappedOp>>> = Vec::with_capacity(max_in_flight);
 
     while next_chunk_start < total || !in_flight.is_empty() {
-        // Fill the in-flight queue up to the configured limit. A submission
-        // failure here (synchronous `WriteFile` error or fault-injected
-        // ERROR_DISK_FULL) must not discard already-drained progress, so we
-        // bail out via the explicit Err path that leaves the caller's
-        // running counter intact.
+        // Fill the in-flight queue up to the configured limit.
         while in_flight.len() < max_in_flight && next_chunk_start < total {
             let len = chunk_size.min(total - next_chunk_start);
             let chunk = &data[next_chunk_start..next_chunk_start + len];
             let offset = base_offset + next_chunk_start as u64;
             let op = match submit_one_write(handle, offset, chunk, use_aligned) {
                 Ok(op) => op,
-                Err(e) => return Err(e),
+                Err(e) => {
+                    // This submission failed synchronously and never queued,
+                    // but earlier iterations pushed ops the kernel has already
+                    // accepted (ERROR_IO_PENDING). Those ops own pinned
+                    // buffers the kernel may still be writing into. Dropping
+                    // `in_flight` now would free them under the kernel - a
+                    // use-after-free with late completions dereferencing freed
+                    // OVERLAPPED structs. Reap every outstanding completion
+                    // first (crediting the durable prefix), then surface the
+                    // original submission error.
+                    *bytes_written_out +=
+                        drain_all_ignoring_completion_errors(port, in_flight.len());
+                    return Err(e);
+                }
             };
             in_flight.push(op);
             next_chunk_start += len;
@@ -170,6 +181,9 @@ pub(super) fn submit_write_batch(
         });
 
         if zero_byte_completion {
+            // Reap the ops still outstanding after this partial drain before
+            // dropping their pinned buffers under the kernel.
+            *bytes_written_out += drain_all_ignoring_completion_errors(port, in_flight.len());
             return Err(io::Error::new(
                 io::ErrorKind::WriteZero,
                 "overlapped write returned zero bytes",
@@ -177,7 +191,16 @@ pub(super) fn submit_write_batch(
         }
 
         for (offset, remaining) in resubmissions {
-            let op = submit_one_write(handle, offset, &remaining, use_aligned)?;
+            let op = match submit_one_write(handle, offset, &remaining, use_aligned) {
+                Ok(op) => op,
+                Err(e) => {
+                    // A resubmission failed synchronously while earlier ops
+                    // remain in flight; drain them before dropping the boxes.
+                    *bytes_written_out +=
+                        drain_all_ignoring_completion_errors(port, in_flight.len());
+                    return Err(e);
+                }
+            };
             in_flight.push(op);
         }
     }

--- a/crates/fast_io/tests/iocp_disk_full_simulation.rs
+++ b/crates/fast_io/tests/iocp_disk_full_simulation.rs
@@ -307,3 +307,77 @@ fn nth_submission_disk_full_skips_earlier_writes() {
         "pre-fault chunk content must match the source bytes"
     );
 }
+
+/// Regression for the mid-batch submission-error use-after-free (#488): with
+/// more than one op allowed in flight, a synchronous submit fault must drain
+/// the in-flight ops the kernel already accepted before their pinned
+/// OVERLAPPED buffers are dropped. Dropping them under an outstanding
+/// `WriteFile` would let the kernel write into freed memory and post late
+/// completions against freed OVERLAPPED structs.
+///
+/// The invariant this test encodes: the doomed batch must (a) surface the
+/// injected disk-full error, (b) not hang waiting on completions it dropped,
+/// (c) drop cleanly, and (d) leave only whole, source-matching chunks on
+/// disk. It intentionally uses `concurrent_ops = 2` so `in_flight` holds an
+/// outstanding op at the moment the fault fires - the single-op tests above
+/// never populate the drain-on-error path because at most one op is ever in
+/// flight.
+#[test]
+fn multi_in_flight_disk_full_drains_before_drop() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable on this host");
+        return;
+    }
+    let _guard = InjectionGuard;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("multi_in_flight.bin");
+    let file = open_writable(&path);
+
+    // 4 KB chunks, up to two in flight, 16 KB payload => four submissions.
+    // Faulting the third leaves at least one earlier op outstanding when the
+    // error path drains.
+    let config = IocpConfig {
+        buffer_size: 4096,
+        concurrent_ops: 2,
+        ..IocpConfig::default()
+    };
+    let mut batch = IocpDiskBatch::new(&config).unwrap();
+    batch.begin_file(file).unwrap();
+
+    let chunk = 4096usize;
+    let payload: Vec<u8> = (0..4 * chunk).map(|i| (i & 0xFF) as u8).collect();
+    batch.write_data(&payload).unwrap();
+
+    inject_next_write_error_for_test(3, ERROR_DISK_FULL as i32);
+    let err = batch
+        .flush()
+        .expect_err("mid-batch submission fault must surface ERROR_DISK_FULL");
+    assert_eq!(err.kind(), io::ErrorKind::StorageFull);
+    assert_eq!(err.raw_os_error(), Some(ERROR_DISK_FULL as i32));
+
+    // Clean drop: a UAF or an un-drained op would surface as a hang, a panic
+    // in Drop, or heap corruption here.
+    drop(batch);
+
+    // Only whole, durable chunks may remain, and their bytes must match the
+    // source prefix. The exact count is not asserted because completion
+    // ordering with two ops in flight is not deterministic; the durable
+    // prefix is always a whole number of chunks of the original data.
+    let on_disk = std::fs::read(&path).unwrap();
+    assert_eq!(
+        on_disk.len() % chunk,
+        0,
+        "only whole chunks may reach disk before the fault, got {} bytes",
+        on_disk.len()
+    );
+    assert!(
+        on_disk.len() <= payload.len(),
+        "on-disk size must not exceed the payload"
+    );
+    assert_eq!(
+        on_disk.as_slice(),
+        &payload[..on_disk.len()],
+        "durable prefix must match the source bytes exactly"
+    );
+}


### PR DESCRIPTION
## Root cause (use-after-free / data-loss)

The batched IOCP disk writer `submit_write_batch` (`crates/fast_io/src/iocp/disk_batch/writer.rs`) keeps up to `max_in_flight` overlapped `WriteFile` operations outstanding at once. Each op is a `Pin<Box<OverlappedOp>>` that owns the buffer the kernel writes into asynchronously; the box must stay alive until the kernel posts that op's completion packet.

On a synchronous submission failure - e.g. `ERROR_DISK_FULL` at what was `writer.rs:127` - the loop did:

```rust
let op = match submit_one_write(handle, offset, chunk, use_aligned) {
    Ok(op) => op,
    Err(e) => return Err(e),   // <-- drops `in_flight` under the kernel
};
```

Returning here drops the `in_flight` vector while earlier ops (accepted with `ERROR_IO_PENDING`) may still be in flight. The kernel then writes into freed buffers and posts late completions that dereference freed `OVERLAPPED` structs - a use-after-free with data-corruption potential under disk-full / permission-error conditions mid-batch.

Two sibling early-return paths in the same function had the identical defect: the `zero_byte_completion` return and the resubmission-loop `?`, both of which can drop a non-empty `in_flight` while the kernel still owns buffers.

## Fix

On each early-error path, reap every outstanding completion before returning, using a new `drain_all_ignoring_completion_errors` helper (`crates/fast_io/src/iocp/disk_batch/completion.rs`). It:

- waits for exactly `in_flight.len()` completion packets (each accepted op posts exactly one), so the buffers outlive the kernel's writes;
- tolerates faulted NTSTATUS completions instead of propagating them - the batch is already doomed, and the goal is only to let the kernel finish so the boxes can be freed safely;
- credits the durable byte prefix into `bytes_written_out`, preserving the existing partial-progress accounting the success path uses (`active.bytes_written += written` in `flush_current`).

The original submission error is still returned unchanged; the drain is cleanup only. Style, ownership (`Pin`/`Box`), and the `OverlappedOp` lifecycle mirror the existing success-path drain.

## Test

Extends `crates/fast_io/tests/iocp_disk_full_simulation.rs` with `multi_in_flight_disk_full_drains_before_drop`, using `concurrent_ops = 2` so an op is actually outstanding when the injected fault fires. The existing single-op tests use `concurrent_ops = 1` and never populate the drain-on-error path. The new test asserts the doomed batch surfaces `StorageFull`, does not hang, drops cleanly (a UAF or un-drained op would manifest as a hang/panic/corruption), and leaves only whole, source-matching chunks on disk.

## Verification

This is Windows-only code (`#[cfg(all(target_os = "windows", feature = "iocp"))]`) and cannot be built or run on the aarch64 macOS dev host or the Linux CI host. Local `cargo fmt --all` passes. Correctness is validated by:

- the **Windows (stable)** CI cell (compiles the `#[cfg(windows)]` path), and
- the **`iocp_disk_full_simulation`** integration test (runs in the Windows cell), including the new multi-in-flight drain-on-error case.