### PR TITLE
perf(transfer): default mmap for large-basis signature read (byte-transparent)

### DIFF
--- a/crates/fast_io/src/mmap_reader.rs
+++ b/crates/fast_io/src/mmap_reader.rs
@@ -76,6 +76,27 @@ impl MmapReader {
     /// Returns an error if the file cannot be opened or mapped.
     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let file = File::open(path)?;
+        Self::from_file(file)
+    }
+
+    /// Memory-maps an already-open file handle.
+    ///
+    /// Unlike [`open`](Self::open), this consumes a caller-provided [`File`]
+    /// instead of re-opening by path. Callers that resolved the file through a
+    /// hardened open (e.g. `O_NOFOLLOW` on the basename) can map it without
+    /// re-traversing the path and re-introducing a symlink-race window.
+    ///
+    /// # Safety
+    ///
+    /// The file must not be modified while the `MmapReader` exists.
+    /// Modifying the file can cause undefined behavior.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file metadata cannot be read or the file cannot
+    /// be mapped (e.g. on NFS, FUSE, procfs, or for a zero-length file on some
+    /// platforms).
+    pub fn from_file(file: File) -> io::Result<Self> {
         let size = file.metadata()?.len();
 
         // SAFETY: We assume the file won't be modified while mapped.

--- a/crates/fast_io/src/mmap_reader_stub.rs
+++ b/crates/fast_io/src/mmap_reader_stub.rs
@@ -38,6 +38,15 @@ impl MmapReader {
     /// On non-Unix platforms, the file is read entirely into a buffer.
     pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let file = File::open(path)?;
+        Self::from_file(file)
+    }
+
+    /// Reads an already-open file handle into memory.
+    ///
+    /// Mirror of the Unix `MmapReader::from_file` API so callers can share one
+    /// code path across platforms. On non-Unix the contents are buffered into a
+    /// `Vec` instead of memory-mapped.
+    pub fn from_file(file: File) -> io::Result<Self> {
         let size = file.metadata()?.len();
         let mut reader = BufReader::new(file);
         let mut data = Vec::with_capacity(size as usize);

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -225,18 +225,91 @@ fn generate_basis_signature(
     };
 
     let parallel = parallel_checksum_enabled();
-    match compute_basis_signature(
+
+    // Large regular baseses read the whole file block-by-block to hash it. A
+    // raw `File` costs one read syscall per block (default block ~700 bytes),
+    // so a multi-GB basis issues millions of syscalls. Memory-mapping the basis
+    // replaces those syscalls with demand-paged access while reading the exact
+    // same bytes in the same order - the per-block rolling and strong sums, and
+    // therefore the wire signature and the resulting delta, are byte-identical.
+    // Small baseses stay on the buffered path (mmap setup is not worth it) and
+    // any mmap failure (NFS/FUSE/procfs, ENOMEM, non-regular file) falls back
+    // to the raw `File` reader.
+    #[cfg(unix)]
+    let signature = if basis_size >= MMAP_BASIS_THRESHOLD_BYTES {
+        match fast_io::MmapReader::from_file(basis_file) {
+            Ok(mapped) => {
+                let _ = mapped.advise_sequential();
+                compute_basis_signature(
+                    mapped,
+                    basis_size,
+                    layout,
+                    config.checksum_algorithm,
+                    parallel,
+                )
+            }
+            Err(_) => match reopen_basis(&basis_path) {
+                Some(file) => compute_basis_signature(
+                    file,
+                    basis_size,
+                    layout,
+                    config.checksum_algorithm,
+                    parallel,
+                ),
+                None => return BasisFileResult::EMPTY,
+            },
+        }
+    } else {
+        compute_basis_signature(
+            basis_file,
+            basis_size,
+            layout,
+            config.checksum_algorithm,
+            parallel,
+        )
+    };
+
+    #[cfg(not(unix))]
+    let signature = compute_basis_signature(
         basis_file,
         basis_size,
         layout,
         config.checksum_algorithm,
         parallel,
-    ) {
+    );
+
+    match signature {
         Ok(sig) => BasisFileResult {
             signature: Some(sig),
             basis_path: Some(basis_path),
         },
         Err(_) => BasisFileResult::EMPTY,
+    }
+}
+
+/// Minimum basis-file size at which the receiver memory-maps the basis for
+/// signature hashing instead of reading it through a raw `File`.
+///
+/// Matches `fast_io::MmapReader`'s own `MMAP_THRESHOLD` (64 KiB). Below this the
+/// buffered read wins because mmap setup and page-fault overhead outweigh the
+/// saved syscalls; above it the syscall-per-block cost dominates. The choice is
+/// a pure local performance knob: the computed signature is byte-identical
+/// either way, so it is never negotiated or sent over the wire.
+#[cfg(unix)]
+const MMAP_BASIS_THRESHOLD_BYTES: u64 = 64 * 1024;
+
+/// Re-opens a basis file through the same hardened, symlink-refusing open used
+/// for the original lookup, so the mmap fallback path never re-introduces a
+/// symlinked-basename window. Returns `None` if the file can no longer be
+/// opened as a regular file, in which case the caller treats the basis as
+/// absent and falls back to whole-file transfer.
+#[cfg(unix)]
+fn reopen_basis(path: &std::path::Path) -> Option<fs::File> {
+    let file = fast_io::open_basis_nofollow(path).ok()?;
+    if file.metadata().ok()?.is_file() {
+        Some(file)
+    } else {
+        None
     }
 }
 
@@ -560,5 +633,135 @@ mod tests {
             try_reference_directories(&rel, &ref_dirs).is_none(),
             "reference-dir lookup must refuse symlinked basename"
         );
+    }
+
+    /// Byte-transparency gate for the default-mmap basis read: the signature
+    /// computed by memory-mapping a large basis (`MmapReader::from_file`) MUST
+    /// be byte-identical to the signature computed by reading the same basis
+    /// through a raw `File`. The signature is what the sender matches against,
+    /// so any divergence between the two read paths would change the delta and
+    /// break interop. Size exceeds `MMAP_BASIS_THRESHOLD_BYTES` so the mmap
+    /// branch is exercised.
+    #[cfg(unix)]
+    #[test]
+    fn mmap_basis_signature_equals_buffered_file_signature() {
+        use std::io::Write;
+
+        let size = (MMAP_BASIS_THRESHOLD_BYTES + 4096) as usize;
+        // Non-trivial, non-repeating bytes so blocks hash distinctly and a
+        // mis-read (wrong offset/length) would surface as a signature diff.
+        let data: Vec<u8> = (0..size).map(|i| ((i * 31 + 7) % 251) as u8).collect();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("basis.bin");
+        {
+            let mut f = fs::File::create(&path).expect("create basis");
+            f.write_all(&data).expect("write basis");
+            f.flush().expect("flush");
+        }
+
+        let layout = calculate_signature_layout(SignatureLayoutParams::new(
+            size as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        ))
+        .expect("layout");
+
+        let mapped = fast_io::MmapReader::from_file(
+            fast_io::open_basis_nofollow(&path).expect("open basis"),
+        )
+        .expect("mmap basis");
+        let via_mmap =
+            compute_basis_signature(mapped, size as u64, layout, SignatureAlgorithm::Md4, false)
+                .expect("mmap signature");
+
+        let file = fast_io::open_basis_nofollow(&path).expect("open basis");
+        let via_file =
+            compute_basis_signature(file, size as u64, layout, SignatureAlgorithm::Md4, false)
+                .expect("file signature");
+
+        assert_eq!(
+            via_mmap, via_file,
+            "mmap basis signature diverged from buffered-file signature",
+        );
+
+        // Also assert against the parallel path so the mmap read composes with
+        // both signature generators used in production.
+        let mapped_par = fast_io::MmapReader::from_file(
+            fast_io::open_basis_nofollow(&path).expect("open basis"),
+        )
+        .expect("mmap basis");
+        let via_mmap_parallel = compute_basis_signature(
+            mapped_par,
+            size as u64,
+            layout,
+            SignatureAlgorithm::Md4,
+            true,
+        )
+        .expect("mmap parallel signature");
+        assert_eq!(
+            via_mmap_parallel, via_file,
+            "mmap parallel basis signature diverged from buffered-file signature",
+        );
+    }
+
+    /// End-to-end check that `generate_basis_signature` (the production entry
+    /// that now defaults to mmap for large baseses) yields the same signature
+    /// the raw-`File` path produces. Guards against the dispatch wrapper picking
+    /// a divergent branch.
+    #[cfg(unix)]
+    #[test]
+    fn generate_basis_signature_mmap_default_matches_raw_file() {
+        use std::io::Write;
+
+        let size = (MMAP_BASIS_THRESHOLD_BYTES + 1234) as usize;
+        let data: Vec<u8> = (0..size).map(|i| ((i * 17 + 3) % 251) as u8).collect();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("basis.bin");
+        {
+            let mut f = fs::File::create(&path).expect("create basis");
+            f.write_all(&data).expect("write basis");
+            f.flush().expect("flush");
+        }
+
+        let cfg = SignatureGenerationConfig {
+            protocol: ProtocolVersion::NEWEST,
+            checksum_length: NonZeroU8::new(16).unwrap(),
+            checksum_algorithm: SignatureAlgorithm::Md4,
+        };
+
+        // Production path (mmap default engaged because size >= threshold).
+        let via_default = generate_basis_signature(
+            fast_io::open_basis_nofollow(&path).expect("open basis"),
+            size as u64,
+            path.clone(),
+            cfg,
+        );
+
+        // Reference: hash the same bytes straight through a raw `File`.
+        let layout = calculate_signature_layout(SignatureLayoutParams::new(
+            size as u64,
+            None,
+            ProtocolVersion::NEWEST,
+            NonZeroU8::new(16).unwrap(),
+        ))
+        .expect("layout");
+        let via_raw = compute_basis_signature(
+            fast_io::open_basis_nofollow(&path).expect("open basis"),
+            size as u64,
+            layout,
+            SignatureAlgorithm::Md4,
+            parallel_checksum_enabled(),
+        )
+        .expect("raw signature");
+
+        assert_eq!(
+            via_default.signature.as_ref(),
+            Some(&via_raw),
+            "generate_basis_signature mmap-default diverged from raw-file signature",
+        );
+        assert_eq!(via_default.basis_path.as_deref(), Some(path.as_path()));
     }
 }


