### PR TITLE
fix(engine): emit delta-transmission debug message on local-copy path

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use logging::info_log;
+use logging::{debug_log, info_log};
 
 use crate::local_copy::overrides::device_identifier;
 use crate::local_copy::{
@@ -51,6 +51,22 @@ pub(crate) fn copy_sources(
     let destination_root = plan.destination_spec().path().to_path_buf();
     let mut context = CopyContext::new(mode, options, handler, destination_root);
     context.set_multi_source(plan.sources().len() > 1);
+
+    // upstream: generator.c:2290-2295 - the generator prints the
+    // delta-transmission status once, gated on DEBUG_GTE(FLIST, 1) (first
+    // active at -vv). Local copies default to whole-file mode; delta is
+    // used only when --no-whole-file is explicitly set.
+    debug_log!(
+        Flist,
+        1,
+        "delta-transmission {}",
+        if context.options().whole_file_enabled() {
+            "disabled for local transfer or --whole-file"
+        } else {
+            "enabled"
+        }
+    );
+
     let result = {
         let context = &mut context;
         (|| -> Result<(), LocalCopyError> {


### PR DESCRIPTION
## Summary

- Upstream `generator.c:2290-2295` emits a `delta-transmission enabled/disabled` debug message at `-vv` (`DEBUG_GTE(FLIST, 1)`) once per transfer
- The remote transfer path (`ReceiverContext::setup_transfer`) already emitted this, but the local-copy path (`engine::copy_sources`) did not
- Add the same `debug_log!(Flist, 1, ...)` call to `copy_sources()` so local transfers (`oc-rsync -avv src/ dst/`) produce the upstream-matching message

## Test plan

- [ ] CI fmt + clippy passes
- [ ] CI nextest passes (no functional change - debug output only)
- [ ] Verify with `oc-rsync -avv src/ dst/` that `delta-transmission disabled for local transfer or --whole-file` appears in output
- [ ] Verify with `oc-rsync -avv --no-whole-file src/ dst/` that `delta-transmission enabled` appears instead