### PR TITLE
feat(transfer): macOS GCD-backed disk-commit writer variant (default-off)

### DIFF
--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -112,6 +112,14 @@ vmsplice = ["fast_io/vmsplice"]
 # fallback. Default off until eviction/throughput benchmarks justify promotion.
 dontcache = ["fast_io/dontcache"]
 
+# macOS Grand Central Dispatch (`dispatch_io`) async disk-commit writer
+# (macOS-only). Selected by the disk-commit thread in preference to the
+# F_NOCACHE + writev macOS writer when io_uring/IOCP are not in play and the
+# write is non-sparse/non-append; sparse/append fall back to the buffered
+# writer. Byte content and fsync semantics match the buffered path. Default
+# off until benchmarks justify promotion. Forwards to `fast_io/macos-gcd`.
+macos-gcd = ["fast_io/macos-gcd"]
+
 
 # Per-thread slab pool for buffer returns - forwards to the engine crate.
 # Forwarded so `--all-features` enables it transitively on engine *and* exposes

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -527,6 +527,16 @@ pub(super) fn make_writer<'a>(
             }
         }
     }
+    // GCD (`dispatch_io`) writer, preferred over the F_NOCACHE + writev
+    // `Macos` writer when the default-off `macos-gcd` feature is enabled.
+    // Sparse and append need Seek, which the channel does not provide, so
+    // they fall back to the buffered writer below.
+    #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+    {
+        if !use_sparse && append_offset == 0 {
+            return Ok(Writer::MacosGcd(fast_io::GcdWriter::from_file(file)?));
+        }
+    }
     #[cfg(target_os = "macos")]
     {
         if !use_sparse && append_offset == 0 {

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -70,7 +70,11 @@ fn is_cross_device_detects_exdev() {
 /// Verifies `make_writer` selects [`Writer::Macos`] when sparse mode is
 /// disabled and `append_offset` is zero, so the `F_NOCACHE` + `writev`
 /// optimization is engaged on the common write path.
-#[cfg(target_os = "macos")]
+///
+/// Gated off when `macos-gcd` is enabled: that feature routes the same
+/// non-sparse/zero-offset path to [`Writer::MacosGcd`] instead (covered by
+/// `make_writer_selects_macos_gcd_when_feature_enabled`).
+#[cfg(all(target_os = "macos", not(feature = "macos-gcd")))]
 #[test]
 fn make_writer_selects_macos_for_non_sparse_zero_offset() {
     let dir = tempfile::tempdir().unwrap();
@@ -138,6 +142,136 @@ fn make_writer_falls_back_to_buffered_when_seek_required() {
     assert!(
         matches!(append_writer, Writer::Buffered(_)),
         "append mode must select Writer::Buffered"
+    );
+}
+
+/// Verifies `make_writer` selects [`Writer::MacosGcd`] for the common
+/// non-sparse, zero-offset path when the `macos-gcd` feature is enabled, so
+/// the GCD (`dispatch_io`) writer replaces the F_NOCACHE + writev writer.
+#[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+#[test]
+fn make_writer_selects_macos_gcd_when_feature_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("macos_gcd_select.bin");
+    let file = fs::File::create(&path).unwrap();
+    let mut write_buf = Vec::with_capacity(256 * 1024);
+
+    let writer = make_writer(
+        file,
+        &mut write_buf,
+        None,
+        None,
+        /* use_sparse */ false,
+        /* append_offset */ 0,
+        /* size_hint */ 0,
+    )
+    .unwrap();
+
+    assert!(
+        matches!(writer, Writer::MacosGcd(_)),
+        "macOS non-sparse zero-offset writes must select Writer::MacosGcd \
+         when the macos-gcd feature is on"
+    );
+}
+
+/// Verifies the GCD writer falls back to [`Writer::Buffered`] under sparse or
+/// append mode, which both require `Seek` that the channel cannot provide.
+#[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+#[test]
+fn make_writer_macos_gcd_falls_back_to_buffered_for_seek() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let sparse_path = dir.path().join("gcd_sparse.bin");
+    let sparse_file = fs::File::create(&sparse_path).unwrap();
+    let mut sparse_buf = Vec::with_capacity(256 * 1024);
+    let sparse_writer = make_writer(
+        sparse_file,
+        &mut sparse_buf,
+        None,
+        None,
+        /* use_sparse */ true,
+        /* append_offset */ 0,
+        /* size_hint */ 0,
+    )
+    .unwrap();
+    assert!(
+        matches!(sparse_writer, Writer::Buffered(_)),
+        "sparse mode must fall back to Writer::Buffered even with macos-gcd on"
+    );
+
+    let append_path = dir.path().join("gcd_append.bin");
+    let append_file = fs::File::create(&append_path).unwrap();
+    let mut append_buf = Vec::with_capacity(256 * 1024);
+    let append_writer = make_writer(
+        append_file,
+        &mut append_buf,
+        None,
+        None,
+        /* use_sparse */ false,
+        /* append_offset */ 4096,
+        /* size_hint */ 0,
+    )
+    .unwrap();
+    assert!(
+        matches!(append_writer, Writer::Buffered(_)),
+        "append mode must fall back to Writer::Buffered even with macos-gcd on"
+    );
+}
+
+/// Verifies a full write-then-commit through [`Writer::MacosGcd`] produces
+/// byte-for-byte the same on-disk file as the buffered writer, exercising the
+/// real `write_chunk` -> `flush_and_sync` -> `finish` disk-commit lifecycle.
+#[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+#[test]
+fn macos_gcd_writer_matches_buffered_byte_for_byte() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Representative payload: several chunks spanning the direct-write
+    // threshold so both the small-buffered and large-direct paths are hit on
+    // the buffered side, and the same bytes flow through the GCD channel.
+    let chunks: Vec<Vec<u8>> = vec![
+        (0..1024u32).map(|i| (i % 251) as u8).collect(),
+        (0..64 * 1024u32).map(|i| (i % 239) as u8).collect(),
+        (0..37u32).map(|i| (i % 211) as u8).collect(),
+        (0..256 * 1024u32).map(|i| (i % 193) as u8).collect(),
+    ];
+
+    let write_all = |mut w: Writer<'_>, path: &Path| {
+        for c in &chunks {
+            w.write_chunk(c).unwrap();
+        }
+        w.flush_and_sync(/* do_fsync */ true, path).unwrap();
+        w.finish(/* do_fsync */ true, path).unwrap();
+    };
+
+    // Obtain a `Writer::Buffered` through `make_writer` by requesting sparse
+    // mode, which always falls back to the buffered variant. The stored writer
+    // carries no sparse state, so `write_chunk` writes the bytes verbatim.
+    let buffered_path = dir.path().join("parity_buffered.bin");
+    let buffered_file = fs::File::create(&buffered_path).unwrap();
+    let mut buffered_buf = Vec::with_capacity(256 * 1024);
+    let buffered_writer = make_writer(
+        buffered_file,
+        &mut buffered_buf,
+        None,
+        None,
+        /* use_sparse */ true,
+        /* append_offset */ 0,
+        /* size_hint */ 0,
+    )
+    .unwrap();
+    assert!(matches!(buffered_writer, Writer::Buffered(_)));
+    write_all(buffered_writer, &buffered_path);
+
+    let gcd_path = dir.path().join("parity_gcd.bin");
+    let gcd_file = fs::File::create(&gcd_path).unwrap();
+    let gcd_writer = Writer::MacosGcd(fast_io::GcdWriter::from_file(gcd_file).unwrap());
+    write_all(gcd_writer, &gcd_path);
+
+    assert_eq!(
+        fs::read(&buffered_path).unwrap(),
+        fs::read(&gcd_path).unwrap(),
+        "GCD writer output must be byte-identical to the buffered writer"
     );
 }
 

