### PR TITLE
feat(delete): emit upstream non-empty-dir and IO-error skip notices

### DIFF
--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -438,11 +438,15 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                     // at verbose level 0 is `NONREG` (info_verbosity[0]), the
                     // same channel the sibling "skipping non-regular file"
                     // notice uses.
+                    // Render with forward slashes so the notice matches
+                    // upstream output on every platform (rsync uses `/`
+                    // universally); the cli frontend applies the same
+                    // normalization when itemizing deletion paths.
                     info_log!(
                         Nonreg,
                         1,
                         "cannot delete non-empty directory: {}",
-                        path.display()
+                        path.display().to_string().replace('\\', "/")
                     );
                     return Ok(());
                 }

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -51,6 +51,7 @@ use std::sync::Arc;
 #[cfg(unix)]
 use fast_io::DirSandbox;
 
+use logging::info_log;
 use protocol::DeleteStats;
 
 use super::cohort_index::CohortIndex;
@@ -421,6 +422,30 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                 Ok(())
             }
             Err(err) => {
+                if is_not_empty(&err) {
+                    // The directory still holds entries after the recursive
+                    // peel - filtered or perishable content the delete pass
+                    // deliberately left in place - so the retried `rmdir`
+                    // reports ENOTEMPTY. Upstream treats this as DR_NOT_EMPTY:
+                    // it prints an FINFO notice once per such directory and
+                    // neither records an I/O error nor counts the directory as
+                    // deleted, so the exit code stays 0.
+                    // upstream: delete.c:117-119 (delete_dir_contents) and
+                    // delete.c:197-199 (delete_item) both
+                    // `rprintf(FINFO, "cannot delete non-empty directory: %s\n", ...)`.
+                    // FINFO renders at the default verbosity (log.c:317-320,
+                    // shown unless `--quiet`); oc's only info category present
+                    // at verbose level 0 is `NONREG` (info_verbosity[0]), the
+                    // same channel the sibling "skipping non-regular file"
+                    // notice uses.
+                    info_log!(
+                        Nonreg,
+                        1,
+                        "cannot delete non-empty directory: {}",
+                        path.display()
+                    );
+                    return Ok(());
+                }
                 if Self::is_fatal_error(&err) {
                     // Fatal: abort the drain. Upstream maps these to
                     // RERR_PARTIAL via `rsyserr(FERROR_XFER, ...)` plus

--- a/crates/engine/src/delete/emitter/tests/error_policy.rs
+++ b/crates/engine/src/delete/emitter/tests/error_policy.rs
@@ -65,6 +65,69 @@ fn non_empty_dir_recurses_via_nested_plan() {
 }
 
 #[test]
+fn non_empty_dir_after_peel_reports_notice_without_error() {
+    // The directory `d/sub` still holds filtered/perishable content after
+    // its nested plan drains, so the retried `rmdir` reports ENOTEMPTY a
+    // second time. Upstream (delete.c:117-119 / :197-199) prints
+    // "cannot delete non-empty directory: <dir>" via FINFO and treats the
+    // outcome as DR_NOT_EMPTY: the user must learn the directory survived,
+    // but the run neither counts it as deleted nor records an I/O error, so
+    // the exit code stays 0. Scripting two ENOTEMPTY failures models the
+    // initial rmdir plus the post-peel retry both failing.
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
+
+    // NONREG (info_verbosity[0]) is the only info category present at the
+    // default verbosity, matching upstream's ungated FINFO rendering.
+    init(VerbosityConfig::from_verbose_level(0));
+    let _ = drain_events();
+
+    let fs = ScriptedDeleteFs::new()
+        .fail("d/sub", io::ErrorKind::DirectoryNotEmpty)
+        .fail("d/sub", io::ErrorKind::DirectoryNotEmpty);
+    let plans = DeletePlanMap::new();
+    plans.insert(plan("d", vec![entry("sub", DeleteEntryKind::Dir)]));
+    plans.insert(plan("d/sub", vec![entry("inner", DeleteEntryKind::File)]));
+    let mut cursor = DirTraversalCursor::new(PathBuf::from("d"));
+    cursor.observe_segment(PathBuf::from("d"), &[]);
+
+    let mut emitter = DeleteEmitter::new(fs, plans, cursor);
+    emitter
+        .emit_all()
+        .expect("drain succeeds despite non-empty dir");
+
+    // The peeled entry was unlinked, but the surviving directory is neither
+    // counted nor treated as an error.
+    assert_eq!(
+        emitter.fs().events(),
+        vec![DeleteEvent {
+            path: PathBuf::from("d/sub/inner"),
+            kind: DeleteEntryKind::File,
+        }],
+    );
+    assert_eq!(emitter.stats().dirs, 0);
+    assert_eq!(emitter.io_error(), 0);
+    assert_eq!(emitter.exit_code(), 0);
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Nonreg,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "cannot delete non-empty directory: d/sub"),
+        "expected upstream non-empty-directory notice; got {messages:?}"
+    );
+}
+
+#[test]
 fn non_empty_dir_without_plan_falls_back_to_remove_dir_all() {
     // When `d/orphan` has no published plan, ENOTEMPTY must route
     // through `DeleteFs::remove_dir_all`, mirroring upstream's

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -135,6 +135,12 @@ pub(crate) struct CopyContext<'a> {
     /// When set to `true` and `--ignore-errors` is not enabled, deletions
     /// are suppressed to prevent data loss.
     io_errors_occurred: bool,
+    /// Guards the one-shot "IO error encountered -- skipping file deletion"
+    /// notice. Upstream prints it exactly once (guarded by a static
+    /// `already_warned`) the first time the delete pass is skipped because a
+    /// general I/O error occurred without `--ignore-errors`.
+    // upstream: generator.c:299 static int already_warned
+    io_error_delete_warning_emitted: bool,
     /// `true` when the active plan carries more than one source operand.
     /// Used to switch `--delete-during` to a deferred sweep so the per-source
     /// keep lists can be merged before any extraneous unlink fires; upstream

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -155,9 +155,10 @@ impl<'a> CopyContext<'a> {
     /// times independently of the generator's delayed-deletion phase.
     // upstream: generator.c:2419 do_delayed_deletions() runs after generate_files()
     pub(super) fn flush_deferred_deletions(&mut self) -> Result<(), LocalCopyError> {
-        if !self.deletions_allowed() {
-            // I/O errors occurred and --ignore-errors is not set;
-            // suppress deletions to prevent data loss.
+        if self.delete_pass_blocked_by_io_error() {
+            // I/O errors occurred and --ignore-errors is not set; suppress
+            // deletions to prevent data loss and emit the one-shot skip
+            // notice. upstream: generator.c:298-305.
             self.deferred_ops.deletions.clear();
             return Ok(());
         }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -142,6 +142,7 @@ impl<'a> CopyContext<'a> {
             deferred_sync,
             checksum_cache: None,
             io_errors_occurred: false,
+            io_error_delete_warning_emitted: false,
             multi_source: false,
             verified_parents: HashSet::new(),
             batch_flist_writer,
@@ -953,5 +954,31 @@ impl<'a> CopyContext<'a> {
     /// - `--ignore-errors` is enabled
     pub(super) const fn deletions_allowed(&self) -> bool {
         !self.io_errors_occurred || self.options.ignore_errors_enabled()
+    }
+
+    /// Returns `true` when the delete pass must be skipped because a general
+    /// I/O error occurred and `--ignore-errors` was not given, emitting the
+    /// upstream skip notice exactly once.
+    ///
+    /// The message renders at the default verbosity through the `NONREG`
+    /// info category (info_verbosity[0], enabled at verbose level 0), the
+    /// same channel oc uses for the sibling "skipping non-regular file"
+    /// notice. `--ignore-errors` keeps [`Self::deletions_allowed`] true, so
+    /// neither the warning nor the skip fires in that case - matching
+    /// upstream, where the flag both suppresses the notice and lets the
+    /// delete pass run.
+    // upstream: generator.c:298-305 delete_in_dir() prints "IO error
+    // encountered -- skipping file deletion" once (guarded by a static
+    // `already_warned`) and returns without deleting whenever
+    // `io_error & IOERR_GENERAL && !ignore_errors`.
+    pub(super) fn delete_pass_blocked_by_io_error(&mut self) -> bool {
+        if self.deletions_allowed() {
+            return false;
+        }
+        if !self.io_error_delete_warning_emitted {
+            self.io_error_delete_warning_emitted = true;
+            info_log!(Nonreg, 1, "IO error encountered -- skipping file deletion");
+        }
+        true
     }
 }

--- a/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/deletion.rs
@@ -57,8 +57,9 @@ pub(super) fn apply_during_transfer_deletions(
     }
 
     // When I/O errors occurred and --ignore-errors is not set, suppress
-    // deletions to prevent data loss (upstream rsync behavior).
-    if !context.deletions_allowed() {
+    // deletions to prevent data loss (upstream rsync behavior) and emit the
+    // one-shot skip notice. upstream: generator.c:298-305.
+    if context.delete_pass_blocked_by_io_error() {
         return Ok(());
     }
 
@@ -93,8 +94,9 @@ pub(super) fn handle_post_transfer_deletions(
     }
 
     // When I/O errors occurred and --ignore-errors is not set, suppress
-    // deletions to prevent data loss (upstream rsync behavior).
-    if !context.deletions_allowed() {
+    // deletions to prevent data loss (upstream rsync behavior) and emit the
+    // one-shot skip notice. upstream: generator.c:298-305.
+    if context.delete_pass_blocked_by_io_error() {
         return Ok(());
     }
 

--- a/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
+++ b/crates/engine/src/local_copy/tests/execute_ignore_errors.rs
@@ -303,6 +303,135 @@ fn delete_suppressed_when_io_errors_and_ignore_errors_not_set() {
 
 #[cfg(unix)]
 #[test]
+fn io_error_skip_deletion_emits_upstream_notice() {
+    // The user must be told that deletions were skipped: silently keeping
+    // extraneous files after a partial read would look like a no-op run, so
+    // upstream prints "IO error encountered -- skipping file deletion" once
+    // before abandoning the delete pass. This asserts the notice reaches the
+    // diagnostic queue, not merely that the extra file survives.
+    // upstream: generator.c:298-305 delete_in_dir().
+    use logging::{DiagnosticEvent, InfoFlag, VerbosityConfig, drain_events, init};
+    use std::os::unix::fs::PermissionsExt;
+
+    // NONREG (info_verbosity[0]) is enabled at verbose level 0, matching
+    // upstream's ungated FINFO rendering of the notice.
+    init(VerbosityConfig::from_verbose_level(0));
+    let _ = drain_events();
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(source.join("baddir")).expect("create baddir");
+    fs::create_dir_all(source.join("zsub")).expect("create zsub");
+    fs::create_dir_all(dest.join("zsub")).expect("create dest zsub");
+
+    fs::write(source.join("baddir/inner.txt"), b"inner").expect("write inner");
+    fs::write(source.join("zsub/keep.txt"), b"keep").expect("write keep");
+    fs::write(dest.join("zsub/keep.txt"), b"keep").expect("write dest keep");
+    fs::write(dest.join("zsub/extra.txt"), b"should survive").expect("write extra");
+
+    fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o000))
+        .expect("make baddir unreadable");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default().recursive(true).delete(true);
+    let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
+
+    let _ = fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o755));
+
+    assert!(result.is_err(), "copy should report I/O error");
+    assert!(
+        dest.join("zsub/extra.txt").exists(),
+        "zsub/extra.txt must survive when the delete pass is skipped"
+    );
+
+    let messages: Vec<String> = drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            DiagnosticEvent::Info {
+                flag: InfoFlag::Nonreg,
+                message,
+                ..
+            } => Some(message),
+            _ => None,
+        })
+        .collect();
+    let notice = "IO error encountered -- skipping file deletion";
+    assert!(
+        messages.iter().any(|m| m == notice),
+        "expected the upstream skip notice {notice:?}; got {messages:?}"
+    );
+    // Upstream guards the notice with a static `already_warned`, so it is
+    // printed at most once even across several suppressed directories.
+    assert_eq!(
+        messages.iter().filter(|m| m.as_str() == notice).count(),
+        1,
+        "skip notice must be emitted exactly once; got {messages:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ignore_errors_suppresses_io_error_skip_notice() {
+    // With --ignore-errors the delete pass runs to completion, so the skip
+    // notice must NOT appear and the extraneous file must be deleted. The
+    // flag both silences the warning and re-enables deletion upstream.
+    // upstream: generator.c:298 `io_error & IOERR_GENERAL && !ignore_errors`.
+    use logging::{DiagnosticEvent, drain_events, init, VerbosityConfig};
+    use std::os::unix::fs::PermissionsExt;
+
+    init(VerbosityConfig::from_verbose_level(0));
+    let _ = drain_events();
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+    fs::create_dir_all(source.join("baddir")).expect("create baddir");
+    fs::create_dir_all(source.join("zsub")).expect("create zsub");
+    fs::create_dir_all(dest.join("zsub")).expect("create dest zsub");
+
+    fs::write(source.join("baddir/inner.txt"), b"inner").expect("write inner");
+    fs::write(source.join("zsub/keep.txt"), b"keep").expect("write keep");
+    fs::write(dest.join("zsub/keep.txt"), b"keep").expect("write dest keep");
+    fs::write(dest.join("zsub/extra.txt"), b"delete me").expect("write extra");
+
+    fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o000))
+        .expect("make baddir unreadable");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .delete(true)
+        .ignore_errors(true);
+    let _ = plan.execute_with_options(LocalCopyExecution::Apply, options);
+
+    let _ = fs::set_permissions(source.join("baddir"), fs::Permissions::from_mode(0o755));
+
+    assert!(
+        !dest.join("zsub/extra.txt").exists(),
+        "extra.txt should be deleted when --ignore-errors re-enables the delete pass"
+    );
+
+    let notice = "IO error encountered -- skipping file deletion";
+    let saw_notice = drain_events().into_iter().any(|event| {
+        matches!(event, DiagnosticEvent::Info { ref message, .. } if message == notice)
+    });
+    assert!(
+        !saw_notice,
+        "--ignore-errors must suppress the skip notice"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn delete_proceeds_when_io_errors_and_ignore_errors_set() {
     // This test is the counterpart: with --ignore-errors, deletions should
     // proceed even when I/O errors occurred during transfer.


### PR DESCRIPTION
## Summary

oc-rsync omitted two user-facing delete-pass notices that upstream rsync 3.4.4 prints. Both were verified missing (only referenced in comments/tests) and confirmed against the upstream C source and the `rsync 3.4.4` binary.

### 1. `cannot delete non-empty directory: <dir>`
- upstream: `delete.c:117-119` (`delete_dir_contents`) and `delete.c:197-199` (`delete_item`), both `rprintf(FINFO, "cannot delete non-empty directory: %s\n", ...)`.
- Fires when a directory still holds filtered or perishable content after the recursive peel, so the retried `rmdir` reports `ENOTEMPTY`.
- The emitter now reports it via the diagnostic queue and treats the outcome as non-empty (`DR_NOT_EMPTY`): the directory is neither counted as deleted nor recorded as an I/O error, so the exit code stays `0` - matching upstream (empirically exit 0).

### 2. `IO error encountered -- skipping file deletion`
- upstream: `generator.c:298-305` (`delete_in_dir`), printed once (static `already_warned`) and the delete pass is abandoned whenever `io_error & IOERR_GENERAL && !ignore_errors`.
- oc already suppressed deletion under this condition but printed nothing; it now emits the notice exactly once at the delete gate.
- `--ignore-errors` suppresses the notice and re-enables the delete pass, matching upstream.

Both messages render at the default verbosity via the `NONREG` info category (`info_verbosity[0]`), the same channel oc uses for the sibling `skipping non-regular file` notice, reproducing upstream's ungated `FINFO` behaviour (`log.c:317-320`, shown unless `--quiet`).

## Verification
- Emitter unit test: persistent-`ENOTEMPTY`-after-peel emits the non-empty notice, keeps `io_error == 0`, and does not count the directory.
- Local-copy tests: a directory-read I/O error emits the skip notice exactly once and the extraneous file survives; `--ignore-errors` suppresses the notice and deletes the extraneous file.
- End-to-end against the built binary: `IO error encountered -- skipping file deletion` renders at exit 23, byte-for-byte with upstream.
- `cargo fmt`, `cargo clippy -p engine --all-features --no-deps -D warnings`, and targeted `nextest` all clean.

## Scope
Edits confined to `crates/engine/src/delete/emitter/` and `crates/engine/src/local_copy/` (context state, the delete gate, and the deferred-deletion flush). No changes to CLI, filters, protocol, or any of the excluded files.