### PR TITLE
docs(checksums): prune stale rustdoc comment

### DIFF
--- a/crates/checksums/src/simd_batch/md5_dispatcher.rs
+++ b/crates/checksums/src/simd_batch/md5_dispatcher.rs
@@ -496,7 +496,6 @@ impl Dispatcher {
     /// NEON batched digest implementation.
     ///
     /// Processes inputs in batches of 4 using NEON SIMD.
-    /// Currently falls back to scalar while NEON MD5 is implemented.
     #[cfg(target_arch = "aarch64")]
     fn digest_batch_neon<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());


### PR DESCRIPTION
## Summary

Rustdoc-first comment cleanup pass over the `checksums` crate.

The crate already enforces `#![deny(missing_docs)]`, so every public type, trait, function, method, and module is documented. A full read-only audit of all non-test source files (rolling rsum, MD4/MD5/SHA/XXH strong hashes, SIMD fast paths + scalar fallbacks, parallel/pipelined helpers, cpu_features, crc32c) found the comment hygiene already excellent: no decorative banners, no commented-out code, no debug/checkpoint noise, and all SIMD safety/parity comments and `upstream:` references intact.

The only issue found was one stale rustdoc line on `Dispatcher::digest_batch_neon`, which claimed the function "falls back to scalar while NEON MD5 is implemented." The function actually calls the real `simd::neon::digest_x4` NEON implementation. Removed the contradictory line; the preceding line already describes the NEON batching accurately.

## Changes
- Remove one outdated rustdoc line in `simd_batch/md5_dispatcher.rs` (docs-only, 1 deletion).

## Verification
- `cargo fmt --all -- --check` clean
- `cargo clippy -p checksums --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo check -p checksums --all-features` clean
- Diff is docs-only; no logic, signature, or cfg-gate changes.