### PR TITLE
feat(transfer): basis read-ahead prefetch (fadvise WILLNEED, default-off)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,13 @@ copy_file_range = ["fast_io/copy_file_range"]
 # `docs/design/mmap-vs-sqpoll-conflict-resolution.md` for the rationale.
 mmap-free-basis = ["engine/mmap-free-basis", "fast_io/mmap-free-basis"]
 
+# EXPERIMENTAL (default-off): basis read-ahead prefetch for the decoupled
+# receiver. Forwards to `transfer/basis-readahead`, which warms upcoming delta
+# basis files into the page cache via posix_fadvise(WILLNEED). Kept out of
+# default features; a bench build enables it and activates it at runtime with
+# OC_RSYNC_BASIS_READAHEAD=1. Pure timing hint - wire output is byte-identical.
+basis-readahead = ["transfer/basis-readahead"]
+
 # ============================================================================
 # OpenSSL Features
 # ============================================================================

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -194,6 +194,9 @@ pub mod win_tmpfile;
 /// macOS-optimized file writer using `F_NOCACHE` and `writev`.
 pub mod macos_io;
 
+/// Kernel read-ahead hint (`POSIX_FADV_WILLNEED`) for basis-file prefetch.
+pub mod willneed;
+
 /// Memory-mapped file reader for efficient large file access.
 #[cfg(unix)]
 pub mod mmap_reader;

--- a/crates/fast_io/src/willneed.rs
+++ b/crates/fast_io/src/willneed.rs
@@ -1,0 +1,81 @@
+//! Kernel read-ahead hint for basis files (`POSIX_FADV_WILLNEED`).
+//!
+//! Warms the page cache for a file the caller is about to read, so a later
+//! `mmap`/`read` finds its pages already resident instead of blocking on disk.
+//! This is a pure advisory hint: it never changes the bytes read, only the
+//! timing of the read.
+//!
+//! `posix_fadvise` is Linux/Android-only (BSD/macOS `libc` has no such symbol),
+//! so on every other platform this is a no-op returning `Ok(())`.
+
+use std::fs::File;
+use std::io;
+
+/// Hints to the kernel that the entire file will be read soon.
+///
+/// On Linux/Android this issues `posix_fadvise(fd, 0, 0, POSIX_FADV_WILLNEED)`
+/// (offset 0, length 0 means "to end of file"), asking the kernel to begin
+/// asynchronous read-ahead into the page cache. The call is advisory: the
+/// kernel may ignore it, and it never alters observable file contents.
+///
+/// On all other platforms this is a no-op returning `Ok(())`.
+///
+/// # Errors
+///
+/// Returns the OS error if `posix_fadvise` reports one. Callers treat a
+/// prefetch failure as a silent no-op (the hint is best-effort).
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[allow(unsafe_code)]
+pub fn hint_basis_willneed(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    // SAFETY: `file` is a valid open file; the borrow guarantees the fd stays
+    // open for the call. offset 0 / len 0 = whole file. POSIX_FADV_WILLNEED
+    // is a pure advisory hint that never accesses user memory.
+    let ret = unsafe { libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_WILLNEED) };
+    if ret != 0 {
+        // posix_fadvise returns the error code directly, not via errno.
+        Err(io::Error::from_raw_os_error(ret))
+    } else {
+        Ok(())
+    }
+}
+
+/// No-op on platforms without `posix_fadvise` (BSD/macOS/Windows).
+///
+/// # Errors
+///
+/// Never returns an error on these platforms.
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+pub fn hint_basis_willneed(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn hint_willneed_on_populated_file_succeeds() {
+        let mut temp = NamedTempFile::new().expect("create temp file");
+        temp.write_all(&[0u8; 64 * 1024]).expect("write");
+        temp.flush().expect("flush");
+
+        let file = temp.reopen().expect("reopen");
+        assert!(
+            hint_basis_willneed(&file).is_ok(),
+            "willneed hint should succeed on a populated file"
+        );
+    }
+
+    #[test]
+    fn hint_willneed_on_empty_file_succeeds() {
+        let temp = NamedTempFile::new().expect("create temp file");
+        let file = temp.reopen().expect("reopen");
+        assert!(
+            hint_basis_willneed(&file).is_ok(),
+            "willneed hint should succeed on an empty file"
+        );
+    }
+}

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -112,6 +112,14 @@ vmsplice = ["fast_io/vmsplice"]
 # fallback. Default off until eviction/throughput benchmarks justify promotion.
 dontcache = ["fast_io/dontcache"]
 
