### PR TITLE
feat(fast_io): anchor sandbox ops on full parent path via RESOLVE_BENEATH (TOCTOU)

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -8,11 +8,12 @@
 
 use std::ffi::{CString, OsStr};
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
 use super::lstat::single_component_leaf;
+use super::nested::{ParentAnchor, anchor_parent};
 
 /// Issue `mkdirat(dirfd, name, mode)`.
 ///
@@ -192,6 +193,11 @@ pub fn mkdirat_via_sandbox_or_fallback(
     {
         return mkdirat(sandbox.current_dirfd(), leaf, mode);
     }
+    if let ParentAnchor::Anchored { dirfd, name } =
+        anchor_parent(sandbox, dest_dir, relative_path, dir_path)?
+    {
+        return mkdirat(dirfd.as_fd(), name, mode);
+    }
     std::fs::create_dir(dir_path)
 }
 
@@ -223,6 +229,11 @@ pub fn symlinkat_via_sandbox_or_fallback(
         && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
     {
         return symlinkat(target, sandbox.current_dirfd(), leaf);
+    }
+    if let ParentAnchor::Anchored { dirfd, name } =
+        anchor_parent(sandbox, dest_dir, relative_path, link_path)?
+    {
+        return symlinkat(target, dirfd.as_fd(), name);
     }
     std::os::unix::fs::symlink(target, link_path)
 }
