### PR TITLE
fix(protocol): drop "none" from client-side negotiation lists

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -268,15 +268,30 @@ pub fn negotiate_capabilities_with_override(
     // When --checksum-choice overrides the selection, advertise only that
     // algorithm (upstream options.c replaces valid_checksums with the user's
     // choice so negotiate_the_strings sees a single-entry list).
+    //
+    // upstream: compat.c:485 get_default_nno_list drops the "none" entry
+    // (num == 0) from the *client* default list; only the server advertises it
+    // (`if (nni->num == 0 && !am_server && !dup_markup) continue;`). "none" is
+    // the sole num == 0 name in both the checksum and compression tables, so
+    // filtering by name mirrors upstream exactly.
+    let default_nno_list = |names: &[&str]| -> String {
+        names
+            .iter()
+            .copied()
+            .filter(|&name| is_server || name != "none")
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+
     let checksum_list = match checksum_override {
         Some(algo) => algo.as_str().to_owned(),
-        None => SUPPORTED_CHECKSUMS.join(" "),
+        None => default_nno_list(SUPPORTED_CHECKSUMS),
     };
     trace_send_list(side, NstrCategory::Checksum, &checksum_list);
     write_vstring(stdout, &checksum_list)?;
 
     if send_compression {
-        let compression_list = supported_compressions().join(" ");
+        let compression_list = default_nno_list(&supported_compressions());
         trace_send_list(side, NstrCategory::Compress, &compression_list);
         write_vstring(stdout, &compression_list)?;
     }

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -2913,3 +2913,68 @@ fn compression_override_none_falls_through_to_normal_negotiation() {
         "without override, legacy protocol defaults to Zlib"
     );
 }
+
+/// The client must omit the "none" entry from both advertised lists while the
+/// server retains it, mirroring upstream `get_default_nno_list` (compat.c:485:
+/// `if (nni->num == 0 && !am_server && !dup_markup) continue;`). Verifies the
+/// exact bytes written to the wire, not just the negotiated result.
+#[test]
+fn test_client_drops_none_server_keeps_it() {
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+
+    // Expected default lists with the client-side "none" drop applied.
+    let filter = |names: &[&str], is_server: bool| -> String {
+        names
+            .iter()
+            .copied()
+            .filter(|&n| is_server || n != "none")
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    let compressions = supported_compressions();
+
+    for is_server in [false, true] {
+        // Peer offers a full list so the exchange completes cleanly.
+        let peer = test_peer_data(true);
+        let mut stdin = &peer[..];
+        let mut stdout = Vec::new();
+
+        negotiate_capabilities(
+            protocol,
+            &mut stdin,
+            &mut stdout,
+            true, // do_negotiation
+            true, // send_compression
+            false,
+            is_server,
+        )
+        .unwrap();
+
+        let mut sent = &stdout[..];
+        let checksum_sent = read_vstring(&mut sent).unwrap();
+        let compress_sent = read_vstring(&mut sent).unwrap();
+
+        assert_eq!(
+            checksum_sent,
+            filter(SUPPORTED_CHECKSUMS, is_server),
+            "checksum list mismatch (is_server={is_server})"
+        );
+        assert_eq!(
+            compress_sent,
+            filter(&compressions, is_server),
+            "compress list mismatch (is_server={is_server})"
+        );
+
+        // The client must never advertise "none"; the server always must.
+        assert_eq!(
+            checksum_sent.split(' ').any(|n| n == "none"),
+            is_server,
+            "checksum 'none' presence must track is_server"
+        );
+        assert_eq!(
+            compress_sent.split(' ').any(|n| n == "none"),
+            is_server,
+            "compress 'none' presence must track is_server"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Upstream `get_default_nno_list` (compat.c:485) omits the `none` entry (num == 0) from the **client's** default checksum and compression lists, advertising it only on the server side:

```c
if (nni->num == 0 && !am_server && !dup_markup)
    continue;
```

oc-rsync serialized `none` unconditionally on both sides, so an oc-rsync **client** sent a trailing ` none` token that upstream clients never emit:

| Side | Upstream client | oc-rsync client (before) |
|------|-----------------|--------------------------|
| checksum | `xxh128 xxh3 xxh64 md5 md4 sha1` | `xxh128 xxh3 xxh64 md5 md4 sha1 none` |
| compress | `zstd ... zlibx zlib` | `zstd ... zlibx zlib none` |

The stray token is harmless to the selection algorithm (`none` is always last, so a stronger algorithm always matches first) but is a byte-level divergence from upstream's negotiation frames, visible in wire captures of an oc-rsync client talking to an upstream server.

## Change

Filter `none` from the advertised lists when `is_server` is false, mirroring upstream exactly. `none` is the sole `num == 0` name in both the checksum and compression tables, so filtering by name is exact. Local selection still uses the full `SUPPORTED_CHECKSUMS` / `supported_compressions()` list, so negotiated results are unchanged. The server side continues to advertise `none`.

## Testing

- New regression test `test_client_drops_none_server_keeps_it` asserts the exact bytes written for both client (`none` absent) and server (`none` present) sides.
- `cargo fmt`, `cargo check -p protocol --all-features --tests`, and `cargo clippy -p protocol --all-features --all-targets -- -D warnings` all pass.