### PR TITLE
test: port upstream testsuite edge cases to nextest (round 4)

### DIFF
--- a/crates/transfer/tests/uts_atimes_preserve.rs
+++ b/crates/transfer/tests/uts_atimes_preserve.rs
@@ -1,0 +1,115 @@
+//! Nextest port of upstream `testsuite/atimes.test` (local-copy leg).
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/atimes.test`.
+//!
+//! # Background
+//!
+//! `-U` / `--atimes` tells rsync to preserve each file's access time in
+//! addition to its modification time. Upstream's atimes.test backdates
+//! `$fromdir/foo`'s atime to a fixed timestamp, runs `rsync -rtUgvvv`, and
+//! `checkit()` confirms the destination tree matches with atimes compared.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! Access-time preservation is an explicit metadata contract: a user who
+//! passes `-U` expects the destination atime to equal the source atime, not
+//! "now" (which is what a plain copy leaves, since reading the source to copy
+//! it updates nothing but writing the dest sets a fresh atime). A regression
+//! that dropped the atime restore would silently leave destination atimes at
+//! transfer time, breaking backup/audit workflows that rely on atime.
+//!
+//! The test encodes the required behaviour, not merely current output: it sets
+//! a distinct, fixed source atime and asserts the destination atime equals it
+//! to the second. Restoring the wrong value (e.g. mtime, or leaving "now")
+//! would fail the equality.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/atimes.test` - the upstream script this file ports.
+//! - `rsync.c` / `generator.c` - `--atimes` restores `st_atime` alongside
+//!   `st_mtime` when the receiver commits the file.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Fixed source atime, matching the spirit of upstream's
+/// `touch -a -t 200102031717.42` (2001-02-03 17:17:42 UTC = 981_213_462).
+const SRC_ATIME_SECS: i64 = 981_213_462;
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(p: &Path) -> std::ffi::OsString {
+    let mut s = p.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// Whole-second Unix atime of `path`.
+fn atime_secs(path: &Path) -> i64 {
+    let meta = fs::metadata(path).unwrap_or_else(|e| panic!("stat {}: {e}", path.display()));
+    let at = meta.accessed().expect("atime");
+    match at.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => d.as_secs() as i64,
+        Err(e) => -(e.duration().as_secs() as i64),
+    }
+}
+
+/// `-U` preserves the source access time on the destination file.
+///
+/// The source atime is set to a fixed past value distinct from both its mtime
+/// and the wall clock, so a pass proves the atime was actually carried over -
+/// not left at transfer time and not confused with the mtime.
+// upstream: --atimes restores st_atime on the receiver
+#[test]
+fn atimes_flag_preserves_source_access_time() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let from = root.path().join("from");
+    let to = root.path().join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+
+    let src = from.join("foo");
+    fs::write(&src, b"").expect("touch foo");
+
+    // Set a fixed atime in the past and an mtime that differs from it, so the
+    // restored atime cannot accidentally equal the mtime.
+    let atime = filetime::FileTime::from_unix_time(SRC_ATIME_SECS, 0);
+    let mtime = filetime::FileTime::from_unix_time(SRC_ATIME_SECS + 86_400, 0);
+    filetime::set_file_times(&src, atime, mtime).expect("set source times");
+
+    // Sanity: the source atime is the fixed value and differs from the wall
+    // clock (so "now" would be an obviously-wrong result).
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs() as i64;
+    assert_eq!(atime_secs(&src), SRC_ATIME_SECS);
+    assert!(
+        now - SRC_ATIME_SECS > 86_400,
+        "source atime must be clearly in the past"
+    );
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-rtUg"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    let dst = to.join("foo");
+    assert!(dst.exists(), "destination file must exist");
+    assert_eq!(
+        atime_secs(&dst),
+        SRC_ATIME_SECS,
+        "-U must restore the source access time on the destination, not leave \
+         it at transfer time or confuse it with the mtime",
+    );
+}

