### PR TITLE
feat(daemon): wire async accept path to real per-connection worker

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,6 +42,15 @@ iconv = ["core/iconv"]
 # Also enables engine optimization features for maximum performance
 parallel = ["engine/lazy-metadata", "checksums/parallel"]
 
+# ============================================================================
+# Daemon Accept Path
+# ============================================================================
+# Compiles the daemon's hybrid tokio accept path. Opt-in and default-off; the
+# shipping binary still runs the synchronous accept loop unless the operator
+# also sets OC_RSYNC_ASYNC_DAEMON at runtime. Enables the async-vs-sync daemon
+# concurrency benchmark.
+async-daemon = ["daemon/async-daemon"]
+
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/daemon/src/cli.rs
+++ b/crates/daemon/src/cli.rs
@@ -92,6 +92,24 @@ where
         .arguments(parsed.remainder)
         .build();
 
+    // Opt-in async accept path for the TCP (non-stdio) daemon. Selected only
+    // when the `async-daemon` feature is compiled in and the operator sets
+    // `OC_RSYNC_ASYNC_DAEMON`; otherwise the daemon runs the default sync
+    // accept loop unchanged. Enables the async-vs-sync concurrency benchmark.
+    #[cfg(feature = "async-daemon")]
+    if std::env::var_os("OC_RSYNC_ASYNC_DAEMON").is_some() {
+        return match crate::daemon::run_async_daemon(config) {
+            Ok(()) => 0,
+            Err(error) => {
+                if write_message(error.message(), stderr).is_err() {
+                    let message = error.message();
+                    let _ = writeln!(stderr.writer_mut(), "{message}");
+                }
+                error.exit_code()
+            }
+        };
+    }
+
     match run_daemon(config) {
         Ok(()) => 0,
         Err(error) => {

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -416,44 +416,147 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
 
 /// Runs the daemon orchestration using the hybrid tokio listener.
 ///
-/// This is the implementation skeleton tracked under issue #1935. The
-/// configuration is parsed identically to [`run_daemon`], but the accept
+/// The configuration is parsed identically to [`run_daemon`], but the accept
 /// loop is hosted on a tokio multi-thread runtime via
-/// [`crate::async_listener::run_hybrid_listener`]. Each accepted connection
-/// is handed to the existing synchronous session handler through
-/// `tokio::task::spawn_blocking`, preserving the wire protocol, auth, and
-/// transfer pipeline unchanged.
+/// [`crate::async_listener::run_hybrid_listener`]. Each accepted connection is
+/// served by the existing synchronous session handler through
+/// `tokio::task::spawn_blocking` (see
+/// [`ConnectionContext::serve_one_connection`]), so the wire protocol, auth,
+/// and transfer pipeline stay byte-identical with the sync daemon; only the
+/// accept + task dispatch is asynchronous.
 ///
-/// # Status
+/// # Selection
 ///
-/// Skeleton. The default daemon CLI continues to dispatch through
-/// [`run_daemon`]; this entrypoint exists for the gated `async-daemon` CI
-/// builds and for downstream embedders that want to opt in early.
-/// Production rollout requires the trigger conditions documented in
-/// `docs/design/daemon-async-runtime-choice.md` (sustained >1k concurrent
-/// connections, blocking-pool measurements, two release cycles of green
-/// async-daemon CI).
+/// This entrypoint is not the default. The TCP daemon dispatch selects it only
+/// when the `async-daemon` cargo feature is compiled in **and** the
+/// `OC_RSYNC_ASYNC_DAEMON` environment variable is set; otherwise the daemon
+/// runs through [`run_daemon`]. It exists to enable the async-vs-sync daemon
+/// concurrency benchmark and for downstream embedders opting in early.
+///
+/// # Limitation: privileged modules unsupported
+///
+/// Privilege drop, chroot, and setuid/setgid are **not** plumbed through the
+/// async accept path. To avoid a silent security regression, this function
+/// fails closed: if any module sets `uid`, `gid`, or `use chroot = true`
+/// (the upstream default for `use chroot` is `true`), or a global daemon
+/// `uid`/`gid`/`chroot` is configured, it returns a `DaemonError` instructing
+/// the operator to use the synchronous daemon. Non-privileged modules
+/// (`use chroot = false`, no `uid`/`gid`) - the benchmark case - run fine.
 ///
 /// # Errors
 ///
-/// Returns a `DaemonError` if option parsing, config loading, runtime
-/// construction, or the initial socket bind fails.
+/// Returns a `DaemonError` if option parsing, config loading, capability
+/// preflight, runtime construction, or the initial socket bind fails, or when
+/// a privileged module is configured (see the limitation above).
 #[cfg(feature = "async-daemon")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-daemon")))]
 pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
     let external_signal_flags = config.take_signal_flags();
     let _ = config.take_pre_bound_listener();
-    let options = RuntimeOptions::parse_with_brand(
-        config.arguments(),
-        config.brand(),
-        config.load_default_paths(),
-    )?;
+    let brand = config.brand();
+    let options =
+        RuntimeOptions::parse_with_brand(config.arguments(), brand, config.load_default_paths())?;
 
     apply_verbosity(options.verbosity());
 
+    let max_connections = options.max_connections.map(NonZeroUsize::get);
+    let socket_options_str = options.socket_options().map(str::to_string);
     let RuntimeOptions {
-        bind_address, port, ..
+        bind_address,
+        port,
+        modules,
+        motd_lines,
+        bandwidth_limit,
+        bandwidth_burst,
+        log_file,
+        reverse_lookup,
+        lock_file,
+        proxy_protocol,
+        daemon_uid,
+        daemon_gid,
+        daemon_chroot,
+        ..
     } = options;
+
+    // Fail closed on privileged configuration: the async accept path does not
+    // perform chroot or setuid/setgid, so silently serving a privileged module
+    // would be a security regression. Reject up front with a clear message.
+    if daemon_uid.is_some() || daemon_gid.is_some() || daemon_chroot.is_some() {
+        return Err(async_privileged_module_error());
+    }
+
+    let log_sink = if let Some(path) = log_file {
+        Some(open_log_sink(&path, brand)?)
+    } else {
+        None
+    };
+
+    apply_startup_hardening(log_sink.as_ref());
+
+    let connection_limiter = if let Some(path) = lock_file {
+        Some(Arc::new(ConnectionLimiter::open(path)?))
+    } else {
+        None
+    };
+
+    let modules: Arc<Vec<ModuleRuntime>> = Arc::new(
+        modules
+            .into_iter()
+            .map(|definition| ModuleRuntime::new(definition, connection_limiter.clone()))
+            .collect(),
+    );
+
+    // Reject privileged per-module settings for the same reason as the global
+    // checks above.
+    for module in modules.iter() {
+        if module.definition.uid.is_some()
+            || module.definition.gid.is_some()
+            || module.definition.use_chroot
+        {
+            return Err(async_privileged_module_error());
+        }
+    }
+
+    // Same capability preflight the sync path runs before binding.
+    if let Err(reason) = preflight_required_capabilities(&modules) {
+        return Err(DaemonError::new(
+            FEATURE_UNAVAILABLE_EXIT_CODE,
+            rsync_error!(
+                FEATURE_UNAVAILABLE_EXIT_CODE,
+                format!("oc-rsyncd: error: {reason}")
+            )
+            .with_role(Role::Daemon),
+        ));
+    }
+
+    let client_socket_options: Arc<Vec<SocketOption>> =
+        if let Some(ref opts_str) = socket_options_str {
+            let parsed = parse_socket_options(opts_str).map_err(|msg| {
+                DaemonError::new(
+                    FEATURE_UNAVAILABLE_EXIT_CODE,
+                    rsync_error!(
+                        FEATURE_UNAVAILABLE_EXIT_CODE,
+                        format!("invalid socket options: {msg}")
+                    )
+                    .with_role(Role::Daemon),
+                )
+            })?;
+            Arc::new(parsed)
+        } else {
+            Arc::new(Vec::new())
+        };
+
+    let context = ConnectionContext::new(
+        modules,
+        Arc::new(motd_lines),
+        log_sink,
+        client_socket_options,
+        bandwidth_limit,
+        bandwidth_burst,
+        reverse_lookup,
+        proxy_protocol,
+    );
+
     let bind_addr = std::net::SocketAddr::new(bind_address, port);
     let worker_threads = std::thread::available_parallelism()
         .map(NonZeroUsize::get)
@@ -478,18 +581,28 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
     };
     let shutdown = Arc::clone(&signal_flags.shutdown);
 
-    // Skeleton handler: log the accepted peer and drop the stream. The
-    // real per-connection wiring lives behind a follow-up that exposes the
-    // sync session handler as a callable closure; see #1935 for the rollout
-    // checklist and `docs/design/daemon-tokio-async-listener-impl.md` for
-    // the integration plan.
-    let worker: crate::async_listener::SyncWorker = Arc::new(|stream, peer| {
-        eprintln!(
-            "async-daemon (skeleton): accepted {peer}, closing immediately [daemon={}]",
-            env!("CARGO_PKG_VERSION")
-        );
-        drop(stream);
-        Ok(())
+    // Bound concurrent in-flight connections to `max_connections` in addition
+    // to any per-module `ConnectionLimiter` already enforced inside the
+    // session handler, mirroring the sync path's daemon-level cap. `None`
+    // leaves dispatch unbounded (matching the sync default).
+    let admission = max_connections.map(|limit| Arc::new(tokio::sync::Semaphore::new(limit)));
+
+    let worker: crate::async_listener::SyncWorker = Arc::new(move |stream, peer| {
+        // Enforce the daemon-level connection cap by refusing to serve past
+        // the limit. Acquiring fails only when the semaphore is exhausted; on
+        // exhaustion write the same `@ERROR: max connections` refusal the sync
+        // path emits, then drop the connection.
+        let _permit = match admission.as_ref() {
+            Some(sem) => match Arc::clone(sem).try_acquire_owned() {
+                Ok(permit) => Some(permit),
+                Err(_) => {
+                    refuse_async_connection_at_capacity(stream, peer, max_connections);
+                    return Ok(());
+                }
+            },
+            None => None,
+        };
+        context.serve_one_connection(stream, peer)
     });
 
     crate::async_listener::run_hybrid_listener(bind_addr, worker_threads, shutdown, worker).map_err(
@@ -504,6 +617,47 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
             )
         },
     )
+}
+
+/// Builds the fail-closed error returned when the async daemon is asked to
+/// serve a privileged (`uid`/`gid`/`use chroot`) module.
+///
+/// The async accept path does not perform chroot or setuid/setgid, so serving
+/// such a module would silently skip the privilege drop. Refusing at startup
+/// keeps the security posture explicit.
+#[cfg(feature = "async-daemon")]
+fn async_privileged_module_error() -> DaemonError {
+    DaemonError::new(
+        FEATURE_UNAVAILABLE_EXIT_CODE,
+        rsync_error!(
+            FEATURE_UNAVAILABLE_EXIT_CODE,
+            "async-daemon does not support privileged (uid/gid/chroot) modules; \
+             use the sync daemon"
+                .to_owned()
+        )
+        .with_role(Role::Daemon),
+    )
+}
+
+/// Writes the upstream-compatible max-connections refusal to an accepted
+/// async socket, then lets it drop.
+///
+/// upstream: clientserver.c:752 - `@ERROR: max connections (%d) reached --
+/// try again later\n`. Mirrors the sync accept loop's `refuse_if_at_capacity`
+/// wording so clients see an identical reply regardless of accept engine.
+#[cfg(feature = "async-daemon")]
+fn refuse_async_connection_at_capacity(
+    mut stream: TcpStream,
+    _peer: SocketAddr,
+    limit: Option<usize>,
+) {
+    let limit = limit.unwrap_or(0);
+    let payload = format!(
+        "{}\n",
+        MODULE_MAX_CONNECTIONS_PAYLOAD.replace("{limit}", &limit.to_string())
+    );
+    let _ = stream.write_all(payload.as_bytes());
+    let _ = stream.flush();
 }
 
 include!("daemon/sections/cli_args.rs");

