### PR TITLE
fix(engine): delete-during before a directory's own children

### DIFF
--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -195,6 +195,18 @@ impl LocalCopyError {
         )
     }
 
+    /// Reports whether this error is the `--max-delete` limit being reached.
+    ///
+    /// Upstream rsync does not abort the transfer when the limit is hit: it
+    /// stops performing further deletions, finishes the transfer, and only
+    /// reports the limit at cleanup (`main.c:1356`, exit code 25). The
+    /// delete-during path defers this error to the end of the directory so a
+    /// mid-transfer `--delete-during` sweep does not skip pending copies.
+    #[must_use]
+    pub const fn is_delete_limit_error(&self) -> bool {
+        matches!(self.kind, LocalCopyErrorKind::DeleteLimitExceeded { .. })
+    }
+
     /// Reports whether this is a failed initial `link_stat` of a source
     /// argument (a missing command-line operand or `--files-from` entry).
     ///

--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -12,7 +12,73 @@ use std::path::Path;
 
 use crate::local_copy::{CopyContext, DeleteTiming, LocalCopyError, delete_extraneous_entries};
 
-/// Handles the deletion phase after transfer, based on the configured timing.
+/// Resolves the effective delete timing for the current directory.
+///
+/// upstream: generator.c shares a single flist across sources so
+/// `delete_during` never unlinks an entry that a later source will recreate.
+/// oc-rsync reads each source directory live, so when more than one source is
+/// in play a `--delete-during` sweep is downgraded to a deferred (`After`)
+/// sweep whose keep-lists are merged across sources in `defer_deletion`.
+fn effective_delete_timing(
+    context: &CopyContext,
+    delete_timing: Option<DeleteTiming>,
+) -> DeleteTiming {
+    let timing = delete_timing.unwrap_or(DeleteTiming::During);
+    if matches!(timing, DeleteTiming::During) && context.multi_source() {
+        DeleteTiming::After
+    } else {
+        timing
+    }
+}
+
+/// Deletes extraneous destination entries for `--delete-during` before the
+/// directory's own children are transferred.
+///
+/// upstream: generator.c:1532-1537 - for a non-INC_RECURSE `delete_during`
+/// run, the generator calls `delete_in_dir()` while itemizing the directory
+/// entry itself, i.e. immediately before it recurses into and processes that
+/// directory's children. The extraneous-entry `*deleting` rows therefore
+/// precede the transfer rows for surviving/new entries in the same directory.
+/// Running the sweep after the child loop (as a post-transfer step) would
+/// invert that order. Deferred timings (`--delete-delay`, `--delete-after`,
+/// and the multi-source `During`->`After` downgrade) are handled after the
+/// loop by [`handle_post_transfer_deletions`].
+#[inline]
+pub(super) fn apply_during_transfer_deletions(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    deletion_enabled: bool,
+    delete_timing: Option<DeleteTiming>,
+    keep_names: &[Cow<'_, OsStr>],
+) -> Result<(), LocalCopyError> {
+    if !deletion_enabled {
+        return Ok(());
+    }
+
+    // When I/O errors occurred and --ignore-errors is not set, suppress
+    // deletions to prevent data loss (upstream rsync behavior).
+    if !context.deletions_allowed() {
+        return Ok(());
+    }
+
+    if matches!(
+        effective_delete_timing(context, delete_timing),
+        DeleteTiming::During
+    ) {
+        delete_extraneous_entries(context, destination, relative, keep_names)?;
+    }
+
+    Ok(())
+}
+
+/// Handles the deferred deletion phases after transfer.
+///
+/// Only `--delete-delay`, `--delete-after`, and the multi-source
+/// `During`->`After` downgrade reach a delete here; immediate `--delete-during`
+/// sweeps are performed before the child loop by
+/// [`apply_during_transfer_deletions`]. `--delete-before` was already handled
+/// by `apply_pre_transfer_deletions`.
 #[inline]
 pub(super) fn handle_post_transfer_deletions(
     context: &mut CopyContext,
@@ -32,21 +98,10 @@ pub(super) fn handle_post_transfer_deletions(
         return Ok(());
     }
 
-    let mut timing = delete_timing.unwrap_or(DeleteTiming::During);
-    // upstream: generator.c shares a single flist across sources so
-    // `delete_during` never unlinks an entry that a later source will recreate.
-    // We share the flist via deferred sweeps when more than one source is in
-    // play, merging per-source keep lists in `defer_deletion`.
-    if matches!(timing, DeleteTiming::During) && context.multi_source() {
-        timing = DeleteTiming::After;
-    }
-
-    match timing {
-        DeleteTiming::Before => {
-            // Already handled by apply_pre_transfer_deletions
-        }
-        DeleteTiming::During => {
-            delete_extraneous_entries(context, destination, relative, keep_names)?;
+    match effective_delete_timing(context, delete_timing) {
+        DeleteTiming::Before | DeleteTiming::During => {
+            // Before: already handled by apply_pre_transfer_deletions.
+            // During: already handled by apply_during_transfer_deletions.
         }
         DeleteTiming::Delay | DeleteTiming::After => {
             // Clone names for deferred processing (data must outlive the plan)

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -27,7 +27,9 @@ use crate::local_copy::{
 
 pub(crate) use batch::capture_batch_file_entry;
 pub(crate) use checksum::prefetch_directory_checksums;
-use deletion::{handle_empty_directory_pruning, handle_post_transfer_deletions};
+use deletion::{
+    apply_during_transfer_deletions, handle_empty_directory_pruning, handle_post_transfer_deletions,
+};
 use destination::{check_destination_state, record_skipped_missing_destination};
 use dir_metadata::{apply_final_directory_metadata, record_directory_completion};
 use entry::process_planned_entry;
@@ -437,6 +439,32 @@ fn copy_directory_recursive_inner(
 
     let plan = plan_directory_entries(context, &entries, relative, root_device)?;
     apply_pre_transfer_deletions(context, destination, relative, &plan)?;
+    // upstream: generator.c:1532-1537 - a non-INC_RECURSE `--delete-during`
+    // sweep runs while the generator itemizes the directory entry, before it
+    // recurses into that directory's children. Emit those `*deleting` rows
+    // ahead of the child transfer rows to match upstream's per-directory
+    // ordering; deferred timings are handled after the child loop.
+    // upstream: main.c:1356 - a `--max-delete` limit does NOT abort the
+    // transfer; the generator stops deleting, finishes every transfer, and
+    // reports the limit at cleanup (exit 25). Because the during-sweep now runs
+    // before this directory's child loop, capture a limit error and re-raise it
+    // only after the children (and metadata) are processed, so pending copies
+    // are not skipped. Any other error still propagates immediately.
+    let mut deferred_delete_limit_error: Option<LocalCopyError> = None;
+    match apply_during_transfer_deletions(
+        context,
+        destination,
+        relative,
+        plan.deletion_enabled,
+        plan.delete_timing,
+        &plan.keep_names,
+    ) {
+        Ok(()) => {}
+        Err(error) if error.is_delete_limit_error() => {
+            deferred_delete_limit_error = Some(error);
+        }
+        Err(error) => return Err(error),
+    }
 
     {
         let cache = prefetch_directory_checksums(context, &plan, destination);
@@ -484,6 +512,15 @@ fn copy_directory_recursive_inner(
                     first_entry_io_error = Some(error);
                 }
             }
+            Err(error) if error.is_delete_limit_error() => {
+                // upstream: main.c:1356 - a --max-delete limit hit while
+                // recursing into a child directory must not abort the parent's
+                // remaining transfers. Defer it, letting the sibling entries
+                // finish, then re-raise at the end of this directory.
+                if deferred_delete_limit_error.is_none() {
+                    deferred_delete_limit_error = Some(error);
+                }
+            }
             Err(error) => return Err(error),
         }
     }
@@ -501,6 +538,11 @@ fn copy_directory_recursive_inner(
 
     if prune_enabled && !kept_any {
         handle_empty_directory_pruning(context, destination, created_directory_on_disk)?;
+        // upstream: the --max-delete limit (exit 25) outranks a partial/IO error
+        // (exit 23/24); raise it first, mirroring the old post-loop ordering.
+        if let Some(error) = deferred_delete_limit_error {
+            return Err(error);
+        }
         if let Some(error) = first_entry_io_error {
             return Err(error);
         }
@@ -526,6 +568,14 @@ fn copy_directory_recursive_inner(
             #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls,
         )?;
+    }
+
+    // upstream: the --max-delete limit (exit 25) is reported after the transfer
+    // and metadata finalization complete, and outranks a partial/IO error
+    // (exit 23/24). Raise the deferred limit error first to preserve the old
+    // post-loop ordering now that the delete-during sweep runs before the loop.
+    if let Some(error) = deferred_delete_limit_error {
+        return Err(error);
     }
 
     // If there were I/O errors during entry processing, propagate the first

--- a/crates/engine/src/local_copy/tests/delete.rs
+++ b/crates/engine/src/local_copy/tests/delete.rs
@@ -598,3 +598,76 @@ fn delete_after_works_with_dry_run() {
     }
 }
 
+/// `--delete-during` must delete a directory's extraneous entries BEFORE it
+/// transfers that same directory's surviving/new children, matching upstream's
+/// per-directory ordering.
+///
+/// upstream: generator.c:1532-1537 - for a non-INC_RECURSE `delete_during` run
+/// the generator calls `delete_in_dir()` while itemizing the directory entry
+/// itself, so the `*deleting` rows for a directory precede the transfer rows
+/// for its children. Verified byte-for-byte against rsync 3.4.4:
+///
+/// ```text
+/// *deleting   sub/stale.txt
+/// >f+++++++++ sub/new.txt
+/// ```
+///
+/// This pins the ordering so a regression that moves the during-sweep back
+/// after the child loop (which would invert it to copy-then-delete, matching
+/// `--delete-after` instead) fails here. It matters because the interleaved
+/// itemize stream is what a downstream consumer (or a diff against upstream)
+/// observes, and because deleting first frees inodes/space before the new
+/// files land.
+#[test]
+fn delete_during_deletes_directory_before_transferring_its_children() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let sub = source.join("sub");
+    fs::create_dir_all(&sub).expect("create source sub");
+    fs::write(sub.join("new.txt"), b"new").expect("write new");
+
+    let dest = temp.path().join("dest");
+    let dest_sub = dest.join("sub");
+    fs::create_dir_all(&dest_sub).expect("create dest sub");
+    // An extraneous entry in the same directory a new file will land in.
+    fs::write(dest_sub.join("stale.txt"), b"stale").expect("write stale");
+
+    let mut source_operand = source.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .delete(true) // delete-during is the default timing
+        .collect_events(true);
+
+    let report = plan
+        .execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("copy with delete-during succeeds");
+
+    assert!(dest_sub.join("new.txt").exists(), "new file must land");
+    assert!(
+        !dest_sub.join("stale.txt").exists(),
+        "extraneous file must be deleted"
+    );
+
+    let records = report.records();
+    let delete_index = records.iter().position(|record| {
+        record.action() == &LocalCopyAction::EntryDeleted
+            && record.relative_path().ends_with("stale.txt")
+    });
+    let copy_index = records.iter().position(|record| {
+        record.action() == &LocalCopyAction::DataCopied
+            && record.relative_path().ends_with("new.txt")
+    });
+
+    let delete_index = delete_index.expect("stale.txt deletion must be recorded");
+    let copy_index = copy_index.expect("new.txt copy must be recorded");
+    assert!(
+        delete_index < copy_index,
+        "delete-during must delete sub/stale.txt before copying sub/new.txt \
+         (delete idx {delete_index}, copy idx {copy_index})"
+    );
+}
+

--- a/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
@@ -242,33 +242,39 @@ fn ignore_errors_option_independent_of_delete_timing() {
 #[cfg(unix)]
 #[test]
 fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
-    // This test simulates what happens when a source file cannot be read:
-    // - The transfer encounters an I/O error
-    // - Without --ignore-errors, deletions should be suppressed
+    // upstream: generator.c:298 - `delete_in_dir` skips ALL file deletion once
+    // `io_error & IOERR_GENERAL` is set and `--ignore-errors` is off, printing
+    // "IO error encountered -- skipping file deletion". The general IO error is
+    // raised while BUILDING the file list (e.g. an unreadable directory whose
+    // `opendir`/`readdir` fails), i.e. before the delete pass of any sibling
+    // directory runs. An unreadable regular *file* does NOT set this flag - that
+    // surfaces later in `send_files` (exit 23) after the delete passes already
+    // ran, so upstream still deletes in that case (verified against rsync 3.4.4).
     //
-    // We create a source file that is unreadable (permission denied) to
-    // trigger the I/O error during transfer.
+    // Since oc-rsync's `--delete-during` now unlinks a directory's extraneous
+    // entries BEFORE transferring that directory's children (matching upstream's
+    // per-directory ordering), the suppression must be driven by the earlier
+    // directory-read error. An unreadable subdirectory sorts before the
+    // extraneous entry's directory and records the IO error first, so the later
+    // directory's during-sweep is suppressed and its extra file survives.
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempdir().expect("tempdir");
     let source = temp.path().join("source");
     let dest = temp.path().join("dest");
-    fs::create_dir_all(&source).expect("create source");
-    fs::create_dir_all(&dest).expect("create dest");
+    fs::create_dir_all(source.join("baddir")).expect("create baddir");
+    fs::create_dir_all(source.join("zsub")).expect("create zsub");
+    fs::create_dir_all(dest.join("zsub")).expect("create dest zsub");
 
-    // Create a readable source file
-    fs::write(source.join("good.txt"), b"good").expect("write good");
-    // Create an unreadable source file to trigger I/O error
-    fs::write(source.join("bad.txt"), b"bad").expect("write bad");
-    fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o000),
-    )
-    .expect("make unreadable");
+    fs::write(source.join("baddir/inner.txt"), b"inner").expect("write inner");
+    fs::write(source.join("zsub/keep.txt"), b"keep").expect("write keep");
+    fs::write(dest.join("zsub/keep.txt"), b"keep").expect("write dest keep");
+    // Extraneous entry in a directory processed AFTER the failing one.
+    fs::write(dest.join("zsub/extra.txt"), b"should survive").expect("write extra");
 
-    // Dest has an extra file that would be deleted
-    fs::write(dest.join("good.txt"), b"old good").expect("write old good");
-    fs::write(dest.join("extra.txt"), b"should survive").expect("write extra");
+    // Make the directory unreadable so the flist build hits a general IO error.
+    fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o000))
+        .expect("make baddir unreadable");
 
     let mut source_operand = source.clone().into_os_string();
     source_operand.push(std::path::MAIN_SEPARATOR.to_string());
@@ -276,25 +282,22 @@ fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
     // --delete WITHOUT --ignore-errors
-    let options = LocalCopyOptions::default().delete(true);
+    let options = LocalCopyOptions::default().recursive(true).delete(true);
 
-    // The copy should fail due to the I/O error
+    // The copy should fail due to the I/O error.
     let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
 
-    // Restore permissions for cleanup
-    let _ = fs::set_permissions(
-        source.join("bad.txt"),
-        fs::Permissions::from_mode(0o644),
-    );
+    // Restore permissions for cleanup.
+    let _ = fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o755));
 
