### PR TITLE
test: port additional upstream testsuite edge cases to nextest

### DIFF
--- a/crates/transfer/tests/uts_duplicate_source_names_copied_once.rs
+++ b/crates/transfer/tests/uts_duplicate_source_names_copied_once.rs
@@ -1,0 +1,88 @@
+//! Port of the upstream rsync 3.4.4 testsuite `duplicates.test`.
+//!
+//! Upstream source of truth:
+//!   `target/interop/upstream-src/rsync-3.4.4/testsuite/duplicates.test`
+//!   `flist.c` `clean_flist()` - the dedup pass that collapses repeated names.
+//!
+//! Why this matters: a user can name the same source more than once on the
+//! command line (shell variable expansion, overlapping wildcards). If the file
+//! list kept both copies, rsync could try to update the first copy while
+//! generating checksums for the second at the same time - a genuine race that
+//! upstream fixes by de-duplicating the flist in `clean_flist()`. The upstream
+//! test lists the same directory ten times and asserts each contained file is
+//! copied *exactly once* (the `grep -c '^name1$' == 1` check), not ten times.
+//!
+//! We assert the observable invariant two ways so the test fails if dedup
+//! regresses in either the wire path or the output path:
+//!   1. Each source file appears exactly once in the destination tree (a
+//!      duplicated flist would still produce one file on disk, but a broken
+//!      dedup that mangled names could drop or misplace it).
+//!   2. With `-vv` itemized output, each transferred name is listed exactly
+//!      once - mirroring upstream's `grep -c` assertion that catches a flist
+//!      that carried the same entry N times.
+
+#![cfg(unix)]
+
+use std::fs;
+
+use test_support::{OcRsyncCliRunner, create_tempdir, require_binary};
+
+/// The same source directory repeated many times on the command line must
+/// still copy each contained file exactly once - both on disk and in the
+/// verbose transfer log.
+#[test]
+fn repeated_source_directory_copies_each_file_exactly_once() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+
+    let tmp = create_tempdir();
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    fs::create_dir_all(&from).expect("create from dir");
+    fs::create_dir_all(&to).expect("create to dir");
+    fs::write(from.join("name1"), b"This is the file\n").expect("write name1");
+    fs::write(from.join("name2"), b"second file\n").expect("write name2");
+
+    // Repeat the trailing-slash source ten times, exactly like upstream's
+    // `'$fromdir/' '$fromdir/' ... '$todir/'` invocation.
+    let src = format!("{}/", from.display());
+    let dst = format!("{}/", to.display());
+    let mut runner = OcRsyncCliRunner::new().arg("-rvv");
+    for _ in 0..10 {
+        runner = runner.arg(&src);
+    }
+    let out = runner.arg(&dst).run().expect("run oc-rsync -rvv x10");
+    out.assert_success();
+
+    // Each file must exist once with the right bytes; a broken dedup that
+    // dropped a name would fail these reads.
+    assert_eq!(
+        fs::read(to.join("name1")).expect("read name1"),
+        b"This is the file\n",
+        "name1 must be copied once with intact contents"
+    );
+    assert_eq!(
+        fs::read(to.join("name2")).expect("read name2"),
+        b"second file\n",
+        "name2 must be copied once with intact contents"
+    );
+
+    // Upstream's core assertion: each name appears exactly once in the
+    // transfer log even though the source was listed ten times. A flist that
+    // failed to dedup would itemize the same name repeatedly.
+    let log = out.stdout_str();
+    let count_lines = |needle: &str| log.lines().filter(|l| l.trim() == needle).count();
+    assert_eq!(
+        count_lines("name1"),
+        1,
+        "name1 must be transferred exactly once despite 10 duplicate sources\n\
+         --- oc-rsync -rvv stdout ---\n{log}"
+    );
+    assert_eq!(
+        count_lines("name2"),
+        1,
+        "name2 must be transferred exactly once despite 10 duplicate sources\n\
+         --- oc-rsync -rvv stdout ---\n{log}"
+    );
+}

