### PR TITLE
fix(metadata): fake-super %stat fidelity for the xattrs conformance test

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -58,6 +58,65 @@ fn is_already_hardlinked(destination: &Path, target: &Path) -> bool {
     }
 }
 
+/// Reports whether the `--link-dest` basis already carries the source's
+/// preserved attributes, mirroring upstream `generator.c:468 unchanged_attrs()`.
+///
+/// When this returns `true` the match is upstream's match_level 3 (data and
+/// attributes both match): the file is hard-linked and metadata is *not*
+/// reapplied (except `--atimes`), so no `user.rsync.%stat` xattr is written
+/// onto the shared basis inode. When `false` (match_level 2, attrs differ),
+/// the caller reapplies metadata like upstream's `try_a_copy` + set_file_attrs.
+///
+/// Compares only the attributes `unchanged_attrs` inspects for a regular file:
+/// permission bits (`perms_differ`), owner/group (`ownership_differs`), and
+/// mtime (`any_time_differs`), each gated on the corresponding preserve option.
+// upstream: generator.c:418-502 perms_differ / ownership_differs / any_time_differs
+fn link_dest_attrs_unchanged(
+    basis: &Path,
+    source: &fs::Metadata,
+    options: &MetadataOptions,
+) -> bool {
+    #[cfg(unix)]
+    {
+        use filetime::FileTime;
+        use std::os::unix::fs::MetadataExt;
+
+        let Ok(basis_meta) = fs::symlink_metadata(basis) else {
+            return false;
+        };
+
+        // A --chmod tweak changes the intended mode away from the source's, so
+        // the basis (which carries the untweaked mode) can never be a
+        // match_level-3 attrs match; force a reapply. Mirrors upstream comparing
+        // file->mode (post dest_mode/tweak) against the basis stat.
+        if options.chmod().is_some() {
+            return false;
+        }
+
+        if options.permissions() && (source.mode() & 0o7777) != (basis_meta.mode() & 0o7777) {
+            return false;
+        }
+        if options.owner() && source.uid() != basis_meta.uid() {
+            return false;
+        }
+        if options.group() && source.gid() != basis_meta.gid() {
+            return false;
+        }
+        if options.times()
+            && FileTime::from_last_modification_time(source)
+                != FileTime::from_last_modification_time(&basis_meta)
+        {
+            return false;
+        }
+        true
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (basis, source, options);
+        false
+    }
+}
+
 /// Result of hard-link and reference-directory processing for a file.
 pub(super) struct LinkOutcome {
     pub(super) copy_source_override: Option<PathBuf>,
@@ -193,24 +252,29 @@ pub(super) fn process_links(
             destination_previously_existed,
         );
         remove_source_entry_if_requested(context, source, Some(record_path), file_type)?;
-        // upstream: generator.c try_dests_reg() - a --link-dest match at
-        // match_level 2 (data matches, attrs differ) still runs set_file_attrs,
-        // reapplying metadata + xattrs so the linked basis ends with the
-        // source's attributes. apply is a no-op when values already match, so
-        // applying unconditionally on the match is safe.
-        apply_file_metadata_with_options(destination, metadata, &metadata_options)
-            .map_err(map_metadata_error)?;
-        #[cfg(all(unix, feature = "xattr"))]
-        sync_xattrs_if_requested(
-            preserve_xattrs,
-            mode,
-            source,
-            destination,
-            true,
-            context.filter_program(),
-        )?;
-        #[cfg(all(any(unix, windows), feature = "acl"))]
-        sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+        // upstream: generator.c:995-1024 try_dests_reg() - for a LINK_DEST match
+        // at match_level 3 (data AND attrs already match the basis) the file is
+        // only hard-linked; set_file_attrs runs *only* under --atimes. Rewriting
+        // metadata unconditionally would, under --fake-super, write a
+        // `user.rsync.%stat` xattr onto the shared basis inode that upstream
+        // never creates. At match_level 2 (attrs differ) upstream does rewrite,
+        // so gate the reapply on whether the basis attributes already match.
+        let attrs_match = link_dest_attrs_unchanged(&link_target, metadata, &metadata_options);
+        if !attrs_match || metadata_options.atimes() {
+            apply_file_metadata_with_options(destination, metadata, &metadata_options)
+                .map_err(map_metadata_error)?;
+            #[cfg(all(unix, feature = "xattr"))]
+            sync_xattrs_if_requested(
+                preserve_xattrs,
+                mode,
+                source,
+                destination,
+                true,
+                context.filter_program(),
+            )?;
+            #[cfg(all(any(unix, windows), feature = "acl"))]
+            sync_acls_if_requested(preserve_acls, mode, source, destination, true)?;
+        }
         return Ok(LinkOutcome {
             copy_source_override: None,
             reference_basis: None,

--- a/crates/engine/src/local_copy/executor/file/copy/links.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/links.rs
@@ -67,14 +67,19 @@ fn is_already_hardlinked(destination: &Path, target: &Path) -> bool {
 /// onto the shared basis inode. When `false` (match_level 2, attrs differ),
 /// the caller reapplies metadata like upstream's `try_a_copy` + set_file_attrs.
 ///
-/// Compares only the attributes `unchanged_attrs` inspects for a regular file:
-/// permission bits (`perms_differ`), owner/group (`ownership_differs`), and
-/// mtime (`any_time_differs`), each gated on the corresponding preserve option.
-// upstream: generator.c:418-502 perms_differ / ownership_differs / any_time_differs
+/// Compares the attributes `unchanged_attrs` inspects for a regular file:
+/// permission bits (`perms_differ`), owner/group (`ownership_differs`), mtime
+/// (`any_time_differs`), and, when `-X` is active, the transferable extended
+/// attributes (`xattrs_differ`), each gated on the corresponding preserve
+/// option. `source` is the source path (for the xattr read) and `source_meta`
+/// its stat.
+// upstream: generator.c:468-502 unchanged_attrs - perms/ownership/time/xattr
 fn link_dest_attrs_unchanged(
     basis: &Path,
-    source: &fs::Metadata,
+    source: &Path,
+    source_meta: &fs::Metadata,
     options: &MetadataOptions,
+    preserve_xattrs: bool,
 ) -> bool {
     #[cfg(unix)]
     {
@@ -93,26 +98,32 @@ fn link_dest_attrs_unchanged(
             return false;
         }
 
-        if options.permissions() && (source.mode() & 0o7777) != (basis_meta.mode() & 0o7777) {
+        if options.permissions() && (source_meta.mode() & 0o7777) != (basis_meta.mode() & 0o7777) {
             return false;
         }
-        if options.owner() && source.uid() != basis_meta.uid() {
+        if options.owner() && source_meta.uid() != basis_meta.uid() {
             return false;
         }
-        if options.group() && source.gid() != basis_meta.gid() {
+        if options.group() && source_meta.gid() != basis_meta.gid() {
             return false;
         }
         if options.times()
-            && FileTime::from_last_modification_time(source)
+            && FileTime::from_last_modification_time(source_meta)
                 != FileTime::from_last_modification_time(&basis_meta)
         {
+            return false;
+        }
+        // upstream: generator.c:501 - xattrs_differ() makes a changed xattr a
+        // match_level-2 (attr change) result, forcing the copy + set_file_attrs
+        // that reapplies the source's xattrs onto the destination.
+        if preserve_xattrs && !::metadata::xattrs_match(source, basis, true).unwrap_or(false) {
             return false;
         }
         true
     }
     #[cfg(not(unix))]
     {
-        let _ = (basis, source, options);
+        let _ = (basis, source, source_meta, options, preserve_xattrs);
         false
     }
 }
@@ -259,7 +270,23 @@ pub(super) fn process_links(
         // `user.rsync.%stat` xattr onto the shared basis inode that upstream
         // never creates. At match_level 2 (attrs differ) upstream does rewrite,
         // so gate the reapply on whether the basis attributes already match.
-        let attrs_match = link_dest_attrs_unchanged(&link_target, metadata, &metadata_options);
+        let preserve_xattrs_flag = {
+            #[cfg(all(unix, feature = "xattr"))]
+            {
+                preserve_xattrs
+            }
+            #[cfg(not(all(unix, feature = "xattr")))]
+            {
+                false
+            }
+        };
+        let attrs_match = link_dest_attrs_unchanged(
+            &link_target,
+            source,
+            metadata,
+            &metadata_options,
+            preserve_xattrs_flag,
+        );
         if !attrs_match || metadata_options.atimes() {
             apply_file_metadata_with_options(destination, metadata, &metadata_options)
                 .map_err(map_metadata_error)?;

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -133,11 +133,19 @@ pub(crate) fn store_effective_fake_super_if_requested(
         return Ok(());
     }
 
-    let stat = ::metadata::effective_source_stat(source, metadata);
+    let mut stat = ::metadata::effective_source_stat(source, metadata);
 
-    // Skip the rewrite when the destination already carries the target stat,
-    // mirroring upstream's "no-op when the current xattr matches" fast path.
+    // The permission-apply step already deflected the destination's stored mode
+    // to the chmod-applied `new_mode` (upstream set_stat_xattr's fmode). Keep it:
+    // `effective_source_stat` only carries the *source* mode, which ignores any
+    // `--chmod` tweak, so overwriting it here would revert `--fake-super
+    // --chmod=...` to the untweaked source mode. Forward only uid/gid/rdev.
+    // upstream: xattrs.c:set_stat_xattr() stores mode = new_mode (post dest_mode
+    // + tweak_mode), not the raw source mode.
     if let Ok(Some(existing)) = ::metadata::load_fake_super(destination) {
+        if options.chmod().is_some() {
+            stat.mode = existing.mode;
+        }
         if existing == stat {
             return Ok(());
         }

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -133,15 +133,20 @@ pub(crate) fn store_effective_fake_super_if_requested(
         return Ok(());
     }
 
-    let mut stat = ::metadata::effective_source_stat(source, metadata);
+    // Only forward a placeholder's recorded stat. When the source carries its
+    // own `user.rsync.%stat` (an earlier fake-super receive), it - not the
+    // placeholder's raw perms - is the source of truth for uid/gid/mode/rdev.
+    // For a real-file source, the ownership + permission apply steps already
+    // wrote or removed the destination `%stat` following upstream's
+    // set_stat_xattr write-or-remove rule, so re-storing here would resurrect a
+    // shim upstream deliberately dropped for a faithful same-owner copy.
+    // upstream: xattrs.c:get_stat_xattr() consumed via x_lstat().
+    let Ok(Some(mut stat)) = ::metadata::load_fake_super(source) else {
+        return Ok(());
+    };
 
-    // The permission-apply step already deflected the destination's stored mode
-    // to the chmod-applied `new_mode` (upstream set_stat_xattr's fmode). Keep it:
-    // `effective_source_stat` only carries the *source* mode, which ignores any
-    // `--chmod` tweak, so overwriting it here would revert `--fake-super
-    // --chmod=...` to the untweaked source mode. Forward only uid/gid/rdev.
-    // upstream: xattrs.c:set_stat_xattr() stores mode = new_mode (post dest_mode
-    // + tweak_mode), not the raw source mode.
+    // A `--chmod` tweak makes the destination's deflected mode (written by the
+    // permission step) authoritative; keep it rather than the placeholder's.
     if let Ok(Some(existing)) = ::metadata::load_fake_super(destination) {
         if options.chmod().is_some() {
             stat.mode = existing.mode;
@@ -151,6 +156,7 @@ pub(crate) fn store_effective_fake_super_if_requested(
         }
     }
 
+    let _ = metadata;
     ::metadata::store_fake_super(destination, &stat).map_err(|error| {
         LocalCopyError::io(
             "store fake-super metadata",

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -279,6 +279,73 @@ pub(super) fn permissions_match(target_mode: u32, existing: &fs::Metadata) -> bo
     (existing.permissions().mode() & 0o7777) == (target_mode & 0o7777)
 }
 
+/// Applies the fake-super permission deflection for a computed mode.
+///
+/// Mirrors upstream `xattrs.c:set_stat_xattr()` under `am_root < 0`: the file's
+/// intended mode (`fmode`, the full `S_IFMT` + chmod-applied mode) is recorded
+/// in the `user.rsync.%stat` xattr, and the *real* on-disk mode is forced to a
+/// self-accessible value - `(fmode & ACCESSPERMS) | (S_ISDIR ? 0700 : 0600)` -
+/// so the destination stays readable/writable during and after the transfer.
+/// Special bits (setuid/setgid/sticky) are dropped from the real mode; they
+/// survive only in the xattr. The normal chmod-to-`fmode` is skipped
+/// (upstream `rsync.c:660` - `ret = am_root < 0 ? 0 : do_chmod_at(...)`).
+///
+/// The ownership step already wrote uid/gid (and a first-guess mode) into the
+/// xattr, so this reloads and rewrites only the mode field to `fmode`, leaving
+/// the recorded uid/gid/rdev intact.
+// upstream: xattrs.c:1188 set_stat_xattr() - mode = (fmode & ACCESSPERMS)
+//           | (S_ISDIR(fst.st_mode) ? 0700 : 0600); real chmod skipped.
+#[cfg(unix)]
+fn apply_fake_super_mode(
+    destination: &Path,
+    fmode: u32,
+    is_dir: bool,
+    options: &MetadataOptions,
+    existing: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
+    const ACCESSPERMS: u32 = 0o777;
+
+    // upstream: xattrs.c:1219-1220 - enable full owner access, dump special bits.
+    let real_mode = (fmode & ACCESSPERMS) | if is_dir { 0o700 } else { 0o600 };
+
+    #[cfg(feature = "xattr")]
+    {
+        use crate::fake_super::{load_fake_super, store_fake_super};
+
+        const S_IFMT: u32 = 0o170000;
+        // The mode stored in the xattr is `fmode` with its S_IFMT type bits so a
+        // later fake-super read can rebuild both the type and the full perms.
+        let type_bits = fmode & S_IFMT;
+        let target_mode = if type_bits != 0 {
+            fmode
+        } else if is_dir {
+            0o040000 | (fmode & 0o7777)
+        } else {
+            0o100000 | (fmode & 0o7777)
+        };
+
+        // Reload the uid/gid/rdev the ownership step recorded and correct only
+        // the mode field to the chmod-applied `fmode`.
+        if let Ok(Some(mut stat)) = load_fake_super(destination)
+            && stat.mode != target_mode
+        {
+            stat.mode = target_mode;
+            store_fake_super(destination, &stat).map_err(|error| {
+                MetadataError::new("store fake-super metadata", destination, error)
+            })?;
+        }
+    }
+
+    if let Some(existing) = existing
+        && permissions_match(real_mode, existing)
+    {
+        return Ok(());
+    }
+
+    // upstream: syscall.c:do_chmod_at() applied to the deflected real mode.
+    chmod_path_honoring_keep_dirlinks(destination, real_mode, options, "preserve permissions")
+}
+
 /// Applies permissions with optional chmod modifiers (path-based).
 ///
 /// When chmod modifiers are configured, applies them on top of the base mode.
@@ -291,6 +358,21 @@ pub(super) fn apply_permissions_with_chmod(
     options: &MetadataOptions,
     existing: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
+    // upstream: rsync.c:577-578 set_file_attrs() - under fake-super (am_root<0)
+    // the intended mode is deflected into the xattr and the real mode is forced
+    // self-accessible; the normal chmod is skipped.
+    #[cfg(unix)]
+    if options.fake_super_enabled() {
+        let fmode = intended_fake_super_mode(destination, metadata, options, existing)?;
+        return apply_fake_super_mode(
+            destination,
+            fmode,
+            metadata.file_type().is_dir(),
+            options,
+            existing,
+        );
+    }
+
     #[cfg(unix)]
     {
         if let Some(modifiers) = options.chmod() {
@@ -352,6 +434,22 @@ pub(super) fn apply_permissions_with_chmod_fd(
     existing: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     use std::os::unix::fs::PermissionsExt;
+
+    // upstream: rsync.c:577-578 set_file_attrs() - fake-super deflects the mode
+    // into the xattr and forces a self-accessible real mode; the open fd (which
+    // could be a regular-file placeholder) is not used for the chmod so the
+    // deflection stays path-based, matching set_stat_xattr().
+    if options.fake_super_enabled() {
+        let _ = fd;
+        let fmode = intended_fake_super_mode(destination, metadata, options, existing)?;
+        return apply_fake_super_mode(
+            destination,
+            fmode,
+            metadata.file_type().is_dir(),
+            options,
+            existing,
+        );
+    }
 
     if let Some(modifiers) = options.chmod() {
         let mut mode = base_mode_for_permissions(destination, metadata, options, existing)?;
@@ -463,6 +561,46 @@ fn chmod_path_honoring_keep_dirlinks(
             .map_err(|error| MetadataError::new(action, destination, error))?;
     }
     Ok(())
+}
+
+/// Computes the intended full mode (`S_IFMT` + perms) that upstream's
+/// `set_file_attrs()` would chmod a non-fake-super destination to.
+///
+/// This is the `new_mode` fed to `set_stat_xattr()` under `am_root < 0`: the
+/// `dest_mode()` result with any `--chmod` / daemon-chmod tweak applied on top.
+/// When `--perms` is active the source mode passes through; otherwise the
+/// umask/exec `dest_mode()` reduction (via [`base_mode_for_permissions`] and
+/// [`compute_dest_mode`]) supplies the baseline. Chmod modifiers, when present,
+/// are layered last so the recorded xattr reflects the same mode a privileged
+/// transfer would have applied on disk.
+// upstream: rsync.c:495-519 set_file_attrs() new_mode / dest_mode + tweak_mode
+#[cfg(unix)]
+fn intended_fake_super_mode(
+    destination: &Path,
+    metadata: &fs::Metadata,
+    options: &MetadataOptions,
+    existing: Option<&fs::Metadata>,
+) -> Result<u32, MetadataError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let base = if options.permissions() || options.chmod().is_some() {
+        base_mode_for_permissions(destination, metadata, options, existing)?
+    } else {
+        let source_mode = metadata.permissions().mode();
+        compute_dest_mode(
+            source_mode,
+            options.destination_is_new(),
+            existing,
+            destination.parent(),
+        )
+        .unwrap_or(source_mode)
+    };
+
+    let mode = match options.chmod() {
+        Some(modifiers) => modifiers.apply(base, metadata.file_type()),
+        None => base,
+    };
+    Ok(mode)
 }
 
 /// Determines the base mode before chmod modifiers are applied.

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -309,8 +309,7 @@ fn apply_fake_super_mode(
     const ACCESSPERMS: u32 = 0o777;
     const S_IFMT: u32 = 0o170000;
 
-    // The intended stored mode carries the S_IFMT type bits so a later fake-super
-    // read can rebuild both the type and the full perms.
+    // Recover the S_IFMT type bits (fmode may arrive with or without them).
     let type_bits = if fmode & S_IFMT != 0 {
         fmode & S_IFMT
     } else if is_dir {

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -282,19 +282,22 @@ pub(super) fn permissions_match(target_mode: u32, existing: &fs::Metadata) -> bo
 /// Applies the fake-super permission deflection for a computed mode.
 ///
 /// Mirrors upstream `xattrs.c:set_stat_xattr()` under `am_root < 0`: the file's
-/// intended mode (`fmode`, the full `S_IFMT` + chmod-applied mode) is recorded
-/// in the `user.rsync.%stat` xattr, and the *real* on-disk mode is forced to a
-/// self-accessible value - `(fmode & ACCESSPERMS) | (S_ISDIR ? 0700 : 0600)` -
-/// so the destination stays readable/writable during and after the transfer.
-/// Special bits (setuid/setgid/sticky) are dropped from the real mode; they
-/// survive only in the xattr. The normal chmod-to-`fmode` is skipped
-/// (upstream `rsync.c:660` - `ret = am_root < 0 ? 0 : do_chmod_at(...)`).
+/// intended mode (`fmode`, the full `S_IFMT` + chmod-applied mode) is compared
+/// against the *real* on-disk mode forced to a self-accessible value -
+/// `(fmode & ACCESSPERMS) | (S_ISDIR ? 0700 : 0600)` - so the destination stays
+/// readable/writable during and after the transfer. Special bits
+/// (setuid/setgid/sticky) are dropped from the real mode; they survive only in
+/// the xattr. The normal chmod-to-`fmode` is skipped (upstream `rsync.c:660`).
 ///
-/// The ownership step already wrote uid/gid (and a first-guess mode) into the
-/// xattr, so this reloads and rewrites only the mode field to `fmode`, leaving
-/// the recorded uid/gid/rdev intact.
-// upstream: xattrs.c:1188 set_stat_xattr() - mode = (fmode & ACCESSPERMS)
-//           | (S_ISDIR(fst.st_mode) ? 0700 : 0600); real chmod skipped.
+/// The `user.rsync.%stat` xattr is only written when the real
+/// mode/uid/gid/rdev cannot faithfully represent the intended values - i.e.
+/// when `real_mode != fmode` (special bits or perms were dropped) or the
+/// destination's on-disk owner/group differ from the intended ones. When the
+/// real attributes already match, upstream writes no shim and removes any stale
+/// `%stat` (`xattrs.c:1225-1237`), so an unprivileged same-owner copy of a
+/// plain 0755 dir / 0644 file leaves no `%stat` behind.
+// upstream: xattrs.c:1188-1237 set_stat_xattr() - mode = (fmode & ACCESSPERMS)
+//           | (S_ISDIR ? 0700 : 0600); write-or-remove based on faithfulness.
 #[cfg(unix)]
 fn apply_fake_super_mode(
     destination: &Path,
@@ -304,35 +307,64 @@ fn apply_fake_super_mode(
     existing: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     const ACCESSPERMS: u32 = 0o777;
+    const S_IFMT: u32 = 0o170000;
+
+    // The intended stored mode carries the S_IFMT type bits so a later fake-super
+    // read can rebuild both the type and the full perms.
+    let type_bits = if fmode & S_IFMT != 0 {
+        fmode & S_IFMT
+    } else if is_dir {
+        0o040000
+    } else {
+        0o100000
+    };
 
     // upstream: xattrs.c:1219-1220 - enable full owner access, dump special bits.
-    let real_mode = (fmode & ACCESSPERMS) | if is_dir { 0o700 } else { 0o600 };
+    let real_mode = type_bits | (fmode & ACCESSPERMS) | if is_dir { 0o700 } else { 0o600 };
 
     #[cfg(feature = "xattr")]
     {
-        use crate::fake_super::{load_fake_super, store_fake_super};
+        use crate::fake_super::{load_fake_super, remove_fake_super, store_fake_super};
+        use std::os::unix::fs::MetadataExt;
 
-        const S_IFMT: u32 = 0o170000;
-        // The mode stored in the xattr is `fmode` with its S_IFMT type bits so a
-        // later fake-super read can rebuild both the type and the full perms.
-        let type_bits = fmode & S_IFMT;
-        let target_mode = if type_bits != 0 {
-            fmode
-        } else if is_dir {
-            0o040000 | (fmode & 0o7777)
-        } else {
-            0o100000 | (fmode & 0o7777)
-        };
+        // The intended stored mode carries the S_IFMT type bits so a later
+        // fake-super read can rebuild both the type and the full perms.
+        let stored_mode = type_bits | (fmode & 0o7777);
 
-        // Reload the uid/gid/rdev the ownership step recorded and correct only
-        // the mode field to the chmod-applied `fmode`.
-        if let Ok(Some(mut stat)) = load_fake_super(destination)
-            && stat.mode != target_mode
-        {
-            stat.mode = target_mode;
-            store_fake_super(destination, &stat).map_err(|error| {
-                MetadataError::new("store fake-super metadata", destination, error)
+        // The ownership step recorded the intended uid/gid/rdev; reload them.
+        let recorded = load_fake_super(destination).ok().flatten();
+        let (want_uid, want_gid, want_rdev) = recorded
+            .as_ref()
+            .map(|s| (s.uid, s.gid, s.rdev))
+            .unwrap_or((0, 0, None));
+
+        // upstream: xattrs.c:1225-1229 - the shim is redundant when the real
+        // (mode & type)==stored mode and the on-disk owner/group already equal
+        // the intended values (rdev is 0 for non-devices). Compare against the
+        // destination's actual on-disk owner/group.
+        let dest_meta = fs::symlink_metadata(destination).ok();
+        let (real_uid, real_gid) = dest_meta
+            .as_ref()
+            .map(|m| (m.uid(), m.gid()))
+            .unwrap_or((want_uid, want_gid));
+
+        let faithful = (real_mode & (S_IFMT | 0o7777)) == stored_mode
+            && real_uid == want_uid
+            && real_gid == want_gid
+            && want_rdev.is_none();
+
+        if faithful {
+            // upstream: xattrs.c:1227-1233 - drop any stale %stat and skip write.
+            remove_fake_super(destination).map_err(|error| {
+                MetadataError::new("remove fake-super metadata", destination, error)
             })?;
+        } else if let Some(mut stat) = recorded {
+            if stat.mode != stored_mode {
+                stat.mode = stored_mode;
+                store_fake_super(destination, &stat).map_err(|error| {
+                    MetadataError::new("store fake-super metadata", destination, error)
+                })?;
+            }
         }
     }
 
@@ -343,7 +375,12 @@ fn apply_fake_super_mode(
     }
 
     // upstream: syscall.c:do_chmod_at() applied to the deflected real mode.
-    chmod_path_honoring_keep_dirlinks(destination, real_mode, options, "preserve permissions")
+    chmod_path_honoring_keep_dirlinks(
+        destination,
+        real_mode & 0o7777,
+        options,
+        "preserve permissions",
+    )
 }
 
 /// Applies permissions with optional chmod modifiers (path-based).

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1064,6 +1064,85 @@ fn fake_super_does_not_chown_destination() {
     }
 }
 
+// upstream: xattrs.c:set_stat_xattr() under am_root<0 - a `--fake-super
+// --chmod=a=` directory keeps a self-accessible real mode (0700) while the
+// intended mode (040000) lands in the `user.rsync.%stat` xattr. Without the
+// deflection the local-copy path chmods the real dir to 000 and every later
+// open of it fails, mirroring the `xattrs` conformance-test failure.
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn fake_super_chmod_deflects_directory_real_mode() {
+    use crate::chmod::ChmodModifiers;
+    use crate::fake_super::load_fake_super;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src_dir");
+    let dst = temp.path().join("dst_dir");
+    fs::create_dir(&src).expect("create src dir");
+    fs::create_dir(&dst).expect("create dst dir");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o700)).expect("chmod src");
+
+    let src_meta = fs::symlink_metadata(&src).expect("stat src");
+    let opts = MetadataOptions::new()
+        .fake_super(true)
+        .preserve_owner(true)
+        .preserve_group(true)
+        .preserve_permissions(true)
+        .with_chmod(Some(ChmodModifiers::parse("a=").expect("parse a=")));
+
+    apply_directory_metadata_with_options(&dst, &src_meta, opts).expect("apply dir metadata");
+
+    // The real directory mode must stay self-accessible (0700), never 000.
+    let real = fs::metadata(&dst).expect("stat dst").mode() & 0o777;
+    if let Ok(Some(stat)) = load_fake_super(&dst) {
+        // Filesystem supports xattrs: assert the full upstream contract.
+        assert_eq!(real, 0o700, "real dir mode must be deflected to 0700");
+        assert_eq!(
+            stat.mode, 0o040_000,
+            "xattr must record the chmod-applied mode (040000), not the source mode"
+        );
+    } else {
+        // No xattr backing (e.g. tmpfs sans user_xattr): still must be readable.
+        assert_eq!(real, 0o700, "real dir mode must be deflected to 0700");
+    }
+}
+
+// upstream: xattrs.c:1220 - regular files are deflected to 0600 (not 0700).
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn fake_super_chmod_deflects_regular_file_real_mode() {
+    use crate::chmod::ChmodModifiers;
+    use crate::fake_super::load_fake_super;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src.txt");
+    let dst = temp.path().join("dst.txt");
+    fs::write(&src, b"data").expect("write src");
+    fs::write(&dst, b"data").expect("write dst");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).expect("chmod src");
+
+    let src_meta = fs::symlink_metadata(&src).expect("stat src");
+    let opts = MetadataOptions::new()
+        .fake_super(true)
+        .preserve_owner(true)
+        .preserve_group(true)
+        .preserve_permissions(true)
+        .with_chmod(Some(ChmodModifiers::parse("a=").expect("parse a=")));
+
+    apply_file_metadata_with_options(&dst, &src_meta, &opts).expect("apply file metadata");
+
+    let real = fs::metadata(&dst).expect("stat dst").mode() & 0o777;
+    assert_eq!(real, 0o600, "real file mode must be deflected to 0600");
+    if let Ok(Some(stat)) = load_fake_super(&dst) {
+        assert_eq!(
+            stat.mode, 0o100_000,
+            "xattr must record the chmod-applied file mode (100000)"
+        );
+    }
+}
+
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn fake_super_skips_rewrite_when_xattr_already_matches() {

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -1143,6 +1143,42 @@ fn fake_super_chmod_deflects_regular_file_real_mode() {
     }
 }
 
+// upstream: xattrs.c:1225-1237 - when the real mode/uid/gid already faithfully
+// represent the intended values (a plain 0755 dir owned by the copying user),
+// set_stat_xattr writes no shim and removes any stale %stat. An unprivileged
+// same-owner fake-super copy of such a directory must leave no %stat behind.
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn fake_super_faithful_directory_writes_no_stat_xattr() {
+    use crate::fake_super::load_fake_super;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src_dir");
+    let dst = temp.path().join("dst_dir");
+    fs::create_dir(&src).expect("create src dir");
+    fs::create_dir(&dst).expect("create dst dir");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).expect("chmod src");
+
+    let src_meta = fs::symlink_metadata(&src).expect("stat src");
+    let opts = MetadataOptions::new()
+        .fake_super(true)
+        .preserve_owner(true)
+        .preserve_group(true)
+        .preserve_permissions(true);
+
+    apply_directory_metadata_with_options(&dst, &src_meta, opts).expect("apply dir metadata");
+
+    // Same-owner 0755 dir: the real 0755 mode already conveys the intent, so no
+    // %stat shim is written (matching upstream's write-or-remove rule).
+    assert!(
+        matches!(load_fake_super(&dst), Ok(None)),
+        "faithful same-owner dir must carry no rsync.%stat xattr"
+    );
+    let real = fs::metadata(&dst).expect("stat dst").mode() & 0o777;
+    assert_eq!(real, 0o755, "real dir mode preserved");
+}
+
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn fake_super_skips_rewrite_when_xattr_already_matches() {

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -251,11 +251,13 @@ pub use special::{
 };
 
 #[cfg(all(feature = "xattr", any(unix, windows)))]
-pub use xattr::{apply_xattrs_from_list, read_xattrs_for_wire, strip_source_xattrs, sync_xattrs};
+pub use xattr::{
+    apply_xattrs_from_list, read_xattrs_for_wire, strip_source_xattrs, sync_xattrs, xattrs_match,
+};
 
 #[cfg(not(all(feature = "xattr", any(unix, windows))))]
 pub use xattr_stub::{
-    apply_xattrs_from_list, read_xattrs_for_wire, strip_source_xattrs, sync_xattrs,
+    apply_xattrs_from_list, read_xattrs_for_wire, strip_source_xattrs, sync_xattrs, xattrs_match,
 };
 
 pub use copy_as::{CopyAsGuard, CopyAsIds, parse_copy_as_spec, switch_effective_ids};

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -187,6 +187,43 @@ pub fn strip_source_xattrs(
     Ok(())
 }
 
+/// Reports whether the transferable extended attributes of `a` and `b` match.
+///
+/// Mirrors upstream `xattrs.c:xattrs_differ()` (consumed by `unchanged_attrs`):
+/// only the attributes that participate in an `-X` transfer are compared - the
+/// rsync-internal `rsync.%*` channel and namespaces the current privilege level
+/// cannot access are excluded (`list_attributes` already applies the namespace
+/// filter). Used by the `--link-dest` match-level check to decide whether a
+/// basis file's xattrs already equal the source's.
+// upstream: xattrs.c xattrs_differ() via generator.c:468 unchanged_attrs()
+pub fn xattrs_match(a: &Path, b: &Path, follow_symlinks: bool) -> Result<bool, MetadataError> {
+    let mut a_map: std::collections::BTreeMap<Vec<u8>, Vec<u8>> = std::collections::BTreeMap::new();
+    for name in list_attributes(a, follow_symlinks)? {
+        if protocol::xattr::is_rsync_internal(&String::from_utf8_lossy(&name)) {
+            continue;
+        }
+        if let Some(value) = read_attribute(a, &name, follow_symlinks)? {
+            a_map.insert(name, value);
+        }
+    }
+
+    let mut b_count = 0usize;
+    for name in list_attributes(b, follow_symlinks)? {
+        if protocol::xattr::is_rsync_internal(&String::from_utf8_lossy(&name)) {
+            continue;
+        }
+        let Some(value) = read_attribute(b, &name, follow_symlinks)? else {
+            continue;
+        };
+        match a_map.get(&name) {
+            Some(a_value) if *a_value == value => b_count += 1,
+            _ => return Ok(false),
+        }
+    }
+
+    Ok(b_count == a_map.len())
+}
+
 /// Synchronises the extended attributes from `source` to `destination`.
 ///
 /// The rsync-internal `rsync.%*` attributes (the fake-super `%stat`/`%aacl`/
@@ -562,6 +599,44 @@ mod tests {
                 .expect("attr2"),
             b"value2"
         );
+    }
+
+    // upstream: xattrs.c xattrs_differ() - a changed value or a missing/extra
+    // transferable attr means the pair differs; the rsync.%* channel is ignored.
+    #[test]
+    fn xattrs_match_detects_value_and_membership_differences() {
+        let dir = tempdir().expect("create temp dir");
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "a").expect("write a");
+        fs::write(&b, "b").expect("write b");
+
+        if !xattrs_supported(&a) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let name = test_xattr_name("nice");
+        write_attribute(&a, &name, b"this is nice, but different", false).expect("write a nice");
+        write_attribute(&b, &name, b"this is nice", false).expect("write b nice");
+        assert!(!xattrs_match(&a, &b, false).expect("compare differing values"));
+
+        // Equal values -> match.
+        write_attribute(&b, &name, b"this is nice, but different", false).expect("update b nice");
+        assert!(xattrs_match(&a, &b, false).expect("compare equal values"));
+
+        // An extra rsync-internal attr on either side is ignored.
+        let stat_name: Vec<u8> = if cfg!(target_os = "linux") {
+            b"user.rsync.%stat".to_vec()
+        } else {
+            b"rsync.%stat".to_vec()
+        };
+        if write_attribute(&b, &stat_name, b"100644 0,0 1:1", false).is_ok() {
+            assert!(
+                xattrs_match(&a, &b, false).expect("compare ignoring %stat"),
+                "rsync.%stat must not affect the xattr match"
+            );
+        }
     }
 
     #[test]

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -188,6 +188,14 @@ pub fn strip_source_xattrs(
 }
 
 /// Synchronises the extended attributes from `source` to `destination`.
+///
+/// The rsync-internal `rsync.%*` attributes (the fake-super `%stat`/`%aacl`/
+/// `%dacl` channel) are excluded from both the copy and the delete pass: a
+/// local single-`-X` copy is upstream's `am_sender && preserve_xattrs < 2`
+/// case, which never transfers them as -X data. Excluding them from the delete
+/// pass also protects the `%stat` that the fake-super metadata step writes on
+/// the destination independently of the xattr transfer.
+// upstream: xattrs.c:259-267 rsync_xal_get() - rsync.%FOO skipped for the sender.
 pub fn sync_xattrs(
     source: &Path,
     destination: &Path,
@@ -198,8 +206,14 @@ pub fn sync_xattrs(
     let mut retained: HashSet<Vec<u8>> = HashSet::with_capacity(source_attrs.len());
 
     for name in &source_attrs {
+        let name_str = String::from_utf8_lossy(name);
+        // upstream: xattrs.c:261 - rsync's own metadata channel is never copied.
+        if protocol::xattr::is_rsync_internal(&name_str) {
+            retained.insert(name.clone());
+            continue;
+        }
         retained.insert(name.clone());
-        let allow = filter.is_none_or(|predicate| predicate(&String::from_utf8_lossy(name)));
+        let allow = filter.is_none_or(|predicate| predicate(&name_str));
 
         if !allow {
             continue;
@@ -218,7 +232,14 @@ pub fn sync_xattrs(
             continue;
         }
 
-        let allow = filter.is_none_or(|predicate| predicate(&String::from_utf8_lossy(name)));
+        let name_str = String::from_utf8_lossy(name);
+        // Never delete rsync's own metadata channel (fake-super %stat/%aacl/%dacl):
+        // it is managed separately and is not part of the -X data set.
+        if protocol::xattr::is_rsync_internal(&name_str) {
+            continue;
+        }
+
+        let allow = filter.is_none_or(|predicate| predicate(&name_str));
 
         if allow {
             remove_attribute(destination, name, follow_symlinks)?;
@@ -577,6 +598,50 @@ mod tests {
             read_attribute(&destination, &attr2, false)
                 .expect("read")
                 .is_none()
+        );
+    }
+
+    // upstream: xattrs.c:259-267 - the rsync.%stat fake-super channel is never
+    // part of the -X data set. It must not be copied from the source, and a
+    // fake-super-written %stat already on the destination must survive the
+    // delete pass. Regression guard for the `xattrs` conformance test's
+    // `--fake-super --chmod=a=` leg.
+    #[test]
+    fn sync_xattrs_leaves_rsync_internal_stat_untouched() {
+        let dir = tempdir().expect("create temp dir");
+        let source = dir.path().join("source.txt");
+        let destination = dir.path().join("dest.txt");
+        fs::write(&source, "source").expect("write source");
+        fs::write(&destination, "dest").expect("write dest");
+
+        if !xattrs_supported(&source) {
+            eprintln!("xattrs not supported, skipping test");
+            return;
+        }
+
+        let stat_name: Vec<u8> = if cfg!(target_os = "linux") {
+            b"user.rsync.%stat".to_vec()
+        } else {
+            b"rsync.%stat".to_vec()
+        };
+
+        // Source carries a stale %stat; destination carries the fake-super one.
+        if write_attribute(&source, &stat_name, b"100644 0,0 1:1", false).is_err() {
+            eprintln!("rsync.%stat namespace not writable, skipping");
+            return;
+        }
+        write_attribute(&destination, &stat_name, b"100000 0,0 2:2", false)
+            .expect("write dest %stat");
+
+        sync_xattrs(&source, &destination, false, None).expect("sync");
+
+        // The destination's fake-super %stat must be preserved verbatim - not
+        // overwritten by the source copy nor deleted by the removal pass.
+        assert_eq!(
+            read_attribute(&destination, &stat_name, false)
+                .expect("read")
+                .expect("dest %stat survives"),
+            b"100000 0,0 2:2",
         );
     }
 

--- a/crates/metadata/src/xattr_stub.rs
+++ b/crates/metadata/src/xattr_stub.rs
@@ -34,6 +34,14 @@ pub fn sync_xattrs(
     Ok(())
 }
 
+/// Reports whether the transferable xattrs of two paths match.
+///
+/// On platforms without xattr support there are no attributes to compare, so
+/// this trivially reports a match.
+pub fn xattrs_match(_a: &Path, _b: &Path, _follow_symlinks: bool) -> Result<bool, MetadataError> {
+    Ok(true)
+}
+
 /// Removes from `destination` every extended attribute that also exists on
 /// `source`.
 ///

--- a/crates/protocol/src/xattr/mod.rs
+++ b/crates/protocol/src/xattr/mod.rs
@@ -40,7 +40,7 @@ mod wire;
 pub use cache::XattrCache;
 pub use entry::{XattrEntry, XattrState};
 pub use list::XattrList;
-pub use prefix::{local_to_wire, wire_to_local};
+pub use prefix::{is_rsync_internal, local_to_wire, wire_to_local};
 pub use wire::{
     RecvXattrResult, XattrDefinition, XattrSet, checksum_matches, read_xattr_definitions,
     recv_xattr, recv_xattr_request, recv_xattr_values, send_sender_xattr_response, send_xattr,

--- a/crates/protocol/src/xattr/prefix.rs
+++ b/crates/protocol/src/xattr/prefix.rs
@@ -190,8 +190,11 @@ pub fn wire_to_local(wire_name: &[u8], am_root: bool) -> Option<Vec<u8>> {
 /// Checks if an xattr name is an rsync internal attribute.
 ///
 /// Rsync internal attributes use the pattern `rsync.%suffix` or `user.rsync.%suffix`.
-/// These are used for storing metadata like stat info and ACLs.
-fn is_rsync_internal(name: &str) -> bool {
+/// These are used for storing metadata like stat info and ACLs (the fake-super
+/// `%stat`/`%aacl`/`%dacl` channel). Upstream never transfers them as -X data:
+/// the sender skips them (`xattrs.c:261-267`, `am_sender && preserve_xattrs < 2`),
+/// so a local copy must exclude them from both the copy and the delete pass.
+pub fn is_rsync_internal(name: &str) -> bool {
     // Check for user.rsync.% pattern (Linux)
     if let Some(suffix) = name.strip_prefix("user.rsync.") {
         return suffix.starts_with('%');


### PR DESCRIPTION
## Summary

Flips the `xattrs` conformance test (`testsuite/xattrs_test.py`) to PASS. The failure was in the `--fake-super` legs of a LOCAL copy: several distinct `%stat` fidelity bugs.

Transport: LOCAL copy (`src/ dst`, `--link-dest`, `--copy-dest`). Feature gate: `--fake-super`/`-X` require the `xattr` feature.

## Root causes and fixes (each mirrors upstream 3.4.4 C)

1. **Real-mode deflection missing under `--chmod`.** A `--fake-super --chmod=a=` directory was chmodded to `000` on disk, so every later `open()` of it failed (`EISDIR`/`EACCES`), aborting the transfer with `failed to preserve timestamps ... Is a directory`. Upstream `xattrs.c:1219-1220 set_stat_xattr()` forces the real mode to `(fmode & ACCESSPERMS) | (S_ISDIR ? 0700 : 0600)` and skips the fake-mode chmod (`rsync.c:660`, `am_root < 0`). Fixed in `metadata/apply/permissions.rs`.

2. **`%stat` written when redundant.** oc wrote a `user.rsync.%stat` shim on every fake-super file/dir. Upstream `xattrs.c:1225-1237` writes it only when the real mode/uid/gid cannot faithfully represent the intended values, and removes any stale one otherwise - so a same-owner `0755` dir / `0644` file under an unprivileged copy carries no `%stat`.

3. **`rsync.%*` copied/deleted by the xattr sync.** The local `-X` xattr sync copied the source's `rsync.%stat` and deleted the fake-super-written one. Upstream `xattrs.c:259-267` never transfers the `rsync.%*` channel for the sender (`am_sender && preserve_xattrs < 2`); exposed `protocol::xattr::is_rsync_internal` and skip those names in both passes.

4. **`--link-dest` exact match rewrote metadata onto the shared inode.** At upstream match_level 3 (`generator.c:995-1024 try_dests_reg()`) a LINK_DEST match only hard-links; `set_file_attrs` runs solely under `--atimes`. oc reapplied metadata unconditionally, writing `%stat` onto the shared basis inode. Gated the reapply on `unchanged_attrs` (perms/owner/group/mtime + `xattrs_differ` via new `metadata::xattrs_match`), so a changed `user.*` attr (match_level 2) still reapplies while an exact match does not.

## lxhost verification (ofer@192.168.21.226, aarch64, upstream rsync 3.4.4)

Before (master): `xattrs` FAIL (`PermissionError ... testtmp/xattrs/to` after `--fake-super --chmod=a=`).

After (this branch):
```
xattrs:        PASS
xattrs-depth:  PASS
acls:          PASS
chmod-option:  PASS
xattrs-hlink:  FAIL   (pre-existing on master, deferred-hard; not touched)
```

`cargo nextest run --workspace --all-features` on lxhost: 30455 tests, 0 product failures. The only failure is the known env-dependent xtask artifact `commands::package::tests::cross_compiler_resolution_falls_back_to_zig` (panics "cross compiler override present" from a stray cross-compiler env var on the host), unrelated to this change.

## Tests

- `metadata`: `fake_super_chmod_deflects_directory_real_mode`, `fake_super_chmod_deflects_regular_file_real_mode`, `fake_super_faithful_directory_writes_no_stat_xattr`, `sync_xattrs_leaves_rsync_internal_stat_untouched`, `xattrs_match_detects_value_and_membership_differences`.