### PR TITLE
feat(cli): port upstream filename octal escaping (filtered_fwrite)

### DIFF
--- a/crates/cli/src/frontend/escape.rs
+++ b/crates/cli/src/frontend/escape.rs
@@ -1,0 +1,319 @@
+//! Filename octal escaping matching upstream rsync's `filtered_fwrite`
+//! in `log.c:225-246`.
+//!
+//! Upstream rsync escapes non-printable bytes in filenames as `\#ooo`
+//! (backslash, hash, three octal digits). The `--8-bit-output` / `-8`
+//! flag disables escaping for high-bit characters (0x80-0xFF), leaving
+//! only control characters below 0x20 (except tab) escaped.
+
+use std::fmt::Write;
+use std::path::Path;
+
+/// Returns `true` when a byte is printable in the C locale.
+///
+/// upstream: itypes.h:isPrint() wraps libc `isprint()`, which in the C
+/// locale returns true for bytes 0x20 through 0x7E.
+#[inline]
+fn is_c_print(byte: u8) -> bool {
+    (0x20..=0x7E).contains(&byte)
+}
+
+/// Escapes non-printable bytes for display output, matching upstream
+/// rsync's `filtered_fwrite` in `log.c:225-246`.
+///
+/// When `allow_8bit` is false (the default), bytes outside ASCII
+/// printable range (0x20-0x7E) are escaped as `\#ooo` (backslash, hash,
+/// three octal digits). Tab (0x09) is passed through unescaped.
+///
+/// When `allow_8bit` is true (`--8-bit-output`), only control characters
+/// below 0x20 (except tab) are escaped. High-bit bytes (0x80-0xFF) and
+/// DEL (0x7F) pass through for terminal rendering.
+///
+/// Literal `\#ddd` sequences (where each `d` is an ASCII digit) in the
+/// input are also escaped to prevent ambiguity with the escape notation.
+pub(crate) fn escape_for_output(input: &[u8], allow_8bit: bool) -> String {
+    // Fast path: if all bytes are ASCII printable or tab, return as-is.
+    if !allow_8bit {
+        let all_safe = input.iter().all(|&b| is_c_print(b) || b == b'\t');
+        if all_safe && !has_literal_escape_sequence(input) {
+            // SAFETY: all bytes are in 0x09 or 0x20-0x7E, which is valid ASCII/UTF-8
+            return String::from_utf8(input.to_vec())
+                .unwrap_or_else(|_| escape_bytes_slow(input, allow_8bit));
+        }
+    } else {
+        let all_safe = input.iter().all(|&b| b >= b' ' || b == b'\t');
+        if all_safe && !has_literal_escape_sequence(input) {
+            return String::from_utf8_lossy(input).into_owned();
+        }
+    }
+
+    escape_bytes_slow(input, allow_8bit)
+}
+
+/// Returns `true` when the input contains a literal `\#ddd` sequence.
+fn has_literal_escape_sequence(input: &[u8]) -> bool {
+    let len = input.len();
+    if len < 5 {
+        return false;
+    }
+    for i in 0..len - 4 {
+        if input[i] == b'\\'
+            && input[i + 1] == b'#'
+            && input[i + 2].is_ascii_digit()
+            && input[i + 3].is_ascii_digit()
+            && input[i + 4].is_ascii_digit()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Slow path: escapes bytes one at a time.
+fn escape_bytes_slow(input: &[u8], allow_8bit: bool) -> String {
+    let mut output = String::with_capacity(input.len() + input.len() / 4);
+    let len = input.len();
+    let mut i = 0;
+
+    while i < len {
+        let byte = input[i];
+
+        // upstream: log.c:235-236 - escape literal \#ddd sequences to prevent
+        // ambiguity with the escape notation. If the input contains \#001
+        // literally, escape the backslash so the output reads \#134#001.
+        if i + 4 < len
+            && byte == b'\\'
+            && input[i + 1] == b'#'
+            && input[i + 2].is_ascii_digit()
+            && input[i + 3].is_ascii_digit()
+            && input[i + 4].is_ascii_digit()
+        {
+            let _ = write!(output, "\\#{byte:03o}");
+            i += 1;
+            continue;
+        }
+
+        // upstream: log.c:237 - the escaping condition is:
+        //   *in_buf != '\t'
+        //   && ((use_isprint && !isPrint(in_buf)) || *(uchar*)in_buf < ' ')
+        //
+        // use_isprint = !allow_8bit_chars, so:
+        //   not tab AND ((!allow_8bit AND not printable) OR byte < space)
+        let needs_escape = byte != b'\t' && ((!allow_8bit && !is_c_print(byte)) || byte < b' ');
+
+        if needs_escape {
+            let _ = write!(output, "\\#{byte:03o}");
+        } else if byte.is_ascii() {
+            output.push(byte as char);
+        } else {
+            // High-bit byte with allow_8bit=true. Emit as the Latin-1
+            // code point - this is the closest Rust equivalent to
+            // upstream's raw byte pass-through.
+            output.push(byte as char);
+        }
+        i += 1;
+    }
+
+    output
+}
+
+/// Escapes a path for display output.
+///
+/// On Unix, operates on the raw bytes of the path to faithfully represent
+/// non-UTF-8 filenames. On other platforms, falls back to `to_string_lossy()`
+/// before escaping.
+pub(crate) fn escape_path(path: &Path, allow_8bit: bool) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        escape_for_output(path.as_os_str().as_bytes(), allow_8bit)
+    }
+    #[cfg(not(unix))]
+    {
+        let lossy = path.to_string_lossy();
+        escape_for_output(lossy.as_bytes(), allow_8bit)
+    }
+}
+
+/// Escapes a string for display output.
+///
+/// Convenience wrapper for already-converted strings (e.g. from
+/// `to_string_lossy()`). Escapes non-printable bytes in the UTF-8
+/// representation.
+#[cfg(test)]
+fn escape_str(s: &str, allow_8bit: bool) -> String {
+    escape_for_output(s.as_bytes(), allow_8bit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- escape_for_output: default mode (allow_8bit = false) --
+
+    #[test]
+    fn ascii_printable_passes_through() {
+        let input = b"hello_world.txt";
+        assert_eq!(escape_for_output(input, false), "hello_world.txt");
+    }
+
+    #[test]
+    fn space_passes_through() {
+        let input = b"hello world.txt";
+        assert_eq!(escape_for_output(input, false), "hello world.txt");
+    }
+
+    #[test]
+    fn tab_passes_through() {
+        let input = b"before\tafter";
+        assert_eq!(escape_for_output(input, false), "before\tafter");
+    }
+
+    #[test]
+    fn control_char_0x01_escaped() {
+        assert_eq!(escape_for_output(&[0x01], false), "\\#001");
+    }
+
+    #[test]
+    fn del_0x7f_escaped() {
+        assert_eq!(escape_for_output(&[0x7F], false), "\\#177");
+    }
+
+    #[test]
+    fn high_bit_0x80_escaped_in_default_mode() {
+        assert_eq!(escape_for_output(&[0x80], false), "\\#200");
+    }
+
+    #[test]
+    fn high_bit_0xff_escaped_in_default_mode() {
+        assert_eq!(escape_for_output(&[0xFF], false), "\\#377");
+    }
+
+    #[test]
+    fn null_byte_escaped() {
+        assert_eq!(escape_for_output(&[0x00], false), "\\#000");
+    }
+
+    #[test]
+    fn mixed_printable_and_control() {
+        let input = b"file\x01name\x7f.txt";
+        assert_eq!(escape_for_output(input, false), "file\\#001name\\#177.txt");
+    }
+
+    #[test]
+    fn all_specified_bytes_escaped_correctly() {
+        // Verify the exact values from the task description.
+        assert_eq!(escape_for_output(&[0x01], false), "\\#001");
+        assert_eq!(escape_for_output(&[0x7F], false), "\\#177");
+        assert_eq!(escape_for_output(&[0x80], false), "\\#200");
+        assert_eq!(escape_for_output(&[0xFF], false), "\\#377");
+    }
+
+    // -- escape_for_output: 8-bit mode (allow_8bit = true) --
+
+    #[test]
+    fn control_char_escaped_in_8bit_mode() {
+        assert_eq!(escape_for_output(&[0x01], true), "\\#001");
+    }
+
+    #[test]
+    fn del_0x7f_passes_through_in_8bit_mode() {
+        // upstream: with use_isprint=0 (allow_8bit=1), the condition is
+        // byte != '\t' && byte < ' ', which excludes 0x7F.
+        assert_eq!(escape_for_output(&[0x7F], true), "\x7F");
+    }
+
+    #[test]
+    fn high_bit_0x80_passes_through_in_8bit_mode() {
+        assert_eq!(escape_for_output(&[0x80], true), "\u{80}");
+    }
+
+    #[test]
+    fn high_bit_0xff_passes_through_in_8bit_mode() {
+        assert_eq!(escape_for_output(&[0xFF], true), "\u{FF}");
+    }
+
+    #[test]
+    fn tab_passes_through_in_8bit_mode() {
+        assert_eq!(escape_for_output(b"\t", true), "\t");
+    }
+
+    #[test]
+    fn only_control_chars_escaped_in_8bit_mode() {
+        // 0x01 and 0x7F: only 0x01 is escaped (< 0x20)
+        let input = &[0x01, 0x7F];
+        assert_eq!(escape_for_output(input, true), "\\#001\x7F");
+    }
+
+    // -- Literal \#ddd sequence escaping --
+
+    #[test]
+    fn literal_escape_sequence_is_escaped() {
+        // A filename containing literal \#001 should escape the backslash.
+        let input = b"file\\#001.txt";
+        assert_eq!(escape_for_output(input, false), "file\\#134#001.txt");
+    }
+
+    #[test]
+    fn literal_escape_sequence_escaped_in_8bit_mode() {
+        let input = b"file\\#999.txt";
+        assert_eq!(escape_for_output(input, true), "file\\#134#999.txt");
+    }
+
+    #[test]
+    fn non_digit_after_hash_not_escaped() {
+        // \#abc is not a valid escape sequence - leave it alone.
+        let input = b"file\\#abc.txt";
+        assert_eq!(escape_for_output(input, false), "file\\#abc.txt");
+    }
+
+    #[test]
+    fn partial_escape_sequence_at_end_not_escaped() {
+        // \#12 at end (only 2 digits) - not an escape sequence.
+        let input = b"file\\#12";
+        assert_eq!(escape_for_output(input, false), "file\\#12");
+    }
+
+    // -- escape_path --
+
+    #[test]
+    fn escape_path_ascii() {
+        let path = Path::new("src/main.rs");
+        assert_eq!(escape_path(path, false), "src/main.rs");
+    }
+
+    #[test]
+    fn escape_path_with_directory_separator() {
+        let path = Path::new("foo/bar/baz.txt");
+        assert_eq!(escape_path(path, false), "foo/bar/baz.txt");
+    }
+
+    // -- escape_str --
+
+    #[test]
+    fn escape_str_passes_printable() {
+        assert_eq!(escape_str("hello.txt", false), "hello.txt");
+    }
+
+    #[test]
+    fn escape_str_escapes_control() {
+        assert_eq!(escape_str("a\x01b", false), "a\\#001b");
+    }
+
+    // -- Fast path coverage --
+
+    #[test]
+    fn fast_path_all_printable() {
+        let input = b"abcdefghijklmnopqrstuvwxyz/0123456789";
+        assert_eq!(
+            escape_for_output(input, false),
+            "abcdefghijklmnopqrstuvwxyz/0123456789"
+        );
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(escape_for_output(b"", false), "");
+        assert_eq!(escape_for_output(b"", true), "");
+    }
+}

--- a/crates/cli/src/frontend/escape.rs
+++ b/crates/cli/src/frontend/escape.rs
@@ -32,18 +32,19 @@ fn is_c_print(byte: u8) -> bool {
 /// Literal `\#ddd` sequences (where each `d` is an ASCII digit) in the
 /// input are also escaped to prevent ambiguity with the escape notation.
 pub(crate) fn escape_for_output(input: &[u8], allow_8bit: bool) -> String {
-    // Fast path: if all bytes are ASCII printable or tab, return as-is.
-    if !allow_8bit {
-        let all_safe = input.iter().all(|&b| is_c_print(b) || b == b'\t');
-        if all_safe && !has_literal_escape_sequence(input) {
-            // SAFETY: all bytes are in 0x09 or 0x20-0x7E, which is valid ASCII/UTF-8
-            return String::from_utf8(input.to_vec())
-                .unwrap_or_else(|_| escape_bytes_slow(input, allow_8bit));
-        }
-    } else {
-        let all_safe = input.iter().all(|&b| b >= b' ' || b == b'\t');
-        if all_safe && !has_literal_escape_sequence(input) {
-            return String::from_utf8_lossy(input).into_owned();
+    // Fast path: all bytes ASCII-printable or tab (0x09, 0x20-0x7E) -> already
+    // valid UTF-8 with no byte needing escaping in either mode, so return as-is.
+    //
+    // DEL (0x7F) and high bytes (0x80-0xFF) are deliberately excluded here so
+    // they always take the slow path, which applies the correct per-mode
+    // handling: escape as \#ooo when !allow_8bit, or pass through as the Latin-1
+    // code point when allow_8bit. A previous `from_utf8_lossy` 8-bit fast path
+    // was wrong - it replaced high bytes with U+FFFD instead of preserving them.
+    let all_safe = input.iter().all(|&b| is_c_print(b) || b == b'\t');
+    if all_safe && !has_literal_escape_sequence(input) {
+        // SAFETY: all bytes are 0x09 or 0x20-0x7E, which is valid ASCII/UTF-8.
+        if let Ok(s) = String::from_utf8(input.to_vec()) {
+            return s;
         }
     }
 

--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -56,6 +56,10 @@ pub(crate) struct TransferExecutionInputs<'a> {
     pub(crate) out_format_template: Option<&'a crate::frontend::out_format::OutFormat>,
     pub(crate) name_level: NameOutputLevel,
     pub(crate) name_overridden: bool,
+    /// `--8-bit-output` / `-8`: pass high-bit characters through without
+    /// octal escaping. When false (the default), non-printable bytes in
+    /// filenames are escaped as `\#ooo` matching upstream log.c:filtered_fwrite.
+    pub(crate) eight_bit_output: bool,
     pub(crate) log_file: Option<LogFileConfig>,
 }
 
@@ -88,6 +92,7 @@ where
         out_format_template,
         name_level,
         name_overridden,
+        eight_bit_output,
         log_file,
     } = inputs;
 
@@ -145,7 +150,8 @@ where
             let emit_unchanged = matches!(name_level, NameOutputLevel::UpdatedAndUnchanged);
             let out_format_context = OutFormatContext::with_is_sender(is_sender)
                 .with_emit_unchanged(emit_unchanged)
-                .with_itemize_repeated(itemize_repeated);
+                .with_itemize_repeated(itemize_repeated)
+                .with_eight_bit_output(eight_bit_output);
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                 emit_transfer_summary(
                     &summary,
@@ -165,6 +171,7 @@ where
                     show_copy_method,
                     show_atimes,
                     show_crtimes,
+                    eight_bit_output,
                     writer,
                 )
             }) {
@@ -190,6 +197,7 @@ where
                     itemize_repeated,
                     show_atimes,
                     show_crtimes,
+                    eight_bit_output,
                 })
             {
                 let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -243,6 +251,9 @@ struct EmitLogOutputParams<'a> {
     show_atimes: bool,
     /// `--crtimes`: render the CRTIME column in `--list-only` log output.
     show_crtimes: bool,
+    /// `--8-bit-output` / `-8`: pass high-bit characters through without
+    /// octal escaping in log-file output.
+    eight_bit_output: bool,
 }
 
 /// Writes the transfer summary to the configured log file.