--- a/crates/transfer/tests/uts_executability_flag_transfer.rs
+++ b/crates/transfer/tests/uts_executability_flag_transfer.rs
@@ -1,0 +1,144 @@
+//! Port of the upstream rsync 3.4.4 testsuite `executability.test`.
+//!
+//! Upstream source of truth:
+//!   `target/interop/upstream-src/rsync-3.4.4/testsuite/executability.test`
+//!   `rsync.c` `dest_mode()` - when `-E` is set without `-p`, only the
+//!   executability bits transfer from source to destination.
+//!
+//! Why this matters: `--executability` (`-E`) is a narrow, easy-to-break
+//! permission-transfer mode. Without `-p` (preserve-perms), a plain recursive
+//! copy must NOT touch the destination's mode at all - the receiver keeps
+//! whatever the file already had. Only when `-E` is added should the *exec bits
+//! alone* follow the source, leaving the read/write bits on the destination
+//! untouched. A regression here silently corrupts permissions: either a copy
+//! rewrites modes it should have left alone, or `-E` fails to propagate the
+//! exec bit and a script arrives non-executable.
+//!
+//! The existing unit test (`metadata::executability_entry_path`) exercises
+//! `apply_metadata_from_file_entry` in isolation. This test guards the
+//! end-to-end CLI transfer, including the upstream test's key negative leg:
+//! "No -E, so nothing should have changed."
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use test_support::{OcRsyncCliRunner, create_tempdir, require_binary};
+
+fn mode_of(path: &Path) -> u32 {
+    fs::metadata(path).expect("stat file").permissions().mode() & 0o7777
+}
+
+fn set_mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).expect("set mode");
+}
+
+/// Full three-phase replay of the upstream `executability.test`: a plain
+/// recursive copy leaves destination modes alone, and only `-E` transfers the
+/// executability bits without disturbing the read/write bits.
+#[test]
+fn executability_flag_transfers_only_exec_bits() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+
+    let tmp = create_tempdir();
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    fs::create_dir_all(&from).expect("create from dir");
+    let src = format!("{}/", from.display());
+    let dst = format!("{}/", to.display());
+
+    let f1 = from.join("1");
+    let f2 = from.join("2");
+    fs::write(&f1, b"#!/bin/sh\necho 'Program One!'\n").expect("write 1");
+    fs::write(&f2, b"#!/bin/sh\necho 'Program Two!'\n").expect("write 2");
+    // Upstream uses 1700 (sticky + rwx) on file 1; the sticky bit is
+    // irrelevant to executability so we use plain 0700 for a portable check.
+    set_mode(&f1, 0o700);
+    set_mode(&f2, 0o600);
+
+    // Phase 1: first copy with no -E and no -p. New files are created, so the
+    // receiver applies the source mode's exec bits on creation (upstream ends
+    // with 1's owner-x present, 2 without). We assert exec-bit parity with the
+    // source rather than exact bytes to stay portable across umask.
+    OcRsyncCliRunner::new()
+        .arg("-r")
+        .arg(&src)
+        .arg(&dst)
+        .run()
+        .expect("run 1")
+        .assert_success();
+    let d1 = to.join("1");
+    let d2 = to.join("2");
+    assert_eq!(
+        mode_of(&d1) & 0o100,
+        0o100,
+        "file 1 was executable at source; a fresh copy must arrive executable"
+    );
+    assert_eq!(
+        mode_of(&d2) & 0o111,
+        0,
+        "file 2 was non-executable at source; a fresh copy must arrive non-executable"
+    );
+
+    // Phase 2: perturb both trees, then re-copy WITHOUT -E. This is upstream's
+    // "No -E, so nothing should have changed" leg: the receiver must leave the
+    // existing destination modes exactly as they are.
+    set_mode(&f1, 0o600);
+    set_mode(&f2, 0o601);
+    set_mode(&d1, 0o700);
+    set_mode(&d2, 0o604);
+    OcRsyncCliRunner::new()
+        .arg("-r")
+        .arg(&src)
+        .arg(&dst)
+        .run()
+        .expect("run 2 (no -E)")
+        .assert_success();
+    assert_eq!(
+        mode_of(&d1),
+        0o700,
+        "without -E or -p, an existing destination's mode must be left untouched (file 1)"
+    );
+    assert_eq!(
+        mode_of(&d2),
+        0o604,
+        "without -E or -p, an existing destination's mode must be left untouched (file 2)"
+    );
+
+    // Phase 3: re-copy WITH -E. Now the exec bits follow the source while the
+    // read/write bits on the destination stay put. Source 1 is now 0600
+    // (no exec) so dest 1 must lose its exec bit; source 2 is 0601 (owner-x)
+    // so dest 2 must gain exec for every class that can already read.
+    OcRsyncCliRunner::new()
+        .arg("-r")
+        .arg("-E")
+        .arg(&src)
+        .arg(&dst)
+        .run()
+        .expect("run 3 (-E)")
+        .assert_success();
+    assert_eq!(
+        mode_of(&d1) & 0o111,
+        0,
+        "-E with a now-non-executable source must clear dest 1's exec bits"
+    );
+    assert_eq!(
+        mode_of(&d1) & 0o666,
+        0o600,
+        "-E must leave dest 1's read/write bits untouched"
+    );
+    assert_eq!(
+        mode_of(&d2) & 0o100,
+        0o100,
+        "-E with an executable source must grant exec on dest 2"
+    );
+    assert_eq!(
+        mode_of(&d2) & 0o666,
+        0o604,
+        "-E must leave dest 2's read/write bits untouched"
+    );
+}

