### PR TITLE
feat(transfer): async reader stack (AsyncCountingReader/ServerReader/CompressedReader)

### DIFF
--- a/crates/transfer/src/reader/compressed.rs
+++ b/crates/transfer/src/reader/compressed.rs
@@ -1,0 +1,149 @@
+//! Async twin of the compressed receiver reader layer.
+//!
+//! This is the `.await`-driven counterpart to the sync `Compressed` arm of
+//! [`ServerReader`](super::ServerReader), which is
+//! `CompressedReader<MultiplexReader<R>>`: the sync decoder pulls
+//! demultiplexed compressed wire bytes off the multiplex layer and inflates
+//! them. This module supplies the analogous type for an
+//! [`AsyncRead`](tokio::io::AsyncRead) transport so the later async receiver
+//! fork has a concrete `R: AsyncRead` compressed reader to run over.
+//!
+//! # The decompression seam (why this is a drain-then-decode twin)
+//!
+//! The transfer crate's [`CompressedReader`] wraps the `compress` crate's
+//! flate2/zstd/lz4 decoders, which are strictly `std::io::Read`-based and expose
+//! no sans-io / resumable driver at this layer (unlike
+//! `protocol::wire::CompressedTokenDecoder`, whose sync and async token drivers
+//! share one sans-io core and differ only in the byte fetch). A streaming
+//! `poll_read` twin would have to suspend *inside* a flate2 `read`, which the
+//! high-level `Read` wrapper cannot do without corrupting the inflate stream
+//! state (a mid-stream `Ok(0)` finalizes the deflate stream prematurely).
+//!
+//! What *is* byte-identical, and is what this twin does, rests on a property of
+//! the layering: decompression is a **pure function of the demultiplexed
+//! compressed byte sequence**. Every wire-visible, order-sensitive side effect
+//! (the `MSG_INFO`/`MSG_ERROR`/... control-frame print/flush) lives in the
+//! multiplex layer *below* decompression, in the shared reader-free
+//! [`dispatch_message_with`](super::MultiplexReader) core, and is already
+//! sync-vs-async parity-proven. So driving the **async** multiplex demux to
+//! produce the identical compressed byte sequence and then inflating it with the
+//! **existing sync** [`CompressedReader`] yields byte-identical decompressed
+//! output and `bytes_read` to the sync path. Only the byte fetch differs
+//! (`.await` on the multiplex demux versus a blocking read), which is exactly the
+//! sans-io principle the rest of the async stack follows.
+//!
+//! The compressed segment a receiver decodes is bounded by the wire, so draining
+//! it before decode does not unbound memory in the intended use. This matches how
+//! `CompressedTokenDecoder::recv_token_async` handles a compressed token: read
+//! the framed compressed bytes off the async transport, then inflate in memory.
+//!
+//! Additive and unwired: only the parity tests drive this type. It is wired by
+//! the async receiver fork (ASY Stage 2C).
+
+use std::io::{self, Cursor, Read};
+
+use compress::algorithm::CompressionAlgorithm;
+
+use crate::compressed_reader::CompressedReader;
+
+/// Async twin of the sync `Compressed` reader arm, gated on `tokio-transfer`.
+///
+/// Decodes a compressed multiplexed stream pulled from an
+/// [`AsyncRead`](tokio::io::AsyncRead) transport, producing the byte-identical
+/// decompressed output the sync `CompressedReader<MultiplexReader<R>>` produces
+/// for the same wire. See the module docs for the decompression-seam argument.
+///
+/// The compressed wire bytes are drained from the async source into an internal
+/// buffer, then inflated by the shared sync [`CompressedReader`] - no decode
+/// logic is duplicated. `read_async` then hands decompressed bytes out
+/// incrementally, matching the chunking a sync `Read::read` on the same buffer
+/// size would produce.
+#[cfg(feature = "tokio-transfer")]
+pub(crate) struct AsyncCompressedReader {
+    /// Sync decoder over the drained compressed bytes. `None` until the first
+    /// `read_async` drains the async source and constructs the decoder.
+    decoder: Option<CompressedReader<Cursor<Vec<u8>>>>,
+    /// Selected decompression algorithm, used to build `decoder` lazily.
+    algorithm: CompressionAlgorithm,
+}
+
+#[cfg(feature = "tokio-transfer")]
+impl AsyncCompressedReader {
+    /// Creates a compressed async reader for `algorithm`.
+    ///
+    /// Mirrors [`CompressedReader::new`] in accepting the algorithm; the inner
+    /// sync decoder is constructed lazily on the first `read_async` once the
+    /// compressed source has been drained (so an unsupported algorithm surfaces
+    /// the same error [`CompressedReader::new`] would raise, at first read).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new(algorithm: CompressionAlgorithm) -> Self {
+        Self {
+            decoder: None,
+            algorithm,
+        }
+    }
+
+    /// Reads decompressed data into `buf`, awaiting the compressed source.
+    ///
+    /// On the first call, drains the entire bounded compressed segment from
+    /// `source` (via [`AsyncReadExt::read`](tokio::io::AsyncReadExt::read)) into
+    /// an internal buffer and builds the shared sync [`CompressedReader`] over it;
+    /// subsequent calls inflate incrementally from that decoder. Because the
+    /// decoder decodes the identical compressed byte sequence the sync path would,
+    /// the delivered bytes and `bytes_read` are byte-identical to the sync
+    /// `CompressedReader<MultiplexReader<R>>`.
+    ///
+    /// `source` should already deliver *demultiplexed* compressed bytes - in the
+    /// receiver fork that is an [`AsyncServerReader`](super::AsyncServerReader) in
+    /// multiplex mode, whose control-frame side-effect ordering is independently
+    /// parity-proven. This layer performs no framing and no dispatch.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn read_async<R>(
+        &mut self,
+        source: &mut R,
+        buf: &mut [u8],
+    ) -> io::Result<usize>
+    where
+        R: tokio::io::AsyncRead + Unpin + ?Sized,
+    {
+        if self.decoder.is_none() {
+            let compressed = drain_async(source).await?;
+            let decoder = CompressedReader::new(Cursor::new(compressed), self.algorithm)?;
+            self.decoder = Some(decoder);
+        }
+        // Safe: constructed just above if it was `None`.
+        let decoder = self.decoder.as_mut().expect("decoder initialized");
+        decoder.read(buf)
+    }
+}
+
+/// Drains an [`AsyncRead`](tokio::io::AsyncRead) to EOF into a `Vec`.
+///
+/// The bounded compressed segment a receiver decodes fits in memory; draining it
+/// once is the twin's byte-fetch step (the `.await` analogue of the sync
+/// decoder's blocking pulls). Reads in 64 KiB chunks - the same
+/// `MULTIPLEX_READER_BUFFER_CAPACITY` / upstream `IO_BUFFER_SIZE` unit the
+/// multiplex layer frames on - so no partial-frame skew is introduced.
+#[cfg(feature = "tokio-transfer")]
+async fn drain_async<R>(source: &mut R) -> io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut out = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        match source.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => out.extend_from_slice(&chunk[..n]),
+            // A multiplexed source surfaces end-of-wire (a frame read past the
+            // last frame) as UnexpectedEof rather than Ok(0); it is the end of
+            // the bounded compressed segment, so drain terminates cleanly - the
+            // async analogue of the sync loop's UnexpectedEof break.
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(out)
+}