-    // The extra file in dest should survive because deletions are suppressed
-    // when I/O errors occur (unless --ignore-errors is set)
+    // The extra file in the later directory must survive because the general IO
+    // error suppresses deletion (upstream generator.c:298).
     assert!(
-        dest.join("extra.txt").exists(),
-        "extra.txt should survive when I/O errors occur without --ignore-errors"
+        dest.join("zsub/extra.txt").exists(),
+        "zsub/extra.txt must survive when a directory-read IO error suppresses deletion"
     );
 
-    // The operation should have reported an error
+    // The operation should have reported an error.
     assert!(result.is_err(), "copy should report I/O error");
 }
 


### PR DESCRIPTION
## Problem

For a non-INC_RECURSE `--delete-during` local copy, upstream deletes a directory's extraneous entries **before** it transfers that directory's own children, so the `*deleting` rows precede the transfer rows within each directory:

```
*deleting   sub/stale.txt
>f+++++++++ sub/new.txt
```

oc-rsync ran the during-sweep **after** the child loop, inverting the order to copy-then-delete (which is what `--delete-after` does), diverging from upstream 3.4.4.

## Upstream reference

`generator.c:1532-1537` - the generator calls `delete_in_dir(fname, ...)` while itemizing the directory entry, before recursing into it. `main.c:1356` - the `--max-delete` limit does not abort the transfer; it stops deleting, finishes the transfer, and reports the limit at cleanup (exit 25). `generator.c:298` - a general IO error raised during flist build suppresses all subsequent deletion.