--- a/crates/transfer/tests/uts_symlink_ignore_no_links_flag.rs
+++ b/crates/transfer/tests/uts_symlink_ignore_no_links_flag.rs
@@ -1,0 +1,95 @@
+//! Port of the upstream rsync 3.4.4 testsuite `symlink-ignore.test`.
+//!
+//! Upstream source of truth:
+//!   `target/interop/upstream-src/rsync-3.4.4/testsuite/symlink-ignore.test`
+//!
+//! Why this matters: rsync's default symlink policy is to *not* copy symlinks
+//! at all. A symlink is only transferred when the user opts in with `-l`
+//! (`--links`), `-L` (`--copy-links`), or `-a` (which implies `-l`). A recursive
+//! copy with only `-r` must silently drop every symlink - dangling, relative,
+//! and absolute alike - while still copying the regular files they point near.
+//!
+//! Regressing this is a real data-integrity hazard in both directions: copying
+//! a symlink that upstream would have skipped can leak a path outside the tree
+//! (a dangling or absolute link), and failing to copy a regular file because a
+//! sibling symlink aborted the walk would silently lose data. The upstream test
+//! guards exactly this: after `rsync -r from/ to`, the referent regular file is
+//! present and none of the three symlink flavours survived.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+
+use test_support::{OcRsyncCliRunner, create_tempdir, require_binary};
+
+/// Build the same symlink fixture `rsync.fns`'s `build_symlinks` creates: a
+/// real regular file `referent` plus three symlinks that must all be ignored.
+fn build_symlinks(from: &Path) {
+    fs::create_dir_all(from).expect("create from dir");
+    fs::write(from.join("referent"), b"referent contents\n").expect("write referent");
+    // Dangling: points at a name that does not exist.
+    symlink("nonexistent-target", from.join("dangling")).expect("dangling symlink");
+    // Relative: points at the sibling regular file.
+    symlink("referent", from.join("relative")).expect("relative symlink");
+    // Absolute: points at an absolute path outside the tree.
+    symlink("/etc/hostname", from.join("absolute")).expect("absolute symlink");
+}
+
+/// A recursive copy without `-l`/`-L`/`-a` copies the regular file but drops
+/// every symlink, matching upstream's default "symlinks should not be copied
+/// at all" policy.
+#[test]
+fn recursive_copy_without_links_flag_drops_all_symlinks() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+
+    let tmp = create_tempdir();
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    build_symlinks(&from);
+
+    // Trailing slash on the source: copy the *contents* of `from` into `to`,
+    // exactly as the upstream test's `"$fromdir/" "$todir"` invocation does.
+    let src = format!("{}/", from.display());
+    let out = OcRsyncCliRunner::new()
+        .arg("-r")
+        .arg(&src)
+        .arg(&to)
+        .run()
+        .expect("run oc-rsync -r");
+    out.assert_success();
+
+    // The regular file must arrive - dropping symlinks must not drop data.
+    let referent = to.join("referent");
+    assert!(
+        referent.is_file(),
+        "referent regular file must be copied under a plain -r transfer"
+    );
+    assert_eq!(
+        fs::read(&referent).expect("read copied referent"),
+        b"referent contents\n",
+        "referent contents must round-trip byte-for-byte"
+    );
+
+    // None of the three symlink flavours may survive the default policy.
+    for name in ["dangling", "relative", "absolute"] {
+        let path = to.join(name);
+        let meta = fs::symlink_metadata(&path);
+        assert!(
+            meta.is_err() || !meta.unwrap().file_type().is_symlink(),
+            "{name} symlink must be ignored by a -r transfer without -l/-L/-a \
+             (upstream default is to not copy symlinks at all)"
+        );
+    }
+
+    // Guard against the "extra level of directories" bug the upstream test
+    // also checks: `to/from` must not exist (the trailing slash means we copy
+    // contents, not the `from` directory itself).
+    assert!(
+        !to.join("from").exists(),
+        "trailing-slash source must copy contents, not nest an extra `from` dir"
+    );
+}


