### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
cargo-deny flags `crossbeam-epoch 0.9.18` under RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` with an invalid underlying pointer). `0.9.20` resolves it.

Reaches the tree transitively via `crossbeam-queue`/`crossbeam-channel` (engine/transfer reorder buffers). Lock-only change; no source or API impact. Repo-wide fix — the advisory was showing red on cargo-deny for all branches.