### PR TITLE
ci: retry musl toolchain install on transient rustup fetch timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,6 +543,26 @@ jobs:
           sudo apt-get clean || true
           df -h /
 
+      # Pre-warm the toolchain download with a short-timeout retry loop so a
+      # transient rustup fetch failure (DNS hang or TCP connect timeout to the
+      # static.rust-lang.org CDN edge) self-heals fast instead of failing the
+      # job. Each attempt is wall-clock capped so a hung connect is killed and
+      # retried rather than eating the job budget. dtolnay/rust-toolchain below
+      # then hits the local cache. 2 retries is plenty; more is wasted time.
+      - name: Pre-install toolchain (short-timeout retry on transient fetch)
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 90 rustup toolchain install "${{ matrix.toolchain }}" \
+                --profile minimal --no-self-update \
+                --target x86_64-unknown-linux-musl; then
+              exit 0
+            fi
+            echo "::warning::rustup toolchain install attempt ${attempt}/3 failed or timed out; retrying"
+            sleep 5
+          done
+          echo "::error::rustup toolchain install failed after 2 retries"
+          exit 1
+
       - name: Install Rust (${{ matrix.toolchain }})
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:


### PR DESCRIPTION
## Problem
The `Linux musl (beta)` job intermittently fails when `dtolnay/rust-toolchain` fetches `channel-rust-*.toml` from `static.rust-lang.org` and the connection times out:
```
error: could not download file from '.../channel-rust-1.88.0.toml' ... tcp connect error: Connection timed out (os error 110)
```
That is a **TCP connect timeout to an already-resolved CDN edge** (DNS had succeeded) on a flaky runner network path — not a repo/URL problem (the URL resolves fine: HTTP 200, ~0.4s).

## Fix
Pre-warm the toolchain with a short-timeout retry loop before the pinned action:
- each attempt is wall-clock capped (`timeout 90`) so a hung connect is killed and retried fast instead of eating the 30-min job budget;
- **2 retries** (3 attempts) with a short backoff — enough to ride out a transient blip, no wasteful long loop;
- covers DNS hangs and connect timeouts generically;
- `dtolnay/rust-toolchain` then hits the local cache (no-op download).

**No manual IP pinning** — `static.rust-lang.org` is a multi-edge CDN, so pinning a derived IP would defeat its failover and could make flakes worse.

Scoped to the job that actually flaked (`linux-musl`, all three toolchains). Same pattern can be lifted into the other toolchain-matrix jobs if they start flaking too.