### PR TITLE
chore(deps): bump tikv-jemallocator to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ xattr = { workspace = true }
 # for its compile-time `malloc_conf` page-return tuning (see src/bin/oc-rsync.rs);
 # Windows keeps mimalloc, which lacks comparable jemalloc support.
 [target.'cfg(unix)'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = "0.7"
 
 [target.'cfg(windows)'.dependencies]
 mimalloc = { workspace = true }

--- a/docs/audits/workspace-dependency-audit.md
+++ b/docs/audits/workspace-dependency-audit.md
@@ -25,7 +25,7 @@ host):
 | Dep | Version | Status | Notes |
 |---|---|---|---|
 | `mimalloc` | 0.1 | used | Windows global allocator in `src/bin/oc-rsync.rs` (`#[cfg(windows)]`). Unix uses jemalloc. |
-| `tikv-jemallocator` | 0.6 | used | Unix global allocator in `src/bin/oc-rsync.rs` (`#[cfg(unix)]`); page return tuned via the `_rjem_malloc_conf` static (dirty/muzzy decay 250 ms) to bound RSS at scale. |
+| `tikv-jemallocator` | 0.7 | used | Unix global allocator in `src/bin/oc-rsync.rs` (`#[cfg(unix)]`); page return tuned via the `_rjem_malloc_conf` static (dirty/muzzy decay 250 ms) to bound RSS at scale. |
 | `rustc-hash` | 2.1 | used | `engine`, `matching`, `protocol`. |
 | `jwalk` | 0.8 | used | `engine/src/walk/walkdir_impl.rs`. |
 | `exacl` | 0.13 | used | `metadata` (acl feature), `daemon` (dev-dep, unix only). |


### PR DESCRIPTION
Bumps the Unix global allocator `tikv-jemallocator` from 0.6 to 0.7.0 (pulling `tikv-jemalloc-sys` 0.6.1+5.3.0 -> 0.7.1+5.3.1, a bundled-jemalloc patch bump).

Supersedes the Dependabot lock-only bump (#6318), which left `Cargo.toml` pinned at `"0.6"` so `--locked` builds failed on the manifest/lock mismatch. This bumps both the manifest and the lockfile.

## Config-symbol survival (the important bit)

`src/bin/oc-rsync.rs` exports a compile-time jemalloc config static on Unix:

```
#[unsafe(no_mangle)]
pub static _rjem_malloc_conf: &[u8] = b"dirty_decay_ms:250,muzzy_decay_ms:250\0";
```

The `_rjem_` prefix must match the sys crate's C build prefix, or jemalloc silently ignores the config and RSS regresses with no failing test. Verified against the resolved `tikv-jemalloc-sys 0.7.1` build.rs: the prefix decision is unchanged from 0.6 - `use_prefix` defaults to true (only disabled by the opt-in `unprefixed_malloc_on_supported_platforms` feature, which we do not enable) and the C build still passes `--with-jemalloc-prefix=_rjem_`. The 0.7.1 patch only bumped bundled jemalloc 5.3.0 -> 5.3.1; the Rust FFI prefix mechanism is untouched. No source change to `src/bin/oc-rsync.rs` is required.

## Host validation (aarch64 Linux, release fat-LTO, no env vars set)

100k empty-file local copy `-a src/ dst/` under `/usr/bin/time -v`, same host and corpus for both:

| Build | Max RSS run 1 | Max RSS no-change |
|-------|--------------|-------------------|
| 0.6 (master baseline) | 77.8 MB | 69.4 MB |
| 0.7 (this branch) | 73.7 MB | 68.7 MB |

0.7 tracks 0.6 within noise (marginally lower) - no regression. Copy was byte-identical (`diff -rq`, 100000 files).

The decay tuning is proven live under 0.7 by sweeping the config via the `_rjem_`-prefixed env override on the 0.7 binary:

- `dirty_decay_ms:-1,muzzy_decay_ms:-1` (never return pages): 80.6 MB
- default static `dirty_decay_ms:250,muzzy_decay_ms:250`: 73.7 MB
- `dirty_decay_ms:0,muzzy_decay_ms:0` (return immediately): 70.6 MB

RSS responds monotonically to the setting, confirming jemalloc reads the config through the `_rjem_` prefix. The decay string is embedded in the binary and `--version` still reports jemalloc on Unix.

(The absolute ~73 MB here vs the ~30 MB quoted when the tuning was added reflects a different measurement environment - this aarch64 host, larger page size - and applies equally to 0.6 and 0.7.)

## Files changed

- `Cargo.toml`: `tikv-jemallocator = "0.6"` -> `"0.7"`
- `Cargo.lock`: regenerated
- `docs/audits/workspace-dependency-audit.md`: version row 0.6 -> 0.7