### PR TITLE
fix(cli): gate --stats created/deleted lines on protocol version

### DIFF
--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -489,16 +489,22 @@ fn emit_stats_detail_block<W: Write + ?Sized>(
         "Number of files: {}{files_breakdown}",
         format_decimal_bytes(total_entries)
     )?;
-    writeln!(
-        stdout,
-        "Number of created files: {}{created_breakdown}",
-        format_decimal_bytes(created_total)
-    )?;
-    writeln!(
-        stdout,
-        "Number of deleted files: {}{deleted_breakdown}",
-        format_decimal_bytes(deleted)
-    )?;
+    // upstream: main.c:429 - `if (protocol_version >= 29)`
+    if summary.protocol_version() >= 29 {
+        writeln!(
+            stdout,
+            "Number of created files: {}{created_breakdown}",
+            format_decimal_bytes(created_total)
+        )?;
+    }
+    // upstream: main.c:431 - `if (protocol_version >= 31)`
+    if summary.protocol_version() >= 31 {
+        writeln!(
+            stdout,
+            "Number of deleted files: {}{deleted_breakdown}",
+            format_decimal_bytes(deleted)
+        )?;
+    }
     writeln!(
         stdout,
         "Number of regular files transferred: {}",

--- a/crates/cli/src/frontend/stats_format.rs
+++ b/crates/cli/src/frontend/stats_format.rs
@@ -28,6 +28,7 @@
 //!     total_bytes_received: 67_890,
 //!     num_created_files: 56,
 //!     num_deleted_files: 0,
+//!     protocol_version: 32,
 //! };
 //!
 //! let formatter = StatsFormatter::new(data);
@@ -69,6 +70,9 @@ pub struct StatsData {
     pub num_created_files: u64,
     /// Number of deleted files.
     pub num_deleted_files: u64,
+    /// Negotiated protocol version - gates display of certain stats lines.
+    /// upstream: main.c:429-433
+    pub protocol_version: u8,
 }
 
 impl Default for StatsData {
@@ -87,6 +91,7 @@ impl Default for StatsData {
             total_bytes_received: 0,
             num_created_files: 0,
             num_deleted_files: 0,
+            protocol_version: 32,
         }
     }
 }