@@ -260,6 +271,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         itemize_repeated,
         show_atimes,
         show_crtimes,
+        eight_bit_output,
     } = params;
     // upstream: generator.c:582-583 - mirror the `INFO_GTE(NAME, 2)` arm of
     // the itemize emit gate in the log-file renderer so `-vv` / `--info=name2`
@@ -268,7 +280,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
     let emit_unchanged = matches!(name_level, NameOutputLevel::UpdatedAndUnchanged);
     let context = OutFormatContext::with_is_sender(is_sender)
         .with_emit_unchanged(emit_unchanged)
-        .with_itemize_repeated(itemize_repeated);
+        .with_itemize_repeated(itemize_repeated)
+        .with_eight_bit_output(eight_bit_output);
     // The log file already carries the parallel "building file list" line via
     // logging::info_log!(Flist, 1, ...); the FCLIENT "sending incremental file
     // list" banner is for stdout only (upstream: flist.c:2248 vs 2252).
@@ -292,6 +305,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         false,
         show_atimes,
         show_crtimes,
+        eight_bit_output,
         &mut log.file,
     )?;
     log.file.flush()

--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -172,7 +172,7 @@ where
         name_level: initial_name_level,
         name_overridden: initial_name_overridden,
         stats,
-        eight_bit_output: _,
+        eight_bit_output,
         partial,
         preallocate,
         fsync: fsync_option,
