### PR TITLE
fix(transfer): decode sender xname as vstring, not varint

### DIFF
--- a/crates/transfer/src/generator/item_flags.rs
+++ b/crates/transfer/src/generator/item_flags.rs
@@ -172,16 +172,31 @@ impl ItemFlags {
 
     /// Reads optional trailing fields based on flags.
     ///
-    /// Returns `(fnamecmp_type, xname)` where each is present only if indicated by flags.
-    /// The `fnamecmp_type` is decoded into a typed `FnameCmpType` enum that mirrors
-    /// upstream `FNAMECMP_*` constants from `rsync.h`.
+    /// Returns `(fnamecmp_type, xname, trailing_bytes)` where each field is
+    /// present only if indicated by flags and `trailing_bytes` is the exact
+    /// number of wire bytes consumed (basis-type byte plus the xname vstring
+    /// prefix and payload). The `fnamecmp_type` is decoded into a typed
+    /// `FnameCmpType` enum that mirrors upstream `FNAMECMP_*` constants from
+    /// `rsync.h`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:403-418` - `read_ndx_and_attrs()` reads the basis-type byte,
+    ///   then the xname via `read_vstring(f_in, buf, MAXPATHLEN)`.
+    /// - `io.c:2004-2020` - `read_vstring()`: the length prefix is a 1- or
+    ///   2-byte vstring (NOT a varint). The high bit of the first byte flags a
+    ///   second byte and `len = (first & ~0x80) * 0x100 + second`. A length of
+    ///   `>= MAXPATHLEN` (4096) is a protocol error, not a value to truncate.
     pub fn read_trailing<R: Read>(
         &self,
         reader: &mut R,
-    ) -> io::Result<(Option<protocol::FnameCmpType>, Option<Vec<u8>>)> {
+    ) -> io::Result<(Option<protocol::FnameCmpType>, Option<Vec<u8>>, u64)> {
+        let mut trailing_bytes: u64 = 0;
+
         let fnamecmp_type = if self.has_basis_type() {
             let mut byte = [0u8; 1];
             reader.read_exact(&mut byte)?;
+            trailing_bytes += 1;
             Some(protocol::FnameCmpType::from_wire(byte[0]).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -198,11 +213,39 @@ impl ItemFlags {
         };
 
         let xname = if self.has_xname() {
-            let xlen = protocol::read_varint(reader)? as usize;
+            // upstream: io.c:2004 read_vstring() - a 1- or 2-byte length prefix,
+            // not a varint. Using read_varint here desyncs the wire stream for
+            // any xname whose length prefix differs between the two encodings.
+            let mut first = [0u8; 1];
+            reader.read_exact(&mut first)?;
+            trailing_bytes += 1;
+            let xlen = if first[0] & 0x80 != 0 {
+                let mut second = [0u8; 1];
+                reader.read_exact(&mut second)?;
+                trailing_bytes += 1;
+                ((first[0] & 0x7F) as usize) * 0x100 + second[0] as usize
+            } else {
+                first[0] as usize
+            };
+
+            // upstream: io.c:2010-2014 - `len >= bufsize` (MAXPATHLEN) aborts
+            // with RERR_PROTOCOL. Truncating instead would leave the unread
+            // tail on the wire and desync every subsequent read.
+            if xlen >= MAX_XNAME_VSTRING_LEN {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "over-long xname vstring received ({xlen} >= {MAX_XNAME_VSTRING_LEN}) {}{}",
+                        error_location!(),
+                        crate::role_trailer::sender()
+                    ),
+                ));
+            }
+
             if xlen > 0 {
-                let actual_len = xlen.min(4096);
-                let mut xname_buf = vec![0u8; actual_len];
+                let mut xname_buf = vec![0u8; xlen];
                 reader.read_exact(&mut xname_buf)?;
+                trailing_bytes += xlen as u64;
                 Some(xname_buf)
             } else {
                 None
@@ -211,6 +254,11 @@ impl ItemFlags {
             None
         };
 
-        Ok((fnamecmp_type, xname))
+        Ok((fnamecmp_type, xname, trailing_bytes))
     }
 }
+
+/// Upstream `MAXPATHLEN` ceiling passed to `read_vstring()` for the xname
+/// field (`rsync.c:408`). A vstring whose length reaches this bound is a
+/// protocol error (`io.c:2010-2014`).
+const MAX_XNAME_VSTRING_LEN: usize = 4096;

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -1014,10 +1014,11 @@ fn item_flags_read_trailing_no_fields() {
     let mut cursor = Cursor::new(&data[..]);
 
     let flags = ItemFlags::from_raw(0x8000); // Just ITEM_TRANSFER
-    let (ftype, xname) = flags.read_trailing(&mut cursor).unwrap();
+    let (ftype, xname, consumed) = flags.read_trailing(&mut cursor).unwrap();
 
     assert!(ftype.is_none());
     assert!(xname.is_none());
+    assert_eq!(consumed, 0);
 }
 
 #[test]
@@ -1027,10 +1028,101 @@ fn item_flags_read_trailing_basis_type() {
     let mut cursor = Cursor::new(&data[..]);
 
     let flags = ItemFlags::from_raw(0x0800); // ITEM_BASIS_TYPE_FOLLOWS
-    let (ftype, xname) = flags.read_trailing(&mut cursor).unwrap();
+    let (ftype, xname, consumed) = flags.read_trailing(&mut cursor).unwrap();
 
     assert_eq!(ftype, Some(protocol::FnameCmpType::BasisDir(0x42)));
     assert!(xname.is_none());
+    assert_eq!(consumed, 1);
+}
+
+/// Encodes an xname length exactly as upstream `write_vstring()` (io.c:2022):
+/// one byte for `len <= 0x7F`, otherwise `[len/0x100 + 0x80, len & 0xFF]`.
+fn encode_xname_vstring(payload: &[u8]) -> Vec<u8> {
+    let len = payload.len();
+    let mut out = Vec::with_capacity(len + 2);
+    if len > 0x7F {
+        out.push((len / 0x100) as u8 + 0x80);
+    }
+    out.push((len & 0xFF) as u8);
+    out.extend_from_slice(payload);
+    out
+}
+
+#[test]
+fn item_flags_read_trailing_short_xname_matches_upstream_vstring() {
+    // A short xname (len <= 0x7F) is a single length byte followed by the
+    // payload. The generator/sender must decode the vstring prefix, not a
+    // varint - upstream io.c:2004 read_vstring().
+    let payload = b"basis.old";
+    let wire = encode_xname_vstring(payload);
+    let mut cursor = Cursor::new(&wire[..]);
+
+    let flags = ItemFlags::from_raw(ItemFlags::ITEM_XNAME_FOLLOWS);
+    let (ftype, xname, consumed) = flags.read_trailing(&mut cursor).unwrap();
+
+    assert!(ftype.is_none());
+    assert_eq!(xname.as_deref(), Some(&payload[..]));
+    // 1 prefix byte + payload; the cursor must be fully drained so the next
+    // wire read (sum_head) stays aligned.
+    assert_eq!(consumed, 1 + payload.len() as u64);
+    assert_eq!(cursor.position() as usize, wire.len());
+}
+
+#[test]
+fn item_flags_read_trailing_long_xname_uses_two_byte_prefix() {
+    // A 200-byte xname exercises the 2-byte vstring prefix. read_varint would
+    // decode [0x80, 0xC8] as a completely different length and desync the
+    // stream; the vstring decode yields exactly 200. upstream io.c:2007-2008.
+    let payload = vec![b'x'; 200];
+    let wire = encode_xname_vstring(&payload);
+    // Sanity: upstream 2-byte framing for len=200 is [0x80, 0xC8].
+    assert_eq!(wire[0], 0x80);
+    assert_eq!(wire[1], 0xC8);
+
+    let mut cursor = Cursor::new(&wire[..]);
+    let flags = ItemFlags::from_raw(ItemFlags::ITEM_XNAME_FOLLOWS);
+    let (_ftype, xname, consumed) = flags.read_trailing(&mut cursor).unwrap();
+
+    assert_eq!(xname.as_deref(), Some(&payload[..]));
+    assert_eq!(consumed, 2 + payload.len() as u64);
+    assert_eq!(cursor.position() as usize, wire.len());
+}
+
+#[test]
+fn item_flags_read_trailing_rejects_over_long_xname() {
+    // upstream io.c:2010-2014: a vstring length of >= MAXPATHLEN (4096) is a
+    // protocol error. Truncating would leave the tail on the wire and desync
+    // every subsequent read, so read_trailing must surface an error instead.
+    // len = 4096 -> two-byte prefix [0x90, 0x00].
+    let wire = [0x90u8, 0x00];
+    let mut cursor = Cursor::new(&wire[..]);
+
+    let flags = ItemFlags::from_raw(ItemFlags::ITEM_XNAME_FOLLOWS);
+    let err = flags
+        .read_trailing(&mut cursor)
+        .expect_err("over-long xname must be rejected, not truncated");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("over-long xname vstring"));
+}
+
+#[test]
+fn item_flags_read_trailing_basis_type_and_xname() {
+    // Combined ITEM_BASIS_TYPE_FOLLOWS + ITEM_XNAME_FOLLOWS: one basis-type
+    // byte precedes the xname vstring. upstream rsync.c:403-408 reads them in
+    // that order.
+    let payload = b"fuzzy";
+    let mut wire = vec![0x42];
+    wire.extend_from_slice(&encode_xname_vstring(payload));
+    let mut cursor = Cursor::new(&wire[..]);
+
+    let flags =
+        ItemFlags::from_raw(ItemFlags::ITEM_BASIS_TYPE_FOLLOWS | ItemFlags::ITEM_XNAME_FOLLOWS);
+    let (ftype, xname, consumed) = flags.read_trailing(&mut cursor).unwrap();
+
+    assert_eq!(ftype, Some(protocol::FnameCmpType::BasisDir(0x42)));
+    assert_eq!(xname.as_deref(), Some(&payload[..]));
+    assert_eq!(consumed, 1 + 1 + payload.len() as u64);
+    assert_eq!(cursor.position() as usize, wire.len());
 }
 
 #[test]

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -289,13 +289,11 @@ impl GeneratorContext {
                 self.timing.total_bytes_read += 2;
             }
 
