### PR TITLE
feat(transfer): async per-file delta-reconstruct loop (tokio-transfer)

### DIFF
--- a/.github/workflows/async-wire-parity.yml
+++ b/.github/workflows/async-wire-parity.yml
@@ -132,6 +132,13 @@ jobs:
             --features tokio-transfer,zstd,lz4 \
             -E 'test(discard_delta_stream_async_matches_sync)'
 
+      - name: Run sync vs async per-file delta-reconstruct parity tests
+        run: |
+          cargo nextest run --locked \
+            -p transfer \
+            --features tokio-transfer,zstd,lz4 \
+            -E 'test(async_reconstruct)'
+
   async-equivalence:
     name: async-vs-default transfer equivalence (stable)
     runs-on: ubuntu-latest

--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -835,6 +835,154 @@ impl<'a> DeltaApplicator<'a> {
 
         Ok((self.output, self.stats))
     }
+
+    /// Async twin of [`apply_token`](Self::apply_token).
+    ///
+    /// Reads and applies the next delta token off an
+    /// [`AsyncRead`](tokio::io::AsyncRead) rather than blocking. Only the wire
+    /// reads are `.await`ed: the async delta-token leaf
+    /// ([`TokenReader::read_token_async`]) and, for a plain pending literal, the
+    /// raw payload `read_exact`. Every byte the token turns into - the literal
+    /// write, the basis block copy, the checksum-verifier update, the sparse
+    /// bookkeeping, and the `see_token` dictionary feed - runs through the exact
+    /// same synchronous helpers the sync path uses ([`Self::apply_literal_bytes`],
+    /// [`Self::apply_literal_from_buffer`], [`Self::apply_block_ref`],
+    /// [`Self::feed_see_token`]). For the same wire bytes it therefore produces a
+    /// byte-identical destination file, an identical [`DeltaApplyResult`], and
+    /// leaves the reader positioned exactly where the sync leaf would - including
+    /// when the source delivers bytes one at a time across `.await` points.
+    ///
+    /// Returns `true` while more tokens remain and `false` on the `End` token,
+    /// matching [`Self::apply_token`].
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:240` - `receive_data()` (the sync twin mirrors this)
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn apply_token_async<R>(
+        &mut self,
+        reader: &mut R,
+        token_reader: &mut TokenReader,
+    ) -> io::Result<bool>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use tokio::io::AsyncReadExt;
+
+        match token_reader.read_token_async(reader).await? {
+            DeltaToken::End => {
+                debug_log!(
+                    Deltasum,
+                    2,
+                    "recv data complete, final offset={}",
+                    self.stats.bytes_written
+                );
+                Ok(false)
+            }
+            DeltaToken::Literal(LiteralData::Ready(data)) => {
+                self.apply_literal_bytes(&data)?;
+                Ok(true)
+            }
+            DeltaToken::Literal(LiteralData::Pending(len)) => {
+                self.token_buffer.resize_for(len);
+                reader.read_exact(self.token_buffer.as_mut_slice()).await?;
+                let len = self.token_buffer.len();
+                self.apply_literal_from_buffer(len)?;
+                Ok(true)
+            }
+            DeltaToken::BlockRef(block_idx) => {
+                self.apply_block_ref(block_idx)?;
+                // upstream: token.c:631 see_deflate_token() - keep the inflate
+                // dictionary synced after every block match. Mirrors the sync
+                // apply_token: only the compressed reader needs the bytes.
+                if token_reader.is_compressed() {
+                    self.feed_see_token(block_idx, token_reader)?;
+                }
+                Ok(true)
+            }
+        }
+    }
+
+    /// Async twin of [`finish`](Self::finish).
+    ///
+    /// Finalizes the sparse write, reads the trailing whole-file checksum off an
+    /// [`AsyncRead`](tokio::io::AsyncRead), and verifies it. Only the trailing
+    /// checksum `read_exact` is `.await`ed; the sparse finish, the size check,
+    /// and the digest comparison are the identical synchronous logic the sync
+    /// [`finish`](Self::finish) runs. For the same wire bytes it verifies the
+    /// same digest against the same computed checksum and returns the same
+    /// `(File, DeltaApplyResult)`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:515` - trailing `read_buf(f_in, sender_file_sum, ...)`
+    #[cfg(feature = "tokio-transfer")]
+    pub async fn finish_async<R>(
+        mut self,
+        reader: &mut R,
+        expected_size: Option<u64>,
+    ) -> io::Result<(File, DeltaApplyResult)>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        use tokio::io::AsyncReadExt;
+
+        if let Some(ref mut sparse) = self.sparse_state {
+            let final_pos = sparse.finish(&mut self.output)?;
+            self.stats.final_pos = Some(final_pos);
+            if let Some(expected) = expected_size {
+                if final_pos != expected {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "sparse file size mismatch: expected {expected} bytes, \
+                             got {final_pos} bytes"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        let expected_len = self.checksum_verifier.digest_len();
+        let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        reader.read_exact(&mut expected[..expected_len]).await?;
+
+        let mut computed = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
+        let computed_len = self.checksum_verifier.finalize_into(&mut computed);
+
+        debug_log!(
+            Deltasum,
+            3,
+            "recv checksum verify expected={:02x?} computed={:02x?}",
+            &expected[..computed_len.min(4)],
+            &computed[..computed_len.min(4)]
+        );
+
+        if computed[..computed_len] != expected[..expected_len] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "checksum verification failed: expected {:02x?}, got {:02x?}",
+                    &expected[..expected_len],
+                    &computed[..computed_len]
+                ),
+            ));
+        }
+
+        debug_log!(
+            Deltasum,
+            1,
+            "recv: {} tokens ({} literal, {} block), {} bytes total ({} literal, {} matched)",
+            self.stats.literal_tokens + self.stats.block_tokens,
+            self.stats.literal_tokens,
+            self.stats.block_tokens,
+            self.stats.bytes_written,
+            self.stats.literal_bytes,
+            self.stats.matched_bytes
+        );
+
+        Ok((self.output, self.stats))
+    }
 }
 
 /// Reads all delta tokens and applies them.