@@ -282,6 +293,37 @@ pub fn linkat_via_sandbox_or_fallback(
                 libc::AT_FDCWD,
                 leader_c.as_ptr(),
                 sandbox.current_dirfd().as_raw_fd(),
+                new_c.as_ptr(),
+                0,
+            )
+        };
+        return if rc == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        };
+    }
+    if let ParentAnchor::Anchored { dirfd, name } =
+        anchor_parent(sandbox, dest_dir, new_relative, new_path)?
+    {
+        // Same shape as the single-component branch: the new parent is
+        // pinned by the RESOLVE_BENEATH-resolved dirfd, the leader stays
+        // on `AT_FDCWD` because it may live outside `dest_dir`.
+        let leader_c = CString::new(leader_path.as_os_str().as_bytes())
+            .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+        let new_c = CString::new(name.as_bytes())
+            .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+        // SAFETY:
+        // - `dirfd.as_fd()` outlives the syscall (owned by `dirfd`).
+        // - Both C strings are valid NUL-terminated and borrowed for
+        //   the duration of the call.
+        // - `flags == 0` matches the standard rsync hardlink shape.
+        #[allow(unsafe_code)]
+        let rc = unsafe {
+            libc::linkat(
+                libc::AT_FDCWD,
+                leader_c.as_ptr(),
+                dirfd.as_fd().as_raw_fd(),
                 new_c.as_ptr(),
                 0,
             )

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/lstat.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/lstat.rs
@@ -10,10 +10,12 @@
 
 use std::ffi::OsStr;
 use std::io;
+use std::os::fd::AsFd;
 use std::path::Path;
 
 use super::AtMetadata;
 use super::metadata::fstatat_nofollow;
+use super::nested::{ParentAnchor, anchor_parent};
 
 /// Result of [`lstat_via_sandbox_or_fallback`].
 ///
@@ -78,6 +80,11 @@ pub fn lstat_via_sandbox_or_fallback(
         && let Some(leaf) = single_component_leaf(dest_dir, relative_path, link_path)
     {
         return fstatat_nofollow(sandbox.current_dirfd(), leaf).map(LstatOutcome::At);
+    }
+    if let ParentAnchor::Anchored { dirfd, name } =
+        anchor_parent(sandbox, dest_dir, relative_path, link_path)?
+    {
+        return fstatat_nofollow(dirfd.as_fd(), name).map(LstatOutcome::At);
     }
     std::fs::symlink_metadata(link_path).map(LstatOutcome::Std)
 }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -34,6 +34,7 @@ mod create;
 mod lstat;
 mod metadata;
 mod metadata_ops;
+mod nested;
 mod open;
 mod read_dir;
 mod rename;

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/nested.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/nested.rs
@@ -1,0 +1,226 @@
+//! Nested-path parent anchoring for the `*_via_sandbox_or_fallback`
+//! helpers.
+//!
+//! The single-component fast path in [`single_component_leaf`] pins the
+//! leaf on the sandbox parent dirfd but leaves multi-component relative
+//! paths (`a/b/leaf`) to re-resolve every interior component through the
+//! ambient namespace on a path-based `std::fs` call. That re-resolution
+//! is a TOCTOU hole: an attacker who swaps an *interior* directory
+//! (`a/b`) for a symlink between the receiver's decide-to-act moment and
+//! the syscall can redirect the leaf op outside the module root.
+//!
+//! [`anchor_parent`] closes that hole by opening the **parent**
+//! directory of the leaf through `openat2(2)` with `RESOLVE_BENEATH`,
+//! anchored on
+//! [`current_dirfd`](crate::dir_sandbox::DirSandbox::current_dirfd), then
+//! handing the caller a parent [`OwnedFd`] plus the leaf name so it can
+//! issue the terminal `*at` op (`symlinkat`, `linkat`, `unlinkat`,
+//! `renameat`, `fstatat`) with `O_NOFOLLOW` semantics against that fd.
+//!
+//! This mirrors upstream rsync's `secure_relative_open()` (see
+//! `syscall.c:secure_relative_open_linux`, gated on
+//! `am_daemon && !am_chrooted`), which opens the parent under
+//! `openat2(RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)` and then performs
+//! the leaf op against the resulting dirfd. `RESOLVE_BENEATH` (not
+//! `RESOLVE_NO_SYMLINKS`) is the deliberate choice: legitimate in-tree
+//! symlinks along the path stay resolvable, only escapes beneath the
+//! anchor are refused with `EXDEV`.
+
+use std::ffi::OsStr;
+use std::io;
+use std::os::fd::OwnedFd;
+use std::path::{Component, Path};
+
+/// Outcome of [`anchor_parent`].
+///
+/// Distinguishes the two cases the caller must handle differently so the
+/// single-component fast path and the graceful-degradation contract stay
+/// byte-identical to today's behaviour.
+pub(super) enum ParentAnchor<'a> {
+    /// The parent was resolved under `RESOLVE_BENEATH`. The caller
+    /// issues the terminal `*at` op against `dirfd` with the leaf
+    /// `name`.
+    ///
+    /// Only constructed on Linux (via `openat2`); on other Unix targets
+    /// [`anchor_parent`] always returns [`ParentAnchor::Fallback`], so
+    /// the variant is dead there but still referenced by the callers'
+    /// `match` arms.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    Anchored {
+        /// Owned parent dirfd; kept alive by the caller for the
+        /// duration of the leaf op.
+        dirfd: OwnedFd,
+        /// Leaf component to pass to the terminal `*at` op.
+        name: &'a OsStr,
+    },
+    /// Nested anchoring is unavailable on this platform/kernel (no
+    /// `openat2`, or `RESOLVE_BENEATH` unsupported) or does not apply
+    /// (single-component path, no sandbox, path mismatch). The caller
+    /// takes its current single-component-or-path-based behaviour
+    /// unchanged.
+    Fallback,
+}
+
+/// Resolve the parent directory of a multi-component relative path under
+/// `RESOLVE_BENEATH`, anchored on the sandbox's current dirfd.
+///
+/// Returns:
+/// - [`ParentAnchor::Anchored`] with the parent dirfd + leaf name when
+///   `sandbox` is `Some`, `full_path == dest_dir.join(relative_path)`,
+///   `relative_path` has two or more `Normal` components, and the kernel
+///   resolved the parent beneath the root.
+/// - [`ParentAnchor::Fallback`] when there is no sandbox, the path is a
+///   single component, the reconstructed path does not match, the
+///   relative path contains a non-`Normal` component (`..`, `.`,
+///   absolute prefix), or `openat2` / `RESOLVE_BENEATH` is unavailable
+///   on the running kernel. In every `Fallback` case the caller keeps
+///   its existing behaviour exactly.
+///
+/// # Errors
+///
+/// Propagates the `openat2(2)` error when the parent open reaches the
+/// kernel and is refused for a *security* reason: `EXDEV` (a `..` or
+/// symlink escape beneath the anchor), `ELOOP`, `ENOENT` (missing
+/// interior component), `ENOTDIR`. These are deliberate refusals - the
+/// caller must **not** fall back to a path-based syscall on this error,
+/// because doing so would re-open the TOCTOU window the anchor closes.
+/// Only `ENOSYS` / `EINVAL` on the resolve flags are folded into
+/// [`ParentAnchor::Fallback`] (kernel lacks the capability).
+pub(super) fn anchor_parent<'a>(
+    sandbox: Option<&crate::dir_sandbox::DirSandbox>,
+    dest_dir: &Path,
+    relative_path: &'a Path,
+    full_path: &Path,
+) -> io::Result<ParentAnchor<'a>> {
+    let Some(sandbox) = sandbox else {
+        return Ok(ParentAnchor::Fallback);
+    };
+    // Every component must be a plain name. A `..`, `.`, or absolute
+    // prefix means we cannot safely split into parent + leaf here, so we
+    // defer to the caller's existing behaviour (path-based). Receiver
+    // relative paths are flist-derived leaf names and never contain
+    // these, so this is a defensive gate, not a hot-path branch.
+    let mut names: Vec<&OsStr> = Vec::new();
+    for comp in relative_path.components() {
+        match comp {
+            Component::Normal(name) => names.push(name),
+            _ => return Ok(ParentAnchor::Fallback),
+        }
+    }
+    // Single component (or empty) is the existing fast path; let the
+    // caller handle it byte-identically.
+    if names.len() < 2 {
+        return Ok(ParentAnchor::Fallback);
+    }
+    // The absolute path the caller intends to act on must be exactly the
+    // sandbox root joined with the relative path; otherwise the sandbox
+    // dirfd is the wrong anchor and we must not act against it.
+    if dest_dir.join(relative_path) != full_path {
+        return Ok(ParentAnchor::Fallback);
+    }
+
+    let (leaf, parent_names) = names.split_last().expect("len >= 2 checked above");
+    let parent_rel: std::path::PathBuf = parent_names.iter().collect();
+
+    #[cfg(target_os = "linux")]
+    {
+        use crate::linux_capabilities::openat2_supported;
+        if openat2_supported() {
+            return match linux::openat2_parent_beneath(sandbox.current_dirfd(), &parent_rel) {
+                Ok(Some(dirfd)) => Ok(ParentAnchor::Anchored { dirfd, name: leaf }),
+                // ENOSYS / EINVAL: capability absent, degrade gracefully.
+                Ok(None) => Ok(ParentAnchor::Fallback),
+                // Deliberate refusal (EXDEV/ELOOP/ENOENT/ENOTDIR): the
+                // op must fail, never silently re-resolve via a path.
+                Err(err) => Err(err),
+            };
+        }
+        Ok(ParentAnchor::Fallback)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        // No kernel-supported beneath-confinement on non-Linux Unix;
+        // keep today's path-based behaviour.
+        let _ = (sandbox, leaf, parent_rel);
+        Ok(ParentAnchor::Fallback)
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::ffi::CString;
+    use std::io;
+    use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    /// `openat2(parent_fd, parent_rel, RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)`
+    /// returning the opened parent directory fd.
+    ///
+    /// `RESOLVE_BENEATH` allows legitimate in-tree symlinks along
+    /// `parent_rel` but refuses any component (symlink target or `..`)
+    /// that would escape beneath `parent_fd`, matching upstream
+    /// `secure_relative_open_linux`. `RESOLVE_NO_MAGICLINKS` refuses
+    /// `/proc`-style magic links, also matching upstream.
+    ///
+    /// Returns `Ok(None)` only on `ENOSYS` (kernel lacks the syscall
+    /// despite the probe) or `EINVAL` (resolve flags unsupported), so
+    /// the caller can degrade to path-based resolution. Every other
+    /// error is a deliberate refusal and is returned verbatim.
+    pub(super) fn openat2_parent_beneath(
+        parent_fd: BorrowedFd<'_>,
+        parent_rel: &Path,
+    ) -> io::Result<Option<OwnedFd>> {
+        let c_rel = CString::new(parent_rel.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "parent path contains interior null byte",
+            )
+        })?;
+
+        // SAFETY: mirrors `dir_sandbox::linux::openat2_beneath`.
+        //
+        // 1. `std::mem::zeroed::<open_how>()` - `libc::open_how` is
+        //    `#[non_exhaustive]`; the all-zero pattern is the documented
+        //    "no constraint" value for every field, which we then
+        //    override explicitly.
+        // 2. `libc::syscall(SYS_openat2, ...)` - `parent_fd.as_raw_fd()`
+        //    is a live borrowed fd outliving the call; `c_rel` is a
+        //    valid NUL-terminated C string borrowed for the call; `how`
+        //    is fully initialised and handed to the kernel with its size
+        //    per the ABI. The kernel retains no pointer past return. A
+        //    non-negative return is a fresh owned fd with `O_CLOEXEC`.
+        // 3. `OwnedFd::from_raw_fd(raw)` - sole owner of the returned
+        //    fd; never aliased or leaked.
+        #[allow(unsafe_code)]
+        let raw = unsafe {
+            let mut how: libc::open_how = std::mem::zeroed();
+            how.flags = (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
+            how.mode = 0;
+            how.resolve = libc::RESOLVE_BENEATH | libc::RESOLVE_NO_MAGICLINKS;
+
+            libc::syscall(
+                libc::SYS_openat2,
+                parent_fd.as_raw_fd(),
+                c_rel.as_ptr(),
+                &how as *const libc::open_how,
+                std::mem::size_of::<libc::open_how>(),
+            )
+        };
+
+        if raw >= 0 {
+            // SAFETY: `raw` is a non-negative fd just returned by
+            // `openat2(2)` with `O_CLOEXEC`; sole owner.
+            #[allow(unsafe_code)]
+            let fd = unsafe { OwnedFd::from_raw_fd(raw as libc::c_int) };
+            return Ok(Some(fd));
+        }
+
+        let err = io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::ENOSYS) | Some(libc::EINVAL) => Ok(None),
+            _ => Err(err),
+        }
+    }
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/rename.rs
@@ -9,11 +9,12 @@
 
 use std::ffi::{CString, OsStr};
 use std::io;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
 use super::lstat::single_component_leaf;
