### PR TITLE
fix(daemon): drain reads during delta phase to prevent transfer deadlock

### DIFF
--- a/crates/daemon/src/daemon/module_state/tests.rs
+++ b/crates/daemon/src/daemon/module_state/tests.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 use std::num::{NonZeroU32, NonZeroU64};
 use std::path::PathBuf;
+use std::sync::atomic::Ordering;
 
 use super::*;
 // Host pattern types are defined in the parent daemon module (via include!() of config_helpers.rs).
@@ -351,6 +352,68 @@ fn module_connection_guard_unlimited() {
     let guard = ModuleConnectionGuard::unlimited();
     assert!(guard.module.is_none());
     assert!(guard.lock_guard.is_none());
+}
+
+#[test]
+fn aborted_transfer_releases_connection_slot() {
+    // Regression for #504 (the deadlock-holds-slot symptom of #503).
+    //
+    // A daemon transfer holds its connection slot via the RAII
+    // `ModuleConnectionGuard` acquired in `process_approved_module`. When a
+    // transfer fails or aborts, the guard drops on unwind and must release the
+    // slot so the module keeps accepting new connections. Before #503 was
+    // fixed, a deadlocked connection thread never unwound, so its guard never
+    // dropped: four wedged connections exhausted a `max connections = 4`
+    // module. This test pins the invariant that a slot acquired and then
+    // released (the drop that a failed/aborted transfer performs) frees the
+    // module for a fresh connection - so even N aborted transfers never wedge
+    // the module at its limit.
+    let limit = NonZeroU32::new(4).unwrap();
+    let def = ModuleDefinition {
+        name: "abort_release".to_owned(),
+        max_connections: Some(limit),
+        ..Default::default()
+    };
+    let runtime: ModuleRuntime = def.into();
+
+    // Simulate five sequential failed/aborted transfers on a 4-slot module.
+    // Each acquisition must succeed because the previous guard was dropped
+    // (as it would be when a transfer returns Err or the thread unwinds).
+    for _ in 0..5 {
+        let guard = runtime
+            .try_acquire_connection()
+            .expect("slot must be free after the prior aborted transfer released it");
+        assert_eq!(runtime.active_connections.load(Ordering::Acquire), 1);
+        // Dropping the guard is exactly what a failed/aborted transfer does.
+        drop(guard);
+        assert_eq!(
+            runtime.active_connections.load(Ordering::Acquire),
+            0,
+            "aborted transfer must release its connection slot"
+        );
+    }
+
+    // Fill every slot, confirm the limit is enforced, then release one and
+    // confirm a new connection is admitted - the module never stays wedged.
+    let mut guards = Vec::new();
+    for _ in 0..limit.get() {
+        guards.push(
+            runtime
+                .try_acquire_connection()
+                .expect("slots below the limit must be acquirable"),
+        );
+    }
+    assert!(
+        matches!(
+            runtime.try_acquire_connection(),
+            Err(ModuleConnectionError::Limit(_))
+        ),
+        "the module must refuse once the limit is reached"
+    );
+    guards.pop();
+    runtime
+        .try_acquire_connection()
+        .expect("releasing a slot must let a new connection in");
 }
 
 #[test]

--- a/crates/daemon/src/daemon/sections/module_access/transfer.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer.rs
@@ -16,6 +16,8 @@
 
 include!("transfer/sandbox.rs");
 
+include!("transfer/draining_reader.rs");
+
 include!("transfer/streams.rs");
 
 include!("transfer/orchestration.rs");

--- a/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
@@ -26,13 +26,23 @@
 // only on the daemon-TCP path; SSH/stdio and local transports keep reading the
 // socket directly and are byte-identical to before.
 //
+// The drain thread runs its read-clone fd in non-blocking mode and polls: an
+// empty socket returns `WouldBlock`, on which the loop re-checks the stop flag
+// and sleeps a couple of milliseconds before retrying. This bounds the
+// stop-flag wake latency on every platform without depending on read-timeout
+// wakeups, which on the daemon's cloned Windows socket fd did not reliably wake
+// a blocked `read()` and wedged `join()` in CI.
+//
 // Shutdown ordering (design doc section 5.2): the drain thread must be stopped
 // and joined before the orchestration TCP goodbye drain runs, because that
 // drain reads a *different* clone of the same socket. The caller holds a
 // `DrainHandle` and calls `stop()` after the transfer engine returns and before
 // the goodbye drain. `Drop` also stops-and-joins as a backstop on every exit
 // path (success, error, early return), so the thread can never outlive the
-// transfer.
+// transfer. Non-blocking mode is a property of the shared socket object (both
+// clones observe it), so the drain thread restores blocking mode on exit -
+// before `stop_and_join()` returns - leaving the goodbye-drain clone a normal
+// blocking socket.
 //
 // upstream: io.c:882-889 perform_io() drains readable multiplex messages
 // whenever it is about to write, keeping the peer's send buffer emptied.
@@ -44,12 +54,44 @@
 /// Size of each socket read the drain thread performs.
 const DRAIN_CHUNK_SIZE: usize = 64 * 1024;
 
+/// Poll interval when the non-blocking drain read has no data ready.
+///
+/// The drain thread runs the read handle in non-blocking mode: an empty socket
+/// returns `WouldBlock` immediately instead of parking the thread. On that
+/// signal the loop re-checks the stop flag and, if still running, sleeps this
+/// long before retrying. This bounds `stop_and_join()`'s wake latency to at
+/// most one interval on every platform, without relying on read-timeout
+/// wakeups (which do not fire reliably on the daemon's cloned Windows socket
+/// fd - the failure mode that wedged `join()` in CI). At ~2 ms the poll adds
+/// negligible latency to real draining (bursty + write-side-flow-bounded) and
+/// is dwarfed by the transfer's own I/O.
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(2);
+
 /// One item handed from the drain thread to the consumer: either a chunk of
 /// wire bytes, or the terminal read result (EOF or error) once the socket
 /// stops yielding data.
 enum DrainItem {
     Data(Vec<u8>),
     End(io::Result<()>),
+}
+
+/// A socket the drain thread reads in non-blocking mode.
+///
+/// The drain loop must be able to switch its read handle to non-blocking so an
+/// empty socket returns `WouldBlock` immediately instead of parking the thread
+/// past `stop()`. This trait exposes just that capability on top of `Read`, so
+/// `DrainingReader::new` stays generic (production wraps a cloned `TcpStream`;
+/// tests wrap a loopback `TcpStream`) while still guaranteeing the poll-loop
+/// contract at the type level.
+trait DrainSource: Read + Send {
+    /// Switches the underlying fd between non-blocking and blocking mode.
+    fn set_drain_nonblocking(&self, nonblocking: bool) -> io::Result<()>;
+}
+
+impl DrainSource for TcpStream {
+    fn set_drain_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        self.set_nonblocking(nonblocking)
+    }
 }
 
 /// A blocking `Read` adapter backed by a background socket-drain thread.
