### PR TITLE
fix(filters): reject 'e' modifier on non-merge rules (EXCLUDE_SELF parity)

### DIFF
--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -22,7 +22,7 @@
 //! - `s` - Sender-side only
 //! - `r` - Receiver-side only
 //! - `x` - Xattr filtering only
-//! - `e` - Exclude-only (forces rule to act as exclude)
+//! - `e` - Exclude-self (merge rules only: exclude the merge file's own name)
 //! - `n` - No-inherit (for merge rules, don't inherit parent rules)
 //! - `w` - Word-split (split pattern on whitespace into multiple rules)
 //! - `C` - CVS mode (add CVS exclusion patterns)

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -127,6 +127,8 @@ fn parse_rule_line_expanded(
 
     if mods.word_split && !pattern.is_empty() {
         validate_side_modifiers(action_char, &mods, line, source_path, line_num)?;
+        // These prefixes are never merge-file rules, so `e` is always invalid.
+        validate_exclude_self_modifier(false, &mods, line, source_path, line_num)?;
         let patterns: Vec<&str> = pattern.split_whitespace().collect();
         if patterns.is_empty() {
             return Err(MergeFileError::parse_error(
@@ -174,10 +176,14 @@ fn parse_rule_line_expanded(
 /// | `s` | `sender_only` | Apply on sender side only |
 /// | `r` | `receiver_only` | Apply on receiver side only |
 /// | `x` | `xattr_only` | Match xattr names only |
-/// | `e` | `exclude_only` | Force rule to exclude |
+/// | `e` | `exclude_self` | Exclude the merge file's own name (merge rules only) |
 /// | `n` | `no_inherit` | Don't inherit parent rules (merge) |
 /// | `w` | `word_split` | Split pattern on whitespace |
 /// | `C` | `cvs_mode` | Add CVS exclusion patterns |
+///
+/// upstream: exclude.c:1256-1259 - the `e` modifier maps to
+/// `FILTRULE_EXCLUDE_SELF` and is valid only on a merge-file rule
+/// (`FILTRULE_MERGE_FILE`); on any other rule upstream jumps to `invalid`.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct RuleModifiers {
     pub(crate) negate: bool,
@@ -185,7 +191,7 @@ pub(crate) struct RuleModifiers {
     pub(crate) sender_only: bool,
     pub(crate) receiver_only: bool,
     pub(crate) xattr_only: bool,
-    pub(crate) exclude_only: bool,
+    pub(crate) exclude_self: bool,
     pub(crate) no_inherit: bool,
     pub(crate) word_split: bool,
     pub(crate) cvs_mode: bool,
@@ -203,7 +209,6 @@ impl RuleModifiers {
             .with_negate(self.negate)
             .with_perishable(self.perishable)
             .with_xattr_only(self.xattr_only)
-            .with_exclude_only(self.exclude_only)
             .with_no_inherit(no_inherit)
             .with_cvs_mode(self.cvs_mode);
 
@@ -253,6 +258,34 @@ fn validate_side_modifiers(
     Ok(())
 }
 
+/// Rejects the `e` (exclude-self) modifier on a non-merge rule.
+///
+/// Upstream only permits `e` on a merge-file rule (`.`/`:`/`merge`/`dir-merge`),
+/// where it sets `FILTRULE_EXCLUDE_SELF` so the merge file's own basename is
+/// excluded. On an include/exclude/protect/risk/hide/show rule upstream jumps to
+/// the `invalid` label and reports a parse error; oc-rsync previously accepted
+/// it silently and stored it in a flag no matching logic read, so the modifier
+/// was a no-op that diverged from upstream on malformed input.
+///
+/// upstream: exclude.c:1256-1259 - `case 'e': if (!(rule->rflags &
+/// FILTRULE_MERGE_FILE)) goto invalid;`
+fn validate_exclude_self_modifier(
+    is_merge: bool,
+    mods: &RuleModifiers,
+    line: &str,
+    source_path: &Path,
+    line_num: usize,
+) -> Result<(), MergeFileError> {
+    if mods.exclude_self && !is_merge {
+        return Err(MergeFileError::parse_error(
+            source_path,
+            line_num,
+            format!("invalid modifier 'e' on non-merge filter rule: {line}"),
+        ));
+    }
+    Ok(())
+}
+
 /// Parses modifiers from a string following the action character.
 ///
 /// Returns the parsed modifiers and the remaining string (pattern).
@@ -269,7 +302,7 @@ pub(crate) fn parse_modifiers(s: &str) -> (RuleModifiers, &str) {
             's' => mods.sender_only = true,
             'r' => mods.receiver_only = true,
             'x' => mods.xattr_only = true,
-            'e' => mods.exclude_only = true,
+            'e' => mods.exclude_self = true,
             'n' => mods.no_inherit = true,
             'w' => mods.word_split = true,
             'C' => mods.cvs_mode = true,
@@ -318,6 +351,14 @@ impl ShortFormAction {
     const fn supports_mods(self) -> bool {
         !matches!(self, Self::Merge)
     }
+
+    /// Whether this action is a merge-file rule (`.`/`:`/`merge`/`dir-merge`).
+    ///
+    /// upstream: `FILTRULE_MERGE_FILE` covers both plain and per-directory
+    /// merges; the `e` modifier is permitted only on these.
+    const fn is_merge(self) -> bool {
+        matches!(self, Self::Merge | Self::DirMerge)
+    }
 }
 
 /// Tries to parse a short-form rule (single character prefix like `+`, `-`, `P`).
@@ -360,12 +401,14 @@ fn try_parse_short_form(
         // unrecognised here and falls through to long-form parsing.
         if mods.cvs_mode && matches!(action, ShortFormAction::Merge | ShortFormAction::DirMerge) {
             validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;
+            validate_exclude_self_modifier(action.is_merge(), &mods, line, source_path, line_num)?;
             let rule = action.to_rule(".cvsignore");
             return Ok(Some(mods.apply(rule)));
         }
         return Ok(None);
     }
     validate_side_modifiers(prefix_char, &mods, line, source_path, line_num)?;
+    validate_exclude_self_modifier(action.is_merge(), &mods, line, source_path, line_num)?;
 
     let rule = action.to_rule(pattern);
     Ok(Some(if action.supports_mods() {

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -384,18 +384,56 @@ fn parse_modifiers_all_flags() {
     assert!(mods.sender_only);
     assert!(mods.receiver_only);
     assert!(mods.xattr_only);
-    assert!(mods.exclude_only);
+    assert!(mods.exclude_self);
     assert!(mods.no_inherit);
     assert!(mods.cvs_mode);
     assert_eq!(pattern, "pattern");
 }
 
+/// The `e` modifier is `FILTRULE_EXCLUDE_SELF`, valid only on a merge-file
+/// rule. On an ordinary exclude/include/etc. rule upstream jumps to `invalid`
+/// (exclude.c:1256-1259). oc-rsync previously accepted `-e *.bak` silently and
+/// stored a flag no matching logic read, so a malformed rule became a no-op
+/// instead of the parse error upstream reports. This test pins the rejection so
+/// the two tools agree on what is a syntax error.
 #[test]
-fn parse_exclude_only_modifier() {
-    let rules = parse_rules("-e *.bak", Path::new("test")).unwrap();
+fn parse_exclude_self_modifier_rejected_on_non_merge_rule() {
+    let err = parse_rules("-e *.bak", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'e'"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `e` word-split combinations on a non-merge rule are equally invalid: the
+/// modifier is rejected before the pattern is expanded.
+#[test]
+fn parse_exclude_self_modifier_rejected_with_word_split() {
+    let err = parse_rules("-ew foo bar", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'e'"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `e` is accepted on a dir-merge rule (upstream sets `FILTRULE_EXCLUDE_SELF`
+/// there). The rule parses successfully as a dir-merge; exclude-self plumbing
+/// is applied at the chain layer via `DirMergeConfig::with_exclude_self`.
+#[test]
+fn parse_exclude_self_modifier_accepted_on_dir_merge_rule() {
+    let rules = parse_rules(":e .rsync-filter", Path::new("test")).unwrap();
     assert_eq!(rules.len(), 1);
-    assert_eq!(rules[0].action(), FilterAction::Exclude);
-    assert!(rules[0].is_exclude_only());
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), ".rsync-filter");
+}
+
+/// `e` is likewise accepted on a plain merge rule.
+#[test]
+fn parse_exclude_self_modifier_accepted_on_merge_rule() {
+    let rules = parse_rules(".e rules.txt", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::Merge);
+    assert_eq!(rules[0].pattern(), "rules.txt");
 }
 
 #[test]

--- a/crates/filters/tests/dir_merge_parsing_comprehensive.rs
+++ b/crates/filters/tests/dir_merge_parsing_comprehensive.rs
@@ -58,16 +58,36 @@ fn dir_merge_both_sides_explicit() {
 }
 
 #[test]
-fn dir_merge_exclude_only_modifier() {
+fn dir_merge_exclude_self_modifier() {
     let dir = TempDir::new().unwrap();
     let rules_path = dir.path().join("rules.txt");
 
-    // Dir-merge with exclude-only modifier
+    // The `e` modifier (FILTRULE_EXCLUDE_SELF) is valid on a dir-merge rule.
+    // upstream: exclude.c:1256-1259 - `e` requires FILTRULE_MERGE_FILE and makes
+    // the merge file's own name be excluded; exclude-self plumbing is applied at
+    // the chain layer, so parsing simply yields a well-formed dir-merge rule.
     fs::write(&rules_path, ":e .rsync-filter\n").unwrap();
 
     let rules = filters::merge::read_rules(&rules_path).unwrap();
     assert_eq!(rules.len(), 1);
-    assert!(rules[0].is_exclude_only());
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), ".rsync-filter");
+}
+
+#[test]
+fn exclude_self_modifier_rejected_on_plain_rule() {
+    let dir = TempDir::new().unwrap();
+    let rules_path = dir.path().join("rules.txt");
+
+    // upstream: exclude.c:1256-1258 - `e` on a non-merge rule jumps to `invalid`.
+    // oc-rsync previously accepted `-e pattern` silently; pin the rejection.
+    fs::write(&rules_path, "-e *.bak\n").unwrap();
+
+    let err = filters::merge::read_rules(&rules_path).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'e'"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -255,10 +255,17 @@ mod exclude_rules {
     }
 
     #[test]
-    fn exclude_with_exclude_only_modifier() {
-        let rules = parse_rules("-e *.log", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert!(rules[0].is_exclude_only());
+    fn exclude_with_exclude_self_modifier_is_rejected() {
+        // upstream: exclude.c:1256-1258 - the `e` (FILTRULE_EXCLUDE_SELF)
+        // modifier requires FILTRULE_MERGE_FILE; on a plain exclude rule
+        // upstream jumps to `invalid`. oc-rsync previously accepted `-e *.log`
+        // and stored a flag no matching logic read, silently diverging from
+        // upstream on malformed input.
+        let err = parse_rules("-e *.log", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'e'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `e` filter-rule modifier maps to upstream rsync's `FILTRULE_EXCLUDE_SELF` and is valid **only on a merge-file rule** (`.`/`:`/`merge`/`dir-merge`), where it causes the merge file's own basename to be excluded. On any other rule upstream jumps to the `invalid` label and reports a parse error.

```c
/* exclude.c:1256-1259 */
case 'e':
    if (!(rule->rflags & FILTRULE_MERGE_FILE))
        goto invalid;
    rule->rflags |= FILTRULE_EXCLUDE_SELF;
    break;
```

oc-rsync's merge parser instead:
- accepted `e` on **any** rule prefix (`+ - P R H S`), and
- stored it in a `FilterRule` flag (`exclude_only`, "force rule to exclude") that **no matching logic ever reads**.

The modifier was therefore a silent no-op that both misdescribed upstream semantics and diverged from upstream by accepting malformed input (e.g. `-e *.log`) that upstream rejects.

The real EXCLUDE_SELF behavior is already implemented at the chain layer via `DirMergeConfig::with_exclude_self` (driven from the CLI directive parser); this PR only fixes the in-crate merge-content parser.

## Change

- Reject `e` on non-merge rules (mirrors upstream `goto invalid`) via a new `validate_exclude_self_modifier` helper, wired into both the word-split and short-form parse paths.
- Keep `e` accepted on merge/dir-merge rules (parses to a well-formed rule; exclude-self is applied at the chain layer).
- Rename the dead `RuleModifiers.exclude_only` field to `exclude_self` and stop wiring it into the unread `FilterRule` flag; correct the misleading module and struct docs.

The pre-existing, now-unused `FilterRule::exclude_only` field/accessors are left untouched to keep the change surgical (they have no non-test consumers anywhere in the workspace).

## Tests

Updated tests to encode the upstream intent:
- `e` on a non-merge rule (plain and word-split forms) is now a parse error.
- `e` on `.`/`:` merge rules parses successfully to the expected action/pattern.

`cargo fmt`, `cargo clippy -p filters --all-features --no-deps --locked -D warnings`, and `cargo test -p filters` all pass locally.

## Follow-up (not in this PR)

Upstream also restricts the `n` (no-inherit) and `w` (word-split) modifiers to merge-file rules (exclude.c:1261-1264, 1279-1282). oc-rsync currently accepts and uses them on plain rules; tightening those is a larger, higher-ripple change left for a separate PR.

upstream: exclude.c:1256-1259