+use super::nested::{ParentAnchor, anchor_parent};
 
 /// `RENAME_NOREPLACE` from `renameat2(2)`.
 ///
@@ -177,6 +178,34 @@ pub fn renameat_via_sandbox_or_fallback(
     {
         let dirfd = sandbox.current_dirfd();
         return renameat(dirfd, old_leaf, dirfd, new_leaf, replace);
+    }
+    // Nested paths: anchor each endpoint's parent under RESOLVE_BENEATH.
+    // Both must anchor for the rename to be confined; if either endpoint
+    // is single-component or anchoring is unavailable we drop to the
+    // path-based fallback rather than mixing an anchored and an ambient
+    // endpoint (which would leave one side re-resolvable).
+    if sandbox.is_some() {
+        let old_anchor = anchor_parent(sandbox, old_dest_dir, old_relative_path, old_link_path)?;
+        let new_anchor = anchor_parent(sandbox, new_dest_dir, new_relative_path, new_link_path)?;
+        if let (
+            ParentAnchor::Anchored {
+                dirfd: old_dirfd,
+                name: old_leaf,
+            },
+            ParentAnchor::Anchored {
+                dirfd: new_dirfd,
+                name: new_leaf,
+            },
+        ) = (old_anchor, new_anchor)
+        {
+            return renameat(
+                old_dirfd.as_fd(),
+                old_leaf,
+                new_dirfd.as_fd(),
+                new_leaf,
+                replace,
+            );
+        }
     }
     std::fs::rename(old_link_path, new_link_path)
 }

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -1509,3 +1509,230 @@ fn read_dir_view_via_sandbox_matches_std_for_subdir_listing() {
 
     assert_eq!(at_names, std_names, "sandbox and std listings must agree");
 }