--- a/crates/transfer/tests/uts_clean_fname_underflow.rs
+++ b/crates/transfer/tests/uts_clean_fname_underflow.rs
@@ -1,0 +1,78 @@
+//! Nextest port of upstream `testsuite/clean-fname-underflow.test`.
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/clean-fname-underflow.test`.
+//!
+//! # Background
+//!
+//! Upstream's `clean_fname()` collapses `.` and `..` path components in place.
+//! A crafted filter path such as `a/../test` walks the write pointer backwards
+//! when it eats the `..`; a boundary bug there can underflow the buffer and
+//! read or write before the start of the name, crashing the process. The
+//! upstream test drives the sender with `--filter='merge a/../test'` and
+//! asserts rsync does not die from a signal - a non-zero exit for the bogus
+//! input is fine, a SIGSEGV/SIGABRT is not.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! This is a memory-safety / crash-hardening guard. `clean_fname()` runs on
+//! attacker-influenceable path strings (filter files, remote file lists), so a
+//! buffer underflow here is a security bug, not a cosmetic one. The test
+//! encodes the invariant "path cleaning never crashes on adversarial `../`
+//! sequences": it must terminate cleanly with an ordinary exit code and never
+//! be killed by a signal. A regression that reintroduced an underflow would
+//! trip `assert_no_signal_death`.
+//!
+//! oc-rsync's path cleaning is memory-safe by construction (no raw pointer
+//! arithmetic), so this port is the positive proof that the safe rewrite still
+//! rejects the crafted input gracefully rather than, say, panicking - a Rust
+//! panic in a server child surfaces as a signal death (SIGABRT) and would be
+//! caught here.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/clean-fname-underflow.test` - the upstream script this file
+//!   ports.
+//! - `util1.c` - `clean_fname()` in-place `.`/`..` collapsing.
+
+#![cfg(unix)]
+
+use std::fs;
+
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// The server-sender invocation with the crafted `merge a/../test` filter must
+/// terminate cleanly - any exit code is acceptable, a signal death is not.
+///
+/// Mirrors the upstream shell test's `if $rsync_bin --server --sender ...` arm:
+/// a non-zero status is expected for bogus input, but `status >= 128`
+/// (signal-killed) is a failure. Here we assert `assert_no_signal_death`, which
+/// is the direct translation of that guard.
+// upstream: util1.c clean_fname() underflow hardening
+#[test]
+fn clean_fname_handles_dotdot_without_crashing() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let workdir = root.path().join("workdir");
+    fs::create_dir_all(workdir.join("mod")).expect("mkdir workdir/mod");
+
+    let out = OcRsyncCliRunner::new()
+        .cwd(&workdir)
+        .args([
+            "--server",
+            "--sender",
+            "-vlr",
+            "--filter=merge a/../test",
+            ".",
+            "mod/",
+        ])
+        .run()
+        .expect("run oc-rsync server sender");
+
+    // The crafted path must not crash the process. A non-zero exit for the
+    // bogus filter is fine; a signal (SIGSEGV/SIGABRT) is the regression this
+    // guard rejects.
+    out.assert_no_signal_death();
+}

