### PR TITLE
feat(transfer): add -vvv trace messages matching upstream receiver.c and flist.c

### DIFF
--- a/crates/transfer/src/delta_apply/applicator.rs
+++ b/crates/transfer/src/delta_apply/applicator.rs
@@ -797,6 +797,8 @@ impl<'a> DeltaApplicator<'a> {
         let expected_len = self.checksum_verifier.digest_len();
         let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
         reader.read_exact(&mut expected[..expected_len])?;
+        // upstream: receiver.c:516-517 DEBUG_GTE(DELTASUM, 2)
+        debug_log!(Deltasum, 2, "got file_sum");
 
         let mut computed = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
         let computed_len = self.checksum_verifier.finalize_into(&mut computed);
@@ -946,6 +948,8 @@ impl<'a> DeltaApplicator<'a> {
         let expected_len = self.checksum_verifier.digest_len();
         let mut expected = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
         reader.read_exact(&mut expected[..expected_len]).await?;
+        // upstream: receiver.c:516-517 DEBUG_GTE(DELTASUM, 2)
+        debug_log!(Deltasum, 2, "got file_sum");
 
         let mut computed = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
         let computed_len = self.checksum_verifier.finalize_into(&mut computed);
@@ -1112,6 +1116,8 @@ pub fn discard_delta_stream<R: Read>(
     // NDX / goodbye. On the discard path there is nothing to verify against.
     let mut sink = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
     reader.read_exact(&mut sink[..checksum_len])?;
+    // upstream: receiver.c:516-517 DEBUG_GTE(DELTASUM, 2)
+    debug_log!(Deltasum, 2, "got file_sum");
 
     debug_log!(Deltasum, 2, "recv delta stream discard complete");
     Ok(())
@@ -1180,6 +1186,8 @@ where
     // NDX / goodbye. On the discard path there is nothing to verify against.
     let mut sink = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
     reader.read_exact(&mut sink[..checksum_len]).await?;
+    // upstream: receiver.c:516-517 DEBUG_GTE(DELTASUM, 2)
+    debug_log!(Deltasum, 2, "got file_sum");
 
     debug_log!(Deltasum, 2, "recv delta stream discard complete");
     Ok(())

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -39,6 +39,15 @@ impl GeneratorContext {
         #[cfg(unix)]
         use std::os::unix::fs::MetadataExt;
 
+        // upstream: flist.c:1396-1398 DEBUG_GTE(FLIST, 2)
+        // ALL_FILTERS = 2 is the common filter_level for send_file_list paths.
+        logging::debug_log!(
+            Flist,
+            2,
+            "[sender] make_file({},*,2)",
+            relative_path.display()
+        );
+
         let file_type = metadata.file_type();
 
         // Native Windows reparse-point detection. `std::fs::FileType::is_symlink`

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -61,6 +61,8 @@ impl ReceiverContext {
             // upstream: generator.c:2355-2357 - phase++ then "generate_files phase=%d"
             // The first `phase++` after the per-segment loop advances 0 -> 1.
             let mut phase: i32 = 1;
+            // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
+            debug_log!(Recv, 1, "recv_files phase={}", phase);
             debug_log!(Genr, 1, "generate_files phase={}", phase);
 
             for _phase_step in 2..=max_phase {
@@ -70,6 +72,8 @@ impl ReceiverContext {
                 // upstream: generator.c:2366-2368 - phase++ on each additional
                 // iteration (covers the redo phase).
                 phase += 1;
+                // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
+                debug_log!(Recv, 1, "recv_files phase={}", phase);
                 debug_log!(Genr, 1, "generate_files phase={}", phase);
             }
 
@@ -89,6 +93,8 @@ impl ReceiverContext {
                 ndx_write_codec.write_ndx_done(&mut *writer)?;
                 writer.flush()?;
                 phase += 1;
+                // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
+                debug_log!(Recv, 1, "recv_files phase={}", phase);
                 // upstream: generator.c:2355-2357, 2366-2368, 2392-2394
                 // "generate_files phase=%d" emitted after each phase++.
                 debug_log!(Genr, 1, "generate_files phase={}", phase);
@@ -204,6 +210,8 @@ impl ReceiverContext {
 
             // upstream: generator.c:2355-2357 - phase++ then "generate_files phase=%d"
             let mut phase: i32 = 1;
+            // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
+            debug_log!(Recv, 1, "recv_files phase={}", phase);
             debug_log!(Genr, 1, "generate_files phase={}", phase);
 
             for _phase_step in 2..=max_phase {
@@ -212,6 +220,8 @@ impl ReceiverContext {
                 self.read_expected_ndx_done_async(ndx_read_codec, reader, "phase transition")
                     .await?;
                 phase += 1;
+                // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
+                debug_log!(Recv, 1, "recv_files phase={}", phase);
                 debug_log!(Genr, 1, "generate_files phase={}", phase);
             }
 
@@ -229,6 +239,8 @@ impl ReceiverContext {
                 ndx_write_codec.write_ndx_done(&mut *writer)?;
                 writer.flush()?;
                 phase += 1;
+                // upstream: receiver.c:692-693 DEBUG_GTE(RECV, 1)
+                debug_log!(Recv, 1, "recv_files phase={}", phase);
                 debug_log!(Genr, 1, "generate_files phase={}", phase);
                 if phase > max_phase {
                     break;
@@ -506,6 +518,9 @@ impl ReceiverContext {
             }
         }
 
+        // upstream: receiver.c:1114-1115 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files finished");
+
         // upstream: generator.c:2436-2437 - "generate_files finished" emitted at
         // the bottom of generate_files() after the final goodbye handshake.
         debug_log!(Genr, 1, "generate_files finished");
@@ -591,6 +606,9 @@ impl ReceiverContext {
                 return Err(e);
             }
         }
+
+        // upstream: receiver.c:1114-1115 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files finished");
 
         // upstream: generator.c:2436-2437 - "generate_files finished".
         debug_log!(Genr, 1, "generate_files finished");

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -16,7 +16,7 @@ use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use logging::info_log;
+use logging::{debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
 use protocol::flist::FileEntry;
 
@@ -305,6 +305,9 @@ impl ReceiverContext {
                 flushed_pending = flushed_pending.saturating_sub(1);
                 let (file_idx, file_path, file_entry, base_iflags) =
                     pending_files_info.pop_front().expect("pipeline not empty");
+
+                // upstream: receiver.c:708-709 DEBUG_GTE(RECV, 1)
+                debug_log!(Recv, 1, "recv_files({})", file_entry.path().display());
 
                 let response_ctx = ResponseContext {
                     config: &request_config,

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -8,7 +8,7 @@
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
-use logging::{PhaseTimer, info_log};
+use logging::{PhaseTimer, debug_log, info_log};
 use protocol::flist::FileEntry;
 use protocol::stats::DeleteStats;
 
@@ -63,6 +63,9 @@ impl ReceiverContext {
             #[cfg(unix)]
             setup.sandbox.as_deref(),
         )?;
+
+        // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files({}) starting", file_count);
 
         let mut delete_stats = DeleteStats::new();
         let mut delete_limit_exceeded = false;

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -8,7 +8,7 @@
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 
-use logging::PhaseTimer;
+use logging::{PhaseTimer, debug_log};
 use protocol::flist::FileEntry;
 use protocol::stats::DeleteStats;
 
@@ -45,6 +45,9 @@ impl ReceiverContext {
                 | self.flist_io_error,
             ..Default::default()
         };
+        // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files({}) starting", file_count);
+
         let mut failed_dirs = crate::receiver::directory::FailedDirectories::new();
         let mut metadata_errors: Vec<(PathBuf, String)> = Vec::new();
 

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -8,7 +8,7 @@
 use std::fs;
 use std::io::{self, Read, Write};
 
-use logging::{PhaseTimer, info_log};
+use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
 use protocol::stats::DeleteStats;
 
@@ -57,6 +57,9 @@ impl ReceiverContext {
             #[cfg(unix)]
             sandbox,
         } = setup;
+
+        // upstream: receiver.c:653-654 DEBUG_GTE(RECV, 1)
+        debug_log!(Recv, 1, "recv_files({}) starting", file_count);
 
         let mut files_transferred = 0;
         let mut bytes_received = 0u64;
@@ -117,6 +120,8 @@ impl ReceiverContext {
             }
 
             let relative_path = file_entry.path();
+            // upstream: receiver.c:708-709 DEBUG_GTE(RECV, 1)
+            debug_log!(Recv, 1, "recv_files({})", relative_path.display());
 
             let file_path = if relative_path.as_os_str() == "." {
                 dest_dir.clone()


### PR DESCRIPTION
## Summary

- Add six missing DEBUG_GTE-gated diagnostic messages that upstream rsync emits at `-vvv` but oc-rsync was missing
- `recv_files(%d) starting` / `recv_files(%s)` / `recv_files phase=%d` / `recv_files finished` (RECV>=1)
- `got file_sum` (DELTASUM>=2) after trailing whole-file checksum receipt
- `[sender] make_file(%s,*,2)` (FLIST>=2) during file entry construction
- All messages gated behind `debug_log!` level checks - zero overhead when not enabled
- No production logic changes - diagnostic output only

## Test plan

- [ ] CI fmt+clippy passes (no new warnings in changed files)
- [ ] CI nextest passes (no behavioral change - messages only emit at -vvv)
- [ ] Verify with `oc-rsync -vvv src dst` that new messages appear in stderr
- [ ] Compare `rsync -vvv` vs `oc-rsync -vvv` output to confirm format parity