--- a/crates/transfer/src/reader/mod.rs
+++ b/crates/transfer/src/reader/mod.rs
@@ -9,12 +9,19 @@ mod counting;
 mod multiplex;
 mod server;
 
+#[cfg(feature = "tokio-transfer")]
+mod compressed;
+
 #[cfg(test)]
 mod tests;
 
 pub(crate) use counting::CountingReader;
 pub(crate) use multiplex::MultiplexReader;
 pub use server::ServerReader;
+
+#[cfg(feature = "tokio-transfer")]
+#[cfg_attr(not(test), allow(unused_imports))]
+pub(crate) use compressed::AsyncCompressedReader;
 
 #[cfg(feature = "tokio-transfer")]
 #[cfg_attr(not(test), allow(unused_imports))]

--- a/crates/transfer/src/reader/multiplex_parity_tests.rs
+++ b/crates/transfer/src/reader/multiplex_parity_tests.rs
@@ -32,7 +32,7 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
 
 use super::{MultiplexReader, MuxSink};
-use crate::reader::{AsyncServerReader, CountingReader, ServerReader};
+use crate::reader::{AsyncCompressedReader, AsyncServerReader, CountingReader, ServerReader};
 
 /// A single observable event on the demux timeline.
 ///
@@ -532,5 +532,153 @@ async fn asyncread_impl_plain_passthrough() {
             data, raw,
             "plain-mode AsyncRead pass-through diverged at read_len {read_len}"
         );
