### PR TITLE
fix(engine): punch sparse holes under --preallocate and --inplace

### DIFF
--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -310,9 +310,14 @@ fn transfer_request_with_sparse_and_append_verify_uses_dense_allocation() {
     assert_eq!(sparse_meta.blocks(), dense_meta.blocks());
 }
 
-#[cfg(unix)]
+/// `--sparse --inplace` writes the source's zero run as a hole rather than
+/// materialising it. Upstream keeps `sparse_files > 0` in inplace mode, so an
+/// inplace update with a large zero run allocates far fewer blocks than a dense
+/// (`--inplace` only) update of the same content.
+// upstream: fileio.c:write_sparse() stays active with inplace (preallocated_len = size_r)
+#[cfg(target_os = "linux")]
 #[test]
-fn transfer_request_with_sparse_and_inplace_uses_dense_allocation() {
+fn transfer_request_with_sparse_and_inplace_punches_hole() {
     use std::fs::{self, OpenOptions};
     use std::io::Write;
     use std::os::unix::fs::MetadataExt;
@@ -348,17 +353,16 @@ fn transfer_request_with_sparse_and_inplace_uses_dense_allocation() {
     updated_file.flush().expect("flush updated source");
     drop(updated_file);
 
-    let (code, stdout, stderr) = run_with_args([
+    let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--inplace"),
         updated_source.as_os_str().to_os_string(),
         dense_dest.as_os_str().to_os_string(),
     ]);
     assert_eq!(code, 0);
-    assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    let (code, stdout, stderr) = run_with_args([
+    let (code, _stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--sparse"),
         OsString::from("--inplace"),
@@ -366,12 +370,18 @@ fn transfer_request_with_sparse_and_inplace_uses_dense_allocation() {
         sparse_dest.clone().into_os_string(),
     ]);
     assert_eq!(code, 0);
-    assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
     let dense_meta = fs::metadata(&dense_dest).expect("dense metadata");
     let sparse_meta = fs::metadata(&sparse_dest).expect("sparse metadata");
 
+    // Content length matches; the sparse update must allocate strictly fewer
+    // blocks than the dense one because the 1 MiB zero run became a hole.
     assert_eq!(dense_meta.len(), sparse_meta.len());
-    assert_eq!(sparse_meta.blocks(), dense_meta.blocks());
+    assert!(
+        sparse_meta.blocks() < dense_meta.blocks(),
+        "inplace sparse update must punch the zero run (sparse={} blocks, dense={} blocks)",
+        sparse_meta.blocks(),
+        dense_meta.blocks(),
+    );
 }

--- a/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
+++ b/crates/cli/src/frontend/tests/transfer_request_with_sparse.rs
@@ -104,34 +104,30 @@ fn transfer_request_with_sparse_copies_all_zero_source_without_extra_blocks() {
     );
 }
 
-#[cfg(unix)]
+/// `--sparse --preallocate` reserves the destination extent, then punches the
+/// source's zero run back out. Upstream keeps `sparse_files > 0` under
+/// `--preallocate` and `do_fallocate()` reports the preallocated length so
+/// `write_sparse()` punches the interior hole (rather than leaving the reserved
+/// blocks allocated).
+// upstream: fileio.c:95 write_sparse() -> do_punch_hole within preallocated_len
+#[cfg(target_os = "linux")]
 #[test]
-fn transfer_request_with_sparse_and_preallocate_allocates_dense() {
+fn transfer_request_with_sparse_and_preallocate_punches_hole() {
     use std::os::unix::fs::MetadataExt;
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
     let source = tmp.path().join("source.bin");
     let mut source_file = std::fs::File::create(&source).expect("create source");
-    source_file.write_all(&[0x10]).expect("write leading byte");
+    source_file.write_all(&[0x10; 4096]).expect("write head");
     source_file
-        .seek(SeekFrom::Start(1024 * 1024))
-        .expect("seek to hole");
-    source_file.write_all(&[0x20]).expect("write trailing byte");
-    source_file.set_len(3 * 1024 * 1024).expect("extend source");
+        .write_all(&vec![0u8; 2 * 1024 * 1024])
+        .expect("write hole");
+    source_file.write_all(&[0x20; 4096]).expect("write tail");
+    let apparent = source_file.metadata().expect("meta").len();
+    drop(source_file);
 
-    let dense_dest = tmp.path().join("dense.bin");
     let prealloc_dest = tmp.path().join("sparse-prealloc.bin");
-
-    let (code, stdout, stderr) = run_with_args([
-        OsString::from(RSYNC),
-        source.clone().into_os_string(),
-        dense_dest.clone().into_os_string(),
-    ]);
-    assert_eq!(code, 0);
-    assert!(stdout.is_empty());
-    assert!(stderr.is_empty());
-
     let (code, stdout, stderr) = run_with_args([
         OsString::from(RSYNC),
         OsString::from("--sparse"),
@@ -143,11 +139,13 @@ fn transfer_request_with_sparse_and_preallocate_allocates_dense() {
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
 
-    let dense_meta = std::fs::metadata(&dense_dest).expect("dense metadata");
     let prealloc_meta = std::fs::metadata(&prealloc_dest).expect("prealloc metadata");
-
-    assert_eq!(dense_meta.len(), prealloc_meta.len());
-    assert_eq!(prealloc_meta.blocks(), dense_meta.blocks());
+    assert_eq!(prealloc_meta.len(), apparent, "content length preserved");
+    assert!(
+        prealloc_meta.blocks() * 512 < apparent,
+        "preallocated zero run must be punched (allocated {}, size {apparent})",
+        prealloc_meta.blocks() * 512,
+    );
 }
 
 #[cfg(unix)]

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -34,11 +34,11 @@ use super::{
     LocalCopyArgumentError, LocalCopyError, LocalCopyErrorKind, LocalCopyExecution,
     LocalCopyMetadata, LocalCopyOptions, LocalCopyProgress, LocalCopyRecord,
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, NestedDirMerge, ReferenceDirectory,
-    SparseWriteState, SparseWriter, compute_backup_path, copy_entry_to_backup,
-    delete_extraneous_entries, filter_program_local_error, follow_symlink_metadata,
-    load_dir_merge_rules_recursive, map_metadata_error, remove_source_entry_if_requested,
-    resolve_dir_merge_path, should_skip_copy, symlink_target_is_safe, trace_make_backup_copy,
-    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
+    SparseWriteState, compute_backup_path, copy_entry_to_backup, delete_extraneous_entries,
+    filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
+    map_metadata_error, remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
+    symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_rename,
+    trace_make_backup_symlink, write_sparse_chunk,
 };
 use crate::delta::DeltaSignatureIndex;
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -260,7 +260,17 @@ impl<'a> CopyContext<'a> {
         }
 
         if sparse {
-            let final_position = sparse_state.finish(writer, destination)?;
+            // upstream: fileio.c:sparse_end() flushes the trailing zero run then
+            // ftruncates to the file's true size. In inplace mode matched blocks
+            // are skipped without advancing the writer, so the final length is
+            // the delta loop's output_position rather than the sparse writer's
+            // stream position; a fresh sparse copy uses the flushed logical end.
+            let sparse_end = sparse_state.finish(writer, destination)?;
+            let final_position = if inplace_mode {
+                output_position
+            } else {
+                sparse_end
+            };
             writer.set_len(final_position).map_err(|error| {
                 LocalCopyError::io(
                     "truncate destination file",

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -18,6 +18,7 @@ impl<'a> CopyContext<'a> {
         index: &DeltaSignatureIndex,
         total_size: u64,
         initial_bytes: u64,
+        preallocated_len: u64,
         start: Instant,
         basis_separate_from_writer: bool,
     ) -> Result<FileCopyOutcome, LocalCopyError> {
@@ -58,6 +59,7 @@ impl<'a> CopyContext<'a> {
         let mut total_bytes = 0u64;
         let mut literal_bytes = 0u64;
         let mut sparse_state = SparseWriteState::default();
+        sparse_state.set_preallocated_len(preallocated_len);
         let mut window: VecDeque<u8> = VecDeque::with_capacity(index.block_length());
         let mut pending_literals = Vec::with_capacity(index.block_length());
         let mut scratch = Vec::with_capacity(index.block_length());

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -508,6 +508,7 @@ impl<'a> CopyContext<'a> {
         delta: Option<&DeltaSignatureIndex>,
         total_size: u64,
         initial_bytes: u64,
+        preallocated_len: u64,
         start: Instant,
         basis_separate_from_writer: bool,
     ) -> Result<FileCopyOutcome, LocalCopyError> {
@@ -524,6 +525,7 @@ impl<'a> CopyContext<'a> {
                 index,
                 total_size,
                 initial_bytes,
+                preallocated_len,
                 start,
                 basis_separate_from_writer,
             );
@@ -555,7 +557,7 @@ impl<'a> CopyContext<'a> {
         if sparse {
             return self.copy_file_contents_sparse(
                 reader, writer, buffer, compress, source, destination, relative,
-                total_size, initial_bytes, expected_remaining, start,
+                total_size, initial_bytes, expected_remaining, preallocated_len, start,
             );
         }
 
@@ -637,12 +639,13 @@ impl<'a> CopyContext<'a> {
         Ok(outcome)
     }
 
-    /// Sparse variant of `copy_file_contents` using the `SparseWriter` decorator.
+    /// Sparse variant of `copy_file_contents`.
     ///
-    /// Wraps the destination writer in a `SparseWriter` that transparently
-    /// converts zero runs into seeks, producing sparse files on supported
-    /// filesystems. The decorator is consumed at finalization, returning
-    /// the final stream position for `set_len`.
+    /// Streams the source through the preallocation-aware [`SparseWriteState`]:
+    /// zero runs beyond any preallocated extent become seeks (natural holes),
+    /// while zero runs inside a preallocated extent are punched out so the
+    /// reserved blocks are actually deallocated.
+    // upstream: fileio.c:write_sparse()
     #[allow(clippy::too_many_arguments)]
     fn copy_file_contents_sparse(
         &mut self,
@@ -656,6 +659,7 @@ impl<'a> CopyContext<'a> {
         total_size: u64,
         initial_bytes: u64,
         expected_remaining: u64,
+        preallocated_len: u64,
         start: Instant,
     ) -> Result<FileCopyOutcome, LocalCopyError> {
         let mut total_bytes: u64 = 0;
@@ -665,7 +669,8 @@ impl<'a> CopyContext<'a> {
         // is a no-op (holes are implicit). Best-effort: a non-NTFS volume or a
         // refused control code falls back to a dense write, never an error.
         let _ = fast_io::mark_file_sparse(writer);
-        let mut sparse_writer = SparseWriter::new(&mut *writer);
+        let mut sparse_state = SparseWriteState::default();
+        sparse_state.set_preallocated_len(preallocated_len);
         let mut compressor = self.start_compressor(compress, source)?;
         let mut compressed_progress: u64 = 0;
         const TIMEOUT_CHECK_INTERVAL: u64 = 1024 * 1024;
@@ -692,9 +697,7 @@ impl<'a> CopyContext<'a> {
                 break;
             }
 
-            sparse_writer.write_all(&buffer[..read]).map_err(|error| {
-                LocalCopyError::io("copy file", destination, error)
-            })?;
+            write_sparse_chunk(writer, &mut sparse_state, &buffer[..read], destination)?;
 
             self.register_progress();
 
@@ -724,11 +727,8 @@ impl<'a> CopyContext<'a> {
             }
         }
 
-        let (inner, final_position, _stats) =
-            sparse_writer.finish_and_position().map_err(|error| {
-                LocalCopyError::io("finish sparse writer", destination.to_path_buf(), error)
-            })?;
-        inner.set_len(final_position).map_err(|error| {
+        let final_position = sparse_state.finish(writer, destination)?;
+        writer.set_len(final_position).map_err(|error| {
             LocalCopyError::io(
                 "truncate destination file",
                 destination.to_path_buf(),

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -165,15 +165,13 @@ pub(crate) fn copy_file(
         return Ok(true);
     }
 
-    // Upstream rsync disables sparse writes whenever `--preallocate` is active
-    // because the preallocation request must materialise every range in the
-    // destination file.  It also turns off sparse handling for append and
-    // in-place modes so the receiver does not punch holes into the portion of
-    // the file that was already present.  Mirror that behaviour here.
-    let use_sparse_writes = context.sparse_enabled()
-        && !context.preallocate_enabled()
-        && !context.append_enabled()
-        && !context.inplace_enabled();
+    // upstream: receiver.c:receive_data() keeps sparse writes active alongside
+    // `--preallocate` and `--inplace`: write_sparse() punches holes inside the
+    // preallocated / existing extent (guided by preallocated_len) instead of
+    // seeking, so those modes still produce sparse output. Append mode is the
+    // exception - upstream flips `sparse_files` off during the append pass
+    // (receiver.c:761,771) so the pre-existing prefix is never hole-punched.
+    let use_sparse_writes = context.sparse_enabled() && !context.append_enabled();
     let partial_enabled = context.partial_enabled();
     let inplace_enabled = context.inplace_enabled();
     let checksum_enabled = context.checksum_enabled();

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -468,13 +468,26 @@ pub(in crate::local_copy) fn execute_transfer(
     let preallocate_target = guard
         .as_ref()
         .map_or(destination, |existing_guard| existing_guard.staging_path());
-    maybe_preallocate_destination(
+    // upstream: receiver.c:319 - preallocated_len records how much of the file
+    // has reserved blocks so a later sparse zero run inside that extent is
+    // punched into a hole rather than seeked over (which would leave the
+    // preallocated blocks allocated).
+    let mut preallocated_len = maybe_preallocate_destination(
         &mut writer,
         preallocate_target,
         file_size,
         append_offset,
         context.preallocate_enabled(),
     )?;
+    // upstream: receiver.c:326-336 - when not preallocating but writing inplace,
+    // the existing destination extent (`size_r`) is already allocated, so a new
+    // interior zero run must be punched rather than seeked. A whole-file inplace
+    // copy truncates to zero first, leaving preallocated_len at 0.
+    if preallocated_len == 0 && inplace_enabled && !whole_file_enabled {
+        if let Some(existing) = existing_metadata {
+            preallocated_len = existing.len();
+        }
+    }
 
     let mut pool_guard = if context.use_buffer_pool() {
         Some(
@@ -535,6 +548,7 @@ pub(in crate::local_copy) fn execute_transfer(
         delta_signature.as_ref(),
         file_size,
         append_offset,
+        preallocated_len,
         start,
         basis_separate_from_writer,
     );

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -23,16 +23,22 @@ use crate::local_copy::LocalCopyError;
 ///
 /// Skips preallocation when disabled, when `total_len` is zero, or when the
 /// file already has at least `total_len` bytes allocated.
-// upstream: receiver.c:recv_files() - preallocate_file()
+///
+/// Returns the preallocated length: the number of bytes now allocated on disk
+/// for the destination (`st_blocks * 512`), or `0` when preallocation was
+/// skipped. This mirrors upstream `do_fallocate()`, whose return value flows
+/// into `preallocated_len` so the sparse writer knows how much of the file has
+/// reserved blocks that must be punched (rather than seeked) to become holes.
+// upstream: receiver.c:319 - preallocated_len = do_fallocate(fd, 0, total_size)
 pub(crate) fn maybe_preallocate_destination(
     file: &mut fs::File,
     path: &Path,
     total_len: u64,
     existing_bytes: u64,
     enabled: bool,
-) -> Result<(), LocalCopyError> {
+) -> Result<u64, LocalCopyError> {
     if !enabled || total_len == 0 || total_len <= existing_bytes {
-        return Ok(());
+        return Ok(0);
     }
 
     preallocate_destination_file(file, path, total_len)
@@ -42,11 +48,11 @@ fn preallocate_destination_file(
     file: &mut fs::File,
     path: &Path,
     total_len: u64,
-) -> Result<(), LocalCopyError> {
+) -> Result<u64, LocalCopyError> {
     #[cfg(unix)]
     {
         if total_len == 0 {
-            return Ok(());
+            return Ok(0);
         }
 
         if total_len > i64::MAX as u64 {
@@ -61,11 +67,18 @@ fn preallocate_destination_file(
         }
 
         let fd = file.as_fd();
+        // upstream: syscall.c:do_fallocate() issues a plain fallocate (opts == 0
+        // when FALLOC_FL_KEEP_SIZE is unavailable) and then returns the actual
+        // allocated length from fstat so the caller can punch holes within the
+        // reserved extent rather than seeking over (and leaving) it.
         match fallocate(fd, FallocateFlags::empty(), 0, total_len) {
-            Ok(()) => Ok(()),
-            Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => file
-                .set_len(total_len)
-                .map_err(|error| LocalCopyError::io("preallocate destination file", path, error)),
+            Ok(()) => Ok(allocated_bytes(file).unwrap_or(total_len)),
+            Err(Errno::OPNOTSUPP | Errno::NOSYS | Errno::INVAL) => {
+                file.set_len(total_len).map_err(|error| {
+                    LocalCopyError::io("preallocate destination file", path, error)
+                })?;
+                Ok(allocated_bytes(file).unwrap_or(total_len))
+            }
             Err(errno) => Err(LocalCopyError::io(
                 "preallocate destination file",
                 path.to_path_buf(),
@@ -77,12 +90,21 @@ fn preallocate_destination_file(
     #[cfg(not(unix))]
     {
         if total_len == 0 {
-            return Ok(());
+            return Ok(0);
         }
 
         file.set_len(total_len)
-            .map_err(|error| LocalCopyError::io("preallocate destination file", path, error))
+            .map_err(|error| LocalCopyError::io("preallocate destination file", path, error))?;
+        Ok(total_len)
     }
+}
+
+/// Returns the number of bytes currently allocated on disk for `file`
+/// (`st_blocks * 512`), mirroring upstream `st.st_blocks * S_BLKSIZE`.
+#[cfg(unix)]
+fn allocated_bytes(file: &fs::File) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    file.metadata().ok().map(|meta| meta.blocks() * 512)
 }
 
 #[cfg(test)]
@@ -247,6 +269,38 @@ mod tests {
             expected_min_blocks,
             metadata.blocks()
         );
+    }
+
+    /// Verify that `maybe_preallocate_destination` returns the allocated length
+    /// so the sparse writer can punch holes inside the reserved extent. Mirrors
+    /// upstream `preallocated_len = do_fallocate(...)`.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn maybe_preallocate_returns_allocated_length() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("prealloc_len.bin");
+        let mut file = fs::File::create(&path).expect("create file");
+
+        let one_mib = 1024 * 1024;
+        let prealloc =
+            maybe_preallocate_destination(&mut file, &path, one_mib, 0, true).expect("preallocate");
+        // The reported allocated length must cover the whole requested extent.
+        assert!(
+            prealloc >= one_mib,
+            "expected preallocated length >= {one_mib}, got {prealloc}"
+        );
+
+        // Disabled preallocation reports zero (no reserved extent to punch).
+        let mut skip = fs::File::create(temp.path().join("skip.bin")).expect("create file");
+        let skipped = maybe_preallocate_destination(
+            &mut skip,
+            &temp.path().join("skip.bin"),
+            one_mib,
+            0,
+            false,
+        )
+        .expect("skip");
+        assert_eq!(skipped, 0, "disabled preallocation should report 0 length");
     }
 
     /// Verify that disabled preallocation does not allocate extra blocks.

--- a/crates/engine/src/local_copy/executor/file/sparse/state.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/state.rs
@@ -4,7 +4,7 @@
 //! sequential write pass, converting zero runs into seeks (holes) and
 //! flushing them with hole-punch or trailing-zero finalization.
 
-// upstream: fileio.c - sparse write buffering logic
+// upstream: fileio.c:write_sparse() - sparse write buffering logic
 
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};
@@ -17,30 +17,72 @@ use super::{SPARSE_WRITE_SIZE, leading_zero_run, trailing_zero_run};
 
 /// Tracks pending zero runs during sparse file writing.
 ///
-/// This struct accumulates consecutive zero bytes and flushes them either
-/// by seeking (for new files) or by punching holes (for in-place updates).
+/// Mirrors upstream `write_sparse()`: consecutive zero bytes are accumulated
+/// and flushed as a single seek or hole-punch when non-zero data (or
+/// finalization) follows. A zero run is punched into a hole when it starts
+/// inside the file's preallocated extent (`start < preallocated_len`) and
+/// seeked over otherwise, matching upstream's `sparse_past_write >=
+/// preallocated_len` decision.
+///
+/// The start of a pending run is the writer's current stream position (the
+/// point just past the last data write), so the state stays correct even when
+/// the caller seeks the writer between chunks (the delta/inplace path).
 #[derive(Default)]
 pub(crate) struct SparseWriteState {
+    /// Accumulated pending zero bytes (upstream `sparse_seek`).
     pending_zero_run: u64,
-    /// Position where the pending zero run starts (used for punch_hole path).
-    #[cfg_attr(not(test), allow(dead_code))]
-    zero_run_start_pos: u64,
+    /// Length of the destination's preallocated extent (upstream
+    /// `preallocated_len`). Zero runs starting below this offset are punched
+    /// into holes; runs starting at or beyond it are seeked over.
+    preallocated_len: u64,
 }
 
 impl SparseWriteState {
+    /// Records the preallocated length so zero runs inside the reserved extent
+    /// are punched out rather than merely seeked over (which would leave the
+    /// preallocated blocks allocated).
+    // upstream: fileio.c:92 - if (sparse_past_write >= preallocated_len)
+    pub(crate) const fn set_preallocated_len(&mut self, len: u64) {
+        self.preallocated_len = len;
+    }
+
     pub(super) const fn accumulate(&mut self, additional: usize) {
         self.pending_zero_run = self.pending_zero_run.saturating_add(additional as u64);
     }
 
-    /// Flushes pending zeros by seeking forward.
+    /// Flushes the pending zero run using upstream's seek-vs-punch rule.
     ///
-    /// This is the default strategy for new files where the filesystem
-    /// automatically creates sparse regions when seeking past end of file.
+    /// The run starts at the writer's current stream position (data writes and
+    /// hole-punches always leave the position just past the last data). Seeks
+    /// forward when that position is at or beyond the preallocated extent (the
+    /// natural-hole case for a fresh file), otherwise punches a hole to
+    /// deallocate the blocks that preallocation reserved.
+    // upstream: fileio.c:90-99 write_sparse()
     fn flush(&mut self, writer: &mut fs::File, destination: &Path) -> Result<(), LocalCopyError> {
         if self.pending_zero_run == 0 {
             return Ok(());
         }
 
+        let start = writer
+            .stream_position()
+            .map_err(|error| LocalCopyError::io("seek in destination file", destination, error))?;
+
+        if start >= self.preallocated_len {
+            self.seek_over(writer, destination)?;
+        } else {
+            punch_hole(writer, destination, start, self.pending_zero_run)?;
+        }
+
+        self.pending_zero_run = 0;
+        Ok(())
+    }
+
+    /// Seeks forward over the pending zero run, creating a natural hole.
+    fn seek_over(
+        &mut self,
+        writer: &mut fs::File,
+        destination: &Path,
+    ) -> Result<(), LocalCopyError> {
         let mut remaining = self.pending_zero_run;
         while remaining > 0 {
             let step = remaining.min(i64::MAX as u64);
@@ -51,32 +93,6 @@ impl SparseWriteState {
                 })?;
             remaining -= step;
         }
-
-        self.pending_zero_run = 0;
-        Ok(())
-    }
-
-    /// Flushes pending zeros by punching a hole in the file.
-    ///
-    /// This is used for in-place updates where we need to deallocate
-    /// disk blocks. Falls back to writing zeros if hole punching is
-    /// not supported.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn flush_with_punch_hole(
-        &mut self,
-        writer: &mut fs::File,
-        destination: &Path,
-    ) -> Result<(), LocalCopyError> {
-        if self.pending_zero_run == 0 {
-            return Ok(());
-        }
-
-        let pos = self.zero_run_start_pos;
-        let len = self.pending_zero_run;
-
-        punch_hole(writer, destination, pos, len)?;
-
-        self.pending_zero_run = 0;
         Ok(())
     }
 
@@ -84,54 +100,40 @@ impl SparseWriteState {
         self.pending_zero_run = next_run as u64;
     }
 
-    /// Updates the starting position for the next zero run.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn set_zero_run_start(&mut self, pos: u64) {
-        self.zero_run_start_pos = pos;
-    }
-
     /// Returns the pending zero run length.
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) const fn pending_zeros(&self) -> u64 {
         self.pending_zero_run
     }
 
-    /// Finishes sparse writing by flushing any remaining zeros via seeking.
+    /// Finishes sparse writing by flushing any remaining zeros.
+    ///
+    /// Returns the final logical file position (including any trailing hole)
+    /// for the caller's `set_len`.
+    // upstream: fileio.c:43 sparse_end()
     pub(crate) fn finish(
         &mut self,
         writer: &mut fs::File,
         destination: &Path,
     ) -> Result<u64, LocalCopyError> {
+        // The logical end of file is the current position plus any trailing
+        // pending zero run that becomes a hole.
+        let position = writer
+            .stream_position()
+            .map_err(|error| LocalCopyError::io("seek in destination file", destination, error))?;
+        let logical_end = position.saturating_add(self.pending_zero_run);
         self.flush(writer, destination)?;
-
-        writer
-            .stream_position()
-            .map_err(|error| LocalCopyError::io("seek in destination file", destination, error))
-    }
-
-    /// Finishes sparse writing by punching holes for any remaining zeros.
-    ///
-    /// Use this variant when updating files in-place to deallocate disk
-    /// blocks for zero regions.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn finish_with_punch_hole(
-        &mut self,
-        writer: &mut fs::File,
-        destination: &Path,
-    ) -> Result<u64, LocalCopyError> {
-        self.flush_with_punch_hole(writer, destination)?;
-
-        writer
-            .stream_position()
-            .map_err(|error| LocalCopyError::io("seek in destination file", destination, error))
+        Ok(logical_end)
     }
 }
 
 /// Writes a chunk of data with sparse hole detection.
 ///
-/// Zero runs within the chunk are accumulated rather than written, and
-/// flushed as seeks when non-zero data follows. This produces sparse
-/// files when the filesystem supports it.
+/// Zero runs within the chunk are accumulated rather than written, and flushed
+/// as seeks (natural holes) or hole-punches (inside a preallocated extent) when
+/// non-zero data follows. This produces sparse files when the filesystem
+/// supports it.
+// upstream: fileio.c:write_sparse()
 pub(crate) fn write_sparse_chunk(
     writer: &mut fs::File,
     state: &mut SparseWriteState,
@@ -164,6 +166,9 @@ pub(crate) fn write_sparse_chunk(
         let data_end = segment_end - trailing;
 
         if data_end > data_start {
+            // upstream: flush the pending zero run (seek or punch) before the
+            // data write. The flush reads the writer's current position as the
+            // run start, so an interleaved external seek stays correct.
             state.flush(writer, destination)?;
             writer
                 .write_all(&chunk[data_start..data_end])

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -700,8 +700,12 @@ fn sparse_state_finish_reports_logical_length() {
     assert_eq!(final_pos, 1024);
 }
 
-/// Multiple interior zero runs within a preallocated extent are each punched
-/// out, deallocating their reserved blocks.
+/// A zero run spanning full sparse segments inside a preallocated extent is
+/// punched out across multiple flush cycles, deallocating its reserved blocks.
+///
+/// The run straddles several `SPARSE_WRITE_SIZE` (32 KiB) segments so each
+/// segment's leading/trailing zero detection carries the run forward and the
+/// accumulated hole is punched (mirroring upstream `write_sparse` chunking).
 #[cfg(target_os = "linux")]
 #[test]
 fn sparse_state_multiple_flush_cycles_punch() {
@@ -711,12 +715,18 @@ fn sparse_state_multiple_flush_cycles_punch() {
     let mut file = NamedTempFile::new().expect("temp file");
     let path = file.path().to_path_buf();
 
-    // Reserve a 16 KiB extent.
+    // head data, a 256 KiB hole spanning many 32 KiB segments, tail data.
+    let head = 4096usize;
+    let hole = 256 * 1024usize;
+    let tail = 4096usize;
+    let total = (head + hole + tail) as u64;
+
+    // Reserve the whole extent.
     rustix::fs::fallocate(
         file.as_file().as_fd(),
         rustix::fs::FallocateFlags::empty(),
         0,
-        16384,
+        total,
     )
     .expect("fallocate");
     let prealloc = file.as_file().metadata().expect("meta").blocks() * 512;
@@ -724,28 +734,26 @@ fn sparse_state_multiple_flush_cycles_punch() {
     let mut state = SparseWriteState::default();
     state.set_preallocated_len(prealloc);
 
-    // Build a buffer with two large interior zero runs surrounded by data.
-    let mut buf = vec![0xCCu8; 16384];
-    for byte in buf.iter_mut().take(4096).skip(1024) {
-        *byte = 0;
+    let mut buf = vec![0u8; head + hole + tail];
+    for byte in buf.iter_mut().take(head) {
+        *byte = 0xCC;
     }
-    for byte in buf.iter_mut().take(12288).skip(8192) {
-        *byte = 0;
+    for byte in buf.iter_mut().skip(head + hole) {
+        *byte = 0xDD;
     }
 
     write_sparse_chunk(file.as_file_mut(), &mut state, &buf, &path).expect("write");
     let final_pos = state.finish(file.as_file_mut(), &path).expect("finish");
-    assert_eq!(final_pos, 16384);
+    assert_eq!(final_pos, total);
     file.as_file_mut().set_len(final_pos).expect("set_len");
 
     // Content survives.
     file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
-    let mut readback = vec![0u8; 16384];
+    let mut readback = vec![0u8; head + hole + tail];
     file.as_file_mut().read_exact(&mut readback).expect("read");
     assert_eq!(readback, buf);
 
-    // The two zero runs were punched: allocation drops below the reserved
-    // extent.
+    // The zero run was punched: allocation drops below the reserved extent.
     let allocated = file.as_file().metadata().expect("meta").blocks() * 512;
     assert!(
         allocated < prealloc,

--- a/crates/engine/src/local_copy/executor/file/sparse/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/tests.rs
@@ -365,55 +365,90 @@ fn write_zeros_fallback_handles_large_length() {
     assert_eq!(metadata.len(), len);
 }
 
+/// A preallocated destination must have its interior zero run punched into a
+/// hole. With `preallocated_len` covering the whole file, `write_sparse_chunk`
+/// mirrors upstream `write_sparse()`'s `do_punch_hole` branch so the reserved
+/// blocks under the zero run are deallocated rather than left allocated.
+// upstream: fileio.c:95 - do_punch_hole(f, sparse_past_write, sparse_seek)
+#[cfg(target_os = "linux")]
 #[test]
-fn sparse_state_flush_with_punch_hole() {
+fn sparse_chunk_punches_hole_within_preallocated_extent() {
+    use rustix::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
+
     let mut file = NamedTempFile::new().expect("temp file");
     let path = file.path().to_path_buf();
 
-    // Pre-allocate with non-zero data
-    let data = vec![0xBBu8; 8192];
-    file.as_file_mut().write_all(&data).expect("write");
-    file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
+    // Reserve blocks for a 3 MiB file, then feed head/hole/tail through the
+    // sparse writer with the preallocated length recorded.
+    let head = 4096usize;
+    let hole = 2 * 1024 * 1024usize;
+    let tail = 4096usize;
+    let total = (head + hole + tail) as u64;
+
+    rustix::fs::fallocate(
+        file.as_file().as_fd(),
+        rustix::fs::FallocateFlags::empty(),
+        0,
+        total,
+    )
+    .expect("fallocate");
+    let prealloc = file.as_file().metadata().expect("meta").blocks() * 512;
+    assert!(prealloc >= total, "extent should be fully reserved");
 
     let mut state = SparseWriteState::default();
-    state.set_zero_run_start(1000);
-    state.accumulate(2000);
+    state.set_preallocated_len(prealloc);
 
-    state
-        .flush_with_punch_hole(file.as_file_mut(), &path)
-        .expect("flush with punch");
+    let mut buf = vec![0u8; head + hole + tail];
+    for byte in buf.iter_mut().take(head) {
+        *byte = 0xAB;
+    }
+    for byte in buf.iter_mut().skip(head + hole) {
+        *byte = 0xCD;
+    }
 
-    // Verify the hole was punched
-    file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
-    let mut buffer = vec![0u8; 8192];
-    file.as_file_mut().read_exact(&mut buffer).expect("read");
+    write_sparse_chunk(file.as_file_mut(), &mut state, &buf, &path).expect("write sparse");
+    let final_pos = state.finish(file.as_file_mut(), &path).expect("finish");
+    assert_eq!(final_pos, total);
+    file.as_file_mut().set_len(final_pos).expect("set_len");
 
-    // Before the hole: unchanged
-    assert!(buffer[..1000].iter().all(|&b| b == 0xBB));
-    // The hole: zeros
-    assert!(buffer[1000..3000].iter().all(|&b| b == 0));
-    // After the hole: unchanged
-    assert!(buffer[3000..].iter().all(|&b| b == 0xBB));
+    // The middle zero run must be punched out: allocation drops well below the
+    // apparent size (only the head/tail data blocks remain).
+    let allocated = file.as_file().metadata().expect("meta").blocks() * 512;
+    assert!(
+        allocated < total,
+        "preallocated extent's zero run was not punched (allocated {allocated} for {total})"
+    );
 }
 
+/// Outside a preallocated extent (`preallocated_len == 0`) the writer seeks
+/// over zero runs to form a natural hole, matching upstream's
+/// `sparse_past_write >= preallocated_len` lseek branch.
+// upstream: fileio.c:93 - do_lseek(f, sparse_seek, SEEK_CUR)
 #[test]
-fn sparse_state_finish_with_punch_hole() {
+fn sparse_chunk_seeks_over_run_without_preallocation() {
     let mut file = NamedTempFile::new().expect("temp file");
     let path = file.path().to_path_buf();
 
-    // Pre-allocate
-    file.as_file_mut().set_len(4096).expect("set length");
-
     let mut state = SparseWriteState::default();
-    state.set_zero_run_start(500);
-    state.accumulate(1000);
+    // preallocated_len defaults to 0: every run is seeked over.
 
-    let final_pos = state
-        .finish_with_punch_hole(file.as_file_mut(), &path)
-        .expect("finish with punch");
+    let mut buf = vec![0u8; 4096];
+    buf[0] = 0x11;
+    // 2048 zeros, then a trailing data byte.
+    buf[4095] = 0x22;
 
-    // Position should be at end of punched hole
-    assert_eq!(final_pos, 1500);
+    write_sparse_chunk(file.as_file_mut(), &mut state, &buf, &path).expect("write sparse");
+    let final_pos = state.finish(file.as_file_mut(), &path).expect("finish");
+    assert_eq!(final_pos, 4096);
+    file.as_file_mut().set_len(final_pos).expect("set_len");
+
+    file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
+    let mut readback = vec![0u8; 4096];
+    file.as_file_mut().read_exact(&mut readback).expect("read");
+    assert_eq!(readback[0], 0x11);
+    assert!(readback[1..4095].iter().all(|&b| b == 0));
+    assert_eq!(readback[4095], 0x22);
 }
 
 #[test]
@@ -635,7 +670,6 @@ fn sparse_state_replace_vs_accumulate() {
     let mut state = SparseWriteState::default();
 
     // Accumulate some zeros
-    state.set_zero_run_start(100);
     state.accumulate(500);
     assert_eq!(state.pending_zeros(), 500);
 
@@ -648,66 +682,75 @@ fn sparse_state_replace_vs_accumulate() {
     assert_eq!(state.pending_zeros(), 300);
 }
 
+/// Without a preallocated extent, `write_sparse_chunk` seeks over interior zero
+/// runs and `finish` reports the full logical length for `set_len`.
 #[test]
-fn sparse_state_zero_run_start_tracking() {
-    let mut state = SparseWriteState::default();
-
-    state.set_zero_run_start(1000);
-    state.accumulate(500);
-
-    // Zero run start should be preserved
+fn sparse_state_finish_reports_logical_length() {
     let mut file = NamedTempFile::new().expect("temp file");
     let path = file.path().to_path_buf();
-    file.as_file_mut().set_len(8192).expect("set length");
 
-    let final_pos = state
-        .finish_with_punch_hole(file.as_file_mut(), &path)
-        .expect("finish");
+    let mut state = SparseWriteState::default();
 
-    // Final position should be start + accumulated
-    assert_eq!(final_pos, 1500);
+    // data, 500-byte hole, data - the hole is seeked over.
+    let mut buf = vec![0u8; 1024];
+    buf[0] = 0x11;
+    buf[1023] = 0x22;
+    write_sparse_chunk(file.as_file_mut(), &mut state, &buf, &path).expect("write");
+    let final_pos = state.finish(file.as_file_mut(), &path).expect("finish");
+    assert_eq!(final_pos, 1024);
 }
 
+/// Multiple interior zero runs within a preallocated extent are each punched
+/// out, deallocating their reserved blocks.
+#[cfg(target_os = "linux")]
 #[test]
-fn sparse_state_multiple_flush_cycles() {
+fn sparse_state_multiple_flush_cycles_punch() {
+    use rustix::fd::AsFd;
+    use std::os::unix::fs::MetadataExt;
+
     let mut file = NamedTempFile::new().expect("temp file");
     let path = file.path().to_path_buf();
 
-    // Pre-allocate
-    let data = vec![0xCCu8; 16384];
-    file.as_file_mut().write_all(&data).expect("write");
-    file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
+    // Reserve a 16 KiB extent.
+    rustix::fs::fallocate(
+        file.as_file().as_fd(),
+        rustix::fs::FallocateFlags::empty(),
+        0,
+        16384,
+    )
+    .expect("fallocate");
+    let prealloc = file.as_file().metadata().expect("meta").blocks() * 512;
 
     let mut state = SparseWriteState::default();
+    state.set_preallocated_len(prealloc);
 
-    // First flush cycle
-    state.set_zero_run_start(1000);
-    state.accumulate(500);
-    state
-        .flush_with_punch_hole(file.as_file_mut(), &path)
-        .expect("first flush");
-    assert_eq!(state.pending_zeros(), 0);
+    // Build a buffer with two large interior zero runs surrounded by data.
+    let mut buf = vec![0xCCu8; 16384];
+    for byte in buf.iter_mut().take(4096).skip(1024) {
+        *byte = 0;
+    }
+    for byte in buf.iter_mut().take(12288).skip(8192) {
+        *byte = 0;
+    }
 
-    // Second flush cycle
-    state.set_zero_run_start(5000);
-    state.accumulate(1000);
-    state
-        .flush_with_punch_hole(file.as_file_mut(), &path)
-        .expect("second flush");
-    assert_eq!(state.pending_zeros(), 0);
+    write_sparse_chunk(file.as_file_mut(), &mut state, &buf, &path).expect("write");
+    let final_pos = state.finish(file.as_file_mut(), &path).expect("finish");
+    assert_eq!(final_pos, 16384);
+    file.as_file_mut().set_len(final_pos).expect("set_len");
 
-    // Verify both holes were punched
+    // Content survives.
     file.as_file_mut().seek(SeekFrom::Start(0)).expect("rewind");
-    let mut buffer = vec![0u8; 16384];
-    file.as_file_mut().read_exact(&mut buffer).expect("read");
+    let mut readback = vec![0u8; 16384];
+    file.as_file_mut().read_exact(&mut readback).expect("read");
+    assert_eq!(readback, buf);
 
-    // First hole: 1000-1500
-    assert!(buffer[..1000].iter().all(|&b| b == 0xCC));
-    assert!(buffer[1000..1500].iter().all(|&b| b == 0));
-    assert!(buffer[1500..5000].iter().all(|&b| b == 0xCC));
-    // Second hole: 5000-6000
-    assert!(buffer[5000..6000].iter().all(|&b| b == 0));
-    assert!(buffer[6000..].iter().all(|&b| b == 0xCC));
+    // The two zero runs were punched: allocation drops below the reserved
+    // extent.
+    let allocated = file.as_file().metadata().expect("meta").blocks() * 512;
+    assert!(
+        allocated < prealloc,
+        "interior zero runs should be punched (allocated {allocated}, reserved {prealloc})"
+    );
 }
 
 #[test]
@@ -810,23 +853,6 @@ fn sparse_state_flush_with_zero_pending_is_noop() {
         .expect("flush zero pending");
 
     // Position should be unchanged
-    let pos = file.as_file_mut().stream_position().expect("position");
-    assert_eq!(pos, 4);
-}
-
-#[test]
-fn sparse_state_flush_with_punch_hole_zero_pending_is_noop() {
-    let mut file = NamedTempFile::new().expect("temp file");
-    let path = file.path().to_path_buf();
-
-    file.as_file_mut().write_all(b"data").expect("write");
-
-    let mut state = SparseWriteState::default();
-
-    state
-        .flush_with_punch_hole(file.as_file_mut(), &path)
-        .expect("flush punch hole zero pending");
-
     let pos = file.as_file_mut().stream_position().expect("position");
     assert_eq!(pos, 4);
 }
@@ -1191,25 +1217,6 @@ fn sparse_state_finish_no_pending() {
         .expect("finish no pending");
 
     assert_eq!(final_pos, 4);
-}
-
-#[test]
-fn sparse_state_finish_with_punch_hole_returns_position() {
-    let mut file = NamedTempFile::new().expect("temp file");
-    let path = file.path().to_path_buf();
-
-    // Pre-allocate
-    file.as_file_mut().set_len(10000).expect("set length");
-
-    let mut state = SparseWriteState::default();
-    state.set_zero_run_start(1000);
-    state.accumulate(500);
-
-    let final_pos = state
-        .finish_with_punch_hole(file.as_file_mut(), &path)
-        .expect("finish punch");
-
-    assert_eq!(final_pos, 1500);
 }
 
 #[test]

--- a/crates/engine/src/local_copy/tests/execute_sparse.rs
+++ b/crates/engine/src/local_copy/tests/execute_sparse.rs
@@ -63,9 +63,65 @@ fn execute_with_sparse_enabled_creates_holes() {
     );
 }
 
-#[cfg(unix)]
+/// `--preallocate --sparse` must reserve the destination extent and then punch
+/// the source's zero run back out, so the on-disk allocation stays sparse.
+///
+/// Mirrors upstream `preallocate_test.py`'s `--preallocate --sparse` leg:
+/// `do_fallocate()` reports the preallocated length and `write_sparse()` uses
+/// `do_punch_hole()` for the zero run inside that extent.
+// upstream: fileio.c:95 write_sparse() -> do_punch_hole within preallocated_len
+#[cfg(target_os = "linux")]
 #[test]
-fn execute_inplace_disables_sparse_writes() {
+fn execute_preallocate_sparse_punches_hole() {
+    use std::os::unix::fs::MetadataExt;
+
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    let source = src_dir.join("holey.bin");
+    let mut source_file = fs::File::create(&source).expect("create source");
+    source_file.write_all(&[0xAB; 4096]).expect("head");
+    source_file
+        .write_all(&vec![0u8; 2 * 1024 * 1024])
+        .expect("hole");
+    source_file.write_all(&[0xCD; 4096]).expect("tail");
+    drop(source_file);
+    let apparent = fs::metadata(&source).expect("meta").len();
+
+    let dest = temp.path().join("dst.bin");
+    let plan = LocalCopyPlan::from_operands(&[
+        source.into_os_string(),
+        dest.clone().into_os_string(),
+    ])
+    .expect("plan");
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().preallocate(true).sparse(true),
+    )
+    .expect("preallocate + sparse copy succeeds");
+
+    let meta = fs::metadata(&dest).expect("dest metadata");
+    assert_eq!(meta.len(), apparent, "content length preserved");
+    assert!(
+        meta.blocks() * 512 < apparent,
+        "preallocated extent's zero run must be punched (allocated {}, size {})",
+        meta.blocks() * 512,
+        apparent,
+    );
+}
+
+/// `--inplace --sparse` must punch out a zero run introduced by the update,
+/// deallocating the blocks the pre-existing dense destination held there.
+///
+/// This mirrors upstream `preallocate_test.py`'s `--inplace --sparse` leg:
+/// upstream keeps `sparse_files > 0` in inplace mode and sets
+/// `preallocated_len = size_r` so `write_sparse()` punches the hole in place
+/// (receiver.c:334, fileio.c:sparse_end updating_basis_or_equiv branch).
+// upstream: fileio.c:47 sparse_end() updating_basis_or_equiv -> do_punch_hole
+#[cfg(target_os = "linux")]
+#[test]
+fn execute_inplace_sparse_punches_hole() {
+    use std::os::unix::fs::MetadataExt;
 
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source-inplace.bin");
@@ -82,34 +138,19 @@ fn execute_inplace_disables_sparse_writes() {
         .expect("extend source");
     drop(source_file);
 
-    let dense_dest = temp.path().join("dense-inplace.bin");
     let sparse_dest = temp.path().join("sparse-inplace.bin");
+    // Dense destination fully populated so the hole must be actively punched.
     let initial = vec![0xCC; 4 * 1024 * 1024];
-    fs::write(&dense_dest, &initial).expect("initialise dense destination");
     fs::write(&sparse_dest, &initial).expect("initialise sparse destination");
 
-    // Backdate destinations so rsync's quick-check detects them as stale
+    // Backdate the destination so rsync's quick-check detects it as stale.
     let past = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
-    fs::File::open(&dense_dest)
-        .unwrap()
-        .set_modified(past)
-        .unwrap();
     fs::File::open(&sparse_dest)
         .unwrap()
         .set_modified(past)
         .unwrap();
 
-    let dense_plan = LocalCopyPlan::from_operands(&[
-        source.clone().into_os_string(),
-        dense_dest.clone().into_os_string(),
-    ])
-    .expect("plan dense");
-    dense_plan
-        .execute_with_options(
-            LocalCopyExecution::Apply,
-            LocalCopyOptions::default().inplace(true),
-        )
-        .expect("dense inplace copy succeeds");
+    let before_blocks = fs::metadata(&sparse_dest).expect("meta").blocks();
 
     let sparse_plan = LocalCopyPlan::from_operands(&[
         source.into_os_string(),
@@ -119,29 +160,34 @@ fn execute_inplace_disables_sparse_writes() {
     sparse_plan
         .execute_with_options(
             LocalCopyExecution::Apply,
-            LocalCopyOptions::default().sparse(true).inplace(true),
+            LocalCopyOptions::default()
+                .sparse(true)
+                .inplace(true)
+                .whole_file(false),
         )
         .expect("sparse inplace copy succeeds");
 
-    let dense_meta = fs::metadata(&dense_dest).expect("dense metadata");
     let sparse_meta = fs::metadata(&sparse_dest).expect("sparse metadata");
 
-    assert_eq!(dense_meta.len(), sparse_meta.len());
-    assert_eq!(
-        fs::read(&dense_dest).expect("read dense destination"),
-        fs::read(&sparse_dest).expect("read sparse destination"),
-    );
+    // Content must match the source byte-for-byte.
+    assert_eq!(sparse_meta.len(), 4 * 1024 * 1024);
+    let readback = fs::read(&sparse_dest).expect("read sparse destination");
+    assert_eq!(readback[0], 0x11);
+    assert_eq!(readback[2 * 1024 * 1024], 0x22);
+    assert!(readback[1..2 * 1024 * 1024].iter().all(|&b| b == 0));
 
-    use std::os::unix::fs::MetadataExt;
-    let dense_blocks = dense_meta.blocks();
-    let sparse_blocks = sparse_meta.blocks();
-    // Allow a small tolerance for filesystem allocation differences (delayed
-    // allocation, alignment, etc.) - the key property is that inplace mode
-    // does not create large sparse holes.
-    let tolerance = (dense_blocks / 10).max(8);
+    // The 2 MiB zero run must be punched: allocation drops well below the
+    // original dense allocation and below the apparent file size.
+    let after_blocks = sparse_meta.blocks();
     assert!(
-        sparse_blocks + tolerance >= dense_blocks,
-        "in-place sparse copy should not create holes (sparse blocks: {sparse_blocks}, dense blocks: {dense_blocks})",
+        after_blocks < before_blocks,
+        "in-place sparse update should punch the hole (before: {before_blocks} blocks, after: {after_blocks})",
+    );
+    assert!(
+        after_blocks * 512 < sparse_meta.len(),
+        "punched file should allocate less than its apparent size (allocated {}, size {})",
+        after_blocks * 512,
+        sparse_meta.len(),
     );
 }
 


### PR DESCRIPTION
## Summary

`--preallocate --sparse` (and `--inplace --sparse`) left the destination file **fully allocated** instead of punching the source's zero runs into holes. The `preallocate` conformance test failed on master:

```
--preallocate --sparse left the file fully allocated (allocated 2105344 for a
2105344-byte file); the preallocated extent's zero run was not punched into a hole
```

### Root cause

The local-copy executor **disabled sparse writes** whenever `--preallocate`, `--inplace`, or `--append` was active, and the sparse writer only ever *seeked* over zero runs. Seeking past zeros cannot deallocate blocks that `fallocate` has already reserved (or that a fully-populated in-place destination already holds), so those files stayed dense.

Upstream keeps `sparse_files > 0` under `--preallocate`/`--inplace`. Its `write_sparse()` decides per zero run: `do_lseek` when the run starts at or beyond `preallocated_len` (natural hole), otherwise `do_punch_hole` to actively free the reserved blocks. `do_fallocate()` returns the allocated length so the writer knows the extent boundary. Verified with `strace`:

```
fallocate(1, 0, 0, 2105343) = 0                                    # preallocate
fallocate(1, FALLOC_FL_KEEP_SIZE|FALLOC_FL_PUNCH_HOLE, 4096, 2097152) = 0   # punch the hole
```

### Fix (engine)

Mirror upstream `write_sparse()` / `do_fallocate()`:

- **`preallocate.rs`** — `maybe_preallocate_destination` now returns the preallocated length (`st_blocks * 512` via fstat), matching `preallocated_len = do_fallocate(...)`.
- **`copy/mod.rs`** — keep sparse active under `--preallocate`/`--inplace`; disable only for `--append` (upstream flips `sparse_files` off during the append pass).
- **`execute/mod.rs`** — thread the preallocated length into the copy; for in-place-without-preallocate, seed it from the existing destination size (upstream `preallocated_len = size_r`).
- **`sparse/state.rs`** — `SparseWriteState` is now preallocation-aware: a pending zero run is punched (`do_punch_hole`) when it starts inside the preallocated/existing extent, and seeked over otherwise. The run start is read from the writer's live position, so an interleaved external seek (the inplace delta path) stays correct.
- **`delta_transfer.rs`** — inplace-sparse truncates to the delta loop's `output_position` (skipped matched blocks do not advance the writer), matching `sparse_end(f, size, updating_basis_or_equiv)`.

The non-delta sparse path now uses the same preallocation-aware `write_sparse_chunk` primitive as the delta path (the seek-only `SparseWriter` decorator remains a public API with its own tests).

### Tests

- Rewrote stale tests that asserted the pre-fix (non-upstream) "dense" behavior to assert the correct hole-punching: `execute_preallocate_sparse_punches_hole`, `execute_inplace_sparse_punches_hole`, `transfer_request_with_sparse_and_preallocate_punches_hole`, `transfer_request_with_sparse_and_inplace_punches_hole`, plus `SparseWriteState` unit coverage for the seek-vs-punch decision. `--append` correctly stays dense.

## Verification (lxhost, aarch64 Linux, upstream rsync 3.4.3-149)

Upstream testsuite — `preallocate` flips to PASS, neighbors not regressed:

```
preallocate: PASS    (FAIL on master)
sparse:      PASS
inplace:     PASS
```

Bounded nextest: engine `test(preallocate)|test(sparse)` = 199 run, **199 passed**. cli sparse tests pass on macOS locally.

Full-workspace `cargo nextest --workspace` is deferred to CI: it reliably wedges on the 3.3 GiB lxhost box (test-listing hang / link OOM, a documented environment limit). CI runs the full nextest matrix on the PR.
