### PR TITLE
fix(daemon): forward-confirm reverse DNS for hosts allow/deny (upstream parity)

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -195,7 +195,7 @@ pub(crate) use self::module_state::{
 #[cfg(test)]
 pub(crate) use self::module_state::{
     TEST_SECRETS_CANDIDATES, TEST_SECRETS_ENV, TestSecretsEnvOverride,
-    clear_test_hostname_overrides, set_test_hostname_override,
+    clear_test_hostname_overrides, set_test_forward_override, set_test_hostname_override,
 };
 
 type SharedLogSink = Arc<Mutex<MessageSink<std::fs::File>>>;
@@ -379,8 +379,10 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
     // Resolve hostname for the synthetic peer (will resolve localhost).
+    // upstream: clientname.c `client_name` forward-confirms unconditionally;
+    // per-module `forward lookup` governs the access-control match.
     let peer_host = if reverse_lookup {
-        resolve_peer_hostname(peer_addr.ip())
+        resolve_peer_hostname(peer_addr.ip(), true)
     } else {
         None
     };

--- a/crates/daemon/src/daemon/module_state/hostname.rs
+++ b/crates/daemon/src/daemon/module_state/hostname.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use dns_lookup::lookup_addr;
+use dns_lookup::{lookup_addr, lookup_host};
 
 use super::ModuleDefinition;
 
@@ -15,9 +15,17 @@ use std::collections::HashMap;
 /// host patterns, or DNS resolution fails. Results are cached in `cache` to avoid
 /// repeated DNS lookups for the same peer.
 ///
+/// The module's `forward lookup` parameter (default true) controls whether the
+/// reverse-DNS name is forward-confirmed: when on, its A/AAAA records must
+/// include `peer_ip`, otherwise the peer is treated as having no resolved
+/// hostname (fail-closed), so a spoofed PTR cannot satisfy a hostname
+/// allow-rule.
+///
 /// upstream: clientserver.c - reverse DNS is performed when `hosts allow` or
-/// `hosts deny` patterns contain hostnames. The `reverse lookup` global parameter
-/// controls whether reverse DNS is attempted at all.
+/// `hosts deny` patterns contain hostnames. The `reverse lookup` parameter
+/// controls whether reverse DNS is attempted at all; the `forward lookup`
+/// parameter (access.c:49 `allow_forward_dns`, default True) forward-confirms
+/// the result.
 pub(crate) fn module_peer_hostname<'a>(
     module: &ModuleDefinition,
     cache: &'a mut Option<Option<String>>,
@@ -29,7 +37,7 @@ pub(crate) fn module_peer_hostname<'a>(
     }
 
     if cache.is_none() {
-        *cache = Some(resolve_peer_hostname(peer_ip));
+        *cache = Some(resolve_peer_hostname(peer_ip, module.forward_lookup));
     }
 
     cache.as_ref().and_then(|value| value.as_deref())
@@ -39,13 +47,52 @@ pub(crate) fn module_peer_hostname<'a>(
 ///
 /// The result is normalized by removing trailing dots and lowercasing, matching
 /// upstream rsync's hostname normalization for `hosts allow`/`hosts deny` matching.
