### PR TITLE
fix: trace SSH stderr socketpair drain fallback on non-Unix

### DIFF
--- a/crates/rsync_io/src/ssh/aux_channel.rs
+++ b/crates/rsync_io/src/ssh/aux_channel.rs
@@ -471,6 +471,17 @@ pub(super) fn configure_stderr_channel(command: &mut Command) -> Option<UnixStre
 #[cfg(not(unix))]
 pub(super) fn configure_stderr_channel(command: &mut Command) -> Option<()> {
     command.stderr(Stdio::piped());
+    // The socketpair-backed async drain fast path is Unix-only, so it
+    // compiles out entirely here. Emit a diagnostic once at the stderr
+    // setup point so a debug run on non-Unix targets shows that the
+    // pipe-based fallback was taken rather than leaving the downgrade
+    // invisible (the Unix arm above traces the equivalent runtime
+    // fallback via `debug_log!`).
+    debug_log!(
+        Connect,
+        2,
+        "ssh stderr: socketpair async drain unavailable on this platform; using pipe-based stderr"
+    );
     None
 }
 


### PR DESCRIPTION
## Problem

The SSH transport's stderr async drain has a socketpair-based fast path (Unix only) with a pipe-based fallback. On Unix, both the success case and the runtime socketpair-allocation-failure fallback are traced (`debug_log!` at levels 3 and 2, plus a one-shot operator warning). But when the fast path compiles out on non-Unix targets, `configure_stderr_channel`'s `#[cfg(not(unix))]` arm silently fell back to `Stdio::piped()` with no diagnostic. The downgrade was invisible: a debug run on a non-Unix platform showed no trace that the async-drain path was unavailable.

## Fix

Emit a `debug_log!(Connect, 2, ...)` in the non-Unix branch at the stderr setup point, mirroring the Unix arm's fallback trace. The message states the socketpair async drain is unavailable on this platform and the pipe-based stderr channel is in use.

This only adds observability. Behavior (pipe fallback, `None` return) is unchanged - covered by the existing `configure_stderr_channel_uses_pipe_on_non_unix` test.

## Verification

- `cargo check -p rsync_io` (macOS) and `cargo check -p rsync_io --target x86_64-pc-windows-gnu` (exercises the non-Unix branch) both compile clean.
- `cargo clippy -p rsync_io --all-features --no-deps -- -D warnings` clean on both targets.
- The fallback is purely platform-cfg (an inline macro in a `#[cfg(not(unix))]` branch, not a separable helper), so it is not unit-testable in isolation; cross-target compile-check confirms it builds.