### PR TITLE
fix(transfer): unregister temp path from cleanup registry on guard drop (leak)

### DIFF
--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -23,10 +23,36 @@ pub use upstream_compat::{
     upstream_compat_enabled,
 };
 
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::Duration;
 
 use tempfile::TempDir;
+
+/// Process-global mutex serializing tests that touch the shared
+/// `engine::CleanupManager` registry (a `OnceLock<Mutex<HashSet>>` singleton).
+///
+/// Because the registry is process-global and tests call `reset_for_testing`
+/// / `register_temp_file` on it, concurrent tests otherwise stomp on each
+/// other's state. Acquiring this guard for the duration of such a test
+/// serializes them without hiding any production race: the registry itself is
+/// mutex-protected and thread-safe; only the test-side `reset`/count
+/// expectations are order-sensitive.
+fn cleanup_registry_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Acquires the process-global cleanup-registry test lock, serializing any
+/// test that mutates the shared `engine::CleanupManager`.
+///
+/// Hold the returned guard for the whole test body. The lock is poison-tolerant
+/// so a panicking test does not deadlock the rest of the suite.
+pub fn cleanup_registry_test_guard() -> MutexGuard<'static, ()> {
+    cleanup_registry_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// Creates a temporary directory with retry logic for transient OS errors.
 ///

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -63,16 +63,15 @@ pub(in crate::disk_commit) fn process_file(
             return discard_file_on_open_failure(file_rx, buf_return_tx, open_err);
         }
     };
-    if needs_rename {
-        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
-    }
-
     // Register the temp file with the global cleanup manager so a SIGKILL
     // (which bypasses Drop) still removes orphaned temp files on restart.
     // Only temp+rename paths produce actual temp files; inplace and device
