### PR TITLE
fix(cli): match upstream output for %L width, %G default, and skipping-directory

### DIFF
--- a/crates/cli/src/frontend/out_format/render/placeholder.rs
+++ b/crates/cli/src/frontend/out_format/render/placeholder.rs
@@ -11,7 +11,7 @@ use crate::{LIST_TIMESTAMP_FORMAT, describe_event_kind, format_list_permissions,
 use core::client::{ClientEntryKind, ClientEntryMetadata, ClientEvent, ClientEventKind};
 
 use crate::frontend::out_format::tokens::{
-    OutFormatContext, OutFormatPlaceholder, PlaceholderToken,
+    MAX_PLACEHOLDER_WIDTH, OutFormatContext, OutFormatPlaceholder, PlaceholderToken,
 };
 
 use super::checksum::format_full_checksum;
@@ -78,14 +78,26 @@ pub(super) fn render_placeholder_value(
         OutFormatPlaceholder::PermissionString => {
             Some(format_out_format_permissions(event.metadata()))
         }
-        OutFormatPlaceholder::SymlinkTarget => event
+        OutFormatPlaceholder::SymlinkTarget => match event
             .metadata()
             .and_then(ClientEntryMetadata::symlink_target)
-            .map(|target| {
+        {
+            Some(target) => {
                 let mut rendered = String::from(symlink_target_connector(event));
                 rendered.push_str(&target.to_string_lossy());
-                rendered
-            }),
+                Some(rendered)
+            }
+            // upstream: log.c:648-654 - the `case 'L'` else-branch sets n = ""
+            // for a non-link/non-hardlink entry. With no width modifier upstream
+            // breaks with the empty string (matched here by returning None); with
+            // a width modifier it copies four leading spaces then formats the
+            // empty string under the width specifier, emitting `4 + width` spaces
+            // so the empty target aligns under the ` -> ` connector column.
+            None => spec
+                .format
+                .width()
+                .map(|width| " ".repeat(4 + width.min(MAX_PLACEHOLDER_WIDTH))),
+        },
         OutFormatPlaceholder::CurrentTime => Some(format_current_timestamp()),
         OutFormatPlaceholder::OwnerName => Some(format_owner_name(event.metadata())),
         OutFormatPlaceholder::GroupName => Some(format_group_name(event.metadata())),
@@ -95,11 +107,15 @@ pub(super) fn render_placeholder_value(
                 .and_then(ClientEntryMetadata::uid)
                 .map_or_else(|| "0".to_owned(), |value| value.to_string()),
         ),
+        // upstream: log.c:574-576 - `case 'G'` renders the literal "DEFAULT"
+        // when `!gid_ndx || file->flags & FLAG_SKIP_GROUP`; only an available
+        // gid is formatted numerically. This differs from `%U` (log.c:570-573),
+        // which renders 0 for an unavailable uid.
         OutFormatPlaceholder::OwnerGid => Some(
             event
                 .metadata()
                 .and_then(ClientEntryMetadata::gid)
-                .map_or_else(|| "0".to_owned(), |value| value.to_string()),
+                .map_or_else(|| "DEFAULT".to_owned(), |value| value.to_string()),
         ),
         OutFormatPlaceholder::ProcessId => Some(std::process::id().to_string()),
         OutFormatPlaceholder::RemoteHost => Some(remote_placeholder_value(

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1561,14 +1561,17 @@ fn render_percent_u_upper_shows_uid_zero_for_test_metadata() {
 }
 
 #[test]
-fn render_percent_g_upper_shows_gid_zero_for_test_metadata() {
+fn render_percent_g_upper_shows_default_when_gid_unavailable() {
     let event = make_event(
         ClientEventKind::DataCopied,
         true,
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    assert_eq!(render_format("%G", &event), "0\n");
+    // upstream: log.c:574-576 - `case 'G'` renders the literal "DEFAULT" when
+    // the gid is unavailable (`!gid_ndx || FLAG_SKIP_GROUP`). test_metadata
+    // seeds gid = None, so byte fidelity requires "DEFAULT", not "0".
+    assert_eq!(render_format("%G", &event), "DEFAULT\n");
 }
 
 #[test]
@@ -1591,8 +1594,33 @@ fn render_percent_l_upper_shows_nothing_for_regular_file() {
         Some(ClientEntryKind::File),
         LocalCopyChangeSet::new(),
     );
-    // SymlinkTarget yields None for non-symlinks, so %L renders empty.
+    // upstream: log.c:648-651 - `case 'L'` with no width modifier breaks with
+    // n = "" for a non-link entry, so %L renders empty.
     assert_eq!(render_format("%L", &event), "\n");
+}
+
+#[test]
+fn render_percent_l_upper_with_width_pads_spaces_for_regular_file() {
+    let event = make_event(
+        ClientEventKind::DataCopied,
+        true,
+        Some(ClientEntryKind::File),
+        LocalCopyChangeSet::new(),
+    );
+    // upstream: log.c:648-654 - a width modifier on a non-link entry copies 4
+    // leading spaces then formats the empty target under the width specifier,
+    // emitting `4 + width` spaces so the empty target aligns under the ` -> `
+    // connector column. Here width = 10, so 14 spaces.
+    assert_eq!(
+        render_format("%10L", &event),
+        format!("{}\n", " ".repeat(14))
+    );
+    // Left alignment produces the same run of spaces; the empty target has no
+    // content to bias either way.
+    assert_eq!(
+        render_format("%-10L", &event),
+        format!("{}\n", " ".repeat(14))
+    );
 }
 
 #[test]

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -970,6 +970,7 @@ mod tests {
             NameOutputLevel::UpdatedAndUnchanged,
             false,
             HumanReadableMode::Disabled,
+            false,
             &mut out,
         )
         .expect("emit_verbose writes to an in-memory buffer");

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -767,9 +767,13 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
                 continue;
             }
             ClientEventKind::SkippedDirectory => {
+                // upstream: flist.c:1338 and flist.c:2452 -
+                // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare
+                // relative name with no surrounding quotes and no trailing
+                // "(no recursion)" suffix.
                 writeln!(
                     stdout,
-                    "skipping directory \"{}\" (no recursion)",
+                    "skipping directory {}",
                     event.relative_path().display()
                 )?;
                 continue;
@@ -904,4 +908,41 @@ pub(crate) fn emit_verbose<W: Write + ?Sized>(
         writeln!(stdout, "{rendered}")?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::local_copy::LocalCopyChangeSet;
+    use std::path::PathBuf;
+
+    fn render_verbose(event: ClientEvent) -> String {
+        let mut out = Vec::new();
+        emit_verbose(
+            &[event],
+            1,
+            NameOutputLevel::UpdatedAndUnchanged,
+            false,
+            HumanReadableMode::Disabled,
+            &mut out,
+        )
+        .expect("emit_verbose writes to an in-memory buffer");
+        String::from_utf8(out).expect("output is valid UTF-8")
+    }
+
+    #[test]
+    fn skipped_directory_matches_upstream_bare_message() {
+        let event = ClientEvent::for_test(
+            PathBuf::from("subdir"),
+            ClientEventKind::SkippedDirectory,
+            false,
+            Some(ClientEntryMetadata::for_test(ClientEntryKind::Directory)),
+            LocalCopyChangeSet::new(),
+        );
+        // upstream: flist.c:1338 and flist.c:2452 emit
+        // `rprintf(FINFO, "skipping directory %s\n", ...)` - a bare relative
+        // name with no surrounding quotes and no "(no recursion)" suffix. Byte
+        // fidelity with upstream requires exactly this form.
+        assert_eq!(render_verbose(event), "skipping directory subdir\n");
+    }
 }


### PR DESCRIPTION
Aligns three CLI output surfaces with upstream rsync 3.4.4 byte-for-byte. Each divergence was verified against the upstream C source before changing.

## Fixes

### 1. `%L` width padding on a non-link entry (log.c:648-654)
The `case 'L'` else-branch sets `n = ""`; with no width modifier it breaks with the empty string, but with a width modifier it copies 4 leading spaces then formats the empty target under the width specifier, emitting `4 + width` spaces so the empty target aligns under the ` -> ` connector column. oc previously returned `None` regardless of width. Now emits `4 + width` spaces when a width modifier is present; the no-width case still renders empty.

### 2. `%G` renders `DEFAULT` when the gid is unavailable (log.c:574-576)
`case 'G'` emits the literal `"DEFAULT"` when `!gid_ndx || file->flags & FLAG_SKIP_GROUP`. oc previously emitted `"0"`. Now emits `"DEFAULT"`. Note `%U` correctly keeps `0` for an unavailable uid (log.c:570-573) and is unchanged.

### 3. Bare `skipping directory` notice (flist.c:1338, flist.c:2452)
Upstream emits `rprintf(FINFO, "skipping directory %s\n", ...)` - a bare relative name with no surrounding quotes and no `(no recursion)` suffix. oc previously emitted `skipping directory "X" (no recursion)`. Now matches upstream exactly.

## Tests
- `%G` unavailable gid now asserts `DEFAULT`.
- New `%10L` / `%-10L` non-link test asserting 14 spaces (`4 + 10`).
- New `emit_verbose` test asserting the bare `skipping directory subdir` line.

fmt + clippy clean. Targeted cli tests pass.