### PR TITLE
fix(core): match upstream error role trailers ([sender]/[generator]) and text

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -222,11 +222,13 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
             ClientError::with_code(code, message)
         }
         LocalCopyErrorKind::DeleteLimitExceeded { skipped } => {
+            // upstream: generator.c:2431 - the generator emits
+            // `Deletions stopped due to --max-delete limit (%d skipped)` via
+            // rprintf(FWARNING, ...) with no pluralized noun, so who_am_i()
+            // yields the `generator` role.
             let code = ExitCode::DeleteLimit;
-            let noun = if skipped == 1 { "entry" } else { "entries" };
-            let text =
-                format!("Deletions stopped due to --max-delete limit ({skipped} {noun} skipped)");
-            let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
+            let text = format!("Deletions stopped due to --max-delete limit ({skipped} skipped)");
+            let message = rsync_error!(code.as_i32(), text).with_role(Role::Generator);
             ClientError::with_code(code, message)
         }
         LocalCopyErrorKind::StopAtReached { .. } => {
@@ -256,8 +258,11 @@ pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientErr
         ExitCode::PartialTransfer
     };
     let path_display = path.display();
-    // upstream: flist.c:1289 - rprintf(c, "file has vanished: %s\n", full_fname(...));
-    // full_fname() wraps the path in double quotes (util1.c:1228).
+    // upstream: flist.c:1317 / sender.c:389 - rprintf(c, "file has vanished: %s\n",
+    // full_fname(...)). full_fname() wraps the path in double quotes (util1.c:1228).
+    // Both call sites (send_file_list building the flist and send_files opening a
+    // source file) run under am_sender, so who_am_i() yields the `sender` role for
+    // vanished (RERR_VANISHED) and per-file read I/O (RERR_PARTIAL) errors alike.
     let text = if error.kind() == io::ErrorKind::NotFound {
         format!("file has vanished: \"{path_display}\"")
     } else {
@@ -266,7 +271,7 @@ pub(crate) fn io_error(action: &str, path: &Path, error: io::Error) -> ClientErr
             upstream_io_error(&error)
         )
     };
-    let message = rsync_error!(code.as_i32(), text).with_role(Role::Client);
+    let message = rsync_error!(code.as_i32(), text).with_role(Role::Sender);
     ClientError::with_code(code, message)
 }
 
@@ -581,9 +586,11 @@ mod tests {
         }
 
         /// upstream: main.c:1338-1345 - non-NotFound I/O errors map to
-        /// RERR_PARTIAL (exit code 23).
+        /// RERR_PARTIAL (exit code 23). The per-file read failure is detected
+        /// by the sender (sender.c:393 send_files), so it carries the
+        /// `[sender]` role, not `[client]`.
         #[test]
