### PR TITLE
fix(metadata): warn-and-continue on unknown --usermap/--groupmap target (upstream parity)

### DIFF
--- a/crates/metadata/src/mapping/name_mapping.rs
+++ b/crates/metadata/src/mapping/name_mapping.rs
@@ -6,12 +6,14 @@
 //! concrete UIDs/GIDs. Used as the backing store for both [`super::UserMapping`]
 //! and [`super::GroupMapping`].
 
-use crate::id_lookup::{lookup_group_name, lookup_user_name};
+use crate::id_lookup::{
+    lookup_group_by_name, lookup_group_name, lookup_user_by_name, lookup_user_name,
+};
 use rustix::process::{RawGid, RawUid};
 use std::io;
 
 use super::parse::{parse_matcher, parse_target};
-use super::types::{MappingKind, MappingParseError, MappingRule};
+use super::types::{MappingKind, MappingParseError, MappingRule, MappingTarget};
 
 /// Parsed mapping rules associated with `--usermap` or `--groupmap`.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -72,11 +74,54 @@ impl NameMapping {
             rules.push(MappingRule { matcher, target });
         }
 
+        // upstream: uidlist.c:547-561 parse_name_map - each rule's target name is
+        // resolved on the receiver at parse time via user_to_uid/group_to_gid and
+        // stored as a concrete id in the idmap list. An unknown name prints
+        // "Unknown --usermap name on receiver: NAME" (FERROR) and the rule is
+        // simply not added; the remaining rules and the transfer proceed
+        // non-fatally. Resolving here (rather than lazily per file) both matches
+        // upstream and keeps an unknown target from aborting a per-file metadata
+        // apply.
+        rules.retain_mut(|rule| Self::resolve_target(kind, &mut rule.target));
+
         Ok(Self {
             rules,
             kind,
             spec: trimmed.to_owned(),
         })
+    }
+
+    /// Resolves a rule's target name to a concrete id in place at parse time.
+    ///
+    /// Numeric targets ([`MappingTarget::Id`]) are already resolved and kept as
+    /// is. A name target is looked up on the receiver via the kind-appropriate
+    /// NSS call; on success the target is rewritten to the resolved id, on
+    /// failure the upstream warning is printed and the caller drops the rule.
+    // upstream: uidlist.c:547-561 - user_to_uid/group_to_gid, drop on failure.
+    fn resolve_target(kind: MappingKind, target: &mut MappingTarget) -> bool {
+        let MappingTarget::Name(name) = target else {
+            return true;
+        };
+        let resolved = match kind {
+            MappingKind::User => lookup_user_by_name(name.as_bytes()),
+            MappingKind::Group => lookup_group_by_name(name.as_bytes()),
+        };
+        match resolved {
+            Ok(Some(id)) => {
+                *target = MappingTarget::Id(id);
+                true
+            }
+            // A lookup error (e.g. NSS failure) is treated like an unknown name,
+            // matching upstream where any non-True user_to_uid return drops the rule.
+            Ok(None) | Err(_) => {
+                let flag = match kind {
+                    MappingKind::User => "user",
+                    MappingKind::Group => "group",
+                };
+                eprintln!("Unknown --{flag}map name on receiver: {name}");
+                false
+            }
+        }
     }
 
     /// Returns the original specification string (post-trim) used to construct

