### PR TITLE
fix(protocol): send --delete instead of --delete-during for bare delete mode

### DIFF
--- a/crates/cli/src/frontend/arguments/parser/entry.rs
+++ b/crates/cli/src/frontend/arguments/parser/entry.rs
@@ -264,17 +264,19 @@ where
         DeleteMode::Delay
     } else if delete_after_flag {
         DeleteMode::After
-    } else if delete_during_flag || delete_flag {
+    } else if delete_during_flag {
         DeleteMode::During
+    } else if delete_flag {
+        DeleteMode::DuringDefault
     } else {
         DeleteMode::Disabled
     };
 
     if delete_excluded && !delete_mode.is_enabled() {
-        delete_mode = DeleteMode::During;
+        delete_mode = DeleteMode::DuringDefault;
     }
     if max_delete.is_some() && !delete_mode.is_enabled() {
-        delete_mode = DeleteMode::During;
+        delete_mode = DeleteMode::DuringDefault;
     }
 
     // Mirror upstream: --delete requires --recursive or --dirs

--- a/crates/cli/src/frontend/arguments/tests.rs
+++ b/crates/cli/src/frontend/arguments/tests.rs
@@ -1592,7 +1592,7 @@ mod delete_modes {
     fn delete_with_recursive() {
         let parsed = parse_test_args(["-r", "--delete", "src/", "dst/"]).expect("parse");
         assert!(parsed.delete_mode.is_enabled());
-        assert_eq!(parsed.delete_mode, DeleteMode::During);
+        assert_eq!(parsed.delete_mode, DeleteMode::DuringDefault);
     }
 
     #[test]

--- a/crates/cli/src/frontend/execution/drive/config.rs
+++ b/crates/cli/src/frontend/execution/drive/config.rs
@@ -380,7 +380,7 @@ pub(crate) fn build_base_config(mut inputs: ConfigInputs) -> ClientConfigBuilder
         DeleteMode::Before => builder.delete_before(true),
         DeleteMode::After => builder.delete_after(true),
         DeleteMode::Delay => builder.delete_delay(true),
-        DeleteMode::During | DeleteMode::Disabled => builder,
+        DeleteMode::During | DeleteMode::DuringDefault | DeleteMode::Disabled => builder,
     };
 
     builder = builder.itemize_changes(inputs.itemize_changes);

--- a/crates/cli/src/frontend/tests/delete.rs
+++ b/crates/cli/src/frontend/tests/delete.rs
@@ -12,7 +12,7 @@ fn delete_flag_is_parsed() {
     ])
     .expect("parse succeeds");
 
-    assert_eq!(parsed.delete_mode, DeleteMode::During);
+    assert_eq!(parsed.delete_mode, DeleteMode::DuringDefault);
     assert!(!parsed.delete_excluded);
 }
 

--- a/crates/cli/tests/option_combinations_delete.rs
+++ b/crates/cli/tests/option_combinations_delete.rs
@@ -11,8 +11,8 @@ fn test_delete_excluded_enables_delete_during() {
     let args = parse_args(["oc-rsync", "--delete-excluded", "--dirs", "src", "dest"]).unwrap();
     assert_eq!(
         args.delete_mode,
-        DeleteMode::During,
-        "--delete-excluded should implicitly enable delete mode (During)"
+        DeleteMode::DuringDefault,
+        "--delete-excluded should implicitly enable delete mode (DuringDefault)"
     );
     assert!(args.delete_excluded, "--delete-excluded flag should be set");
 }
