### PR TITLE
fix(compress): use upstream DEFAULT_DONT_COMPRESS skip-compress suffix list

### DIFF
--- a/crates/compress/src/skip_compress/decider.rs
+++ b/crates/compress/src/skip_compress/decider.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 use crate::zlib::{CompressionLevel, CountingZlibEncoder};
 
-use super::defaults::{self, COMPOUND_EXTENSIONS};
+use super::defaults;
 use super::magic::KNOWN_SIGNATURES;
 use super::types::{CompressionDecision, FileCategory, Suffix};
 use super::{DEFAULT_COMPRESSION_THRESHOLD, DEFAULT_SAMPLE_SIZE};
@@ -228,19 +228,14 @@ impl CompressionDecider {
         Ok(ratio < self.compression_threshold)
     }
 
-    /// Extracts and normalizes the file extension from a path.
+    /// Extracts and normalizes the file's final suffix.
+    ///
+    /// Mirrors upstream `token.c:set_compression()`, which matches only the
+    /// substring after the last `.` in the basename (`strrchr(fname, '.')`) and
+    /// treats a leading-dot dotfile (`.bashrc`) as having no suffix. Rust's
+    /// `Path::extension()` follows the same rules: `foo.tar.gz` yields `gz`, and
+    /// `.hidden` yields `None`.
     pub(crate) fn extract_extension(path: &Path) -> Option<Suffix> {
-        let file_name = path.file_name()?.to_str()?;
-        let lower = file_name.to_ascii_lowercase();
-
-        // Compound suffixes (`.tar.gz`) must match the full filename to win
-        // over the trailing simple extension (`gz`).
-        for compound in COMPOUND_EXTENSIONS {
-            if lower.ends_with(compound) {
-                return Some(Suffix::new(compound.trim_start_matches('.')));
-            }
-        }
-
         path.extension()
             .and_then(|ext| ext.to_str())
             .map(Suffix::new)

--- a/crates/compress/src/skip_compress/defaults.rs
+++ b/crates/compress/src/skip_compress/defaults.rs
@@ -1,83 +1,44 @@
-//! Default skip-compress extension lists.
+//! Default skip-compress suffix list.
 //!
-//! These lists mirror upstream rsync's built-in set of file extensions that
-//! typically don't benefit from compression during transfer.
+//! This list mirrors upstream rsync's built-in `DEFAULT_DONT_COMPRESS` set of
+//! file suffixes that typically don't benefit from compression during transfer.
 //!
-//! upstream: `loadparm.c:lp_dont_compress()` provides the default suffix list
-//! that `token.c:init_set_compression()` loads into the suffix tree.
+//! upstream: `default-dont-compress.h` defines `DEFAULT_DONT_COMPRESS`, which
+//! `token.c:init_set_compression()` loads into the suffix tree via
+//! `loadparm.c:lp_dont_compress()`. Each upstream entry is a `*.suffix` glob
+//! whose match key is the substring after the final `.` (upstream matches with
+//! `strrchr(fname, '.')`, i.e. the last suffix only - there is no compound
+//! `.tar.gz` handling).
 
 use std::collections::HashSet;
 
 use super::Suffix;
 
-/// Known compound extensions checked before simple extension lookup.
+/// Upstream default suffixes that skip compression.
 ///
-/// These multi-part suffixes (e.g., `tar.gz`) must be matched against the full
-/// filename to avoid false positives from the final extension alone.
-pub const COMPOUND_EXTENSIONS: &[&str] = &[".tar.gz", ".tar.bz2", ".tar.xz", ".tar.zst"];
-
-/// Image file extensions that are already compressed.
-const IMAGE_EXTENSIONS: &[&str] = &[
-    "jpg", "jpeg", "jpe", "png", "gif", "webp", "heic", "heif", "avif", "tif", "tiff", "bmp",
-    "ico", "svg", "svgz", "psd", "raw", "arw", "cr2", "nef", "orf", "sr2",
+/// This is the exact set from upstream `default-dont-compress.h`
+/// (`DEFAULT_DONT_COMPRESS`), stored without the leading `*.` and lowercased to
+/// match upstream's case-insensitive suffix comparison.
+const DEFAULT_DONT_COMPRESS: &[&str] = &[
+    "3g2", "3gp", "7z", "aac", "ace", "apk", "avi", "bz2", "deb", "dmg", "ear", "f4v", "flac",
+    "flv", "gpg", "gz", "iso", "jar", "jpeg", "jpg", "lrz", "lz", "lz4", "lzma", "lzo", "m1a",
+    "m1v", "m2a", "m2ts", "m2v", "m4a", "m4b", "m4p", "m4r", "m4v", "mka", "mkv", "mov", "mp1",
+    "mp2", "mp3", "mp4", "mpa", "mpeg", "mpg", "mpv", "mts", "odb", "odf", "odg", "odi", "odm",
+    "odp", "ods", "odt", "oga", "ogg", "ogm", "ogv", "ogx", "opus", "otg", "oth", "otp", "ots",
+    "ott", "oxt", "png", "qt", "rar", "rpm", "rz", "rzip", "spx", "squashfs", "sxc", "sxd", "sxg",
+    "sxm", "sxw", "sz", "tbz", "tbz2", "tgz", "tlz", "ts", "txz", "tzo", "vob", "war", "webm",
+    "webp", "xz", "z", "zip", "zst",
 ];
 
-/// Video file extensions that are already compressed.
-const VIDEO_EXTENSIONS: &[&str] = &[
-    "mp4", "m4v", "mkv", "avi", "mov", "wmv", "flv", "webm", "mpeg", "mpg", "vob", "ogv", "3gp",
-    "3g2", "ts", "mts", "m2ts",
-];
-
-/// Audio file extensions that are already compressed.
-const AUDIO_EXTENSIONS: &[&str] = &[
-    "mp3", "m4a", "aac", "ogg", "oga", "opus", "flac", "wma", "wav", "aiff", "ape", "mka", "ac3",
-    "dts",
-];
-
-/// Archive and compressed file extensions.
-const ARCHIVE_EXTENSIONS: &[&str] = &[
-    "zip", "gz", "gzip", "bz2", "bzip2", "xz", "lzma", "7z", "rar", "zst", "zstd", "lz4", "lzo",
-    "z", "cab", "arj", "lzh", "tar.gz", "tar.bz2", "tar.xz", "tar.zst", "tgz", "tbz", "tbz2",
-    "txz",
-];
-
-/// Package format extensions (pre-compressed).
-const PACKAGE_EXTENSIONS: &[&str] = &[
-    "deb", "rpm", "apk", "jar", "war", "ear", "egg", "whl", "gem", "nupkg", "snap", "appx", "msix",
-];
-
-/// Document format extensions (often pre-compressed internally).
-const DOCUMENT_EXTENSIONS: &[&str] = &[
-    "pdf", "epub", "mobi", "azw", "azw3", "docx", "xlsx", "pptx", "odt", "ods", "odp",
-];
-
-/// Disk image extensions (often compressed or encrypted).
-const DISK_IMAGE_EXTENSIONS: &[&str] =
-    &["iso", "img", "dmg", "vhd", "vhdx", "vmdk", "qcow", "qcow2"];
-
-/// All default extension groups in declaration order.
-const ALL_GROUPS: &[&[&str]] = &[
-    IMAGE_EXTENSIONS,
-    VIDEO_EXTENSIONS,
-    AUDIO_EXTENSIONS,
-    ARCHIVE_EXTENSIONS,
-    PACKAGE_EXTENSIONS,
-    DOCUMENT_EXTENSIONS,
-    DISK_IMAGE_EXTENSIONS,
-];
-
-/// Returns the complete default set of skip-compress extensions.
+/// Returns the complete default set of skip-compress suffixes.
 ///
-/// Each entry is a `Suffix` in canonical lowercase form. The list mirrors
-/// upstream rsync's built-in skip-compress defaults.
+/// Each entry is a `Suffix` in canonical lowercase form. The list is the exact
+/// upstream `DEFAULT_DONT_COMPRESS` set.
 #[must_use]
 pub fn default_skip_extensions() -> HashSet<Suffix> {
-    let total: usize = ALL_GROUPS.iter().map(|g| g.len()).sum();
-    let mut set = HashSet::with_capacity(total);
-    for group in ALL_GROUPS {
-        for ext in *group {
-            set.insert(Suffix::new(ext));
-        }
+    let mut set = HashSet::with_capacity(DEFAULT_DONT_COMPRESS.len());
+    for ext in DEFAULT_DONT_COMPRESS {
+        set.insert(Suffix::new(ext));
     }
     set
 }
@@ -86,24 +47,47 @@ pub fn default_skip_extensions() -> HashSet<Suffix> {
 mod tests {
     use super::*;
 
+    /// The default set must contain exactly the upstream `DEFAULT_DONT_COMPRESS`
+    /// suffixes. A count drift here means the list diverged from upstream, which
+    /// changes which files get compressed on the wire vs upstream rsync.
     #[test]
-    fn default_set_is_non_empty() {
+    fn default_set_matches_upstream_count() {
         let exts = default_skip_extensions();
-        assert!(exts.len() > 80, "expected at least 80 default extensions");
+        assert_eq!(
+            exts.len(),
+            DEFAULT_DONT_COMPRESS.len(),
+            "default skip set must equal upstream DEFAULT_DONT_COMPRESS ({} suffixes)",
+            DEFAULT_DONT_COMPRESS.len(),
+        );
     }
 
+    /// Every upstream suffix must be present. Guards against silently dropping a
+    /// suffix upstream skips (which would compress an already-compressed file).
     #[test]
-    fn default_set_contains_common_formats() {
+    fn default_set_contains_every_upstream_suffix() {
         let exts = default_skip_extensions();
-        for expected in &["jpg", "mp4", "mp3", "zip", "pdf", "iso"] {
-            assert!(exts.contains(*expected), "missing extension: {expected}");
+        for expected in DEFAULT_DONT_COMPRESS {
+            assert!(
+                exts.contains(*expected),
+                "missing upstream suffix: {expected}"
+            );
         }
     }
 
+    /// Suffixes that upstream does NOT list must not be skipped. oc-rsync
+    /// previously invented entries (e.g. `pdf`, `docx`, `heic`, `wav`) that
+    /// upstream compresses; skipping them diverges from upstream on the wire.
     #[test]
-    fn compound_extensions_included() {
+    fn default_set_excludes_non_upstream_suffixes() {
         let exts = default_skip_extensions();
-        assert!(exts.contains("tar.gz"));
-        assert!(exts.contains("tar.bz2"));
+        for unexpected in &[
+            "pdf", "docx", "xlsx", "pptx", "epub", "heic", "heif", "avif", "tiff", "bmp", "wav",
+            "wma", "aiff", "gzip", "bzip2", "img", "vhd", "vmdk", "qcow2", "cab", "whl", "gem",
+        ] {
+            assert!(
+                !exts.contains(*unexpected),
+                "suffix {unexpected} is not in upstream DEFAULT_DONT_COMPRESS and must not be skipped",
+            );
+        }
     }
 }

--- a/crates/compress/src/skip_compress/tests.rs
+++ b/crates/compress/src/skip_compress/tests.rs
@@ -9,12 +9,11 @@ use super::*;
 fn default_skip_list_includes_common_formats() {
     let decider = CompressionDecider::with_default_skip_list();
 
+    // Only suffixes present in upstream DEFAULT_DONT_COMPRESS may appear here.
     assert!(decider.skip_extensions().contains("jpg"));
     assert!(decider.skip_extensions().contains("jpeg"));
     assert!(decider.skip_extensions().contains("png"));
-    assert!(decider.skip_extensions().contains("gif"));
     assert!(decider.skip_extensions().contains("webp"));
-    assert!(decider.skip_extensions().contains("heic"));
 
     assert!(decider.skip_extensions().contains("mp4"));
     assert!(decider.skip_extensions().contains("mkv"));
@@ -36,7 +35,10 @@ fn default_skip_list_includes_common_formats() {
     assert!(decider.skip_extensions().contains("rar"));
     assert!(decider.skip_extensions().contains("zst"));
 
-    assert!(decider.skip_extensions().contains("pdf"));
+    // Suffixes upstream compresses must NOT be in the default skip set.
+    assert!(!decider.skip_extensions().contains("gif"));
+    assert!(!decider.skip_extensions().contains("heic"));
+    assert!(!decider.skip_extensions().contains("pdf"));
 }
 
 #[test]
@@ -219,18 +221,29 @@ fn extract_extension_simple() {
 }
 
 #[test]
-fn extract_extension_compound() {
+fn extract_extension_uses_last_suffix_only() {
+    // upstream token.c matches strrchr(fname, '.'): the last suffix wins, so
+    // `archive.tar.gz` matches via `gz`, not a compound `tar.gz`.
     assert_eq!(
         CompressionDecider::extract_extension(Path::new("archive.tar.gz"))
             .unwrap()
             .as_str(),
-        "tar.gz"
+        "gz"
     );
     assert_eq!(
         CompressionDecider::extract_extension(Path::new("backup.tar.bz2"))
             .unwrap()
             .as_str(),
-        "tar.bz2"
+        "bz2"
+    );
+}
+
+#[test]
+fn extract_extension_dotfile_has_no_suffix() {
+    // upstream guards `s == fname`: a leading-dot dotfile has no suffix.
+    assert_eq!(
+        CompressionDecider::extract_extension(Path::new(".bashrc")),
+        None
     );
 }
 

--- a/crates/compress/tests/comprehensive_coverage.rs
+++ b/crates/compress/tests/comprehensive_coverage.rs
@@ -364,7 +364,8 @@ mod skip_compress {
         let decider = CompressionDecider::with_default_skip_list();
         let extensions = decider.skip_extensions();
 
-        let image_exts = ["jpg", "jpeg", "png", "gif", "webp", "heic"];
+        // Only upstream DEFAULT_DONT_COMPRESS suffixes (no gif/heic/pdf).
+        let image_exts = ["jpg", "jpeg", "png", "webp"];
         for ext in image_exts {
             assert!(extensions.contains(ext), "Missing image extension: {ext}");
         }
@@ -384,7 +385,9 @@ mod skip_compress {
             assert!(extensions.contains(ext), "Missing archive extension: {ext}");
         }
 
-        assert!(extensions.contains("pdf"));
+        assert!(!extensions.contains("gif"));
+        assert!(!extensions.contains("heic"));
+        assert!(!extensions.contains("pdf"));
     }
 
     #[test]
@@ -396,7 +399,7 @@ mod skip_compress {
             "video.mp4",
             "audio.mp3",
             "archive.zip",
-            "document.pdf",
+            "backup.tar.gz",
         ];
         for file in skip_files {
             assert_eq!(

--- a/crates/compress/tests/incompressible_data.rs
+++ b/crates/compress/tests/incompressible_data.rs
@@ -609,15 +609,9 @@ mod skip_compress_functionality {
     fn skip_compress_detects_image_extensions() {
         let decider = CompressionDecider::with_default_skip_list();
 
-        let image_files = [
-            "photo.jpg",
-            "image.jpeg",
-            "picture.png",
-            "animation.gif",
-            "modern.webp",
-            "phone.heic",
-            "raw.cr2",
-        ];
+        // Only suffixes in upstream DEFAULT_DONT_COMPRESS are skipped by
+        // extension. gif/heic/cr2 are NOT upstream suffixes.
+        let image_files = ["photo.jpg", "image.jpeg", "picture.png", "modern.webp"];
 
         for file in image_files {
             let decision = decider.should_compress(Path::new(file), None);
@@ -625,6 +619,15 @@ mod skip_compress_functionality {
                 decision,
                 CompressionDecision::Skip,
                 "{file} should be skipped"
+            );
+        }
+
+        for file in ["animation.gif", "phone.heic", "raw.cr2"] {
+            let decision = decider.should_compress(Path::new(file), None);
+            assert_eq!(
+                decision,
+                CompressionDecision::AutoDetect,
+                "{file} is not an upstream skip suffix and must not skip by extension"
             );
         }
     }
@@ -701,9 +704,12 @@ mod skip_compress_functionality {
     }
 
     #[test]
-    fn skip_compress_detects_document_extensions() {
+    fn skip_compress_does_not_skip_document_extensions() {
         let decider = CompressionDecider::with_default_skip_list();
 
+        // Upstream DEFAULT_DONT_COMPRESS does not list document formats, so they
+        // are compressed (subject to content auto-detection), not skipped by
+        // extension. This matches upstream rsync's default behavior.
         let document_files = [
             "report.pdf",
             "document.docx",
@@ -716,8 +722,8 @@ mod skip_compress_functionality {
             let decision = decider.should_compress(Path::new(file), None);
             assert_eq!(
                 decision,
-                CompressionDecision::Skip,
-                "{file} should be skipped"
+                CompressionDecision::AutoDetect,
+                "{file} is not an upstream skip suffix and must not skip by extension"
             );
         }
     }
@@ -806,7 +812,7 @@ mod skip_compress_functionality {
             "VIDEO.MP4",
             "AUDIO.MP3",
             "ARCHIVE.ZIP",
-            "DOCUMENT.PDF",
+            "FILE.7Z",
         ];
 
         for file in uppercase_files {
@@ -823,7 +829,7 @@ mod skip_compress_functionality {
             "Video.Mp4",
             "Audio.Mp3",
             "Archive.ZiP",
-            "Document.PdF",
+            "File.7z",
         ];
 
         for file in mixed_case_files {

--- a/crates/compress/tests/skip_compress_patterns.rs
+++ b/crates/compress/tests/skip_compress_patterns.rs
@@ -18,177 +18,60 @@ use compress::skip_compress::{
 mod default_skip_list {
     use super::*;
 
+    /// The complete upstream `DEFAULT_DONT_COMPRESS` suffix set from
+    /// `default-dont-compress.h` (leading `*.` stripped). The default skip list
+    /// must equal this set exactly - any drift changes which files get
+    /// compressed on the wire relative to upstream rsync.
+    const UPSTREAM_DONT_COMPRESS: &[&str] = &[
+        "3g2", "3gp", "7z", "aac", "ace", "apk", "avi", "bz2", "deb", "dmg", "ear", "f4v", "flac",
+        "flv", "gpg", "gz", "iso", "jar", "jpeg", "jpg", "lrz", "lz", "lz4", "lzma", "lzo", "m1a",
+        "m1v", "m2a", "m2ts", "m2v", "m4a", "m4b", "m4p", "m4r", "m4v", "mka", "mkv", "mov", "mp1",
+        "mp2", "mp3", "mp4", "mpa", "mpeg", "mpg", "mpv", "mts", "odb", "odf", "odg", "odi", "odm",
+        "odp", "ods", "odt", "oga", "ogg", "ogm", "ogv", "ogx", "opus", "otg", "oth", "otp", "ots",
+        "ott", "oxt", "png", "qt", "rar", "rpm", "rz", "rzip", "spx", "squashfs", "sxc", "sxd",
+        "sxg", "sxm", "sxw", "sz", "tbz", "tbz2", "tgz", "tlz", "ts", "txz", "tzo", "vob", "war",
+        "webm", "webp", "xz", "z", "zip", "zst",
+    ];
+
     #[test]
-    fn default_list_includes_all_image_formats() {
+    fn default_list_contains_every_upstream_suffix() {
         let decider = CompressionDecider::with_default_skip_list();
         let extensions = decider.skip_extensions();
-
-        let images = [
-            "jpg", "jpeg", "jpe", "png", "gif", "webp", "heic", "heif", "avif",
-        ];
-        for ext in images {
+        for ext in UPSTREAM_DONT_COMPRESS {
             assert!(
-                extensions.contains(ext),
-                "Default skip list should contain image extension: {ext}"
-            );
-        }
-
-        let more_images = ["tif", "tiff", "bmp", "ico", "svg", "svgz", "psd"];
-        for ext in more_images {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain extended image extension: {ext}"
-            );
-        }
-
-        let raw_formats = ["raw", "arw", "cr2", "nef", "orf", "sr2"];
-        for ext in raw_formats {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain RAW image extension: {ext}"
+                extensions.contains(*ext),
+                "Default skip list is missing upstream suffix: {ext}"
             );
         }
     }
 
     #[test]
-    fn default_list_includes_all_video_formats() {
+    fn default_list_has_no_non_upstream_suffixes() {
         let decider = CompressionDecider::with_default_skip_list();
-        let extensions = decider.skip_extensions();
-
-        let videos = [
-            "mp4", "m4v", "mkv", "avi", "mov", "wmv", "flv", "webm", "mpeg", "mpg", "vob", "ogv",
-            "3gp", "3g2", "ts", "mts", "m2ts",
-        ];
-        for ext in videos {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain video extension: {ext}"
-            );
-        }
-    }
-
-    #[test]
-    fn default_list_includes_all_audio_formats() {
-        let decider = CompressionDecider::with_default_skip_list();
-        let extensions = decider.skip_extensions();
-
-        let audio = [
-            "mp3", "m4a", "aac", "ogg", "oga", "opus", "flac", "wma", "wav", "aiff", "ape", "mka",
-            "ac3", "dts",
-        ];
-        for ext in audio {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain audio extension: {ext}"
-            );
-        }
-    }
-
-    #[test]
-    fn default_list_includes_all_archive_formats() {
-        let decider = CompressionDecider::with_default_skip_list();
-        let extensions = decider.skip_extensions();
-
-        let archives = [
-            "zip", "gz", "gzip", "bz2", "bzip2", "xz", "lzma", "7z", "rar",
-        ];
-        for ext in archives {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain archive extension: {ext}"
-            );
-        }
-
-        let modern = ["zst", "zstd", "lz4", "lzo"];
-        for ext in modern {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain modern compression extension: {ext}"
-            );
-        }
-
-        let legacy = ["z", "cab", "arj", "lzh"];
-        for ext in legacy {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain legacy compression extension: {ext}"
-            );
-        }
-
-        let compound = ["tar.gz", "tar.bz2", "tar.xz", "tgz", "tbz", "tbz2", "txz"];
-        for ext in compound {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain compound archive extension: {ext}"
-            );
-        }
-    }
-
-    #[test]
-    fn default_list_includes_package_formats() {
-        let decider = CompressionDecider::with_default_skip_list();
-        let extensions = decider.skip_extensions();
-
-        let packages = [
-            "deb", "rpm", "apk", "jar", "war", "ear", "egg", "whl", "gem", "nupkg", "snap", "appx",
-            "msix",
-        ];
-        for ext in packages {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain package extension: {ext}"
-            );
-        }
-    }
-
-    #[test]
-    fn default_list_includes_document_formats() {
-        let decider = CompressionDecider::with_default_skip_list();
-        let extensions = decider.skip_extensions();
-
-        let docs = ["pdf", "epub", "mobi", "azw", "azw3"];
-        for ext in docs {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain document extension: {ext}"
-            );
-        }
-
-        // Office formats wrap their content in deflate/zip - skip recompression.
-        let office = ["docx", "xlsx", "pptx", "odt", "ods", "odp"];
-        for ext in office {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain Office extension: {ext}"
-            );
-        }
-    }
-
-    #[test]
-    fn default_list_includes_disk_images() {
-        let decider = CompressionDecider::with_default_skip_list();
-        let extensions = decider.skip_extensions();
-
-        let disk_images = ["iso", "img", "dmg", "vhd", "vhdx", "vmdk", "qcow", "qcow2"];
-        for ext in disk_images {
-            assert!(
-                extensions.contains(ext),
-                "Default skip list should contain disk image extension: {ext}"
-            );
-        }
-    }
-
-    #[test]
-    fn default_skip_list_is_not_empty() {
-        let decider = CompressionDecider::with_default_skip_list();
-        assert!(
-            !decider.skip_extensions().is_empty(),
-            "Default skip list should contain extensions"
+        assert_eq!(
+            decider.skip_extensions().len(),
+            UPSTREAM_DONT_COMPRESS.len(),
+            "Default skip list must equal upstream DEFAULT_DONT_COMPRESS exactly"
         );
-        assert!(
-            decider.skip_extensions().len() > 50,
-            "Default skip list should have a substantial number of extensions"
-        );
+    }
+
+    #[test]
+    fn default_list_excludes_suffixes_upstream_compresses() {
+        let decider = CompressionDecider::with_default_skip_list();
+        let extensions = decider.skip_extensions();
+        // These were invented by oc-rsync but upstream compresses them.
+        let non_upstream = [
+            "gif", "heic", "heif", "avif", "tif", "tiff", "bmp", "ico", "svg", "psd", "raw", "cr2",
+            "wmv", "wma", "wav", "aiff", "ape", "ac3", "dts", "gzip", "bzip2", "cab", "arj", "lzh",
+            "egg", "whl", "gem", "nupkg", "snap", "pdf", "epub", "mobi", "docx", "xlsx", "pptx",
+            "img", "vhd", "vmdk", "qcow", "qcow2",
+        ];
+        for ext in non_upstream {
+            assert!(
+                !extensions.contains(ext),
+                "Default skip list must not contain non-upstream suffix: {ext}"
+            );
+        }
     }
 }
 
@@ -202,7 +85,6 @@ mod pattern_matching {
         let skip_files = [
             "photo.jpg",
             "image.png",
-            "animation.gif",
             "picture.webp",
             "movie.mp4",
             "clip.mkv",
@@ -214,9 +96,6 @@ mod pattern_matching {
             "data.gz",
             "backup.tar.gz",
             "files.7z",
-            "document.pdf",
-            "book.epub",
-            "report.docx",
             "package.deb",
             "application.rpm",
             "library.jar",
@@ -245,6 +124,10 @@ mod pattern_matching {
             "config.json",
             "data.csv",
             "log.txt",
+            // Suffixes upstream compresses (not in DEFAULT_DONT_COMPRESS).
+            "animation.gif",
+            "document.pdf",
+            "report.docx",
         ];
 
         for file in unknown_files {
@@ -268,7 +151,6 @@ mod pattern_matching {
             ("VIDEO.MKV", CompressionDecision::Skip),
             ("AUDIO.mp3", CompressionDecision::Skip),
             ("Archive.ZIP", CompressionDecision::Skip),
-            ("Document.PDF", CompressionDecision::Skip),
             ("BACKUP.TAR.GZ", CompressionDecision::Skip),
         ];
 
@@ -311,7 +193,7 @@ mod pattern_matching {
             "/var/backups/archive.tar.gz",
             "../relative/path/video.mp4",
             "./current/dir/audio.mp3",
-            "nested/directory/structure/document.pdf",
+            "nested/directory/structure/package.rpm",
         ];
 
         for file in files_with_paths {
@@ -1231,7 +1113,8 @@ mod integration {
             ("vacation/IMG_1234.jpg", CompressionDecision::Skip),
             ("videos/movie.mp4", CompressionDecision::Skip),
             ("music/song.mp3", CompressionDecision::Skip),
-            ("documents/report.pdf", CompressionDecision::Skip),
+            // Upstream does not skip .pdf; it is compressed (auto-detected).
+            ("documents/report.pdf", CompressionDecision::AutoDetect),
             ("backups/data.tar.gz", CompressionDecision::Skip),
             ("source/main.rs", CompressionDecision::AutoDetect),
             ("logs/application.log", CompressionDecision::AutoDetect),


### PR DESCRIPTION
## Summary

The default skip-compress suffix list in `crates/compress/src/skip_compress/defaults.rs` was an invented set rather than a mirror of upstream rsync, despite its doc comment claiming otherwise. It diverged from upstream in both directions:

- **Added** dozens of suffixes upstream compresses: `pdf`, `docx`, `xlsx`, `pptx`, `epub`, `gif`, `heic`, `heif`, `avif`, `tiff`, `bmp`, `ico`, `svg`, `psd`, RAW camera formats, `wmv`, `wma`, `wav`, `aiff`, `ape`, `ac3`, `dts`, `gzip`, `bzip2`, `cab`, `arj`, `lzh`, `egg`, `whl`, `gem`, `nupkg`, `snap`, `img`, `vhd`, `vmdk`, `qcow`, `qcow2`, ...
- **Omitted** many suffixes upstream does skip: `3g2`, `ace`, `f4v`, `gpg`, `lrz`, `lz`, `m1a`, `m1v`, `m2a`, `m2v`, `m4b`, `m4p`, `m4r`, `mp1`, `mp2`, `mpa`, `mpv`, `odb`-`oxt` family, `qt`, `rz`, `rzip`, `spx`, `squashfs`, `sxc`-`sxw`, `sz`, `tlz`, `tzo`, ...

This changed which files get compressed on the wire relative to upstream rsync's default `dont compress` behavior.

## Fix

- Replace the list with the exact `DEFAULT_DONT_COMPRESS` set from upstream `default-dont-compress.h` (loaded via `loadparm.c:lp_dont_compress`).
- Remove the invented compound-extension (`.tar.gz`) special-casing. Upstream `token.c:set_compression` matches only the substring after the final `.` (`strrchr(fname, '.')`), so `archive.tar.gz` already matches via `gz`. Suffix extraction now uses `Path::extension()`, which mirrors upstream's last-suffix rule including the leading-dot dotfile guard (`s == fname`).

## Tests

Updated tests to encode upstream parity (not the previous invented behavior):
- The default set must equal `DEFAULT_DONT_COMPRESS` exactly (count + membership).
- Suffixes upstream compresses (`pdf`, `gif`, `heic`, `docx`, ...) must auto-detect, not skip by extension.
- Last-suffix extraction and dotfile handling assertions.

All 979 compress-crate tests pass. `cargo fmt` and `cargo clippy -p compress --all-features --no-deps --locked -D warnings` clean.

## References

- upstream `default-dont-compress.h`: `DEFAULT_DONT_COMPRESS`
- upstream `token.c:init_set_compression()` / `set_compression()`
- upstream `loadparm.c:lp_dont_compress()`