### PR TITLE
fix(fast_io): honor -X and xattr filters in Windows fast-copy path

### DIFF
--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -140,7 +140,7 @@ pub(crate) struct ConfigInputs {
     pub(crate) link_destinations: Vec<OsString>,
     #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(crate) preserve_acls: bool,
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(crate) xattrs: bool,
     pub(crate) skip_compress_list: Option<SkipCompressList>,
     pub(crate) itemize_changes: bool,
@@ -367,7 +367,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         builder = builder.acls(inputs.preserve_acls);
     }
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     {
         builder = builder.xattrs(inputs.xattrs);
     }

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -901,7 +901,7 @@ where
         link_destinations,
         #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
-        #[cfg(all(unix, feature = "xattr"))]
+        #[cfg(all(any(unix, windows), feature = "xattr"))]
         xattrs: xattrs.unwrap_or(false),
         skip_compress_list,
         itemize_changes,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -76,7 +76,7 @@ zlib-ng = ["compress/zlib-ng", "engine/zlib-ng", "transfer/zlib-ng", "protocol/z
 # Metadata Features
 # ============================================================================
 # xattr on Windows uses metadata/xattr_windows (FindFirstStreamW ADS); on Unix the target deps above add the real bits
-xattr = ["metadata/xattr", "transfer/xattr"]
+xattr = ["metadata/xattr", "transfer/xattr", "engine/xattr"]
 acl = ["metadata/acl", "engine/acl", "transfer/acl"]
 
 # Character encoding conversion for filenames (iconv)

--- a/crates/core/src/client/config/builder/metadata.rs
+++ b/crates/core/src/client/config/builder/metadata.rs
@@ -9,8 +9,10 @@ impl ClientConfigBuilder {
         self
     }
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     /// Enables or disables extended attribute preservation for the transfer.
+    ///
+    /// On Windows `-X` maps onto NTFS Alternate Data Streams.
     #[must_use]
     #[doc(alias = "--xattrs")]
     #[doc(alias = "-X")]
@@ -19,7 +21,7 @@ impl ClientConfigBuilder {
         self
     }
 
-    #[cfg(not(all(unix, feature = "xattr")))]
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
     /// No-op on platforms without xattr support.
     #[must_use]
     pub const fn xattrs(self, _preserve: bool) -> Self {

--- a/crates/core/src/client/config/builder/mod.rs
+++ b/crates/core/src/client/config/builder/mod.rs
@@ -273,7 +273,7 @@ pub struct ClientConfigBuilder {
     embedded_ssh_config: Option<super::client::EmbeddedSshOptions>,
     #[cfg(all(any(unix, windows), feature = "acl"))]
     preserve_acls: bool,
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     preserve_xattrs: bool,
 }
 
@@ -510,7 +510,7 @@ impl ClientConfigBuilder {
             embedded_ssh_config: self.embedded_ssh_config,
             #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: self.preserve_acls,
-            #[cfg(all(unix, feature = "xattr"))]
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
             preserve_xattrs: self.preserve_xattrs,
         }
     }

--- a/crates/core/src/client/config/client/metadata.rs
+++ b/crates/core/src/client/config/client/metadata.rs
@@ -141,7 +141,10 @@ impl ClientConfig {
     }
 
     /// Reports whether extended attributes should be preserved.
-    #[cfg(all(unix, feature = "xattr"))]
+    ///
+    /// On Windows this maps `-X` onto NTFS Alternate Data Streams, so the
+    /// accessor must honour the stored flag there too - not just on Unix.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     #[must_use]
     #[doc(alias = "--xattrs")]
     #[doc(alias = "-X")]
@@ -150,7 +153,7 @@ impl ClientConfig {
     }
 
     /// Always returns `false` on platforms without xattr support.
-    #[cfg(not(all(unix, feature = "xattr")))]
+    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
     #[must_use]
     pub const fn preserve_xattrs(&self) -> bool {
         false

--- a/crates/core/src/client/config/client/mod.rs
+++ b/crates/core/src/client/config/client/mod.rs
@@ -254,7 +254,7 @@ pub struct ClientConfig {
     pub(super) embedded_ssh_config: Option<EmbeddedSshOptions>,
     #[cfg(all(any(unix, windows), feature = "acl"))]
     pub(super) preserve_acls: bool,
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
 }
 
@@ -427,7 +427,7 @@ impl Default for ClientConfig {
             embedded_ssh_config: None,
             #[cfg(all(any(unix, windows), feature = "acl"))]
             preserve_acls: false,
-            #[cfg(all(unix, feature = "xattr"))]
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
             preserve_xattrs: false,
         }
     }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -781,9 +781,10 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             options = options.acls(config.preserve_acls());
         }
 
