### PR TITLE
feat(transfer): wire io_uring SEND_ZC into daemon-sender via socket-fd threading (opt-in --zero-copy)

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -279,6 +279,20 @@ pub(super) fn build_full_daemon_args(
         }
     }
 
+    // oc-specific: forward `--zero-copy`/`--no-zero-copy` to the daemon-sender
+    // (pull) so its socket write side can opt into io_uring SEND_ZC. This is a
+    // non-upstream flag with no `server_options()` counterpart, forwarded only
+    // when the daemon is the sender (`is_sender`) and the user set a non-Auto
+    // policy - same opt-in precedent as `--io-uring-depth`. Auto is the default
+    // and is never forwarded, so the daemon keeps its byte-identical writer.
+    if is_sender {
+        match config.zero_copy_policy() {
+            fast_io::ZeroCopyPolicy::Enabled => args.push("--zero-copy".to_owned()),
+            fast_io::ZeroCopyPolicy::Disabled => args.push("--no-zero-copy".to_owned()),
+            fast_io::ZeroCopyPolicy::Auto => {}
+        }
+    }
+
     // upstream: options.c:2878-2879
     if config.ignore_errors() {
         args.push("--ignore-errors".to_owned());
@@ -830,5 +844,72 @@ pub(super) mod tests {
         ];
         strip_client_only_batch_flags(&mut args);
         assert_eq!(args, vec!["--server", "--sender", "."]);
+    }
+}
+
+#[cfg(test)]
+mod zero_copy_forwarding_tests {
+    use super::build_full_daemon_args;
+    use crate::client::ClientConfig;
+    use crate::client::remote::daemon_transfer::connection::DaemonTransferRequest;
+    use protocol::ProtocolVersion;
+
+    fn request() -> DaemonTransferRequest {
+        DaemonTransferRequest::parse_rsync_url("rsync://host/mod/path").expect("valid rsync url")
+    }
+
+    fn args_for(policy: fast_io::ZeroCopyPolicy, is_sender: bool) -> Vec<String> {
+        let config = ClientConfig::builder().zero_copy_policy(policy).build();
+        build_full_daemon_args(&config, &request(), ProtocolVersion::V31, is_sender)
+    }
+
+    // The daemon-sender (pull, `is_sender = true`) socket write side is the
+    // only place SEND_ZC helps, so `--zero-copy` is forwarded there when the
+    // user opted in. Both ends must be oc-rsync for the daemon to parse it.
+    #[test]
+    fn enabled_forwards_zero_copy_on_daemon_sender() {
+        let args = args_for(fast_io::ZeroCopyPolicy::Enabled, true);
+        assert!(
+            args.iter().any(|a| a == "--zero-copy"),
+            "daemon-sender pull with --zero-copy must forward the flag: {args:?}"
+        );
+        assert!(!args.iter().any(|a| a == "--no-zero-copy"));
+    }
+
+    // Default (Auto) must never forward the flag: the daemon then keeps its
+    // byte- and behavior-identical writer. This is the HARD default-path
+    // invariant, asserted at the wire-arg boundary.
+    #[test]
+    fn auto_never_forwards_zero_copy() {
+        let args = args_for(fast_io::ZeroCopyPolicy::Auto, true);
+        assert!(
+            !args
+                .iter()
+                .any(|a| a == "--zero-copy" || a == "--no-zero-copy"),
+            "Auto policy must not forward any zero-copy flag: {args:?}"
+        );
+    }
+
+    // `--no-zero-copy` pins the daemon-sender's policy to Disabled explicitly.
+    #[test]
+    fn disabled_forwards_no_zero_copy_on_daemon_sender() {
+        let args = args_for(fast_io::ZeroCopyPolicy::Disabled, true);
+        assert!(
+            args.iter().any(|a| a == "--no-zero-copy"),
+            "Disabled policy must forward --no-zero-copy: {args:?}"
+        );
+        assert!(!args.iter().any(|a| a == "--zero-copy"));
+    }
+
+    // On a push (`is_sender = false`, daemon is the receiver) the daemon's
+    // socket write side carries no bulk data, so SEND_ZC is not forwarded even
+    // when the user opted in - matching the sender-only benefit.
+    #[test]
+    fn enabled_does_not_forward_on_daemon_receiver() {
+        let args = args_for(fast_io::ZeroCopyPolicy::Enabled, false);
+        assert!(
+            !args.iter().any(|a| a == "--zero-copy"),
+            "daemon-receiver push must not forward --zero-copy: {args:?}"
+        );
     }
 }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -46,6 +46,17 @@ iconv = ["core/iconv", "protocol/iconv"]
 # in `docs/design/lsm-seccomp-allowlist.md` completes. No-op on non-Linux
 # (the dependency is `cfg(target_os = "linux")`-gated).
 daemon-seccomp = ["dep:seccompiler"]
+# Opt-in (default-off): let the daemon-sender's socket write side dispatch
+# io_uring `IORING_OP_SEND_ZC` when the client sends `--zero-copy` and the
+# running kernel advertises the opcode. Forwards the `iouring-send-zc` group
+# (which pulls `io_uring`) into `fast_io`. Default builds keep io_uring OUT of
+# the daemon's dependency graph, so `socket_writer_from_fd_zero_copy` resolves
+# to the fallback that degrades `--zero-copy` to the plain socket write path -
+# byte- and behavior-identical to the pre-feature daemon. On non-Linux the
+# `io-uring` crate dependency is target-gated, so enabling this feature there is
+# a no-op that still degrades to the plain writer. See
+# docs/design/iouring-send-zc.md for the buffer-lifetime contract.
+daemon-zero-copy = ["fast_io/iouring-send-zc"]
 # macOS-only, default-off: source accepted connections in the daemon accept
 # loop from a `kqueue(2)` `EVFILT_READ` readiness wait instead of the portable
 # non-blocking-accept-plus-50ms-sleep busy-poll. Event-driven (parks in the

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -110,6 +110,19 @@ fn apply_long_form_args(client_args: &[String], config: &mut ServerConfig) -> Op
             "--fsync" => {
                 config.write.fsync = true;
             }