+    }
+}
+
+/// Builds a compressed multiplexed wire: deflate `payload`, then frame the
+/// compressed bytes into one or more `MSG_DATA` frames (split at `frame_split`
+/// so the compressed stream spans multiple demuxed frames, matching a real
+/// multi-frame transfer). The receiver demuxes the frames, concatenates the
+/// compressed bytes, and inflates them back to `payload`.
+fn compressed_multiplex_wire(payload: &[u8], frame_split: usize) -> Vec<u8> {
+    use compress::zlib::{CompressionLevel, compress_to_vec};
+
+    let compressed = compress_to_vec(payload, CompressionLevel::Default).unwrap();
+    let mut wire = Vec::new();
+    let mut off = 0;
+    while off < compressed.len() {
+        let end = (off + frame_split.max(1)).min(compressed.len());
+        protocol::send_msg(
+            &mut wire,
+            protocol::MessageCode::Data,
+            &compressed[off..end],
+        )
+        .unwrap();
+        off = end;
+    }
+    wire
+}
+
+/// Drives the **sync** compressed receiver path over `wire`:
+/// `ServerReader` in multiplex mode, then `activate_compression(Zlib)`, so the
+/// inner `CompressedReader<MultiplexReader<_>>` demuxes and inflates. Returns the
+/// decompressed bytes.
+fn drive_sync_compressed(wire: &[u8], read_len: usize) -> Vec<u8> {
+    use compress::algorithm::CompressionAlgorithm;
+
+    let mut server = ServerReader::new_plain(Cursor::new(wire.to_vec()))
+        .activate_multiplex()
+        .expect("activate multiplex")
+        .activate_compression(CompressionAlgorithm::Zlib)
+        .expect("activate compression");
+
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+    loop {
+        // The multiplex loop surfaces end-of-wire as UnexpectedEof (a frame read
+        // past the last frame), identical for both drivers - see the demux
+        // harness above. Terminating on it preserves parity.
+        match server.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => panic!("sync compressed read failed: {err}"),
+        }
+    }
+    data
+}
+
+/// Drives the **async** compressed twin over `reader`:
+/// `AsyncServerReader` in multiplex mode (the async demux, whose control-frame
+/// side-effect ordering is parity-proven elsewhere) feeding
+/// `AsyncCompressedReader`, which inflates the demuxed compressed bytes with the
+/// shared sync decoder. Returns the decompressed bytes.
+async fn drive_async_compressed<R: AsyncRead + Unpin + Send + 'static>(
+    reader: R,
+    read_len: usize,
+) -> Vec<u8> {
+    use compress::algorithm::CompressionAlgorithm;
+
+    let mut server = AsyncServerReader::new_plain(reader)
+        .activate_multiplex()
+        .expect("activate multiplex");
+    let mut decompressor = AsyncCompressedReader::new(CompressionAlgorithm::Zlib);
+
+    let mut data = Vec::new();
+    let mut buf = vec![0u8; read_len];
+    loop {
+        match decompressor.read_async(&mut server, &mut buf).await {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(err) => panic!("async compressed read failed: {err}"),
+        }
+    }
+    data
+}
+
+/// End-to-end sync-vs-async parity for the compressed reader layer: the async
+/// twin (async multiplex demux -> `AsyncCompressedReader` sync inflate) must
+/// deliver the byte-identical decompressed stream the sync compressed path
+/// delivers, and both must equal the original payload. Covers the required
+/// compressed round-trip across read-buffer sizes and multi-frame splits.
+#[tokio::test(flavor = "current_thread")]
+async fn compressed_round_trip_parity_whole_stream() {
+    // A payload large enough to compress across several demuxed frames and to
+    // span many small decompressed reads.
+    let mut payload = Vec::new();
+    for i in 0..4000u32 {
+        payload.extend_from_slice(format!("line {i} of the compressed corpus\n").as_bytes());
+    }
+
+    for frame_split in [37usize, 512, 65536] {
+        let wire = compressed_multiplex_wire(&payload, frame_split);
+        for read_len in READ_LENS {
+            let sync_data = drive_sync_compressed(&wire, read_len);
+            let async_data = drive_async_compressed(Cursor::new(wire.clone()), read_len).await;
+
+            assert_eq!(
+                sync_data, payload,
+                "sync compressed path lost bytes (frame_split {frame_split}, read_len {read_len})"
+            );
+            assert_eq!(
+                async_data, sync_data,
+                "async compressed twin diverged from sync (frame_split {frame_split}, \
+                 read_len {read_len})"
+            );
+        }
+    }
+}
+
+/// Same compressed round-trip, but the async transport yields bytes in tiny
+/// chunks so the compressed frames reassemble across many `.await` points before
+/// decode. The decompressed output must stay byte-identical to the sync path
+/// regardless of transport fragmentation.
+#[tokio::test(flavor = "current_thread")]
+async fn compressed_round_trip_parity_chunked_delivery() {
+    let mut payload = Vec::new();
+    for i in 0..2000u32 {
+        payload.extend_from_slice(format!("chunk {i} payload data\n").as_bytes());
+    }
+
+    let frame_split = 200usize;
+    let wire = compressed_multiplex_wire(&payload, frame_split);
+    let sync_data = drive_sync_compressed(&wire, 64);
+
+    for chunk in [1usize, 2, 3, 7, 13] {
+        for read_len in READ_LENS {
+            let reader = ChunkedReader {
+                inner: Cursor::new(wire.clone()),
+                chunk,
+            };
+            let async_data = drive_async_compressed(reader, read_len).await;
+            assert_eq!(
+                async_data, payload,
+                "async compressed twin lost bytes (chunk {chunk}, read_len {read_len})"
+            );
+            assert_eq!(
+                async_data, sync_data,
+                "async compressed twin diverged from sync (chunk {chunk}, read_len {read_len})"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What this builds

The async twin of the receiver reader stack, gated on `tokio-transfer` and unwired (dead-code-allowed) until the async receiver fork lands. It gives the later `R: AsyncRead` receiver fork concrete async reader types to run `protocol::recv_msg_into_async` / `recv_token_async` over.

Three layers, faithful `tokio::io::AsyncRead`-driven twins of the sync stack:

- **AsyncCountingReader** - the `tokio::io::AsyncRead` impl already on `CountingReader<R>` (same type, same shared `bytes_received` `Arc<AtomicU64>`, only the read primitive differs: `poll_read` vs blocking `read`). Byte-exact accounting: increments by the exact bytes each `poll_read` adds to the `ReadBuf`.
- **AsyncServerReader** - the plain + multiplex mode dispatch twin of `ServerReader`. The multiplex arm drives the shared, reader-free demux core (`MultiplexReader::read_async` / `read_async_with`), so control-frame side effects fire through the same `dispatch_message_with` path as the sync driver. Includes a real `AsyncRead` impl with a `MuxState` that holds an in-flight demux future across `Poll::Pending` (mid-frame suspension safety).
- **AsyncCompressedReader** (new in this PR) - async twin of the sync `Compressed` arm (`CompressedReader<MultiplexReader<R>>`). Drives the async multiplex demux to produce the identical compressed byte sequence, then inflates with the existing sync `CompressedReader` - no decode logic duplicated.

## Side-effect ordering (the audit's flagged hazard)

Fully preservable. The crux is that the multiplex demux's inline control-frame side effects (`MSG_INFO`/`MSG_CLIENT` -> stdout+flush, every `MSG_*ERROR*`/`MSG_WARNING` -> stderr) all route through a single shared, reader-free dispatch core (`dispatch_message_with`) via a `MuxSink` trait. The sync and async drivers call that core at the identical point relative to data delivery (immediately after each frame read), differing only in the byte fetch (`.await` vs blocking). They therefore cannot diverge on effect ordering. Parity tests capture the ordered effect timeline through a `CapturingSink` (not real stdout) and compare it frame-for-frame, including under tiny-chunk transports that reassemble frames across many `.await` points.

The one genuine seam: decompression. The transfer crate's decoders (`compress` crate's flate2/zstd/lz4) are strictly `std::io::Read`-based with no sans-io / resumable driver at this layer, so a streaming `poll_read` twin cannot suspend inside a flate2 `read` without corrupting inflate state. Decompression is, however, a pure function of the demultiplexed compressed byte sequence, and every order-sensitive side effect lives in the multiplex layer *below* it (already parity-proven). So `AsyncCompressedReader` drains the bounded compressed segment from the async demux, then inflates it with the shared sync decoder - byte-identical output and `bytes_read`, only the byte fetch differing. This mirrors the codebase's own `CompressedTokenDecoder::recv_token_async` (read framed compressed bytes async, inflate in memory).

## Parity-test coverage

All in `crates/transfer/src/reader/multiplex_parity_tests.rs` (gated `cfg(all(test, feature = "tokio-transfer"))`). Sync-vs-async, asserting identical decoded bytes, identical final `bytes_received`, and identical control-frame side-effect emission order:

- plain passthrough (`asyncread_impl_plain_passthrough`)
- multiplex with MSG_INFO/MSG_WARNING/MSG_ERROR/MSG_CLIENT/MSG_ERROR_XFER control frames interleaved mid-data + keep-alive empty frames (`demux_parity_*`, side-effect ORDER via `CapturingSink`)
- short/partial reads, EOF, multi-frame spanning across read buffers (read_len 8/64/4096) and tiny-chunk transports (chunk 1/2/3/7/13)
- full-stack counter parity: `CountingReader` -> `BufReader` -> `ServerReader` vs `CountingReader` -> `tokio::BufReader` -> `AsyncServerReader`, asserting exact wire-length byte count (`reader_stack_parity_*`)
- `AsyncRead` impl (poll-driven, not the inherent `read_async`) parity (`asyncread_impl_parity_*`)
- **compressed round-trip** (new): deflate a multi-frame payload, decode via sync `ServerReader` compressed path vs `AsyncCompressedReader` over the async demux; whole-stream (frame splits 37/512/65536, read_len 8/64/4096) and chunked delivery (chunk 1/2/3/7/13)

`cargo nextest run -p transfer --features tokio-transfer -E 'test(async_reader) or test(parity)'`: 41 tests run, 41 passed.

## Scope / edits

- Touched only `crates/transfer/src/reader/`: new `compressed.rs`, `mod.rs` module decl + re-export, `multiplex_parity_tests.rs` compressed round-trip tests.
- No `Cargo.toml` edit, no `lib.rs` edit. No sync reader behavior changed (byte-identical default build; new module is `#[cfg(feature = "tokio-transfer")]`, unwired, dead-code-allowed pending the receiver fork).
- fmt clean; clippy clean with `--features tokio-transfer --all-targets` AND on the default build.