--- a/crates/daemon/src/daemon/sections/server_runtime.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime.rs
@@ -16,6 +16,8 @@ include!("server_runtime/reload.rs");
 
 include!("server_runtime/connection.rs");
 
+include!("server_runtime/connection_context.rs");
+
 include!("server_runtime/accept_engine.rs");
 
 include!("server_runtime/accept_loop.rs");

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -188,62 +188,29 @@ fn spawn_connection_worker(
     state: &AcceptLoopState<'_>,
 ) -> thread::JoinHandle<WorkerResult> {
     let peer_addr = normalize_peer_address(raw_peer_addr);
-    let modules = Arc::clone(&state.modules);
-    let motd_lines = Arc::clone(&state.motd_lines);
-    let log_for_worker = state.log_sink.as_ref().map(Arc::clone);
+    // Build the shareable per-connection context once; the same context type
+    // and `serve_session` core drive the async accept path, keeping the wire
+    // behaviour byte-identical across both accept engines.
+    let context = ConnectionContext::new(
+        Arc::clone(&state.modules),
+        Arc::clone(&state.motd_lines),
+        state.log_sink.as_ref().map(Arc::clone),
+        Arc::clone(&state.client_socket_options),
+        state.bandwidth_limit,
+        state.bandwidth_burst,
+        state.reverse_lookup,
+        state.proxy_protocol,
+    );
     let conn_guard = state.connection_counter.acquire();
-    let bandwidth_limit = state.bandwidth_limit;
-    let bandwidth_burst = state.bandwidth_burst;
-    let reverse_lookup = state.reverse_lookup;
-    let proxy_protocol = state.proxy_protocol;
 
     thread::spawn(move || {
         let _conn_guard = conn_guard;
-        // upstream rsync forks per connection, so a crash only
-        // kills that child.  We use threads, so catch_unwind
-        // isolates panics to the faulting connection and keeps
-        // the daemon alive.
-        let result = std::panic::catch_unwind(
-            std::panic::AssertUnwindSafe(|| {
-                let modules_vec = modules.as_ref();
-                let motd_vec = motd_lines.as_ref();
-                handle_session(
-                    stream,
-                    peer_addr,
-                    SessionParams {
-                        modules: modules_vec.as_slice(),
-                        motd_lines: motd_vec.as_slice(),
-                        daemon_limit: bandwidth_limit,
-                        daemon_burst: bandwidth_burst,
-                        log_sink: log_for_worker.clone(),
-                        reverse_lookup,
-                        proxy_protocol,
-                    },
-                )
-            }),
-        );
-        match result {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(error)) => {
-                Err((Some(peer_addr), error))
-            }
-            Err(payload) => {
-                let description =
-                    describe_panic_payload(payload);
-                if let Some(log) = log_for_worker.as_ref() {
-                    let text = format!(
-                        "connection handler for {peer_addr} \
-                         panicked: {description}"
-                    );
-                    let message = rsync_error!(
-                        SOCKET_IO_EXIT_CODE,
-                        text
-                    )
-                    .with_role(Role::Daemon);
-                    log_message(log, &message);
-                }
-                Ok(())
-            }
+        // upstream rsync forks per connection, so a crash only kills that
+        // child. `serve_session` isolates panics via `catch_unwind` so a
+        // faulting connection cannot tear down the daemon.
+        match context.serve_session(stream, raw_peer_addr) {
+            Ok(()) => Ok(()),
+            Err(error) => Err((Some(peer_addr), error)),
         }
     })
 }