-pub(in crate::daemon) fn resolve_peer_hostname(peer_ip: IpAddr) -> Option<String> {
+///
+/// When `forward_lookup` is true (the upstream default), the PTR-derived name is
+/// forward-confirmed before being returned: the name's A/AAAA records must
+/// include `peer_ip`. A name that does not forward-resolve back to the peer -
+/// a spoofed or stale PTR record - yields `None`, so hostname allow-rules
+/// fail closed and a forged PTR cannot satisfy a `hosts allow = <name>` rule.
+/// This mirrors upstream `clientname.c:check_name`, which replaces an
+/// unconfirmed name with the "UNKNOWN" placeholder.
+///
+/// upstream: clientname.c:416 `check_name` forward-confirms the reverse-DNS
+/// name against the peer address; access.c:49 gates forward DNS on the
+/// `forward lookup` daemon parameter (default True, daemon-parm.h:197).
+pub(in crate::daemon) fn resolve_peer_hostname(
+    peer_ip: IpAddr,
+    forward_lookup: bool,
+) -> Option<String> {
+    let name = reverse_lookup_name(peer_ip)?;
+    if forward_lookup && !forward_confirms(&name, peer_ip) {
+        return None;
+    }
+    Some(name)
+}
+
+/// Performs the PTR (reverse) lookup and normalizes the result.
+fn reverse_lookup_name(peer_ip: IpAddr) -> Option<String> {
     #[cfg(test)]
     if let Some(mapped) = TEST_HOSTNAME_OVERRIDES.with(|map| map.borrow().get(&peer_ip).cloned()) {
         return mapped.map(normalize_hostname_owned);
     }
 
     lookup_addr(&peer_ip).ok().map(normalize_hostname_owned)
+}
+
+/// Forward-resolves `name` and returns whether `peer_ip` is among its A/AAAA
+/// records. A forward lookup that fails (name does not resolve) returns false,
+/// matching upstream `check_name`'s fail-closed behaviour on `getaddrinfo`
+/// error (clientname.c:437-441).
+fn forward_confirms(name: &str, peer_ip: IpAddr) -> bool {
+    #[cfg(test)]
+    if let Some(addrs) = TEST_FORWARD_OVERRIDES.with(|map| map.borrow().get(name).cloned()) {
+        return addrs.contains(&peer_ip);
+    }
+
+    lookup_host(name)
+        .map(|addrs| addrs.into_iter().any(|addr| addr == peer_ip))
+        .unwrap_or(false)
 }
 
 /// Normalizes a hostname by removing trailing dots and lowercasing.
@@ -61,6 +108,8 @@ pub(super) fn normalize_hostname_owned(mut name: String) -> String {
 thread_local! {
     pub(in crate::daemon) static TEST_HOSTNAME_OVERRIDES: RefCell<HashMap<IpAddr, Option<String>>> =
         RefCell::new(HashMap::new());
+    pub(in crate::daemon) static TEST_FORWARD_OVERRIDES: RefCell<HashMap<String, Vec<IpAddr>>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Sets a test override for hostname resolution of the given address.
@@ -73,9 +122,24 @@ pub(crate) fn set_test_hostname_override(addr: IpAddr, hostname: Option<&str>) {
     });
 }
 
-/// Clears all test hostname resolution overrides.
+/// Sets a test override for the forward (A/AAAA) resolution of `name`.
+///
+/// The normalized `name` resolves to `addrs`; forward-confirmation succeeds
+/// only when the peer IP is among them. A name with no override forward-
+/// resolves to an empty set, so confirmation fails closed.
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn set_test_forward_override(name: &str, addrs: &[IpAddr]) {
+    let normalized = normalize_hostname_owned(name.to_owned());
+    TEST_FORWARD_OVERRIDES.with(|map| {
+        map.borrow_mut().insert(normalized, addrs.to_vec());
+    });
+}
+
+/// Clears all test hostname resolution overrides (reverse and forward).
 #[cfg(test)]
 #[allow(dead_code)]
 pub(crate) fn clear_test_hostname_overrides() {
     TEST_HOSTNAME_OVERRIDES.with(|map| map.borrow_mut().clear());
+    TEST_FORWARD_OVERRIDES.with(|map| map.borrow_mut().clear());
 }

--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -28,7 +28,9 @@ pub(in crate::daemon) use hostname::resolve_peer_hostname;
 pub(crate) use runtime::{ModuleConnectionError, ModuleRuntime};
 
 #[cfg(test)]
-pub(crate) use hostname::{clear_test_hostname_overrides, set_test_hostname_override};
+pub(crate) use hostname::{
+    clear_test_hostname_overrides, set_test_forward_override, set_test_hostname_override,
+};
 #[cfg(test)]
 use runtime::ModuleConnectionGuard;
 #[cfg(test)]

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -108,8 +108,12 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
     // peer address.
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
+    // upstream: clientname.c `client_name` forward-confirms the reverse-DNS
+    // name unconditionally, so this pre-module log/registry name is confirmed
+    // too. Per-module `forward lookup` still governs the access-control match
+    // in `module_peer_hostname`.
     let peer_host = if reverse_lookup {
-        resolve_peer_hostname(peer_addr.ip())
+        resolve_peer_hostname(peer_addr.ip(), true)
     } else {
         None
     };

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -59,22 +59,40 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 ///
 /// Returns the module path itself when no positional was supplied or when
 /// the stripped tail is empty (push directly into the module root).
+///
+/// Returns `None` when the destination tail contains a `..` traversal
+/// segment, symmetric to `resolve_sender_sources`. Downstream file-list
+/// sanitisation and the `DirSandbox` already confine the write, so this is a
+/// no-op for every currently-valid destination path (a `..`-free tail is
+/// unaffected); the guard rejects the escape up front as defense-in-depth.
+///
+/// upstream: util1.c:1035 `sanitize_path` collapses `..` against the module
+/// root depth on the receiver side, behind the chroot wall. oc-rsync mirrors
+/// the check explicitly because the daemon does not always chroot.
 fn resolve_receiver_dest(
     module_path: &std::path::Path,
     client_args: &[String],
     module_name: &str,
-) -> std::path::PathBuf {
+) -> Option<std::path::PathBuf> {
     let positionals = extract_module_relative_paths(client_args, module_name);
     // upstream: main.c:1203-1204 - `local_name = get_local_name(flist, argv[0])`
     // uses the FIRST remaining positional (after the `.` placeholder has been
     // consumed by `do_server_recv` at line 1166). For a receiver that
     // translates to the last wire positional - the destination.
     let Some(last) = positionals.last() else {
-        return module_path.to_path_buf();
+        return Some(module_path.to_path_buf());
     };
     let tail = last.trim();
     if tail.is_empty() || tail == "." {
-        return module_path.to_path_buf();
+        return Some(module_path.to_path_buf());
+    }
+    // Reject `..` traversal segments so the joined destination cannot escape
+    // the module root, symmetric to the sender-source guard below.
+    let trimmed_for_scan = tail.trim_start_matches(['/', '\\']);
+    for component in std::path::Path::new(trimmed_for_scan).components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return None;
+        }
     }
     // Defensive: a path arriving here that is absolute on the host OS
     // (Unix `is_absolute()` or a leading `/` that Windows treats as