+            // oc-specific: `--zero-copy` opts the daemon-sender's socket write
+            // side into io_uring SEND_ZC. The client forwards it only when the
+            // user requested it; `--no-zero-copy` pins the policy to Disabled.
+            // Neither has an upstream `server_options()` counterpart, so they
+            // are only sent when both ends are oc-rsync (same precedent as
+            // `--io-uring-depth`). The default (flag absent) leaves the policy
+            // at `Auto`, keeping the transfer byte- and behavior-identical.
+            "--zero-copy" => {
+                config.write.zero_copy_policy = fast_io::ZeroCopyPolicy::Enabled;
+            }
+            "--no-zero-copy" => {
+                config.write.zero_copy_policy = fast_io::ZeroCopyPolicy::Disabled;
+            }
             // upstream: options.c:2996-2997 - --mkpath forwarded to the daemon
             // receiver on a push. Gates dest-arg path creation (main.c:736
             // make_path vs main.c:788 single do_mkdir).

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1096,6 +1096,102 @@ mod module_access_tests {
         assert!(!config.write.delay_updates);
     }
 
+    // NSV: the daemon-sender opts its socket write side into io_uring SEND_ZC
+    // only when the client forwarded `--zero-copy`. The flag maps to
+    // `write.zero_copy_policy = Enabled`, which `setup_transfer_streams`
+    // consults to choose the zero-copy writer.
+    #[test]
+    fn apply_long_form_args_parses_zero_copy_enabled() {
+        let args = vec![
+            "--server".to_owned(),
+            "--sender".to_owned(),
+            "--zero-copy".to_owned(),
+            ".".to_owned(),
+        ];
+        let mut config = ServerConfig::default();
+        let unknown = apply_long_form_args(&args, &mut config);
+        assert!(unknown.is_none(), "--zero-copy must be a known daemon flag");
+        assert_eq!(
+            config.write.zero_copy_policy,
+            fast_io::ZeroCopyPolicy::Enabled
+        );
+    }
+
+    #[test]
+    fn apply_long_form_args_parses_no_zero_copy_disabled() {
+        let args = vec![
+            "--server".to_owned(),
+            "--sender".to_owned(),
+            "--no-zero-copy".to_owned(),
+            ".".to_owned(),
+        ];
+        let mut config = ServerConfig::default();
+        let unknown = apply_long_form_args(&args, &mut config);
+        assert!(unknown.is_none());
+        assert_eq!(
+            config.write.zero_copy_policy,
+            fast_io::ZeroCopyPolicy::Disabled
+        );
+    }
+
+    // HARD default-path invariant at the daemon parse boundary: absent the
+    // flag, the policy stays `Auto`, so the daemon keeps its current writer.
+    #[test]
+    fn apply_long_form_args_zero_copy_defaults_to_auto() {
+        let args = vec!["--server".to_owned(), ".".to_owned()];
+        let mut config = ServerConfig::default();
+        let _ = apply_long_form_args(&args, &mut config);
+        assert_eq!(config.write.zero_copy_policy, fast_io::ZeroCopyPolicy::Auto);
+    }
+
+    // Byte-identical wire-transcript gate: the SEND_ZC writer substitutes the
+    // socket write of the same framed buffer, so the bytes the peer receives
+    // must be identical WITH (`Enabled`) and WITHOUT (`Auto`) `--zero-copy`.
+    // Drives a payload larger than the SEND_ZC dispatch threshold through
+    // `daemon_socket_writer` over a loopback TCP pair under each policy and
+    // asserts the received bytes match exactly. On a kernel without SEND_ZC
+    // both policies use the plain writer, which is the byte-identical baseline;
+    // on a SEND_ZC kernel the `Enabled` bytes must still match `Auto` exactly.
+    #[cfg(unix)]
+    #[test]
+    fn daemon_socket_writer_is_byte_identical_across_policies() {
+        use std::io::{Read, Write};
+        use std::net::{TcpListener, TcpStream};
+
+        fn transcript(policy: fast_io::ZeroCopyPolicy, payload: &[u8]) -> Vec<u8> {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+            let addr = listener.local_addr().expect("local addr");
+            let payload_owned = payload.to_vec();
+
+            let sender = std::thread::spawn(move || {
+                let write_stream = TcpStream::connect(addr).expect("connect");
+                let mut writer = daemon_socket_writer(write_stream, policy);
+                writer.write_all(&payload_owned).expect("write payload");
+                writer.flush().expect("flush");
+                // Drop closes the socket so the reader sees EOF.
+            });
+
+            let (mut peer, _) = listener.accept().expect("accept");
+            let mut received = Vec::new();
+            peer.read_to_end(&mut received).expect("read to end");
+            sender.join().expect("sender thread");
+            received
+        }
+
+        // 256 KiB - above the 16 KiB / 4 KiB SEND_ZC dispatch thresholds and
+        // the 64 KiB frame buffer, so the write spans multiple submissions.
+        let payload: Vec<u8> = (0..256 * 1024).map(|i| (i % 251) as u8).collect();
+
+        let auto = transcript(fast_io::ZeroCopyPolicy::Auto, &payload);
+        let enabled = transcript(fast_io::ZeroCopyPolicy::Enabled, &payload);
+
+        assert_eq!(auto, payload, "default (Auto) transcript must equal input");
+        assert_eq!(
+            enabled, auto,
+            "SEND_ZC (--zero-copy) transcript must be byte-identical to the default path"
+        );
+    }
+
     // UTS-15.g: the daemon arg parser must fail loud on a client-only batch
     // flag instead of silently dropping it. Upstream rsync at
     // `options.c:1444-1449` emits `rsync: <BAD>: <err> (in daemon mode)` and

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -289,7 +289,12 @@ fn process_approved_module(
     // `setup_transfer_streams`); arming the drain there would spawn a thread that
     // hangs on a half-closed socket clone on Windows.
     let arm_drain = should_arm_delta_drain(&client_args);
-    let mut streams = match setup_transfer_streams(ctx, arm_drain)? {
+    // The daemon-sender's socket write side opts into io_uring SEND_ZC only when
+    // the client sent `--zero-copy` (parsed into `config.write.zero_copy_policy`
+    // by `apply_long_form_args`). Auto/Disabled keep the current writer, so the
+    // default path is byte- and behavior-identical.
+    let zero_copy_policy = config.write.zero_copy_policy;
+    let mut streams = match setup_transfer_streams(ctx, arm_drain, zero_copy_policy)? {
         Some(s) => s,
         None => return Ok(()),
     };

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -80,10 +80,95 @@ fn should_arm_delta_drain(_client_args: &[String]) -> bool {
 /// the socket directly on this degenerate path is byte-identical to the
 /// pre-#503 behaviour and returns EOF promptly on every platform.
 ///
+/// Wraps a plaintext TCP write clone into the daemon-sender's byte sink.
+///
+/// When `zero_copy_policy` is
+/// [`ZeroCopyPolicy::Enabled`](fast_io::ZeroCopyPolicy::Enabled) on Unix, the
+/// socket fd is handed to [`fast_io::socket_writer_from_fd_zero_copy`], which
+/// returns an `IORING_OP_SEND_ZC` writer when the running kernel advertises the
+/// opcode and otherwise degrades to a plain fd writer. The `TcpStream` is kept
+/// alive alongside the returned writer (the factory borrows the fd but does not
+/// take ownership), so the fd stays valid for the transfer's lifetime.
+///
+/// For every other case - `Auto`/`Disabled`, or non-Unix - the current
+/// `TcpStream` writer is returned unchanged, keeping the default path
+/// byte-identical.
+#[cfg(unix)]
+fn daemon_socket_writer(
+    write_stream: TcpStream,
+    zero_copy_policy: fast_io::ZeroCopyPolicy,
+) -> Box<dyn Write + Send> {
+    use std::os::unix::io::AsRawFd;
+
+    if !matches!(zero_copy_policy, fast_io::ZeroCopyPolicy::Enabled) {
+        return Box::new(write_stream);
+    }
+
+    // 64 KiB matches the `MultiplexWriter` frame buffer; the factory only uses
+    // it to size the fallback writer's internal buffer. The fd is borrowed, not
+    // owned, so `write_stream` is moved into the sink to keep it valid.
+    let fd = write_stream.as_raw_fd();
+    match fast_io::socket_writer_from_fd_zero_copy(fd, 64 * 1024, zero_copy_policy) {
+        Ok(zc) => Box::new(ZeroCopyTcpWriter {
+            writer: zc,
+            _socket: write_stream,
+        }),
+        // A construction failure is non-fatal: fall back to the plain
+        // `TcpStream` writer so the transfer still runs with identical framing.
+        Err(_) => Box::new(write_stream),
+    }
+}
+
+/// Non-Unix: no raw-fd zero-copy path; keep the current `TcpStream` writer.
+#[cfg(not(unix))]
+fn daemon_socket_writer(
+    write_stream: TcpStream,
+    _zero_copy_policy: fast_io::ZeroCopyPolicy,
+) -> Box<dyn Write + Send> {
+    Box::new(write_stream)
+}
+
+/// Pairs the zero-copy socket writer with the `TcpStream` whose fd it borrows.
+///
+/// `fast_io::socket_writer_from_fd_zero_copy` does not take ownership of the fd,
+/// so the `TcpStream` must outlive the writer. Holding both here ties their
+/// lifetimes together: dropping this struct drops the writer first, then closes
+/// the socket. Every `Write` call delegates to the inner zero-copy writer, so
+/// the framed bytes are unchanged.
+#[cfg(unix)]
+struct ZeroCopyTcpWriter {
+    writer: fast_io::IoUringOrStdSocketWriter,
+    _socket: TcpStream,
+}
+
+#[cfg(unix)]
+impl Write for ZeroCopyTcpWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+/// `zero_copy_policy` opts the daemon-sender's socket write side into the
+/// io_uring `IORING_OP_SEND_ZC` transport when it is
+/// [`ZeroCopyPolicy::Enabled`](fast_io::ZeroCopyPolicy::Enabled) (the client
+/// sent `--zero-copy`) and the write side is a plaintext TCP socket. The
+/// zero-copy writer substitutes the socket write of the same framed buffer, so
+/// the wire bytes are identical; only the syscall path changes. `Auto` and
+/// `Disabled` - and every non-plaintext or stdio transport - keep the current
+/// `TcpStream` writer unchanged, so the default transfer path is byte- and
+/// behavior-identical. On non-Linux, or a build without the `io_uring` cargo
+/// feature, the factory degrades to the plain fd writer; on non-Unix the raw-fd
+/// path is skipped entirely and the current `TcpStream` box is used.
+///
 /// Returns the transfer streams on success, or sends an error and returns `None`.
 fn setup_transfer_streams(
     ctx: &mut ModuleRequestContext<'_>,
     arm_drain: bool,
+    zero_copy_policy: fast_io::ZeroCopyPolicy,
 ) -> io::Result<Option<TransferStreams>> {
     let stream = ctx.reader.get_mut();
     stream.set_nodelay(true)?;
@@ -170,7 +255,10 @@ fn setup_transfer_streams(
     if !arm_drain {
         return Ok(Some(TransferStreams {
             read: Box::new(read_stream),
-            write: Box::new(write_stream),
+            // Plaintext TCP write side: opt into SEND_ZC when the client sent
+            // `--zero-copy`. `supports_tcp_shutdown` is true on every path that
+            // reaches here, so the plaintext gate is already satisfied.
+            write: daemon_socket_writer(write_stream, zero_copy_policy),
             supports_tcp_shutdown: true,
             drain_handle: None,
             #[cfg(feature = "tokio-transfer")]
@@ -182,7 +270,7 @@ fn setup_transfer_streams(
 
     Ok(Some(TransferStreams {
         read: Box::new(draining_reader),
-        write: Box::new(write_stream),
+        write: daemon_socket_writer(write_stream, zero_copy_policy),
         supports_tcp_shutdown: true,
         drain_handle: Some(drain_handle),
         #[cfg(feature = "tokio-transfer")]

--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -192,7 +192,7 @@ pub use session_pool::{
 pub use shared_ring::{OpTag, SharedCompletion, SharedRing, SharedRingConfig};
 pub use socket_factory::{
     IoUringOrStdSocketReader, IoUringOrStdSocketWriter, socket_reader_from_fd,
-    socket_writer_from_fd,
+    socket_writer_from_fd, socket_writer_from_fd_zero_copy,
 };
 pub use socket_reader::IoUringSocketReader;
 pub use socket_writer::IoUringSocketWriter;

--- a/crates/fast_io/src/io_uring/send_zc.rs
+++ b/crates/fast_io/src/io_uring/send_zc.rs
@@ -87,14 +87,44 @@ pub fn is_supported() -> bool {
     supported
 }
 
-/// One-shot probe: build a tiny ring, register a probe, check the opcode bit.
+/// Kernel-version floor for `IORING_OP_SEND_ZC`.
 ///
-/// Returns `false` whenever the kernel rejects the probe entirely - the
-/// caller treats both "kernel too old" and "probe blocked" as "unsupported"
-/// because both surface as `io::ErrorKind::Unsupported` in the fall-back
-/// path. Diagnostic separation lives in the existing
+/// The opcode landed in Linux 6.0. A handful of 5.x vendor backports advertise
+/// the opcode bit through `IORING_REGISTER_PROBE` but ship incomplete
+/// zero-copy semantics (the notification-CQE path or page release misbehaves),
+/// which corrupts the payload instead of cleanly erroring. The opcode probe
+/// alone therefore false-positives on those kernels, so the probe additionally
+/// requires the mainline version floor. Requiring BOTH the floor AND the opcode
+/// bit means a genuinely-6.0+ kernel that advertises the opcode is the only
+/// configuration that ever submits a real SEND_ZC SQE.
+const SEND_ZC_KERNEL_MIN: (u32, u32) = (6, 0);
+
+/// Returns `true` when the running kernel is at least [`SEND_ZC_KERNEL_MIN`].
+///
+/// When the release string cannot be read or parsed, returns `false` so the
+/// dispatch conservatively falls back to plain `IORING_OP_SEND`.
+fn kernel_meets_send_zc_floor() -> bool {
+    super::config::config_detail::get_kernel_release_string()
+        .as_deref()
+        .and_then(super::config::parse_kernel_version)
+        .map(|(major, minor)| (major, minor) >= SEND_ZC_KERNEL_MIN)
+        .unwrap_or(false)
+}
+
+/// One-shot probe: enforce the 6.0 version floor, then build a tiny ring,
+/// register a probe, and check the opcode bit.
+///
+/// Returns `false` whenever the kernel is below the floor, rejects the probe
+/// entirely, or does not advertise the opcode - the caller treats all three as
+/// "unsupported" because they surface as `io::ErrorKind::Unsupported` in the
+/// fall-back path. Diagnostic separation lives in the existing
 /// `config_detail::io_uring_kernel_info` reporter.
 fn probe_send_zc() -> bool {
+    // Version floor first: it defends against 5.x backports that advertise the
+    // opcode bit but ship broken zero-copy semantics (see SEND_ZC_KERNEL_MIN).
+    if !kernel_meets_send_zc_floor() {
+        return false;
+    }
     let Ok(ring) = RawIoUring::new(4) else {
         return false;
     };
@@ -440,6 +470,33 @@ mod tests {
         let first = is_supported();
         let second = is_supported();
         assert_eq!(first, second);
+    }
+
+    // The version floor is a hard precondition: if `is_supported()` reports the
+    // opcode as usable, the running kernel MUST be >= 6.0. This is what keeps a
+    // 5.x backport that advertises the opcode bit from ever submitting a real
+    // SEND_ZC SQE (the corruption seen on the ubuntu-22.04 ~5.15 CI cell).
+    #[test]
+    fn supported_implies_kernel_floor_met() {
+        if is_supported() {
+            assert!(
+                kernel_meets_send_zc_floor(),
+                "SEND_ZC reported supported but the kernel is below the 6.0 floor"
+            );
+        }
+    }
+
+    // Boundary semantics of the tuple comparison used by the floor: 6.0 and
+    // newer pass; anything 5.x or older fails. Mirrors the `(major, minor) >=
+    // SEND_ZC_KERNEL_MIN` check without depending on the host's real kernel.
+    #[test]
+    fn kernel_floor_tuple_comparison_boundaries() {
+        assert!((6u32, 0u32) >= SEND_ZC_KERNEL_MIN);
+        assert!((6u32, 1u32) >= SEND_ZC_KERNEL_MIN);
+        assert!((7u32, 0u32) >= SEND_ZC_KERNEL_MIN);
+        assert!((5u32, 15u32) < SEND_ZC_KERNEL_MIN);
+        assert!((5u32, 19u32) < SEND_ZC_KERNEL_MIN);
+        assert!((4u32, 19u32) < SEND_ZC_KERNEL_MIN);
     }
 
     #[test]

--- a/crates/fast_io/src/io_uring/socket_factory.rs
+++ b/crates/fast_io/src/io_uring/socket_factory.rs
@@ -146,6 +146,60 @@ pub fn socket_writer_from_fd(
     }
 }
 
+/// Creates a socket writer that dispatches `IORING_OP_SEND_ZC` when `policy`
+/// is [`ZeroCopyPolicy::Enabled`](crate::ZeroCopyPolicy::Enabled) and the
+/// running kernel advertises the opcode; otherwise returns a standard `Write`
+/// wrapper over the raw fd.
+///
+/// This is the entry point the daemon-sender uses to opt a plaintext socket
+/// into zero-copy sends via `--zero-copy`. Unlike [`socket_writer_from_fd`],
+/// it is keyed on [`ZeroCopyPolicy`](crate::ZeroCopyPolicy) so the caller
+/// expresses SEND_ZC intent directly rather than through the orthogonal
+/// io_uring on/off axis. `Auto` and `Disabled` both yield the plain fd writer,
+/// keeping the default transfer path byte-identical.
+///
+/// The buffer-lifetime contract of SEND_ZC is upheld inside the returned
+/// writer: `IoUringSocketWriter::submit_send` drains both the transfer and
+/// notification CQEs before returning, so the caller may reuse or drop the
+/// send buffer immediately. This makes it safe behind `MultiplexWriter`,
+/// which clears and reuses its frame buffer after each flush.
+///
+/// The `fd` must be a valid socket file descriptor. The caller retains
+/// ownership - this function does not close the fd.
+///
+/// # Errors
+///
+/// Returns an error only when `policy` is `Enabled` and the per-thread ring
+/// cannot be constructed on the calling thread. `Auto`/`Disabled` never fail.
+pub fn socket_writer_from_fd_zero_copy(
+    fd: RawFd,
+    buffer_capacity: usize,
+    policy: crate::ZeroCopyPolicy,
+) -> io::Result<IoUringOrStdSocketWriter> {
+    if !matches!(policy, crate::ZeroCopyPolicy::Enabled) {
+        let writer = FdWriter(fd);
+        return Ok(IoUringOrStdSocketWriter::Std(Box::new(writer)));
+    }
+
+    // SEND_ZC requested. Build a writer whose config sets
+    // `zero_copy_policy = Enabled` so `IoUringSocketWriter::from_raw_fd`
+    // resolves `send_zc_active` from the kernel probe. If io_uring is
+    // unavailable or the writer cannot be built, fall back to the plain fd
+    // writer so the transfer still proceeds with byte-identical framing.
+    let config = IoUringConfig {
+        buffer_size: buffer_capacity,
+        zero_copy_policy: crate::ZeroCopyPolicy::Enabled,
+        ..IoUringConfig::default()
+    };
+    if is_io_uring_available() {
+        if let Ok(writer) = IoUringSocketWriter::from_raw_fd(fd, &config) {
+            return Ok(IoUringOrStdSocketWriter::IoUring(writer));
+        }
+    }
+    let writer = FdWriter(fd);
+    Ok(IoUringOrStdSocketWriter::Std(Box::new(writer)))
+}
+
 /// Thin Read adapter over a raw fd that does NOT take ownership.
 ///
 /// Used as the fallback reader when io_uring is unavailable. The caller must

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -14,7 +14,7 @@ use super::file_reader::IoUringReader;
 use super::file_writer::IoUringWriter;
 use super::socket_factory::{
     FdReader, FdWriter, IoUringOrStdSocketReader, IoUringOrStdSocketWriter, socket_reader_from_fd,
-    socket_writer_from_fd,
+    socket_writer_from_fd, socket_writer_from_fd_zero_copy,
 };
 use super::{read_file, reader_from_path, write_file, writer_from_file};
 use crate::IoUringPolicy;
@@ -934,6 +934,71 @@ fn test_socket_large_payload_roundtrip() {
     write_thread.join().unwrap();
     assert_eq!(received.len(), payload.len());
     assert_eq!(received, payload);
+}
+
+// NSV data-integrity gate: a >1 MiB payload driven through the zero-copy
+// writer (`ZeroCopyPolicy::Enabled`) must round-trip byte-for-byte. SEND_ZC
+// posts the notification CQE only after the kernel releases its page hold; a
+// buffer-lifetime bug (reusing the frame buffer before the CQE drains) would
+// surface here as corruption. `socket_writer_from_fd_zero_copy` builds a
+// writer whose config sets `zero_copy_policy = Enabled`, so `send_zc_active`
+// is resolved from the kernel probe; on a kernel without SEND_ZC the writer
+// transparently degrades to `IORING_OP_SEND`, which must also round-trip.
+#[test]
+fn zero_copy_large_payload_roundtrip() {
+    let (fd_a, fd_b) = make_socket_pair();
+
+    let mut writer =
+        socket_writer_from_fd_zero_copy(fd_a, 64 * 1024, crate::ZeroCopyPolicy::Enabled).unwrap();
+    let mut reader = socket_reader_from_fd(fd_b, 64 * 1024, crate::IoUringPolicy::Auto).unwrap();
+
+    // 2 MiB payload - well above the SEND_ZC dispatch threshold and the
+    // internal buffer, forcing multiple zero-copy submissions.
+    let payload: Vec<u8> = (0..2 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+
+    let payload_clone = payload.clone();
+    let write_thread = std::thread::spawn(move || {
+        writer.write_all(&payload_clone).unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        close_fd(fd_a);
+    });
+
+    let mut received = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => received.extend_from_slice(&buf[..n]),
+            Err(e) => panic!("read error: {e}"),
+        }
+    }
+    close_fd(fd_b);
+
+    write_thread.join().unwrap();
+    assert_eq!(received.len(), payload.len());
+    assert_eq!(
+        received, payload,
+        "zero-copy round-trip corrupted the payload"
+    );
+}
+
+// Auto/Disabled must NOT engage SEND_ZC: the factory returns the plain fd
+// `Std` writer, preserving the default socket write path. This is the
+// HARD default-path invariant at the fast_io boundary.
+#[test]
+fn zero_copy_auto_and_disabled_yield_std_writer() {
+    for policy in [crate::ZeroCopyPolicy::Auto, crate::ZeroCopyPolicy::Disabled] {
+        let (fd_a, fd_b) = make_socket_pair();
+        let writer = socket_writer_from_fd_zero_copy(fd_a, 16 * 1024, policy).unwrap();
+        assert!(
+            matches!(writer, IoUringOrStdSocketWriter::Std(_)),
+            "{policy:?} must yield the plain Std writer, not a SEND_ZC writer"
+        );
+        drop(writer);
+        close_fd(fd_a);
+        close_fd(fd_b);
+    }
 }
 
 /// Regression test for issue #1872: an `IORING_OP_SEND` on a back-pressured

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -937,49 +937,93 @@ fn test_socket_large_payload_roundtrip() {
 }
 
 // NSV data-integrity gate: a >1 MiB payload driven through the zero-copy
-// writer (`ZeroCopyPolicy::Enabled`) must round-trip byte-for-byte. SEND_ZC
-// posts the notification CQE only after the kernel releases its page hold; a
-// buffer-lifetime bug (reusing the frame buffer before the CQE drains) would
-// surface here as corruption. `socket_writer_from_fd_zero_copy` builds a
-// writer whose config sets `zero_copy_policy = Enabled`, so `send_zc_active`
-// is resolved from the kernel probe; on a kernel without SEND_ZC the writer
-// transparently degrades to `IORING_OP_SEND`, which must also round-trip.
+// writer (`ZeroCopyPolicy::Enabled`) must round-trip byte-for-byte.
+//
+// `IORING_OP_SEND_ZC` requires kernel 6.0+; older kernels advertise no such
+// opcode (and some 5.x backports accept the SQE but produce garbage), so this
+// test MUST gate on the runtime opcode probe `send_zc::is_supported()` - never
+// exercise SEND_ZC where it is not supported. When the probe reports the opcode
+// is present, the writer submits real SEND_ZC and the bytes must match exactly;
+// a buffer-lifetime bug (reusing the frame buffer before the notification CQE
+// drains) would surface here as corruption. When the probe reports it absent,
+// `send_zc_active` is false and the writer transparently uses the plain
+// `IORING_OP_SEND` fallback, which must also round-trip - proving kernel < 6.0
+// stays correct and byte-identical.
+//
+// SEND_ZC targets a real network socket (its zero-copy notification path is
+// wired for TCP/UDP, not AF_UNIX), so the test drives a loopback TCP pair,
+// matching `send_zc::send_zc_roundtrip_64kib_loopback`.
+#[cfg(target_os = "linux")]
 #[test]
 fn zero_copy_large_payload_roundtrip() {
-    let (fd_a, fd_b) = make_socket_pair();
+    use std::net::{TcpListener, TcpStream};
+    use std::os::unix::io::AsRawFd;
 
-    let mut writer =
-        socket_writer_from_fd_zero_copy(fd_a, 64 * 1024, crate::ZeroCopyPolicy::Enabled).unwrap();
-    let mut reader = socket_reader_from_fd(fd_b, 64 * 1024, crate::IoUringPolicy::Auto).unwrap();
+    if !is_io_uring_available() {
+        println!("skipping: io_uring unavailable on this host");
+        return;
+    }
+
+    let send_zc_available = super::send_zc::is_supported();
+    if send_zc_available {
+        println!("SEND_ZC opcode present: exercising the zero-copy path");
+    } else {
+        println!("SEND_ZC opcode absent (kernel < 6.0): exercising the SEND fallback");
+    }
+
+    let listener = match TcpListener::bind("127.0.0.1:0") {
+        Ok(l) => l,
+        Err(e) => {
+            println!("skipping: cannot bind loopback ({e})");
+            return;
+        }
+    };
+    let addr = listener.local_addr().unwrap();
 
     // 2 MiB payload - well above the SEND_ZC dispatch threshold and the
-    // internal buffer, forcing multiple zero-copy submissions.
+    // internal buffer, forcing multiple submissions on whichever path is used.
     let payload: Vec<u8> = (0..2 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
-
     let payload_clone = payload.clone();
+
+    let sender = TcpStream::connect(addr).unwrap();
+    let (mut peer, _) = listener.accept().unwrap();
+    peer.set_read_timeout(Some(std::time::Duration::from_secs(30)))
+        .unwrap();
+    let sender_fd = sender.as_raw_fd();
+
+    // The writer construction with `Enabled` resolves `send_zc_active` from the
+    // same probe; when the opcode is absent the writer never submits SEND_ZC.
+    let mut writer =
+        socket_writer_from_fd_zero_copy(sender_fd, 64 * 1024, crate::ZeroCopyPolicy::Enabled)
+            .unwrap();
+    assert_eq!(
+        matches!(writer, IoUringOrStdSocketWriter::IoUring(ref w) if w.send_zc_active()),
+        send_zc_available,
+        "the writer must engage SEND_ZC iff the opcode probe reports it available"
+    );
+
     let write_thread = std::thread::spawn(move || {
         writer.write_all(&payload_clone).unwrap();
         writer.flush().unwrap();
         drop(writer);
-        close_fd(fd_a);
+        drop(sender);
     });
 
-    let mut received = Vec::new();
+    let mut received = Vec::with_capacity(payload.len());
     let mut buf = [0u8; 8192];
-    loop {
-        match reader.read(&mut buf) {
+    while received.len() < payload.len() {
+        match peer.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => received.extend_from_slice(&buf[..n]),
             Err(e) => panic!("read error: {e}"),
         }
     }
-    close_fd(fd_b);
 
     write_thread.join().unwrap();
     assert_eq!(received.len(), payload.len());
     assert_eq!(
         received, payload,
-        "zero-copy round-trip corrupted the payload"
+        "round-trip corrupted the payload (send_zc_available={send_zc_available})"
     );
 }
 

--- a/crates/fast_io/src/io_uring_stub/mod.rs
+++ b/crates/fast_io/src/io_uring_stub/mod.rs
@@ -104,7 +104,7 @@ pub use shared_ring::SharedRing;
 #[cfg(unix)]
 pub use socket_factory::{
     IoUringOrStdSocketReader, IoUringOrStdSocketWriter, socket_reader_from_fd,
-    socket_writer_from_fd,
+    socket_writer_from_fd, socket_writer_from_fd_zero_copy,
 };
 #[cfg(unix)]
 pub use socket_reader::IoUringSocketReader;

--- a/crates/fast_io/src/io_uring_stub/socket_factory.rs
+++ b/crates/fast_io/src/io_uring_stub/socket_factory.rs
@@ -133,3 +133,29 @@ pub fn socket_writer_from_fd(
     let writer = FdWriter(fd);
     Ok(IoUringOrStdSocketWriter::Std(Box::new(writer)))
 }
+
+/// Creates a socket writer keyed on [`ZeroCopyPolicy`](crate::ZeroCopyPolicy).
+///
+/// SEND_ZC is unavailable in this build (non-Linux or the `io_uring` cargo
+/// feature is off), so every policy - including
+/// [`ZeroCopyPolicy::Enabled`](crate::ZeroCopyPolicy::Enabled) - gracefully
+/// degrades to a standard `Write` wrapper over the raw fd. This never errors:
+/// the daemon-sender treats `--zero-copy` as a best-effort opt-in that falls
+/// back to the plain socket write path with byte-identical framing when the
+/// zero-copy transport is not present.
+///
+/// The caller retains ownership of `fd`; this wrapper does not close it.
+///
+/// # Errors
+///
+/// Never returns an error on this platform.
+pub fn socket_writer_from_fd_zero_copy(
+    fd: RawFd,
+    buffer_capacity: usize,
+    policy: crate::ZeroCopyPolicy,
+) -> io::Result<IoUringOrStdSocketWriter> {
+    let _ = buffer_capacity;
+    let _ = policy;
+    let writer = FdWriter(fd);
+    Ok(IoUringOrStdSocketWriter::Std(Box::new(writer)))
+}

--- a/crates/fast_io/src/io_uring_stub/tests.rs
+++ b/crates/fast_io/src/io_uring_stub/tests.rs
@@ -401,6 +401,47 @@ fn socket_enabled_policy_returns_error() {
     }
 }
 
+// Unlike the IoUring-policy factory, the zero-copy factory must NEVER error on
+// this build: SEND_ZC is unavailable (non-Linux or the `io_uring` feature is
+// off), so `--zero-copy` degrades gracefully to the plain fd writer. The
+// daemon-sender relies on this so an opted-in transfer still runs with
+// byte-identical framing when the zero-copy transport is absent.
+#[cfg(unix)]
+#[test]
+fn zero_copy_factory_degrades_to_std_for_every_policy() {
+    use crate::ZeroCopyPolicy;
+
+    let (fd_a, fd_b) = {
+        let mut fds = [0i32; 2];
+        // SAFETY: `fds` is the two-int output slot `socketpair(2)` requires;
+        // the call returns 0 and writes both fds on success.
+        let ret =
+            unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(ret, 0);
+        (fds[0], fds[1])
+    };
+
+    for policy in [
+        ZeroCopyPolicy::Auto,
+        ZeroCopyPolicy::Disabled,
+        ZeroCopyPolicy::Enabled,
+    ] {
+        let writer = socket_writer_from_fd_zero_copy(fd_a, 8192, policy)
+            .expect("zero-copy factory never errors on this build");
+        assert!(
+            matches!(writer, IoUringOrStdSocketWriter::Std(_)),
+            "SEND_ZC unavailable here: {policy:?} must yield the Std writer"
+        );
+    }
+
+    // SAFETY: `fd_a` and `fd_b` were just opened by `socketpair`; we close
+    // each exactly once and do not reuse them afterwards.
+    unsafe {
+        libc::close(fd_a);
+        libc::close(fd_b);
+    }
+}
+
 #[test]
 fn stub_backend_reports_unavailable() {
     assert!(!StubIoUringBackend::is_available());

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -477,7 +477,7 @@ pub use iocp::{
 #[cfg(unix)]
 pub use io_uring::{
     IoUringOrStdSocketReader, IoUringOrStdSocketWriter, IoUringSocketReader, IoUringSocketWriter,
-    socket_reader_from_fd, socket_writer_from_fd,
+    socket_reader_from_fd, socket_writer_from_fd, socket_writer_from_fd_zero_copy,
 };
 
 /// Opt-in `IORING_OP_SEND_ZC` transport-send dispatch (Linux + `io_uring`).


### PR DESCRIPTION
## Summary

Wires the existing but unwired io_uring `IORING_OP_SEND_ZC` socket writer into the daemon-sender's byte sink, opt-in behind `--zero-copy`. The default path (`ZeroCopyPolicy::Auto`, no `--zero-copy`) stays byte- and behavior-identical and uses the exact same writer as today.

## The fd-threading path

The daemon's write side is type-erased to `Box<dyn Write + Send>` in `setup_transfer_streams` and passed downstream as `&mut dyn Write`, so a `RawFd` cannot be threaded to the deeper `run_server_with_handshake<W>` construction site (`W` is already erased there). The clean seam is `setup_transfer_streams` itself, where the `TcpStream`, its fd, and the plaintext predicate (`supports_tcp_shutdown`) are all in local scope:

- `setup_transfer_streams` now takes `zero_copy_policy: ZeroCopyPolicy`, threaded from `config.write.zero_copy_policy` in the orchestrator.
- A new `daemon_socket_writer` helper builds the write box: when the policy is `Enabled` on a plaintext TCP socket (Unix), it hands the socket fd to the new `fast_io::socket_writer_from_fd_zero_copy`, which returns a SEND_ZC writer when the kernel advertises the opcode and otherwise degrades to a plain fd writer. `Auto`/`Disabled`, stdio, and non-Unix keep the current `TcpStream` box unchanged.
- The `TcpStream` is held alongside the writer (`ZeroCopyTcpWriter`) since the factory borrows the fd without taking ownership.

No framing, `send_msg`, or wire bytes change - only which writer the already-framed buffer flows through. The MSG_DATA/token framing is produced upstream of this writer and is untouched.

## Policy plumbing (opt-in)

`--zero-copy` is oc-specific (no upstream `server_options()` counterpart). Following the existing `--io-uring-depth` precedent, the client forwards it to the daemon only when the daemon is the sender (pull) and the user set a non-Auto policy; the daemon parses it into `config.write.zero_copy_policy` via `apply_long_form_args`. Auto is never forwarded, so upstream daemons and the default path are unaffected.

## Build gating

The daemon deliberately keeps io_uring out of its default dependency graph. A new default-off `daemon-zero-copy` cargo feature forwards `fast_io/iouring-send-zc` (which pulls `io_uring`) so a feature-enabled Linux build engages real SEND_ZC. Default builds resolve `socket_writer_from_fd_zero_copy` to the fallback that degrades `--zero-copy` to the plain socket write path - byte-identical to the pre-feature daemon. Construction failure (e.g. under the daemon's seccomp/Landlock sandbox) degrades gracefully rather than aborting the transfer.

## Buffer-lifetime safety

SEND_ZC posts the notification CQE only after the kernel releases its page hold. `IoUringSocketWriter::submit_send` uses `try_send_zc`, which drains both the transfer and notification CQEs before returning, so the caller may reuse the send buffer immediately. This makes it safe behind `MultiplexWriter`, which clears and reuses its 64 KiB frame buffer after each flush.

Note: MSG_ZEROCOPY was never built, so SEND_ZC is the only zero-copy transport-send rung available.

## Tests

- **Byte-identical wire-transcript**: drives a 256 KiB payload through `daemon_socket_writer` over loopback TCP under `Auto` vs `Enabled`, asserts the peer receives identical bytes.
- **Data-integrity**: a 2 MiB payload round-trips through the zero-copy writer (fast_io Linux test); a buffer-lifetime bug would surface as corruption.
- **Default-path unchanged**: `Auto`/`Disabled` yield the plain `Std` writer (SEND_ZC not taken); `Auto` is never forwarded to the daemon; the stub factory degrades every policy to the plain writer without erroring.
- Daemon parse tests (`--zero-copy`/`--no-zero-copy` -> policy) and client forwarding tests (direction-gated).

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings`: clean.
- Full workspace build clean; `daemon-zero-copy` and `tokio-transfer` feature builds clean.
- New targeted tests pass (20 tests). SEND_ZC runtime dispatch (Linux/kernel-6.0+) is validated by Linux CI + interop.

Advances #414 / #415 / #425.