@@ -22,8 +22,8 @@ fn test_max_delete_enables_delete_during() {
     let args = parse_args(["oc-rsync", "--max-delete=100", "--dirs", "src", "dest"]).unwrap();
     assert_eq!(
         args.delete_mode,
-        DeleteMode::During,
-        "--max-delete should implicitly enable delete mode (During)"
+        DeleteMode::DuringDefault,
+        "--max-delete should implicitly enable delete mode (DuringDefault)"
     );
     assert_eq!(
         args.max_delete,
@@ -113,7 +113,7 @@ fn test_delete_excluded_and_max_delete_together() {
     .unwrap();
     assert_eq!(
         args.delete_mode,
-        DeleteMode::During,
+        DeleteMode::DuringDefault,
         "Both options should enable delete mode"
     );
     assert!(args.delete_excluded);
@@ -125,8 +125,8 @@ fn test_delete_flag_enables_during_mode() {
     let args = parse_args(["oc-rsync", "--delete", "--dirs", "src", "dest"]).unwrap();
     assert_eq!(
         args.delete_mode,
-        DeleteMode::During,
-        "--delete should enable During mode"
+        DeleteMode::DuringDefault,
+        "--delete should enable DuringDefault mode"
     );
 }
 

--- a/crates/core/src/client/config/builder/deletion.rs
+++ b/crates/core/src/client/config/builder/deletion.rs
@@ -6,7 +6,7 @@ impl ClientConfigBuilder {
     #[doc(alias = "--delete")]
     pub const fn delete(mut self, delete: bool) -> Self {
         self.delete_mode = if delete {
-            DeleteMode::During
+            DeleteMode::DuringDefault
         } else {
             DeleteMode::Disabled
         };

--- a/crates/core/src/client/config/builder/tests.rs
+++ b/crates/core/src/client/config/builder/tests.rs
@@ -104,9 +104,9 @@ fn default_batch_config_is_none() {
 }
 
 #[test]
-fn delete_sets_during_and_resets_to_disabled() {
+fn delete_sets_during_default_and_resets_to_disabled() {
     let config = ClientConfigBuilder::default().delete(true).build();
-    assert_eq!(config.delete_mode(), DeleteMode::During);
+    assert_eq!(config.delete_mode(), DeleteMode::DuringDefault);
     assert!(config.delete());
 
     let config = ClientConfigBuilder::default()

--- a/crates/core/src/client/config/enums/delete.rs
+++ b/crates/core/src/client/config/enums/delete.rs
@@ -1,4 +1,10 @@
 /// Deletion scheduling selected by the caller.
+///
+/// Upstream rsync distinguishes bare `--delete` (sets `delete_mode` only) from
+/// `--delete-during` (sets `delete_during`). Both use during-transfer timing,
+/// but `--delete` serializes as `--delete` on the wire while `--delete-during`
+/// serializes as `--delete-during`. The `DuringDefault` variant preserves this
+/// distinction - upstream: `options.c:2818-2829 server_options()`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 pub enum DeleteMode {
     /// Do not remove extraneous destination entries.
@@ -6,8 +12,15 @@ pub enum DeleteMode {
     Disabled,
     /// Remove extraneous entries before transferring file data.
     Before,
-    /// Remove extraneous entries while processing directory contents (upstream default).
+    /// Remove extraneous entries while processing directory contents - explicit
+    /// `--delete-during` (upstream: `delete_during` variable). Serialized as
+    /// `--delete-during` on the wire.
     During,
+    /// Bare `--delete` without a specific timing variant (upstream: `delete_mode`
+    /// variable). Behaves identically to `During` but serialized as `--delete`
+    /// on the wire. Suppressed when `--delete-excluded` is active, matching
+    /// upstream `options.c:2827 (delete_mode && !delete_excluded)`.
+    DuringDefault,
     /// Record deletions during the walk and prune entries after transfers finish.
     Delay,
     /// Remove extraneous entries after the transfer completes.
@@ -47,6 +60,11 @@ mod tests {
     }
 
     #[test]
+    fn is_enabled_during_default() {
+        assert!(DeleteMode::DuringDefault.is_enabled());
+    }
+
+    #[test]
     fn is_enabled_delay() {
         assert!(DeleteMode::Delay.is_enabled());
     }
@@ -70,6 +88,7 @@ mod tests {
         assert_eq!(format!("{:?}", DeleteMode::Disabled), "Disabled");
         assert_eq!(format!("{:?}", DeleteMode::Before), "Before");
         assert_eq!(format!("{:?}", DeleteMode::During), "During");
+        assert_eq!(format!("{:?}", DeleteMode::DuringDefault), "DuringDefault");
         assert_eq!(format!("{:?}", DeleteMode::Delay), "Delay");
         assert_eq!(format!("{:?}", DeleteMode::After), "After");
     }

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/arguments.rs
@@ -258,11 +258,18 @@ pub(super) fn build_full_daemon_args(
             }
         }
 
-        // upstream: options.c:2818-2829
+        // upstream: options.c:2818-2829 - explicit timing variants are always
+        // sent; bare --delete (DuringDefault) is suppressed when
+        // --delete-excluded is active.
         match config.delete_mode() {
             DeleteMode::Before => args.push("--delete-before".to_owned()),
             DeleteMode::Delay => args.push("--delete-delay".to_owned()),
             DeleteMode::During => args.push("--delete-during".to_owned()),
+            DeleteMode::DuringDefault => {
+                if !config.delete_excluded() {
+                    args.push("--delete".to_owned());
+                }
+            }
             DeleteMode::After => args.push("--delete-after".to_owned()),
             DeleteMode::Disabled => {}
         }

--- a/crates/core/src/client/remote/invocation/builder.rs
+++ b/crates/core/src/client/remote/invocation/builder.rs
@@ -249,12 +249,19 @@ impl<'a> RemoteInvocationBuilder<'a> {
     /// `--key=value` tokens rather than single-character flags. The order mirrors
     /// upstream for predictable interop testing.
     fn append_long_form_args(&self, args: &mut Vec<OsString>) {
-        // upstream: options.c - delete_mode forwarded as
-        // --delete-before/during/after/delay timing variants.
+        // upstream: options.c:2818-2829 - delete timing variants. Explicit
+        // --delete-before/during/after/delay are always sent. Bare --delete
+        // (DuringDefault) is suppressed when --delete-excluded is active,
+        // matching upstream: `else if (delete_mode && !delete_excluded)`.
         match self.config.delete_mode() {
             DeleteMode::Disabled => {}
             DeleteMode::Before => args.push(OsString::from("--delete-before")),
             DeleteMode::During => args.push(OsString::from("--delete-during")),
+            DeleteMode::DuringDefault => {
+                if !self.config.delete_excluded() {
+                    args.push(OsString::from("--delete"));
+                }
+            }
             DeleteMode::After => args.push(OsString::from("--delete-after")),
             DeleteMode::Delay => args.push(OsString::from("--delete-delay")),
         }

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -687,7 +687,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             DeleteMode::Before => options.delete_before(true),
             DeleteMode::After => options.delete_after(true),
             DeleteMode::Delay => options.delete_delay(true),
-            DeleteMode::During | DeleteMode::Disabled => options,
+            DeleteMode::During | DeleteMode::DuringDefault | DeleteMode::Disabled => options,
         };
 
         options

--- a/crates/core/src/client/tests/builder_compress.rs
+++ b/crates/core/src/client/tests/builder_compress.rs
@@ -81,7 +81,7 @@ fn builder_enables_delete() {
         .build();
 
     assert!(config.delete());
-    assert_eq!(config.delete_mode(), DeleteMode::During);
+    assert_eq!(config.delete_mode(), DeleteMode::DuringDefault);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Upstream rsync distinguishes bare `--delete` (sets `delete_mode`) from `--delete-during` (sets `delete_during`) in `server_options()` - both use during-transfer timing but serialize differently on the wire. oc-rsync collapsed both into `DeleteMode::During`, sending `--delete-during` even when the user specified `--delete`.
- Adds `DeleteMode::DuringDefault` variant to preserve the upstream distinction: bare `--delete` serializes as `--delete` on the wire, explicit `--delete-during` serializes as `--delete-during`.
- Matches upstream `options.c:2827` suppression: bare `--delete` is omitted from server args when `--delete-excluded` is active (upstream: `delete_mode && !delete_excluded`), while explicit timing variants are always sent.
- Applies to both SSH invocation and daemon transfer argument builders.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p core -p cli --all-targets --all-features --no-deps -- -D warnings` passes
- [x] All existing delete mode tests updated for the new variant
- [ ] CI nextest validates no regressions
- [ ] Interop validation against upstream rsync 3.4.4