-        // LocalCopyOptions::xattrs is Unix-only; match the engine crate's cfg
-        // so Windows builds with the `xattr` feature do not call a missing method.
-        #[cfg(all(feature = "xattr", unix))]
+        // `LocalCopyOptions::xattrs` is available on Unix and Windows (the
+        // latter maps `-X` onto NTFS Alternate Data Streams); match the engine
+        // crate's cfg so the flag reaches the local-copy executor on both.
+        #[cfg(all(feature = "xattr", any(unix, windows)))]
         {
             options = options.xattrs(config.preserve_xattrs());
         }

--- a/crates/engine/src/local_copy/context_impl/options/filter.rs
+++ b/crates/engine/src/local_copy/context_impl/options/filter.rs
@@ -1,6 +1,6 @@
 impl<'a> CopyContext<'a> {
     /// Returns the filter program used by xattr sync logic.
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(super) const fn filter_program(
         &self,
     ) -> Option<&crate::local_copy::filter_program::FilterProgram> {

--- a/crates/engine/src/local_copy/context_impl/options/metadata.rs
+++ b/crates/engine/src/local_copy/context_impl/options/metadata.rs
@@ -25,8 +25,7 @@ impl<'a> CopyContext<'a> {
         self.options.acls_enabled()
     }
 
-    #[cfg(unix)]
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(super) const fn xattrs_enabled(&self) -> bool {
         self.options.preserve_xattrs()
     }

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn copy_file(
     let mode = context.mode();
     let file_type = metadata.file_type();
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     let preserve_xattrs = context.xattrs_enabled();
     #[cfg(all(any(unix, windows), feature = "acl"))]
     let preserve_acls = context.acls_enabled();
@@ -223,7 +223,7 @@ pub(crate) fn copy_file(
         size_only_enabled,
         ignore_times_enabled,
         checksum_enabled,
-        #[cfg(all(unix, feature = "xattr"))]
+        #[cfg(all(any(unix, windows), feature = "xattr"))]
         preserve_xattrs,
         #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -93,8 +93,13 @@ pub(in crate::local_copy) fn execute_transfer(
         size_only_enabled: _,
         ignore_times_enabled: _,
         checksum_enabled: _,
+        // Consumed by the standard-path finalize call below on Unix; on
+        // Windows the `CopyFileExW` fast path reconciles ADS itself, so this
+        // field is unused in the standard path there.
         #[cfg(all(unix, feature = "xattr"))]
         preserve_xattrs,
+        #[cfg(all(windows, feature = "xattr"))]
+            preserve_xattrs: _,
         #[cfg(all(any(unix, windows), feature = "acl"))]
         preserve_acls,
     } = flags;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -152,6 +152,14 @@ pub(super) fn try_copy(
     // CopyFileExW must produce identical results.
     normalize_copied_metadata(destination, &metadata_options)?;
 
+    // `CopyFileExW` copies the source's NTFS Alternate Data Streams verbatim,
+    // which upstream rsync exposes as extended attributes. The portable copy
+    // path only carries the streams the user asked for, so bring the fast
+    // path's destination into line with the requested `-X` state and any
+    // selective xattr `--filter`. Mirrors the macOS clonefile fast path.
+    #[cfg(feature = "xattr")]
+    reconcile_copied_ads(context, source, destination, flags)?;
+
     let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
     let total_bytes = Some(metadata_snapshot.len());
     let change_set = LocalCopyChangeSet::for_file(
@@ -219,6 +227,52 @@ fn normalize_copied_metadata(
         filetime::set_file_mtime(destination, now)
             .map_err(|e| LocalCopyError::io("normalize copied mtime", destination, e))?;
     }
+    Ok(())
+}
+
+/// Brings the streams `CopyFileExW` copied into line with the requested `-X`
+/// state and any selective xattr `--filter`.
+///
+/// `CopyFileExW` copies every named NTFS Alternate Data Stream (rsync's
+/// Windows extended attributes) verbatim. The portable copy path only carries
+/// the attributes the user requested, so:
+///
+/// - Without `--xattrs`, strip every source-originated stream, matching a
+///   freshly `open()`ed destination.
+/// - With `--xattrs` and a selective xattr filter, reset to that clean slate
+///   and re-add only the streams whose names pass the filter.
+/// - With `--xattrs` and no selective filter, keep every stream verbatim.
+///
+/// upstream: xattrs.c:rsync_xal_set() - only `--xattrs` transfers attributes,
+/// and per-name include/exclude rules gate which survive.
+#[cfg(feature = "xattr")]
+fn reconcile_copied_ads(
+    context: &CopyContext,
+    source: &Path,
+    destination: &Path,
+    flags: TransferFlags,
+) -> Result<(), LocalCopyError> {
+    use crate::local_copy::metadata_sync::map_metadata_error;
+
+    if !flags.xattrs_enabled() {
+        ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;
+        return Ok(());
+    }
+
+    let Some(program) = context.filter_program() else {
+        return Ok(());
+    };
+    if !program.has_xattr_rules() {
+        return Ok(());
+    }
+
+    // Reset to a clean slate then re-copy only the streams the selective
+    // filter admits, so a filtered-out source stream `CopyFileExW` pre-copied
+    // does not survive on the destination.
+    ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;
+    let filter = |name: &str| program.allows_xattr(name);
+    ::metadata::sync_xattrs(source, destination, false, Some(&filter))
+        .map_err(map_metadata_error)?;
     Ok(())
 }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -253,6 +253,17 @@ fn reconcile_copied_ads(
     flags: TransferFlags,
 ) -> Result<(), LocalCopyError> {
     use crate::local_copy::metadata_sync::map_metadata_error;
+    use std::path::PathBuf;
+
+    // A `--files-from` source can carry a literal `.` path component (e.g.
+    // `dir\.\file`). `strip_source_xattrs`/`sync_xattrs` prepend the `\\?\`
+    // verbatim prefix, which disables the kernel's `.` resolution, so
+    // `FindFirstStreamW` fails `NotFound` - which `is_vanished_error` then
+    // misreads as a vanished source. Re-collect through `components()` to drop
+    // mid-path `.`, matching the resolved path `CopyFileExW` itself used.
+    let source: PathBuf = source.components().collect();
+    let destination: PathBuf = destination.components().collect();
+    let (source, destination) = (source.as_path(), destination.as_path());
 
     if !flags.xattrs_enabled() {
         ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -265,16 +265,6 @@ fn reconcile_copied_ads(
     let destination: PathBuf = destination.components().collect();
     let (source, destination) = (source.as_path(), destination.as_path());
 
-    eprintln!(
-        "OC_ADS_DIAG reconcile src={} xattrs_enabled={} program={} has_xattr_rules={}",
-        source.display(),
-        flags.xattrs_enabled(),
-        context.filter_program().is_some(),
-        context
-            .filter_program()
-            .map_or(false, |p| p.has_xattr_rules()),
-    );
-
     if !flags.xattrs_enabled() {
         ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;
         return Ok(());

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -27,8 +27,8 @@ use crate::local_copy::{
     LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
-use super::super::finalize::finalize_guard_and_metadata;
 use super::super::TransferFlags;
+use super::super::finalize::finalize_guard_and_metadata;
 
 /// Returns whether the current transfer satisfies every `CopyFileExW` precondition.
 ///

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs
@@ -20,15 +20,15 @@ use std::time::Instant;
 
 use logging::debug_log;
 
-use ::metadata::MetadataOptions;
+use metadata::MetadataOptions;
 
 use crate::local_copy::{
     CopyContext, CopyMethodKind, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet,
     LocalCopyError, LocalCopyExecution, LocalCopyMetadata, LocalCopyRecord,
 };
 
-use super::super::TransferFlags;
 use super::super::finalize::finalize_guard_and_metadata;
+use super::super::TransferFlags;
 
 /// Returns whether the current transfer satisfies every `CopyFileExW` precondition.
 ///
@@ -264,6 +264,16 @@ fn reconcile_copied_ads(
     let source: PathBuf = source.components().collect();
     let destination: PathBuf = destination.components().collect();
     let (source, destination) = (source.as_path(), destination.as_path());
+
+    eprintln!(
+        "OC_ADS_DIAG reconcile src={} xattrs_enabled={} program={} has_xattr_rules={}",
+        source.display(),
+        flags.xattrs_enabled(),
+        context.filter_program().is_some(),
+        context
+            .filter_program()
+            .map_or(false, |p| p.has_xattr_rules()),
+    );
 
     if !flags.xattrs_enabled() {
         ::metadata::strip_source_xattrs(source, destination, false).map_err(map_metadata_error)?;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
@@ -49,8 +49,12 @@ pub(super) struct TransferFlags {
     pub ignore_times_enabled: bool,
     /// Whether to use checksums for comparison.
     pub checksum_enabled: bool,
-    /// Whether to preserve extended attributes (Unix only).
-    #[cfg(all(unix, feature = "xattr"))]
+    /// Whether to preserve extended attributes.
+    ///
+    /// On Unix this is POSIX extended attributes; on Windows it maps `-X`
+    /// onto NTFS Alternate Data Streams so the `CopyFileExW` fast path can
+    /// decide whether to keep or strip the streams the kernel copied.
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub preserve_xattrs: bool,
     /// Whether to preserve ACLs (Unix only).
     #[cfg(all(any(unix, windows), feature = "acl"))]
@@ -62,11 +66,11 @@ impl TransferFlags {
     /// accounting for compile-time feature flags.
     #[inline]
     pub(super) const fn xattrs_enabled(self) -> bool {
-        #[cfg(all(unix, feature = "xattr"))]
+        #[cfg(all(any(unix, windows), feature = "xattr"))]
         {
             self.preserve_xattrs
         }
-        #[cfg(not(all(unix, feature = "xattr")))]
+        #[cfg(not(all(any(unix, windows), feature = "xattr")))]
         {
             false
         }

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -4,10 +4,10 @@
 
 use std::path::Path;
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 use filters::FilterAction;
 use filters::FilterRule;
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 use globset::{GlobBuilder, GlobMatcher};
 use thiserror::Error;
 
@@ -53,7 +53,7 @@ pub struct FilterProgram {
     dir_merge_rules: Vec<DirMergeRule>,
     exclude_if_present_rules: Vec<ExcludeIfPresentRule>,
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     xattr_rules: Vec<XattrRule>,
 }
 
@@ -68,13 +68,13 @@ impl FilterProgram {
         let mut exclude_if_present_rules = Vec::new();
         let mut current_segment = FilterSegment::default();
 
-        #[cfg(all(unix, feature = "xattr"))]
+        #[cfg(all(any(unix, windows), feature = "xattr"))]
         let mut xattr_rules = Vec::new();
 
         for entry in entries {
             match entry {
                 FilterProgramEntry::Rule(rule) => {
-                    #[cfg(all(unix, feature = "xattr"))]
+                    #[cfg(all(any(unix, windows), feature = "xattr"))]
                     {
                         if rule.is_xattr_only() {
                             let compiled = XattrRule::new(&rule)?;
@@ -83,7 +83,7 @@ impl FilterProgram {
                             current_segment.push_rule(rule)?;
                         }
                     }
-                    #[cfg(not(all(unix, feature = "xattr")))]
+                    #[cfg(not(all(any(unix, windows), feature = "xattr")))]
                     {
                         current_segment.push_rule(rule)?;
                     }
@@ -93,7 +93,7 @@ impl FilterProgram {
                     instructions.clear();
                     dir_merge_rules.clear();
                     exclude_if_present_rules.clear();
-                    #[cfg(all(unix, feature = "xattr"))]
+                    #[cfg(all(any(unix, windows), feature = "xattr"))]
                     {
                         xattr_rules.clear();
                     }
@@ -127,7 +127,7 @@ impl FilterProgram {
             instructions,
             dir_merge_rules,
             exclude_if_present_rules,
-            #[cfg(all(unix, feature = "xattr"))]
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
             xattr_rules,
         })
     }
@@ -150,11 +150,11 @@ impl FilterProgram {
                     | FilterInstruction::ExcludeIfPresent { .. } => false,
                 });
 
-        #[cfg(all(unix, feature = "xattr"))]
+        #[cfg(all(any(unix, windows), feature = "xattr"))]
         {
             filters_empty && self.xattr_rules.is_empty()
         }
-        #[cfg(not(all(unix, feature = "xattr")))]
+        #[cfg(not(all(any(unix, windows), feature = "xattr")))]
         {
             filters_empty
         }
@@ -275,12 +275,12 @@ impl FilterProgram {
         Ok(false)
     }
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(crate) const fn has_xattr_rules(&self) -> bool {
         !self.xattr_rules.is_empty()
     }
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(crate) fn allows_xattr(&self, name: &str) -> bool {
         if self.xattr_rules.is_empty() {
             return true;
@@ -341,14 +341,14 @@ impl FilterProgramError {
     }
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 #[derive(Clone, Debug)]
 struct XattrRule {
     action: FilterAction,
     matcher: GlobMatcher,
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 impl XattrRule {
     fn new(rule: &FilterRule) -> Result<Self, FilterProgramError> {
         debug_assert!(rule.is_xattr_only());

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -140,7 +140,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) contimeout: Option<Duration>,
     pub(super) stop_at: Option<SystemTime>,
 
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
     #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_nfsv4_acls: bool,
@@ -266,7 +266,7 @@ impl LocalCopyOptionsBuilder {
             timeout: None,
             contimeout: None,
             stop_at: None,
-            #[cfg(all(unix, feature = "xattr"))]
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
             preserve_xattrs: false,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_nfsv4_acls: false,

--- a/crates/engine/src/local_copy/options/builder/setters_metadata.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_metadata.rs
@@ -157,7 +157,7 @@ impl LocalCopyOptionsBuilder {
     }
 
     /// Enables extended attribute preservation.
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     #[must_use]
     pub fn preserve_xattrs(mut self, enabled: bool) -> Self {
         self.preserve_xattrs = enabled;
@@ -165,7 +165,7 @@ impl LocalCopyOptionsBuilder {
     }
 
     /// Alias for `preserve_xattrs` for rsync compatibility.
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     #[must_use]
     pub fn xattrs(mut self, enabled: bool) -> Self {
         self.preserve_xattrs = enabled;

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -191,7 +191,7 @@ impl LocalCopyOptionsBuilder {
             timeout: self.timeout,
             contimeout: self.contimeout,
             stop_at: self.stop_at,
-            #[cfg(all(unix, feature = "xattr"))]
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
             preserve_xattrs: self.preserve_xattrs,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_nfsv4_acls: self.preserve_nfsv4_acls,

--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -179,14 +179,21 @@ pub(super) fn is_effective_root() -> bool {
     false
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 impl LocalCopyOptions {
     /// Reports whether extended attribute preservation has been requested.
+    ///
+    /// On Windows the "extended attributes" surface is NTFS Alternate Data
+    /// Streams; the Windows `CopyFileExW` fast path consults this to decide
+    /// whether the streams the kernel copied must be stripped afterwards.
     #[must_use]
     pub const fn preserve_xattrs(&self) -> bool {
         self.preserve_xattrs
     }
+}
 
+#[cfg(all(unix, feature = "xattr"))]
+impl LocalCopyOptions {
     /// Reports whether NFSv4 ACL preservation has been requested.
     #[must_use]
     pub const fn preserve_nfsv4_acls(&self) -> bool {

--- a/crates/engine/src/local_copy/options/metadata/setters.rs
+++ b/crates/engine/src/local_copy/options/metadata/setters.rs
@@ -190,7 +190,7 @@ impl LocalCopyOptions {
     }
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(any(unix, windows), feature = "xattr"))]
 impl LocalCopyOptions {
     /// Requests that extended attributes be preserved when copying entries.
     #[must_use]
@@ -200,7 +200,10 @@ impl LocalCopyOptions {
         self.preserve_xattrs = preserve;
         self
     }
+}
 
+#[cfg(all(unix, feature = "xattr"))]
+impl LocalCopyOptions {
     /// Requests that NFSv4 ACLs be preserved when copying entries.
     ///
     /// NFSv4 ACLs are distinct from POSIX ACLs and use an ACE-based model

--- a/crates/engine/src/local_copy/options/metadata/setters.rs
+++ b/crates/engine/src/local_copy/options/metadata/setters.rs
@@ -193,6 +193,8 @@ impl LocalCopyOptions {
 #[cfg(all(any(unix, windows), feature = "xattr"))]
 impl LocalCopyOptions {
     /// Requests that extended attributes be preserved when copying entries.
+    ///
+    /// On Windows `-X` maps onto NTFS Alternate Data Streams.
     #[must_use]
     #[doc(alias = "--xattrs")]
     #[doc(alias = "-X")]

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -220,7 +220,7 @@ pub struct LocalCopyOptions {
     pub(super) timeout: Option<Duration>,
     pub(super) contimeout: Option<Duration>,
     pub(super) stop_at: Option<SystemTime>,
-    #[cfg(all(unix, feature = "xattr"))]
+    #[cfg(all(any(unix, windows), feature = "xattr"))]
     pub(super) preserve_xattrs: bool,
     #[cfg(all(unix, feature = "xattr"))]
     pub(super) preserve_nfsv4_acls: bool,
@@ -350,7 +350,7 @@ impl LocalCopyOptions {
             timeout: None,
             contimeout: None,
             stop_at: None,
-            #[cfg(all(unix, feature = "xattr"))]
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
             preserve_xattrs: false,
             #[cfg(all(unix, feature = "xattr"))]
             preserve_nfsv4_acls: false,

--- a/crates/engine/tests/wincopy_ads_xattr.rs
+++ b/crates/engine/tests/wincopy_ads_xattr.rs
@@ -1,0 +1,167 @@
+//! Windows fast-copy (`CopyFileExW`) xattr/ADS gating tests.
+//!
+//! On Windows an rsync "extended attribute" is an NTFS Alternate Data Stream
+//! (`file:name:$DATA`). `CopyFileExW` copies every named stream verbatim, so
+//! the local-copy fast path must reproduce the portable path's behaviour:
+//! without `-X` the destination carries no source streams, with `-X` the
+//! streams are kept, and a selective xattr `--filter` excluding a stream name
+//! drops that stream. Mirrors upstream rsync: xattrs are only transferred when
+//! `--xattrs` is requested (`xattrs.c:rsync_xal_set()`).
+
+#![cfg(all(windows, feature = "xattr"))]
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use engine::local_copy::{
+    FilterProgram, FilterProgramEntry, LocalCopyExecution, LocalCopyOptions, LocalCopyPlan,
+};
+use filters::FilterRule;
+use tempfile::tempdir;
+
+/// Writes `value` into the named alternate data stream `file:name:$DATA`.
+fn write_ads(file: &Path, name: &str, value: &[u8]) {
+    let stream = format!("{}:{}", file.display(), name);
+    let mut handle = fs::File::create(&stream).expect("create ADS");
+    handle.write_all(value).expect("write ADS");
+}
+
+/// Reads the named alternate data stream, or `None` when it does not exist.
+fn read_ads(file: &Path, name: &str) -> Option<Vec<u8>> {
+    let stream = format!("{}:{}", file.display(), name);
+    let mut handle = fs::File::open(&stream).ok()?;
+    let mut buf = Vec::new();
+    handle.read_to_end(&mut buf).ok()?;
+    Some(buf)
+}
+
+/// Returns `true` when the temp volume supports NTFS alternate data streams.
+/// FAT/exFAT-backed runners cannot host streams, so those cases skip.
+fn ads_supported(file: &Path) -> bool {
+    let stream = format!("{}:oc_probe", file.display());
+    match fs::File::create(&stream) {
+        Ok(mut h) => h.write_all(b"1").is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// Runs a plain recursive local copy (whole-file, so the `CopyFileExW` fast
+/// path is eligible) with the supplied options and returns the dest file path.
+fn run_copy(source_dir: &Path, dest_dir: &Path, options: LocalCopyOptions) {
+    let operands = vec![
+        source_dir.to_path_buf().into_os_string(),
+        dest_dir.to_path_buf().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("local copy succeeds");
+}
+
+/// (a) Without `-X`, the fast path must strip the source ADS so the
+/// destination matches a freshly written portable-path copy.
+#[test]
+fn wincopy_without_xattrs_drops_ads() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_file = source.join("payload.bin");
+    fs::write(&source_file, b"data").expect("write source");
+    if !ads_supported(&source_file) {
+        return;
+    }
+    write_ads(&source_file, "stream", b"secret");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .whole_file(true)
+        .xattrs(false);
+    run_copy(&source, &dest, options);
+
+    let dest_file = dest.join("src").join("payload.bin");
+    assert!(dest_file.exists(), "destination payload must exist");
+    assert_eq!(
+        read_ads(&dest_file, "stream"),
+        None,
+        "ADS must not survive a fast copy when --xattrs is off"
+    );
+}
+
+/// (b) With `-X`, the fast path keeps the source ADS verbatim.
+#[test]
+fn wincopy_with_xattrs_keeps_ads() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_file = source.join("payload.bin");
+    fs::write(&source_file, b"data").expect("write source");
+    if !ads_supported(&source_file) {
+        return;
+    }
+    write_ads(&source_file, "stream", b"secret");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .whole_file(true)
+        .xattrs(true);
+    run_copy(&source, &dest, options);
+
+    let dest_file = dest.join("src").join("payload.bin");
+    assert!(dest_file.exists(), "destination payload must exist");
+    assert_eq!(
+        read_ads(&dest_file, "stream").as_deref(),
+        Some(b"secret".as_slice()),
+        "ADS must survive a fast copy when --xattrs is on"
+    );
+}
+
+/// (c) A selective xattr filter excluding the stream name drops it even with
+/// `-X` on. The presence of xattr filter rules also forces the fast path to
+/// defer to the portable copy path, which applies the per-name filter.
+#[test]
+fn wincopy_selective_filter_excludes_named_stream() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&source).expect("create source");
+    fs::create_dir_all(&dest).expect("create dest");
+
+    let source_file = source.join("payload.bin");
+    fs::write(&source_file, b"data").expect("write source");
+    if !ads_supported(&source_file) {
+        return;
+    }
+    write_ads(&source_file, "keep", b"one");
+    write_ads(&source_file, "drop", b"two");
+
+    let program = FilterProgram::new([FilterProgramEntry::Rule(
+        FilterRule::exclude("drop").with_xattr_only(true),
+    )])
+    .expect("filter program");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .whole_file(true)
+        .xattrs(true)
+        .with_filter_program(Some(program));
+    run_copy(&source, &dest, options);
+
+    let dest_file = dest.join("src").join("payload.bin");
+    assert!(dest_file.exists(), "destination payload must exist");
+    assert_eq!(
+        read_ads(&dest_file, "keep").as_deref(),
+        Some(b"one".as_slice()),
+        "unfiltered ADS must survive"
+    );
+    assert_eq!(
+        read_ads(&dest_file, "drop"),
+        None,
+        "ADS excluded by a selective xattr filter must be dropped"
+    );
+}

--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -238,6 +238,16 @@ fn ads_zone_identifier_round_trips_through_xattrs() {
         String::from_utf8_lossy(&output.stderr),
     );
 
+    eprintln!(
+        "OC_ADS_DIAG test(zone) oc-rsync stderr:\n{}\nstdout:\n{}\ndst streams: {:?}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+        std::fs::read_dir(&dst).ok().map(|rd| rd
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect::<Vec<_>>()),
+    );
+
     let dst_file = dst.join("downloaded.exe");
     assert!(dst_file.is_file(), "dest primary stream missing");
 

--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -225,7 +225,7 @@ fn ads_zone_identifier_round_trips_through_xattrs() {
     let src_arg = format!("{}\\", src.display());
     let dst_arg = format!("{}\\", dst.display());
     let output = Command::new(&oc_rsync)
-        .args(["--xattrs", "--archive", "--debug=all"])
+        .args(["--xattrs", "--archive"])
         .arg(&src_arg)
         .arg(&dst_arg)
         .output()
@@ -236,16 +236,6 @@ fn ads_zone_identifier_round_trips_through_xattrs() {
         output.status.code(),
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
-    );
-
-    eprintln!(
-        "OC_ADS_DIAG test(zone) oc-rsync stderr:\n{}\nstdout:\n{}\ndst streams: {:?}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout),
-        std::fs::read_dir(&dst).ok().map(|rd| rd
-            .filter_map(Result::ok)
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .collect::<Vec<_>>()),
     );
 
     let dst_file = dst.join("downloaded.exe");
@@ -325,7 +315,7 @@ fn ads_multi_stream_round_trips() {
     let src_arg = format!("{}\\", src.display());
     let dst_arg = format!("{}\\", dst.display());
     let output = Command::new(&oc_rsync)
-        .args(["--xattrs", "--archive", "--debug=all"])
+        .args(["--xattrs", "--archive"])
         .arg(&src_arg)
         .arg(&dst_arg)
         .output()

--- a/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
+++ b/crates/metadata/tests/windows_ads_xattrs_roundtrip.rs
@@ -225,7 +225,7 @@ fn ads_zone_identifier_round_trips_through_xattrs() {
     let src_arg = format!("{}\\", src.display());
     let dst_arg = format!("{}\\", dst.display());
     let output = Command::new(&oc_rsync)
-        .args(["--xattrs", "--archive"])
+        .args(["--xattrs", "--archive", "--debug=all"])
         .arg(&src_arg)
         .arg(&dst_arg)
         .output()
@@ -325,7 +325,7 @@ fn ads_multi_stream_round_trips() {
     let src_arg = format!("{}\\", src.display());
     let dst_arg = format!("{}\\", dst.display());
     let output = Command::new(&oc_rsync)
-        .args(["--xattrs", "--archive"])
+        .args(["--xattrs", "--archive", "--debug=all"])
         .arg(&src_arg)
         .arg(&dst_arg)
         .output()


### PR DESCRIPTION
## Bug

The Windows local-copy fast path (`wincopy`, dispatching `CopyFileExW` /
ReFS reflink in `crates/engine/src/local_copy/executor/file/copy/transfer/execute/wincopy.rs`)
copied NTFS Alternate Data Streams unconditionally. `CopyFileExW` copies
every named data stream verbatim, so a fast-path copy carried the source's
ADS (which rsync exposes as extended attributes) even when the user did not
pass `-X`/`--xattrs`, and it ignored selective xattr filter rules.

## Portable-path parity

The portable copy path opens a fresh destination and only carries the
attributes the transfer requested. The fast path bypassed that, so its
output diverged from the standard write path and from upstream rsync, which
only transfers xattrs under `--xattrs` (`xattrs.c:rsync_xal_set()`) and gates
individual names through include/exclude rules.

This is the same hazard the macOS `clonefile` fast path already handles: a
zero-copy/kernel-copy clone duplicates all xattrs, so the path must reconcile
them afterward.

## Fix

- After `CopyFileExW`, reconcile the copied ADS in `wincopy::try_copy` via a
  new `reconcile_copied_ads` helper that mirrors the portable path:
  - without `-X`: strip every source-originated stream (`strip_source_xattrs`),
    matching a freshly written destination;
  - with `-X` and a selective xattr filter: reset to a clean slate then
    re-copy only the streams whose names pass the filter
    (`sync_xattrs` with the filter predicate);
  - with `-X` and no filter: keep the streams verbatim.
- The existing metadata ADS backend (`strip_source_xattrs`/`sync_xattrs`,
  already cross-platform) and the filter program's `has_xattr_rules`/
  `allows_xattr` are reused - no duplicated decision logic.
- Threaded `-X` (`preserve_xattrs`) and the xattr filter program through to
  the Windows executor by widening the relevant `cfg(all(unix, feature =
  "xattr"))` gates to `cfg(all(any(unix, windows), feature = "xattr"))`
  (option field/builder/accessors, `TransferFlags`, the filter program's
  xattr-rule handling, and the CLI wiring), so `-X` has effect on the fast
  path. NFSv4-ACL and Unix-only sync paths stay Unix-gated.

## Test

New `crates/engine/tests/wincopy_ads_xattr.rs`, gated
`#[cfg(all(windows, feature = "xattr"))]`, drives a real recursive local copy
(whole-file, so the fast path is eligible) and asserts:

- (a) `-X` off -> destination has no ADS;
- (b) `-X` on -> destination keeps the ADS;
- (c) selective xattr filter excluding a stream name -> that stream is
  dropped while unfiltered streams survive.

Volumes without ADS support (FAT/exFAT runners) skip gracefully.

## Verification

- `cargo build -p engine` and `cargo check -p engine -p cli --tests` on
  macOS: non-Windows builds unaffected.
- `cargo check -p engine -p cli --tests --target x86_64-pc-windows-gnu`:
  the Windows cfg (including the new gated test) compiles.
- `cargo fmt --all -- --check` and `cargo clippy -p engine -p cli -p filters
  --all-targets --all-features --no-deps -- -D warnings`: clean.
- The Windows-only test relies on CI's Windows cell to execute.