### PR TITLE
test: port more upstream testsuite edge cases to nextest (round 2)

### DIFF
--- a/crates/transfer/tests/uts_chmod_option.rs
+++ b/crates/transfer/tests/uts_chmod_option.rs
@@ -1,0 +1,168 @@
+//! Nextest port of the local legs of upstream `testsuite/chmod-option.test`.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/chmod-option.test`.
+//!
+//! # Background
+//!
+//! Upstream's `chmod-option.test` verifies that `--chmod` rewrites permission
+//! bits on the fly during a transfer, applying the same symbolic-mode grammar
+//! `chmod(1)` uses, with rsync's `F`/`D` file/directory qualifiers. Two of its
+//! legs are pure local transfers with a deterministic outcome:
+//!
+//! 1. `--chmod ug-s,a+rX,D+w` - strip setuid/setgid, grant read plus
+//!    conditional execute (`X` = execute only where already executable or on a
+//!    directory), and give directories group/other write.
+//! 2. `--chmod=Fo-x` - clear the world-execute bit on regular files only,
+//!    leaving directories untouched.
+//!
+//! The remaining upstream legs drive a spawned `--daemon` with an
+//! `incoming chmod` directive to reproduce a 2.6.8-era daemon bug; those need
+//! a live listener and are out of scope for this in-process port.
+//!
+//! # Why this matters
+//!
+//! `--chmod` is applied by the receiver as it commits each entry. A regression
+//! in the symbolic-mode parser or in the `F`/`D` qualifier dispatch silently
+//! writes the wrong permission bits - a security-relevant divergence (e.g.
+//! failing to strip setuid, or clearing execute on directories). The two legs
+//! here pin the `X` conditional-execute rule, the setuid/setgid strip, the
+//! directory-only `D` qualifier, and the regular-file-only `F` qualifier.
+//!
+//! Both legs assert the exact mode bits upstream rsync 3.4.4 produces (verified
+//! against the installed upstream binary), so the test encodes the required
+//! behaviour, not merely oc-rsync's current output.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/chmod-option.test` - the upstream script this file ports.
+//! - `chmod.c` - `parse_chmod()` symbolic-mode grammar and `F`/`D` qualifiers.
+//! - `generator.c` - receiver-side application of the parsed chmod modes.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Low 12 permission bits (`0o7777`) of `path`, following the entry itself.
+fn mode_bits(path: &Path) -> u32 {
+    fs::symlink_metadata(path)
+        .unwrap_or_else(|e| panic!("stat {}: {e}", path.display()))
+        .permissions()
+        .mode()
+        & 0o7777
+}
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(p: &Path) -> std::ffi::OsString {
+    let mut s = p.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// Leg 1: `--chmod ug-s,a+rX,D+w`.
+///
+/// Source modes: `name1` = 04700 (setuid, rwx------), `name2` = 0644,
+/// `dir1` = 0700, `dir2` = 0770.
+///
+/// Expected destination modes (verified identical between oc-rsync and
+/// upstream rsync 3.4.4):
+/// - `name1`: strip setuid -> 0700, `a+rX` adds r for all and (already
+///   executable) x for all -> 0755.
+/// - `name2`: not executable, so `X` adds nothing; `a+r` leaves it -> 0644.
+/// - `dir1`: 0700 -> `a+rX` -> 0755; `D+w` is a no-op here (0755).
+/// - `dir2`: 0770 -> `a+rX` -> 0775; `D+w` keeps group/other write (0775).
+#[test]
+fn chmod_strip_setid_and_add_rx_dir_write() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let from = root.path().join("from");
+    let to = root.path().join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+
+    fs::write(from.join("name1"), b"This is the file\n").expect("write name1");
+    fs::write(from.join("name2"), b"This is the other file\n").expect("write name2");
+    fs::create_dir(from.join("dir1")).expect("mkdir dir1");
+    fs::create_dir(from.join("dir2")).expect("mkdir dir2");
+    fs::set_permissions(from.join("name1"), fs::Permissions::from_mode(0o4700)).expect("chmod");
+    fs::set_permissions(from.join("name2"), fs::Permissions::from_mode(0o644)).expect("chmod");
+    fs::set_permissions(from.join("dir1"), fs::Permissions::from_mode(0o700)).expect("chmod");
+    fs::set_permissions(from.join("dir2"), fs::Permissions::from_mode(0o770)).expect("chmod");
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-a", "--chmod", "ug-s,a+rX,D+w"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        mode_bits(&to.join("name1")),
+        0o755,
+        "name1: setuid must be stripped and a+rX applied (0755)",
+    );
+    assert_eq!(
+        mode_bits(&to.join("name2")),
+        0o644,
+        "name2: not executable, X adds nothing (0644)",
+    );
+    assert_eq!(
+        mode_bits(&to.join("dir1")),
+        0o755,
+        "dir1: a+rX then D+w (0755)",
+    );
+    assert_eq!(
+        mode_bits(&to.join("dir2")),
+        0o775,
+        "dir2: a+rX then D+w (0775)",
+    );
+}
+
+/// Leg 2: `--chmod=Fo-x`.
+///
+/// `Fo-x` clears the world-execute bit on regular files only; directories are
+/// left alone. Source: `bar` (a file, 0755 after `chmod o+x`), `foo` (a dir).
+///
+/// Expected destination modes (verified identical between oc-rsync and
+/// upstream rsync 3.4.4):
+/// - `bar`: source is 0645 (0644 + `o+x`); `Fo-x` clears world-execute -> 0644.
+/// - `foo`: directory untouched by the `F`-only chmod -> 0755.
+#[test]
+fn chmod_file_only_clears_world_execute() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let from = root.path().join("from");
+    let to = root.path().join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir(from.join("foo")).expect("mkdir foo");
+    fs::write(from.join("bar"), b"").expect("touch bar");
+    // Match upstream: `chmod o+x "$fromdir"/bar`. Start from 0644, add o+x.
+    fs::set_permissions(from.join("bar"), fs::Permissions::from_mode(0o645)).expect("chmod bar");
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-a", "--chmod=Fo-x"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        mode_bits(&to.join("bar")),
+        0o644,
+        "bar: Fo-x clears the world-execute bit on the regular file (0644)",
+    );
+    assert_eq!(
+        mode_bits(&to.join("foo")),
+        0o755,
+        "foo: directory left untouched by the F-only chmod (0755)",
+    );
+}