### PR DESCRIPTION
## Summary

Ports three deterministic, self-contained cases from the upstream rsync 3.4.4 testsuite into the nextest suite as fast local-copy integration tests, so they run on every PR instead of only the weekly `runtests.py` interop job. Advances #155.

All three use the shared `test-support` harness (`OcRsyncCliRunner`, `require_binary`) landed in #6279/#6288 and live alongside the existing `uts_*` ports in `crates/transfer/tests/`.

## Cases ported

- **`symlink-ignore.test`** -> `uts_symlink_ignore_no_links_flag.rs`
  A recursive copy without `-l`/`-L`/`-a` must drop every symlink (dangling, relative, absolute) while still copying regular files. Guards rsync's default "symlinks are not copied at all" policy - a regression could leak a path outside the tree or silently lose data.

- **`duplicates.test`** -> `uts_duplicate_source_names_copied_once.rs`
  The same source directory listed ten times on the command line must copy each contained file exactly once (`clean_flist()` dedup). Asserts the invariant both on disk and in `-vv` itemized output, mirroring upstream's `grep -c '^name1$' == 1` check. A duplicated flist risks the update-vs-checksum race the upstream dedup fixes.

- **`executability.test`** -> `uts_executability_flag_transfer.rs`
  `-E` (`--executability`) transfers only the exec bits from source to destination. The key negative leg ("No -E, so nothing should have changed") asserts a plain copy leaves an existing destination's mode untouched, and the positive leg asserts `-E` propagates exec bits without disturbing read/write bits. Complements the existing unit test on `apply_metadata_from_file_entry` with end-to-end CLI coverage.

## Verification

Built the workspace binary and ran each test targeted on macOS (aarch64):

```
test recursive_copy_without_links_flag_drops_all_symlinks ... ok
test repeated_source_directory_copies_each_file_exactly_once ... ok
test executability_flag_transfers_only_exec_bits ... ok
```

`cargo fmt -p transfer -- --check` and `cargo clippy -p transfer --tests --all-features --no-deps -- -D warnings` both clean. Tests are Unix-gated (POSIX perms/symlinks) and self-skip when the binary is not built.