### PR TITLE
fix(engine): keep prune-empty-dirs parent of skipped non-regular file

### DIFF
--- a/crates/engine/src/local_copy/executor/directory/recursive/entry.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/entry.rs
@@ -44,7 +44,16 @@ pub(super) fn process_planned_entry(
                 context.summary_mut().record_symlink_total();
             }
             context.record_skipped_non_regular(record_relative);
-            return Ok(false);
+            // upstream: flist.c:flist_sort_and_clean() prunes empty dirs against
+            // the built flist, which still holds non-regular entries (symlinks,
+            // FIFOs, devices) even when their preservation flag (-l/-D) is off.
+            // The generator only skips transferring them later
+            // (generator.c:1695-1701 "skipping non-regular file"), so the entry
+            // still reprieves its parent directory from pruning and the (empty)
+            // parent is created. Ensure the directory exists and count it as
+            // kept so `--prune-empty-dirs` does not over-prune the parent.
+            ensure_directory(context)?;
+            return Ok(true);
         }
         EntryAction::SkipMountPoint => {
             // upstream: flist.c:1319 - INFO_GTE(MOUNT, 1) gates

--- a/crates/engine/src/local_copy/tests/execute_prune_empty_dirs.rs
+++ b/crates/engine/src/local_copy/tests/execute_prune_empty_dirs.rs
@@ -792,3 +792,41 @@ fn prune_empty_dirs_cascading_after_filter_removes_all_files() {
     // sub1 should be pruned because after excluding .log files, it's empty
     assert!(!ctx.dest.join("source").join("root_dir/sub1").exists(), "sub1 should be pruned (all .log files excluded)");
 }
+
+/// A directory whose only child is a non-regular file that is skipped because
+/// its preservation flag is off (here a symlink without `-l`) must still be
+/// kept, matching upstream `flist.c` prune_empty_dirs: the entry stays in the
+/// flist and reprieves its parent, and the generator only skips transferring
+/// it later (generator.c:1695-1701). Regression guard against over-pruning the
+/// parent directory of a skipped non-regular file.
+#[cfg(unix)]
+#[test]
+fn prune_empty_dirs_keeps_dir_with_only_skipped_symlink() {
+    let ctx = test_helpers::setup_copy_test();
+
+    test_helpers::create_test_tree(
+        &ctx.source,
+        &[("has_link", None), ("real/file.txt", Some(b"content"))],
+    );
+    std::os::unix::fs::symlink("nowhere", ctx.source.join("has_link").join("link"))
+        .expect("create symlink");
+
+    let operands = vec![ctx.source.into_os_string(), ctx.dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    // Symlinks are not preserved by default, so `link` is skipped as a
+    // non-regular file; its parent directory must survive the prune pass.
+    let options = LocalCopyOptions::default().prune_empty_dirs(true);
+
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    assert!(
+        ctx.dest.join("source").join("has_link").is_dir(),
+        "parent of a skipped non-regular file must be kept (upstream prune_empty_dirs)"
+    );
+    assert!(
+        fs::symlink_metadata(ctx.dest.join("source").join("has_link").join("link")).is_err(),
+        "the symlink itself is not preserved without -l"
+    );
+    assert!(ctx.dest.join("source").join("real/file.txt").exists());
+}


### PR DESCRIPTION
## Problem

The local-copy `--prune-empty-dirs` (`-m`) pass over-pruned a directory whose only child is a non-regular file (symlink / FIFO / device) that is skipped because its preservation flag (`-l` / `-D`) is off.

Upstream `flist.c` `prune_empty_dirs` runs against the built file list, which still contains such non-regular entries; the generator only skips *transferring* them later (`generator.c:1695-1701`, "skipping non-regular file"). The entry therefore reprieves its parent directory from pruning, and the empty parent directory is still created. oc-rsync treated `EntryAction::SkipNonRegular` as not-keeping, so it pruned a directory that upstream keeps.

## Reproduction

Tree with `symdir/link` (a symlink) and no other content, no `-l`:

```
$ rsync -rm src/ dst/        # upstream 3.4.4
skipping non-regular file "symdir/link"
$ find dst -type d
dst/symdir                    # empty dir KEPT
```

Before this change oc-rsync pruned `symdir`. After the fix both tools produce byte-for-byte identical output.

## Fix

Mark `SkipNonRegular` as kept and ensure its parent directory exists, mirroring upstream's flist-driven prune reprieve. Excluded entries (`SkipExcluded`) stay not-keeping since they are absent from the flist, so directories containing only excluded files are still pruned (unchanged).

## Verification

- Empirically confirmed identical to rsync 3.4.4 across `-am`, `-rm`, and `--exclude` modes; genuinely empty directories are still pruned.
- Added regression test `prune_empty_dirs_keeps_dir_with_only_skipped_symlink`.
- `cargo fmt` + `cargo check -p engine --all-features --tests` clean.