### PR TITLE
fix(filters): match upstream CVS-perishable gating and rule-modifier parsing

### DIFF
--- a/crates/cli/src/frontend/filter_rules/cvs.rs
+++ b/crates/cli/src/frontend/filter_rules/cvs.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use core::client::{DirMergeEnforcedKind, DirMergeOptions, FilterRuleKind, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
+use protocol::SUPPORTED_PROTOCOL_BOUNDS;
 
 use crate::frontend::defaults::CVS_EXCLUDE_PATTERNS;
 
@@ -37,9 +38,15 @@ pub(crate) fn append_cvs_exclude_rules(
 /// list from these three sources only; the per-directory merge is the
 /// separate `:C` rule.
 pub(crate) fn cvs_default_exclude_rules() -> Result<Vec<FilterRuleSpec>, Message> {
+    // upstream: exclude.c:1350 get_cvs_excludes() - the built-in default_cvsignore()
+    // list is parsed with the perishable template only when `protocol_version >= 30`.
+    // The `-C` rules are assembled at argument-parse time (before negotiation), so
+    // key the gate on the newest protocol oc negotiates with a modern peer
+    // (SUPPORTED_PROTOCOL_BOUNDS.1 == 32), which is always >= 30.
+    let perishable = SUPPORTED_PROTOCOL_BOUNDS.1 >= 30;
     let mut cvs_rules: Vec<FilterRuleSpec> = CVS_EXCLUDE_PATTERNS
         .iter()
-        .map(|pattern| FilterRuleSpec::exclude((*pattern).to_owned()).with_perishable(true))
+        .map(|pattern| FilterRuleSpec::exclude((*pattern).to_owned()).with_perishable(perishable))
         .collect();
 
     // upstream: exclude.c:1393-1402 scopes FILTRULE_CLEAR_LIST ('!') to the
@@ -99,7 +106,12 @@ where
             continue;
         }
 
-        destination.push(FilterRuleSpec::exclude(trimmed.to_owned()).with_perishable(true));
+        // upstream: exclude.c:1355-1357 get_cvs_excludes() - the `$HOME/.cvsignore`
+        // and `$CVSIGNORE` sources are parsed with a plain `rule_template(rflags)`,
+        // NOT the perishable template. Only the built-in `default_cvsignore()`
+        // list (exclude.c:1350) carries FILTRULE_PERISHABLE, so these rules must
+        // not be perishable.
+        destination.push(FilterRuleSpec::exclude(trimmed.to_owned()));
     }
 }
 

--- a/crates/filters/src/chain/config.rs
+++ b/crates/filters/src/chain/config.rs
@@ -127,6 +127,13 @@ impl DirMergeConfig {
         self
     }
 
+    /// Returns whether patterns are anchored to the transfer root (the `/`
+    /// FILTRULE_ABS_PATH modifier on the dir-merge rule).
+    #[must_use]
+    pub(super) const fn is_anchor_root(&self) -> bool {
+        self.anchor_root
+    }
+
     /// Marks parsed rules as perishable.
     #[must_use]
     pub const fn with_perishable(mut self, perishable: bool) -> Self {

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -416,10 +416,18 @@ impl FilterChain {
                 }
             }
 
+            // upstream: exclude.c:200-228 add_rule - FILTRULE_ABS_PATH keeps a
+            // leading `/` anchored to the transfer root, so a dir-merge declared
+            // with the `/` modifier skips the merge-directory re-anchoring.
+            let reanchor_dir = if config.is_anchor_root() {
+                None
+            } else {
+                rel_dir_prefix.as_deref()
+            };
             let mut modified_rules: Vec<FilterRule> = rules
                 .into_iter()
                 .map(|rule| config.apply_modifiers(rule))
-                .map(|rule| reanchor_merge_rule(rule, rel_dir_prefix.as_deref()))
+                .map(|rule| reanchor_merge_rule(rule, reanchor_dir))
                 .map(|rule| apply_merge_implicit_sender_side(rule, delete_excluded))
                 .collect();
 