+# Basis read-ahead prefetch (Unix). Warms upcoming delta basis files into the
+# page cache via posix_fadvise(WILLNEED) on a background worker, so the
+# decoupled receiver stops blocking serially on basis reads. Pure timing hint:
+# wire output stays byte-identical. Default off; even when compiled in it stays
+# inert unless runtime-activated via OC_RSYNC_BASIS_READAHEAD=1, and is disabled
+# for --inplace / --append. See docs/design/basis-readahead.md (follow-up).
+basis-readahead = []
+
 
 # Per-thread slab pool for buffer returns - forwards to the engine crate.
 # Forwarded so `--all-features` enables it transitively on engine *and* exposes

--- a/crates/transfer/src/basis_prefetch/fadvise.rs
+++ b/crates/transfer/src/basis_prefetch/fadvise.rs
@@ -1,0 +1,73 @@
+//! `posix_fadvise(WILLNEED)` prefetcher backed by a background worker thread.
+//!
+//! Basis paths are handed to a bounded channel; a single worker opens each
+//! file read-only and issues [`fast_io::willneed::hint_basis_willneed`], then
+//! drops the handle. The bounded channel provides backpressure so the main
+//! thread never queues an unbounded backlog of hints. All errors (open,
+//! hint, closed channel) are silent no-ops - the hint is best-effort.
+//!
+//! Uses `std::sync::mpsc::sync_channel` (bounded, in std) rather than a new
+//! dependency - transfer already avoids crossbeam-channel in production code.
+
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
+use std::thread::JoinHandle;
+
+use super::BasisPrefetcher;
+
+/// Read-ahead prefetcher that warms basis pages via `posix_fadvise(WILLNEED)`.
+pub struct FadviseWillneedPrefetcher {
+    /// Bounded queue of basis paths to warm; `None` after shutdown.
+    tx: Option<SyncSender<PathBuf>>,
+    /// Background worker draining the queue; joined on drop.
+    worker: Option<JoinHandle<()>>,
+}
+
+impl FadviseWillneedPrefetcher {
+    /// Spawns the worker with a bounded queue of `depth` pending hints.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the worker thread cannot be spawned.
+    pub fn new(depth: usize) -> io::Result<Self> {
+        let (tx, rx) = sync_channel::<PathBuf>(depth.max(1));
+        let worker = std::thread::Builder::new()
+            .name("basis-prefetch".to_string())
+            .spawn(move || {
+                // Drain until the sender is dropped. Each hint is best-effort.
+                for path in rx.iter() {
+                    if let Ok(file) = File::open(&path) {
+                        let _ = fast_io::willneed::hint_basis_willneed(&file);
+                    }
+                }
+            })?;
+        Ok(Self {
+            tx: Some(tx),
+            worker: Some(worker),
+        })
+    }
+}
+
+impl BasisPrefetcher for FadviseWillneedPrefetcher {
+    fn prefetch(&self, path: &Path) {
+        // Non-blocking: if the queue is full the worker is already saturated,
+        // so drop this hint rather than stall the pipeline's main thread.
+        if let Some(tx) = self.tx.as_ref() {
+            match tx.try_send(path.to_path_buf()) {
+                Ok(()) | Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {}
+            }
+        }
+    }
+}
+
+impl Drop for FadviseWillneedPrefetcher {
+    fn drop(&mut self) {
+        // Close the channel so the worker's `rx.iter()` terminates, then join.
+        self.tx = None;
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}

--- a/crates/transfer/src/basis_prefetch/mod.rs
+++ b/crates/transfer/src/basis_prefetch/mod.rs
@@ -1,0 +1,118 @@
+//! Basis-file read-ahead prefetch (default-off, feature-gated).
+//!
+//! The decoupled receiver pipeline resolves each upcoming file's basis path
+//! ahead of the disk-commit stage, then later blocks the main thread on a
+//! serial `MapFile::open` of that basis during delta-token processing. On an
+//! I/O-wait-bound receiver those blocking basis reads dominate wall-clock time
+//! while the disk sits underused.
+//!
+//! A [`BasisPrefetcher`] issues a kernel read-ahead hint
+//! (`posix_fadvise(POSIX_FADV_WILLNEED)`) on look-ahead basis paths so their
+//! pages are warm in the page cache by the time the pipeline reaches them.
+//!
+//! # Correctness
+//!
+//! This is a pure timing optimization. `posix_fadvise(WILLNEED)` never changes
+//! the bytes read from the basis file, so the wire output and the reconstructed
+//! destination are byte-identical whether or not a prefetcher runs. The only
+//! observable effect is that later basis reads may complete faster.
+//!
+//! The default [`NullPrefetcher`] does nothing and spawns no threads. The
+//! active [`FadviseWillneedPrefetcher`] is only compiled in under the
+//! `basis-readahead` feature on Unix, and even then is only selected when the
+//! transfer does not mutate a file's basis in place (see [`select_prefetcher`]).
+
+use std::path::Path;
+use std::sync::Arc;
+
+#[cfg(all(unix, feature = "basis-readahead"))]
+mod fadvise;
+
+#[cfg(all(unix, feature = "basis-readahead"))]
+pub use fadvise::FadviseWillneedPrefetcher;
+
+/// Number of look-ahead files to prefetch and the prefetch channel depth.
+///
+/// Matches the pipeline's short look-ahead window: prefetching further than
+/// this wastes page cache without reducing main-thread stalls, and the bounded
+/// channel of the same depth provides natural backpressure.
+pub const PREFETCH_DEPTH: usize = 4;
+
+/// Issues read-ahead hints for upcoming basis files.
+///
+/// Implementations must be cheap to call and must never block the caller for
+/// a meaningful duration - the hint is fire-and-forget. A failed or ignored
+/// hint is a silent no-op.
+pub trait BasisPrefetcher: Send + Sync {
+    /// Requests that the kernel begin warming the page cache for `path`.
+    ///
+    /// Best-effort: any error (missing file, open failure, unsupported
+    /// platform) is silently ignored.
+    fn prefetch(&self, path: &Path);
+}
+
+/// Prefetcher that does nothing. The default when the feature is off or the
+/// transfer is on the correctness disable-list.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullPrefetcher;
+
+impl BasisPrefetcher for NullPrefetcher {
+    #[inline]
+    fn prefetch(&self, _path: &Path) {}
+}
+
+/// Correctness disable-list inputs for [`select_prefetcher`].
+///
+/// Prefetch must be disabled whenever writing one file can mutate the basis of
+/// a later file, because warming a stale basis into cache would not help and
+/// the in-place write races the read-ahead. `--inplace` and `--append` both
+/// write directly into the destination that may serve as a later basis.
+#[derive(Debug, Clone, Copy)]
+pub struct PrefetchDisableList {
+    /// `--inplace`: destination is written in place, mutating potential bases.
+    pub inplace: bool,
+    /// `--append`: destination is extended in place, mutating potential bases.
+    pub append: bool,
+}
+
+/// Selects the prefetcher for a transfer.
+///
+/// Returns [`NullPrefetcher`] when the `basis-readahead` feature is not
+/// compiled in, when the platform is not Unix, when the runtime env activation
+/// (`OC_RSYNC_BASIS_READAHEAD=1`) is absent, or when the transfer is on the
+/// correctness disable-list. Otherwise returns an active
+/// [`FadviseWillneedPrefetcher`].
+///
+/// The default build always returns [`NullPrefetcher`], so production behavior
+/// is unchanged unless the feature is compiled in AND enabled.
+#[must_use]
+pub fn select_prefetcher(disable: PrefetchDisableList) -> Arc<dyn BasisPrefetcher> {
+    #[cfg(all(unix, feature = "basis-readahead"))]
+    {
+        if !disable.inplace && !disable.append && basis_readahead_env_enabled() {
+            if let Ok(p) = FadviseWillneedPrefetcher::new(PREFETCH_DEPTH) {
+                return Arc::new(p);
+            }
+        }
+        Arc::new(NullPrefetcher)
+    }
+
+    #[cfg(not(all(unix, feature = "basis-readahead")))]
+    {
+        let _ = disable;
+        Arc::new(NullPrefetcher)
+    }
+}
+
+/// Runtime activation gate, consulted only when the feature is compiled in.
+///
+/// Lets a single feature-enabled bench binary toggle prefetch via
+/// `OC_RSYNC_BASIS_READAHEAD=1` without a CLI surface. Absent or any other
+/// value keeps prefetch off.
+#[cfg(all(unix, feature = "basis-readahead"))]
+fn basis_readahead_env_enabled() -> bool {
+    std::env::var_os("OC_RSYNC_BASIS_READAHEAD").is_some_and(|v| v == "1")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/transfer/src/basis_prefetch/tests.rs
+++ b/crates/transfer/src/basis_prefetch/tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+use std::path::PathBuf;
+
+#[test]
+fn null_prefetcher_is_a_noop() {
+    let p = NullPrefetcher;
+    // Must not panic or block on any path, existing or not.
+    p.prefetch(&PathBuf::from("/nonexistent/basis/file"));
+    BasisPrefetcher::prefetch(&p, &PathBuf::from("/tmp"));
+}
+
+#[test]
+fn select_returns_null_under_inplace() {
+    let p = select_prefetcher(PrefetchDisableList {
+        inplace: true,
+        append: false,
+    });
+    // Disable-list forces Null even with the feature on; prefetch is a no-op.
+    p.prefetch(&PathBuf::from("/nonexistent"));
+}
+
+#[test]
+fn select_returns_null_under_append() {
+    let p = select_prefetcher(PrefetchDisableList {
+        inplace: false,
+        append: true,
+    });
+    p.prefetch(&PathBuf::from("/nonexistent"));
+}
+
+#[cfg(not(all(unix, feature = "basis-readahead")))]
+#[test]
+fn select_returns_null_when_feature_off() {
+    // With the feature off the enabled path must still be Null - no threads,
+    // no behavior change. This exercises the default production build.
+    let p = select_prefetcher(PrefetchDisableList {
+        inplace: false,
+        append: false,
+    });
+    p.prefetch(&PathBuf::from("/nonexistent"));
+}
+
+#[cfg(all(unix, feature = "basis-readahead"))]
+mod fadvise_active {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn fadvise_prefetcher_hints_and_joins_cleanly() {
+        let mut temp = NamedTempFile::new().expect("temp file");
+        temp.write_all(&[0u8; 64 * 1024]).expect("write");
+        temp.flush().expect("flush");
+        let path = temp.path().to_path_buf();
+
+        let prefetcher = FadviseWillneedPrefetcher::new(PREFETCH_DEPTH).expect("spawn worker");
+        prefetcher.prefetch(&path);
+        // A missing path must be a silent no-op, not a panic.
+        prefetcher.prefetch(&PathBuf::from("/nonexistent/basis/file"));
+        // Dropping joins the worker; the test hangs if join deadlocks.
+        drop(prefetcher);
+    }
+
+    #[test]
+    fn fadvise_prefetcher_handles_many_paths_with_backpressure() {
+        let prefetcher = FadviseWillneedPrefetcher::new(PREFETCH_DEPTH).expect("spawn worker");
+        // Enqueue far more than the channel depth; try_send must never block.
+        for _ in 0..1000 {
+            prefetcher.prefetch(&PathBuf::from("/nonexistent"));
+        }
+        drop(prefetcher);
+    }
+
+    #[test]
+    fn fadvise_prefetcher_hints_a_real_basis_file() {
+        // Exercise the active prefetcher directly (what select_prefetcher
+        // returns when the env gate is on). Env mutation is avoided because the
+        // crate denies unsafe; the gate is covered by construction here.
+        let mut temp = NamedTempFile::new().expect("temp file");
+        temp.write_all(&[0u8; 128 * 1024]).expect("write");
+        temp.flush().expect("flush");
+
+        let prefetcher = FadviseWillneedPrefetcher::new(PREFETCH_DEPTH).expect("spawn worker");
+        prefetcher.prefetch(temp.path());
+        drop(prefetcher);
+    }
+}

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -120,6 +120,7 @@ pub(crate) fn is_early_close_error(e: &io::Error) -> bool {
     generator::is_early_close_error(e)
 }
 
+pub mod basis_prefetch;
 mod compressed_reader;
 mod compressed_writer;
 pub mod config;

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -107,6 +107,17 @@ impl ReceiverContext {
         let mut file_iter = files_to_transfer.into_iter();
         let mut pending_files_info: VecDeque<(usize, PathBuf, &FileEntry, u32)> =
             VecDeque::with_capacity(pipeline.window_size());
+
+        // Basis read-ahead prefetch (default-off, feature-gated). Selecting the
+        // prefetcher never changes wire output: `posix_fadvise(WILLNEED)` is a
+        // pure page-cache timing hint. Disabled for --inplace / --append (a
+        // file's write mutates a later file's basis) and on the redo pass
+        // (redo requests carry no basis).
+        let prefetcher =
+            crate::basis_prefetch::select_prefetcher(crate::basis_prefetch::PrefetchDisableList {
+                inplace: request_config.inplace,
+                append: request_config.append,
+            });
         let mut files_transferred = 0usize;
         let mut bytes_received = 0u64;
         let mut total_literal_bytes = 0u64;
@@ -240,6 +251,22 @@ impl ReceiverContext {
                                 })
                                 .collect()
                         };
+
+                        // Basis read-ahead: warm the resolved basis paths for the
+                        // look-ahead window (this batch) so the disk-commit stage
+                        // finds their pages in cache instead of blocking on serial
+                        // reads. Uses BasisFileResult::basis_path (the RESOLVED
+                        // path - fuzzy/reference-dir aware), not a naive dest/name.
+                        // No-op (NullPrefetcher) on the default build. Bounded to
+                        // PREFETCH_DEPTH entries to match the channel depth.
+                        for basis_result in sig_results
+                            .iter()
+                            .take(crate::basis_prefetch::PREFETCH_DEPTH)
+                        {
+                            if let Some(ref basis_path) = basis_result.basis_path {
+                                prefetcher.prefetch(basis_path);
+                            }
+                        }
 
                         // Send requests sequentially (wire order matters).
                         for ((file_idx, file_entry, file_path, base_iflags), basis_result) in


### PR DESCRIPTION
## Summary

The decoupled receiver pipeline is I/O-wait-bound: the main thread blocks **serially** on basis-file disk reads (`MapFile::open` -> `map_ptr` -> `folio_wait_bit_common`) during delta-token processing. Measurements show the disk at only ~66% util while ~33-40% of receiver wall-clock is spent waiting on those basis reads.

This PR issues `posix_fadvise(POSIX_FADV_WILLNEED)` on upcoming files' **resolved** basis paths ahead of time, so the kernel warms the page cache before the pipeline reaches each basis. This is the kernel-hint strategy: zero userspace memory, byte-identical output.

## Behavior

- **Default-OFF and feature-gated** behind `basis-readahead`. The default build compiles in only `NullPrefetcher` (empty impl), spawns no threads, and is byte-for-byte unchanged.
- **Runtime-activated** for bench: even when the feature is compiled in, the active prefetcher is only selected when `OC_RSYNC_BASIS_READAHEAD=1`. No CLI surface.
- **Correctness disable-list:** prefetch is forced to `NullPrefetcher` under `--inplace` and `--append` (writing one file mutates a later file's basis) and on the redo pass (redo requests carry no basis).
- **Byte-identical wire even when ON:** `fadvise(WILLNEED)` is a pure page-cache timing hint on local basis reads. It never changes the bytes read, so wire output and the reconstructed destination are identical. Stated in the module doc.

## Design

- `fast_io::willneed::hint_basis_willneed` - safe wrapper over `posix_fadvise` (Linux/Android; no-op on BSD/macOS/Windows, matching platform `libc` availability). The single `unsafe` block lives in the permitted `fast_io` crate; `transfer` stays `#![deny(unsafe_code)]`.
- `transfer::basis_prefetch` - `BasisPrefetcher` trait, `NullPrefetcher` default, and `FadviseWillneedPrefetcher` (Unix + feature) draining a bounded `std::sync::mpsc::sync_channel` on a background worker (depth 4 = backpressure; `Drop` closes + joins). Uses std rather than adding a dependency.
- Wired into `run_pipeline_loop_decoupled`: after signatures are computed (`!is_redo_pass`), the resolved `BasisFileResult.basis_path` for the look-ahead window is handed to the prefetcher. The send/response/token/disk-commit paths are untouched.

## Verification

- `cargo clippy -p fast_io` / `-p transfer` (default) / `-p transfer --features basis-readahead` - all clean with `-D warnings`.
- `cargo nextest -p fast_io -E 'test(willneed)|test(hint)'` - 4 passed.
- `cargo nextest -p transfer [--features basis-readahead] -E 'test(basis_prefetch)|test(prefetch)'` - 6 passed (feature on), 4 passed (default, incl. feature-off Null selector).
- `cargo check -p bin --features basis-readahead` - workspace passthrough resolves.

## Follow-up

An lxhost A/B bench and the default-on decision are deliberately left as follow-up. This PR does **not** flip the default.