### PR TITLE
feat(transfer): async receiver finalization twins (tokio-transfer)

### DIFF
--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -125,6 +125,125 @@ impl ReceiverContext {
         Ok(())
     }
 
+    /// Async twin of [`read_expected_ndx_done`](Self::read_expected_ndx_done).
+    ///
+    /// Reads one NDX off an [`AsyncRead`](tokio::io::AsyncRead) via the codec's
+    /// `.await` NDX reader - the counterpart of the sync `read_ndx` used above,
+    /// sharing the same delta-decode leaf - and applies the identical NDX_DONE
+    /// (-1) validation and error text. It consumes the same bytes and yields the
+    /// same result as the sync leaf. Gated on `tokio-transfer`.
+    #[cfg(feature = "tokio-transfer")]
+    pub(in crate::receiver) async fn read_expected_ndx_done_async<R>(
+        &self,
+        ndx_read_codec: &mut NdxCodecEnum,
+        reader: &mut R,
+        context: &str,
+    ) -> io::Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        let ndx = ndx_read_codec.read_ndx_async(reader).await?;
+        if ndx != -1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected NDX_DONE (-1) from sender during {context}, got {ndx} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Async twin of [`exchange_phase_done`](Self::exchange_phase_done).
+    ///
+    /// The request half - `write_ndx_done` / `write_ndx` and `flush` on the
+    /// synchronous `writer` - stays blocking, exactly as `receive_file_async`
+    /// keeps its per-file request half sync. Only the sender's echoed NDX_DONE
+    /// reads become `.await` (via
+    /// [`read_expected_ndx_done_async`](Self::read_expected_ndx_done_async)). The
+    /// phase-counter walk, the `reclaim_oldest_segment` bookkeeping, and the
+    /// `Genr` debug emissions are the identical sync logic, so for the same wire
+    /// bytes this exchanges the same NDX_DONE sequence and emits the same
+    /// diagnostics as the blocking path.
+    ///
+    /// Gated on `tokio-transfer`; consumed by the async finalization sequence.
+    #[cfg(feature = "tokio-transfer")]
+    pub(in crate::receiver) async fn exchange_phase_done_async<R, W>(
+        &mut self,
+        reader: &mut R,
+        writer: &mut W,
+        ndx_write_codec: &mut NdxCodecEnum,
+        ndx_read_codec: &mut NdxCodecEnum,
+    ) -> io::Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+        W: Write + ?Sized,
+    {
+        let inc_recurse = self
+            .compat_flags
+            .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
+
+        let max_phase: i32 = if self.protocol.supports_multi_phase() {
+            2
+        } else {
+            1
+        };
+
+        if inc_recurse {
+            let num_segments = self.ndx_segments.len();
+            for _ in 0..num_segments {
+                // upstream: receiver.c:573 - flist_free(first_flist)
+                self.reclaim_oldest_segment();
+                ndx_write_codec.write_ndx_done(&mut *writer)?;
+                writer.flush()?;
+                self.read_expected_ndx_done_async(ndx_read_codec, reader, "segment completion")
+                    .await?;
+            }
+
+            // upstream: generator.c:2355-2357 - phase++ then "generate_files phase=%d"
+            let mut phase: i32 = 1;
+            debug_log!(Genr, 1, "generate_files phase={}", phase);
+
+            for _phase_step in 2..=max_phase {
+                ndx_write_codec.write_ndx_done(&mut *writer)?;
+                writer.flush()?;
+                self.read_expected_ndx_done_async(ndx_read_codec, reader, "phase transition")
+                    .await?;
+                phase += 1;
+                debug_log!(Genr, 1, "generate_files phase={}", phase);
+            }
+
+            ndx_write_codec.write_ndx_done(&mut *writer)?;
+            writer.flush()?;
+
+            // upstream: generator.c:2391-2394 - protocol >= 29 emits a final phase.
+            if self.protocol.supports_multi_phase() {
+                phase += 1;
+                debug_log!(Genr, 1, "generate_files phase={}", phase);
+            }
+        } else {
+            let mut phase: i32 = 0;
+            loop {
+                ndx_write_codec.write_ndx_done(&mut *writer)?;
+                writer.flush()?;
+                phase += 1;
+                debug_log!(Genr, 1, "generate_files phase={}", phase);
+                if phase > max_phase {
+                    break;
+                }
+                self.read_expected_ndx_done_async(ndx_read_codec, reader, "phase transition")
+                    .await?;
+            }
+        }
+
+        self.read_expected_ndx_done_async(ndx_read_codec, reader, "sender final")
+            .await?;
+
+        Ok(())
+    }
+
     /// Handles the goodbye handshake at end of transfer.
     ///
     /// For protocol >= 31, sends `NDX_DEL_STATS` (when `--delete` ran) followed
