### PR TITLE
fix(fast_io): IOCP short-write resume, handle RAII, drain timeout, errno parity

### DIFF
--- a/crates/fast_io/src/iocp/disk_batch/completion.rs
+++ b/crates/fast_io/src/iocp/disk_batch/completion.rs
@@ -13,8 +13,11 @@
 
 use std::io;
 use std::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
-use windows_sys::Win32::Foundation::{ERROR_HANDLE_EOF, FALSE, WAIT_TIMEOUT};
+use windows_sys::Win32::Foundation::{
+    ERROR_HANDLE_EOF, FALSE, RtlNtStatusToDosError, WAIT_TIMEOUT,
+};
 use windows_sys::Win32::System::IO::{GetQueuedCompletionStatusEx, OVERLAPPED_ENTRY};
 
 use crate::iocp::completion_port::CompletionPort;
@@ -30,10 +33,25 @@ use crate::iocp::completion_port::CompletionPort;
 /// constant so a single drain call can reap the entire cohort.
 const COMPLETION_DRAIN_BATCH: usize = 64;
 
-/// Wait timeout for completion drains, in milliseconds. The disk batch
-/// always knows how many completions are outstanding so it waits
-/// indefinitely (`u32::MAX`) until every submitted write has been reaped.
+/// Wait timeout for success-path completion drains, in milliseconds. On the
+/// success path the disk batch always knows how many completions are
+/// outstanding and every op the kernel accepted is guaranteed to post exactly
+/// one packet, so it waits indefinitely (`u32::MAX`) until every submitted
+/// write has been reaped.
 const DRAIN_TIMEOUT_MS: u32 = u32::MAX;
+
+/// Per-wait timeout for the abort-drain path, in milliseconds. Bounds each
+/// individual `GetQueuedCompletionStatusEx` wait so the abort drain wakes up
+/// periodically to re-check the overall deadline instead of parking forever.
+const ABORT_DRAIN_WAIT_MS: u32 = 100;
+
+/// Overall wall-clock budget for the abort-drain path. On the error/abort
+/// path we are cleaning up residual outstanding ops whose completions the
+/// kernel *should* still post, but an unexpectedly wedged port or a miscounted
+/// residual would otherwise hang the disk-commit thread forever. Bounding the
+/// total wait converts a potential hang into a surfaced timeout while still
+/// giving the kernel ample time (seconds) to post the outstanding packets.
+const ABORT_DRAIN_BUDGET: Duration = Duration::from_secs(5);
 
 /// Countdown for the test-only `WriteFile` fault injector. When non-zero,
 /// each submission decrements the counter; once it hits zero the next
@@ -289,12 +307,48 @@ pub(super) fn drain_completions(port: &CompletionPort, max: usize) -> io::Result
 /// does not hide the failure; it only guarantees the buffers outlive the
 /// kernel's writes. The returned byte count preserves partial progress the
 /// same way the success path does.