--- a/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
@@ -1,0 +1,129 @@
+/// Shareable per-connection runtime context.
+///
+/// Groups every piece of daemon-wide state a single connection needs to run
+/// its full session (module table, MOTD, log sink, bandwidth limits, client
+/// socket options, and the reverse-lookup / PROXY-protocol toggles). All
+/// fields are owned or `Arc`-shared so the context can be cloned cheaply and
+/// handed to a worker on either the synchronous thread-per-connection accept
+/// loop or the tokio `spawn_blocking` async accept path.
+///
+/// The context is built once and shared; both accept paths run the same
+/// [`ConnectionContext::serve_session`] core so the per-connection wire
+/// behaviour (PROXY header parsing, greeting, module select, auth, transfer)
+/// is byte-identical regardless of which accept engine sourced the socket.
+#[derive(Clone)]
+struct ConnectionContext {
+    modules: Arc<Vec<ModuleRuntime>>,
+    motd_lines: Arc<Vec<String>>,
+    log_sink: Option<SharedLogSink>,
+    // Read only by the async accept path's `serve_one_connection`; the sync
+    // accept loop applies client socket options in `handle_accepted_connection`
+    // before wrapping the stream, so this field is unused in default builds.
+    #[cfg_attr(not(feature = "async-daemon"), allow(dead_code))]
+    client_socket_options: Arc<Vec<SocketOption>>,
+    bandwidth_limit: Option<NonZeroU64>,
+    bandwidth_burst: Option<NonZeroU64>,
+    reverse_lookup: bool,
+    proxy_protocol: bool,
+}
+
+impl ConnectionContext {
+    /// Builds the shared per-connection context from the resolved runtime
+    /// state assembled by the accept-loop startup sequence.
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        modules: Arc<Vec<ModuleRuntime>>,
+        motd_lines: Arc<Vec<String>>,
+        log_sink: Option<SharedLogSink>,
+        client_socket_options: Arc<Vec<SocketOption>>,
+        bandwidth_limit: Option<NonZeroU64>,
+        bandwidth_burst: Option<NonZeroU64>,
+        reverse_lookup: bool,
+        proxy_protocol: bool,
+    ) -> Self {
+        Self {
+            modules,
+            motd_lines,
+            log_sink,
+            client_socket_options,
+            bandwidth_limit,
+            bandwidth_burst,
+            reverse_lookup,
+            proxy_protocol,
+        }
+    }
+
+    /// Runs the full legacy `@RSYNCD:` session for one already-wrapped
+    /// connection under `catch_unwind` panic isolation.
+    ///
+    /// This is the shared session core used by both the synchronous
+    /// `spawn_connection_worker` and the async accept path. The caller is
+    /// responsible for having applied the accepted-stream socket tuning and
+    /// client socket options before wrapping the raw socket in `stream`.
+    ///
+    /// `raw_peer_addr` is the un-normalized accept-time address; the function
+    /// normalizes it exactly as the sync worker does. A panic escaping the
+    /// session is caught, logged, and swallowed so the daemon stays alive,
+    /// matching upstream's fork-per-connection crash isolation.
+    ///
+    /// upstream: clientserver.c - `start_daemon()` forks a child per
+    /// connection which runs `rsync_module()`.
+    fn serve_session(
+        &self,
+        stream: DaemonStream,
+        raw_peer_addr: SocketAddr,
+    ) -> io::Result<()> {
+        let peer_addr = normalize_peer_address(raw_peer_addr);
+        let log_for_worker = self.log_sink.clone();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            handle_session(
+                stream,
+                peer_addr,
+                SessionParams {
+                    modules: self.modules.as_slice(),
+                    motd_lines: self.motd_lines.as_slice(),
+                    daemon_limit: self.bandwidth_limit,
+                    daemon_burst: self.bandwidth_burst,
+                    log_sink: log_for_worker.clone(),
+                    reverse_lookup: self.reverse_lookup,
+                    proxy_protocol: self.proxy_protocol,
+                },
+            )
+        }));
+
+        match result {
+            Ok(inner) => inner,
+            Err(payload) => {
+                let description = describe_panic_payload(payload);
+                if let Some(log) = log_for_worker.as_ref() {
+                    let text =
+                        format!("connection handler for {peer_addr} panicked: {description}");
+                    let message =
+                        rsync_error!(SOCKET_IO_EXIT_CODE, text).with_role(Role::Daemon);
+                    log_message(log, &message);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Serves a single accepted connection from a raw `TcpStream`.
+    ///
+    /// Applies the accepted-stream socket tuning and client socket options,
+    /// wraps the socket in a [`DaemonStream`], and delegates to
+    /// [`ConnectionContext::serve_session`]. This is the entry point used by
+    /// the async accept path, which receives raw sockets from the tokio
+    /// listener and has already enforced admission control before dispatch.
+    #[cfg(feature = "async-daemon")]
+    fn serve_one_connection(
+        &self,
+        tcp_stream: TcpStream,
+        raw_peer_addr: SocketAddr,
+    ) -> io::Result<()> {
+        apply_accepted_stream_tcp_notsent_lowat(&tcp_stream);
+        let stream = DaemonStream::plain(tcp_stream);
+        apply_client_options(&stream, &self.client_socket_options, self.log_sink.as_ref());
+        self.serve_session(stream, raw_peer_addr)
+    }
+}

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -243,6 +243,8 @@ include!("tests/chunks/daemon_hardlinks_relative_receive.rs");
 // Daemon itemize end-to-end tests
 include!("tests/chunks/daemon_itemize_push.rs");
 include!("tests/chunks/daemon_itemize_pull.rs");
+// Hybrid async accept path end-to-end tests (feature = "async-daemon")
+include!("tests/chunks/daemon_async_push_pull.rs");
 // Daemon delta transfer end-to-end test
 include!("tests/chunks/daemon_delta_transfer.rs");
 // Daemon mode negotiation tests

--- a/crates/daemon/src/tests/chunks/daemon_async_push_pull.rs
+++ b/crates/daemon/src/tests/chunks/daemon_async_push_pull.rs
@@ -1,0 +1,178 @@
+/// Integration coverage for the hybrid async accept path
+/// ([`crate::run_async_daemon`]).
+///
+/// Boots the async daemon on an ephemeral loopback port with a single
+/// non-privileged (`use chroot = false`) read-write module, then drives a real
+/// push and pull through it via `core::client::run_client`. The transferred
+/// bytes must be identical in both directions, proving the async accept path
+/// serves genuine sessions with the same wire behaviour as the sync daemon
+/// (only accept + dispatch is async; the per-connection worker is the existing
+/// synchronous session handler run under `spawn_blocking`).
+///
+/// A companion test pins the fail-closed behaviour: a module that requests a
+/// privileged setting (`use chroot`, the upstream default) must be rejected at
+/// startup rather than served without the privilege drop.
+#[cfg(all(unix, feature = "async-daemon"))]
+#[test]
+fn daemon_async_accept_push_pull_byte_identical() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let temp = tempdir().expect("tempdir");
+
+    // Module directory seeded with a small file for the pull leg.
+    let module_dir = temp.path().join("module");
+    fs::create_dir_all(&module_dir).expect("create module dir");
+    let payload = b"async-daemon byte-identity payload\n";
+    fs::write(module_dir.join("seed.txt"), payload).expect("seed module file");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[async]\n\
+         path = {}\n\
+         read only = false\n\
+         use chroot = false\n",
+        module_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    // Reserve an ephemeral port, then release it so the async daemon can bind
+    // its own tokio listener on the same address (it does not accept a
+    // pre-bound listener).
+    let (port, held_listener) = allocate_test_port();
+    drop(held_listener);
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--no-detach"),
+            OsString::from("--address"),
+            OsString::from("127.0.0.1"),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+        ])
+        .build();
+
+    let daemon_handle = thread::spawn(move || crate::run_async_daemon(daemon_config));
+
+    // Wait for the async listener to accept connections. The port was just
+    // released, so retry until connect succeeds or the daemon exits.
+    let target = std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let ready = loop {
+        if daemon_handle.is_finished() {
+            let result = daemon_handle.join().expect("daemon thread");
+            panic!("async daemon exited before accepting connections: {result:?}");
+        }
+        if TcpStream::connect_timeout(&target, Duration::from_millis(100)).is_ok() {
+            break true;
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+    assert!(ready, "async daemon did not become ready in time");
+
+    let rsync_url = format!("rsync://127.0.0.1:{port}/async/");
+
+    // Pull: seed.txt from the module into a fresh local directory.
+    let pull_dest = temp.path().join("pull_dest");
+    fs::create_dir_all(&pull_dest).expect("create pull dest");
+    let mut pull_dest_arg = pull_dest.clone().into_os_string();
+    pull_dest_arg.push("/");
+    let mut pull_src_arg = OsString::from(&rsync_url);
+    pull_src_arg.push("seed.txt");
+
+    let pull_config = core::client::ClientConfig::builder()
+        .transfer_args([pull_src_arg, pull_dest_arg])
+        .build();
+    match core::client::run_client(pull_config) {
+        Ok(_) => {}
+        Err(e) => {
+            let _ = daemon_handle.join();
+            panic!("async daemon pull failed: {e}");
+        }
+    }
+    assert_eq!(
+        fs::read(pull_dest.join("seed.txt")).expect("read pulled file"),
+        payload,
+        "pulled bytes must be identical to the module source"
+    );
+
+    // Push: a new file from a local source dir into the module.
+    let push_src = temp.path().join("push_src");
+    fs::create_dir_all(&push_src).expect("create push src");
+    let push_payload = b"pushed through the async accept path\n";
+    fs::write(push_src.join("pushed.txt"), push_payload).expect("write push src file");
+    let mut push_src_arg = push_src.clone().into_os_string();
+    push_src_arg.push("/");
+
+    let push_config = core::client::ClientConfig::builder()
+        .transfer_args([push_src_arg, OsString::from(&rsync_url)])
+        .build();
+    match core::client::run_client(push_config) {
+        Ok(_) => {}
+        Err(e) => {
+            let _ = daemon_handle.join();
+            panic!("async daemon push failed: {e}");
+        }
+    }
+    assert_eq!(
+        fs::read(module_dir.join("pushed.txt")).expect("read pushed file"),
+        push_payload,
+        "pushed bytes must land in the module byte-for-byte"
+    );
+
+    // The tokio accept loop only stops on a shutdown signal, which this test
+    // does not raise; nextest runs each test in its own process, so the still
+    // -running daemon thread is reaped when the process exits. Detach it after
+    // asserting success in both directions.
+    drop(daemon_handle);
+}
+
+/// The async accept path fails closed on privileged modules: a module that
+/// leaves `use chroot` at its default (true) must be refused at startup, since
+/// chroot / setuid / setgid are not plumbed through the async worker.
+#[cfg(all(unix, feature = "async-daemon"))]
+#[test]
+fn daemon_async_rejects_privileged_module() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+
+    let temp = tempdir().expect("tempdir");
+    let module_dir = temp.path().join("module");
+    fs::create_dir_all(&module_dir).expect("create module dir");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    // `use chroot` defaults to true, so omitting it configures a privileged
+    // module that the async path must reject.
+    let config_content = format!("[priv]\npath = {}\n", module_dir.display());
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    let (port, held_listener) = allocate_test_port();
+    drop(held_listener);
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--no-detach"),
+            OsString::from("--address"),
+            OsString::from("127.0.0.1"),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+        ])
+        .build();
+
+    let result = crate::run_async_daemon(daemon_config);
+    let error = result.expect_err("privileged module must be rejected");
+    let rendered = error.message().to_string();
+    assert!(
+        rendered.contains("async-daemon does not support privileged"),
+        "expected privileged-module refusal, got: {rendered}"
+    );
+}

