### PR TITLE
fix(filters): align unknown-rule error text and exit code with upstream

### DIFF
--- a/crates/core/src/client/error.rs
+++ b/crates/core/src/client/error.rs
@@ -237,6 +237,11 @@ pub(crate) fn map_local_copy_error(error: LocalCopyError) -> ClientError {
                 rsync_error!(code.as_i32(), "stopping at requested limit").with_role(Role::Client);
             ClientError::with_code(code, message)
         }
+        LocalCopyErrorKind::FilterSyntax { message } => {
+            let code = ExitCode::Syntax;
+            let msg = rsync_error!(code.as_i32(), "{}", message).with_role(Role::Client);
+            ClientError::with_code(code, msg)
+        }
     }
 }
 

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -226,13 +226,9 @@ pub(crate) fn load_dir_merge_rules_recursive(
         .map_err(|error| LocalCopyError::io("read filter file", path, error))?;
     let mut entries = DirMergeEntries::default();
 
-    let map_error = |error: FilterParseError| {
-        LocalCopyError::io(
-            "parse filter file",
-            path.to_path_buf(),
-            io::Error::new(io::ErrorKind::InvalidData, error.to_string()),
-        )
-    };
+    // upstream: exclude.c:1212 - unrecognised filter rules exit with
+    // RERR_SYNTAX (1), not RERR_PARTIAL (23).
+    let map_error = |error: FilterParseError| LocalCopyError::filter_syntax(error.to_string());
 
     let mut contents = String::new();
     io::BufReader::new(file)

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -273,7 +273,7 @@ pub(crate) fn parse_filter_directive_line(
     }
 
     Err(FilterParseError::new(format!(
-        "unsupported filter directive '{trimmed}'"
+        "Unknown filter rule: `{trimmed}'"
     )))
 }
 

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -117,6 +117,17 @@ impl LocalCopyError {
         Self::new(LocalCopyErrorKind::StopAtReached { target })
     }
 
+    /// Constructs a filter syntax error (exit code 1, `RERR_SYNTAX`).
+    ///
+    /// upstream: exclude.c:1212 - unrecognised filter rules exit with
+    /// `RERR_SYNTAX` (1), not `RERR_PARTIAL` (23).
+    #[must_use]
+    pub fn filter_syntax(message: impl Into<String>) -> Self {
+        Self::new(LocalCopyErrorKind::FilterSyntax {
+            message: message.into(),
+        })
+    }
+
     /// Returns the exit code that mirrors upstream rsync's behaviour.
     ///
     /// See the struct-level documentation for mappings to `core::exit_code::ExitCode`.
@@ -144,6 +155,7 @@ impl LocalCopyError {
                 TIMEOUT_EXIT_CODE
             }
             LocalCopyErrorKind::DeleteLimitExceeded { .. } => MAX_DELETE_EXIT_CODE,
+            LocalCopyErrorKind::FilterSyntax { .. } => MISSING_OPERANDS_EXIT_CODE,
         }
     }
 
@@ -167,6 +179,7 @@ impl LocalCopyError {
                 "RERR_TIMEOUT"
             }
             LocalCopyErrorKind::DeleteLimitExceeded { .. } => "RERR_DEL_LIMIT",
+            LocalCopyErrorKind::FilterSyntax { .. } => "RERR_SYNTAX",
         }
     }
 
@@ -281,6 +294,15 @@ pub enum LocalCopyErrorKind {
     StopAtReached {
         /// The requested wall-clock deadline.
         target: SystemTime,
+    },
+    /// A filter rule could not be parsed.
+    ///
+    /// upstream: exclude.c:1212 - `Unknown filter rule: \`%s'` exits with
+    /// `RERR_SYNTAX` (1).
+    #[error("{message}")]
+    FilterSyntax {
+        /// Human-readable error message (already formatted to match upstream).
+        message: String,
     },
 }
 

--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -353,7 +353,7 @@ impl FilterChain {
             // `:C` (FILTRULE_CVS_IGNORE) parse their content as whitespace
             // separated tokens with every token implicitly an exclude.
             // Standard parse_rules would reject names like `one-in-one-out`
-            // as "unrecognized filter rule", aborting the walk.
+            // as "Unknown filter rule", aborting the walk.
             let rules = if config.no_prefixes() {
                 // upstream: exclude.c:1116-1133 - the `-`/`+` modifier on the
                 // dir-merge template skips short-prefix dispatch, so each

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -549,6 +549,6 @@ fn parse_rule_line(
     Err(MergeFileError::parse_error(
         source_path,
         line_num,
-        format!("unrecognized filter rule: {line}"),
+        format!("Unknown filter rule: `{line}'"),
     ))
 }

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -127,7 +127,7 @@ fn parse_error_unrecognized() {
     let result = parse_rules("invalid rule", Path::new("test.rules"));
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(err.message.contains("unrecognized"));
+    assert!(err.message.contains("Unknown filter rule"));
     assert_eq!(err.line, Some(1));
 }
 

--- a/crates/filters/tests/filter_rule_syntax.rs
+++ b/crates/filters/tests/filter_rule_syntax.rs
@@ -1200,7 +1200,7 @@ mod error_handling {
         let result = parse_rules("invalid rule", Path::new("test.rules"));
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.message.contains("unrecognized"));
+        assert!(err.message.contains("Unknown filter rule"));
         assert_eq!(err.line, Some(1));
     }
 

--- a/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
+++ b/crates/transfer/tests/exclude_lsh_cvs_wire_expansion.rs
@@ -27,7 +27,7 @@
 //!   `exclude.c:get_cvs_excludes()`.
 //! - A wire `:C .cvsignore` dir-merge switches the `DirMergeConfig` into
 //!   CVS-mode so the chain parses each whitespace token in `.cvsignore` as
-//!   an exclude rule instead of failing on `unrecognized filter rule:
+//!   an exclude rule instead of failing on `Unknown filter rule:
 //!   one-in-one-out`.
 
 use std::path::Path;


### PR DESCRIPTION
## Summary

- Align filter-rule error message text with upstream rsync `exclude.c:1212` format: `Unknown filter rule: \`%s'` (backtick + single-quote quoting)
- Fix exit code from 23 (`RERR_PARTIAL`) to 1 (`RERR_SYNTAX`) for filter parse errors in the engine's per-directory merge path
- Two divergent sites corrected:
  - `crates/filters/src/merge/parse.rs` - merge-file rule parser (text only; exit code already correct via `compile_filter_error`)
  - `crates/engine/src/local_copy/dir_merge/parse/line.rs` - per-dir merge line parser (text + exit code)

## Details

Added `LocalCopyErrorKind::FilterSyntax` variant so the engine's `load_dir_merge_rules_recursive` maps parse failures to exit code 1 (`RERR_SYNTAX`) instead of wrapping them as `LocalCopyError::io(InvalidData)` which mapped to exit code 23 (`RERR_PARTIAL`).

Updated 2 test assertions and 2 comments that referenced the old error text.

## Test plan

- [ ] CI passes (fmt, clippy, nextest, all platforms)
- [ ] `cargo clippy -p filters -p engine --all-features --no-deps -- -D warnings` clean
- [ ] Tests in `crates/filters/src/merge/tests.rs` and `crates/filters/tests/filter_rule_syntax.rs` pass with updated assertions