+
+// ---------------------------------------------------------------------
+// SEC nested-path parent anchoring (RESOLVE_BENEATH) tests.
+//
+// These cover the interior-directory TOCTOU gap the single-component
+// fast path could not close: for `dest/a/b/leaf` the leaf op must be
+// confined to a parent resolved beneath the sandbox root, so a swapped
+// interior symlink (`a/b -> outside`) cannot redirect the op. On Linux
+// 5.6+ the anchor refuses the escape in-kernel (EXDEV/ELOOP/ENOTDIR);
+// on kernels/platforms without openat2 the helper degrades to today's
+// path-based behaviour, which these tests account for.
+
+/// Returns whether `openat2(RESOLVE_BENEATH)` anchoring is live on this
+/// host. Off implies the graceful path-based fallback is exercised.
+fn nested_anchor_live() -> bool {
+    cfg!(target_os = "linux") && crate::linux_capabilities::openat2_supported()
+}
+
+#[test]
+fn nested_symlinkat_via_sandbox_creates_under_interior_dir() {
+    // Legitimate nested create: `a/b/link` with real interior dirs must
+    // succeed and place the symlink exactly under the resolved parent.
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir_all(root.join("a/b")).expect("mkdir a/b");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("a/b/link");
+    let link_path = root.join(rel);
+    symlinkat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &root,
+        rel,
+        &link_path,
+        Path::new("../target"),
+    )
+    .expect("nested symlinkat");
+
+    let meta = std::fs::symlink_metadata(&link_path).expect("stat link");
+    assert!(meta.is_symlink(), "nested symlink must be created");
+}
+
+#[test]
+fn nested_symlinkat_via_sandbox_allows_legit_intree_symlink() {
+    // RESOLVE_BENEATH must NOT reject an in-tree symlink along the path:
+    // `a/blink -> b` (both inside root) is legitimate and the create at
+    // `a/blink/link` must resolve through it to `a/b/link`.
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir_all(root.join("a/b")).expect("mkdir a/b");
+    // In-tree relative symlink a/blink -> b.
+    symlink("b", root.join("a/blink")).expect("plant in-tree symlink");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("a/blink/link");
+    let link_path = root.join(rel);
+    symlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link_path, Path::new("t"))
+        .expect("create through in-tree symlink must succeed");
+
+    // The real entry lands under the resolved directory a/b.
+    let resolved = root.join("a/b/link");
+    assert!(
+        std::fs::symlink_metadata(&resolved).is_ok(),
+        "entry must exist under the symlink target dir a/b"
+    );
+}
+
+#[test]
+fn nested_symlinkat_via_sandbox_refuses_interior_symlink_escape() {
+    // The keystone security assertion: an interior directory swapped for
+    // a symlink pointing OUTSIDE the root must not let the create escape.
+    let (_keep, root) = canonical_tempdir();
+    let outside = root.join("outside");
+    std::fs::create_dir(&outside).expect("mkdir outside");
+    std::fs::create_dir(root.join("a")).expect("mkdir a");
+    // a/evil -> ../outside : an interior-component symlink that escapes
+    // beneath the sandbox root.
+    symlink(&outside, root.join("a/evil")).expect("plant escaping symlink");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("a/evil/pwned");
+    let link_path = root.join(rel);
+    let result = symlinkat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &root,
+        rel,
+        &link_path,
+        Path::new("payload"),
+    );
+
+    if nested_anchor_live() {
+        let err = result.expect_err("interior symlink escape must be refused");
+        let raw = err.raw_os_error();
+        assert!(
+            matches!(
+                raw,
+                Some(libc::EXDEV) | Some(libc::ELOOP) | Some(libc::ENOTDIR)
+            ),
+            "expected EXDEV/ELOOP/ENOTDIR, got {raw:?}"
+        );
+        assert!(
+            !outside.join("pwned").exists(),
+            "no entry may be created outside the root"
+        );
+    } else {
+        // Without openat2 the helper degrades to the path-based fallback,
+        // which follows the symlink (today's behaviour). Assert only that
+        // the call is total; the security guarantee is the Linux gate.
+        let _ = result;
+    }
+}
+
+#[test]
+fn nested_unlinkat_via_sandbox_refuses_interior_symlink_escape() {
+    // Deleting `a/evil/victim` where `a/evil -> outside` must not reach
+    // the outside file when anchoring is live.
+    let (_keep, root) = canonical_tempdir();
+    let outside = root.join("outside");
+    std::fs::create_dir(&outside).expect("mkdir outside");
+    let victim = outside.join("victim");
+    std::fs::write(&victim, b"keep me").expect("write victim");
+    std::fs::create_dir(root.join("a")).expect("mkdir a");
+    symlink(&outside, root.join("a/evil")).expect("plant escaping symlink");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("a/evil/victim");
+    let link_path = root.join(rel);
+    let result =
+        unlink_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link_path, UnlinkFlags::File);
+
+    if nested_anchor_live() {
+        let err = result.expect_err("unlink through interior symlink escape must be refused");
+        let raw = err.raw_os_error();
+        assert!(
+            matches!(
+                raw,
+                Some(libc::EXDEV) | Some(libc::ELOOP) | Some(libc::ENOTDIR)
+            ),
+            "expected EXDEV/ELOOP/ENOTDIR, got {raw:?}"
+        );
+        assert!(
+            victim.exists(),
+            "outside victim must survive a refused unlink"
+        );
+    } else {
+        let _ = result;
+    }
+}
+
+#[test]
+fn nested_mkdirat_via_sandbox_creates_under_interior_dir() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir_all(root.join("a/b")).expect("mkdir a/b");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("a/b/newdir");
+    let dir_path = root.join(rel);
+    mkdirat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &dir_path, 0o755)
+        .expect("nested mkdirat");
+
+    assert!(dir_path.is_dir(), "nested directory must be created");
+}
+
+#[test]
+fn nested_lstat_via_sandbox_stats_under_interior_dir() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir_all(root.join("a/b")).expect("mkdir a/b");
+    std::fs::write(root.join("a/b/file"), b"hi").expect("write");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("a/b/file");
+    let full = root.join(rel);
+    let outcome =
+        lstat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &full).expect("nested lstat");
+    // dev/ino must match the real entry regardless of which path served.
+    let std_meta = std::fs::symlink_metadata(&full).expect("std stat");
+    assert_eq!(outcome.dev(), std_meta.dev());
+    assert_eq!(outcome.ino(), std_meta.ino());
+}
+
+#[test]
+fn nested_renameat_via_sandbox_commits_under_interior_dir() {
+    let (_keep, root) = canonical_tempdir();
+    std::fs::create_dir_all(root.join("a/b")).expect("mkdir a/b");
+    std::fs::write(root.join("a/b/tmp"), b"payload").expect("write tmp");
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let old_rel = Path::new("a/b/tmp");
+    let new_rel = Path::new("a/b/final");
+    let old_full = root.join(old_rel);
+    let new_full = root.join(new_rel);
+    renameat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &root,
+        old_rel,
+        &old_full,
+        &root,
+        new_rel,
+        &new_full,
+        true,
+    )
+    .expect("nested renameat");
+
+    assert!(!old_full.exists(), "temp name must be gone after rename");
+    assert_eq!(
+        std::fs::read(&new_full).expect("read final"),
+        b"payload",
+        "final name must hold the renamed payload"
+    );
+}
+
+#[test]
+fn single_component_symlinkat_unchanged_by_nested_path() {
+    // Regression guard: the common single-component case must still take
+    // the existing fast path and behave byte-identically.
+    let (_keep, root) = canonical_tempdir();
+    let sandbox = DirSandbox::open_root(&root).expect("sandbox");
+
+    let rel = Path::new("link");
+    let link_path = root.join(rel);
+    symlinkat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link_path, Path::new("target"))
+        .expect("single-component symlinkat");
+    assert!(
+        std::fs::symlink_metadata(&link_path)
+            .expect("stat")
+            .is_symlink(),
+        "single-component symlink must still be created"
+    );
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -99,7 +99,12 @@ fn lstat_via_sandbox_takes_at_path_for_single_component() {
 }
 
 #[test]