-            let (fnamecmp_type, xname) = iflags.read_trailing(&mut *reader)?;
-            if iflags.has_basis_type() {
-                self.timing.total_bytes_read += 1;
-            }
-            if let Some(ref xname_data) = xname {
-                self.timing.total_bytes_read += 4 + xname_data.len() as u64;
-            }
+            let (fnamecmp_type, xname, trailing_bytes) = iflags.read_trailing(&mut *reader)?;
+            // upstream: rsync.c:403-418 - the basis-type byte plus the xname
+            // vstring (1- or 2-byte prefix + payload). read_trailing reports the
+            // exact wire bytes consumed so this count never drifts from the wire.
+            self.timing.total_bytes_read += trailing_bytes;
 
             // upstream: sender.c:280-284 - drain the generator's xattr request
             // when preserve_xattrs && ITEM_REPORT_XATTR is set. The generator


### PR DESCRIPTION
## Problem

The generator/sender request loop reads the receiver's per-file attributes via `read_ndx_and_attrs` (`transfer_loop.rs` -> `ItemFlags::read_trailing`). When `ITEM_XNAME_FOLLOWS` is set, the alternate basis name (used for fuzzy/alt-dest basis matches) is framed on the wire as a **vstring**, not a varint.

Upstream `write_vstring` (io.c:2022) / `read_vstring` (io.c:2004) encode the length as a 1- or 2-byte prefix: for `len <= 0x7F` a single byte, otherwise `[len/0x100 + 0x80, len & 0xFF]`. The high bit of the first byte flags a second byte and `len = (first & ~0x80) * 0x100 + second`.