-    // writes operate on the final destination.
+    // writes operate on the final destination. The guard records its
+    // registration so its Drop unregisters the path on both success and error,
+    // preventing a per-errored-file PathBuf leak into the global set.
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
+        cleanup_guard.mark_registered();
     }
 
     let mut output = make_writer(
@@ -272,10 +271,7 @@ pub(in crate::disk_commit) fn process_whole_file(
     let (file, mut cleanup_guard, needs_rename) = open_output_file(&begin, config)?;
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
-    }
-
-    if needs_rename {
-        CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
+        cleanup_guard.mark_registered();
     }
 
     let mut output = make_writer(

--- a/crates/transfer/src/disk_commit/tests.rs
+++ b/crates/transfer/src/disk_commit/tests.rs
@@ -990,6 +990,7 @@ fn partial_mode_relative_partial_dir() {
 /// before exit, removing temp files that never reached the commit+rename step.
 #[test]
 fn cleanup_manager_removes_orphaned_temp_files_on_simulated_signal() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 
@@ -1079,6 +1080,7 @@ fn cleanup_manager_removes_orphaned_temp_files_on_simulated_signal() {
 /// This is the counterpart to the orphan test: committed files must survive.
 #[test]
 fn cleanup_manager_unregisters_on_successful_commit() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 
@@ -1133,6 +1135,7 @@ fn cleanup_manager_unregisters_on_successful_commit() {
 /// orphaned. Only the orphan should be removed by `cleanup()`.
 #[test]
 fn cleanup_manager_mixed_committed_and_orphaned_files() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 
@@ -1247,6 +1250,7 @@ fn cleanup_manager_mixed_committed_and_orphaned_files() {
 /// from `CleanupManager` after commit, matching the chunked path behavior.
 #[test]
 fn cleanup_manager_whole_file_unregisters_on_commit() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 
@@ -1296,6 +1300,7 @@ fn cleanup_manager_whole_file_unregisters_on_commit() {
 /// so there is no orphan temp file to clean up.
 #[test]
 fn cleanup_manager_inplace_skips_registration() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 

--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -458,6 +458,7 @@ fn parity_zero_bytes_suppresses_partial_dir_retention() {
 /// after rename, so cleanup must not try to remove it.
 #[test]
 fn parity_partial_retention_unregisters_from_cleanup_manager() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 
@@ -504,6 +505,7 @@ fn parity_partial_retention_unregisters_from_cleanup_manager() {
 /// into the partial directory. The original temp path must be unregistered.
 #[test]
 fn parity_partial_dir_retention_unregisters_from_cleanup_manager() {
+    let _registry_lock = test_support::cleanup_registry_test_guard();
     let manager = engine::CleanupManager::global();
     manager.reset_for_testing();
 

--- a/crates/transfer/src/receiver/transfer/file_async.rs
+++ b/crates/transfer/src/receiver/transfer/file_async.rs
@@ -245,6 +245,7 @@ impl ReceiverContext {
             }
         };
         CleanupManager::global().register_temp_file(temp_guard.path().to_path_buf());
+        temp_guard.mark_registered();
 
         let file_verifier = ChecksumVerifier::new(
             self.negotiated_algorithms.as_ref(),

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -257,6 +257,7 @@ impl ReceiverContext {
                 }
             };
             CleanupManager::global().register_temp_file(temp_guard.path().to_path_buf());
+            temp_guard.mark_registered();
 
             let use_sparse = self.config.flags.sparse;
 

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -276,6 +276,13 @@ struct SandboxAnchor {
 pub struct TempFileGuard {
     path: PathBuf,
     keep_on_drop: bool,
+    /// When `true`, this path was registered with the global
+    /// [`engine::CleanupManager`] and Drop must remove it from the registry
+    /// after the file is deleted-or-committed, so an errored transfer does not
+    /// leak its `PathBuf` into the process-global set forever.
+    ///
+    /// [`mark_registered`]: TempFileGuard::mark_registered
+    registered: bool,
     /// SEC-1.r sandbox anchor: when present, Drop routes the unlink through
     /// `unlinkat(sandbox.current_dirfd(), leaf, 0)` so a symlink swap on the
     /// temp parent between create and unlink cannot redirect the cleanup.
@@ -294,6 +301,7 @@ impl TempFileGuard {
         Self {
             path,
             keep_on_drop: false,
+            registered: false,
             #[cfg(unix)]
             anchor: None,
         }
@@ -315,6 +323,7 @@ impl TempFileGuard {
         Self {
             path,
             keep_on_drop: true,
+            registered: false,
             #[cfg(unix)]
             anchor: None,
         }
@@ -350,6 +359,7 @@ impl TempFileGuard {
         Self {
             path,
             keep_on_drop: false,
+            registered: false,
             anchor,
         }
     }
@@ -358,6 +368,24 @@ impl TempFileGuard {
     #[inline]
     pub const fn keep(&mut self) {
         self.keep_on_drop = true;
+    }
+
+    /// Record that this guard's path was registered with the global
+    /// [`engine::CleanupManager`].
+    ///
+    /// Callers that register the temp path for signal-handler cleanup must
+    /// call this so the guard's Drop removes the path from the registry once
+    /// the file has been deleted-or-committed. This closes the leak where an
+    /// errored transfer's `PathBuf` stayed in the process-global set forever
+    /// in a long-running daemon.
+    ///
+    /// The signal-handler contract is preserved: the entry is removed only in
+    /// Drop, after the file is unlinked (error path) or has been committed
+    /// (kept path), so a SIGINT before Drop still finds the in-flight temp
+    /// registered and cleans it up.
+    #[inline]
+    pub const fn mark_registered(&mut self) {
+        self.registered = true;
     }
 
     /// Get the path to the temp file.
@@ -442,7 +470,13 @@ fn is_cross_device_error(e: &io::Error) -> bool {
 
 impl Drop for TempFileGuard {
     fn drop(&mut self) {
+        // Delete the temp file first (unless kept), then remove the path from
+        // the global cleanup registry. Ordering matters: a SIGINT arriving
+        // before this Drop still finds the in-flight temp registered and
+        // cleans it; once the file is unlinked-or-committed here it no longer
+        // needs a registry entry, so leaving it in would leak the PathBuf.
         if self.keep_on_drop {
+            self.unregister();
             return;
         }
         // Best-effort: the file may never have been created, may already be renamed
@@ -459,11 +493,26 @@ impl Drop for TempFileGuard {
                         &self.path,
                         fast_io::UnlinkFlags::File,
                     );
+                    self.unregister();
                     return;
                 }
             }
         }
         let _ = std::fs::remove_file(&self.path);
+        self.unregister();
+    }
+}
+
+impl TempFileGuard {
+    /// Removes this guard's path from the global [`engine::CleanupManager`]
+    /// registry when it was registered. Idempotent: `HashSet::remove` is a
+    /// no-op for an absent key, so a double-unregister (e.g. an explicit
+    /// pre-`keep` unregister followed by this Drop) is harmless.
+    #[inline]
+    fn unregister(&self) {
+        if self.registered {
+            engine::CleanupManager::global().unregister_temp_file(&self.path);
+        }
     }
 }
 
@@ -939,5 +988,99 @@ mod tests {
         let result = guard.rename_to_partial_dir(Path::new("/"), &partial_dir);
 
         assert!(result.is_err());
+    }
+
+    /// Regression (#515): an errored transfer's temp path must be removed from
+    /// the global `CleanupManager` when the guard drops, otherwise a
+    /// long-running daemon leaks a `PathBuf` per errored file forever. The
+    /// guard is registered, then dropped WITHOUT `keep()` (the error path);
+    /// after Drop the registry must no longer contain the path.
+    #[test]
+    fn errored_guard_unregisters_from_cleanup_manager_on_drop() {
+        let _lock = test_support::cleanup_registry_test_guard();
+        let manager = engine::CleanupManager::global();
+        manager.reset_for_testing();
+
+        let dir = tempdir().expect("create temp dir");
+        let temp_path = dir.path().join(".errored.AbCdEf");
+        fs::write(&temp_path, b"partial data").unwrap();
+
+        {
+            let mut guard = TempFileGuard::new(temp_path.clone());
+            manager.register_temp_file(temp_path.clone());
+            guard.mark_registered();
+            assert_eq!(manager.temp_file_count(), 1);
+            // Guard drops here on the error path (no keep()).
+        }
+
+        assert_eq!(
+            manager.temp_file_count(),
+            0,
+            "errored guard must unregister its temp path from CleanupManager on drop"
+        );
+        assert!(
+            !temp_path.exists(),
+            "errored guard must still delete the temp file on drop"
+        );
+    }
+
+    /// The kept (success) path must also leave the registry clean after Drop.
+    /// The guard is registered and marked kept; on Drop it does not delete the
+    /// (committed) file but must remove the stale registry entry.
+    #[test]
+    fn kept_guard_unregisters_from_cleanup_manager_on_drop() {
+        let _lock = test_support::cleanup_registry_test_guard();
+        let manager = engine::CleanupManager::global();
+        manager.reset_for_testing();
+
+        let dir = tempdir().expect("create temp dir");
+        let temp_path = dir.path().join(".kept.XyZ123");
+        fs::write(&temp_path, b"committed data").unwrap();
+
+        {
+            let mut guard = TempFileGuard::new(temp_path.clone());
+            manager.register_temp_file(temp_path.clone());
+            guard.mark_registered();
+            guard.keep();
+        }
+
+        assert_eq!(
+            manager.temp_file_count(),
+            0,
+            "kept guard must unregister its temp path from CleanupManager on drop"
+        );
+        assert!(
+            temp_path.exists(),
+            "kept guard must not delete the committed file on drop"
+        );
+        fs::remove_file(&temp_path).ok();
+    }
+
+    /// An unregistered guard (e.g. an in-place / device target that was never
+    /// registered) must not touch the registry on Drop.
+    #[test]
+    fn unregistered_guard_leaves_cleanup_manager_untouched() {
+        let _lock = test_support::cleanup_registry_test_guard();
+        let manager = engine::CleanupManager::global();
+        manager.reset_for_testing();
+
+        let other = PathBuf::from("/tmp/.unrelated.Aa0000");
+        manager.register_temp_file(other.clone());
+
+        let dir = tempdir().expect("create temp dir");
+        let temp_path = dir.path().join(".never_registered.Zz9999");
+        fs::write(&temp_path, b"data").unwrap();
+
+        {
+            // No mark_registered(): Drop must not remove any registry entry.
+            let _guard = TempFileGuard::new(temp_path);
+        }
+
+        assert_eq!(
+            manager.temp_file_count(),
+            1,
+            "an unregistered guard must not disturb other registry entries on drop"
+        );
+        manager.unregister_temp_file(&other);
     }
 }

--- a/crates/transfer/src/transfer_ops/response.rs
+++ b/crates/transfer/src/transfer_ops/response.rs
@@ -107,6 +107,7 @@ pub fn process_file_response<R: Read>(
 
     if needs_rename {
         CleanupManager::global().register_temp_file(cleanup_guard.path().to_path_buf());
+        cleanup_guard.mark_registered();
     }
 
     // upstream: receiver.c:307-308 - in append mode, seek past existing content


### PR DESCRIPTION
## The leak

`TempFileGuard::drop` deleted the temp file from disk but never removed its path from the process-global `CleanupManager` `HashSet`. The matching `unregister_temp_file` was called only on the success branch (before `keep()`), so every errored transfer leaked its `PathBuf` into the global set forever:

- delta-apply error, checksum-redo, sparse-size mismatch, fsync/rename failure
- partial-dir / partial retention rename failure (the `Err` branches of `retain_partial_file` unlink the temp on drop but left the registry entry behind)

In a long-running thread-per-connection daemon this accumulates unboundedly.

## The fix

`TempFileGuard` now tracks whether its path was registered (`registered` flag, set via `mark_registered()` at each register site) and removes it from the registry in `Drop` after the file is deleted (error path) or committed (kept path).

Ordering is deliberate: the file is unlinked-or-committed **first**, then the registry entry is removed. A SIGINT arriving before `Drop` still finds the in-flight temp registered and cleans it; only a dropped temp is unregistered. `HashSet::remove` is idempotent, so the existing explicit unregister-before-`keep` calls on the success paths remain correct and are now belt-and-suspenders.

## Signal-cleanup contract preserved

A temp still in-flight (guard not yet dropped) stays registered so a SIGINT cleans it; only dropped (deleted-or-committed) temps are unregistered. No change to actual file deletion or commit. `core` signal-integration and `sigint_temp_cleanup` tests pass.

## Duplicate-block cleanup

`disk_commit/process/file_ops.rs` had two identical `register_temp_file` blocks in each of `process_file` and `process_whole_file` (harmless due to `HashSet` dedup, but dead). Removed the duplicates.

## Tests

- New regression tests in `temp_guard.rs`: an **errored** guard, a **kept** guard, and an **unregistered** guard, asserting registry membership after `Drop`.
- The pre-existing `cleanup_manager_*` / `parity_*_cleanup_manager` tests raced under parallel execution because they mutate the process-global singleton (`reset_for_testing` + destructive `cleanup()`). They now serialize through a shared `test_support::cleanup_registry_test_guard()` lock, which removes that cross-test state bleed without masking a real bug (the registry itself is mutex-protected and thread-safe).

Advances #515.