### PR TITLE
fix(engine): dirfd-anchor the production delete pass (TOCTOU)

### DIFF
--- a/crates/engine/src/delete/context/core.rs
+++ b/crates/engine/src/delete/context/core.rs
@@ -435,8 +435,15 @@ impl DeleteContext {
         use super::super::parallel_consumer::ParallelDeleteEmitter;
         use super::super::reorder_buffer::{DeleteCohortKey, DeleteOperation};
 
-        let (plans, mut cursor, policy) = self.into_drain_parts().map_err(io::Error::from)?;
-        let emitter = ParallelDeleteEmitter::with_policy(fs, policy);
+        let parts = self.into_drain_parts().map_err(io::Error::from)?;
+        let plans = parts.plans;
+        let mut cursor = parts.cursor;
+        let emitter = ParallelDeleteEmitter::with_policy(fs, parts.policy);
+        #[cfg(unix)]
+        let emitter = match parts.sandbox {
+            Some(sandbox) => emitter.with_sandbox_rooted(sandbox, parts.sandbox_root),
+            None => emitter,
+        };
         let mut rank: u64 = 0;
         while let Some(dir) = cursor.next_ready() {
             let Some(plan) = plans.take(&dir) else {
@@ -493,8 +500,14 @@ impl DeleteContext {
     /// only hold sender clones, never `Arc<DirTraversalCursor>`.
     #[cfg(not(feature = "parallel-delete-consumer"))]
     pub(super) fn into_emitter<F: DeleteFs>(self, fs: F) -> Result<DeleteEmitter<F>, DeleteError> {
-        let (plans, cursor, policy) = self.into_drain_parts()?;
-        Ok(DeleteEmitter::with_policy(fs, plans, cursor, policy))
+        let parts = self.into_drain_parts()?;
+        let emitter = DeleteEmitter::with_policy(fs, parts.plans, parts.cursor, parts.policy);
+        #[cfg(unix)]
+        let emitter = match parts.sandbox {
+            Some(sandbox) => emitter.with_sandbox_rooted(sandbox, parts.sandbox_root),
+            None => emitter,
+        };
+        Ok(emitter)
     }
 
     /// Extracts the owned drain inputs (plan map, traversal cursor,
@@ -503,9 +516,7 @@ impl DeleteContext {
     /// path under the `parallel-delete-consumer` feature. The
     /// channel-shutdown semantics and `Arc::try_unwrap` invariant are
     /// preserved exactly because both paths consume `self` by value.
-    fn into_drain_parts(
-        self,
-    ) -> Result<(DeletePlanMap, DirTraversalCursor, EmitterErrorPolicy), DeleteError> {
+    fn into_drain_parts(self) -> Result<DrainParts, DeleteError> {
         let plans = Arc::try_unwrap(self.plans).map_err(|still_shared| {
             DeleteError::PlanMapStillShared {
                 strong_count: Arc::strong_count(&still_shared),
@@ -529,11 +540,74 @@ impl DeleteContext {
             .take()
             .ok_or(DeleteError::CursorReceiverAlreadyTaken)?;
 
+        // SEC-1.q / #506: open the delete root as a `DirSandbox` so the
+        // production emitter dispatches every unlink through the
+        // dirfd-anchored `*_at` syscalls, closing the parent-component
+        // symlink-swap TOCTOU. Open BEFORE `cursor_root` is moved into the
+        // cursor. A failure (root missing, not a directory, non-unix)
+        // yields `None` and the emitter stays on the path-based fallback -
+        // the deletion OUTCOMES are byte-identical either way; only the
+        // syscall mechanism differs.
+        #[cfg(unix)]
+        let sandbox = open_delete_sandbox(&self.cursor_root);
+        #[cfg(unix)]
+        let sandbox_root = self.cursor_root.clone();
+
         let mut cursor = DirTraversalCursor::new(self.cursor_root);
         while let Ok(obs) = rx.recv() {
             cursor.observe_segment(obs.dir, &obs.children);
         }
 
-        Ok((plans, cursor, self.policy))
+        Ok(DrainParts {
+            plans,
+            cursor,
+            policy: self.policy,
+            #[cfg(unix)]
+            sandbox,
+            #[cfg(unix)]
+            sandbox_root,
+        })
+    }
+}
+
+/// Owned inputs the drain needs, extracted from a consumed [`DeleteContext`].
+///
+/// Bundles the plan map, traversal cursor, and emitter policy shared by the
+/// sequential and parallel drain paths, plus the optional SEC-1.q
+/// [`fast_io::DirSandbox`] anchor (and the absolute root it was opened at)
+/// that lets the production emitter dispatch through the dirfd-anchored
+/// `*_at` syscalls.
+struct DrainParts {
+    plans: DeletePlanMap,
+    cursor: DirTraversalCursor,
+    policy: EmitterErrorPolicy,
+    #[cfg(unix)]
+    sandbox: Option<Arc<fast_io::DirSandbox>>,
+    #[cfg(unix)]
+    sandbox_root: PathBuf,
+}
+
+/// Opens `root` as a [`fast_io::DirSandbox`] for the delete emitter.
+///
+/// Returns `Some` when `root` resolves to a real (non-symlink) directory
+/// the process can open. Any failure - the delete root does not exist, is
+/// a symlink, or the platform refuses the open - is logged at debug level
+/// and yields `None` so the emitter transparently falls back to the
+/// path-based syscalls. This mirrors the receiver's
+/// `open_sandbox_for_dest` fallback contract: a sandbox open failure must
+/// never turn a working delete into a failure.
+#[cfg(unix)]
+fn open_delete_sandbox(root: &Path) -> Option<Arc<fast_io::DirSandbox>> {
+    match fast_io::DirSandbox::open_root(root) {
+        Ok(sandbox) => Some(Arc::new(sandbox)),
+        Err(err) => {
+            logging::debug_log!(
+                Del,
+                2,
+                "DirSandbox::open_root({}) failed: {err}; falling back to path-based delete syscalls",
+                root.display()
+            );
+            None
+        }
     }
 }

--- a/crates/engine/src/delete/context/tests.rs
+++ b/crates/engine/src/delete/context/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for [`DeleteContext`], [`EmitterTiming`], and the
 //! cursor-channel drain protocol.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::fs::File;
 use std::io;
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use protocol::flist::FileEntry;
 use tempfile::TempDir;
 
-use super::super::emitter::{DeleteEvent, RecordingDeleteFs};
+use super::super::emitter::RecordingDeleteFs;
 #[cfg(not(feature = "parallel-delete-consumer"))]
 use super::super::error::DeleteError;
 use super::super::plan::DeleteEntryKind;
@@ -214,10 +214,25 @@ fn during_mode_drains_one_directory_through_emitter() {
         .expect("drain succeeds");
     let events = outcome.fs.events();
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].path, dir.join("drop"));
+    // #506: the production emit path now dispatches through the SEC-1.q
+    // dirfd anchor on unix, so `RecordingDeleteFs` records the leaf-only
+    // name; the path-based fallback records the absolute path. Either way
+    // the entry identified is "drop" and the stats/outcome are identical.
+    assert_eq!(recorded_leaf(&events[0].path), OsStr::new("drop"));
     assert_eq!(events[0].kind, DeleteEntryKind::File);
     assert_eq!(outcome.stats.files, 1);
     assert_eq!(outcome.exit_code, 0);
+}
+
+/// Returns the leaf name of a `RecordingDeleteFs` event path.
+///
+/// The production emit path dispatches through the SEC-1.q dirfd anchor on
+/// unix (recording the leaf only) and through the path-based methods on the
+/// fallback and non-unix (recording the absolute path). `file_name()`
+/// normalises both to the leaf so assertions stay mechanism-agnostic while
+/// still pinning WHICH entry was deleted (Rule 9).
+fn recorded_leaf(path: &Path) -> &OsStr {
+    path.file_name().unwrap_or(path.as_os_str())
 }
 
 #[test]
@@ -248,9 +263,16 @@ fn before_mode_drains_pre_walk_pass_across_dirs() {
     let outcome = ctx
         .emit_all(RecordingDeleteFs::new())
         .expect("drain succeeds");
-    let names: Vec<PathBuf> = outcome.fs.events().iter().map(|e| e.path.clone()).collect();
-    assert!(names.iter().any(|p| p == &a.join("x")));
-    assert!(names.iter().any(|p| p == &b.join("y")));
+    // #506: leaf-only under the dirfd anchor, absolute under the path
+    // fallback; compare on leaf names so the assertion is mechanism-agnostic.
+    let leaves: Vec<OsString> = outcome
+        .fs
+        .events()
+        .iter()
+        .map(|e| recorded_leaf(&e.path).to_os_string())
+        .collect();
+    assert!(leaves.iter().any(|n| n == OsStr::new("x")));
+    assert!(leaves.iter().any(|n| n == OsStr::new("y")));
     assert_eq!(outcome.stats.files, 2);
 }
 
@@ -348,13 +370,12 @@ fn record_drain_outcome_carries_recorded_events() {
     ctx.begin_directory(make_segment(&[]));
     ctx.publish_plan_for(&dir).unwrap();
     let outcome = ctx.emit_one(RecordingDeleteFs::new()).unwrap();
-    assert_eq!(
-        outcome.fs.events(),
-        vec![DeleteEvent {
-            path: dir.join("victim"),
-            kind: DeleteEntryKind::File,
-        }]
-    );
+    let events = outcome.fs.events();
+    assert_eq!(events.len(), 1);
+    // #506: leaf-only under the SEC-1.q dirfd anchor, absolute under the
+    // path-based fallback; assert the identified entry and kind.
+    assert_eq!(recorded_leaf(&events[0].path), OsStr::new("victim"));
+    assert_eq!(events[0].kind, DeleteEntryKind::File);
 }
 
 /// ATU-4 (#2381): channel-shutdown drain terminates as soon as every
@@ -454,4 +475,111 @@ fn channel_drain_completes_when_worker_panics_mid_send() {
         outcome.stats.files, 1,
         "the survivor file is deleted exactly once"
     );
+}
+
+/// #506 (production wiring): the drain built by `DeleteContext` now attaches
+/// a `DirSandbox` opened at the delete root, so the emitter dispatches every
+/// unlink through the SEC-1.q dirfd-anchored `*_at` syscalls rather than the
+/// TOCTOU-prone path-based `std::fs::remove_*`. `RecordingDeleteFs` records
+/// the leaf-only name for a `*_at` dispatch and the absolute path for the
+/// path-based fallback, so a leaf-only recording proves the anchor is engaged
+/// on the production path this task wires. WHY it matters: without the anchor,
+/// a parent path component swapped for a symlink between plan-time and
+/// unlink-time could redirect the delete outside the destination tree.
+#[cfg(unix)]
+#[test]
+fn production_drain_dispatches_through_dirfd_anchor() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sub");
+    fs::create_dir(&dir).unwrap();
+    touch(&dir, "drop");
+
+    let ctx = DeleteContext::new(dir.clone(), EmitterTiming::During);
+    ctx.observe_directory(dir.clone(), &[]);
+    ctx.begin_directory(make_segment(&[]));
+    ctx.publish_plan_for(&dir).expect("publish plan");
+
+    let outcome = ctx
+        .emit_one(RecordingDeleteFs::new())
+        .expect("drain succeeds");
+    let events = outcome.fs.events();
+    assert_eq!(events.len(), 1);
+    // A bare leaf ("drop", no separators) can only come from the
+    // dirfd-anchored `unlink_file_at`; the path-based fallback would record
+    // the absolute path. This is the load-bearing proof that the production
+    // drain now rides the sandbox.
+    assert_eq!(events[0].path, PathBuf::from("drop"));
+    assert_eq!(events[0].kind, DeleteEntryKind::File);
+    assert_eq!(outcome.stats.files, 1);
+}
+
+/// #506 (TOCTOU regression): the dirfd anchor the production drain attaches
+/// refuses to delete through a parent component that was swapped for a
+/// symlink pointing outside the destination tree. Proven deterministically
+/// by program order (no threads, no sleeps): the emitter opens the delete
+/// root's dirfd when the drain starts, so a later ancestor-symlink swap
+/// cannot redirect the anchored `unlinkat`. Uses the real `RealDeleteFs` so
+/// the live `unlinkat(2)` runs. The out-of-tree sentinel must survive; only
+/// the in-tree leaf may be removed.
+///
+/// Gated off the parallel feature because it drives the sequential
+/// `into_emitter`/`emit_all` API directly to open the dirfd before the swap;
+/// the parallel consumer's equivalent anchor is covered by the DFD tests in
+/// `parallel_consumer.rs`.
+#[cfg(all(unix, not(feature = "parallel-delete-consumer")))]
+#[test]
+fn production_drain_refuses_ancestor_symlink_escape() {
+    use crate::delete::RealDeleteFs;
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Delete root is `root`; the plan targets `root/victim`.
+    let root = tmp.path().join("root");
+    fs::create_dir(&root).unwrap();
+    let victim = root.join("victim");
+    touch(&root, "victim");
+
+    // Sentinel OUTSIDE the delete tree; a redirected unlink would try to
+    // remove `outside/victim`. It must be untouched.
+    let outside = tmp.path().join("outside");
+    fs::create_dir(&outside).unwrap();
+    let sentinel = outside.join("victim");
+    File::create(&sentinel).expect("write sentinel");
+
+    let ctx = DeleteContext::new(root.clone(), EmitterTiming::During);
+    ctx.observe_directory(root.clone(), &[]);
+    ctx.begin_directory(make_segment(&[]));
+    ctx.publish_plan_for(&root).expect("publish plan");
+
+    // Build the emitter (opens the root dirfd), THEN swap the delete root
+    // for a symlink pointing at `outside`. The dirfd captured at build time
+    // pins the real inode; the path `root/victim` now names `outside/victim`
+    // for any path-based resolver, but the anchored unlink is immune.
+    let emitter = ctx
+        .into_emitter(RealDeleteFs)
+        .expect("emitter built with sandbox");
+    assert!(
+        emitter.sandbox().is_some(),
+        "the production drain must attach a DirSandbox at the delete root",
+    );
+
+    fs::rename(&root, tmp.path().join("root.bak")).expect("move real root aside");
+    symlink(&outside, &root).expect("plant root symlink");
+
+    let mut emitter = emitter;
+    emitter.emit_all().expect("drain returns Ok");
+
+    // The out-of-tree sentinel survives: the anchored unlink refused the
+    // symlink redirect.
+    assert!(
+        sentinel.exists(),
+        "outside sentinel must survive; the dirfd anchor refused the ancestor-symlink redirect",
+    );
+    // The real in-tree victim (now under root.bak, since the anchor points
+    // at the original inode) was removed.
+    assert!(
+        !tmp.path().join("root.bak").join("victim").exists(),
+        "the anchored unlink must remove the real in-tree victim",
+    );
+    let _ = victim; // original in-tree path, documented for clarity
 }

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -119,6 +119,18 @@ pub struct DeleteEmitter<F: DeleteFs> {
     /// pre-SEC-1.q caller contract.
     #[cfg(unix)]
     sandbox: Option<Arc<DirSandbox>>,
+    /// Absolute root the attached [`DirSandbox`] was opened at.
+    ///
+    /// Plan directory keys are absolute in the production local-copy
+    /// cleanup path (they equal the destination directory), but the
+    /// sandbox `openat` walk needs a path relative to the sandbox root.
+    /// When set, [`Self::open_plan_dirfd`] resolves each plan directory by
+    /// stripping this prefix so an absolute key like `/dst/sub` opens as
+    /// `sub` under the root. When `None` (the unit-test convention where
+    /// plan keys are already relative to the sandbox root), the emitter
+    /// falls back to [`plan_directory_to_relative`].
+    #[cfg(unix)]
+    sandbox_root: Option<PathBuf>,
 }
 
 impl<F: DeleteFs> DeleteEmitter<F> {
@@ -148,6 +160,8 @@ impl<F: DeleteFs> DeleteEmitter<F> {
             pending: None,
             #[cfg(unix)]
             sandbox: None,
+            #[cfg(unix)]
+            sandbox_root: None,
         }
     }
 
@@ -164,6 +178,23 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     #[must_use]
     pub fn with_sandbox(mut self, sandbox: Arc<DirSandbox>) -> Self {
         self.sandbox = Some(sandbox);
+        self
+    }
+
+    /// Attaches a [`DirSandbox`] together with the absolute `root` it was
+    /// opened at.
+    ///
+    /// Identical to [`Self::with_sandbox`] except the emitter also records
+    /// the sandbox root so [`Self::open_plan_dirfd`] can resolve absolute
+    /// plan directory keys (the production local-copy cleanup path keys
+    /// plans on the absolute destination directory) relative to that root
+    /// before the `openat` walk. Callers with plan keys already relative
+    /// to the root can keep using [`Self::with_sandbox`].
+    #[cfg(unix)]
+    #[must_use]
+    pub fn with_sandbox_rooted(mut self, sandbox: Arc<DirSandbox>, root: PathBuf) -> Self {
+        self.sandbox = Some(sandbox);
+        self.sandbox_root = Some(root);
         self
     }
 
@@ -342,7 +373,17 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     #[cfg(unix)]
     fn open_plan_dirfd(&self, plan_directory: &Path) -> Option<std::os::fd::OwnedFd> {
         let sandbox = self.sandbox.as_ref()?;
-        let relative = plan_directory_to_relative(plan_directory);
+        // When the sandbox root is known and the plan directory is an
+        // absolute key beneath it (the local-copy cleanup path), resolve
+        // the plan directory relative to that root. `strip_prefix` on the
+        // root's own key yields the empty path, which `open_dir_at`
+        // re-opens as ".". Fall back to `plan_directory_to_relative` for
+        // the unit-test convention where plan keys are already relative.
+        let relative = self
+            .sandbox_root
+            .as_ref()
+            .and_then(|root| plan_directory.strip_prefix(root).ok())
+            .unwrap_or_else(|| plan_directory_to_relative(plan_directory));
         open_dir_at(sandbox.root_dirfd(), relative).ok()
     }
 

--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -134,6 +134,14 @@ pub struct ParallelDeleteEmitter<F: DeleteFs> {
     /// consumer falls back to path-based dispatch (the original behaviour).
     #[cfg(unix)]
     sandbox: Option<Arc<DirSandbox>>,
+    /// Absolute root the attached [`DirSandbox`] was opened at, used to
+    /// resolve absolute cohort directory keys (the local-copy cleanup path
+    /// keys cohorts on the absolute destination directory) relative to the
+    /// sandbox root before the per-cohort `openat` walk. `None` for the
+    /// unit-test convention where cohort keys are already relative to the
+    /// root.
+    #[cfg(unix)]
+    sandbox_root: Option<std::path::PathBuf>,
 }
 
 /// Mutex-protected [`CohortBatcher`] paired with a [`Condvar`] for the
@@ -173,6 +181,8 @@ impl<F: DeleteFs + Sync + Send + 'static> ParallelDeleteEmitter<F> {
             shared: Arc::new(SharedBatcher::default()),
             #[cfg(unix)]
             sandbox: None,
+            #[cfg(unix)]
+            sandbox_root: None,
         }
     }
 
@@ -189,6 +199,22 @@ impl<F: DeleteFs + Sync + Send + 'static> ParallelDeleteEmitter<F> {
     #[must_use]
     pub fn with_sandbox(mut self, sandbox: Arc<DirSandbox>) -> Self {
         self.sandbox = Some(sandbox);
+        self
+    }
+
+    /// Attaches a [`DirSandbox`] together with the absolute `root` it was
+    /// opened at, so absolute cohort directory keys resolve relative to the
+    /// root before the per-cohort `openat` walk. Mirrors
+    /// [`super::emitter::DeleteEmitter::with_sandbox_rooted`].
+    #[cfg(unix)]
+    #[must_use]
+    pub fn with_sandbox_rooted(
+        mut self,
+        sandbox: Arc<DirSandbox>,
+        root: std::path::PathBuf,
+    ) -> Self {
+        self.sandbox = Some(sandbox);
+        self.sandbox_root = Some(root);
         self
     }
 
@@ -276,6 +302,10 @@ impl<F: DeleteFs + Sync + Send + 'static> ParallelDeleteEmitter<F> {
         let consumer_sandbox = self.sandbox.clone();
         #[cfg(not(unix))]
         let consumer_sandbox = None::<()>;
+        #[cfg(unix)]
+        let consumer_sandbox_root = self.sandbox_root.clone();
+        #[cfg(not(unix))]
+        let consumer_sandbox_root = None::<()>;
         let fs = self.fs;
         let policy = self.policy;
         let shared = self.shared;
@@ -284,7 +314,15 @@ impl<F: DeleteFs + Sync + Send + 'static> ParallelDeleteEmitter<F> {
         let consumer_shared = Arc::clone(&shared);
         let consumer_handle = std::thread::Builder::new()
             .name("oc-rsync-del-consumer".into())
-            .spawn(move || consumer_loop(consumer_shared, consumer_fs, policy, consumer_sandbox))
+            .spawn(move || {
+                consumer_loop(
+                    consumer_shared,
+                    consumer_fs,
+                    policy,
+                    consumer_sandbox,
+                    consumer_sandbox_root,
+                )
+            })
             .map_err(|err| {
                 io::Error::other(format!(
                     "failed to spawn parallel delete consumer thread: {err}"
@@ -329,6 +367,8 @@ fn consumer_loop<F: DeleteFs + Sync + Send>(
     policy: EmitterErrorPolicy,
     #[cfg(unix)] sandbox: Option<Arc<DirSandbox>>,
     #[cfg(not(unix))] _sandbox: Option<()>,
+    #[cfg(unix)] sandbox_root: Option<std::path::PathBuf>,
+    #[cfg(not(unix))] _sandbox_root: Option<()>,
 ) -> io::Result<ConsumerSummary> {
     let mut summary = ConsumerSummary::default();
     loop {
@@ -344,12 +384,17 @@ fn consumer_loop<F: DeleteFs + Sync + Send>(
             let sandbox_ref = sandbox.as_ref();
             #[cfg(not(unix))]
             let sandbox_ref = None::<()>;
+            #[cfg(unix)]
+            let sandbox_root_ref = sandbox_root.as_deref();
+            #[cfg(not(unix))]
+            let sandbox_root_ref = None::<()>;
             dispatch_cohort(
                 &fs,
                 &policy,
                 entry.key.path(),
                 &entry.ops,
                 sandbox_ref,
+                sandbox_root_ref,
                 &mut summary,
             )?;
         }
@@ -392,21 +437,30 @@ fn dispatch_cohort<F: DeleteFs + Sync + Send>(
     ops: &[DeleteOperation],
     #[cfg(unix)] sandbox: Option<&Arc<DirSandbox>>,
     #[cfg(not(unix))] _sandbox: Option<()>,
+    #[cfg(unix)] sandbox_root: Option<&std::path::Path>,
+    #[cfg(not(unix))] _sandbox_root: Option<()>,
     summary: &mut ConsumerSummary,
 ) -> io::Result<()> {
     if ops.is_empty() {
         return Ok(());
     }
 
-    // SEC-1.q: open the cohort's destination-relative parent directory once
-    // via the sandbox so every op dispatches through the dirfd-anchored
-    // `*_at` methods. A failed open (vanished parent, or no sandbox
-    // attached) leaves `parent_fd` as `None` and each op transparently
-    // falls back to the path-based method, preserving the original
-    // behaviour.
+    // SEC-1.q: open the cohort's parent directory once via the sandbox so
+    // every op dispatches through the dirfd-anchored `*_at` methods. When
+    // the sandbox root is known and the cohort key is an absolute path
+    // beneath it (the local-copy cleanup path), resolve the cohort dir
+    // relative to that root; otherwise fall back to
+    // `plan_directory_to_relative` (the unit-test convention of relative
+    // cohort keys). A failed open (vanished parent, or no sandbox attached)
+    // leaves `parent_fd` as `None` and each op transparently falls back to
+    // the path-based method, preserving the original behaviour.
     #[cfg(unix)]
-    let parent_handle: Option<std::os::fd::OwnedFd> = sandbox
-        .and_then(|sb| open_dir_at(sb.root_dirfd(), plan_directory_to_relative(cohort_dir)).ok());
+    let parent_handle: Option<std::os::fd::OwnedFd> = sandbox.and_then(|sb| {
+        let relative = sandbox_root
+            .and_then(|root| cohort_dir.strip_prefix(root).ok())
+            .unwrap_or_else(|| plan_directory_to_relative(cohort_dir));
+        open_dir_at(sb.root_dirfd(), relative).ok()
+    });
     #[cfg(unix)]
     let parent_fd = parent_handle.as_ref().map(std::os::fd::AsFd::as_fd);
 

--- a/crates/engine/tests/delete_emitter_timing_modes.rs
+++ b/crates/engine/tests/delete_emitter_timing_modes.rs
@@ -59,6 +59,27 @@ fn dir_child(parent: &str, name: &str) -> FileEntry {
     FileEntry::new_directory(path, 0o755)
 }
 
+/// Collects the leaf name of every recorded delete dispatch.
+///
+/// The production drain now attaches a `DirSandbox` (#506), so on unix the
+/// emitter dispatches through the dirfd-anchored `*_at` trait methods and
+/// `RecordingDeleteFs` records the LEAF name; the path-based fallback (and
+/// non-unix) records the absolute path. `file_name()` normalises both to the
+/// leaf so the deletion-OUTCOME assertions - which entries were deleted -
+/// stay identical across the mechanism switch. The syscall mechanism changed;
+/// the set of entries deleted did not.
+fn deleted_leaves(events: &[engine::delete::DeleteEvent]) -> Vec<OsString> {
+    events
+        .iter()
+        .map(|e| {
+            e.path
+                .file_name()
+                .unwrap_or(e.path.as_os_str())
+                .to_os_string()
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Per-mode wiring tests
 // ---------------------------------------------------------------------------
@@ -92,9 +113,9 @@ fn during_mode_emits_one_directory_per_work_unit() {
     // single directory varies across platforms (NTFS vs POSIX readdir).
     let events = outcome.fs.events();
     assert_eq!(events.len(), 2);
-    let paths: Vec<_> = events.iter().map(|e| &e.path).collect();
-    assert!(paths.contains(&&dir.join("drop_x")));
-    assert!(paths.contains(&&dir.join("drop_y")));
+    let leaves = deleted_leaves(&events);
+    assert!(leaves.contains(&OsString::from("drop_x")));
+    assert!(leaves.contains(&OsString::from("drop_y")));
     assert_eq!(outcome.stats.files, 2);
 }
 
@@ -130,15 +151,18 @@ fn before_mode_drains_all_plans_in_one_pre_pass() {
     let outcome = ctx
         .emit_all(RecordingDeleteFs::new())
         .expect("drain succeeds");
-    let paths: Vec<PathBuf> = outcome.fs.events().iter().map(|e| e.path.clone()).collect();
+    let leaves = deleted_leaves(&outcome.fs.events());
     // a1, a2 inside a (reversed: a2, a1); b1 inside b. Root has only
     // the two subdirs as extras, but they reappear in the cursor and
     // their per-dir plan handles the contents. The root drain itself
     // will try to rmdir a/b but they have contents - the emitter
-    // recurses via the nested plans, NOT remove_dir_all.
-    assert!(paths.contains(&a.join("a1")));
-    assert!(paths.contains(&a.join("a2")));
-    assert!(paths.contains(&b.join("b1")));
+    // recurses via the nested plans, NOT remove_dir_all. Every planned
+    // leaf must be deleted; leaf names are unique across a/ and b/ so
+    // membership pins the exact entries regardless of the path-vs-leaf
+    // recording (#506 dirfd anchor).
+    assert!(leaves.contains(&OsString::from("a1")));
+    assert!(leaves.contains(&OsString::from("a2")));
+    assert!(leaves.contains(&OsString::from("b1")));
 }
 
 /// DDP-E3 (#2267): --delete-after. Plans accumulate during transfer;
@@ -179,10 +203,13 @@ fn after_mode_accumulates_plans_then_drains_at_end() {
     let outcome = ctx
         .emit_all(RecordingDeleteFs::new())
         .expect("drain succeeds");
-    let paths: Vec<PathBuf> = outcome.fs.events().iter().map(|e| e.path.clone()).collect();
-    assert!(paths.contains(&d1.join("one")));
-    assert!(paths.contains(&d1.join("two")));
-    assert!(paths.contains(&d2.join("three")));
+    // Leaf names are unique across d1/ and d2/, so leaf membership pins the
+    // exact deleted entries regardless of the path-vs-leaf recording that
+    // the #506 dirfd anchor introduces.
+    let leaves = deleted_leaves(&outcome.fs.events());
+    assert!(leaves.contains(&OsString::from("one")));
+    assert!(leaves.contains(&OsString::from("two")));
+    assert!(leaves.contains(&OsString::from("three")));
 }
 
 /// DDP-E4 (#2268): --delete-delay. Identical drain shape to After at the


### PR DESCRIPTION
## The verified gap

The local-copy cleanup delete pass (`crates/engine/src/local_copy/executor/cleanup.rs:149`) drained through `DeleteContext::emit_one` with **no `DirSandbox` attached**, so `RealDeleteFs` dispatched every unlink through path-based `std::fs::remove_*`. A parent path component swapped for a symlink between plan-time and unlink-time could redirect the delete outside the destination tree.

The dirfd-anchored `*_at` trait methods (`unlinkat`/`recursive_unlinkat`, `O_DIRECTORY | O_NOFOLLOW`) and the `.with_sandbox()` wiring already existed on both the sequential `DeleteEmitter` and the parallel `ParallelDeleteEmitter`, but `.with_sandbox()` was only ever called from tests. The sole production builder (`DeleteContext::into_emitter`) never attached one.

The receiver delete pass (`crates/transfer/src/receiver/directory/deletion.rs`) already routes its scan and unlinks through the sandbox-anchored `fast_io::*_via_sandbox_or_fallback` helpers (SEC-1.q2), so the local-copy emit path was the **sole remaining TOCTOU-prone production caller** of the emitter.

## The fix

- Open a `DirSandbox` at the delete root inside `DeleteContext::into_drain_parts` — the one place shared by the sequential `into_emitter` and the parallel `emit_via_parallel_consumer` — so both production drivers benefit from one change. The sandbox is opened from `cursor_root` before it is moved into the traversal cursor.
- Attach it to the emitter via a new `with_sandbox_rooted(sandbox, root)` builder on both emitters. Absolute plan/cohort directory keys (the cleanup path keys plans on the absolute destination) are resolved relative to the sandbox root before the `openat` walk; when no root is recorded (the unit-test convention of relative keys) the emitter falls back to `plan_directory_to_relative`.
- Graceful fallback: `open_delete_sandbox` mirrors the receiver's `open_sandbox_for_dest` — a sandbox-open failure (root missing, not a directory, non-unix) logs at debug and yields `None`, leaving the emitter on the path-based syscalls. A working delete is never regressed into a failure.
- `#[cfg(unix)]`-gated throughout; non-unix stays path-based (the `*_at` family is unix-only), no behavior change there.

## Outcome parity

Delete outcomes are byte-identical: the same set of entries is deleted, the same `DeleteStats` counts accumulate, and the same error semantics/exit codes apply. Only the syscall mechanism changes (path-based -> dirfd-anchored). The DECIDE phase, filter evaluation, and which entries are planned are untouched.

Three existing `DeleteContext` tests that asserted on the absolute recorded path were updated to assert on the deleted entry's leaf name plus stats/outcome, because `RecordingDeleteFs` records the leaf-only name for a `*_at` dispatch (the path is supplied by the dispatcher, not the fake). The deletion outcome those tests verify is unchanged.

## Regression test (encodes WHY)

- `production_drain_refuses_ancestor_symlink_escape` — builds a delete plan for `root/victim`, opens the emitter (capturing the root dirfd), **then** swaps the delete root for a symlink pointing at an out-of-tree `outside/`, then drains. Asserts the out-of-tree sentinel survives and only the real in-tree victim is removed. Deterministic (program order, no threads/sleeps) using the live `RealDeleteFs` `unlinkat(2)`.
- `production_drain_dispatches_through_dirfd_anchor` — proves the production drain now records a leaf-only dispatch, which can only come from the dirfd-anchored `unlink_file_at`.
- The existing "no sandbox -> path-based fallback" contract remains covered by `emitter/tests/sandbox.rs`.

## Verification

- `cargo build -p engine -p transfer` (and with `--features parallel-delete-consumer`): clean.
- `cargo clippy -p engine -p transfer --all-targets --no-deps -- -D warnings` (both feature configs): clean.
- `cargo test -p engine --lib delete`: 330 passed (334 with the parallel feature).
- Tests run in CI; the interop cell is the gate.

Advances #506.