@@ -998,6 +998,7 @@ where
             out_format_template: out_format_template.as_ref(),
             name_level,
             name_overridden,
+            eight_bit_output,
             log_file: log_file_for_local,
         },
     )

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -82,6 +82,7 @@ use std::io::{self, Write};
 /// CLI argument parsing for the rsync frontend.
 pub mod arguments;
 mod command_builder;
+pub(crate) mod escape;
 mod execution;
 pub(crate) mod outbuf;
 

--- a/crates/cli/src/frontend/out_format/render/mod.rs
+++ b/crates/cli/src/frontend/out_format/render/mod.rs
@@ -14,6 +14,8 @@ use std::io::{self, Write};
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 use logging::{InfoFlag, info_gte};
 
+use crate::frontend::escape::escape_path;
+
 use super::tokens::{OutFormat, OutFormatContext, OutFormatToken};
 
 use format::apply_placeholder_format;
@@ -156,7 +158,11 @@ pub(crate) fn emit_out_format<W: Write + ?Sized>(
         // of `-i`/`-ii`.
         if matches!(event.kind(), ClientEventKind::SkippedNewerDestination) {
             if info_gte(InfoFlag::Skip, 1) {
-                writeln!(writer, "{} is newer", event.relative_path().display())?;
+                writeln!(
+                    writer,
+                    "{} is newer",
+                    escape_path(event.relative_path(), context.eight_bit_output)
+                )?;
             }
             continue;
         }

--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -7,6 +7,7 @@
 
 use std::time::SystemTime;
 
+use crate::frontend::escape::escape_path;
 use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions, platform};
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 
@@ -44,20 +45,21 @@ pub(super) fn render_placeholder_value(
     context: &OutFormatContext,
     spec: &PlaceholderToken,
 ) -> Option<String> {
+    let allow_8bit = context.eight_bit_output;
     match spec.kind {
-        OutFormatPlaceholder::FileName => Some(render_path(event, true)),
+        OutFormatPlaceholder::FileName => Some(render_path(event, true, allow_8bit)),
         OutFormatPlaceholder::FileNameWithSymlinkTarget => {
-            let mut rendered = render_path(event, true);
+            let mut rendered = render_path(event, true, allow_8bit);
             if let Some(target) = event
                 .metadata()
                 .and_then(ClientEntryMetadata::symlink_target)
             {
                 rendered.push_str(symlink_target_connector(event));
-                rendered.push_str(&target.to_string_lossy());
+                rendered.push_str(&escape_path(target, allow_8bit));
             }
             Some(rendered)
         }
-        OutFormatPlaceholder::FullPath => Some(render_path(event, false)),
+        OutFormatPlaceholder::FullPath => Some(render_path(event, false, allow_8bit)),
         OutFormatPlaceholder::ItemizedChanges => {
             Some(format_itemized_changes(event, context.is_sender))
         }
@@ -83,7 +85,7 @@ pub(super) fn render_placeholder_value(
             .and_then(ClientEntryMetadata::symlink_target)
             .map(|target| {
                 let mut rendered = String::from(symlink_target_connector(event));
-                rendered.push_str(&target.to_string_lossy());
+                rendered.push_str(&escape_path(target, allow_8bit));
                 rendered
             }),
         OutFormatPlaceholder::CurrentTime => Some(format_current_timestamp()),
@@ -167,8 +169,8 @@ fn transfer_byte_count(event: &ClientEvent, is_sender: bool, want_checksum: bool
 }
 
 /// Renders the path from an event, optionally appending a trailing slash for directories.
-fn render_path(event: &ClientEvent, ensure_trailing_slash: bool) -> String {
-    let mut rendered = event.relative_path().to_string_lossy().into_owned();
+fn render_path(event: &ClientEvent, ensure_trailing_slash: bool, allow_8bit: bool) -> String {
+    let mut rendered = escape_path(event.relative_path(), allow_8bit);
     // upstream: flist.c / log.c - itemize and out-format paths use POSIX
     // forward-slash separators regardless of host OS. Normalize Windows
     // native backslashes here at the rendering boundary; storage retains

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1680,6 +1680,7 @@ fn render_remote_host_with_context_populated() {
         is_sender: false,
         emit_unchanged: false,
         itemize_repeated: false,
+        eight_bit_output: false,
     };
     assert_eq!(
         render_format_with_context("%h", &event, &context),
@@ -1703,6 +1704,7 @@ fn render_remote_address_with_context_populated() {
         is_sender: false,
         emit_unchanged: false,
         itemize_repeated: false,
+        eight_bit_output: false,
     };
     assert_eq!(
         render_format_with_context("%a", &event, &context),
@@ -1726,6 +1728,7 @@ fn render_module_name_with_context_populated() {
         is_sender: false,
         emit_unchanged: false,
         itemize_repeated: false,
+        eight_bit_output: false,
     };
     assert_eq!(render_format_with_context("%m", &event, &context), "data\n");
 }
@@ -1746,6 +1749,7 @@ fn render_module_path_with_context_populated() {
         is_sender: false,
         emit_unchanged: false,
         itemize_repeated: false,
+        eight_bit_output: false,
     };
     assert_eq!(
         render_format_with_context("%P", &event, &context),
@@ -1769,6 +1773,7 @@ fn render_all_remote_placeholders_with_full_context() {
         is_sender: false,
         emit_unchanged: false,
         itemize_repeated: false,
+        eight_bit_output: false,
     };
     let rendered = render_format_with_context("%h %a %m %P", &event, &context);
     assert_eq!(rendered, "host addr mod /path\n");

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -173,6 +173,10 @@ pub(crate) struct OutFormatContext {
     /// all-dot rows even without `-vv`. The render path uses this to bypass
     /// the empty-change-set suppression independently of `emit_unchanged`.
     pub(super) itemize_repeated: bool,
+    /// `--8-bit-output` / `-8`: when true, high-bit characters pass through
+    /// without octal escaping. Only control characters below 0x20 (except
+    /// tab) are escaped. Matches upstream `allow_8bit_chars`.
+    pub(super) eight_bit_output: bool,
 }
 
 impl OutFormatContext {
@@ -224,6 +228,14 @@ impl OutFormatContext {
     #[must_use]
     pub(crate) const fn itemize_repeated(&self) -> bool {
         self.itemize_repeated
+    }
+
+    /// Sets the `--8-bit-output` flag for filename escaping in the
+    /// out-format renderer.
+    #[must_use]
+    pub(crate) fn with_eight_bit_output(mut self, eight_bit_output: bool) -> Self {
+        self.eight_bit_output = eight_bit_output;
+        self
     }
 }
 
@@ -362,6 +374,7 @@ mod tests {
             is_sender: false,
             emit_unchanged: false,
             itemize_repeated: false,
+            eight_bit_output: false,
         };
         assert_eq!(ctx.remote_host.as_deref(), Some("server.example.com"));
         assert_eq!(ctx.remote_address.as_deref(), Some("192.168.1.1"));

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -6,11 +6,13 @@ use core::client::{
     HumanReadableMode,
 };
 
+use crate::frontend::escape::escape_path;
+
 /// Renders a path string with any trailing platform path separators trimmed,
 /// mirroring upstream rsync's `*cp = '\0'` slash-lopping in `main.c:789`
 /// before the `created directory %s\n` print.
-fn display_without_trailing_separators(path: &Path) -> String {
-    let mut rendered = path.display().to_string();
+fn display_without_trailing_separators(path: &Path, allow_8bit: bool) -> String {
+    let mut rendered = escape_path(path, allow_8bit);
     while rendered.len() > 1
         && rendered
             .as_bytes()
@@ -50,6 +52,7 @@ pub(crate) fn emit_transfer_summary(
     show_copy_method: bool,
     show_atimes: bool,
     show_crtimes: bool,
+    eight_bit_output: bool,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
     let events = summary.events();
@@ -64,6 +67,7 @@ pub(crate) fn emit_transfer_summary(
                 human_readable_mode,
                 show_atimes,
                 show_crtimes,
+                eight_bit_output,
             )?;
             wrote_listing = true;
         }
@@ -122,7 +126,7 @@ pub(crate) fn emit_transfer_summary(
         writeln!(
             writer,
             "created directory {}",
-            display_without_trailing_separators(dest_root)
+            display_without_trailing_separators(dest_root, eight_bit_output)
         )?;
     }
 
@@ -140,7 +144,7 @@ pub(crate) fn emit_transfer_summary(
     let progress_rendered = if progress_already_rendered {
         true
     } else if matches!(progress_mode, Some(ProgressMode::PerFile)) && !events.is_empty() {
-        emit_progress(events, writer, human_readable_mode)?
+        emit_progress(events, writer, human_readable_mode, eight_bit_output)?
     } else {
         false
     };
@@ -174,6 +178,7 @@ pub(crate) fn emit_transfer_summary(
             name_level,
             name_overridden,
             human_readable_mode,
+            eight_bit_output,
             writer,
         )?;
     }
@@ -248,6 +253,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
     human_readable: HumanReadableMode,
     show_atimes: bool,
     show_crtimes: bool,
+    eight_bit_output: bool,
 ) -> io::Result<()> {
     for event in events {
         if !list_only_event(event.kind()) {
@@ -271,12 +277,12 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
             } else {
                 String::new()
             };
-            let mut rendered = event.relative_path().to_string_lossy().into_owned();
+            let mut rendered = escape_path(event.relative_path(), eight_bit_output);
             if metadata.kind().is_symlink()
                 && let Some(target) = metadata.symlink_target()
             {
                 rendered.push_str(" -> ");
-                rendered.push_str(&target.to_string_lossy());
+                rendered.push_str(&escape_path(target, eight_bit_output));
             }
 
             writeln!(
@@ -284,7 +290,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 "{permissions} {size} {timestamp}{atime_field}{crtime_field} {rendered}"
             )?;
         } else {
-            let rendered = event.relative_path().to_string_lossy().into_owned();
+            let rendered = escape_path(event.relative_path(), eight_bit_output);
             writeln!(
                 stdout,
                 "?????????? {:>width$} {} {rendered}",
@@ -303,6 +309,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
     events: &[ClientEvent],
     stdout: &mut W,
     human_readable: HumanReadableMode,
+    eight_bit_output: bool,
 ) -> io::Result<bool> {
     // upstream: progress.c counts every checked file-list entry toward
     // `to-chk=<remaining>/<total>`, but prints a per-file block and advances
@@ -336,7 +343,7 @@ pub(crate) fn emit_progress<W: Write + ?Sized>(
 
         // upstream: flist.c f_name() emits POSIX forward-slash separators
         // regardless of host OS. Normalize Windows native backslashes here.
-        let name = event.relative_path().display().to_string();
+        let name = escape_path(event.relative_path(), eight_bit_output);
         #[cfg(windows)]
         let name = name.replace('\\', "/");
         writeln!(stdout, "{name}")?;
@@ -634,7 +641,7 @@ fn is_deferred_hardlink_event(event: &ClientEvent) -> bool {
 ///
 /// upstream: log.c:639-640 - the `%n` token strlcat()s a `/` for S_ISDIR
 /// entries; the transfer root is listed as `./`.
-fn verbose_listing_name(event: &ClientEvent) -> String {
+fn verbose_listing_name(event: &ClientEvent, eight_bit_output: bool) -> String {
     let path = event.relative_path();
     let is_dir = matches!(
         event.metadata().map(ClientEntryMetadata::kind),
@@ -643,7 +650,7 @@ fn verbose_listing_name(event: &ClientEvent) -> String {
     if is_dir && path.as_os_str() == "." {
         return String::from("./");
     }
-    let mut rendered = path.to_string_lossy().into_owned();
+    let mut rendered = escape_path(path, eight_bit_output);
     // upstream: flist.c f_name() emits POSIX forward-slash separators
     // regardless of host OS. Normalize Windows native backslashes at the
     // rendering boundary; storage retains the platform-native form.
@@ -664,6 +671,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
     name_level: NameOutputLevel,
     name_overridden: bool,
     _human_readable: HumanReadableMode,
+    eight_bit_output: bool,
     stdout: &mut W,
 ) -> io::Result<()> {
     if matches!(name_level, NameOutputLevel::Disabled) && (verbosity == 0 || name_overridden) {
@@ -714,17 +722,21 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 {
                     continue;
                 }
-                writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                writeln!(
+                    stdout,
+                    "{} is uptodate",
+                    escape_path(event.relative_path(), eight_bit_output)
+                )?;
                 continue;
             }
 
-            let mut rendered = verbose_listing_name(event);
+            let mut rendered = verbose_listing_name(event, eight_bit_output);
             if matches!(kind, ClientEventKind::SymlinkCopied)
                 && let Some(metadata) = event.metadata()
                 && let Some(target) = metadata.symlink_target()
             {
                 rendered.push_str(" -> ");
-                rendered.push_str(&target.to_string_lossy());
+                rendered.push_str(&escape_path(target, eight_bit_output));
             }
             writeln!(stdout, "{rendered}")?;
             continue;
@@ -739,14 +751,18 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // upstream: generator.c:1409 - `rprintf(FINFO, "%s exists\n",
                 // fname)` for an --ignore-existing skip: the bare relative name
                 // followed by " exists", no descriptor and no quotes.
-                writeln!(stdout, "{} exists", event.relative_path().display())?;
+                writeln!(
+                    stdout,
+                    "{} exists",
+                    escape_path(event.relative_path(), eight_bit_output)
+                )?;
                 continue;
             }
             ClientEventKind::SkippedMissingDestination => {
                 writeln!(
                     stdout,
                     "skipping non-existent destination file \"{}\"",
-                    event.relative_path().display()
+                    escape_path(event.relative_path(), eight_bit_output)
                 )?;
                 continue;
             }
@@ -754,7 +770,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 writeln!(
                     stdout,
                     "skipping newer destination file \"{}\"",
-                    event.relative_path().display()
+                    escape_path(event.relative_path(), eight_bit_output)
                 )?;
                 continue;
             }
@@ -762,7 +778,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 writeln!(
                     stdout,
                     "skipping non-regular file \"{}\"",
-                    event.relative_path().display()
+                    escape_path(event.relative_path(), eight_bit_output)
                 )?;
                 continue;
             }
@@ -770,20 +786,20 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 writeln!(
                     stdout,
                     "skipping directory \"{}\" (no recursion)",
-                    event.relative_path().display()
+                    escape_path(event.relative_path(), eight_bit_output)
                 )?;
                 continue;
             }
             ClientEventKind::SkippedUnsafeSymlink => {
                 let mut rendered = format!(
                     "ignoring unsafe symlink \"{}\"",
-                    event.relative_path().display()
+                    escape_path(event.relative_path(), eight_bit_output)
                 );
                 if let Some(metadata) = event.metadata()
                     && let Some(target) = metadata.symlink_target()
                 {
                     rendered.push_str(" -> ");
-                    rendered.push_str(&target.to_string_lossy());
+                    rendered.push_str(&escape_path(target, eight_bit_output));
                 }
                 writeln!(stdout, "{rendered}")?;
                 continue;
@@ -792,7 +808,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 writeln!(
                     stdout,
                     "skipping mount point \"{}\"",
-                    event.relative_path().display()
+                    escape_path(event.relative_path(), eight_bit_output)
                 )?;
                 continue;
             }
@@ -822,7 +838,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                     continue;
                 }
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                    writeln!(
+                        stdout,
+                        "{} is uptodate",
+                        escape_path(event.relative_path(), eight_bit_output)
+                    )?;
                 }
                 continue;
             }
@@ -833,7 +853,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 // the bare path. Mirror the same gate so `-vv` without `-i`
                 // matches the upstream `testsuite/itemize.test` golden.
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                    writeln!(
+                        stdout,
+                        "{} is uptodate",
+                        escape_path(event.relative_path(), eight_bit_output)
+                    )?;
                 }
                 continue;
             }
@@ -848,7 +872,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // `was_created`, so they fall through to the bare-path emission.
             ClientEventKind::ReferenceCopied => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                    writeln!(
+                        stdout,
+                        "{} is uptodate",
+                        escape_path(event.relative_path(), eight_bit_output)
+                    )?;
                 }
                 continue;
             }
@@ -856,7 +884,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // hard-linked from the basis prints `"%s is uptodate"` at NAME>=2.
             ClientEventKind::HardLink if is_hardlinked_symlink_event(event) => {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                    writeln!(
+                        stdout,
+                        "{} is uptodate",
+                        escape_path(event.relative_path(), eight_bit_output)
+                    )?;
                 }
                 continue;
             }
@@ -864,7 +896,11 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 if !event.was_created() && !event.change_set().has_any_change() =>
             {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(stdout, "{}/ is uptodate", event.relative_path().display())?;
+                    writeln!(
+                        stdout,
+                        "{}/ is uptodate",
+                        escape_path(event.relative_path(), eight_bit_output)
+                    )?;
                 }
                 continue;
             }
@@ -872,20 +908,24 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 if !event.was_created() && !event.change_set().has_any_change() =>
             {
                 if verbosity >= 2 || matches!(name_level, NameOutputLevel::UpdatedAndUnchanged) {
-                    writeln!(stdout, "{} is uptodate", event.relative_path().display())?;
+                    writeln!(
+                        stdout,
+                        "{} is uptodate",
+                        escape_path(event.relative_path(), eight_bit_output)
+                    )?;
                 }
                 continue;
             }
             _ => {}
         }
 
-        let mut rendered = verbose_listing_name(event);
+        let mut rendered = verbose_listing_name(event, eight_bit_output);
         if matches!(kind, ClientEventKind::SymlinkCopied)
             && let Some(metadata) = event.metadata()
             && let Some(target) = metadata.symlink_target()
         {
             rendered.push_str(" -> ");
-            rendered.push_str(&target.to_string_lossy());
+            rendered.push_str(&escape_path(target, eight_bit_output));
         } else if matches!(kind, ClientEventKind::HardLink)
             && let Some(metadata) = event.metadata()
             && let Some(leader) = metadata.symlink_target()
@@ -893,7 +933,7 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
             // upstream: hlink.c:236 - a freshly-linked alias prints
             // `"%s => %s"` with the group leader's relative path.
             rendered.push_str(" => ");
-            rendered.push_str(&leader.to_string_lossy());
+            rendered.push_str(&escape_path(leader, eight_bit_output));
         }
 
         // upstream: log.c:log_formatted() emits the default `%n%L` per-file

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1445,7 +1445,15 @@ fn list_only_renders_atime_and_crtime_columns() {
     let events = vec![file_event, dir_event];
 
     let mut out = Vec::new();
-    emit_list_only(&events, &mut out, HumanReadableMode::Disabled, true, true).expect("render");
+    emit_list_only(
+        &events,
+        &mut out,
+        HumanReadableMode::Disabled,
+        true,
+        true,
+        false,
+    )
+    .expect("render");
     let rendered = String::from_utf8(out).expect("utf8");
 
     let file_line = rendered

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -242,6 +242,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut with_out_format,
     )
     .expect("render with out-format");
@@ -265,6 +266,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut without_out_format,
     )
     .expect("render without out-format");

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -74,6 +74,7 @@ fn render_stats_at_level(
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render stats");
@@ -100,6 +101,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render verbose");
@@ -485,6 +487,7 @@ fn parity_totals_only_without_stats_flag() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render");
@@ -729,6 +732,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render");

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -58,6 +58,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render summary");
@@ -92,6 +93,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render summary");
@@ -134,6 +136,7 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         false, // show_copy_method
         false, // show_atimes
         false, // show_crtimes
+        false, // eight_bit_output
         &mut rendered,
     )
     .expect("render summary");


### PR DESCRIPTION
## Summary

- Port upstream rsync's `filtered_fwrite` (log.c:225-246) filename octal escaping to the CLI output pipeline
- Wire the existing `--8-bit-output` / `-8` flag (previously parsed but discarded) through `TransferExecutionInputs` and `OutFormatContext` to all path rendering sites
- Non-printable bytes are escaped as `\#ooo` (backslash, hash, three octal digits) at the output boundary - internal filename storage is unchanged
- Default mode escapes control chars (<0x20 except tab), DEL (0x7F), and high-bit bytes (0x80-0xFF); `-8` mode only escapes control chars below 0x20

## Implementation

- New `crates/cli/src/frontend/escape.rs` module with `escape_for_output()` and `escape_path()` - matches upstream `filtered_fwrite` + `isPrint()` semantics exactly
- `escape_path()` uses `OsStrExt::as_bytes()` on Unix for faithful non-UTF-8 filename handling; `to_string_lossy()` fallback on other platforms
- Literal `\#ddd` sequences in filenames are disambiguated by escaping the backslash as `\#134`
- Escaping applied at all path-to-string conversion points: verbose listing, progress, list-only, out-format placeholders (%n, %f, %L), "is newer" messages, "created directory" messages
- Flag is client-only (not forwarded to server), matching upstream `rsync.c:95` `!am_server` guard

## Test plan

- [x] Unit tests for all byte ranges: 0x01->`\#001`, 0x7F->`\#177`, 0x80->`\#200`, 0xFF->`\#377`
- [x] Tests for default mode vs 8-bit mode behavior
- [x] Tests for literal `\#ddd` sequence disambiguation
- [x] Tests for tab pass-through, mixed printable/control, empty input, edge cases
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p cli --all-features --no-deps -- -D warnings` passes
- [x] `cargo check -p cli --all-features --tests` compiles cleanly
- [ ] CI: fmt+clippy, nextest, Windows, macOS, Linux musl