-fn lstat_via_sandbox_falls_back_for_multi_component() {
+fn lstat_via_sandbox_multi_component_anchors_or_falls_back() {
+    // A multi-component relative path now resolves its parent under
+    // openat2(RESOLVE_BENEATH) where the kernel supports it, and only
+    // degrades to the path-based fallback where it does not. Assert the
+    // correct outcome variant for each capability state and confirm the
+    // reported dev/ino matches the real entry either way.
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("sub")).expect("mkdir sub");
     std::fs::write(root.join("sub/file"), b"hello").expect("write");
@@ -108,10 +113,22 @@ fn lstat_via_sandbox_falls_back_for_multi_component() {
     let rel = Path::new("sub/file");
     let link = root.join(rel);
     let outcome = lstat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &link).expect("lstat");
-    assert!(
-        matches!(outcome, LstatOutcome::Std(_)),
-        "multi-component paths must take the fallback until SEC-1.f descent is wired"
-    );
+
+    if crate::linux_capabilities::openat2_supported() {
+        assert!(
+            matches!(outcome, LstatOutcome::At(_)),
+            "multi-component paths must anchor via openat2(RESOLVE_BENEATH) when supported"
+        );
+    } else {
+        assert!(
+            matches!(outcome, LstatOutcome::Std(_)),
+            "multi-component paths degrade to the path-based fallback without openat2"
+        );
+    }
+
+    let std_meta = std::fs::symlink_metadata(&link).expect("std stat");
+    assert_eq!(outcome.dev(), std_meta.dev());
+    assert_eq!(outcome.ino(), std_meta.ino());
 }
 
 #[test]
@@ -280,7 +297,10 @@ fn unlink_via_sandbox_takes_at_path_for_single_component_dir() {
 }
 
 #[test]