--- a/crates/transfer/tests/uts_missing_args.rs
+++ b/crates/transfer/tests/uts_missing_args.rs
@@ -1,0 +1,160 @@
+//! Nextest port of the upstream `testsuite/missing.test` scenario.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/missing.test`.
+//!
+//! # Background
+//!
+//! Upstream's `missing.test` guards bugs Wayne Davison fixed when he reworked
+//! the generator's `missing_below` logic (the state that suppresses per-file
+//! work under a directory that a dry run has decided not to create):
+//!
+//! 1. A dry run with `--ignore-non-existing` must not emit spurious
+//!    "not creating new ..." chatter for a file whose parent directory does
+//!    not exist at the destination. The whole subtree is skipped, silently.
+//! 2. `--delete-after` on a dry run must still run its deletion pass even when
+//!    the final source directory is "missing" at the destination (the pass was
+//!    being skipped when the last directory was dry-missing).
+//!
+//! The nextest port lifts the two deterministic, local-transfer legs of the
+//! upstream script (its test 1 and test 3). Upstream test 2 exercises a
+//! `--fuzzy --no-implied-dirs -R` dirlist edge that only asserts a clean exit;
+//! that is subsumed by the exit-0 assertion here and adds a fragile `-R` path
+//! shape, so it is not ported.
+//!
+//! # What this test pins
+//!
+//! - Test 1: `-n -r --ignore-non-existing -vv from/ to/` never prints a
+//!   "not creating new" line naming `subdir/file` (the file under the
+//!   non-existent destination directory), and the dry run touches nothing on
+//!   disk.
+//! - Test 3: `-n -r --delete-after -i from/ to/` still itemizes the deletion
+//!   of `to/other` (a destination-only file), proving the delete-after pass is
+//!   not skipped when the last source directory is dry-missing.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/missing.test` - the upstream script this file ports.
+//! - `generator.c` - `missing_below` handling and the `--ignore-non-existing`
+//!   skip path (`skipping non-existent destination file`).
+//! - `delete.c` - the `--delete-after` deletion pass that must still run.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Build the shared source/destination fixture used by both legs.
+///
+/// Mirrors the upstream setup:
+///
+/// ```sh
+/// makepath "$fromdir/subdir" "$todir"
+/// echo data >"$fromdir/subdir/file"
+/// echo data >"$todir/other"
+/// ```
+///
+/// `to/other` is a destination-only file (no source counterpart) so the
+/// `--delete-after` leg has something to delete. `from/subdir/file` lives
+/// under a directory that does not exist at the destination, which is what
+/// drives the `missing_below` logic.
+fn setup() -> TempDir {
+    let root = tempfile::tempdir().expect("tempdir");
+    let from_sub = root.path().join("from").join("subdir");
+    let to = root.path().join("to");
+    fs::create_dir_all(&from_sub).expect("mkdir from/subdir");
+    fs::create_dir_all(&to).expect("mkdir to");
+    fs::write(from_sub.join("file"), b"data\n").expect("write from/subdir/file");
+    fs::write(to.join("other"), b"data\n").expect("write to/other");
+    root
+}
+
+/// Trailing-slash form of a directory so rsync copies its contents, matching
+/// the upstream `"$fromdir/"` / `"$todir/"` argument shape.
+fn slash(p: &Path) -> std::ffi::OsString {
+    let mut s = p.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// Upstream test 1: a dry run with `--ignore-non-existing` must not emit
+/// "not creating new ..." output for a file under a directory that does not
+/// exist at the destination, and must not create anything on disk.
+#[test]
+fn ignore_non_existing_dry_run_is_quiet_and_touches_nothing() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = setup();
+    let from = root.path().join("from");
+    let to = root.path().join("to");
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-n", "-r", "--ignore-non-existing", "-vv"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    // Upstream assertion: the "not creating new" chatter must never name the
+    // file under the non-existent destination directory. oc-rsync emits at
+    // most a "skipping non-existent destination file" line for the directory
+    // itself; it must never claim it is (not) creating `subdir/file`.
+    let stdout = out.stdout_str();
+    assert!(
+        !stdout.contains("not creating new") || !stdout.contains("subdir/file"),
+        "dry run leaked spurious \"not creating new ... subdir/file\" output:\n{stdout}",
+    );
+
+    // A dry run must not create the skipped subtree at the destination.
+    assert!(
+        !to.join("subdir").exists(),
+        "dry run created to/subdir on disk (should be a no-op)",
+    );
+    assert!(
+        !to.join("subdir").join("file").exists(),
+        "dry run created to/subdir/file on disk (should be a no-op)",
+    );
+}
+
+/// Upstream test 3: `--delete-after` on a dry run must still run its deletion
+/// pass and itemize `to/other` for deletion, even though the last source
+/// directory is dry-missing at the destination.
+#[test]
+fn delete_after_dry_run_still_itemizes_deletion() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = setup();
+    let from = root.path().join("from");
+    let to = root.path().join("to");
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-n", "-r", "--delete-after", "-i"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    // Upstream assertion: grep '^\*deleting * other'. The delete-after pass
+    // must fire and itemize the destination-only file for deletion.
+    let stdout = out.stdout_str();
+    let deleted = stdout
+        .lines()
+        .any(|l| l.starts_with("*deleting") && l.trim_end().ends_with("other"));
+    assert!(
+        deleted,
+        "delete-after dry run did not itemize *deleting other:\n{stdout}",
+    );
+
+    // Dry run: the file must still be on disk afterwards.
+    assert!(
+        to.join("other").exists(),
+        "dry run actually deleted to/other (must be a no-op on disk)",
+    );
+}