--- a/docs/design/daemon-tokio-async-listener-impl.md
+++ b/docs/design/daemon-tokio-async-listener-impl.md
@@ -1,6 +1,6 @@
 # Daemon Tokio Async Listener - Implementation Plan
 
-Status: Design (TODO #1935)
+Status: Implemented (accept path wired; opt-in, default-off)
 Audience: daemon maintainers, transfer-pipeline maintainers, release engineering
 Scope: concrete implementation steps for replacing the synchronous accept loop in
 `crates/daemon` with a Tokio-driven listener that bridges to the existing sync
@@ -116,6 +116,61 @@ Non-goals:
   Mitigation: measured once per connection, negligible against handshake cost.
 - Tokio dependency surface. Mitigation: feature-gated; default builds remain
   Tokio-free.
+
+## 6a. Wired implementation
+
+The accept path is now wired to a real per-connection worker (previously a
+skeleton that dropped each accepted socket):
+
+- `crates/daemon/src/daemon/sections/server_runtime/connection_context.rs`
+  introduces `ConnectionContext`, a cheaply-clonable bundle of the daemon-wide
+  per-connection state (module table, MOTD, log sink, client socket options,
+  bandwidth limits, reverse-lookup / PROXY toggles). Its `serve_session` core
+  runs the full legacy `@RSYNCD:` session under `catch_unwind` and is shared by
+  both accept engines. The synchronous `spawn_connection_worker` builds the same
+  context and calls `serve_session`, so the extract is behaviour-preserving; the
+  async worker calls `serve_one_connection`, which additionally applies the
+  accepted-stream socket tuning and client socket options before delegating to
+  `serve_session`. Only accept + task dispatch differ between the two paths; the
+  wire behaviour is byte-identical.
+
+- `run_async_daemon` builds one shared `ConnectionContext` and passes a
+  `SyncWorker` closure to `run_hybrid_listener`.
+
+### Runtime selection
+
+The shipping binary still runs the synchronous accept loop by default. The TCP
+(non-stdio) daemon dispatch selects the async path only when **both** hold:
+
+- the binary is built with `--features async-daemon` (forwarded from
+  `crates/cli` via its own `async-daemon` feature), and
+- the `OC_RSYNC_ASYNC_DAEMON` environment variable is set at runtime.
+
+When the variable is unset or the feature is off, the sync path is unchanged.
+This gate lives in `crates/daemon/src/cli.rs` and only affects the TCP daemon;
+the stdio (inetd / remote-shell) path is untouched. It exists to enable the
+async-vs-sync daemon concurrency benchmark (ASY-4).
+
+### Admission control
+
+`run_async_daemon` enforces the daemon-level `max connections` cap with a
+`tokio::sync::Semaphore` sized to the configured limit, in addition to any
+per-module `ConnectionLimiter` the session handler already applies. On
+exhaustion it writes the same `@ERROR: max connections (N) reached -- try again
+later` refusal the sync accept loop emits, then drops the connection.
+
+### Limitation: privileged modules unsupported
+
+Privilege drop, chroot, and setuid/setgid are **not** plumbed through the async
+accept path. To avoid a silent security regression, `run_async_daemon` fails
+closed: if any module sets `uid`, `gid`, or `use chroot = true` (the upstream
+default for `use chroot` is `true`), or a global daemon `uid`/`gid`/`chroot` is
+configured, it returns a `DaemonError` with the message
+`async-daemon does not support privileged (uid/gid/chroot) modules; use the
+sync daemon`. Non-privileged modules (`use chroot = false`, no `uid`/`gid`) -
+the benchmark case - run normally. Lifting this limitation requires threading
+the chroot / setuid / setgid sequence through the async dispatch and is tracked
+as a follow-up under #1751.
 
 ## 7. References
 


### PR DESCRIPTION
## Summary

The `async-daemon` accept path (`run_async_daemon`) was a skeleton: it bound a
tokio listener but installed a no-op worker that dropped every accepted socket.
This wires it to a real per-connection worker using the **async accept +
`spawn_blocking` sync workers** model - each connection is served by the
existing synchronous session handler inside `spawn_blocking`, so the wire
protocol, auth, and transfer pipeline stay byte-identical. Only accept + task
dispatch is async.

## What was wired

- **Shared per-connection context.** New
  `crates/daemon/src/daemon/sections/server_runtime/connection_context.rs`
  introduces `ConnectionContext`, a cheaply-clonable bundle of the daemon-wide
  per-connection state (module table, MOTD, log sink, client socket options,
  bandwidth limits, reverse-lookup / PROXY toggles). Its `serve_session` core
  runs the full legacy `@RSYNCD:` session under `catch_unwind` and is shared by
  both accept engines.
- **Byte-identical sync refactor.** The synchronous `spawn_connection_worker`
  now builds the same context and calls `serve_session` - a pure extract-method
  with no behaviour or ordering change. The `SessionParams` fields, peer-address
  normalization, and panic-log-and-swallow semantics are preserved exactly.
- **`run_async_daemon` build-out.** Builds the same runtime state the sync path
  assembles (log sink, module table, capability preflight, startup hardening,
  client socket options) and hands a `SyncWorker` to `run_hybrid_listener`.
- **Admission control.** Enforces the daemon-level `max connections` cap with a
  `tokio::sync::Semaphore` in addition to the per-module `ConnectionLimiter`,
  emitting the same `@ERROR: max connections (N) reached -- try again later`
  refusal as the sync loop.
- **Fail closed on privileged config.** Privilege drop / chroot / setuid /
  setgid are not plumbed through the async path. Rather than silently skipping
  them, `run_async_daemon` returns a clear error when any module sets `uid`,
  `gid`, or `use chroot = true` (the upstream default), or a global
  `uid`/`gid`/`chroot` is configured:
  `async-daemon does not support privileged (uid/gid/chroot) modules; use the
  sync daemon`. Non-privileged modules (the benchmark case) run normally.

## Runtime selection

Default off. The shipping binary runs the sync accept loop unless **both**:

- built with `--features async-daemon` (forwarded from `crates/cli` via a new
  `async-daemon` feature), and
- the `OC_RSYNC_ASYNC_DAEMON` environment variable is set at runtime.

The gate lives in `crates/daemon/src/cli.rs` and covers the TCP daemon only;
the stdio (inetd / remote-shell) path is untouched.

```sh
cargo build -p cli --release --features async-daemon
OC_RSYNC_ASYNC_DAEMON=1 oc-rsync --daemon --config rsyncd.conf --port 8730
```

## Tests

- `daemon_async_accept_push_pull_byte_identical` (Unix): boots the async daemon
  on an ephemeral port with a non-privileged module and drives a real pull and
  push through it, asserting byte-identity in both directions.
- `daemon_async_rejects_privileged_module` (Unix): asserts the fail-closed
  refusal for a default (`use chroot`) module.

Both gated on `#[cfg(all(unix, feature = "async-daemon"))]`.

## Enables

The async-vs-sync daemon concurrency benchmark (ASY-4).