### PR TITLE
fix(transfer): dirfd-anchor receiver commit/backup rename (TOCTOU)

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -59,7 +59,7 @@ pub(super) fn commit_file(
     // With delay_updates, backup happens during the sweep, not here.
     let backup_notice = if !config.delay_updates {
         if let Some(ref backup_config) = config.backup {
-            make_backup(&begin.file_path, backup_config)?
+            make_backup(&begin.file_path, backup_config, config)?
         } else {
             None
         }
@@ -73,7 +73,7 @@ pub(super) fn commit_file(
         if let Some(parent) = staging_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let result = rename_with_io_uring_fallback(cleanup_guard.path(), &staging_path)?;
+        let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)?;
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
         cleanup_guard.keep();
         return Ok(CommitOutcome {
@@ -84,7 +84,7 @@ pub(super) fn commit_file(
     }
 
     let was_copy = if needs_rename {
-        let result = rename_with_io_uring_fallback(cleanup_guard.path(), &begin.file_path)?;
+        let result = rename_config_sandboxed(config, cleanup_guard.path(), &begin.file_path)?;
         CleanupManager::global().unregister_temp_file(cleanup_guard.path());
         result
     } else if begin.is_inplace {
@@ -145,18 +145,18 @@ pub(super) fn partial_dir_path(file_path: &Path) -> PathBuf {
 /// - `cleanup.c:130-135` - `keep_partial && got_literal` guard
 /// - `receiver.c:340-345` - `do_rename(partialptr, fname)` for `--partial`
 pub(super) fn retain_partial_file(
-    partial_mode: &PartialMode,
+    config: &DiskCommitConfig,
     cleanup_guard: &mut TempFileGuard,
     dest_path: &Path,
 ) {
-    match partial_mode {
+    match &config.partial_mode {
         PartialMode::None => {}
         PartialMode::Partial => {
             // upstream: cleanup.c:130-135 - rename temp file directly to
             // the destination. The incomplete content replaces any existing
             // file at the destination path.
             let temp_path = cleanup_guard.path().to_path_buf();
-            match rename_with_io_uring_fallback(cleanup_guard.path(), dest_path) {
+            match rename_config_sandboxed(config, cleanup_guard.path(), dest_path) {
                 Ok(_) => {
                     // upstream: cleanup.c:174-178 - stamp modtime=0 on
                     // retained partial files so --update does not skip them
@@ -255,6 +255,66 @@ pub(super) fn rename_with_io_uring_fallback(old_path: &Path, new_path: &Path) ->
     }
 }
 
+/// SEC-1.j: dirfd-anchor the temp→final commit rename against the receiver's
+/// destination sandbox, falling back to [`rename_with_io_uring_fallback`].
+///
+/// When the `config` carries a [`fast_io::DirSandbox`] rooted at its
+/// `dest_dir`, and both the temp leaf and the final leaf are single components
+/// directly under that root (the default in-destination temp pattern also used
+/// by the temp-file create, see `temp_guard::try_create_new`), the rename routes
+/// through [`fast_io::renameat_via_sandbox_or_fallback`]. Both leaves resolve
+/// against the pinned destination dirfd, so a symlink swap on the commit parent
+/// between temp-create and rename cannot redirect the final file outside the
+/// tree.
+///
+/// In every other case (no sandbox, multi-component relative path, or a
+/// `--temp-dir`/partial-dir on a different parent) it falls back to the existing
+/// io_uring / `std::fs::rename` path with the EXDEV copy+remove backstop, so a
+/// working rename is never regressed. The anchored path shares the destination
+/// parent for both leaves, so EXDEV cannot arise there.
+///
+/// Returns `Ok(false)` for an in-place rename, `Ok(true)` when the EXDEV
+/// copy+remove fallback ran.
+#[cfg(unix)]
+pub(super) fn rename_config_sandboxed(
+    config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<bool> {
+    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
+        && let (Some(old_leaf), Some(new_leaf)) = (old_path.file_name(), new_path.file_name())
+        && old_path.parent() == Some(dest_dir)
+        && new_path.parent() == Some(dest_dir)
+    {
+        // Both endpoints are single components under the sandbox root, so the
+        // dirfd anchor applies. `replace = true` matches `fs::rename`'s
+        // overwrite-the-destination semantics (upstream `do_rename`).
+        fast_io::renameat_via_sandbox_or_fallback(
+            Some(sandbox.as_ref()),
+            dest_dir,
+            Path::new(old_leaf),
+            old_path,
+            dest_dir,
+            Path::new(new_leaf),
+            new_path,
+            true,
+        )?;
+        return Ok(false);
+    }
+    rename_with_io_uring_fallback(old_path, new_path)
+}
+
+/// Non-Unix: the `*at` sandbox helpers do not exist, so the commit rename keeps
+/// the path-based [`rename_with_io_uring_fallback`] with no behavior change.
+#[cfg(not(unix))]
+pub(super) fn rename_config_sandboxed(
+    _config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<bool> {
+    rename_with_io_uring_fallback(old_path, new_path)
+}
+
 /// Returns `true` when an I/O error represents a cross-device link (EXDEV).
 ///
 /// On Unix, `raw_os_error() == libc::EXDEV` (errno 18). On Windows,
@@ -271,6 +331,88 @@ pub(super) fn is_cross_device(e: &io::Error) -> bool {
     }
 }
 
+/// SEC-1.j: dirfd-anchor the `--backup` rename against the receiver's
+/// destination sandbox, otherwise `std::fs::rename`.
+///
+/// The backup rename moves an existing destination file to its backup name
+/// (`file~` or `<backup-dir>/...`). When the sandbox is present and both the
+/// original and the backup are single components directly under `dest_dir`, the
+/// rename resolves both leaves against the pinned dirfd so a symlink swap on the
+/// parent cannot redirect the backup outside the tree. Otherwise it falls back
+/// to the original path-based [`std::fs::rename`] with no behavior change (no
+/// io_uring/EXDEV path is introduced on the backup rename, matching prior
+/// semantics).
+#[cfg(unix)]
+fn backup_rename_sandboxed(
+    config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<()> {
+    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
+        && let (Some(old_leaf), Some(new_leaf)) = (old_path.file_name(), new_path.file_name())
+        && old_path.parent() == Some(dest_dir)
+        && new_path.parent() == Some(dest_dir)
+    {
+        return fast_io::renameat_via_sandbox_or_fallback(
+            Some(sandbox.as_ref()),
+            dest_dir,
+            Path::new(old_leaf),
+            old_path,
+            dest_dir,
+            Path::new(new_leaf),
+            new_path,
+            true,
+        );
+    }
+    fs::rename(old_path, new_path)
+}
+
+#[cfg(not(unix))]
+fn backup_rename_sandboxed(
+    _config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<()> {
+    fs::rename(old_path, new_path)
+}
+
+/// SEC-1.j: create the `--backup-dir` parent, dirfd-anchoring the leaf `mkdir`
+/// against the receiver's destination sandbox when possible.
+///
+/// When the sandbox is present and `parent` is a single component directly
+/// under `dest_dir`, the final directory component is created via
+/// [`fast_io::mkdirat_via_sandbox_or_fallback`] so a symlink swap on the
+/// destination root cannot redirect it. Deeper trees, or the no-sandbox case,
+/// keep the original recursive [`std::fs::create_dir_all`] so behavior is
+/// unchanged (`create_dir_all` is idempotent for already-existing ancestors).
+#[cfg(unix)]
+fn create_dir_all_sandboxed(config: &DiskCommitConfig, parent: &Path) -> io::Result<()> {
+    if let (Some(sandbox), Some(dest_dir)) = (config.sandbox.as_ref(), config.dest_dir.as_deref())
+        && parent.parent() == Some(dest_dir)
+        && let Some(leaf) = parent.file_name()
+    {
+        return match fast_io::mkdirat_via_sandbox_or_fallback(
+            Some(sandbox.as_ref()),
+            dest_dir,
+            Path::new(leaf),
+            parent,
+            0o777,
+        ) {
+            Ok(()) => Ok(()),
+            // Match `create_dir_all`'s idempotence: an already-present dir is
+            // not an error.
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+            Err(e) => Err(e),
+        };
+    }
+    fs::create_dir_all(parent)
+}
+
+#[cfg(not(unix))]
+fn create_dir_all_sandboxed(_config: &DiskCommitConfig, parent: &Path) -> io::Result<()> {
+    fs::create_dir_all(parent)
+}
+
 /// Creates a backup of the destination file before overwriting.
 ///
 /// Mirrors upstream `backup.c:make_backup()` which renames the existing file
@@ -283,27 +425,28 @@ pub(super) fn is_cross_device(e: &io::Error) -> bool {
 /// is never seeded with the user's `--info=backup` selection.
 pub(super) fn make_backup(
     file_path: &Path,
-    config: &BackupConfig,
+    backup_config: &BackupConfig,
+    config: &DiskCommitConfig,
 ) -> io::Result<Option<BackupNotice>> {
     if !file_path.exists() {
         return Ok(None);
     }
 
     let backup_path = compute_backup_path(
-        &config.dest_dir,
+        &backup_config.dest_dir,
         file_path,
         None,
-        config.backup_dir.as_deref(),
-        &config.suffix,
+        backup_config.backup_dir.as_deref(),
+        &backup_config.suffix,
     );
 
     if let Some(parent) = backup_path.parent() {
         if !parent.exists() {
-            fs::create_dir_all(parent)?;
+            create_dir_all_sandboxed(config, parent)?;
         }
     }
 
-    fs::rename(file_path, &backup_path)?;
+    backup_rename_sandboxed(config, file_path, &backup_path)?;
     // upstream: backup.c:216-217 - DEBUG_GTE(BACKUP, 1) on the RENAME success
     // branch of link_or_rename. disk_commit always uses rename here.
     trace_make_backup_rename(&file_path.display().to_string());
@@ -313,11 +456,11 @@ pub(super) fn make_backup(
     // actual `info_log!` emission happens on the main thread; see
     // `crate::pipeline::receiver::emit_backup_notice`.
     let file_rel = file_path
-        .strip_prefix(&config.dest_dir)
+        .strip_prefix(&backup_config.dest_dir)
         .unwrap_or(file_path)
         .to_path_buf();
     let backup_rel = backup_path
-        .strip_prefix(&config.dest_dir)
+        .strip_prefix(&backup_config.dest_dir)
         .unwrap_or(&backup_path)
         .to_path_buf();
     Ok(Some(BackupNotice {

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -112,7 +112,7 @@ pub(in crate::disk_commit) fn process_file(
                 let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - retain partial on unexpected disconnect
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
+                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::new(
@@ -215,7 +215,7 @@ pub(in crate::disk_commit) fn process_file(
                 // if any data was written, the transfer made progress worth
                 // retaining for later resume.
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
+                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::other(reason));
@@ -229,7 +229,7 @@ pub(in crate::disk_commit) fn process_file(
                 let _ = output.finish(false, &begin.file_path);
                 // upstream: cleanup.c - same partial retention on shutdown
                 if bytes_written > 0 && needs_rename {
-                    retain_partial_file(&config.partial_mode, &mut cleanup_guard, &begin.file_path);
+                    retain_partial_file(config, &mut cleanup_guard, &begin.file_path);
                 }
                 drop(cleanup_guard);
                 return Err(io::Error::new(

--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -28,11 +28,13 @@ pub(super) use self::file_ops::{process_file, process_whole_file};
 
 // Re-exported for the in-module test suite (`use super::*`), which exercises
 // the rename/cross-device/backup helpers and the writer selector directly.
+#[cfg(all(test, unix))]
+use self::commit::rename_config_sandboxed;
 #[cfg(test)]
 use self::commit::{is_cross_device, make_backup, partial_dir_path, rename_with_io_uring_fallback};
 #[cfg(all(test, target_os = "macos"))]
 use self::file_ops::make_writer;
 #[cfg(test)]
-use super::config::BackupConfig;
+use super::config::{BackupConfig, DiskCommitConfig};
 #[cfg(all(test, target_os = "macos"))]
 use super::writer::Writer;

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -336,7 +336,7 @@ fn make_backup_returns_destination_relative_notice() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup(&file_path, &config)
+    let notice = make_backup(&file_path, &config, &DiskCommitConfig::default())
         .expect("make_backup succeeds")
         .expect("notice produced when an existing file is backed up");
 
@@ -363,6 +363,103 @@ fn make_backup_missing_file_is_noop() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup(&file_path, &config).expect("make_backup succeeds");
+    let notice = make_backup(&file_path, &config, &DiskCommitConfig::default())
+        .expect("make_backup succeeds");
     assert!(notice.is_none(), "no notice when nothing was backed up");
+}
+
+/// #507 (TOCTOU regression): the dirfd anchor on the commit rename refuses to
+/// land the final file through a destination parent that was swapped for a
+/// symlink pointing outside the tree.
+///
+/// Proven deterministically by program order (no threads, no sleeps): the
+/// `DirSandbox` opens the destination root's dirfd before the swap, so a later
+/// symlink swap on the `dest_dir` path cannot redirect the anchored
+/// `renameat`. The out-of-tree location must stay empty; the final file must
+/// land in the real (now-moved-aside) destination directory, never through the
+/// symlink. WHY it matters: without the anchor, `fs::rename(temp, dest/name)`
+/// would follow the swapped symlink and write the received file outside the
+/// destination tree.
+#[cfg(unix)]
+#[test]
+fn commit_rename_refuses_parent_symlink_escape() {
+    use std::sync::Arc;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let staging = std::fs::canonicalize(tmp.path()).expect("canon");
+
+    // Destination root holds the temp file and the final name.
+    let dest_dir = staging.join("dest");
+    fs::create_dir(&dest_dir).unwrap();
+    let temp_path = dest_dir.join(".tmp.payload");
+    fs::write(&temp_path, b"received content").unwrap();
+    let final_path = dest_dir.join("payload.bin");
+
+    // Out-of-tree location a redirected rename would land the file in. Must
+    // stay empty.
+    let outside = staging.join("outside");
+    fs::create_dir(&outside).unwrap();
+    let dest_aside = staging.join("dest.aside");
+
+    // Open the sandbox at the real dest root BEFORE any swap; the dirfd pins
+    // the real inode.
+    let sandbox = Arc::new(fast_io::DirSandbox::open_root(&dest_dir).expect("open sandbox"));
+    let config = DiskCommitConfig {
+        sandbox: Some(sandbox),
+        dest_dir: Some(dest_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+
+    // Move the real dest aside and plant a symlink at the original path
+    // pointing at `outside`. Any path-based resolver now routes
+    // `dest/payload.bin` to `outside/payload.bin`; the anchored renameat is
+    // immune because its dirfd still names the moved-aside real directory.
+    fs::rename(&dest_dir, &dest_aside).expect("move dest aside");
+    std::os::unix::fs::symlink(&outside, &dest_dir).expect("plant dest symlink");
+
+    // Pass the ORIGINAL path strings (temp_path, final_path), exactly as
+    // production does: the receiver holds `dest_dir/<leaf>` paths that predate
+    // the swap. The gate resolves both leaves against the pinned dirfd, so the
+    // stale path strings do not follow the symlink.
+    let was_copy = rename_config_sandboxed(&config, &temp_path, &final_path)
+        .expect("anchored commit rename succeeds");
+    assert!(!was_copy, "same-parent rename is never a cross-device copy");
+
+    // The out-of-tree location must be empty: the anchor refused the redirect.
+    assert!(
+        !outside.join("payload.bin").exists(),
+        "final file must not land outside the tree through the swapped symlink",
+    );
+    // The final file landed in the real (moved-aside) destination directory.
+    assert!(
+        dest_aside.join("payload.bin").exists(),
+        "anchored rename must place the final file inside the real destination",
+    );
+    assert_eq!(
+        fs::read(dest_aside.join("payload.bin")).unwrap(),
+        b"received content",
+    );
+}
+
+/// Fallback parity: with no sandbox attached, `rename_config_sandboxed` uses
+/// the path-based [`rename_with_io_uring_fallback`], moving the temp file to
+/// its final destination exactly as before. Proves the sandbox wiring never
+/// regresses a working rename on the common (no-sandbox) path.
+#[cfg(unix)]
+#[test]
+fn commit_rename_without_sandbox_uses_path_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let temp_path = dir.path().join(".tmp.payload");
+    let final_path = dir.path().join("payload.bin");
+    fs::write(&temp_path, b"fallback content").unwrap();
+
+    let config = DiskCommitConfig::default();
+    assert!(config.sandbox.is_none());
+
+    let was_copy = rename_config_sandboxed(&config, &temp_path, &final_path)
+        .expect("path-based rename succeeds");
+    assert!(!was_copy);
+    assert!(!temp_path.exists(), "temp file renamed away");
+    assert!(final_path.exists());
+    assert_eq!(fs::read(&final_path).unwrap(), b"fallback content");
 }


### PR DESCRIPTION
## Verified gap

The receiver threads its destination `DirSandbox` into `DiskCommitConfig.sandbox` (config.rs; passed to `commit_file` via file_ops.rs). The temp-file **create** is already dirfd-anchored (`temp_guard::try_create_new` -> `openat` with `O_NOFOLLOW`) and the `--backup-dir`/receiver mkdir is anchored (`mkdirat_via_sandbox_or_fallback`), but the **commit-side renames** ran path-based `fs::rename` while the live sandbox was ignored. A destination parent swapped for a symlink between temp-create and rename could redirect the final file outside the tree (write-escape). The helper `fast_io::renameat_via_sandbox_or_fallback` already existed but was called nowhere in the commit path.

## Sites changed (all in `crates/transfer/src/disk_commit/process/commit.rs`)

- Atomic `temp -> final` rename (`commit_file`).
- `--delay-updates` staging rename (`commit_file`, `.~tmp~` stage).
- `--partial` retain rename (`retain_partial_file`).
- `--backup` rename + its `--backup-dir` parent `create_dir_all` (`make_backup`).

New helpers `rename_config_sandboxed` / `backup_rename_sandboxed` / `create_dir_all_sandboxed` route through the dirfd-anchored `renameat`/`mkdirat` when `config.sandbox` is `Some` **and** both leaves are single components directly under the destination root (the same gate the temp-create already uses). Every other case - no sandbox, multi-component/`--temp-dir`/partial-dir path, or non-Unix - falls back to the pre-existing path-based syscall (`rename_with_io_uring_fallback` with its EXDEV copy+remove backstop for the main rename; plain `fs::rename`/`create_dir_all` for backup, preserving prior backup semantics). `#[cfg(unix)]` gated; non-Unix stays path-based.

## Outcome parity

Only the syscall mechanism changes (rename -> `renameat` against a pinned dirfd). Same final file content/location, same temp cleanup, same backup/partial/delay-updates semantics, same stats, same error/exit codes. The anchor shares the destination parent for both leaves, so EXDEV cannot arise on the anchored path. Any sandbox-open/gate miss degrades gracefully to the original path-based rename - a working rename is never regressed or slowed beyond the dirfd resolve the receiver already performs for temp-create.

## Regression tests (`disk_commit/process/tests.rs`)

- `commit_rename_refuses_parent_symlink_escape` - deterministic (no threads/sleeps): open the sandbox at the dest root, swap the `dest_dir` path for an out-of-tree symlink, run the anchored commit rename with the original (pre-swap) path strings, assert the final file lands **inside** the real destination and the out-of-tree location stays empty.
- `commit_rename_without_sandbox_uses_path_fallback` - proves the no-sandbox path still moves temp -> final via the path-based fallback.

## Scope / notes

- Local-copy commit (`executor/file/guard.rs`) has no sandbox; it is a narrower both-endpoints-local (not daemon-reachable) follow-up, deliberately out of scope here.
- The interop cell is the gate.
- Advances #507.
