### PR TITLE
fix(transfer): do not delete --inplace destination on mid-transfer abort (data loss)

### DIFF
--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -429,7 +429,15 @@ fn open_output_file(
 ) -> io::Result<(fs::File, TempFileGuard, bool)> {
     if begin.is_device_target {
         let file = fs::OpenOptions::new().write(true).open(&begin.file_path)?;
-        Ok((file, TempFileGuard::new(begin.file_path.clone()), false))
+        // The guard wraps the real device node, not a temp file. A
+        // mid-transfer error must NOT unlink it (upstream never unlinks an
+        // inplace/device target - receiver.c:1054 gates on !one_inplace), so
+        // seed it keep-on-drop.
+        Ok((
+            file,
+            TempFileGuard::keep_dest(begin.file_path.clone()),
+            false,
+        ))
     } else if begin.is_inplace {
         // upstream: receiver.c:855 - do_open(fname, O_WRONLY|O_CREAT, 0600)
         let opened = fs::OpenOptions::new()
@@ -455,7 +463,17 @@ fn open_output_file(
             use std::io::Seek;
             file.seek(io::SeekFrom::Start(begin.append_offset))?;
         }
-        Ok((file, TempFileGuard::new(begin.file_path.clone()), false))
+        // The guard wraps the real destination file, not a temp file. On a
+        // mid-transfer error the guard must LEAVE the partial write in place
+        // rather than delete the user's existing file. upstream: receiver.c:1054
+        // gates the destination unlink on !one_inplace, so an inplace target is
+        // never unlinked; a partial inplace write stays. keep_dest() seeds the
+        // guard keep-on-drop so its Drop is a no-op on the error path.
+        Ok((
+            file,
+            TempFileGuard::keep_dest(begin.file_path.clone()),
+            false,
+        ))
     } else {
         // SEC-1.r: when the dest_dir + sandbox carrier is plumbed, route the
         // temp-file create through `openat(dirfd, leaf, O_WRONLY|O_CREAT|

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -1335,6 +1335,148 @@ fn cleanup_manager_inplace_skips_registration() {
     h.file_tx.send(FileMessage::Shutdown).unwrap();
     h.join_handle.join().unwrap();
 }
+
+/// #511 (data-loss regression): a mid-transfer error on an `--inplace`
+/// transfer must LEAVE the pre-existing destination in place, never delete
+/// it. The inplace path writes directly to the real destination (no
+/// temp+rename), so the cleanup guard wraps the live dest. A prior
+/// implementation dropped that guard on the error path, which unlinked the
+/// user's destination - non-adversarial data loss from a network drop.
+///
+/// WHY it matters: upstream `receiver.c:1054` gates the destination unlink
+/// on `!one_inplace`, so an interrupted inplace transfer never removes the
+/// dest; the partial write stays (the documented `--inplace` risk the user
+/// opted into). This test fails if the guard ever unlinks the inplace dest
+/// again.
+#[test]
+fn inplace_abort_does_not_delete_existing_destination() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("inplace_abort_preexisting.dat");
+
+    // Pre-existing destination the user must not lose.
+    fs::write(&file_path, b"the user's existing data").unwrap();
+    assert!(file_path.exists());
+
+    let config = DiskCommitConfig::default();
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: true,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    // Partial bytes land directly in the real destination (inplace).
+    h.file_tx
+        .send(FileMessage::Chunk(b"partial".to_vec()))
+        .unwrap();
+
+    // Simulate a mid-transfer error (network drop) via Abort.
+    h.file_tx
+        .send(FileMessage::Abort {
+            reason: "simulated mid-transfer network drop".into(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err(), "abort must surface as an error");
+
+    // The whole fix: the destination must still exist after the aborted
+    // inplace transfer. Upstream leaves the partial write; we must not
+    // delete the user's file.
+    assert!(
+        file_path.exists(),
+        "inplace abort must NOT delete the pre-existing destination"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
+/// #511 control: a mid-transfer abort on the default (non-inplace)
+/// temp+rename path with `PartialMode::None` still discards the temp file,
+/// so a pre-existing destination is left exactly as it was - untouched by
+/// the failed new transfer. This proves the fix is scoped to the inplace
+/// guard and does not weaken temp-file cleanup on the error path.
+#[test]
+fn non_inplace_abort_discards_temp_and_leaves_existing_dest() {
+    let dir = test_support::create_tempdir();
+    let file_path = dir.path().join("non_inplace_abort_preexisting.dat");
+
+    // Pre-existing destination. A non-inplace transfer writes to a temp
+    // file and only renames onto this dest on success, so an aborted new
+    // transfer must leave it untouched.
+    fs::write(&file_path, b"prior destination content").unwrap();
+
+    let config = DiskCommitConfig {
+        partial_mode: PartialMode::None,
+        ..DiskCommitConfig::default()
+    };
+    let h = spawn_disk_thread(config).unwrap();
+
+    h.file_tx
+        .send(FileMessage::Begin(Box::new(BeginMessage {
+            file_path: file_path.clone(),
+            target_size: 100,
+            file_entry_index: 0,
+            checksum_verifier: None,
+            is_device_target: false,
+            is_inplace: false,
+            append_offset: 0,
+            xattr_list: None,
+        })))
+        .unwrap();
+
+    h.file_tx
+        .send(FileMessage::Chunk(b"new partial".to_vec()))
+        .unwrap();
+    h.file_tx
+        .send(FileMessage::Abort {
+            reason: "simulated mid-transfer network drop".into(),
+        })
+        .unwrap();
+
+    let result = h.result_rx.recv().unwrap();
+    assert!(result.is_err());
+
+    // The pre-existing destination is untouched: the temp file was discarded
+    // and never renamed over it. The original content survives verbatim.
+    assert!(
+        file_path.exists(),
+        "pre-existing destination must survive a failed non-inplace transfer"
+    );
+    assert_eq!(
+        fs::read(&file_path).unwrap(),
+        b"prior destination content",
+        "pre-existing destination content must be untouched by the aborted temp transfer"
+    );
+
+    // No orphan temp file must remain in the destination directory.
+    let leftover_temps: Vec<_> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with(".non_inplace_abort_preexisting.dat.")
+        })
+        .collect();
+    assert!(
+        leftover_temps.is_empty(),
+        "aborted non-inplace transfer must discard its temp file"
+    );
+
+    h.file_tx.send(FileMessage::Shutdown).unwrap();
+    h.join_handle.join().unwrap();
+}
+
 /// Verifies that aborting a multi-chunk transfer mid-stream with
 /// `PartialMode::PartialDir` moves the partial file to the partial-dir,
 /// not the final destination. The partial file should contain only the

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -299,6 +299,27 @@ impl TempFileGuard {
         }
     }
 
+    /// Create a guard for an in-place / device write target that must never
+    /// be unlinked on a mid-transfer error.
+    ///
+    /// Unlike [`new`](TempFileGuard::new), `path` is the real destination
+    /// file (not a temp file), so the guard is constructed already
+    /// keep-on-drop: an aborted `--inplace` or device transfer leaves the
+    /// partial write in place instead of deleting the user's existing file.
+    /// This mirrors upstream `receiver.c:1054`, which gates the destination
+    /// unlink on `!one_inplace` and so never unlinks an in-place target.
+    /// The success path still calls [`keep`](TempFileGuard::keep), which is
+    /// an idempotent no-op here.
+    #[inline]
+    pub const fn keep_dest(path: PathBuf) -> Self {
+        Self {
+            path,
+            keep_on_drop: true,
+            #[cfg(unix)]
+            anchor: None,
+        }
+    }
+
     /// Create a new guard with an optional SEC-1.r sandbox anchor.
     ///
     /// When `sandbox` and `dest_dir` are both `Some` and the temp file lives


### PR DESCRIPTION
## Data-loss path (confirmed against the code)

In the pipelined receiver disk-commit path, `--inplace` and device transfers open the **real destination** directly (no temp+rename) and wrap it in a `TempFileGuard`:

- `crates/transfer/src/disk_commit/process/file_ops.rs` `open_output_file` returns `TempFileGuard::new(begin.file_path.clone())` with `needs_rename = false` for both `is_device_target` and `is_inplace`. `TempFileGuard::new` sets `keep_on_drop = false`, so its `Drop` calls `remove_file(path)`.
- On any error before commit - channel disconnect, `Abort`, `Shutdown`, or a mid-loop `?` from `write_chunk`/`sparse.write`/`make_writer` - the partial-retention step is gated `if bytes_written > 0 && needs_rename`. For inplace/device `needs_rename` is `false`, so retention is skipped and `drop(cleanup_guard)` runs `TempFileGuard::drop`, which unlinks the path = **the user's live destination**.

The synchronous (`sync.rs`) and async (`file_async.rs`) receivers are safe: they use `open_tmpfile` (temp + rename), so an aborted temp is discarded and the dest is untouched. Only the pipelined path wraps the real dest.

Result: a network drop mid-transfer on `--inplace` destroys the user's existing file, where upstream leaves the partial write.

## Upstream reference (source of truth)

`receiver.c:1054`: `else if (!one_inplace) do_unlink_at(fnametmp);` - upstream unlinks the destination only when `!one_inplace`, i.e. **never for `--inplace`**. A partial inplace write is left in place (the documented `--inplace` risk the user opted into, not an invented deletion).

## Fix

Add `TempFileGuard::keep_dest()`, which constructs the guard already keep-on-drop, and use it for the inplace and device paths in `open_output_file`. An aborted inplace/device transfer now **leaves the partial destination in place** instead of deleting it, matching upstream. The temp+rename path is unchanged (its `Drop` still discards the temp file on error). The success path calls `keep()` unconditionally - an idempotent no-op here - so committed transfers are byte-identical.

## Regression tests

- `inplace_abort_does_not_delete_existing_destination`: aborts an inplace transfer to a pre-existing dest mid-stream and asserts the dest **still exists** afterward (the whole fix).
- `non_inplace_abort_discards_temp_and_leaves_existing_dest` (control): an aborted non-inplace transfer still discards its temp file and leaves any pre-existing dest untouched, proving the fix is scoped to the inplace guard and does not weaken temp-file cleanup.

## Verification

- `cargo build -p transfer`, `cargo clippy -p transfer --all-targets --no-deps -- -D warnings`: clean.
- `cargo test -p transfer --lib disk_commit -- --test-threads=1`: 103 passed. (The `CleanupManager` global-singleton tests race under parallel execution both before and after this change - a pre-existing artifact of the shared global, unrelated here.)
- New regression tests pass in isolation.
- All transfer integration `--test` targets compile; ran `uts_dd_symlink_dirlink_basis_topologies` (inplace wiring), `incremental_transfer`, `empty_file_handling`, `delta_applicator_equivalence`: all pass.

Advances #511.
