### PR TITLE
test: port upstream testsuite edge cases to nextest (round 3)

### DIFF
--- a/crates/transfer/tests/uts_backup_suffix_and_dir.rs
+++ b/crates/transfer/tests/uts_backup_suffix_and_dir.rs
@@ -1,0 +1,212 @@
+//! Nextest port of the upstream `testsuite/backup.test` scenario.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/backup.test`.
+//!
+//! # Background
+//!
+//! Upstream's `backup.test` verifies `--backup`: before overwriting a changed
+//! destination file, rsync preserves the old version. Two placement modes
+//! exist and this test pins both:
+//!
+//! - In-place suffix: the old file is renamed beside the new one with the
+//!   backup suffix (default `~`, overridable with `--suffix`). Upstream drives
+//!   this leg with `--no-whole-file --backup` and greps for
+//!   `backed up name to name~`.
+//! - Backup directory: with `--backup-dir=DIR` the old version is relocated
+//!   under `DIR` at the same relative path, and the `~` suffix is dropped.
+//!   Upstream greps for `backed up name to .../name`.
+//!
+//! # Why this matters
+//!
+//! Backup is a destructive-avoidance feature: a regression that skips the
+//! rename, writes to the wrong path, applies the suffix in backup-dir mode, or
+//! omits the `--info=backup` message silently loses the user's prior data or
+//! breaks scripts that parse the backup log. The suffix-vs-directory split is
+//! two genuinely different placement paths in the generator, so both are
+//! exercised. The `backed up X to Y` wording must match upstream byte-for-byte
+//! (`backup.c:353`) because tooling greps for it.
+//!
+//! # What this test pins
+//!
+//! 1. Default `~` suffix: after an update the new content lands, `name~` holds
+//!    the prior content, and `backed up name to name~` is emitted.
+//! 2. Custom `--suffix=.bak`: same, with `name.bak` as the backup.
+//! 3. `--backup-dir`: the prior content is relocated under the backup dir at
+//!    the same relative name (no `~`), and the message names that path.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/backup.test` - the upstream script this file ports.
+//! - `backup.c:353` - `rprintf(FINFO, "backed up %s to %s\n", fname, buf)`.
+//! - `options.c` - `--backup` / `--backup-dir` / `--suffix` wiring.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use filetime::{FileTime, set_file_mtime};
+use tempfile::TempDir;
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// A fixed old timestamp used to backdate destination files so rsync's
+/// quick-check (matching size + mtime) never short-circuits the transfer.
+fn backdate(path: &Path) {
+    // 2000-01-01T00:00:00Z, comfortably older than the freshly written source.
+    set_file_mtime(path, FileTime::from_unix_time(946_684_800, 0)).expect("backdate mtime");
+}
+
+/// Seed `dest` with `old` content and backdate it, so a later transfer of
+/// `new` content triggers an overwrite (and thus a backup).
+fn seed_dest(dest: &Path, old: &str) {
+    fs::write(dest, old).expect("seed dest");
+    backdate(dest);
+}
+
+#[test]
+fn backup_default_suffix_preserves_prior_version() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    fs::write(from.join("name1"), "new-content\n").expect("write source");
+    seed_dest(&to.join("name1"), "old-content\n");
+
+    // Upstream: $RSYNC -ai --info=backup --no-whole-file --backup from/ to/
+    let out = OcRsyncCliRunner::new()
+        .args(["-ai", "--info=backup", "--no-whole-file", "--backup"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        fs::read_to_string(to.join("name1")).unwrap(),
+        "new-content\n",
+        "new content must overwrite dest"
+    );
+    assert_eq!(
+        fs::read_to_string(to.join("name1~")).unwrap(),
+        "old-content\n",
+        "prior content must survive in the ~ backup"
+    );
+    assert!(
+        out.stdout_contains("backed up name1 to name1~"),
+        "missing upstream backup message; stdout was:\n{}",
+        out.stdout_str()
+    );
+}
+
+#[test]
+fn backup_custom_suffix_names_the_backup() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    fs::write(from.join("name1"), "fresh\n").expect("write source");
+    seed_dest(&to.join("name1"), "stale\n");
+
+    let out = OcRsyncCliRunner::new()
+        .args([
+            "-ai",
+            "--info=backup",
+            "--no-whole-file",
+            "--backup",
+            "--suffix=.bak",
+        ])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(fs::read_to_string(to.join("name1")).unwrap(), "fresh\n");
+    assert_eq!(
+        fs::read_to_string(to.join("name1.bak")).unwrap(),
+        "stale\n",
+        "custom --suffix must name the backup"
+    );
+    assert!(
+        out.stdout_contains("backed up name1 to name1.bak"),
+        "missing custom-suffix backup message; stdout was:\n{}",
+        out.stdout_str()
+    );
+}
+
+#[test]
+fn backup_dir_relocates_prior_version_without_suffix() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let from = base.join("from");
+    let to = base.join("to");
+    let bak = base.join("bak");
+    fs::create_dir_all(from.join("deep")).expect("mkdir from/deep");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    // Nested source path, mirroring upstream's deep/name1 layout.
+    fs::write(from.join("deep/name1"), "v-new\n").expect("write source");
+    fs::create_dir_all(to.join("deep")).expect("mkdir to/deep");
+    seed_dest(&to.join("deep/name1"), "v-old\n");
+
+    // Upstream: $RSYNC -ai --info=backup --no-whole-file --backup --backup-dir=BAK from/ to/
+    let mut backup_dir_arg = std::ffi::OsString::from("--backup-dir=");
+    backup_dir_arg.push(&bak);
+    let out = OcRsyncCliRunner::new()
+        .args([
+            std::ffi::OsString::from("-ai"),
+            std::ffi::OsString::from("--info=backup"),
+            std::ffi::OsString::from("--no-whole-file"),
+            std::ffi::OsString::from("--backup"),
+            backup_dir_arg,
+        ])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        fs::read_to_string(to.join("deep/name1")).unwrap(),
+        "v-new\n"
+    );
+    // No in-place ~ backup when a backup-dir is used.
+    assert!(
+        !to.join("deep/name1~").exists(),
+        "backup-dir mode must not also create an in-place ~ backup"
+    );
+    // Prior content relocated under the backup dir at the same relative path.
+    assert_eq!(
+        fs::read_to_string(bak.join("deep/name1")).unwrap(),
+        "v-old\n",
+        "prior content must land under the backup dir at deep/name1"
+    );
+    assert!(
+        out.stdout_contains("backed up deep/name1 to"),
+        "missing backup-dir message; stdout was:\n{}",
+        out.stdout_str()
+    );
+}
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(path: &Path) -> std::ffi::OsString {
+    let mut s = path.as_os_str().to_os_string();
+    s.push("/");
+    s
+}

