### PR TITLE
fix(core): send --ignore-times as compact 'I' flag over remote shell

### DIFF
--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -404,9 +404,8 @@ impl<'a> RemoteInvocationBuilder<'a> {
         if self.config.size_only() {
             args.push(OsString::from("--size-only"));
         }
-        if self.config.ignore_times() {
-            args.push(OsString::from("--ignore-times"));
-        }
+        // upstream: options.c:2711-2712 - --ignore-times is emitted as the
+        // compact `I` letter in build_flag_string(), not as a long-form arg.
         if self.config.ignore_existing() {
             args.push(OsString::from("--ignore-existing"));
         }
@@ -737,6 +736,14 @@ impl<'a> RemoteInvocationBuilder<'a> {
         // upstream: options.c:2707-2708 - always_checksum.
         if self.config.checksum() {
             flags.push('c');
+        }
+        // upstream: options.c:2711-2712 - ignore_times rides in the compact
+        // flag string as `I`, NOT as a long-form `--ignore-times`. Emitting the
+        // long form lands `--ignore-times` as a positional path on the remote
+        // server's arg parser (link_stat "--ignore-times" failed), so the
+        // compact letter is mandatory here.
+        if self.config.ignore_times() {
+            flags.push('I');
         }
         // upstream: options.c:2713-2714 - relative_paths.
         if effective_relative {

--- a/crates/core/src/client/remote/invocation/tests.rs
+++ b/crates/core/src/client/remote/invocation/tests.rs
@@ -465,7 +465,6 @@ const UPSTREAM_SERVER_LONG_ARGS: &[&str] = &[
     "--trust-sender",
     "--checksum-seed",
     "--size-only",
-    "--ignore-times",
     "--ignore-existing",
     "--existing",
     "--ignore-missing-args",
@@ -1642,13 +1641,22 @@ fn includes_munge_links_long_arg() {
     );
 }
 
+/// upstream: options.c:2711-2712 - `--ignore-times` is emitted as the compact
+/// `I` letter in the flag string, never as a long-form `--ignore-times` arg.
+/// The long form leaks onto the remote server's positional path list
+/// (`link_stat "--ignore-times" failed`), so the compact letter is required.
 #[test]
-fn includes_ignore_times_long_arg() {
+fn ignore_times_rides_compact_flag_not_long_arg() {
     let config = ClientConfig::builder().ignore_times(true).build();
     let args = build_sender_args(&config);
     assert!(
-        args.iter().any(|a| a == "--ignore-times"),
-        "expected --ignore-times in args: {args:?}"
+        args.iter()
+            .any(|a| a.starts_with('-') && !a.starts_with("--") && a.contains('I')),
+        "expected 'I' in the compact flag string: {args:?}"
+    );
+    assert!(
+        !args.iter().any(|a| a == "--ignore-times"),
+        "must not emit long-form --ignore-times: {args:?}"
     );
 }
 
@@ -2258,6 +2266,8 @@ fn all_flags_enabled_produces_valid_invocation() {
         ('r', "recursive"),
         ('z', "compress"),
         ('c', "checksum"),
+        // upstream: options.c:2711-2712 - ignore_times rides as compact 'I'.
+        ('I', "ignore_times"),
         ('H', "hard_links"),
         ('n', "dry_run"),
         ('W', "whole_file"),
@@ -2306,7 +2316,6 @@ fn all_flags_enabled_produces_valid_invocation() {
         "--safe-links",
         "--munge-links",
         "--size-only",
-        "--ignore-times",
         "--ignore-existing",
         "--existing",
         "--remove-source-files",


### PR DESCRIPTION
The remote-shell invocation builder emitted --ignore-times as a long-form argument, which the server-side arg parser does not recognise. The flag leaked into the positional path list and the sender aborted with link_stat "--ignore-times" failed (exit 23).

Emit ignore_times as the compact 'I' letter in the flag string instead, matching upstream options.c:2711-2712 (argstr[x++] = 'I'). Drop the erroneous long-form push.

<!--
Title format: <prefix>(<scope>): <imperative summary>
Conventional prefix is load-bearing - a labeler workflow categorizes release
notes from it. Keep titles under 70 characters; put detail in the body.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

- 1-3 bullets describing what changes and why.

## Test plan

- [ ] CI: fmt + clippy, nextest (stable), Windows, macOS, Linux musl.
- [ ] Add targeted local repro steps if applicable: `cargo nextest run -p <crate> -E 'test(<pattern>)'`.

## Coordination

- Related PRs / issues:
- Depends on:
- Blocked by:

## Conventional commit prefix

Pick one; PR title prefix must match the change category:

- `feat:` - new user-visible feature
- `fix:` - bug fix
- `perf:` - performance improvement
- `refactor:` - non-functional restructuring
- `docs:` - documentation only
- `test:` - tests only
- `style:` - formatting / lints, no behaviour change
- `chore:` - tooling, deps, housekeeping
- `ci:` - CI configuration

## Security considerations

Fill only if this PR touches `SECURITY.md`, daemon code, sandbox / `*at`
helpers, auth, or anything in the SEC-1 chain. Otherwise delete this section.

- Threat surface affected:
- Mitigations / tests added:
- Cross-references (`SECURITY.md`, design docs):

## Pre-merge checklist

- [ ] Conventional commit prefix on PR title matches the change category.
- [ ] `cargo fmt --all` run locally.
- [ ] `CHANGELOG.md` updated if user-visible.
- [ ] `SECURITY.md` updated if security-relevant.
- [ ] No references to internal tooling or non-human authoring aids; hyphens, not em-dashes.
