### PR TITLE
feat(protocol): add read_varint_bounded and read_varint_size

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -202,9 +202,9 @@ pub use negotiation::{
 };
 pub use stats::{DeleteStats, TransferStats};
 pub use varint::{
-    decode_varint, encode_varint_to_vec, read_int, read_longint, read_varint, read_varint30_int,
-    read_varlong, read_varlong30, write_int, write_longint, write_varint, write_varint30_int,
-    write_varlong, write_varlong30,
+    decode_varint, encode_varint_to_vec, read_int, read_longint, read_varint, read_varint_bounded,
+    read_varint_size, read_varint30_int, read_varlong, read_varlong30, write_int, write_longint,
+    write_varint, write_varint30_int, write_varlong, write_varlong30,
 };
 #[cfg(feature = "tokio-transfer")]
 pub use varint::{read_int_async, read_longint_async, read_varint_async, read_varlong_async};

--- a/crates/protocol/src/varint/decode.rs
+++ b/crates/protocol/src/varint/decode.rs
@@ -78,6 +78,63 @@ pub fn read_varint<R: Read + ?Sized>(reader: &mut R) -> io::Result<i32> {
     Ok(value)
 }
 
+/// Reads a varint and validates it falls within the inclusive range `[lo, hi]`.
+///
+/// Mirrors upstream `io.c:read_varint_bounded()`. Upstream aborts the transfer
+/// with `RERR_PROTOCOL` on an out-of-range wire value; here the equivalent is a
+/// typed [`io::ErrorKind::InvalidData`], which higher layers map to the same
+/// protocol error. `what` names the field for the diagnostic, matching the
+/// upstream message so both peers surface an equivalent explanation.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidData`] when the decoded value is `< lo` or
+/// `> hi`, and propagates the read errors of [`read_varint`] on a truncated or
+/// overflowing encoding.
+#[inline]
+pub fn read_varint_bounded<R: Read + ?Sized>(
+    reader: &mut R,
+    lo: i32,
+    hi: i32,
+    what: &str,
+) -> io::Result<i32> {
+    let v = read_varint(reader)?;
+    if v < lo || v > hi {
+        return Err(invalid_data(&format!(
+            "wire value {what} out of range: {v} not in [{lo},{hi}]"
+        )));
+    }
+    Ok(v)
+}
+
+/// Reads a varint destined for a `usize`, rejecting negatives and values above
+/// `max`.
+///
+/// Mirrors upstream `io.c:read_varint_size()`, which guards `usize` conversions
+/// so a negative wire value cannot wrap to `~SIZE_MAX`. Callers reading a
+/// length or count from the wire should use this instead of casting the result
+/// of [`read_varint`] directly. Upstream aborts with `RERR_PROTOCOL` on a bad
+/// value; the Rust equivalent is a typed [`io::ErrorKind::InvalidData`].
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidData`] when the decoded value is negative or
+/// exceeds `max`, and propagates the read errors of [`read_varint`].
+#[inline]
+pub fn read_varint_size<R: Read + ?Sized>(
+    reader: &mut R,
+    max: usize,
+    what: &str,
+) -> io::Result<usize> {
+    let v = read_varint(reader)?;
+    if v < 0 || (v as usize) > max {
+        return Err(invalid_data(&format!(
+            "wire size {what} out of range: {v} > {max}"
+        )));
+    }
+    Ok(v as usize)
+}
+
 /// Reads a variable-length 64-bit integer using rsync's varlong format.
 ///
 /// This is the inverse of [`super::write_varlong`], mirroring upstream's

--- a/crates/protocol/src/varint/mod.rs
+++ b/crates/protocol/src/varint/mod.rs
@@ -43,8 +43,8 @@ mod table;
 mod tests;
 
 pub use decode::{
-    decode_varint, read_int, read_longint, read_varint, read_varint30_int, read_varlong,
-    read_varlong30,
+    decode_varint, read_int, read_longint, read_varint, read_varint_bounded, read_varint_size,
+    read_varint30_int, read_varlong, read_varlong30,
 };
 #[cfg(feature = "tokio-transfer")]
 pub use decode_async::{read_int_async, read_longint_async, read_varint_async, read_varlong_async};

--- a/crates/protocol/src/varint/tests.rs
+++ b/crates/protocol/src/varint/tests.rs
@@ -1988,3 +1988,69 @@ fn decode_bytes_consumed_at_boundaries() {
         );
     }
 }
+
+fn encoded(value: i32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_varint_to_vec(value, &mut buf);
+    buf
+}
+
+#[test]
+fn read_varint_bounded_accepts_in_range() {
+    // Boundaries (lo and hi) are inclusive, matching upstream's `< lo || > hi`.
+    for (value, lo, hi) in [(0, 0, 0), (5, 0, 10), (10, 0, 10), (-3, -5, 5)] {
+        let mut cursor = Cursor::new(encoded(value));
+        let got =
+            read_varint_bounded(&mut cursor, lo, hi, "test").expect("in-range value should decode");
+        assert_eq!(got, value);
+    }
+}
+
+#[test]
+fn read_varint_bounded_rejects_below_and_above() {
+    // A value one past either boundary is a protocol error (InvalidData). This
+    // is the parity guarantee vs upstream io.c:read_varint_bounded, which aborts
+    // with RERR_PROTOCOL; callers must not receive an out-of-range value.
+    for (value, lo, hi) in [(-1, 0, 10), (11, 0, 10)] {
+        let mut cursor = Cursor::new(encoded(value));
+        let err = read_varint_bounded(&mut cursor, lo, hi, "flag")
+            .expect_err("out-of-range value must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}
+
+#[test]
+fn read_varint_size_accepts_non_negative_within_max() {
+    for (value, max) in [(0usize, 0usize), (7, 100), (100, 100)] {
+        let mut cursor = Cursor::new(encoded(value as i32));
+        let got = read_varint_size(&mut cursor, max, "len").expect("valid size should decode");
+        assert_eq!(got, value);
+    }
+}
+
+#[test]
+fn read_varint_size_rejects_negative() {
+    // A negative wire value would wrap to ~SIZE_MAX on a raw cast; upstream
+    // io.c:read_varint_size guards this. The guard must fire before any cast.
+    let mut cursor = Cursor::new(encoded(-1));
+    let err =
+        read_varint_size(&mut cursor, 1024, "xattr").expect_err("negative size must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn read_varint_size_rejects_above_max() {
+    let mut cursor = Cursor::new(encoded(2048));
+    let err = read_varint_size(&mut cursor, 1024, "xattr")
+        .expect_err("size exceeding max must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn read_varint_size_propagates_truncated_read() {
+    // No wire bytes at all: the underlying read_varint EOF must surface, not a
+    // range error, so callers can distinguish a short stream from a bad value.
+    let mut cursor = Cursor::new(Vec::new());
+    let err = read_varint_size(&mut cursor, 1024, "len").expect_err("truncated input must error");
+    assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+}


### PR DESCRIPTION
## Summary

Upstream rsync defines two varint validation wrappers in `io.c` that guard wire-supplied values before use:

- `read_varint_bounded(f, lo, hi, what)` (io.c:1904-1913) - rejects a decoded varint outside the inclusive `[lo, hi]` range.
- `read_varint_size(f, max, what)` (io.c:1917-1926) - rejects negative values (which would wrap to `~SIZE_MAX` on a raw `usize` cast) and values exceeding `max`.

Neither existed in the `protocol` crate, so callers that read a bounded range or a length/count from the wire had to duplicate the checks inline. This PR adds both as public primitives in `crates/protocol/src/varint/decode.rs` and re-exports them at the crate root.

## Behavior

Upstream aborts the transfer with `RERR_PROTOCOL` on a bad value. The Rust equivalent is a typed `io::ErrorKind::InvalidData`, which higher layers already map to the same protocol error. Truncated or overflowing encodings propagate unchanged from `read_varint`. This mirrors the existing `read_varlong` precedent of surfacing a typed error rather than panicking on malformed wire input.

## Tests

Six unit tests covering: in-range acceptance (inclusive boundaries), below/above rejection, non-negative-within-max acceptance, negative rejection (the `~SIZE_MAX` wrap guard), above-max rejection, and truncated-read propagation (EOF, not a range error).

All 5881 protocol-crate tests pass. `cargo fmt` and `cargo clippy -p protocol --all-features --no-deps --locked -D warnings` clean.

## References

- upstream `io.c:1904-1913` `read_varint_bounded`
- upstream `io.c:1917-1926` `read_varint_size`