### PR TITLE
feat(logging): oc-specific --debug categories for accelerated-I/O fallback visibility

### DIFF
--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -32,6 +32,11 @@ pub(crate) struct DebugFlagSettings {
     pub(crate) recv: Option<u8>,
     pub(crate) send: Option<u8>,
     pub(crate) time: Option<u8>,
+    // oc-specific accelerated-I/O fallback visibility categories.
+    pub(crate) iouring: Option<u8>,
+    pub(crate) clone: Option<u8>,
+    pub(crate) sockopt: Option<u8>,
+    pub(crate) iocp: Option<u8>,
     pub(crate) help_requested: bool,
 }
 
@@ -67,6 +72,10 @@ impl DebugFlagSettings {
             ("recv", self.recv),
             ("send", self.send),
             ("time", self.time),
+            ("iouring", self.iouring),
+            ("clone", self.clone),
+            ("sockopt", self.sockopt),
+            ("iocp", self.iocp),
         ]
         .into_iter()
         .filter_map(|(name, level)| level.filter(|&l| l > 0).map(|l| (name, l)))
@@ -99,6 +108,10 @@ impl DebugFlagSettings {
         self.recv = Some(level);
         self.send = Some(level);
         self.time = Some(level);
+        self.iouring = Some(level);
+        self.clone = Some(level);
+        self.sockopt = Some(level);
+        self.iocp = Some(level);
     }
 
     const fn disable_all(&mut self) {
@@ -126,6 +139,10 @@ impl DebugFlagSettings {
         self.recv = Some(0);
         self.send = Some(0);
         self.time = Some(0);
+        self.iouring = Some(0);
+        self.clone = Some(0);
+        self.sockopt = Some(0);
+        self.iocp = Some(0);
     }
 
     pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
@@ -181,6 +198,10 @@ impl DebugFlagSettings {
             "recv" => self.recv = Some(level),
             "send" => self.send = Some(level),
             "time" => self.time = Some(level),
+            "iouring" => self.iouring = Some(level),
+            "clone" => self.clone = Some(level),
+            "sockopt" => self.sockopt = Some(level),
+            "iocp" => self.iocp = Some(level),
             _ => return Err(debug_flag_error(display)),
         }
 
@@ -192,7 +213,7 @@ impl DebugFlagSettings {
     const KNOWN_FLAGS: &'static [&'static str] = &[
         "acl", "backup", "bind", "chdir", "connect", "cmd", "del", "deltasum", "dup", "exit",
         "filter", "flist", "fuzzy", "genr", "hash", "hlink", "iconv", "io", "nstr", "own", "proto",
-        "recv", "send", "time",
+        "recv", "send", "time", "iouring", "clone", "sockopt", "iocp",
     ];
 
     pub(super) fn parse_flag_and_level<'a>(&self, input: &'a str) -> (&'a str, u8) {
@@ -303,4 +324,10 @@ Options added at each level of verbosity:\n\
 2) BIND,CONNECT,CMD,DEL,DELTASUM,DUP,FILTER,FLIST,ICONV\n\
 3) ACL,BACKUP,CONNECT2,DEL2,DELTASUM2,EXIT,FILTER2,FLIST2,FUZZY,GENR,OWN,RECV,SEND,TIME\n\
 4) CMD2,DEL3,DELTASUM3,EXIT2,FLIST3,ICONV2,OWN2,PROTO,TIME2\n\
-5) CHDIR,DELTASUM4,FLIST4,FUZZY2,HASH,HLINK\n";
+5) CHDIR,DELTASUM4,FLIST4,FUZZY2,HASH,HLINK\n\
+\n\
+oc-rsync extensions (accelerated-I/O fallback visibility):\n\
+IOURING    Debug io_uring probe and dispatch-vs-fallback decisions\n\
+CLONE      Debug clonefile/reflink/copy_file_range CoW dispatch and fallback\n\
+SOCKOPT    Debug TCP/socket tuning apply-or-skip decisions\n\
+IOCP       Debug Windows IOCP dispatch and fallback\n";

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -207,6 +207,32 @@ fn debug_accepts_comma_separated_tokens() {
 }
 
 #[test]