--- a/crates/transfer/tests/uts_delay_updates_atomic.rs
+++ b/crates/transfer/tests/uts_delay_updates_atomic.rs
@@ -1,0 +1,93 @@
+//! Nextest port of upstream `testsuite/delay-updates.test` (local-copy leg).
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/delay-updates.test`.
+//!
+//! # Background
+//!
+//! `--delay-updates` stages every updated file under a `.~tmp~` scratch
+//! directory in the destination and only renames them into place at the end of
+//! the transfer, so an interrupted run never leaves half-written files visible.
+//! Upstream's delay-updates.test runs `rsync -aiv --delay-updates` and
+//! `checkit()` confirms the destination matches - and, implicitly, that the
+//! `.~tmp~` staging directory does not survive a successful run.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! The contract is atomicity plus cleanup: after a successful transfer every
+//! updated file holds the new content (proving the delayed rename fired) and no
+//! `.~tmp~` staging directory remains (proving the scratch area was cleaned).
+//! A regression that renamed too early would break the atomicity guarantee; a
+//! regression that skipped cleanup would leak a `.~tmp~` directory into the
+//! user's tree. This test pins both.
+//!
+//! The update uses distinct source/destination sizes and a backdated
+//! destination so rsync's quick-check cannot skip the transfer on matching
+//! size+mtime - the delayed rename must actually run for the assertion to be
+//! meaningful.
+//!
+//! Only the first (clean) leg of the upstream script is ported. The second leg
+//! seeds a pre-existing `.~tmp~/foo` and depends on quick-check timing that is
+//! nondeterministic in a program-order test; porting it would risk flakiness
+//! for no added coverage of the atomic-rename contract.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/delay-updates.test` - the upstream script this file ports.
+//! - `receiver.c` / `generator.c` - `--delay-updates` stages into `partialptr`
+//!   under `.~tmp~` and renames at `finish_transfer()` time.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(p: &Path) -> std::ffi::OsString {
+    let mut s = p.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// `--delay-updates` atomically installs the new content and leaves no
+/// `.~tmp~` staging directory behind after a successful run.
+// upstream: --delay-updates stages under .~tmp~ then renames at finish
+#[test]
+fn delay_updates_atomic_rename_and_cleanup() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let from = root.path().join("from");
+    let to = root.path().join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    // Source and destination differ in both size and mtime so quick-check
+    // cannot skip: the delayed rename must run for the content to change.
+    fs::write(from.join("foo"), b"AAAA").expect("write source");
+    fs::write(to.join("foo"), b"ZZ").expect("write stale dest");
+    let old = filetime::FileTime::from_unix_time(946_684_800, 0); // 2000-01-01
+    filetime::set_file_mtime(to.join("foo"), old).expect("backdate dest");
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-aiv", "--delay-updates"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    assert_eq!(
+        fs::read(to.join("foo")).expect("read dest"),
+        b"AAAA",
+        "the delayed rename must have installed the new content",
+    );
+    assert!(
+        !to.join(".~tmp~").exists(),
+        "the .~tmp~ staging directory must be cleaned up after a successful \
+         --delay-updates run, not leaked into the destination tree",
+    );
+}