+///
+/// # Bounded wait
+///
+/// Each `GetQueuedCompletionStatusEx` wait is capped at [`ABORT_DRAIN_WAIT_MS`]
+/// and the loop enforces an overall [`ABORT_DRAIN_BUDGET`] deadline. On the
+/// success path every accepted op is guaranteed to post a completion, but on
+/// this abort path a wedged completion port or a miscounted residual could
+/// otherwise park the disk-commit thread inside the wait forever. When the
+/// budget elapses with ops still outstanding the drain gives up, emits a
+/// throttled `tracing::warn!`, and returns the bytes reaped so far - the caller
+/// is already propagating the original abort error, so a bounded return
+/// converts a potential hang into a surfaced timeout without masking the
+/// primary failure.
 pub(super) fn drain_all_ignoring_completion_errors(
     port: &CompletionPort,
+    outstanding: usize,
+) -> usize {
+    let deadline = Instant::now() + ABORT_DRAIN_BUDGET;
+    drain_all_ignoring_completion_errors_until(port, outstanding, deadline)
+}
+
+/// Deadline-bounded core of [`drain_all_ignoring_completion_errors`], split out
+/// so tests can drive a short deadline against a port that will never post a
+/// completion and assert the drain returns instead of hanging.
+fn drain_all_ignoring_completion_errors_until(
+    port: &CompletionPort,
     mut outstanding: usize,
+    deadline: Instant,
 ) -> usize {
     let mut bytes = 0usize;
     while outstanding > 0 {
+        if Instant::now() >= deadline {
+            // The kernel still owes us `outstanding` completions but the budget
+            // is spent. Surface the timeout diagnostically; the caller returns
+            // the original abort error regardless.
+            tracing::warn!(
+                outstanding,
+                budget_ms = ABORT_DRAIN_BUDGET.as_millis() as u64,
+                "IOCP abort-drain timed out waiting for outstanding completions",
+            );
+            break;
+        }
         let batch = outstanding.min(COMPLETION_DRAIN_BATCH);
         let mut entries: Vec<OVERLAPPED_ENTRY> = vec![zeroed_entry(); batch];
         let mut removed: u32 = 0;
@@ -307,19 +361,20 @@ pub(super) fn drain_all_ignoring_completion_errors(
                 entries.as_mut_ptr(),
                 batch as u32,
                 &mut removed,
-                DRAIN_TIMEOUT_MS,
+                ABORT_DRAIN_WAIT_MS,
                 FALSE,
             )
         };
 
         if ok == FALSE {
             let err = io::Error::last_os_error();
-            // Spurious wake without entries: retry until the outstanding ops
-            // report. Any other failure means the port itself is unusable, so
-            // there is no way left to observe the remaining completions; stop
-            // to avoid spinning forever. This matches the pre-existing posture
-            // of the success path, where `drain_completions` also returns on
-            // such an error and the caller drops the in-flight queue.
+            // Bounded-wait expiry with no entries: loop so the deadline check
+            // at the top can decide whether to keep waiting or give up. Any
+            // other failure means the port itself is unusable, so there is no
+            // way left to observe the remaining completions; stop to avoid
+            // spinning forever. This matches the pre-existing posture of the
+            // success path, where `drain_completions` also returns on such an
+            // error and the caller drops the in-flight queue.
             if matches!(err.raw_os_error(), Some(c) if c as u32 == WAIT_TIMEOUT) {
                 continue;
             }
@@ -348,15 +403,24 @@ pub(super) fn drain_all_ignoring_completion_errors(
     bytes
 }
 
-/// Translates the small set of NTSTATUS codes that overlapped file I/O can
-/// produce into Win32 DOS error codes.
+/// Translates an NTSTATUS from `OVERLAPPED::Internal` into its Win32 DOS error
+/// code so a faulted overlapped completion surfaces the same `errno`/exit code
+/// as an equivalent synchronous Win32 failure (and, in turn, the same
+/// cross-platform mapping the standard and io_uring writers produce).
+///
+/// Delegates to `ntdll!RtlNtStatusToDosError`, the OS's own authoritative and
+/// complete NTSTATUS -> Win32 table, rather than a hand-maintained subset. A
+/// partial table left common disk faults - `STATUS_DISK_FULL` (0xC000007F),
+/// `STATUS_ACCESS_DENIED` (0xC0000022), `STATUS_DEVICE_*` - falling through to
+/// the raw NTSTATUS value, which is not a valid Win32 error and produces
+/// exit-code/message divergence from the other writers.
 fn ntstatus_to_dos_error(status: u32) -> u32 {
-    match status {
-        0xC000_0011 => ERROR_HANDLE_EOF, // STATUS_END_OF_FILE
-        0xC000_0120 => 995,              // STATUS_CANCELLED
-        0xC000_009A => 1450,             // STATUS_INSUFFICIENT_RESOURCES
-        0xC000_00B5 => 121,              // STATUS_IO_TIMEOUT
-        other => other,
+    // SAFETY: `RtlNtStatusToDosError` is a pure translation function in
+    // ntdll.dll with no preconditions on `status`; any NTSTATUS (including
+    // unrecognised ones, which map to ERROR_MR_MID_NOT_FOUND) is valid input.
+    #[allow(unsafe_code)]
+    unsafe {
+        RtlNtStatusToDosError(status as i32)
     }
 }
 
@@ -366,5 +430,76 @@ fn zeroed_entry() -> OVERLAPPED_ENTRY {
     #[allow(unsafe_code)]
     unsafe {
         std::mem::zeroed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows_sys::Win32::Foundation::{
+        ERROR_ACCESS_DENIED, ERROR_DISK_FULL, ERROR_OPERATION_ABORTED,
+    };
+
+    // Common NTSTATUS values overlapped file I/O can surface, paired with the
+    // Win32 error code the other writers (standard/io_uring) and upstream
+    // rsync produce for the same failure. Verifying the mapping goes through
+    // `RtlNtStatusToDosError` guards against a regression back to the partial
+    // hand table that leaked raw NTSTATUS values for common disk faults.
+    #[test]
+    fn ntstatus_maps_to_matching_win32_error() {
+        // STATUS_END_OF_FILE -> ERROR_HANDLE_EOF (drain_completions relies on
+        // this exact equality to raise UnexpectedEof).
+        assert_eq!(ntstatus_to_dos_error(0xC000_0011), ERROR_HANDLE_EOF);
+        // STATUS_DISK_FULL -> ERROR_DISK_FULL (112). The old partial table
+        // fell through to the raw 0xC000_007F here, diverging from every
+        // other writer's ENOSPC-equivalent exit code.
+        assert_eq!(ntstatus_to_dos_error(0xC000_007F), ERROR_DISK_FULL);
+        // STATUS_ACCESS_DENIED -> ERROR_ACCESS_DENIED (5).
+        assert_eq!(ntstatus_to_dos_error(0xC000_0022), ERROR_ACCESS_DENIED);
+        // STATUS_CANCELLED -> ERROR_OPERATION_ABORTED (995).
+        assert_eq!(ntstatus_to_dos_error(0xC000_0120), ERROR_OPERATION_ABORTED);
+    }
+
+    // A faulted NTSTATUS must round-trip through io::Error as the mapped Win32
+    // code, not the raw status, so callers observe the same errno as a
+    // synchronous failure.
+    #[test]
+    fn faulted_status_round_trips_as_win32_errno() {
+        let dos = ntstatus_to_dos_error(0xC000_007F);
+        let err = io::Error::from_raw_os_error(dos as i32);
+        assert_eq!(err.raw_os_error(), Some(ERROR_DISK_FULL as i32));
+    }
+
+    // The abort-drain must return once its deadline elapses instead of parking
+    // forever when the kernel never posts the outstanding completions. Drive a
+    // fresh port with a residual count but no submitted ops and an
+    // already-expired deadline: the loop must give up promptly and report zero
+    // reaped bytes rather than hang.
+    #[test]
+    fn abort_drain_returns_on_deadline_instead_of_hanging() {
+        let port = CompletionPort::new(1).expect("create completion port");
+        let deadline = Instant::now() - Duration::from_millis(1);
+        let start = Instant::now();
+        let bytes = drain_all_ignoring_completion_errors_until(&port, 4, deadline);
+        assert_eq!(bytes, 0, "no completions were posted, so no bytes reaped");
+        assert!(
+            start.elapsed() < ABORT_DRAIN_BUDGET,
+            "abort-drain must return on the deadline, not run the full budget",
+        );
+    }
+
+    // A short but non-zero budget must also terminate: no ops are outstanding
+    // that will ever complete, so the drain waits at most one bounded wait
+    // slice past the deadline before returning.
+    #[test]
+    fn abort_drain_bounds_total_wait() {
+        let port = CompletionPort::new(1).expect("create completion port");
+        let deadline = Instant::now() + Duration::from_millis(50);
+        let start = Instant::now();
+        let _ = drain_all_ignoring_completion_errors_until(&port, 2, deadline);
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "bounded abort-drain must not approach the full 5s budget here",
+        );
     }
 }

--- a/crates/fast_io/src/iocp/disk_batch/mod.rs
+++ b/crates/fast_io/src/iocp/disk_batch/mod.rs
@@ -61,7 +61,7 @@ use super::config::IocpConfig;
 use crate::page_aligned::{PageAlignedBuffer, round_up_to_page};
 
 use buffer::BatchBuffer;
-use writer::{close_overlapped_handle, reopen_overlapped, submit_write_batch};
+use writer::{OverlappedHandle, reopen_overlapped, submit_write_batch};
 
 pub use buffer::{bounce_copies_avoided, reset_bounce_copies_avoided_for_test};
 pub use completion::{
@@ -116,10 +116,10 @@ struct ActiveFile {
     /// version - returned by [`IocpDiskBatch::commit_file`] so callers can
     /// rename/finalize via the same handle they passed in.
     file: File,
-    /// Handle reopened with `FILE_FLAG_OVERLAPPED` for IOCP submission. Owned
-    /// by the active-file slot and closed when the file is committed or a
-    /// subsequent `begin_file` rotates it out.
-    overlapped_handle: HANDLE,
+    /// Handle reopened with `FILE_FLAG_OVERLAPPED` for IOCP submission. The
+    /// RAII guard closes the handle on drop, so committing the file or a
+    /// subsequent `begin_file` that rotates the slot out cannot leak it.
+    overlapped_handle: OverlappedHandle,
     /// Cumulative bytes successfully written and reaped from the port.
     bytes_written: u64,
     /// Per-file completion key associated with the port.
@@ -200,10 +200,9 @@ impl IocpDiskBatch {
         let key = self.next_completion_key;
         self.next_completion_key = self.next_completion_key.wrapping_add(1).max(1);
 
-        if let Err(e) = self.port.associate(overlapped_handle, key) {
-            close_overlapped_handle(overlapped_handle);
-            return Err(e);
-        }
+        // On failure `overlapped_handle` drops here, closing the reopened
+        // handle - no manual CloseHandle needed on the error path.
+        self.port.associate(overlapped_handle.raw(), key)?;
 
         self.current_file = Some(ActiveFile {
             file,
@@ -292,14 +291,16 @@ impl IocpDiskBatch {
             #[allow(unsafe_code)]
             let ok = unsafe { FlushFileBuffers(raw) };
             if ok != TRUE {
-                let err = io::Error::last_os_error();
-                close_overlapped_handle(active.overlapped_handle);
-                return Err(err);
+                // `active` (including its overlapped-handle RAII guard) drops
+                // on this early return, closing the reopened handle.
+                return Err(io::Error::last_os_error());
             }
         }
 
-        close_overlapped_handle(active.overlapped_handle);
-        Ok((active.file, bytes_written))
+        // Destructure so `overlapped_handle` drops (closing the reopened
+        // handle) while `file` is returned to the caller for finalization.
+        let ActiveFile { file, .. } = active;
+        Ok((file, bytes_written))
     }
 
     /// Returns the bytes successfully written to the current file (drained).
@@ -349,7 +350,7 @@ impl IocpDiskBatch {
         let mut written = 0usize;
         let result = submit_write_batch(
             &self.port,
-            active.overlapped_handle,
+            active.overlapped_handle.raw(),
             &self.buffer.as_slice()[..len],
             base_offset,
             chunk_size,
@@ -370,10 +371,9 @@ impl IocpDiskBatch {
     /// new file mid-stream (the previous file's data has already been
     /// flushed by the caller of `flush_current`).
     fn finalize_current_file(&mut self) {
-        if let Some(active) = self.current_file.take() {
-            close_overlapped_handle(active.overlapped_handle);
-            // `active.file` drops here, closing the original handle.
-        }
+        // Dropping the taken `ActiveFile` closes both the overlapped handle
+        // (via its RAII guard) and the original `File`.
+        drop(self.current_file.take());
     }
 }
 

--- a/crates/fast_io/src/iocp/disk_batch/tests.rs
+++ b/crates/fast_io/src/iocp/disk_batch/tests.rs
@@ -327,6 +327,45 @@ fn no_leaked_overlapped_handles_after_many_rotations() {
 }
 
 #[test]
+fn overlapped_handle_guard_closes_handle_on_drop() {
+    // The RAII guard must close the reopened overlapped handle when it drops,
+    // including on early-return/error paths that never reach commit_file. Drive
+    // the guard directly: reopen a handle, capture its raw value, drop the
+    // guard, and confirm the kernel no longer recognises the handle.
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::GetHandleInformation;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("guard_drop.bin");
+    let file = open_writable(&path);
+    let raw = file.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+
+    let config = IocpConfig::default();
+    let guard = super::writer::reopen_overlapped(raw, &config).unwrap();
+    let reopened = guard.raw();
+
+    // While the guard is alive the reopened handle is valid.
+    let mut flags: u32 = 0;
+    // SAFETY: `reopened` is a live handle owned by `guard`.
+    #[allow(unsafe_code)]
+    let ok_before = unsafe { GetHandleInformation(reopened, &mut flags) };
+    assert_ne!(ok_before, 0, "reopened handle must be valid before drop");
+
+    drop(guard);
+
+    // After drop the handle value should no longer resolve. GetHandleInformation
+    // returns 0 (with ERROR_INVALID_HANDLE) for a closed handle.
+    // SAFETY: querying a (now closed) handle value is defined; the call only
+    // reads kernel handle-table state and cannot dereference user memory.
+    #[allow(unsafe_code)]
+    let ok_after = unsafe { GetHandleInformation(reopened, &mut flags) };
+    assert_eq!(
+        ok_after, 0,
+        "guard drop must close the reopened overlapped handle"
+    );
+}
+
+#[test]
 fn completion_ordering_independent_of_submission_order() {
     // Multiple in-flight writes may complete out of order. The drain
     // loop must reconcile each completion with its OVERLAPPED pointer
@@ -409,7 +448,7 @@ fn aligned_write_path_increments_bounce_counter() {
     let mut written = 0usize;
     super::writer::submit_write_batch(
         &batch.port,
-        batch.current_file.as_ref().unwrap().overlapped_handle,
+        batch.current_file.as_ref().unwrap().overlapped_handle.raw(),
         &vec![0x42u8; 4096],
         0,
         4096,

--- a/crates/fast_io/src/iocp/disk_batch/writer.rs
+++ b/crates/fast_io/src/iocp/disk_batch/writer.rs
@@ -26,6 +26,32 @@ use super::completion::{
     drain_all_ignoring_completion_errors, drain_completions, take_injected_write_error,
 };
 
+/// RAII guard owning the overlapped handle returned by [`reopen_overlapped`].
+///
+/// The handle is closed exactly once on drop, so every early-return and error
+/// path releases it without a manual `CloseHandle` at each call site. Callers
+/// that must hand the raw handle to a Win32 API borrow it via [`Self::raw`];
+/// the guard retains ownership and the borrowed handle must not be closed by
+/// the caller. The wrapped handle is never null or `INVALID_HANDLE_VALUE`
+/// because [`reopen_overlapped`] rejects those before constructing the guard.
+pub(super) struct OverlappedHandle {
+    handle: HANDLE,
+}
+
+impl OverlappedHandle {
+    /// Borrows the raw handle for use with Win32 APIs. Ownership stays with
+    /// the guard; the returned handle must not be closed by the caller.
+    pub(super) fn raw(&self) -> HANDLE {
+        self.handle
+    }
+}
+
+impl Drop for OverlappedHandle {
+    fn drop(&mut self) {
+        close_overlapped_handle(self.handle);
+    }
+}
+
 /// Reopens an existing file handle with `FILE_FLAG_OVERLAPPED` so it can be
 /// associated with a completion port.
 ///
@@ -36,9 +62,11 @@ use super::completion::{
 /// cache; combined with the page-aligned buffer chunks the writer issues,
 /// the kernel can dispatch each `WriteFile` without a bounce copy.
 /// `config.write_through` similarly maps to `FILE_FLAG_WRITE_THROUGH`.
-/// The returned handle must be closed with `CloseHandle` once no longer
-/// needed.
-pub(super) fn reopen_overlapped(handle: HANDLE, config: &IocpConfig) -> io::Result<HANDLE> {
+/// The returned [`OverlappedHandle`] closes the underlying handle on drop.
+pub(super) fn reopen_overlapped(
+    handle: HANDLE,
+    config: &IocpConfig,
+) -> io::Result<OverlappedHandle> {
     let mut flags = FILE_FLAG_OVERLAPPED;
     if config.unbuffered {
         flags |= FILE_FLAG_NO_BUFFERING;
@@ -65,11 +93,11 @@ pub(super) fn reopen_overlapped(handle: HANDLE, config: &IocpConfig) -> io::Resu
         return Err(io::Error::last_os_error());
     }
 
-    Ok(new_handle)
+    Ok(OverlappedHandle { handle: new_handle })
 }
 
 /// Closes a handle obtained from [`reopen_overlapped`].
-pub(super) fn close_overlapped_handle(handle: HANDLE) {
+fn close_overlapped_handle(handle: HANDLE) {
     if handle.is_null() || handle == INVALID_HANDLE_VALUE {
         return;
     }


### PR DESCRIPTION
Round-two hardening of the Windows IOCP disk-commit path (`crates/fast_io/src/iocp/disk_batch/`), building on the mid-batch drain-on-error fix in #6331. Advances #489.

Each item was verified against the code before implementing. One was already handled and is left unchanged.

## IOCP-H-3 short-write offset resume - already handled (no change)
`writer.rs` already resubmits the unwritten tail of a partial `WriteFile` completion at `original_offset + transferred`, not the whole buffer and not past the gap. Confirmed correct; no change made.

## IOCP-H-4 handle-leak RAII - confirmed gap, fixed
The reopened `FILE_FLAG_OVERLAPPED` handle was a raw `HANDLE` on `ActiveFile`, closed only by manual `CloseHandle` calls at four sites (begin_file associate-failure, commit_file fsync-error, commit success, finalize/Drop). No leak today, but not RAII-guaranteed - any future early-return between reopen and those sites would leak.

Fix: wrap it in an `OverlappedHandle` guard whose `Drop` closes the handle. All release sites now drop the guard instead of calling `CloseHandle`, so an early return cannot leak it.

## IOCP-H-5 abort-drain timeout - confirmed gap, fixed
`drain_all_ignoring_completion_errors` (the abort/error-cleanup drain from #6331) waited with an infinite (`u32::MAX`) `GetQueuedCompletionStatusEx` timeout and `continue`d on spurious `WAIT_TIMEOUT` forever. A wedged completion port or a miscounted residual would park the disk-commit thread indefinitely.

Fix: each wait is bounded (100 ms) under an overall 5 s budget. On expiry the drain emits a `tracing::warn!` and returns the bytes reaped so far; the caller still propagates the original abort error, so a potential hang becomes a surfaced timeout without masking the primary failure. The success path (`drain_completions`) is intentionally unchanged - every op the kernel accepted there is guaranteed to post a completion.

## IOCP-H-6 NTSTATUS to errno parity - confirmed gap, fixed
The hand-maintained four-entry `ntstatus_to_dos_error` table passed unrecognised statuses through verbatim (`other => other`), so common disk faults - `STATUS_DISK_FULL` (0xC000007F), `STATUS_ACCESS_DENIED` (0xC0000022), device errors - surfaced the raw NTSTATUS instead of a valid Win32 error, diverging from the standard/io_uring writers and upstream exit codes.

Fix: delegate to `ntdll!RtlNtStatusToDosError` (available under the already-enabled `Win32_Foundation` feature) - the OS's authoritative, complete NTSTATUS to Win32 mapping. `STATUS_END_OF_FILE` still maps to `ERROR_HANDLE_EOF`, preserving the `UnexpectedEof` special case in `drain_completions`.

## Tests (Windows + iocp gated)
- `overlapped_handle_guard_closes_handle_on_drop`: guard Drop closes the reopened handle (verified via `GetHandleInformation`).
- `ntstatus_maps_to_matching_win32_error` / `faulted_status_round_trips_as_win32_errno`: EOF, disk-full, access-denied, cancelled map to the expected Win32 errno and round-trip through `io::Error`.
- `abort_drain_returns_on_deadline_instead_of_hanging` / `abort_drain_bounds_total_wait`: abort-drain returns on its deadline rather than hanging when the kernel never posts the outstanding completions.

## Verification
- Non-Windows unaffected: `cargo build -p fast_io -p transfer` and `cargo clippy -p fast_io -p transfer --no-deps -- -D warnings` both clean. No public API change; the non-Windows stub is untouched.
- Windows cross-compile: `cargo check -p fast_io -p transfer --target x86_64-pc-windows-gnu --features iocp` (with `--tests`) compiles clean. None of the changed files appear in Windows-target clippy output (pre-existing Windows-target lints in untouched files - pump.rs, copy_basis_range.rs, etc. - are unrelated).

The Windows IOCP CI cell is the runtime gate for the gated tests.
