### PR TITLE
fix(protocol): remap ACL user/group ids via id-list for cross-host -A (upstream parity)

### DIFF
--- a/crates/metadata/src/acl_exacl/apply.rs
+++ b/crates/metadata/src/acl_exacl/apply.rs
@@ -8,6 +8,7 @@ use exacl::AclOption;
 use exacl::setfacl;
 use protocol::acl::AclCache;
 
+use crate::AclIdMapper;
 use crate::MetadataError;
 
 use super::error::is_unsupported_error;
@@ -33,6 +34,9 @@ use super::reset::reset_acl_from_mode;
 /// * `access_ndx` - Index into the access ACL cache.
 /// * `default_ndx` - Optional index into the default ACL cache (directories only).
 /// * `follow_symlinks` - Whether to follow symlinks. If `false`, returns immediately.
+/// * `id_map` - Optional cross-host id remapper for named ACL entries. When
+///   present, each named user/group id is remapped through the received id-list
+///   and `--usermap`/`--groupmap`, matching upstream `match_acl_ids()`.
 ///
 /// # Errors
 ///
@@ -51,6 +55,7 @@ pub fn apply_acls_from_cache(
     default_ndx: Option<u32>,
     follow_symlinks: bool,
     mode: Option<u32>,
+    id_map: Option<&AclIdMapper>,
 ) -> Result<(), MetadataError> {
     if !follow_symlinks {
         return Ok(());
@@ -59,7 +64,7 @@ pub fn apply_acls_from_cache(
     if let Some(acl) = cache.get_access(access_ndx) {
         // upstream: acls.c:change_sacl_perms() - reconstruct base entries from mode
         let reconstructed = reconstruct_acl(acl, mode);
-        let entries = rsync_acl_to_entries(&reconstructed);
+        let entries = rsync_acl_to_entries(&reconstructed, id_map);
         if !entries.is_empty() {
             if let Err(e) = setfacl(&[destination], &entries, None) {
                 if !is_unsupported_error(&e) {
@@ -78,7 +83,7 @@ pub fn apply_acls_from_cache(
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     if let Some(def_ndx) = default_ndx {
         if let Some(def_acl) = cache.get_default(def_ndx) {
-            let entries = rsync_acl_to_entries(def_acl);
+            let entries = rsync_acl_to_entries(def_acl, id_map);
             if !entries.is_empty() {
                 if let Err(e) = setfacl(&[destination], &entries, Some(AclOption::DEFAULT_ACL)) {
                     if !is_unsupported_error(&e) {

--- a/crates/metadata/src/acl_exacl/reconstruct.rs
+++ b/crates/metadata/src/acl_exacl/reconstruct.rs
@@ -10,6 +10,7 @@ use protocol::acl::{
 };
 
 use super::perms::rsync_perms_to_exacl;
+use crate::AclIdMapper;
 use crate::id_lookup::{
     lookup_group_by_name, lookup_group_name, lookup_user_by_name, lookup_user_name,
 };
@@ -80,7 +81,14 @@ pub(super) fn reconstruct_acl(acl: &RsyncAcl, mode: Option<u32>) -> RsyncAcl {
 ///   incoming named entries.
 /// - `uidlist.c:243-294` `recv_add_id` - falls back to the raw wire id when
 ///   the name does not resolve; emits the `DEBUG_GTE(OWN, 2)` mapping line.
-pub(super) fn rsync_acl_to_entries(acl: &RsyncAcl) -> Vec<AclEntry> {
+///
+/// # Cross-host remapping
+///
+/// When `id_map` is present, named entry ids are remapped through the received
+/// id-list plus `--usermap`/`--groupmap`, mirroring upstream `match_acl_ids()`
+/// (`acls.c:1059-1081`). Without a mapper the receiver falls back to the
+/// name-based NSS resolution described above.
+pub(super) fn rsync_acl_to_entries(acl: &RsyncAcl, id_map: Option<&AclIdMapper>) -> Vec<AclEntry> {
     let mut entries = Vec::new();
 
     // upstream: acls.c:866-878 - base entries for POSIX ACLs only (Linux/FreeBSD).
@@ -117,7 +125,7 @@ pub(super) fn rsync_acl_to_entries(acl: &RsyncAcl) -> Vec<AclEntry> {
 
     for ida in acl.names.iter() {
         let perms = rsync_perms_to_exacl(ida.permissions() as u8);
-        let mapped_id = resolve_ida_id(ida);
+        let mapped_id = resolve_ida_id(ida, id_map);
         let name = mapped_id.to_string();
 
         if ida.access & NAME_IS_USER != 0 {
@@ -146,9 +154,35 @@ pub(super) fn rsync_acl_to_entries(acl: &RsyncAcl) -> Vec<AclEntry> {
 ///    falls back to `id2 = id` at `uidlist.c:282` and the receiver still
 ///    calls `sys_acl_set_info()` with whatever id is in `ida->id`
 ///    (`acls.c:404`), so unmappable IDs flow through to the kernel.
-fn resolve_ida_id(ida: &IdAccess) -> u32 {
+///
+/// When `id_map` is present it takes precedence: the id is remapped through the
+/// received id-list plus `--usermap`/`--groupmap`, mirroring upstream
+/// `match_acl_ids()` (`acls.c:1059-1081`). The id-list already folds in the
+/// sender-supplied name resolution, so this is the cross-host path.
+fn resolve_ida_id(ida: &IdAccess, id_map: Option<&AclIdMapper>) -> u32 {
     let is_user = ida.access & NAME_IS_USER != 0;
     let wire = ida.id;
+
+    // upstream: acls.c:1069-1072 match_racl_ids - convert every named entry id
+    // through the same uid/gid table as file owners (match_uid/match_gid).
+    if let Some(mapper) = id_map {
+        let mapped = if is_user {
+            mapper.map_uid(wire)
+        } else {
+            mapper.map_gid(wire)
+        };
+        let name_str = ida
+            .name
+            .as_deref()
+            .map(String::from_utf8_lossy)
+            .unwrap_or_default();
+        if is_user {
+            trace_acl_uid_remap(wire, &name_str, mapped);
+        } else {
+            trace_acl_gid_remap(wire, &name_str, mapped);
+        }
+        return mapped;
+    }
 
     if let Some(name_bytes) = ida.name.as_deref() {
         let name_str = String::from_utf8_lossy(name_bytes);

--- a/crates/metadata/src/acl_exacl/tests.rs
+++ b/crates/metadata/src/acl_exacl/tests.rs
@@ -146,7 +146,7 @@ fn rsync_perms_to_exacl_all_bits() {
 #[test]
 fn rsync_acl_to_entries_empty_acl() {
     let acl = RsyncAcl::new();
-    let entries = rsync_acl_to_entries(&acl);
+    let entries = rsync_acl_to_entries(&acl, None);
     assert!(entries.is_empty());
 }
 
@@ -154,7 +154,7 @@ fn rsync_acl_to_entries_empty_acl() {
 #[test]
 fn rsync_acl_to_entries_base_entries() {
     let acl = RsyncAcl::from_mode(0o754);
-    let entries = rsync_acl_to_entries(&acl);
+    let entries = rsync_acl_to_entries(&acl, None);
 
     // user_obj(rwx) + group_obj(r-x) + other_obj(r--)
     assert_eq!(entries.len(), 3);
@@ -177,7 +177,7 @@ fn rsync_acl_to_entries_named_user_and_group() {
     acl.names.push(IdAccess::user(1000, 0x07));
     acl.names.push(IdAccess::group(100, 0x05));
 
-    let entries = rsync_acl_to_entries(&acl);
+    let entries = rsync_acl_to_entries(&acl, None);
 
     // Find named entries (skip base entries on Linux/FreeBSD)
     let named: Vec<_> = entries.iter().filter(|e| !e.name.is_empty()).collect();
@@ -188,6 +188,77 @@ fn rsync_acl_to_entries_named_user_and_group() {
     assert_eq!(named[1].kind, AclEntryKind::Group);
     assert_eq!(named[1].name, "100");
     assert_eq!(named[1].perms, Perm::READ | Perm::EXECUTE);
+}
+
+#[test]
+fn rsync_acl_to_entries_remaps_named_ids_via_id_map() {
+    // WHY: on a cross-host `-A` transfer the sender ships the ACL entry's own
+    // namespace uid/gid (1000). Without the id-list remap the ACL would land on
+    // whatever principal owns 1000 on the receiver. The AclIdMapper (built from
+    // the received uid/gid id-lists) must convert 1000 -> 2000, exactly as
+    // upstream match_acl_ids()/match_uid() do for file owners.
+    // upstream: acls.c:1069-1072, uidlist.c:483-484.
+    use crate::AclIdMapper;
+    use protocol::acl::IdAccess;
+    use std::collections::HashMap;
+
+    let mut uid = HashMap::new();
+    uid.insert(1000u32, 2000u32);
+    let mut gid = HashMap::new();
+    gid.insert(1000u32, 3000u32);
+
+    #[cfg(unix)]
+    let mapper = AclIdMapper::new(uid, gid, None, None, false);
+    #[cfg(not(unix))]
+    let mapper = AclIdMapper::new(uid, gid, false);
+
+    let mut acl = RsyncAcl::from_mode(0o755);
+    // No wire name: the non-inc_recurse path relies entirely on the id-list.
+    acl.names.push(IdAccess::user(1000, 0x07));
+    acl.names.push(IdAccess::group(1000, 0x05));
+
+    let entries = rsync_acl_to_entries(&acl, Some(&mapper));
+    let named: Vec<_> = entries.iter().filter(|e| !e.name.is_empty()).collect();
+    assert_eq!(named.len(), 2);
+    assert_eq!(named[0].kind, AclEntryKind::User);
+    assert_eq!(
+        named[0].name, "2000",
+        "named user id must be remapped through the id-list (1000 -> 2000)"
+    );
+    assert_eq!(named[1].kind, AclEntryKind::Group);
+    assert_eq!(
+        named[1].name, "3000",
+        "named group id must be remapped through the id-list (1000 -> 3000)"
+    );
+}
+
+#[test]
+fn rsync_acl_to_entries_id_map_numeric_ids_passthrough() {
+    // WHY: with --numeric-ids upstream exchanges no id-list and applies ids
+    // verbatim (recv_id_list guard `numeric_ids <= 0`). The mapper must be a
+    // no-op even when a stale table is present.
+    use crate::AclIdMapper;
+    use protocol::acl::IdAccess;
+    use std::collections::HashMap;
+
+    let mut uid = HashMap::new();
+    uid.insert(1000u32, 2000u32);
+
+    #[cfg(unix)]
+    let mapper = AclIdMapper::new(uid, HashMap::new(), None, None, true);
+    #[cfg(not(unix))]
+    let mapper = AclIdMapper::new(uid, HashMap::new(), true);
+
+    let mut acl = RsyncAcl::from_mode(0o755);
+    acl.names.push(IdAccess::user(1000, 0x07));
+
+    let entries = rsync_acl_to_entries(&acl, Some(&mapper));
+    let named: Vec<_> = entries.iter().filter(|e| !e.name.is_empty()).collect();
+    assert_eq!(named.len(), 1);
+    assert_eq!(
+        named[0].name, "1000",
+        "numeric-ids must keep the raw wire id (no remap)"
+    );
 }
 
 #[cfg(unix)]
@@ -206,7 +277,7 @@ fn rsync_acl_to_entries_preserves_unmappable_named_user() {
     acl.names
         .push(IdAccess::user_with_name(unmappable_uid, 0x07, unknown_name));
 
-    let entries = rsync_acl_to_entries(&acl);
+    let entries = rsync_acl_to_entries(&acl, None);
     let named: Vec<_> = entries.iter().filter(|e| !e.name.is_empty()).collect();
     assert_eq!(
         named.len(),
@@ -251,7 +322,7 @@ fn rsync_acl_to_entries_remap_emits_own_debug() {
         b"oc_rsync_test_ghost_group".to_vec(),
     ));
 
-    let _ = rsync_acl_to_entries(&acl);
+    let _ = rsync_acl_to_entries(&acl, None);
 
     let messages: Vec<String> = drain_events()
         .into_iter()
@@ -285,7 +356,7 @@ fn apply_acls_from_cache_skips_symlinks() {
     File::create(&file).expect("create file");
 
     let cache = AclCache::new();
-    let result = apply_acls_from_cache(&file, &cache, 0, None, false, None);
+    let result = apply_acls_from_cache(&file, &cache, 0, None, false, None, None);
     assert!(result.is_ok());
 }
 
@@ -299,7 +370,7 @@ fn apply_acls_from_cache_applies_basic_acl() {
     let acl = RsyncAcl::from_mode(0o644);
     let ndx = cache.store_access(acl);
 
-    let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+    let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
     assert!(result.is_ok());
 }
 
@@ -313,7 +384,7 @@ fn apply_acls_from_cache_empty_acl_resets() {
     let acl = RsyncAcl::new();
     let ndx = cache.store_access(acl);
 
-    let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+    let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
     assert!(result.is_ok());
 }
 
@@ -337,6 +408,7 @@ fn apply_acls_from_cache_directory_with_default() {
         Some(default_ndx),
         true,
         Some(0o755),
+        None,
     );
     assert!(result.is_ok());
 }
@@ -348,7 +420,7 @@ fn apply_acls_from_cache_missing_index_is_noop() {
     File::create(&file).expect("create file");
 
     let cache = AclCache::new();
-    let result = apply_acls_from_cache(&file, &cache, 99, None, true, Some(0o644));
+    let result = apply_acls_from_cache(&file, &cache, 99, None, true, Some(0o644), None);
     assert!(result.is_ok());
 }
 

--- a/crates/metadata/src/acl_idmap.rs
+++ b/crates/metadata/src/acl_idmap.rs
@@ -1,0 +1,176 @@
+//! Cross-host ID remapping for named ACL entries.
+//!
+//! Named user/group ACL entries carry a sender-side numeric id on the wire.
+//! On a cross-namespace transfer that id is meaningless on the receiver, so it
+//! must be remapped through the same uid/gid id-list that file ownership uses,
+//! plus any `--usermap`/`--groupmap` rules.
+//!
+//! [`AclIdMapper`] is an owned snapshot of that mapping state. It is built once
+//! at receiver setup time from the received id-lists and the parsed mappings,
+//! then shared (via `Arc`) with the disk-commit path that applies cached ACLs.
+//!
+//! # Upstream Reference
+//!
+//! - `uidlist.c:481-484` `recv_id_list()` calls `match_acl_ids()` after the
+//!   uid/gid lists have been read so ACL ids are converted with the same table
+//!   as file owners.
+//! - `acls.c:1059-1081` `match_racl_ids()`/`match_acl_ids()` walk every named
+//!   entry and replace `ida->id` with `match_uid(id)`/`match_gid(id)`.
+
+use std::collections::HashMap;
+
+#[cfg(unix)]
+use crate::mapping::{GroupMapping, UserMapping};
+
+/// Remaps sender-side ACL user/group ids to receiver-side ids.
+///
+/// The remap mirrors upstream `match_uid`/`match_gid`: consult the id-list
+/// snapshot first (remote id -> local id, already folded through name-based
+/// NSS resolution when the sender sent names), then apply `--usermap` /
+/// `--groupmap` on top exactly like `metadata::apply::ownership` does for file
+/// owners. When `numeric_ids` is set no remap occurs, matching upstream's
+/// `recv_id_list()` guard.
+#[derive(Clone, Debug, Default)]
+pub struct AclIdMapper {
+    /// Remote uid -> local uid snapshot from the received uid id-list.
+    uid_map: HashMap<u32, u32>,
+    /// Remote gid -> local gid snapshot from the received gid id-list.
+    gid_map: HashMap<u32, u32>,
+    /// Parsed `--usermap` rules, applied after the id-list.
+    #[cfg(unix)]
+    user_mapping: Option<UserMapping>,
+    /// Parsed `--groupmap` rules, applied after the id-list.
+    #[cfg(unix)]
+    group_mapping: Option<GroupMapping>,
+    /// When set, ids pass through unchanged (upstream `numeric_ids`).
+    numeric_ids: bool,
+}
+
+impl AclIdMapper {
+    /// Builds a mapper from id-list snapshots and the parsed mappings.
+    ///
+    /// `uid_map`/`gid_map` are the remote->local tables from the received
+    /// uid/gid id-lists (see [`crate`]'s receiver id-list handling). Pass empty
+    /// maps when no id-list was received; the `--usermap`/`--groupmap` rules and
+    /// the numeric-id fallback still apply.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn new(
+        uid_map: HashMap<u32, u32>,
+        gid_map: HashMap<u32, u32>,
+        user_mapping: Option<UserMapping>,
+        group_mapping: Option<GroupMapping>,
+        numeric_ids: bool,
+    ) -> Self {
+        Self {
+            uid_map,
+            gid_map,
+            user_mapping,
+            group_mapping,
+            numeric_ids,
+        }
+    }
+
+    /// Builds a mapper from id-list snapshots (non-Unix: no `--usermap`).
+    #[cfg(not(unix))]
+    #[must_use]
+    pub fn new(uid_map: HashMap<u32, u32>, gid_map: HashMap<u32, u32>, numeric_ids: bool) -> Self {
+        Self {
+            uid_map,
+            gid_map,
+            numeric_ids,
+        }
+    }
+
+    /// Remaps a named-user ACL id to the local uid.
+    ///
+    /// upstream: acls.c:1070 `ida->id = match_uid(ida->id)`.
+    #[must_use]
+    pub fn map_uid(&self, id: u32) -> u32 {
+        if self.numeric_ids {
+            return id;
+        }
+        let mut mapped = self.uid_map.get(&id).copied().unwrap_or(id);
+        #[cfg(unix)]
+        if let Some(mapping) = &self.user_mapping
+            && let Ok(Some(remapped)) = mapping.map_uid(mapped, self.numeric_ids)
+        {
+            mapped = remapped;
+        }
+        mapped
+    }
+
+    /// Remaps a named-group ACL id to the local gid.
+    ///
+    /// upstream: acls.c:1072 `ida->id = match_gid(ida->id, NULL)`.
+    #[must_use]
+    pub fn map_gid(&self, id: u32) -> u32 {
+        if self.numeric_ids {
+            return id;
+        }
+        let mut mapped = self.gid_map.get(&id).copied().unwrap_or(id);
+        #[cfg(unix)]
+        if let Some(mapping) = &self.group_mapping
+            && let Ok(Some(remapped)) = mapping.map_gid(mapped, self.numeric_ids)
+        {
+            mapped = remapped;
+        }
+        mapped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn mapper(uid: HashMap<u32, u32>, gid: HashMap<u32, u32>, numeric: bool) -> AclIdMapper {
+        AclIdMapper::new(uid, gid, None, None, numeric)
+    }
+
+    #[cfg(not(unix))]
+    fn mapper(uid: HashMap<u32, u32>, gid: HashMap<u32, u32>, numeric: bool) -> AclIdMapper {
+        AclIdMapper::new(uid, gid, numeric)
+    }
+
+    #[test]
+    fn id_list_remaps_named_user_across_namespaces() {
+        // WHY: a cross-host `-A` transfer carries the sender-side uid (1000). If
+        // the receiver applied it verbatim the ACL would land on whatever user
+        // owns uid 1000 locally. The id-list (built from the wire uid list where
+        // "alice" resolved to 2000) must remap 1000 -> 2000, mirroring upstream
+        // match_acl_ids/match_uid (acls.c:1070, uidlist.c:297).
+        let mut uid = HashMap::new();
+        uid.insert(1000u32, 2000u32);
+        let m = mapper(uid, HashMap::new(), false);
+        assert_eq!(m.map_uid(1000), 2000);
+    }
+
+    #[test]
+    fn id_list_remaps_named_group_across_namespaces() {
+        let mut gid = HashMap::new();
+        gid.insert(1000u32, 2000u32);
+        let m = mapper(HashMap::new(), gid, false);
+        assert_eq!(m.map_gid(1000), 2000);
+    }
+
+    #[test]
+    fn unmapped_id_passes_through() {
+        // WHY: upstream recv_add_id falls back to `id2 = id` (uidlist.c:282) for
+        // ids not in the list, so the raw wire id must survive rather than being
+        // dropped or zeroed.
+        let m = mapper(HashMap::new(), HashMap::new(), false);
+        assert_eq!(m.map_uid(4242), 4242);
+        assert_eq!(m.map_gid(4242), 4242);
+    }
+
+    #[test]
+    fn numeric_ids_disables_remap() {
+        // WHY: upstream recv_id_list is guarded by `numeric_ids <= 0`; with
+        // --numeric-ids no id-list is exchanged and ACL ids stay numeric.
+        let mut uid = HashMap::new();
+        uid.insert(1000u32, 2000u32);
+        let m = mapper(uid, HashMap::new(), true);
+        assert_eq!(m.map_uid(1000), 1000);
+    }
+}

--- a/crates/metadata/src/acl_idmap.rs
+++ b/crates/metadata/src/acl_idmap.rs
@@ -90,12 +90,12 @@ impl AclIdMapper {
         if self.numeric_ids {
             return id;
         }
-        let mut mapped = self.uid_map.get(&id).copied().unwrap_or(id);
+        let mapped = self.uid_map.get(&id).copied().unwrap_or(id);
         #[cfg(unix)]
         if let Some(mapping) = &self.user_mapping
             && let Ok(Some(remapped)) = mapping.map_uid(mapped, self.numeric_ids)
         {
-            mapped = remapped;
+            return remapped;
         }
         mapped
     }
@@ -108,12 +108,12 @@ impl AclIdMapper {
         if self.numeric_ids {
             return id;
         }
-        let mut mapped = self.gid_map.get(&id).copied().unwrap_or(id);
+        let mapped = self.gid_map.get(&id).copied().unwrap_or(id);
         #[cfg(unix)]
         if let Some(mapping) = &self.group_mapping
             && let Ok(Some(remapped)) = mapping.map_gid(mapped, self.numeric_ids)
         {
-            mapped = remapped;
+            return remapped;
         }
         mapped
     }

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -117,7 +117,7 @@ mod tests {
     fn apply_acls_from_cache_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
-        let result = apply_acls_from_cache(dst, &cache, 0, None, false, None);
+        let result = apply_acls_from_cache(dst, &cache, 0, None, false, None, None);
         assert!(result.is_ok());
     }
 
@@ -125,7 +125,7 @@ mod tests {
     fn apply_acls_from_cache_with_default_ndx_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
-        let result = apply_acls_from_cache(dst, &cache, 0, Some(1), true, Some(0o644));
+        let result = apply_acls_from_cache(dst, &cache, 0, Some(1), true, Some(0o644), None);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/src/acl_noop.rs
+++ b/crates/metadata/src/acl_noop.rs
@@ -5,6 +5,7 @@
 //! `acl` feature is disabled, or because the platform has no ACL
 //! implementation (e.g., Windows, Android).
 
+use crate::AclIdMapper;
 use crate::MetadataError;
 use protocol::acl::{AclCache, RsyncAcl};
 use std::path::Path;
@@ -57,6 +58,7 @@ pub fn apply_acls_from_cache(
     _default_ndx: Option<u32>,
     _follow_symlinks: bool,
     _mode: Option<u32>,
+    _id_map: Option<&AclIdMapper>,
 ) -> Result<(), MetadataError> {
     warn_acl_unsupported();
     Ok(())

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -3,6 +3,7 @@
     any(target_os = "ios", target_os = "tvos", target_os = "watchos")
 ))]
 
+use crate::AclIdMapper;
 use crate::MetadataError;
 use protocol::acl::{AclCache, RsyncAcl};
 use std::path::Path;
@@ -64,6 +65,7 @@ pub fn apply_acls_from_cache(
     default_ndx: Option<u32>,
     follow_symlinks: bool,
     mode: Option<u32>,
+    id_map: Option<&AclIdMapper>,
 ) -> Result<(), MetadataError> {
     let _ = (
         destination,
@@ -72,6 +74,7 @@ pub fn apply_acls_from_cache(
         default_ndx,
         follow_symlinks,
         mode,
+        id_map,
     );
     warn_acl_unsupported();
     Ok(())

--- a/crates/metadata/src/acl_stub.rs
+++ b/crates/metadata/src/acl_stub.rs
@@ -125,7 +125,7 @@ mod tests {
     fn apply_acls_from_cache_returns_ok() {
         let dst = Path::new("/nonexistent/dst");
         let cache = AclCache::new();
-        let result = apply_acls_from_cache(dst, &cache, 0, None, false, None);
+        let result = apply_acls_from_cache(dst, &cache, 0, None, false, None, None);
         assert!(result.is_ok());
     }
 }

--- a/crates/metadata/src/acl_windows/dacl.rs
+++ b/crates/metadata/src/acl_windows/dacl.rs
@@ -26,6 +26,7 @@ use super::common::{
     OwnedSecurityDescriptor, access_mask_to_rsync_perms, is_unsupported,
     rsync_perms_to_access_mask, to_wide, warn_partial_apply, win32_error,
 };
+use crate::AclIdMapper;
 use crate::MetadataError;
 
 /// Reads the DACL for `path` and returns it together with the owning
@@ -271,12 +272,16 @@ pub fn apply_acls_from_cache(
     default_ndx: Option<u32>,
     follow_symlinks: bool,
     mode: Option<u32>,
+    id_map: Option<&AclIdMapper>,
 ) -> Result<(), MetadataError> {
     if !follow_symlinks {
         return Ok(());
     }
 
     let _ = default_ndx; // Default ACLs are POSIX-only; ignored on Windows.
+    // Windows resolves ACL principals by SID/name, not numeric uid/gid, so the
+    // POSIX id-list remapper does not apply here.
+    let _ = id_map;
 
     let Some(acl) = cache.get_access(access_ndx) else {
         return Ok(());

--- a/crates/metadata/src/acl_windows/tests/dacl.rs
+++ b/crates/metadata/src/acl_windows/tests/dacl.rs
@@ -50,7 +50,7 @@ fn apply_acls_from_cache_skips_when_not_following() {
     let file = dir.path().join("test");
     File::create(&file).expect("file");
     let cache = AclCache::new();
-    let result = apply_acls_from_cache(&file, &cache, 0, None, false, None);
+    let result = apply_acls_from_cache(&file, &cache, 0, None, false, None, None);
     assert!(result.is_ok());
 }
 
@@ -60,7 +60,7 @@ fn apply_acls_from_cache_missing_index_is_noop() {
     let file = dir.path().join("test");
     File::create(&file).expect("file");
     let cache = AclCache::new();
-    let result = apply_acls_from_cache(&file, &cache, 99, None, true, Some(0o644));
+    let result = apply_acls_from_cache(&file, &cache, 99, None, true, Some(0o644), None);
     assert!(result.is_ok());
 }
 
@@ -72,7 +72,7 @@ fn apply_acls_from_cache_empty_cache_no_op() {
     let mut cache = AclCache::new();
     let acl = RsyncAcl::from_mode(0o644);
     let ndx = cache.store_access(acl);
-    let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+    let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
     assert!(result.is_ok());
 }
 

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -68,6 +68,8 @@
 //! - `core::client` integrates these helpers for local filesystem copies.
 //! - [`filetime`] for lower-level timestamp manipulation utilities.
 
+mod acl_idmap;
+
 #[cfg(all(
     feature = "acl",
     any(target_os = "linux", target_os = "macos", target_os = "freebsd")
@@ -183,6 +185,8 @@ pub fn am_root() -> bool {
         false
     }
 }
+
+pub use acl_idmap::AclIdMapper;
 
 #[cfg(all(
     feature = "acl",

--- a/crates/metadata/tests/acl_handling.rs
+++ b/crates/metadata/tests/acl_handling.rs
@@ -1067,7 +1067,7 @@ mod apply_acls_from_cache_tests {
         let acl = RsyncAcl::from_mode(0o644);
         let ndx = cache.store_access(acl);
 
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
         assert!(result.is_ok());
     }
 
@@ -1081,7 +1081,7 @@ mod apply_acls_from_cache_tests {
         let acl = RsyncAcl::from_mode(0o644);
         let ndx = cache.store_access(acl);
 
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, false, None);
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, false, None, None);
         assert!(result.is_ok());
     }
 
@@ -1095,7 +1095,7 @@ mod apply_acls_from_cache_tests {
         let acl = RsyncAcl::new();
         let ndx = cache.store_access(acl);
 
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
         assert!(result.is_ok());
     }
 
@@ -1106,7 +1106,7 @@ mod apply_acls_from_cache_tests {
         fs::write(&file, b"data").expect("write file");
 
         let cache = AclCache::new();
-        let result = apply_acls_from_cache(&file, &cache, 42, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, 42, None, true, Some(0o644), None);
         assert!(result.is_ok());
     }
 
@@ -1121,7 +1121,7 @@ mod apply_acls_from_cache_tests {
         for i in 0..3 {
             let file = temp.path().join(format!("file_{i}.txt"));
             fs::write(&file, b"data").expect("write file");
-            let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o755));
+            let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o755), None);
             assert!(result.is_ok());
         }
     }
@@ -1146,6 +1146,7 @@ mod apply_acls_from_cache_tests {
             Some(default_ndx),
             true,
             Some(0o755),
+            None,
         );
         assert!(result.is_ok());
     }
@@ -1185,7 +1186,7 @@ mod apply_acls_from_cache_tests {
         let mut cache = AclCache::new();
         let ndx = cache.store_access(acl);
 
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
         match result {
             Ok(()) => {}
             Err(err) => {
@@ -1228,7 +1229,7 @@ mod noop_apply_acls_tests {
         let acl = RsyncAcl::from_mode(0o644);
         let ndx = cache.store_access(acl);
 
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
         assert!(result.is_ok());
     }
 }
@@ -1301,7 +1302,7 @@ mod unmappable_id_remap_tests {
 
         let mut cache = AclCache::new();
         let ndx = cache.store_access(acl);
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
 
         match result {
             Ok(()) => {}
@@ -1333,7 +1334,7 @@ mod unmappable_id_remap_tests {
 
         let mut cache = AclCache::new();
         let ndx = cache.store_access(acl);
-        let _ = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let _ = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
 
         let messages = drain_own_messages();
         let expected = format!(
@@ -1364,7 +1365,7 @@ mod unmappable_id_remap_tests {
 
         let mut cache = AclCache::new();
         let ndx = cache.store_access(acl);
-        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644));
+        let result = apply_acls_from_cache(&file, &cache, ndx, None, true, Some(0o644), None);
 
         match result {
             Ok(()) => {}

--- a/crates/protocol/src/acl/entry.rs
+++ b/crates/protocol/src/acl/entry.rs
@@ -554,4 +554,13 @@ impl AclCache {
     pub fn default_count(&self) -> usize {
         self.default_acls.len()
     }
+
+    /// Iterates over every cached ACL (access then default).
+    ///
+    /// Used by the sender to feed each named entry's user/group id into the
+    /// shared uid/gid id-list, mirroring upstream `add_uid`/`add_gid` in
+    /// `send_ida_entries` (`acls.c:592-595`).
+    pub fn iter_acls(&self) -> impl Iterator<Item = &RsyncAcl> {
+        self.access_acls.iter().chain(self.default_acls.iter())
+    }
 }

--- a/crates/protocol/src/acl/tests.rs
+++ b/crates/protocol/src/acl/tests.rs
@@ -343,7 +343,7 @@ mod wire_roundtrip_tests {
 
         let mut cache = AclCache::new();
         let mut buf = Vec::new();
-        send_acl(&mut buf, &access_acl, None, false, &mut cache).unwrap();
+        send_acl(&mut buf, &access_acl, None, false, &mut cache, false).unwrap();
 
         let mut cursor = Cursor::new(buf);
         let (access_result, default_result) = recv_acl(&mut cursor, false).unwrap();
@@ -371,7 +371,15 @@ mod wire_roundtrip_tests {
 
         let mut cache = AclCache::new();
         let mut buf = Vec::new();
-        send_acl(&mut buf, &access_acl, Some(&default_acl), true, &mut cache).unwrap();
+        send_acl(
+            &mut buf,
+            &access_acl,
+            Some(&default_acl),
+            true,
+            &mut cache,
+            false,
+        )
+        .unwrap();
 
         let mut cursor = Cursor::new(buf);
         let (access_result, default_result) = recv_acl(&mut cursor, true).unwrap();
@@ -785,7 +793,15 @@ mod wire_format_compatibility {
         let mut cache = AclCache::new();
         let mut buf = Vec::new();
 
-        send_acl(&mut buf, &access_acl, Some(&default_acl), true, &mut cache).unwrap();
+        send_acl(
+            &mut buf,
+            &access_acl,
+            Some(&default_acl),
+            true,
+            &mut cache,
+            false,
+        )
+        .unwrap();
 
         // Should have two ACL transmissions
         let mut cursor = Cursor::new(&buf);
@@ -811,7 +827,7 @@ mod wire_format_compatibility {
         let mut cache = AclCache::new();
         let mut buf = Vec::new();
 
-        send_acl(&mut buf, &access_acl, None, false, &mut cache).unwrap();
+        send_acl(&mut buf, &access_acl, None, false, &mut cache, false).unwrap();
 
         // Only access ACL sent
         let mut cursor = Cursor::new(&buf);
@@ -1004,6 +1020,7 @@ mod receive_acl_cached_tests {
             Some(&default_acl),
             true,
             &mut send_cache,
+            false,
         )
         .unwrap();
 

--- a/crates/protocol/src/acl/wire/send.rs
+++ b/crates/protocol/src/acl/wire/send.rs
@@ -143,6 +143,9 @@ pub fn send_rsync_acl<W: Write>(
 /// * `default_acl` - The directory's default ACL (ignored for non-directories)
 /// * `is_directory` - Whether this entry is a directory
 /// * `cache` - ACL cache for deduplication
+/// * `include_names` - Whether to write user/group name strings after each
+///   named entry. Upstream sends names only when `inc_recurse && !numeric_ids`
+///   (`acls.c:597`); the receiver otherwise remaps ids through the id-list.
 ///
 /// # Upstream Reference
 ///
@@ -153,12 +156,13 @@ pub fn send_acl<W: Write>(
     default_acl: Option<&RsyncAcl>,
     is_directory: bool,
     cache: &mut AclCache,
+    include_names: bool,
 ) -> io::Result<()> {
-    send_rsync_acl(writer, access_acl, AclType::Access, cache, false)?;
+    send_rsync_acl(writer, access_acl, AclType::Access, cache, include_names)?;
 
     if is_directory {
         let def_acl = default_acl.cloned().unwrap_or_default();
-        send_rsync_acl(writer, &def_acl, AclType::Default, cache, false)?;
+        send_rsync_acl(writer, &def_acl, AclType::Default, cache, include_names)?;
     }
 
     Ok(())

--- a/crates/protocol/src/acl/wire/tests.rs
+++ b/crates/protocol/src/acl/wire/tests.rs
@@ -122,6 +122,37 @@ fn send_recv_ida_entries_roundtrip() {
 }
 
 #[test]
+fn send_ida_entries_ships_name_only_when_include_names() {
+    // WHY: upstream writes the ACL entry name only under inc_recurse
+    // (acls.c:597 `if (inc_recurse && name)`); otherwise the receiver remaps
+    // the id through the shared id-list (match_acl_ids). The name must travel
+    // when include_names=true so the inc_recurse receiver can resolve it, and
+    // must be dropped when false so the non-inc_recurse wire stays byte-compatible
+    // with upstream.
+    let mut entries = IdaEntries::new();
+    entries.push(IdAccess::user_with_name(1000, 0x07, b"alice".to_vec()));
+
+    // include_names = true: the name rides the wire and round-trips.
+    let mut with_names = Vec::new();
+    send_ida_entries(&mut with_names, &entries, true).unwrap();
+    let mut cursor = Cursor::new(with_names);
+    let (received, _mask) = recv_ida_entries(&mut cursor).unwrap();
+    assert_eq!(received.len(), 1);
+    assert_eq!(
+        received.iter().next().unwrap().name.as_deref(),
+        Some(&b"alice"[..])
+    );
+
+    // include_names = false: no name on the wire (non-inc_recurse default).
+    let mut without_names = Vec::new();
+    send_ida_entries(&mut without_names, &entries, false).unwrap();
+    let mut cursor = Cursor::new(without_names);
+    let (received, _mask) = recv_ida_entries(&mut cursor).unwrap();
+    assert_eq!(received.len(), 1);
+    assert_eq!(received.iter().next().unwrap().name, None);
+}
+
+#[test]
 fn send_recv_directory_acl() {
     let access_acl = {
         let mut acl = RsyncAcl::new();
@@ -142,7 +173,15 @@ fn send_recv_directory_acl() {
     let mut cache = AclCache::new();
     let mut buf = Vec::new();
 
-    send_acl(&mut buf, &access_acl, Some(&default_acl), true, &mut cache).unwrap();
+    send_acl(
+        &mut buf,
+        &access_acl,
+        Some(&default_acl),
+        true,
+        &mut cache,
+        false,
+    )
+    .unwrap();
 
     let mut cursor = Cursor::new(buf);
     let (access_result, default_result) = recv_acl(&mut cursor, true).unwrap();
@@ -393,7 +432,7 @@ fn send_recv_file_acl_no_default() {
     let mut buf = Vec::new();
 
     // File (not directory) - no default ACL sent
-    send_acl(&mut buf, &access_acl, None, false, &mut cache).unwrap();
+    send_acl(&mut buf, &access_acl, None, false, &mut cache, false).unwrap();
 
     let mut cursor = Cursor::new(buf);
     let (access_result, default_result) = recv_acl(&mut cursor, false).unwrap();

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1652,6 +1652,7 @@ mod acl_integration {
             Some(&default_acl),
             true,
             &mut acl_cache,
+            false,
         )
         .unwrap();
 
@@ -1883,6 +1884,7 @@ mod acl_integration {
                 Some(&default_acl),
                 true,
                 &mut acl_cache,
+                false,
             )
             .unwrap();
         }
@@ -1995,6 +1997,7 @@ mod acl_integration {
             Some(&default_acl),
             true,
             &mut acl_cache,
+            false,
         )
         .unwrap();
 

--- a/crates/protocol/src/flist/write/mod.rs
+++ b/crates/protocol/src/flist/write/mod.rs
@@ -114,6 +114,11 @@ pub struct FileListWriter {
     ///
     /// Tuple: (access_acl, optional_default_acl_for_dirs).
     pending_acl: Option<(RsyncAcl, Option<RsyncAcl>)>,
+    /// Whether to write user/group name strings for named ACL entries.
+    ///
+    /// Upstream writes ACL names only when `inc_recurse && !numeric_ids`
+    /// (`acls.c:597`); otherwise the receiver remaps ids through the id-list.
+    acl_send_names: bool,
     /// Xattr cache for sender-side deduplication across entries.
     /// upstream: xattrs.c - `find_matching_xattr()` + `rsync_xal_store()`
     xattr_cache: XattrCache,
@@ -140,6 +145,7 @@ impl FileListWriter {
             first_ndx: 0,
             acl_cache: AclCache::new(),
             pending_acl: None,
+            acl_send_names: false,
             xattr_cache: XattrCache::new(),
             checksum_seed: 0,
         }
@@ -163,6 +169,7 @@ impl FileListWriter {
             first_ndx: 0,
             acl_cache: AclCache::new(),
             pending_acl: None,
+            acl_send_names: false,
             xattr_cache: XattrCache::new(),
             checksum_seed: 0,
         }
@@ -245,6 +252,28 @@ impl FileListWriter {
     pub const fn with_preserve_acls(mut self, preserve: bool) -> Self {
         self.preserve.acls = preserve;
         self
+    }
+
+    /// Sets whether user/group name strings are written for named ACL entries.
+    ///
+    /// Upstream sends ACL names only when `inc_recurse && !numeric_ids`
+    /// (`acls.c:597`); otherwise the receiver remaps ids through the id-list.
+    #[inline]
+    #[must_use]
+    pub const fn with_acl_send_names(mut self, send_names: bool) -> Self {
+        self.acl_send_names = send_names;
+        self
+    }
+
+    /// Returns the sender-side ACL cache accumulated across written entries.
+    ///
+    /// Used to feed named-entry user/group ids into the shared uid/gid id-list
+    /// before it is transmitted, mirroring upstream `add_uid`/`add_gid` in
+    /// `send_ida_entries` (`acls.c:592-595`).
+    #[inline]
+    #[must_use]
+    pub const fn acl_cache(&self) -> &AclCache {
+        &self.acl_cache
     }
 
     /// Sets the ACL data for the next `write_entry` call.
@@ -422,6 +451,7 @@ impl FileListWriter {
                 default_acl.as_ref(),
                 entry.is_dir(),
                 &mut self.acl_cache,
+                self.acl_send_names,
             )?;
         } else {
             self.pending_acl = None;

--- a/crates/protocol/src/idlist/mod.rs
+++ b/crates/protocol/src/idlist/mod.rs
@@ -152,6 +152,19 @@ impl IdList {
             .unwrap_or(remote_id)
     }
 
+    /// Returns an owned `remote id -> local id` snapshot of the resolved list.
+    ///
+    /// Used by the receiver to build a thread-shareable ACL id remapper
+    /// (`AclIdMapper`) that outlives the borrow of the receiver context, since
+    /// cached ACLs are applied on the disk-commit thread.
+    #[must_use]
+    pub fn resolved_map(&self) -> HashMap<u32, u32> {
+        self.entries
+            .iter()
+            .map(|(remote, entry)| (*remote, entry.local_id))
+            .collect()
+    }
+
     /// Writes the ID list to the wire.
     ///
     /// # Wire Format

--- a/crates/protocol/tests/acl_compat_309.rs
+++ b/crates/protocol/tests/acl_compat_309.rs
@@ -250,13 +250,13 @@ fn acl_send_cache_deduplication() {
     let mut cache = AclCache::new();
 
     // First send: literal ACL data.
-    send_acl(&mut buf_first, &acl, None, false, &mut cache).unwrap();
+    send_acl(&mut buf_first, &acl, None, false, &mut cache, false).unwrap();
     assert!(!buf_first.is_empty(), "ACL data must be written to wire");
     assert_eq!(cache.access_count(), 1, "cache must store the ACL");
 
     // Second send: cache hit (smaller payload).
     let mut buf_second = Vec::new();
-    send_acl(&mut buf_second, &acl, None, false, &mut cache).unwrap();
+    send_acl(&mut buf_second, &acl, None, false, &mut cache, false).unwrap();
     assert!(
         buf_second.len() < buf_first.len(),
         "cache hit ({} bytes) must be smaller than literal ({} bytes)",
@@ -279,13 +279,21 @@ fn directory_acl_includes_default() {
 
     let mut buf_dir = Vec::new();
     let mut cache_dir = AclCache::new();
-    send_acl(&mut buf_dir, &access, Some(&default), true, &mut cache_dir).unwrap();
+    send_acl(
+        &mut buf_dir,
+        &access,
+        Some(&default),
+        true,
+        &mut cache_dir,
+        false,
+    )
+    .unwrap();
     assert_eq!(cache_dir.access_count(), 1);
     assert_eq!(cache_dir.default_count(), 1);
 
     let mut buf_file = Vec::new();
     let mut cache_file = AclCache::new();
-    send_acl(&mut buf_file, &access, None, false, &mut cache_file).unwrap();
+    send_acl(&mut buf_file, &access, None, false, &mut cache_file, false).unwrap();
     assert_eq!(cache_file.access_count(), 1);
     assert_eq!(cache_file.default_count(), 0);
 
@@ -307,11 +315,11 @@ fn different_acl_modes_are_distinct_cache_entries() {
     let mut cache = AclCache::new();
     let mut buf = Vec::new();
 
-    send_acl(&mut buf, &acl_644, None, false, &mut cache).unwrap();
+    send_acl(&mut buf, &acl_644, None, false, &mut cache, false).unwrap();
     assert_eq!(cache.access_count(), 1);
 
     buf.clear();
-    send_acl(&mut buf, &acl_755, None, false, &mut cache).unwrap();
+    send_acl(&mut buf, &acl_755, None, false, &mut cache, false).unwrap();
     assert_eq!(
         cache.access_count(),
         2,

--- a/crates/transfer/src/disk_commit/config.rs
+++ b/crates/transfer/src/disk_commit/config.rs
@@ -114,6 +114,12 @@ pub struct DiskCommitConfig {
     /// ACL cache from flist reception, shared via `Arc` for thread safety.
     /// When `Some`, the disk thread applies cached ACLs after metadata.
     pub acl_cache: Option<Arc<AclCache>>,
+    /// Cross-host id remapper for named ACL entries, shared via `Arc`. Built
+    /// from the received uid/gid id-lists plus `--usermap`/`--groupmap` so the
+    /// disk thread remaps ACL ids like file owners.
+    ///
+    /// upstream: acls.c:1059-1081 `match_acl_ids()`.
+    pub acl_id_map: Option<Arc<metadata::AclIdMapper>>,
     /// SPSC channel capacity for the disk commit thread.
     ///
     /// Controls how many `FileMessage` items can be buffered between the
@@ -183,6 +189,7 @@ impl Default for DiskCommitConfig {
             metadata_opts: None,
             backup: None,
             acl_cache: None,
+            acl_id_map: None,
             channel_capacity: DEFAULT_CHANNEL_CAPACITY,
             io_uring_policy: fast_io::IoUringPolicy::Auto,
             io_uring_depth: None,

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -8,6 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
+use metadata::AclIdMapper;
 use protocol::acl::AclCache;
 
 use crate::delta_apply::ChecksumVerifier;
@@ -41,6 +42,7 @@ pub(super) fn apply_file_metadata(
             file_entry,
             config.metadata_opts.as_ref(),
             config.acl_cache.as_deref(),
+            config.acl_id_map.as_deref(),
             begin.xattr_list.as_ref(),
         )
     }
@@ -60,6 +62,7 @@ fn apply_metadata_acls_and_xattrs(
     file_entry: Option<&protocol::flist::FileEntry>,
     metadata_opts: Option<&metadata::MetadataOptions>,
     acl_cache: Option<&AclCache>,
+    acl_id_map: Option<&AclIdMapper>,
     xattr_list: Option<&protocol::xattr::XattrList>,
 ) -> Option<(PathBuf, String)> {
     let (opts, entry) = match (metadata_opts, file_entry) {
@@ -85,6 +88,7 @@ fn apply_metadata_acls_and_xattrs(
                 entry.def_acl_ndx(),
                 follow,
                 Some(entry.mode()),
+                acl_id_map,
             ) {
                 return Some((file_path.to_path_buf(), e.to_string()));
             }

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -258,6 +258,15 @@ impl GeneratorContext {
     pub(crate) fn build_flist_writer(&self) -> protocol::flist::FileListWriter {
         use crate::shared::ChecksumFactory;
 
+        // upstream: acls.c:597 - ACL entry names are written only under
+        // incremental recursion and when names (not numeric ids) are used.
+        // Without inc_recurse the receiver remaps ACL ids through the id-list
+        // (match_acl_ids), so no per-entry name is needed on the wire.
+        let inc_recurse = self
+            .compat_flags
+            .is_some_and(|f| f.contains(protocol::CompatibilityFlags::INC_RECURSE));
+        let acl_send_names = inc_recurse && !self.config.flags.numeric_ids;
+
         let mut writer = if let Some(flags) = self.compat_flags {
             protocol::flist::FileListWriter::with_compat_flags(self.protocol, flags)
         } else {
@@ -272,6 +281,7 @@ impl GeneratorContext {
         .with_preserve_atimes(self.config.flags.atimes)
         .with_preserve_crtimes(self.config.flags.crtimes)
         .with_preserve_acls(self.config.flags.acls)
+        .with_acl_send_names(acl_send_names)
         .with_preserve_xattrs(self.config.flags.xattrs)
         .with_checksum_seed(self.checksum_seed);
 

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -74,15 +74,66 @@ impl GeneratorContext {
             .is_some_and(|f| f.contains(CompatibilityFlags::ID0_NAMES));
         let protocol_version = self.protocol.as_u8();
 
-        if self.config.flags.owner {
+        // upstream: uidlist.c:409,412 - send the uid/gid list when preserving
+        // ownership OR ACLs. `--acls` injects named-entry ids into the same
+        // list (see collect_acl_id_mappings), so the receiver can remap them.
+        if self.config.flags.owner || self.config.flags.acls {
             self.uid_list.write(writer, id0_names, protocol_version)?;
         }
-        if self.config.flags.group {
+        if self.config.flags.group || self.config.flags.acls {
             self.gid_list.write(writer, id0_names, protocol_version)?;
         }
 
         writer.flush()
     }
+
+    /// Feeds named ACL-entry user/group ids into the shared uid/gid id-list.
+    ///
+    /// Mirrors upstream `send_ida_entries()` (`acls.c:592-595`), which calls
+    /// `add_uid(ida->id)`/`add_gid(ida->id)` for every named ACL entry (unless
+    /// `numeric_ids`) so the receiver remaps those ids through the same table as
+    /// file owners via `match_acl_ids()` (`uidlist.c:483-484`).
+    ///
+    /// Must run after the file list is sent (so the ACL cache is fully
+    /// populated) and before [`Self::send_id_lists`]. No-op under `numeric_ids`
+    /// or when the sender-side ACL cache is unavailable.
+    #[cfg(unix)]
+    pub(crate) fn collect_acl_id_mappings(&mut self) {
+        use metadata::id_lookup::{lookup_group_name, lookup_user_name};
+
+        if self.config.flags.numeric_ids || !self.config.flags.acls {
+            return;
+        }
+
+        let Some(writer) = self.incremental.flist_writer_cache.as_ref() else {
+            return;
+        };
+
+        // Snapshot the (id, is_user) pairs so the borrow of the cache ends
+        // before we mutate the id-lists.
+        let named: Vec<(u32, bool)> = writer
+            .acl_cache()
+            .iter_acls()
+            .flat_map(|acl| acl.names.iter())
+            .map(|ida| (ida.id, ida.is_user()))
+            .collect();
+
+        for (id, is_user) in named {
+            if is_user {
+                if !self.uid_list.contains(id) {
+                    let name = lookup_user_name(id).ok().flatten();
+                    self.uid_list.add_id(id, name);
+                }
+            } else if !self.gid_list.contains(id) {
+                let name = lookup_group_name(id).ok().flatten();
+                self.gid_list.add_id(id, name);
+            }
+        }
+    }
+
+    /// No-op on non-Unix platforms - ACL ids are not remapped by numeric id.
+    #[cfg(not(unix))]
+    pub(crate) fn collect_acl_id_mappings(&mut self) {}
 
     /// Sends io_error flag for protocol < 30.
     ///

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -92,6 +92,10 @@ impl GeneratorContext {
             self.send_file_list(writer)?
         };
 
+        // upstream: acls.c:592-595 - named ACL-entry ids join the shared id-list
+        // so the receiver remaps them like file owners. Runs after the file list
+        // is sent (ACL cache complete) and before the id-list is transmitted.
+        self.collect_acl_id_mappings();
         self.send_id_lists(writer)?;
         self.send_io_error_flag(writer)?;
 

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
-use metadata::{MetadataOptions, apply_metadata_with_cached_stat};
+use metadata::{AclIdMapper, MetadataOptions, apply_metadata_with_cached_stat};
 use protocol::acl::AclCache;
 use protocol::flist::FileEntry;
 use protocol::xattr::XattrList;
@@ -43,6 +43,7 @@ impl ReceiverContext {
         dest_dir: &Path,
         metadata_opts: &MetadataOptions,
         acl_cache: Option<&AclCache>,
+        acl_id_map: Option<&AclIdMapper>,
         writer: &mut W,
         #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> io::Result<Vec<(PathBuf, String)>> {
@@ -267,6 +268,7 @@ impl ReceiverContext {
             .collect();
 
         let acl_cache_clone = acl_cache.cloned();
+        let acl_id_map_clone = acl_id_map.cloned();
         let results = crate::parallel_io::map_blocking(
             entry_snapshots,
             self.parallel_thresholds
@@ -282,6 +284,7 @@ impl ReceiverContext {
                     &dir_path,
                     &entry,
                     acl_cache_clone.as_ref(),
+                    acl_id_map_clone.as_ref(),
                     true, // directories always follow symlinks
                 ) {
                     return Some((dir_path, e.to_string()));
@@ -402,6 +405,7 @@ impl ReceiverContext {
         metadata_opts: &MetadataOptions,
         failed_dirs: &mut FailedDirectories,
         acl_cache: Option<&AclCache>,
+        acl_id_map: Option<&AclIdMapper>,
         #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
     ) -> io::Result<Option<bool>> {
         let relative_path = entry.path();
@@ -528,7 +532,9 @@ impl ReceiverContext {
         }
 
         // Apply cached ACLs after metadata (non-fatal errors)
-        if let Err(e) = apply_acls_from_receiver_cache(&dir_path, entry, acl_cache, true) {
+        if let Err(e) =
+            apply_acls_from_receiver_cache(&dir_path, entry, acl_cache, acl_id_map, true)
+        {
             if self.config.flags.verbose && self.config.connection.client_mode {
                 info_log!(
                     Misc,
@@ -731,6 +737,7 @@ mod touch_up_dirs_tests {
             .create_directories(
                 dest,
                 &opts,
+                None,
                 None,
                 &mut writer,
                 #[cfg(unix)]

--- a/crates/transfer/src/receiver/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/file_list/id_lists.rs
@@ -44,8 +44,10 @@ impl ReceiverContext {
 
         let protocol_version = self.protocol.as_u8();
 
-        // upstream: uidlist.c:467 - recv_uid_list()
-        if self.config.flags.owner {
+        // upstream: uidlist.c:465 - read the uid list when preserving ownership
+        // OR ACLs (`preserve_uid || preserve_acls`). The sender injects named
+        // ACL-entry ids into this list so the receiver can remap them.
+        if self.config.flags.owner || self.config.flags.acls {
             self.uid_list.read_with_kind(
                 reader,
                 id0_names,
@@ -55,8 +57,8 @@ impl ReceiverContext {
             )?;
         }
 
-        // upstream: uidlist.c:471 - recv_gid_list()
-        if self.config.flags.group {
+        // upstream: uidlist.c:473 - read the gid list under the same condition.
+        if self.config.flags.group || self.config.flags.acls {
             self.gid_list.read_with_kind(
                 reader,
                 id0_names,
@@ -97,7 +99,9 @@ impl ReceiverContext {
 
         let protocol_version = self.protocol.as_u8();
 
-        if self.config.flags.owner {
+        // upstream: uidlist.c:465,473 - `preserve_uid || preserve_acls` /
+        // `preserve_gid || preserve_acls`.
+        if self.config.flags.owner || self.config.flags.acls {
             self.uid_list.read_with_kind(
                 reader,
                 id0_names,
@@ -107,7 +111,7 @@ impl ReceiverContext {
             )?;
         }
 
-        if self.config.flags.group {
+        if self.config.flags.group || self.config.flags.acls {
             self.gid_list.read_with_kind(
                 reader,
                 id0_names,

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -13,6 +13,7 @@ use protocol::filters::FilterRuleWireFormat;
 use protocol::flist::FileEntry;
 
 use filters::FilterSet;
+use metadata::AclIdMapper;
 
 /// Shared configuration produced by [`ReceiverContext::setup_transfer`].
 ///
@@ -28,6 +29,13 @@ pub(in crate::receiver) struct PipelineSetup {
     /// thread via `Arc` so cached ACLs can be applied after file metadata.
     /// `None` when `--acls` is not active.
     pub(in crate::receiver) acl_cache: Option<Arc<AclCache>>,
+    /// Cross-host id remapper for named ACL entries, built from the received
+    /// uid/gid id-lists plus `--usermap`/`--groupmap`. Shared with the disk
+    /// commit thread via `Arc`. `None` when `--acls` is not active.
+    ///
+    /// upstream: acls.c:1059-1081 `match_acl_ids()` converts every named ACL
+    /// entry id through the same table as file owners.
+    pub(in crate::receiver) acl_id_map: Option<Arc<AclIdMapper>>,
     /// Parent-dirfd carrier rooted at the destination tree.
     ///
     /// Opened once via [`fast_io::secure_open_dir`] when `setup_transfer`
@@ -61,6 +69,7 @@ pub(in crate::receiver) fn apply_acls_from_receiver_cache(
     destination: &std::path::Path,
     entry: &FileEntry,
     acl_cache: Option<&AclCache>,
+    id_map: Option<&AclIdMapper>,
     follow_symlinks: bool,
 ) -> Result<(), metadata::MetadataError> {
     let cache = match acl_cache {
@@ -78,6 +87,7 @@ pub(in crate::receiver) fn apply_acls_from_receiver_cache(
         entry.def_acl_ndx(),
         follow_symlinks,
         Some(entry.mode()),
+        id_map,
     )
 }
 

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -14,7 +14,7 @@ use protocol::flist::FileEntry;
 use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
 use crate::delta_apply::ChecksumVerifier;
 
-use metadata::{MetadataOptions, apply_metadata_with_cached_stat};
+use metadata::{AclIdMapper, MetadataOptions, apply_metadata_with_cached_stat};
 use protocol::acl::AclCache;
 
 use super::apply_acls_from_receiver_cache;
@@ -248,6 +248,7 @@ pub(super) fn try_reference_dest(
     metadata_opts: &MetadataOptions,
     metadata_errors: &mut Vec<(PathBuf, String)>,
     acl_cache: Option<&AclCache>,
+    acl_id_map: Option<&AclIdMapper>,
 ) -> bool {
     if reference_directories.is_empty() {
         return false;
@@ -308,6 +309,7 @@ pub(super) fn try_reference_dest(
                         &dest_path,
                         entry,
                         acl_cache,
+                        acl_id_map,
                         !entry.is_symlink(),
                     ) {
                         metadata_errors.push((dest_path, e.to_string()));
@@ -335,6 +337,7 @@ pub(super) fn try_reference_dest(
                             &dest_path,
                             entry,
                             acl_cache,
+                            acl_id_map,
                             !entry.is_symlink(),
                         ) {
                             metadata_errors.push((dest_path, e.to_string()));
@@ -545,6 +548,7 @@ mod info_copy_emission_tests {
             &metadata_opts,
             &mut metadata_errors,
             None,
+            None,
         );
 
         // Restore writable permissions so tempdir cleanup succeeds.
@@ -604,6 +608,7 @@ mod info_copy_emission_tests {
             false,
             &metadata_opts,
             &mut metadata_errors,
+            None,
             None,
         );
 
@@ -695,6 +700,7 @@ mod symlink_basis_tests {
             copy_links,
             &metadata_opts,
             &mut metadata_errors,
+            None,
             None,
         )
     }

--- a/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_directories.rs
@@ -216,6 +216,7 @@ mod create_directory_incremental_tests {
             &opts,
             &mut failed,
             None,
+            None,
             #[cfg(unix)]
             None,
         );
@@ -252,6 +253,7 @@ mod create_directory_incremental_tests {
             &entry,
             &opts,
             &mut failed,
+            None,
             None,
             #[cfg(unix)]
             None,
@@ -293,6 +295,7 @@ mod create_directory_incremental_tests {
             &opts,
             &mut failed,
             None,
+            None,
             #[cfg(unix)]
             None,
         );
@@ -323,6 +326,7 @@ mod create_directory_incremental_tests {
             &entry,
             &opts,
             &mut failed,
+            None,
             None,
             #[cfg(unix)]
             None,
@@ -381,6 +385,7 @@ mod create_directory_incremental_tests {
             &opts,
             &mut failed,
             None,
+            None,
             #[cfg(unix)]
             None,
         );
@@ -438,6 +443,7 @@ mod create_directory_incremental_tests {
             &entry,
             &opts,
             &mut failed,
+            None,
             None,
             #[cfg(unix)]
             None,
@@ -537,6 +543,7 @@ mod incremental_mode_tests {
             &entry,
             &opts,
             &mut failed,
+            None,
             None,
             #[cfg(unix)]
             None,

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -78,6 +78,7 @@ impl ReceiverContext {
     /// Optimized for the 100K-file no-change scan path: pre-computes config
     /// flags, skips metadata/ACL/xattr work when the corresponding features are
     /// disabled, and avoids per-file allocations where possible.
+    #[allow(clippy::too_many_arguments)]
     pub(in crate::receiver) fn build_files_to_transfer<
         'a,
         W: Write + crate::writer::MsgInfoSender + ?Sized,
@@ -90,6 +91,7 @@ impl ReceiverContext {
         metadata_errors: &mut Vec<(PathBuf, String)>,
         stats: &mut TransferStats,
         acl_cache: Option<&protocol::acl::AclCache>,
+        acl_id_map: Option<&metadata::AclIdMapper>,
     ) -> Vec<(usize, &'a FileEntry, PathBuf, u32)> {
         // upstream: generator.c:1234-1235 - "recv_generator(%s,%d)" emitted at
         // the top of recv_generator() for every file the generator considers
@@ -289,6 +291,7 @@ impl ReceiverContext {
                         metadata_opts,
                         metadata_errors,
                         acl_cache,
+                        acl_id_map,
                         emit_itemize,
                         unchanged_iflags,
                         has_acls,
@@ -314,6 +317,7 @@ impl ReceiverContext {
                         metadata_opts,
                         metadata_errors,
                         acl_cache,
+                        acl_id_map,
                     )
                 {
                     continue;
@@ -444,6 +448,7 @@ impl ReceiverContext {
         metadata_opts: &MetadataOptions,
         metadata_errors: &mut Vec<(PathBuf, String)>,
         acl_cache: Option<&protocol::acl::AclCache>,
+        acl_id_map: Option<&metadata::AclIdMapper>,
         emit_itemize: bool,
         unchanged_iflags: u32,
         has_acls: bool,
@@ -477,9 +482,13 @@ impl ReceiverContext {
 
         // upstream: rsync.c:set_file_attrs() -> set_acl() for ACL preservation
         if has_acls {
-            if let Err(e) =
-                apply_acls_from_receiver_cache(file_path, entry, acl_cache, !entry.is_symlink())
-            {
+            if let Err(e) = apply_acls_from_receiver_cache(
+                file_path,
+                entry,
+                acl_cache,
+                acl_id_map,
+                !entry.is_symlink(),
+            ) {
                 metadata_errors.push((file_path.to_path_buf(), e.to_string()));
                 return;
             }

--- a/crates/transfer/src/receiver/transfer/file_async.rs
+++ b/crates/transfer/src/receiver/transfer/file_async.rs
@@ -105,6 +105,7 @@ pub(in crate::receiver) struct AsyncFileContext<'a> {
     pub(in crate::receiver) checksum_length: std::num::NonZeroU8,
     pub(in crate::receiver) checksum_algorithm: signature::SignatureAlgorithm,
     pub(in crate::receiver) acl_cache: Option<&'a std::sync::Arc<AclCache>>,
+    pub(in crate::receiver) acl_id_map: Option<&'a std::sync::Arc<metadata::AclIdMapper>>,
     #[cfg(unix)]
     pub(in crate::receiver) sandbox: Option<&'a std::sync::Arc<fast_io::DirSandbox>>,
 }
@@ -353,6 +354,7 @@ impl ReceiverContext {
             &file_path,
             file_entry,
             ctx.acl_cache.map(std::sync::Arc::as_ref),
+            ctx.acl_id_map.map(std::sync::Arc::as_ref),
             !file_entry.is_symlink(),
         ) {
             outcome
@@ -586,6 +588,7 @@ mod tests {
                     seed_config: checksums::strong::Md5Seed::none(),
                 },
                 acl_cache: None,
+                acl_id_map: None,
                 #[cfg(unix)]
                 sandbox: None,
             };
@@ -669,6 +672,7 @@ mod tests {
                 seed_config: checksums::strong::Md5Seed::none(),
             },
             acl_cache: None,
+            acl_id_map: None,
             #[cfg(unix)]
             sandbox: None,
         };

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -147,6 +147,7 @@ impl ReceiverContext {
             metadata_opts: Some(setup.metadata_opts.clone()),
             backup,
             acl_cache: setup.acl_cache.clone(),
+            acl_id_map: setup.acl_id_map.clone(),
             io_uring_policy: self.config.write.io_uring_policy,
             io_uring_depth: self.config.write.io_uring_depth,
             partial_mode,

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -46,6 +46,7 @@ impl ReceiverContext {
             &setup.dest_dir,
             &setup.metadata_opts,
             setup.acl_cache.as_deref(),
+            setup.acl_id_map.as_deref(),
             writer,
             #[cfg(unix)]
             setup.sandbox.as_deref(),
@@ -98,6 +99,7 @@ impl ReceiverContext {
             &mut metadata_errors,
             &mut stats,
             setup.acl_cache.as_deref(),
+            setup.acl_id_map.as_deref(),
         );
 
         let mut files_transferred: usize = 0;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -59,6 +59,7 @@ impl ReceiverContext {
                     &setup.metadata_opts,
                     &mut failed_dirs,
                     setup.acl_cache.as_deref(),
+                    setup.acl_id_map.as_deref(),
                     #[cfg(unix)]
                     setup.sandbox.as_deref(),
                 )?;
@@ -131,6 +132,7 @@ impl ReceiverContext {
             &mut metadata_errors,
             &mut stats,
             setup.acl_cache.as_deref(),
+            setup.acl_id_map.as_deref(),
         );
 
         let mut files_transferred: usize = 0;

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -389,6 +389,16 @@ impl ReceiverContext {
             None
         };
 
+        // upstream: uidlist.c:483-484 match_acl_ids() - build the cross-host id
+        // remapper for named ACL entries from the received uid/gid id-lists plus
+        // `--usermap`/`--groupmap`, snapshotted so it can ride the Arc onto the
+        // disk-commit thread that applies cached ACLs.
+        let acl_id_map = if self.config.flags.acls {
+            Some(Arc::new(self.build_acl_id_mapper()))
+        } else {
+            None
+        };
+
         // SEC-1.e: open the destination root as a sandboxed dirfd carrier.
         // The carrier rides through every per-entry operation so the
         // SEC-1.f-j cutover sites can replace path-based syscalls with
@@ -428,6 +438,7 @@ impl ReceiverContext {
                 checksum_length,
                 checksum_algorithm,
                 acl_cache,
+                acl_id_map,
                 #[cfg(unix)]
                 sandbox,
             },
@@ -524,6 +535,34 @@ impl ReceiverContext {
             entry.set_name(PathBuf::from(&target_basename));
         }
         parent.unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    /// Builds the cross-host ACL id remapper from the received id-lists.
+    ///
+    /// Snapshots the resolved remote->local uid/gid maps and, on Unix, the
+    /// parsed `--usermap`/`--groupmap` rules so named ACL entries are remapped
+    /// exactly like file owners.
+    ///
+    /// upstream: uidlist.c:483-484 + acls.c:1059-1081 - `match_acl_ids()`.
+    #[cfg(unix)]
+    fn build_acl_id_mapper(&self) -> metadata::AclIdMapper {
+        metadata::AclIdMapper::new(
+            self.uid_list.resolved_map(),
+            self.gid_list.resolved_map(),
+            self.config.user_mapping.clone(),
+            self.config.group_mapping.clone(),
+            self.config.flags.numeric_ids,
+        )
+    }
+
+    /// Builds the cross-host ACL id remapper (non-Unix: no `--usermap`).
+    #[cfg(not(unix))]
+    fn build_acl_id_mapper(&self) -> metadata::AclIdMapper {
+        metadata::AclIdMapper::new(
+            self.uid_list.resolved_map(),
+            self.gid_list.resolved_map(),
+            self.config.flags.numeric_ids,
+        )
     }
 
     /// Forwards a server-receiver-side `--files-from=<localpath>` file to the

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -53,6 +53,7 @@ impl ReceiverContext {
             checksum_length,
             checksum_algorithm,
             acl_cache,
+            acl_id_map,
             #[cfg(unix)]
             sandbox,
         } = setup;
@@ -67,6 +68,7 @@ impl ReceiverContext {
             &dest_dir,
             &metadata_opts,
             acl_cache.as_deref(),
+            acl_id_map.as_deref(),
             writer,
             #[cfg(unix)]
             sandbox.as_deref(),
@@ -472,6 +474,7 @@ impl ReceiverContext {
                 &file_path,
                 file_entry,
                 acl_cache.as_deref(),
+                acl_id_map.as_deref(),
                 !file_entry.is_symlink(),
             ) {
                 metadata_errors.push((file_path.clone(), acl_err.to_string()));


### PR DESCRIPTION
## Problem

On a cross-host \`-A\` (ACL) transfer where sender and receiver have different uid/gid namespaces, named ACL entries were applied with the raw, unremapped sender-side ids. A file whose ACL granted \`user:alice:rwx\` (sender uid 1000) landed on whatever principal happened to own uid 1000 on the receiver, instead of the receiver's \`alice\`.

Root cause: the ACL path was disconnected from the shared uid/gid id-list that file ownership uses for name-based remapping.

- The sender never fed named ACL-entry ids into the shared id-list (only file owners were collected), and never sent the id-list at all unless \`-o\`/\`-g\` was also set.
- ACL entry names never reached the wire (\`include_names\` was hard-coded \`false\`).
- The receiver applied ACL ids verbatim, ignoring both the received id-list and \`--usermap\`/\`--groupmap\`.

## Upstream reference

Upstream feeds each named ACL entry's id into the shared uid/gid list via \`add_uid\`/\`add_gid\` in \`send_ida_entries\` (acls.c:592-595), sends the list whenever \`preserve_uid || preserve_acls\` (uidlist.c:409-413), and on the receiver converts every ACL id through the same table via \`match_acl_ids()\` (uidlist.c:483-484, acls.c:1059-1081). Names are written on the wire only under \`inc_recurse\` (acls.c:597).

## Changes

**Sender**
- Feed named ACL-entry user/group ids into the shared \`uid_list\`/\`gid_list\` after the file list is sent and before the id-list is transmitted (\`collect_acl_id_mappings\`), mirroring \`add_uid\`/\`add_gid\`.
- Send the uid/gid list when \`owner || acls\` / \`group || acls\` (was \`owner\`/\`group\` only).
- Write ACL entry names when \`inc_recurse && !numeric_ids\` (was never).

**Receiver**
- Read the uid/gid list when \`owner || acls\` / \`group || acls\`.
- Build an owned \`AclIdMapper\` snapshot (remote->local uid/gid maps + \`--usermap\`/\`--groupmap\`) at setup, shared via \`Arc\` with the disk-commit thread, and remap every named ACL id through it on apply, mirroring \`match_acl_ids()\`. Falls back to the existing name-based NSS resolution when no mapper is present (local copy) and passes ids through unchanged under \`--numeric-ids\`.

## Tests

- \`AclIdMapper\`: id-list remap for named user/group across namespaces, unmapped-id pass-through, \`--numeric-ids\` disables remap.
- \`rsync_acl_to_entries_remaps_named_ids_via_id_map\`: end-to-end reconstruct remaps 1000->2000 with no wire name (the non-inc_recurse cross-host path).
- \`send_ida_entries_ships_name_only_when_include_names\`: name rides the wire under \`include_names=true\`, dropped under \`false\` (upstream wire compatibility).

Unix ACL semantics; Linux CI is the runtime gate. Build/clippy/fmt clean on protocol/metadata/transfer.