--- a/crates/transfer/tests/uts_fuzzy_local_basis_reuse.rs
+++ b/crates/transfer/tests/uts_fuzzy_local_basis_reuse.rs
@@ -1,0 +1,190 @@
+//! Nextest port of upstream `testsuite/fuzzy.test` (local-copy legs).
+//!
+//! Upstream test source:
+//! `target/interop/upstream-src/rsync-3.4.4/testsuite/fuzzy.test`.
+//!
+//! # Background
+//!
+//! `--fuzzy` lets the receiver reuse a same-content, differently-named file
+//! already present in the destination directory as the delta basis for a new
+//! transfer, instead of sending the whole file. Upstream's fuzzy.test seeds
+//! `$todir/rsync2.c` with the exact bytes of `$fromdir/rsync.c`, then runs
+//! `rsync -avvi --no-whole-file --fuzzy` and asserts the resulting tree
+//! matches - which only holds if the basis was actually reused.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! oc-rsync had a local-copy regression (#505, fixed in PR #6333 via the
+//! engine tail-match) where `--fuzzy` failed to reuse a differently-named
+//! same-content basis: the file was resent as pure literal data instead of
+//! matching against the fuzzy basis. That defeats the entire point of the
+//! option (bandwidth/IO savings) and silently diverges from upstream.
+//!
+//! These tests pin the fixed behaviour with a positive/negative control on
+//! the `--stats` counters, which are the observable signal for "was the basis
+//! reused":
+//!
+//! - **Positive** (`--fuzzy`): `Matched data` is the full file size and
+//!   `Literal data` is 0 - the basis was reused, nothing was resent.
+//! - **Negative** (no `--fuzzy`): `Literal data` is the full file size and
+//!   `Matched data` is 0 - with no basis of the same name, the file is resent
+//!   whole, proving the positive case's match came from the fuzzy basis and
+//!   not from some unrelated quick-check shortcut.
+//!
+//! A regression that reintroduced #505 would flip the positive case back to
+//! all-literal and fail the `Matched > 0` assertion.
+//!
+//! The scope is deliberately local-copy only. The #505 fix was local-copy
+//! specific; the wire-path fuzzy still carries a pre-existing efficiency gap
+//! (the last partial block is emitted as literal), so a wire-mode assertion on
+//! exact byte counts would be nondeterministic. Local copy is the path the fix
+//! landed on and the one this regression guard protects.
+//!
+//! # Upstream References
+//!
+//! - `testsuite/fuzzy.test` - the upstream script this file ports.
+//! - `generator.c` - `find_fuzzy()` selects the fuzzy basis in the receiver's
+//!   destination directory.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use test_support::{OcRsyncCliRunner, require_binary};
+
+/// Trailing-slash form so rsync copies a directory's contents.
+fn slash(p: &Path) -> std::ffi::OsString {
+    let mut s = p.as_os_str().to_os_string();
+    s.push("/");
+    s
+}
+
+/// Extract the integer byte value from a `--stats` line like
+/// `Matched data: 26,669 bytes`, stripping the thousands separators.
+fn stat_bytes(stats: &str, label: &str) -> u64 {
+    let line = stats
+        .lines()
+        .find(|l| l.trim_start().starts_with(label))
+        .unwrap_or_else(|| panic!("stats output missing `{label}` line:\n{stats}"));
+    let digits: String = line
+        .chars()
+        .skip_while(|c| *c != ':')
+        .filter(|c| c.is_ascii_digit())
+        .collect();
+    digits
+        .parse()
+        .unwrap_or_else(|_| panic!("could not parse `{label}` value from `{line}`"))
+}
+
+/// Seed a source file plus a differently-named destination file with the same
+/// bytes, backdating the destination so quick-check cannot skip the transfer
+/// on its own. Returns the source directory, destination directory, and the
+/// file's size.
+fn seed_fuzzy_pair(root: &Path) -> (std::path::PathBuf, std::path::PathBuf, u64) {
+    let from = root.join("from");
+    let to = root.join("to");
+    fs::create_dir_all(&from).expect("mkdir from");
+    fs::create_dir_all(&to).expect("mkdir to");
+
+    // A body large enough to span several blocks so a match is meaningful, and
+    // deterministic so both control arms transfer the identical payload.
+    let mut body = Vec::with_capacity(24_000);
+    for i in 0..24_000u32 {
+        body.push((i.wrapping_mul(2_654_435_761) >> 13) as u8);
+    }
+    let src = from.join("rsync.c");
+    fs::write(&src, &body).expect("write source");
+
+    // Differently-named basis with identical content in the destination dir.
+    let basis = to.join("rsync2.c");
+    fs::write(&basis, &body).expect("write fuzzy basis");
+    // Backdate the basis so its mtime differs from the source; without a
+    // same-name quick-check hit, only the fuzzy path can reuse it.
+    let old = filetime::FileTime::from_unix_time(981_213_462, 0);
+    filetime::set_file_mtime(&basis, old).expect("backdate basis");
+
+    (from, to, body.len() as u64)
+}
+
+/// Positive control: `--fuzzy` reuses the differently-named same-content basis
+/// so the whole file matches and nothing is resent as literal data.
+///
+/// This is the direct regression guard for #505 / PR #6333: before the fix the
+/// file was resent whole (all literal), so `Matched data` would be 0 here.
+// upstream: generator.c find_fuzzy() basis selection
+#[test]
+fn fuzzy_local_reuses_differently_named_basis() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let (from, to, size) = seed_fuzzy_pair(root.path());
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-a", "--no-whole-file", "--fuzzy", "--stats"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    let stats = out.stdout_str();
+    let matched = stat_bytes(&stats, "Matched data:");
+    let literal = stat_bytes(&stats, "Literal data:");
+
+    assert_eq!(
+        matched, size,
+        "--fuzzy must match the entire file against the differently-named \
+         basis (#505 regression guard); got Matched={matched}, expected {size}\n{stats}",
+    );
+    assert_eq!(
+        literal, 0,
+        "--fuzzy must resend nothing as literal when the basis is identical; \
+         got Literal={literal}\n{stats}",
+    );
+
+    // The bytes must also be correct, not just the counters.
+    let dst = to.join("rsync.c");
+    assert_eq!(
+        fs::read(&dst).expect("read dest"),
+        fs::read(from.join("rsync.c")).expect("read src"),
+        "fuzzy-reconstructed file must be byte-identical to the source",
+    );
+}
+
+/// Negative control: without `--fuzzy` the same seed transfers the file whole
+/// as literal data, proving the positive case's match came from the fuzzy
+/// basis and not from an unrelated quick-check or same-name shortcut.
+// upstream: generator.c - no fuzzy basis is consulted without --fuzzy
+#[test]
+fn without_fuzzy_local_resends_whole_file_as_literal() {
+    if !require_binary("oc-rsync") {
+        return;
+    }
+    let root = tempfile::tempdir().expect("tempdir");
+    let (from, to, size) = seed_fuzzy_pair(root.path());
+
+    let out = OcRsyncCliRunner::new()
+        .args(["-a", "--no-whole-file", "--stats"])
+        .arg(slash(&from))
+        .arg(slash(&to))
+        .run()
+        .expect("run oc-rsync");
+    out.assert_success();
+
+    let stats = out.stdout_str();
+    let matched = stat_bytes(&stats, "Matched data:");
+    let literal = stat_bytes(&stats, "Literal data:");
+
+    assert_eq!(
+        literal, size,
+        "without --fuzzy the file has no basis and is resent whole as literal; \
+         got Literal={literal}, expected {size}\n{stats}",
+    );
+    assert_eq!(
+        matched, 0,
+        "without --fuzzy nothing may be matched against the unrelated basis; \
+         got Matched={matched}\n{stats}",
+    );
+}


