### PR TITLE
fix(cli): distinguish %b/%c transfer-byte direction per upstream

### DIFF
--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -66,16 +66,13 @@ pub(super) fn render_placeholder_value(
             Some(format_numeric_value(length as i64, &spec.format))
         }
         OutFormatPlaceholder::BytesTransferred => Some(format_numeric_value(
-            event.bytes_transferred() as i64,
+            transfer_byte_count(event, context.is_sender, false) as i64,
             &spec.format,
         )),
-        OutFormatPlaceholder::ChecksumBytes => {
-            let checksum_bytes = match event.kind() {
-                ClientEventKind::DataCopied => event.bytes_transferred(),
-                _ => 0,
-            };
-            Some(format_numeric_value(checksum_bytes as i64, &spec.format))
-        }
+        OutFormatPlaceholder::ChecksumBytes => Some(format_numeric_value(
+            transfer_byte_count(event, context.is_sender, true) as i64,
+            &spec.format,
+        )),
         OutFormatPlaceholder::Operation => Some(describe_event_kind(event.kind()).to_owned()),
         OutFormatPlaceholder::ModifyTime => Some(format_out_format_mtime(event.metadata())),
         OutFormatPlaceholder::PermissionString => {
@@ -122,6 +119,50 @@ pub(super) fn render_placeholder_value(
             'P',
         )),
         OutFormatPlaceholder::FullChecksum => Some(format_full_checksum(event)),
+    }
+}
+
+/// Wire size of the `sum_head` a receiver sends per transferred file: four
+/// 32-bit little-endian fields (count, blength, s2length, remainder). In the
+/// local-copy path transfers are always whole-file, so the header is empty
+/// (count=0) and its size is the constant 16 bytes the sender reads back.
+///
+/// upstream: rsync.h:200 `struct sum_struct`; match.c:380 `write_sum_head()`.
+const SUM_HEAD_WIRE_BYTES: u64 = 16;
+
+/// Resolves the byte count for `%b` / `%c`, selecting the direction the way
+/// upstream does.
+///
+/// upstream: log.c:672-684 - `%b` and `%c` are the two per-file wire byte
+/// deltas. When the entry was not transferred (`!(iflags & ITEM_TRANSFER)`)
+/// both render 0. Otherwise `(!!am_sender) ^ (*p == 'c')` selects between the
+/// bytes written (`total_data_written - initial_data_written`) and the bytes
+/// read (`total_data_read - initial_data_read`). On the sender the written
+/// direction carries the file data and the read direction carries the checksum
+/// header echoed back; on the receiver they swap onto the opposite physical
+/// counters. The net semantic is role-independent: `%b` always reports the
+/// file-data bytes and `%c` always reports the checksum-header bytes.
+///
+/// oc-rsync's local-copy engine records the file-data bytes as
+/// `bytes_transferred`; the checksum direction is the whole-file empty
+/// [`SUM_HEAD_WIRE_BYTES`] header. `want_checksum` picks between the two, and
+/// the `is_sender` XOR reproduces upstream's counter mapping so `%b`/`%c`
+/// remain correct for either transfer role.
+fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool) -> u64 {
+    if !matches!(event.kind(), ClientEventKind::DataCopied) {
+        return 0;
+    }
+    // upstream `(!!am_sender) ^ (*p == 'c')`: true -> the bytes-written counter,
+    // false -> the bytes-read counter. On the sender the written counter holds
+    // the file data (read holds the checksum header); on the receiver the roles
+    // of the two physical counters swap. Map each selected counter back to the
+    // quantity oc-rsync tracks per file so the printed value matches upstream.
+    let selects_written = is_sender ^ want_checksum;
+    let written_is_data = is_sender;
+    if selects_written == written_is_data {
+        event.bytes_transferred()
+    } else {
+        SUM_HEAD_WIRE_BYTES
     }
 }
 

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1417,9 +1417,68 @@ fn render_percent_b_shows_bytes_transferred() {
         true,
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
+    )
+    .with_bytes_transferred_for_test(5043);
+    // Local copy => sender; %b reports the file-data bytes written.
+    // upstream log.c:672-684, verified against rsync 3.4.4 (`%b`=5043).
+    let ctx = OutFormatContext::with_is_sender(true);
+    assert_eq!(render_format_with_context("%b", &event, &ctx), "5043\n");
+}
+
+#[test]
+fn render_percent_b_and_c_differ_by_direction_on_sender() {
+    // upstream log.c:672-684 - on the sender `%b` = file data written,
+    // `%c` = the 16-byte sum_head read back. Verified against rsync 3.4.4:
+    // a local push of a 5000-byte file prints `%b`=5043 `%c`=16.
+    let event = make_event(
+        ClientEventKind::DataCopied,
+        true,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    )
+    .with_bytes_transferred_for_test(5043);
+    let ctx = OutFormatContext::with_is_sender(true);
+    assert_eq!(render_format_with_context("%b", &event, &ctx), "5043\n");
+    assert_eq!(render_format_with_context("%c", &event, &ctx), "16\n");
+    assert_ne!(
+        render_format_with_context("%b", &event, &ctx),
+        render_format_with_context("%c", &event, &ctx),
+        "%b and %c must not collapse to the same value on the sender",
     );
-    // ClientEvent::for_test seeds bytes_transferred=0.
-    assert_eq!(render_format("%b", &event), "0\n");
+}
+
+#[test]
+fn render_percent_b_and_c_swap_counters_on_receiver() {
+    // upstream log.c:672-684 - on the receiver the (!!am_sender) ^ (*p == 'c')
+    // selector maps the file-data bytes to the read counter and the sum_head to
+    // the write counter, so `%b` still reports the file data and `%c` the
+    // 16-byte header - the semantic value is role-independent.
+    let event = make_event(
+        ClientEventKind::DataCopied,
+        true,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    )
+    .with_bytes_transferred_for_test(5043);
+    let ctx = OutFormatContext::with_is_sender(false);
+    assert_eq!(render_format_with_context("%b", &event, &ctx), "5043\n");
+    assert_eq!(render_format_with_context("%c", &event, &ctx), "16\n");
+}
+
+#[test]
+fn render_percent_b_and_c_zero_for_non_transfer() {
+    // upstream log.c:674-675 - `!(iflags & ITEM_TRANSFER)` forces both to 0.
+    // A metadata-only reuse is not a transfer, so neither escape counts bytes.
+    let event = make_event(
+        ClientEventKind::MetadataReused,
+        false,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    )
+    .with_bytes_transferred_for_test(5043);
+    let ctx = OutFormatContext::with_is_sender(true);
+    assert_eq!(render_format_with_context("%b", &event, &ctx), "0\n");
+    assert_eq!(render_format_with_context("%c", &event, &ctx), "0\n");
 }
 
 #[test]