+fn debug_accepts_oc_accelerated_io_categories() {
+    let flags = vec![OsString::from("iouring,clone,sockopt,iocp")];
+    let settings = parse_debug_flags(&flags).expect("flags parse");
+    assert_eq!(settings.iouring, Some(1));
+    assert_eq!(settings.clone, Some(1));
+    assert_eq!(settings.sockopt, Some(1));
+    assert_eq!(settings.iocp, Some(1));
+
+    // Case-insensitive parsing mirrors upstream parse_output_words().
+    let flags = vec![OsString::from("IOURING,CLONE")];
+    let settings = parse_debug_flags(&flags).expect("flags parse");
+    assert_eq!(settings.iouring, Some(1));
+    assert_eq!(settings.clone, Some(1));
+}
+
+#[test]
+fn debug_all_includes_oc_accelerated_io_categories() {
+    let flags = vec![OsString::from("all")];
+    let settings = parse_debug_flags(&flags).expect("flags parse");
+    assert_eq!(settings.iouring, Some(1));
+    assert_eq!(settings.clone, Some(1));
+    assert_eq!(settings.sockopt, Some(1));
+    assert_eq!(settings.iocp, Some(1));
+}
+
+#[test]
 fn debug_flist_levels() {
     let flags = vec![OsString::from("flist")];
     let settings = parse_debug_flags(&flags).expect("flags parse");

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -195,7 +195,20 @@ fn bind_with_backlog(
     // has no equivalent, so the call is skipped there.
     #[cfg(unix)]
     if fast_io::reuse_port_supported() {
-        let _ = socket.set_reuse_port(true);
+        match socket.set_reuse_port(true) {
+            Ok(()) => logging::debug_log!(Sockopt, 1, "SO_REUSEPORT set on listener {addr}"),
+            Err(_) => logging::debug_log!(
+                Sockopt,
+                1,
+                "SO_REUSEPORT apply failed on listener {addr}: single-listener fallback"
+            ),
+        }
+    } else {
+        logging::debug_log!(
+            Sockopt,
+            1,
+            "SO_REUSEPORT unsupported on this platform: skipped for listener {addr}"
+        );
     }
 
     // For IPv6 sockets, set IPV6_V6ONLY to avoid conflicts with the separate

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -127,6 +127,12 @@ pub(super) fn try_clone(
     let Some(clone_method) = clone_method else {
         // clonefile failed (cross-device, non-APFS, etc.) - caller falls
         // through to normal copy path.
+        debug_log!(
+            Clone,
+            1,
+            "CoW clone unavailable for {}: using standard copy",
+            record_path.display()
+        );
         return Ok(false);
     };
 
@@ -135,6 +141,13 @@ pub(super) fn try_clone(
         Send,
         1,
         "cloned {}: {} bytes (CoW)",
+        record_path.display(),
+        file_size
+    );
+    debug_log!(
+        Clone,
+        1,
+        "CoW clone succeeded: dst={} ({} bytes)",
         record_path.display(),
         file_size
     );

--- a/crates/fast_io/src/io_uring/config.rs
+++ b/crates/fast_io/src/io_uring/config.rs
@@ -306,6 +306,11 @@ pub fn is_io_uring_available() -> bool {
     IO_URING_AVAILABLE.store(available, Ordering::Relaxed);
     IO_URING_CHECKED.store(true, Ordering::Relaxed);
     logging::debug_log!(Io, 1, "{reason}");
+    if available {
+        logging::debug_log!(Iouring, 1, "io_uring available: {reason}");
+    } else {
+        logging::debug_log!(Iouring, 1, "io_uring unavailable: {reason}");
+    }
     available
 }
 

--- a/crates/fast_io/src/iocp/config.rs
+++ b/crates/fast_io/src/iocp/config.rs
@@ -190,6 +190,11 @@ fn probe_iocp() -> bool {
 
     if handle.is_null() {
         IOCP_STATUS.store(UNAVAILABLE, Ordering::Relaxed);
+        logging::debug_log!(
+            Iocp,
+            1,
+            "IOCP unavailable: CreateIoCompletionPort failed - using standard I/O"
+        );
         return false;
     }
 
@@ -204,6 +209,7 @@ fn probe_iocp() -> bool {
     SKIP_EVENT_AVAILABLE.store(true, Ordering::Relaxed);
 
     IOCP_STATUS.store(AVAILABLE, Ordering::Relaxed);
+    logging::debug_log!(Iocp, 1, "IOCP available (Windows): dispatching IOCP writer");
     true
 }
 

--- a/crates/fast_io/src/socket_options.rs
+++ b/crates/fast_io/src/socket_options.rs
@@ -433,11 +433,17 @@ pub fn set_tcp_quickack(stream: &TcpStream) -> io::Result<bool> {
     #[cfg(target_os = "linux")]
     {
         set_socket_int_option(stream, libc::IPPROTO_TCP, libc::TCP_QUICKACK, 1)?;
+        logging::debug_log!(Sockopt, 1, "TCP_QUICKACK set");
         Ok(true)
     }
     #[cfg(not(target_os = "linux"))]
     {
         let _ = stream;
+        logging::debug_log!(
+            Sockopt,
+            1,
+            "TCP_QUICKACK unsupported on this platform: skipped"
+        );
         Ok(false)
     }
 }
@@ -484,11 +490,17 @@ pub fn set_so_max_pacing_rate(stream: &TcpStream, bytes_per_sec: u32) -> io::Res
             libc::SO_MAX_PACING_RATE,
             bytes_per_sec as i32,
         )?;
+        logging::debug_log!(Sockopt, 1, "SO_MAX_PACING_RATE set: {bytes_per_sec} B/s");
         Ok(true)
     }
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (stream, bytes_per_sec);
+        logging::debug_log!(
+            Sockopt,
+            1,
+            "SO_MAX_PACING_RATE unsupported on this platform: skipped"
+        );
         Ok(false)
     }
 }