### PR DESCRIPTION
Ports four high-value upstream rsync 3.4.4 testsuite cases into the nextest
suite, prioritizing regression protection for a recently-fixed bug and
security/crash hardening. Advances #155.

## Cases ported

Each new file cites its upstream `testsuite/*.test` source in the module
doc-comment and encodes *why* the behaviour matters (not just what it does).

- **`uts_fuzzy_local_basis_reuse.rs`** (`testsuite/fuzzy.test`) - **the
  headline lock-in.** Local-copy `--fuzzy` must reuse a same-content,
  differently-named destination file as the delta basis instead of resending
  it whole. This is a direct regression guard for the local-copy `--fuzzy`
  fix (#505, engine tail-match). Positive control: with `--fuzzy`, `--stats`
  reports `Matched data` = full file size and `Literal data` = 0. Negative
  control: without `--fuzzy`, the same seed resends the file whole (`Literal`
  = full size, `Matched` = 0), proving the match came from the fuzzy basis and
  not an unrelated quick-check shortcut.

  Scope is deliberately local-copy only: that is the path the fix landed on.
  The wire-path fuzzy still carries a pre-existing efficiency gap (last
  partial block emitted as literal), so a wire-mode byte-count assertion would
  be nondeterministic - out of scope here on purpose.

- **`uts_clean_fname_underflow.rs`** (`testsuite/clean-fname-underflow.test`)
  - security/crash hardening. Drives the server-sender with a crafted
  `--filter='merge a/../test'` path and asserts the process is never killed by
  a signal (a non-zero exit for the bogus input is fine). Path cleaning runs
  on attacker-influenceable strings, so a buffer underflow / panic there is a
  security bug; this is the positive proof the safe path handles adversarial
  `../` sequences gracefully.

- **`uts_atimes_preserve.rs`** (`testsuite/atimes.test`) - metadata contract.
  `-U` must restore the source access time on the destination. The source
  atime is set to a fixed past value distinct from both its mtime and the wall
  clock, so a pass proves the atime was actually carried over, not left at
  transfer time or confused with the mtime.

- **`uts_delay_updates_atomic.rs`** (`testsuite/delay-updates.test`, leg 1) -
  atomicity + cleanup. `--delay-updates` must install the new content via the
  delayed rename and leave no `.~tmp~` staging directory behind. Uses distinct
  source/dest sizes plus a backdated destination so quick-check cannot skip the
  transfer. Only the deterministic first leg is ported; the second leg depends
  on quick-check timing that is nondeterministic in a program-order test.

## Platform-noise guardrails

- Distinct sizes / backdated destinations dodge quick-check skips.
- No timing sleeps; deterministic program-order only.
- No assertions on macOS `com.apple.provenance` xattr state.

## Non-overlap confirmation

Cross-checked against the 23 already-ported `uts_*` / `nxt_*` files. None of
fuzzy, clean-fname-underflow, atimes, or delay-updates was previously ported.

## Verification

All four files pass locally (5 test functions) against the freshly built
release binary; `cargo fmt` and `cargo clippy -p transfer --tests -- -D
warnings` are clean.