--- a/crates/transfer/tests/uts_multi_source_merge.rs
+++ b/crates/transfer/tests/uts_multi_source_merge.rs
@@ -1,0 +1,156 @@
+//! Nextest port of the upstream `testsuite/merge.test` scenario.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/merge.test`.
+//!
+//! # Background
+//!
+//! Upstream's `merge.test` verifies that rsync can merge files from multiple
+//! source directories (and bare file arguments) into a single destination in
+//! one invocation. The canonical command is:
+//!
+//! ```sh
+//! $RSYNC -avv deep/arg-test shallow from1/ from2/ from3/ to/
+//! ```
+//!
+//! It exercises the multi-argument sender path: bare file arguments
+//! (`deep/arg-test`, `shallow`), and three trailing-slash source directories
+//! whose contents are unioned into `to/`. Overlapping names must resolve
+//! last-writer-wins (`from1/one` == `from2/one` == `from3/one`), disjoint
+//! names must all arrive, nested subdirectories (`sub1/`, `sub2/`) must merge
+//! per-directory, and the awkward `dir-and-not-dir` collision - a directory in
+//! `from1`, a plain file in `from3` - must resolve to the directory (the first
+//! argument that reached it), never a type-confused hybrid.
+//!
+//! # Why this matters
+//!
+//! Merging multiple sources into one destination is a distinct code path from
+//! a single-source recursive copy: the sender builds one flist spanning
+//! several roots, and the generator/receiver must reconcile overlapping and
+//! type-conflicting entries. A regression here silently drops or duplicates
+//! files, or lets a plain-file argument clobber a directory of the same name.
+//!
+//! # What this test pins
+//!
+//! The transfer exits 0 and the destination tree is byte-for-byte the union
+//! upstream `merge.test` builds in its `chk/` reference tree: every disjoint
+//! file present with its own payload, every overlapping name carrying the
+//! shared payload, nested `sub1`/`sub2` merged, and `dir-and-not-dir`
+//! resolved to the directory form holding `inside`.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/merge.test` - the upstream script this file ports.
+//! - `flist.c` - multi-root file-list construction (`send_file_list`).
+//! - `generator.c` - per-directory reconciliation of merged entries.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+use test_support::{DirDiff, DirDiffOptions, OcRsyncCliRunner, require_binary};
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("mkdir parent");
+    }
+    fs::write(path, contents).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+/// Build the three source directories plus the two bare-file arguments,
+/// mirroring the upstream `merge.test` fixture block verbatim (dropping only
+/// the never-referenced `from3/six` payload asymmetries - kept faithful here).
+fn build_sources(root: &Path) {
+    write(&root.join("from1/one"), "one\n");
+    write(&root.join("from2/one"), "one\n");
+    write(&root.join("from3/one"), "one\n");
+    write(&root.join("from1/two"), "two\n");
+    write(&root.join("from2/three"), "three\n");
+    write(&root.join("from3/four"), "four\n");
+    write(&root.join("from1/five"), "five\n");
+    write(&root.join("from3/six"), "six\n");
+    write(&root.join("from2/sub1/uno"), "sub1\n");
+    write(&root.join("from3/sub1/uno"), "sub1\n");
+    write(&root.join("from3/sub1/dos"), "sub2\n");
+    write(&root.join("from2/sub1/tres"), "sub3\n");
+    write(&root.join("from3/sub2/subby"), "subby\n");
+    // dir-and-not-dir: a directory in from1 (with a file inside), a plain
+    // file in from3. The directory argument reaches `to/` first and must win.
+    write(&root.join("from1/dir-and-not-dir/inside"), "extra\n");
+    write(&root.join("from3/dir-and-not-dir"), "not-dir\n");
+    // Bare file arguments.
+    write(&root.join("deep/arg-test"), "arg-test\n");
+    write(&root.join("shallow"), "shallow\n");
+}
+
+/// Build the reference `chk/` tree upstream diffs `to/` against.
+///
+/// Upstream constructs it with a series of `cp_touch ... chk` calls; we write
+/// the resulting union directly. `dir-and-not-dir` is the directory form (the
+/// plain-file `from3` variant is shadowed).
+fn build_expected(chk: &Path) {
+    write(&chk.join("one"), "one\n");
+    write(&chk.join("two"), "two\n");
+    write(&chk.join("three"), "three\n");
+    write(&chk.join("four"), "four\n");
+    write(&chk.join("five"), "five\n");
+    write(&chk.join("six"), "six\n");
+    write(&chk.join("arg-test"), "arg-test\n");
+    write(&chk.join("shallow"), "shallow\n");
+    write(&chk.join("sub1/uno"), "sub1\n");
+    write(&chk.join("sub1/dos"), "sub2\n");
+    write(&chk.join("sub1/tres"), "sub3\n");
+    write(&chk.join("sub2/subby"), "subby\n");
+    write(&chk.join("dir-and-not-dir/inside"), "extra\n");
+}
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(p: &Path) -> std::ffi::OsString {
+    let mut s = p.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+#[test]
+fn multiple_sources_merge_into_one_destination() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    build_sources(base);
+
+    let to = base.join("to");
+    let chk = base.join("chk");
+    build_expected(&chk);
+
+    // Upstream: $RSYNC -avv deep/arg-test shallow from1/ from2/ from3/ to/
+    // Run with the source root as cwd so the bare relative arguments resolve,
+    // exactly like the upstream `cd "$tmpdir"` preamble.
+    let out = OcRsyncCliRunner::new()
+        .cwd(base)
+        .args([
+            "-a",
+            "deep/arg-test",
+            "shallow",
+            "from1/",
+            "from2/",
+            "from3/",
+        ])
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    // Structural + content + mode comparison against the upstream chk tree.
+    // mtimes are intentionally not compared: the sources are created at
+    // slightly different wall-clock instants, and upstream itself normalizes
+    // directory times before diffing rather than pinning them.
+    match DirDiff::compare(&chk, &to, DirDiffOptions::structural()).expect("diff") {
+        Ok(()) => {}
+        Err(mismatch) => panic!("{}", mismatch.into_panic_message()),
+    }
+}


