### PR TITLE
docs(bandwidth): add rustdoc and prune noise comments

### DIFF
--- a/crates/bandwidth/src/limiter/core/limiter.rs
+++ b/crates/bandwidth/src/limiter/core/limiter.rs
@@ -110,6 +110,11 @@ impl BandwidthLimiter {
         self.simulated_elapsed_us = 0;
     }
 
+    /// Caps outstanding debt at the configured burst size, if any.
+    ///
+    /// With no burst configured, debt is left unbounded so long idle periods
+    /// can accumulate arbitrary allowance. When a burst cap is set, this bounds
+    /// the debt (and therefore the maximum single sleep) to `burst` bytes.
     #[inline]
     fn clamp_debt_to_burst(&mut self) {
         if let Some(burst) = self.burst_bytes {
@@ -216,6 +221,9 @@ impl BandwidthLimiter {
         let elapsed_us = end
             .checked_duration_since(start)
             .map_or(0, |duration| duration.as_micros().min(u128::from(u64::MAX)));
+        // A short sleep (the backend woke earlier than requested) leaves debt
+        // unpaid. Carry the un-slept remainder forward as simulated elapsed
+        // time so the next register() credits it and pacing stays on target.
         if sleep_us > elapsed_us {
             self.simulated_elapsed_us = sleep_us - elapsed_us;
         }

--- a/crates/bandwidth/src/limiter/test_support.rs
+++ b/crates/bandwidth/src/limiter/test_support.rs
@@ -407,7 +407,6 @@ mod tests {
     #[test]
     fn recorded_sleep_session_clear_empties_buffer() {
         let mut session = recorded_sleep_session();
-        // Add some durations
         append_recorded_sleeps(vec![Duration::from_secs(1), Duration::from_secs(2)]);
         session.clear();
         assert!(session.is_empty());
@@ -602,7 +601,6 @@ mod tests {
     #[test]
     fn recorded_sleep_session_default() {
         let session: RecordedSleepSession = Default::default();
-        // Should be able to use the session
         let _ = session.is_empty();
     }
 

--- a/crates/bandwidth/src/limiter/tests/configuration.rs
+++ b/crates/bandwidth/src/limiter/tests/configuration.rs
@@ -428,7 +428,6 @@ fn reset_clears_all_mutable_state() {
     let _ = limiter.register(10000);
     let _ = limiter.register(5000);
 
-    // Reset
     limiter.reset();
 
     // All mutable state should be cleared


### PR DESCRIPTION
## Summary

Rustdoc-first comment cleanup for the `bandwidth` crate. Documentation and comments only; no logic, signature, or behaviour changes.

## Findings

The crate was already in excellent shape. It compiles under `#![deny(missing_docs)]`, so every public type, trait, function, method, and module already carries accurate `///` rustdoc, and the production-source inline comments all add real value (upstream `io.c`/`options.c` references, fallback rationale, precision notes). No public item was missing documentation.

## Changes

- `limiter/core/limiter.rs`: documented the private `clamp_debt_to_burst` helper (burst-cap invariant) and added a concise inline note explaining the short-sleep carryover accounting in `register()` - the two least self-evident pieces of the pacing math.
- Removed three pure-restatement comments in tests that only echoed the adjacent call (`// Add some durations`, `// Should be able to use the session`, `// Reset`).

All "why"/intent comments in the test suite (which explain expected values and pacing arithmetic) were preserved, as were every upstream reference.

## Verification

- `cargo fmt --all` - clean, diff confined to the bandwidth crate
- `cargo clippy -p bandwidth --all-targets --all-features --no-deps -- -D warnings` - no issues
- `cargo check -p bandwidth --all-features` - passes
- `git diff` shows only comment/doc lines changed (+8 / -3)