-fn unlink_via_sandbox_falls_back_for_multi_component() {
+fn unlink_via_sandbox_removes_multi_component_end_to_end() {
+    // A multi-component path anchors its parent under RESOLVE_BENEATH
+    // where supported and falls back to std::fs::remove_file otherwise;
+    // in both cases the leaf must be removed end-to-end.
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("sub")).expect("mkdir sub");
     let path = root.join("sub/file");
@@ -289,10 +309,10 @@ fn unlink_via_sandbox_falls_back_for_multi_component() {
 
     let rel = Path::new("sub/file");
     unlink_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &path, UnlinkFlags::File)
-        .expect("unlink fallback");
+        .expect("unlink multi-component");
     assert!(
         !path.exists(),
-        "multi-component path must fall back to std::fs::remove_file"
+        "multi-component leaf must be removed (anchored or fallback)"
     );
 }
 
@@ -782,6 +802,11 @@ fn renameat_via_sandbox_takes_at_path_for_single_component() {
 
 #[test]
 fn renameat_via_sandbox_falls_back_for_multi_component_source() {
+    // A multi-component source paired with a single-component dest must
+    // take the path-based fallback: the nested anchor only engages when
+    // BOTH endpoints resolve their parents, never mixing an anchored and
+    // an ambient endpoint. The dest here is single-component, so the
+    // helper drops to std::fs::rename regardless of openat2 support.
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("sub")).expect("mkdir sub");
     let src = root.join("sub").join("src");
@@ -1303,10 +1328,11 @@ fn recursive_unlinkat_fallback_treats_missing_root_as_success() {
 }
 
 #[test]
-fn recursive_unlinkat_falls_back_for_multi_component_relative() {
-    // Multi-component relative paths take the path-based fallback
-    // (the SEC-1.f / SEC-1.g family does the same); the helper
-    // must still remove the subtree end-to-end.
+fn recursive_unlinkat_removes_multi_component_relative_end_to_end() {
+    // Multi-component relative paths anchor their parent under
+    // RESOLVE_BENEATH where supported and fall back to the path-based
+    // walk otherwise; either way the helper must remove the subtree
+    // end-to-end while leaving the parent directory intact.
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("outer")).expect("mkdir outer");
     let inner = root.join("outer").join("inner");

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/unlink.rs
@@ -11,6 +11,7 @@
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io;
+use std::os::fd::AsFd;
 use std::os::fd::AsRawFd;
 use std::os::fd::BorrowedFd;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
@@ -19,6 +20,7 @@ use std::path::Path;
 use super::errno_location;
 use super::lstat::single_component_leaf;
 use super::metadata::fstatat_nofollow;
+use super::nested::{ParentAnchor, anchor_parent};
 use super::open::openat;
 use std::ffi::CString;
 
@@ -141,6 +143,11 @@ pub fn unlink_via_sandbox_or_fallback(
     {
         return unlinkat(sandbox.current_dirfd(), leaf, flags);
     }
+    if let ParentAnchor::Anchored { dirfd, name } =
+        anchor_parent(sandbox, dest_dir, relative_path, link_path)?
+    {
+        return unlinkat(dirfd.as_fd(), name, flags);
+    }
     match flags {
         UnlinkFlags::File => std::fs::remove_file(link_path),
         UnlinkFlags::Dir => std::fs::remove_dir(link_path),
@@ -207,6 +214,11 @@ pub fn recursive_unlinkat_via_sandbox_or_fallback(
         && let Some(leaf) = single_component_leaf(dest_dir, relative_path, target_path)
     {
         return recursive_unlinkat(sandbox.current_dirfd(), leaf);
+    }
+    if let ParentAnchor::Anchored { dirfd, name } =
+        anchor_parent(sandbox, dest_dir, relative_path, target_path)?
+    {
+        return recursive_unlinkat(dirfd.as_fd(), name);
     }
     match std::fs::remove_dir_all(target_path) {
         Ok(()) => Ok(()),

--- a/crates/transfer/tests/fstatat_swap_resistance.rs
+++ b/crates/transfer/tests/fstatat_swap_resistance.rs
@@ -13,10 +13,11 @@
 //!    following the link.
 //! 2. When the entry is a regular file, both the sandbox-anchored and
 //!    path-based stats agree on `dev` / `ino`.
-//! 3. When the relative path has multiple components, the helper falls
-//!    back to `std::fs::symlink_metadata` (the SEC-1.f cutover only
-//!    touches single-component paths today; multi-component descent is
-//!    SEC-1.f's follow-up work).
+//! 3. When the relative path has multiple components, the helper anchors
+//!    its parent under `openat2(RESOLVE_BENEATH)` where the kernel
+//!    supports it (Linux 5.6+) and degrades to
+//!    `std::fs::symlink_metadata` otherwise; either way the reported
+//!    dev/ino match the real entry.
 
 #![cfg(unix)]
 
@@ -93,7 +94,13 @@ fn sandbox_anchored_lstat_dev_ino_matches_path_lstat() {
 }
 
 #[test]
-fn multi_component_path_falls_back_to_path_based_lstat() {
+fn multi_component_path_anchors_or_falls_back_lstat() {
+    // A multi-component relative path now resolves its parent under
+    // openat2(RESOLVE_BENEATH) where the kernel supports it (Linux 5.6+,
+    // the CI runners) and only degrades to the path-based fallback where
+    // it does not (macOS, older kernels). Gate the expected outcome on
+    // the capability probe and confirm dev/ino match the real entry in
+    // both states.
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("sub")).expect("mkdir sub");
     let file_path = root.join("sub/file");
@@ -105,9 +112,26 @@ fn multi_component_path_falls_back_to_path_based_lstat() {
     let outcome = lstat_via_sandbox_or_fallback(Some(&sandbox), &root, rel, &file_path)
         .expect("multi-comp lstat");
 
-    assert!(
-        matches!(outcome, LstatOutcome::Std(_)),
-        "multi-component paths take the std fallback until the sandbox descent stack is wired"
+    if fast_io::openat2_supported() {
+        assert!(
+            matches!(outcome, LstatOutcome::At(_)),
+            "multi-component paths must anchor via openat2(RESOLVE_BENEATH) when supported"
+        );
+    } else {
+        assert!(
+            matches!(outcome, LstatOutcome::Std(_)),
+            "multi-component paths degrade to the path-based fallback without openat2"
+        );
+    }
+
+    let std_meta = std::fs::symlink_metadata(&file_path).expect("std stat");
+    assert_eq!(
+        std::os::unix::fs::MetadataExt::dev(&std_meta),
+        outcome.dev()
+    );
+    assert_eq!(
+        std::os::unix::fs::MetadataExt::ino(&std_meta),
+        outcome.ino()
     );
 }
 

--- a/crates/transfer/tests/sec_1_m_symlink_swap_attack.rs
+++ b/crates/transfer/tests/sec_1_m_symlink_swap_attack.rs
@@ -69,9 +69,17 @@ use std::thread;
 use crossbeam_channel::{Receiver, Sender, bounded};
 use fast_io::{
     DirSandbox, LstatOutcome, UnlinkFlags, lstat_via_sandbox_or_fallback,
-    unlink_via_sandbox_or_fallback,
+    symlinkat_via_sandbox_or_fallback, unlink_via_sandbox_or_fallback,
 };
 use tempfile::{TempDir, tempdir};
+
+/// Returns whether `openat2(RESOLVE_BENEATH)` nested-parent anchoring is
+/// live on this host. When off (non-Linux, or Linux < 5.6), the helpers
+/// degrade to the path-based fallback and the interior-symlink guarantee
+/// is not enforced; Linux CI is the runtime gate for the refusal.
+fn nested_anchor_live() -> bool {
+    cfg!(target_os = "linux") && fast_io::openat2_supported()
+}
 
 /// `tempdir()` may sit under a symlink prefix on macOS / some CI
 /// runners; canonicalise so the sandbox open succeeds under
@@ -452,4 +460,71 @@ fn scenario_3_repeated_race_keeps_sensitive_tree_untouched() {
         b"never-touched",
         "sensitive file contents must be byte-identical after the full stress loop"
     );
+}
+
+/// Scenario 4: interior-directory symlink escape (the SEC nested-path
+/// anchoring keystone). The receiver acts on a multi-component path
+/// `dest/a/EVIL/link`. An attacker replaces the *interior* directory
+/// `dest/a/EVIL` with a symlink pointing OUTSIDE the destination root.
+///
+/// Before the nested-parent anchor, the leaf op fell to a path-based
+/// syscall that re-resolved `a/EVIL` through the ambient namespace,
+/// following the symlink and creating the entry outside the root. With
+/// the `openat2(RESOLVE_BENEATH)` parent anchor the interior escape is
+/// refused in-kernel (EXDEV/ELOOP/ENOTDIR) and the outside tree is never
+/// written. This is the exact gap `single_component_leaf` could not
+/// close: the leaf is single-component, but the *parent* path is not.
+#[test]
+fn scenario_4_interior_dir_symlink_escape_is_refused() {
+    let (_keep, parent) = canonical_tempdir();
+
+    // Sensitive tree outside the destination sandbox root.
+    let outside = parent.join("outside");
+    std::fs::create_dir(&outside).expect("mkdir outside");
+
+    let dest = parent.join("dest");
+    let a = dest.join("a");
+    std::fs::create_dir_all(&a).expect("mkdir dest/a");
+    // Interior-component symlink escape: dest/a/EVIL -> ../../outside.
+    symlink(&outside, a.join("EVIL")).expect("plant escaping interior symlink");
+
+    let sandbox = DirSandbox::open_root(&dest).expect("sandbox open");
+
+    let rel = Path::new("a/EVIL/link");
+    let link_path = dest.join(rel);
+    let result = symlinkat_via_sandbox_or_fallback(
+        Some(&sandbox),
+        &dest,
+        rel,
+        &link_path,
+        Path::new("payload"),
+    );
+
+    if nested_anchor_live() {
+        let err = result.expect_err("interior-dir symlink escape must be refused");
+        let raw = err.raw_os_error();
+        assert!(
+            matches!(
+                raw,
+                Some(libc::EXDEV) | Some(libc::ELOOP) | Some(libc::ENOTDIR)
+            ),
+            "expected EXDEV/ELOOP/ENOTDIR from the RESOLVE_BENEATH parent open, got {raw:?}"
+        );
+        assert!(
+            !outside.join("link").exists(),
+            "no entry may be created outside the destination root via the interior symlink"
+        );
+        assert!(
+            std::fs::read_dir(&outside)
+                .expect("read outside")
+                .next()
+                .is_none(),
+            "the outside tree must remain empty after the refused escape"
+        );
+    } else {
+        // No kernel RESOLVE_BENEATH: the helper degrades to the
+        // path-based fallback (today's behaviour). Assert the call is
+        // total; the security refusal is asserted on the Linux gate.
+        let _ = result;
+    }
 }

--- a/crates/transfer/tests/unlinkat_swap_resistance.rs
+++ b/crates/transfer/tests/unlinkat_swap_resistance.rs
@@ -120,13 +120,13 @@ fn unlink_via_sandbox_dir_flag_refuses_non_empty_directory() {
     assert!(dir.is_dir(), "directory must survive a failed rmdir");
 }
 
-/// Multi-component paths fall back to `std::fs::remove_file` until the
-/// sandbox descent stack is wired through every executor. This pins
-/// the documented deferral so a future regression does not silently
-/// promote multi-component paths into the path-based fallback without
-/// re-evaluating the TOCTOU exposure.
+/// Multi-component paths anchor their parent under
+/// `openat2(RESOLVE_BENEATH)` where the kernel supports it and degrade
+/// to `std::fs::remove_file` otherwise; either way the leaf is removed
+/// end-to-end. This pins the removal contract across both capability
+/// states so a future regression cannot silently drop the leaf.
 #[test]
-fn unlink_via_sandbox_multi_component_takes_fallback() {
+fn unlink_via_sandbox_multi_component_removes_leaf() {
     let (_keep, root) = canonical_tempdir();
     std::fs::create_dir(root.join("sub")).expect("mkdir sub");
     let path = root.join("sub/file");
@@ -138,6 +138,6 @@ fn unlink_via_sandbox_multi_component_takes_fallback() {
         .expect("unlink");
     assert!(
         !path.exists(),
-        "multi-component fallback must remove the leaf via std::fs::remove_file"
+        "multi-component leaf must be removed (anchored or fallback)"
     );
 }


### PR DESCRIPTION
## Problem

The `DirSandbox` `*_via_sandbox_or_fallback` helpers only anchored **single-component leaves** through the sandbox dirfd. Any relative path with an **interior component** (`dest/a/b/leaf`) fell through to a path-based `std::fs` syscall (`std::fs::rename`, `symlink`, `remove_file`, ...) that re-resolved the interior components through the ambient namespace.

That re-resolution is a TOCTOU hole (daemon-non-chroot): an attacker who swaps an **interior directory** (`a/b`) for a symlink between the receiver's decide-to-act moment and the syscall can redirect the leaf op outside the module root. `single_component_leaf` (crates/fast_io/.../at_syscalls/lstat.rs) returned `None` for any interior-component path, so these ops were never confined.

## Fix

New shared helper `anchor_parent` (crates/fast_io/src/dir_sandbox/at_syscalls/nested.rs) opens the **parent** directory of a multi-component relative path via `openat2(RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)`, anchored on the sandbox's current dirfd, then performs the terminal `*at` op against that parent fd (existing `O_NOFOLLOW`-on-leaf semantics).

This mirrors upstream rsync's `secure_relative_open_linux` (`syscall.c`, gated `am_daemon && !am_chrooted`). Deliberately uses `RESOLVE_BENEATH` (not `RESOLVE_NO_SYMLINKS`): **legitimate in-tree symlinks** along the path stay resolvable, only escapes beneath the anchor are refused with `EXDEV`.

### Ops now nested-anchored
`symlinkat`, `linkat` (hardlink), `unlinkat`, `recursive_unlinkat`, `mkdirat`, `lstat` (fstatat), `renameat`.

### Invariants preserved
- **Single-component paths** keep the existing fast path byte-for-byte (nested anchor only engages for >= 2 `Normal` components with a matching reconstructed path).
- **Legitimate in-tree symlinks** still work (`RESOLVE_BENEATH` allows them).
- **Graceful fallback**: when `openat2` is unavailable (`ENOSYS`) or the resolve flags are unsupported (`EINVAL`), the helper degrades to today's path-based behaviour. Probe is the existing `OnceLock`-cached `openat2_supported()`.
- A deliberate in-kernel refusal (`EXDEV`/`ELOOP`/`ENOENT`/`ENOTDIR`) is **propagated, never silently re-resolved via a path** (which would defeat the confinement).
- Non-daemon / chroot / non-unix receivers unchanged (anchoring only engages where the sandbox is attached).

## Out of scope (follow-up steps)

Ops that do not use the sandbox helpers at all - `mknod`, `chown`/`chmod`/`utimes`/`xattr`/`acl`, basis-open - are separate follow-up steps.

## Tests

- fast_io unit tests (nested.rs behaviour via the public helpers): interior-symlink escape refused (Linux gate), legitimate in-tree symlink succeeds, single-component unchanged, nested create/stat/rename/mkdir under real interior dirs, fallback when anchoring is unavailable.
- transfer integration `scenario_4_interior_dir_symlink_escape_is_refused`: proves `dest/a/EVIL/link` with `EVIL -> outside` is refused and the outside tree stays empty.

`openat2`/`RESOLVE_BENEATH` is Linux-only; the runtime refusal assertions gate on `openat2_supported()`, with **Linux CI as the runtime gate**. macOS/Windows verify compile + graceful fallback + non-linux stubs. The interop cell is the gate that legitimate in-tree symlinks / nested transfers are not rejected.

Advances #508.