### PR TITLE
perf(daemon): kqueue socket-readiness for macOS daemon accept (default-off)

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -46,6 +46,15 @@ iconv = ["core/iconv", "protocol/iconv"]
 # in `docs/design/lsm-seccomp-allowlist.md` completes. No-op on non-Linux
 # (the dependency is `cfg(target_os = "linux")`-gated).
 daemon-seccomp = ["dep:seccompiler"]
+# macOS-only, default-off: source accepted connections in the daemon accept
+# loop from a `kqueue(2)` `EVFILT_READ` readiness wait instead of the portable
+# non-blocking-accept-plus-50ms-sleep busy-poll. Event-driven (parks in the
+# kernel until a connection arrives or the signal-check timeout elapses) rather
+# than busy-waiting, dropping first-connection latency on a quiet daemon from up
+# to 50ms to a syscall round-trip. Falls back to the portable engines if kqueue
+# setup fails, so it never breaks connection service. Off by default: the
+# default build uses the portable accept path unchanged. No-op on non-macOS.
+macos-kqueue = []
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -338,7 +338,7 @@ impl AcceptEngine for MultiListenerEngine {
 /// connection service.
 ///
 /// [`submit_read_level`]: fast_io::KqueueLoop::submit_read_level
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 struct KqueueAcceptEngine {
     /// Registered listeners keyed by their `EVFILT_READ` user-data index.
     listeners: Vec<(TcpListener, SocketAddr)>,
@@ -347,7 +347,7 @@ struct KqueueAcceptEngine {
     log_sink: Option<SharedLogSink>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 impl KqueueAcceptEngine {
     /// Signal-check cadence for the `kevent(2)` wait, matching the dual-stack
     /// engine's `recv_timeout` interval so shutdown latency is identical.
@@ -424,7 +424,7 @@ impl KqueueAcceptEngine {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 impl AcceptEngine for KqueueAcceptEngine {
     fn poll(&mut self) -> Result<AcceptOutcome, DaemonError> {
         let events = match self.kq.wait(Some(Self::WAIT_TIMEOUT)) {
@@ -480,7 +480,7 @@ impl AcceptEngine for KqueueAcceptEngine {
 /// the caller falls back to the portable engines, threading `listeners` back out
 /// unchanged on failure. Any kqueue error is non-fatal: connection service must
 /// continue through the blocking engine.
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 fn try_build_kqueue_engine(
     listeners: Vec<TcpListener>,
     bound_addresses: &[SocketAddr],
@@ -521,7 +521,7 @@ fn build_accept_engine(
     bound_addresses: &[SocketAddr],
     state: &AcceptLoopState<'_>,
 ) -> Result<Box<dyn AcceptEngine>, DaemonError> {
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
     let listeners = match try_build_kqueue_engine(listeners, bound_addresses, state) {
         Ok(engine) => return Ok(engine),
         Err(listeners) => listeners,

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -1360,7 +1360,7 @@ fn relay_accept_item_bails_on_shutdown_when_full() {
     ));
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 #[test]
 fn kqueue_engine_poll_idle_when_no_connection() {
     // A quiet daemon must yield Idle (not error, not busy-spin): the kevent
@@ -1385,7 +1385,7 @@ fn kqueue_engine_poll_idle_when_no_connection() {
     engine.shutdown();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 #[test]
 fn kqueue_engine_poll_returns_connection_with_blocking_reset() {
     // The kqueue engine must accept a real client via EVFILT_READ readiness and
@@ -1434,7 +1434,7 @@ fn kqueue_engine_poll_returns_connection_with_blocking_reset() {
     let _ = client.join();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 #[test]
 fn kqueue_engine_level_triggered_backlog_is_not_stranded() {
     // Level-triggered readiness must re-surface a queued backlog on successive
@@ -1475,7 +1475,7 @@ fn kqueue_engine_level_triggered_backlog_is_not_stranded() {
     drop(clients);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 #[test]
 fn kqueue_engine_needs_one_poll_per_queued_connection() {
     // Admission-lockstep invariant: the engine must NOT drain and buffer a
@@ -1531,7 +1531,7 @@ fn kqueue_engine_needs_one_poll_per_queued_connection() {
     drop(clients);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
 #[test]
 fn kqueue_engine_shutdown_is_idempotent() {
     // shutdown() must be safe to call more than once (the accept loop calls it
@@ -1547,4 +1547,42 @@ fn kqueue_engine_shutdown_is_idempotent() {
     // Polling after shutdown has no listeners; wait over an empty kqueue simply
     // times out to Idle without error.
     assert!(matches!(engine.poll().expect("poll"), AcceptOutcome::Idle));
+}
+
+#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]
+#[test]
+fn kqueue_engine_delivers_queued_connection_without_sleep_floor() {
+    // The whole point of the readiness engine: a connection already queued on
+    // the listen backlog must be delivered by an `EVFILT_READ` wake, not after
+    // the portable engine's 50ms `WouldBlock` sleep floor. Connect a client and
+    // let the kernel enqueue it, then assert the very first poll returns the
+    // Connection and does so well under the 50ms busy-poll interval this engine
+    // replaces. A regression to the sleep-then-retry shape would push the first
+    // delivering poll to >= 50ms and trip this bound.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+
+    let client = TcpStream::connect(local).expect("connect");
+    // Give the kernel a moment to place the connection on the backlog so the
+    // EVFILT_READ registration sees it ready on the first wait.
+    thread::sleep(Duration::from_millis(20));
+
+    let mut engine =
+        KqueueAcceptEngine::new(vec![listener], &[local], None).expect("kqueue engine");
+
+    let start = std::time::Instant::now();
+    let outcome = engine.poll().expect("poll");
+    let elapsed = start.elapsed();
+
+    assert!(
+        matches!(outcome, AcceptOutcome::Connection(_, _)),
+        "an already-queued connection must be delivered on the first poll"
+    );
+    assert!(
+        elapsed < Duration::from_millis(50),
+        "readiness wake must beat the 50ms busy-poll floor, took {elapsed:?}"
+    );
+
+    engine.shutdown();
+    drop(client);
 }


### PR DESCRIPTION
## Summary

Gates the macOS `kqueue` `EVFILT_READ` accept engine behind a new **default-off** `macos-kqueue` cargo feature, replacing the daemon accept loop's ~50ms `WouldBlock` busy-poll with event-driven socket readiness when the feature is enabled.

This is a quality/correctness fix (event-driven vs busy-wait), not a perf-flip: the feature stays off by default.

## The change

- New `macos-kqueue` feature in `crates/daemon/Cargo.toml` (default-off, no-op on non-macOS).
- The `KqueueAcceptEngine` (struct, impls, `try_build_kqueue_engine`, and the `build_accept_engine` branch) moves from an unconditional `#[cfg(target_os = "macos")]` to `#[cfg(all(target_os = "macos", feature = "macos-kqueue"))]`.
- With the feature **on**, the accept loop parks in a single `kevent(2)` wait over all listener fds until a connection arrives or the 100ms signal-check timeout elapses. First-connection latency on a quiet daemon drops from up to 50ms to a syscall round-trip.
- Listeners register level-triggered `EVFILT_READ` and the engine yields exactly one connection per poll, keeping `--max-connections` admission in lockstep with the loop's per-iteration worker reap - identical to the portable engines.

## Fallback (safe)

If `kqueue(2)` setup fails, `build_accept_engine` falls back to the portable `SingleListenerEngine` / `MultiListenerEngine`, so a kqueue error never breaks connection service or drops connections. Shutdown/signal handling and `--max-connections` accounting are unchanged.

## Default build unchanged

With `macos-kqueue` off (the default), the accept path is byte-for-byte the portable non-blocking-accept path. The five existing kqueue engine unit tests are gated behind the feature too.

## Tests

Added `kqueue_engine_delivers_queued_connection_without_sleep_floor`: a pre-queued connection is delivered on the first poll in under the 50ms busy-poll floor, pinning the readiness improvement.

Verified on aarch64 macOS (Rust 1.88.0):
- Default: `cargo build -p daemon -p fast_io`, `cargo clippy -p daemon -p fast_io --no-deps -D warnings`, `cargo test -p daemon --lib server_runtime` (82 pass, kqueue tests correctly gated out).
- Feature: `cargo build -p daemon --all-features`, feature clippy clean, `cargo test -p daemon --lib --features daemon/macos-kqueue` (6 kqueue tests pass, 87 server_runtime total).

Advances #490.