## Fix

- Move the immediate single-source `During` sweep to before the child loop (mirroring the existing `--delete-before` pre-transfer pass in `apply_pre_transfer_deletions`). Deferred timings (`--delete-delay`, `--delete-after`, and the multi-source `During`->`After` downgrade) still run after the loop.
- The `--max-delete` sweep now runs mid-transfer, so its `DeleteLimitExceeded` error is captured and re-raised only after the child loop and metadata finalization, ensuring pending copies still run and the exit-25 error still outranks a partial/IO error (exit 23/24) as before.
- Added `LocalCopyError::is_delete_limit_error()` predicate for the deferral.
- IO-error deletion suppression is unchanged (still driven by `deletions_allowed()`).

## Verification

Verified byte-for-byte against rsync 3.4.4:
- `--delete-during`/`-after`/`-delay` itemize order now matches exactly.
- `--max-delete=2` end-state matches: `keep.txt` updated, 2 files deleted, exit 25 (previously oc left `keep.txt` stale).

New `delete_during_deletes_directory_before_transferring_its_children` pins the per-directory ordering. The `ignore-errors` suppression test was rewritten to encode the real upstream directory-read suppression (`generator.c:298`) rather than an unreadable regular file, which upstream still deletes.

Targeted `cargo test -p engine` groups (delete/ignore_errors/max_delete/prune + delete integration suites) pass; `cargo fmt`/`clippy -p engine` clean. Two unrelated pre-existing macOS xattr flakes (`execute_preserves_read_only_permissions`, `archive_preserves_mixed_permissions_across_files`) fail identically on the base.