@@ -472,7 +480,15 @@ impl FilterChain {
                             .with_cvs_mode(descriptor.cvs_mode)
                             .with_inherit(true)
                             .with_sender_only(descriptor.sender_only)
-                            .with_receiver_only(descriptor.receiver_only),
+                            .with_receiver_only(descriptor.receiver_only)
+                            // upstream: exclude.c - FILTRULE_NO_PREFIXES / ABS_PATH
+                            // from the `:`-rule template propagate to the
+                            // registered per-directory config.
+                            .with_no_prefixes(
+                                descriptor.no_prefixes,
+                                descriptor.no_prefixes_include,
+                            )
+                            .with_anchor_root(descriptor.abs_path),
                     );
                 }
                 pushed_count += self.load_inline_dir_merge(directory, depth, &descriptor)?;
@@ -520,7 +536,17 @@ impl FilterChain {
             }
         };
 
-        let rules = if descriptor.cvs_mode {
+        // upstream: exclude.c:1116-1133 - a dir-merge template carrying
+        // FILTRULE_NO_PREFIXES (`-`/`+`) skips the short-prefix dispatch and
+        // consumes each line as a literal exclude (or include for `+`).
+        let rules = if descriptor.no_prefixes {
+            parse_rules_no_prefixes(
+                &content,
+                &merge_path,
+                descriptor.no_prefixes_include,
+                descriptor.cvs_mode,
+            )
+        } else if descriptor.cvs_mode {
             parse_cvs_ignore_tokens(&content)
         } else {
             match parse_rules(&content, &merge_path) {
@@ -719,6 +745,15 @@ struct InlineDirMerge {
     sender_only: bool,
     /// Receiver-side counterpart of [`Self::sender_only`] (`r` modifier).
     receiver_only: bool,
+    /// `-`/`+` modifier (FILTRULE_NO_PREFIXES): each merged line is a literal
+    /// pattern rather than a prefixed rule.
+    no_prefixes: bool,
+    /// Pairs with [`Self::no_prefixes`]: `true` selects the `+` (include)
+    /// variant, `false` the `-` (exclude) variant.
+    no_prefixes_include: bool,
+    /// `/` modifier (FILTRULE_ABS_PATH): anchor merged rules to the transfer
+    /// root rather than the merge file's own directory.
+    abs_path: bool,
 }
 
 /// Splits parsed rules into ordinary entries plus dir-merge descriptors.
@@ -769,12 +804,16 @@ fn split_dir_merge_rules(rules: Vec<FilterRule>) -> (Vec<FilterRule>, Vec<Inline
     let mut dir_merges = Vec::new();
     for rule in rules {
         if matches!(rule.action(), FilterAction::DirMerge) {
+            let (no_prefixes, no_prefixes_include) = rule.no_prefixes();
             dir_merges.push(InlineDirMerge {
                 filename: rule.pattern().to_owned(),
                 cvs_mode: rule.is_cvs_mode(),
                 no_inherit: rule.is_no_inherit(),
                 sender_only: rule.applies_to_sender() && !rule.applies_to_receiver(),
                 receiver_only: rule.applies_to_receiver() && !rule.applies_to_sender(),
+                no_prefixes,
+                no_prefixes_include,
+                abs_path: rule.is_abs_path(),
             });
         } else {
             keep.push(rule);

--- a/crates/filters/src/compiled/clear.rs
+++ b/crates/filters/src/compiled/clear.rs
@@ -31,6 +31,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(true, false);
@@ -52,6 +55,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(false, true);
@@ -73,6 +79,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(true, true);
@@ -101,6 +110,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, false, false);
@@ -120,6 +132,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, true, false);

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -44,6 +44,9 @@ impl CompiledRule {
             exclude_only: _,
             no_inherit: _,
             cvs_mode: _,
+            abs_path: _,
+            no_prefixes: _,
+            no_prefixes_include: _,
         } = rule;
         debug_assert!(
             !xattr_only,
@@ -203,6 +206,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Exclude);
@@ -224,6 +230,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
@@ -242,6 +251,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.perishable);
@@ -265,6 +277,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
@@ -293,6 +308,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
@@ -333,6 +351,9 @@ mod tests {
                 exclude_only: false,
                 no_inherit: false,
                 cvs_mode: false,
+                abs_path: false,
+                no_prefixes: false,
+                no_prefixes_include: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -362,6 +383,9 @@ mod tests {
                 exclude_only: false,
                 no_inherit: false,
                 cvs_mode: false,
+                abs_path: false,
+                no_prefixes: false,
+                no_prefixes_include: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -388,6 +412,9 @@ mod tests {
                 exclude_only: false,
                 no_inherit: false,
                 cvs_mode: false,
+                abs_path: false,
+                no_prefixes: false,
+                no_prefixes_include: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -412,6 +439,9 @@ mod tests {
                 exclude_only: false,
                 no_inherit: false,
                 cvs_mode: false,
+                abs_path: false,
+                no_prefixes: false,
+                no_prefixes_include: false,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -442,6 +472,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -474,6 +507,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         use std::path::Path;
@@ -497,6 +533,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         use std::path::Path;
@@ -555,6 +594,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         })
         .unwrap()
     }
@@ -752,6 +794,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.negate);
@@ -767,6 +812,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled2 = CompiledRule::new(rule2).unwrap();
         assert!(!compiled2.negate);

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -191,6 +191,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("file.bak"), false, true));
@@ -211,6 +214,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), false, true));
@@ -230,6 +236,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("node_modules"), true, true));
@@ -249,6 +258,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), true, true));
@@ -269,6 +281,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Protect);
@@ -288,6 +303,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Risk);
@@ -306,6 +324,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
@@ -325,6 +346,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build/main.o"), false, true));
@@ -350,6 +374,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -381,6 +408,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -402,6 +432,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("file.txt"), false, true));
@@ -418,6 +451,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled_negated = CompiledRule::new(rule_negated).unwrap();
         assert!(!compiled_negated.matches(Path::new("file.txt"), false, true));
