### PR TITLE
fix(release): ship xattr (NTFS ADS) in Windows release binary

### DIFF
--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -641,7 +641,7 @@ jobs:
         shell: pwsh
         run: |
           $env:OC_RSYNC_PACKAGE_DEFAULT_FEATURES = "0"
-          $env:OC_RSYNC_PACKAGE_FEATURES = "zstd lz4 iconv"
+          $env:OC_RSYNC_PACKAGE_FEATURES = "zstd lz4 iconv xattr acl"
           cargo xtask package --tarball --tarball-target x86_64-pc-windows-msvc --profile dist
 
       - name: Rename tarball with toolchain


### PR DESCRIPTION
## The gap

PR #6325 added NTFS Alternate Data Stream (ADS) support to the `-X`/`--xattrs` path on Windows, widening the metadata xattr chain to `any(unix, windows)` (FindFirstStreamW backend in `xattr_windows.rs`). However, the Windows **release** binary is built with `--no-default-features` and an explicit feature list of `"zstd lz4 iconv"` -- with no `xattr`. As a result the ADS support was compiled OUT of the shipped Windows artifact, and `--xattrs` silently no-ops for real Windows users.

`.github/workflows/release-cross.yml` (windows job, `Build Windows tarball` step) sets:

```
$env:OC_RSYNC_PACKAGE_DEFAULT_FEATURES = "0"
$env:OC_RSYNC_PACKAGE_FEATURES = "zstd lz4 iconv"
```

`xtask/src/commands/package/build.rs` maps `OC_RSYNC_PACKAGE_FEATURES` directly to `--features` on the `--workspace --bins` build, so those are the exact features the shipped `oc-rsync.exe` gets.

## The fix

Add `xattr` and `acl` to the Windows release feature set:

```
$env:OC_RSYNC_PACKAGE_FEATURES = "zstd lz4 iconv xattr acl"
```

Both are real, tested Windows features:

- `xattr` engages the FindFirstStreamW / NTFS-ADS backend (`metadata::xattr_windows`). This is the confirmed `--xattrs` gap.
- `acl` engages the Win32 GetSecurityInfo/SetSecurityInfo DACL backend (`metadata::acl_windows`), mirroring upstream `acls.c` over NTFS DACLs.

The required `Windows ACL/xattr` CI cell already builds and tests `metadata --features acl,xattr` on `windows-latest`, and the nightly `windows-nightly-xattr-ads.yml` cell already proves the xattr ADS backend builds and round-trips -- so both feature chains compile and pass on real Windows.

The xtask package build has no separate hardcoded Windows feature default; the release env var is the single source of truth for the shipped feature set, so this one-line change covers both the CI env and a local `cargo xtask package` invocation (when the same env vars are set).

Unix/macOS release feature sets are unchanged (they already include `xattr`/`acl` via defaults).

## Verification

Cross-compiled the `oc-rsync` binary for Windows from the dev host with the new feature string:

- `--no-default-features --features "zstd lz4 iconv xattr"` builds and links cleanly for `x86_64-pc-windows-gnu`, producing `oc-rsync.exe`. This proves the confirmed ADS gap is closed.
- With `acl` added, every Rust crate (metadata, cli, bin) compiles cleanly. The `acl` link step only fails when cross-compiling from a unix host, because `metadata/build.rs` gates its `-lacl` directive on `cfg!(unix)` (which is host-evaluated). On the native `windows-latest` release runner the build script returns early and emits no `-lacl`, so `acl` links via the `windows` crate DACL APIs -- exactly as the required CI cell already validates. Full-build gating remains the release CI on a native Windows runner.

Advances #510.