@@ -616,16 +628,23 @@ pub fn set_tcp_cork(stream: &TcpStream, cork: bool) -> io::Result<bool> {
     #[cfg(target_os = "linux")]
     {
         set_socket_int_option(stream, libc::IPPROTO_TCP, libc::TCP_CORK, i32::from(cork))?;
+        logging::debug_log!(Sockopt, 1, "TCP_CORK set: cork={cork}");
         Ok(true)
     }
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     {
         set_socket_int_option(stream, libc::IPPROTO_TCP, libc::TCP_NOPUSH, i32::from(cork))?;
+        logging::debug_log!(Sockopt, 1, "TCP_NOPUSH set: cork={cork}");
         Ok(true)
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "freebsd")))]
     {
         let _ = (stream, cork);
+        logging::debug_log!(
+            Sockopt,
+            1,
+            "TCP output corking unsupported on this platform: skipped"
+        );
         Ok(false)
     }
 }

--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -265,6 +265,11 @@ impl VerbosityConfig {
             "recv" => DebugFlag::Recv,
             "send" => DebugFlag::Send,
             "time" => DebugFlag::Time,
+            // oc-specific accelerated-I/O fallback visibility categories.
+            "iouring" => DebugFlag::Iouring,
+            "clone" => DebugFlag::Clone,
+            "sockopt" => DebugFlag::Sockopt,
+            "iocp" => DebugFlag::Iocp,
             _ => return Err(format!("unknown debug flag: {name}")),
         };
 
@@ -380,6 +385,21 @@ mod tests {
         assert_eq!(config.debug.flist, 3);
 
         assert!(config.apply_debug_flag("invalid").is_err());
+    }
+
+    #[test]
+    fn test_apply_oc_accelerated_io_debug_flags() {
+        let mut config = VerbosityConfig::default();
+
+        config.apply_debug_flag("iouring").unwrap();
+        config.apply_debug_flag("clone2").unwrap();
+        config.apply_debug_flag("SOCKOPT").unwrap();
+        config.apply_debug_flag("iocp").unwrap();
+
+        assert_eq!(config.debug.iouring, 1);
+        assert_eq!(config.debug.clone, 2);
+        assert_eq!(config.debug.sockopt, 1);
+        assert_eq!(config.debug.iocp, 1);
     }
 
     #[test]

--- a/crates/logging/src/levels/debug.rs
+++ b/crates/logging/src/levels/debug.rs
@@ -63,6 +63,14 @@ pub enum DebugFlag {
     Send,
     /// Timing information.
     Time,
+    /// io_uring probe and dispatch-vs-fallback decisions (oc-specific).
+    Iouring,
+    /// clonefile / reflink / copy_file_range CoW dispatch and fallback (oc-specific).
+    Clone,
+    /// TCP/socket tuning apply-or-skip decisions (oc-specific).
+    Sockopt,
+    /// Windows IOCP dispatch and fallback (oc-specific).
+    Iocp,
 }
 
 /// Per-flag debug verbosity levels.
