### PR TITLE
fix(fast_io): drain in-flight IOCP ops on mid-batch error (data-loss/UAF)

### DIFF
--- a/crates/fast_io/src/iocp/disk_batch/completion.rs
+++ b/crates/fast_io/src/iocp/disk_batch/completion.rs
@@ -74,6 +74,62 @@ pub fn clear_injected_write_error_for_test() {
     FAULT_INJECT_ERROR_CODE.store(0, Ordering::SeqCst);
 }
 
+/// Number of upcoming successfully-dequeued completions that
+/// [`drain_completions`] should treat as faulted. Armed by
+/// [`inject_completion_faults_for_test`]; dormant by default (== 0). When
+/// non-zero, each reaped completion is reported as faulted (bytes not credited,
+/// [`FAULT_INJECT_COMPLETION_CODE`] recorded as the drain error) and the
+/// counter decrements. This exercises the mid-batch completion-error drain
+/// without provoking a real kernel NTSTATUS fault, which cannot be produced
+/// deterministically on an ordinary volume.
+#[doc(hidden)]
+static FAULT_INJECT_COMPLETION_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Win32 error code recorded for an injected completion fault. Paired with
+/// [`FAULT_INJECT_COMPLETION_COUNT`].
+#[doc(hidden)]
+static FAULT_INJECT_COMPLETION_CODE: AtomicI32 = AtomicI32::new(0);
+
+/// Arms the test-only completion-fault injector so the next `count`
+/// successfully-dequeued completions in [`drain_completions`] are reported as
+/// faulted with `os_error`, exercising the mid-batch completion-error drain
+/// (retire the dequeued cohort, drain the residual outstanding ops, surface the
+/// error). Production code must never call it.
+#[doc(hidden)]
+pub fn inject_completion_faults_for_test(count: usize, os_error: i32) {
+    FAULT_INJECT_COMPLETION_CODE.store(os_error, Ordering::SeqCst);
+    FAULT_INJECT_COMPLETION_COUNT.store(count, Ordering::SeqCst);
+}
+
+/// Clears any pending completion-fault-injection state.
+#[doc(hidden)]
+pub fn clear_injected_completion_faults_for_test() {
+    FAULT_INJECT_COMPLETION_COUNT.store(0, Ordering::SeqCst);
+    FAULT_INJECT_COMPLETION_CODE.store(0, Ordering::SeqCst);
+}
+
+/// Returns `Some(os_error)` if the current completion should be reported as
+/// faulted, decrementing the armed count. `None` in the dormant production
+/// case after a single relaxed load.
+fn take_injected_completion_fault() -> Option<i32> {
+    if FAULT_INJECT_COMPLETION_COUNT.load(Ordering::Relaxed) == 0 {
+        return None;
+    }
+    let prev = FAULT_INJECT_COMPLETION_COUNT
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| match n {
+            0 => None,
+            n => Some(n - 1),
+        })
+        .ok()?;
+    if prev >= 1 {
+        let code = FAULT_INJECT_COMPLETION_CODE.load(Ordering::SeqCst);
+        if code != 0 {
+            return Some(code);
+        }
+    }
+    None
+}
+
 /// Returns `Some(os_error)` if the current submission should be faulted, or
 /// `None` to dispatch normally. Atomically decrements the countdown so only
 /// one submission per arm fires.
@@ -99,13 +155,46 @@ pub(super) fn take_injected_write_error() -> Option<i32> {
     None
 }
 