@@ -84,9 +102,9 @@ fn resolve_receiver_dest(
     let rel = std::path::Path::new(tail);
     if rel.is_absolute() || tail.starts_with('/') || tail.starts_with('\\') {
         let stripped = tail.trim_start_matches(['/', '\\']);
-        return module_path.join(stripped);
+        return Some(module_path.join(stripped));
     }
-    module_path.join(rel)
+    Some(module_path.join(rel))
 }
 
 /// Resolves the sender's on-disk source paths from the client's positional

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -90,8 +90,15 @@ fn build_server_config(
     // always the module root; legacy tests that push straight into the module
     // root keep that behaviour.
     let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
-        let dest = resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name);
-        vec![OsString::from(dest.as_os_str())]
+        match resolve_receiver_dest(std::path::Path::new(&module.path), client_args, &module.name) {
+            Some(dest) => vec![OsString::from(dest.as_os_str())],
+            None => {
+                let payload =
+                    "@ERROR: requested path resolves outside module root".to_owned();
+                send_error_and_exit(ctx.reader.get_mut(), ctx.limiter, ctx.messages, &payload)?;
+                return Ok(None);
+            }
+        }
     } else {
         match resolve_sender_sources(std::path::Path::new(&module.path), client_args, &module.name) {
             Some(sources) => sources

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2042,7 +2042,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_joins_subpath_with_module_root() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         assert_eq!(dest, std::path::Path::new("/srv/upload/realdir/"));
     }
 
@@ -2050,7 +2050,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_falls_back_to_module_root_for_bare_module() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         assert_eq!(dest, std::path::Path::new("/srv/upload"));
     }
 
@@ -2058,7 +2058,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_falls_back_to_module_root_when_no_positional() {
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         assert_eq!(dest, std::path::Path::new("/srv/upload"));
     }
 