--- a/crates/transfer/tests/uts_mkpath_create_dest_path.rs
+++ b/crates/transfer/tests/uts_mkpath_create_dest_path.rs
@@ -1,0 +1,128 @@
+//! Nextest port of the upstream `testsuite/mkpath.test` scenario.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/mkpath.test`.
+//!
+//! # Background
+//!
+//! Upstream's `mkpath.test` verifies the `--mkpath` option, which tells rsync
+//! to create any missing leading components of the destination path before
+//! transferring. Without `--mkpath`, rsync only creates the final destination
+//! directory (or none at all for a single-file copy); a multi-level missing
+//! prefix like `to/foo/bar/baz/down/deep/` is an error. With `--mkpath` the
+//! whole prefix is materialized.
+//!
+//! The upstream script drives several distinct shapes through the flag:
+//!
+//! ```sh
+//! $RSYNC -aiv --mkpath from/text $deep_dir/new     # single file -> new leaf name
+//! $RSYNC -aiv --mkpath from/text $deep_dir/         # single file -> into a new dir
+//! $RSYNC -aiv --mkpath from/text to_text            # no missing path at all
+//! ```
+//!
+//! # Why this matters
+//!
+//! `--mkpath` changes destination-path resolution: the difference between
+//! "create only the final dir" and "create the entire missing prefix" is a
+//! distinct code path with sharp edges. The trailing-slash distinction
+//! (`.../deep/new` names a file leaf, `.../deep/` names a directory the source
+//! file lands inside) must be honored while simultaneously fabricating the
+//! prefix. A regression here either refuses valid `--mkpath` copies or, worse,
+//! silently mis-parents the file (writing `deep` as a file instead of a
+//! directory, or dropping the leaf rename).
+//!
+//! # What this test pins
+//!
+//! For each upstream shape, the transfer exits 0 and the expected file lands at
+//! exactly the expected path with the source contents, with the full
+//! previously-missing directory prefix created.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/mkpath.test` - the upstream script this file ports.
+//! - `options.c` - `--mkpath` option wiring (`mkpath_dest_arg`).
+//! - `generator.c` - destination-prefix directory materialization.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Trailing-slash form of a path (as an `OsString` argument).
+fn slash(path: &Path) -> std::ffi::OsString {
+    let mut s = path.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// Run oc-rsync from `cwd` with `-a --mkpath` plus `args`, asserting exit 0.
+fn run_mkpath<I, S>(cwd: &Path, args: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let out = OcRsyncCliRunner::new()
+        .cwd(cwd)
+        .arg("-a")
+        .arg("--mkpath")
+        .args(args)
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+}
+
+#[test]
+fn mkpath_creates_missing_destination_prefix() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+
+    // Source file, mirroring upstream's `from/text`.
+    let from = base.join("from");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::write(from.join("text"), "mkpath payload\n").expect("write source");
+
+    // Upstream: deep_dir=to/foo/bar/baz/down/deep
+    let deep_rel = "to/foo/bar/baz/down/deep";
+
+    // Leg 1: single file -> a new leaf name several missing levels down.
+    // $RSYNC -aiv --mkpath from/text $deep_dir/new
+    run_mkpath(base, ["from/text", &format!("{deep_rel}/new")]);
+    let leaf = base.join(format!("{deep_rel}/new"));
+    assert!(
+        leaf.is_file(),
+        "leaf file not created at {}",
+        leaf.display()
+    );
+    assert_eq!(fs::read_to_string(&leaf).unwrap(), "mkpath payload\n");
+    fs::remove_dir_all(base.join("to")).expect("cleanup to");
+
+    // Leg 2: single file -> into a brand-new directory (trailing slash).
+    // $RSYNC -aiv --mkpath from/text $deep_dir/
+    let deep_dir = base.join(deep_rel);
+    run_mkpath(base, ["from/text".into(), slash(&deep_dir)]);
+    let into_dir = deep_dir.join("text");
+    assert!(
+        into_dir.is_file(),
+        "file not placed inside new dir at {}",
+        into_dir.display()
+    );
+    assert_eq!(fs::read_to_string(&into_dir).unwrap(), "mkpath payload\n");
+    fs::remove_dir_all(base.join("to")).expect("cleanup to");
+
+    // Leg 3: no missing path at all - a plain leaf in the cwd.
+    // $RSYNC -aiv --mkpath from/text to_text
+    run_mkpath(base, ["from/text", "to_text"]);
+    let plain = base.join("to_text");
+    assert!(
+        plain.is_file(),
+        "plain leaf not created at {}",
+        plain.display()
+    );
+    assert_eq!(fs::read_to_string(&plain).unwrap(), "mkpath payload\n");
+}