--- a/crates/transfer/src/disk_commit/writer.rs
+++ b/crates/transfer/src/disk_commit/writer.rs
@@ -138,9 +138,9 @@ impl Seek for ReusableBufWriter<'_> {
 /// [`fast_io::MacosWriter`], which pairs `F_NOCACHE` (for files above 1 MiB)
 /// with `writev(2)` scatter-gather flushes.
 ///
-/// Sparse mode requires `Seek`, which none of `IoUring`, `Iocp`, or `Macos`
-/// provide, so callers must select `Buffered` whenever `use_sparse` is set
-/// or `append_offset` is non-zero.
+/// Sparse mode requires `Seek`, which none of `IoUring`, `Iocp`, `Macos`, or
+/// `MacosGcd` provide, so callers must select `Buffered` whenever `use_sparse`
+/// is set or `append_offset` is non-zero.
 pub(super) enum Writer<'a> {
     Buffered(ReusableBufWriter<'a>),
     #[cfg(all(target_os = "linux", feature = "io_uring"))]
@@ -153,6 +153,15 @@ pub(super) enum Writer<'a> {
     },
     #[cfg(target_os = "macos")]
     Macos(fast_io::MacosWriter),
+    /// Grand Central Dispatch (`dispatch_io`) async writer (macOS + the
+    /// default-off `macos-gcd` feature). Selected in preference to `Macos`
+    /// only for non-sparse, non-append writes; sparse/append need `Seek`,
+    /// which the channel does not provide, so those fall back to `Buffered`.
+    /// Each `write_chunk` submits one `dispatch_io_write` and blocks until it
+    /// drains, so its byte content and fsync semantics match the buffered
+    /// path. See `fast_io::GcdWriter`.
+    #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+    MacosGcd(fast_io::GcdWriter),
     /// vmsplice zero-copy writer for already-demuxed literal chunks. Selected
     /// only when `io_uring` is not engaged (Linux + `vmsplice` feature, non-
     /// sparse, non-append). Per-chunk it falls back to a buffered write when
@@ -194,6 +203,11 @@ impl<'a> Writer<'a> {
                 debug_assert!(false, "sparse mode must select buffered writer");
                 unreachable!("sparse mode must select buffered writer")
             }