### PR DESCRIPTION
## Problem

The receiver-side **basis read** — reading the existing destination/basis file to compute the rolling + strong block checksums that form the delta signature — reads the basis through a raw `fs::File`. `generate_file_signature` (and its windowed parallel sibling) call `read_exact` once per block, and the default block size is roughly 700 bytes. For a multi-GB basis that is on the order of one read syscall per block, i.e. millions of syscalls, for large-file delta transfers. This is a non-io_uring, purely local read-path cost.

## Change

Default to memory-mapping the basis for the signature read when the basis is a regular file at or above a 64 KiB threshold (matching `fast_io::MmapReader`'s existing `MMAP_THRESHOLD`). Small baseses stay on the buffered read where mmap setup and page-fault overhead are not worth it.

- New `MmapReader::from_file(File)` in `fast_io` maps an **already-open** handle rather than re-opening by path, so the basis stays behind the hardened `open_basis_nofollow` (`O_NOFOLLOW` on the basename). No symlink-race window is re-introduced.
- `advise_sequential()` is issued after mapping to hint the kernel's readahead for the streaming block scan.
- Graceful fallback: if mmap fails (NFS/FUSE/procfs, `ENOMEM`, non-regular file), the code re-opens through the same hardened path and reads via the raw `File`. If the re-open fails the basis is treated as absent (whole-file transfer), exactly as before.
- Non-Unix keeps the existing buffered `File` path unchanged (the change is gated `#[cfg(unix)]`); the non-mmap fallback remains for every platform/case where mmap is unavailable.

## Byte-transparency (the gate)

mmap only changes **how** the bytes are read, never **which** bytes. The signature depends solely on each block's bytes read in index order; mmap yields the identical bytes in the identical order, so the per-block rolling and strong sums, the wire signature, the delta, and therefore the wire output are byte-identical. There is no wire or protocol change and interop is unaffected. This is asserted by two new tests:

- `mmap_basis_signature_equals_buffered_file_signature` — signature via `MmapReader::from_file` equals signature via raw `File`, for both the sequential and parallel generators.
- `generate_basis_signature_mmap_default_matches_raw_file` — the production entry point with the mmap default engaged produces the same `FileSignature` the raw-`File` path produces.

## Verification

- `cargo build` / `cargo clippy --all-features` (incl. `--tests`) clean on `fast_io`, `signature`, `transfer`.
- `cargo test -p transfer --lib -- basis` — 36 passed (incl. the 2 new byte-transparency tests).
- `cargo test -p signature --lib` — 102 passed (parity tests).
- `cargo test -p fast_io --lib -- mmap` — 6 passed.
- Delta/basis integration targets green: `incremental_transfer`, `fuzzy_level2_basis_search`, `uts_fuzzy_local_basis_reuse`, `nxt_4_reverse_daemon_delta`, `delta_applicator_equivalence`.

This is a non-io_uring optimization; interop is the gate and the delta stays byte-identical.