--- a/crates/transfer/tests/uts_trimslash_source_arg.rs
+++ b/crates/transfer/tests/uts_trimslash_source_arg.rs
@@ -1,0 +1,129 @@
+//! Nextest port of the upstream `testsuite/trimslash.test` scenario.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/trimslash.test`.
+//!
+//! # Background
+//!
+//! Upstream's `trimslash.test` exercises rsync's tiny trailing-slash trimmer
+//! (upstream `util1.c:trim_trailing_slashes`) via a standalone `trimslash`
+//! helper. The rule it enforces: any run of trailing slashes on a path
+//! collapses to the semantics of a single trailing slash, except that a path
+//! of pure slashes (`//`, `////`) trims down to a single `/`.
+//!
+//! For rsync itself, this trimming is what makes a source argument's trailing
+//! slash meaningful: `src/` and `src///` both mean "copy the *contents* of
+//! `src` into the destination", while `src` (no slash) means "copy the `src`
+//! directory itself into the destination". This test ports the trimmer's
+//! observable contract into the transfer layer, where it actually matters,
+//! rather than shelling out to a private helper binary that oc-rsync does not
+//! ship.
+//!
+//! # Why this matters
+//!
+//! The trailing-slash distinction is one of rsync's most notorious usability
+//! cliffs: getting it wrong nests a directory one level too deep or flattens a
+//! copy that should have been nested. A regression in trailing-slash trimming
+//! silently changes destination layout for a huge fraction of real invocations.
+//! Because multiple trailing slashes must be treated identically to one, a
+//! naive "strip exactly one slash" implementation is wrong - this test guards
+//! against exactly that.
+//!
+//! # What this test pins
+//!
+//! - `src/` copies the contents of `src` (dest gains `sub/`), not `src` itself.
+//! - `src///` behaves identically to `src/` (multiple slashes collapse).
+//! - `src` (no trailing slash) copies the directory itself (dest gains
+//!   `src/sub/`).
+//!
+//! # Upstream References
+//!
+//! - `testsuite/trimslash.test` - the upstream script this file ports.
+//! - `util1.c` - `trim_trailing_slashes()`, the function under test.
+//! - `flist.c` - trailing-slash handling of source args (`send_file_list`).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Build a `src` dir containing a single nested file, so the contents-vs-dir
+/// distinction is observable purely from which directory names appear in dest.
+fn build_src(base: &Path) -> std::path::PathBuf {
+    let src = base.join("src");
+    fs::create_dir_all(src.join("sub")).expect("mkdir src/sub");
+    fs::write(src.join("sub/file"), "payload\n").expect("write nested file");
+    src
+}
+
+/// Run a copy of `source_arg` into a fresh `dest`, asserting exit 0, and
+/// return the dest path.
+fn copy_into(base: &Path, dest_name: &str, source_arg: std::ffi::OsString) -> std::path::PathBuf {
+    let dest = base.join(dest_name);
+    fs::create_dir_all(&dest).expect("mkdir dest");
+    let mut dest_arg = dest.as_os_str().to_os_string();
+    dest_arg.push("/");
+    let out = OcRsyncCliRunner::new()
+        .arg("-a")
+        .arg(source_arg)
+        .arg(dest_arg)
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+    dest
+}
+
+/// Append `n` slashes to `path`'s string form.
+fn with_slashes(path: &Path, n: usize) -> std::ffi::OsString {
+    let mut s = path.as_os_str().to_os_string();
+    for _ in 0..n {
+        s.push("/");
+    }
+    s
+}
+
+#[test]
+fn trailing_slashes_collapse_to_single_slash_semantics() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root: TempDir = tempfile::tempdir().expect("tempdir");
+    let base = root.path();
+    let src = build_src(base);
+
+    // `src/` copies contents: dest gains `sub/`, not `src/`.
+    let d1 = copy_into(base, "dst_one_slash", with_slashes(&src, 1));
+    assert!(
+        d1.join("sub/file").is_file(),
+        "single trailing slash must copy contents"
+    );
+    assert!(
+        !d1.join("src").exists(),
+        "single trailing slash must not nest the src dir itself"
+    );
+
+    // `src///` must behave identically to `src/` (collapse of multiple slashes).
+    let d3 = copy_into(base, "dst_triple_slash", with_slashes(&src, 3));
+    assert!(
+        d3.join("sub/file").is_file(),
+        "multiple trailing slashes must collapse to contents-copy"
+    );
+    assert!(
+        !d3.join("src").exists(),
+        "multiple trailing slashes must not nest the src dir itself"
+    );
+
+    // `src` (no slash) copies the directory itself: dest gains `src/sub/`.
+    let d0 = copy_into(base, "dst_no_slash", src.as_os_str().to_os_string());
+    assert!(
+        d0.join("src/sub/file").is_file(),
+        "no trailing slash must nest the src directory itself"
+    );
+    assert!(
+        !d0.join("sub").exists(),
+        "no trailing slash must not copy contents flat"
+    );
+}