@@ -122,6 +130,14 @@ pub struct DebugLevels {
     pub send: u8,
     /// Timing information level.
     pub time: u8,
+    /// io_uring probe/dispatch level (oc-specific).
+    pub iouring: u8,
+    /// clonefile/reflink/copy_file_range CoW level (oc-specific).
+    pub clone: u8,
+    /// Socket tuning level (oc-specific).
+    pub sockopt: u8,
+    /// Windows IOCP dispatch level (oc-specific).
+    pub iocp: u8,
 }
 
 impl DebugLevels {
@@ -153,6 +169,10 @@ impl DebugLevels {
             DebugFlag::Recv => self.recv,
             DebugFlag::Send => self.send,
             DebugFlag::Time => self.time,
+            DebugFlag::Iouring => self.iouring,
+            DebugFlag::Clone => self.clone,
+            DebugFlag::Sockopt => self.sockopt,
+            DebugFlag::Iocp => self.iocp,
         }
     }
 
@@ -183,6 +203,10 @@ impl DebugLevels {
             DebugFlag::Recv => self.recv = level,
             DebugFlag::Send => self.send = level,
             DebugFlag::Time => self.time = level,
+            DebugFlag::Iouring => self.iouring = level,
+            DebugFlag::Clone => self.clone = level,
+            DebugFlag::Sockopt => self.sockopt = level,
+            DebugFlag::Iocp => self.iocp = level,
         }
     }
 
@@ -212,6 +236,10 @@ impl DebugLevels {
         self.recv = level;
         self.send = level;
         self.time = level;
+        self.iouring = level;
+        self.clone = level;
+        self.sockopt = level;
+        self.iocp = level;
     }
 }
 
@@ -263,6 +291,26 @@ mod tests {
         fn debug_flag_equality() {
             assert_eq!(DebugFlag::Acl, DebugFlag::Acl);
             assert_ne!(DebugFlag::Acl, DebugFlag::Backup);
+        }
+
+        #[test]
+        fn oc_debug_flags_get_set_roundtrip() {
+            let mut levels = DebugLevels::default();
+            for flag in [
+                DebugFlag::Iouring,
+                DebugFlag::Clone,
+                DebugFlag::Sockopt,
+                DebugFlag::Iocp,
+            ] {
+                assert_eq!(levels.get(flag), 0);
+                levels.set(flag, 3);
+                assert_eq!(levels.get(flag), 3);
+            }
+            levels.set_all(5);
+            assert_eq!(levels.get(DebugFlag::Iouring), 5);
+            assert_eq!(levels.get(DebugFlag::Clone), 5);
+            assert_eq!(levels.get(DebugFlag::Sockopt), 5);
+            assert_eq!(levels.get(DebugFlag::Iocp), 5);
         }
     }
 
@@ -325,6 +373,10 @@ mod tests {
                 recv: 22,
                 send: 23,
                 time: 24,
+                iouring: 25,
+                clone: 26,
+                sockopt: 27,
+                iocp: 28,
             };
 
             assert_eq!(levels.get(DebugFlag::Acl), 1);
@@ -351,6 +403,10 @@ mod tests {
             assert_eq!(levels.get(DebugFlag::Recv), 22);
             assert_eq!(levels.get(DebugFlag::Send), 23);
             assert_eq!(levels.get(DebugFlag::Time), 24);
+            assert_eq!(levels.get(DebugFlag::Iouring), 25);
+            assert_eq!(levels.get(DebugFlag::Clone), 26);
+            assert_eq!(levels.get(DebugFlag::Sockopt), 27);
+            assert_eq!(levels.get(DebugFlag::Iocp), 28);
         }
 
         #[test]

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -298,6 +298,35 @@ mod tests {
     }
 
     #[test]