@@ -437,6 +473,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -460,6 +499,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -486,6 +528,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -519,6 +564,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -547,6 +595,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -580,6 +631,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -612,6 +666,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -443,6 +443,9 @@ mod tests {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         };
         inner
             .include_exclude

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -123,7 +123,8 @@ fn parse_rule_line_expanded(
         return Ok(vec![parse_rule_line(line, source_path, line_num)?]);
     };
 
-    let (mods, pattern) = parse_modifiers(rest);
+    // These action characters are never merge-file rules, so `is_merge` is false.
+    let (mods, pattern) = parse_modifiers(rest, false, line, source_path, line_num)?;
 
     if mods.word_split && !pattern.is_empty() {
         validate_side_modifiers(action_char, &mods, line, source_path, line_num)?;
@@ -180,6 +181,9 @@ fn parse_rule_line_expanded(
 /// | `n` | `no_inherit` | Don't inherit parent rules (merge) |
 /// | `w` | `word_split` | Split pattern on whitespace |
 /// | `C` | `cvs_mode` | Add CVS exclusion patterns |
+/// | `/` | `abs_path` | Anchor merged rules to the transfer root (merge rules only) |
+/// | `-` | `no_prefixes` | Merged lines are literal excludes (merge rules only) |
+/// | `+` | `no_prefixes`+`no_prefixes_include` | Merged lines are literal includes (merge rules only) |
 ///
 /// upstream: exclude.c:1256-1259 - the `e` modifier maps to
 /// `FILTRULE_EXCLUDE_SELF` and is valid only on a merge-file rule
@@ -195,6 +199,12 @@ pub(crate) struct RuleModifiers {
     pub(crate) no_inherit: bool,
     pub(crate) word_split: bool,
     pub(crate) cvs_mode: bool,
+    /// `/` modifier: FILTRULE_ABS_PATH (merge / dir-merge rules).
+    pub(crate) abs_path: bool,
+    /// `-` / `+` modifier: FILTRULE_NO_PREFIXES (merge / dir-merge rules).
+    pub(crate) no_prefixes: bool,
+    /// Set alongside [`Self::no_prefixes`] when the `+` variant is used.
+    pub(crate) no_prefixes_include: bool,
 }
 
 impl RuleModifiers {
@@ -210,7 +220,9 @@ impl RuleModifiers {
             .with_perishable(self.perishable)
             .with_xattr_only(self.xattr_only)
             .with_no_inherit(no_inherit)
-            .with_cvs_mode(self.cvs_mode);
+            .with_cvs_mode(self.cvs_mode)
+            .with_abs_path(self.abs_path)
+            .with_no_prefixes(self.no_prefixes, self.no_prefixes_include);
 
         if self.sender_only && !self.receiver_only {
             rule = rule.with_sides(true, false);
@@ -288,16 +300,37 @@ fn validate_exclude_self_modifier(
 
 /// Parses modifiers from a string following the action character.
 ///
-/// Returns the parsed modifiers and the remaining string (pattern).
-/// Modifiers are single characters that can appear in any order before the pattern.
+/// Returns the parsed modifiers and the remaining string (pattern). Modifiers
+/// are single characters that can appear in any order before the pattern.
 ///
-/// upstream: exclude.c lines 1220-1288 - modifier character handling
-pub(crate) fn parse_modifiers(s: &str) -> (RuleModifiers, &str) {
+/// `is_merge` indicates whether the rule is a merge / dir-merge rule
+/// (`FILTRULE_MERGE_FILE`), which gates the `/`, `-`, and `+` modifiers.
+/// `full_line` and `line_num`/`source_path` are used only for error messages.
+///
+/// Any character that is not a recognised modifier is a syntax error, matching
+/// upstream's `invalid:` label rather than silently treating it as the start of
+/// the pattern.
+///
+/// upstream: exclude.c:1175-1227 - the modifier loop and its `invalid:` label.
+pub(crate) fn parse_modifiers<'a>(
+    s: &'a str,
+    is_merge: bool,
+    full_line: &str,
+    source_path: &Path,
+    line_num: usize,
+) -> Result<(RuleModifiers, &'a str), MergeFileError> {
     let mut mods = RuleModifiers::default();
 
     for (idx, ch) in s.char_indices() {
         match ch {
-            '!' => mods.negate = true,
+            '!' => {
+                // upstream: exclude.c:1191-1196 - negation is meaningless as a
+                // merge-file default, so `!` on a merge rule is invalid.
+                if is_merge {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.negate = true;
+            }
             'p' => mods.perishable = true,
             's' => mods.sender_only = true,
             'r' => mods.receiver_only = true,
@@ -306,17 +339,61 @@ pub(crate) fn parse_modifiers(s: &str) -> (RuleModifiers, &str) {
             'n' => mods.no_inherit = true,
             'w' => mods.word_split = true,
             'C' => mods.cvs_mode = true,
+            // upstream: exclude.c:1215-1216 - `/` sets FILTRULE_ABS_PATH.
+            '/' => mods.abs_path = true,
+            // upstream: exclude.c:1197-1213 - `-`/`+` set FILTRULE_NO_PREFIXES
+            // and are valid only on a merge-file rule that has not already set
+            // the flag; `+` additionally sets FILTRULE_INCLUDE.
+            '-' => {
+                if !is_merge || mods.no_prefixes {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.no_prefixes = true;
+            }
+            '+' => {
+                if !is_merge || mods.no_prefixes {
+                    return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
+                }
+                mods.no_prefixes = true;
+                mods.no_prefixes_include = true;
+            }
             ' ' | '_' => {
                 let remainder = &s[idx + ch.len_utf8()..];
-                return (mods, remainder.trim_start());
+                return Ok((mods, remainder.trim_start()));
             }
             _ => {
-                return (mods, &s[idx..]);
+                return Err(invalid_modifier(ch, idx, full_line, source_path, line_num));
             }
         }
     }
 
-    (mods, "")
+    Ok((mods, ""))
+}
+
+/// Builds the upstream `invalid modifier` parse error.
+///
+/// `idx` is the byte offset of the offending character within the modifier
+/// string (the text after the action character). Upstream reports the position
+/// relative to the whole rule string, where the action character is position 0,
+/// so the reported position is `idx + 1`.
+///
+/// upstream: exclude.c:1180-1184 - `rprintf(FERROR, "invalid modifier '%c' at
+/// position %d in filter rule: %s\n", *s, (int)(s - *rulestr_ptr), *rulestr_ptr)`.
+fn invalid_modifier(
+    ch: char,
+    idx: usize,
+    full_line: &str,
+    source_path: &Path,
+    line_num: usize,
+) -> MergeFileError {
+    MergeFileError::parse_error(
+        source_path,
+        line_num,
+        format!(
+            "invalid modifier '{ch}' at position {} in filter rule: {full_line}",
+            idx + 1
+        ),
+    )
 }
 
 /// Short-form rule action types.
@@ -393,7 +470,7 @@ fn try_parse_short_form(
         return Ok(None);
     };
 
-    let (mods, pattern) = parse_modifiers(rest);
+    let (mods, pattern) = parse_modifiers(rest, action.is_merge(), line, source_path, line_num)?;
     if pattern.is_empty() {
         // upstream: exclude.c:1404-1408 - a merge / dir-merge rule with the
         // `C` (CVS-ignore) modifier and an empty pattern defaults to the

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -346,10 +346,26 @@ fn parse_show_with_negate() {
 }
 
 #[test]
-fn parse_modifier_with_no_space() {
-    let rules = parse_rules("-!/path/*.txt", Path::new("test")).unwrap();
+fn parse_modifier_negate_then_pattern() {
+    // upstream requires a space (or `_`) between the modifiers and the pattern.
+    // `-! /path/*.txt` is `-` (exclude) with the `!` (negate) modifier and the
+    // pattern `/path/*.txt`.
+    let rules = parse_rules("-! /path/*.txt", Path::new("test")).unwrap();
     assert_eq!(rules[0].pattern(), "/path/*.txt");
     assert!(rules[0].is_negated());
+}
+
+#[test]
+fn parse_modifier_unknown_char_without_separator_errors() {
+    // upstream: exclude.c:1180-1184 - without a separator the modifier loop
+    // keeps consuming characters, so the `p` in `path` is read as the
+    // perishable modifier and the following `a` hits the `invalid:` label
+    // rather than being treated as the start of the pattern.
+    let err = parse_rules("-!/path/*.txt", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier 'a'"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]
@@ -364,21 +380,29 @@ fn rule_modifiers_default() {
 
 #[test]
 fn parse_modifiers_empty_string() {
-    let (mods, pattern) = parse_modifiers("");
+    let (mods, pattern) = parse_modifiers("", false, "", Path::new("test"), 1).unwrap();
     assert!(!mods.negate);
     assert_eq!(pattern, "");
 }
 
 #[test]
 fn parse_modifiers_space_only() {
-    let (mods, pattern) = parse_modifiers(" pattern");
+    let (mods, pattern) =
+        parse_modifiers(" pattern", false, " pattern", Path::new("test"), 1).unwrap();
     assert!(!mods.negate);
     assert_eq!(pattern, "pattern");
 }
 
 #[test]
 fn parse_modifiers_all_flags() {
-    let (mods, pattern) = parse_modifiers("!psrxenC pattern");
+    let (mods, pattern) = parse_modifiers(
+        "!psrxenC pattern",
+        false,
+        "-!psrxenC pattern",
+        Path::new("test"),
+        1,
+    )
+    .unwrap();
     assert!(mods.negate);
     assert!(mods.perishable);
     assert!(mods.sender_only);
@@ -479,9 +503,60 @@ fn parse_word_split_include() {
 
 #[test]
 fn parse_cvs_mode_modifier() {
-    let (mods, pattern) = parse_modifiers("C pattern");
+    let (mods, pattern) =
+        parse_modifiers("C pattern", false, "-C pattern", Path::new("test"), 1).unwrap();
     assert!(mods.cvs_mode);
     assert_eq!(pattern, "pattern");
+}
+
+#[test]
+fn parse_dir_merge_no_prefixes_exclude_modifier() {
+    // upstream: exclude.c:1197-1209 - `:- .filt` sets FILTRULE_NO_PREFIXES on a
+    // dir-merge rule (exclude variant).
+    let rules = parse_rules(":- .filt", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].action(), FilterAction::DirMerge);
+    assert_eq!(rules[0].pattern(), ".filt");
+    assert_eq!(rules[0].no_prefixes(), (true, false));
+}
+
+#[test]
+fn parse_dir_merge_no_prefixes_include_modifier() {
+    // upstream: exclude.c:1210-1213 - `:+ .filt` sets FILTRULE_NO_PREFIXES and
+    // FILTRULE_INCLUDE (include variant).
+    let rules = parse_rules(":+ .filt", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].no_prefixes(), (true, true));
+}
+
+#[test]
+fn parse_dir_merge_abs_path_modifier() {
+    // upstream: exclude.c:1215-1216 - `:/ .filt` sets FILTRULE_ABS_PATH.
+    let rules = parse_rules(":/ .filt", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 1);
+    assert!(rules[0].is_abs_path());
+}
+
+#[test]
+fn parse_no_prefixes_modifier_on_non_merge_errors() {
+    // upstream: exclude.c:1197-1199 - `-`/`+` require FILTRULE_MERGE_FILE, so a
+    // plain exclude rule with `-` in its modifiers is invalid.
+    let err = parse_rules("-- pattern", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier '-'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn parse_negate_modifier_on_merge_errors() {
+    // upstream: exclude.c:1191-1196 - `!` is meaningless on a merge default and
+    // is rejected on merge / dir-merge rules.
+    let err = parse_rules(":! .filt", Path::new("test")).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid modifier '!'"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -75,6 +75,23 @@ pub struct FilterRule {
     /// (sets `FILTRULE_NO_PREFIXES | FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT
     /// | FILTRULE_CVS_IGNORE`).
     pub(crate) cvs_mode: bool,
+    /// `/` modifier on a merge / dir-merge rule: FILTRULE_ABS_PATH. Anchors the
+    /// merged rules to the transfer root rather than the merge file's directory.
+    ///
+    /// upstream: exclude.c:1215-1216 - `case '/': rule->rflags |= FILTRULE_ABS_PATH;`
+    pub(crate) abs_path: bool,
+    /// `-`/`+` modifier on a merge / dir-merge rule: FILTRULE_NO_PREFIXES.
+    /// Consumes the merged file's lines as literal patterns instead of running
+    /// them through the prefix dispatch.
+    ///
+    /// upstream: exclude.c:1197-1213 - `case '-'`/`case '+'`.
+    pub(crate) no_prefixes: bool,
+    /// Pairs with [`Self::no_prefixes`] to select the `+` (include) variant.
+    /// When both are set, literal lines become include rules; the `-` variant
+    /// leaves this false and lines become exclude rules.
+    ///
+    /// upstream: exclude.c:1210-1213 - `+` also sets FILTRULE_INCLUDE.
+    pub(crate) no_prefixes_include: bool,
 }
 
 impl FilterRule {
@@ -106,6 +123,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -137,6 +157,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -168,6 +191,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -189,6 +215,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -211,6 +240,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -236,6 +268,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -261,6 +296,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -290,6 +328,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -319,6 +360,9 @@ impl FilterRule {
             exclude_only: false,
             no_inherit: false,
             cvs_mode: false,
+            abs_path: false,
+            no_prefixes: false,
+            no_prefixes_include: false,
         }
     }
 
@@ -466,6 +510,43 @@ impl FilterRule {
     #[must_use]
     pub const fn with_cvs_mode(mut self, cvs_mode: bool) -> Self {
         self.cvs_mode = cvs_mode;
+        self
+    }
+
+    /// Returns whether the rule carries the `/` (FILTRULE_ABS_PATH) modifier.
+    ///
+    /// On merge / dir-merge rules this anchors the merged rules to the transfer
+    /// root instead of the merge file's own directory.
+    ///
+    /// upstream: exclude.c:1215-1216 - `case '/'`
+    #[must_use]
+    pub const fn is_abs_path(&self) -> bool {
+        self.abs_path
+    }
+
+    /// Sets the `/` (FILTRULE_ABS_PATH) modifier on this rule.
+    #[must_use]
+    pub const fn with_abs_path(mut self, abs_path: bool) -> Self {
+        self.abs_path = abs_path;
+        self
+    }
+
+    /// Returns whether the rule carries the `-`/`+` (FILTRULE_NO_PREFIXES)
+    /// modifier and, via the second element, whether it is the `+` (include)
+    /// variant.
+    ///
+    /// upstream: exclude.c:1197-1213 - `case '-'`/`case '+'`
+    #[must_use]
+    pub const fn no_prefixes(&self) -> (bool, bool) {
+        (self.no_prefixes, self.no_prefixes_include)
+    }
+
+    /// Sets the `-`/`+` (FILTRULE_NO_PREFIXES) modifier on this rule. `include`
+    /// selects the `+` variant (literal includes); otherwise literal excludes.
+    #[must_use]
+    pub const fn with_no_prefixes(mut self, no_prefixes: bool, include: bool) -> Self {
+        self.no_prefixes = no_prefixes;
+        self.no_prefixes_include = include;
         self
     }
 

--- a/crates/filters/tests/dir_merge_parsing_comprehensive.rs
+++ b/crates/filters/tests/dir_merge_parsing_comprehensive.rs
@@ -119,12 +119,31 @@ fn dir_merge_with_space_separator() {
 }
 
 #[test]
-fn dir_merge_no_separator() {
+fn dir_merge_requires_separator_before_pattern() {
     let dir = TempDir::new().unwrap();
     let rules_path = dir.path().join("rules.txt");
 
-    // No separator - pattern starts immediately after modifiers
+    // upstream: exclude.c:1226 - without a separator, the modifier loop reads
+    // `.` (after the `n` modifier) as another modifier character and rejects
+    // it. rsync 3.4.4 emits:
+    //   invalid modifier '.' at position 2 in filter rule: :n.rsync-filter
     fs::write(&rules_path, ":n.rsync-filter\n").unwrap();
+
+    let err = filters::merge::read_rules(&rules_path).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("invalid modifier '.' at position 2 in filter rule: :n.rsync-filter"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn dir_merge_with_separator_parses_no_inherit() {
+    let dir = TempDir::new().unwrap();
+    let rules_path = dir.path().join("rules.txt");
+
+    // The space-separated form is the valid spelling: `:n .rsync-filter`.
+    fs::write(&rules_path, ":n .rsync-filter\n").unwrap();
 
     let rules = filters::merge::read_rules(&rules_path).unwrap();
     assert_eq!(rules.len(), 1);

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -29,11 +29,15 @@ mod include_rules {
     }
 
     #[test]
-    fn short_form_include_no_space() {
-        let rules = parse_rules("+*.txt", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Include);
-        assert_eq!(rules[0].pattern(), "*.txt");
+    fn short_form_include_no_space_errors() {
+        // upstream: exclude.c:1226 - a short-prefix rule requires a separator
+        // before the pattern. `+*.txt` reads `*` as a modifier and rejects it:
+        //   invalid modifier '*' at position 1 in filter rule: +*.txt
+        let err = parse_rules("+*.txt", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier '*'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -169,11 +173,14 @@ mod exclude_rules {
     }
 
     #[test]
-    fn short_form_exclude_no_space() {
-        let rules = parse_rules("-*.bak", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Exclude);
-        assert_eq!(rules[0].pattern(), "*.bak");
+    fn short_form_exclude_no_space_errors() {
+        // upstream: exclude.c:1226 - `-*.bak` reads `*` as a modifier:
+        //   invalid modifier '*' at position 1 in filter rule: -*.bak
+        let err = parse_rules("-*.bak", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier '*'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -523,10 +530,16 @@ mod hide_show_rules {
     }
 
     #[test]
-    fn hide_long_form_case_insensitive() {
-        let rules = parse_rules("HIDE *.secret", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Exclude);
+    fn hide_long_form_uppercase_errors() {
+        // upstream long-form keywords are lowercase only. `HIDE *.secret` is
+        // parsed as the `H` (hide) short prefix followed by an invalid `I`
+        // modifier, matching rsync 3.4.4:
+        //   invalid modifier 'I' at position 1 in filter rule: HIDE *.secret
+        let err = parse_rules("HIDE *.secret", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'I'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -549,10 +562,15 @@ mod hide_show_rules {
     }
 
     #[test]
-    fn show_long_form_case_insensitive() {
-        let rules = parse_rules("SHOW *.public", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Include);
+    fn show_long_form_uppercase_errors() {
+        // upstream: `SHOW *.public` parses as the `S` (show) short prefix then
+        // an invalid `H` modifier:
+        //   invalid modifier 'H' at position 1 in filter rule: SHOW *.public
+        let err = parse_rules("SHOW *.public", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'H'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -651,10 +669,15 @@ mod protect_risk_rules {
     }
 
     #[test]
-    fn protect_long_form_case_insensitive() {
-        let rules = parse_rules("PROTECT /important", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Protect);
+    fn protect_long_form_uppercase_errors() {
+        // upstream: `PROTECT /important` parses as the `P` (protect) short prefix
+        // then an invalid `R` modifier:
+        //   invalid modifier 'R' at position 1 in filter rule: PROTECT /important
+        let err = parse_rules("PROTECT /important", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'R'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -673,10 +696,15 @@ mod protect_risk_rules {
     }
 
     #[test]
-    fn risk_long_form_case_insensitive() {
-        let rules = parse_rules("RISK /temp", Path::new("test")).unwrap();
-        assert_eq!(rules.len(), 1);
-        assert_eq!(rules[0].action(), FilterAction::Risk);
+    fn risk_long_form_uppercase_errors() {
+        // upstream: `RISK /temp` parses as the `R` (risk) short prefix then an
+        // invalid `I` modifier:
+        //   invalid modifier 'I' at position 1 in filter rule: RISK /temp
+        let err = parse_rules("RISK /temp", Path::new("test")).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid modifier 'I'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Four output/behavior fidelity fixes to match upstream rsync 3.4.4 (`exclude.c`), verified against a local `rsync 3.4.4` build.

### 1. `-C` HOME/env cvsignore patterns wrongly perishable
`crates/cli/src/frontend/filter_rules/cvs.rs` marked `$HOME/.cvsignore` and `$CVSIGNORE` patterns perishable.

- upstream `exclude.c:1355-1357`: those two sources are parsed with a plain `rule_template(rflags)`; only the built-in `default_cvsignore()` list carries `FILTRULE_PERISHABLE`.
- Before: `FilterRuleSpec::exclude(pat).with_perishable(true)` for HOME/env patterns.
- After: `FilterRuleSpec::exclude(pat)` (not perishable).

### 2. `-C` built-in list unconditionally perishable
`cvs.rs` always set the built-in list perishable.

- upstream `exclude.c:1350`: perishable is gated on `protocol_version >= 30`.
- After: gated on `SUPPORTED_PROTOCOL_BOUNDS.1 >= 30` (the newest protocol negotiated; the `-C` rules are assembled at argument-parse time before negotiation). Effect is unchanged today (oc negotiates 32) but the code now mirrors upstream's condition.

### 3. Unknown rule-modifier char silently treated as start-of-pattern
`crates/filters/src/merge/parse.rs` `parse_modifiers` returned the remainder as the pattern on an unrecognised modifier char.

- upstream `exclude.c:1180-1226`: an unknown modifier hits the `invalid:` label and errors.
- After: `parse_modifiers` returns a `Result` and emits the upstream text byte-for-byte, e.g. `invalid modifier 'I' at position 1 in filter rule: HIDE *.secret`. `!` is also rejected on merge rules (upstream `exclude.c:1191-1196`).
- Several existing tests pinned the old lenient behavior (`+*.txt`, `-*.bak`, `:n.rsync-filter`, uppercase long-forms `HIDE`/`SHOW`/`PROTECT`/`RISK`). All of these error in upstream 3.4.4 too; the tests were updated to assert the upstream error text/position.

### 4. `/` (ABS_PATH) and `+`/`-` (NO_PREFIXES) modifiers on dir-merge not parsed
`parse_modifiers` did not recognise `/`, `+`, `-` on `:`/`.` merge rules.

- upstream `exclude.c:1197-1216`: `/` sets `FILTRULE_ABS_PATH`; `-`/`+` set `FILTRULE_NO_PREFIXES` (and `+` also `FILTRULE_INCLUDE`), valid only on merge-file rules.
- After: parsed and threaded through `FilterRule` -> `InlineDirMerge` -> `DirMergeConfig` (`with_no_prefixes` / `with_anchor_root`); the persistent per-directory reload skips merge-directory re-anchoring when `abs_path` is set.

### Tests
- `filters --lib`: 352 passed.
- `filters` integration suite: green (updated the lenient-behavior tests to upstream semantics; added tests for HOME/env non-perishable, unknown-modifier error, and `:/`/`:+`/`:-` parsing).
- `cli` filter tests: green.
- fmt + clippy (`filters`, `cli`, `--all-targets -D warnings`): clean.

Advances #516.