### PR DESCRIPTION
Ports three more deterministic upstream rsync 3.4.4 testsuite cases into the
nextest suite. All run as local, in-process oc-rsync transfers (no daemon, no
network, no root) and pass on macOS.

## Cases ported

- **`testsuite/mkpath.test`** -> `crates/transfer/tests/uts_mkpath_create_dest_path.rs`
  Pins `--mkpath`: rsync must fabricate the entire missing destination prefix
  (`to/foo/bar/baz/down/deep/...`), honoring the trailing-slash file-leaf vs
  into-a-new-dir distinction, and the no-missing-path case. Guards against a
  regression that refuses valid `--mkpath` copies or mis-parents the file.

- **`testsuite/backup.test`** -> `crates/transfer/tests/uts_backup_suffix_and_dir.rs`
  Pins `--backup` in three modes: default `~` suffix, custom `--suffix=.bak`,
  and `--backup-dir` relocation (no suffix, same relative path). Also asserts
  the `backed up X to Y` message wording (upstream `backup.c:353`), which
  tooling greps for. Backup is a destructive-avoidance feature - a regression
  silently loses the user's prior file version.

- **`testsuite/trimslash.test`** -> `crates/transfer/tests/uts_trimslash_source_arg.rs`
  Pins trailing-slash trimming (upstream `util1.c:trim_trailing_slashes`) via
  observable transfer behavior: `src/` and `src///` both copy contents (multiple
  slashes collapse to one), while `src` copies the directory itself. Guards
  against a naive strip-exactly-one-slash implementation that would change
  destination layout for a huge fraction of real invocations.

## Non-overlap

Distinct from all previously ported cases (NXT-* daemon/remote set, the
UTS-NEXTEST-EDGE daemon-munge/delete-missing/refuse/compress/batch set, and
rounds 1-2: symlink-ignore, duplicates, executability, missing, merge,
chmod-option). New unique filenames; each cites its upstream `.test` source and
encodes why the behavior matters.

Advances #155.