@@ -853,6 +1001,41 @@ pub fn apply_delta_stream<R: Read>(
     debug_log!(Deltasum, 2, "recv delta stream start");
 
     while applicator.apply_token(reader, token_reader)? {}
+    Ok(())
+}
+
+/// Async twin of [`apply_delta_stream`].
+///
+/// Reads and applies all delta tokens off an [`AsyncRead`](tokio::io::AsyncRead)
+/// via [`DeltaApplicator::apply_token_async`], reconstructing the destination
+/// file exactly as the sync [`apply_delta_stream`] does. The caller finalizes
+/// with [`DeltaApplicator::finish_async`] to consume and verify the trailing
+/// whole-file checksum. Only the wire reads are `.await`ed; the reconstruction
+/// (literal writes, basis block copies, checksum-verifier updates, sparse
+/// bookkeeping, `see_token` dictionary feed) runs through the same synchronous
+/// applicator helpers, so for the same wire bytes the async path produces a
+/// byte-identical destination file and an identical [`DeltaApplyResult`].
+///
+/// This is the composable async RECONSTRUCT loop the tokio receiver uses on the
+/// normal receive path (the `.await` counterpart of the `receiver.c:240`
+/// `receive_data()` call), the reconstructing peer of the discard-path
+/// [`discard_delta_stream_async`]. Gated on `tokio-transfer`.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:240` - `receive_data()` (the sync twin mirrors this)
+#[cfg(feature = "tokio-transfer")]
+pub async fn apply_delta_stream_async<R>(
+    reader: &mut R,
+    applicator: &mut DeltaApplicator<'_>,
+    token_reader: &mut TokenReader,
+) -> io::Result<()>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    debug_log!(Deltasum, 2, "recv delta stream start");
+
+    while applicator.apply_token_async(reader, token_reader).await? {}
     Ok(())
 }
 

--- a/crates/transfer/src/delta_apply/mod.rs
+++ b/crates/transfer/src/delta_apply/mod.rs
@@ -31,11 +31,11 @@ mod checksum;
 mod sparse;
 
 pub use crate::token_reader::{DeltaToken, LiteralData, TokenReader};