@@ -182,6 +301,73 @@ impl ReceiverContext {
                 if ndx == NDX_DEL_STATS {
                     // Consume the 5 varints of deletion statistics
                     let _stats = protocol::stats::DeleteStats::read_from(reader)?;
+                    continue;
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expected goodbye NDX_DONE echo (-1) from sender, got {ndx} {}{}",
+                        crate::role_trailer::error_location!(),
+                        crate::role_trailer::receiver()
+                    ),
+                ));
+            }
+
+            ndx_write_codec.write_ndx_done(&mut *writer)?;
+            writer.flush()?;
+        }
+
+        Ok(())
+    }
+
+    /// Async twin of [`handle_goodbye`](Self::handle_goodbye).
+    ///
+    /// The send half - `write_ndx` / `write_ndx_done`, `pending_del_stats.write_to`,
+    /// and `flush` on the synchronous `writer` - stays blocking; only the
+    /// sender's goodbye echo NDX reads (and the `NDX_DEL_STATS` payload drain)
+    /// become `.await` (via `read_ndx_async` and
+    /// [`DeleteStats::read_from_async`](protocol::stats::DeleteStats::read_from_async)).
+    /// The protocol gating, the early-delete-stats emission, and the echo-skip
+    /// loop are the identical sync logic, so for the same wire bytes this
+    /// exchanges the same goodbye frames as the blocking path.
+    ///
+    /// Gated on `tokio-transfer`; consumed by the async finalization sequence.
+    #[cfg(feature = "tokio-transfer")]
+    pub(in crate::receiver) async fn handle_goodbye_async<R, W>(
+        &self,
+        reader: &mut R,
+        writer: &mut W,
+        ndx_write_codec: &mut NdxCodecEnum,
+        ndx_read_codec: &mut NdxCodecEnum,
+    ) -> io::Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+        W: Write + ?Sized,
+    {
+        if !self.protocol.supports_goodbye_exchange() {
+            return Ok(());
+        }
+
+        // upstream: generator.c:2393-2394 - early write_del_stats(f_out).
+        if self.protocol.supports_extended_goodbye() && self.config.flags.delete {
+            ndx_write_codec.write_ndx(&mut *writer, NDX_DEL_STATS)?;
+            self.pending_del_stats.write_to(&mut *writer)?;
+        }
+
+        ndx_write_codec.write_ndx_done(&mut *writer)?;
+        writer.flush()?;
+
+        if self.protocol.supports_extended_goodbye() {
+            // upstream: main.c:875-906 read_final_goodbye() - the sender may
+            // send NDX_DEL_STATS before the NDX_DONE echo. Loop to skip it.
+            loop {
+                let ndx = ndx_read_codec.read_ndx_async(reader).await?;
+                if ndx == NDX_DONE {
+                    break;
+                }
+                if ndx == NDX_DEL_STATS {
+                    // Consume the 5 varints of deletion statistics.
+                    let _stats = protocol::stats::DeleteStats::read_from_async(reader).await?;
                     continue;
                 }
                 return Err(io::Error::new(
@@ -327,6 +513,88 @@ impl ReceiverContext {
         // INC_RECURSE diagnostic I4 (#2199): emit cumulative NDX conversion
         // call count and partition_point comparison depth from the receiver
         // side. Aggregated across all receiver transfers in this process.
+        let (ndx_calls, ndx_cmps) = crate::receiver::ndx_convert_totals();
+        debug_log!(
+            Genr,
+            1,
+            "receiver ndx_convert totals: calls={} partition_point_depth={}",
+            ndx_calls,
+            ndx_cmps
+        );
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!(
+            target: "rsync::receiver::ndx_convert",
+            calls = ndx_calls,
+            partition_point_depth = ndx_cmps,
+            "receiver ndx_convert totals"
+        );
+
+        // FSM: finalization complete. Advance to Complete.
+        self.pipeline
+            .advance_to(TransferPhase::Complete)
+            .map_err(crate::fsm_error)?;
+
+        Ok(())
+    }
+
+    /// Async twin of [`finalize_transfer`](Self::finalize_transfer).
+    ///
+    /// Runs the receiver's end-of-transfer finalization sequence with `.await`
+    /// on every wire read: the phase-done exchange
+    /// ([`exchange_phase_done_async`](Self::exchange_phase_done_async)), the
+    /// client-mode sender-stats read
+    /// ([`receive_stats_async`](Self::receive_stats_async)), and the goodbye
+    /// handshake ([`handle_goodbye_async`](Self::handle_goodbye_async)). The FSM
+    /// advances, the trailing flush (with the same early-close tolerance), and
+    /// the `Genr`/`ndx_convert` diagnostics are the identical sync logic - only
+    /// the wire reads differ, so for the same wire bytes this drives the same
+    /// finalization frames and emits the same diagnostics as the blocking path.
+    ///
+    /// This is the async finalization tail the coupled async receiver driver
+    /// (the deferred atomic ASY receiver fork) calls after its per-file
+    /// [`receive_file_async`](crate::receiver::ReceiverContext::receive_file_async)
+    /// loop, in place of [`finalize_transfer`](Self::finalize_transfer). Gated on
+    /// `tokio-transfer`.
+    #[cfg(feature = "tokio-transfer")]
+    #[allow(dead_code)]
+    pub(in crate::receiver) async fn finalize_transfer_async<R, W>(
+        &mut self,
+        reader: &mut R,
+        writer: &mut W,
+    ) -> io::Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+        W: Write + ?Sized,
+    {
+        // FSM: delta transfer complete. Advance to Finalization.
+        self.pipeline
+            .advance_to(TransferPhase::Finalization)
+            .map_err(crate::fsm_error)?;
+
+        let mut ndx_write_codec = create_ndx_codec(self.protocol.as_u8());
+        let mut ndx_read_codec = create_ndx_codec(self.protocol.as_u8());
+
+        self.exchange_phase_done_async(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)
+            .await?;
+
+        if self.config.connection.client_mode {
+            let _sender_stats = self.receive_stats_async(reader).await?;
+        }
+
+        self.handle_goodbye_async(reader, writer, &mut ndx_write_codec, &mut ndx_read_codec)
+            .await?;
+
+        // upstream: main.c:1067/1117/1123 - io_flush(FULL_FLUSH) after the final
+        // NDX_DONE write. Fail-loud unless the peer already shut down.
+        if let Err(e) = writer.flush() {
+            if !crate::is_early_close_error(&e) {
+                return Err(e);
+            }
+        }
+
+        // upstream: generator.c:2436-2437 - "generate_files finished".
+        debug_log!(Genr, 1, "generate_files finished");
+
         let (ndx_calls, ndx_cmps) = crate::receiver::ndx_convert_totals();
         debug_log!(
             Genr,
@@ -524,6 +792,229 @@ mod genr_debug_emission_tests {
             msgs.is_empty(),
             "Flist debug emissions must be gated; got: {msgs:?}"
         );
+    }
+}
+
+#[cfg(all(test, feature = "tokio-transfer"))]
+mod finalize_parity_tests {
+    //! Sync vs async wire-byte parity for the receiver finalization tail.
+    //!
+    //! Builds the sender-side finalization wire (the NDX_DONE phase echoes,
+    //! optional sender stats, and the goodbye echo) with the sync codec - the
+    //! exact bytes the sync [`finalize_transfer`] reads - then drives that
+    //! identical wire through both [`finalize_transfer`] and the `.await`-based
+    //! [`finalize_transfer_async`]. Asserts both succeed, consume the same byte
+    //! count, and drive the receiver's writer to the same captured bytes,
+    //! including when the async wire is delivered one byte at a time across
+    //! `.await` points. Also covers `exchange_phase_done` / `handle_goodbye`
+    //! transitively (finalize composes them), and pins the error text: a
+    //! non-NDX_DONE in place of a phase echo rejects identically on both paths.
+
+    use std::ffi::OsString;
+    use std::io::{Cursor, Write};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use protocol::ProtocolVersion;
+    use protocol::codec::{NdxCodec, create_ndx_codec};
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::role::ServerRole;
+
+    /// Delivers at most `chunk` bytes per `poll_read`, forcing the async
+    /// finalize reads to cross `.await` boundaries mid-value when `chunk == 1`.
+    struct ChunkedReader {
+        inner: Cursor<Vec<u8>>,
+        chunk: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(bytes: Vec<u8>, chunk: usize) -> Self {
+            Self {
+                inner: Cursor::new(bytes),
+                chunk: chunk.max(1),
+            }
+        }
+
+        fn consumed(&self) -> u64 {
+            self.inner.position()
+        }
+    }
+
+    impl AsyncRead for ChunkedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let limit = self.chunk.min(buf.remaining());
+            if limit == 0 {
+                return Poll::Ready(Ok(()));
+            }
+            let pos = self.inner.position() as usize;
+            let data = self.inner.get_ref();
+            if pos >= data.len() {
+                return Poll::Ready(Ok(()));
+            }
+            let end = (pos + limit).min(data.len());
+            let slice = data[pos..end].to_vec();
+            buf.put_slice(&slice);
+            self.inner.set_position(end as u64);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    /// A capturing writer with a no-op `MsgInfoSender`, so the receiver's
+    /// finalize send-half (NDX_DONE frames) is recorded for parity comparison.
+    struct CaptureWriter(Vec<u8>);
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl crate::writer::MsgInfoSender for CaptureWriter {
+        fn send_msg_info(&mut self, _data: &[u8]) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn handshake_for(protocol_version: u8) -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    fn receiver_for(protocol_version: u8) -> ReceiverContext {
+        let handshake = handshake_for(protocol_version);
+        let config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(protocol_version).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+        ctx.advance_pipeline_to_delta_transfer_for_test();
+        ctx
+    }
+
+    /// Builds the sender-side finalization wire the receiver reads: `phase_dones`
+    /// NDX_DONE frames for the phase exchange, then `goodbye_dones` NDX_DONE
+    /// frames for the goodbye echo. Encoded with the same codec the receiver
+    /// decodes with, so the bytes are exactly what the wire carries.
+    fn build_finalize_wire(
+        protocol_version: u8,
+        phase_dones: usize,
+        goodbye_dones: usize,
+    ) -> Vec<u8> {
+        let mut codec = create_ndx_codec(protocol_version);
+        let mut wire = Vec::new();
+        for _ in 0..(phase_dones + goodbye_dones) {
+            codec.write_ndx_done(&mut wire).unwrap();
+        }
+        wire
+    }
+
+    /// The async finalization tail consumes the identical sender wire and drives
+    /// the receiver's writer to the identical bytes as the sync tail, on both a
+    /// legacy (single-phase, no extended goodbye) and a modern (multi-phase,
+    /// extended goodbye) protocol - even when the wire is delivered one byte per
+    /// poll. Non-client so no sender-stats read is interleaved (that leaf has its
+    /// own parity test).
+    #[tokio::test(flavor = "current_thread")]
+    async fn finalize_transfer_async_matches_sync() {
+        // Protocol 32: multi-phase (3 phase NDX_DONE) + extended goodbye
+        // (1 echo NDX_DONE). Protocol 28: single-phase (2 phase NDX_DONE:
+        // one write+read at phase 1, then phase 2 > max_phase=1 breaks after
+        // the second read) and no goodbye exchange.
+        //
+        // Phase-done counts are derived by tracing exchange_phase_done's
+        // non-inc-recurse loop for the fresh (single-segment) receiver.
+        for (protocol, phase_dones, goodbye_dones) in [(28u8, 2usize, 0usize), (32u8, 3, 1)] {
+            let wire = build_finalize_wire(protocol, phase_dones, goodbye_dones);
+
+            // Sync reference.
+            let mut sync_ctx = receiver_for(protocol);
+            let mut sync_reader = Cursor::new(wire.clone());
+            let mut sync_writer = CaptureWriter(Vec::new());
+            sync_ctx
+                .finalize_transfer(&mut sync_reader, &mut sync_writer)
+                .expect("sync finalize must succeed");
+            let sync_consumed = sync_reader.position();
+            let sync_sent = sync_writer.0.clone();
+
+            for chunk in [1usize, 2, 3, wire.len().max(1)] {
+                let mut async_ctx = receiver_for(protocol);
+                let mut async_reader = ChunkedReader::new(wire.clone(), chunk);
+                let mut async_writer = CaptureWriter(Vec::new());
+                async_ctx
+                    .finalize_transfer_async(&mut async_reader, &mut async_writer)
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!("protocol={protocol} chunk={chunk}: async finalize failed: {e}")
+                    });
+
+                assert_eq!(
+                    async_reader.consumed(),
+                    sync_consumed,
+                    "protocol={protocol} chunk={chunk}: async finalize consumed a different byte count"
+                );
+                assert_eq!(
+                    async_writer.0, sync_sent,
+                    "protocol={protocol} chunk={chunk}: async finalize send-half diverged from sync"
+                );
+            }
+        }
+    }
+
+    /// A non-NDX_DONE value in place of the sender's first phase echo is rejected
+    /// identically by both the sync and async phase exchange: same `InvalidData`
+    /// kind, so the async twin does not silently accept a desynced phase frame.
+    #[tokio::test(flavor = "current_thread")]
+    async fn exchange_phase_done_async_rejects_non_done_like_sync() {
+        let protocol = 32u8;
+        // A single valid NDX (0), which is not NDX_DONE (-1), where the first
+        // phase echo is expected. Both paths write their first NDX_DONE, then
+        // read this and must reject it.
+        let mut codec = create_ndx_codec(protocol);
+        let mut wire = Vec::new();
+        codec.write_ndx(&mut wire, 0).unwrap();
+
+        let mut sync_ctx = receiver_for(protocol);
+        let mut sync_reader = Cursor::new(wire.clone());
+        let mut sync_writer = CaptureWriter(Vec::new());
+        let sync_err = sync_ctx
+            .finalize_transfer(&mut sync_reader, &mut sync_writer)
+            .expect_err("sync finalize must reject a non-NDX_DONE phase echo");
+
+        let mut async_ctx = receiver_for(protocol);
+        let mut async_reader = ChunkedReader::new(wire, 1);
+        let mut async_writer = CaptureWriter(Vec::new());
+        let async_err = async_ctx
+            .finalize_transfer_async(&mut async_reader, &mut async_writer)
+            .await
+            .expect_err("async finalize must reject a non-NDX_DONE phase echo");
+
+        assert_eq!(
+            async_err.kind(),
+            sync_err.kind(),
+            "async finalize error kind must match sync"
+        );
+        assert_eq!(async_err.kind(), std::io::ErrorKind::InvalidData);
     }
 }
 

--- a/docs/design/asy-7-receiver-tokio-prototype.md
+++ b/docs/design/asy-7-receiver-tokio-prototype.md
@@ -586,4 +586,49 @@ fix, not part of this receiver rung.
    benefit (the ASY-3 shape already exists), and an unverified fork risks
    a wire/stats divergence - both worse than none per the stop clause.
 
+## 11. Finalization async twins landed (prerequisite for the atomic fork)
+
+Status: The receiver's end-of-transfer wire twins - the last pieces of the
+async building-block surface named in section 10.1 as still missing - now
+exist alongside the earlier reader-stack, file-list, per-file, and
+sender-stats twins:
+
+- `ReceiverContext::read_expected_ndx_done_async` - `.await` NDX_DONE (-1)
+  validation via `NdxCodecEnum::read_ndx_async`.
+- `ReceiverContext::exchange_phase_done_async` - the phase-done exchange
+  with `.await` on the sender's echoed NDX_DONE reads; the request-half
+  `write_ndx_done`/`flush`, the phase-counter walk, and the
+  `reclaim_oldest_segment` bookkeeping stay the identical sync logic.
+- `ReceiverContext::handle_goodbye_async` - the goodbye handshake with
+  `.await` on the echo NDX read and the `NDX_DEL_STATS` drain
+  (`DeleteStats::read_from_async`); the send-half stays sync.
+- `ReceiverContext::finalize_transfer_async` - composes the three twins
+  plus the already-landed `receive_stats_async` into the async
+  finalization tail, mirroring `finalize_transfer` byte-for-byte with
+  `.await` only on the wire reads.
+
+All four are `#[cfg(feature = "tokio-transfer")]`, additive, and have no
+non-test caller: like `receive_file_async`, they are the leaves the
+deferred atomic receiver fork (section 10.1) will call after its per-file
+loop, in place of the sync `finalize_transfer`. They keep the request/send
+half synchronous exactly as the per-file leg does, so no async NDX-write
+codec is required. Equivalence is pinned by
+`finalize_parity_tests` in `receiver/transfer/phases.rs`: the sender-side
+finalization wire is built with the sync codec, then driven through both
+`finalize_transfer` and `finalize_transfer_async` (including one byte per
+poll) with byte-consumption + send-half parity asserted, plus an
+error-parity case (a non-NDX_DONE in place of a phase echo rejects
+identically). Default build untouched; `cargo clippy -p transfer` (no
+feature) and a `x86_64-pc-windows-gnu` cross-build of the feature both
+pass - the twins introduce no unix-only type, so the `DirSandbox`/`RawFd`
+gating hazard that a prior async leg tripped does not apply here.
+
+This leaves exactly one code rung before the atomic driver fork: nothing.
+The async building-block surface (reader stack, file list, per-file
+reconstruct+commit, sender stats, phase-done, goodbye, finalization) is
+complete. What remains is (1) the atomic ~20-30-function receiver driver
+fork of section 10.1 - which stays STOP until it can be CI-verified
+byte-identical per section 10.2 - and (2) ASY-4 (the thread-pool-vs-async
+benchmark, no code). No other async twin is missing.
+
 <!-- CI skip-path verification probe for required upstream-testsuite check. -->


### PR DESCRIPTION
## Summary

Adds the async wire twins for the receiver's end-of-transfer finalization
tail - the last missing pieces of the async building-block surface below the
(deferred, STOP-until-CI) atomic async receiver driver fork. All gated behind
`tokio-transfer`, additive, byte-identical to the sync path.

New twins in `crates/transfer/src/receiver/transfer/phases.rs`:

- `read_expected_ndx_done_async` - `.await` NDX_DONE (-1) validation via
  `NdxCodecEnum::read_ndx_async`.
- `exchange_phase_done_async` - the phase-done exchange with `.await` on the
  sender's echoed NDX_DONE reads. The request-half `write_ndx_done`/`flush`,
  the phase-counter walk, the `reclaim_oldest_segment` bookkeeping, and the
  `Genr` diagnostics stay the identical sync logic.
- `handle_goodbye_async` - the goodbye handshake with `.await` on the echo NDX
  read and the `NDX_DEL_STATS` payload drain (`DeleteStats::read_from_async`);
  the send-half stays sync.
- `finalize_transfer_async` - composes those three plus the already-landed
  `receive_stats_async` into the async finalization tail, mirroring
  `finalize_transfer` byte-for-byte with `.await` only on the wire reads.

The request/send half stays synchronous exactly as `receive_file_async` keeps
its per-file request half sync, so no async NDX-write codec is required. Every
primitive the twins call (`read_ndx_async`, `read_stat_async`,
`read_from_async`, `write_ndx`/`write_ndx_done`) already exists.

## Why this slice, not the full loop

The full receiver loop conversion is an atomic ~20-30-function driver fork
whose byte-identity is unverifiable in the local environment (nextest hangs);
the design record (docs/design/asy-7-receiver-tokio-prototype.md, four scoping
passes) marks it STOP until it can be CI-verified byte-identical. Shipping a
partial receiver that genuinely awaits a real read is not byte-identical-safe
(the read is fused into `run_pipeline_loop_decoupled`'s wire-observable frame).
This PR lands the genuinely-landable, individually-equivalence-tested building
blocks - matching how `receive_stats_async` and `receive_file_async` shipped -
completing the async twin surface. Section 11 of the design doc records the
outcome.

## Equivalence evidence

`finalize_parity_tests` builds the sender-side finalization wire with the sync
codec (the exact bytes the sync path reads), then drives it through both
`finalize_transfer` and `finalize_transfer_async`:

- `finalize_transfer_async_matches_sync` - protocol 28 (single-phase, no
  extended goodbye) and 32 (multi-phase, extended goodbye); asserts identical
  byte consumption and identical send-half output, incl. one byte per poll.
- `exchange_phase_done_async_rejects_non_done_like_sync` - a non-NDX_DONE in
  place of a phase echo rejects with the same `InvalidData` kind on both paths.

## Verification

- `cargo fmt --all`
- `cargo clippy -p transfer --features tokio-transfer --all-targets --no-deps --locked -- -D warnings` - clean
- `cargo clippy -p transfer` (default, no feature) - clean (default build untouched)
- `cargo build -p transfer --features tokio-transfer --target x86_64-pc-windows-gnu` - passes (twins introduce no unix-only type; the `DirSandbox`/`RawFd` gating hazard does not apply)
- `cargo nextest run -p transfer --features tokio-transfer,zstd,lz4 -E 'test(finalize_parity)|test(async_receiver)|test(parity)|test(equivalence)'` - 48 passed, 0 failed

## Scope

Default (threaded) build byte-identical; every new item is
`#[cfg(feature = "tokio-transfer")]`.