@@ -2073,7 +2073,7 @@ mod module_access_tests {
             "upload/srcB/".to_owned(),
             "upload/destdir/".to_owned(),
         ];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         assert_eq!(dest, std::path::Path::new("/srv/upload/destdir/"));
     }
 
@@ -2081,9 +2081,19 @@ mod module_access_tests {
     fn resolve_receiver_dest_rejoins_absolute_path_under_module_root() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         // Absolute path is forced under the module root - no escape.
         assert_eq!(dest, std::path::Path::new("/srv/upload/etc/passwd"));
+    }
+
+    #[test]
+    fn resolve_receiver_dest_rejects_parent_dir_traversal() {
+        // Defense-in-depth: a `..` segment in the receiver destination is
+        // rejected up front, symmetric to `resolve_sender_sources`. Every
+        // valid (dotdot-free) tail is unaffected; this only fails the escape.
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/../../etc/passwd".to_owned()];
+        assert!(resolve_receiver_dest(module_path, &args, "upload").is_none());
     }
 
     // URV-5.b.REOPEN: classify_client_path_against_module is the pure helper
@@ -2667,7 +2677,7 @@ mod module_access_tests {
         // the same way they do on Linux.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         // Path::join uses the host separator on Windows, so a trailing
         // slash on the positional collapses into a backslash-terminated
         // PathBuf. The assertion compares via Path equality so the
@@ -2686,7 +2696,7 @@ mod module_access_tests {
         // containment guarantee on Windows hosts.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload").expect("valid dest");
         // After stripping the leading `/`, the resolver hands the bare
         // string `etc/passwd` to Path::join, which prepends the host
         // separator (`\` on Windows) but does not rewrite the embedded

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -85,8 +85,11 @@ fn handle_session(
         peer_addr
     };
 
+    // upstream: clientname.c `client_name` forward-confirms the reverse-DNS
+    // name unconditionally; per-module `forward lookup` still governs the
+    // access-control match in `module_peer_hostname`.
     let peer_host = if reverse_lookup {
-        resolve_peer_hostname(peer_addr.ip())
+        resolve_peer_hostname(peer_addr.ip(), true)
     } else {
         None
     };

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -64,6 +64,7 @@ use crate::daemon::{
     read_trimmed_line,
     render_help,
     sanitize_module_identifier,
+    set_test_forward_override,
     set_test_hostname_override,
 };
 
@@ -157,6 +158,8 @@ include!("tests/chunks/module_definition_wildcard_any_allows_all.rs");
 include!("tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs");
 include!("tests/chunks/module_hostname_deny_fails_closed_when_dns_unresolved.rs");
 include!("tests/chunks/module_ip_deny_unaffected_by_dns_failure.rs");
+include!("tests/chunks/module_peer_hostname_forward_confirm_rejects_spoofed_ptr.rs");
+include!("tests/chunks/module_peer_hostname_forward_lookup_off_restores_ptr_only.rs");
 include!("tests/chunks/module_peer_hostname_missing_resolution_denies_hostname_only_rules.rs");
 include!("tests/chunks/module_peer_hostname_resolution_before_chroot_denies_unknown.rs");
 include!("tests/chunks/module_peer_hostname_skips_lookup_when_disabled.rs");

--- a/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
+++ b/crates/daemon/src/tests/chunks/module_hostname_allow_fails_closed_under_chroot.rs
@@ -65,6 +65,9 @@ fn module_hostname_allow_fails_closed_under_chroot() {
     // so the refusal above is attributable to the DNS failure and not a
     // broken matcher.
     set_test_hostname_override(peer, Some("test-host.example"));
+    // A legitimate peer's PTR name forward-resolves back to its address, so
+    // the module-default `forward lookup = yes` confirmation passes.
+    set_test_forward_override("test-host.example", &[peer]);
     let mut cache = None;
     let resolved = module_peer_hostname(&module, &mut cache, peer, true);
     assert_eq!(

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_forward_confirm_rejects_spoofed_ptr.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_forward_confirm_rejects_spoofed_ptr.rs
@@ -1,0 +1,45 @@
+/// A spoofed PTR record - one whose forward (A/AAAA) resolution does not
+/// include the peer's address - must not satisfy a hostname `hosts allow`
+/// rule. With `forward lookup = yes` (the module default), the reverse-DNS
+/// name is forward-confirmed against the peer address; an unconfirmed name is
+/// treated as no hostname, so the allow-rule fails closed.
+///
+/// upstream: clientname.c:416 `check_name` - a name whose forward lookup does
+/// not match the peer address is replaced with "UNKNOWN"; access.c:49
+/// `allow_forward_dns` gates this on the `forward lookup` parameter.
+#[test]
+fn module_peer_hostname_forward_confirm_rejects_spoofed_ptr() {
+    clear_test_hostname_overrides();
+    let module = module_with_host_patterns(&["trusted.example.com"], &[]);
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5));
+
+    // Attacker controls the PTR record and points it at the trusted name.
+    set_test_hostname_override(peer, Some("trusted.example.com"));
+    // But the forward lookup of that name resolves to a DIFFERENT address,
+    // so the confirmation fails.
+    set_test_forward_override(
+        "trusted.example.com",
+        &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))],
+    );
+
+    let mut cache = None;
+    let resolved = module_peer_hostname(&module, &mut cache, peer, true);
+    assert!(
+        resolved.is_none(),
+        "a PTR name that does not forward-resolve to the peer must be rejected"
+    );
+    assert!(
+        !module.permits(peer, resolved),
+        "spoofed PTR must not satisfy a hostname `hosts allow` rule"
+    );
+
+    // Positive control: when the forward lookup DOES include the peer, the
+    // name is confirmed and the allow-rule matches.
+    let mut cache = None;
+    set_test_forward_override("trusted.example.com", &[peer]);
+    let resolved = module_peer_hostname(&module, &mut cache, peer, true);
+    assert_eq!(resolved, Some("trusted.example.com"));
+    assert!(module.permits(peer, resolved));
+
+    clear_test_hostname_overrides();
+}

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_forward_lookup_off_restores_ptr_only.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_forward_lookup_off_restores_ptr_only.rs
@@ -1,0 +1,36 @@
+/// `forward lookup = no` restores upstream's PTR-only behaviour: the
+/// reverse-DNS name is trusted without forward-confirmation. This mirrors
+/// upstream access.c where `allow_forward_dns` (from `lp_forward_lookup`)
+/// being false skips the forward check entirely.
+///
+/// upstream: access.c:49 - `if (!allow_forward_dns) return 0;` short-circuits
+/// the forward lookup when the `forward lookup` parameter is disabled.
+#[test]
+fn module_peer_hostname_forward_lookup_off_restores_ptr_only() {
+    clear_test_hostname_overrides();
+    let module = ModuleDefinition {
+        forward_lookup: false,
+        ..module_with_host_patterns(&["trusted.example.com"], &[])
+    };
+    let peer = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 6));
+
+    // PTR points at the trusted name; the forward lookup does NOT include the
+    // peer (would fail confirmation) - but with `forward lookup = no` the
+    // confirmation is skipped and the PTR name is trusted as-is.
+    set_test_hostname_override(peer, Some("trusted.example.com"));
+    set_test_forward_override(
+        "trusted.example.com",
+        &[IpAddr::V4(Ipv4Addr::new(198, 51, 100, 2))],
+    );
+
+    let mut cache = None;
+    let resolved = module_peer_hostname(&module, &mut cache, peer, true);
+    assert_eq!(
+        resolved,
+        Some("trusted.example.com"),
+        "forward lookup = no must trust the PTR name without confirmation"
+    );
+    assert!(module.permits(peer, resolved));
+
+    clear_test_hostname_overrides();
+}