--- a/crates/metadata/src/mapping/tests.rs
+++ b/crates/metadata/src/mapping/tests.rs
@@ -154,7 +154,9 @@ fn parse_range_source() {
 
 #[test]
 fn parse_pattern_source() {
-    let mapping = NameMapping::parse(MappingKind::User, "test*:nobody").expect("parse mapping");
+    // `root` is universally present, so the name target resolves and the rule
+    // survives parse-time resolution (upstream uidlist.c:547-561).
+    let mapping = NameMapping::parse(MappingKind::User, "test*:root").expect("parse mapping");
     assert_eq!(mapping.len(), 1);
 }
 
@@ -181,8 +183,54 @@ fn parse_empty_source_maps_nameless_id() {
 
 #[test]
 fn parse_target_as_name() {
-    let mapping = NameMapping::parse(MappingKind::User, "100:nobody").expect("parse mapping");
+    // A known name target (`root`) resolves at parse time and the rule is kept.
+    let mapping = NameMapping::parse(MappingKind::User, "100:root").expect("parse mapping");
     assert_eq!(mapping.len(), 1);
+    // upstream stores the resolved id in the idmap list, so the target is now
+    // numeric: applying the rule maps id 100 to root's uid (0).
+    let mapped = mapping.map_uid(100, false).expect("map uid");
+    assert_eq!(mapped, Some(0));
+}
+
+/// A name that cannot exist as a system account: `:` is not a legal username
+/// character and the string is long enough to never collide with a real entry.
+const UNRESOLVABLE_NAME: &str = "oc_rsync_nonexistent_map_target_00000000";
+
+#[test]
+fn parse_unknown_user_target_drops_rule_non_fatally() {
+    // upstream: uidlist.c:547-561 - an unknown --usermap target name is warned
+    // about once and the rule is skipped; parse still succeeds (non-fatal).
+    let spec = format!("100:{UNRESOLVABLE_NAME}");
+    let mapping = NameMapping::parse(MappingKind::User, &spec).expect("parse must not fail");
+    assert!(
+        mapping.is_empty(),
+        "unknown target rule must be dropped, not retained"
+    );
+    // The dropped rule no longer maps its source id: apply falls through to the
+    // default (unmapped) behaviour instead of aborting the metadata apply.
+    assert_eq!(mapping.map_uid(100, false).expect("map uid"), None);
+}
+
+#[test]
+fn parse_unknown_group_target_drops_rule_non_fatally() {
+    let spec = format!("100:{UNRESOLVABLE_NAME}");
+    let mapping = NameMapping::parse(MappingKind::Group, &spec).expect("parse must not fail");
+    assert!(mapping.is_empty());
+    assert_eq!(mapping.map_gid(100, false).expect("map gid"), None);
+}
+
+#[test]
+fn parse_keeps_valid_rule_alongside_unknown_target() {
+    // A valid rule declared before an unknown-target rule still applies; the
+    // unknown one is silently dropped (after its one-time warning) and the
+    // transfer continues. Mirrors upstream dropping only the offending rule.
+    let spec = format!("100:root, 200:{UNRESOLVABLE_NAME}, 300:0");
+    let mapping = NameMapping::parse(MappingKind::User, &spec).expect("parse must not fail");
+    assert_eq!(mapping.len(), 2, "only the unknown-target rule is dropped");
+    assert_eq!(mapping.map_uid(100, false).expect("map uid"), Some(0));
+    // The dropped rule's source id is now unmapped.
+    assert_eq!(mapping.map_uid(200, false).expect("map uid"), None);
+    assert_eq!(mapping.map_uid(300, false).expect("map uid"), Some(0));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

An unknown `--usermap`/`--groupmap` **target** name aborted a per-file metadata apply (and, in turn, the transfer). `MappingTarget` resolved its target name lazily per file (`crates/metadata/src/mapping/types.rs` `resolve_uid`/`resolve_gid`); when the name did not resolve on the receiver it returned an `io::ErrorKind::NotFound` that propagated through `map_uid`/`map_gid` -> `resolve_ownership` -> `MetadataError`, aborting the apply.

Upstream does not do this. In `uidlist.c:547-561` (`parse_name_map`), each rule's target name is resolved once, **at parse time on the receiver**, via `user_to_uid`/`group_to_gid`. On an unknown name it prints:

```
Unknown --usermap name on receiver: NAME
```

(the `--groupmap` equivalent for groups), then simply **does not add that rule** to the idmap list and continues. The remaining rules and the transfer proceed non-fatally.

## Fix

- Resolve each rule's target name at parse time in `NameMapping::parse` (matching upstream's parse-time resolution), rewriting a resolved name target to a concrete numeric id (as upstream stores it in the idmap list).
- On an unknown target name (or a lookup failure), print the upstream warning text once, drop that single rule, and continue. Other rules and the transfer are unaffected.
- A source id that would have matched the dropped rule now falls through to the next matching rule (or the default/unmapped behaviour), exactly as upstream after it skips the rule.
- Valid rules, numeric-id ranges, and first-match-wins are unchanged.

The warning text and stream match upstream byte-for-byte (`rprintf(FERROR, ...)` -> stderr; the code, not the man page, is the source of truth here).

## Tests

- `parse_unknown_user_target_drops_rule_non_fatally` / `parse_unknown_group_target_drops_rule_non_fatally`: an unknown target drops the rule, parse still succeeds, the source id is left unmapped (no abort).
- `parse_keeps_valid_rule_alongside_unknown_target`: a valid rule alongside an unknown-target rule still applies; only the offending rule is dropped.
- Existing name-target parse tests pinned to `nobody` were repointed to `root` (universally present) so they deterministically exercise the resolve-and-keep path.
- `cargo test -p metadata --lib` (411 pass), `--test uidgid_integration` (15 pass), and the affected CLI arg integration targets all green. `cargo build`/`cargo clippy -p metadata -p core --all-targets` clean.

Advances #518.