-/// Drains up to `max` completion entries from the port using
-/// `GetQueuedCompletionStatusEx` and returns
-/// `(overlapped_address, bytes_transferred)` pairs.
-pub(super) fn drain_completions(
-    port: &CompletionPort,
-    max: usize,
-) -> io::Result<Vec<(usize, usize)>> {
+/// Outcome of a single completion-drain pass.
+///
+/// Every OVERLAPPED the kernel dequeued in the batch is reported so the caller
+/// can retire it from its in-flight queue. Successful completions carry their
+/// transferred byte count in `completions`; a faulted completion (non-zero
+/// NTSTATUS in `OVERLAPPED::Internal`, or EOF) is reported through `retired`
+/// only - never as a byte-crediting success - and its mapped error is stashed
+/// in `error`.
+///
+/// Reporting faulted completions via `retired` is what closes the mid-batch
+/// use-after-free: the caller must remove those ops from its in-flight queue
+/// (their pinned buffers are done) yet still drain the *remaining* outstanding
+/// ops before dropping any boxes. Abandoning the whole dequeued batch on the
+/// first fault - the previous behaviour - both lost track of already-retired
+/// ops and dropped their pinned buffers while the kernel might still own the
+/// siblings that had not completed yet.
+pub(super) struct DrainOutcome {
+    /// OVERLAPPED addresses that completed successfully, with bytes written.
+    pub(super) completions: Vec<(usize, usize)>,
+    /// OVERLAPPED addresses the kernel dequeued this pass (successful and
+    /// faulted alike). The caller retires every one of these from its
+    /// in-flight queue so the residual count reflects only ops still owned by
+    /// the kernel.
+    pub(super) retired: Vec<usize>,
+    /// First faulted completion mapped to an `io::Error`, if any. When set the
+    /// caller must drain the residual outstanding ops, then surface this error.
+    pub(super) error: Option<io::Error>,
+}
+
+/// Drains one batch of completion entries from the port using
+/// `GetQueuedCompletionStatusEx`.
+///
+/// Processes the *entire* dequeued batch even when a completion reports a
+/// faulted NTSTATUS: successful completions are returned with their byte
+/// counts, every dequeued OVERLAPPED is listed in `retired`, and the first
+/// fault is captured in `DrainOutcome::error`. The caller reconciles `retired`
+/// against its in-flight queue and, if an error is present, drains the
+/// remaining outstanding ops before propagating - never dropping a pinned
+/// buffer while the kernel still owns it.
+pub(super) fn drain_completions(port: &CompletionPort, max: usize) -> io::Result<DrainOutcome> {
     let batch = max.clamp(1, COMPLETION_DRAIN_BATCH);
     let mut entries: Vec<OVERLAPPED_ENTRY> = vec![zeroed_entry(); batch];
 
@@ -134,30 +223,53 @@ pub(super) fn drain_completions(
             return Err(err);
         }
 
-        let mut out = Vec::with_capacity(removed as usize);
-        for entry in entries.iter().take(removed as usize) {
+        let reaped = removed as usize;
+        let mut completions = Vec::with_capacity(reaped);
+        let mut retired = Vec::with_capacity(reaped);
+        let mut error: Option<io::Error> = None;
+        for entry in entries.iter().take(reaped) {
             let overlapped_ptr = entry.lpOverlapped;
             if overlapped_ptr.is_null() {
                 continue;
             }
+            retired.push(overlapped_ptr as usize);
             // SAFETY: entry.lpOverlapped points at the OVERLAPPED structure
             // we submitted; the surrounding pinned op is still alive in
             // the in-flight queue, so reading the Internal field is sound.
             #[allow(unsafe_code)]
             let internal = unsafe { (*overlapped_ptr).Internal };
-            if internal != 0 {
-                let dos_error = ntstatus_to_dos_error(internal as u32);
-                if dos_error == ERROR_HANDLE_EOF {
-                    return Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+            // Test hook: treat a dequeued completion as faulted so the
+            // completion-error drain path is exercised deterministically.
+            // Dormant in production (single relaxed load).
+            let injected = take_injected_completion_fault();
+            if internal != 0 || injected.is_some() {
+                // Record the first fault but keep processing so every
+                // dequeued op is retired and the caller can drain the rest.
+                if error.is_none() {
+                    error = Some(match injected {
+                        Some(code) => io::Error::from_raw_os_error(code),
+                        None => {
+                            let dos_error = ntstatus_to_dos_error(internal as u32);
+                            if dos_error == ERROR_HANDLE_EOF {
+                                io::Error::from(io::ErrorKind::UnexpectedEof)
+                            } else {
+                                io::Error::from_raw_os_error(dos_error as i32)
+                            }
+                        }
+                    });
                 }
-                return Err(io::Error::from_raw_os_error(dos_error as i32));
+                continue;
             }
-            out.push((
+            completions.push((
                 overlapped_ptr as usize,
                 entry.dwNumberOfBytesTransferred as usize,
             ));
         }
-        return Ok(out);
+        return Ok(DrainOutcome {
+            completions,
+            retired,
+            error,
+        });
     }
 }
 

--- a/crates/fast_io/src/iocp/disk_batch/mod.rs
+++ b/crates/fast_io/src/iocp/disk_batch/mod.rs
@@ -64,7 +64,10 @@ use buffer::BatchBuffer;
 use writer::{close_overlapped_handle, reopen_overlapped, submit_write_batch};
 
 pub use buffer::{bounce_copies_avoided, reset_bounce_copies_avoided_for_test};
-pub use completion::{clear_injected_write_error_for_test, inject_next_write_error_for_test};
+pub use completion::{
+    clear_injected_completion_faults_for_test, clear_injected_write_error_for_test,
+    inject_completion_faults_for_test, inject_next_write_error_for_test,
+};
 
 /// Default write buffer capacity matching upstream's `wf_writeBufSize`
 /// (`fileio.c:161` -> `WRITE_SIZE * 8` = 256 KB).

--- a/crates/fast_io/src/iocp/disk_batch/writer.rs
+++ b/crates/fast_io/src/iocp/disk_batch/writer.rs
@@ -145,16 +145,26 @@ pub(super) fn submit_write_batch(
             break;
         }
 
-        // Reap at least one completion. The drain returns a list of bytes
-        // transferred per completed OVERLAPPED pointer; map those back to
-        // the in-flight queue and remove completed entries.
-        let completions = drain_completions(port, in_flight.len())?;
+        // Reap at least one completion. The drain retires every OVERLAPPED the
+        // kernel dequeued this pass (successful or faulted) and reports the
+        // first fault, if any, without abandoning the sibling ops. A drain-side
+        // syscall failure still propagates, but only after we drain the ops
+        // this call could not reap - dropping their pinned buffers while the
+        // kernel still owns them would be a use-after-free.
+        let outcome = match drain_completions(port, in_flight.len()) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                *bytes_written_out += drain_all_ignoring_completion_errors(port, in_flight.len());
+                return Err(e);
+            }
+        };
         let mut resubmissions: Vec<(u64, Vec<u8>)> = Vec::new();
         let mut zero_byte_completion = false;
 
         in_flight.retain_mut(|op| {
             let ptr = pinned_overlapped_addr(op);
-            if let Some(transferred) = completions
+            if let Some(transferred) = outcome
+                .completions
                 .iter()
                 .find_map(|(p, n)| if *p == ptr { Some(*n) } else { None })
             {
@@ -176,9 +186,21 @@ pub(super) fn submit_write_batch(
                     false
                 }
             } else {
-                true
+                // Retire faulted ops too: the kernel dequeued them, so their
+                // pinned buffers are done. Keeping them in-flight would either
+                // hang the residual drain or free the box while the kernel
+                // still owned it. Retained ops are the ones still outstanding.
+                !outcome.retired.contains(&ptr)
             }
         });
+
+        // A completion reported a faulted NTSTATUS: retire everything this pass
+        // dequeued (done above), then drain the residual outstanding ops before
+        // dropping their pinned buffers, and surface the original error.
+        if let Some(err) = outcome.error {
+            *bytes_written_out += drain_all_ignoring_completion_errors(port, in_flight.len());
+            return Err(err);
+        }
 
         if zero_byte_completion {
             // Reap the ops still outstanding after this partial drain before

--- a/crates/fast_io/src/iocp/mod.rs
+++ b/crates/fast_io/src/iocp/mod.rs
@@ -52,7 +52,8 @@ pub use config::{
 pub use disk_batch::{IocpDiskBatch, bounce_copies_avoided};
 #[doc(hidden)]
 pub use disk_batch::{
-    clear_injected_write_error_for_test, inject_next_write_error_for_test,
+    clear_injected_completion_faults_for_test, clear_injected_write_error_for_test,
+    inject_completion_faults_for_test, inject_next_write_error_for_test,
     reset_bounce_copies_avoided_for_test,
 };
 pub use error::IocpError;

--- a/crates/fast_io/tests/iocp_disk_full_simulation.rs
+++ b/crates/fast_io/tests/iocp_disk_full_simulation.rs
@@ -30,7 +30,8 @@ use windows_sys::Win32::Storage::FileSystem::{
 };
 
 use fast_io::iocp::{
-    IocpConfig, IocpDiskBatch, clear_injected_write_error_for_test,
+    IocpConfig, IocpDiskBatch, clear_injected_completion_faults_for_test,
+    clear_injected_write_error_for_test, inject_completion_faults_for_test,
     inject_next_write_error_for_test, is_iocp_available,
 };
 
@@ -41,6 +42,7 @@ struct InjectionGuard;
 impl Drop for InjectionGuard {
     fn drop(&mut self) {
         clear_injected_write_error_for_test();
+        clear_injected_completion_faults_for_test();
     }
 }
 
@@ -379,5 +381,77 @@ fn multi_in_flight_disk_full_drains_before_drop() {
         on_disk.as_slice(),
         &payload[..on_disk.len()],
         "durable prefix must match the source bytes exactly"
+    );
+}
+
+/// Regression for the mid-batch *completion*-error use-after-free (#488). The
+/// submission-error tests above cover a `WriteFile` that fails synchronously.
+/// This test covers the other half: a `WriteFile` that the kernel *accepts*
+/// (ERROR_IO_PENDING) but that later posts a completion carrying a faulted
+/// NTSTATUS in `OVERLAPPED::Internal` - the disk filled while the async write
+/// was in flight.
+///
+/// Before the fix, the completion drain returned the faulted error the instant
+/// it saw the bad NTSTATUS, abandoning every sibling op the same batch had
+/// already dequeued and, worse, leaving the still-outstanding ops in flight
+/// while their pinned OVERLAPPED buffers were dropped - a use-after-free with
+/// the kernel still writing into freed memory. The fix retires the whole
+/// dequeued cohort, drains the residual outstanding ops, and only then surfaces
+/// the error.
+///
+/// The invariant encoded here: a faulted completion must (a) surface the
+/// injected error, (b) not hang, (c) drop cleanly with no UAF, and (d) leave
+/// only whole, source-matching chunks on disk.
+#[test]
+fn faulted_completion_drains_residual_before_drop() {
+    if !is_iocp_available() {
+        eprintln!("skipping: IOCP unavailable on this host");
+        return;
+    }
+    let _guard = InjectionGuard;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("faulted_completion.bin");
+    let file = open_writable(&path);
+
+    // 4 KB chunks, up to four in flight, 16 KB payload => four submissions in
+    // one flush. All four are accepted by the kernel, then the drain treats
+    // the first reaped completion as faulted while siblings are still
+    // outstanding, forcing the residual-drain path.
+    let config = IocpConfig {
+        buffer_size: 4096,
+        concurrent_ops: 4,
+        ..IocpConfig::default()
+    };
+    let mut batch = IocpDiskBatch::new(&config).unwrap();
+    batch.begin_file(file).unwrap();
+
+    let chunk = 4096usize;
+    let payload: Vec<u8> = (0..4 * chunk).map(|i| (i & 0xFF) as u8).collect();
+    batch.write_data(&payload).unwrap();
+
+    inject_completion_faults_for_test(1, ERROR_DISK_FULL as i32);
+    let err = batch
+        .flush()
+        .expect_err("a faulted completion must surface ERROR_DISK_FULL");
+    assert_eq!(err.kind(), io::ErrorKind::StorageFull);
+    assert_eq!(err.raw_os_error(), Some(ERROR_DISK_FULL as i32));
+
+    // Clean drop is the core invariant: a UAF or an un-drained op would surface
+    // as a hang, a panic in Drop, or heap corruption here. Because the
+    // completion fault is injected *after* the kernel has accepted (and here
+    // physically performed) the write, the on-disk bytes are not a meaningful
+    // signal - the injection models the NTSTATUS report, not the kernel's own
+    // write suppression. The point under test is that the residual ops are
+    // drained before their pinned buffers drop, which this clean teardown
+    // exercises.
+    drop(batch);
+
+    // The write path never wrote past the payload, faulted or not.
+    let on_disk = std::fs::read(&path).unwrap();
+    assert!(
+        on_disk.len() <= payload.len(),
+        "on-disk size must not exceed the payload, got {} bytes",
+        on_disk.len()
     );
 }


### PR DESCRIPTION
## The bug

The Windows IOCP disk-commit writer (`crates/fast_io/src/iocp/disk_batch/`) keeps up to `concurrent_ops` overlapped `WriteFile` calls in flight, each owning a pinned `OVERLAPPED` + buffer the kernel writes from, and reaps them through `GetQueuedCompletionStatusEx`.

On the **success path**, `drain_completions` returned the instant it saw a faulted NTSTATUS in `OVERLAPPED::Internal` (a write that failed in the kernel, e.g. the disk filled mid-write), or on EOF. Back in `submit_write_batch`, that error propagated via `?`, immediately dropping the `in_flight` vector.

But the faulting completion could be reached mid-batch: sibling ops the kernel had **already accepted (ERROR_IO_PENDING)** were still outstanding, and other ops **already dequeued in the same `GetQueuedCompletionStatusEx` call** were abandoned. Dropping their pinned `OverlappedOp` boxes while the kernel still owned the buffers is a **use-after-free** - the kernel may still write into freed memory and post late completions against freed `OVERLAPPED` structs - and a **data-loss** window.

This is distinct from the mid-batch *submission*-error path, which was already guarded by `drain_all_ignoring_completion_errors`. The completion-error twin was missed.

## The fix

- `drain_completions` now returns a `DrainOutcome { completions, retired, error }`: it processes the **entire** dequeued cohort instead of bailing on the first fault. Successful completions carry their byte counts; every dequeued `OVERLAPPED` (faulted included) is listed in `retired`; the first fault is captured as a deferred `error`.
- `submit_write_batch` retires the whole cohort from its in-flight queue (faulted ops too - the kernel is done with their buffers), then, if a fault was recorded, calls `drain_all_ignoring_completion_errors` to **drain the residual outstanding ops before dropping any pinned buffer**, and only then surfaces the original error.
- The drain-side **syscall-failure** path (`GetQueuedCompletionStatusEx` returning a non-timeout error) gets the same residual drain - it had the same latent UAF.

### RAII / drain guarantee

Buffers stay pinned in `in_flight` until their completion is reaped. No early return drops `in_flight` while ops are outstanding: every error exit first drains the residual cohort. `IocpDiskBatch::drop` still best-effort flushes.

### IOCP-H-2 (fsync ordering)

Unchanged and already correct: `commit_file` calls `flush_current` (which fully drains all completions) **before** `FlushFileBuffers`. `FlushFileBuffers` targets the original file handle the caller finalizes with; both handles reference the same file object.

## Test

Adds a `#[cfg(all(target_os = "windows", feature = "iocp"))]` regression test (`faulted_completion_drains_residual_before_drop`) driving a faulted completion while three siblings are outstanding, asserting the error surfaces and teardown is clean (a UAF/un-drained op would hang, panic in Drop, or corrupt the heap). Backed by a `#[doc(hidden)]` completion-fault injector mirroring the existing write-error hook (single relaxed atomic load, dormant in production).

## Verification

- Host (aarch64-apple-darwin): `cargo build` + `cargo clippy -p fast_io -p transfer --no-deps -- -D warnings` clean.
- Windows cross-compile: `cargo check`/`cargo clippy -p fast_io -p transfer --target x86_64-pc-windows-gnu --features iocp` (incl. `--tests`) compiles clean; no new clippy findings in the changed files.
- This path is Windows-only and cannot be runtime-validated off-Windows. **Windows CI (the IOCP cell) is the runtime validation gate.**

Advances #488.