### PR TITLE
test(test-support): add OcRsyncCliRunner + LshRunnerStub harnesses

### DIFF
--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -11,3 +11,10 @@ description = "Shared test utilities for the oc-rsync workspace"
 
 [dependencies]
 tempfile = { workspace = true }
+
+# Rust port of upstream `support/lsh.sh`. Built as a workspace binary so tests
+# can resolve its path via `CARGO_BIN_EXE_lsh-stub` and drive oc-rsync's
+# remote-shell code paths locally (design section 5).
+[[bin]]
+name = "lsh-stub"
+path = "src/bin/lsh-stub.rs"

--- a/crates/test-support/src/bin/lsh-stub.rs
+++ b/crates/test-support/src/bin/lsh-stub.rs
@@ -1,0 +1,115 @@
+//! Local-shell stub: a std-only Rust port of upstream `support/lsh.sh`.
+//!
+//! Upstream's `lsh.sh` is a "remote shell" that only pretends to connect to
+//! `localhost` (or `lh`), running the remote command locally. oc-rsync test
+//! legs point `--rsh` / `RSYNC_RSH` at this binary to drive remote-shell code
+//! paths without a real SSH server.
+//!
+//! Argv handling mirrors `lsh.sh` exactly:
+//!
+//! - `-l USER` / `-lUSER`: run the command via `sudo -H -u USER sh -c ...`.
+//! - `--no-cd`: do not change directory before running.
+//! - any other `-*`: silently dropped (ssh-style flags oc-rsync may pass).
+//! - `localhost`: connect, default cd to `$HOME` (like ssh).
+//! - `lh`: connect, imply `--no-cd`.
+//! - anything else: print an error to stderr and exit 1.
+//!
+//! Everything after the accepted host token is the remote argv, run in-process
+//! as a child with stdio inherited so oc-rsync's protocol streams pass through
+//! transparently.
+//!
+//! Unix-only: it depends on `sh -c` and POSIX process semantics. The build is
+//! gated so Windows does not attempt to compile it.
+
+#[cfg(unix)]
+fn main() {
+    std::process::exit(run());
+}
+
+#[cfg(unix)]
+fn run() -> i32 {
+    use std::process::Command;
+
+    let mut args = std::env::args().skip(1).peekable();
+
+    let mut user: Option<String> = None;
+    // Default matches upstream: cd to the user's home unless the host is "lh"
+    // or an explicit --no-cd was passed.
+    let mut do_cd = true;
+    let mut connected = false;
+
+    while let Some(arg) = args.next() {
+        if arg == "-l" {
+            user = args.next();
+        } else if let Some(u) = arg.strip_prefix("-l") {
+            user = Some(u.to_string());
+        } else if arg == "--no-cd" {
+            do_cd = false;
+        } else if arg.starts_with('-') {
+            // ssh-style flag oc-rsync may emit; upstream drops it.
+        } else if arg == "localhost" {
+            connected = true;
+            break;
+        } else if arg == "lh" {
+            do_cd = false;
+            connected = true;
+            break;
+        } else {
+            eprintln!("lsh-stub: unable to connect to host {arg}");
+            return 1;
+        }
+    }
+
+    if !connected {
+        eprintln!("lsh-stub: no host specified");
+        return 1;
+    }
+
+    // The remainder is the remote command. Upstream joins it with spaces and
+    // hands it to `sh -c` / `eval`, so a single joined string reproduces the
+    // same word-splitting behaviour oc-rsync's callers expect.
+    let remote: Vec<String> = args.collect();
+    if remote.is_empty() {
+        eprintln!("lsh-stub: empty remote command");
+        return 1;
+    }
+    let joined = remote.join(" ");
+
+    let mut cmd = if let Some(user) = user {
+        // Mirror `sudo -H -u USER sh -c "cd '$HOME' && CMD"`.
+        let script = if do_cd {
+            match std::env::var("HOME") {
+                Ok(home) => format!("cd '{home}' && {joined}"),
+                Err(_) => joined.clone(),
+            }
+        } else {
+            joined.clone()
+        };
+        let mut c = Command::new("sudo");
+        c.args(["-H", "-u", &user, "sh", "-c", &script]);
+        c
+    } else {
+        let mut c = Command::new("sh");
+        c.arg("-c").arg(&joined);
+        if do_cd {
+            if let Ok(home) = std::env::var("HOME") {
+                c.current_dir(home);
+            }
+        }
+        c
+    };
+
+    match cmd.status() {
+        Ok(status) => status.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("lsh-stub: failed to exec remote command: {e}");
+            1
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn main() {
+    eprintln!("lsh-stub is Unix-only");
+    std::process::exit(1);
+}

--- a/crates/test-support/src/cli.rs
+++ b/crates/test-support/src/cli.rs
@@ -1,0 +1,544 @@
+//! Process runner for the built `oc-rsync` binary.
+//!
+//! [`OcRsyncCliRunner`] locates the workspace `oc-rsync` executable, spawns it
+//! with a caller-supplied argv / env / cwd / stdin, enforces a wall-time
+//! timeout, and returns a structured [`CliOutput`]. It backs the operational
+//! ports described in `docs/design/uts-nextest-edge-b-test-harness.md`
+//! section 4.
+//!
+//! Failure is loud, not silent: a missing binary or a spawn error surfaces as a
+//! typed [`RunnerError`] rather than a skipped assertion. Tests that want to
+//! self-skip when the binary is absent should gate on
+//! [`crate::require_binary`] first.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::skip::locate_workspace_binary;
+
+/// Default wall-time cap for a single invocation.
+///
+/// Section 4.4 of the harness design: 30 s is the hard kill-switch so a
+/// regression that would otherwise hang (e.g. a goodbye-flush stall) fails
+/// loud inside nextest's per-test budget instead of stalling the cell.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Poll interval used while waiting for the child to exit.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Error raised when a runner cannot locate, spawn, or drive the binary.
+///
+/// Distinct from the child's own non-zero exit: a non-zero exit is a
+/// successful *run* that produced a [`CliOutput`], whereas these variants mean
+/// the run never completed cleanly.
+#[derive(Debug)]
+pub enum RunnerError {
+    /// The `oc-rsync` binary could not be found in `target/{debug,release}/`
+    /// and `CARGO_BIN_EXE_oc-rsync` was unset or pointed at a missing file.
+    BinaryNotFound,
+    /// The OS failed to spawn the child process.
+    Spawn(std::io::Error),
+    /// Collecting the child's output failed.
+    Wait(std::io::Error),
+    /// The child exceeded the configured wall-time timeout and was killed.
+    Timeout {
+        /// The timeout that was exceeded.
+        after: Duration,
+        /// stderr captured up to the kill point, lossily decoded.
+        stderr: String,
+    },
+}
+
+impl std::fmt::Display for RunnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RunnerError::BinaryNotFound => write!(
+                f,
+                "oc-rsync binary not found (set CARGO_BIN_EXE_oc-rsync or build the workspace)"
+            ),
+            RunnerError::Spawn(e) => write!(f, "failed to spawn oc-rsync: {e}"),
+            RunnerError::Wait(e) => write!(f, "failed to collect child output: {e}"),
+            RunnerError::Timeout { after, stderr } => write!(
+                f,
+                "oc-rsync exceeded {after:?} timeout and was killed; stderr so far:\n{stderr}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RunnerError {}
+
+/// Locate the `oc-rsync` binary.
+///
+/// Prefers Cargo's `CARGO_BIN_EXE_oc-rsync` (set for integration tests of a
+/// crate that depends on the `oc-rsync` bin target) and falls back to
+/// [`locate_workspace_binary`] which walks the enclosing profile directory.
+#[must_use]
+fn locate_oc_rsync() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_oc-rsync") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    locate_workspace_binary("oc-rsync")
+}
+
+/// Builder + executor for a single `oc-rsync` invocation.
+///
+/// Construct with [`OcRsyncCliRunner::new`] (auto-locates the binary), chain
+/// the builder setters, then call [`run`](OcRsyncCliRunner::run). Every setter
+/// takes `self` by value and returns it, matching the repo's builder
+/// convention.
+pub struct OcRsyncCliRunner {
+    binary: Option<PathBuf>,
+    args: Vec<OsString>,
+    env: BTreeMap<OsString, OsString>,
+    env_clear: bool,
+    stdin: Option<Vec<u8>>,
+    timeout: Duration,
+    cwd: Option<PathBuf>,
+}
+
+impl Default for OcRsyncCliRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OcRsyncCliRunner {
+    /// Create a runner, auto-locating the `oc-rsync` binary.
+    ///
+    /// Binary resolution is deferred to [`run`](OcRsyncCliRunner::run): if the
+    /// binary is missing, `run` returns [`RunnerError::BinaryNotFound`] rather
+    /// than panicking in the constructor. This lets a test build the runner and
+    /// still choose to self-skip.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            binary: locate_oc_rsync(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            env_clear: false,
+            stdin: None,
+            timeout: DEFAULT_TIMEOUT,
+            cwd: None,
+        }
+    }
+
+    /// Override the binary path (e.g. to test a specific build profile).
+    #[must_use]
+    pub fn binary(mut self, path: impl Into<PathBuf>) -> Self {
+        self.binary = Some(path.into());
+        self
+    }
+
+    /// Append a single argument.
+    #[must_use]
+    pub fn arg(mut self, a: impl AsRef<OsStr>) -> Self {
+        self.args.push(a.as_ref().to_os_string());
+        self
+    }
+
+    /// Append several arguments.
+    #[must_use]
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        for a in args {
+            self.args.push(a.as_ref().to_os_string());
+        }
+        self
+    }
+
+    /// Set an environment variable for the child.
+    #[must_use]
+    pub fn env(mut self, key: impl AsRef<OsStr>, val: impl AsRef<OsStr>) -> Self {
+        self.env
+            .insert(key.as_ref().to_os_string(), val.as_ref().to_os_string());
+        self
+    }
+
+    /// Clear the inherited environment before applying [`env`](Self::env)
+    /// overrides. Useful for tests that must not leak `RSYNC_*` from the host.
+    #[must_use]
+    pub fn env_clear(mut self) -> Self {
+        self.env_clear = true;
+        self
+    }
+
+    /// Provide bytes to feed on the child's stdin.
+    #[must_use]
+    pub fn stdin(mut self, data: impl Into<Vec<u8>>) -> Self {
+        self.stdin = Some(data.into());
+        self
+    }
+
+    /// Override the wall-time timeout (default 30 s).
+    #[must_use]
+    pub fn timeout(mut self, t: Duration) -> Self {
+        self.timeout = t;
+        self
+    }
+
+    /// Set the working directory for the child.
+    #[must_use]
+    pub fn cwd(mut self, p: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(p.into());
+        self
+    }
+
+    /// Run synchronously, enforcing the timeout.
+    ///
+    /// Returns a [`CliOutput`] on any completed run (including non-zero exit).
+    /// Returns a [`RunnerError`] if the binary is missing, the spawn fails, or
+    /// the child overruns the timeout (in which case it is killed and reaped).
+    pub fn run(self) -> Result<CliOutput, RunnerError> {
+        let binary = self.binary.ok_or(RunnerError::BinaryNotFound)?;
+
+        let mut cmd = Command::new(&binary);
+        cmd.args(&self.args);
+        if self.env_clear {
+            cmd.env_clear();
+        }
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+        if let Some(dir) = &self.cwd {
+            cmd.current_dir(dir);
+        }
+        cmd.stdin(if self.stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let start = Instant::now();
+        let mut child = cmd.spawn().map_err(RunnerError::Spawn)?;
+
+        if let Some(data) = &self.stdin {
+            // Write on a scratch thread so a child that never drains stdin
+            // cannot deadlock us; the timeout below still reaps such a child.
+            let mut sink = child.stdin.take().expect("stdin was piped");
+            let data = data.clone();
+            // Detached: the thread finishes when the child consumes the input
+            // or when the pipe closes on child exit. Dropping the JoinHandle
+            // does not detach the OS thread, which is intended here.
+            let _ = thread::spawn(move || {
+                let _ = sink.write_all(&data);
+                // Dropping `sink` closes the pipe, signalling EOF.
+            });
+        }
+
+        // Poll for completion under the timeout. Draining the pipes happens
+        // after exit via `wait_with_output`; the payloads in operational tests
+        // are small (design section 8), so pipe buffers do not fill before the
+        // child exits.
+        loop {
+            match child.try_wait().map_err(RunnerError::Wait)? {
+                Some(_) => break,
+                None => {
+                    if start.elapsed() >= self.timeout {
+                        let _ = child.kill();
+                        let output = child.wait_with_output().map_err(RunnerError::Wait)?;
+                        return Err(RunnerError::Timeout {
+                            after: self.timeout,
+                            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                        });
+                    }
+                    thread::sleep(POLL_INTERVAL);
+                }
+            }
+        }
+
+        let output = child.wait_with_output().map_err(RunnerError::Wait)?;
+        let duration = start.elapsed();
+
+        #[cfg(unix)]
+        let signal = {
+            use std::os::unix::process::ExitStatusExt;
+            output.status.signal()
+        };
+        #[cfg(not(unix))]
+        let signal = None;
+
+        Ok(CliOutput {
+            status: output.status.code(),
+            signal,
+            stdout: output.stdout,
+            stderr: output.stderr,
+            duration,
+        })
+    }
+}
+
+/// Captured result of a completed `oc-rsync` run.
+pub struct CliOutput {
+    /// The process exit code, or `None` when the child died from a signal.
+    pub status: Option<i32>,
+    /// The terminating signal number on Unix, or `None` for a normal exit.
+    pub signal: Option<i32>,
+    /// Raw stdout bytes.
+    pub stdout: Vec<u8>,
+    /// Raw stderr bytes.
+    pub stderr: Vec<u8>,
+    /// Wall-clock duration of the run.
+    pub duration: Duration,
+}
+
+impl CliOutput {
+    /// Assert the run exited 0. Panics with captured stderr on mismatch.
+    pub fn assert_success(&self) -> &Self {
+        assert_eq!(
+            self.status,
+            Some(0),
+            "expected exit 0, got status={:?} signal={:?}\nstderr:\n{}",
+            self.status,
+            self.signal,
+            self.stderr_str()
+        );
+        self
+    }
+
+    /// Assert the run exited with exactly `code`.
+    pub fn assert_exit(&self, code: i32) -> &Self {
+        assert_eq!(
+            self.status,
+            Some(code),
+            "expected exit {code}, got status={:?} signal={:?}\nstderr:\n{}",
+            self.status,
+            self.signal,
+            self.stderr_str()
+        );
+        self
+    }
+
+    /// Assert the exit code is one of `codes`.
+    ///
+    /// Used by tests that accept a partial-transfer code (23) alongside 0.
+    pub fn assert_exit_in(&self, codes: &[i32]) -> &Self {
+        assert!(
+            self.status.is_some_and(|c| codes.contains(&c)),
+            "expected exit in {codes:?}, got status={:?} signal={:?}\nstderr:\n{}",
+            self.status,
+            self.signal,
+            self.stderr_str()
+        );
+        self
+    }
+
+    /// Assert the child was not killed by a signal.
+    ///
+    /// Backs the crafted-input ports (design section 4.3) that must reject
+    /// malformed input cleanly, never crash with SIGSEGV/SIGABRT.
+    pub fn assert_no_signal_death(&self) -> &Self {
+        assert!(
+            self.signal.is_none(),
+            "child died from signal {:?}\nstderr:\n{}",
+            self.signal,
+            self.stderr_str()
+        );
+        self
+    }
+
+    /// stdout as a lossily-decoded UTF-8 string.
+    #[must_use]
+    pub fn stdout_str(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.stdout)
+    }
+
+    /// stderr as a lossily-decoded UTF-8 string.
+    #[must_use]
+    pub fn stderr_str(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.stderr)
+    }
+
+    /// Whether stderr contains `needle` (lossy match).
+    #[must_use]
+    pub fn stderr_contains(&self, needle: &str) -> bool {
+        self.stderr_str().contains(needle)
+    }
+
+    /// Whether stdout contains `needle` (lossy match).
+    #[must_use]
+    pub fn stdout_contains(&self, needle: &str) -> bool {
+        self.stdout_str().contains(needle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_not_found_variant_when_unlocatable() {
+        // Why: Rule 12 - when no binary can be located at all, run must yield
+        // the dedicated BinaryNotFound variant so callers can distinguish
+        // "not built" from "spawn failed", never a silent success.
+        let mut runner = OcRsyncCliRunner::new();
+        runner.binary = None;
+        assert!(matches!(runner.run(), Err(RunnerError::BinaryNotFound)));
+    }
+
+    #[test]
+    fn bad_binary_path_is_a_loud_spawn_error() {
+        // Why: an override pointing at a real-but-absent path must fail loudly
+        // as a Spawn error, never spawn garbage or return Ok.
+        let err = OcRsyncCliRunner::new()
+            .binary("/nonexistent/oc-rsync-xyzzy")
+            .arg("--version")
+            .run();
+        assert!(matches!(err, Err(RunnerError::Spawn(_))));
+    }
+
+    #[test]
+    fn runs_a_real_command_and_captures_output() {
+        // Why: proves the spawn/capture path end-to-end against a binary that
+        // is guaranteed present on every host. Uses the `binary` override so
+        // the test does not depend on oc-rsync being built. Asserts exit 0 and
+        // no signal death.
+        let (prog, args): (&str, &[&str]) = if cfg!(windows) {
+            ("cmd", &["/C", "exit", "0"])
+        } else {
+            ("true", &[])
+        };
+        let Some(path) = crate::skip::locate_command_on_path(prog) else {
+            eprintln!("skipping: {prog} not on PATH");
+            return;
+        };
+        let out = OcRsyncCliRunner::new()
+            .binary(path)
+            .args(args)
+            .run()
+            .expect("run should succeed");
+        out.assert_success().assert_no_signal_death();
+        assert_eq!(out.status, Some(0));
+    }
+
+    #[test]
+    fn nonzero_exit_is_ok_not_error() {
+        // Why: a non-zero exit is a completed run, not a RunnerError. Tests
+        // assert on exit codes, so run must return Ok(CliOutput) carrying the
+        // code, reserving Err for spawn/timeout faults.
+        let (prog, args): (&str, &[&str]) = if cfg!(windows) {
+            ("cmd", &["/C", "exit", "3"])
+        } else {
+            ("sh", &["-c", "exit 3"])
+        };
+        let Some(path) = crate::skip::locate_command_on_path(prog) else {
+            eprintln!("skipping: {prog} not on PATH");
+            return;
+        };
+        let out = OcRsyncCliRunner::new()
+            .binary(path)
+            .args(args)
+            .run()
+            .expect("run itself should succeed");
+        out.assert_exit(3);
+        out.assert_exit_in(&[0, 3]);
+    }
+
+    #[test]
+    fn timeout_kills_a_hanging_child() {
+        // Why: the timeout is the only hang kill-switch (design 4.4). A child
+        // that sleeps longer than the timeout must be killed and reported as
+        // RunnerError::Timeout, never allowed to stall the test.
+        if cfg!(windows) {
+            // `sleep` semantics differ; the Unix path proves the mechanism.
+            return;
+        }
+        let Some(path) = crate::skip::locate_command_on_path("sleep") else {
+            eprintln!("skipping: sleep not on PATH");
+            return;
+        };
+        let start = Instant::now();
+        let err = OcRsyncCliRunner::new()
+            .binary(path)
+            .arg("30")
+            .timeout(Duration::from_millis(200))
+            .run();
+        assert!(matches!(err, Err(RunnerError::Timeout { .. })));
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "timeout must fire promptly, not wait for the child"
+        );
+    }
+
+    #[test]
+    fn stdin_is_delivered_to_the_child() {
+        // Why: the stdin plumbing must actually reach the child; a broken pipe
+        // path would silently drop input and mask protocol-input regressions.
+        // `cat` echoes stdin to stdout, so we round-trip a payload.
+        if cfg!(windows) {
+            return;
+        }
+        let Some(path) = crate::skip::locate_command_on_path("cat") else {
+            eprintln!("skipping: cat not on PATH");
+            return;
+        };
+        let out = OcRsyncCliRunner::new()
+            .binary(path)
+            .stdin(b"hello harness\n".to_vec())
+            .run()
+            .expect("run should succeed");
+        out.assert_success();
+        assert_eq!(out.stdout, b"hello harness\n");
+    }
+
+    #[test]
+    fn env_clear_then_set_isolates_the_child() {
+        // Why: env_clear must genuinely wipe the inherited environment so a
+        // test isolating RSYNC_* behaviour is not polluted by the host, while
+        // an explicit env() set after clearing still reaches the child.
+        if cfg!(windows) {
+            return;
+        }
+        let Some(path) = crate::skip::locate_command_on_path("sh") else {
+            eprintln!("skipping: sh not on PATH");
+            return;
+        };
+        let out = OcRsyncCliRunner::new()
+            .binary(path)
+            .env_clear()
+            .env("HARNESS_MARKER", "present")
+            .args(["-c", "printf '%s' \"$HARNESS_MARKER\""])
+            .run()
+            .expect("run should succeed");
+        out.assert_success();
+        assert_eq!(out.stdout, b"present");
+    }
+
+    #[test]
+    fn cwd_sets_the_child_working_directory() {
+        // Why: cwd must actually change the child's directory; ports that pass
+        // relative source/dest paths rely on it. `pwd` reports the effective
+        // directory, which must match the temp dir we set.
+        if cfg!(windows) {
+            return;
+        }
+        let Some(path) = crate::skip::locate_command_on_path("pwd") else {
+            eprintln!("skipping: pwd not on PATH");
+            return;
+        };
+        let dir = crate::create_tempdir();
+        // Canonicalize to absorb symlinked temp roots (e.g. /var -> /private
+        // on macOS) so the comparison is against the real path pwd prints.
+        let canon = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+        let out = OcRsyncCliRunner::new()
+            .binary(path)
+            .cwd(&canon)
+            .run()
+            .expect("run should succeed");
+        out.assert_success();
+        assert_eq!(out.stdout_str().trim_end(), canon.to_string_lossy());
+    }
+}

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -5,9 +5,13 @@
 //! This crate provides helpers that multiple test suites need, avoiding
 //! duplicated retry logic and setup boilerplate across crates.
 
