### PR TITLE
fix(transfer): validate sum-header wire fields to reject malformed input (DoS)

### DIFF
--- a/crates/transfer/src/receiver/tests/file_list/wire_attrs.rs
+++ b/crates/transfer/src/receiver/tests/file_list/wire_attrs.rs
@@ -102,6 +102,84 @@ fn sum_head_read_insufficient_data() {
     assert_eq!(result.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
 }
 
+/// Encodes a raw 16-byte sum_head wire frame from signed field values.
+fn sum_head_bytes(count: i32, blength: i32, s2length: i32, remainder: i32) -> Vec<u8> {
+    let mut data = Vec::with_capacity(16);
+    data.extend_from_slice(&count.to_le_bytes());
+    data.extend_from_slice(&blength.to_le_bytes());
+    data.extend_from_slice(&s2length.to_le_bytes());
+    data.extend_from_slice(&remainder.to_le_bytes());
+    data
+}
+
+/// A crafted sum_head with an enormous strong-sum length must be rejected with
+/// `InvalidData` (RERR_PROTOCOL) rather than driving a multi-gigabyte `vec!`.
+/// Guards the OOM site at `generator/protocol_io.rs` `vec![0u8; s2length]`.
+#[test]
+fn sum_head_rejects_oversized_s2length() {
+    let data = sum_head_bytes(1, 512, i32::MAX, 0);
+    let err = SumHead::read(&mut Cursor::new(data)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// A crafted sum_head with a negative block count must be rejected, mirroring
+/// upstream io.c:2029, so `Vec::with_capacity(count)` never sees garbage.
+#[test]
+fn sum_head_rejects_negative_count() {
+    let data = sum_head_bytes(-1, 512, 16, 0);
+    let err = SumHead::read(&mut Cursor::new(data)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// A block length beyond the legacy MAX_BLOCK_SIZE ceiling is rejected
+/// (upstream io.c:2050).
+#[test]
+fn sum_head_rejects_oversized_blength() {
+    let data = sum_head_bytes(1, i32::MAX, 16, 0);
+    let err = SumHead::read(&mut Cursor::new(data)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// A zero block length with a non-zero count is nonsense (division-by-zero) and
+/// must be rejected.
+#[test]
+fn sum_head_rejects_zero_blength_with_blocks() {
+    let data = sum_head_bytes(4, 0, 16, 0);
+    let err = SumHead::read(&mut Cursor::new(data)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// A remainder larger than the block length is rejected (upstream io.c:2062).
+#[test]
+fn sum_head_rejects_remainder_over_blength() {
+    let data = sum_head_bytes(1, 512, 16, 513);
+    let err = SumHead::read(&mut Cursor::new(data)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+/// A legitimate large-file sum_head (SHA1 20-byte strong sums, max block size,
+/// many blocks) must still decode cleanly - the bounds mirror upstream exactly,
+/// so any header upstream accepts, oc accepts.
+#[test]
+fn sum_head_accepts_legit_large_transfer() {
+    // count near the u32 edge, blength at the legacy ceiling, s2length = SHA1.
+    let data = sum_head_bytes(1_000_000, 1 << 29, 20, (1 << 29) - 1);
+    let sum_head = SumHead::read(&mut Cursor::new(data)).unwrap();
+    assert_eq!(sum_head.count, 1_000_000);
+    assert_eq!(sum_head.blength, 1 << 29);
+    assert_eq!(sum_head.s2length, 20);
+    assert_eq!(sum_head.remainder, (1 << 29) - 1);
+}
+
+/// The zero-count whole-file sentinel (`count=0`) with all-zero fields decodes
+/// as an empty header, unaffected by the new bounds.
+#[test]
+fn sum_head_accepts_empty_whole_file() {
+    let data = sum_head_bytes(0, 0, 0, 0);
+    let sum_head = SumHead::read(&mut Cursor::new(data)).unwrap();
+    assert!(sum_head.is_empty());
+}
+
 #[test]
 fn sender_attrs_read_protocol_28_returns_default_iflags() {
     // Protocol 28 just reads the NDX byte, no iflags

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -184,26 +184,103 @@ impl SumHead {
         Ok(())
     }
 
-    /// Decodes a sum_head from its 16-byte little-endian wire representation.
+    /// Decodes and validates a sum_head from its 16-byte little-endian wire
+    /// representation.
+    ///
+    /// The four fields arrive from an authenticated but untrusted peer and size
+    /// downstream allocations (`Vec::with_capacity(count)`,
+    /// `vec![0u8; s2length]`, per-block `vec![0u8; s2length]`). Without bounds a
+    /// malicious sum_head is a memory-exhaustion (DoS) vector, so every field is
+    /// range-checked exactly as upstream does before it is used.
     ///
     /// Shared by the sync [`read`](Self::read) and async
-    /// [`read_async`](Self::read_async) leaves so the field decode can never
-    /// diverge between them.
-    #[must_use]
-    fn from_wire_bytes(buf: &[u8; 16]) -> Self {
-        Self {
-            count: i32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as u32,
-            blength: i32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]) as u32,
-            s2length: i32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]) as u32,
-            remainder: i32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]) as u32,
+    /// [`read_async`](Self::read_async) leaves so the field decode + validation
+    /// can never diverge between them. Rejections return an
+    /// [`io::ErrorKind::InvalidData`] error, which the receiver already maps to
+    /// the `RERR_PROTOCOL` (exit code 2) path for malformed wire input.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:2025-2067` - `read_sum_head()` validates every field and calls
+    ///   `exit_cleanup(RERR_PROTOCOL)` on any out-of-range value.
+    fn from_wire_bytes(buf: &[u8; 16]) -> io::Result<Self> {
+        // Fields are signed on the wire (write_int/read_int); decode as i32 so
+        // the negative-value guards below mirror upstream's `< 0` checks.
+        let count = i32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        let blength = i32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        let s2length = i32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        let remainder = i32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
+
+        // upstream: io.c:2029 - reject negative block count.
+        if count < 0 {
+            return Err(Self::malformed(format!("invalid checksum count {count}")));
         }
+        // upstream: io.c:2039-2048 - guard against overflow in the downstream
+        // `count * per_entry_size` allocation arithmetic. Each signature block
+        // occupies `4 + s2length` wire bytes; MAX_STRONG_SUM_LEN bounds the
+        // second factor so the product cannot overflow usize.
+        let per_entry = 4usize + Self::MAX_STRONG_SUM_LEN;
+        if (count as usize).checked_mul(per_entry).is_none() {
+            return Err(Self::malformed(format!(
+                "invalid checksum count {count} (allocation overflow)"
+            )));
+        }
+        // upstream: io.c:2050-2054 - blength in (0, max_blength]. We use the
+        // legacy MAX_BLOCK_SIZE (1<<29) as the permissive ceiling so any header
+        // accepted by either protocol era is accepted here; a zero/negative
+        // block length is nonsense (division-by-zero) when count > 0.
+        if blength < 0
+            || blength as u32 > signature::MAX_BLOCK_SIZE_OLD
+            || (count > 0 && blength == 0)
+        {
+            return Err(Self::malformed(format!("invalid block length {blength}")));
+        }
+        // upstream: io.c:2056-2060 - s2length in [0, xfer_sum_len]. oc's longest
+        // negotiable transfer digest is SHA1 at MAX_STRONG_SUM_LEN (20) bytes.
+        if s2length < 0 || s2length as usize > Self::MAX_STRONG_SUM_LEN {
+            return Err(Self::malformed(format!(
+                "invalid checksum length {s2length}"
+            )));
+        }
+        // upstream: io.c:2061-2066 - remainder in [0, blength].
+        if remainder < 0 || remainder > blength {
+            return Err(Self::malformed(format!(
+                "invalid remainder length {remainder}"
+            )));
+        }
+
+        Ok(Self {
+            count: count as u32,
+            blength: blength as u32,
+            s2length: s2length as u32,
+            remainder: remainder as u32,
+        })
+    }
+
+    /// Maximum strong-sum length accepted in a sum_head, in bytes.
+    ///
+    /// Mirrors upstream's `xfer_sum_len` ceiling (`io.c:2056`): the length of
+    /// the longest transfer checksum oc can negotiate. SHA1 (20 bytes) is the
+    /// longest supported transfer digest, so s2length may not exceed 20.
+    const MAX_STRONG_SUM_LEN: usize = 20;
+
+    /// Builds a `RERR_PROTOCOL`-mapped error for a malformed sum_head field.
+    fn malformed(detail: String) -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "malformed sum_head: {detail} {}{}",
+                crate::role_trailer::error_location!(),
+                crate::role_trailer::receiver()
+            ),
+        )
     }
 
     /// Reads a sum_head from the wire in rsync format.
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         let mut buf = [0u8; 16];
         reader.read_exact(&mut buf)?;
-        Ok(Self::from_wire_bytes(&buf))
+        Self::from_wire_bytes(&buf)
     }
 
     /// Async twin of [`read`](Self::read).
@@ -221,7 +298,7 @@ impl SumHead {
 
         let mut buf = [0u8; 16];
         reader.read_exact(&mut buf).await?;
-        Ok(Self::from_wire_bytes(&buf))
+        Self::from_wire_bytes(&buf)
     }
 }
 

--- a/crates/transfer/tests/sum_head_async_parity.rs
+++ b/crates/transfer/tests/sum_head_async_parity.rs
@@ -58,12 +58,19 @@ impl AsyncRead for ChunkedReader {
 
 #[tokio::test(flavor = "current_thread")]
 async fn sum_head_read_async_matches_sync() {
+    // All fixtures are valid sum_heads: `SumHead::read` now validates the wire
+    // fields (upstream io.c:2025-2067) and rejects out-of-range values, so a
+    // parity fixture must stay within the accepted ranges while still setting
+    // high bytes across all four fields to exercise byte-level decode parity.
     let cases = [
         SumHead::empty(),
         SumHead::new(1, 700, 16, 0),
         SumHead::new(1234, 65536, 2, 511),
-        SumHead::new(u32::MAX, u32::MAX, u32::MAX, u32::MAX),
-        SumHead::new(0, 0, 0, 1),
+        // Large-but-valid: count with three nonzero bytes, blength at the legacy
+        // MAX_BLOCK_SIZE ceiling (1<<29), s2length at the SHA1 cap (20),
+        // remainder just below blength.
+        SumHead::new(0x00FF_FFFF, 1 << 29, 20, (1 << 29) - 1),
+        SumHead::new(2, 1024, 8, 1023),
     ];
 
     for head in cases {


### PR DESCRIPTION
## Problem

`SumHead::from_wire_bytes` (crates/transfer/src/receiver/wire.rs) decoded the 16-byte sum-header from an authenticated but untrusted peer with **zero validation**. The raw fields size three downstream allocations, giving a peer memory-exhaustion (DoS) vectors:

- `generator/protocol_io.rs:693` - `vec![0u8; sum_head.s2length]` (s2length up to 2 GiB, x count)
- `generator/protocol_io.rs:684` - `Vec::with_capacity(sum_head.count)` (count up to ~2 G entries)
- `receiver/wire.rs:572` - `vec![0u8; s2length]` per block

## Fix

Validate every field at decode time, mirroring upstream `read_sum_head` (io.c:2025-2067) exactly. Bounds added, with upstream line refs:

| Field | Rule | Upstream |
|-------|------|----------|
| `count` | `>= 0`; `count * (4 + max_sum_len)` must not overflow `usize` | io.c:2029, io.c:2039-2048 |
| `blength` | `>= 0`, `<= MAX_BLOCK_SIZE_OLD` (1<<29), and `> 0` when `count > 0` | io.c:2050-2054 |
| `s2length` | `>= 0`, `<= 20` (longest negotiable transfer digest = SHA1) | io.c:2056-2060 |
| `remainder` | `>= 0`, `<= blength` | io.c:2061-2066 |

The s2length ceiling is **20** (SHA1), not 16: oc negotiates SHA1 as a transfer checksum (`delta_apply/checksum.rs` `MAX_DIGEST_LEN = 20`), so a 16-byte cap would reject legitimate SHA1 transfers. The blength ceiling uses the legacy `MAX_BLOCK_SIZE_OLD` so any header accepted by either protocol era is accepted here (no access to the negotiated protocol version at this decode site; permissive-but-safe).

## Error mapping

Rejections return `io::ErrorKind::InvalidData` - the same typed error the receiver already surfaces for malformed wire input (fnamecmp type, xname length), which maps to the `RERR_PROTOCOL` (exit code 2) path. No panic, no allocation on the rejection path.

## Legit transfers unaffected

Bounds mirror upstream exactly: any sum-header upstream accepts, oc accepts. A new test asserts a large legitimate header (1M blocks, max block size, SHA1 20-byte sums, near-max remainder) still decodes cleanly; the existing round-trip test (s2length=20) still passes.

## Tests

Added to `receiver/tests/file_list/wire_attrs.rs`: crafted headers with oversized s2length / negative count / oversized blength / zero-blength-with-blocks / remainder>blength all return `InvalidData` with no allocation; legit large + whole-file (count=0) headers still decode. `cargo test -p transfer --lib sum_head`: 17 passed. Clippy + fmt clean.

Advances #512.