@@ -122,7 +164,7 @@ impl DrainingReader {
     /// receiver only ever has a bounded window of outstanding file requests, so
     /// the peer can only stream a bounded amount of delta data ahead of what
     /// the consumer drains.
-    fn new<R: Read + Send + 'static>(mut source: R) -> (Self, DrainHandle) {
+    fn new<R: DrainSource + 'static>(source: R) -> (Self, DrainHandle) {
         let (tx, rx): (
             std::sync::mpsc::Sender<DrainItem>,
             std::sync::mpsc::Receiver<DrainItem>,
@@ -133,18 +175,41 @@ impl DrainingReader {
         });
         let thread_inner = Arc::clone(&inner);
 
+        // Put the drain fd in non-blocking mode so `read()` returns `WouldBlock`
+        // on an empty socket instead of parking the thread. This is what lets
+        // the loop notice the stop flag within one `DRAIN_POLL_INTERVAL` on
+        // every platform - no reliance on read-timeout wakeups, which do not
+        // fire reliably on the daemon's cloned Windows socket fd and previously
+        // wedged `join()` in CI. A failure to set non-blocking is non-fatal:
+        // the loop still functions (it may just block on `read()` until data or
+        // FIN), matching the earlier best-effort read-timeout handling.
+        //
+        // On both Unix (`ioctl` FIONBIO / `SO_NONBLOCK`) and Windows
+        // (`ioctlsocket` FIONBIO), non-blocking mode is a property of the shared
+        // socket object, so it is also observed by the daemon's OTHER clone of
+        // this socket - the `DaemonStream` the orchestrator's goodbye drain
+        // reads. The drain thread therefore restores BLOCKING mode on exit
+        // (below), before `stop_and_join()` returns, so the goodbye drain sees a
+        // normal blocking socket and its bounded read-timeout loop behaves as
+        // before. `stop()` joins the thread, so the restore is complete before
+        // the goodbye drain runs.
+        let _ = source.set_drain_nonblocking(true);
+
         let handle = thread::Builder::new()
             .name("daemon-delta-drain".to_owned())
             .spawn(move || {
+                let mut source = source;
                 let mut buf = vec![0u8; DRAIN_CHUNK_SIZE];
-                loop {
+                // Run the drain loop, then unconditionally restore blocking mode
+                // on the shared socket so the goodbye-drain clone is unaffected.
+                'drain: loop {
                     if thread_inner.stop.load(Ordering::Acquire) {
-                        return;
+                        break 'drain;
                     }
                     match source.read(&mut buf) {
                         Ok(0) => {
                             let _ = tx.send(DrainItem::End(Ok(())));
-                            return;
+                            break 'drain;
                         }
                         Ok(n) => {
                             // Unbounded send never blocks, so the thread loops
@@ -152,17 +217,18 @@ impl DrainingReader {
                             // receive buffer drained. A send error means the
                             // consumer dropped the receiver (transfer over).
                             if tx.send(DrainItem::Data(buf[..n].to_vec())).is_err() {
-                                return;
+                                break 'drain;
                             }
                         }
-                        // A read timeout (set on the socket by the caller so a
-                        // blocking `read()` cannot pin the thread past `stop()`)
-                        // or an interrupted syscall is not a wire error: loop
-                        // back to re-check the stop flag and keep draining. This
-                        // is what makes `stop_and_join()` reliably unblock the
-                        // thread on every platform, including Windows, where a
-                        // permanently-blocking `read()` would otherwise never
-                        // observe the stop flag and `join()` would hang.
+                        // Non-blocking read with no data ready (`WouldBlock`),
+                        // or an interrupted syscall: not a wire error. Re-check
+                        // the stop flag, then sleep one poll interval before
+                        // retrying. This bounds the stop-flag observation
+                        // latency on every platform without depending on
+                        // read-timeout semantics, so `stop_and_join()` always
+                        // unblocks the thread within ~one interval. `TimedOut`
+                        // is tolerated too as a backstop for any handle still
+                        // carrying a stale read timeout.
                         Err(ref e)
                             if matches!(
                                 e.kind(),
@@ -171,14 +237,22 @@ impl DrainingReader {
                                     | io::ErrorKind::TimedOut
                             ) =>
                         {
-                            continue
+                            if thread_inner.stop.load(Ordering::Acquire) {
+                                break 'drain;
+                            }
+                            thread::sleep(DRAIN_POLL_INTERVAL);
+                            continue;
                         }
                         Err(e) => {
                             let _ = tx.send(DrainItem::End(Err(e)));
-                            return;
+                            break 'drain;
                         }
                     }
                 }
+                // Restore blocking mode on the shared socket before the thread
+                // exits (and thus before `stop_and_join()` returns), so the
+                // separate goodbye-drain clone reads a blocking socket.
+                let _ = source.set_drain_nonblocking(false);
             })
             .expect("failed to spawn daemon delta-drain thread");
 
@@ -349,12 +423,17 @@ mod draining_reader_tests {
     #[test]
     fn stop_joins_promptly_when_peer_is_silent() {
         // Regression (#503, Windows CI): a silent peer that connects but never
-        // sends and never closes leaves the drain thread parked in a blocking
-        // `read()`. With a read timeout on the socket, the loop wakes, observes
-        // the stop flag, and exits, so `stop()`'s join returns instead of
-        // hanging forever. This is the exact deadlock the daemon negotiation
-        // tests hit on Windows, where a blocking `read()` only unblocks on peer
-        // close. The join must complete well within the read timeout budget.
+        // sends and never closes must NOT leave the drain thread parked. The
+        // non-blocking poll loop returns `WouldBlock` on the empty socket and
+        // checks the stop flag every poll interval, so `stop()`'s join returns
+        // promptly instead of hanging forever. This is the exact deadlock the
+        // daemon negotiation tests hit on Windows, where a blocking `read()`
+        // (even with a read timeout on the cloned fd) never observed the stop
+        // flag. The join must complete well within a second.
+        //
+        // The socket is deliberately left in default (blocking) mode here to
+        // prove the fix does not depend on the caller pre-arming a read timeout
+        // or non-blocking flag: `DrainingReader::new` sets non-blocking itself.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
         let addr = listener.local_addr().expect("local addr");
         // Accept and then sit silent, holding the connection open (no data,
@@ -366,9 +445,10 @@ mod draining_reader_tests {
             thread::sleep(std::time::Duration::from_secs(2));
             drop(server);
         });
+        // Left in default blocking mode on purpose: the drain thread flips it
+        // to non-blocking itself, so the prompt join must not depend on any
+        // caller-side timeout or flag.
         let sock = TcpStream::connect(addr).expect("connect loopback");
-        sock.set_read_timeout(Some(std::time::Duration::from_millis(200)))
-            .expect("set read timeout");
         let (reader, handle) = DrainingReader::new(sock);
 
         let start = std::time::Instant::now();
@@ -379,5 +459,98 @@ mod draining_reader_tests {
         );
         drop(reader);
         let _ = silent_peer.join();
+    }
+
+    #[test]
+    fn replays_all_buffered_bytes_before_stop() {
+        // Queue-drain invariant (mirrors upstream perform_io io.c:882): every
+        // byte the drain thread pulled off the socket must be replayed to the
+        // consumer in order, even after `stop()` halts further draining. The
+        // consumer reads the full transfer payload through the reader, then
+        // stops the handle; no byte the thread already buffered may be lost.
+        let payload: Vec<u8> = (0..40_000u32).map(|i| (i % 249) as u8).collect();
+        let sock = spawn_socket_feeder(payload.clone(), 3000);
+        let (mut reader, handle) = DrainingReader::new(sock);
+
+        // Drain the entire payload through the reader (it arrives via the
+        // background thread's queue), then stop.
+        let mut received = Vec::with_capacity(payload.len());
+        reader.read_to_end(&mut received).expect("read to end");
+        handle.stop();
+
+        assert_eq!(
+            received, payload,
+            "every drained byte must replay to the consumer in order, no goodbye-byte loss"
+        );
+    }
+
+    #[test]
+    fn goodbye_clone_reads_after_drain_stops() {
+        // The goodbye drain reads the socket via a SEPARATE clone
+        // (`ctx.reader`'s `DaemonStream`), not the drain clone. Putting the
+        // drain clone in non-blocking mode must not disturb bytes that arrive
+        // for the goodbye reader on another clone of the same connection. Here
+        // the drain thread consumes the first burst; after `stop()`, a second
+        // clone reads a trailing "goodbye" burst intact.
+        //
+        // The peer is sequenced (send first burst, wait for a go-ahead, then
+        // send goodbye) so the drain thread cannot race the goodbye bytes into
+        // its own queue - matching the real daemon order where `stop()` runs
+        // after the engine's goodbye and before the goodbye-drain clone reads.
+        use std::sync::mpsc::channel;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let first: Vec<u8> = (0..8_000u32).map(|i| (i % 251) as u8).collect();
+        let goodbye: Vec<u8> = vec![0xABu8; 512];
+        let first_for_peer = first.clone();
+        let goodbye_for_peer = goodbye.clone();
+        let (go_tx, go_rx) = channel::<()>();
+        let peer = thread::spawn(move || {
+            let (mut server, _) = listener.accept().expect("accept");
+            server.write_all(&first_for_peer).expect("write first burst");
+            server.flush().expect("flush first");
+            // Wait until the consumer has drained the first burst and stopped
+            // the drain thread before writing the trailing goodbye bytes.
+            let _ = go_rx.recv();
+            server.write_all(&goodbye_for_peer).expect("write goodbye");
+            server.flush().expect("flush goodbye");
+            thread::sleep(std::time::Duration::from_millis(50));
+            drop(server);
+        });
+
+        let drain_sock = TcpStream::connect(addr).expect("connect loopback");
+        // The goodbye reader is a separate clone of the same socket, exactly as
+        // the daemon splits `read_stream` (drain) from `ctx.reader` (goodbye).
+        let mut goodbye_reader = drain_sock.try_clone().expect("clone for goodbye");
+        let (mut reader, handle) = DrainingReader::new(drain_sock);
+
+        // Consume the first burst through the drain reader.
+        let mut got_first = vec![0u8; first.len()];
+        reader.read_exact(&mut got_first).expect("read first burst");
+        assert_eq!(got_first, first, "drain reader must replay the first burst intact");
+
+        // Stop the drain thread (drain clone stays non-blocking, then dropped),
+        // then let the peer send its trailing goodbye bytes.
+        handle.stop();
+        drop(reader);
+        go_tx.send(()).expect("signal peer to send goodbye");
+
+        // The separate goodbye clone must read the trailing bytes; the
+        // non-blocking flag on the drain clone must not have stolen or reordered
+        // them. Give the goodbye clone a bounded read timeout so the test cannot
+        // hang if the invariant is violated.
+        goodbye_reader
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .expect("set goodbye read timeout");
+        let mut got_goodbye = Vec::new();
+        goodbye_reader
+            .read_to_end(&mut got_goodbye)
+            .expect("read goodbye burst");
+        assert_eq!(
+            got_goodbye, goodbye,
+            "the separate goodbye clone must read the trailing bytes intact after drain stop"
+        );
+
+        let _ = peer.join();
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
@@ -1,0 +1,331 @@
+// Background socket-drain reader for the daemon delta-transfer phase (#503).
+//
+// The daemon splits one TCP socket into two blocking `try_clone()` fds (see
+// `streams.rs`). The receiver delta loop writes a batch of file requests, then
+// blocks reading the sender's response - with no interleaved drain of incoming
+// frames. Once both ~128 KB kernel socket buffers fill, neither direction can
+// make progress: a full-duplex write-write deadlock. Over SSH/stdio the peer
+// runs in a separate process with independent pipe buffers, so the same engine
+// code does not wedge; the fault is specific to the single-socket daemon path.
+//
+// `DrainingReader` breaks the wedge the same way upstream's `perform_io` does:
+// it guarantees the peer's send buffer is always being drained. A dedicated
+// background thread continuously reads the read-clone fd into an unbounded
+// queue; the main receiver loop pulls bytes from that queue instead of blocking
+// on the socket directly. Because the peer's bytes are always being consumed
+// off the wire, the peer never blocks writing, so this side's writes always
+// drain and the deadlock is structurally impossible. The queue is unbounded so
+// the drain thread never blocks on a full queue and stop draining the socket -
+// that would re-arm the wedge. In-memory growth is bounded by the protocol's
+// own write-side flow control (the receiver keeps only a bounded window of
+// outstanding requests), mirroring upstream's `iobuf.in` that grows as needed.
+//
+// This is a transparent byte pipe: it preserves every byte and its order, so
+// the multiplex framing, wire format, and goodbye handshake are unchanged. It
+// changes only *when* the socket is read, not *what* is read. It is constructed
+// only on the daemon-TCP path; SSH/stdio and local transports keep reading the
+// socket directly and are byte-identical to before.
+//
+// Shutdown ordering (design doc section 5.2): the drain thread must be stopped
+// and joined before the orchestration TCP goodbye drain runs, because that
+// drain reads a *different* clone of the same socket. The caller holds a
+// `DrainHandle` and calls `stop()` after the transfer engine returns and before
+// the goodbye drain. `Drop` also stops-and-joins as a backstop on every exit
+// path (success, error, early return), so the thread can never outlive the
+// transfer.
+//
+// upstream: io.c:882-889 perform_io() drains readable multiplex messages
+// whenever it is about to write, keeping the peer's send buffer emptied.
+//
+// This file is `include!`d into the `crate::daemon` scope, so it reuses the
+// enclosing module's imports (`Arc`, `Mutex`, `AtomicBool`, `Ordering`,
+// `thread`, `io`, `Read`) and fully qualifies the `mpsc` types it adds.
+
+/// Size of each socket read the drain thread performs.
+const DRAIN_CHUNK_SIZE: usize = 64 * 1024;
+
+/// One item handed from the drain thread to the consumer: either a chunk of
+/// wire bytes, or the terminal read result (EOF or error) once the socket
+/// stops yielding data.
+enum DrainItem {
+    Data(Vec<u8>),
+    End(io::Result<()>),
+}
+
+/// A blocking `Read` adapter backed by a background socket-drain thread.
+///
+/// Wraps the daemon's read-clone fd and spawns a thread that continuously
+/// reads it into an unbounded channel. `Read::read` serves bytes from the
+/// channel, so the consuming receiver loop never blocks on the socket while a
+/// write would otherwise wedge. See the module comment for the full rationale
+/// and shutdown contract.
+struct DrainingReader {
+    rx: std::sync::mpsc::Receiver<DrainItem>,
+    /// Leftover bytes from a chunk that did not fit the caller's buffer.
+    residual: Vec<u8>,
+    residual_pos: usize,
+    /// Shared stop flag and join handle, also held by the caller's
+    /// `DrainHandle` so the thread can be stopped before the goodbye drain.
+    inner: Arc<DrainInner>,
+}
+
+/// Shared shutdown state between the reader and its external stop handle.
+struct DrainInner {
+    stop: AtomicBool,
+    join: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+/// External stop handle for a `DrainingReader`'s background thread.
+///
+/// Held by the daemon transfer orchestrator so the drain thread can be
+/// stopped and joined *before* the TCP goodbye drain reads the socket via a
+/// different clone. `stop()` is idempotent.
+struct DrainHandle {
+    inner: Arc<DrainInner>,
+}
+
+impl DrainInner {
+    /// Signals the drain thread to stop and joins it. Idempotent: safe to call
+    /// from both the external `DrainHandle` and `DrainingReader::drop`.
+    fn stop_and_join(&self) {
+        self.stop.store(true, Ordering::Release);
+        if let Ok(mut guard) = self.join.lock() {
+            if let Some(handle) = guard.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+impl DrainHandle {
+    /// Stops the background drain thread and joins it. Must be called before
+    /// the orchestration goodbye drain reads the socket via another clone.
+    fn stop(&self) {
+        self.inner.stop_and_join();
+    }
+}
+
+impl DrainingReader {
+    /// Wraps `source` (a daemon read-clone fd) and spawns the drain thread.
+    ///
+    /// Returns the reader plus a `DrainHandle` for out-of-band shutdown. The
+    /// thread reads `source` into an unbounded channel until EOF, error, or the
+    /// stop flag is set.
+    ///
+    /// The channel is unbounded so the drain thread NEVER blocks on send: it
+    /// keeps the kernel socket receive buffer continuously drained, which is
+    /// what breaks the wedge (a bounded queue would let the thread block on a
+    /// full queue and stop draining the socket, re-arming the deadlock). This
+    /// mirrors upstream's `iobuf.in`, which grows as needed rather than
+    /// applying back-pressure to the peer mid-transfer. In-memory growth is
+    /// naturally bounded by the protocol's own write-side flow control: the
+    /// receiver only ever has a bounded window of outstanding file requests, so
+    /// the peer can only stream a bounded amount of delta data ahead of what
+    /// the consumer drains.
+    fn new<R: Read + Send + 'static>(mut source: R) -> (Self, DrainHandle) {
+        let (tx, rx): (
+            std::sync::mpsc::Sender<DrainItem>,
+            std::sync::mpsc::Receiver<DrainItem>,
+        ) = std::sync::mpsc::channel();
+        let inner = Arc::new(DrainInner {
+            stop: AtomicBool::new(false),
+            join: Mutex::new(None),
+        });
+        let thread_inner = Arc::clone(&inner);
+
+        let handle = thread::Builder::new()
+            .name("daemon-delta-drain".to_owned())
+            .spawn(move || {
+                let mut buf = vec![0u8; DRAIN_CHUNK_SIZE];
+                loop {
+                    if thread_inner.stop.load(Ordering::Acquire) {
+                        return;
+                    }
+                    match source.read(&mut buf) {
+                        Ok(0) => {
+                            let _ = tx.send(DrainItem::End(Ok(())));
+                            return;
+                        }
+                        Ok(n) => {
+                            // Unbounded send never blocks, so the thread loops
+                            // straight back to `read()` and keeps the socket
+                            // receive buffer drained. A send error means the
+                            // consumer dropped the receiver (transfer over).
+                            if tx.send(DrainItem::Data(buf[..n].to_vec())).is_err() {
+                                return;
+                            }
+                        }
+                        Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                        Err(e) => {
+                            let _ = tx.send(DrainItem::End(Err(e)));
+                            return;
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn daemon delta-drain thread");
+
+        if let Ok(mut guard) = inner.join.lock() {
+            *guard = Some(handle);
+        }
+
+        let reader = DrainingReader {
+            rx,
+            residual: Vec::new(),
+            residual_pos: 0,
+            inner: Arc::clone(&inner),
+        };
+        let stop_handle = DrainHandle { inner };
+        (reader, stop_handle)
+    }
+
+    /// Copies as many residual bytes as fit into `out`, returning the count.
+    fn drain_residual(&mut self, out: &mut [u8]) -> usize {
+        let available = self.residual.len() - self.residual_pos;
+        let n = available.min(out.len());
+        out[..n].copy_from_slice(&self.residual[self.residual_pos..self.residual_pos + n]);
+        self.residual_pos += n;
+        if self.residual_pos == self.residual.len() {
+            self.residual.clear();
+            self.residual_pos = 0;
+        }
+        n
+    }
+}
+
+impl Read for DrainingReader {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+
+        // Serve any bytes left over from a previous oversized chunk first.
+        if self.residual_pos < self.residual.len() {
+            return Ok(self.drain_residual(out));
+        }
+
+        // Items are FIFO, so the terminal `End` only arrives after every
+        // `Data` chunk has been drained: no wire bytes are dropped ahead of
+        // EOF/error.
+        match self.rx.recv() {
+            Ok(DrainItem::Data(chunk)) => {
+                self.residual = chunk;
+                self.residual_pos = 0;
+                Ok(self.drain_residual(out))
+            }
+            Ok(DrainItem::End(result)) => match result {
+                Ok(()) => Ok(0),
+                Err(e) => Err(e),
+            },
+            // Sender dropped without a terminal item (thread stopped): treat as
+            // clean EOF - the caller's higher-level framing surfaces any real
+            // truncation.
+            Err(_) => Ok(0),
+        }
+    }
+}
+
+impl Drop for DrainingReader {
+    fn drop(&mut self) {
+        // Backstop for every exit path: stop and join the thread so it can
+        // never outlive the transfer or race the goodbye drain. Idempotent
+        // with the external `DrainHandle::stop`.
+        self.inner.stop_and_join();
+    }
+}
+
+#[cfg(test)]
+mod draining_reader_tests {
+    //! Byte-pipe fidelity and anti-deadlock (#503) tests for `DrainingReader`.
+
+    use super::DrainingReader;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+
+    /// A loopback TCP pair: the background writer feeds `payload` in small
+    /// chunks with a flush between them, mimicking a peer streaming delta
+    /// tokens into a socket the receiver reads through a `DrainingReader`.
+    fn spawn_socket_feeder(payload: Vec<u8>, chunk: usize) -> TcpStream {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let feeder = thread::spawn(move || {
+            let (mut server, _) = listener.accept().expect("accept");
+            for part in payload.chunks(chunk.max(1)) {
+                server.write_all(part).expect("write chunk");
+                server.flush().expect("flush chunk");
+            }
+            // Drop `server` -> FIN -> EOF on the reader side.
+        });
+        let client = TcpStream::connect(addr).expect("connect loopback");
+        // Detach: the feeder finishes on its own; the reader observes EOF.
+        let _ = feeder;
+        client
+    }
+
+    #[test]
+    fn preserves_bytes_and_order() {
+        // Every byte the peer writes must arrive at the consumer in order,
+        // regardless of chunking: the wrapper is a transparent byte pipe.
+        let payload: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let sock = spawn_socket_feeder(payload.clone(), 1500);
+        let (mut reader, _handle) = DrainingReader::new(sock);
+
+        let mut received = Vec::new();
+        reader.read_to_end(&mut received).expect("read to end");
+        assert_eq!(received, payload, "DrainingReader must preserve every byte in order");
+    }
+
+    #[test]
+    fn drains_socket_while_consumer_is_slow() {
+        // The anti-deadlock guarantee (#503): the background thread keeps the
+        // socket receive buffer drained even when the consumer reads slowly.
+        // A payload larger than the kernel socket buffer would wedge a
+        // single-threaded reader that only reads after writing; here the drain
+        // thread consumes it while the consumer trickles reads one byte at a
+        // time, and all bytes still arrive intact.
+        let payload: Vec<u8> = (0..500_000u32).map(|i| (i % 253) as u8).collect();
+        let sock = spawn_socket_feeder(payload.clone(), 4096);
+        let (mut reader, _handle) = DrainingReader::new(sock);
+
+        let mut received = Vec::with_capacity(payload.len());
+        let mut one = [0u8; 1];
+        loop {
+            match reader.read(&mut one) {
+                Ok(0) => break,
+                Ok(_) => received.push(one[0]),
+                Err(e) => panic!("read error: {e}"),
+            }
+        }
+        assert_eq!(received.len(), payload.len());
+        assert_eq!(received, payload);
+    }
+
+    #[test]
+    fn stop_handle_joins_thread_idempotently() {
+        // The external stop handle must halt and join the drain thread before
+        // the goodbye drain runs, and be safe to call more than once (Drop
+        // calls it again). No panic, no hang.
+        let payload = vec![7u8; 64];
+        let sock = spawn_socket_feeder(payload, 16);
+        let (reader, handle) = DrainingReader::new(sock);
+        handle.stop();
+        handle.stop(); // idempotent
+        drop(reader); // Drop's stop_and_join must also be a no-op now.
+    }
+
+    #[test]
+    fn surfaces_eof_after_all_bytes() {
+        // After the last chunk, a read returns Ok(0) exactly once the queue is
+        // drained - no bytes dropped ahead of EOF.
+        let payload = vec![1u8, 2, 3, 4, 5];
+        let sock = spawn_socket_feeder(payload.clone(), 2);
+        let (mut reader, _handle) = DrainingReader::new(sock);
+        let mut got = Vec::new();
+        reader.read_to_end(&mut got).expect("read to end");
+        assert_eq!(got, payload);
+        // Subsequent reads keep returning EOF.
+        let mut extra = [0u8; 4];
+        assert_eq!(reader.read(&mut extra).expect("post-eof read"), 0);
+    }
+}

--- a/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
@@ -155,7 +155,24 @@ impl DrainingReader {
                                 return;
                             }
                         }
-                        Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                        // A read timeout (set on the socket by the caller so a
+                        // blocking `read()` cannot pin the thread past `stop()`)
+                        // or an interrupted syscall is not a wire error: loop
+                        // back to re-check the stop flag and keep draining. This
+                        // is what makes `stop_and_join()` reliably unblock the
+                        // thread on every platform, including Windows, where a
+                        // permanently-blocking `read()` would otherwise never
+                        // observe the stop flag and `join()` would hang.
+                        Err(ref e)
+                            if matches!(
+                                e.kind(),
+                                io::ErrorKind::Interrupted
+                                    | io::ErrorKind::WouldBlock
+                                    | io::ErrorKind::TimedOut
+                            ) =>
+                        {
+                            continue
+                        }
                         Err(e) => {
                             let _ = tx.send(DrainItem::End(Err(e)));
                             return;
@@ -327,5 +344,40 @@ mod draining_reader_tests {
         // Subsequent reads keep returning EOF.
         let mut extra = [0u8; 4];
         assert_eq!(reader.read(&mut extra).expect("post-eof read"), 0);
+    }
+
+    #[test]
+    fn stop_joins_promptly_when_peer_is_silent() {
+        // Regression (#503, Windows CI): a silent peer that connects but never
+        // sends and never closes leaves the drain thread parked in a blocking
+        // `read()`. With a read timeout on the socket, the loop wakes, observes
+        // the stop flag, and exits, so `stop()`'s join returns instead of
+        // hanging forever. This is the exact deadlock the daemon negotiation
+        // tests hit on Windows, where a blocking `read()` only unblocks on peer
+        // close. The join must complete well within the read timeout budget.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        // Accept and then sit silent, holding the connection open (no data,
+        // no FIN) until the test drops it.
+        let silent_peer = thread::spawn(move || {
+            let (server, _) = listener.accept().expect("accept");
+            // Park the accepted socket alive; the reader must not depend on a
+            // FIN to stop its drain thread.
+            thread::sleep(std::time::Duration::from_secs(2));
+            drop(server);
+        });
+        let sock = TcpStream::connect(addr).expect("connect loopback");
+        sock.set_read_timeout(Some(std::time::Duration::from_millis(200)))
+            .expect("set read timeout");
+        let (reader, handle) = DrainingReader::new(sock);
+
+        let start = std::time::Instant::now();
+        handle.stop();
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "stop() must join the drain thread promptly even with a silent peer"
+        );
+        drop(reader);
+        let _ = silent_peer.join();
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs
@@ -26,12 +26,21 @@
 // only on the daemon-TCP path; SSH/stdio and local transports keep reading the
 // socket directly and are byte-identical to before.
 //
-// The drain thread runs its read-clone fd in non-blocking mode and polls: an
-// empty socket returns `WouldBlock`, on which the loop re-checks the stop flag
-// and sleeps a couple of milliseconds before retrying. This bounds the
-// stop-flag wake latency on every platform without depending on read-timeout
-// wakeups, which on the daemon's cloned Windows socket fd did not reliably wake
-// a blocked `read()` and wedged `join()` in CI.
+// The drain thread bounds its blocking `read()` with a short read timeout
+// (`SO_RCVTIMEO`) and polls: an idle socket returns `TimedOut`, on which the
+// loop re-checks the stop flag before retrying. This bounds the stop-flag wake
+// latency so `stop_and_join()` never hangs on a silent peer.
+//
+// CRITICAL: the drain fd must NOT be put in non-blocking mode. All of the
+// daemon's socket clones (read, write, goodbye) are `try_clone()`s of the same
+// underlying socket, which on Unix share one open file description. `O_NONBLOCK`
+// lives on that shared description, so flipping the drain clone non-blocking
+// ALSO makes the concurrent WRITE clone non-blocking: the sender's `write_all`
+// then hits `WouldBlock` on a full send buffer and the transfer aborts /
+// truncates (`multiplexed payload truncated`, code 23). A read timeout instead
+// sets only `SO_RCVTIMEO`; it leaks onto sibling clones too, but the write clone
+// only ever writes (governed by `SO_SNDTIMEO`, left unset), so its writes stay
+// blocking and lossless.
 //
 // Shutdown ordering (design doc section 5.2): the drain thread must be stopped
 // and joined before the orchestration TCP goodbye drain runs, because that
@@ -39,10 +48,9 @@
 // `DrainHandle` and calls `stop()` after the transfer engine returns and before
 // the goodbye drain. `Drop` also stops-and-joins as a backstop on every exit
 // path (success, error, early return), so the thread can never outlive the
-// transfer. Non-blocking mode is a property of the shared socket object (both
-// clones observe it), so the drain thread restores blocking mode on exit -
-// before `stop_and_join()` returns - leaving the goodbye-drain clone a normal
-// blocking socket.
+// transfer. The read timeout leaks onto the shared socket object, so the drain
+// thread clears it on exit - before `stop_and_join()` returns - leaving the
+// goodbye-drain clone a normal blocking socket.
 //
 // upstream: io.c:882-889 perform_io() drains readable multiplex messages
 // whenever it is about to write, keeping the peer's send buffer emptied.
@@ -54,18 +62,21 @@
 /// Size of each socket read the drain thread performs.
 const DRAIN_CHUNK_SIZE: usize = 64 * 1024;
 
-/// Poll interval when the non-blocking drain read has no data ready.
+/// Read timeout that bounds each blocking drain `read()`.
 ///
-/// The drain thread runs the read handle in non-blocking mode: an empty socket
-/// returns `WouldBlock` immediately instead of parking the thread. On that
-/// signal the loop re-checks the stop flag and, if still running, sleeps this
-/// long before retrying. This bounds `stop_and_join()`'s wake latency to at
-/// most one interval on every platform, without relying on read-timeout
-/// wakeups (which do not fire reliably on the daemon's cloned Windows socket
-/// fd - the failure mode that wedged `join()` in CI). At ~2 ms the poll adds
-/// negligible latency to real draining (bursty + write-side-flow-bounded) and
-/// is dwarfed by the transfer's own I/O.
-const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(2);
+/// The drain thread reads with this `SO_RCVTIMEO` so an idle socket returns
+/// `TimedOut` instead of parking the thread indefinitely. On that signal the
+/// loop re-checks the stop flag and retries, so `stop_and_join()`'s wake
+/// latency is at most one interval on every platform. A read timeout (unlike
+/// non-blocking mode) does not disturb the concurrent write clone's blocking
+/// writes - see the module comment. At ~50 ms it adds negligible latency to
+/// real draining (bursty + write-side-flow-bounded) and is dwarfed by the
+/// transfer's own I/O.
+const DRAIN_READ_TIMEOUT: Duration = Duration::from_millis(50);
+
+/// Brief yield after a timed-out/would-block read to guard against a busy-spin
+/// on the rare path where the read timeout could not be armed.
+const DRAIN_SPIN_GUARD: Duration = Duration::from_millis(2);
 
 /// One item handed from the drain thread to the consumer: either a chunk of
 /// wire bytes, or the terminal read result (EOF or error) once the socket
@@ -75,22 +86,24 @@ enum DrainItem {
     End(io::Result<()>),
 }
 
-/// A socket the drain thread reads in non-blocking mode.
+/// A socket the drain thread reads with a bounded read timeout.
 ///
-/// The drain loop must be able to switch its read handle to non-blocking so an
-/// empty socket returns `WouldBlock` immediately instead of parking the thread
-/// past `stop()`. This trait exposes just that capability on top of `Read`, so
-/// `DrainingReader::new` stays generic (production wraps a cloned `TcpStream`;
-/// tests wrap a loopback `TcpStream`) while still guaranteeing the poll-loop
-/// contract at the type level.
+/// The drain loop must be able to arm a read timeout so an idle socket returns
+/// `TimedOut` and the loop can observe `stop()` promptly, without ever putting
+/// the shared socket in non-blocking mode (which would make the sibling write
+/// clone non-blocking and truncate the transfer - see the module comment). This
+/// trait exposes just that capability on top of `Read`, so `DrainingReader::new`
+/// stays generic (production wraps a cloned `TcpStream`; tests wrap a loopback
+/// `TcpStream`) while still guaranteeing the poll-loop contract at the type
+/// level.
 trait DrainSource: Read + Send {
-    /// Switches the underlying fd between non-blocking and blocking mode.
-    fn set_drain_nonblocking(&self, nonblocking: bool) -> io::Result<()>;
+    /// Sets (or clears, with `None`) the read timeout on the underlying fd.
+    fn set_drain_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()>;
 }
 
 impl DrainSource for TcpStream {
-    fn set_drain_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
-        self.set_nonblocking(nonblocking)
+    fn set_drain_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.set_read_timeout(timeout)
     }
 }
 
@@ -175,32 +188,31 @@ impl DrainingReader {
         });
         let thread_inner = Arc::clone(&inner);
 
-        // Put the drain fd in non-blocking mode so `read()` returns `WouldBlock`
-        // on an empty socket instead of parking the thread. This is what lets
-        // the loop notice the stop flag within one `DRAIN_POLL_INTERVAL` on
-        // every platform - no reliance on read-timeout wakeups, which do not
-        // fire reliably on the daemon's cloned Windows socket fd and previously
-        // wedged `join()` in CI. A failure to set non-blocking is non-fatal:
-        // the loop still functions (it may just block on `read()` until data or
-        // FIN), matching the earlier best-effort read-timeout handling.
+        // Arm a short read timeout so `read()` returns `TimedOut` on an idle
+        // socket, letting the loop observe the stop flag within one
+        // `DRAIN_READ_TIMEOUT` on every platform. A read timeout - unlike
+        // non-blocking mode - only sets `SO_RCVTIMEO`; it leaks onto the shared
+        // socket object (and thus the sibling write clone), but the write clone
+        // never reads, so its blocking writes stay lossless. Non-blocking mode
+        // would leak onto the write clone and abort/truncate the transfer.
+        // Setting the timeout is best-effort: on failure the loop still works
+        // (it may block on `read()` until data or FIN); the FIN on a real
+        // transfer close still unblocks it, and `Drop` remains a backstop.
         //
-        // On both Unix (`ioctl` FIONBIO / `SO_NONBLOCK`) and Windows
-        // (`ioctlsocket` FIONBIO), non-blocking mode is a property of the shared
-        // socket object, so it is also observed by the daemon's OTHER clone of
-        // this socket - the `DaemonStream` the orchestrator's goodbye drain
-        // reads. The drain thread therefore restores BLOCKING mode on exit
-        // (below), before `stop_and_join()` returns, so the goodbye drain sees a
-        // normal blocking socket and its bounded read-timeout loop behaves as
-        // before. `stop()` joins the thread, so the restore is complete before
-        // the goodbye drain runs.
-        let _ = source.set_drain_nonblocking(true);
+        // The timeout leaks onto the daemon's OTHER clone of this socket - the
+        // `DaemonStream` the orchestrator's goodbye drain reads - so the drain
+        // thread CLEARS it on exit (below), before `stop_and_join()` returns, so
+        // the goodbye drain sees a normal blocking socket and its own bounded
+        // read-timeout loop behaves as before. `stop()` joins the thread, so the
+        // clear is complete before the goodbye drain runs.
+        let _ = source.set_drain_read_timeout(Some(DRAIN_READ_TIMEOUT));
 
         let handle = thread::Builder::new()
             .name("daemon-delta-drain".to_owned())
             .spawn(move || {
                 let mut source = source;
                 let mut buf = vec![0u8; DRAIN_CHUNK_SIZE];
-                // Run the drain loop, then unconditionally restore blocking mode
+                // Run the drain loop, then unconditionally clear the read timeout
                 // on the shared socket so the goodbye-drain clone is unaffected.
                 'drain: loop {
                     if thread_inner.stop.load(Ordering::Acquire) {
@@ -220,15 +232,15 @@ impl DrainingReader {
                                 break 'drain;
                             }
                         }
-                        // Non-blocking read with no data ready (`WouldBlock`),
-                        // or an interrupted syscall: not a wire error. Re-check
-                        // the stop flag, then sleep one poll interval before
-                        // retrying. This bounds the stop-flag observation
-                        // latency on every platform without depending on
-                        // read-timeout semantics, so `stop_and_join()` always
-                        // unblocks the thread within ~one interval. `TimedOut`
-                        // is tolerated too as a backstop for any handle still
-                        // carrying a stale read timeout.
+                        // Read timeout elapsed on an idle socket (`TimedOut`), or
+                        // an interrupted syscall: not a wire error. Re-check the
+                        // stop flag and retry. This bounds the stop-flag
+                        // observation latency to one `DRAIN_READ_TIMEOUT` on every
+                        // platform, so `stop_and_join()` always unblocks the
+                        // thread promptly. `WouldBlock` is tolerated too as a
+                        // backstop, though the drain fd is never put in
+                        // non-blocking mode (that would truncate the sibling write
+                        // clone - see the module comment).
                         Err(ref e)
                             if matches!(
                                 e.kind(),
@@ -240,7 +252,12 @@ impl DrainingReader {
                             if thread_inner.stop.load(Ordering::Acquire) {
                                 break 'drain;
                             }
-                            thread::sleep(DRAIN_POLL_INTERVAL);
+                            // The read timeout already paces the loop (each
+                            // `read()` blocks up to `DRAIN_READ_TIMEOUT`). A brief
+                            // yield guards against a busy-spin if the timeout could
+                            // not be armed and the fd nonetheless returns
+                            // `WouldBlock`.
+                            thread::sleep(DRAIN_SPIN_GUARD);
                             continue;
                         }
                         Err(e) => {
@@ -249,10 +266,10 @@ impl DrainingReader {
                         }
                     }
                 }
-                // Restore blocking mode on the shared socket before the thread
+                // Clear the read timeout on the shared socket before the thread
                 // exits (and thus before `stop_and_join()` returns), so the
-                // separate goodbye-drain clone reads a blocking socket.
-                let _ = source.set_drain_nonblocking(false);
+                // separate goodbye-drain clone reads a normal blocking socket.
+                let _ = source.set_drain_read_timeout(None);
             })
             .expect("failed to spawn daemon delta-drain thread");
 
@@ -424,16 +441,14 @@ mod draining_reader_tests {
     fn stop_joins_promptly_when_peer_is_silent() {
         // Regression (#503, Windows CI): a silent peer that connects but never
         // sends and never closes must NOT leave the drain thread parked. The
-        // non-blocking poll loop returns `WouldBlock` on the empty socket and
-        // checks the stop flag every poll interval, so `stop()`'s join returns
-        // promptly instead of hanging forever. This is the exact deadlock the
-        // daemon negotiation tests hit on Windows, where a blocking `read()`
-        // (even with a read timeout on the cloned fd) never observed the stop
-        // flag. The join must complete well within a second.
+        // bounded read timeout makes `read()` return `TimedOut` on the idle
+        // socket and the loop checks the stop flag each interval, so `stop()`'s
+        // join returns promptly instead of hanging forever. The join must
+        // complete well within a second.
         //
-        // The socket is deliberately left in default (blocking) mode here to
-        // prove the fix does not depend on the caller pre-arming a read timeout
-        // or non-blocking flag: `DrainingReader::new` sets non-blocking itself.
+        // The socket is left in default (no read timeout) mode here to prove the
+        // fix does not depend on the caller pre-arming anything:
+        // `DrainingReader::new` arms the read timeout itself.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
         let addr = listener.local_addr().expect("local addr");
         // Accept and then sit silent, holding the connection open (no data,
@@ -445,9 +460,8 @@ mod draining_reader_tests {
             thread::sleep(std::time::Duration::from_secs(2));
             drop(server);
         });
-        // Left in default blocking mode on purpose: the drain thread flips it
-        // to non-blocking itself, so the prompt join must not depend on any
-        // caller-side timeout or flag.
+        // Left with no read timeout on purpose: the drain thread arms it
+        // itself, so the prompt join must not depend on any caller-side flag.
         let sock = TcpStream::connect(addr).expect("connect loopback");
         let (reader, handle) = DrainingReader::new(sock);
 
@@ -487,11 +501,13 @@ mod draining_reader_tests {
     #[test]
     fn goodbye_clone_reads_after_drain_stops() {
         // The goodbye drain reads the socket via a SEPARATE clone
-        // (`ctx.reader`'s `DaemonStream`), not the drain clone. Putting the
-        // drain clone in non-blocking mode must not disturb bytes that arrive
-        // for the goodbye reader on another clone of the same connection. Here
-        // the drain thread consumes the first burst; after `stop()`, a second
-        // clone reads a trailing "goodbye" burst intact.
+        // (`ctx.reader`'s `DaemonStream`), not the drain clone. Arming the
+        // drain clone's read timeout must not disturb bytes that arrive for the
+        // goodbye reader on another clone of the same connection, and the drain
+        // thread must clear that timeout on stop so the goodbye reader sees a
+        // normal blocking socket. Here the drain thread consumes the first
+        // burst; after `stop()`, a second clone reads a trailing "goodbye" burst
+        // intact.
         //
         // The peer is sequenced (send first burst, wait for a go-ahead, then
         // send goodbye) so the drain thread cannot race the goodbye bytes into
@@ -529,16 +545,17 @@ mod draining_reader_tests {
         reader.read_exact(&mut got_first).expect("read first burst");
         assert_eq!(got_first, first, "drain reader must replay the first burst intact");
 
-        // Stop the drain thread (drain clone stays non-blocking, then dropped),
-        // then let the peer send its trailing goodbye bytes.
+        // Stop the drain thread (it clears the read timeout on exit, then the
+        // drain clone is dropped), then let the peer send its trailing goodbye
+        // bytes.
         handle.stop();
         drop(reader);
         go_tx.send(()).expect("signal peer to send goodbye");
 
-        // The separate goodbye clone must read the trailing bytes; the
-        // non-blocking flag on the drain clone must not have stolen or reordered
-        // them. Give the goodbye clone a bounded read timeout so the test cannot
-        // hang if the invariant is violated.
+        // The separate goodbye clone must read the trailing bytes; the drain
+        // clone's read timeout must not have stolen or reordered them. Give the
+        // goodbye clone a bounded read timeout so the test cannot hang if the
+        // invariant is violated.
         goodbye_reader
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))
             .expect("set goodbye read timeout");
@@ -552,5 +569,63 @@ mod draining_reader_tests {
         );
 
         let _ = peer.join();
+    }
+
+    #[test]
+    fn sibling_write_clone_stays_blocking_and_lossless() {
+        // Regression for the truncation bug (code 23, `multiplexed payload
+        // truncated`): the daemon's read, write, and goodbye handles are all
+        // `try_clone()`s of one socket sharing a single open file description.
+        // If `DrainingReader::new` had put the drain clone in NON-blocking mode,
+        // the sibling WRITE clone would become non-blocking too and the sender's
+        // `write_all` would abort with `WouldBlock` on a full send buffer,
+        // truncating the transfer. The read-timeout fix must leave the write
+        // clone blocking so a large write drains fully and losslessly even when
+        // the peer reads slowly enough to fill the send buffer.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        // Payload larger than a typical socket send buffer, so a non-blocking
+        // write clone would return `WouldBlock` before draining it all and the
+        // peer would receive fewer bytes. A blocking write clone streams it in
+        // full regardless of send-buffer pressure.
+        let payload: Vec<u8> = (0..1_000_000u32).map(|i| (i % 251) as u8).collect();
+        let payload_len = payload.len();
+
+        // Peer reads exactly `payload_len` bytes, draining the sender's send
+        // buffer so a blocking `write_all` completes. Reading a fixed count
+        // (not to EOF) avoids depending on a FIN: the drain thread keeps its own
+        // clone of the client socket open, so the last handle never closes.
+        let peer = thread::spawn(move || {
+            let (mut server, _) = listener.accept().expect("accept");
+            let mut got = vec![0u8; payload_len];
+            server.read_exact(&mut got).expect("peer read exact");
+            got
+        });
+
+        let sock = TcpStream::connect(addr).expect("connect loopback");
+        let mut write_clone = sock.try_clone().expect("clone for write");
+        // Arming the read timeout on the drain clone must NOT make `write_clone`
+        // non-blocking (which would truncate the write below).
+        let (_reader, handle) = DrainingReader::new(sock);
+
+        // Write from a dedicated thread so the test cannot deadlock if the
+        // invariant is violated: the peer drains concurrently.
+        let payload_for_writer = payload.clone();
+        let writer = thread::spawn(move || {
+            write_clone
+                .write_all(&payload_for_writer)
+                .expect("blocking write_all must not fail with WouldBlock");
+            write_clone.flush().expect("flush");
+        });
+
+        writer.join().expect("writer join");
+        let got = peer.join().expect("peer join");
+        assert_eq!(
+            got.len(),
+            payload_len,
+            "the sibling write clone must deliver every byte (no truncation)"
+        );
+        assert_eq!(got, payload, "write clone bytes must arrive intact and in order");
+        handle.stop();
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -400,6 +400,18 @@ fn process_approved_module(
         async_socket,
     );
 
+    // #503: stop and join the background delta-drain thread before the TCP
+    // goodbye drain below reads the socket via a different clone. The engine's
+    // own goodbye handshake completed inside `execute_transfer` (it read
+    // through the `DrainingReader`), so stopping here only halts draining of
+    // any post-goodbye trailing bytes, which the drain-until-EOF loop below
+    // discards anyway. Joining before that loop prevents two readers competing
+    // for the same socket. `Drop` on `streams` is a backstop for early-return
+    // paths above that never reach this point.
+    if let Some(drain) = streams.drain_handle.take() {
+        drain.stop();
+    }
+
     // Graceful TCP shutdown: drain peer's goodbye, then linger + close.
     //
     // Background:

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -281,7 +281,15 @@ fn process_approved_module(
     // primary defenses.
     engage_seccomp_sandbox(ctx)?;
 
-    let mut streams = match setup_transfer_streams(ctx)? {
+    // #503: arm the background delta-drain thread only for a real transfer. An
+    // empty client-arg list means the peer requested the module then dropped the
+    // socket without sending a transfer request, so no bidirectional delta data
+    // flows and there is nothing to deadlock. Reading the socket directly on that
+    // degenerate path returns EOF promptly on every platform (see
+    // `setup_transfer_streams`); arming the drain there would spawn a thread that
+    // hangs on a half-closed socket clone on Windows.
+    let arm_drain = should_arm_delta_drain(&client_args);
+    let mut streams = match setup_transfer_streams(ctx, arm_drain)? {
         Some(s) => s,
         None => return Ok(()),
     };

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -32,6 +32,20 @@ struct TransferStreams {
     async_socket: Option<TcpStream>,
 }
 
+/// Decides whether the #503 background delta-drain thread should be armed.
+///
+/// The drain thread is anti-deadlock machinery for the bidirectional delta
+/// phase (design doc Approach C). That phase only occurs when the client
+/// actually requested a transfer, which it does by sending a non-empty argument
+/// list after `@RSYNCD: OK`. When the post-`OK` argument read returns an empty
+/// list the peer dropped the socket without requesting a transfer, so no delta
+/// data flows and there is nothing to deadlock. Such a connection must NOT arm
+/// the drain: its background thread would block reading a half-closed socket
+/// clone, which on Windows never unblocks and hangs the daemon worker.
+fn should_arm_delta_drain(client_args: &[String]) -> bool {
+    !client_args.is_empty()
+}
+
 /// Sets up the transfer streams for the transfer engine.
 ///
 /// For TCP/TLS connections, configures TCP_NODELAY and clones the stream to get
@@ -39,9 +53,22 @@ struct TransferStreams {
 /// mode), opens fresh stdin/stdout handles since the original pair is consumed
 /// by the BufReader.
 ///
+/// `arm_drain` gates the #503 background delta-drain thread: it is spawned only
+/// when a real transfer will run (the client sent a non-empty argument list).
+/// A connection whose post-`OK` argument read hit EOF - the peer dropped the
+/// socket without ever requesting a transfer - carries no bidirectional delta
+/// data, so it cannot hit the write-write deadlock the drain thread guards
+/// against. Arming the drain for such a connection would spawn a thread that
+/// blocks reading a half-closed socket clone; on Windows that thread's `recv`
+/// on a `try_clone`d socket handle does not observe the peer's close and never
+/// unblocks, wedging `stop_and_join()` and hanging the daemon worker. Reading
+/// the socket directly on this degenerate path is byte-identical to the
+/// pre-#503 behaviour and returns EOF promptly on every platform.
+///
 /// Returns the transfer streams on success, or sends an error and returns `None`.
 fn setup_transfer_streams(
     ctx: &mut ModuleRequestContext<'_>,
+    arm_drain: bool,
 ) -> io::Result<Option<TransferStreams>> {
     let stream = ctx.reader.get_mut();
     stream.set_nodelay(true)?;
@@ -119,6 +146,23 @@ fn setup_transfer_streams(
     // and truncate the sender's writes (code 23). A read timeout leaks only
     // `SO_RCVTIMEO`, harmless to the write-only clone; the drain thread clears it
     // on exit so the goodbye clone reads a normal blocking socket.
+    //
+    // Armed only for a real transfer (`arm_drain`, i.e. the client sent a
+    // non-empty argument list). An empty-args connection - the peer requested a
+    // module then dropped the socket without sending a transfer request - has no
+    // delta phase to deadlock, so it reads the socket directly and returns EOF
+    // promptly (see the fn-level doc for the Windows wedge this avoids).
+    if !arm_drain {
+        return Ok(Some(TransferStreams {
+            read: Box::new(read_stream),
+            write: Box::new(write_stream),
+            supports_tcp_shutdown: true,
+            drain_handle: None,
+            #[cfg(feature = "tokio-transfer")]
+            async_socket,
+        }));
+    }
+
     let (draining_reader, drain_handle) = DrainingReader::new(read_stream);
 
     Ok(Some(TransferStreams {
@@ -361,5 +405,35 @@ fn execute_transfer(
             }
             1
         }
+    }
+}
+
+#[cfg(test)]
+mod delta_drain_gate_tests {
+    //! Gating tests for the #503 delta-drain thread (`should_arm_delta_drain`).
+
+    use super::should_arm_delta_drain;
+
+    #[test]
+    fn empty_client_args_do_not_arm_the_drain() {
+        // Regression (#503, Windows CI): a peer that requested a module then
+        // dropped the socket sends an empty argument list. That connection has
+        // no delta phase, so it must read the socket directly rather than spawn
+        // a drain thread that hangs on a half-closed socket clone on Windows.
+        assert!(
+            !should_arm_delta_drain(&[]),
+            "empty client args means no transfer requested: the drain must stay off"
+        );
+    }
+
+    #[test]
+    fn non_empty_client_args_arm_the_drain() {
+        // A real transfer request (non-empty argv) can enter the bidirectional
+        // delta phase, so the anti-deadlock drain thread must be armed.
+        let args = vec!["--server".to_owned(), "--sender".to_owned()];
+        assert!(
+            should_arm_delta_drain(&args),
+            "a real transfer request must arm the anti-deadlock drain"
+        );
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -10,6 +10,16 @@ struct TransferStreams {
     write: Box<dyn Write + Send>,
     /// Whether the write side supports TCP shutdown (false for stdio/pipes).
     supports_tcp_shutdown: bool,
+    /// Stop handle for the daemon-TCP background drain thread (#503).
+    ///
+    /// Present only for the socket path, where `read` wraps a
+    /// [`DrainingReader`] whose background thread continuously drains the
+    /// peer's send buffer during the delta phase to prevent the full-duplex
+    /// write-write deadlock. `None` for stdio/pipe transports, which read the
+    /// socket directly and cannot wedge. The caller stops this handle after
+    /// the transfer engine returns and before the goodbye drain reads the
+    /// socket via another clone.
+    drain_handle: Option<DrainHandle>,
     /// Pre-erasure socket clone for the tokio driver (ASY sub-rung 2).
     ///
     /// For the daemon module transfer over a real socket this carries an extra
@@ -50,6 +60,11 @@ fn setup_transfer_streams(
             read: Box::new(stdin),
             write: Box::new(stdout),
             supports_tcp_shutdown: false,
+            // Stdio/pipe transports have independent read/write pipe buffers
+            // and a peer in a separate process, so they cannot hit the
+            // single-socket write-write deadlock (#503). Read the pipe
+            // directly - no drain thread.
+            drain_handle: None,
             // Stdio/pipe transports have no socket to hand the tokio driver.
             #[cfg(feature = "tokio-transfer")]
             async_socket: None,
@@ -86,10 +101,21 @@ fn setup_transfer_streams(
     #[cfg(feature = "tokio-transfer")]
     let async_socket = tcp.try_clone().ok();
 
+    // #503: wrap the read-clone fd in a `DrainingReader` so a background thread
+    // continuously drains the peer's send buffer during the delta phase. This
+    // is the daemon-TCP-only anti-deadlock mechanism (design doc Approach C):
+    // it keeps the peer's writes flowing so neither direction wedges on a full
+    // socket buffer. The wrapper is a transparent byte pipe, so every wire byte
+    // and the multiplex framing are unchanged. The `DrainHandle` is stopped by
+    // the orchestrator before the goodbye drain reads the socket via another
+    // clone.
+    let (draining_reader, drain_handle) = DrainingReader::new(read_stream);
+
     Ok(Some(TransferStreams {
-        read: Box::new(read_stream),
+        read: Box::new(draining_reader),
         write: Box::new(write_stream),
         supports_tcp_shutdown: true,
+        drain_handle: Some(drain_handle),
         #[cfg(feature = "tokio-transfer")]
         async_socket,
     }))

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -444,11 +444,20 @@ mod delta_drain_gate_tests {
     #[test]
     fn non_empty_client_args_arm_the_drain() {
         // A real transfer request (non-empty argv) can enter the bidirectional
-        // delta phase, so the anti-deadlock drain thread must be armed.
+        // delta phase, so on Unix the anti-deadlock drain thread must be armed.
+        // On non-Unix (Windows) the drain is gated off entirely - its background
+        // thread cannot be reliably stopped - so even a real transfer uses the
+        // raw read clone (the master path).
         let args = vec!["--server".to_owned(), "--sender".to_owned()];
+        #[cfg(unix)]
         assert!(
             should_arm_delta_drain(&args),
-            "a real transfer request must arm the anti-deadlock drain"
+            "a real transfer request must arm the anti-deadlock drain on Unix"
+        );
+        #[cfg(not(unix))]
+        assert!(
+            !should_arm_delta_drain(&args),
+            "the drain is gated off on non-Unix even for a real transfer"
         );
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -108,18 +108,15 @@ fn setup_transfer_streams(
     // socket buffer. The wrapper is a transparent byte pipe, so every wire byte
     // and the multiplex framing are unchanged. The `DrainHandle` is stopped by
     // the orchestrator before the goodbye drain reads the socket via another
-    // clone.
+    // clone (`ctx.reader`'s `DaemonStream`, a separate fd), so putting this
+    // drain clone in non-blocking mode cannot affect the goodbye read.
     //
-    // Bound the drain thread's blocking `read()` with a short socket read
-    // timeout so `DrainHandle::stop()` can reliably wake and join the thread on
-    // every platform. Without it, a thread parked in a blocking `read()` never
-    // observes the stop flag until the peer closes the socket; on Windows that
-    // wedges `join()` indefinitely. The drain loop treats a timeout as "re-check
-    // the stop flag and keep reading", so this does not drop any wire bytes and
-    // the byte-pipe semantics are unchanged. Mirrors the bounded goodbye-drain
-    // read timeout the orchestrator already uses on this same socket. A failure
-    // to set the timeout is non-fatal: fall back to the untimed blocking read.
-    let _ = read_stream.set_read_timeout(Some(Duration::from_millis(200)));
+    // `DrainingReader::new` runs this clone in non-blocking mode: an empty
+    // socket returns `WouldBlock` and the drain loop polls the stop flag every
+    // couple of milliseconds instead of parking in a blocking `read()`. That
+    // guarantees `DrainHandle::stop()` can wake and join the thread promptly on
+    // every platform - including Windows, where a read timeout on the cloned
+    // socket fd did not reliably wake the blocked read and wedged `join()`.
     let (draining_reader, drain_handle) = DrainingReader::new(read_stream);
 
     Ok(Some(TransferStreams {

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -42,8 +42,23 @@ struct TransferStreams {
 /// data flows and there is nothing to deadlock. Such a connection must NOT arm
 /// the drain: its background thread would block reading a half-closed socket
 /// clone, which on Windows never unblocks and hangs the daemon worker.
+///
+/// #6297: the drain is additionally gated to Unix. On Windows the drain thread
+/// parks in a blocking `recv()` on the cloned socket that `SO_RCVTIMEO` does not
+/// interrupt, so `stop_and_join()` never returns and every daemon connection
+/// wedges at teardown (all four daemon-negotiation tests time out on the Windows
+/// feature-flag jobs, on every branch commit, but pass on master). The #503
+/// deadlock is a Unix-specific full-socket-buffer wedge, so on non-Unix the
+/// daemon uses the raw read clone - byte-identical to master, which passes these
+/// tests - and never spawns the drain thread.
+#[cfg(unix)]
 fn should_arm_delta_drain(client_args: &[String]) -> bool {
     !client_args.is_empty()
+}
+
+#[cfg(not(unix))]
+fn should_arm_delta_drain(_client_args: &[String]) -> bool {
+    false
 }
 
 /// Sets up the transfer streams for the transfer engine.

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -109,6 +109,17 @@ fn setup_transfer_streams(
     // and the multiplex framing are unchanged. The `DrainHandle` is stopped by
     // the orchestrator before the goodbye drain reads the socket via another
     // clone.
+    //
+    // Bound the drain thread's blocking `read()` with a short socket read
+    // timeout so `DrainHandle::stop()` can reliably wake and join the thread on
+    // every platform. Without it, a thread parked in a blocking `read()` never
+    // observes the stop flag until the peer closes the socket; on Windows that
+    // wedges `join()` indefinitely. The drain loop treats a timeout as "re-check
+    // the stop flag and keep reading", so this does not drop any wire bytes and
+    // the byte-pipe semantics are unchanged. Mirrors the bounded goodbye-drain
+    // read timeout the orchestrator already uses on this same socket. A failure
+    // to set the timeout is non-fatal: fall back to the untimed blocking read.
+    let _ = read_stream.set_read_timeout(Some(Duration::from_millis(200)));
     let (draining_reader, drain_handle) = DrainingReader::new(read_stream);
 
     Ok(Some(TransferStreams {

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -108,15 +108,17 @@ fn setup_transfer_streams(
     // socket buffer. The wrapper is a transparent byte pipe, so every wire byte
     // and the multiplex framing are unchanged. The `DrainHandle` is stopped by
     // the orchestrator before the goodbye drain reads the socket via another
-    // clone (`ctx.reader`'s `DaemonStream`, a separate fd), so putting this
-    // drain clone in non-blocking mode cannot affect the goodbye read.
+    // clone (`ctx.reader`'s `DaemonStream`, a separate fd).
     //
-    // `DrainingReader::new` runs this clone in non-blocking mode: an empty
-    // socket returns `WouldBlock` and the drain loop polls the stop flag every
-    // couple of milliseconds instead of parking in a blocking `read()`. That
-    // guarantees `DrainHandle::stop()` can wake and join the thread promptly on
-    // every platform - including Windows, where a read timeout on the cloned
-    // socket fd did not reliably wake the blocked read and wedged `join()`.
+    // `DrainingReader::new` arms only a bounded read timeout on this clone (NOT
+    // non-blocking mode): an idle socket returns `TimedOut` and the drain loop
+    // polls the stop flag instead of parking in a blocking `read()`, so
+    // `DrainHandle::stop()` joins the thread promptly on every platform. It must
+    // NOT use non-blocking mode: `read_stream`/`write_stream` share one open
+    // file description, so a non-blocking flag would leak onto the write clone
+    // and truncate the sender's writes (code 23). A read timeout leaks only
+    // `SO_RCVTIMEO`, harmless to the write-only clone; the drain thread clears it
+    // on exit so the goodbye clone reads a normal blocking socket.
     let (draining_reader, drain_handle) = DrainingReader::new(read_stream);
 
     Ok(Some(TransferStreams {

--- a/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
@@ -11,6 +11,18 @@ fn apply_module_timeout(stream: &DaemonStream, module: &ModuleDefinition) -> io:
         let duration = Duration::from_secs(timeout.get());
         stream.set_read_timeout(Some(duration))?;
         stream.set_write_timeout(Some(duration))?;
+    } else {
+        // #503 (design doc section 4.4): when the module sets no `timeout`,
+        // clear the leaked 10-second accept-time `SOCKET_TIMEOUT` (armed in
+        // listener.rs) so the data phase matches upstream's `io_timeout = 0`
+        // default (io.c:179 short-circuits the timeout check when unset).
+        // Without this, the accept-time guard persists through the delta phase
+        // and fires on a wedged read as `code 23`. This MUST ship with the
+        // Approach C drain thread: alone it would turn the deadlock's abort
+        // into an indefinite hang; the drain thread guarantees the phase
+        // cannot deadlock, so removing the timeout is safe.
+        stream.set_read_timeout(None)?;
+        stream.set_write_timeout(None)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Fixes the confirmed P1 daemon-transport delta deadlock (#503) using **Approach C** from `docs/design/daemon-delta-deadlock-fix.md`, co-landed with the section 4.4 timeout-clear and a #504 slot-release regression test. Daemon-TCP scoped; SSH/stdio, local, the shared multiplex writer, and the goodbye handshake are untouched.

## Root cause

The daemon splits one TCP socket into two blocking `try_clone()` fds (`streams.rs:78` read / `:87` write). The receiver delta path (`transfer/pipeline.rs`) writes a batch of file requests, flushes once, then blocks reading the response - with no interleaved drain of incoming frames. Once both ~128 KB kernel socket buffers fill, neither direction makes progress: a full-duplex write-write deadlock. Over SSH/stdio the peer runs in a separate process with independent pipe buffers, so the same engine code does not wedge - the fault is specific to the single-socket daemon path with bidirectional delta flow.

A leaked 10-second accept-time socket timeout (`listener.rs:242`) fires on the wedged read and surfaces the deadlock as `code 23 / failed to fill whole buffer`; with a long module `timeout` it hangs indefinitely instead.

## Fix

**Primary (Approach C):** a new `DrainingReader` (`transfer/draining_reader.rs`) wraps the daemon read-clone fd. A background thread continuously reads the socket into an unbounded queue while the receiver loop consumes from it, so the peer's send buffer is always drained and neither direction wedges - the same anti-deadlock guarantee upstream `perform_io` provides (`io.c:882-889`). The queue is unbounded so the drain thread never blocks on a full queue and stops draining the socket (which would re-arm the wedge); in-memory growth is bounded by the receiver's outstanding-request window, mirroring upstream's `iobuf.in`. It is a transparent byte pipe - every wire byte and the multiplex framing are unchanged. The drain thread is daemon-TCP-only (`setup_transfer_streams` TCP branch); stdio/local get no drain. It is stopped and joined before the TCP goodbye drain reads the socket via another clone (`orchestration.rs`), with `Drop` as a backstop on every exit path.

**Secondary (section 4.4, co-landed):** `apply_module_timeout` (`module_spec.rs`) now clears the socket read/write timeout to `None` when the module sets no `timeout`, matching upstream's `io_timeout = 0` default (`io.c:179`). This must ship with the primary fix - alone it would turn the deadlock's abort into a hang; with the drain thread guaranteeing the phase cannot deadlock, it is safe and removes the spurious code-23 abort.

**#504 relationship:** the connection-slot RAII (`ModuleConnectionGuard`) is already correct on all exit paths. The deadlock previously kept the thread from unwinding so the guard never dropped, exhausting the module's slots (the downstream slot-leak symptom). Fixing the deadlock resolves it. A regression test pins that an aborted transfer releases its slot so the module keeps accepting connections.

## Files

- `crates/daemon/src/daemon/sections/module_access/transfer/draining_reader.rs` (new) - the drain reader/thread + tests.
- `crates/daemon/src/daemon/sections/module_access/transfer/streams.rs` - wrap the read clone on the TCP path; carry the stop handle.
- `crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs` - stop/join the drain thread before the goodbye drain.
- `crates/daemon/src/daemon/sections/module_parsing/module_spec.rs` - clear the leaked timeout when no module `timeout`.
- `crates/daemon/src/daemon/module_state/tests.rs` - #504 slot-release regression test.

## Verification (Linux validation host, aarch64)

Built `--bin oc-rsync` (release). A/B on the design-doc dbg503 recipe (128 x 4 MiB, seeded basis, backdated dst, mid-file `dd conv=notrunc` mutation, re-sync over a no-chroot daemon module):

| Case | master | this branch |
|------|--------|-------------|
| dbg503 128x4MiB delta push | **rc=23 (deadlock)** | **rc=0, trees match** |

- **Upstream parity:** same 128x4MiB delta workload, oc client -> upstream rsync 3.4.x daemon: rc=0, trees match.
- **Non-regression (all pass):** plain local `-a` copy; SSH-loopback `--no-whole-file` delta; daemon `--whole-file`; daemon quick-check skip.
- **#504 stress:** 6 forced aborted daemon transfers on a `max connections = 4` module, then a legitimate transfer is still accepted (rc=0) - the slot is not wedged.
- fmt + clippy (`-D warnings`, `--locked`) clean; new DrainingReader byte-fidelity/anti-deadlock unit tests + slot-release regression test pass.

## Residual risk

Low, daemon-TCP scoped. The drain thread lifecycle (spawn at stream setup, stop+join before goodbye, Drop backstop) is the one new concurrency seam; it is covered by unit tests and the join ordering is asserted against the goodbye drain. Wire bytes are byte-identical (transparent byte pipe), so upstream parity holds.