+pub mod cli;
+pub mod lsh;
 pub mod skip;
 pub mod upstream_compat;
 
+pub use cli::{CliOutput, OcRsyncCliRunner, RunnerError};
+pub use lsh::{LSH_STUB_BIN, LshError, LshRunnerStub};
 pub use skip::{
     locate_command_on_path, locate_workspace_binary, require_binary, require_command_on_path,
     require_unix,

--- a/crates/test-support/src/lsh.rs
+++ b/crates/test-support/src/lsh.rs
@@ -1,0 +1,113 @@
+//! Locator for the `lsh-stub` local-shell helper binary.
+//!
+//! [`LshRunnerStub`] resolves the path to the compiled `lsh-stub` executable
+//! (the Rust port of upstream `support/lsh.sh`, see `src/bin/lsh-stub.rs`) so a
+//! test can drive oc-rsync's remote-shell code paths locally. The path feeds
+//! either `--rsh <path>` on the argv or `RSYNC_RSH=<path>` in the environment.
+//!
+//! Resolution prefers Cargo's `CARGO_BIN_EXE_lsh-stub` (set when a crate's
+//! integration tests depend on `test-support`'s bin target) and falls back to
+//! [`crate::locate_workspace_binary`]. Missing binary is a loud typed error,
+//! not a silent skip; gate on [`crate::require_binary`] to self-skip.
+//!
+//! Unix-only: the stub itself depends on `sh`/`sudo`, and the remote-shell
+//! ports that consume it are `#[cfg(unix)]` (design section 5.4).
+
+use std::path::PathBuf;
+
+use crate::skip::locate_workspace_binary;
+
+/// The bin-target name of the compiled stub.
+pub const LSH_STUB_BIN: &str = "lsh-stub";
+
+/// Error raised when the `lsh-stub` helper cannot be located.
+#[derive(Debug)]
+pub enum LshError {
+    /// The `lsh-stub` binary was not found via `CARGO_BIN_EXE_lsh-stub` nor in
+    /// `target/{debug,release}/`. Build the workspace (or the `test-support`
+    /// bin target) before running remote-shell ports.
+    StubNotFound,
+}
+
+impl std::fmt::Display for LshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LshError::StubNotFound => write!(
+                f,
+                "lsh-stub binary not found (set CARGO_BIN_EXE_lsh-stub or build test-support)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LshError {}
+
+/// Resolved handle to the `lsh-stub` remote-shell helper.
+///
+/// Construct with [`locate`](LshRunnerStub::locate); pass its
+/// [`path`](LshRunnerStub::path) to `--rsh`, or apply it to a
+/// [`crate::OcRsyncCliRunner`] via the `RSYNC_RSH` env var.
+pub struct LshRunnerStub {
+    path: PathBuf,
+}
+
+impl LshRunnerStub {
+    /// Locate the compiled `lsh-stub` binary.
+    ///
+    /// Returns [`LshError::StubNotFound`] if the helper is not built, so the
+    /// failure is loud rather than a silently-skipped remote-shell leg.
+    pub fn locate() -> Result<Self, LshError> {
+        let path = std::env::var_os("CARGO_BIN_EXE_lsh-stub")
+            .map(PathBuf::from)
+            .filter(|p| p.is_file())
+            .or_else(|| locate_workspace_binary(LSH_STUB_BIN))
+            .ok_or(LshError::StubNotFound)?;
+        Ok(Self { path })
+    }
+
+    /// The absolute path to the stub, for use as an `--rsh` argument.
+    #[must_use]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// The value to assign to `RSYNC_RSH` when driving oc-rsync via env rather
+    /// than an explicit `--rsh` flag.
+    #[must_use]
+    pub fn rsh_env_value(&self) -> std::ffi::OsString {
+        self.path.clone().into_os_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locate_finds_the_built_stub_or_reports_loudly() {
+        // Why: the stub is a workspace [[bin]], so under `cargo test`
+        // CARGO_BIN_EXE_lsh-stub is set and locate() must succeed and return a
+        // real file. If it is somehow unbuilt the error must be the dedicated
+        // StubNotFound variant, never a silent None - Rule 12.
+        match LshRunnerStub::locate() {
+            Ok(stub) => {
+                assert!(
+                    stub.path().is_file(),
+                    "located stub path must be a real file: {}",
+                    stub.path().display()
+                );
+                // The RSYNC_RSH value must equal the resolved path so the two
+                // invocation styles (--rsh vs env) stay consistent.
+                assert_eq!(stub.rsh_env_value(), stub.path().as_os_str());
+            }
+            Err(LshError::StubNotFound) => {
+                // Acceptable only when the bin genuinely is not built; the
+                // env var proves whether cargo wired it.
+                assert!(
+                    std::env::var_os("CARGO_BIN_EXE_lsh-stub").is_none(),
+                    "CARGO_BIN_EXE_lsh-stub was set yet locate() failed"
+                );
+            }
+        }
+    }
+}

--- a/crates/test-support/tests/lsh_stub.rs
+++ b/crates/test-support/tests/lsh_stub.rs
@@ -1,0 +1,76 @@
+//! Integration test for the `lsh-stub` remote-shell helper.
+//!
+//! Unit tests in `src/lsh.rs` cannot exercise the compiled stub because
+//! `CARGO_BIN_EXE_lsh-stub` is only injected for integration-test targets.
+//! This test resolves the built binary through [`LshRunnerStub`] and drives it
+//! exactly as oc-rsync would use `--rsh`: spawn it with a `localhost` host and
+//! a remote command, and confirm the command ran locally.
+
+#![cfg(unix)]
+
+use std::process::Command;
+
+use test_support::LshRunnerStub;
+
+#[test]
+fn stub_runs_remote_command_locally_via_localhost() {
+    // Why: the whole point of the stub is to make oc-rsync's remote-shell path
+    // execute the "remote" argv on the local host. If the host token were
+    // mishandled or the argv dropped, no output would appear - so a matching
+    // stdout is proof the remote-shell seam works.
+    let stub = LshRunnerStub::locate().expect("lsh-stub must be built for integration tests");
+
+    let out = Command::new(stub.path())
+        .args(["localhost", "printf", "%s", "remote-ran"])
+        .output()
+        .expect("spawn lsh-stub");
+
+    assert!(
+        out.status.success(),
+        "stub exited non-zero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "remote-ran");
+}
+
+#[test]
+fn stub_rejects_unknown_host_loudly() {
+    // Why: upstream lsh.sh refuses any host other than localhost/lh with a
+    // non-zero exit. Mirroring that keeps a misconfigured test from silently
+    // "succeeding" against a host the stub cannot honour.
+    let stub = LshRunnerStub::locate().expect("lsh-stub must be built for integration tests");
+
+    let out = Command::new(stub.path())
+        .args(["some-remote-host", "echo", "x"])
+        .output()
+        .expect("spawn lsh-stub");
+
+    assert!(!out.status.success(), "unknown host must fail");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("unable to connect"),
+        "expected a connect-refusal message on stderr"
+    );
+}
+
+#[test]
+fn stub_strips_bare_ssh_style_flags_before_the_host() {
+    // Why: oc-rsync may pass bundled ssh-style flags (e.g. -oBatchMode=yes)
+    // ahead of the host. The stub must drop such bare `-*` tokens the way
+    // upstream lsh.sh does and still reach the host token. (Flags that take a
+    // separate value are not honoured by lsh.sh either: its `-*) shift` drops
+    // only the flag, so a lone value would be misread as the host - we mirror
+    // that exactly rather than diverge.)
+    let stub = LshRunnerStub::locate().expect("lsh-stub must be built for integration tests");
+
+    let out = Command::new(stub.path())
+        .args(["-oBatchMode=yes", "-q", "localhost", "printf", "ok"])
+        .output()
+        .expect("spawn lsh-stub");
+
+    assert!(
+        out.status.success(),
+        "stub exited non-zero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "ok");
+}


### PR DESCRIPTION
## Summary

Adds the next two process-runner harness primitives from the UTS-NEXTEST-EDGE.b design (`docs/design/uts-nextest-edge-b-test-harness.md` sections 4 and 5), building on the self-skip helpers.

**STACKED on #6282** (`test/self-skip-helpers`, baking). This branch inherits `skip.rs` (`locate_workspace_binary`/`require_binary`) and its `lib.rs` module additions to avoid a conflict on `crates/test-support/src/lib.rs`. Rebase onto `master` once #6282 merges. Does not duplicate #6282's or #6279's (DirDiff) changes.

## What landed

- **`OcRsyncCliRunner`** (`src/cli.rs`): builder that locates the workspace `oc-rsync` binary (`CARGO_BIN_EXE_oc-rsync`, else the enclosing profile dir via the inherited `locate_workspace_binary`), spawns it with argv / env / `env_clear` / cwd / stdin, and enforces a wall-time timeout via a `try_wait` poll loop (no new dep). Returns a structured `CliOutput` with `assert_success` / `assert_exit` / `assert_exit_in` / `assert_no_signal_death` and stdout/stderr accessors. Missing binary, spawn failure, and timeout surface as loud typed `RunnerError` variants (Rule 12) rather than silent skips.

- **`LshRunnerStub`** (`src/lsh.rs`) + **`lsh-stub`** bin (`src/bin/lsh-stub.rs`): a std-only Rust port of upstream `support/lsh.sh` for driving `--rsh` / `RSYNC_RSH` remote-shell test legs locally. The stub strips ssh-style flags, honours `localhost` / `lh` (with `--no-cd`), `sudo`s `-l USER`, and execs the remote argv via `sh -c` with stdio inherited. Unix-gated (design section 5.4); the Windows `main` exits non-zero. `LshRunnerStub` resolves the built binary path for use as `--rsh` / `RSYNC_RSH`.

All std-only, **no new dependencies, no `unsafe`** (test-support is on the unsafe-DENY list). `Cargo.lock` unchanged.

## Deferred (follow-ups, per the task scope)

- **`OcRsyncDaemonHarness`** (design section 3): heavier daemon lifecycle (spawn, TCP-readiness poll, secrets/munge, RAII reap). Deferred to keep this PR to the cleanly-landable process-runner subset.
- **`WireCapture`** (design section 7): the design itself defers it behind a pcap/root gate; tracked as UTS-NEXTEST-EDGE.c.

## Tests

Behavioural unit + integration tests, each encoding *why* the behaviour matters:
- typed `BinaryNotFound` / `Spawn` errors over silent success;
- non-zero exit is `Ok(CliOutput)`, not an error;
- the timeout kill-switch fires promptly on a hanging child;
- stdin / `env_clear`+`env` / cwd plumbing actually reach the child;
- `lsh-stub` runs the remote argv locally via `localhost`, rejects unknown hosts loudly, and strips bare ssh-style flags (upstream-faithful parsing).

## Verification (macOS, single-crate)

- `cargo fmt --all -- --check` clean
- `cargo clippy -p test-support --all-targets --all-features --no-deps --locked -- -D warnings` — no issues
- `cargo test -p test-support --locked` — 18 passed