@@ -126,6 +131,7 @@ impl StatsFormatter {
     ///     total_bytes_received: 67_890,
     ///     num_created_files: 56,
     ///     num_deleted_files: 0,
+    ///     protocol_version: 32,
     /// };
     ///
     /// let formatter = StatsFormatter::new(data);
@@ -143,19 +149,25 @@ impl StatsFormatter {
         )
         .unwrap();
 
-        writeln!(
-            output,
-            "Number of created files: {}",
-            format_number(self.data.num_created_files)
-        )
-        .unwrap();
+        // upstream: main.c:429 - `if (protocol_version >= 29)`
+        if self.data.protocol_version >= 29 {
+            writeln!(
+                output,
+                "Number of created files: {}",
+                format_number(self.data.num_created_files)
+            )
+            .unwrap();
+        }
 
-        writeln!(
-            output,
-            "Number of deleted files: {}",
-            format_number(self.data.num_deleted_files)
-        )
-        .unwrap();
+        // upstream: main.c:431 - `if (protocol_version >= 31)`
+        if self.data.protocol_version >= 31 {
+            writeln!(
+                output,
+                "Number of deleted files: {}",
+                format_number(self.data.num_deleted_files)
+            )
+            .unwrap();
+        }
 
         writeln!(
             output,
@@ -512,6 +524,7 @@ mod tests {
             total_bytes_received: 67_890,
             num_created_files: 56,
             num_deleted_files: 0,
+            protocol_version: 32,
         };
 
         let formatter = StatsFormatter::new(data);
@@ -564,6 +577,7 @@ mod tests {
             total_bytes_received: 3_333_333_333,
             num_created_files: 222_222_222,
             num_deleted_files: 111_111_111,
+            protocol_version: 32,
         };
 
         let formatter = StatsFormatter::new(data);

--- a/crates/cli/tests/output_parity.rs
+++ b/crates/cli/tests/output_parity.rs
@@ -206,6 +206,7 @@ fn stats_full_output_format() {
         file_list_transfer_time: 0.0,
         total_bytes_sent: 12_345,
         total_bytes_received: 67_890,
+        protocol_version: 32,
     };
 
     let formatter = StatsFormatter::new(data);

--- a/crates/core/src/client/remote/async_ssh_transport.rs
+++ b/crates/core/src/client/remote/async_ssh_transport.rs
@@ -417,7 +417,11 @@ fn run_async_session(
         let _ = inbound.await;
 
         match server_outcome {
-            Ok((stats, elapsed)) => Ok(convert_server_stats_to_summary(stats, elapsed)),
+            Ok((stats, elapsed, proto_version)) => {
+                let mut summary = convert_server_stats_to_summary(stats, elapsed);
+                summary.set_protocol_version(proto_version);
+                Ok(summary)
+            }
             Err(err) => Err(err),
         }
     })
@@ -555,7 +559,7 @@ fn run_blocking_server(
     mut writer: SyncWriter,
     batch_ctx: Option<BatchContext>,
     start: Instant,
-) -> Result<(ServerStats, Duration), ClientError> {
+) -> Result<(ServerStats, Duration, u8), ClientError> {
     let batch_recording = batch_ctx.as_ref().map(|ctx| {
         let is_sender = config.role == ServerRole::Generator;
         build_batch_recording(ctx, is_sender)
@@ -563,6 +567,7 @@ fn run_blocking_server(
 
     let handshake = crate::server::perform_handshake(&mut reader, &mut writer)
         .map_err(|e| invalid_argument_error(&format!("async SSH handshake failed: {e}"), 5))?;
+    let negotiated_protocol = handshake.protocol.as_u8();
 
     let transfer_result = crate::server::run_server_with_handshake(
         config,
@@ -579,7 +584,7 @@ fn run_blocking_server(
     drop(writer);
 
     match transfer_result {
-        Ok(stats) => Ok((stats, start.elapsed())),
+        Ok(stats) => Ok((stats, start.elapsed(), negotiated_protocol)),
         Err(err) => {
             let exit = ExitCode::from_io_error(&err);
             Err(invalid_argument_error_typed(

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -93,7 +93,9 @@ pub(crate) fn run_pull_transfer(
     .map_err(|e| invalid_argument_error(&format!("transfer failed: {e}"), 23))?;
     let elapsed = start.elapsed();
 
-    Ok(convert_server_stats_to_summary(server_stats, elapsed))
+    let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+    summary.set_protocol_version(protocol.as_u8());
+    Ok(summary)
 }
 
 /// Executes a push transfer (local to remote).
@@ -166,7 +168,9 @@ pub(crate) fn run_push_transfer(
     match result {
         Ok(server_stats) => {
             let elapsed = start.elapsed();
-            Ok(convert_server_stats_to_summary(server_stats, elapsed))
+            let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+            summary.set_protocol_version(protocol.as_u8());
+            Ok(summary)
         }
         Err(ref e) if dry_run && is_dry_run_remote_close(e) => {
             // upstream: clientserver.c - during --dry-run push, the daemon closes

--- a/crates/core/src/client/remote/embedded_ssh_transfer.rs
+++ b/crates/core/src/client/remote/embedded_ssh_transfer.rs
@@ -357,6 +357,7 @@ fn run_transfer_over_embedded_ssh(
 
     let handshake = crate::server::perform_handshake(&mut reader, &mut writer)
         .map_err(|e| invalid_argument_error(&format!("handshake failed: {e}"), 5))?;
+    let negotiated_protocol = handshake.protocol.as_u8();
 
     let mut adapter = observer.map(|obs| ServerProgressAdapter::new(obs, start));
     let progress: Option<&mut dyn TransferProgressCallback> = adapter
@@ -388,7 +389,11 @@ fn run_transfer_over_embedded_ssh(
 
     match transfer_result {
         Ok(stats) => match goodbye_outcome {
-            Ok(()) => Ok(convert_server_stats_to_summary(stats, elapsed)),
+            Ok(()) => {
+                let mut summary = convert_server_stats_to_summary(stats, elapsed);
+                summary.set_protocol_version(negotiated_protocol);
+                Ok(summary)
+            }
             Err(e) => Err(invalid_argument_error(
                 &format!("embedded SSH goodbye phase failed: {e}"),
                 ExitCode::Timeout.as_i32(),

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -167,11 +167,13 @@ fn run_pull_transfer(
     let progress: Option<&mut dyn TransferProgressCallback> = adapter
         .as_mut()
         .map(|a| a as &mut dyn TransferProgressCallback);
-    let server_stats =
+    let (server_stats, negotiated_protocol) =
         run_server_over_ssh_connection(server_config, connection, progress, batch_ctx)?;
     let elapsed = start.elapsed();
 
-    Ok(convert_server_stats_to_summary(server_stats, elapsed))
+    let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+    summary.set_protocol_version(negotiated_protocol);
+    Ok(summary)
 }
 
 /// Executes a push transfer (local → remote).
@@ -202,11 +204,13 @@ fn run_push_transfer(
     let progress: Option<&mut dyn TransferProgressCallback> = adapter
         .as_mut()
         .map(|a| a as &mut dyn TransferProgressCallback);
-    let server_stats =
+    let (server_stats, negotiated_protocol) =
         run_server_over_ssh_connection(server_config, connection, progress, batch_ctx)?;
     let elapsed = start.elapsed();
 
-    Ok(convert_server_stats_to_summary(server_stats, elapsed))
+    let mut summary = convert_server_stats_to_summary(server_stats, elapsed);
+    summary.set_protocol_version(negotiated_protocol);
+    Ok(summary)
 }
 
 /// Executes a proxy transfer (remote → remote via local).
@@ -249,7 +253,7 @@ fn run_server_over_ssh_connection(
     connection: SshConnection,
     progress: Option<&mut dyn crate::server::TransferProgressCallback>,
     batch_ctx: Option<BatchContext>,
-) -> Result<crate::server::ServerStats, ClientError> {
+) -> Result<(crate::server::ServerStats, u8), ClientError> {
     let (reader, mut writer, mut child_handle) = connection
         .split()
         .map_err(|e| invalid_argument_error(&format!("failed to split SSH connection: {e}"), 23))?;
@@ -289,6 +293,7 @@ fn run_server_over_ssh_connection(
             crate::exit_code::ExitCode::ConnectionTimeout.as_i32(),
         ));
     }
+    let negotiated_protocol = handshake.protocol.as_u8();
     let transfer_result = crate::server::run_server_with_handshake(
         config,
         handshake,
@@ -315,7 +320,7 @@ fn run_server_over_ssh_connection(
         Ok(stats) => {
             // upstream: take MAX of transfer and child exit codes.
             if child_exit_code.is_success() {
-                Ok(stats)
+                Ok((stats, negotiated_protocol))
             } else {
                 Err(invalid_argument_error_typed(
                     &format!(

--- a/crates/core/src/client/summary/mod.rs
+++ b/crates/core/src/client/summary/mod.rs
@@ -46,7 +46,7 @@ use std::time::Duration;
 use engine::local_copy::{LocalCopyReport, LocalCopySummary};
 
 /// Summary of the work performed by a client transfer.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ClientSummary {
     stats: LocalCopySummary,
     events: Vec<ClientEvent>,
@@ -57,6 +57,26 @@ pub struct ClientSummary {
     /// such as `RERR_PARTIAL` (23), `RERR_VANISHED` (24), or
     /// `RERR_DEL_LIMIT` (25).
     io_error_exit_code: Option<i32>,
+    /// Negotiated protocol version for the transfer.
+    ///
+    /// Defaults to the newest supported version (32) for local copies.
+    /// Set to the actual negotiated version for remote/daemon transfers.
+    /// upstream: main.c:429-433 gates stats lines on protocol version.
+    protocol_version: u8,
+}
+
+/// Newest protocol version, used as default for local copies.
+const DEFAULT_PROTOCOL_VERSION: u8 = 32;
+
+impl Default for ClientSummary {
+    fn default() -> Self {
+        Self {
+            stats: LocalCopySummary::default(),
+            events: Vec::new(),
+            io_error_exit_code: None,
+            protocol_version: DEFAULT_PROTOCOL_VERSION,
+        }
+    }
 }
 
 impl ClientSummary {
@@ -78,6 +98,7 @@ impl ClientSummary {
             stats,
             events,
             io_error_exit_code: None,
+            protocol_version: DEFAULT_PROTOCOL_VERSION,
         }
     }
 
@@ -87,6 +108,7 @@ impl ClientSummary {
             stats: summary,
             events: Vec::new(),
             io_error_exit_code: None,
+            protocol_version: DEFAULT_PROTOCOL_VERSION,
         }
     }
 
@@ -377,6 +399,21 @@ impl ClientSummary {
     /// bitfield values into the process exit code.
     pub(crate) fn set_io_error_exit_code(&mut self, code: i32) {
         self.io_error_exit_code = Some(code);
+    }
+
+    /// Returns the negotiated protocol version for the transfer.
+    ///
+    /// Defaults to the newest supported version (32) for local copies.
+    /// For remote/daemon transfers, reflects the actual negotiated version.
+    /// upstream: main.c:429-433 gates stats lines on this value.
+    #[must_use]
+    pub const fn protocol_version(&self) -> u8 {
+        self.protocol_version
+    }
+
+    /// Records the negotiated protocol version from a remote transfer.
+    pub(crate) fn set_protocol_version(&mut self, version: u8) {
+        self.protocol_version = version;
     }
 }
 


### PR DESCRIPTION
## Summary

- Gate "Number of created files" stats line on `protocol_version >= 29` and "Number of deleted files" on `protocol_version >= 31`, matching upstream `main.c:429-433`
- Thread the negotiated protocol version through `ClientSummary` (defaults to NEWEST=32 for local copies, set to actual negotiated version for daemon/SSH/embedded-SSH/async-SSH transfers)
- Gate both `emit_stats_detail_block` (render.rs) and `StatsFormatter::format()` (stats_format.rs) display paths

## Test plan

- [ ] CI fmt+clippy pass (verified locally)
- [ ] Existing stats output tests pass (local copies use protocol 32, all lines still shown)
- [ ] Interop with older rsync versions (protocol 28-30) omits the gated lines correctly
- [ ] `StatsData` doctests and integration tests updated with new `protocol_version` field