+    fn oc_accelerated_io_debug_flags_gated_off_by_default() {
+        init(VerbosityConfig::default());
+        drain_events();
+
+        // Default config leaves oc-specific categories at level 0, so a
+        // gated debug_log! must be a no-op and emit nothing.
+        for flag in [
+            DebugFlag::Iouring,
+            DebugFlag::Clone,
+            DebugFlag::Sockopt,
+            DebugFlag::Iocp,
+        ] {
+            assert!(!debug_gte(flag, 1));
+        }
+        crate::debug_log!(Iouring, 1, "should not emit");
+        crate::debug_log!(Clone, 1, "should not emit");
+        crate::debug_log!(Sockopt, 1, "should not emit");
+        crate::debug_log!(Iocp, 1, "should not emit");
+        assert!(drain_events().is_empty());
+
+        // Enabling the category makes the same call emit exactly one event.
+        let mut config = VerbosityConfig::default();
+        config.debug.clone = 1;
+        init(config);
+        crate::debug_log!(Clone, 1, "CoW clone succeeded");
+        assert_eq!(drain_events().len(), 1);
+    }
+
+    #[test]
     fn multiple_events_ordering() {
         init(VerbosityConfig::default());
         drain_events();


### PR DESCRIPTION
## Summary

Adds four oc-rsync-specific `--debug` categories that reuse the existing
`DEBUG_GTE`-style mechanism to give operators visibility into which
accelerated-I/O path ran versus fell back to the standard path. Real oc
features only - no categories for anything that does not exist.

Categories (plain UPPERCASE, matching upstream's DEBUG category style):

| Category | Covers |
|----------|--------|
| `IOURING` | io_uring probe availability and dispatch-vs-fallback |
| `CLONE`   | clonefile / FICLONE reflink / copy_file_range CoW dispatch and fallback |
| `SOCKOPT` | TCP/socket tuning apply-or-skip (QUICKACK, SO_MAX_PACING_RATE, TCP_CORK/NOPUSH, SO_REUSEPORT) |
| `IOCP`    | Windows IOCP dispatch and fallback |

## Mechanism reused (not reinvented)

- Category enum: `crates/logging/src/levels/debug.rs` (`DebugFlag` + `DebugLevels` get/set/set_all)
- Runtime gate: `crates/logging/src/thread_local.rs` `debug_gte`
- Emit facade: `crates/logging/src/macros.rs` `debug_log!`
- Logging parser: `crates/logging/src/config.rs` `apply_debug_flag`
- CLI parser/validator + `--debug=help`: `crates/cli/src/frontend/execution/flags/debug.rs`
- CLI runtime wiring: `crates/cli/src/frontend/execution/drive/options.rs`

## Emit sites

- `fast_io/src/io_uring/config.rs` - probe result (available vs unavailable), `IOURING`
- `engine/.../execute/clonefile.rs` - CoW attempt success and fall-through, `CLONE`
- `fast_io/src/socket_options.rs` - QUICKACK / pacing / cork apply-or-skip, `SOCKOPT`
- `daemon/.../server_runtime/listener.rs` - SO_REUSEPORT apply/skip on the listener, `SOCKOPT`
- `fast_io/src/iocp/config.rs` - IOCP probe dispatch vs fallback, `IOCP`

Messages are terse and factual, naming the primitive and outcome (e.g.
`TCP_QUICKACK set`, `CoW clone succeeded: dst=... (N bytes)`,
`io_uring unavailable: ...`).

## Design

- **Additive, default-off, zero-cost.** With no `--debug` category selected the
  `debug_gte` gate short-circuits before any formatting, so there is no
  behaviour or output change and no runtime cost on the default path.
- **DIP.** `fast_io`, `engine`, and `daemon` already depend on `logging` and
  emit through the safe `debug_log!` facade. No new global logger, no
  low-level -> high-level dependency, and no unsafe added to any crate.
- **Upstream fidelity.** The upstream `--debug=help` block is preserved
  byte-for-byte; the oc categories are listed in a clearly separated
  "oc-rsync extensions" section appended after it.

## Verification

- `cargo fmt --all`
- `cargo clippy` (all-features + default-features) on logging/fast_io/engine/cli/daemon: clean
  (one pre-existing `manual_ok_err` default-feature lint in an untouched daemon file is unrelated)
- `cargo nextest -p logging -p cli -E 'test(debug)'`: 155 tests pass, including the
  `--debug=help` golden and new parser/gate tests
- Binary sanity: `--debug=clone -aX src/ dst/` prints the `CoW clone succeeded` line on a
  local clonefile copy; a run without `--debug` prints nothing extra

## Follow-up

Tier-2 categories (`SPILL`, `UNCACHE`, `SPARSE`) are intentionally out of scope
here and left as a documented follow-up. Separately, `--debug=all` does not
expand to per-category levels in the runtime apply path - a pre-existing gap
that affects the upstream categories identically (e.g. `deltasum`), so it is
not addressed in this change.