### PR TITLE
fix(cli): list symlinks and specials in --list-only output

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -120,6 +120,10 @@ where
     // inc_recurse is on, which compat.c:172 disables when `!recurse`. Mirror
     // that gate so single-file (`-v`) transfers don't get a spurious banner.
     let recursive = config.recursive();
+    // Capture the preserve-links state before `config` is consumed so the
+    // `--list-only` renderer knows whether to append the ` -> <target>` arrow
+    // to symlink rows (upstream: generator.c:1183 gates it on preserve_links).
+    let preserve_links = config.links();
 
     let result = {
         let observer = live_progress
@@ -151,7 +155,8 @@ where
             let out_format_context = OutFormatContext::with_is_sender(is_sender)
                 .with_emit_unchanged(emit_unchanged)
                 .with_itemize_repeated(itemize_repeated)
-                .with_eight_bit_output(eight_bit_output);
+                .with_eight_bit_output(eight_bit_output)
+                .with_preserve_links(preserve_links);
             if let Err(error) = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
                 emit_transfer_summary(
                     &summary,
@@ -198,6 +203,7 @@ where
                     show_atimes,
                     show_crtimes,
                     eight_bit_output,
+                    preserve_links,
                 })
             {
                 let _ = with_output_writer(stdout, stderr, msgs_to_stderr, |writer| {
@@ -254,6 +260,9 @@ struct EmitLogOutputParams<'a> {
     /// `--8-bit-output` / `-8`: pass high-bit characters through without
     /// octal escaping in log-file output.
     eight_bit_output: bool,
+    /// `--links` / `-l`: whether symlink rows in `--list-only` log output get
+    /// the ` -> <target>` arrow (upstream: generator.c:1183).
+    preserve_links: bool,
 }
 
 /// Writes the transfer summary to the configured log file.
@@ -272,6 +281,7 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         show_atimes,
         show_crtimes,
         eight_bit_output,
+        preserve_links,
     } = params;
     // upstream: generator.c:582-583 - mirror the `INFO_GTE(NAME, 2)` arm of
     // the itemize emit gate in the log-file renderer so `-vv` / `--info=name2`
@@ -281,7 +291,8 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
     let context = OutFormatContext::with_is_sender(is_sender)
         .with_emit_unchanged(emit_unchanged)
         .with_itemize_repeated(itemize_repeated)
-        .with_eight_bit_output(eight_bit_output);
+        .with_eight_bit_output(eight_bit_output)
+        .with_preserve_links(preserve_links);
     // The log file already carries the parallel "building file list" line via
     // logging::info_log!(Flist, 1, ...); the FCLIENT "sending incremental file
     // list" banner is for stdout only (upstream: flist.c:2248 vs 2252).

--- a/crates/cli/src/frontend/out_format/render/tests.rs
+++ b/crates/cli/src/frontend/out_format/render/tests.rs
@@ -1681,6 +1681,7 @@ fn render_remote_host_with_context_populated() {
         emit_unchanged: false,
         itemize_repeated: false,
         eight_bit_output: false,
+        preserve_links: false,
     };
     assert_eq!(
         render_format_with_context("%h", &event, &context),
@@ -1705,6 +1706,7 @@ fn render_remote_address_with_context_populated() {
         emit_unchanged: false,
         itemize_repeated: false,
         eight_bit_output: false,
+        preserve_links: false,
     };
     assert_eq!(
         render_format_with_context("%a", &event, &context),
@@ -1729,6 +1731,7 @@ fn render_module_name_with_context_populated() {
         emit_unchanged: false,
         itemize_repeated: false,
         eight_bit_output: false,
+        preserve_links: false,
     };
     assert_eq!(render_format_with_context("%m", &event, &context), "data\n");
 }
@@ -1750,6 +1753,7 @@ fn render_module_path_with_context_populated() {
         emit_unchanged: false,
         itemize_repeated: false,
         eight_bit_output: false,
+        preserve_links: false,
     };
     assert_eq!(
         render_format_with_context("%P", &event, &context),
@@ -1774,6 +1778,7 @@ fn render_all_remote_placeholders_with_full_context() {
         emit_unchanged: false,
         itemize_repeated: false,
         eight_bit_output: false,
+        preserve_links: false,
     };
     let rendered = render_format_with_context("%h %a %m %P", &event, &context);
     assert_eq!(rendered, "host addr mod /path\n");

--- a/crates/cli/src/frontend/out_format/tokens.rs
+++ b/crates/cli/src/frontend/out_format/tokens.rs
@@ -177,6 +177,14 @@ pub(crate) struct OutFormatContext {
     /// without octal escaping. Only control characters below 0x20 (except
     /// tab) are escaped. Matches upstream `allow_8bit_chars`.
     pub(super) eight_bit_output: bool,
+    /// `--links` / `-l` (also set by `-a`): whether symbolic links are
+    /// preserved.
+    ///
+    /// Controls whether `--list-only` output appends ` -> <target>` to a
+    /// symlink row. Upstream `generator.c:1183` only sets the arrow when
+    /// `preserve_links && S_ISLNK(f->mode)`; without `-l` the symlink is
+    /// still listed (with its target-length size) but no target string.
+    pub(super) preserve_links: bool,
 }
 
 impl OutFormatContext {
@@ -236,6 +244,24 @@ impl OutFormatContext {
     pub(crate) fn with_eight_bit_output(mut self, eight_bit_output: bool) -> Self {
         self.eight_bit_output = eight_bit_output;
         self
+    }
+
+    /// Sets the `--links` / `-l` (preserve-symlinks) flag.
+    ///
+    /// upstream: generator.c:1183 - the ` -> <target>` arrow in `--list-only`
+    /// output is gated on `preserve_links`.
+    #[must_use]
+    pub(crate) fn with_preserve_links(mut self, preserve_links: bool) -> Self {
+        self.preserve_links = preserve_links;
+        self
+    }
+
+    /// Returns whether symbolic links are preserved (`-l` / `-a`), which the
+    /// `--list-only` renderer uses to decide whether to append the symlink
+    /// target arrow.
+    #[must_use]
+    pub(crate) const fn preserve_links(&self) -> bool {
+        self.preserve_links
     }
 }
 
@@ -375,6 +401,7 @@ mod tests {
             emit_unchanged: false,
             itemize_repeated: false,
             eight_bit_output: false,
+            preserve_links: false,
         };
         assert_eq!(ctx.remote_host.as_deref(), Some("server.example.com"));
         assert_eq!(ctx.remote_address.as_deref(), Some("192.168.1.1"));

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -68,6 +68,7 @@ pub(crate) fn emit_transfer_summary(
                 show_atimes,
                 show_crtimes,
                 eight_bit_output,
+                out_format_context.preserve_links(),
             )?;
             wrote_listing = true;
         }
@@ -247,6 +248,7 @@ fn format_list_time_column(time: Option<std::time::SystemTime>, blank: bool) -> 
     format!("{value:>width$}")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_list_only<W: Write + ?Sized>(
     events: &[ClientEvent],
     stdout: &mut W,
@@ -254,6 +256,7 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
     show_atimes: bool,
     show_crtimes: bool,
     eight_bit_output: bool,
+    preserve_links: bool,
 ) -> io::Result<()> {
     for event in events {
         if !list_only_event(event.kind()) {
@@ -278,7 +281,12 @@ pub(crate) fn emit_list_only<W: Write + ?Sized>(
                 String::new()
             };
             let mut rendered = escape_path(event.relative_path(), eight_bit_output);
-            if metadata.kind().is_symlink()
+            // upstream: generator.c:1183 list_file_entry() - the ` -> <target>`
+            // arrow is emitted only when `preserve_links && S_ISLNK(f->mode)`.
+            // Without `--links`/`-l` the symlink is still listed (with its
+            // target-length size) but no target string.
+            if preserve_links
+                && metadata.kind().is_symlink()
                 && let Some(target) = metadata.symlink_target()
             {
                 rendered.push_str(" -> ");

--- a/crates/cli/src/frontend/tests/list_only.rs
+++ b/crates/cli/src/frontend/tests/list_only.rs
@@ -1403,6 +1403,79 @@ fn list_only_mixed_file_types_in_single_listing() {
 /// entry types. Both fields are right-justified in a width of `1 +
 /// strlen(timestamp)` (20 for the 19-char "YYYY/MM/DD HH:MM:SS" form), so a
 /// value carries one leading space and a blank fills the whole column.
+/// upstream: generator.c:1183 list_file_entry() - the ` -> <target>` arrow is
+/// gated on `preserve_links`. Without `-l` the symlink is still listed (perms
+/// start with `l`, size is the target length) but no target string is shown.
+/// FIFOs, sockets, and devices render their own permstring type char.
+#[test]
+fn list_only_renders_specials_and_symlink_arrow_gate() {
+    use core::client::{ClientEntryMetadata, ClientEvent, ListOnlyEntryFields};
+    use std::path::PathBuf;
+
+    use crate::frontend::progress::emit_list_only;
+
+    fn fields(mode: u32, size: u64, target: Option<&str>) -> ListOnlyEntryFields {
+        ListOnlyEntryFields {
+            mode,
+            size,
+            mtime: 1_700_000_000,
+            mtime_nsec: 0,
+            atime: 0,
+            atime_nsec: 0,
+            crtime: 0,
+            crtime_nsec: 0,
+            symlink_target: target.map(PathBuf::from),
+            is_symlink: target.is_some(),
+        }
+    }
+
+    fn render(fields: &ListOnlyEntryFields, name: &str, preserve_links: bool) -> String {
+        let meta = ClientEntryMetadata::from_list_only_entry(fields);
+        let event = ClientEvent::from_list_only_entry(PathBuf::from(name), meta);
+        let mut out = Vec::new();
+        emit_list_only(
+            std::slice::from_ref(&event),
+            &mut out,
+            HumanReadableMode::Disabled,
+            false,
+            false,
+            false,
+            preserve_links,
+        )
+        .expect("render");
+        String::from_utf8(out).expect("utf8").trim_end().to_owned()
+    }
+
+    // Symlink: target length is the size column (6 = len("target")).
+    let link = fields(0o120_777, 6, Some("target"));
+
+    let with_links = render(&link, "link.txt", true);
+    assert!(
+        with_links.starts_with('l') && with_links.ends_with("link.txt -> target"),
+        "preserve_links must render the arrow: {with_links:?}"
+    );
+
+    let without_links = render(&link, "link.txt", false);
+    assert!(
+        without_links.starts_with('l') && without_links.ends_with("link.txt"),
+        "symlink still listed without -l: {without_links:?}"
+    );
+    assert!(
+        !without_links.contains("->"),
+        "no arrow without preserve_links: {without_links:?}"
+    );
+
+    // FIFO / socket / char device carry distinct permstring type chars.
+    let fifo = render(&fields(0o010_644, 0, None), "pipe", false);
+    assert!(fifo.starts_with('p'), "FIFO renders as 'p': {fifo:?}");
+
+    let sock = render(&fields(0o140_755, 0, None), "sock", false);
+    assert!(sock.starts_with('s'), "socket renders as 's': {sock:?}");
+
+    let chr = render(&fields(0o020_644, 0, None), "chr", false);
+    assert!(chr.starts_with('c'), "char device renders as 'c': {chr:?}");
+}
+
 #[test]
 fn list_only_renders_atime_and_crtime_columns() {
     use core::client::{ClientEntryMetadata, ClientEvent, ListOnlyEntryFields};
@@ -1452,6 +1525,7 @@ fn list_only_renders_atime_and_crtime_columns() {
         true,
         true,
         false,
+        true,
     )
     .expect("render");
     let rendered = String::from_utf8(out).expect("utf8");

--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -838,6 +838,7 @@ impl<'a> LocalCopyOptionsBuilder<'a> {
             .append_verify(config.append_verify())
             .partial(config.partial())
             .force_replacements(config.force_replacements())
+            .list_only(config.list_only())
     }
 
     fn apply_paths_and_backups(

--- a/crates/engine/src/local_copy/context_impl/options/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/options/transfer.rs
@@ -83,6 +83,10 @@ impl<'a> CopyContext<'a> {
         self.options.specials_enabled()
     }
 
+    pub(super) const fn list_only_enabled(&self) -> bool {
+        self.options.list_only_enabled()
+    }
+
     pub(super) const fn force_replacements_enabled(&self) -> bool {
         self.options.force_replacements_enabled()
     }

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -138,8 +138,14 @@ fn decide_entry_action(
     // (i.e., --copy-links did NOT resolve it to the referent).  When
     // --copy-links is active and the target is a FIFO or device, we must
     // fall through to the FIFO / device branches below.
+    // upstream: generator.c:1155 list_file_entry() lists every flist entry, so
+    // `--list-only` records symlinks, FIFOs, and devices (dry-run only reports
+    // them) even without `--links`/`--specials`/`--devices`; a real transfer
+    // without those flags still skips the non-regular entry.
+    let list_only = context.list_only_enabled();
+
     if entry_type.is_symlink() && effective_type.is_symlink() {
-        if context.links_enabled() {
+        if context.links_enabled() || list_only {
             return Ok(EntryAction::CopySymlink);
         }
         *keep_name = false;
@@ -147,7 +153,7 @@ fn decide_entry_action(
     }
 
     if is_fifo(effective_type) {
-        if context.specials_enabled() {
+        if context.specials_enabled() || list_only {
             return Ok(EntryAction::CopyFifo);
         }
         *keep_name = false;
@@ -158,7 +164,7 @@ fn decide_entry_action(
         if context.copy_devices_as_files_enabled() {
             return Ok(EntryAction::CopyDeviceAsFile);
         }
-        if context.devices_enabled() {
+        if context.devices_enabled() || list_only {
             return Ok(EntryAction::CopyDevice);
         }
         *keep_name = false;

--- a/crates/engine/src/local_copy/executor/sources/handlers.rs
+++ b/crates/engine/src/local_copy/executor/sources/handlers.rs
@@ -223,7 +223,10 @@ pub(super) fn handle_symlink_copy(
     destination_behaves_like_directory: bool,
     prefer_root_destination: bool,
 ) -> Result<(), LocalCopyError> {
-    if context.links_enabled() {
+    // upstream: generator.c:1155 list_file_entry() lists every flist entry,
+    // so `--list-only` must record the symlink (dry-run only reports it) even
+    // when `--links` is off; a real transfer without `--links` still skips it.
+    if context.links_enabled() || context.list_only_enabled() {
         let target = compute_special_target_path(
             destination_path,
             destination_base,
@@ -263,7 +266,10 @@ pub(super) fn handle_fifo_copy(
     destination_behaves_like_directory: bool,
     prefer_root_destination: bool,
 ) -> Result<bool, LocalCopyError> {
-    if !context.specials_enabled() {
+    // upstream: generator.c:1155 list_file_entry() lists FIFOs/sockets in
+    // `--list-only` output regardless of `--specials`; a real transfer without
+    // `--specials` still skips them.
+    if !context.specials_enabled() && !context.list_only_enabled() {
         context.record_skipped_non_regular(record_path);
         return Ok(true);
     }
@@ -316,7 +322,10 @@ pub(super) fn handle_device_copy(
 
     if context.copy_devices_as_files_enabled() {
         let _ = copy_file(context, source_path, &target, metadata, record_path)?;
-    } else if !context.devices_enabled() {
+    } else if !context.devices_enabled() && !context.list_only_enabled() {
+        // upstream: generator.c:1155 list_file_entry() lists devices in
+        // `--list-only` output regardless of `--devices`; a real transfer
+        // without `--devices` still skips them.
         context.record_skipped_non_regular(record_path);
         return Ok(true);
     } else {

--- a/crates/engine/src/local_copy/options/builder/definition.rs
+++ b/crates/engine/src/local_copy/options/builder/definition.rs
@@ -120,6 +120,7 @@ pub struct LocalCopyOptionsBuilder {
     pub(super) append: bool,
     pub(super) append_verify: bool,
     pub(super) collect_events: bool,
+    pub(super) list_only: bool,
 
     pub(super) preserve_hard_links: bool,
 
@@ -250,6 +251,7 @@ impl LocalCopyOptionsBuilder {
             append: false,
             append_verify: false,
             collect_events: false,
+            list_only: false,
             preserve_hard_links: false,
             relative_paths: false,
             one_file_system: 0,

--- a/crates/engine/src/local_copy/options/builder/setters_staging.rs
+++ b/crates/engine/src/local_copy/options/builder/setters_staging.rs
@@ -78,6 +78,15 @@ impl LocalCopyOptionsBuilder {
         self
     }
 
+    /// Enables `--list-only` listing semantics.
+    ///
+    /// upstream: generator.c:1155 `list_file_entry()`.
+    #[must_use]
+    pub fn list_only(mut self, enabled: bool) -> Self {
+        self.list_only = enabled;
+        self
+    }
+
     /// Enables hard link preservation.
     #[must_use]
     pub fn hard_links(mut self, enabled: bool) -> Self {

--- a/crates/engine/src/local_copy/options/builder/validation.rs
+++ b/crates/engine/src/local_copy/options/builder/validation.rs
@@ -175,6 +175,7 @@ impl LocalCopyOptionsBuilder {
             append: self.append,
             append_verify: self.append_verify,
             collect_events: self.collect_events,
+            list_only: self.list_only,
             preserve_hard_links: self.preserve_hard_links,
             relative_paths: self.relative_paths,
             one_file_system: self.one_file_system,

--- a/crates/engine/src/local_copy/options/staging.rs
+++ b/crates/engine/src/local_copy/options/staging.rs
@@ -154,6 +154,23 @@ impl LocalCopyOptions {
         self
     }
 
+    /// Enables `--list-only` semantics: enumerate and list every entry
+    /// (including symlinks, devices, FIFOs, and sockets) rather than skipping
+    /// non-regular files as a real transfer would.
+    ///
+    /// upstream: generator.c:1155 `list_file_entry()`.
+    #[must_use]
+    pub const fn list_only(mut self, list_only: bool) -> Self {
+        self.list_only = list_only;
+        self
+    }
+
+    /// Reports whether `--list-only` listing semantics are active.
+    #[must_use]
+    pub const fn list_only_enabled(&self) -> bool {
+        self.list_only
+    }
+
     /// Reports whether sparse handling has been requested.
     #[must_use]
     pub const fn sparse_enabled(&self) -> bool {

--- a/crates/engine/src/local_copy/options/types.rs
+++ b/crates/engine/src/local_copy/options/types.rs
@@ -199,6 +199,15 @@ pub struct LocalCopyOptions {
     pub(super) append: bool,
     pub(super) append_verify: bool,
     pub(super) collect_events: bool,
+    /// Mirrors the client's `--list-only` state. When set, the engine runs in
+    /// dry-run mode but lists every enumerated entry - including symlinks,
+    /// devices, FIFOs, and sockets - instead of skipping non-regular files.
+    ///
+    /// upstream: generator.c:1155 `list_file_entry()` lists every flist entry
+    /// regardless of `--links`/`--devices`/`--specials` because list-only mode
+    /// never runs the generator's non-regular skip path (main.c:708
+    /// `get_local_name()` returns NULL for `list_only`).
+    pub(super) list_only: bool,
     pub(super) preserve_hard_links: bool,
     pub(super) relative_paths: bool,
     pub(super) one_file_system: u8,
@@ -334,6 +343,7 @@ impl LocalCopyOptions {
             append: false,
             append_verify: false,
             collect_events: false,
+            list_only: false,
             preserve_hard_links: false,
             relative_paths: false,
             one_file_system: 0,

--- a/crates/engine/src/local_copy/plan/metadata.rs
+++ b/crates/engine/src/local_copy/plan/metadata.rs
@@ -36,22 +36,27 @@ impl LocalCopyFileKind {
         if file_type.is_file() {
             return Self::File;
         }
-        if is_fifo(file_type) {
-            return Self::Fifo;
-        }
+        // Sockets and devices must be classified before the `is_fifo` helper,
+        // which deliberately treats sockets as FIFOs for CopyFifo routing
+        // (support.rs). Distinguishing the kind here keeps `--list-only`
+        // permission strings faithful to upstream (`s` for sockets, `c`/`b`
+        // for devices) rather than collapsing them to `p`.
         #[cfg(unix)]
         {
             use std::os::unix::fs::FileTypeExt;
 
+            if file_type.is_socket() {
+                return Self::Socket;
+            }
             if file_type.is_char_device() {
                 return Self::CharDevice;
             }
             if file_type.is_block_device() {
                 return Self::BlockDevice;
             }
-            if file_type.is_socket() {
-                return Self::Socket;
-            }
+        }
+        if is_fifo(file_type) {
+            return Self::Fifo;
         }
         Self::Other
     }

--- a/crates/engine/src/local_copy/tests/list_only.rs
+++ b/crates/engine/src/local_copy/tests/list_only.rs
@@ -571,6 +571,204 @@ fn list_only_shows_device_nodes_when_enabled() {
     assert!(!collector.records.is_empty());
 }
 
+/// upstream: generator.c:1155 list_file_entry() lists every flist entry, so
+/// `--list-only` must record a symlink even without `--links`; a real transfer
+/// without `--links` skips it. This encodes WHY the two modes differ: listing
+/// enumerates the flist, transfer applies the generator's skip logic.
+#[cfg(unix)]
+#[test]
+fn list_only_lists_symlink_without_links_flag() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+
+    fs::create_dir(&source).expect("create source");
+    fs::create_dir(&dest).expect("create dest");
+
+    fs::write(source.join("target.txt"), b"target").expect("write target");
+    symlink("target.txt", source.join("link.txt")).expect("create symlink");
+
+    let mut source_operand = source.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR_STR);
+
+    let operands = vec![source_operand, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let mut collector = RecordCollector::new();
+
+    // list_only is set but links is NOT: without list_only this symlink is
+    // skipped as non-regular.
+    plan.execute_with_options_and_handler(
+        LocalCopyExecution::DryRun,
+        LocalCopyOptions::default().recursive(true).list_only(true),
+        Some(&mut collector),
+    )
+    .expect("dry run succeeds");
+
+    let link_record = collector
+        .records
+        .iter()
+        .find(|r| r.relative_path().to_string_lossy() == "link.txt")
+        .expect("symlink must be listed in list-only mode");
+
+    assert_eq!(link_record.action(), &LocalCopyAction::SymlinkCopied);
+    let metadata = link_record.metadata().expect("metadata present");
+    assert_eq!(metadata.kind(), LocalCopyFileKind::Symlink);
+    assert_eq!(
+        metadata
+            .symlink_target()
+            .expect("symlink target captured")
+            .to_string_lossy(),
+        "target.txt"
+    );
+}
+
+/// upstream: generator.c:1155 list_file_entry() lists FIFOs regardless of
+/// `--specials`. `--list-only` records the FIFO; a real transfer without
+/// `--specials` skips it.
+#[cfg(unix)]
+#[test]
+fn list_only_lists_fifo_without_specials_flag() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+
+    fs::create_dir(&source).expect("create source");
+    fs::create_dir(&dest).expect("create dest");
+
+    mkfifo_for_tests(&source.join("pipe"), 0o644).expect("mkfifo");
+
+    let mut source_operand = source.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR_STR);
+
+    let operands = vec![source_operand, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let mut collector = RecordCollector::new();
+
+    plan.execute_with_options_and_handler(
+        LocalCopyExecution::DryRun,
+        LocalCopyOptions::default().recursive(true).list_only(true),
+        Some(&mut collector),
+    )
+    .expect("dry run succeeds");
+
+    let fifo_record = collector
+        .records
+        .iter()
+        .find(|r| r.relative_path().to_string_lossy() == "pipe")
+        .expect("FIFO must be listed in list-only mode");
+
+    assert_eq!(fifo_record.action(), &LocalCopyAction::FifoCopied);
+    assert_eq!(
+        fifo_record.metadata().expect("metadata present").kind(),
+        LocalCopyFileKind::Fifo
+    );
+}
+
+/// A socket must classify as `Socket`, not `Fifo`, so `--list-only` renders it
+/// with the `s` permission char (upstream permstring). The `is_fifo` routing
+/// helper deliberately treats sockets as FIFOs for CopyFifo dispatch, so the
+/// kind derivation must distinguish them independently.
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    ))
+))]
+#[test]
+fn list_only_reports_socket_kind_not_fifo() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+
+    fs::create_dir(&source).expect("create source");
+    fs::create_dir(&dest).expect("create dest");
+
+    mksocket_for_tests(&source.join("sock")).expect("mksocket");
+
+    let mut source_operand = source.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR_STR);
+
+    let operands = vec![source_operand, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let mut collector = RecordCollector::new();
+
+    plan.execute_with_options_and_handler(
+        LocalCopyExecution::DryRun,
+        LocalCopyOptions::default().recursive(true).list_only(true),
+        Some(&mut collector),
+    )
+    .expect("dry run succeeds");
+
+    let sock_record = collector
+        .records
+        .iter()
+        .find(|r| r.relative_path().to_string_lossy() == "sock")
+        .expect("socket must be listed in list-only mode");
+
+    assert_eq!(
+        sock_record.metadata().expect("metadata present").kind(),
+        LocalCopyFileKind::Socket,
+        "socket must not collapse to Fifo kind"
+    );
+}
+
+/// A normal (non-list-only) transfer without `--links`/`--specials` must still
+/// skip non-regular entries as upstream's generator does, guarding against the
+/// list-only relaxation leaking into real transfers.
+#[cfg(unix)]
+#[test]
+fn transfer_without_list_only_skips_symlink_and_fifo() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source");
+    let dest = temp.path().join("dest");
+
+    fs::create_dir(&source).expect("create source");
+    fs::create_dir(&dest).expect("create dest");
+
+    fs::write(source.join("target.txt"), b"target").expect("write target");
+    symlink("target.txt", source.join("link.txt")).expect("create symlink");
+    mkfifo_for_tests(&source.join("pipe"), 0o644).expect("mkfifo");
+
+    let mut source_operand = source.into_os_string();
+    source_operand.push(std::path::MAIN_SEPARATOR_STR);
+
+    let operands = vec![source_operand, dest.into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let mut collector = RecordCollector::new();
+
+    // Default options: no list_only, no links, no specials.
+    plan.execute_with_options_and_handler(
+        LocalCopyExecution::DryRun,
+        LocalCopyOptions::default().recursive(true),
+        Some(&mut collector),
+    )
+    .expect("dry run succeeds");
+
+    for name in ["link.txt", "pipe"] {
+        let record = collector
+            .records
+            .iter()
+            .find(|r| r.relative_path().to_string_lossy() == name)
+            .unwrap_or_else(|| panic!("{name} record present"));
+        assert_eq!(
+            record.action(),
+            &LocalCopyAction::SkippedNonRegular,
+            "{name} must be skipped in a non-list-only transfer"
+        );
+    }
+}
+
 #[test]
 fn list_only_handles_size_zero_files() {
     let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Problem

`oc-rsync --list-only` omitted symlinks (without `-l`), FIFOs, sockets, and devices from the listing. It classified them as `SkippedNonRegular` and printed `skipping non-regular file "X"` instead of listing them.

Upstream rsync lists **every** file-list entry in list-only mode - the generator's non-regular skip path never runs because `get_local_name()` returns NULL for `list_only` (`generator.c:1155` `list_file_entry`).

### Before / After vs upstream 3.4.4

Tree: a regular file, a symlink (`link.txt -> target`), a FIFO (`p`), a socket (`sock`).

```
# oc-rsync --list-only t/   (BEFORE)
-rw-r--r--  14 ... file.txt
skipping non-regular file "link.txt"
skipping non-regular file "p"

# oc-rsync --list-only t/   (AFTER == upstream)
drwxr-xr-x 160 ... .
-rw-r--r--  14 ... file.txt
lrwxr-xr-x   6 ... link.txt
prw-r--r--   0 ... p
srwxr-xr-x   0 ... sock
```

Verified byte-for-byte against `rsync 3.4.4` across `--list-only` with no flags, `-l`, `-D`, `-a`, `-r`, `-rl` for symlinks, FIFOs, sockets, and character devices.

## Fix

- Thread a `list_only` flag through `LocalCopyOptions`. In list-only mode the directory planner (`decide_entry_action`) and top-level source handlers record symlinks/FIFOs/devices for listing instead of skipping them. Gated strictly on list-only: a real transfer without `-l`/`-D`/`--specials` still skips non-regular files exactly as before (covered by a regression test).
- The ` -> <target>` arrow is gated on `preserve_links` to match `generator.c:1183` (`preserve_links && S_ISLNK`): without `-l` the symlink is listed with its target-length size but no target string. Threaded via `OutFormatContext`.
- Fixed a latent kind-derivation bug surfaced by socket listing: the `is_fifo` routing helper treats sockets as FIFOs for `CopyFifo` dispatch, so `LocalCopyFileKind::from_file_type` must classify sockets before that helper to render the correct `s` permission char.

## Tests

- engine: list-only lists a symlink without `-l`, a FIFO without `--specials`, a socket reports `Socket` kind (non-Apple), and a non-list-only transfer still produces `SkippedNonRegular` for symlink+FIFO.
- cli: `emit_list_only` renders the symlink arrow only with `preserve_links`, and FIFO/socket/char-device permstring type chars.

`cargo fmt`, `cargo clippy -p engine -p cli --all-targets` clean; targeted nextest green.