`read_trailing` decoded this length with `protocol::read_varint()` - a different encoding whose byte layout diverges from the vstring framing. Any xname whose vstring prefix differs from the varint interpretation desynced the entire wire stream (the sender then misreads the following `sum_head`, aborting with "block length must be non-zero"-class errors). It also **silently truncated** lengths above 4096 and read only the truncated count, leaving the unread tail on the wire; upstream instead aborts with `RERR_PROTOCOL` on `len >= MAXPATHLEN` (io.c:2010-2014).

## Fix

- Decode the xname length as a vstring prefix (matching the receiver-side decode in `receiver/wire.rs`, which was already correct).
- Reject over-long lengths (`>= 4096`) with an `InvalidData` protocol error instead of truncating.
- Return the exact number of trailing wire bytes consumed so the transfer loop's `total_bytes_read` accounting stays aligned (the previous `4 + len` assumed a 4-byte varint prefix).

## Upstream references

- `rsync.c:403-418` - `read_ndx_and_attrs()` reads the basis-type byte then `read_vstring(f_in, buf, MAXPATHLEN)`.
- `io.c:2004-2020` - `read_vstring()` length framing and the `len >= bufsize` protocol-error abort.
- `io.c:2022` - `write_vstring()` (the encoding the sender must decode).
- `generator.c:591`, `sender.c:195` - the `write_vstring(..., xname, ...)` call sites.

## Tests

Added parity tests encoding the upstream `write_vstring` framing:
- short xname (1-byte prefix) decodes and fully drains the cursor,
- 200-byte xname exercises the 2-byte prefix `[0x80, 0xC8]`,
- `len == 4096` (`[0x90, 0x00]`) is rejected, not truncated,
- combined basis-type + xname reads in the correct order.

`cargo fmt`, `cargo clippy -p transfer -- -D warnings`, and `cargo test -p transfer --lib item_flags` (15 passed) all green.