### PR DESCRIPTION
Ports three more deterministic, local-transfer legs from the upstream rsync 3.4.4 testsuite into native nextest integration tests, so behaviors that currently only run through the `continue-on-error` runtests.py harness become required per-PR checks. Advances #155.

Each new test lives in `crates/transfer/tests/`, uses the shared `test-support` harness (`OcRsyncCliRunner`, `require_binary`, `DirDiff`), cites its upstream source file, and is gated `#![cfg(unix)]`.

## Cases ported

- **`missing.test` -> `uts_missing_args.rs`** (2 legs)
  - `--ignore-non-existing` on a dry run must not emit spurious "not creating new ..." output for a file under a directory that does not exist at the destination, and must touch nothing on disk.
  - `--delete-after` on a dry run must still run its deletion pass and itemize `*deleting other` (a dest-only file) even when the last source directory is dry-missing.
  - Why: guards the generator `missing_below` logic and the delete-after pass gating - a regression here silently drops the deletion pass or leaks per-file chatter.

- **`merge.test` -> `uts_multi_source_merge.rs`** (1 leg)
  - Three source directories plus two bare file arguments union into one destination in a single invocation; overlapping names resolve, nested `sub1`/`sub2` merge, and a `dir-and-not-dir` directory-vs-file collision resolves to the directory. Diffed against the upstream `chk` reference tree via `DirDiff`.
  - Why: multi-root flist construction is a distinct sender/generator path from a single recursive copy; a regression drops/duplicates files or lets a plain-file arg clobber a same-named directory.

- **`chmod-option.test` -> `uts_chmod_option.rs`** (2 legs)
  - `--chmod ug-s,a+rX,D+w` and `--chmod=Fo-x` produce the exact permission bits, asserting the `X` conditional-execute rule, setuid/setgid strip, and the `D`/`F` directory/file qualifiers.
  - Expected mode bits were verified identical between oc-rsync and the installed upstream rsync 3.4.4 binary, so the test encodes required behavior, not just current output.
  - The remaining upstream legs drive a live `--daemon` with `incoming chmod`; those are out of scope for this in-process port.

## Verification

All five test functions pass locally (`cargo test -p transfer --test uts_missing_args --test uts_multi_source_merge --test uts_chmod_option`). `cargo fmt` and `cargo clippy -p transfer --tests --no-deps -- -D warnings` are clean.

## No overlap

These cases and filenames are distinct from the NXT-* set, the UTS-NEXTEST-EDGE.f/h/l/n/o set, and from #6324 (symlink-ignore, duplicates, executability). Branched off master.