-        fn io_error_non_notfound_uses_partial_transfer_code() {
+        fn io_error_non_notfound_uses_partial_transfer_code_and_sender_role() {
             let io_err = io::Error::new(ErrorKind::PermissionDenied, "permission denied");
             let error = io_error("read", Path::new("/test/file.txt"), io_err);
 
@@ -591,12 +598,15 @@ mod tests {
             let msg = error.to_string();
             assert!(msg.contains("failed to read"));
             assert!(msg.contains("/test/file.txt"));
+            assert!(msg.contains("[sender="), "{msg}");
         }
 
         /// upstream: main.c:1338-1345 - NotFound I/O errors map to
-        /// RERR_VANISHED (exit code 24).
+        /// RERR_VANISHED (exit code 24). Upstream emits `file has vanished`
+        /// from the sender (flist.c:1317 / sender.c:389), so who_am_i() tags
+        /// the diagnostic `[sender]`, not `[client]`.
         #[test]
-        fn io_error_notfound_uses_vanished_code() {
+        fn io_error_notfound_uses_vanished_code_and_sender_role() {
             let io_err = io::Error::new(ErrorKind::NotFound, "file not found");
             let error = io_error("read", Path::new("/test/file.txt"), io_err);
 
@@ -604,6 +614,7 @@ mod tests {
             let msg = error.to_string();
             assert!(msg.contains("file has vanished"));
             assert!(msg.contains("/test/file.txt"));
+            assert!(msg.contains("[sender="), "{msg}");
         }
 
         /// upstream: flist.c send_file_list() - a missing source argument

--- a/crates/core/src/client/tests/builder_metadata.rs
+++ b/crates/core/src/client/tests/builder_metadata.rs
@@ -356,12 +356,15 @@ fn builder_enables_stats() {
 
 #[test]
 fn map_local_copy_error_reports_delete_limit() {
+    // upstream: generator.c:2431 - `Deletions stopped due to --max-delete
+    // limit (%d skipped)` with the generator role and no pluralized noun.
     let mapped = map_local_copy_error(LocalCopyError::delete_limit_exceeded(2));
     assert_eq!(mapped.exit_code(), MAX_DELETE_EXIT_CODE);
     let rendered = mapped.message().to_string();
     assert!(
-        rendered.contains("Deletions stopped due to --max-delete limit (2 entries skipped)"),
+        rendered.contains("Deletions stopped due to --max-delete limit (2 skipped)"),
         "unexpected diagnostic: {rendered}"
     );
+    assert!(rendered.contains("[generator="), "unexpected diagnostic: {rendered}");
 }
 

--- a/crates/core/src/client/tests/error_helpers.rs
+++ b/crates/core/src/client/tests/error_helpers.rs
@@ -106,7 +106,12 @@ mod error_helper_tests {
     }
 
     #[test]
-    fn map_local_copy_error_for_delete_limit_handles_pluralisation() {
+    fn map_local_copy_error_for_delete_limit_matches_upstream_generator_wording() {
+        // upstream: generator.c:2431 emits `Deletions stopped due to
+        // --max-delete limit (%d skipped)` verbatim - no pluralized noun - and
+        // the message originates in the generator, so who_am_i() tags it
+        // `[generator]`. oc must reproduce both the exact wording (skip count,
+        // no invented `entry`/`entries` noun) and the generator role trailer.
         let singular = map_local_copy_error(LocalCopyError::delete_limit_exceeded(1));
         let plural = map_local_copy_error(LocalCopyError::delete_limit_exceeded(2));
 
@@ -116,8 +121,19 @@ mod error_helper_tests {
         let singular_rendered = render(&singular);
         let plural_rendered = render(&plural);
 
-        assert!(singular_rendered.contains("1 entry skipped"), "{singular_rendered}");
-        assert!(plural_rendered.contains("2 entries skipped"), "{plural_rendered}");
+        assert!(
+            singular_rendered
+                .contains("Deletions stopped due to --max-delete limit (1 skipped)"),
+            "{singular_rendered}"
+        );
+        assert!(
+            plural_rendered.contains("Deletions stopped due to --max-delete limit (2 skipped)"),
+            "{plural_rendered}"
+        );
+        assert!(singular_rendered.contains("[generator="), "{singular_rendered}");
+        assert!(plural_rendered.contains("[generator="), "{plural_rendered}");
+        assert!(!singular_rendered.contains("entry"), "{singular_rendered}");
+        assert!(!plural_rendered.contains("entries"), "{plural_rendered}");
     }
 
     #[test]

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -269,7 +269,9 @@ pub enum LocalCopyErrorKind {
         duration: Duration,
     },
     /// Deletions were halted because the configured limit was exceeded.
-    #[error("Deletions stopped due to --max-delete limit ({skipped} {} skipped)", if *skipped == 1 { "entry" } else { "entries" })]
+    // upstream: generator.c:2431 - `Deletions stopped due to --max-delete
+    // limit (%d skipped)` with no pluralized noun.
+    #[error("Deletions stopped due to --max-delete limit ({skipped} skipped)")]
     DeleteLimitExceeded {
         /// Number of entries that were skipped after reaching the limit.
         skipped: u64,
@@ -400,17 +402,22 @@ mod tests {
     }
 
     #[test]
-    fn local_copy_error_delete_limit_exceeded_message_singular() {
-        let error = LocalCopyError::delete_limit_exceeded(1);
-        let message = error.to_string();
-        assert!(message.contains("1 entry skipped"));
-    }
-
-    #[test]
-    fn local_copy_error_delete_limit_exceeded_message_plural() {
-        let error = LocalCopyError::delete_limit_exceeded(5);
-        let message = error.to_string();
-        assert!(message.contains("5 entries skipped"));
+    fn local_copy_error_delete_limit_exceeded_message_matches_upstream() {
+        // upstream: generator.c:2431 emits `Deletions stopped due to
+        // --max-delete limit (%d skipped)` verbatim with no `entry`/`entries`
+        // noun, so the count renders identically for one or many skips.
+        let one = LocalCopyError::delete_limit_exceeded(1).to_string();
+        let many = LocalCopyError::delete_limit_exceeded(5).to_string();
+        assert!(
+            one.contains("Deletions stopped due to --max-delete limit (1 skipped)"),
+            "{one}"
+        );
+        assert!(
+            many.contains("Deletions stopped due to --max-delete limit (5 skipped)"),
+            "{many}"
+        );
+        assert!(!one.contains("entry"), "{one}");
+        assert!(!many.contains("entries"), "{many}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix three error-output divergences vs upstream rsync 3.4.4 (protocol 32). Exit codes are unchanged; only the role trailer and message text move to match `who_am_i()` and the exact upstream wording. Advances #514.

## Divergence 1 - vanished / per-file read I/O: `[client]` -> `[sender]`

Upstream emits `file has vanished` and per-file read failures from the sender:
- `flist.c:1317` (`send_file_list`) and `sender.c:389` (`send_files`) emit `file has vanished: %s`.
- `sender.c:393` emits the per-file read failure (`send_files failed to open`).

Both run under `am_sender`, so `who_am_i()` returns `sender`. oc now tags the vanished (RERR_VANISHED, 24) and per-file read I/O (RERR_PARTIAL, 23) diagnostics `[sender]` instead of `[client]`.

## Divergence 2 - `--max-delete`: extra noun + `[client]` -> `[generator]`

Upstream `generator.c:2431`:
```c
rprintf(FWARNING, "Deletions stopped due to --max-delete limit (%d skipped)\n", skipped_deletes);
```
It is emitted by the generator (`who_am_i()` -> `generator`) with a bare `(%d skipped)` - no `entry`/`entries` noun.

Before/after (`oc-rsync -r --delete --max-delete=2`, 3 skipped):
```
before: oc-rsync error: Deletions stopped due to --max-delete limit (3 entries skipped) (code 25) ... [client=...]
after:  oc-rsync error: Deletions stopped due to --max-delete limit (3 skipped) (code 25) ... [generator=...]
```
Upstream for reference:
```
Deletions stopped due to --max-delete limit (3 skipped)
rsync error: the --max-delete limit stopped deletions (code 25) at main.c(1356) [sender=3.4.4]
```
The engine-side `LocalCopyError` Display for `DeleteLimitExceeded` is aligned to the same bare wording so the invented noun exists nowhere in the tree.

## Divergence 3 - clap arg errors (assessed, NOT changed)

Upstream renders option errors as two lines:
```
rsync: --badoption: unknown option
rsync error: syntax or usage error (code 1) at main.c(1806) [client=3.4.4]
```
oc folds the whole clap error into the single summary line. This is a symptom of oc's global error-summary render model (it also repeats the detail in the summary and lacks the inline `[role]` on line 1) rather than a localized clap issue, and clap cannot reproduce upstream's exact per-error wording (`--badoption: unknown option`). Reshaping it correctly is a broader error-render-model change that would touch many pinned output-fidelity tests, so it is intentionally left out of this role-trailer PR and noted for a dedicated follow-up.

## Tests

- `crates/core/src/client/error.rs`: `io_error_*` unit tests now assert the `[sender=` trailer (renamed to reflect intent).
- `crates/core/src/client/tests/error_helpers.rs`, `builder_metadata.rs`: assert the bare upstream wording + `[generator=` trailer, no invented noun.
- `crates/engine/src/local_copy/error.rs`: merged the singular/plural Display tests into one asserting the upstream wording (upstream has no plural form).

Verified locally: `cargo build`/`clippy -D warnings` clean on core+cli+engine; targeted `cargo test --lib` for the changed error-rendering tests pass; built binary reproduces the corrected output. Full test suite runs in CI (nextest); interop cell is the gate.