### PR TITLE
fix: omit "none" from client negotiation algorithm list

### DIFF
--- a/crates/protocol/src/negotiation/capabilities/negotiate.rs
+++ b/crates/protocol/src/negotiation/capabilities/negotiate.rs
@@ -270,13 +270,13 @@ pub fn negotiate_capabilities_with_override(
     // choice so negotiate_the_strings sees a single-entry list).
     let checksum_list = match checksum_override {
         Some(algo) => algo.as_str().to_owned(),
-        None => SUPPORTED_CHECKSUMS.join(" "),
+        None => advertised_list(SUPPORTED_CHECKSUMS.iter().copied(), is_server),
     };
     trace_send_list(side, NstrCategory::Checksum, &checksum_list);
     write_vstring(stdout, &checksum_list)?;
 
     if send_compression {
-        let compression_list = supported_compressions().join(" ");
+        let compression_list = advertised_list(supported_compressions(), is_server);
         trace_send_list(side, NstrCategory::Compress, &compression_list);
         write_vstring(stdout, &compression_list)?;
     }
@@ -455,6 +455,36 @@ pub(super) fn choose_compression_algorithm(
 
     // No common algorithm found - use "none"
     Ok(CompressionAlgorithm::None)
+}
+
+/// Builds the space-separated algorithm list a peer advertises during
+/// `negotiate_the_strings()`.
+///
+/// Mirrors upstream `get_default_nno_list()` (compat.c:462-504): names are
+/// joined with a single space with no leading or trailing space, and the
+/// client (`is_server == false`) omits the `none` entry. Upstream skips the
+/// zero-numbered item on the client with
+/// `if (nni->num == 0 && !am_server && !dup_markup) continue;`
+/// (compat.c:485-486); both `CSUM_NONE` and `CPRES_NONE` are `0`
+/// (lib/md-defines.h:26, rsync.h:1177), so `none` is the entry dropped. The
+/// server still advertises `none`. This keeps the emitted vstring byte-for-byte
+/// identical to upstream, which matters because a mismatched client list
+/// changes the wire bytes (length prefix plus payload) exchanged at
+/// protocol >= 30.
+fn advertised_list<'a>(names: impl IntoIterator<Item = &'a str>, is_server: bool) -> String {
+    let mut out = String::new();
+    for name in names {
+        // upstream: compat.c:485-486 - the client drops the num == 0 ("none")
+        // entry; the server keeps it.
+        if !is_server && name == "none" {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(name);
+    }
+    out
 }
 
 /// Writes a vstring (variable-length string) using upstream rsync's format.

--- a/crates/protocol/src/negotiation/capabilities/tests.rs
+++ b/crates/protocol/src/negotiation/capabilities/tests.rs
@@ -420,6 +420,57 @@ fn test_negotiate_nstr_summary_omits_negotiated_when_forced() {
 }
 
 #[test]
+fn test_client_checksum_list_omits_none_matches_upstream() {
+    // WHY: upstream get_default_nno_list drops the num == 0 ("none") entry on
+    // the client (compat.c:485-486, `!am_server`). The advertised list is
+    // framed as a vstring on the wire; an extra " none" token changes the
+    // length prefix and payload bytes, diverging from upstream and risking an
+    // interop desync at protocol >= 30. Assert the exact client checksum list.
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+    let client_response = b"\x03md5\x04zlib";
+    let mut stdin = &client_response[..];
+    let mut stdout = Vec::new();
+
+    // is_server = false (client side).
+    negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, true, false, false).unwrap();
+
+    // Decode the first vstring the client emitted: the checksum list.
+    let mut sent = &stdout[..];
+    let checksum_list = read_vstring(&mut sent).unwrap();
+    assert_eq!(checksum_list, "xxh128 xxh3 xxh64 md5 md4 sha1");
+    assert!(
+        !checksum_list.split(' ').any(|n| n == "none"),
+        "client checksum list must omit none: {checksum_list}"
+    );
+
+    // The compression list follows and must also omit "none" on the client.
+    let compression_list = read_vstring(&mut sent).unwrap();
+    assert!(
+        !compression_list.split(' ').any(|n| n == "none"),
+        "client compression list must omit none: {compression_list}"
+    );
+}
+
+#[test]
+fn test_server_checksum_list_includes_none_matches_upstream() {
+    // WHY: the server (am_server == 1) keeps the "none" entry
+    // (compat.c:485-486), so its advertised checksum list ends with " none".
+    // This is the complement of the client case and pins the exact server
+    // wire bytes so both directions stay byte-identical to upstream.
+    let protocol = ProtocolVersion::try_from(32).unwrap();
+    let client_response = b"\x03md5\x04zlib";
+    let mut stdin = &client_response[..];
+    let mut stdout = Vec::new();
+
+    // is_server = true (server side).
+    negotiate_capabilities(protocol, &mut stdin, &mut stdout, true, true, false, true).unwrap();
+
+    let mut sent = &stdout[..];
+    let checksum_list = read_vstring(&mut sent).unwrap();
+    assert_eq!(checksum_list, "xxh128 xxh3 xxh64 md5 md4 sha1 none");
+}
+
+#[test]
 fn test_vstring_two_byte_format() {
     // Test vstring encoding for length > 127
     let test_str = "x".repeat(200); // 200 bytes > 127, needs 2-byte format


### PR DESCRIPTION
The protocol 30+ algorithm negotiation (`negotiate_the_strings`) exchanges a space-separated algorithm-name list per side. Upstream `get_default_nno_list` drops the zero-numbered entry ("none", where `CSUM_NONE`/`CPRES_NONE == 0`) on the client and keeps it on the server (compat.c:485-486, `if (nni->num == 0 && !am_server && !dup_markup) continue;`).

oc-rsync advertised "none" unconditionally via `SUPPORTED_CHECKSUMS.join(" ")` / `supported_compressions().join(" ")`, so a **client** emitted an extra trailing ` none` token versus upstream. That changes both the vstring length prefix and payload bytes on the wire. The server direction already matched upstream.

## Byte comparison (default checksum list, protocol >= 30)

| Side | upstream | oc before | oc after |
|------|----------|-----------|----------|
| server | `xxh128 xxh3 xxh64 md5 md4 sha1 none` | matches | matches |
| client | `xxh128 xxh3 xxh64 md5 md4 sha1` | `... sha1 none` (diverged) | matches |

No trailing space was present in either build (both `join(" ")` and `get_default_nno_list` avoid leading/trailing spaces); the divergence was the extra `none` token on the client.

## Fix

A new `advertised_list()` helper filters `none` from the advertised list when `!is_server`, matching upstream `get_default_nno_list`. Selection logic still keeps `none` in the local support set, so no negotiated outcome changes - only the advertised wire bytes are corrected.

## Tests

Two new tests pin the exact client and server checksum-list bytes and assert the client omits `none` from both the checksum and compression lists, encoding why (byte mismatch here desyncs negotiation with upstream at protocol >= 30). Targeted `nextest -p protocol`: 10 passed. fmt + clippy (all-features) clean.