--- a/crates/cli/src/frontend/tests/out/checksum.rs
+++ b/crates/cli/src/frontend/tests/out/checksum.rs
@@ -113,14 +113,28 @@ fn out_format_renders_checksum_bytes_for_data_copy_events() {
         .find(|event| matches!(event.kind(), ClientEventKind::DataCopied))
         .expect("data copy event present");
 
-    let mut output = Vec::new();
-    parse_out_format(OsStr::new("%c"))
-        .expect("parse %c")
-        .render(event, &OutFormatContext::default(), &mut output)
-        .expect("render %c");
-
-    let rendered = String::from_utf8(output).expect("utf8");
-    assert_eq!(rendered.trim_end(), contents.len().to_string());
+    // upstream log.c:672-684 - on a transferred file `%c` reports the
+    // checksum-direction bytes, i.e. the 16-byte sum_head, NOT the file-data
+    // bytes. `%b` reports the file data. Verified against rsync 3.4.4: a local
+    // copy prints `%c`=16 for any transferred file regardless of size.
+    let render = |token: &str| {
+        let mut output = Vec::new();
+        parse_out_format(OsStr::new(token))
+            .expect("parse token")
+            .render(event, &OutFormatContext::default(), &mut output)
+            .expect("render token");
+        String::from_utf8(output)
+            .expect("utf8")
+            .trim_end()
+            .to_owned()
+    };
+    assert_eq!(render("%c"), "16");
+    assert_ne!(
+        render("%c"),
+        contents.len().to_string(),
+        "%c must not collapse onto the file-data byte count",
+    );
+    assert_ne!(render("%b"), render("%c"));
 }
 
 #[test]

--- a/crates/core/src/client/summary/event.rs
+++ b/crates/core/src/client/summary/event.rs
@@ -401,6 +401,18 @@ impl ClientEvent {
         self
     }
 
+    /// Seeds the per-event transferred-byte count for testing purposes.
+    ///
+    /// Mirrors the `bytes_transferred` field populated by the local-copy engine
+    /// so renderer tests can exercise the `%b` / `%c` direction split without
+    /// running a transfer.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn with_bytes_transferred_for_test(mut self, bytes: u64) -> Self {
+        self.bytes_transferred = bytes;
+        self
+    }
+
     /// Constructs a [`ClientEntryMetadata`] for testing purposes.
     #[doc(hidden)]
     pub fn test_metadata(kind: ClientEntryKind) -> ClientEntryMetadata {


### PR DESCRIPTION
## Problem

The `--out-format` / `--log-format` `%b` and `%c` escapes both rendered the file-data byte count for a transferred file, so `%c` collapsed onto `%b`. This diverges from upstream observable output.

Upstream `log.c:672-684`:

```c
case 'b':
case 'c':
    if (!(iflags & ITEM_TRANSFER))
        b = 0;
    else if ((!!am_sender) ^ (*p == 'c'))
        b = total_data_written - initial_data_written;
    else
        b = total_data_read - initial_data_read;
```

`%b` names the file-data direction and `%c` the checksum-header direction, selected by `(!!am_sender) ^ (*p == 'c')`. For the local-copy whole-file path the checksum header is the empty 16-byte `sum_head` (`rsync.h:200` `struct sum_struct`, `match.c:380` `write_sum_head`).

## Fix

- Route `%b` / `%c` through a single direction-aware helper that mirrors the upstream `(!!am_sender) ^ (*p == 'c')` selector, using the already-threaded `is_sender` context. Non-transfer events render 0 for both, per `log.c:674-675`.
- `%b` reports the tracked `bytes_transferred` (file data); `%c` reports the 16-byte `sum_head` constant.

## Before / after (local copy of a 5000-byte file, verified vs rsync 3.4.4)

| escape | before (oc) | after (oc) | upstream 3.4.4 |
|--------|-------------|-----------|----------------|
| `%b`   | 5000        | 5000      | 5043           |
| `%c`   | **5000**    | **16**    | **16**         |

`%c` no longer collapses onto the file-data count. (The `%b` magnitude gap 5000 vs 5043 - wire/token overhead - and the `%o` operation-name wording are separate, pre-existing accounting differences, out of scope here.)

## Tests

- Corrected `out_format_renders_checksum_bytes_for_data_copy_events` (was pinning the old buggy `%c` == file-size); now asserts `%c` == 16 and `%b` != `%c`.
- Added sender/receiver direction tests and a non-transfer zero test in the render suite.
- `cargo fmt`, `cargo clippy -p cli -p core -D warnings` clean; targeted `cargo test -p cli` green.