+            #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+            Writer::MacosGcd(_) => {
+                debug_assert!(false, "sparse mode must select buffered writer");
+                unreachable!("sparse mode must select buffered writer")
+            }
             #[cfg(all(target_os = "linux", feature = "vmsplice"))]
             Writer::Vmsplice(_) => {
                 debug_assert!(false, "sparse mode must select buffered writer");
@@ -217,6 +231,8 @@ impl<'a> Writer<'a> {
             Writer::Iocp { batch } => batch.write_data(data),
             #[cfg(target_os = "macos")]
             Writer::Macos(w) => w.write_all(data),
+            #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+            Writer::MacosGcd(w) => w.write_all(data),
             #[cfg(all(target_os = "linux", feature = "vmsplice"))]
             Writer::Vmsplice(w) => w.write_chunk(data).map(|_| ()),
             #[cfg(all(target_os = "linux", feature = "dontcache"))]
@@ -256,6 +272,20 @@ impl<'a> Writer<'a> {
                     w.flush().map_err(|e| {
                         io::Error::other(format!("flush failed for {file_path:?}: {e}"))
                     })
+                }
+            }
+            #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+            Writer::MacosGcd(w) => {
+                // Each `write_chunk` already drove its `dispatch_io_write` to
+                // completion, so there is no userspace buffer to flush; the
+                // non-fsync case is a no-op. The fsync path forces the
+                // durability barrier on the channel-owned descriptor.
+                if do_fsync {
+                    w.sync_all().map_err(|e| {
+                        io::Error::new(e.kind(), format!("fsync failed for {file_path:?}: {e}"))
+                    })
+                } else {
+                    Ok(())
                 }
             }
             #[cfg(all(target_os = "linux", feature = "vmsplice"))]
@@ -320,6 +350,8 @@ impl<'a> Writer<'a> {
             }),
             #[cfg(target_os = "macos")]
             Writer::Macos(_) => Ok(()),
+            #[cfg(all(target_os = "macos", feature = "macos-gcd"))]
+            Writer::MacosGcd(_) => Ok(()),
             #[cfg(all(target_os = "linux", feature = "vmsplice"))]
             Writer::Vmsplice(_) => Ok(()),
             #[cfg(all(target_os = "linux", feature = "dontcache"))]


### PR DESCRIPTION
## Summary

Wires a macOS Grand Central Dispatch (`dispatch_io`) file-writer into the disk-commit path, behind the existing default-off `macos-gcd` cargo feature. The GCD primitives (`GcdReader`/`GcdWriter`/`GcdQueue`) already existed in `crates/fast_io/src/gcd/`; this adds the write-path dispatch that consumes `GcdWriter`.

## Changes

- **New gated variant** `Writer::MacosGcd(fast_io::GcdWriter)` in `crates/transfer/src/disk_commit/writer.rs`, gated `#[cfg(all(target_os = "macos", feature = "macos-gcd"))]`, mirroring the existing accelerated variants' dispatch arms (`write_chunk`, `flush_and_sync`, `finish`, `buffered_for_sparse`).
  - `write_chunk` -> `GcdWriter::write_all` (each call drives one `dispatch_io_write` to completion).
  - `flush_and_sync(false)` is a no-op (writes already drained); `flush_and_sync(true)` -> `sync_all` (`fsync`). `finish` drops the writer, gracefully closing the channel.
- **`make_writer` dispatch** in `process/file_ops.rs`: selects `MacosGcd` in preference to the F_NOCACHE + writev `Macos` writer, only when the feature is on and the write is non-sparse and non-append.
- **Fallback conditions:** sparse-writing (`use_sparse`) and append/inplace-resume (`append_offset != 0`) both require `Seek`, which the GCD channel cannot express, so they fall back to the `Buffered` writer - matching how the `Macos`/`Vmsplice`/`Dontcache` variants gate.
- **New `macos-gcd` feature** in `crates/transfer/Cargo.toml`, forwarding to `fast_io/macos-gcd`.

## Correctness

The written bytes and fsync/finish semantics are identical to the buffered path. A new parity test drives the real `write_chunk` -> `flush_and_sync(fsync)` -> `finish(fsync)` lifecycle through both `MacosGcd` and `Buffered` over multi-chunk representative data and asserts the on-disk files are byte-for-byte equal. Selection and sparse/append-fallback tests are also added (all gated on `macos-gcd`).

**The default build (feature off) selects the identical writer as before** - the pre-existing `make_writer_selects_macos` test is retained (now gated `not(feature = "macos-gcd")`).

## Verification (aarch64 macOS)

- `cargo build -p transfer` and `cargo clippy -p transfer --no-deps -- -D warnings` (default, feature off): clean.
- `cargo clippy -p transfer --features macos-gcd --no-deps -- -D warnings` and `--all-features`: clean.
- `cargo test -p transfer --lib disk_commit` both ways (single-threaded): default 99 pass, feature-on 101 pass, including the 3 new `macos-gcd` tests.

The feature stays default-off pending the follow-up bench.