-#[cfg(feature = "tokio-transfer")]
-pub use applicator::discard_delta_stream_async;
 pub use applicator::{
     BasisWriterKind, DeltaApplicator, DeltaApplyConfig, DeltaApplyResult, apply_delta_stream,
     discard_delta_stream,
 };
+#[cfg(feature = "tokio-transfer")]
+pub use applicator::{apply_delta_stream_async, discard_delta_stream_async};
 pub use checksum::ChecksumVerifier;
 pub use sparse::SparseWriteState;

--- a/crates/transfer/tests/delta_applicator_equivalence.rs
+++ b/crates/transfer/tests/delta_applicator_equivalence.rs
@@ -624,3 +624,351 @@ fn equivalence_checksum_mismatch_both_invalid() {
     .expect_err("applicator must reject");
     assert_eq!(app_err.kind(), std::io::ErrorKind::InvalidData);
 }
+
+// ---------------------------------------------------------------------------
+// Async reconstruct-loop parity (ASY, `tokio-transfer`).
+//
+// `apply_delta_stream_async` + `DeltaApplicator::finish_async` are the `.await`
+// twins of the sync `apply_delta_stream` + `finish` reconstruct path. Only the
+// wire reads are awaited; the literal writes, basis block copies, checksum
+// verification, sparse bookkeeping, and `see_token` dictionary feed run through
+// the SAME synchronous applicator helpers. For the SAME wire bytes the async
+// path MUST therefore reconstruct a byte-identical destination file, return an
+// identical `DeltaApplyResult`, verify the same trailing checksum, and leave the
+// reader positioned exactly where the sync path would - including when the wire
+// is delivered one byte at a time across `.await` points (the case that would
+// break a naive async decoder assuming a whole token arrives per poll). These
+// tests pin that WHY against the sync applicator the equivalence gate above
+// already proves matches the live receiver loop.
+#[cfg(feature = "tokio-transfer")]
+mod async_parity {
+    use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, ReadBuf};
+    use transfer::delta_apply::apply_delta_stream_async;
+
+    /// Delivers at most `chunk` bytes per `poll_read`, forcing async reads to
+    /// cross `.await` boundaries mid-token when `chunk` is small.
+    struct ChunkedReader {
+        inner: Cursor<Vec<u8>>,
+        chunk: usize,
+    }
+
+    impl AsyncRead for ChunkedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let limit = self.chunk.min(buf.remaining());
+            if limit == 0 {
+                return Poll::Ready(Ok(()));
+            }
+            let pos = self.inner.position() as usize;
+            let data = self.inner.get_ref();
+            if pos >= data.len() {
+                return Poll::Ready(Ok(()));
+            }
+            let end = (pos + limit).min(data.len());
+            let slice = data[pos..end].to_vec();
+            buf.put_slice(&slice);
+            self.inner.set_position(end as u64);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// Async twin of [`applicator_apply`]: drives `apply_delta_stream_async` +
+    /// `finish_async` on a current-thread runtime, reading the wire through a
+    /// [`ChunkedReader`] with the given `chunk` size. Returns the result and the
+    /// final reader position so callers can assert stream alignment.
+    #[allow(clippy::too_many_arguments)]
+    fn applicator_apply_async(
+        output_path: &Path,
+        sparse: bool,
+        signature: Option<&FileSignature>,
+        basis_path: Option<&Path>,
+        wire: &[u8],
+        token_reader: &mut TokenReader,
+        algo: ChecksumAlgorithm,
+        seed: i32,
+        expected_size: Option<u64>,
+        chunk: usize,
+    ) -> std::io::Result<(transfer::delta_apply::DeltaApplyResult, u64)> {
+        let out = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(output_path)?;
+        let config = DeltaApplyConfig {
+            sparse,
+            ..Default::default()
+        };
+        let verifier = ChecksumVerifier::for_algorithm_seeded(algo, seed);
+        let mut applicator = DeltaApplicator::new(out, &config, verifier, signature, basis_path)?;
+        let mut reader = ChunkedReader {
+            inner: Cursor::new(wire.to_vec()),
+            chunk: chunk.max(1),
+        };
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let result = rt.block_on(async {
+            apply_delta_stream_async(&mut reader, &mut applicator, token_reader).await?;
+            let (_out, result) = applicator.finish_async(&mut reader, expected_size).await?;
+            std::io::Result::Ok(result)
+        })?;
+        Ok((result, reader.inner.position()))
+    }
+
+    /// Runs the sync applicator and the async applicator over the SAME wire and
+    /// asserts byte-identical output, identical stats, and identical stream
+    /// consumption across a range of chunk sizes (including byte-at-a-time).
+    #[allow(clippy::too_many_arguments)]
+    fn assert_async_matches_sync(
+        compression: Option<protocol::CompressionAlgorithm>,
+        wire: &[u8],
+        sparse: bool,
+        signature: Option<&FileSignature>,
+        basis_path: Option<&Path>,
+        algo: ChecksumAlgorithm,
+        seed: i32,
+        expected_size: Option<u64>,
+        expected_output: &[u8],
+        dir: &TempDir,
+        label: &str,
+    ) {
+        // Sync baseline.
+        let sync_out = dir.path().join(format!("{label}_sync.bin"));
+        let mut sync_reader = TokenReader::new(compression).expect("sync reader");
+        let sync_res = applicator_apply(
+            &sync_out,
+            sparse,
+            signature,
+            basis_path,
+            wire,
+            &mut sync_reader,
+            algo,
+            seed,
+            expected_size,
+        )
+        .unwrap_or_else(|e| panic!("{label}: sync applies cleanly: {e}"));
+        let sync_bytes = read_file(&sync_out);
+        assert_eq!(
+            sync_bytes, expected_output,
+            "{label}: sync output != expected"
+        );
+
+        // Async twin across chunk sizes. A chunk of 1 forces every read to cross
+        // an await boundary mid-token; the last chunk reads the whole wire at once.
+        for chunk in [1usize, 2, 3, 5, 7, wire.len().max(1)] {
+            let async_out = dir.path().join(format!("{label}_async_{chunk}.bin"));
+            let mut async_reader = TokenReader::new(compression).expect("async reader");
+            let (async_res, consumed) = applicator_apply_async(
+                &async_out,
+                sparse,
+                signature,
+                basis_path,
+                wire,
+                &mut async_reader,
+                algo,
+                seed,
+                expected_size,
+                chunk,
+            )
+            .unwrap_or_else(|e| panic!("{label}/chunk={chunk}: async applies cleanly: {e}"));
+
+            assert_eq!(
+                read_file(&async_out),
+                sync_bytes,
+                "{label}/chunk={chunk}: async output != sync output"
+            );
+            assert_eq!(
+                async_res.literal_bytes, sync_res.literal_bytes,
+                "{label}/chunk={chunk}: literal_bytes differ"
+            );
+            assert_eq!(
+                async_res.bytes_written, sync_res.bytes_written,
+                "{label}/chunk={chunk}: bytes_written differ"
+            );
+            assert_eq!(
+                async_res.final_pos, sync_res.final_pos,
+                "{label}/chunk={chunk}: final_pos differ"
+            );
+            assert_eq!(
+                consumed,
+                wire.len() as u64,
+                "{label}/chunk={chunk}: async consumed the whole wire (no desync)"
+            );
+        }
+    }
+
+    /// Plain literal-only stream: reconstruct + verified MD5 checksum, no basis.
+    #[test]
+    fn async_reconstruct_plain_literal_only_matches_sync() {
+        let payload = basis_payload(4096);
+        let ops = vec![
+            Op::Literal(b"hello world".to_vec()),
+            Op::Literal(vec![0xAB; 300]),
+        ];
+        let algo = ChecksumAlgorithm::MD5;
+        let seed = 0;
+        let dir = tempdir().expect("tempdir");
+        let expected = expected_output(&ops, &payload, BLOCK_LEN as usize);
+        let mut wire = encode_plain(&ops);
+        append_checksum(&mut wire, algo, seed, &expected);
+        assert_async_matches_sync(
+            None,
+            &wire,
+            false,
+            None,
+            None,
+            algo,
+            seed,
+            None,
+            &expected,
+            &dir,
+            "plain_lit",
+        );
+    }
+
+    /// Plain mixed literal + basis block copies: exercises `apply_block_ref` on
+    /// the async path, including the trailing remainder block.
+    #[test]
+    fn async_reconstruct_plain_mixed_matches_sync() {
+        let block_len = BLOCK_LEN as usize;
+        let payload = basis_payload(block_len * 2 + 137);
+        let ops = vec![
+            Op::Literal(b"prefix".to_vec()),
+            Op::Block(0),
+            Op::Literal(vec![7u8; 64]),
+            Op::Block(2),
+            Op::Block(1),
+        ];
+        let algo = ChecksumAlgorithm::MD5;
+        let seed = 0;
+        let dir = tempdir().expect("tempdir");
+        let basis_path = write_basis(&dir, &payload);
+        let signature = make_signature(&payload);
+        let expected = expected_output(&ops, &payload, block_len);
+        let mut wire = encode_plain(&ops);
+        append_checksum(&mut wire, algo, seed, &expected);
+        assert_async_matches_sync(
+            None,
+            &wire,
+            false,
+            Some(&signature),
+            Some(basis_path.as_path()),
+            algo,
+            seed,
+            None,
+            &expected,
+            &dir,
+            "plain_mixed",
+        );
+    }
+
+    /// Compressed (`-z`) mixed stream with >=2 block matches: exercises the
+    /// async inflate decoder AND the `see_token` dictionary-sync feed after each
+    /// block ref. A missing/reordered async `see_token` corrupts the output.
+    #[test]
+    fn async_reconstruct_compressed_mixed_matches_sync() {
+        let block_len = BLOCK_LEN as usize;
+        let payload = basis_payload(block_len * 4 + 200);
+        let ops = vec![
+            Op::Literal(b"compressed prefix data that deflates".to_vec()),
+            Op::Block(0),
+            Op::Block(1),
+            Op::Literal(vec![0x5A; 256]),
+            Op::Block(3),
+            Op::Literal(b"tail literal".to_vec()),
+        ];
+        let algo = ChecksumAlgorithm::MD5;
+        let seed = 0;
+        let dir = tempdir().expect("tempdir");
+        let basis_path = write_basis(&dir, &payload);
+        let signature = make_signature(&payload);
+        let expected = expected_output(&ops, &payload, block_len);
+        let mut wire = encode_compressed(&ops, &payload, block_len);
+        append_checksum(&mut wire, algo, seed, &expected);
+        assert_async_matches_sync(
+            Some(protocol::CompressionAlgorithm::Zlib),
+            &wire,
+            false,
+            Some(&signature),
+            Some(basis_path.as_path()),
+            algo,
+            seed,
+            None,
+            &expected,
+            &dir,
+            "compressed_mixed",
+        );
+    }
+
+    /// Sparse trailing-zeros reconstruct: the async `finish_async` records the
+    /// same `final_pos` and passes the same size check as sync `finish`.
+    #[test]
+    fn async_reconstruct_sparse_matches_sync() {
+        let algo = ChecksumAlgorithm::MD5;
+        let seed = 0;
+        let dir = tempdir().expect("tempdir");
+        let mut literal = b"head".to_vec();
+        literal.extend_from_slice(&[0u8; 8192]);
+        let ops = vec![Op::Literal(literal.clone())];
+        let expected = literal.clone();
+        let expected_size = expected.len() as u64;
+        let mut wire = encode_plain(&ops);
+        append_checksum(&mut wire, algo, seed, &expected);
+        assert_async_matches_sync(
+            None,
+            &wire,
+            true,
+            None,
+            None,
+            algo,
+            seed,
+            Some(expected_size),
+            &expected,
+            &dir,
+            "sparse",
+        );
+    }
+
+    /// A corrupted trailing checksum makes `finish_async` reject with
+    /// `InvalidData`, exactly like the sync `finish` - the async path must not
+    /// silently accept a bad digest.
+    #[test]
+    fn async_reconstruct_checksum_mismatch_rejects() {
+        let ops = vec![Op::Literal(b"some literal content".to_vec())];
+        let algo = ChecksumAlgorithm::MD5;
+        let seed = 0;
+        let dir = tempdir().expect("tempdir");
+        let expected = expected_output(&ops, &[], BLOCK_LEN as usize);
+        let mut wire = encode_plain(&ops);
+        append_checksum(&mut wire, algo, seed, &expected);
+        let last = wire.len() - 1;
+        wire[last] ^= 0xFF;
+
+        for chunk in [1usize, wire.len()] {
+            let out = dir.path().join(format!("mismatch_{chunk}.bin"));
+            let mut reader = TokenReader::new(None).expect("plain");
+            let err = applicator_apply_async(
+                &out,
+                false,
+                None,
+                None,
+                &wire,
+                &mut reader,
+                algo,
+                seed,
+                None,
+                chunk,
+            )
+            .expect_err("async must reject corrupted checksum");
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
+}


### PR DESCRIPTION
## What

Advances the async migration to its next rung: composes the async delta-token leaf into a **reconstructing** async per-file delta loop that produces byte-identical output to the sync reconstruct path. This is the reconstructing peer of the discard-path `discard_delta_stream_async` (#6284), which only consumed and aligned the stream without writing.

### New surface (all gated on `tokio-transfer`)

- `apply_delta_stream_async` - the `.await` twin of `apply_delta_stream`. Reads and applies all delta tokens off an `AsyncRead`, reconstructing the destination file exactly as the sync loop does.
- `DeltaApplicator::apply_token_async` - `.await` twin of `apply_token`.
- `DeltaApplicator::finish_async` - `.await` twin of `finish` (sparse finalize + size check + trailing whole-file checksum read + verify).

Only the wire reads are awaited (the async delta-token leaf and the pending-literal / trailing-checksum `read_exact`). Every byte the token turns into - literal writes, basis block copies, checksum-verifier updates, sparse bookkeeping, and the `see_token` inflate-dictionary feed after each block match - runs through the exact same synchronous applicator helpers the sync path uses. For the same wire bytes the async path therefore produces a byte-identical destination file, an identical `DeltaApplyResult`, and verifies the same trailing checksum.

## Parity evidence

New `async_parity` module in `delta_applicator_equivalence.rs` runs the sync applicator and the async applicator over the **same** wire and asserts byte-identical output, identical stats (`literal_bytes` / `bytes_written` / `final_pos`), and identical stream consumption, across chunk sizes down to **one byte per poll** (forcing every read to cross an `.await` boundary mid-token):

- `async_reconstruct_plain_literal_only_matches_sync` - literal-only, verified MD5.
- `async_reconstruct_plain_mixed_matches_sync` - mixed literal + basis block copies (incl. trailing remainder block).
- `async_reconstruct_compressed_mixed_matches_sync` - `-z` zlib with >=2 block matches, exercising the async inflate decoder and the `see_token` dictionary-sync feed.
- `async_reconstruct_sparse_matches_sync` - trailing-zeros sparse file, `finish_async` size check.
- `async_reconstruct_checksum_mismatch_rejects` - corrupted trailing checksum rejected with `InvalidData` on both byte-at-a-time and whole-wire delivery.

Wired into `async-wire-parity.yml`.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy -p transfer --features tokio-transfer --all-targets --no-deps --locked -D warnings` - clean.
- `cargo clippy -p transfer` (default, no async) - clean (default build untouched).
- `cargo nextest run -p transfer --features tokio-transfer,zstd,lz4 -E 'test(async_reconstruct)|test(discard_delta_stream_async_matches_sync)|test(equivalence)'` - 13 passed, 0 failed.

## Scope

The full receiver wire-up (converting the receiver per-file loop - `SumHead::read` -> temp-open -> apply -> `finish` - to async and threading an `AsyncRead` through the tokio driver) is a large, separate rung and is intentionally out of scope here to avoid shipping a half-wired receiver. The tokio driver still hosts the sync server body on the runtime; this PR lands the composable reconstructing leaf it will call, with a parity gate proving it byte-matches sync.

Upstream reference: `receiver.c:240` `receive_data()`.