--- a/crates/daemon/src/tests/chunks/module_peer_hostname_uses_override.rs
+++ b/crates/daemon/src/tests/chunks/module_peer_hostname_uses_override.rs
@@ -4,6 +4,9 @@ fn module_peer_hostname_uses_override() {
     let module = module_with_host_patterns(&["trusted.example.com"], &[]);
     let peer = IpAddr::V4(Ipv4Addr::LOCALHOST);
     set_test_hostname_override(peer, Some("Trusted.Example.Com"));
+    // forward lookup (module default true) confirms the PTR name resolves
+    // back to the peer; a legitimate host does.
+    set_test_forward_override("trusted.example.com", &[peer]);
     let mut cache = None;
     let resolved = module_peer_hostname(&module, &mut cache, peer, true);
     assert_eq!(resolved, Some("trusted.example.com"));


### PR DESCRIPTION
Two bounded daemon access/path hardening fixes. Advances #509.

## Fix 1 (MEDIUM) - forward-confirmed reverse DNS for hostname ACL rules

`resolve_peer_hostname` previously did a PTR-only reverse lookup, so a spoofed PTR record could forge a hostname match against `hosts allow` / `hosts deny` HOSTNAME patterns.

Upstream forward-confirms the reverse-DNS name (`clientname.c:416 check_name`): after the PTR lookup it resolves the returned name's A/AAAA records and requires the peer IP to be among them. The `forward lookup` daemon parameter (`access.c:49 allow_forward_dns`, `daemon-parm.h:197`, P_LOCAL, **default True**) gates forward DNS.

Change:
- The per-module `forward lookup` parameter was already parsed, defaulted (true), module-defaulted, and exposed via `ModuleDefinition::forward_lookup` - it just was not wired into DNS resolution. This threads it into `module_peer_hostname` -> `resolve_peer_hostname`.
- When `forward lookup` is on (default), after the PTR lookup the name's A/AAAA records are resolved and the peer IP must be among them; otherwise the peer is treated as having **no confirmed hostname** (fail-closed). Hostname allow-rules therefore fail closed, and hostname deny-rules still cannot be bypassed. `forward lookup = no` restores PTR-only behaviour, matching upstream `!allow_forward_dns`.
- IP/CIDR `hosts allow`/`deny` rules are unchanged. Non-hostname configs behave identically.
- Pre-module log/registry hostname resolution (`daemon.rs`, `session_runtime.rs`, `inetd.rs`) forward-confirms unconditionally, matching upstream `client_name` which always runs `check_name`.

## Fix 2 (LOW, defensive) - `resolve_receiver_dest` `..` guard

`resolve_receiver_dest` lacked the `..` / `ParentDir` rejection that `resolve_sender_sources` already had. Added the symmetric guard: a destination tail containing a `..` segment now returns the same `@ERROR: requested path resolves outside module root` path.

This is a pure defensive add - downstream file-list sanitisation and the strict `DirSandbox` already confine the write, so it is a **no-op for every currently-valid destination path** (only rejects `..`, which is already rejected downstream). upstream: `util1.c:1035 sanitize_path`.

## Config parameter

`forward lookup` (bool, P_LOCAL, default **True**) - already present in the config parser and `ModuleDefinition`; this PR wires it into the DNS matcher. Name and default match upstream exactly.

## Tests

New:
- `module_peer_hostname_forward_confirm_rejects_spoofed_ptr` - a PTR name whose forward lookup does not include the peer IP is rejected for a hostname allow-rule; accepted when it does.
- `module_peer_hostname_forward_lookup_off_restores_ptr_only` - `forward lookup = no` trusts the PTR name without confirmation.
- `resolve_receiver_dest_rejects_parent_dir_traversal` - `..` destination is rejected.

Existing positive-case hostname tests updated to also register a forward override (a legitimate peer's PTR name forward-resolves back to its address). `..`-failure and disabled-lookup tests are unaffected. IP/CIDR deny test (`module_ip_deny_unaffected_by_dns_failure`) still passes - confirms IP rules unaffected.

Verified on macOS: `cargo build -p daemon -p core`, targeted `cargo test -p daemon --lib`, and full `cargo test -p daemon --lib` all green; `cargo fmt -p daemon -p core -- --check` clean. Clippy on all changed files is clean (a pre-existing `manual_ok_err` lint in `module_directives.rs`, unrelated to this PR and present on master, is the only diagnostic from a stricter local clippy).